### PR TITLE
Add agent runner, graph expand skill and ops

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -1,17 +1,25 @@
 """Agent package consolidating agent utilities and implementations."""
 
+from .agent_types import AgentResult, ToolCallRecord
 from .extract_agent import (
     KeywordExtraction,
     KeywordExtractor,
     extract_keywords_from_statement,
 )
 from .rerank_agent import RerankAgent, RerankResult, rerank_nodes_with_query
+from .runner import AgentRunner
+from .tool_schema import registry_to_tools, skill_to_tool_schema
 
 __all__ = [
+    "AgentResult",
+    "AgentRunner",
     "KeywordExtraction",
     "KeywordExtractor",
-    "extract_keywords_from_statement",
     "RerankAgent",
     "RerankResult",
+    "ToolCallRecord",
+    "extract_keywords_from_statement",
     "rerank_nodes_with_query",
+    "registry_to_tools",
+    "skill_to_tool_schema",
 ]

--- a/codeminer/agent/agent_types.py
+++ b/codeminer/agent/agent_types.py
@@ -1,0 +1,29 @@
+"""Data types for the agent runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ToolCallRecord:
+    """Record of a single tool invocation during an agent run."""
+
+    tool_call_id: str
+    skill_id: str
+    arguments: Dict[str, Any]
+    result: Any = None
+    duration_ms: float = 0.0
+    error: Optional[str] = None
+
+
+@dataclass
+class AgentResult:
+    """Outcome of ``AgentRunner.run()``."""
+
+    answer: str
+    tool_calls: List[ToolCallRecord] = field(default_factory=list)
+    messages: List[Dict[str, Any]] = field(default_factory=list)
+    total_turns: int = 0
+    total_duration_ms: float = 0.0

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -1,0 +1,239 @@
+"""Lightweight agent runner using LLM tool calling.
+
+Implements a think → act → observe loop that lets an LLM decide which
+CodeMiner skills to invoke, execute them, and iterate until the LLM
+produces a final answer.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Optional, Set
+
+from ..llm.litellm_chat import LiteLLMChat
+from ..log_utils import get_logger
+from .agent_types import AgentResult, ToolCallRecord
+from .skills.registry import SkillRegistry
+from .tool_schema import registry_to_tools
+
+logger = get_logger(__name__)
+
+_DEFAULT_SYSTEM_PROMPT = """\
+You are a code search agent. You have access to tools that search a \
+codebase and retrieve relevant code snippets. Use the tools iteratively \
+to find the information needed, then provide a concise answer.
+
+Guidelines:
+- Start with broad searches, then narrow down.
+- Use graph_expand to find structurally related code after an initial search.
+- When you have enough context, provide a final answer directly.
+"""
+
+# Maximum characters for a single tool result to avoid context blowup.
+_MAX_RESULT_CHARS = 16_000
+
+
+class AgentRunner:
+    """LLM-driven agent loop over the CodeMiner skill registry.
+
+    Usage::
+
+        from codeminer.llm.litellm_chat import LiteLLMChat
+        from codeminer.agent.skills.registry import SkillRegistry
+
+        llm = LiteLLMChat(model="gpt-4o")
+        runner = AgentRunner(llm, SkillRegistry())
+        result = runner.run("How does authentication work in this repo?")
+        print(result.answer)
+    """
+
+    def __init__(
+        self,
+        llm: LiteLLMChat,
+        registry: Optional[SkillRegistry] = None,
+        *,
+        system_prompt: Optional[str] = None,
+        max_turns: int = 10,
+        exclude_skills: Optional[Set[str]] = None,
+    ) -> None:
+        self.llm = llm
+        self.registry = registry or SkillRegistry()
+        self.system_prompt = system_prompt or _DEFAULT_SYSTEM_PROMPT
+        self.max_turns = max_turns
+        self.tools = registry_to_tools(self.registry, exclude=exclude_skills)
+
+    def run(
+        self,
+        query: str,
+        *,
+        max_turns: Optional[int] = None,
+    ) -> AgentResult:
+        """Execute the agent loop and return the result."""
+        max_turns = max_turns or self.max_turns
+        messages: List[Dict[str, Any]] = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": query},
+        ]
+        all_tool_calls: List[ToolCallRecord] = []
+        start = time.monotonic()
+
+        for turn in range(max_turns):
+            logger.debug("agent turn %d/%d", turn + 1, max_turns)
+
+            call_kwargs: Dict[str, Any] = {}
+            if self.tools:
+                call_kwargs["tools"] = self.tools
+
+            response = self.llm._call_raw(messages, **call_kwargs)
+            choice = response.choices[0]
+            assistant_msg = choice.message
+
+            # Append assistant message to conversation
+            messages.append(_message_to_dict(assistant_msg))
+
+            # Check for tool calls
+            tool_calls = getattr(assistant_msg, "tool_calls", None)
+            if not tool_calls:
+                # Terminal: LLM produced a final answer
+                answer = getattr(assistant_msg, "content", None) or ""
+                elapsed = (time.monotonic() - start) * 1000
+                return AgentResult(
+                    answer=answer,
+                    tool_calls=all_tool_calls,
+                    messages=messages,
+                    total_turns=turn + 1,
+                    total_duration_ms=elapsed,
+                )
+
+            # Execute each tool call
+            for tc in tool_calls:
+                record = self._execute_tool_call(tc)
+                all_tool_calls.append(record)
+
+                # Append tool response message
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": _serialize_result(
+                            record.result if record.error is None else record.error
+                        ),
+                    }
+                )
+
+        # Max turns exhausted — return whatever we have
+        elapsed = (time.monotonic() - start) * 1000
+        last_content = ""
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant" and msg.get("content"):
+                last_content = msg["content"]
+                break
+
+        return AgentResult(
+            answer=last_content,
+            tool_calls=all_tool_calls,
+            messages=messages,
+            total_turns=max_turns,
+            total_duration_ms=elapsed,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _execute_tool_call(self, tc: Any) -> ToolCallRecord:
+        """Execute a single tool call from the LLM response."""
+        skill_id = tc.function.name
+        try:
+            arguments = json.loads(tc.function.arguments)
+        except (json.JSONDecodeError, TypeError):
+            arguments = {}
+
+        meta = self.registry.get(skill_id)
+        if meta is None or meta.executor_fn is None:
+            return ToolCallRecord(
+                tool_call_id=tc.id,
+                skill_id=skill_id,
+                arguments=arguments,
+                error=f"Skill {skill_id!r} not available",
+            )
+
+        start = time.monotonic()
+        try:
+            result = meta.executor_fn(**arguments)
+            elapsed = (time.monotonic() - start) * 1000
+            logger.debug(
+                "tool %s completed in %.0fms",
+                skill_id,
+                elapsed,
+            )
+            return ToolCallRecord(
+                tool_call_id=tc.id,
+                skill_id=skill_id,
+                arguments=arguments,
+                result=result,
+                duration_ms=elapsed,
+            )
+        except Exception as exc:
+            elapsed = (time.monotonic() - start) * 1000
+            logger.warning("tool %s failed: %s", skill_id, exc)
+            return ToolCallRecord(
+                tool_call_id=tc.id,
+                skill_id=skill_id,
+                arguments=arguments,
+                error=str(exc),
+                duration_ms=elapsed,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _message_to_dict(msg: Any) -> Dict[str, Any]:
+    """Convert a litellm response message to a raw dict."""
+    if hasattr(msg, "model_dump"):
+        d = msg.model_dump(exclude_none=True)
+    elif hasattr(msg, "to_dict"):
+        d = msg.to_dict()
+    else:
+        d = {
+            "role": getattr(msg, "role", "assistant"),
+            "content": getattr(msg, "content", None),
+        }
+        tool_calls = getattr(msg, "tool_calls", None)
+        if tool_calls:
+            d["tool_calls"] = [
+                tc.model_dump(exclude_none=True) if hasattr(tc, "model_dump") else tc
+                for tc in tool_calls
+            ]
+    return d
+
+
+def _serialize_result(result: Any) -> str:
+    """Serialize a tool result to a string for the LLM."""
+    if isinstance(result, str):
+        text = result
+    elif isinstance(result, (list, tuple)):
+        items = []
+        for item in result:
+            if hasattr(item, "model_dump"):
+                items.append(item.model_dump(exclude_none=True))
+            elif hasattr(item, "__dict__"):
+                items.append(item.__dict__)
+            else:
+                items.append(item)
+        text = json.dumps(items, default=str, ensure_ascii=False)
+    elif hasattr(result, "model_dump"):
+        text = json.dumps(result.model_dump(exclude_none=True), default=str)
+    else:
+        try:
+            text = json.dumps(result, default=str, ensure_ascii=False)
+        except (TypeError, ValueError):
+            text = str(result)
+
+    if len(text) > _MAX_RESULT_CHARS:
+        text = text[:_MAX_RESULT_CHARS] + "\n... (truncated)"
+    return text

--- a/codeminer/agent/skills/core.py
+++ b/codeminer/agent/skills/core.py
@@ -22,6 +22,7 @@ class SkillType(str, Enum):
     TRANSFORM = "transform"
     RERANK = "rerank"
     AGGREGATE = "aggregate"
+    EXPAND = "expand"
     CUSTOM = "custom"
 
 

--- a/codeminer/agent/skills/graph_expand/config.yaml
+++ b/codeminer/agent/skills/graph_expand/config.yaml
@@ -1,0 +1,65 @@
+skill_id: graph_expand
+skill_type: expand
+operator: graph.walk
+cost: medium
+
+defaults:
+  method: bfs
+  top_k: 50
+  hops: 2
+  direction: both
+  damping: 0.85
+  filter_tests: true
+
+inputs:
+  - name: seed_nodes
+    type: List[QueriedNode]
+    required: true
+    description: Seed nodes from upstream search results to expand from
+  - name: method
+    type: str
+    required: false
+    default: bfs
+    description: Expansion method - "bfs" for k-hop BFS or "ppr" for Personalized PageRank
+  - name: top_k
+    type: int
+    required: false
+    default: 50
+  - name: hops
+    type: int
+    required: false
+    default: 2
+    description: Number of hops for BFS expansion
+  - name: direction
+    type: str
+    required: false
+    default: both
+    description: Edge traversal direction - "forward", "backward", or "both"
+  - name: damping
+    type: float
+    required: false
+    default: 0.85
+    description: PPR damping factor (only used with method=ppr)
+  - name: filter_tests
+    type: bool
+    required: false
+    default: true
+  - name: edge_types
+    type: List[str]
+    required: false
+    description: Edge types to traverse (null for all)
+  - name: node_types
+    type: List[str]
+    required: false
+    description: Node types to include in results (null for all)
+
+outputs:
+  type: List[QueriedNode]
+  description: Expanded related symbols with content
+
+index_requirements:
+  - type: symbol_graph
+    max_age_seconds: 3600
+    scope: current_repo
+
+resources: []

--- a/codeminer/agent/skills/graph_expand/executor.py
+++ b/codeminer/agent/skills/graph_expand/executor.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Callable, List, Optional
+
+
+def create_executor(context: Any) -> Callable[..., List[Any]]:
+    """Factory: returns a callable that expands seed nodes via the symbol graph.
+
+    Parameters
+    ----------
+    context:
+        An ``ExpandContext`` instance (from ``codeminer.ops.expand``)
+        that carries the loaded ``CodeGraph``.
+    """
+    from ....graph.roi_subgraph import ROISubgraph
+    from ....ops.expand import _nodeinfo_to_queried
+
+    def execute(
+        seed_nodes: List[Any],
+        method: str = "bfs",
+        top_k: int = 50,
+        **kwargs: Any,
+    ) -> List[Any]:
+        if context.code_graph is None:
+            raise RuntimeError("Symbol graph not available")
+
+        hops: int = kwargs.get("hops", 2)
+        direction: str = kwargs.get("direction", "both")
+        damping: float = kwargs.get("damping", 0.85)
+        filter_tests: bool = kwargs.get("filter_tests", True)
+        edge_types: Optional[List[str]] = kwargs.get("edge_types")
+        node_types: Optional[List[str]] = kwargs.get("node_types")
+
+        # Extract seed names
+        seed_names = []
+        for node in seed_nodes:
+            name = getattr(node, "node_name", None) or (
+                node if isinstance(node, str) else None
+            )
+            if name:
+                seed_names.append(name)
+
+        if not seed_names:
+            return []
+
+        roi = ROISubgraph(context.code_graph)
+
+        if method == "ppr":
+            node_infos = roi.expand_ppr(
+                node_names=seed_names,
+                top_k=top_k,
+                damping=damping,
+                filter_tests=filter_tests,
+            )
+            seed_set = set(seed_names)
+            node_infos = [n for n in node_infos if n.node_name not in seed_set]
+        else:
+            subgraph = roi.extract_subgraph(
+                node_names=seed_names,
+                k_hop=hops,
+                edge_types=edge_types,
+                direction=direction,
+            )
+            node_infos = roi.get_filtered_subgraph_nodes(
+                subgraph,
+                exclude_nodes=seed_names,
+                filter_tests=filter_tests,
+                node_types=node_types,
+            )
+
+        return _nodeinfo_to_queried(node_infos)[:top_k]
+
+    return execute

--- a/codeminer/agent/skills/graph_expand/skill.md
+++ b/codeminer/agent/skills/graph_expand/skill.md
@@ -1,0 +1,38 @@
+# graph_expand
+
+Expand seed code blocks along the symbol graph to discover structurally related symbols in bulk.
+
+## When to use
+
+- After an initial search (BM25, embedding, or regex) has identified seed code locations
+- When you need to find callers, callees, class members, imported dependencies, or other structurally related code
+- When you want to enlarge the context around known functions/classes at the code-chunk level
+
+## When NOT to use
+
+- As a first retrieval step (requires seed nodes from an upstream search)
+- For semantic similarity search (use `embedding_search` instead)
+- When the symbol graph has not been built
+
+## Parameters
+
+| Parameter     | Type       | Default | Description                                              |
+|---------------|------------|---------|----------------------------------------------------------|
+| seed_nodes    | List[QueriedNode] | required | Seed nodes from upstream search results         |
+| method        | str        | bfs     | `"bfs"` for k-hop BFS or `"ppr"` for Personalized PageRank |
+| top_k         | int        | 50      | Maximum number of expanded nodes to return               |
+| hops          | int        | 2       | Number of hops for BFS expansion                         |
+| direction     | str        | both    | `"forward"`, `"backward"`, or `"both"`                   |
+| damping       | float      | 0.85    | PPR damping factor (only for method=ppr)                 |
+| filter_tests  | bool       | true    | Exclude test files from results                          |
+| edge_types    | List[str]  | null    | Edge types to traverse (null = all)                      |
+| node_types    | List[str]  | null    | Node types to include (null = all)                       |
+
+## Output
+
+`List[QueriedNode]` — expanded related symbols with file path, line range, score, and source content.
+
+## Methods
+
+- **BFS** (`method: bfs`): Local k-hop neighborhood expansion. Good for finding directly related code within a bounded radius.
+- **PPR** (`method: ppr`): Personalized PageRank over the full graph seeded from the input nodes. Good for finding globally relevant code weighted by structural importance.

--- a/codeminer/agent/skills/loader.py
+++ b/codeminer/agent/skills/loader.py
@@ -27,6 +27,7 @@ _CONTEXT_KEY_FOR_TYPE: Dict[str, str] = {
     "aggregate": "retrieve",
     "rerank": "rerank",
     "transform": "transform",
+    "expand": "expand",
 }
 
 

--- a/codeminer/agent/tool_schema.py
+++ b/codeminer/agent/tool_schema.py
@@ -1,0 +1,82 @@
+"""Convert SkillMetadata to OpenAI function-calling tool schemas.
+
+This module bridges the SkillRegistry to LLM tool-calling APIs.
+``registry_to_tools`` produces the ``tools`` list that litellm
+(and any OpenAI-compatible provider) accepts.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set
+
+from .skills.core import SkillMetadata
+from .skills.registry import SkillRegistry
+
+# Map SkillInputSpec.type_hint strings to JSON Schema types.
+_TYPE_MAP: Dict[str, Dict[str, str]] = {
+    "str": {"type": "string"},
+    "int": {"type": "integer"},
+    "float": {"type": "number"},
+    "bool": {"type": "boolean"},
+}
+
+
+def skill_to_tool_schema(meta: SkillMetadata) -> Dict[str, Any]:
+    """Convert a single ``SkillMetadata`` to an OpenAI function tool dict."""
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+
+    for inp in meta.inputs:
+        prop: Dict[str, Any] = dict(_TYPE_MAP.get(inp.type_hint, {}))
+        if inp.description:
+            prop["description"] = inp.description
+        if inp.default is not None:
+            prop["default"] = inp.default
+        properties[inp.name] = prop
+
+        if inp.required:
+            required.append(inp.name)
+
+    description = (meta.skill_doc or meta.description or "").strip()
+    # Truncate long descriptions to avoid bloating the tool list
+    if len(description) > 1024:
+        description = description[:1021] + "..."
+
+    return {
+        "type": "function",
+        "function": {
+            "name": meta.skill_id,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                **({"required": required} if required else {}),
+            },
+        },
+    }
+
+
+def registry_to_tools(
+    registry: Optional[SkillRegistry] = None,
+    *,
+    exclude: Optional[Set[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Convert all skills in the registry to OpenAI tool schemas.
+
+    Args:
+        registry: Registry to read from; defaults to the singleton.
+        exclude: Skill IDs to skip (e.g. internal-only skills).
+
+    Returns:
+        List of tool dicts ready for ``litellm.completion(tools=...)``.
+    """
+    reg = registry or SkillRegistry()
+    exclude = exclude or set()
+    tools: List[Dict[str, Any]] = []
+
+    for skill_id, meta in reg.list_skills().items():
+        if skill_id in exclude:
+            continue
+        tools.append(skill_to_tool_schema(meta))
+
+    return tools

--- a/codeminer/compiler/index_builders.py
+++ b/codeminer/compiler/index_builders.py
@@ -167,13 +167,27 @@ class SymbolGraphBuilder:
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
 
-        from ..scip_interface.scip_indexer import SCIPIndexer
+        from ..scip_interface import (
+            SCIPPythonIndexer,
+            SCIPRustIndexer,
+            SCIPTypeScriptIndexer,
+        )
+
+        _INDEXER_MAP = {
+            "python": SCIPPythonIndexer,
+            "rust": SCIPRustIndexer,
+            "typescript": SCIPTypeScriptIndexer,
+            "javascript": SCIPTypeScriptIndexer,
+        }
+
+        indexer_cls = _INDEXER_MAP.get(self.language)
+        if indexer_cls is None:
+            raise ValueError(f"Unsupported language for symbol graph: {self.language}")
 
         os.makedirs(output_dir, exist_ok=True)
-        indexer = SCIPIndexer(
+        indexer = indexer_cls(
             project_root=repo_path,
             output_dir=output_dir,
-            language=self.language,
         )
         graph = indexer.run_pipeline(
             output_file=os.path.join(output_dir, "graph.pkl"),

--- a/codeminer/compiler/index_builders.py
+++ b/codeminer/compiler/index_builders.py
@@ -7,7 +7,8 @@ when ``ResourcePlan`` indicates they are missing or stale.
 Concrete builders wrap existing index infrastructure:
   - ``BM25IndexBuilder``   → ``BM25CodeIndexer``
   - ``VectorIndexBuilder`` → ``build_hierarchical_vector_store``
-  - ``SymbolGraphBuilder`` → ``SCIPIndexer``
+  - ``SymbolGraphBuilder`` → ``SCIPPythonIndexer``
+  / ``SCIPRustIndexer`` / ``SCIPTypeScriptIndexer``
 """
 
 from __future__ import annotations

--- a/codeminer/compiler/ir_algebra.py
+++ b/codeminer/compiler/ir_algebra.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import Any, Dict, Iterable, List, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 
 @dataclass(slots=True)
@@ -117,6 +117,27 @@ class HybridUnion(AlgebraOp):
 
     def with_children(self, children: Sequence[AlgebraOp]) -> "HybridUnion":
         return replace(self, branches=list(children))
+
+
+@dataclass(slots=True)
+class GraphExpand(AlgebraOp):
+    """Graph-based context expansion (BFS k-hop or PPR)."""
+
+    method: str = "bfs"
+    top_k: int = 50
+    hops: int = 2
+    direction: str = "both"
+    damping: float = 0.85
+    edge_types: Optional[List[str]] = None
+    source: AlgebraOp = field(default_factory=RelationRef)
+
+    def iter_children(self) -> Iterable[AlgebraOp]:
+        yield self.source
+
+    def with_children(self, children: Sequence[AlgebraOp]) -> "GraphExpand":
+        if len(children) != 1:
+            raise ValueError("GraphExpand expects one child.")
+        return replace(self, source=children[0])
 
 
 @dataclass(slots=True)

--- a/codeminer/llm/litellm_chat.py
+++ b/codeminer/llm/litellm_chat.py
@@ -82,10 +82,13 @@ class LiteLLMChat:
     def _call(self, messages: List[ChatMessage], **overrides: Any) -> Any:
         """Build kwargs and call ``litellm.completion``."""
         msg_dicts = [{"role": m.role, "content": m.content} for m in messages]
+        return self._call_raw(msg_dicts, **overrides)
 
+    def _call_raw(self, messages: List[Dict[str, Any]], **overrides: Any) -> Any:
+        """Like ``_call`` but accepts raw message dicts (for tool-calling flows)."""
         kwargs: Dict[str, Any] = {
             "model": self.model,
-            "messages": msg_dicts,
+            "messages": messages,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
             **self.extra_kwargs,

--- a/codeminer/ops/expand.py
+++ b/codeminer/ops/expand.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from ..compiler.execution import ExecutionEngine
+from ..compiler.ir_exec import ExecutionNode
+from ..compiler.ir_physical import PhysicalOperator
+from ..graph.code_graph import CodeGraph
+from ..graph.roi_subgraph import ROISubgraph
+from ..log_utils import get_logger
+from ..types import NodeInfo, QueriedNode
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ExpandContext:
+    """Shared resources for graph expansion operators."""
+
+    code_graph: Optional[CodeGraph] = None
+    default_top_k: int = 50
+    default_hops: int = 2
+    default_direction: str = "both"
+    default_method: str = "bfs"
+    default_damping: float = 0.85
+    filter_tests: bool = True
+
+
+def register_expand_ops(engine: ExecutionEngine, context: ExpandContext) -> None:
+    """Register graph-expansion execution kernels on the provided engine."""
+    engine.register(PhysicalOperator.GRAPH_WALK.value, _graph_walk_kernel(context))
+
+
+def _graph_walk_kernel(context: ExpandContext):
+    """Return a kernel that expands seed nodes along graph edges."""
+
+    def run(node: ExecutionNode, inputs: List[object]) -> List[QueriedNode]:
+        if context.code_graph is None:
+            raise RuntimeError("graph.walk operator invoked but no CodeGraph provided.")
+
+        # --- extract params ---
+        params = node.params
+        method = str(params.get("method", context.default_method))
+        top_k = int(params.get("top_k", context.default_top_k))
+        hops = int(params.get("hops", context.default_hops))
+        direction = str(params.get("direction", context.default_direction))
+        damping = float(params.get("damping", context.default_damping))
+        filter_tests = bool(params.get("filter_tests", context.filter_tests))
+        edge_types: Optional[List[str]] = params.get("edge_types")
+        node_types: Optional[List[str]] = params.get("node_types")
+
+        # --- extract seed node names from upstream inputs ---
+        seed_names = _extract_seeds(inputs)
+        if not seed_names:
+            logger.warning("graph.walk: no seed nodes provided — returning empty")
+            return []
+
+        logger.debug(
+            "graph.walk: method=%s seeds=%d top_k=%d hops=%d direction=%s",
+            method,
+            len(seed_names),
+            top_k,
+            hops,
+            direction,
+        )
+
+        roi = ROISubgraph(context.code_graph)
+
+        if method == "ppr":
+            node_infos = roi.expand_ppr(
+                node_names=seed_names,
+                top_k=top_k,
+                damping=damping,
+                filter_tests=filter_tests,
+            )
+            # Exclude seeds from PPR results
+            seed_set = set(seed_names)
+            node_infos = [n for n in node_infos if n.node_name not in seed_set]
+        else:
+            # BFS k-hop expansion
+            subgraph = roi.extract_subgraph(
+                node_names=seed_names,
+                k_hop=hops,
+                edge_types=edge_types,
+                direction=direction,
+            )
+            node_infos = roi.get_filtered_subgraph_nodes(
+                subgraph,
+                exclude_nodes=seed_names,
+                filter_tests=filter_tests,
+                node_types=node_types,
+            )
+
+        # Convert NodeInfo -> QueriedNode
+        results = _nodeinfo_to_queried(node_infos)
+        return results[:top_k]
+
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_seeds(inputs: List[object]) -> List[str]:
+    """Flatten upstream inputs into a list of seed node names."""
+    names: List[str] = []
+    for inp in inputs:
+        if isinstance(inp, (list, tuple)):
+            for item in inp:
+                name = _get_node_name(item)
+                if name:
+                    names.append(name)
+        else:
+            name = _get_node_name(inp)
+            if name:
+                names.append(name)
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: List[str] = []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            unique.append(n)
+    return unique
+
+
+def _get_node_name(item: object) -> Optional[str]:
+    """Extract node_name from a QueriedNode/NodeInfo or plain string."""
+    if isinstance(item, str):
+        return item
+    if hasattr(item, "node_name"):
+        return item.node_name  # type: ignore[union-attr]
+    return None
+
+
+def _nodeinfo_to_queried(nodes: List[NodeInfo]) -> List[QueriedNode]:
+    """Convert NodeInfo list to QueriedNode list, assigning rank-based scores."""
+    results: List[QueriedNode] = []
+    for rank, ni in enumerate(nodes):
+        score = ni.score if ni.score is not None else 1.0 / (rank + 1)
+        results.append(
+            QueriedNode(
+                node_name=ni.node_name,
+                type=ni.type,
+                file=ni.file,
+                start_line=ni.start_line,
+                end_line=ni.end_line,
+                score=score,
+                content=ni.content,
+            )
+        )
+    return results

--- a/test/agent/test_agent_graph_vertex.py
+++ b/test/agent/test_agent_graph_vertex.py
@@ -1,0 +1,239 @@
+"""Integration test: AgentRunner + graph_expand skill + Vertex AI backend.
+
+Uses the real httpie/cli repo (from conftest.py) with SCIP-python to
+build a symbol graph, then lets the LLM agent explore it via graph_expand.
+
+Run unit tests (no LLM, no SCIP)::
+
+    conda run -n codeminer python -B -m pytest \
+    test/agent/test_agent_graph_vertex.py::TestGraphExpandExecutor -xvs
+
+Run integration tests (requires Vertex AI + scip-python)::
+
+    conda run -n codeminer python -B -m pytest \
+    test/agent/test_agent_graph_vertex.py -xvs -m integration
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codeminer.agent.agent_types import AgentResult
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.skills.core import SkillInputSpec, SkillMetadata, SkillType
+from codeminer.agent.skills.graph_expand.executor import create_executor
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.llm.llm_config import LLMConfig, LLMProvider, create_llm
+from codeminer.ops.expand import ExpandContext
+
+# ---------------------------------------------------------------------------
+# Real SCIP graph from httpie/cli repo
+# ---------------------------------------------------------------------------
+
+HTTPIE_GRAPH_DIR = Path("/tmp/httpie-cli-graph")
+HTTPIE_GRAPH_FILE = HTTPIE_GRAPH_DIR / "graph.pkl"
+
+
+@pytest.fixture(scope="session")
+def httpie_graph(httpie_cli_repo) -> CodeGraph:
+    """Build (or load cached) SCIP symbol graph for the httpie/cli repo.
+
+    Uses ``LSIndexer`` (the unified language-server router) and
+    ``skip_level="graph"`` so repeated runs reuse the cached graph.pkl.
+    """
+    from codeminer.ls_router import LSIndexer
+
+    indexer = LSIndexer(
+        project_root=str(httpie_cli_repo),
+        output_dir=str(HTTPIE_GRAPH_DIR),
+        language="python",
+    )
+
+    graph = indexer.run_pipeline(
+        output_file=str(HTTPIE_GRAPH_FILE),
+        skip_level="graph",
+    )
+
+    if graph is None:
+        pytest.skip("SCIP pipeline failed — scip-python may not be available")
+
+    print(f"\nhttpie graph: {len(graph.graph.vs)} nodes, {len(graph.graph.es)} edges")
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: real httpie graph + Vertex AI
+# ---------------------------------------------------------------------------
+
+
+def _register_graph_expand(registry: SkillRegistry, graph: CodeGraph) -> None:
+    """Register graph_expand skill backed by a real CodeGraph."""
+    ctx = ExpandContext(code_graph=graph)
+    raw_executor = create_executor(ctx)
+
+    registry.register(
+        SkillMetadata(
+            skill_id="graph_expand",
+            skill_type=SkillType.EXPAND,
+            inputs=[
+                SkillInputSpec(
+                    name="seed_nodes",
+                    type_hint="str",
+                    required=True,
+                    description="Comma-separated qualified symbol names to expand from",
+                ),
+                SkillInputSpec(
+                    name="method",
+                    type_hint="str",
+                    required=False,
+                    default="bfs",
+                    description=(
+                        'Expansion method: "bfs" for k-hop BFS or "ppr" for '
+                        "Personalized PageRank"
+                    ),
+                ),
+                SkillInputSpec(
+                    name="top_k",
+                    type_hint="int",
+                    required=False,
+                    default=20,
+                ),
+                SkillInputSpec(
+                    name="hops",
+                    type_hint="int",
+                    required=False,
+                    default=2,
+                    description="Number of hops for BFS expansion",
+                ),
+            ],
+            executor_fn=_wrap_executor_for_agent(raw_executor),
+            description=(
+                "Expand from seed code symbols to find structurally related "
+                "symbols (callers, callees, class members, references) in the "
+                "code graph. seed_nodes is a comma-separated list of qualified "
+                "symbol names (e.g. 'httpie.cli.definition.HTTPieArgumentParser')."
+            ),
+        )
+    )
+
+
+@pytest.mark.integration
+class TestAgentGraphVertexAI:
+    """End-to-end: LLM agent uses graph_expand on the real httpie graph."""
+
+    @pytest.fixture()
+    def registry_with_graph(self, httpie_graph):
+        SkillRegistry.reset()
+        reg = SkillRegistry()
+        _register_graph_expand(reg, httpie_graph)
+        yield reg
+        SkillRegistry.reset()
+
+    @pytest.fixture()
+    def vertex_llm(self):
+        try:
+            config = LLMConfig(
+                model_name="gemini-2.5-flash",
+                provider=LLMProvider.VERTEX_GEMINI,
+                temperature=0.0,
+                max_tokens=2048,
+            )
+            return create_llm(config)
+        except Exception as e:
+            pytest.skip(f"Vertex AI not available: {e}")
+
+    def test_agent_explores_httpie_graph(
+        self,
+        vertex_llm,
+        registry_with_graph,
+        httpie_graph,
+    ):
+        """Agent should use graph_expand to discover httpie symbols."""
+        # Pick some real symbols from the graph for the system prompt
+        sample_symbols = _sample_symbol_names(httpie_graph, max_count=15)
+        symbol_list = "\n".join(f"- {s}" for s in sample_symbols)
+
+        system_prompt = (
+            "You are a code exploration agent for the httpie/cli Python project. "
+            "You have a graph_expand tool that finds structurally related code "
+            "symbols (callers, callees, references) given seed symbol names.\n\n"
+            f"Here are some symbols in the codebase:\n{symbol_list}\n\n"
+            "Use graph_expand to explore relationships, then summarize findings."
+        )
+
+        runner = AgentRunner(
+            llm=vertex_llm,
+            registry=registry_with_graph,
+            system_prompt=system_prompt,
+            max_turns=5,
+        )
+
+        # Ask about a core httpie symbol
+        seed = sample_symbols[0] if sample_symbols else "httpie.core.main"
+        result = runner.run(
+            f"What symbols are related to {seed!r}? "
+            f"Use graph_expand with seed_nodes={seed!r} to find out."
+        )
+
+        assert isinstance(result, AgentResult)
+        assert result.total_turns >= 1
+        assert len(result.tool_calls) >= 1
+        assert any(tc.skill_id == "graph_expand" for tc in result.tool_calls)
+        assert len(result.answer) > 0
+
+        # At least one tool call should have succeeded
+        successful = [tc for tc in result.tool_calls if tc.error is None]
+        assert len(successful) >= 1
+
+        print(f"\n--- Agent Result (httpie graph) ---")
+        print(f"Turns: {result.total_turns}")
+        print(f"Tool calls: {len(result.tool_calls)}")
+        for tc in result.tool_calls:
+            n_results = len(tc.result) if isinstance(tc.result, list) else "N/A"
+            print(
+                f"  {tc.skill_id}({tc.arguments}) "
+                f"-> {n_results} results, error={tc.error}"
+            )
+        print(f"Answer:\n{result.answer[:800]}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wrap_executor_for_agent(executor_fn):
+    """Wrap the graph_expand executor so it accepts string-based args from LLM.
+
+    The raw executor expects ``seed_nodes: List[Any]``, but the LLM will
+    pass a comma-separated string. This wrapper handles the conversion.
+    """
+
+    def wrapped(seed_nodes, method="bfs", top_k=20, hops=2, **kwargs):
+        if isinstance(seed_nodes, str):
+            seed_nodes = [s.strip() for s in seed_nodes.split(",") if s.strip()]
+        return executor_fn(
+            seed_nodes=seed_nodes,
+            method=method,
+            top_k=int(top_k),
+            hops=int(hops),
+            **kwargs,
+        )
+
+    return wrapped
+
+
+def _sample_symbol_names(graph: CodeGraph, max_count: int = 15) -> list[str]:
+    """Pick representative symbol names from the graph for the system prompt."""
+    from codeminer.types import is_symbol_node
+
+    symbols = []
+    for v in graph.graph.vs:
+        if is_symbol_node(v) and v["name"].startswith("httpie."):
+            symbols.append(v["name"])
+        if len(symbols) >= max_count:
+            break
+    return symbols

--- a/test/agent/test_roi_rerank.py
+++ b/test/agent/test_roi_rerank.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
 
         # Print filtered nodes (sample 3 nodes), return type is NodeInfo
         for i, node in enumerate(filtered_nodes[:3]):
-            print(f"Filtered node {i+1}")
+            print(f"Filtered node {i + 1}")
             print(f"Node Name: {node.node_name}")
             print(f"Node Type: {node.type}")
             print(f"Node File: {node.file}")
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 
         # Print ranked nodes
         for i, node in enumerate(ranked_nodes):
-            print(f"Rank {i+1} (Score: {node.score:.4f})")
+            print(f"Rank {i + 1} (Score: {node.score:.4f})")
             print(f"Node Name: {node.node_name}")
             print(f"Node Type: {node.type}")
             print(f"Node File: {node.file}")

--- a/test/agent/test_runner.py
+++ b/test/agent/test_runner.py
@@ -1,0 +1,257 @@
+"""Tests for the agent runner (codeminer.agent.runner)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.agent.agent_types import AgentResult
+from codeminer.agent.runner import AgentRunner, _serialize_result
+from codeminer.agent.skills.core import (
+    SkillInputSpec,
+    SkillMetadata,
+    SkillOutputSpec,
+    SkillType,
+)
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.llm.litellm_chat import LiteLLMChat
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_llm():
+    """Return a mock LiteLLMChat."""
+    return MagicMock(spec=LiteLLMChat)
+
+
+def _make_response(content=None, tool_calls=None):
+    """Build a fake litellm response object."""
+    msg = SimpleNamespace(
+        role="assistant",
+        content=content,
+        tool_calls=tool_calls,
+    )
+    choice = SimpleNamespace(message=msg)
+    return SimpleNamespace(choices=[choice])
+
+
+def _make_tool_call(tc_id, name, arguments_json):
+    """Build a fake tool call object."""
+    return SimpleNamespace(
+        id=tc_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments_json),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+@pytest.fixture()
+def echo_registry():
+    """Registry with a simple echo skill."""
+    reg = SkillRegistry()
+    reg.register(
+        SkillMetadata(
+            skill_id="echo",
+            skill_type=SkillType.CUSTOM,
+            inputs=[SkillInputSpec(name="text", type_hint="str", required=True)],
+            outputs=SkillOutputSpec(type_hint="str"),
+            executor_fn=lambda text: f"echo: {text}",
+        )
+    )
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Runner tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRunner:
+    def test_direct_answer_no_tools(self):
+        """LLM answers directly without tool calls → 1 turn, no tool records."""
+        llm = _make_llm()
+        llm._call_raw.return_value = _make_response(content="The answer is 42.")
+
+        runner = AgentRunner(llm, SkillRegistry())
+        result = runner.run("What is the answer?")
+
+        assert isinstance(result, AgentResult)
+        assert result.answer == "The answer is 42."
+        assert result.total_turns == 1
+        assert result.tool_calls == []
+        llm._call_raw.assert_called_once()
+
+    def test_single_tool_call(self, echo_registry):
+        """LLM calls one tool, then gives a final answer."""
+        llm = _make_llm()
+
+        # Turn 1: LLM requests tool call
+        tc = _make_tool_call("call_1", "echo", '{"text": "hello"}')
+        # Turn 2: LLM gives final answer
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(content="Done. The echo said hello."),
+        ]
+
+        runner = AgentRunner(llm, echo_registry)
+        result = runner.run("Echo hello")
+
+        assert result.answer == "Done. The echo said hello."
+        assert result.total_turns == 2
+        assert len(result.tool_calls) == 1
+
+        record = result.tool_calls[0]
+        assert record.skill_id == "echo"
+        assert record.arguments == {"text": "hello"}
+        assert record.result == "echo: hello"
+        assert record.error is None
+
+    def test_multiple_tool_calls_in_one_response(self, echo_registry):
+        """LLM returns multiple tool calls in a single response."""
+        llm = _make_llm()
+
+        tc1 = _make_tool_call("call_1", "echo", '{"text": "a"}')
+        tc2 = _make_tool_call("call_2", "echo", '{"text": "b"}')
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc1, tc2]),
+            _make_response(content="Got both."),
+        ]
+
+        runner = AgentRunner(llm, echo_registry)
+        result = runner.run("Echo a and b")
+
+        assert len(result.tool_calls) == 2
+        assert result.tool_calls[0].result == "echo: a"
+        assert result.tool_calls[1].result == "echo: b"
+
+    def test_max_turns_limit(self, echo_registry):
+        """Runner stops after max_turns even if LLM keeps calling tools."""
+        llm = _make_llm()
+        tc = _make_tool_call("call_x", "echo", '{"text": "loop"}')
+        # Always return a tool call, never a final answer
+        llm._call_raw.return_value = _make_response(tool_calls=[tc])
+
+        runner = AgentRunner(llm, echo_registry, max_turns=3)
+        result = runner.run("loop forever")
+
+        assert result.total_turns == 3
+        assert len(result.tool_calls) == 3
+
+    def test_unknown_skill_returns_error(self):
+        """Tool call for unregistered skill records an error."""
+        llm = _make_llm()
+        tc = _make_tool_call("call_1", "nonexistent", "{}")
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(content="Failed."),
+        ]
+
+        runner = AgentRunner(llm, SkillRegistry())
+        result = runner.run("test")
+
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].error is not None
+        assert "not available" in result.tool_calls[0].error
+
+    def test_executor_exception_handled(self):
+        """Executor that raises returns error in tool response."""
+        reg = SkillRegistry()
+        reg.register(
+            SkillMetadata(
+                skill_id="fail",
+                skill_type=SkillType.CUSTOM,
+                inputs=[],
+                executor_fn=lambda: (_ for _ in ()).throw(ValueError("boom")),
+            )
+        )
+
+        llm = _make_llm()
+        tc = _make_tool_call("call_1", "fail", "{}")
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(content="It failed."),
+        ]
+
+        runner = AgentRunner(llm, reg)
+        result = runner.run("fail")
+
+        assert result.tool_calls[0].error is not None
+        assert "boom" in result.tool_calls[0].error
+
+    def test_tool_messages_appended(self, echo_registry):
+        """Verify tool-role messages are appended to conversation."""
+        llm = _make_llm()
+        tc = _make_tool_call("call_1", "echo", '{"text": "hi"}')
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(content="Done."),
+        ]
+
+        runner = AgentRunner(llm, echo_registry)
+        result = runner.run("hi")
+
+        tool_msgs = [m for m in result.messages if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "call_1"
+        assert "echo: hi" in tool_msgs[0]["content"]
+
+    def test_exclude_skills(self, echo_registry):
+        """Excluded skills should not appear in tool schemas."""
+        llm = _make_llm()
+        llm._call_raw.return_value = _make_response(content="ok")
+
+        runner = AgentRunner(llm, echo_registry, exclude_skills={"echo"})
+        assert runner.tools == []
+
+
+# ---------------------------------------------------------------------------
+# Serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeResult:
+    def test_string_passthrough(self):
+        assert _serialize_result("hello") == "hello"
+
+    def test_list_of_dicts(self):
+        result = _serialize_result([{"a": 1}, {"b": 2}])
+        assert '"a": 1' in result
+
+    def test_pydantic_model(self):
+        from pydantic import BaseModel
+
+        class Foo(BaseModel):
+            x: int = 1
+
+        result = _serialize_result(Foo())
+        assert '"x": 1' in result
+
+    def test_list_of_pydantic(self):
+        from pydantic import BaseModel
+
+        class Bar(BaseModel):
+            v: str = "ok"
+
+        result = _serialize_result([Bar(), Bar()])
+        assert '"v": "ok"' in result
+
+    def test_truncation(self):
+        long = "x" * 20000
+        result = _serialize_result(long)
+        assert len(result) <= 16100  # _MAX_RESULT_CHARS + small overhead
+        assert "truncated" in result

--- a/test/agent/test_tool_schema.py
+++ b/test/agent/test_tool_schema.py
@@ -1,0 +1,212 @@
+"""Tests for tool schema generation (codeminer.agent.tool_schema)."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.agent.skills.core import (
+    Cost,
+    SkillInputSpec,
+    SkillMetadata,
+    SkillOutputSpec,
+    SkillType,
+)
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.agent.tool_schema import registry_to_tools, skill_to_tool_schema
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_meta():
+    return SkillMetadata(
+        skill_id="test_search",
+        skill_type=SkillType.RETRIEVAL,
+        inputs=[
+            SkillInputSpec(
+                name="query",
+                type_hint="str",
+                required=True,
+                description="Search query",
+            ),
+            SkillInputSpec(
+                name="top_k",
+                type_hint="int",
+                required=False,
+                default=20,
+                description="Max results",
+            ),
+            SkillInputSpec(
+                name="filter_test",
+                type_hint="bool",
+                required=False,
+                default=False,
+            ),
+        ],
+        outputs=SkillOutputSpec(type_hint="List[QueriedNode]"),
+        skill_doc="A test search skill.\nSearches code.",
+        cost=Cost.LOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# skill_to_tool_schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestSkillToToolSchema:
+    def test_basic_structure(self, sample_meta):
+        schema = skill_to_tool_schema(sample_meta)
+
+        assert schema["type"] == "function"
+        func = schema["function"]
+        assert func["name"] == "test_search"
+        assert "A test search skill" in func["description"]
+
+        params = func["parameters"]
+        assert params["type"] == "object"
+        assert "query" in params["properties"]
+        assert params["required"] == ["query"]
+
+    def test_type_mapping_str(self, sample_meta):
+        schema = skill_to_tool_schema(sample_meta)
+        props = schema["function"]["parameters"]["properties"]
+        assert props["query"]["type"] == "string"
+
+    def test_type_mapping_int(self, sample_meta):
+        schema = skill_to_tool_schema(sample_meta)
+        props = schema["function"]["parameters"]["properties"]
+        assert props["top_k"]["type"] == "integer"
+
+    def test_type_mapping_bool(self, sample_meta):
+        schema = skill_to_tool_schema(sample_meta)
+        props = schema["function"]["parameters"]["properties"]
+        assert props["filter_test"]["type"] == "boolean"
+
+    def test_type_mapping_float(self):
+        meta = SkillMetadata(
+            skill_id="test_float",
+            skill_type=SkillType.CUSTOM,
+            inputs=[SkillInputSpec(name="damping", type_hint="float")],
+        )
+        schema = skill_to_tool_schema(meta)
+        assert (
+            schema["function"]["parameters"]["properties"]["damping"]["type"]
+            == "number"
+        )
+
+    def test_complex_type_unconstrained(self):
+        """Complex types like List[QueriedNode] should produce empty schema."""
+        meta = SkillMetadata(
+            skill_id="test_complex",
+            skill_type=SkillType.CUSTOM,
+            inputs=[SkillInputSpec(name="nodes", type_hint="List[QueriedNode]")],
+        )
+        schema = skill_to_tool_schema(meta)
+        props = schema["function"]["parameters"]["properties"]
+        # No "type" key for complex types
+        assert "type" not in props["nodes"]
+
+    def test_default_values(self, sample_meta):
+        schema = skill_to_tool_schema(sample_meta)
+        props = schema["function"]["parameters"]["properties"]
+        assert props["top_k"]["default"] == 20
+
+    def test_description_field(self, sample_meta):
+        schema = skill_to_tool_schema(sample_meta)
+        props = schema["function"]["parameters"]["properties"]
+        assert props["query"]["description"] == "Search query"
+
+    def test_required_only_required_params(self, sample_meta):
+        schema = skill_to_tool_schema(sample_meta)
+        required = schema["function"]["parameters"]["required"]
+        assert required == ["query"]
+        assert "top_k" not in required
+        assert "filter_test" not in required
+
+    def test_no_required_omits_key(self):
+        """If no params are required, the 'required' key should be absent."""
+        meta = SkillMetadata(
+            skill_id="test_optional",
+            skill_type=SkillType.CUSTOM,
+            inputs=[SkillInputSpec(name="x", type_hint="int", required=False)],
+        )
+        schema = skill_to_tool_schema(meta)
+        assert "required" not in schema["function"]["parameters"]
+
+    def test_description_fallback_to_description(self):
+        meta = SkillMetadata(
+            skill_id="test_fb",
+            skill_type=SkillType.CUSTOM,
+            description="Fallback desc",
+        )
+        schema = skill_to_tool_schema(meta)
+        assert schema["function"]["description"] == "Fallback desc"
+
+    def test_description_empty(self):
+        meta = SkillMetadata(
+            skill_id="test_empty",
+            skill_type=SkillType.CUSTOM,
+        )
+        schema = skill_to_tool_schema(meta)
+        assert schema["function"]["description"] == ""
+
+    def test_long_description_truncated(self):
+        meta = SkillMetadata(
+            skill_id="test_long",
+            skill_type=SkillType.CUSTOM,
+            skill_doc="x" * 2000,
+        )
+        schema = skill_to_tool_schema(meta)
+        desc = schema["function"]["description"]
+        assert len(desc) <= 1024
+        assert desc.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# registry_to_tools tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryToTools:
+    @pytest.fixture(autouse=True)
+    def _reset_registry(self):
+        SkillRegistry.reset()
+        yield
+        SkillRegistry.reset()
+
+    def test_empty_registry(self):
+        tools = registry_to_tools(SkillRegistry())
+        assert tools == []
+
+    def test_populated_registry(self):
+        reg = SkillRegistry()
+        reg.register(
+            SkillMetadata(
+                skill_id="skill_a",
+                skill_type=SkillType.RETRIEVAL,
+                inputs=[SkillInputSpec(name="q", type_hint="str", required=True)],
+            )
+        )
+        reg.register(
+            SkillMetadata(
+                skill_id="skill_b",
+                skill_type=SkillType.TRANSFORM,
+            )
+        )
+
+        tools = registry_to_tools(reg)
+        assert len(tools) == 2
+        names = {t["function"]["name"] for t in tools}
+        assert names == {"skill_a", "skill_b"}
+
+    def test_exclude_skills(self):
+        reg = SkillRegistry()
+        reg.register(SkillMetadata(skill_id="keep", skill_type=SkillType.CUSTOM))
+        reg.register(SkillMetadata(skill_id="drop", skill_type=SkillType.CUSTOM))
+
+        tools = registry_to_tools(reg, exclude={"drop"})
+        assert len(tools) == 1
+        assert tools[0]["function"]["name"] == "keep"

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -154,7 +154,7 @@ class TestVectorIndexBuilder:
 
 
 class TestSymbolGraphBuilder:
-    @patch("codeminer.scip_interface.scip_indexer.SCIPIndexer")
+    @patch("codeminer.scip_interface.SCIPPythonIndexer")
     def test_build_returns_status(self, MockSCIP, tmp_path):
         mock_graph = MagicMock()
         mock_graph.graph.vs = list(range(50))  # 50 nodes
@@ -175,7 +175,7 @@ class TestSymbolGraphBuilder:
         assert status.metadata["node_count"] == 50
         assert status.metadata["language"] == "python"
 
-    @patch("codeminer.scip_interface.scip_indexer.SCIPIndexer")
+    @patch("codeminer.scip_interface.SCIPPythonIndexer")
     def test_build_handles_none_graph(self, MockSCIP, tmp_path):
         mock_indexer = MagicMock()
         mock_indexer.run_pipeline.return_value = None

--- a/test/ops/test_expand.py
+++ b/test/ops/test_expand.py
@@ -1,0 +1,321 @@
+"""Tests for graph expansion ops (codeminer.ops.expand)."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.compiler.execution import ExecutionEngine
+from codeminer.compiler.ir_exec import ExecutionNode
+from codeminer.compiler.ir_physical import PhysicalOperator
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.ops.expand import (
+    ExpandContext,
+    _extract_seeds,
+    _nodeinfo_to_queried,
+    register_expand_ops,
+)
+from codeminer.types import (
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NodeInfo,
+    QueriedNode,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_graph(tmp_path):
+    """Build a small synthetic CodeGraph for testing.
+
+    Structure:
+        src/app.py (file)
+          ├── AppClass (class, lines 0-50)
+          │     ├── AppClass.run (method, lines 5-20)
+          │     └── AppClass.stop (method, lines 25-45)
+          └── helper_fn (function, lines 55-70)
+
+        src/utils.py (file)
+          └── parse_config (function, lines 0-30)
+
+    Edges:
+        AppClass.run --reference--> parse_config
+        helper_fn --reference--> AppClass.stop
+    """
+    # Write dummy source files so get_node_content can read them
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    app_lines = [""] * 80
+    app_lines[0] = "class AppClass:"
+    app_lines[5] = "    def run(self):"
+    app_lines[6] = "        pass"
+    app_lines[25] = "    def stop(self):"
+    app_lines[26] = "        pass"
+    app_lines[55] = "def helper_fn():"
+    app_lines[56] = "    pass"
+    (src_dir / "app.py").write_text("\n".join(app_lines))
+
+    utils_lines = [""] * 40
+    utils_lines[0] = "def parse_config():"
+    utils_lines[1] = "    pass"
+    (src_dir / "utils.py").write_text("\n".join(utils_lines))
+
+    g = CodeGraph(project_root=str(tmp_path))
+
+    # --- src/app.py ---
+    g.add_file_node("src/app.py")
+    g.add_symbol_node(
+        "src/app.py:AppClass",
+        line=0,
+        scope_start_line=0,
+        scope_end_line=50,
+        symbol_type=NODE_TYPE_CLASS,
+    )
+    g.add_containment_edge("src/app.py:AppClass")
+
+    g.update_current_scope("src/app.py:AppClass", 0, 50)
+    g.add_symbol_node(
+        "src/app.py:AppClass.run()",
+        line=5,
+        scope_start_line=5,
+        scope_end_line=20,
+        symbol_type=NODE_TYPE_METHOD,
+    )
+    g.add_containment_edge("src/app.py:AppClass.run()")
+
+    g.add_symbol_node(
+        "src/app.py:AppClass.stop()",
+        line=25,
+        scope_start_line=25,
+        scope_end_line=45,
+        symbol_type=NODE_TYPE_METHOD,
+    )
+    g.add_containment_edge("src/app.py:AppClass.stop()")
+
+    # Reset scope to file for helper_fn
+    g.scope_stack = [{"src/app.py": None}]
+    g.current_scope = "src/app.py"
+    g.add_symbol_node(
+        "src/app.py:helper_fn()",
+        line=55,
+        scope_start_line=55,
+        scope_end_line=70,
+        symbol_type=NODE_TYPE_FUNCTION,
+    )
+    g.add_containment_edge("src/app.py:helper_fn()")
+
+    # --- src/utils.py ---
+    g.add_file_node("src/utils.py")
+    g.add_symbol_node(
+        "src/utils.py:parse_config()",
+        line=0,
+        scope_start_line=0,
+        scope_end_line=30,
+        symbol_type=NODE_TYPE_FUNCTION,
+    )
+    g.add_containment_edge("src/utils.py:parse_config()")
+
+    # --- Reference edges ---
+    g.current_scope = "src/app.py:AppClass.run()"
+    g.add_symbol_reference("src/utils.py:parse_config()")
+
+    g.current_scope = "src/app.py:helper_fn()"
+    g.add_symbol_reference("src/app.py:AppClass.stop()")
+
+    return g
+
+
+@pytest.fixture()
+def expand_context(sample_graph):
+    return ExpandContext(code_graph=sample_graph, default_top_k=50, default_hops=2)
+
+
+@pytest.fixture()
+def engine_with_expand(expand_context):
+    engine = ExecutionEngine()
+    register_expand_ops(engine, expand_context)
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# Helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSeeds:
+    def test_from_queried_nodes(self):
+        nodes = [
+            QueriedNode(node_name="a"),
+            QueriedNode(node_name="b"),
+        ]
+        assert _extract_seeds([nodes]) == ["a", "b"]
+
+    def test_from_strings(self):
+        assert _extract_seeds([["x", "y"]]) == ["x", "y"]
+
+    def test_deduplicates(self):
+        nodes = [QueriedNode(node_name="a"), QueriedNode(node_name="a")]
+        assert _extract_seeds([nodes]) == ["a"]
+
+    def test_empty_input(self):
+        assert _extract_seeds([]) == []
+        assert _extract_seeds([[]]) == []
+
+
+class TestNodeInfoToQueried:
+    def test_preserves_ppr_score(self):
+        infos = [NodeInfo(node_name="a", type="function", score=0.42)]
+        result = _nodeinfo_to_queried(infos)
+        assert len(result) == 1
+        assert isinstance(result[0], QueriedNode)
+        assert result[0].score == 0.42
+
+    def test_assigns_rank_score_when_missing(self):
+        infos = [
+            NodeInfo(node_name="a", type="function"),
+            NodeInfo(node_name="b", type="function"),
+        ]
+        result = _nodeinfo_to_queried(infos)
+        assert result[0].score == 1.0  # 1/(0+1)
+        assert result[1].score == 0.5  # 1/(1+1)
+
+
+# ---------------------------------------------------------------------------
+# Kernel tests
+# ---------------------------------------------------------------------------
+
+
+class TestGraphWalkKernel:
+    def _make_exec_node(self, **params):
+        return ExecutionNode(
+            node_id="test_expand",
+            operator=PhysicalOperator.GRAPH_WALK.value,
+            params=params,
+            deps=[],
+        )
+
+    def test_bfs_1hop_from_class(self, engine_with_expand):
+        """BFS 1-hop from AppClass should find its methods and the file."""
+        node = self._make_exec_node(method="bfs", hops=1, direction="both")
+        seeds = [QueriedNode(node_name="src/app.py:AppClass")]
+        kernel = engine_with_expand._kernels[PhysicalOperator.GRAPH_WALK.value]
+        results = kernel(node, [seeds])
+
+        result_names = {r.node_name for r in results}
+        # AppClass is the seed, should be excluded
+        assert "src/app.py:AppClass" not in result_names
+        # Methods are 1-hop via containment
+        assert "src/app.py:AppClass.run()" in result_names
+        assert "src/app.py:AppClass.stop()" in result_names
+
+    def test_bfs_2hop_reaches_cross_file_reference(self, engine_with_expand):
+        """BFS 2-hop from AppClass should reach parse_config via run()."""
+        node = self._make_exec_node(method="bfs", hops=2, direction="both")
+        seeds = [QueriedNode(node_name="src/app.py:AppClass")]
+        kernel = engine_with_expand._kernels[PhysicalOperator.GRAPH_WALK.value]
+        results = kernel(node, [seeds])
+
+        result_names = {r.node_name for r in results}
+        assert "src/utils.py:parse_config()" in result_names
+
+    def test_bfs_forward_only(self, engine_with_expand):
+        """Forward-only BFS from run() should reach parse_config but not AppClass."""
+        node = self._make_exec_node(method="bfs", hops=1, direction="forward")
+        seeds = [QueriedNode(node_name="src/app.py:AppClass.run()")]
+        kernel = engine_with_expand._kernels[PhysicalOperator.GRAPH_WALK.value]
+        results = kernel(node, [seeds])
+
+        result_names = {r.node_name for r in results}
+        assert "src/utils.py:parse_config()" in result_names
+
+    def test_bfs_edge_type_filter(self, engine_with_expand):
+        """BFS with reference-only edges from AppClass should
+        not find methods (contain edges)."""
+        node = self._make_exec_node(
+            method="bfs",
+            hops=2,
+            direction="both",
+            edge_types=[EDGE_TYPE_REFERENCE],
+        )
+        seeds = [QueriedNode(node_name="src/app.py:AppClass")]
+        kernel = engine_with_expand._kernels[PhysicalOperator.GRAPH_WALK.value]
+        results = kernel(node, [seeds])
+
+        result_names = {r.node_name for r in results}
+        # Methods are connected via CONTAIN, not REFERENCE
+        assert "src/app.py:AppClass.run()" not in result_names
+        assert "src/app.py:AppClass.stop()" not in result_names
+
+    def test_ppr_returns_scored_results(self, engine_with_expand):
+        """PPR expansion should return scored results."""
+        node = self._make_exec_node(method="ppr", top_k=10)
+        seeds = [QueriedNode(node_name="src/app.py:AppClass.run()")]
+        kernel = engine_with_expand._kernels[PhysicalOperator.GRAPH_WALK.value]
+        results = kernel(node, [seeds])
+
+        assert len(results) > 0
+        assert all(isinstance(r, QueriedNode) for r in results)
+        assert all(r.score is not None and r.score >= 0 for r in results)
+        # Seed should be excluded
+        assert all(r.node_name != "src/app.py:AppClass.run()" for r in results)
+
+    def test_top_k_limits_results(self, engine_with_expand):
+        """top_k should limit the number of returned results."""
+        node = self._make_exec_node(method="bfs", hops=3, top_k=2)
+        seeds = [QueriedNode(node_name="src/app.py:AppClass")]
+        kernel = engine_with_expand._kernels[PhysicalOperator.GRAPH_WALK.value]
+        results = kernel(node, [seeds])
+
+        assert len(results) <= 2
+
+    def test_no_graph_raises(self):
+        """Kernel should raise RuntimeError when no graph is provided."""
+        ctx = ExpandContext(code_graph=None)
+        engine = ExecutionEngine()
+        register_expand_ops(engine, ctx)
+
+        node = ExecutionNode(
+            node_id="test",
+            operator=PhysicalOperator.GRAPH_WALK.value,
+            params={"method": "bfs"},
+            deps=[],
+        )
+        kernel = engine._kernels[PhysicalOperator.GRAPH_WALK.value]
+        with pytest.raises(RuntimeError, match="no CodeGraph"):
+            kernel(node, [[QueriedNode(node_name="x")]])
+
+    def test_empty_seeds_returns_empty(self, engine_with_expand):
+        """Empty seed list should return empty results."""
+        node = self._make_exec_node(method="bfs", hops=1)
+        kernel = engine_with_expand._kernels[PhysicalOperator.GRAPH_WALK.value]
+        results = kernel(node, [[]])
+        assert results == []
+
+    def test_results_include_content(self, engine_with_expand):
+        """Expanded nodes should include source content."""
+        node = self._make_exec_node(method="bfs", hops=1, direction="both")
+        seeds = [QueriedNode(node_name="src/app.py:AppClass")]
+        kernel = engine_with_expand._kernels[PhysicalOperator.GRAPH_WALK.value]
+        results = kernel(node, [seeds])
+
+        # At least some results should have content
+        results_with_content = [r for r in results if r.content]
+        assert len(results_with_content) > 0
+
+
+# ---------------------------------------------------------------------------
+# Registration test
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterExpandOps:
+    def test_registers_graph_walk(self):
+        ctx = ExpandContext(code_graph=None)
+        engine = ExecutionEngine()
+        register_expand_ops(engine, ctx)
+        assert PhysicalOperator.GRAPH_WALK.value in engine._kernels


### PR DESCRIPTION
## Summary
Adds the core agent runner infrastructure and graph-based code expansion capabilities. This enables an LLM-driven tool-calling loop over CodeMiner skills and introduces graph traversal (BFS/PPR) as both a skill and an execution engine operator.

## Changes
- **Agent runner** (`codeminer/agent/runner.py`): LLM-driven think→act→observe loop with tool-calling support
- **Tool schema** (`codeminer/agent/tool_schema.py`): Converts SkillMetadata to OpenAI function-calling format
- **Agent types** (`codeminer/agent/agent_types.py`): `AgentResult` and `ToolCallRecord` data classes
- **LiteLLM `_call_raw`** (`codeminer/llm/litellm_chat.py`): Raw message dict method for tool-calling flows
- **Graph expand skill** (`codeminer/agent/skills/graph_expand/`): Config, executor, and documentation for symbol graph traversal
- **Graph expand ops** (`codeminer/ops/expand.py`): `graph.walk` execution kernel (BFS k-hop and Personalized PageRank)
- **GraphExpand IR node** (`codeminer/compiler/ir_algebra.py`): Algebraic operator for graph expansion in query plans
- **Tests**: Comprehensive test suites for agent runner, tool schema, graph expand ops, and graph vertex integration

## Type of Change
- [x] New feature
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

New test files:
- `test/agent/test_runner.py` — agent runner loop tests
- `test/agent/test_tool_schema.py` — tool schema conversion tests
- `test/agent/test_agent_graph_vertex.py` — graph vertex integration tests
- `test/ops/test_expand.py` — BFS/PPR expansion, edge filtering, top_k, error handling

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published