### PR TITLE
[Update] Add BM25-transgraph compatibility

### DIFF
--- a/codeminer/bm25_index.py
+++ b/codeminer/bm25_index.py
@@ -6,6 +6,8 @@ from llama_index.core.schema import TextNode
 from llama_index.retrievers.bm25 import BM25Retriever
 
 from .code_graph import CodeGraph
+from .types import is_symbol_node, NODE_TYPE_FILE, NODE_TYPE_DIRECTORY
+from .transverse_graph import wrap_code_snippet
 
 
 class BM25CodeIndexer:
@@ -31,6 +33,7 @@ class BM25CodeIndexer:
         self.documents = []
         self.nodes = []
         self.retriever = None
+        self.code_graph: CodeGraph = None
 
         # Build the index immediately if a code_graph is provided
         if code_graph is not None:
@@ -46,6 +49,7 @@ class BM25CodeIndexer:
         # Reset the index
         self.documents = []
         self.nodes = []
+        self.code_graph = code_graph
 
         # Convert graph nodes to documents
         for vertex in code_graph.graph.vs:
@@ -78,60 +82,64 @@ class BM25CodeIndexer:
         node_type = vertex["type"] if "type" in vertex.attributes() else "unknown"
         node_name = vertex["name"]
 
-        # Extract content based on node type
-        if node_type == "file":
-            content = f"File: {node_name}"
-            metadata = {"type": "file", "path": node_name}
-        elif node_type == "symbol":
-            # Get file attribute if exists
+        metadata = {
+            "node_id": node_name,
+            "type": node_type,
+            "name": node_name,
+        }
+
+        if node_type == NODE_TYPE_FILE:
+            # File node: add file path under "file" to align with graph/search consumers
+            metadata["file"] = node_name
+            content_lines = [f"File: {node_name}"]
+            # Optionally include basic identifiers from file path for tokenization
+            content_lines.append(f"PathTokens: {node_name.replace('/', ' ').replace('.', ' ')}")
+            content = "\n".join(content_lines)
+        elif node_type == NODE_TYPE_DIRECTORY:
+            # Directory node
+            content = f"Directory: {node_name}"
+        elif is_symbol_node(node_type):
+            # Symbol-like nodes: class/function/method/field/symbol
             file_path = vertex["file"] if "file" in vertex.attributes() else None
-
-            # Get line range if it exists
             start_line = (
-                vertex["start_line"] if "start_line" in vertex.attributes() else None
+                vertex["start_line"] if "start_line" in vertex.attributes() and vertex["start_line"] is not None else 0
             )
-            end_line = vertex["end_line"] if "end_line" in vertex.attributes() else None
+            end_line = (
+                vertex["end_line"] if "end_line" in vertex.attributes() and vertex["end_line"] is not None else 0
+            )
 
-            # Enhance content text with additional variations of the symbol name
-            # to improve fuzzy matching and partial matches
-            enriched_name = self._enrich_symbol_name(node_name)
-
-            content_parts = [f"Symbol: {node_name}", f"Variants: {enriched_name}"]
-            if file_path:
-                content_parts.append(f"File: {file_path}")
-            if start_line and end_line:
-                content_parts.append(f"Lines: {start_line}-{end_line}")
-
-            content = "\n".join(content_parts)
-
-            # Create metadata
-            metadata = {"type": "symbol", "name": node_name}
             if file_path:
                 metadata["file"] = file_path
-            if start_line:
-                metadata["start_line"] = start_line
-            if end_line:
-                metadata["end_line"] = end_line
-        elif node_type == "directory":
-            # For directories, just use the name
-            content = f"Directory: {node_name}"
-            metadata = {"type": "directory", "name": node_name}
+            # Use simplified symbol name consistent with traverse graph utilities
+            simplified_name = node_name.split(":")[-1] if ":" in node_name else node_name
+            metadata["name"] = simplified_name
+            metadata["start_line"] = start_line
+            metadata["end_line"] = end_line
+
+            # Enrich text with name variants to improve BM25 matching
+            enriched_name = self._enrich_symbol_name(simplified_name)
+            parts = [f"Symbol: {simplified_name}", f"Variants: {enriched_name}"]
+            if file_path:
+                parts.append(f"File: {file_path}")
+            parts.append(f"Lines: {start_line}-{end_line}")
+            content = "\n".join(parts)
         else:
-            # root node
-            content = f"Root node: {node_name}"
-            metadata = {"type": "root", "name": node_name}
+            # Unknown or root-like node types: index minimally
+            content = f"Node: {node_name} Type: {node_type}"
 
-        # Add any additional attributes as metadata
+        # Include additional attributes (except ones we already standardized)
         for key in vertex.attributes():
-            if key not in ["name", "type", "file", "start_line", "end_line"]:
+            if key not in [
+                "name",
+                "type",
+                "file",
+                "start_line",
+                "end_line",
+            ]:
                 metadata[key] = vertex[key]
-
-        # Store the node ID in metadata for retrieval
-        metadata["node_id"] = node_id
 
         # Create a unique ID for the document
         doc_id = f"node_{node_id}"
-
         return Document(text=content, metadata=metadata, id_=doc_id)
 
     def _enrich_symbol_name(self, name: str) -> str:
@@ -199,7 +207,6 @@ class BM25CodeIndexer:
 
         Args:
             query: Search query
-            top_k: Optional override for number of results to return
 
         Returns:
             List of dictionaries containing matched nodes with scores
@@ -223,7 +230,7 @@ class BM25CodeIndexer:
                     result_node.score or 0.0
                 ),  # Ensure score is included and convert to float
                 "node_id": metadata.get("node_id"),
-                "node_type": metadata.get("type", "unknown"),
+                "type": metadata.get("type", "unknown"),  # Fixed: use "type" instead of "node_type"
                 "name": metadata.get("name", ""),
             }
 
@@ -235,6 +242,55 @@ class BM25CodeIndexer:
             processed_results.append(result)
 
         return processed_results
+
+    def search_graph_like(self, query: str, return_code_content: bool = False, wrap_with_ln: bool = True) -> List[Dict[str, Any]]:
+        """
+        Results in the exact same format as RepoEntitySearcher.get_node_data.
+        """
+
+        if self.retriever is None or self.code_graph is None:
+            raise ValueError("Index has not been built. Call build_index_from_graph first.")
+
+        results = self.retriever.retrieve(query)
+        output: List[Dict[str, Any]] = []
+
+        for result_node in results:
+            nid = result_node.node.metadata.get("node_id")
+            if nid not in self.code_graph.name_to_vertex:
+                continue
+            vertex_id = self.code_graph.name_to_vertex[nid]
+            vertex = self.code_graph.graph.vs[vertex_id]
+
+            formatted_data: Dict[str, Any] = {
+                "node_id": nid,
+                "type": vertex["type"] if "type" in vertex.attributes() else "unknown",
+            }
+
+            code_content = self.code_graph.get_node_content(vertex_id)
+            if code_content:
+                start_line = 0
+                end_line = 0
+                if (
+                    "start_line" in vertex.attributes() and vertex["start_line"] is not None
+                ):
+                    start_line = vertex["start_line"]
+                if "end_line" in vertex.attributes() and vertex["end_line"] is not None:
+                    end_line = vertex["end_line"]
+                formatted_data["start_line"] = start_line
+                formatted_data["end_line"] = end_line
+
+                if vertex["type"] == NODE_TYPE_FILE:
+                    end_line = len(code_content.split("\n"))
+                    formatted_data["end_line"] = end_line
+
+                if return_code_content and wrap_with_ln:
+                    formatted_data["code_content"] = wrap_code_snippet(code_content, start_line, end_line)
+                elif return_code_content:
+                    formatted_data["code_content"] = code_content
+
+            output.append(formatted_data)
+
+        return output
 
     def save_index(self, directory_path: str):
         """

--- a/test/test_transgraph.py
+++ b/test/test_transgraph.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from codeminer.bm25_index import BM25CodeIndexer
 from codeminer.scip_interface import SCIPIndexer
 from codeminer.transverse_graph import (
     RepoDependencySearcher,
@@ -278,13 +279,69 @@ def test_transgraph_simple():
     return True
 
 
+def test_bm25_transgraph_compatibility():
+    """Test compatibility between BM25 graph-like output and traverse graph get_node_data."""
+    repo_path = Path(__file__).parent / "simple_repo"
+    assert repo_path.exists(), f"Test repository not found at {repo_path}"
+    print(f"Using repo: {repo_path}")
+
+    # Build graph
+    output_path = Path.home() / ".codeminer" / "compat_test_smoke"
+    if not output_path.exists():
+        output_path.mkdir(parents=True)
+    indexer = SCIPIndexer(str(repo_path), output_dir=str(output_path))
+    graph = indexer.run_pipeline(project_name="compat_test_smoke", force=True)
+    print("Graph built successfully")
+
+    entity_searcher = RepoEntitySearcher(graph)
+
+    # Pick a query derived from a real file name
+    file_nodes = entity_searcher.get_all_nodes_by_type(NODE_TYPE_FILE)
+    assert file_nodes, "Should have at least one file node"
+    probe_file = file_nodes[0]["name"]
+    query = Path(probe_file).stem
+    print(f"Probe file: {probe_file}")
+    print(f"Query: {query}")
+
+    # Build BM25 and run graph-like search
+    bm25 = BM25CodeIndexer(code_graph=graph, top_k=10, language="english")
+    r1 = bm25.search_graph_like(query, return_code_content=True, wrap_with_ln=True)
+    assert r1, "BM25 should return at least one node"
+    nid = r1[0]["node_id"]
+
+    # Get graph truth for the exact same node_id
+    r2 = entity_searcher.get_node_data([nid], return_code_content=True, wrap_with_ln=True)
+    assert r2 and r2[0], "Graph should return the same node data"
+
+    # Print summaries
+    b1 = r1[0]
+    g1 = r2[0]
+    print("BM25 first node:", {k: b1.get(k) for k in ["node_id", "type", "start_line", "end_line", "name"] if k in b1})
+    print("Graph node:", {k: g1.get(k) for k in ["node_id", "type", "start_line", "end_line", "name"] if k in g1})
+
+    b1_code = b1.get("code_content", "")
+    g1_code = g1.get("code_content", "")
+    print("BM25 code_content (head):\n", b1_code[:500])
+    print("Graph code_content (head):\n", g1_code[:500])
+
+    # equality on keys
+    keys = set(["node_id", "type"]) | set(k for k in ("start_line", "end_line", "code_content") if k in g1)
+    for k in keys:
+        assert b1.get(k) == g1.get(k), f"Mismatch on {k}: {b1.get(k)} != {g1.get(k)}"
+
+    print("BM25 graph-like output == traverse graph output: PASS")
+    return True
+
+
 # Example usage
 if __name__ == "__main__":
     print("Starting simple repository traverse test...")
     success = test_transgraph_simple()
+    compat_success = test_bm25_transgraph_compatibility()
 
-    if success:
+    if success and compat_success:
         print("\n🎉 All tests completed successfully!")
+        
     else:
         print("\n❌ Some tests failed!")
         exit(1)


### PR DESCRIPTION
Add `search_graph_like` method to BM25CodeIndexer for consistent output format with `RepoEntitySearcher.get_node_data`

e.g.
```python
# BM25 
bm25_result = bm25.search_graph_like(query, return_code_content=True, wrap_with_ln=True)
nid = bm25_result[0]["node_id"]
# graph
graph_result = entity_searcher.get_node_data([nid], return_code_content=True, wrap_with_ln=True)

assert bm25_result[0] == graph_result[0] 
```

Potential next steps: clean up code components and unify test structure