### PR TITLE
SCIP multi-lang robustness + deterministic/consensus SWE-bench synthesis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,29 @@ jobs:
         run: |
           npm config set prefix "$HOME/.npm-global"
           export PATH="$HOME/.npm-global/bin:$PATH"
-          npm install -g @sourcegraph/scip-typescript
+          npm install -g @sourcegraph/scip-typescript yarn
           echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+
+      - name: Install bear (best effort)
+        shell: bash -l {0}
+        run: |
+          if command -v bear >/dev/null 2>&1; then
+            bear --version || true
+            exit 0
+          fi
+          if command -v apt-get >/dev/null 2>&1; then
+            if command -v sudo >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y bear
+            elif [ "$(id -u)" = "0" ]; then
+              apt-get update
+              apt-get install -y bear
+            else
+              echo "WARN: apt-get available but no sudo/root; cannot install bear"
+            fi
+          else
+            echo "WARN: apt-get not available; skipping bear install"
+          fi
 
       - name: Run test suite
         shell: bash -l {0}

--- a/codeminer/dataset/synthesize/query_synthesizer.py
+++ b/codeminer/dataset/synthesize/query_synthesizer.py
@@ -15,7 +15,10 @@ Query Types:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
+import math
+import random
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,7 +34,17 @@ from codeminer.dataset.utils import (
     QueryType,
     get_prompt_for_query_type,
 )
+from codeminer.graph.roi_subgraph import ROISubgraph
 from codeminer.log_utils import get_logger
+from codeminer.scip_interface.scip_indexer import SCIPIndexer
+from codeminer.types import (
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NodeInfo,
+    is_symbol_node,
+)
+from codeminer.utils import is_test_file
 
 logger = get_logger(__name__)
 
@@ -57,6 +70,16 @@ class TargetDiscoveryResult(BaseModel):
 
     target_files: List[str] = Field(default_factory=list)
     target_symbols: List[str] = Field(default_factory=list)
+    target_symbol_nodes: List[NodeInfo] = Field(default_factory=list)
+    rationale: Optional[str] = Field(default=None)
+
+
+class BehavioralSelectionResult(BaseModel):
+    """Structured output for behavior-first synthesis from sampled code blocks."""
+
+    question: str = Field(description="Natural-language behavioral question.")
+    focus: Optional[str] = Field(default=None)
+    required_block_ids: List[str] = Field(default_factory=list)
     rationale: Optional[str] = Field(default=None)
 
 
@@ -76,6 +99,50 @@ class RepoSnapshot:
             )
             parts.append(f"File extensions (top): {lang_summary}")
         return "\n\n".join(parts)
+
+
+@dataclass
+class SampledCodeBlock:
+    block_id: str
+    node_id: int
+    node_name: str
+    file_path: str
+    node_type: str
+    start_line: int
+    end_line: int
+    content: str
+    char_count: int
+    line_count: int
+
+    def to_node_info(self, *, include_content: bool = True) -> NodeInfo:
+        return NodeInfo(
+            node_name=self.node_name,
+            type=self.node_type,
+            file=self.file_path,
+            start_line=self.start_line,
+            end_line=self.end_line,
+            content=self.content if include_content else None,
+        )
+
+    def to_code_location(self) -> CodeLocation:
+        symbol_type = None
+        if self.node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+            symbol_type = "function"
+        elif self.node_type == NODE_TYPE_CLASS:
+            symbol_type = "class"
+        return CodeLocation(
+            file_path=self.file_path,
+            symbol_type=symbol_type,
+            start_line=self.start_line,
+            end_line=self.end_line,
+        )
+
+
+@dataclass
+class BehavioralContext:
+    core_block: SampledCodeBlock
+    candidate_blocks: List[SampledCodeBlock]
+    neighborhood_blocks: List[SampledCodeBlock]
 
 
 class ClaudeQuerySynthesizer:
@@ -100,6 +167,13 @@ class ClaudeQuerySynthesizer:
         max_metadata_chars: int = 800,
         max_top_level: int = 40,
         max_extensions: int = 8,
+        min_block_chars: int = 100,
+        max_candidate_blocks: int = 24,
+        max_neighbor_blocks: int = 8,
+        neighbor_k_hop: int = 1,
+        max_block_chars_in_prompt: int = 1800,
+        sampling_seed: Optional[int] = None,
+        behavioral_consensus_runs: int = 3,
     ) -> None:
         self.model = model
         self.max_turns = max_turns
@@ -109,6 +183,13 @@ class ClaudeQuerySynthesizer:
         self.max_metadata_chars = max_metadata_chars
         self.max_top_level = max_top_level
         self.max_extensions = max_extensions
+        self.min_block_chars = min_block_chars
+        self.max_candidate_blocks = max_candidate_blocks
+        self.max_neighbor_blocks = max_neighbor_blocks
+        self.neighbor_k_hop = neighbor_k_hop
+        self.max_block_chars_in_prompt = max_block_chars_in_prompt
+        self.sampling_seed = sampling_seed
+        self.behavioral_consensus_runs = max(1, behavioral_consensus_runs)
 
         # Parse query type (difficulty_level is a deprecated alias).
         if difficulty_level is not None:
@@ -150,23 +231,41 @@ class ClaudeQuerySynthesizer:
             instance, repo_root=repo_root, cache_dir=cache_dir
         )
         snapshot = self._snapshot_repo(repo_path)
-        discovered = self._discover_targets(instance, snapshot)
-        result = self._generate_question(
-            instance,
-            snapshot,
-            ground_truth=ground_truth,
-            discovered_targets=discovered,
+        behavioral_context = self._prepare_behavioral_context(
+            instance, repo_path, cache_dir=cache_dir
         )
+        if self.query_type == QueryType.BEHAVIORAL and behavioral_context is not None:
+            result = self._generate_behavioral_question_with_consensus(
+                instance=instance,
+                snapshot=snapshot,
+                behavioral_context=behavioral_context,
+            )
+            gt = self._build_ground_truth_from_blocks(
+                result.get("selected_blocks") or [behavioral_context.core_block]
+            )
+            discovered = self._build_discovery_from_blocks(
+                result.get("selected_blocks") or [behavioral_context.core_block]
+            )
+            target_symbol_nodes = self._build_symbol_nodes_from_blocks(
+                result.get("selected_blocks") or [behavioral_context.core_block]
+            )
+        else:
+            discovered = self._discover_targets(instance, snapshot)
+            result = self._generate_question(
+                instance,
+                snapshot,
+                ground_truth=ground_truth,
+                discovered_targets=discovered,
+            )
+            gt = self._build_ground_truth(
+                instance,
+                ground_truth,
+                discovered_targets=discovered,
+            )
+            target_symbol_nodes = self._build_symbol_nodes_from_ground_truth(gt)
 
         instance_id = instance.get("instance_id", "unknown")
         query_id = f"{instance_id}_{self.query_type.value}"
-
-        # Build ground truth structure
-        gt = self._build_ground_truth(
-            instance,
-            ground_truth,
-            discovered_targets=discovered,
-        )
 
         return {
             "query_id": query_id,
@@ -179,12 +278,20 @@ class ClaudeQuerySynthesizer:
             "ground_truth": gt.to_dict() if gt else None,
             "target_files": gt.to_dict()["target_files"] if gt else [],
             "target_symbols": gt.to_dict()["target_symbols"] if gt else [],
+            "target_symbol_nodes": [
+                self._dump_node_info(node) for node in target_symbol_nodes
+            ],
             "focus": result.get("focus"),
             "hints": result.get("hints"),
             "repo_snapshot": snapshot.format_summary(),
             "discovered_target_files": discovered.target_files,
             "discovered_target_symbols": discovered.target_symbols,
+            "discovered_target_symbol_nodes": [
+                self._dump_node_info(node) for node in discovered.target_symbol_nodes
+            ],
             "discovery_rationale": discovered.rationale,
+            "core_block_id": result.get("core_block_id"),
+            "selected_block_ids": result.get("selected_block_ids"),
         }
 
     async def synthesize_query_async(
@@ -211,23 +318,41 @@ class ClaudeQuerySynthesizer:
             instance, repo_root=repo_root, cache_dir=cache_dir
         )
         snapshot = self._snapshot_repo(repo_path)
-        discovered = await self._discover_targets_async(instance, snapshot)
-        result = await self._generate_question_async(
-            instance,
-            snapshot,
-            ground_truth=ground_truth,
-            discovered_targets=discovered,
+        behavioral_context = self._prepare_behavioral_context(
+            instance, repo_path, cache_dir=cache_dir
         )
+        if self.query_type == QueryType.BEHAVIORAL and behavioral_context is not None:
+            result = await self._generate_behavioral_question_with_consensus_async(
+                instance=instance,
+                snapshot=snapshot,
+                behavioral_context=behavioral_context,
+            )
+            gt = self._build_ground_truth_from_blocks(
+                result.get("selected_blocks") or [behavioral_context.core_block]
+            )
+            discovered = self._build_discovery_from_blocks(
+                result.get("selected_blocks") or [behavioral_context.core_block]
+            )
+            target_symbol_nodes = self._build_symbol_nodes_from_blocks(
+                result.get("selected_blocks") or [behavioral_context.core_block]
+            )
+        else:
+            discovered = await self._discover_targets_async(instance, snapshot)
+            result = await self._generate_question_async(
+                instance,
+                snapshot,
+                ground_truth=ground_truth,
+                discovered_targets=discovered,
+            )
+            gt = self._build_ground_truth(
+                instance,
+                ground_truth,
+                discovered_targets=discovered,
+            )
+            target_symbol_nodes = self._build_symbol_nodes_from_ground_truth(gt)
 
         instance_id = instance.get("instance_id", "unknown")
         query_id = f"{instance_id}_{self.query_type.value}"
-
-        # Build ground truth structure
-        gt = self._build_ground_truth(
-            instance,
-            ground_truth,
-            discovered_targets=discovered,
-        )
 
         return {
             "query_id": query_id,
@@ -240,12 +365,20 @@ class ClaudeQuerySynthesizer:
             "ground_truth": gt.to_dict() if gt else None,
             "target_files": gt.to_dict()["target_files"] if gt else [],
             "target_symbols": gt.to_dict()["target_symbols"] if gt else [],
+            "target_symbol_nodes": [
+                self._dump_node_info(node) for node in target_symbol_nodes
+            ],
             "focus": result.get("focus"),
             "hints": result.get("hints"),
             "repo_snapshot": snapshot.format_summary(),
             "discovered_target_files": discovered.target_files,
             "discovered_target_symbols": discovered.target_symbols,
+            "discovered_target_symbol_nodes": [
+                self._dump_node_info(node) for node in discovered.target_symbol_nodes
+            ],
             "discovery_rationale": discovered.rationale,
+            "core_block_id": result.get("core_block_id"),
+            "selected_block_ids": result.get("selected_block_ids"),
         }
 
     def synthesize_queries(
@@ -353,6 +486,498 @@ class ClaudeQuerySynthesizer:
     def _is_hidden(self, path: Path) -> bool:
         return any(part.startswith(".") for part in path.parts)
 
+    def _prepare_behavioral_context(
+        self,
+        instance: Dict[str, Any],
+        repo_path: str,
+        *,
+        cache_dir: Optional[str] = None,
+    ) -> Optional[BehavioralContext]:
+        graph = self._load_or_build_code_graph(
+            instance=instance,
+            repo_path=repo_path,
+            cache_dir=cache_dir,
+        )
+        if graph is None:
+            return None
+
+        candidates = self._sample_candidate_blocks(graph, instance)
+        if not candidates:
+            return None
+
+        core_block = self._pick_core_block(candidates, graph)
+        neighborhood = self._collect_neighborhood_blocks(
+            graph=graph,
+            core_block=core_block,
+            candidate_blocks=candidates,
+        )
+        return BehavioralContext(
+            core_block=core_block,
+            candidate_blocks=candidates,
+            neighborhood_blocks=neighborhood,
+        )
+
+    def _load_or_build_code_graph(
+        self,
+        instance: Dict[str, Any],
+        repo_path: str,
+        *,
+        cache_dir: Optional[str] = None,
+    ):
+        language = self._infer_instance_language(instance)
+        repo_name = (instance.get("repo") or "repo").replace("/", "__")
+        graph_cache_root = (
+            Path(cache_dir).expanduser() / "scip_graph_cache"
+            if cache_dir
+            else Path("/tmp") / "scip_graph_cache"
+        )
+        output_dir = graph_cache_root / repo_name
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            indexer = SCIPIndexer(
+                project_root=repo_path,
+                output_dir=output_dir,
+                language=language,
+            )
+            return indexer.run_pipeline(skip_level="graph", report_profile=False)
+        except Exception as exc:
+            logger.warning(
+                "Failed to build code graph for %s (%s): %s",
+                instance.get("instance_id", "unknown"),
+                language,
+                exc,
+            )
+            return None
+
+    def _infer_instance_language(self, instance: Dict[str, Any]) -> str:
+        language_group = (instance.get("language_group") or "").lower()
+        if "rust" in language_group:
+            return "rust"
+        if "javascript" in language_group or "typescript" in language_group:
+            return "ts"
+        if "c++" in language_group or language_group == "c":
+            return "cpp"
+        return "python"
+
+    def _sample_candidate_blocks(
+        self,
+        code_graph,
+        instance: Dict[str, Any],
+    ) -> List[SampledCodeBlock]:
+        graph = code_graph.get_graph()
+        blocks: List[SampledCodeBlock] = []
+
+        for node in graph.vs:
+            attrs = node.attributes()
+            node_type = attrs.get("type", "")
+            if not is_symbol_node(node_type):
+                continue
+
+            file_path = attrs.get("file")
+            if not file_path or is_test_file(file_path):
+                continue
+
+            start_line = attrs.get("start_line")
+            end_line = attrs.get("end_line")
+            if (
+                not isinstance(start_line, int)
+                or not isinstance(end_line, int)
+                or end_line <= start_line
+            ):
+                continue
+
+            content = code_graph.get_node_content(node.index)
+            if not content:
+                continue
+            content = content.strip()
+            if len(content) < self.min_block_chars:
+                continue
+
+            line_count = content.count("\n") + 1
+            block = SampledCodeBlock(
+                block_id=f"blk_{len(blocks) + 1:03d}",
+                node_id=node.index,
+                node_name=node["name"],
+                file_path=file_path,
+                node_type=node_type,
+                start_line=start_line,
+                end_line=end_line,
+                content=content,
+                char_count=len(content),
+                line_count=line_count,
+            )
+            blocks.append(block)
+
+        if not blocks:
+            return []
+
+        run_id = instance.get("synthesis_run_id")
+        if self.sampling_seed is None:
+            rng = random.Random()
+        else:
+            seed_input = (
+                f"{self.sampling_seed}:"
+                f"{instance.get('instance_id') or instance.get('repo') or 'seed'}:"
+                f"{run_id or 0}"
+            )
+            seed = int(hashlib.md5(seed_input.encode("utf-8")).hexdigest()[:8], 16)
+            rng = random.Random(seed)
+        if len(blocks) > self.max_candidate_blocks:
+            blocks = rng.sample(blocks, self.max_candidate_blocks)
+
+        return sorted(blocks, key=lambda blk: blk.char_count, reverse=True)
+
+    def _pick_core_block(
+        self, blocks: List[SampledCodeBlock], code_graph
+    ) -> SampledCodeBlock:
+        graph = code_graph.get_graph()
+        scored = sorted(
+            blocks,
+            key=lambda blk: blk.char_count + 20 * graph.degree(blk.node_id),
+            reverse=True,
+        )
+        return scored[0]
+
+    def _collect_neighborhood_blocks(
+        self,
+        *,
+        graph,
+        core_block: SampledCodeBlock,
+        candidate_blocks: List[SampledCodeBlock],
+    ) -> List[SampledCodeBlock]:
+        try:
+            roi = ROISubgraph(graph)
+            subgraph = roi.extract_subgraph(
+                [core_block.node_name],
+                k_hop=self.neighbor_k_hop,
+                direction="both",
+            )
+            nodes = roi.get_filtered_subgraph_nodes(
+                subgraph,
+                exclude_nodes=[core_block.node_name],
+                filter_tests=True,
+                node_types=[NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_CLASS],
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to collect neighborhood for core block %s: %s",
+                core_block.node_name,
+                exc,
+            )
+            nodes = []
+
+        by_name = {blk.node_name: blk for blk in candidate_blocks}
+        neighborhood: List[SampledCodeBlock] = []
+        for node in nodes:
+            matched = by_name.get(node.node_name)
+            if matched is None:
+                continue
+            if matched.block_id == core_block.block_id:
+                continue
+            neighborhood.append(matched)
+            if len(neighborhood) >= self.max_neighbor_blocks:
+                break
+
+        if not neighborhood:
+            for blk in candidate_blocks:
+                if blk.block_id == core_block.block_id:
+                    continue
+                neighborhood.append(blk)
+                if len(neighborhood) >= self.max_neighbor_blocks:
+                    break
+
+        return neighborhood
+
+    def _generate_behavioral_question(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+        run_index: int = 0,
+    ) -> Dict[str, Any]:
+        prompt = self._build_behavioral_prompt(
+            instance=instance,
+            snapshot=snapshot,
+            behavioral_context=behavioral_context,
+            run_index=run_index,
+        )
+        payload = self._run_agent(prompt, cwd=str(snapshot.root))
+        return self._parse_behavioral_payload(payload, behavioral_context)
+
+    async def _generate_behavioral_question_async(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+        run_index: int = 0,
+    ) -> Dict[str, Any]:
+        prompt = self._build_behavioral_prompt(
+            instance=instance,
+            snapshot=snapshot,
+            behavioral_context=behavioral_context,
+            run_index=run_index,
+        )
+        payload = await self._run_agent_async(prompt, cwd=str(snapshot.root))
+        return self._parse_behavioral_payload(payload, behavioral_context)
+
+    def _generate_behavioral_question_with_consensus(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        runs = []
+        for idx in range(self.behavioral_consensus_runs):
+            runs.append(
+                self._generate_behavioral_question(
+                    instance=instance,
+                    snapshot=snapshot,
+                    behavioral_context=behavioral_context,
+                    run_index=idx,
+                )
+            )
+        return self._aggregate_behavioral_consensus(runs, behavioral_context)
+
+    async def _generate_behavioral_question_with_consensus_async(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        runs = []
+        for idx in range(self.behavioral_consensus_runs):
+            runs.append(
+                await self._generate_behavioral_question_async(
+                    instance=instance,
+                    snapshot=snapshot,
+                    behavioral_context=behavioral_context,
+                    run_index=idx,
+                )
+            )
+        return self._aggregate_behavioral_consensus(runs, behavioral_context)
+
+    def _aggregate_behavioral_consensus(
+        self,
+        runs: List[Dict[str, Any]],
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        if not runs:
+            return {
+                "question": self._fallback_question(None),
+                "focus": None,
+                "hints": None,
+                "selected_blocks": [behavioral_context.core_block],
+                "core_block_id": behavioral_context.core_block.block_id,
+                "selected_block_ids": [behavioral_context.core_block.block_id],
+            }
+
+        vote_counts: Dict[str, int] = {}
+        for run in runs:
+            for block in run.get("selected_blocks", []):
+                vote_counts[block.block_id] = vote_counts.get(block.block_id, 0) + 1
+
+        core_id = behavioral_context.core_block.block_id
+        majority = math.ceil(len(runs) / 2)
+
+        pool = {
+            blk.block_id: blk
+            for blk in [behavioral_context.core_block]
+            + behavioral_context.neighborhood_blocks
+        }
+        selected_blocks = [
+            pool[block_id]
+            for block_id, votes in sorted(
+                vote_counts.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+            if votes >= majority and block_id in pool
+        ]
+        if not selected_blocks:
+            selected_blocks = [behavioral_context.core_block]
+        if core_id not in {blk.block_id for blk in selected_blocks}:
+            selected_blocks.insert(0, behavioral_context.core_block)
+
+        best_run = max(
+            runs,
+            key=lambda run: sum(
+                vote_counts.get(blk.block_id, 0)
+                for blk in run.get("selected_blocks", [])
+            ),
+        )
+        return {
+            "question": best_run.get("question") or self._fallback_question(None),
+            "focus": best_run.get("focus"),
+            "hints": None,
+            "selected_blocks": selected_blocks,
+            "core_block_id": behavioral_context.core_block.block_id,
+            "selected_block_ids": [blk.block_id for blk in selected_blocks],
+        }
+
+    def _build_behavioral_prompt(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+        run_index: int = 0,
+    ) -> str:
+        core = behavioral_context.core_block
+        neighborhood = list(behavioral_context.neighborhood_blocks)
+        if neighborhood:
+            seed_src = (
+                f"{instance.get('instance_id', 'unknown')}:"
+                f"{instance.get('synthesis_run_id', 0)}:{run_index}"
+            )
+            seed = int(hashlib.md5(seed_src.encode("utf-8")).hexdigest()[:8], 16)
+            random.Random(seed).shuffle(neighborhood)
+        all_blocks = [core] + neighborhood
+
+        block_text = "\n\n".join(
+            self._format_prompt_block(block) for block in all_blocks
+        )
+        return (
+            "You are generating a behavioral code-search query from sampled code blocks.\n"
+            "Goal: describe what the behavior does, "
+            "without exposing implementation identifiers.\n"
+            "Rules:\n"
+            "1) The question MUST NOT mention function names, "
+            "class names, signatures, or file paths.\n"
+            "2) Pick required blocks (IDs) that are necessary to satisfy the behavior.\n"
+            "3) Always include the core block ID in required_block_ids.\n"
+            "4) Return strict JSON only with keys: question, "
+            "focus, required_block_ids, rationale.\n\n"
+            f"Repository summary:\n{snapshot.format_summary()}\n\n"
+            f"Source instance id: {instance.get('instance_id', 'unknown')}\n\n"
+            f"Verification pass: {run_index + 1}\n\n"
+            f"Sampled blocks:\n{block_text}"
+        )
+
+    def _format_prompt_block(self, block: SampledCodeBlock) -> str:
+        content = block.content
+        if len(content) > self.max_block_chars_in_prompt:
+            content = (
+                content[: self.max_block_chars_in_prompt]
+                + "\n# ... truncated for synthesis context ..."
+            )
+        return (
+            f"[{block.block_id}] type={block.node_type} "
+            f"lines={block.start_line}-{block.end_line} "
+            f"chars={block.char_count}\n"
+            f"{content}"
+        )
+
+    def _parse_behavioral_payload(
+        self,
+        payload: str,
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        blob = self._extract_json_blob(payload)
+        try:
+            parsed = BehavioralSelectionResult.model_validate_json(blob)
+            question = parsed.question.strip()
+            focus = parsed.focus
+            selected_ids = parsed.required_block_ids
+        except ValidationError:
+            question = self._coerce_question_text(blob)
+            focus = None
+            selected_ids = []
+
+        question = self._sanitize_question(question)
+        if not question:
+            question = self._fallback_question(None)
+        if not question.endswith("?"):
+            question = question.rstrip(".") + "?"
+
+        pool = {
+            blk.block_id: blk
+            for blk in [behavioral_context.core_block]
+            + behavioral_context.neighborhood_blocks
+        }
+        selected_blocks = [
+            pool[block_id] for block_id in selected_ids if block_id in pool
+        ]
+        if behavioral_context.core_block.block_id not in {
+            blk.block_id for blk in selected_blocks
+        }:
+            selected_blocks.insert(0, behavioral_context.core_block)
+
+        return {
+            "question": question,
+            "focus": focus,
+            "hints": None,
+            "selected_blocks": selected_blocks,
+            "core_block_id": behavioral_context.core_block.block_id,
+            "selected_block_ids": [blk.block_id for blk in selected_blocks],
+        }
+
+    def _build_discovery_from_blocks(
+        self,
+        blocks: List[SampledCodeBlock],
+    ) -> TargetDiscoveryResult:
+        files = list(dict.fromkeys(block.file_path for block in blocks))
+        symbols = list(dict.fromkeys(block.node_name for block in blocks))
+        return TargetDiscoveryResult(
+            target_files=files,
+            target_symbols=symbols,
+            target_symbol_nodes=self._build_symbol_nodes_from_blocks(blocks),
+            rationale="graph-sampled behavioral blocks",
+        )
+
+    def _build_ground_truth_from_blocks(
+        self,
+        blocks: List[SampledCodeBlock],
+    ) -> Optional[GroundTruth]:
+        if not blocks:
+            return None
+
+        primary_locations: List[CodeLocation] = []
+        for block in blocks:
+            loc = block.to_code_location()
+            loc.symbol = self._extract_symbol_name(block.node_name, block.file_path)
+            primary_locations.append(loc)
+        return GroundTruth(primary_locations=primary_locations)
+
+    def _extract_symbol_name(self, node_name: str, file_path: str) -> Optional[str]:
+        if ":" in node_name:
+            prefix, symbol = node_name.split(":", 1)
+            if prefix.endswith(file_path) or prefix == file_path:
+                return symbol.rstrip("()") or None
+            return symbol.rstrip("()") or None
+        return node_name.rstrip("()") or None
+
+    def _build_symbol_nodes_from_blocks(
+        self,
+        blocks: List[SampledCodeBlock],
+    ) -> List[NodeInfo]:
+        return [block.to_node_info(include_content=True) for block in blocks]
+
+    def _build_symbol_nodes_from_ground_truth(
+        self,
+        gt: Optional[GroundTruth],
+    ) -> List[NodeInfo]:
+        if gt is None:
+            return []
+        nodes: List[NodeInfo] = []
+        for loc in gt.primary_locations:
+            nodes.append(
+                NodeInfo(
+                    node_name=loc.node_id,
+                    type=loc.symbol_type or "",
+                    file=loc.file_path,
+                    start_line=loc.start_line,
+                    end_line=loc.end_line,
+                )
+            )
+        return nodes
+
+    def _dump_node_info(self, node: NodeInfo) -> Dict[str, Any]:
+        return node.model_dump(exclude_none=True)
+
     def _build_ground_truth(
         self,
         instance: Dict[str, Any],
@@ -410,6 +1035,13 @@ class ClaudeQuerySynthesizer:
                             file_path=file_path,
                             symbol=symbol_name or None,
                             symbol_type=symbol_type,
+                        )
+                    )
+                elif discovered_targets.target_files:
+                    primary_locations.append(
+                        CodeLocation(
+                            file_path=discovered_targets.target_files[0],
+                            symbol=symbol_id.rstrip("()") or None,
                         )
                     )
 
@@ -722,7 +1354,7 @@ class ClaudeQuerySynthesizer:
         context_parts.append(
             "Explore the repository and identify likely implementation targets.\n"
             "Return strict JSON with keys: target_files (array of relative file paths), "
-            "target_symbols (array of `file_path:SymbolName` or `file_path:function_name()`), "
+            "target_symbols (array of symbol identifiers in repository-native format), "
             "rationale (string or null). Keep arrays concise (<= 8)."
         )
 
@@ -876,11 +1508,15 @@ class ClaudeQuerySynthesizer:
             return TargetDiscoveryResult()
         file_pattern = r"\b[\w./-]+\.(?:py|rs|js|ts|go|java|cpp|c|h|hpp)\b"
         files = list(dict.fromkeys(re.findall(file_pattern, text)))
-        symbol_pattern = (
-            r"\b[\w./-]+\.(?:py|rs|js|ts|go|java|cpp|c|h|hpp):"
-            r"[A-Za-z_][\w.:]*(?:\(\))?\b"
-        )
-        symbols = list(dict.fromkeys(re.findall(symbol_pattern, text)))
+        symbol_patterns = [
+            r"\b[\w./-]+\.(?:py|rs|js|ts|go|java|cpp|c|h|hpp):[A-Za-z_][\w.:]*(?:\(\))?\b",
+            r"\b[\w/]+#[A-Za-z_]\w*(?:\(\))?\b",
+            r"\b[\w/]+/[A-Za-z_]\w*(?:\(\))?\b",
+        ]
+        symbols: List[str] = []
+        for pattern in symbol_patterns:
+            symbols.extend(re.findall(pattern, text))
+        symbols = list(dict.fromkeys(symbols))
         return TargetDiscoveryResult(
             target_files=files[:8],
             target_symbols=symbols[:8],

--- a/codeminer/dataset/utils.py
+++ b/codeminer/dataset/utils.py
@@ -24,6 +24,7 @@ class QueryType(str, Enum):
     """
 
     BEHAVIORAL = "behavioral"
+    MODULE_HINT = "module_hint"
     FILE_HINT = "file_hint"
     SYMBOL_HINT = "symbol_hint"
     REASONING = "reasoning"
@@ -105,7 +106,7 @@ class GroundTruth:
             "secondary_locations": [loc.to_dict() for loc in self.secondary_locations],
             "context_locations": [loc.to_dict() for loc in self.context_locations],
             # Flat lists for compatibility with existing evaluation scripts
-            "target_files": list({loc.file_path for loc in self.primary_locations}),
+            "target_files": sorted({loc.file_path for loc in self.primary_locations}),
             "target_symbols": [
                 loc.node_id for loc in self.primary_locations if loc.symbol
             ],

--- a/codeminer/scip_interface/scip_decode_ts.py
+++ b/codeminer/scip_interface/scip_decode_ts.py
@@ -214,7 +214,6 @@ class SCIPTypeScriptGraphDecoder:
         package_prefix = None
         parts = original_symbol.split(" ")
         if len(parts) >= 5 and parts[0] == "scip-typescript":
-            manager = parts[1]  # npm, yarn, pnpm
             package_name = parts[2]
             version = parts[3]
 
@@ -290,7 +289,9 @@ class SCIPTypeScriptGraphDecoder:
             original_symbol: Original symbol name (for additional context)
 
         Returns:
-            Symbol type: NODE_TYPE_CLASS, NODE_TYPE_METHOD, NODE_TYPE_FIELD, or NODE_TYPE_FUNCTION
+            Symbol type:
+            NODE_TYPE_CLASS, NODE_TYPE_METHOD, NODE_TYPE_FIELD,
+            or NODE_TYPE_FUNCTION
         """
 
         if ":" in unified_symbol:
@@ -319,7 +320,8 @@ class SCIPTypeScriptGraphDecoder:
 
     def _process_symbol(self, symbol, line, symbol_roles, enclosing_ranges, file_path):
         self.logger.scip_debug(
-            f"Processing TS symbol: {symbol} at line {line}, roles: {symbol_roles}, file: {file_path}"
+            f"Processing TS symbol: {symbol} at line {line}, "
+            f"roles: {symbol_roles}, file: {file_path}"
         )
 
         # Skip function arguments (symbols ending with .(xxx))
@@ -328,19 +330,18 @@ class SCIPTypeScriptGraphDecoder:
 
         # Exit scopes that have ended based on current line
         try:
-            self.logger.scip_debug(
-                f"Scope stack before exit: {[list(s.keys())[0] for s in self.code_graph.scope_stack]}"
-            )
+            scope_stack_names = [list(s.keys())[0] for s in self.code_graph.scope_stack]
+            self.logger.scip_debug(f"Scope stack before exit: {scope_stack_names}")
             self.code_graph.exit_scopes_by_line(line)
-            self.logger.scip_debug(
-                f"Scope stack after exit: {[list(s.keys())[0] for s in self.code_graph.scope_stack]}"
-            )
+            scope_stack_names = [list(s.keys())[0] for s in self.code_graph.scope_stack]
+            self.logger.scip_debug(f"Scope stack after exit: {scope_stack_names}")
         except Exception as e:
             self.logger.error(f"Error exiting scopes at line {line}: {e}")
             raise
 
         # Clean up the symbol by simply splitting on spaces and taking the last part
-        # For example: "scip-typescript npm test-project 1.0.0 src/`calculator.ts`/Calculator#add()."
+        # For example:
+        # "scip-typescript npm test-project 1.0.0 src/`calculator.ts`/Calculator#add()."
         # Will become: "src/`calculator.ts`/Calculator#add()."
         # IMPORTANT: Keep original symbol for hash and package extraction
         cleaned_symbol = symbol.split(" ")[-1]
@@ -351,9 +352,8 @@ class SCIPTypeScriptGraphDecoder:
         if not match:
             return
 
-        module_path = match.group(1)
-
-        # Unify symbol name format (pass original symbol for hash/package extraction, file_path for extension)
+        # Unify symbol name format (pass original symbol for hash/package
+        # extraction, file_path for extension)
         unified_symbol = self._unify_symbol_name(cleaned_symbol, symbol, file_path)
 
         # Classify symbol type (pass both original and unified for context)
@@ -395,11 +395,14 @@ class SCIPTypeScriptGraphDecoder:
             if unified_symbol in self.code_graph.name_to_vertex:
                 vertex_id = self.code_graph.name_to_vertex[unified_symbol]
                 self.code_graph.graph.vs[vertex_id]["scip_symbol"] = symbol
-                self.code_graph.graph.vs[vertex_id]["display_name"] = self._get_display_name(unified_symbol)
+                self.code_graph.graph.vs[vertex_id]["display_name"] = (
+                    self._get_display_name(unified_symbol)
+                )
 
             # Add containment edge
             self.logger.scip_debug(
-                f"Adding containment edge for {unified_symbol}, current scope: {self.code_graph.current_scope}"
+                f"Adding containment edge for {unified_symbol}, "
+                f"current scope: {self.code_graph.current_scope}"
             )
             self.code_graph.add_containment_edge(unified_symbol)
 
@@ -408,7 +411,8 @@ class SCIPTypeScriptGraphDecoder:
             if symbol_type in [NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD]:
                 try:
                     self.logger.scip_debug(
-                        f"Updating scope to {unified_symbol} [{scope_start_line}-{scope_end_line}]"
+                        f"Updating scope to {unified_symbol} "
+                        f"[{scope_start_line}-{scope_end_line}]"
                     )
                     self.code_graph.update_current_scope(
                         unified_symbol, scope_start_line, scope_end_line
@@ -420,7 +424,8 @@ class SCIPTypeScriptGraphDecoder:
         # Handle definition with no enclosing range
         elif is_definition:
             self.logger.scip_debug(
-                f"Adding symbol without enclosing range: {unified_symbol}, current scope: {self.code_graph.current_scope}"
+                f"Adding symbol without enclosing range: {unified_symbol}, "
+                f"current scope: {self.code_graph.current_scope}"
             )
             self.code_graph.add_symbol_node(
                 unified_symbol, line, symbol_type=symbol_type
@@ -430,7 +435,9 @@ class SCIPTypeScriptGraphDecoder:
             if unified_symbol in self.code_graph.name_to_vertex:
                 vertex_id = self.code_graph.name_to_vertex[unified_symbol]
                 self.code_graph.graph.vs[vertex_id]["scip_symbol"] = symbol
-                self.code_graph.graph.vs[vertex_id]["display_name"] = self._get_display_name(unified_symbol)
+                self.code_graph.graph.vs[vertex_id]["display_name"] = (
+                    self._get_display_name(unified_symbol)
+                )
 
             # Add 'contain' edge from current scope to symbol
             self.code_graph._add_edge(
@@ -440,9 +447,7 @@ class SCIPTypeScriptGraphDecoder:
         # Handle reference (not a definition)
         # Use bitwise check instead of exact match to handle all reference types
         else:
-            self.code_graph.add_symbol_reference(
-                unified_symbol, module_path, symbol_type
-            )
+            self.code_graph.add_symbol_reference(unified_symbol, file_path, symbol_type)
 
     def save_graph(self, output_path):
         self.code_graph.save_graph(output_path)

--- a/codeminer/scip_interface/scip_indexer_clang.py
+++ b/codeminer/scip_interface/scip_indexer_clang.py
@@ -2,6 +2,7 @@
 """
 SCIP indexer for C/C++ projects using scip-clang.
 """
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -33,7 +34,8 @@ class SCIPClangIndexer(SCIPIndexerBase):
         Initialize the Clang SCIP indexer.
 
         Args:
-            project_root: Root directory of the C/C++ project (must contain compile_commands.json)
+            project_root: Root directory of the C/C++ project
+                (must contain compile_commands.json)
             output_dir: Directory to store output files (defaults to /tmp/project_name)
             exclude_patterns: List of patterns to exclude from indexing
             profiler: Profiler instance for performance tracking
@@ -189,10 +191,10 @@ class SCIPClangIndexer(SCIPIndexerBase):
             if not comp_db.exists():
                 comp_db = self.project_root / "build" / "compile_commands.json"
 
-        # Check if compilation database exists
-        if not comp_db.exists():
+        # Check if compilation database exists and is valid
+        if not self._is_valid_compdb(comp_db):
             logger.error(
-                f"Compilation database not found. Tried:\n"
+                f"Compilation database missing or invalid. Tried:\n"
                 f"  - {self.project_root / 'compile_commands.json'}\n"
                 f"  - {self.project_root / 'build' / 'compile_commands.json'}\n\n"
                 f"Please generate a compilation database first:\n"
@@ -216,9 +218,191 @@ class SCIPClangIndexer(SCIPIndexerBase):
         if success:
             default_index = self.project_root / "index.scip"
             if default_index.exists() and default_index != self.index_file:
-                logger.info(
-                    f"Moving index from {default_index} to {self.index_file}"
-                )
+                logger.info(f"Moving index from {default_index} to {self.index_file}")
                 default_index.rename(self.index_file)
 
         return success
+
+    def _auto_generate_compdb(self) -> Optional[Path]:
+        """
+        Try generating compile_commands.json with common build flows.
+        Returns the path if successful, otherwise None.
+        """
+        # 1) CMake projects
+        compdb = self._auto_generate_compdb_cmake()
+        if compdb is not None:
+            return compdb
+
+        # 2) Make/Autotools projects via Bear
+        return self._auto_generate_compdb_bear()
+
+    def _is_valid_compdb(self, compdb: Path) -> bool:
+        """Check compile_commands.json is parseable and non-empty."""
+        if not compdb.exists() or not compdb.is_file():
+            return False
+        try:
+            if compdb.stat().st_size < 4:
+                return False
+            with compdb.open("r", encoding="utf-8") as fp:
+                payload = json.load(fp)
+            return isinstance(payload, list) and len(payload) > 0
+        except Exception:
+            return False
+
+    def _auto_generate_compdb_cmake(self) -> Optional[Path]:
+        cmake_lists = self.project_root / "CMakeLists.txt"
+        if not cmake_lists.exists() or not shutil.which("cmake"):
+            return None
+
+        build_dir = self.project_root / "build"
+        build_dir.mkdir(exist_ok=True)
+
+        cmd = [
+            "cmake",
+            "-S",
+            str(self.project_root),
+            "-B",
+            str(build_dir),
+            "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+        ]
+        logger.info("Attempting CMake compilation DB generation: %s", " ".join(cmd))
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.warning("Failed to generate compile_commands.json with CMake: %s", e)
+            if e.stderr:
+                logger.warning("cmake stderr: %s", e.stderr.strip())
+            return None
+
+        compdb = build_dir / "compile_commands.json"
+        return compdb if compdb.exists() else None
+
+    def _auto_generate_compdb_bear(self) -> Optional[Path]:
+        if not shutil.which("bear"):
+            logger.info("bear not found; skipping Make-based compilation DB generation")
+            return None
+        if not shutil.which("make"):
+            logger.info("make not found; cannot run bear -- make")
+            return None
+
+        logger.info("Attempting Make compilation DB generation with bear")
+        success = self._run_build_command(["bear", "--", "make", "-j"])
+        if not success:
+            # Fall back to non-parallel in case jobs trigger flaky build scripts.
+            success = self._run_build_command(["bear", "--", "make"])
+        if not success:
+            # Some autotools repos have stale/incomplete Makefiles after checkout.
+            # Try bootstrapping and configuring, then retry.
+            logger.info("Initial bear+make failed; attempting autotools bootstrap")
+            self._bootstrap_autotools()
+            # Clear stale artifacts before rebuilding (best effort).
+            self._run_build_command(["make", "clean"])
+            success = self._run_build_command(["bear", "--", "make", "-j"])
+            if not success:
+                success = self._run_build_command(["bear", "--", "make"])
+        if not success:
+            return None
+
+        for candidate in (
+            self.project_root / "compile_commands.json",
+            self.project_root / "build" / "compile_commands.json",
+        ):
+            if candidate.exists():
+                return candidate
+        return None
+
+    def _bootstrap_autotools(self) -> None:
+        autogen = self.project_root / "autogen.sh"
+        configure = self.project_root / "configure"
+        configure_ac = self.project_root / "configure.ac"
+
+        if autogen.exists():
+            logger.info("Running autogen.sh")
+            self._run_build_command(["sh", str(autogen)])
+        elif configure_ac.exists() and shutil.which("autoreconf"):
+            logger.info("Running autoreconf -fi")
+            self._run_build_command(["autoreconf", "-fi"])
+
+        if configure.exists():
+            configure_cmd = ["sh", str(configure)]
+            # jq recommends builtin oniguruma when building from source.
+            repo_hint = self.project_root.name.lower()
+            if repo_hint in {"jq", "jqlang_jq"}:
+                configure_cmd.append("--with-oniguruma=builtin")
+            logger.info("Running configure command: %s", " ".join(configure_cmd))
+            self._run_build_command(configure_cmd)
+
+    def _run_build_command(self, cmd: List[str], timeout_sec: int = 1200) -> bool:
+        logger.info("Running build command: %s", " ".join(cmd))
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+            )
+            return True
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Command timed out after %ss: %s", timeout_sec, " ".join(cmd)
+            )
+            return False
+        except subprocess.CalledProcessError as e:
+            logger.warning("Command failed: %s", " ".join(cmd))
+            if e.stderr:
+                logger.warning("stderr: %s", e.stderr[:600].strip())
+            return False
+
+    def run_pipeline(
+        self,
+        output_file: Optional[str] = None,
+        skip_level: Optional[str] = None,
+        *,
+        reset_profiler: bool = True,
+        report_profile: bool = True,
+        **kwargs,
+    ):
+        """
+        Run C/C++ pipeline with compile_commands.json auto-discovery/generation.
+        """
+        # Drop Python-specific kwargs that may be forwarded by callers.
+        kwargs.pop("project_name", None)
+        kwargs.pop("target_dir", None)
+        kwargs.pop("cwd", None)
+
+        if "compdb_path" not in kwargs or not kwargs["compdb_path"]:
+            for candidate in (
+                self.project_root / "compile_commands.json",
+                self.project_root / "build" / "compile_commands.json",
+            ):
+                if self._is_valid_compdb(candidate):
+                    kwargs["compdb_path"] = str(candidate)
+                    break
+                if candidate.exists():
+                    logger.warning(
+                        "Ignoring invalid compilation database: %s", candidate
+                    )
+            else:
+                generated = self._auto_generate_compdb()
+                if generated is not None and self._is_valid_compdb(generated):
+                    kwargs["compdb_path"] = str(generated)
+                elif generated is not None:
+                    logger.warning(
+                        "Auto-generated compilation database is invalid: %s", generated
+                    )
+
+        return super().run_pipeline(
+            output_file=output_file,
+            skip_level=skip_level,
+            reset_profiler=reset_profiler,
+            report_profile=report_profile,
+            **kwargs,
+        )

--- a/codeminer/scip_interface/scip_indexer_rust.py
+++ b/codeminer/scip_interface/scip_indexer_rust.py
@@ -63,7 +63,8 @@ class SCIPRustIndexer(SCIPIndexerBase):
             return True
         except (subprocess.CalledProcessError, FileNotFoundError):
             logger.error(
-                "rust-analyzer not found. Please install it with: rustup component add rust-analyzer"
+                "rust-analyzer not found. Please install it with: "
+                "rustup component add rust-analyzer"
             )
             return False
 
@@ -137,4 +138,28 @@ class SCIPRustIndexer(SCIPIndexerBase):
         return super().generate_index(
             config_path=config_path,
             exclude_vendored_libraries=exclude_vendored_libraries,
+        )
+
+    def run_pipeline(
+        self,
+        output_file: Optional[str] = None,
+        skip_level: Optional[str] = None,
+        *,
+        reset_profiler: bool = True,
+        report_profile: bool = True,
+        **kwargs,
+    ):
+        """
+        Run Rust pipeline while ignoring Python-specific kwargs.
+        """
+        kwargs.pop("project_name", None)
+        kwargs.pop("target_dir", None)
+        kwargs.pop("cwd", None)
+
+        return super().run_pipeline(
+            output_file=output_file,
+            skip_level=skip_level,
+            reset_profiler=reset_profiler,
+            report_profile=report_profile,
+            **kwargs,
         )

--- a/codeminer/scip_interface/scip_indexer_ts.py
+++ b/codeminer/scip_interface/scip_indexer_ts.py
@@ -2,6 +2,8 @@
 """
 SCIP indexer for TypeScript and JavaScript projects using scip-typescript.
 """
+import json
+import shutil
 import subprocess
 from pathlib import Path
 from typing import List, Optional, Union
@@ -62,7 +64,8 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
             return True
         except (subprocess.CalledProcessError, FileNotFoundError):
             logger.error(
-                "scip-typescript not found. Please install it with: npm install -g @sourcegraph/scip-typescript"
+                "scip-typescript not found. Please install it with: "
+                "npm install -g @sourcegraph/scip-typescript"
             )
             return False
 
@@ -122,6 +125,90 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
 
         return SCIPTypeScriptGraphDecoder
 
+    def _install_dependencies(self, timeout_sec: int = 600) -> None:
+        """
+        Install Node dependencies in project root before indexing.
+
+        scip-typescript requires project dependencies to be available for
+        reliable indexing, especially for JS projects inferred from package.json.
+        """
+        package_json = self.project_root / "package.json"
+        if not package_json.exists():
+            return
+
+        if (self.project_root / "yarn.lock").exists() and shutil.which("yarn"):
+            cmd = ["yarn", "install", "--frozen-lockfile"]
+        elif (self.project_root / "pnpm-lock.yaml").exists() and shutil.which("pnpm"):
+            cmd = ["pnpm", "install", "--frozen-lockfile"]
+        elif (self.project_root / "package-lock.json").exists():
+            cmd = ["npm", "ci"]
+        else:
+            cmd = ["npm", "install"]
+
+        logger.info("Installing TypeScript dependencies: %s", " ".join(cmd))
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                cwd=self.project_root,
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+            )
+        except FileNotFoundError:
+            logger.warning(
+                "Package manager command not found (%s). Continuing without install.",
+                cmd[0],
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Dependency install timed out after %ss. Continuing anyway.",
+                timeout_sec,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.warning("Dependency install failed: %s", e)
+            if e.stderr:
+                logger.warning("install stderr: %s", e.stderr[:500].strip())
+
+    def _normalize_workspace_kwargs(self, kwargs: dict) -> dict:
+        """
+        Ensure workspace flags are consistent with available package managers.
+        """
+        yarn_available = bool(shutil.which("yarn"))
+        pnpm_available = bool(shutil.which("pnpm"))
+        npm_available = bool(shutil.which("npm"))
+
+        if kwargs.get("yarn_workspaces") and not yarn_available:
+            logger.warning(
+                "yarn_workspaces requested but yarn is not installed; disabling."
+            )
+            kwargs["yarn_workspaces"] = False
+            if npm_available:
+                kwargs["npm_workspaces"] = True
+
+        if kwargs.get("pnpm_workspaces") and not pnpm_available:
+            logger.warning(
+                "pnpm_workspaces requested but pnpm is not installed; disabling."
+            )
+            kwargs["pnpm_workspaces"] = False
+            if npm_available:
+                kwargs["npm_workspaces"] = True
+
+        if kwargs.get("npm_workspaces") and not npm_available:
+            logger.warning(
+                "npm_workspaces requested but npm is not installed; disabling."
+            )
+            kwargs["npm_workspaces"] = False
+
+        # Keep flags mutually exclusive.
+        if kwargs.get("yarn_workspaces"):
+            kwargs["pnpm_workspaces"] = False
+            kwargs["npm_workspaces"] = False
+        elif kwargs.get("pnpm_workspaces"):
+            kwargs["npm_workspaces"] = False
+
+        return kwargs
+
     def generate_index(
         self,
         project_name: Optional[str] = None,
@@ -143,10 +230,82 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
         Returns:
             bool: True if index generation was successful, False otherwise
         """
+        # Guardrail: if no explicit ts/js config exists, force infer mode.
+        has_tsconfig = (self.project_root / "tsconfig.json").exists()
+        has_jsconfig = (self.project_root / "jsconfig.json").exists()
+        if not infer_tsconfig and not has_tsconfig and not has_jsconfig:
+            infer_tsconfig = True
+            logger.info(
+                "No tsconfig.json/jsconfig.json in %s; forcing infer_tsconfig=True",
+                self.project_root,
+            )
+
         return super().generate_index(
             project_name=project_name,
             infer_tsconfig=infer_tsconfig,
             yarn_workspaces=yarn_workspaces,
             pnpm_workspaces=pnpm_workspaces,
             npm_workspaces=npm_workspaces,
+        )
+
+    def run_pipeline(
+        self,
+        output_file: Optional[str] = None,
+        skip_level: Optional[str] = None,
+        *,
+        reset_profiler: bool = True,
+        report_profile: bool = True,
+        **kwargs,
+    ):
+        """
+        Run TypeScript pipeline with language-specific defaults.
+
+        If neither tsconfig.json nor jsconfig.json exists, enable
+        --infer-tsconfig automatically unless caller explicitly sets it.
+        """
+        # Drop Python-specific kwargs that may be forwarded by callers.
+        kwargs.pop("target_dir", None)
+        kwargs.pop("cwd", None)
+
+        # Auto-select workspace mode when not explicitly provided.
+        workspace_flags = ("yarn_workspaces", "pnpm_workspaces", "npm_workspaces")
+        has_workspace_mode = any(kwargs.get(flag) for flag in workspace_flags)
+        if not has_workspace_mode:
+            package_json = self.project_root / "package.json"
+            if package_json.exists():
+                try:
+                    payload = json.loads(package_json.read_text(encoding="utf-8"))
+                    has_workspaces = bool(payload.get("workspaces"))
+                except Exception:
+                    has_workspaces = False
+                if has_workspaces:
+                    if (
+                        self.project_root / "pnpm-workspace.yaml"
+                    ).exists() and shutil.which("pnpm"):
+                        kwargs["pnpm_workspaces"] = True
+                        logger.info("Detected pnpm workspace in %s", self.project_root)
+                    elif (self.project_root / "yarn.lock").exists() and shutil.which(
+                        "yarn"
+                    ):
+                        kwargs["yarn_workspaces"] = True
+                        logger.info("Detected yarn workspace in %s", self.project_root)
+                    else:
+                        kwargs["npm_workspaces"] = True
+                        logger.info("Detected npm workspace in %s", self.project_root)
+
+        # Forced default for dataset-style repos:
+        # scip-typescript frequently fails on root projects without tsconfig.
+        if "infer_tsconfig" not in kwargs:
+            kwargs["infer_tsconfig"] = True
+            logger.info("Enabling infer_tsconfig for %s", self.project_root)
+
+        kwargs = self._normalize_workspace_kwargs(kwargs)
+        self._install_dependencies()
+        logger.info("TypeScript run_pipeline kwargs: %s", kwargs)
+        return super().run_pipeline(
+            output_file=output_file,
+            skip_level=skip_level,
+            reset_profiler=reset_profiler,
+            report_profile=report_profile,
+            **kwargs,
         )

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -3,6 +3,32 @@
 [SCIP](https://github.com/sourcegraph/scip/tree/main) is a code intelligence protocol for index, which has powerful support for multiple languages, e.g. python, C++, etc.
 We copy the scip.proto to the local directory for convenience.
 
+### Multilingual Prerequisites
+
+Besides `scip-python`, multilingual indexing requires extra tooling:
+
+- TypeScript/JavaScript (`scip-typescript`):
+  - Node.js 18 or 20
+  - `npm`
+  - `yarn` for repos using Yarn workspaces (optional but commonly needed)
+  - `pnpm` for pnpm workspaces (optional)
+- C/C++ (`scip-clang`):
+  - `scip-clang`
+  - `cmake` for CMake-based projects
+  - `bear` for Make/Autotools projects (e.g., repositories without CMake compile DB)
+- Rust (`rust-analyzer`):
+  - stable toolchain with `rust-analyzer` component
+
+Example installs:
+```bash
+# TypeScript workspace tooling
+npm install -g @sourcegraph/scip-typescript yarn
+
+# C/C++ Make-based compilation database helper
+# Ubuntu/Debian:
+sudo apt-get update && sudo apt-get install -y bear
+```
+
 ### Setup scip-python (Custom Fork)
 
 We use a custom fork of scip-python with exclude-config support, located in `third_party/scip-python`.

--- a/scripts/swebench_graph_index.py
+++ b/scripts/swebench_graph_index.py
@@ -1,129 +1,456 @@
 """
-This script preprocesses and creates graph indexes for SWE-bench instances.
-It generates SCIP-based code graphs for each instance in the dataset.
+Build SCIP graph indexes for multiple benchmark sources.
 
-Usage example:
-    python scripts/swebench_graph_index.py --dataset princeton-nlp/SWE-bench_Lite \
-        --split test --filter-instance "^(django__django-11099)$" \
-        --output-path /tmp/swebench_indexes
+Supported sources:
+- swebench
+- swebench_multilingual
+- locbench
+- sampled_csv (for sampled instance lists like selected.csv/selected_instances.csv)
 """
 
+from __future__ import annotations
+
 import argparse
+import csv
 import json
 import logging
+import re
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
+from codeminer.dataset.locbench import LocbenchDataset
 from codeminer.dataset.swebench import SwebenchDataset
+from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
 from codeminer.log_utils import get_logger
 from codeminer.profiler import Profiler
 from codeminer.scip_interface.scip_indexer import SCIPIndexer
 
 logger = get_logger(__name__)
 
+DEFAULT_MULTILINGUAL_REPO_LANG_CSV = (
+    Path(__file__).resolve().parents[1]
+    / "codeminer"
+    / "dataset"
+    / "collect"
+    / "data"
+    / "swebench_multilingual_repos.csv"
+)
 
-def parse_args():
-    """Parse command line arguments."""
+
+@dataclass
+class IndexTask:
+    instance: Dict[str, Any]
+    dataset_obj: Any
+    language: str
+    source_kind: str
+
+
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Preprocess and create graph indexes for SWE-bench instances",
+        description="Create SCIP graph indexes for benchmark instances.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
-    # Dataset configuration
+    parser.add_argument(
+        "--source",
+        type=str,
+        choices=["swebench", "swebench_multilingual", "locbench", "sampled_csv"],
+        default="swebench",
+        help="Source type for instances to index.",
+    )
     parser.add_argument(
         "--dataset",
         type=str,
         default="princeton-nlp/SWE-bench_Verified",
-        help="SWE-bench dataset name",
+        help="Dataset name used when source is swebench.",
     )
     parser.add_argument(
-        "--split",
+        "--multilingual-dataset",
         type=str,
-        default="test",
-        help="Dataset split to use",
+        default="SWE-bench/SWE-bench_Multilingual",
+        help="Dataset name used when source is swebench_multilingual.",
+    )
+    parser.add_argument(
+        "--locbench-dataset",
+        type=str,
+        default="czlll/Loc-Bench_V1",
+        help="Dataset name used when source is locbench.",
+    )
+    parser.add_argument(
+        "--sampled-csv",
+        type=str,
+        default=None,
+        help="CSV file for sampled_csv source (e.g., selected.csv/selected_instances.csv).",
+    )
+    parser.add_argument(
+        "--sampled-python-dataset",
+        type=str,
+        default="princeton-nlp/SWE-bench_Verified",
+        help="Python backing dataset used to enrich sampled CSV rows if needed.",
+    )
+    parser.add_argument(
+        "--sampled-multilingual-dataset",
+        type=str,
+        default="SWE-bench/SWE-bench_Multilingual",
+        help="Multilingual backing dataset used to enrich sampled CSV rows if needed.",
+    )
+    parser.add_argument(
+        "--sampled-locbench-dataset",
+        type=str,
+        default=None,
+        help="Optional LocBench backing dataset to enrich sampled CSV rows.",
+    )
+    parser.add_argument(
+        "--split", type=str, default="test", help="Dataset split to use."
     )
     parser.add_argument(
         "--filter-instance",
         type=str,
         default=".*",
-        help="Regex pattern to filter instances (default: .* processes all instances)",
+        help="Regex pattern to filter instance IDs.",
     )
-
-    # # Index selection
-    # parser.add_argument(
-    #     "--idx-range",
-    #     type=int,
-    #     nargs=2,
-    #     default=None,
-    #     help="Range of instance indices to process (e.g., 0 10 for instances 0-9)",
-    # )
-
-    # Output configuration
     parser.add_argument(
         "--output-path",
         type=str,
         default=None,
-        help="Path to store the generated graph indexes (default: ~/.codeminer/)",
+        help="Path to store generated graph indexes.",
     )
-
-    # SCIP indexer configuration
     parser.add_argument(
         "--exclude-patterns",
         type=str,
         nargs="+",
         default=["test*"],
-        help="Patterns to exclude from indexing (e.g., test/ docs/)",
+        help="Patterns to exclude from indexing.",
     )
     parser.add_argument(
         "--skip-level",
         type=str,
-        choices=["graph", "decode", "raw", None],
+        choices=["graph", "decode", "raw", "none"],
         default="graph",
-        help=(
-            "Cache/skip level: 'graph' (check graph.pkl), 'decode' (check "
-            "index.decoded), 'raw' (check index.scip), or None (run full pipeline)"
-        ),
+        help="Cache/skip level for indexing pipeline.",
     )
-
-    # Repository cache
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force full re-index (equivalent to skip-level=none).",
+    )
     parser.add_argument(
         "--cache-dir",
         type=str,
         default="~/.codeminer",
-        help="Directory to cache repositories",
+        help="Cache directory for datasets.",
+    )
+    parser.add_argument(
+        "--repo-cache-dir",
+        type=str,
+        default=None,
+        help="Directory for checked-out repositories (defaults to cache-dir).",
     )
     parser.add_argument(
         "--profile-dir",
         type=str,
         default=None,
-        help=(
-            "Directory to store profiler summaries (default: "
-            "<output-path>/profile_log)"
-        ),
+        help="Directory to store profiler summaries (default: <output-path>/profile_log).",
     )
-
+    parser.add_argument(
+        "--language",
+        type=str,
+        default="auto",
+        choices=["auto", "python", "rust", "ts", "cpp"],
+        help="SCIP index language. Use auto to infer per instance.",
+    )
+    parser.add_argument(
+        "--default-language",
+        type=str,
+        default="python",
+        choices=["python", "rust", "ts", "cpp"],
+        help="Fallback language when auto inference is inconclusive.",
+    )
+    parser.add_argument(
+        "--multilingual-repo-language-csv",
+        type=str,
+        default=str(DEFAULT_MULTILINGUAL_REPO_LANG_CSV),
+        help="Repo->language CSV used for multilingual language inference.",
+    )
     return parser.parse_args()
 
 
-def main():
-    """Main function to process SWE-bench instances and create graph indexes."""
+def _dataset_kwargs(args: argparse.Namespace) -> Dict[str, Any]:
+    return {
+        "split": args.split,
+        "filter_instance": args.filter_instance,
+        "root": args.cache_dir,
+        "repo_root": args.repo_cache_dir or args.cache_dir,
+        "log": True,
+    }
+
+
+def _map_language_label(label: Optional[str], default_language: str) -> str:
+    if not label:
+        return default_language
+    text = label.lower()
+    if "rust" in text:
+        return "rust"
+    if "javascript" in text or "typescript" in text or text == "ts" or text == "js":
+        return "ts"
+    if "c++" in text or text == "cpp" or text == "c":
+        return "cpp"
+    if "python" in text:
+        return "python"
+    return default_language
+
+
+def _load_repo_language_map(csv_path: Path) -> Dict[str, str]:
+    if not csv_path.exists():
+        return {}
+    mapping: Dict[str, str] = {}
+    with csv_path.open("r", encoding="utf-8") as fp:
+        reader = csv.DictReader(fp)
+        for row in reader:
+            repo = row.get("repo") or row.get("Repository")
+            lang = row.get("language") or row.get("Language")
+            if repo and lang:
+                mapping[repo] = lang
+    return mapping
+
+
+def _normalize_rows(rows: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    return [dict(r) for r in rows]
+
+
+def _build_dataset(source: str, args: argparse.Namespace):
+    kwargs = _dataset_kwargs(args)
+    if source == "swebench":
+        return SwebenchDataset(dataset=args.dataset, **kwargs)
+    if source == "swebench_multilingual":
+        return SwebenchMultilingualDataset(dataset=args.multilingual_dataset, **kwargs)
+    if source == "locbench":
+        return LocbenchDataset(dataset=args.locbench_dataset, **kwargs)
+    raise ValueError(f"Unsupported source: {source}")
+
+
+def _read_sampled_csv(csv_path: Path, pattern: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    regex = re.compile(pattern)
+    with csv_path.open("r", encoding="utf-8") as fp:
+        reader = csv.DictReader(fp)
+        for row in reader:
+            iid = row.get("instance_id", "")
+            if iid and regex.match(iid):
+                rows.append(dict(row))
+    return rows
+
+
+def _load_instance_map(dataset_obj: Any) -> Dict[str, Dict[str, Any]]:
+    records = _normalize_rows(dataset_obj.load())
+    return {
+        record["instance_id"]: record for record in records if record.get("instance_id")
+    }
+
+
+def _resolve_sampled_instances(
+    args: argparse.Namespace,
+    repo_language_map: Dict[str, str],
+) -> List[IndexTask]:
+    if not args.sampled_csv:
+        raise ValueError("--sampled-csv is required when --source sampled_csv")
+
+    sampled_rows = _read_sampled_csv(
+        Path(args.sampled_csv).expanduser(), args.filter_instance
+    )
+    logger.info("Loaded %d sampled CSV rows", len(sampled_rows))
+
+    kwargs = _dataset_kwargs(args)
+    py_obj = SwebenchDataset(dataset=args.sampled_python_dataset, **kwargs)
+    ml_obj = SwebenchMultilingualDataset(
+        dataset=args.sampled_multilingual_dataset, **kwargs
+    )
+    py_map = _load_instance_map(py_obj)
+    ml_map = _load_instance_map(ml_obj)
+
+    loc_obj = None
+    loc_map: Dict[str, Dict[str, Any]] = {}
+    if args.sampled_locbench_dataset:
+        loc_obj = LocbenchDataset(dataset=args.sampled_locbench_dataset, **kwargs)
+        loc_map = _load_instance_map(loc_obj)
+
+    tasks: List[IndexTask] = []
+    missing: List[str] = []
+    for row in sampled_rows:
+        instance_id = row.get("instance_id")
+        if not instance_id:
+            continue
+
+        lang_label = row.get("language_group") or row.get("language")
+        preferred = _map_language_label(lang_label, default_language="python")
+
+        source_obj = py_obj
+        source_kind = "swebench"
+        source_row = py_map.get(instance_id)
+
+        if preferred != "python":
+            source_obj = ml_obj
+            source_kind = "swebench_multilingual"
+            source_row = ml_map.get(instance_id)
+        if source_row is None and instance_id in py_map:
+            source_obj = py_obj
+            source_kind = "swebench"
+            source_row = py_map[instance_id]
+        if source_row is None and instance_id in ml_map:
+            source_obj = ml_obj
+            source_kind = "swebench_multilingual"
+            source_row = ml_map[instance_id]
+        if source_row is None and instance_id in loc_map and loc_obj is not None:
+            source_obj = loc_obj
+            source_kind = "locbench"
+            source_row = loc_map[instance_id]
+
+        merged: Dict[str, Any]
+        if source_row is None:
+            merged = dict(row)
+            if not merged.get("repo") or not merged.get("base_commit"):
+                missing.append(instance_id)
+                continue
+        else:
+            merged = {**source_row, **row}
+            merged["repo"] = merged.get("repo") or source_row.get("repo")
+            merged["base_commit"] = merged.get("base_commit") or source_row.get(
+                "base_commit"
+            )
+
+        language = _infer_language(
+            instance=merged,
+            source_kind=source_kind,
+            forced_language=args.language,
+            default_language=args.default_language,
+            repo_language_map=repo_language_map,
+        )
+        tasks.append(
+            IndexTask(
+                instance=merged,
+                dataset_obj=source_obj,
+                language=language,
+                source_kind=source_kind,
+            )
+        )
+
+    if missing:
+        preview = ", ".join(missing[:5])
+        raise ValueError(
+            "Sampled CSV rows missing repo/base_commit and not found in backing datasets: "
+            f"{preview} (total={len(missing)})"
+        )
+    return tasks
+
+
+def _infer_language(
+    *,
+    instance: Mapping[str, Any],
+    source_kind: str,
+    forced_language: str,
+    default_language: str,
+    repo_language_map: Mapping[str, str],
+) -> str:
+    if forced_language != "auto":
+        return forced_language
+    if source_kind in {"swebench", "locbench"}:
+        return "python"
+
+    label = (
+        instance.get("language_group")
+        or instance.get("language")
+        or repo_language_map.get(instance.get("repo", ""))
+    )
+    return _map_language_label(str(label) if label else None, default_language)
+
+
+def _resolve_tasks(
+    args: argparse.Namespace,
+    repo_language_map: Dict[str, str],
+) -> List[IndexTask]:
+    if args.source == "sampled_csv":
+        return _resolve_sampled_instances(args, repo_language_map)
+
+    dataset_obj = _build_dataset(args.source, args)
+    dataset_rows = _normalize_rows(dataset_obj.load())
+    logger.info("Loaded %d instances from %s", len(dataset_rows), args.source)
+    return [
+        IndexTask(
+            instance=instance,
+            dataset_obj=dataset_obj,
+            language=_infer_language(
+                instance=instance,
+                source_kind=args.source,
+                forced_language=args.language,
+                default_language=args.default_language,
+                repo_language_map=repo_language_map,
+            ),
+            source_kind=args.source,
+        )
+        for instance in dataset_rows
+    ]
+
+
+def _ensure_required_fields(tasks: List[IndexTask]) -> None:
+    missing: List[str] = []
+    for task in tasks:
+        instance = task.instance
+        if not instance.get("repo") or not instance.get("base_commit"):
+            missing.append(instance.get("instance_id", "unknown"))
+    if missing:
+        preview = ", ".join(missing[:5])
+        raise ValueError(
+            "Missing required fields repo/base_commit for instances: "
+            f"{preview} (total={len(missing)})"
+        )
+
+
+def _write_profile(
+    profile_output_dir: Path,
+    *,
+    instance: Mapping[str, Any],
+    source_kind: str,
+    language: str,
+    profile_summary: Any,
+) -> None:
+    sections_payload = [
+        {
+            "label": label,
+            "total": stats.total,
+            "count": stats.count,
+            "average": stats.average,
+            "min": stats.safe_min,
+            "max": stats.max_duration,
+            "errors": stats.errors,
+        }
+        for label, stats in profile_summary
+    ]
+    profile_payload = {
+        "instance_id": instance.get("instance_id"),
+        "repo": instance.get("repo"),
+        "base_commit": instance.get("base_commit"),
+        "source": source_kind,
+        "language": language,
+        "total_duration": sum(section["total"] for section in sections_payload),
+        "sections": sections_payload,
+    }
+    profile_file = (
+        profile_output_dir
+        / f"{str(instance.get('instance_id')).replace('/', '__')}.json"
+    )
+    profile_file.write_text(json.dumps(profile_payload, indent=2), encoding="utf-8")
+    logger.info("Saved profiler results to %s", profile_file)
+
+
+def main() -> None:
     args = parse_args()
 
-    # Load and filter dataset
-    logger.info(f"Loading dataset: {args.dataset}, split: {args.split}")
-    logger.info(f"Filter pattern: {args.filter_instance}")
-
-    dataset_obj = SwebenchDataset.from_args(args)
-    dataset = dataset_obj.load()
-
-    logger.info(f"Loaded {len(dataset)} instances from dataset")
-
-    # Set default output index path if not specified
     if args.output_path is None:
         args.output_path = str(Path.home() / ".codeminer")
-
-    output_path = Path(args.output_path)
+    output_path = Path(args.output_path).expanduser()
     output_path.mkdir(parents=True, exist_ok=True)
-    logger.info(f"Graph indexes will be stored in: {output_path}")
+    logger.info("Graph indexes will be stored in: %s", output_path)
 
     profile_output_dir = (
         Path(args.profile_dir).expanduser()
@@ -131,31 +458,49 @@ def main():
         else output_path / "profile_log"
     )
     profile_output_dir.mkdir(parents=True, exist_ok=True)
-    logger.info(f"Profiler summaries will be stored in: {profile_output_dir}")
+    logger.info("Profiler summaries will be stored in: %s", profile_output_dir)
 
-    # Process each instance
-    for idx, instance in enumerate(dataset):
+    repo_language_map = _load_repo_language_map(
+        Path(args.multilingual_repo_language_csv).expanduser()
+    )
+    tasks = _resolve_tasks(args, repo_language_map)
+    _ensure_required_fields(tasks)
+
+    logger.info("Prepared %d indexing tasks from source=%s", len(tasks), args.source)
+    effective_skip_level: Optional[str] = None
+    if not args.force:
+        effective_skip_level = None if args.skip_level == "none" else args.skip_level
+    logger.info(
+        "Index mode: force=%s, skip_level=%s",
+        args.force,
+        effective_skip_level if effective_skip_level is not None else "none",
+    )
+
+    for idx, task in enumerate(tasks):
+        instance = task.instance
         instance_id = instance["instance_id"]
         repo = instance["repo"]
         base_commit = instance["base_commit"]
 
-        logger.info(f"\n{'='*80}")
-        logger.info(f"Processing instance {idx + 1}/{len(dataset)}: {instance_id}")
-        logger.info(f"Repository: {repo}")
-        logger.info(f"Base commit: {base_commit}")
-        logger.info(f"{'='*80}")
+        logger.info("\n%s", "=" * 80)
+        logger.info("Processing instance %d/%d: %s", idx + 1, len(tasks), instance_id)
+        logger.info("Repository: %s", repo)
+        logger.info("Base commit: %s", base_commit)
+        logger.info("Source/language: %s / %s", task.source_kind, task.language)
+        logger.info("%s", "=" * 80)
 
         try:
-            # Process the instance (clone repo and checkout commit)
-            dataset_obj.process_instance(instance, repo_root=args.cache_dir)
-            repo_path = dataset_obj.get_repo_path(instance, repo_root=args.cache_dir)
-            logger.info(f"Repository checked out at: {repo_path}")
+            task.dataset_obj.process_instance(
+                instance, repo_root=args.repo_cache_dir or args.cache_dir
+            )
+            repo_path = task.dataset_obj.get_repo_path(
+                instance, repo_root=args.repo_cache_dir or args.cache_dir
+            )
+            logger.info("Repository checked out at: %s", repo_path)
 
-            # Create output directory for this instance
             instance_output_dir = output_path / instance_id.replace("/", "__")
             instance_output_dir.mkdir(parents=True, exist_ok=True)
 
-            # Initialize SCIP indexer
             profiler = Profiler(
                 name=f"scip_indexer[{instance_id}]",
                 logger=logger,
@@ -167,67 +512,46 @@ def main():
                 output_dir=instance_output_dir,
                 exclude_patterns=args.exclude_patterns,
                 profiler=profiler,
+                language=task.language,
             )
 
-            # Run the indexing pipeline
-            logger.info(f"Starting graph indexing for {instance_id}")
+            logger.info("Starting graph indexing for %s", instance_id)
             graph = indexer.run_pipeline(
-                project_name=instance_id,
-                skip_level=args.skip_level,
+                skip_level=effective_skip_level,
                 report_profile=False,
             )
-            logger.info(f"Profiler summary for {instance_id}:")
+            logger.info("Profiler summary for %s:", instance_id)
             profile_summary = profiler.report(reset=True)
-
-            sections_payload = [
-                {
-                    "label": label,
-                    "total": stats.total,
-                    "count": stats.count,
-                    "average": stats.average,
-                    "min": stats.safe_min,
-                    "max": stats.max_duration,
-                    "errors": stats.errors,
-                }
-                for label, stats in profile_summary
-            ]
-            profile_payload = {
-                "instance_id": instance_id,
-                "repo": repo,
-                "base_commit": base_commit,
-                "total_duration": sum(section["total"] for section in sections_payload),
-                "sections": sections_payload,
-            }
-            profile_file = profile_output_dir / f"{instance_id.replace('/', '__')}.json"
-            profile_file.write_text(json.dumps(profile_payload, indent=2))
-            logger.info(f"Saved profiler results to {profile_file}")
-
-            # indexer.clear_cache(level="decode")
+            _write_profile(
+                profile_output_dir,
+                instance=instance,
+                source_kind=task.source_kind,
+                language=task.language,
+                profile_summary=profile_summary,
+            )
 
             if graph:
-                logger.info(f"  Successfully created graph index for {instance_id}")
-                logger.info(f"   Graph saved to: {indexer.graph_file}")
+                logger.info("Successfully created graph index for %s", instance_id)
+                logger.info("Graph saved to: %s", indexer.graph_file)
                 logger.info(
-                    (
-                        f"   Graph stats: {len(graph.graph.vs)} nodes, "
-                        f"{len(graph.graph.es)} edges"
-                    )
+                    "Graph stats: %d nodes, %d edges",
+                    len(graph.graph.vs),
+                    len(graph.graph.es),
                 )
             else:
-                logger.error(f"L Failed to create graph index for {instance_id}")
+                logger.error("Failed to create graph index for %s", instance_id)
 
-        except Exception as e:
-            logger.error(f"L Error processing instance {instance_id}: {e}")
-            import traceback
-
-            logger.error(traceback.format_exc())
+        except Exception as exc:
+            logger.error(
+                "Error processing instance %s: %s", instance_id, exc, exc_info=True
+            )
             continue
 
-    logger.info(f"\n{'='*80}")
+    logger.info("\n%s", "=" * 80)
     logger.info("Graph indexing complete!")
-    logger.info(f"Processed {len(dataset)} instances")
-    logger.info(f"Indexes stored in: {output_path}")
-    logger.info(f"{'='*80}")
+    logger.info("Processed %d instances", len(tasks))
+    logger.info("Indexes stored in: %s", output_path)
+    logger.info("%s", "=" * 80)
 
 
 if __name__ == "__main__":

--- a/scripts/synthesize_swebench.py
+++ b/scripts/synthesize_swebench.py
@@ -48,6 +48,7 @@ def _to_compact_record(item: Dict[str, Any]) -> Dict[str, Any]:
         "query": item.get("query"),
         "category": item.get("query_type") or item.get("difficulty"),
         "gt_symbols": item.get("target_symbols") or [],
+        "gt_symbol_nodes": item.get("target_symbol_nodes") or [],
         "gt_files": item.get("target_files") or [],
     }
 
@@ -79,6 +80,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--max-turns", type=int, default=10)
     parser.add_argument(
+        "--sampling-seed",
+        type=int,
+        default=None,
+        help="Optional random seed for deterministic block sampling.",
+    )
+    parser.add_argument(
+        "--behavioral-consensus-runs",
+        type=int,
+        default=3,
+        help="Number of behavioral generation passes for GT consensus voting.",
+    )
+    parser.add_argument(
         "--permission-mode",
         type=str,
         default="bypassPermissions",
@@ -108,7 +121,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=[QueryType.BEHAVIORAL.value],
         help=(
             "Query types to synthesize (space or comma separated): "
-            "behavioral,module_hint,file_hint,symbol_hint,reasoning"
+            "behavioral,module_hint,file_hint,symbol_hint,reasoning "
+            "(default: behavioral)"
         ),
     )
     parser.add_argument(
@@ -203,6 +217,8 @@ def main() -> None:
             allowed_tools=allowed_tools,
             permission_mode=args.permission_mode,
             query_type=query_type,
+            sampling_seed=args.sampling_seed,
+            behavioral_consensus_runs=args.behavioral_consensus_runs,
         )
         results = synthesizer.synthesize_queries(
             expanded_inputs,

--- a/scripts/synthesize_swebench.sh
+++ b/scripts/synthesize_swebench.sh
@@ -7,10 +7,12 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CACHE_DIR="${CACHE_DIR:-$HOME/.codeminer}"
 OUTPUT_DIR="${OUTPUT_DIR:-$CACHE_DIR/swebench_sampling}"
 SELECTED_INSTANCES="${SELECTED_INSTANCES:-$OUTPUT_DIR/selected_instances.json}"
-SYNTHESIS_LIMIT="${SYNTHESIS_LIMIT:-}"
+SYNTHESIS_LIMIT="${SYNTHESIS_LIMIT:-1}"
 REPEAT_PER_INSTANCE="${REPEAT_PER_INSTANCE:-1}"
 INSTANCE_ID="${INSTANCE_ID:-}"
-QUERY_TYPES="${QUERY_TYPES:-behavioral,module_hint,file_hint,symbol_hint,reasoning}"
+QUERY_TYPES="${QUERY_TYPES:-behavioral}"
+SAMPLING_SEED="${SAMPLING_SEED:-}"
+BEHAVIORAL_CONSENSUS_RUNS="${BEHAVIORAL_CONSENSUS_RUNS:-3}"
 
 cd "${ROOT_DIR}"
 
@@ -21,6 +23,9 @@ fi
 if [[ -n "${INSTANCE_ID}" ]]; then
   EXTRA_ARGS+=(--instance-id "${INSTANCE_ID}")
 fi
+if [[ -n "${SAMPLING_SEED}" ]]; then
+  EXTRA_ARGS+=(--sampling-seed "${SAMPLING_SEED}")
+fi
 PYTHONPATH=. python scripts/synthesize_swebench.py \
   --cache-dir "${CACHE_DIR}" \
   --repo-cache-dir "${CACHE_DIR}" \
@@ -28,4 +33,5 @@ PYTHONPATH=. python scripts/synthesize_swebench.py \
   --selected-instances "${SELECTED_INSTANCES}" \
   --query-types "${QUERY_TYPES}" \
   --repeat-per-instance "${REPEAT_PER_INSTANCE}" \
+  --behavioral-consensus-runs "${BEHAVIORAL_CONSENSUS_RUNS}" \
   "${EXTRA_ARGS[@]}"

--- a/test/scip/test_scip_multilingual.py
+++ b/test/scip/test_scip_multilingual.py
@@ -1,999 +1,117 @@
 #!/usr/bin/env python3
 """
-Unified SCIP indexer test for C++, Rust, and TypeScript.
-
-This test supports indexing and decoding SCIP indexes for all three languages.
-It supports two modes:
-1. Local mode: Test with a local repository
-2. SWE-bench_Multilingual mode: Test with SWE-bench_Multilingual dataset
-
-Usage:
-    # Local mode - C++
-    python test/scip/test_scip_multilingual.py --lang cpp \
-        --repo test/scip/simple_repos/cpp_simple
-    python test/scip/test_scip_multilingual.py --lang cpp \
-        --repo test/scip/simple_repos/cpp_simple --clean
-
-    # Local mode - Rust
-    python test/scip/test_scip_multilingual.py --lang rust \
-        --repo test/scip/simple_repos/rust_simple
-    python test/scip/test_scip_multilingual.py --lang rust \
-        --repo test/scip/simple_repos/rust_simple --clean
-
-    # Local mode - TypeScript
-    python test/scip/test_scip_multilingual.py --lang ts \
-        --repo test/scip/simple_repos/typescript_simple
-
-    # SWE-bench_Multilingual mode
-    python test/scip/test_scip_multilingual.py --lang cpp \
-        --swebench-multilingual --num-instances 10
-    python test/scip/test_scip_multilingual.py --lang rust \
-        --swebench-multilingual --num-instances 5
-    python test/scip/test_scip_multilingual.py --lang ts \
-        --swebench-multilingual --num-instances 3
-
-    # Pytest mode
-    pytest test/scip/test_scip_multilingual.py -k test_cpp_multi -q
+Integration tests for multilingual SCIP indexing via unified run_pipeline().
 """
 
-import argparse
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
 from codeminer.scip_interface import SCIPIndexer
 
-# ==============================================================================
-# Common Utilities
-# ==============================================================================
 
-
-def verify_scip_output(
-    decoded_file: Path, language: str, expected_symbols=None
-) -> bool:
-    """
-    Verify the SCIP output contains expected symbols.
-
-    Args:
-        decoded_file: Path to the decoded SCIP file
-        language: Language (C++, Rust, TypeScript)
-        expected_symbols: List of symbols to check for (optional)
-
-    Returns:
-        bool: True if verification passed
-    """
-    print("\n" + "=" * 80)
-    print("Verifying SCIP output...")
-    print("=" * 80)
-
-    if not decoded_file.exists():
-        print(f"❌ Decoded file not found: {decoded_file}")
-        return False
-
-    content = decoded_file.read_text()
-
-    # Default expected symbols per language
-    if expected_symbols is None:
-        if language == "C++":
-            expected_symbols = [
-                "MathUtils",  # Namespace
-                "add",  # Function
-                "Shape",  # Base class
-                "Rectangle",  # Derived class
-                "Circle",  # Derived class
-            ]
-        elif language == "Rust":
-            expected_symbols = [
-                "math_utils",  # Module
-                "add",  # Function
-                "multiply",  # Function
-                "Shape",  # Trait
-                "Rectangle",  # Struct
-                "Circle",  # Struct
-            ]
-        elif language == "TypeScript":
-            expected_symbols = [
-                "add",  # Function
-                "multiply",  # Function
-                "Calculator",  # Class
-            ]
-
-    if not expected_symbols:
-        print("No symbols specified for verification, skipping...")
-        return True
-
-    print("\nChecking for expected symbols:")
-    found_symbols = []
-    missing_symbols = []
-
-    for symbol in expected_symbols:
-        if symbol in content:
-            found_symbols.append(symbol)
-            print(f"  ✅ Found: {symbol}")
-        else:
-            missing_symbols.append(symbol)
-            print(f"  ⚠️  Missing: {symbol}")
-
-    print(f"\nSummary: {len(found_symbols)}/{len(expected_symbols)} symbols found")
-
-    return len(found_symbols) > 0
-
-
-# ==============================================================================
-# C++ Build and Indexing
-# ==============================================================================
-
-
-def build_cpp_project(repo_path: Path, clean: bool = False) -> bool:
-    """
-    Build the C++ project and generate compile_commands.json using CMake.
-
-    Args:
-        repo_path: Path to the repository
-        clean: Whether to clean before building
-
-    Returns:
-        bool: True if build was successful
-    """
-    build_dir = repo_path / "build"
-
-    if clean and build_dir.exists():
-        print(f"Cleaning build directory: {build_dir}")
-        import shutil
-
-        shutil.rmtree(build_dir)
-
-    # Create build directory
-    build_dir.mkdir(exist_ok=True)
-
-    print("\n" + "=" * 80)
-    print("Building C++ project with CMake...")
-    print("=" * 80)
-
-    # Run cmake to generate build files
-    print("\nRunning CMake...")
-    result = subprocess.run(
-        [
-            "cmake",
-            "-B",
-            str(build_dir),
-            "-S",
-            str(repo_path),
-            "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-        ],
-        capture_output=True,
-        text=True,
-    )
-
-    if result.returncode != 0:
-        print(f"❌ CMake failed:")
-        print(result.stderr)
-        return False
-
-    print("✅ CMake configuration successful")
-
-    # Build the project
-    print("\nBuilding project...")
-    result = subprocess.run(
-        ["cmake", "--build", str(build_dir)],
-        capture_output=True,
-        text=True,
-    )
-
-    if result.returncode != 0:
-        print(f"❌ Build failed:")
-        print(result.stderr)
-        return False
-
-    print("✅ Build successful")
-
-    # Check if compile_commands.json was generated
-    compdb = build_dir / "compile_commands.json"
-    if not compdb.exists():
-        print(f"❌ compile_commands.json not found at {compdb}")
-        return False
-
-    print(f"✅ Generated compilation database at: {compdb}")
-    return True
-
-
-def generate_cpp_compilation_database(repo_path: Path) -> bool:
-    """
-    Try to generate a compilation database for C++ repository.
-
-    Args:
-        repo_path: Path to the repository root
-
-    Returns:
-        bool: True if compilation database was generated or already exists
-    """
-    # Check if compilation database already exists
-    compdb_locations = [
-        repo_path / "compile_commands.json",
-        repo_path / "build" / "compile_commands.json",
-    ]
-
-    for compdb in compdb_locations:
-        if compdb.exists():
-            print(f"✅ Found existing compilation database: {compdb}")
-            return True
-
-    print("\n🔧 Attempting to generate compilation database...")
-
-    # Try CMake if CMakeLists.txt exists
-    if (repo_path / "CMakeLists.txt").exists():
-        print("  Found CMakeLists.txt, trying CMake...")
-        try:
-            build_dir = repo_path / "build"
-            build_dir.mkdir(exist_ok=True)
-
-            result = subprocess.run(
-                [
-                    "cmake",
-                    "-B",
-                    str(build_dir),
-                    "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
-                ],
-                cwd=repo_path,
-                capture_output=True,
-                text=True,
-                timeout=300,
-            )
-
-            if result.returncode == 0:
-                compdb = build_dir / "compile_commands.json"
-                if compdb.exists():
-                    print(f"  ✅ Generated compilation database with CMake: {compdb}")
-                    return True
-
-        except Exception as e:
-            print(f"  ⚠️  CMake error: {str(e)[:200]}")
-
-    print("  ❌ Could not generate compilation database")
+def _tools_ready(language: str) -> bool:
+    if language == "cpp":
+        return bool(shutil.which("scip-clang")) and bool(shutil.which("cmake"))
+    if language == "rust":
+        return bool(shutil.which("rust-analyzer"))
+    if language == "ts":
+        return bool(shutil.which("scip-typescript"))
     return False
 
 
-def run_cpp_simple(args):
-    """Test C++ SCIP indexer with a local repository."""
-    repo_path = Path(args.repo).absolute()
-
-    if not repo_path.exists():
-        print(f"Error: Repository path does not exist: {repo_path}")
-        return False
-
-    print("=" * 80)
-    print("SCIP C++ Indexer Test - Simple Mode")
-    print("=" * 80)
-    print(f"Repository path: {repo_path}")
-    print("=" * 80)
-
-    # Build the project if CMakeLists.txt exists
-    if (repo_path / "CMakeLists.txt").exists():
-        print("\n📦 Found CMakeLists.txt, building project...")
-        if not build_cpp_project(repo_path, clean=args.clean):
-            print("\n❌ Build failed")
-            return False
-    else:
-        print("\n ⚠️ No CMakeLists.txt found, skipping build")
-
-    # Check for compilation database
-    compdb = repo_path / "compile_commands.json"
-    if not compdb.exists():
-        compdb = repo_path / "build" / "compile_commands.json"
-
-    if not compdb.exists():
-        print(f"\n❌ Error: Compilation database not found!")
-        return False
-
-    print(f"\n✅ Found compilation database: {compdb}")
-
-    # Set output directory
-    output_dir = (
-        Path(args.output_dir).absolute()
-        if args.output_dir
-        else repo_path / "scip_output"
-    )
-    print(f"Output directory: {output_dir}")
-
-    # Create the indexer
-    indexer = SCIPIndexer(project_root=repo_path, output_dir=output_dir, language="cpp")
-
-    # Generate SCIP index
-    print("\n" + "=" * 80)
-    print("Step 1: Generating SCIP index...")
-    print("=" * 80)
-
-    success = indexer.generate_index(
-        compdb_path=str(compdb),
-        show_compiler_diagnostics=getattr(args, "show_compiler_diagnostics", False),
-    )
-
-    if not success:
-        print("\n❌ Failed to generate SCIP index")
-        return False
-
-    print(f"\n✅ SCIP index generated at: {indexer.index_file}")
-
-    # Decode SCIP index
-    print("\n" + "=" * 80)
-    print("Step 2: Decoding SCIP index...")
-    print("=" * 80)
-
-    success = indexer.decode_index()
-
-    if not success:
-        print("\n❌ Failed to decode SCIP index")
-        return False
-
-    print(f"\n✅ SCIP index decoded at: {indexer.decoded_file}")
-
-    # Show file sizes
-    index_size = indexer.index_file.stat().st_size / (1024 * 1024)
-    decoded_size = indexer.decoded_file.stat().st_size / (1024 * 1024)
-
-    print("\n" + "=" * 80)
-    print("Output Files:")
-    print("=" * 80)
-    print(f"Binary SCIP index: {indexer.index_file} ({index_size:.2f} MB)")
-    print(f"Decoded SCIP index: {indexer.decoded_file} ({decoded_size:.2f} MB)")
-    print("=" * 80)
-
-    # Verify output if it's test_cpp_simple
-    if "test_cpp_simple" in str(repo_path):
-        verify_scip_output(indexer.decoded_file, "C++")
-
-    print("\n✅ Test completed successfully!")
-    return True
-
-
-def run_cpp_multi(args):
-    """Test C++ SCIP indexer with SWE-bench_Multilingual dataset."""
-    from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
-
-    dataset_obj = SwebenchMultilingualDataset(split="test", filter_instance=".*")
-
-    all_dataset = dataset_obj.load()
-
-    # Filter for C/C++ projects
-    cpp_instances = []
-    cpp_repo_keywords = [
-        "fmtlib/",
-        "nlohmann/",
-        "jqlang/",
-        "redis/",
-        "valkey-io/",
-        "micropython/",
-    ]
-
-    for inst in all_dataset:
-        repo = inst["repo"]
-        if any(keyword in repo for keyword in cpp_repo_keywords):
-            cpp_instances.append(inst)
-
-    if len(cpp_instances) == 0:
-        print(f"❌ No C/C++ instances found in dataset")
-        return False
-
-    # Limit dataset
-    if args.num_instances is not None:
-        dataset = cpp_instances[: min(args.num_instances, len(cpp_instances))]
-    else:
-        dataset = cpp_instances
-
-    print(
-        f"\n✓ Found {len(cpp_instances)} total C/C++ instances, testing {len(dataset)}"
-    )
-
-    success_count = 0
-    failed_instances = []
-
-    for idx, instance in enumerate(dataset):
-        instance_id = instance["instance_id"]
-        print(f"\n{'=' * 80}")
-        print(f"Processing C++ instance [{idx + 1}/{len(dataset)}]: {instance_id}")
-        print(f"{'=' * 80}")
-
-        try:
-            dataset_obj.process_instance(instance)
-            repo_path = dataset_obj.get_repo_path(instance)
-            output_path = f"./scip_output/cpp/{instance_id}"
-
-            if not generate_cpp_compilation_database(Path(repo_path)):
-                failed_instances.append(
-                    (instance_id, "Could not generate compilation database")
-                )
-                continue
-
-            indexer = SCIPIndexer(repo_path, output_dir=output_path, language="cpp")
-
-            if not indexer.generate_index(show_compiler_diagnostics=False):
-                failed_instances.append((instance_id, "Failed to generate index"))
-                continue
-
-            if not indexer.decode_index():
-                failed_instances.append((instance_id, "Failed to decode index"))
-                continue
-
-            print(f"\n✅ Successfully processed {instance_id}")
-            success_count += 1
-
-        except Exception as e:
-            print(f"\n❌ Error processing {instance_id}: {str(e)}")
-            failed_instances.append((instance_id, str(e)))
-
-    print(f"\n{'=' * 80}")
-    print(
-        f"Total: {len(dataset)} | Success: {success_count} | Failed: {len(failed_instances)}"
-    )
-    print(f"{'=' * 80}")
-
-    return success_count == len(dataset)
-
-
-# ==============================================================================
-# Rust Build and Indexing
-# ==============================================================================
-
-
-def build_rust_project(repo_path: Path, clean: bool = False) -> bool:
-    """
-    Build the Rust project using Cargo.
-
-    Args:
-        repo_path: Path to the repository
-        clean: Whether to clean before building
-
-    Returns:
-        bool: True if build was successful
-    """
-    if clean:
-        print(f"Cleaning build artifacts...")
-        result = subprocess.run(
-            ["cargo", "clean"],
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode == 0:
-            print("✅ Clean successful")
-
-    print("\n" + "=" * 80)
-    print("Building Rust project with Cargo...")
-    print("=" * 80)
-
-    result = subprocess.run(
-        ["cargo", "build"],
-        cwd=repo_path,
+def _ensure_cpp_compdb(repo: Path) -> None:
+    compdb = repo / "build" / "compile_commands.json"
+    if compdb.exists():
+        return
+    subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(repo),
+            "-B",
+            str(repo / "build"),
+            "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+        ],
+        check=True,
         capture_output=True,
         text=True,
     )
 
-    if result.returncode != 0:
-        print(f"❌ Cargo build failed:")
-        print(result.stderr)
-        return False
 
-    print("✅ Build successful")
-    return True
-
-
-def run_rust_simple(args):
-    """Test Rust SCIP indexer with a local repository."""
-    repo_path = Path(args.repo).absolute()
-
-    if not repo_path.exists():
-        print(f"Error: Repository path does not exist: {repo_path}")
-        return False
-
-    print("=" * 80)
-    print("SCIP Rust Indexer Test - Simple Mode")
-    print("=" * 80)
-    print(f"Repository path: {repo_path}")
-    print("=" * 80)
-
-    # Check for Cargo.toml
-    if not (repo_path / "Cargo.toml").exists():
-        print("\n❌ Error: No Cargo.toml found!")
-        return False
-
-    # Build the project
-    print("\n📦 Building Rust project...")
-    if not build_rust_project(repo_path, clean=args.clean):
-        print("\n❌ Build failed")
-        return False
-
-    # Set output directory
-    output_dir = (
-        Path(args.output_dir).absolute()
-        if args.output_dir
-        else repo_path / "scip_output"
-    )
-    print(f"\nOutput directory: {output_dir}")
-
-    # Create the indexer
-    indexer = SCIPIndexer(
-        project_root=repo_path, output_dir=output_dir, language="rust"
-    )
-
-    # Generate SCIP index
-    print("\n" + "=" * 80)
-    print("Step 1: Generating SCIP index...")
-    print("=" * 80)
-
-    success = indexer.generate_index(
-        exclude_vendored_libraries=getattr(args, "exclude_vendored", True),
-    )
-
-    if not success:
-        print("\n❌ Failed to generate SCIP index")
-        return False
-
-    print(f"\n✅ SCIP index generated at: {indexer.index_file}")
-
-    # Decode SCIP index
-    print("\n" + "=" * 80)
-    print("Step 2: Decoding SCIP index...")
-    print("=" * 80)
-
-    success = indexer.decode_index()
-
-    if not success:
-        print("\n❌ Failed to decode SCIP index")
-        return False
-
-    print(f"\n✅ SCIP index decoded at: {indexer.decoded_file}")
-
-    # Show file sizes
-    index_size = indexer.index_file.stat().st_size / (1024 * 1024)
-    decoded_size = indexer.decoded_file.stat().st_size / (1024 * 1024)
-
-    print("\n" + "=" * 80)
-    print("Output Files:")
-    print("=" * 80)
-    print(f"Binary SCIP index: {indexer.index_file} ({index_size:.2f} MB)")
-    print(f"Decoded SCIP index: {indexer.decoded_file} ({decoded_size:.2f} MB)")
-    print("=" * 80)
-
-    # Verify output if it's test_rust_simple
-    if "test_rust_simple" in str(repo_path):
-        verify_scip_output(indexer.decoded_file, "Rust")
-
-    print("\n✅ Test completed successfully!")
-    return True
+def _repo_keywords(language: str) -> list[str]:
+    if language == "cpp":
+        return [
+            "fmtlib/",
+            "nlohmann/",
+            "jqlang/",
+            "redis/",
+            "valkey-io/",
+            "micropython/",
+        ]
+    if language == "rust":
+        return [
+            "astral-sh/ruff",
+            "pola-rs/polars",
+            "tokio-rs/",
+            "rust-lang/",
+        ]
+    if language == "ts":
+        return [
+            "vuejs/",
+            "mui/",
+            "darkreader/",
+            "sveltejs/",
+            "axios/",
+            "expressjs/",
+            "insomnia/",
+            "dayjs/",
+        ]
+    return []
 
 
-def run_rust_multi(args):
-    """Test Rust SCIP indexer with SWE-bench_Multilingual dataset."""
-    from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
-
+def _pick_swebench_multilingual_instance(language: str) -> dict:
     dataset_obj = SwebenchMultilingualDataset(split="test", filter_instance=".*")
+    rows = dataset_obj.load()
+    keywords = _repo_keywords(language)
+    matches = [row for row in rows if any(k in row["repo"] for k in keywords)]
+    if not matches:
+        raise RuntimeError(f"No SWE-bench_Multilingual instances for {language}")
+    return dict(matches[0])
+
+
+@pytest.mark.parametrize("language", ["cpp", "rust", "ts"])
+def test_run_pipeline_swebench_multilingual_instance(
+    tmp_path: Path,
+    language: str,
+) -> None:
+    if not _tools_ready(language):
+        pytest.skip(f"Required tooling for {language} is not available in PATH")
 
-    all_dataset = dataset_obj.load()
-
-    # Filter for Rust projects
-    rust_instances = []
-    rust_repo_keywords = [
-        "tokio-rs/",
-        "serde-rs/",
-        "clap-rs/",
-        "rayon-rs/",
-        "sharkdp/",
-        "nushell/",
-    ]
-
-    for inst in all_dataset:
-        repo = inst["repo"]
-        if any(keyword in repo for keyword in rust_repo_keywords):
-            rust_instances.append(inst)
-
-    if len(rust_instances) == 0:
-        print(f"❌ No Rust instances found in dataset")
-        return False
-
-    # Limit dataset
-    if args.num_instances is not None:
-        dataset = rust_instances[: min(args.num_instances, len(rust_instances))]
-    else:
-        dataset = rust_instances
-
-    print(
-        f"\n✓ Found {len(rust_instances)} total Rust instances, testing {len(dataset)}"
-    )
-
-    success_count = 0
-    failed_instances = []
-
-    for idx, instance in enumerate(dataset):
-        instance_id = instance["instance_id"]
-        print(f"\n{'=' * 80}")
-        print(f"Processing Rust instance [{idx + 1}/{len(dataset)}]: {instance_id}")
-        print(f"{'=' * 80}")
-
-        try:
-            dataset_obj.process_instance(instance)
-            repo_path = dataset_obj.get_repo_path(instance)
-            output_path = f"./scip_output/rust/{instance_id}"
-
-            if not (Path(repo_path) / "Cargo.toml").exists():
-                failed_instances.append((instance_id, "No Cargo.toml found"))
-                continue
-
-            indexer = SCIPIndexer(repo_path, output_dir=output_path, language="rust")
-
-            if not indexer.generate_index(exclude_vendored_libraries=True):
-                failed_instances.append((instance_id, "Failed to generate index"))
-                continue
-
-            if not indexer.decode_index():
-                failed_instances.append((instance_id, "Failed to decode index"))
-                continue
-
-            print(f"\n✅ Successfully processed {instance_id}")
-            success_count += 1
-
-        except Exception as e:
-            print(f"\n❌ Error processing {instance_id}: {str(e)}")
-            failed_instances.append((instance_id, str(e)))
-
-    print(f"\n{'=' * 80}")
-    print(
-        f"Total: {len(dataset)} | Success: {success_count} | Failed: {len(failed_instances)}"
-    )
-    print(f"{'=' * 80}")
-
-    return success_count == len(dataset)
-
-
-# ==============================================================================
-# TypeScript Indexing
-# ==============================================================================
-
-
-def run_ts_simple(args):
-    """Test TypeScript SCIP indexer with a local repository."""
-    repo_path = Path(args.repo).absolute()
-
-    if not repo_path.exists():
-        print(f"Error: Repository path does not exist: {repo_path}")
-        return False
-
-    print("=" * 80)
-    print("SCIP TypeScript Indexer Test - Simple Mode")
-    print("=" * 80)
-    print(f"Repository path: {repo_path}")
-    print("=" * 80)
-
-    # Install dependencies if package.json exists
-    package_json = repo_path / "package.json"
-    if package_json.exists():
-        print("\n📦 Installing npm dependencies...")
-        result = subprocess.run(
-            ["npm", "install"],
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-        if result.returncode == 0:
-            print("✅ npm install successful")
-        else:
-            print(f"⚠️  npm install failed: {result.stderr[:200]}")
-
-    # Set output directory
-    output_dir = (
-        Path(args.output_dir).absolute()
-        if args.output_dir
-        else repo_path / "scip_output"
-    )
-    print(f"\nOutput directory: {output_dir}")
-
-    # Create the indexer
-    indexer = SCIPIndexer(project_root=repo_path, output_dir=output_dir, language="ts")
-
-    # Generate SCIP index
-    print("\n" + "=" * 80)
-    print("Step 1: Generating SCIP index...")
-    print("=" * 80)
-
-    # Check if tsconfig.json exists
-    tsconfig = repo_path / "tsconfig.json"
-    infer_tsconfig = not tsconfig.exists()
-
-    if infer_tsconfig:
-        print("⚠️  No tsconfig.json found, will infer TypeScript configuration")
-
-    success = indexer.generate_index(infer_tsconfig=infer_tsconfig)
-
-    if not success:
-        print("\n❌ Failed to generate SCIP index")
-        return False
-
-    print(f"\n✅ SCIP index generated at: {indexer.index_file}")
-
-    # Decode SCIP index
-    print("\n" + "=" * 80)
-    print("Step 2: Decoding SCIP index...")
-    print("=" * 80)
-
-    success = indexer.decode_index()
-
-    if not success:
-        print("\n❌ Failed to decode SCIP index")
-        return False
-
-    print(f"\n✅ SCIP index decoded at: {indexer.decoded_file}")
-
-    # Show file sizes
-    index_size = indexer.index_file.stat().st_size / (1024 * 1024)
-    decoded_size = indexer.decoded_file.stat().st_size / (1024 * 1024)
-
-    print("\n" + "=" * 80)
-    print("Output Files:")
-    print("=" * 80)
-    print(f"Binary SCIP index: {indexer.index_file} ({index_size:.2f} MB)")
-    print(f"Decoded SCIP index: {indexer.decoded_file} ({decoded_size:.2f} MB)")
-    print("=" * 80)
-
-    # Verify output if it's test_typescript_simple
-    if "test_typescript_simple" in str(repo_path):
-        verify_scip_output(indexer.decoded_file, "TypeScript")
-
-    print("\n✅ Test completed successfully!")
-    return True
-
-
-def run_ts_multi(args):
-    """Test TypeScript SCIP indexer with SWE-bench_Multilingual dataset."""
-    from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
-
-    dataset_obj = SwebenchMultilingualDataset(split="test", filter_instance=".*")
-
-    all_dataset = dataset_obj.load()
-
-    # Filter for TypeScript/JavaScript projects
-    ts_instances = []
-    ts_repo_keywords = [
-        "vuejs/",
-        "mui/",
-        "darkreader/",
-        "sveltejs/",
-        "axios/",
-        "expressjs/",
-        "insomnia/",
-        "dayjs/",
-    ]
-
-    for inst in all_dataset:
-        repo = inst["repo"]
-        if any(keyword in repo for keyword in ts_repo_keywords):
-            ts_instances.append(inst)
-
-    if len(ts_instances) == 0:
-        print(f"❌ No TypeScript instances found in dataset")
-        return False
-
-    # Limit dataset
-    if args.num_instances is not None:
-        dataset = ts_instances[: min(args.num_instances, len(ts_instances))]
-    else:
-        dataset = ts_instances
-
-    print(
-        f"\n✓ Found {len(ts_instances)} total TypeScript instances, testing {len(dataset)}"
-    )
-
-    success_count = 0
-    failed_instances = []
-
-    for idx, instance in enumerate(dataset):
-        instance_id = instance["instance_id"]
-        print(f"\n{'=' * 80}")
-        print(
-            f"Processing TypeScript instance [{idx + 1}/{len(dataset)}]: {instance_id}"
-        )
-        print(f"{'=' * 80}")
-
-        try:
-            dataset_obj.process_instance(instance)
-            repo_path = dataset_obj.get_repo_path(instance)
-            output_path = f"./scip_output/ts/{instance_id}"
-
-            # Install dependencies if package.json exists
-            package_json = Path(repo_path) / "package.json"
-            if package_json.exists():
-                print("  Installing dependencies...")
-                subprocess.run(
-                    ["npm", "install"],
-                    cwd=repo_path,
-                    capture_output=True,
-                    text=True,
-                    timeout=300,
-                )
-
-            indexer = SCIPIndexer(repo_path, output_dir=output_path, language="ts")
-
-            # Check if tsconfig.json exists
-            tsconfig = Path(repo_path) / "tsconfig.json"
-            infer_tsconfig = not tsconfig.exists()
-
-            if not indexer.generate_index(infer_tsconfig=infer_tsconfig):
-                failed_instances.append((instance_id, "Failed to generate index"))
-                continue
-
-            if not indexer.decode_index():
-                failed_instances.append((instance_id, "Failed to decode index"))
-                continue
-
-            print(f"\n✅ Successfully processed {instance_id}")
-            success_count += 1
-
-        except Exception as e:
-            print(f"\n❌ Error processing {instance_id}: {str(e)}")
-            failed_instances.append((instance_id, str(e)))
-
-    print(f"\n{'=' * 80}")
-    print(
-        f"Total: {len(dataset)} | Success: {success_count} | Failed: {len(failed_instances)}"
-    )
-    print(f"{'=' * 80}")
-
-    return success_count == len(dataset)
-
-
-# ==============================================================================
-# Main / Pytest Entry
-# ==============================================================================
-
-
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Unified SCIP indexer test for C++, Rust, and TypeScript"
-    )
-
-    # Language selection
-    parser.add_argument(
-        "--lang",
-        choices=["cpp", "rust", "ts"],
-        required=True,
-        help="Language to test (cpp, rust, ts)",
-    )
-
-    # Mode selection
-    mode_group = parser.add_mutually_exclusive_group()
-    mode_group.add_argument(
-        "--repo",
-        type=str,
-        help="Path to local repository (local mode)",
-    )
-    mode_group.add_argument(
-        "--swebench-multilingual",
-        dest="swebench_multilingual",
-        action="store_true",
-        help="Test with SWE-bench_Multilingual dataset",
-    )
-    mode_group.add_argument(
-        "--multisweb",
-        dest="swebench_multilingual",
-        action="store_true",
-        help=argparse.SUPPRESS,
-    )
-
-    # Common arguments
-    parser.add_argument(
-        "--clean",
-        action="store_true",
-        help="[Local mode] Clean build artifacts before building",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=str,
-        help="[Local mode] Output directory for SCIP files",
-    )
-
-    # C++ specific arguments
-    parser.add_argument(
-        "--show-compiler-diagnostics",
-        action="store_true",
-        help="[C++ only] Show compiler diagnostics during indexing",
-    )
-
-    # Rust specific arguments
-    parser.add_argument(
-        "--exclude-vendored",
-        action="store_true",
-        default=True,
-        help="[Rust only] Exclude vendored libraries from indexing (default: True)",
-    )
-
-    # SWE-bench_Multilingual mode arguments
-    parser.add_argument(
-        "--num-instances",
-        type=int,
-        default=None,
-        help="[SWE-bench_Multilingual mode] Number of instances to test",
-    )
-
-    return parser
-
-
-def run(args: argparse.Namespace) -> bool:
-    # Run test based on language and mode
-    if args.lang == "cpp":
-        if args.swebench_multilingual:
-            print("\n=== Running C++ SWE-bench_Multilingual mode ===\n")
-            return run_cpp_multi(args)
-        if args.repo:
-            print("\n=== Running C++ Local mode ===\n")
-            return run_cpp_simple(args)
-        raise ValueError("Please specify either --repo or --swebench-multilingual")
-
-    if args.lang == "rust":
-        if args.swebench_multilingual:
-            print("\n=== Running Rust SWE-bench_Multilingual mode ===\n")
-            return run_rust_multi(args)
-        if args.repo:
-            print("\n=== Running Rust Local mode ===\n")
-            return run_rust_simple(args)
-        raise ValueError("Please specify either --repo or --swebench-multilingual")
-
-    if args.lang == "ts":
-        if args.swebench_multilingual:
-            print("\n=== Running TypeScript SWE-bench_Multilingual mode ===\n")
-            return run_ts_multi(args)
-        if args.repo:
-            print("\n=== Running TypeScript Local mode ===\n")
-            return run_ts_simple(args)
-        raise ValueError("Please specify either --repo or --swebench-multilingual")
-
-    raise ValueError(f"Unsupported language: {args.lang}")
-
-
-def main():
-    parser = build_parser()
-    args = parser.parse_args()
     try:
-        success = run(args)
-    except ValueError as exc:
-        parser.error(str(exc))
-    exit(0 if success else 1)
+        instance = _pick_swebench_multilingual_instance(language)
+    except Exception as exc:
+        pytest.skip(
+            f"SWE-bench_Multilingual unavailable or no matching instance: {exc}"
+        )
 
+    dataset_obj = SwebenchMultilingualDataset(split="test", filter_instance=".*")
+    dataset_obj.process_instance(instance)
+    repo_path = Path(dataset_obj.get_repo_path(instance))
 
-@pytest.fixture(scope="session")
-def swebench_cpp_args() -> argparse.Namespace:
-    parser = build_parser()
-    return parser.parse_args(
-        ["--lang", "cpp", "--swebench-multilingual", "--num-instances", "1"]
+    if language == "cpp":
+        _ensure_cpp_compdb(repo_path)
+
+    kwargs = {"infer_tsconfig": True} if language == "ts" else {}
+    indexer = SCIPIndexer(
+        project_root=repo_path,
+        output_dir=tmp_path / f"scip_multi_{language}",
+        language=language,
     )
+    graph = indexer.run_pipeline(skip_level="graph", report_profile=False, **kwargs)
 
-
-@pytest.fixture(scope="session")
-def swebench_rust_args() -> argparse.Namespace:
-    parser = build_parser()
-    return parser.parse_args(
-        ["--lang", "rust", "--swebench-multilingual", "--num-instances", "1"]
-    )
-
-
-@pytest.fixture(scope="session")
-def swebench_ts_args() -> argparse.Namespace:
-    parser = build_parser()
-    return parser.parse_args(
-        ["--lang", "ts", "--swebench-multilingual", "--num-instances", "1"]
-    )
-
-
-def test_cpp_multi(swebench_cpp_args: argparse.Namespace) -> None:
-    assert run(swebench_cpp_args)
-
-
-def test_rust_multi(swebench_rust_args: argparse.Namespace) -> None:
-    assert run(swebench_rust_args)
-
-
-def test_ts_multi(swebench_ts_args: argparse.Namespace) -> None:
-    assert run(swebench_ts_args)
-
-
-if __name__ == "__main__":
-    main()
+    assert graph is not None, f"run_pipeline returned None for {language} (dataset)"
+    assert len(graph.graph.vs) > 0, f"no graph nodes for {language} (dataset)"


### PR DESCRIPTION
## Summary

This PR improves **multilingual SCIP indexing reliability** (especially for TypeScript and C/C++) and updates CI/docs accordingly. It also enhances the **SWE-bench query synthesis pipeline** with deterministic sampling and behavioral consensus generation, plus minor data-format fixes for stable downstream evaluation.

## Changes

* **CI/CD (SCIP multi-lang deps)**

  * Install `yarn` alongside `@sourcegraph/scip-typescript` and add best-effort installation of `bear` for Make/Autotools compilation database generation.
  * Keep CI aligned with multi-language indexing prerequisites.
* **Docs**

  * Add/expand `docs/scip_index.md` with multilingual prerequisites and example installs (TS workspace tooling, `bear`, etc.).
* **TypeScript SCIP indexing robustness**

  * Improve `scip_indexer_ts`:

    * Auto-enable `infer_tsconfig` when repo lacks `tsconfig.json/jsconfig.json` (common in dataset repos).
    * Auto-detect workspace mode (pnpm/yarn/npm workspaces) and normalize flags based on available package managers.
    * Best-effort dependency install (`npm/yarn/pnpm`) before indexing for more reliable symbol resolution.
    * Log normalized kwargs for easier debugging.
  * Fix TS decoding reference path usage (ensure references use `file_path` consistently).
* **C/C++ SCIP indexing robustness**

  * Improve `scip_indexer_clang`:

    * Validate `compile_commands.json` and treat missing/invalid compdb as actionable.
    * Add auto-generation of compilation DB:

      * CMake flow (`-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`)
      * Bear flow for Make/Autotools (`bear -- make`), with autotools bootstrap fallback (best effort).
    * Add `run_pipeline` wrapper to auto-discover/generate compdb and ignore Python-specific kwargs passed by callers.
* **Rust SCIP indexing ergonomics**

  * Add `run_pipeline` wrapper to ignore Python-specific kwargs forwarded by callers (matches TS/Clang behavior).
* **SWE-bench synthesis + scripts**

  * Extend `scripts/synthesize_swebench.py`:

    * Add `--sampling-seed` for deterministic block sampling.
    * Add `--behavioral-consensus-runs` to run multiple behavioral generations and vote for GT consensus.
    * Include `gt_symbol_nodes` in compact output record for evaluation compatibility.
  * Update `scripts/synthesize_swebench.sh` defaults to safer/debug-friendly settings:

    * default `SYNTHESIS_LIMIT=1`, default `QUERY_TYPES=behavioral`, expose consensus runs and seed.
* **Minor data-format fix**

  * Sort `target_files` for stable output ordering (`codeminer/dataset/utils.py`).
* **Tests**

  * Refactor `test/scip/test_scip_multilingual.py` (large cleanup + pytest alignment + updated dataset mode naming) and streamline CI execution.

## Type of Change

* [x] Bug fix (SCIP indexing failures / missing deps / invalid compdb)
* [x] New feature (auto-compdb generation, TS dependency install + workspace inference, synthesis seed + consensus)
* [ ] Breaking change
* [x] Documentation update
* [x] Refactoring
* [ ] Performance improvement
* [x] Tests

## Testing

* [x] Tests pass locally
* [ ] Added new tests for the changes

**How to test**

* Run unit tests:

  * `pytest`
* SCIP indexing smoke tests (examples):

  * TypeScript: run TypeScript indexer on a repo **without** `tsconfig.json` and confirm it succeeds via `infer_tsconfig` + dependency install.
  * C/C++: run clang indexer on a repo **without** `compile_commands.json` and confirm it attempts CMake/bear generation (bear optional but recommended).
* SWE-bench synthesis:

  * `bash scripts/synthesize_swebench.sh`
  * Deterministic run:

    * `SAMPLING_SEED=123 SYNTHESIS_LIMIT=5 bash scripts/synthesize_swebench.sh`
  * Consensus tuning:

    * `BEHAVIORAL_CONSENSUS_RUNS=5 bash scripts/synthesize_swebench.sh`

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [ ] Any dependent changes have been merged and published
