### PR TITLE
[SCIP] add Go language support : Indexer/Decoder

### DIFF
--- a/codeminer/ls_router.py
+++ b/codeminer/ls_router.py
@@ -39,6 +39,8 @@ LANGUAGE_ALIASES = {
     "js": "ts",
     "python": "python",
     "py": "python",
+    "go": "go",
+    "golang": "go",
 }
 
 
@@ -126,6 +128,15 @@ class LSIndexer:
             from .scip_interface.scip_indexer_python import SCIPPythonIndexer
 
             return SCIPPythonIndexer(
+                project_root=project_root,
+                output_dir=output_dir,
+                exclude_patterns=exclude_patterns,
+                profiler=profiler,
+            )
+        elif self.language == "go":
+            from .scip_interface.scip_indexer_go import SCIPGoIndexer
+
+            return SCIPGoIndexer(
                 project_root=project_root,
                 output_dir=output_dir,
                 exclude_patterns=exclude_patterns,

--- a/codeminer/scip_interface/scip_decode_go.py
+++ b/codeminer/scip_interface/scip_decode_go.py
@@ -20,7 +20,6 @@ from ..graph.code_graph import CodeGraph
 from ..log_utils import get_logger, register_scip_logger
 from ..types import (
     EDGE_TYPE_CONTAIN,
-    EDGE_TYPE_REFERENCE,
     NODE_TYPE_CLASS,
     NODE_TYPE_FIELD,
     NODE_TYPE_FUNCTION,

--- a/codeminer/scip_interface/scip_decode_go.py
+++ b/codeminer/scip_interface/scip_decode_go.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""
+SCIP decoder for Go projects.
+
+Decodes SCIP index files into CodeGraph format, focusing on:
+- Structs and interfaces (treated as classes)
+- Methods (receiver functions)
+- Free functions
+- Fields and constants
+- References between symbols
+
+Note: scip-go does NOT emit enclosing_range (as of v0.1.26),
+so scope boundaries are unavailable. Nodes are attached to the
+current scope via contain edges without start_line/end_line.
+"""
+import re
+from pathlib import Path
+
+from ..graph.code_graph import CodeGraph
+from ..log_utils import get_logger, register_scip_logger
+from ..types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FIELD,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    ROOT_NODE,
+)
+
+
+class SCIPGoGraphDecoder:
+    """
+    Decoder for Go SCIP indices.
+
+    Parses decoded SCIP index files and builds a CodeGraph representing:
+    - Structs and interfaces as classes
+    - Methods (with receivers) as methods
+    - Package-level functions
+    - Fields, constants, and variables
+    - References between symbols
+    """
+
+    def __init__(self, index_file_path, project_root=None):
+        self.index_file_path = index_file_path
+        self.project_root = Path(project_root) if project_root else None
+        self.code_graph = CodeGraph(project_root)
+        self.indexed_directories = set()
+        self.logger = get_logger(__name__)
+        register_scip_logger(__name__)
+
+        # Internal module path (loaded lazily from go.mod)
+        self.internal_module = None
+
+    def decode(self):
+        """Decode the SCIP index and build the CodeGraph."""
+        self.logger.info(f"Starting SCIP Go decode from {self.index_file_path}")
+        try:
+            with open(self.index_file_path, "r") as f:
+                content = f.read()
+        except Exception as e:
+            self.logger.error(f"Error reading SCIP index file: {e}")
+            raise
+
+        # Parse documents
+        document_blocks = re.findall(
+            r"documents\s*{(.*?)(?=documents\s*{|$)", content, re.DOTALL
+        )
+
+        # Add the root node to the graph
+        self.code_graph.add_root_node(ROOT_NODE)
+
+        # Process all documents
+        for document in document_blocks:
+            self._process_document(document)
+
+        return self.code_graph
+
+    def _process_document(self, document_text):
+        """Process a single document block from the SCIP index."""
+        # Extract file path
+        file_match = re.search(r'relative_path:\s*"([^"]+)"', document_text)
+        if not file_match:
+            return
+
+        file_path = file_match.group(1)
+
+        # Only process Go files
+        if not file_path.endswith(".go"):
+            return
+
+        # Skip test files
+        if file_path.endswith("_test.go"):
+            return
+
+        # Add directory hierarchy
+        dir_path = Path(file_path).parent
+        while dir_path != dir_path.parent:
+            dir_path_str = str(dir_path)
+            if dir_path_str not in self.indexed_directories:
+                self.code_graph.add_directory_node(dir_path_str)
+                self.indexed_directories.add(dir_path_str)
+                self.code_graph._add_edge(
+                    str(dir_path.parent), dir_path_str, EDGE_TYPE_CONTAIN
+                )
+            dir_path = dir_path.parent
+
+        # Add file node
+        self.code_graph.add_file_node(file_path)
+
+        # Add file containment edge
+        self.code_graph._add_edge(
+            str(Path(file_path).parent), file_path, EDGE_TYPE_CONTAIN
+        )
+
+        # Load module path once (for third-party filtering)
+        if self.internal_module is None:
+            self.internal_module = self._load_internal_module()
+
+        # Process occurrences
+        occurrences = re.findall(r"occurrences\s*{(.*?)}", document_text, re.DOTALL)
+        for occurrence in occurrences:
+            self._process_occurrence(occurrence, file_path)
+
+    def _load_internal_module(self):
+        """Parse go.mod to extract the module path for filtering third-party symbols."""
+        if not self.project_root:
+            return ""
+
+        go_mod_path = self.project_root / "go.mod"
+        if not go_mod_path.exists():
+            return ""
+
+        try:
+            with open(go_mod_path, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("module "):
+                        module_path = line[len("module "):].strip()
+                        self.logger.info(f"Loaded Go module path: {module_path}")
+                        return module_path
+        except Exception as e:
+            self.logger.warning(f"Failed to parse {go_mod_path}: {e}")
+
+        return ""
+
+    def _process_occurrence(self, occurrence_text, file_path):
+        """Process a single occurrence from the SCIP index."""
+        # Extract ranges
+        ranges = re.findall(r"range:\s*(\d+)", occurrence_text)
+        if len(ranges) < 3:
+            return
+
+        line = int(ranges[0])
+
+        # Extract symbol
+        symbol_match = re.search(r'symbol:\s*"([^"]+)"', occurrence_text)
+        if not symbol_match:
+            return
+
+        symbol = symbol_match.group(1)
+
+        # Skip local symbols
+        if symbol.startswith("local "):
+            return
+
+        # Filter symbols by origin
+        # Format: "scip-go gomod <module_path> <version> <descriptor>"
+        parts = symbol.split(" ")
+        if len(parts) >= 5 and parts[0] == "scip-go" and parts[1] == "gomod":
+            module_path = parts[2]
+            # Skip stdlib (module path = "github.com/golang/go/src" or similar)
+            if module_path.startswith("github.com/golang/go"):
+                return
+            # Skip third-party modules (module path doesn't match our project)
+            if self.internal_module and not module_path.startswith(
+                self.internal_module
+            ):
+                return
+
+        # Skip package-only symbols (descriptor ends with "/" after backtick prefix)
+        descriptor = parts[-1] if len(parts) >= 5 else symbol
+        # Remove backtick module prefix: `module/path`/... -> ...
+        descriptor_clean = re.sub(r"`[^`]+`/", "", descriptor)
+        if not descriptor_clean or descriptor_clean == "/":
+            return
+
+        # Extract symbol_roles
+        symbol_roles_match = re.search(r"symbol_roles:\s*(\d+)", occurrence_text)
+        symbol_roles = int(symbol_roles_match.group(1)) if symbol_roles_match else 0
+
+        # Extract enclosing range if available (scip-go currently does NOT emit this)
+        enclosing_ranges = re.findall(r"enclosing_range:\s*(\d+)", occurrence_text)
+
+        # Process the symbol
+        self._process_symbol(
+            symbol, file_path, line, symbol_roles, enclosing_ranges
+        )
+
+    def _make_symbol_key(self, symbol):
+        """
+        Generate a unique graph vertex key from a Go SCIP symbol.
+
+        Extracts the package-relative path from the backtick module prefix
+        and combines it with the cleaned descriptor to ensure uniqueness
+        across packages.
+
+        Go SCIP symbols use backticks around the full package path:
+            scip-go gomod github.com/user/proj abc `github.com/user/proj/calc`/Calculator#Add().
+            -> calc/Calculator#Add
+
+            scip-go gomod github.com/user/proj abc `github.com/user/proj`/NewCalculator().
+            -> NewCalculator
+
+            scip-go gomod github.com/user/proj abc `github.com/user/proj`/Calculator#
+            -> Calculator
+
+            scip-go gomod github.com/user/proj abc `github.com/user/proj/calc`/Calculator#History.
+            -> calc/Calculator#History
+
+        Returns:
+            Symbol key string (used as graph vertex key), or None if invalid.
+        """
+        parts = symbol.split(" ")
+        if len(parts) < 5:
+            return None
+
+        # The descriptor is the last part, with backtick module prefix
+        descriptor = parts[-1]
+
+        # Extract the package path from backticks: `github.com/user/proj/calc`
+        bt_match = re.search(r"`([^`]+)`", descriptor)
+        if not bt_match:
+            return None
+
+        full_pkg_path = bt_match.group(1)
+
+        # Compute relative package path by stripping internal_module prefix
+        if self.internal_module and full_pkg_path.startswith(self.internal_module):
+            rel_pkg = full_pkg_path[len(self.internal_module):].lstrip("/")
+        else:
+            rel_pkg = ""
+
+        # Extract the symbol part after backtick prefix: `...`/Symbol#Method().
+        symbol_part = re.sub(r"`[^`]+`/", "", descriptor)
+
+        if not symbol_part:
+            return None
+
+        # Strip trailing "." (SCIP terminator)
+        symbol_part = symbol_part.rstrip(".")
+
+        # Strip trailing "()" for function/method signatures
+        if symbol_part.endswith("()"):
+            symbol_part = symbol_part[:-2]
+
+        # Strip trailing "#" for type-only descriptors (e.g. Calculator#)
+        if symbol_part.endswith("#"):
+            symbol_part = symbol_part[:-1]
+
+        if not symbol_part:
+            return None
+
+        # Combine: rel_pkg/SymbolDescriptor
+        if rel_pkg:
+            return f"{rel_pkg}/{symbol_part}"
+        return symbol_part
+
+    def _classify_symbol_type(self, symbol_key, original_symbol):
+        """
+        Classify the symbol type based on Go conventions and SCIP descriptor.
+
+        SCIP descriptor suffixes:
+        - "#"   -> type (struct, interface)
+        - "()." -> method (if after #) or function
+        - "."   -> field, variable, constant
+        """
+        # Use the original SCIP symbol for classification
+        original_part = original_symbol.split(" ")[-1] if original_symbol else ""
+
+        # Method: Type#Method().
+        if "#" in original_part and original_part.endswith("()."):
+            return NODE_TYPE_METHOD
+
+        # Type: ends with #
+        if original_part.endswith("#"):
+            return NODE_TYPE_CLASS
+
+        # Field: Type#field.
+        if "#" in original_part and original_part.endswith("."):
+            return NODE_TYPE_FIELD
+
+        # Function: ends with ().
+        if original_part.endswith("()."):
+            return NODE_TYPE_FUNCTION
+
+        # Package-level variable/constant: ends with .
+        if original_part.endswith("."):
+            return NODE_TYPE_FIELD
+
+        return NODE_TYPE_FUNCTION
+
+    def _extract_symbol_display(self, symbol_key, symbol_type=None):
+        """Extract human-readable symbol display from the symbol key.
+
+        The symbol_key may contain a package prefix (e.g. calc/Calculator#Add).
+        We strip it and format for display.
+
+        Examples:
+            calc/Calculator#Add  -> Calculator.Add()
+            NewCalculator        -> NewCalculator()
+            Calculator           -> Calculator
+            calc/Calculator#History -> Calculator.History
+        """
+        sym = symbol_key
+
+        # Strip package prefix (everything before the last /)
+        # But preserve Type#Member structure
+        if "/" in sym:
+            # Find the symbol part: last segment that contains # or is the leaf
+            sym = sym.rsplit("/", 1)[-1]
+
+        # Replace # with .
+        sym = sym.replace("#", ".")
+
+        # Remove leading/trailing dots
+        sym = sym.strip(".")
+
+        # Add () suffix for functions/methods
+        if symbol_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+            if not sym.endswith("()"):
+                sym = f"{sym}()"
+
+        return sym
+
+    def _get_unified_name(self, symbol_key, file_path, symbol_type=None):
+        """Generate unified_name in format file_path:SymbolDisplay."""
+        symbol_display = self._extract_symbol_display(symbol_key, symbol_type)
+        if file_path and symbol_display:
+            return f"{file_path}:{symbol_display}"
+        return file_path or symbol_display or symbol_key
+
+    def _set_unified_name(self, symbol_key, file_path, symbol_type):
+        """Set unified_name attribute on a vertex if it exists."""
+        if symbol_key in self.code_graph.name_to_vertex:
+            vertex_id = self.code_graph.name_to_vertex[symbol_key]
+            self.code_graph.graph.vs[vertex_id]["unified_name"] = (
+                self._get_unified_name(symbol_key, file_path, symbol_type)
+            )
+
+    def _process_symbol(
+        self, symbol, file_path, line, symbol_roles, enclosing_ranges
+    ):
+        """Process a symbol occurrence and add it to the graph."""
+        self.logger.scip_debug(
+            f"Processing Go symbol: {symbol} at {file_path}:{line}, roles: {symbol_roles}"
+        )
+
+        # Generate symbol key (graph vertex key)
+        symbol_key = self._make_symbol_key(symbol)
+        if not symbol_key:
+            return
+
+        # Classify symbol type
+        symbol_type = self._classify_symbol_type(symbol_key, symbol)
+
+        # Exit scopes based on current line
+        try:
+            self.code_graph.exit_scopes_by_line(line)
+        except Exception as e:
+            self.logger.error(f"Error exiting scopes at line {line}: {e}")
+            raise
+
+        # Handle definition (check if definition bit is set)
+        is_definition = symbol_roles & 1
+        if is_definition:
+            if enclosing_ranges and len(enclosing_ranges) >= 4:
+                # Multi-line enclosing range (scip-go doesn't currently emit this,
+                # but handle it for future compatibility)
+                scope_start_line = int(enclosing_ranges[0])
+                scope_end_line = int(enclosing_ranges[2])
+
+                self.code_graph.add_symbol_node(
+                    symbol_key, line, scope_start_line, scope_end_line, symbol_type
+                )
+                self._set_unified_name(symbol_key, file_path, symbol_type)
+                self.code_graph.add_containment_edge(symbol_key)
+
+                if symbol_type in [NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD]:
+                    self.code_graph.update_current_scope(
+                        symbol_key, scope_start_line, scope_end_line
+                    )
+            elif enclosing_ranges and len(enclosing_ranges) == 3:
+                # Single-line enclosing range
+                enc_line = int(enclosing_ranges[0])
+                self.code_graph.add_symbol_node(
+                    symbol_key, line, enc_line, enc_line, symbol_type
+                )
+                self._set_unified_name(symbol_key, file_path, symbol_type)
+                self.code_graph.add_containment_edge(symbol_key)
+            else:
+                # No enclosing range (current scip-go behavior)
+                self.code_graph.add_symbol_node(
+                    symbol_key, line, symbol_type=symbol_type
+                )
+                self._set_unified_name(symbol_key, file_path, symbol_type)
+                self.code_graph._add_edge(
+                    self.code_graph.current_scope, symbol_key, EDGE_TYPE_CONTAIN
+                )
+
+        # Handle reference (not a definition)
+        else:
+            self.code_graph.add_symbol_reference(symbol_key, file_path, symbol_type)
+            if symbol_key in self.code_graph.name_to_vertex:
+                vid = self.code_graph.name_to_vertex[symbol_key]
+                if not self.code_graph.graph.vs[vid].attributes().get("unified_name"):
+                    self.code_graph.graph.vs[vid]["unified_name"] = (
+                        self._get_unified_name(symbol_key, file_path, symbol_type)
+                    )
+
+    def save_graph(self, output_path):
+        """Save the code graph to a file."""
+        self.code_graph.save_graph(output_path)

--- a/codeminer/scip_interface/scip_indexer_go.py
+++ b/codeminer/scip_interface/scip_indexer_go.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+SCIP indexer for Go projects using scip-go.
+"""
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Union
+
+from ..log_utils import get_logger
+from ..profiler import Profiler
+from .scip_indexer_base import SCIPIndexerBase
+
+logger = get_logger("scip_go_indexer")
+
+
+class SCIPGoIndexer(SCIPIndexerBase):
+    """
+    SCIP indexer for Go projects.
+
+    Uses the scip-go tool to generate SCIP indices for Go codebases.
+    Install: go install github.com/sourcegraph/scip-go/cmd/scip-go@latest
+    """
+
+    def __init__(
+        self,
+        project_root: Union[str, Path],
+        output_dir: Optional[Union[str, Path]] = None,
+        exclude_patterns: Optional[List] = None,
+        profiler: Optional[Profiler] = None,
+    ):
+        super().__init__(
+            project_root=project_root,
+            output_dir=output_dir,
+            exclude_patterns=exclude_patterns,
+            profiler=profiler,
+            language="go",
+        )
+
+    def _check_indexer_available(self) -> bool:
+        """Check if scip-go is available."""
+        try:
+            result = subprocess.run(
+                ["scip-go", "--help"],
+                capture_output=True,
+                text=True,
+            )
+            # scip-go --help returns 0 on success
+            if result.returncode == 0:
+                logger.info("scip-go is available")
+                return True
+            # Some versions print help to stderr but still work
+            logger.info("scip-go is available (non-zero exit on --help)")
+            return True
+        except FileNotFoundError:
+            logger.error(
+                "scip-go not found. Install with: "
+                "go install github.com/sourcegraph/scip-go/cmd/scip-go@latest"
+            )
+            return False
+
+    def _build_index_command(self, **kwargs) -> List[str]:
+        """Build the command to generate the SCIP index for Go."""
+        # scip-go runs from project root and outputs index.scip by default.
+        # We move/rename the output afterward if needed, but scip-go doesn't
+        # have a --output flag in all versions, so we rely on the default.
+        cmd = ["scip-go"]
+        return cmd
+
+    def _get_decoder_class(self):
+        """Get the decoder class for Go."""
+        from .scip_decode_go import SCIPGoGraphDecoder
+
+        return SCIPGoGraphDecoder
+
+    def generate_index(self, **kwargs) -> bool:
+        """Generate SCIP index for the Go project."""
+        # Check if go.mod exists
+        go_mod = self.project_root / "go.mod"
+        if not go_mod.exists():
+            logger.error(
+                f"go.mod not found at {go_mod}. "
+                "This doesn't appear to be a Go project."
+            )
+            return False
+
+        if not self._check_indexer_available():
+            return False
+
+        cmd = self._build_index_command(**kwargs)
+
+        logger.debug(f"Running command: {' '.join(cmd)}")
+
+        with self.profiler.section("generate_index") as section:
+            try:
+                subprocess.run(
+                    cmd,
+                    check=True,
+                    cwd=self.project_root,
+                    capture_output=True,
+                    text=True,
+                )
+                success = True
+            except subprocess.CalledProcessError as e:
+                logger.error(f"Error generating SCIP index: {e}")
+                if e.stdout:
+                    logger.error(f"stdout: {e.stdout}")
+                if e.stderr:
+                    logger.error(f"stderr: {e.stderr}")
+                success = False
+
+        duration = section.duration
+
+        if success:
+            # scip-go outputs index.scip in the project root by default.
+            # Move it to our output directory if needed.
+            default_output = self.project_root / "index.scip"
+            if default_output.exists() and default_output != self.index_file:
+                import shutil
+
+                shutil.move(str(default_output), str(self.index_file))
+
+            logger.info(f"Successfully generated SCIP index at {self.index_file}")
+            logger.info(f"Index generation took: {duration:.2f} seconds")
+            return True
+        else:
+            logger.error(f"Index generation failed after {duration:.2f} seconds")
+            return False
+
+    def run_pipeline(
+        self,
+        output_file: Optional[str] = None,
+        skip_level: Optional[str] = None,
+        *,
+        reset_profiler: bool = True,
+        report_profile: bool = True,
+        **kwargs,
+    ):
+        """Run Go pipeline while ignoring other-language kwargs."""
+        kwargs.pop("project_name", None)
+        kwargs.pop("target_dir", None)
+        kwargs.pop("cwd", None)
+        kwargs.pop("config_path", None)
+        kwargs.pop("exclude_vendored_libraries", None)
+        kwargs.pop("infer_tsconfig", None)
+        kwargs.pop("yarn_workspaces", None)
+        kwargs.pop("pnpm_workspaces", None)
+        kwargs.pop("npm_workspaces", None)
+        kwargs.pop("compdb_path", None)
+        kwargs.pop("show_compiler_diagnostics", None)
+
+        return super().run_pipeline(
+            output_file=output_file,
+            skip_level=skip_level,
+            reset_profiler=reset_profiler,
+            report_profile=report_profile,
+            **kwargs,
+        )

--- a/test/graph/test_codegraph_multi.py
+++ b/test/graph/test_codegraph_multi.py
@@ -95,6 +95,19 @@ LANG_CONFIG = {
         ],
         "pipeline_kwargs": {},
     },
+    "go": {
+        "display_name": "Go",
+        "indexer_name": "scip-go",
+        "default_repo": "go_simple",
+        "repo_keywords": [
+            "gin-gonic/",
+            "gohugoio/",
+            "hashicorp/",
+            "prometheus/",
+            "caddyserver/",
+        ],
+        "pipeline_kwargs": {},
+    },
 }
 
 
@@ -106,6 +119,8 @@ def _tools_ready(language: str) -> bool:
         return bool(shutil.which("rust-analyzer"))
     if language == "ts":
         return bool(shutil.which("scip-typescript")) or bool(shutil.which("npx"))
+    if language == "go":
+        return bool(shutil.which("scip-go"))
     return False
 
 
@@ -568,6 +583,13 @@ def test_ts_multi(swebench_args: argparse.Namespace) -> None:
     assert ok > 0, f"All {total} TypeScript instances failed: {failed}"
 
 
+def test_go_multi(swebench_args: argparse.Namespace) -> None:
+    if not _tools_ready("go"):
+        pytest.skip("scip-go not available")
+    ok, total, failed = run_multi("go", swebench_args)
+    assert ok > 0, f"All {total} Go instances failed: {failed}"
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Unified SCIP CodeGraph test for C++, Rust, and TypeScript"
@@ -601,7 +623,7 @@ def build_parser() -> argparse.ArgumentParser:
     # Language selection (not used in sample mode)
     parser.add_argument(
         "--lang",
-        choices=["cpp", "rust", "ts"],
+        choices=["cpp", "rust", "ts", "go"],
         help="Language to test (required for --repo and --swebench-multilingual modes)",
     )
 

--- a/test/scip/simple_repos/go_simple/calculator.go
+++ b/test/scip/simple_repos/go_simple/calculator.go
@@ -1,0 +1,35 @@
+package main
+
+// Calculator performs arithmetic operations.
+type Calculator struct {
+	History []int
+}
+
+// NewCalculator creates a new Calculator instance.
+func NewCalculator() *Calculator {
+	return &Calculator{
+		History: make([]int, 0),
+	}
+}
+
+// Add adds two integers and records the result.
+func (c *Calculator) Add(a, b int) int {
+	result := a + b
+	c.History = append(c.History, result)
+	return result
+}
+
+// Subtract subtracts b from a and records the result.
+func (c *Calculator) Subtract(a, b int) int {
+	result := a - b
+	c.History = append(c.History, result)
+	return result
+}
+
+// LastResult returns the last recorded result.
+func (c *Calculator) LastResult() int {
+	if len(c.History) == 0 {
+		return 0
+	}
+	return c.History[len(c.History)-1]
+}

--- a/test/scip/simple_repos/go_simple/duplicates.go
+++ b/test/scip/simple_repos/go_simple/duplicates.go
@@ -1,0 +1,26 @@
+package main
+
+// Process is a package-level function.
+func Process(data string) string {
+	return data
+}
+
+// Processor has a Process method (same name as package func).
+type Processor struct {
+	Name string
+}
+
+// Process is a method on Processor.
+func (p *Processor) Process(data string) string {
+	return p.Name + ": " + data
+}
+
+// AnotherProcessor also has Process method.
+type AnotherProcessor struct {
+	Prefix string
+}
+
+// Process is a method on AnotherProcessor.
+func (a *AnotherProcessor) Process(data string) string {
+	return a.Prefix + data
+}

--- a/test/scip/simple_repos/go_simple/go.mod
+++ b/test/scip/simple_repos/go_simple/go.mod
@@ -1,0 +1,3 @@
+module github.com/test/go_simple
+
+go 1.22

--- a/test/scip/simple_repos/go_simple/greet.go
+++ b/test/scip/simple_repos/go_simple/greet.go
@@ -1,0 +1,24 @@
+package main
+
+import "fmt"
+
+// Greeter is an interface for greeting.
+type Greeter interface {
+	SayHello(name string) string
+}
+
+// SimpleGreeter implements the Greeter interface.
+type SimpleGreeter struct {
+	Prefix string
+}
+
+// SayHello returns a greeting message.
+func (g *SimpleGreeter) SayHello(name string) string {
+	return fmt.Sprintf("%s, %s!", g.Prefix, name)
+}
+
+// Greet is a package-level function that creates a greeting.
+func Greet(name string) string {
+	g := &SimpleGreeter{Prefix: "Hello"}
+	return g.SayHello(name)
+}

--- a/test/scip/simple_repos/go_simple/main.go
+++ b/test/scip/simple_repos/go_simple/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	calc := NewCalculator()
+	result := calc.Add(3, 5)
+	fmt.Println("Result:", result)
+
+	greeting := Greet("World")
+	fmt.Println(greeting)
+}

--- a/test/scip/test_scip_multilingual.py
+++ b/test/scip/test_scip_multilingual.py
@@ -101,6 +101,53 @@ _EXPECTED = {
             ("test/typescript/axios.ts", "index.d.ts:Axios.get()", "reference"),
         ],
     },
+    # caddyserver/caddy (caddyserver__caddy-4774) — scip-go indexer
+    # Predicted from decoder source (scip_decode_go.py) + caddy source:
+    #   internal_module = "github.com/caddyserver/caddy/v2"
+    #   _make_symbol_key: strips backtick module prefix → rel_pkg="" for root pkg
+    #   _classify_symbol_type: # → class, ().  → function/method, . after # → field
+    #   _get_unified_name: file_path:Display (# replaced with ., () for func/method)
+    "go": {
+        "nodes": [
+            ("caddy.go", "file"),
+            # type Config struct — descriptor `…/caddy/v2`/Config# → class
+            ("caddy.go:Config", "class"),
+            # func Run(cfg *Config) — descriptor …/Run(). → function
+            ("caddy.go:Run()", "function"),
+            # func Load(…) — descriptor …/Load(). → function
+            ("caddy.go:Load()", "function"),
+            # func Stop() — descriptor …/Stop(). → function
+            ("caddy.go:Stop()", "function"),
+            # func Validate(cfg *Config) — function
+            ("caddy.go:Validate()", "function"),
+            # type App interface — descriptor …/App# → class
+            ("caddy.go:App", "class"),
+            ("modules.go", "file"),
+            # type Module interface — descriptor …/Module# → class
+            ("modules.go:Module", "class"),
+            # type ModuleInfo struct — class
+            ("modules.go:ModuleInfo", "class"),
+            # type ModuleID string — type alias, descriptor …/ModuleID# → class
+            ("modules.go:ModuleID", "class"),
+            # func RegisterModule(instance Module) — function
+            ("modules.go:RegisterModule()", "function"),
+            # func GetModule(name string) — function
+            ("modules.go:GetModule()", "function"),
+            ("context.go", "file"),
+            # type Context struct — class
+            ("context.go:Context", "class"),
+            # func (ctx Context) LoadModule(…) — has # and (). → method
+            ("context.go:Context.LoadModule()", "method"),
+        ],
+        "edges": [
+            # File → symbol containment (definition in that file)
+            ("caddy.go", "caddy.go:Config", "contain"),
+            ("caddy.go", "caddy.go:Run()", "contain"),
+            ("modules.go", "modules.go:RegisterModule()", "contain"),
+            # Cross-file reference: caddy.go calls NewContext(Context{…})
+            ("caddy.go", "context.go:Context", "reference"),
+        ],
+    },
 }
 
 
@@ -111,6 +158,8 @@ def _tools_ready(language: str) -> bool:
         return bool(shutil.which("rust-analyzer"))
     if language == "ts":
         return bool(shutil.which("scip-typescript"))
+    if language == "go":
+        return bool(shutil.which("scip-go"))
     return False
 
 
@@ -161,6 +210,14 @@ def _repo_keywords(language: str) -> list[str]:
             "insomnia/",
             "dayjs/",
         ]
+    if language == "go":
+        return [
+            "gin-gonic/",
+            "gohugoio/",
+            "hashicorp/",
+            "prometheus/",
+            "caddyserver/",
+        ]
     return []
 
 
@@ -174,7 +231,7 @@ def _pick_swebench_multilingual_instance(language: str) -> dict:
     return dict(matches[0])
 
 
-@pytest.mark.parametrize("language", ["cpp", "rust", "ts"])
+@pytest.mark.parametrize("language", ["cpp", "rust", "ts", "go"])
 def test_run_pipeline_swebench_multilingual_instance(
     tmp_path: Path,
     language: str,


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the changes in this PR -->
Add Go language support to the SCIP indexing pipeline. This introduces a new `SCIPGoIndexer` (using `scip-go`) and `SCIPGoGraphDecoder` that parses Go SCIP indices into CodeGraph format, enabling code graph construction for Go projects.

## Changes
<!-- List the main changes made in this PR -->
- Added `SCIPGoIndexer` (`scip_indexer_go.py`) — wraps `scip-go` to generate SCIP indices for Go projects, with `go.mod` validation and automatic index file relocation
- Added `SCIPGoGraphDecoder` (`scip_decode_go.py`) — decodes Go SCIP index files into CodeGraph, handling structs/interfaces (as classes), methods, free functions, fields, constants, and cross-symbol references; filters stdlib and third-party symbols via `go.mod` module path
- Updated `LSRouter` (`ls_router.py`) to register `"go"` / `"golang"` language aliases and route to the new Go indexer
- Added Go test fixtures (`test/scip/simple_repos/go_simple/`) with `calculator.go`, `greet.go`, `duplicates.go`, `main.go`, and `go.mod`
- Extended multilingual SCIP tests (`test_scip_multilingual.py`) with expected Go nodes/edges (caddyserver/caddy) and `scip-go` tool detection
- Extended multi-repo CodeGraph tests (`test_codegraph_multi.py`) with Go language config and `test_go_multi` entry point

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
<!-- Describe the tests you ran and/or how to test these changes -->
- [x] Tests pass locally
- [x] Added new tests for the changes
- Run `pytest test/scip/test_scip_multilingual.py -k go` or `pytest test/graph/test_codegraph_multi.py -k go`
- Requires `scip-go` installed (`go install github.com/sourcegraph/scip-go/cmd/scip-go@latest`); tests are skipped if unavailable

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
