### PR TITLE
Add skeleton mode; fix CI env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,13 @@ jobs:
           auto-activate-base: false
           remove-profiles: false
 
+      - name: Create scip env (empty conda env for SCIP indexer)
+        shell: bash -l {0}
+        run: |
+          if ! conda env list | grep -q 'scip-env'; then
+            conda env create --quiet --solver=libmamba --file codeminer/scip_interface/scip-environment.yml
+          fi
+
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -101,6 +101,7 @@ class CodeChunker:
         chunk_depth: int = 2,
         include_header_epilogue: bool = False,
         l2_level_exclusive: bool = True,
+        skeleton_mode: bool = False,
     ):
         """
         Initialize the code chunker for a specific language.
@@ -113,18 +114,21 @@ class CodeChunker:
             include_header_epilogue: Whether to include file headers and epilogues. Default: False
             l2_level_exclusive: When chunk_depth is 2, whether to omit L1 container nodes
                 (classes/structs/impls) and emit only L2 members. Default: True.
+            skeleton_mode: Emit signature-only skeletons instead of full bodies when True.
         """
         self.language = language
         self.max_lines_per_chunk = max_lines_per_chunk
         self.chunk_depth = chunk_depth
         self.include_header_epilogue = include_header_epilogue
         self.l2_level_exclusive = l2_level_exclusive
+        self.skeleton_mode = skeleton_mode
         self._chunker = create_chunker(
             language,
             max_lines_per_chunk=self.max_lines_per_chunk,
             chunk_depth=self.chunk_depth,
             include_header_epilogue=self.include_header_epilogue,
             l2_level_exclusive=self.l2_level_exclusive,
+            skeleton_mode=self.skeleton_mode,
         )
         if repo_config is None:
             repo_config = RepoChunkingConfig()
@@ -136,18 +140,27 @@ class CodeChunker:
             []
         )  # List of node IDs in code graph format (dir/file.py:A.b(), dir/file.py:A)
 
-    def chunk_file(self, file_path: str, relative_path: Optional[str] = None):
+    def chunk_file(
+        self,
+        file_path: str,
+        relative_path: Optional[str] = None,
+        skeleton_mode: Optional[bool] = None,
+    ):
         """
         Chunk a code file into function/class level pieces.
 
         Args:
             file_path: Path to the code file to chunk
             relative_path: Relative path for node_id generation. If None, uses file_path.
+            skeleton_mode: Override instance-level skeleton setting. When True, chunk content
+                contains signatures only.
 
         Returns:
             List of CodeChunk objects
         """
-        chunks = self._chunker.chunk_file(file_path, relative_path)
+        chunks = self._chunker.chunk_file(
+            file_path, relative_path=relative_path, skeleton_mode=skeleton_mode
+        )
         # Collect unique node IDs from chunks
         self._update_nodes_from_chunks(chunks)
         return chunks
@@ -412,6 +425,7 @@ class CodeChunker:
                 chunk_depth=self.chunk_depth,
                 include_header_epilogue=self.include_header_epilogue,
                 l2_level_exclusive=self.l2_level_exclusive,
+                skeleton_mode=self.skeleton_mode,
             )
 
         chunker = self._chunkers[language]
@@ -420,9 +434,13 @@ class CodeChunker:
         if repo_path:
             relative_path = str(file_path.relative_to(repo_path))
             # Pass relative path to chunker for proper node_id generation
-            return chunker.chunk_file(str(file_path), relative_path)
+            return chunker.chunk_file(
+                str(file_path),
+                relative_path=relative_path,
+                skeleton_mode=self.skeleton_mode,
+            )
         else:
-            return chunker.chunk_file(str(file_path))
+            return chunker.chunk_file(str(file_path), skeleton_mode=self.skeleton_mode)
 
     def chunk_swebench_instance(
         self,

--- a/codeminer/code_chunking/__init__.py
+++ b/codeminer/code_chunking/__init__.py
@@ -15,6 +15,7 @@ def create_chunker(
     chunk_depth: int = 2,
     include_header_epilogue: bool = False,
     l2_level_exclusive: bool = True,
+    skeleton_mode: bool = False,
 ) -> BaseCodeChunker:
     """
     Create a code chunker for the specified language.
@@ -29,6 +30,7 @@ def create_chunker(
         include_header_epilogue: Whether to include file headers and epilogues. Default: False
         l2_level_exclusive: When chunk_depth is 2, whether to omit L1 container nodes
             (classes/structs/impls) and emit only L2 members. Default: True.
+        skeleton_mode: Emit signature-only skeletons instead of full bodies when True.
 
     Returns:
         Language-specific code chunker instance
@@ -44,6 +46,7 @@ def create_chunker(
             chunk_depth=chunk_depth,
             include_header_epilogue=include_header_epilogue,
             l2_level_exclusive=l2_level_exclusive,
+            skeleton_mode=skeleton_mode,
         )
     elif language in ("cpp", "c++", "cxx"):
         return CppCodeChunker(
@@ -51,6 +54,7 @@ def create_chunker(
             chunk_depth=chunk_depth,
             include_header_epilogue=include_header_epilogue,
             l2_level_exclusive=l2_level_exclusive,
+            skeleton_mode=skeleton_mode,
         )
     elif language == "rust":
         return RustCodeChunker(
@@ -58,6 +62,7 @@ def create_chunker(
             chunk_depth=chunk_depth,
             include_header_epilogue=include_header_epilogue,
             l2_level_exclusive=l2_level_exclusive,
+            skeleton_mode=skeleton_mode,
         )
     else:
         raise ValueError(f"Unsupported language: {language}")

--- a/codeminer/code_chunking/base.py
+++ b/codeminer/code_chunking/base.py
@@ -35,6 +35,7 @@ class BaseCodeChunker(ABC):
         chunk_depth: int = 2,
         include_header_epilogue: bool = False,
         l2_level_exclusive: bool = True,
+        skeleton_mode: bool = False,
     ):
         """
         Initialize the code chunker for a specific language.
@@ -54,12 +55,16 @@ class BaseCodeChunker(ABC):
             l2_level_exclusive: When chunk_depth is 2 (method/member level), whether to exclude
                 the containing type/scope chunks (classes, structs, impls). Default: True to keep
                 L2-only output; set to False to emit both L1 container chunks and L2 members.
+            skeleton_mode: When True, emit skeletonized content (signatures only) for file- and
+                type-level chunks. File-level skeletons list top-level definitions. Type-level
+                skeletons list member signatures. Defaults to False (emit full source).
         """
         self.language = language
         self.max_lines_per_chunk = max_lines_per_chunk
         self.chunk_depth = chunk_depth
         self.include_header_epilogue = include_header_epilogue
         self.l2_level_exclusive = l2_level_exclusive
+        self.skeleton_mode = skeleton_mode
         try:
             self.parser = get_parser(language)
             self.tree_sitter_language = get_language(language)
@@ -71,7 +76,10 @@ class BaseCodeChunker(ABC):
             sys.exit(1)
 
     def chunk_file(
-        self, file_path: str, relative_path: Optional[str] = None
+        self,
+        file_path: str,
+        relative_path: Optional[str] = None,
+        skeleton_mode: Optional[bool] = None,
     ) -> List[CodeChunk]:
         """
         Chunk a code file into function/class level pieces.
@@ -79,6 +87,8 @@ class BaseCodeChunker(ABC):
         Args:
             file_path: Absolute path to the code file to chunk
             relative_path: Relative path for node_id generation
+            skeleton_mode: Override instance-level skeleton setting. When True, chunks contain
+                signature-only skeletons instead of full bodies.
 
         Returns:
             List of CodeChunk objects representing the chunks
@@ -107,9 +117,28 @@ class BaseCodeChunker(ABC):
         # Use relative_path for node_id generation, fallback to file_path
         path_for_node_id = relative_path if relative_path else file_path
 
+        use_skeleton = self.skeleton_mode if skeleton_mode is None else skeleton_mode
+
         if self.chunk_depth == 0:
             if not lines:
                 return []
+            if use_skeleton:
+                skeleton_content = self._build_file_skeleton(
+                    top_level_nodes, code_content
+                )
+                if not skeleton_content:
+                    return []
+                return [
+                    CodeChunk(
+                        skeleton_content,
+                        0,
+                        len(lines) - 1,
+                        "file",
+                        Path(file_path).name,
+                        file_path,
+                        path_for_node_id,
+                    )
+                ]
             return self._split_by_max_lines(
                 lines=lines,
                 start_line=0,
@@ -122,7 +151,12 @@ class BaseCodeChunker(ABC):
 
         # Generate chunks
         chunks = self._generate_chunks(
-            lines, top_level_nodes, file_path, path_for_node_id
+            lines=lines,
+            definitions=top_level_nodes,
+            file_path=file_path,
+            path_for_node_id=path_for_node_id,
+            code_content=code_content,
+            skeleton_mode=use_skeleton,
         )
 
         # logger.debug(f"Generated {len(chunks)} chunks from {file_path}")
@@ -145,6 +179,87 @@ class BaseCodeChunker(ABC):
             class_name = name.split(".")[0]
             prefix_lines.append(f"class {class_name}:")
         return "\n".join(prefix_lines) + "\n"
+
+    def _find_first_child(self, node, target_types: Tuple[str, ...]):
+        """Depth-first search for the first child node matching one of target_types."""
+        for child in node.children:
+            if child.type in target_types:
+                return child
+            found = self._find_first_child(child, target_types)
+            if found:
+                return found
+        return None
+
+    def _get_signature_stop_types(self, def_type: str) -> Tuple[str, ...]:
+        """
+        Identify AST node types that represent the start of a body we want to strip.
+        Override in subclasses for language-specific constructs.
+        """
+        # Reasonable defaults across languages we support.
+        if def_type in ("function", "method"):
+            return ("block", "compound_statement")
+        if def_type in ("class", "struct", "enum", "trait"):
+            return ("block", "field_declaration_list")
+        if def_type == "impl":
+            return ("declaration_list",)
+        return ("block",)
+
+    def _extract_signature_text(self, node, def_type: str, code_content: str) -> str:
+        """
+        Slice out the signature/heading for a node, stopping before the first body-like child.
+        Falls back to the full node text when no stop child is found.
+        """
+        stop_child = self._find_first_child(
+            node, self._get_signature_stop_types(def_type)
+        )
+        stop_byte = stop_child.start_byte if stop_child else node.end_byte
+        return code_content[node.start_byte : stop_byte].rstrip()
+
+    def _get_child_definitions(self, node, def_type: str) -> List[Tuple]:
+        """
+        Return child definitions for container nodes (e.g., methods inside a class).
+        Language-specific chunkers override this as needed. Defaults to no children.
+        """
+        return []
+
+    def _build_definition_skeleton(
+        self, node, def_type: str, code_content: str
+    ) -> Optional[str]:
+        """
+        Build a skeleton string for a single definition. Container nodes append child signatures.
+        """
+        signature = self._extract_signature_text(node, def_type, code_content)
+        if not signature:
+            return None
+
+        child_defs = self._get_child_definitions(node, def_type)
+        if not child_defs:
+            return signature
+
+        lines = [signature]
+        for child_node, _, child_type in child_defs:
+            child_signature = self._extract_signature_text(
+                child_node, child_type, code_content
+            )
+            if child_signature:
+                indented = "\n".join(
+                    f"    {line}" for line in child_signature.splitlines()
+                )
+                lines.append(indented)
+        return "\n".join(lines)
+
+    def _build_file_skeleton(self, definitions: List[Tuple], code_content: str) -> str:
+        """
+        Build a skeleton for a file chunk: list top-level definitions (exclude methods).
+        """
+        entries: List[str] = []
+        for node, _, def_type in definitions:
+            if def_type == "method":
+                continue
+            skeleton = self._build_definition_skeleton(node, def_type, code_content)
+            if skeleton:
+                entries.append(skeleton)
+        return "\n".join(entries)
 
     def _split_by_max_lines(
         self,
@@ -212,6 +327,8 @@ class BaseCodeChunker(ABC):
         definitions: List[Tuple],
         file_path: str,
         path_for_node_id: str,
+        code_content: str,
+        skeleton_mode: bool = False,
     ) -> List[CodeChunk]:
         """
         Generate code chunks from the file content and AST definitions.
@@ -221,6 +338,8 @@ class BaseCodeChunker(ABC):
             definitions: List of (node, name, type) tuples
             file_path: Path to the source file
             path_for_node_id: Path to use for node_id generation
+            code_content: Raw file content for signature extraction
+            skeleton_mode: When True, emit skeletonized content
 
         Returns:
             List of CodeChunk objects
@@ -252,17 +371,32 @@ class BaseCodeChunker(ABC):
             # Create chunk for the function/class definition
             # Generate node_id in graph format: file_path:symbol_name
             node_id = self._generate_node_id(path_for_node_id, name, def_type)
-            chunks.extend(
-                self._split_by_max_lines(
-                    lines=lines,
-                    start_line=start_line,
-                    end_line=end_line,
-                    chunk_type=def_type,
-                    name=name,
-                    file_path=file_path,
-                    node_id=node_id,
+            if skeleton_mode:
+                skeleton = self._build_definition_skeleton(node, def_type, code_content)
+                if skeleton:
+                    chunks.append(
+                        CodeChunk(
+                            skeleton,
+                            start_line,
+                            end_line,
+                            def_type,
+                            name,
+                            file_path,
+                            node_id,
+                        )
+                    )
+            else:
+                chunks.extend(
+                    self._split_by_max_lines(
+                        lines=lines,
+                        start_line=start_line,
+                        end_line=end_line,
+                        chunk_type=def_type,
+                        name=name,
+                        file_path=file_path,
+                        node_id=node_id,
+                    )
                 )
-            )
 
             current_line = end_line + 1
 

--- a/codeminer/code_chunking/cpp_chunker.py
+++ b/codeminer/code_chunking/cpp_chunker.py
@@ -9,7 +9,13 @@ from .base import BaseCodeChunker
 
 
 class CppCodeChunker(BaseCodeChunker):
-    """Code chunker specifically for C++ files."""
+    """
+    Code chunker specifically for C++ files.
+
+    L1 entities: free functions and class/struct definitions.
+    L2 entities: methods declared/defined inside class bodies.
+    Skeleton mode: file skeleton lists L1 declarations; class skeleton lists method signatures.
+    """
 
     def __init__(
         self,
@@ -154,3 +160,9 @@ class CppCodeChunker(BaseCodeChunker):
             if child.type in ("identifier", "field_identifier"):
                 return child.text.decode("utf-8")
         return None
+
+    def _get_child_definitions(self, node, def_type: str):
+        """Return method definitions for class skeletons."""
+        if def_type != "class":
+            return []
+        return self._find_class_methods(node)

--- a/codeminer/code_chunking/python_chunker.py
+++ b/codeminer/code_chunking/python_chunker.py
@@ -9,7 +9,13 @@ from .base import BaseCodeChunker
 
 
 class PythonCodeChunker(BaseCodeChunker):
-    """Code chunker specifically for Python files."""
+    """
+    Code chunker specifically for Python files.
+
+    L1 entities: module-level functions and classes.
+    L2 entities: methods inside classes (including async and decorated definitions).
+    Skeleton mode: module skeleton lists L1 definitions; class skeleton lists method signatures.
+    """
 
     def __init__(
         self,
@@ -190,3 +196,15 @@ class PythonCodeChunker(BaseCodeChunker):
         """
         # Method name extraction is the same as function name extraction
         return self._extract_function_name(node)
+
+    def _get_child_definitions(self, node, def_type: str):
+        """Return class methods for class skeletons."""
+        if def_type != "class":
+            return []
+
+        target_node = node
+        if node.type == "decorated_definition":
+            target_node = self._extract_definition_from_decorated(node)
+        if not target_node:
+            return []
+        return self._find_class_methods(target_node)

--- a/codeminer/code_chunking/rust_chunker.py
+++ b/codeminer/code_chunking/rust_chunker.py
@@ -9,7 +9,13 @@ from .base import BaseCodeChunker
 
 
 class RustCodeChunker(BaseCodeChunker):
-    """Code chunker for Rust source files."""
+    """
+    Code chunker for Rust source files.
+
+    L1 entities: free functions plus struct/enum/trait/impl blocks.
+    L2 entities: functions inside impl blocks.
+    Skeleton mode: file skeleton lists L1 declarations; impl skeleton lists method signatures.
+    """
 
     def __init__(
         self,
@@ -98,3 +104,10 @@ class RustCodeChunker(BaseCodeChunker):
 
     def _extract_method_name(self, node) -> Optional[str]:
         return self._extract_function_name(node)
+
+    def _get_child_definitions(self, node, def_type: str):
+        """Return impl methods for impl skeletons."""
+        if def_type != "impl":
+            return []
+        _, target_name = self._extract_impl_label(node)
+        return self._find_impl_methods(node, target_name)

--- a/test/chunker/test_python_chunker.py
+++ b/test/chunker/test_python_chunker.py
@@ -4,6 +4,7 @@ Regression tests for the Python code chunker using the httpie CLI repository.
 """
 
 from pathlib import Path
+from textwrap import dedent
 
 from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
 
@@ -55,3 +56,36 @@ def test_python_chunker_chunk_file(httpie_cli_repo):
     assert chunks, "Chunker did not return any chunks for httpie/core.py"
     assert any(chunk.chunk_type == "function" for chunk in chunks)
     assert any(chunk.name == "raw_main" for chunk in chunks)
+
+
+def test_python_chunker_skeleton_mode(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        dedent(
+            """
+            def top_level(a, b):
+                return a + b
+
+            class MyClass:
+                def method_one(self, x: int) -> int:
+                    return x
+            """
+        ).lstrip()
+    )
+
+    chunker = CodeChunker(
+        language="python",
+        chunk_depth=2,
+        l2_level_exclusive=False,
+    )
+    chunks = chunker.chunk_file(str(sample), skeleton_mode=True)
+
+    # Class skeleton should carry method signatures but no bodies.
+    class_chunk = next(chunk for chunk in chunks if chunk.chunk_type == "class")
+    assert "class MyClass" in class_chunk.content
+    assert "def method_one" in class_chunk.content
+    assert "return x" not in class_chunk.content
+
+    method_chunk = next(chunk for chunk in chunks if chunk.chunk_type == "method")
+    assert "def method_one" in method_chunk.content
+    assert "return x" not in method_chunk.content


### PR DESCRIPTION
## Summary
Introduce a skeleton mode for the code chunker (L1/L2) across Python/C++/Rust and update the CI pipeline to provision a dedicated `scip-env` for the SCIP indexer.

## Changes
- Added `skeleton_mode` support to `CodeChunker` and the underlying language-specific chunkers (Python, C++, Rust), including:
  - Instance-level `skeleton_mode` flag and per-call override on `chunk_file`.
  - File-level skeletons that list top-level definitions (L1) without bodies.
  - Type-level skeletons (classes / impls) that list member signatures (L2) without bodies.
- Implemented skeleton-aware chunk generation in `BaseCodeChunker`, including:
  - Signature extraction using AST structure and language-specific stop nodes.
  - Container-aware child definition discovery via `_get_child_definitions` in Python/Cpp/Rust chunkers.
- Updated repo-level chunking to propagate `skeleton_mode` when chunking via `RepoChunkingConfig`.
- Extended CI workflow:
  - Added a `Create scip env` step that creates the `scip-env` conda environment from `codeminer/scip_interface/scip-environment.yml` if it does not already exist.
  - Kept the existing dependency installation and test steps unchanged.
- Added a Python chunker test to validate skeleton mode behavior:
  - Verifies that class skeletons include method signatures but no bodies.
  - Verifies that method chunks in skeleton mode also omit bodies.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
<!-- Describe the tests you ran and/or how to test these changes -->
- [x] Tests pass locally
- [x] Added new tests for the changes

**How to test:**
- Create/activate the conda environment and run the test suite, for example:
  - `pytest test/chunker/test_python_chunker.py`
  - or the project’s standard test command.
- Push to a branch or open this PR and confirm:
  - CI successfully creates/uses `scip-env`.
  - All workflow steps complete with a green status.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
