### PR TITLE
[VectorDB] Support index metrics (l2, ip) in the FAISS vector store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 *.decoded
 key.cfg
 logs/
+uv.lock

--- a/codeminer/eval/retrieval_eval.py
+++ b/codeminer/eval/retrieval_eval.py
@@ -79,16 +79,18 @@ def evaluate_predictions(
     ks: Sequence[int],
 ) -> Dict[str, Dict[int, Dict[str, float]]]:
     """Evaluate retrieved nodes against targets for multiple cutoffs."""
-    # Extract file paths directly from node_id (format: "file.py" or "file.py:symbol")
-    normalized_files = []
+    # For file-level: collect unique files in ranking order (no duplicates)
+    seen_files = set()
+    unique_files_ordered = []
     for node in nodes:
         if node.node_id:
             file_path = (
                 node.node_id.split(":")[0] if ":" in node.node_id else node.node_id
             )
             normalized = normalize_file_path(file_path)
-            if normalized:
-                normalized_files.append(normalized)
+            if normalized and normalized not in seen_files:
+                seen_files.add(normalized)
+                unique_files_ordered.append(normalized)
 
     # Build symbol predictions from node_id
     normalized_symbols = [
@@ -99,7 +101,9 @@ def evaluate_predictions(
 
     metrics = {"files": {}, "symbols": {}}
     for k in ks:
-        metrics["files"][k] = compute_metrics(normalized_files[:k], target_files)
+        # File-level: evaluate against top-k unique files
+        metrics["files"][k] = compute_metrics(unique_files_ordered[:k], target_files)
+        # Symbol-level: evaluate against top-k nodes/symbols
         metrics["symbols"][k] = compute_metrics(normalized_symbols[:k], target_symbols)
     return metrics
 

--- a/codeminer/eval/retrieval_eval.py
+++ b/codeminer/eval/retrieval_eval.py
@@ -55,6 +55,31 @@ def build_symbol_prediction(node: QueriedNode) -> Optional[str]:
     return None
 
 
+def extract_predictions(
+    nodes: Sequence[QueriedNode],
+) -> Tuple[List[str], List[str]]:
+    """Extract unique files and symbols from retrieved nodes."""
+    seen_files = set()
+    unique_files_ordered = []
+    for node in nodes:
+        if node.node_id:
+            file_path = (
+                node.node_id.split(":")[0] if ":" in node.node_id else node.node_id
+            )
+            normalized = normalize_file_path(file_path)
+            if normalized and normalized not in seen_files:
+                seen_files.add(normalized)
+                unique_files_ordered.append(normalized)
+
+    normalized_symbols = [
+        value
+        for value in (build_symbol_prediction(node) for node in nodes)
+        if value is not None
+    ]
+
+    return unique_files_ordered, normalized_symbols
+
+
 def compute_metrics(
     predictions: Sequence[str],
     targets: Sequence[str],
@@ -79,25 +104,7 @@ def evaluate_predictions(
     ks: Sequence[int],
 ) -> Dict[str, Dict[int, Dict[str, float]]]:
     """Evaluate retrieved nodes against targets for multiple cutoffs."""
-    # For file-level: collect unique files in ranking order (no duplicates)
-    seen_files = set()
-    unique_files_ordered = []
-    for node in nodes:
-        if node.node_id:
-            file_path = (
-                node.node_id.split(":")[0] if ":" in node.node_id else node.node_id
-            )
-            normalized = normalize_file_path(file_path)
-            if normalized and normalized not in seen_files:
-                seen_files.add(normalized)
-                unique_files_ordered.append(normalized)
-
-    # Build symbol predictions from node_id
-    normalized_symbols = [
-        value
-        for value in (build_symbol_prediction(node) for node in nodes)
-        if value is not None
-    ]
+    unique_files_ordered, normalized_symbols = extract_predictions(nodes)
 
     metrics = {"files": {}, "symbols": {}}
     for k in ks:

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -62,6 +62,8 @@ class CodeVectorStore:
         self.dimension = dimension
         self.index_type = index_type
         self.index_metric = index_metric.lower()
+        if self.index_metric not in ["ip", "l2"]:
+            raise ValueError(f"Unsupported index_metric: {index_metric}. Must be 'ip' or 'l2'.")
         self.store_path = Path(store_path) if store_path else None
         self.index_params = index_params or {}
         self.profiler = profiler

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -37,6 +37,7 @@ class CodeVectorStore:
         embedding_provider: str = "openai",
         dimension: int = 1536,
         index_type: str = "flat",
+        index_metric: str = "ip",
         store_path: Optional[str] = None,
         index_params: Optional[Dict[str, Any]] = None,
         profiler: Optional[Profiler] = None,
@@ -50,6 +51,7 @@ class CodeVectorStore:
             embedding_provider: Provider for embeddings ("openai", "huggingface")
             dimension: Dimension of the embedding vectors
             index_type: Type of FAISS index ("flat", "ivf", "hnsw")
+            index_metric: Distance metric ("ip" for inner product, "l2" for L2 distance)
             store_path: Path to store/load the vector store
             index_params: Additional parameters for index construction (e.g., nlist)
             profiler: Optional profiler instance to capture detailed timings
@@ -59,6 +61,7 @@ class CodeVectorStore:
         self.embedding_provider = embedding_provider
         self.dimension = dimension
         self.index_type = index_type
+        self.index_metric = index_metric.lower()
         self.store_path = Path(store_path) if store_path else None
         self.index_params = index_params or {}
         self.profiler = profiler
@@ -130,10 +133,16 @@ class CodeVectorStore:
     def _build_faiss_index(self) -> faiss.Index:
         """Create a FAISS index according to the configured index_type."""
         index_type = self.index_type.lower()
+        metric = self.index_metric
         params = self.index_params
 
         if index_type == "flat":
-            return faiss.IndexFlatL2(self.dimension)
+            if metric == "ip":
+                return faiss.IndexFlatIP(self.dimension)
+            elif metric == "l2":
+                return faiss.IndexFlatL2(self.dimension)
+            else:
+                raise ValueError(f"Unsupported metric for flat index: {metric}")
 
         if index_type == "ivf":
             nlist = int(params.get("nlist", 1024))
@@ -356,6 +365,7 @@ class CodeVectorStore:
             "embedding_provider": self.embedding_provider,
             "dimension": self.dimension,
             "index_type": self.index_type,
+            "index_metric": self.index_metric,
             "index_params": self.index_params,
         }
         with open(config_path, "w") as f:
@@ -405,6 +415,14 @@ class CodeVectorStore:
                     self.index_type,
                     saved_index_type,
                 )
+            saved_metric = config.get("index_metric")
+            if saved_metric and saved_metric != self.index_metric:
+                logger.warning(
+                    "Index metric mismatch: expected %s, got %s",
+                    self.index_metric,
+                    saved_metric,
+                )
+                self.index_metric = saved_metric
             saved_params = config.get("index_params")
             if saved_params and saved_params != self.index_params:
                 logger.warning("Index params mismatch between config and runtime")
@@ -457,6 +475,7 @@ class CodeVectorStore:
             "embedding_provider": self.embedding_provider,
             "dimension": self.dimension,
             "index_type": self.index_type,
+            "index_metric": self.index_metric,
             "index_params": self.index_params,
             "vector_store_size": len(self.documents),
         }

--- a/examples/retrieve_rerank.py
+++ b/examples/retrieve_rerank.py
@@ -42,6 +42,7 @@ from codeminer.eval.retrieval_eval import (
     average_metrics,
     collect_targets,
     evaluate_predictions,
+    extract_predictions,
 )
 from codeminer.llm.llm_config import LLMProvider
 from codeminer.log_utils import get_logger
@@ -220,6 +221,12 @@ def parse_args():
         default="~/.codeminer/",
         help="Directory to cache cloned repositories for dataset instances",
     )
+    parser.add_argument(
+        "--result-path",
+        type=str,
+        default=None,
+        help="Path to store retrieval results in json format",
+    )
 
     return parser.parse_args()
 
@@ -274,6 +281,7 @@ def run_pipeline(args):
     aggregate = {}
     metrics_k = sorted(set(args.metrics_k))
     eval_count = 0
+    all_results = [] if args.result_path else None
 
     # Process each instance
     for _, instance in enumerate(dataset_instances):
@@ -313,15 +321,6 @@ def run_pipeline(args):
         query = instance["problem_statement"]
         results = pipeline.query(query=query, top_k=max(max(metrics_k), args.top_k))
 
-        # for i, node in enumerate(results[: args.top_k]):
-        #     logger.info("--------------------------------")
-        #     logger.info(f"Rank {i + 1} (Score: {node.score:.4f})")
-        #     logger.info(f"  Node Name: {node.node_name}")
-        #     logger.info(f"  Node Type: {node.type}")
-        #     logger.info(f"  File: {node.file}")
-        #     logger.info(f"  Lines: {node.start_line}-{node.end_line}")
-        #     logger.info(f"  Content: {node.content}")
-
         metadata = eval_metadata.get(instance_id)
         if metadata:
             target_files, target_symbols = collect_targets(metadata)
@@ -345,11 +344,43 @@ def run_pipeline(args):
                         stats["recall"],
                         int(stats["hits"]),
                     )
+        else:
+            metrics = None
+            target_files = []
+            target_symbols = []
+
+        # Collect results if result_path is provided
+        if all_results is not None:
+            max_k = max(metrics_k)
+
+            unique_files_ordered, normalized_symbols = extract_predictions(results)
+            metric_k_files = unique_files_ordered[:max_k]
+            metric_k_node_ids = normalized_symbols[:max_k]
+
+            result_entry = {
+                "instance_id": instance_id,
+                "metric_k_node_ids": metric_k_node_ids,
+                "metric_k_files": metric_k_files,
+                "target_files": (
+                    list(metadata.get("target_files", [])) if metadata else []
+                ),
+                "symbols_modified": (
+                    list(metadata.get("symbols_modified", [])) if metadata else []
+                ),
+                "symbols_added": (
+                    list(metadata.get("symbols_added", [])) if metadata else []
+                ),
+                "symbols_deleted": (
+                    list(metadata.get("symbols_deleted", [])) if metadata else []
+                ),
+                "metrics": metrics,
+            }
+            all_results.append(result_entry)
 
     if aggregate and eval_count:
         averaged = average_metrics(aggregate, eval_count)
         logger.info(
-            "=== Aggregate Retrieval Metrics (over %d instances) ===", eval_count
+            "=== Aggregate Retrieval Rerank Metrics (over %d instances) ===", eval_count
         )
         for scope, per_k in averaged.items():
             for k, stats in per_k.items():
@@ -362,6 +393,16 @@ def run_pipeline(args):
                     stats["recall"],
                     stats["avg_hits"],
                 )
+
+    # Save results to JSON file if result_path is provided
+    if args.result_path and all_results is not None:
+        result_path = Path(args.result_path).expanduser().resolve()
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(result_path, "w", encoding="utf-8") as f:
+            json.dump(all_results, f, indent=2, ensure_ascii=False)
+
+        logger.info(f"Results saved to {result_path} ({len(all_results)} instances)")
 
 
 def main():

--- a/scripts/build_embeddings.py
+++ b/scripts/build_embeddings.py
@@ -10,6 +10,9 @@ Usage:
     # Build with custom embedding model
     python scripts/build_embeddings.py --embedding-model nomic-ai/CodeRankEmbed
 
+    # Build with custom index metric (ip: inner product, l2: L2 distance)
+    python scripts/build_embeddings.py --index-metric l2
+
     # Build with filter (for testing)
     python scripts/build_embeddings.py --filter-instance "^(astropy__astropy-12907)$"
 
@@ -96,6 +99,13 @@ def parse_args():
         type=int,
         default=8,
         help="Batch size for embedding encoding",
+    )
+    parser.add_argument(
+        "--index-metric",
+        type=str,
+        default="ip",
+        choices=["ip", "l2"],
+        help="Distance metric for FAISS index (ip: inner product, l2: L2 distance)",
     )
 
     # Repository processing configuration
@@ -241,6 +251,7 @@ def build_embeddings(args):
                     embedding_model=args.embedding_model,
                     embedding_provider=args.embedding_provider,
                     dimension=args.embedding_dimension,
+                    index_metric=args.index_metric,
                     store_path=str(instance_final_dir),
                     profiler=instance_profiler,
                     **embedding_kwargs,


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
This pull request introduces support for configurable **distance metrics** in the FAISS vector store, allowing users to choose between **inner product ("ip")** and **L2 distance ("l2")** for similarity search. The changes affect both the core vector store implementation and the embedding build script, providing greater flexibility and transparency for embedding workflows.

## Changes
<!-- List the main changes made in this PR -->


### Vector Store Enhancements
* Added an `index_metric` parameter to the `VectorStore` class, enabling selection between "ip" (inner product) and "l2" (L2 distance) for FAISS index construction, with validation and error handling for unsupported metrics. 
* Persisted the `index_metric` value in the vector store's configuration when saving and loading, with warnings for mismatches between runtime and stored metrics to ensure consistency. 
* Included the `index_metric` in the output of the `get_stats` method for improved transparency in vector store metadata.

### Embedding Build Script Updates
* Added a new `--index-metric` command-line argument to `build_embeddings.py`, allowing users to specify the distance metric when building embeddings. Usage instructions and argument parsing were updated accordingly. 
* Passed the selected `index_metric` from the script to the vector store during embedding construction to ensure user-specified metric is used.


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
<!-- Describe the tests you ran and/or how to test these changes -->
- [x] Tests pass locally
- [ ] Added new tests for the changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
