### PR TITLE
New JS/TS chunker, hybrid retrieval

### DIFF
--- a/codeminer/__init__.py
+++ b/codeminer/__init__.py
@@ -1,5 +1,10 @@
 from .agent import KeywordExtractor, RerankAgent
-from .code_chunker import CodeChunker, RepoChunkingConfig
+from .code_chunker import (
+    CodeChunker,
+    HybridChunkingConfig,
+    HybridChunkingResult,
+    RepoChunkingConfig,
+)
 from .graph.code_graph import CodeGraph
 from .index import BM25CodeIndexer, RegexNodeIndex
 from .index.embedding import CodeVectorStore, create_code_vector_store
@@ -15,6 +20,8 @@ __all__ = [
     "RerankAgent",
     "CodeChunker",
     "RepoChunkingConfig",
+    "HybridChunkingConfig",
+    "HybridChunkingResult",
     "RegexNodeIndex",
     "CodeVectorStore",
     "create_code_vector_store",

--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -26,6 +26,8 @@ class RepoChunkingConfig:
     python_extensions: Set[str] = None
     cpp_extensions: Set[str] = None
     rust_extensions: Set[str] = None
+    javascript_extensions: Set[str] = None
+    typescript_extensions: Set[str] = None
 
     # Directory filtering
     ignore_dirs: Set[str] = None
@@ -49,6 +51,12 @@ class RepoChunkingConfig:
 
         if self.rust_extensions is None:
             self.rust_extensions = {".rs"}
+
+        if self.javascript_extensions is None:
+            self.javascript_extensions = {".js", ".jsx", ".mjs"}
+
+        if self.typescript_extensions is None:
+            self.typescript_extensions = {".ts", ".tsx", ".mts", ".cts"}
 
         if self.ignore_dirs is None:
             self.ignore_dirs = {
@@ -343,6 +351,12 @@ class CodeChunker:
             elif language.lower() == "rust":
                 for ext in self.repo_config.rust_extensions:
                     extension_to_language[ext] = "rust"
+            elif language.lower() in ("javascript", "js"):
+                for ext in self.repo_config.javascript_extensions:
+                    extension_to_language[ext] = "javascript"
+            elif language.lower() in ("typescript", "ts"):
+                for ext in self.repo_config.typescript_extensions:
+                    extension_to_language[ext] = "typescript"
             else:
                 logger.warning("Language %r not supported yet", language)
 

--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -94,6 +94,43 @@ class RepoChunkingConfig:
             }
 
 
+@dataclass
+class HybridChunkingConfig:
+    """
+    Configuration for hybrid chunk selection.
+
+    The goal is to route high-importance chunks to a stronger embedding model while
+    sending the rest to a smaller/faster model. Importance is currently measured
+    with a simple heuristic (chunk size), but the config keeps things flexible for
+    future graph-aware signals.
+    """
+
+    importance_metric: str = "chunk_size"
+    high_importance_ratio: float = 0.3
+    min_high_importance_lines: int = 40
+
+    def __post_init__(self):
+        if self.high_importance_ratio <= 0 or self.high_importance_ratio > 1:
+            logger.warning(
+                "high_importance_ratio must be in (0, 1]; falling back to 0.3"
+            )
+            self.high_importance_ratio = 0.3
+
+
+@dataclass
+class HybridChunkingResult:
+    """Result of hybrid chunk selection with importance annotations."""
+
+    primary_chunks: List[Dict[str, Any]]
+    secondary_chunks: List[Dict[str, Any]]
+    cutoff_score: float
+    config: HybridChunkingConfig
+
+    def all_chunks(self) -> List[Dict[str, Any]]:
+        """Return all annotated chunks, primary first."""
+        return self.primary_chunks + self.secondary_chunks
+
+
 # For backward compatibility, expose the old class name
 class CodeChunker:
     """
@@ -655,3 +692,85 @@ class CodeChunker:
     def clear_nodes(self):
         """Clear the collected nodes list."""
         self.nodes.clear()
+
+    # Hybrid chunking helpers -------------------------------------------------
+    def hybrid_chunk_repository(
+        self,
+        repo_path: str,
+        hybrid_config: Optional[HybridChunkingConfig] = None,
+    ) -> HybridChunkingResult:
+        """
+        Chunk the repository and annotate chunks with importance tiers for hybrid
+        embedding strategies. Primary chunks can be embedded with a larger/more
+        accurate model while secondary chunks use a lighter model.
+
+        Args:
+            repo_path: Path to the repository root.
+            hybrid_config: Configuration controlling the importance heuristic.
+
+        Returns:
+            HybridChunkingResult with primary/secondary chunk lists that include
+            importance metadata.
+        """
+        config = hybrid_config or HybridChunkingConfig()
+        chunks = self.chunk_repository(repo_path)
+        if not chunks:
+            return HybridChunkingResult(
+                primary_chunks=[],
+                secondary_chunks=[],
+                cutoff_score=0.0,
+                config=config,
+            )
+
+        # Score chunks using the selected heuristic
+        scored_chunks = [
+            (self._score_chunk_importance(chunk, config), chunk) for chunk in chunks
+        ]
+        scored_chunks.sort(key=lambda pair: pair[0], reverse=True)
+
+        num_primary = max(1, int(len(scored_chunks) * config.high_importance_ratio))
+        cutoff_score = scored_chunks[num_primary - 1][0] if scored_chunks else 0.0
+
+        primary_chunks: List[Dict[str, Any]] = []
+        secondary_chunks: List[Dict[str, Any]] = []
+
+        for idx, (score, chunk) in enumerate(scored_chunks):
+            tier = "primary"
+            if idx >= num_primary or score < config.min_high_importance_lines:
+                tier = "secondary"
+
+            annotated = chunk._asdict()
+            annotated["importance_score"] = score
+            annotated["importance_tier"] = tier
+
+            if tier == "primary":
+                primary_chunks.append(annotated)
+            else:
+                secondary_chunks.append(annotated)
+
+        return HybridChunkingResult(
+            primary_chunks=primary_chunks,
+            secondary_chunks=secondary_chunks,
+            cutoff_score=cutoff_score,
+            config=config,
+        )
+
+    def _score_chunk_importance(
+        self, chunk: CodeChunk, config: HybridChunkingConfig
+    ) -> float:
+        """
+        Score a chunk for importance. Currently uses chunk size (lines of code)
+        as a simple heuristic, but can be extended with graph reference counts
+        or other signals.
+        """
+        if config.importance_metric == "chunk_size":
+            return max(1, chunk.end_line - chunk.start_line + 1)
+
+        if config.importance_metric == "content_length":
+            return len(chunk.content)
+
+        logger.warning(
+            "Unknown importance_metric %r; defaulting to chunk_size",
+            config.importance_metric,
+        )
+        return max(1, chunk.end_line - chunk.start_line + 1)

--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -121,8 +121,8 @@ class HybridChunkingConfig:
 class HybridChunkingResult:
     """Result of hybrid chunk selection with importance annotations."""
 
-    primary_chunks: List[Dict[str, Any]]
-    secondary_chunks: List[Dict[str, Any]]
+    primary_chunks: List[CodeChunk]
+    secondary_chunks: List[CodeChunk]
     cutoff_score: float
     config: HybridChunkingConfig
 
@@ -731,22 +731,18 @@ class CodeChunker:
         num_primary = max(1, int(len(scored_chunks) * config.high_importance_ratio))
         cutoff_score = scored_chunks[num_primary - 1][0] if scored_chunks else 0.0
 
-        primary_chunks: List[Dict[str, Any]] = []
-        secondary_chunks: List[Dict[str, Any]] = []
+        primary_chunks: List[CodeChunk] = []
+        secondary_chunks: List[CodeChunk] = []
 
         for idx, (score, chunk) in enumerate(scored_chunks):
             tier = "primary"
             if idx >= num_primary or score < config.min_high_importance_lines:
                 tier = "secondary"
 
-            annotated = chunk._asdict()
-            annotated["importance_score"] = score
-            annotated["importance_tier"] = tier
-
             if tier == "primary":
-                primary_chunks.append(annotated)
+                primary_chunks.append(chunk)
             else:
-                secondary_chunks.append(annotated)
+                secondary_chunks.append(chunk)
 
         return HybridChunkingResult(
             primary_chunks=primary_chunks,

--- a/codeminer/code_chunking/__init__.py
+++ b/codeminer/code_chunking/__init__.py
@@ -4,6 +4,7 @@ Code chunking module for splitting source code files into semantic chunks.
 
 from .base import BaseCodeChunker, CodeChunk
 from .cpp_chunker import CppCodeChunker
+from .js_chunker import JsTsCodeChunker
 from .python_chunker import PythonCodeChunker
 from .rust_chunker import RustCodeChunker
 
@@ -72,6 +73,16 @@ def create_chunker(
             skeleton_mode=skeleton_mode,
             include_l2_in_file_skeleton=include_l2_in_file_skeleton,
         )
+    elif language in ("javascript", "js", "typescript", "ts"):
+        return JsTsCodeChunker(
+            language=language,
+            max_lines_per_chunk=max_lines_per_chunk,
+            chunk_depth=chunk_depth,
+            include_header_epilogue=include_header_epilogue,
+            l2_level_exclusive=l2_level_exclusive,
+            skeleton_mode=skeleton_mode,
+            include_l2_in_file_skeleton=include_l2_in_file_skeleton,
+        )
     else:
         raise ValueError(f"Unsupported language: {language}")
 
@@ -82,5 +93,6 @@ __all__ = [
     "PythonCodeChunker",
     "CppCodeChunker",
     "RustCodeChunker",
+    "JsTsCodeChunker",
     "create_chunker",
 ]

--- a/codeminer/code_chunking/js_chunker.py
+++ b/codeminer/code_chunking/js_chunker.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+JavaScript/TypeScript code chunker implementation.
+"""
+
+from typing import List, Optional, Tuple
+
+from .base import BaseCodeChunker
+
+
+class JsTsCodeChunker(BaseCodeChunker):
+    """
+    Chunker for JavaScript and TypeScript source files.
+
+    L1 entities: top-level functions and classes.
+    L2 entities: methods within classes.
+    Skeleton mode: file skeleton lists L1 declarations and member signatures;
+    class skeleton lists method signatures.
+    """
+
+    def __init__(
+        self,
+        language: str = "javascript",
+        max_lines_per_chunk: Optional[int] = None,
+        chunk_depth: int = 2,
+        l2_level_exclusive: bool = True,
+        **kwargs,
+    ):
+        normalized = language.lower()
+        language_key = (
+            "typescript" if normalized in ("typescript", "ts") else "javascript"
+        )
+        super().__init__(
+            language_key,
+            max_lines_per_chunk=max_lines_per_chunk,
+            chunk_depth=chunk_depth,
+            l2_level_exclusive=l2_level_exclusive,
+            **kwargs,
+        )
+
+    def _find_top_level_definitions(
+        self, root_node, include_l2_in_file_skeleton: bool = False
+    ) -> List[Tuple]:
+        definitions: List[Tuple] = []
+
+        include_type_level = self.chunk_depth < 2 or not self.l2_level_exclusive
+        include_methods = self.chunk_depth >= 2 or include_l2_in_file_skeleton
+
+        for child in root_node.children:
+            target = self._unwrap_export(child)
+            if target is None:
+                continue
+
+            if target.type == "function_declaration":
+                name = self._extract_function_name(target)
+                if name:
+                    definitions.append((target, name, "function"))
+            elif target.type == "class_declaration":
+                name = self._extract_class_name(target)
+                if name:
+                    if include_type_level:
+                        definitions.append((target, name, "class"))
+                    if include_methods:
+                        methods = self._find_class_methods(target)
+                        definitions.extend(methods)
+
+        definitions.sort(key=lambda entry: entry[0].start_point[0])
+        return definitions
+
+    def _unwrap_export(self, node):
+        """Peel off export nodes to get the underlying declaration."""
+        if node.type in ("export_statement", "export_clause"):
+            for child in node.children:
+                if child.type in ("function_declaration", "class_declaration"):
+                    return child
+        return node
+
+    def _extract_signature_text(self, node, def_type: str, code_content: str) -> str:
+        stop_types = {
+            "function": ("statement_block",),
+            "method": ("statement_block",),
+            "class": ("class_body",),
+        }.get(def_type, ("statement_block",))
+        return self._extract_signature_text_default(node, stop_types, code_content)
+
+    def _build_file_skeleton(
+        self,
+        definitions: List[Tuple],
+        code_content: str,
+        include_l2: Optional[bool] = None,
+    ) -> str:
+        include_l2 = (
+            self.include_l2_in_file_skeleton if include_l2 is None else include_l2
+        )
+        container_names = {
+            name for _, name, def_type in definitions if def_type == "class"
+        }
+        entries: List[str] = []
+        for node, name, def_type in definitions:
+            if def_type == "method":
+                if not include_l2:
+                    continue
+                parent = name.split(".", 1)[0] if "." in name else None
+                if parent and parent in container_names:
+                    continue
+                signature = self._extract_signature_text(node, def_type, code_content)
+                if signature:
+                    entries.append(self._indent_lines(signature))
+                continue
+
+            skeleton = self._build_definition_skeleton(
+                node,
+                def_type,
+                code_content=code_content,
+                include_children=include_l2,
+            )
+            if skeleton:
+                entries.append(skeleton)
+        return "\n".join(entries)
+
+    def _extract_function_name(self, node) -> Optional[str]:
+        for child in node.children:
+            if child.type == "identifier":
+                return child.text.decode("utf-8")
+        return None
+
+    def _extract_class_name(self, node) -> Optional[str]:
+        for child in node.children:
+            if child.type == "identifier":
+                return child.text.decode("utf-8")
+        return None
+
+    def _find_class_methods(self, class_node) -> List[Tuple]:
+        methods: List[Tuple] = []
+        class_name = self._extract_class_name(class_node)
+
+        for child in class_node.children:
+            if child.type != "class_body":
+                continue
+            for member in child.children:
+                if member.type == "method_definition":
+                    method_name = self._extract_method_name(member)
+                    if method_name:
+                        full_name = (
+                            f"{class_name}.{method_name}" if class_name else method_name
+                        )
+                        methods.append((member, full_name, "method"))
+        return methods
+
+    def _extract_method_name(self, node) -> Optional[str]:
+        for child in node.children:
+            if child.type in (
+                "property_identifier",
+                "identifier",
+                "private_property_identifier",
+            ):
+                return child.text.decode("utf-8")
+        return None
+
+    def _get_child_definitions(self, node, def_type: str):
+        """Return method definitions for class skeletons."""
+        if def_type != "class":
+            return []
+        return self._find_class_methods(node)

--- a/codeminer/index/embedding/__init__.py
+++ b/codeminer/index/embedding/__init__.py
@@ -3,7 +3,17 @@ Embedding module for CodeMiner.
 Provides vector storage and semantic search capabilities for code chunks.
 """
 
-from .builders import build_hybrid_vector_stores
+from .builders import (
+    VectorStoreBuilder,
+    build_hierarchical_vector_store,
+    build_hybrid_vector_stores,
+)
 from .vector_store import CodeVectorStore, create_code_vector_store
 
-__all__ = ["CodeVectorStore", "create_code_vector_store", "build_hybrid_vector_stores"]
+__all__ = [
+    "CodeVectorStore",
+    "create_code_vector_store",
+    "build_hierarchical_vector_store",
+    "build_hybrid_vector_stores",
+    "VectorStoreBuilder",
+]

--- a/codeminer/index/embedding/__init__.py
+++ b/codeminer/index/embedding/__init__.py
@@ -3,6 +3,7 @@ Embedding module for CodeMiner.
 Provides vector storage and semantic search capabilities for code chunks.
 """
 
+from .builders import build_hybrid_vector_stores
 from .vector_store import CodeVectorStore, create_code_vector_store
 
-__all__ = ["CodeVectorStore", "create_code_vector_store"]
+__all__ = ["CodeVectorStore", "create_code_vector_store", "build_hybrid_vector_stores"]

--- a/codeminer/index/embedding/builders.py
+++ b/codeminer/index/embedding/builders.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Reusable embedding builders for hierarchical and hybrid pipelines.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ...code_chunker import CodeChunker, HybridChunkingConfig, RepoChunkingConfig
+from ...log_utils import get_logger
+from ...profiler import Profiler
+from .vector_store import CodeVectorStore
+
+logger = get_logger(__name__)
+
+
+def build_hybrid_vector_stores(
+    *,
+    repo_path: str,
+    index_path: str,
+    languages: Optional[List[str]] = None,
+    chunk_depth: int = 2,
+    max_lines_per_chunk: Optional[int] = 100,
+    hybrid_config: Optional[HybridChunkingConfig] = None,
+    primary_embedding_model: str,
+    primary_embedding_provider: str = "openai",
+    primary_embedding_dimension: Optional[int] = 1536,
+    primary_embedding_kwargs: Optional[Dict[str, object]] = None,
+    secondary_embedding_model: str = "text-embedding-3-small",
+    secondary_embedding_provider: str = "openai",
+    secondary_embedding_dimension: Optional[int] = 1536,
+    secondary_embedding_kwargs: Optional[Dict[str, object]] = None,
+    index_metric: str = "ip",
+    profiler: Optional[Profiler] = None,
+) -> Dict[str, CodeVectorStore]:
+    """
+    Build two vector stores by routing "primary" chunks to a stronger embedding
+    model and "secondary" chunks to a cheaper model using HybridChunkingConfig.
+
+    Returns:
+        Mapping ``{\"primary\": CodeVectorStore, \"secondary\": CodeVectorStore}``.
+    """
+    repo_path = str(Path(repo_path).resolve())
+    languages = languages or ["python"]
+    chunker = CodeChunker(
+        language=languages[0],
+        repo_config=RepoChunkingConfig(languages=languages),
+        max_lines_per_chunk=max_lines_per_chunk,
+        chunk_depth=chunk_depth,
+        l2_level_exclusive=True,
+        skeleton_mode=False,
+    )
+    hybrid_cfg = hybrid_config or HybridChunkingConfig()
+    hybrid_result = chunker.hybrid_chunk_repository(repo_path, hybrid_config=hybrid_cfg)
+
+    primary_path = Path(index_path) / "primary"
+    secondary_path = Path(index_path) / "secondary"
+    primary_path.mkdir(parents=True, exist_ok=True)
+    secondary_path.mkdir(parents=True, exist_ok=True)
+
+    primary_kwargs = primary_embedding_kwargs or {}
+    primary_store = CodeVectorStore(
+        embedding_model=primary_embedding_model,
+        embedding_provider=primary_embedding_provider,
+        dimension=primary_embedding_dimension,
+        index_metric=index_metric,
+        store_path=str(primary_path),
+        profiler=profiler,
+        **primary_kwargs,
+    )
+    secondary_kwargs = secondary_embedding_kwargs or {}
+    secondary_store = CodeVectorStore(
+        embedding_model=secondary_embedding_model,
+        embedding_provider=secondary_embedding_provider,
+        dimension=secondary_embedding_dimension,
+        index_metric=index_metric,
+        store_path=str(secondary_path),
+        profiler=profiler,
+        **secondary_kwargs,
+    )
+
+    if hybrid_result.primary_chunks:
+        primary_store.add_code_chunks(hybrid_result.primary_chunks, level="l2")
+        primary_store.save(str(primary_path))
+    else:
+        logger.warning("Hybrid chunker produced no primary chunks.")
+
+    if hybrid_result.secondary_chunks:
+        secondary_store.add_code_chunks(hybrid_result.secondary_chunks, level="l2")
+        secondary_store.save(str(secondary_path))
+    else:
+        logger.warning("Hybrid chunker produced no secondary chunks.")
+
+    logger.info(
+        "Built hybrid vector stores",
+        extra={
+            "primary_chunks": len(hybrid_result.primary_chunks),
+            "secondary_chunks": len(hybrid_result.secondary_chunks),
+            "index_path": str(index_path),
+        },
+    )
+
+    return {"primary": primary_store, "secondary": secondary_store}

--- a/codeminer/index/embedding/builders.py
+++ b/codeminer/index/embedding/builders.py
@@ -19,9 +19,11 @@ def build_hybrid_vector_stores(
     repo_path: str,
     index_path: str,
     languages: Optional[List[str]] = None,
-    chunk_depth: int = 2,
     max_lines_per_chunk: Optional[int] = 100,
     hybrid_config: Optional[HybridChunkingConfig] = None,
+    hybrid_levels: Optional[List[str]] = None,
+    shared_levels: Optional[List[str]] = None,
+    plan_name: str = "hybrid",
     primary_embedding_model: str,
     primary_embedding_provider: str = "openai",
     primary_embedding_dimension: Optional[int] = 1536,
@@ -37,24 +39,50 @@ def build_hybrid_vector_stores(
     Build two vector stores by routing "primary" chunks to a stronger embedding
     model and "secondary" chunks to a cheaper model using HybridChunkingConfig.
 
+    Hybrid chunking can be limited to specific levels (e.g., only L2), while
+    other levels (e.g., L0 file skeletons) can be added to the primary store.
+
     Returns:
         Mapping ``{\"primary\": CodeVectorStore, \"secondary\": CodeVectorStore}``.
     """
     repo_path = str(Path(repo_path).resolve())
     languages = languages or ["python"]
-    chunker = CodeChunker(
-        language=languages[0],
-        repo_config=RepoChunkingConfig(languages=languages),
-        max_lines_per_chunk=max_lines_per_chunk,
-        chunk_depth=chunk_depth,
-        l2_level_exclusive=True,
-        skeleton_mode=False,
-    )
-    hybrid_cfg = hybrid_config or HybridChunkingConfig()
-    hybrid_result = chunker.hybrid_chunk_repository(repo_path, hybrid_config=hybrid_cfg)
+    hybrid_levels = [lvl.lower() for lvl in (hybrid_levels or ["l2"])]
+    shared_levels = [lvl.lower() for lvl in (shared_levels or [])]
 
-    primary_path = Path(index_path) / "primary"
-    secondary_path = Path(index_path) / "secondary"
+    base_path = Path(index_path)
+    if plan_name:
+        base_path = base_path / plan_name
+
+    level_configs = {
+        "l0": dict(
+            chunker_kwargs=dict(
+                language=languages[0],
+                repo_config=RepoChunkingConfig(languages=languages),
+                max_lines_per_chunk=None,
+                chunk_depth=0,
+                skeleton_mode=True,
+            )
+        ),
+        "l2": dict(
+            chunker_kwargs=dict(
+                language=languages[0],
+                repo_config=RepoChunkingConfig(languages=languages),
+                max_lines_per_chunk=max_lines_per_chunk,
+                chunk_depth=2,
+                l2_level_exclusive=True,
+                skeleton_mode=False,
+            )
+        ),
+    }
+
+    hybrid_cfg = hybrid_config or HybridChunkingConfig()
+
+    if not hybrid_levels:
+        raise ValueError("hybrid_levels must include at least one level (e.g., ['l2'])")
+
+    primary_path = base_path / "primary"
+    secondary_path = base_path / "secondary"
     primary_path.mkdir(parents=True, exist_ok=True)
     secondary_path.mkdir(parents=True, exist_ok=True)
 
@@ -79,25 +107,159 @@ def build_hybrid_vector_stores(
         **secondary_kwargs,
     )
 
-    if hybrid_result.primary_chunks:
-        primary_store.add_code_chunks(hybrid_result.primary_chunks, level="l2")
-        primary_store.save(str(primary_path))
-    else:
-        logger.warning("Hybrid chunker produced no primary chunks.")
+    hybrid_counts = {"primary": 0, "secondary": 0}
 
-    if hybrid_result.secondary_chunks:
-        secondary_store.add_code_chunks(hybrid_result.secondary_chunks, level="l2")
-        secondary_store.save(str(secondary_path))
-    else:
-        logger.warning("Hybrid chunker produced no secondary chunks.")
+    for level in hybrid_levels:
+        if level not in level_configs:
+            logger.warning("Unsupported hybrid level %s; skipping", level)
+            continue
+        chunker_cfg = level_configs[level]["chunker_kwargs"]
+        chunker = CodeChunker(**chunker_cfg)
+        hybrid_result = chunker.hybrid_chunk_repository(
+            repo_path, hybrid_config=hybrid_cfg
+        )
+
+        if hybrid_result.primary_chunks:
+            primary_store.add_code_chunks(hybrid_result.primary_chunks, level=level)
+            hybrid_counts["primary"] += len(hybrid_result.primary_chunks)
+        else:
+            logger.warning(
+                "Hybrid chunker produced no primary chunks at level %s", level
+            )
+
+        if hybrid_result.secondary_chunks:
+            secondary_store.add_code_chunks(hybrid_result.secondary_chunks, level=level)
+            hybrid_counts["secondary"] += len(hybrid_result.secondary_chunks)
+        else:
+            logger.warning(
+                "Hybrid chunker produced no secondary chunks at level %s", level
+            )
+
+    # Add any shared (non-hybrid) levels to the primary store
+    for level in shared_levels:
+        if level not in level_configs:
+            logger.warning("Unsupported shared level %s; skipping", level)
+            continue
+        chunker_cfg = level_configs[level]["chunker_kwargs"]
+        chunker = CodeChunker(**chunker_cfg)
+        chunks = chunker.chunk_repository(repo_path=repo_path)
+        if not chunks:
+            logger.warning("No chunks generated for shared level %s", level)
+            continue
+        primary_store.add_code_chunks(
+            [chunk._asdict() for chunk in chunks], level=level
+        )
+
+    primary_store.save(str(primary_path))
+    secondary_store.save(str(secondary_path))
 
     logger.info(
         "Built hybrid vector stores",
         extra={
-            "primary_chunks": len(hybrid_result.primary_chunks),
-            "secondary_chunks": len(hybrid_result.secondary_chunks),
+            "primary_chunks": hybrid_counts["primary"],
+            "secondary_chunks": hybrid_counts["secondary"],
+            "shared_levels": shared_levels,
+            "hybrid_levels": hybrid_levels,
             "index_path": str(index_path),
         },
     )
 
     return {"primary": primary_store, "secondary": secondary_store}
+
+
+def build_hierarchical_vector_store(
+    *,
+    repo_path: str,
+    index_path: str,
+    plan_name: Optional[str] = None,
+    languages: Optional[List[str]] = None,
+    max_lines_per_chunk: Optional[int] = None,
+    build_levels: Optional[List[str]] = None,
+    embedding_model: str,
+    embedding_provider: str,
+    embedding_dimension: Optional[int],
+    embedding_kwargs: Optional[Dict[str, object]] = None,
+    index_metric: str = "ip",
+    profiler: Optional[Profiler] = None,
+) -> CodeVectorStore:
+    """
+    Build a hierarchical vector store (L0/L2) for a repository.
+    """
+    languages = languages or ["python"]
+    build_levels = [level.lower() for level in (build_levels or ["l0", "l2"])]
+    repo_cfg = RepoChunkingConfig(languages=languages)
+
+    chunks_by_level = {}
+    level_configs = {
+        "l0": dict(
+            chunker_kwargs=dict(
+                language=languages[0],
+                repo_config=repo_cfg,
+                max_lines_per_chunk=None,
+                chunk_depth=0,
+                skeleton_mode=True,
+            )
+        ),
+        "l2": dict(
+            chunker_kwargs=dict(
+                language=languages[0],
+                repo_config=repo_cfg,
+                max_lines_per_chunk=max_lines_per_chunk,
+                chunk_depth=2,
+                l2_level_exclusive=True,
+                skeleton_mode=False,
+            )
+        ),
+    }
+
+    for level in build_levels:
+        cfg = level_configs.get(level)
+        if not cfg:
+            continue
+        chunker = CodeChunker(**cfg["chunker_kwargs"])
+        chunks_by_level[level] = chunker.chunk_repository(repo_path=repo_path)
+
+    l0_chunks = chunks_by_level.get("l0", [])
+    l2_chunks = chunks_by_level.get("l2", [])
+
+    if not l0_chunks and not l2_chunks:
+        raise ValueError("No code chunks generated from repository.")
+
+    store_path = Path(index_path)
+    if plan_name:
+        store_path = store_path / plan_name
+    store_path.mkdir(parents=True, exist_ok=True)
+    vector_store = CodeVectorStore(
+        embedding_model=embedding_model,
+        embedding_provider=embedding_provider,
+        dimension=embedding_dimension,
+        index_metric=index_metric,
+        store_path=str(store_path),
+        profiler=profiler,
+        **(embedding_kwargs or {}),
+    )
+
+    if l0_chunks:
+        vector_store.add_code_chunks(
+            [chunk._asdict() for chunk in l0_chunks], level="l0"
+        )
+    if l2_chunks:
+        vector_store.add_code_chunks(
+            [chunk._asdict() for chunk in l2_chunks], level="l2"
+        )
+
+    vector_store.save(str(store_path))
+    return vector_store
+
+
+class VectorStoreBuilder:
+    """Builder class wrapping common vector store build operations."""
+
+    def __init__(self, profiler: Optional[Profiler] = None) -> None:
+        self.profiler = profiler
+
+    def hierarchical(self, **kwargs) -> CodeVectorStore:
+        return build_hierarchical_vector_store(profiler=self.profiler, **kwargs)
+
+    def hybrid(self, **kwargs) -> Dict[str, CodeVectorStore]:
+        return build_hybrid_vector_stores(profiler=self.profiler, **kwargs)

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -8,7 +8,7 @@ import json
 import pickle
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Set
 
 import faiss
 from langchain_community.docstore import InMemoryDocstore
@@ -159,8 +159,10 @@ class CodeVectorStore:
         """
         Determine if a result should be filtered based on score threshold.
 
-        For inner product (ip): higher scores are better (similarity), filter if score < threshold
-        For L2 distance (l2): lower scores are better (distance), filter if score > threshold
+        For inner product (ip): higher scores are better (similarity),
+        filter if score < threshold
+        For L2 distance (l2): lower scores are better (distance),
+        filter if score > threshold
         """
         if self.index_metric == "ip":
             # Inner product: higher is better (similarity score)
@@ -192,7 +194,8 @@ class CodeVectorStore:
 
         Args:
             code_chunks: List of code chunk dictionaries with content and metadata
-            level: Index level to add chunks to ("l0" for file skeletons, "l2" for functions/methods)
+            level: Index level to add chunks to
+            ("l0" for file skeletons, "l2" for functions/methods)
         """
         if not code_chunks:
             logger.warning("No code chunks provided")
@@ -271,6 +274,7 @@ class CodeVectorStore:
         top_k: int = 10,
         score_threshold: Optional[float] = None,
         level: Level = "l2",
+        mask_node_ids: Optional[Set[str]] = None,
     ) -> List[NodeInfo]:
         """
         Search for similar code chunks using semantic similarity.
@@ -280,6 +284,7 @@ class CodeVectorStore:
             top_k: Number of top results to return
             score_threshold: Minimum similarity score threshold
             level: Index level to search ("l0" for file skeletons, "l2" for functions/methods)
+            mask_node_ids: Optional set of CodeChunk.node_id values to filter results.
 
         Returns:
             List of NodeInfo objects with scores populated
@@ -292,7 +297,6 @@ class CodeVectorStore:
 
         logger.debug(f"Searching {level} for: {query[:100]}...")
 
-        # Perform similarity search with scores
         docs_with_scores = vector_store.similarity_search_with_score(query, k=top_k)
 
         # Convert to NodeInfo objects
@@ -319,7 +323,14 @@ class CodeVectorStore:
             )
             results.append(node_with_score)
 
-        logger.debug(f"Found {len(results)} results in {level}")
+        if mask_node_ids:
+            results = [r for r in results if r.node_id in mask_node_ids]
+        if top_k:
+            results = results[:top_k]
+
+        logger.debug(
+            f"Found {len(results)} results in {level} (masked={bool(mask_node_ids)})"
+        )
         return results
 
     def search_with_content(
@@ -328,6 +339,7 @@ class CodeVectorStore:
         top_k: int = 10,
         score_threshold: Optional[float] = None,
         level: Level = "l2",
+        mask_node_ids: Optional[Set[str]] = None,
     ) -> List[NodeInfo]:
         """
         Search and return results with content included.
@@ -337,6 +349,7 @@ class CodeVectorStore:
             top_k: Number of top results to return
             score_threshold: Minimum similarity score threshold
             level: Index level to search ("l0" for file skeletons, "l2" for functions/methods)
+            mask_node_ids: Optional set of CodeChunk.node_id values to filter results.
 
         Returns:
             List of NodeInfo objects with content populated
@@ -347,7 +360,6 @@ class CodeVectorStore:
             logger.warning(f"No {level} vector store available. Add code chunks first.")
             return []
 
-        # Perform similarity search with scores
         docs_with_scores = vector_store.similarity_search_with_score(query, k=top_k)
 
         # Convert to NodeInfo objects
@@ -375,6 +387,15 @@ class CodeVectorStore:
             )
             results.append(node_with_content)
 
+        if mask_node_ids:
+            results = [r for r in results if r.node_id in mask_node_ids]
+        if top_k:
+            results = results[:top_k]
+
+        logger.debug(
+            f"Found {len(results)} results with content in {level} "
+            f"(masked={bool(mask_node_ids)})"
+        )
         return results
 
     def hierarchical_search(

--- a/codeminer/model/__init__.py
+++ b/codeminer/model/__init__.py
@@ -1,6 +1,7 @@
 """Model module for CodeMiner."""
 
 from .agentless_pipeline import AgentlessPipeline
+from .hybrid_retrieve_plan import HybridEmbeddingConfig, build_hybrid_embeddings
 from .retrieve_rerank_pipeline import (
     RetrieveRerankPipeline,
     RetrieveStageConfig,
@@ -11,5 +12,7 @@ __all__ = [
     "RetrieveRerankPipeline",
     "RetrieveStageConfig",
     "build_retrieve_plan",
+    "HybridEmbeddingConfig",
+    "build_hybrid_embeddings",
     "AgentlessPipeline",
 ]

--- a/codeminer/model/hybrid_retrieve_plan.py
+++ b/codeminer/model/hybrid_retrieve_plan.py
@@ -35,11 +35,13 @@ class HybridEmbeddingConfig:
 
     # Chunking
     max_lines_per_chunk: Optional[int] = 100
-    chunk_depth: int = 2
     languages: Optional[List[str]] = None
 
     # Hybrid chunking params
     hybrid_chunking: HybridChunkingConfig = field(default_factory=HybridChunkingConfig)
+    hybrid_levels: List[str] = field(default_factory=lambda: ["l2"])
+    shared_levels: List[str] = field(default_factory=lambda: ["l0"])
+    plan_name: str = "hybrid"
 
 
 def build_hybrid_embeddings(
@@ -64,9 +66,11 @@ def build_hybrid_embeddings(
         repo_path=config.repo_path,
         index_path=str(config.index_path),
         languages=languages,
-        chunk_depth=config.chunk_depth,
         max_lines_per_chunk=config.max_lines_per_chunk,
         hybrid_config=config.hybrid_chunking,
+        hybrid_levels=config.hybrid_levels,
+        shared_levels=config.shared_levels,
+        plan_name=config.plan_name,
         primary_embedding_model=config.primary_embedding_model,
         primary_embedding_provider=config.primary_embedding_provider,
         primary_embedding_dimension=config.primary_embedding_dimension,

--- a/codeminer/model/hybrid_retrieve_plan.py
+++ b/codeminer/model/hybrid_retrieve_plan.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Hybrid embedding pipeline that pairs hybrid chunking with two embedding models.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..code_chunker import HybridChunkingConfig
+from ..index.embedding import CodeVectorStore, build_hybrid_vector_stores
+from ..log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class HybridEmbeddingConfig:
+    """
+    Configuration for hybrid embedding pipeline.
+    """
+
+    repo_path: str
+    index_path: Path
+
+    primary_embedding_model: str
+    primary_embedding_provider: str = "openai"
+    primary_embedding_dimension: Optional[int] = 1536
+    primary_embedding_kwargs: Dict[str, object] = field(default_factory=dict)
+
+    secondary_embedding_model: str = "text-embedding-3-small"
+    secondary_embedding_provider: str = "openai"
+    secondary_embedding_dimension: Optional[int] = 1536
+    secondary_embedding_kwargs: Dict[str, object] = field(default_factory=dict)
+
+    # Chunking
+    max_lines_per_chunk: Optional[int] = 100
+    chunk_depth: int = 2
+    languages: Optional[List[str]] = None
+
+    # Hybrid chunking params
+    hybrid_chunking: HybridChunkingConfig = field(default_factory=HybridChunkingConfig)
+
+
+def build_hybrid_embeddings(
+    config: HybridEmbeddingConfig,
+) -> Dict[str, CodeVectorStore]:
+    """
+    Materialize primary/secondary vector stores using hybrid chunking.
+    """
+    languages = config.languages or ["python"]
+    logger.info(
+        "Building hybrid embeddings",
+        extra={
+            "repo_path": config.repo_path,
+            "index_path": str(config.index_path),
+            "languages": languages,
+            "primary_model": config.primary_embedding_model,
+            "secondary_model": config.secondary_embedding_model,
+        },
+    )
+
+    return build_hybrid_vector_stores(
+        repo_path=config.repo_path,
+        index_path=str(config.index_path),
+        languages=languages,
+        chunk_depth=config.chunk_depth,
+        max_lines_per_chunk=config.max_lines_per_chunk,
+        hybrid_config=config.hybrid_chunking,
+        primary_embedding_model=config.primary_embedding_model,
+        primary_embedding_provider=config.primary_embedding_provider,
+        primary_embedding_dimension=config.primary_embedding_dimension,
+        primary_embedding_kwargs=config.primary_embedding_kwargs,
+        secondary_embedding_model=config.secondary_embedding_model,
+        secondary_embedding_provider=config.secondary_embedding_provider,
+        secondary_embedding_dimension=config.secondary_embedding_dimension,
+        secondary_embedding_kwargs=config.secondary_embedding_kwargs,
+    )

--- a/codeminer/model/retrieve_rerank_pipeline.py
+++ b/codeminer/model/retrieve_rerank_pipeline.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
-from ..code_chunker import CodeChunker, RepoChunkingConfig
-from ..index.embedding import CodeVectorStore
+from ..code_chunker import CodeChunker
+from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..llm.llm_config import LLMConfig, LLMProvider
 from ..log_utils import get_logger
@@ -108,6 +108,7 @@ class RetrieveRerankPipeline:
         rerank_window_size: Optional[int] = None,
         rerank_window_step: Optional[int] = None,
         enable_rerank: bool = True,
+        vector_masks: Optional[Dict[str, Set[str]]] = None,
     ) -> None:
         self.repo_path = self._validate_repo(repo_path)
         self.index_path = Path(index_path)
@@ -184,6 +185,7 @@ class RetrieveRerankPipeline:
             regex_index=None,
             default_top_k=self._default_stage_top_k,
             default_level=self.retrieval_level,
+            masks=vector_masks or {},
         )
         register_retrieve_ops(self.engine, self.retrieve_context)
 
@@ -310,50 +312,19 @@ class RetrieveRerankPipeline:
             vector_store.clear()
 
         logger.info("Building hierarchical vector store index.")
-        # Build L0 and L2 chunks
-        repo_cfg = RepoChunkingConfig(languages=self.languages)
-
-        # L0 chunks (file-level skeletons)
-        l0_chunker = CodeChunker(
-            language=self.languages[0],
-            repo_config=repo_cfg,
-            max_lines_per_chunk=None,
-            chunk_depth=0,
-            skeleton_mode=True,
-        )
-        l0_chunks = l0_chunker.chunk_repository(repo_path=self.repo_path)
-
-        # L2 chunks (function/method-level)
-        l2_chunker = CodeChunker(
-            language=self.languages[0],
-            repo_config=repo_cfg,
+        vector_store = build_hierarchical_vector_store(
+            repo_path=self.repo_path,
+            index_path=str(self.index_path),
+            plan_name=None,
+            languages=self.languages,
             max_lines_per_chunk=self.max_lines_per_chunk,
-            chunk_depth=2,
-            l2_level_exclusive=True,
-            skeleton_mode=False,
-        )
-        l2_chunks = l2_chunker.chunk_repository(repo_path=self.repo_path)
-
-        if not l0_chunks and not l2_chunks:
-            raise ValueError("No code chunks generated from repository.")
-
-        # Add L0 chunks
-        if l0_chunks:
-            l0_chunks_for_indexing = [chunk._asdict() for chunk in l0_chunks]
-            vector_store.add_code_chunks(l0_chunks_for_indexing, level="l0")
-
-        # Add L2 chunks
-        if l2_chunks:
-            l2_chunks_for_indexing = [chunk._asdict() for chunk in l2_chunks]
-            vector_store.add_code_chunks(l2_chunks_for_indexing, level="l2")
-
-        vector_store.save(str(self.index_path))
-        logger.info(
-            "Hierarchical vector store built and cached.",
-            extra={
-                "l0_chunks": len(l0_chunks),
-                "l2_chunks": len(l2_chunks),
-            },
+            build_levels=["l0", "l2"],
+            embedding_model=embedding_model,
+            embedding_provider=embedding_provider,
+            embedding_dimension=embedding_dimension,
+            embedding_kwargs=embedding_kwargs,
+            index_metric=self.index_metric,
+            profiler=self.profiler,
         )
         return vector_store
 

--- a/codeminer/ops/retrieve.py
+++ b/codeminer/ops/retrieve.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from ..index.embedding.vector_store import CodeVectorStore
 from ..index.regex_idx.regex_idx import RegexNodeIndex
@@ -24,6 +24,7 @@ class RetrieveContext:
     regex_index: Optional[RegexNodeIndex] = None
     default_top_k: int = 10
     default_level: str = "l2"  # "l0" (file skeletons) or "l2" (functions/methods)
+    masks: Dict[str, Set[str]] = field(default_factory=dict)
 
 
 def register_retrieve_ops(engine: ExecutionEngine, context: RetrieveContext) -> None:
@@ -84,24 +85,37 @@ def _vector_kernel(context: RetrieveContext):
         # Support hierarchical retrieval level (l0 = file skeletons, l2 = functions/methods)
         level = node.params.get("level", context.default_level)
 
+        mask_name = node.params.get("mask") or node.params.get("mask_name")
+        mask_ids = context.masks.get(mask_name) if mask_name else None
+        search_top_k = top_k
+
         logger.debug(
             "Executing vector retrieval",
             extra={
                 "query": query,
-                "k": top_k,
+                "k": search_top_k,
                 "level": level,
                 "score_threshold": score_threshold,
+                "mask": mask_name,
             },
         )
 
         scored = store.search(
-            query=query, top_k=top_k, score_threshold=score_threshold, level=level
+            query=query,
+            top_k=search_top_k,
+            score_threshold=score_threshold,
+            level=level,
+            mask_node_ids=mask_ids,
         )
 
         content_map: Dict[Tuple[str, str, Optional[int], Optional[int]], str] = {}
         if include_content:
             with_content = store.search_with_content(
-                query=query, top_k=top_k, score_threshold=score_threshold, level=level
+                query=query,
+                top_k=search_top_k,
+                score_threshold=score_threshold,
+                level=level,
+                mask_node_ids=mask_ids,
             )
             for item in with_content:
                 data = _dump_model(item)
@@ -127,6 +141,10 @@ def _vector_kernel(context: RetrieveContext):
             data["content"] = content_map.get(key)
             normalized.append(QueriedNode(**data))
 
+        if mask_ids:
+            normalized = [item for item in normalized if item.node_id in mask_ids]
+        if top_k:
+            normalized = normalized[:top_k]
         return normalized
 
     return run

--- a/examples/hybrid_retrieve.py
+++ b/examples/hybrid_retrieve.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Example script for running hybrid retrieval with primary/secondary embeddings.
+
+This assumes you have already built hybrid embeddings for the target repo using
+``scripts/build_hybrid_embedding.sh`` or ``scripts/build_embeddings.py --hybrid``.
+Primary and secondary vector stores are expected under:
+  <index_dir>/<plan_name>/primary
+  <index_dir>/<plan_name>/secondary
+"""
+
+import argparse
+from pathlib import Path
+from typing import List
+
+from codeminer.code_chunker import CodeChunker, HybridChunkingConfig, RepoChunkingConfig
+from codeminer.log_utils import get_logger
+from codeminer.model.retrieve_rerank_pipeline import (
+    RetrieveRerankPipeline,
+    RetrieveStageConfig,
+)
+
+logger = get_logger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run hybrid retrieval with primary/secondary embeddings",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo-path",
+        required=True,
+        help="Path to the repository to search.",
+    )
+    parser.add_argument(
+        "--index-dir",
+        required=True,
+        help="Directory containing hybrid vector stores (with plan name subdir).",
+    )
+    parser.add_argument(
+        "--plan-name",
+        default="hybrid",
+        help="Plan name used during embedding build (subdir under index-dir).",
+    )
+    parser.add_argument(
+        "--query",
+        required=True,
+        help="Query text to retrieve relevant code chunks.",
+    )
+    parser.add_argument(
+        "--languages",
+        nargs="+",
+        default=["python"],
+        help="Languages to consider during retrieval.",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=20,
+        help="Number of candidates to retrieve before optional rerank.",
+    )
+    parser.add_argument(
+        "--max-lines-per-chunk",
+        type=int,
+        default=200,
+        help="Maximum lines per chunk (must match the build step).",
+    )
+    parser.add_argument(
+        "--primary-model",
+        default="jinaai/jina-code-embeddings-1.5b",
+        help="Primary embedding model used during build.",
+    )
+    parser.add_argument(
+        "--primary-provider",
+        default="huggingface",
+        help="Primary embedding provider.",
+    )
+    parser.add_argument(
+        "--primary-dim",
+        type=int,
+        default=1536,
+        help="Primary embedding dimension.",
+    )
+    parser.add_argument(
+        "--secondary-model",
+        default="Salesforce/SweRankEmbed-Small",
+        help="Secondary embedding model used during build.",
+    )
+    parser.add_argument(
+        "--secondary-provider",
+        default="huggingface",
+        help="Secondary embedding provider.",
+    )
+    parser.add_argument(
+        "--secondary-dim",
+        type=int,
+        default=768,
+        help="Secondary embedding dimension.",
+    )
+    parser.add_argument(
+        "--masked",
+        action="store_true",
+        help=(
+            "Use masked mode: reuse a single index and filter results by hybrid "
+            "importance without rebuilding hybrid indices."
+        ),
+    )
+    parser.add_argument(
+        "--high-importance-ratio",
+        type=float,
+        default=0.3,
+        help="Hybrid masking: ratio of chunks treated as primary.",
+    )
+    parser.add_argument(
+        "--min-high-importance-lines",
+        type=int,
+        default=10,
+        help="Hybrid masking: minimum lines to qualify as primary.",
+    )
+    parser.add_argument(
+        "--rerank",
+        action="store_true",
+        help="Enable rerank stage (requires rerank model/server configured separately).",
+    )
+    parser.add_argument(
+        "--retrieval-level",
+        type=str,
+        default="l2",
+        choices=["l0", "l2"],
+        help="Retrieval level to query.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    plan_dir = Path(args.index_dir) / args.plan_name
+    primary_index = plan_dir / "primary"
+    secondary_index = plan_dir / "secondary"
+    if args.masked:
+        # Masked mode expects a single index directory; reuse primary path for both stages
+        if not primary_index.exists():
+            raise FileNotFoundError(f"Expected index at {primary_index}")
+        secondary_index = primary_index
+    else:
+        if not primary_index.exists() or not secondary_index.exists():
+            raise FileNotFoundError(
+                f"Expected hybrid indexes at {primary_index} and {secondary_index}"
+            )
+
+    vector_masks = {}
+    if args.masked:
+        mask_cfg = HybridChunkingConfig(
+            high_importance_ratio=args.high_importance_ratio,
+            min_high_importance_lines=args.min_high_importance_lines,
+        )
+        chunker = CodeChunker(
+            language=args.languages[0],
+            repo_config=RepoChunkingConfig(languages=args.languages),
+            max_lines_per_chunk=args.max_lines_per_chunk,
+            chunk_depth=2,
+            l2_level_exclusive=True,
+        )
+        hybrid_result = chunker.hybrid_chunk_repository(
+            repo_path=args.repo_path, hybrid_config=mask_cfg
+        )
+        vector_masks = {
+            "primary": {chunk["node_id"] for chunk in hybrid_result.primary_chunks},
+            "secondary": {chunk["node_id"] for chunk in hybrid_result.secondary_chunks},
+        }
+
+    # Define two dense retrieval stages; when masked,
+    # both use the same index but different masks
+    stages: List[RetrieveStageConfig] = [
+        RetrieveStageConfig(
+            engine="dense",
+            weight=0.7,
+            top_k=args.top_k,
+            params={
+                "embedding_model": args.primary_model,
+                "embedding_provider": args.primary_provider,
+                "embedding_dimension": args.primary_dim,
+                "max_lines_per_chunk": args.max_lines_per_chunk,
+                "languages": args.languages,
+                "index_path": str(primary_index),
+                "mask_name": "primary" if args.masked else None,
+            },
+        ),
+        RetrieveStageConfig(
+            engine="dense",
+            weight=0.3,
+            top_k=args.top_k,
+            params={
+                "embedding_model": args.secondary_model,
+                "embedding_provider": args.secondary_provider,
+                "embedding_dimension": args.secondary_dim,
+                "max_lines_per_chunk": args.max_lines_per_chunk,
+                "languages": args.languages,
+                "index_path": str(secondary_index),
+                "mask_name": "secondary" if args.masked else None,
+            },
+        ),
+    ]
+
+    pipeline = RetrieveRerankPipeline(
+        repo_path=args.repo_path,
+        index_path=str(primary_index),
+        retrieval_plan=stages,
+        retrieval_level=args.retrieval_level,
+        embedding_model=args.primary_model,
+        embedding_provider=args.primary_provider,
+        embedding_dimension=args.primary_dim,
+        max_lines_per_chunk=args.max_lines_per_chunk,
+        languages=args.languages,
+        enable_rerank=args.rerank,
+        vector_masks=vector_masks,
+    )
+
+    results = pipeline.query(args.query)
+    for idx, node in enumerate(results[: args.top_k], start=1):
+        print(f"[{idx}] score={node.score:.4f} node_id={node.node_id}")
+        print(node.content[:500])
+        print("-" * 40)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_embeddings.py
+++ b/scripts/build_embeddings.py
@@ -15,12 +15,15 @@ import logging
 import sys
 from pathlib import Path
 
-from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+from codeminer.code_chunker import HybridChunkingConfig
 from codeminer.env.process_swebench_data import (
     load_filter_swebench_dataset,
     process_swebench_instance,
 )
-from codeminer.index.embedding import CodeVectorStore
+from codeminer.index.embedding import (
+    build_hierarchical_vector_store,
+    build_hybrid_vector_stores,
+)
 from codeminer.log_utils import get_logger
 from codeminer.profiler import Profiler
 
@@ -96,6 +99,45 @@ def parse_args():
         choices=["ip", "l2"],
         help="Distance metric for FAISS index (ip: inner product, l2: L2 distance)",
     )
+    parser.add_argument(
+        "--hybrid",
+        action="store_true",
+        help=(
+            "Enable hybrid embedding: primary/secondary models with importance "
+            "routing (L2 hybrid, L0 shared)."
+        ),
+    )
+    parser.add_argument(
+        "--secondary-embedding-model",
+        type=str,
+        default="text-embedding-3-small",
+        help="Secondary embedding model for hybrid mode.",
+    )
+    parser.add_argument(
+        "--secondary-embedding-provider",
+        type=str,
+        default="openai",
+        choices=["openai", "huggingface"],
+        help="Secondary embedding provider for hybrid mode.",
+    )
+    parser.add_argument(
+        "--secondary-embedding-dimension",
+        type=int,
+        default=1536,
+        help="Secondary embedding dimension for hybrid mode.",
+    )
+    parser.add_argument(
+        "--high-importance-ratio",
+        type=float,
+        default=0.2,
+        help="Hybrid: ratio of chunks treated as primary (sorted by importance).",
+    )
+    parser.add_argument(
+        "--min-high-importance-lines",
+        type=int,
+        default=1,
+        help="Hybrid: minimum lines threshold to keep a chunk in primary tier.",
+    )
 
     # Repository processing configuration
     parser.add_argument(
@@ -121,6 +163,14 @@ def parse_args():
         default=["L0", "L2"],
         choices=["L0", "L2"],
         help="Chunk levels to build and index (choose one or both)",
+    )
+    parser.add_argument(
+        "--plan-name",
+        type=str,
+        default=None,
+        help=(
+            "Optional plan name to nest embedding artifacts under " "(e.g., 'hybrid')."
+        ),
     )
 
     # Storage configuration
@@ -218,100 +268,61 @@ def build_embeddings(args):
                 continue
             elif config_file.exists() and args.force_rebuild:
                 logger.info(
-                    f"⚠ Embedding already exists but force-rebuild is enabled, rebuilding..."
+                    f" Embedding already exists but force-rebuild is enabled, rebuilding..."
                 )
 
-            # Shared repo config
-            repo_cfg = RepoChunkingConfig(languages=list(args.languages))
+            embedding_kwargs = {}
+            if args.trust_remote_code:
+                embedding_kwargs["model_kwargs"] = {"trust_remote_code": True}
+            if args.batch_size:
+                embedding_kwargs["encode_kwargs"] = {"batch_size": args.batch_size}
 
-            # Build requested levels
-            chunks_by_level = {}
-
-            level_configs = {
-                "l0": {
-                    "log": "Generating L0 chunks (file-level skeletons)...",
-                    "profiler_section": "chunk_repository_l0",
-                    "chunker_kwargs": dict(
-                        language=args.languages[0],
-                        repo_config=repo_cfg,
-                        max_lines_per_chunk=None,
-                        chunk_depth=0,
-                        skeleton_mode=True,
-                    ),
-                    "log_suffix": "L0 chunks (file skeletons)",
-                },
-                "l2": {
-                    "log": "Generating L2 chunks (function/method-level)...",
-                    "profiler_section": "chunk_repository_l2",
-                    "chunker_kwargs": dict(
-                        language=args.languages[0],
-                        repo_config=repo_cfg,
-                        max_lines_per_chunk=args.max_lines_per_chunk,
-                        chunk_depth=2,
-                        l2_level_exclusive=True,
-                        skeleton_mode=False,
-                    ),
-                    "log_suffix": "L2 chunks (functions/methods)",
-                },
-            }
-
-            for level in build_levels:
-                cfg = level_configs[level]
-                logger.info(cfg["log"])
-                with instance_profiler.section(cfg["profiler_section"]):
-                    chunker = CodeChunker(**cfg["chunker_kwargs"])
-                    chunks_by_level[level] = chunker.chunk_repository(
-                        repo_path=repo_path
+            logger.info(
+                "Building %s vector store...",
+                "hybrid" if args.hybrid else "hierarchical",
+            )
+            plan_name = args.plan_name or ("hybrid" if args.hybrid else None)
+            with instance_profiler.section("build_vector_store"):
+                if args.hybrid:
+                    hybrid_cfg = HybridChunkingConfig(
+                        high_importance_ratio=args.high_importance_ratio,
+                        min_high_importance_lines=args.min_high_importance_lines,
                     )
-                logger.info(
-                    f"Generated {len(chunks_by_level[level])} {cfg['log_suffix']}"
-                )
-
-            l0_chunks = chunks_by_level.get("l0", [])
-            l2_chunks = chunks_by_level.get("l2", [])
-
-            if not l0_chunks and not l2_chunks:
-                logger.warning(f"No code chunks generated from repository, skipping...")
-                continue
-
-            # [Main] Create vector store
-            logger.info("Creating vector store...")
-            with instance_profiler.section("create_vector_store"):
-                # Prepare embedding kwargs
-                embedding_kwargs = {}
-                if args.trust_remote_code:
-                    embedding_kwargs["model_kwargs"] = {"trust_remote_code": True}
-                if args.batch_size:
-                    embedding_kwargs["encode_kwargs"] = {"batch_size": args.batch_size}
-
-                vector_store = CodeVectorStore(
-                    embedding_model=args.embedding_model,
-                    embedding_provider=args.embedding_provider,
-                    dimension=args.embedding_dimension,
-                    index_metric=args.index_metric,
-                    store_path=str(instance_final_dir),
-                    profiler=instance_profiler,
-                    **embedding_kwargs,
-                )
-
-            # [Main] Add L0 chunks to vector store
-            if l0_chunks:
-                logger.info("Adding L0 chunks to vector store...")
-                with instance_profiler.section("add_chunks_l0"):
-                    l0_chunks_for_indexing = [chunk._asdict() for chunk in l0_chunks]
-                    vector_store.add_code_chunks(l0_chunks_for_indexing, level="l0")
-
-            # [Main] Add L2 chunks to vector store
-            if l2_chunks:
-                logger.info("Adding L2 chunks to vector store...")
-                with instance_profiler.section("add_chunks_l2"):
-                    l2_chunks_for_indexing = [chunk._asdict() for chunk in l2_chunks]
-                    vector_store.add_code_chunks(l2_chunks_for_indexing, level="l2")
-
-            # Save vector store
-            logger.info("Saving vector store...")
-            with instance_profiler.section("save_vector_store"):
-                vector_store.save(str(instance_final_dir))
+                    build_hybrid_vector_stores(
+                        repo_path=repo_path,
+                        index_path=str(instance_final_dir),
+                        languages=list(args.languages),
+                        max_lines_per_chunk=args.max_lines_per_chunk,
+                        hybrid_config=hybrid_cfg,
+                        hybrid_levels=["l2"],
+                        shared_levels=["l0"],
+                        plan_name=plan_name,
+                        primary_embedding_model=args.embedding_model,
+                        primary_embedding_provider=args.embedding_provider,
+                        primary_embedding_dimension=args.embedding_dimension,
+                        primary_embedding_kwargs=embedding_kwargs,
+                        secondary_embedding_model=args.secondary_embedding_model,
+                        secondary_embedding_provider=args.secondary_embedding_provider,
+                        secondary_embedding_dimension=args.secondary_embedding_dimension,
+                        secondary_embedding_kwargs=embedding_kwargs,
+                        index_metric=args.index_metric,
+                        profiler=instance_profiler,
+                    )
+                else:
+                    build_hierarchical_vector_store(
+                        repo_path=repo_path,
+                        index_path=str(instance_final_dir),
+                        plan_name=plan_name,
+                        languages=list(args.languages),
+                        max_lines_per_chunk=args.max_lines_per_chunk,
+                        build_levels=build_levels,
+                        embedding_model=args.embedding_model,
+                        embedding_provider=args.embedding_provider,
+                        embedding_dimension=args.embedding_dimension,
+                        embedding_kwargs=embedding_kwargs,
+                        index_metric=args.index_metric,
+                        profiler=instance_profiler,
+                    )
 
             # Save profiler report
             if args.profile_dir:
@@ -335,9 +346,6 @@ def build_embeddings(args):
                     "instance_id": instance_id,
                     "repo": instance.get("repo", "unknown"),
                     "base_commit": instance.get("base_commit", "unknown"),
-                    "l0_chunks": len(l0_chunks),
-                    "l2_chunks": len(l2_chunks),
-                    "total_chunks": len(l0_chunks) + len(l2_chunks),
                     "embedding_model": args.embedding_model,
                     "embedding_dimension": args.embedding_dimension,
                     "total_duration": sum(
@@ -352,15 +360,8 @@ def build_embeddings(args):
                 profile_file.write_text(json.dumps(profile_payload, indent=2))
                 logger.info(f"Saved profiler results to {profile_file}")
 
-            logger.info(
-                f"✓ Successfully built hierarchical embedding for {instance_id}"
-            )
-            logger.info(
-                f"  - L0 chunks (file skeletons): {len(vector_store.l0_documents)}"
-            )
-            logger.info(
-                f"  - L2 chunks (functions/methods): {len(vector_store.l2_documents)}"
-            )
+            mode = "hybrid" if args.hybrid else "hierarchical"
+            logger.info(f"✓ Successfully built {mode} embedding for {instance_id}")
             logger.info(f"  - Saved to: {instance_final_dir}")
 
         except Exception as e:

--- a/scripts/build_hybrid_embedding.sh
+++ b/scripts/build_hybrid_embedding.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build hybrid embeddings using a strong primary model and a lighter secondary one.
+# Primary: jinaai/jina-code-embeddings-1.5b
+# Secondary: Salesforce/SweRankEmbed-Small
+
+PRIMARY_MODEL="jinaai/jina-code-embeddings-1.5b"
+SECONDARY_MODEL="Salesforce/SweRankEmbed-Small"
+
+python scripts/build_embeddings.py \
+  --hybrid \
+  --embedding-model "${PRIMARY_MODEL}" \
+  --embedding-provider "huggingface" \
+  --embedding-dimension 1536 \
+  --secondary-embedding-model "${SECONDARY_MODEL}" \
+  --secondary-embedding-provider "huggingface" \
+  --secondary-embedding-dimension 768 \
+  --high-importance-ratio 0.3 \
+  --min-high-importance-lines 20 \
+  "$@"

--- a/test/chunker/test_hybrid_chunker.py
+++ b/test/chunker/test_hybrid_chunker.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Tests for hybrid chunking logic using the httpie/cli repo fixture."""
+
+from codeminer.code_chunker import CodeChunker, HybridChunkingConfig, RepoChunkingConfig
+
+
+def test_hybrid_chunker_assigns_primary_secondary(httpie_cli_repo):
+    chunker = CodeChunker(
+        language="python",
+        repo_config=RepoChunkingConfig(languages=["python"]),
+        chunk_depth=2,
+    )
+    # Keep thresholds permissive so both tiers are populated on real repos
+    config = HybridChunkingConfig(
+        high_importance_ratio=0.2,
+        min_high_importance_lines=1,
+    )
+
+    result = chunker.hybrid_chunk_repository(httpie_cli_repo, hybrid_config=config)
+
+    assert result.primary_chunks, "No primary chunks returned"
+    assert result.secondary_chunks, "No secondary chunks returned"
+    assert len(result.all_chunks()) == len(result.primary_chunks) + len(
+        result.secondary_chunks
+    )
+
+    # Primary chunks should have scores at least as high as the cutoff; secondary lower.
+    primary_scores = [chunk["importance_score"] for chunk in result.primary_chunks]
+    secondary_scores = [chunk["importance_score"] for chunk in result.secondary_chunks]
+
+    assert all(score >= result.cutoff_score for score in primary_scores)
+    assert any(score < result.cutoff_score for score in secondary_scores)
+
+    for chunk in result.primary_chunks:
+        assert chunk["importance_tier"] == "primary"
+
+    for chunk in result.secondary_chunks:
+        assert chunk["importance_tier"] == "secondary"
+
+    print(
+        f"Primary chunks: {len(result.primary_chunks)}, "
+        f"Secondary chunks: {len(result.secondary_chunks)}"
+    )

--- a/test/chunker/test_js_chunker.py
+++ b/test/chunker/test_js_chunker.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Regression tests for the JavaScript/TypeScript code chunker.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+
+EXPRESS_URL = "https://github.com/expressjs/express.git"
+EXPRESS_PATH = Path("/tmp/expressjs_express_test_repo")
+
+
+@pytest.fixture(scope="module")
+def express_repo():
+    if not EXPRESS_PATH.exists():
+        subprocess.run(
+            ["git", "clone", "--depth", "1", EXPRESS_URL, str(EXPRESS_PATH)],
+            check=True,
+        )
+    return EXPRESS_PATH
+
+
+def _collect_chunks(repo_root: Path, chunk_depth: int):
+    repo_config = RepoChunkingConfig(languages=["javascript"])
+    chunker = CodeChunker(
+        language="javascript",
+        repo_config=repo_config,
+        max_lines_per_chunk=None,
+        chunk_depth=chunk_depth,
+    )
+    chunks = chunker.chunk_repository(str(repo_root))
+    js_files = sorted(repo_root.rglob("*.js"))
+    return chunks, js_files
+
+
+def test_js_chunker_level_zero(express_repo):
+    chunks, js_files = _collect_chunks(express_repo, chunk_depth=0)
+    assert js_files, "No JS files detected in express repository"
+    assert len(chunks) >= len(js_files)
+    assert all(chunk.chunk_type == "file" for chunk in chunks)
+
+
+def test_js_chunker_level_one(express_repo):
+    chunks, _ = _collect_chunks(express_repo, chunk_depth=1)
+    chunk_types = {chunk.chunk_type for chunk in chunks}
+    assert "method" not in chunk_types
+    assert "function" in chunk_types
+
+
+def test_js_chunker_level_two(express_repo):
+    chunks, _ = _collect_chunks(express_repo, chunk_depth=2)
+    function_chunks = [chunk for chunk in chunks if chunk.chunk_type == "function"]
+    assert function_chunks, "Expected function chunks when chunk_depth=2"
+    # Ensure chunker is emitting node identifiers with file context
+    assert any("lib/router" in chunk.node_id for chunk in function_chunks)


### PR DESCRIPTION
## Summary
Add JavaScript/TypeScript chunker support and introduce a hybrid chunking + embedding pipeline (primary/secondary stores + masks), along with hierarchical/hybrid embedding builders, retrieval masks, and example/CLI tooling.

## Changes
- **Repo + chunker API**
  - Extended `RepoChunkingConfig` with `javascript_extensions` / `typescript_extensions` and wired them into `_discover_files`.
  - Exported `HybridChunkingConfig` and `HybridChunkingResult` from `codeminer.__init__`.

- **Hybrid chunking (per-repo)**
  - Added `HybridChunkingConfig` to control importance routing (metric, `high_importance_ratio`, `min_high_importance_lines`).
  - Added `HybridChunkingResult` to group `primary_chunks`, `secondary_chunks`, and `cutoff_score`.
  - Implemented `CodeChunker.hybrid_chunk_repository(...)`:
    - Uses `chunk_repository` to collect chunks, scores them via `_score_chunk_importance`, and splits them into primary/secondary tiers.
    - Currently uses simple heuristics (chunk size/content length) but is structured to accept richer signals later.

- **JavaScript/TypeScript chunker**
  - Introduced `JsTsCodeChunker` and exported it via `create_chunker` for `"javascript" | "js" | "typescript" | "ts"`.
  - Supports:
    - L1: top-level `function` and `class` declarations (with `export` unwrapping).
    - L2: methods inside classes.
    - Skeleton mode for file/class skeletons with member signatures and no bodies.

- **Embedding builders (hierarchical + hybrid)**
  - Added `codeminer/index/embedding/builders.py` with:
    - `build_hierarchical_vector_store(...)` to build a unified L0/L2 vector store using `CodeChunker` and store chunks by level.
    - `build_hybrid_vector_stores(...)` to build two stores:
      - `primary`: higher-importance chunks (e.g., L2) + shared levels (e.g., L0).
      - `secondary`: lower-importance chunks.
  - Added `VectorStoreBuilder` helper with `.hierarchical(...)` and `.hybrid(...)` methods.
  - Exported these builders from `codeminer.index.embedding.__init__`.

- **Vector store and retrieval masks**
  - Extended `CodeVectorStore.search` / `search_with_content` with:
    - `mask_node_ids: Optional[Set[str]]` to filter results by a set of node IDs.
    - Post-filtering + re-truncation by `top_k` and richer debug logging.
  - Extended `RetrieveContext` with a `masks: Dict[str, Set[str]]` field and:
    - Updated `retrieve` op to accept `mask` / `mask_name` in node params and apply masks in both score-only and content queries.

- **Hierarchical retrieval pipeline**
  - Refactored `RetrieveRerankPipeline._initialize_vector_store` to use `build_hierarchical_vector_store(...)` instead of manual L0/L2 chunking and indexing.
  - Added optional `vector_masks` argument and passed it into `RetrieveContext` so retrieval stages can apply masks (e.g., for hybrid masked mode).
  - Kept logging around successful hierarchical index builds.

- **Hybrid embedding pipeline**
  - Added `HybridEmbeddingConfig` (`codeminer/model/hybrid_retrieve_plan.py`) to capture hybrid build settings:
    - Repo/index paths, primary and secondary embedding models/providers/dims.
    - Chunking parameters, `HybridChunkingConfig`, `hybrid_levels`, `shared_levels`, `plan_name`.
  - Added `build_hybrid_embeddings(config)` to wrap `build_hybrid_vector_stores(...)` with a higher-level config object.
  - Exported `HybridEmbeddingConfig` and `build_hybrid_embeddings` from `codeminer.model.__init__`.

- **CLI / example scripts**
  - Extended `scripts/build_embeddings.py`:
    - Added `--hybrid` mode, secondary embedding flags, `--high-importance-ratio`, `--min-high-importance-lines`, and `--plan-name`.
    - In hybrid mode, calls `build_hybrid_vector_stores(...)` and logs hybrid-specific metadata; in non-hybrid mode, falls back to `build_hierarchical_vector_store(...)`.
  - Added `scripts/build_hybrid_embedding.sh` helper for a Jina-code (primary) + SweRank (secondary) hybrid setup.
  - Added `examples/hybrid_retrieve.py`:
    - Demonstrates hybrid retrieval over primary/secondary indexes or a single masked index.
    - Uses `HybridChunkingConfig` + `CodeChunker` to derive masks in `--masked` mode.
    - Builds a two-stage `RetrieveRerankPipeline` with dense retrieval stages and optional rerank.

- **Tests**
  - Added `test/chunker/test_hybrid_chunker.py`:
    - Uses `httpie_cli_repo` fixture and `HybridChunkingConfig` to assert that primary/secondary tiers are both populated, respect `cutoff_score`, and annotate `importance_tier`.
  - Added `test/chunker/test_js_chunker.py`:
    - Clones the Express.js repo as a fixture and verifies:
      - `chunk_depth=0`: per-file chunks of type `file`.
      - `chunk_depth=1`: no `method` chunks, but `function` chunks exist.
      - `chunk_depth=2`: function chunks are present and `node_id` carries file context (e.g., `lib/router`).

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
<!-- Describe the tests you ran and/or how to test these changes -->
- [ ] Tests pass locally
- [x] Added new tests for the changes

**How to test:**
- Run the new chunker tests:
  - `pytest test/chunker/test_js_chunker.py`
  - `pytest test/chunker/test_hybrid_chunker.py`
- Run the broader test suite (if available), e.g.:
  - `pytest`
- (Optional) Build embeddings:
  - Hierarchical: `python scripts/build_embeddings.py ...`
  - Hybrid: `scripts/build_hybrid_embedding.sh ...`
- (Optional) Manually sanity-check retrieval:
  - Use `examples/hybrid_retrieve.py` to query the repo against the built indices (both regular and `--masked` modes).

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
