### PR TITLE
[Examples] Update retrieval rerank pipeline to support hierarchical vector store

### DIFF
--- a/codeminer/model/agentless_pipeline.py
+++ b/codeminer/model/agentless_pipeline.py
@@ -7,7 +7,7 @@ from langchain_core.prompts import PromptTemplate
 from pydantic import BaseModel, Field
 
 from ..graph.code_graph import CodeGraph
-from ..graph.transverse_graph import RepoEntitySearcher, traverse_tree_structure
+from ..graph.transverse_graph import traverse_tree_structure
 from ..llm.llm_config import LLMConfig, LLMProvider, create_llm
 from ..log_utils import get_logger
 from ..scip_interface import SCIPIndexer
@@ -156,9 +156,6 @@ class AgentlessPipeline:
         if not self.code_graph:
             raise ValueError("Failed to build code graph")
 
-        # Initialize searcher
-        self.entity_searcher = RepoEntitySearcher(self.code_graph)
-
         # Initialize LLM
         llm_config = LLMConfig(
             model_name=llm_model,
@@ -242,14 +239,14 @@ class AgentlessPipeline:
             candidate_files = result.files
             logger.debug(f"[Stage 1] EXTRACTED CANDIDATE FILES: {candidate_files}")
         except Exception as e:
-            raise ValueError(f"Error in Stage 1: {e}")
+            raise ValueError(f"Error in Stage 1: {e}") from e
 
         if not candidate_files:
             raise ValueError("LLM did not return any file candidates")
 
         # Filter valid file nodes
         files = [
-            file for file in candidate_files if self.entity_searcher.has_node(file)
+            file for file in candidate_files if file in self.code_graph.name_to_vertex
         ]
 
         return files[: self.top_n_files]
@@ -269,7 +266,7 @@ class AgentlessPipeline:
         file_structures = []
         for file_path in file_paths:
             try:
-                if self.entity_searcher.has_node(file_path):
+                if file_path in self.code_graph.name_to_vertex:
                     structure = traverse_tree_structure(
                         code_graph=self.code_graph,
                         root=file_path,
@@ -283,7 +280,7 @@ class AgentlessPipeline:
                             f"### {file_path} ###\n```\n{structure}\n```\n"
                         )
             except Exception as e:
-                raise ValueError(f"Error processing file {file_path}: {e}")
+                raise ValueError(f"Error processing file {file_path}: {e}") from e
 
         if not file_structures:
             raise ValueError("No file structures to process")
@@ -301,7 +298,7 @@ class AgentlessPipeline:
             candidate_nodes = result.nodes
             logger.debug(f"[Stage 2] EXTRACTED CANDIDATE NODES: {candidate_nodes}")
         except Exception as e:
-            raise ValueError(f"Error in Stage 2: {e}")
+            raise ValueError(f"Error in Stage 2: {e}") from e
 
         if not candidate_nodes:
             raise ValueError("LLM did not return any node candidates")
@@ -324,29 +321,34 @@ class AgentlessPipeline:
         content_map: dict = {}
 
         for symbol_node_id in symbols:
-            if not self.entity_searcher.has_node(symbol_node_id):
+            if symbol_node_id not in self.code_graph.name_to_vertex:
                 raise ValueError(f"Skip missing node: {symbol_node_id}")
 
             try:
-                node_data_list = self.entity_searcher.get_node_data(
-                    [symbol_node_id],
-                    return_code_content=True,
-                    wrap_with_ln=True,
-                )
+                # Get node info from code_graph
+                vertex_id = self.code_graph.name_to_vertex[symbol_node_id]
+                node_info = self.code_graph.get_node_info_by_name(symbol_node_id)
+                if not node_info:
+                    raise ValueError(f"Could not get node info for {symbol_node_id}")
+
+                # Get code content
+                code_content = self.code_graph.get_node_content(vertex_id)
+                if code_content:
+                    # Wrap with line numbers
+                    lines = code_content.split("\n")
+                    numbered_lines = [
+                        f"{i + 1}: {line}" for i, line in enumerate(lines)
+                    ]
+                    code_content = "\n".join(numbered_lines)
+
+                if not code_content:
+                    raise ValueError(
+                        f"Empty code content retrieved for node: {symbol_node_id}"
+                    )
             except Exception as exc:
-                raise ValueError(f"Error getting code for {symbol_node_id}: {exc}")
-
-            if not node_data_list:
                 raise ValueError(
-                    f"No code content available for node: {symbol_node_id}"
-                )
-
-            node_data = node_data_list[0]
-            code_content = node_data.get("code_content", "")
-            if not code_content:
-                raise ValueError(
-                    f"Empty code content retrieved for node: {symbol_node_id}"
-                )
+                    f"Error getting code for {symbol_node_id}: {exc}"
+                ) from exc
 
             code_segments.append(
                 f"### {symbol_node_id} ###\n```\n{code_content}\n```\n"
@@ -367,7 +369,7 @@ class AgentlessPipeline:
             shortlisted_node_ids = result.refined_nodes
             logger.debug(f"[Stage 3] EXTRACTED NODES: {shortlisted_node_ids}")
         except Exception as e:
-            raise ValueError(f"Error in Stage 3: {e}")
+            raise ValueError(f"Error in Stage 3: {e}") from e
 
         candidate_set = set(usable_symbols)
         results: List[QueriedNode] = []
@@ -378,7 +380,11 @@ class AgentlessPipeline:
                     f"Discarding node not part of Stage 2 results: {node_id}"
                 )
 
-            attrs = self.entity_searcher.get_node_data([node_id])[0]
+            # Get node attributes from code_graph
+            attrs = self.code_graph.get_node_info_by_name(node_id)
+            if not attrs:
+                raise ValueError(f"Could not get node info for {node_id}")
+
             results.append(
                 QueriedNode(
                     node_name=node_id,

--- a/codeminer/model/agentless_pipeline.py
+++ b/codeminer/model/agentless_pipeline.py
@@ -322,7 +322,7 @@ class AgentlessPipeline:
 
         for symbol_node_id in symbols:
             if symbol_node_id not in self.code_graph.name_to_vertex:
-                raise ValueError(f"Skip missing node: {symbol_node_id}")
+                raise ValueError(f"Missing node: {symbol_node_id}")
 
             try:
                 # Get node info from code_graph

--- a/codeminer/model/retrieve_rerank_pipeline.py
+++ b/codeminer/model/retrieve_rerank_pipeline.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
-from ..code_chunker import CodeChunker
+from ..code_chunker import CodeChunker, RepoChunkingConfig
 from ..index.embedding import CodeVectorStore
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..llm.llm_config import LLMConfig, LLMProvider
@@ -35,7 +35,7 @@ class RetrieveStageConfig:
     def __post_init__(self) -> None:
         if self.engine not in SUPPORTED_ENGINES:
             raise ValueError(
-                f"Unsupported retrieval engine '{self.engine}'. "
+                f"Unsupported retrieval engine {self.engine!r}. "
                 f"Expected one of: {', '.join(sorted(SUPPORTED_ENGINES))}"
             )
         if self.weight <= 0:
@@ -56,7 +56,7 @@ def build_retrieve_plan(mode: str = "dense") -> List[RetrieveStageConfig]:
             RetrieveStageConfig(engine="sparse", weight=0.4, top_k=RETRIEVAL_TOP_K),
         ]
     raise ValueError(
-        f"Unknown retrieval mode '{mode}'. Choose from: dense, sparse, hybrid."
+        f"Unknown retrieval mode {mode!r}. Choose from: dense, sparse, hybrid."
     )
 
 
@@ -93,6 +93,7 @@ class RetrieveRerankPipeline:
         *,
         retrieval_plan: Optional[Sequence[RetrieveStageConfig]] = None,
         retrieval_mode: str = "dense",
+        retrieval_level: str = "l2",
         embedding_model: str = "nomic-ai/CodeRankEmbed",
         embedding_provider: str = "huggingface",
         embedding_dimension: int = 768,
@@ -115,6 +116,12 @@ class RetrieveRerankPipeline:
         self.max_lines_per_chunk = max_lines_per_chunk
         self._chunks = None
         self.enable_rerank = enable_rerank
+        # Retrieval level: "l0" (file skeletons) or "l2" (functions/methods)
+        if retrieval_level not in ("l0", "l2"):
+            raise ValueError(
+                f"Invalid retrieval_level {retrieval_level!r}. Must be 'l0' or 'l2'."
+            )
+        self.retrieval_level = retrieval_level
 
         plan = (
             list(retrieval_plan)
@@ -176,6 +183,7 @@ class RetrieveRerankPipeline:
             vector_store=self.vector_store,
             regex_index=None,
             default_top_k=self._default_stage_top_k,
+            default_level=self.retrieval_level,
         )
         register_retrieve_ops(self.engine, self.retrieve_context)
 
@@ -195,6 +203,7 @@ class RetrieveRerankPipeline:
                 "repo": self.repo_path,
                 "index_path": str(self.index_path),
                 "retrieval_plan": [stage.engine for stage in self.retrieve_plan],
+                "retrieval_level": self.retrieval_level,
                 "dense_index": bool(self.vector_store),
                 "sparse_index": bool(self.bm25_index),
                 "rerank_model": rerank_model if self.enable_rerank else "disabled",
@@ -271,23 +280,64 @@ class RetrieveRerankPipeline:
             **embedding_kwargs,
         )
         model_suffix = embedding_model.replace("/", "__")
+        # Check for hierarchical index structure (l0/ and l2/ directories)
         config_file = self.index_path / f"config_{model_suffix}.json"
+        l0_path = self.index_path / "l0"
+        l2_path = self.index_path / "l2"
 
-        if config_file.exists():
+        # Load if either top-level config exists or hierarchical structure exists
+        if config_file.exists() or (l0_path.exists() and l2_path.exists()):
             logger.info(
-                "Loading vector store from cache.",
+                "Loading hierarchical vector store from cache.",
                 extra={"index_path": str(self.index_path)},
             )
             vector_store.load(str(self.index_path))
         else:
-            logger.info("Building vector store index.")
-            chunks = self._ensure_chunks()
-            chunks_for_indexing = [chunk._asdict() for chunk in chunks]
-            vector_store.add_code_chunks(chunks_for_indexing)
+            logger.info("Building hierarchical vector store index.")
+            # Build L0 and L2 chunks
+            repo_cfg = RepoChunkingConfig(languages=self.languages)
+
+            # L0 chunks (file-level skeletons)
+            l0_chunker = CodeChunker(
+                language=self.languages[0],
+                repo_config=repo_cfg,
+                max_lines_per_chunk=None,
+                chunk_depth=0,
+                skeleton_mode=True,
+            )
+            l0_chunks = l0_chunker.chunk_repository(repo_path=self.repo_path)
+
+            # L2 chunks (function/method-level)
+            l2_chunker = CodeChunker(
+                language=self.languages[0],
+                repo_config=repo_cfg,
+                max_lines_per_chunk=self.max_lines_per_chunk,
+                chunk_depth=2,
+                l2_level_exclusive=True,
+                skeleton_mode=False,
+            )
+            l2_chunks = l2_chunker.chunk_repository(repo_path=self.repo_path)
+
+            if not l0_chunks and not l2_chunks:
+                raise ValueError("No code chunks generated from repository.")
+
+            # Add L0 chunks
+            if l0_chunks:
+                l0_chunks_for_indexing = [chunk._asdict() for chunk in l0_chunks]
+                vector_store.add_code_chunks(l0_chunks_for_indexing, level="l0")
+
+            # Add L2 chunks
+            if l2_chunks:
+                l2_chunks_for_indexing = [chunk._asdict() for chunk in l2_chunks]
+                vector_store.add_code_chunks(l2_chunks_for_indexing, level="l2")
+
             vector_store.save(str(self.index_path))
             logger.info(
-                "Vector store built and cached.",
-                extra={"chunk_count": len(chunks_for_indexing)},
+                "Hierarchical vector store built and cached.",
+                extra={
+                    "l0_chunks": len(l0_chunks),
+                    "l2_chunks": len(l2_chunks),
+                },
             )
         return vector_store
 
@@ -378,4 +428,4 @@ class RetrieveRerankPipeline:
             return PhysicalOperator.FAISS_RETRIEVE.value
         if stage.engine == "sparse":
             return PhysicalOperator.BM25_TOPK.value
-        raise ValueError(f"Unsupported engine '{stage.engine}'.")
+        raise ValueError(f"Unsupported engine {stage.engine!r}.")

--- a/codeminer/ops/retrieve.py
+++ b/codeminer/ops/retrieve.py
@@ -23,6 +23,7 @@ class RetrieveContext:
     vector_store: Optional[CodeVectorStore] = None
     regex_index: Optional[RegexNodeIndex] = None
     default_top_k: int = 10
+    default_level: str = "l2"  # "l0" (file skeletons) or "l2" (functions/methods)
 
 
 def register_retrieve_ops(engine: ExecutionEngine, context: RetrieveContext) -> None:
@@ -80,18 +81,27 @@ def _vector_kernel(context: RetrieveContext):
         top_k = _resolve_top_k(node.params, context.default_top_k)
         score_threshold = node.params.get("score_threshold")
         include_content = bool(node.params.get("return_content", False))
+        # Support hierarchical retrieval level (l0 = file skeletons, l2 = functions/methods)
+        level = node.params.get("level", context.default_level)
 
         logger.debug(
             "Executing vector retrieval",
-            extra={"query": query, "k": top_k, "score_threshold": score_threshold},
+            extra={
+                "query": query,
+                "k": top_k,
+                "level": level,
+                "score_threshold": score_threshold,
+            },
         )
 
-        scored = store.search(query=query, top_k=top_k, score_threshold=score_threshold)
+        scored = store.search(
+            query=query, top_k=top_k, score_threshold=score_threshold, level=level
+        )
 
         content_map: Dict[Tuple[str, str, Optional[int], Optional[int]], str] = {}
         if include_content:
             with_content = store.search_with_content(
-                query=query, top_k=top_k, score_threshold=score_threshold
+                query=query, top_k=top_k, score_threshold=score_threshold, level=level
             )
             for item in with_content:
                 data = _dump_model(item)
@@ -182,7 +192,7 @@ def _hybrid_kernel():
             Tuple[str, str, Optional[int], Optional[int]], QueriedNode
         ] = {}
 
-        for weight, results in zip(weights, branches):
+        for weight, results in zip(weights, branches, strict=True):
             for rank, item in enumerate(results):
                 base_score = item.score or 0.0
                 if base_score == 0.0:

--- a/examples/retrieve_rerank.py
+++ b/examples/retrieve_rerank.py
@@ -12,16 +12,21 @@ Usage:
     python examples/retrieve_rerank.py --dataset swebench_lite
 
     # Run on LocBench with custom filter
-    python examples/retrieve_rerank.py --dataset locbench_v1 --filter-instance "^(joselc__life-sim-first-try-2)$"
+    python examples/retrieve_rerank.py --dataset locbench_v1 \\
+        --filter-instance "^(joselc__life-sim-first-try-2)$"
 
     # Run on SWE-bench with custom embedding model
-    python examples/retrieve_rerank.py --dataset swebench_lite --embedding-model nomic-ai/CodeRankEmbed --embedding-provider huggingface
+    python examples/retrieve_rerank.py --dataset swebench_lite \\
+        --embedding-model nomic-ai/CodeRankEmbed \\
+        --embedding-provider huggingface
 
     # Run with hybrid (dense + sparse) retrieval before rerank
     python examples/retrieve_rerank.py --dataset swebench_lite --retrieval-mode hybrid
 
     # Override cache directories (one for indices, one for repos)
-    python examples/retrieve_rerank.py --dataset swebench_lite --index-cache-dir /tmp/codeminer/index --repo-cache-dir ~/.codeminer/
+    python examples/retrieve_rerank.py --dataset swebench_lite \\
+        --index-cache-dir /tmp/codeminer/index \\
+        --repo-cache-dir ~/.codeminer/
 """
 
 import argparse
@@ -152,7 +157,8 @@ def parse_args():
         type=int,
         default=10,
         help=(
-            "Number of candidates per LLM rerank window (None processes all candidates at once)."
+            "Number of candidates per LLM rerank window "
+            "(None processes all candidates at once)."
         ),
     )
     parser.add_argument(
@@ -186,6 +192,16 @@ def parse_args():
         choices=["dense", "sparse", "hybrid"],
         help="Retrieval plan to run (dense-only, BM25-only, or hybrid).",
     )
+    parser.add_argument(
+        "--retrieval-level",
+        type=str,
+        default="l2",
+        choices=["l0", "l2"],
+        help=(
+            "Hierarchical index level for dense retrieval "
+            "(l0=file skeletons, l2=functions/methods)."
+        ),
+    )
 
     # Evaluation configuration
     default_eval_path = Path.home() / ".codeminer" / "swebench_lite_gt.json"
@@ -202,7 +218,7 @@ def parse_args():
         "--metrics-k",
         type=int,
         nargs="+",
-        default=[1, 3, 5, 10],
+        default=[1, 3, 5, 10, 20],
         help="Cutoffs for accuracy/precision/recall reporting",
     )
 
@@ -322,6 +338,7 @@ def run_pipeline(args):
             languages=args.languages,
             max_lines_per_chunk=args.max_lines_per_chunk,
             retrieval_plan=retrieve_plan,
+            retrieval_level=args.retrieval_level,
             rerank_window_size=args.rerank_window_size,
             rerank_window_step=args.rerank_window_step,
             enable_rerank=not args.retrieval_only,
@@ -410,6 +427,7 @@ def main():
     logger.info("Dataset type: %s", args.dataset)
     logger.info("Embedding model: %s", args.embedding_model)
     logger.info("Retrieval mode: %s", args.retrieval_mode)
+    logger.info("Retrieval level: %s", args.retrieval_level)
     if args.retrieval_only:
         logger.info("Mode: Retrieval-only (reranking disabled)")
     else:


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
This pull request introduces hierarchical code chunking and retrieval, enabling dense retrieval at different levels of code granularity (file skeletons or functions/methods). The changes refactor the retrieval pipeline to support this feature, update the agentless pipeline to remove the now-unnecessary `RepoEntitySearcher`, and improve error handling and logging. Additionally, the example script is updated with new options and improved formatting.

## Changes
<!-- List the main changes made in this PR -->
**Hierarchical Retrieval and Chunking**

* Added support for hierarchical code chunking and retrieval levels (`l0` for file skeletons, `l2` for functions/methods) in the dense retrieval pipeline, including chunk creation, indexing, and retrieval logic. (`codeminer/model/retrieve_rerank_pipeline.py`, `codeminer/ops/retrieve.py`) [[1]](diffhunk://#diff-2ec522d0e1ca4ee2ed886ab9c8473c6a7c62ac4a2ccfc3586a8e70fcdfb171d1R96) [[2]](diffhunk://#diff-2ec522d0e1ca4ee2ed886ab9c8473c6a7c62ac4a2ccfc3586a8e70fcdfb171d1R283-R340) [[3]](diffhunk://#diff-a3709341be5e9fe11a9f394457e02e06d2569720260eaa9b393ad5a464b19096R26) [[4]](diffhunk://#diff-a3709341be5e9fe11a9f394457e02e06d2569720260eaa9b393ad5a464b19096R84-R104)
* Updated the example script to expose a `--retrieval-level` argument and improved help formatting for multi-line options. (`examples/retrieve_rerank.py`) [[1]](diffhunk://#diff-8c62885dfeae3ba8d07177ff4a1d3beebe456647401aa3dcc953d226f4e3f78fR195-R204) [[2]](diffhunk://#diff-8c62885dfeae3ba8d07177ff4a1d3beebe456647401aa3dcc953d226f4e3f78fL155-R161)

**Refactoring and Removal of Unused Components**

* Removed the use of `RepoEntitySearcher` from the agentless pipeline, replacing its functionality with direct queries to `CodeGraph` and simplifying node lookups and content retrieval. (`codeminer/model/agentless_pipeline.py`) [[1]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL10-R10) [[2]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL159-L161) [[3]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL245-R249) [[4]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL272-R269) [[5]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL327-R351) [[6]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL381-R387)

**Error Handling and Logging Improvements**

* Improved error propagation by using `raise ... from ...` for better traceback, and enhanced logging messages for clarity and debugging. (`codeminer/model/agentless_pipeline.py`, `codeminer/model/retrieve_rerank_pipeline.py`, `codeminer/ops/retrieve.py`) [[1]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL245-R249) [[2]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL286-R283) [[3]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL304-R301) [[4]](diffhunk://#diff-c72a8b0fb767c2c22a214d66a52ed43d024b5e3379101067903ef09c75cd89bfL370-R372) [[5]](diffhunk://#diff-2ec522d0e1ca4ee2ed886ab9c8473c6a7c62ac4a2ccfc3586a8e70fcdfb171d1L38-R38) [[6]](diffhunk://#diff-2ec522d0e1ca4ee2ed886ab9c8473c6a7c62ac4a2ccfc3586a8e70fcdfb171d1L59-R59) [[7]](diffhunk://#diff-2ec522d0e1ca4ee2ed886ab9c8473c6a7c62ac4a2ccfc3586a8e70fcdfb171d1L381-R431)

**API and Argument Changes**

* Added validation and propagation of the `retrieval_level` argument throughout the retrieval pipeline, context, and operator registration. (`codeminer/model/retrieve_rerank_pipeline.py`, `codeminer/ops/retrieve.py`) [[1]](diffhunk://#diff-2ec522d0e1ca4ee2ed886ab9c8473c6a7c62ac4a2ccfc3586a8e70fcdfb171d1R119-R124) [[2]](diffhunk://#diff-2ec522d0e1ca4ee2ed886ab9c8473c6a7c62ac4a2ccfc3586a8e70fcdfb171d1R186) [[3]](diffhunk://#diff-2ec522d0e1ca4ee2ed886ab9c8473c6a7c62ac4a2ccfc3586a8e70fcdfb171d1R206) [[4]](diffhunk://#diff-a3709341be5e9fe11a9f394457e02e06d2569720260eaa9b393ad5a464b19096R26) [[5]](diffhunk://#diff-a3709341be5e9fe11a9f394457e02e06d2569720260eaa9b393ad5a464b19096R84-R104)

**Miscellaneous**

* Updated default metrics cutoffs and improved example script formatting for multi-line commands. (`examples/retrieve_rerank.py`) [[1]](diffhunk://#diff-8c62885dfeae3ba8d07177ff4a1d3beebe456647401aa3dcc953d226f4e3f78fL205-R221) [[2]](diffhunk://#diff-8c62885dfeae3ba8d07177ff4a1d3beebe456647401aa3dcc953d226f4e3f78fL15-R29)


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
<!-- Describe the tests you ran and/or how to test these changes -->
- [x] Tests pass locally
- [ ] Added new tests for the changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
