### PR TITLE
ci: parallelize CI into 3 jobs (~40min → ~18min)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,52 @@ on:
 permissions:
   contents: read
 
+# ---------------------------------------------------------------
+# Shared skip condition used by every job.
+# ---------------------------------------------------------------
+# Allows skipping via:
+#   - workflow_dispatch input
+#   - [skip tests] in commit message
+#   - [skip tests] in PR title or skip-tests label
+
 jobs:
-  tests:
+  # =============================================================
+  # Job 1 — Unit tests  (pure logic, mocks only, ~1 min)
+  # =============================================================
+  unit:
+    if: ${{ !((github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_tests == 'true' || github.event.inputs.skip_tests == true)) || (github.event_name == 'push' && contains(github.event.head_commit.message, '[skip tests]')) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.title, '[skip tests]') || contains(github.event.pull_request.labels.*.name, 'skip-tests')))) }}
+    runs-on: self-hosted
+    steps:
+      - name: Prepare temp HOME
+        run: |
+          mkdir -p "$RUNNER_TEMP/home"
+          echo "HOME=$RUNNER_TEMP/home" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up codeminer conda env
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: codeminer-test
+          python-version: "3.12"
+          auto-activate-base: false
+          remove-profiles: false
+
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Run unit tests
+        shell: bash -l {0}
+        run: pytest -m "not slow and not integration" -x --tb=short
+
+  # =============================================================
+  # Job 2 — Integration tests  (clone repos, SCIP, chunkers, ~15 min)
+  # =============================================================
+  integration:
     if: ${{ !((github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_tests == 'true' || github.event.inputs.skip_tests == true)) || (github.event_name == 'push' && contains(github.event.head_commit.message, '[skip tests]')) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.title, '[skip tests]') || contains(github.event.pull_request.labels.*.name, 'skip-tests')))) }}
     runs-on: self-hosted
     steps:
@@ -127,6 +171,81 @@ jobs:
             echo "WARN: apt-get not available; skipping bear install"
           fi
 
-      - name: Run test suite
+      - name: Run integration tests
         shell: bash -l {0}
-        run: pytest
+        run: pytest -m "integration" --tb=short
+
+  # =============================================================
+  # Job 3 — Slow tests  (LLM API, GPU embeddings, ~15 min)
+  # =============================================================
+  slow:
+    if: ${{ !((github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_tests == 'true' || github.event.inputs.skip_tests == true)) || (github.event_name == 'push' && contains(github.event.head_commit.message, '[skip tests]')) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.title, '[skip tests]') || contains(github.event.pull_request.labels.*.name, 'skip-tests')))) }}
+    runs-on: self-hosted
+    steps:
+      - name: Prepare temp HOME
+        run: |
+          mkdir -p "$RUNNER_TEMP/home"
+          echo "HOME=$RUNNER_TEMP/home" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up codeminer conda env
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: codeminer-test
+          python-version: "3.12"
+          auto-activate-base: false
+          remove-profiles: false
+
+      - name: Create scip env (empty conda env for SCIP indexer)
+        shell: bash -l {0}
+        run: |
+          if ! conda env list | grep -q 'scip-env'; then
+            conda env create --quiet --solver=libmamba --file codeminer/scip_interface/scip-environment.yml
+          fi
+
+      - name: Build and install scip-python (local fork) into scip env
+        shell: bash -l {0}
+        run: |
+          git submodule update --init --recursive third_party/scip-python
+          conda run -n scip-env bash -lc "
+            set -euo pipefail
+            cd third_party/scip-python
+            npm ci
+            cd packages/pyright-scip
+            npm ci
+            npm run build
+            npm install -g .
+          "
+
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+
+      - name: Install Rust toolchain + rust-analyzer
+        shell: bash -l {0}
+        run: |
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          fi
+          if [ -f "$HOME/.cargo/env" ]; then
+            . "$HOME/.cargo/env"
+          fi
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          rustup toolchain install stable nightly
+          rustup component add rust-analyzer --toolchain nightly
+
+      - name: Install scip-typescript
+        shell: bash -l {0}
+        run: |
+          npm config set prefix "$HOME/.npm-global"
+          export PATH="$HOME/.npm-global/bin:$PATH"
+          npm install -g @sourcegraph/scip-typescript yarn
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+
+      - name: Run slow tests (LLM + embedding)
+        shell: bash -l {0}
+        run: pytest -m "slow" --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "flake8>=4.0.1",
     "flake8-bugbear>=24.4.0",
 ]
-test = ["pytest>=6.0.0", "pytest-cov>=3.0.0"]
+test = ["pytest>=6.0.0", "pytest-cov>=3.0.0", "pytest-xdist>=3.0.0"]
 
 [tool.setuptools]
 include-package-data = true
@@ -74,6 +74,10 @@ norecursedirs = [
     "env",
     "build",
     "dist",
+]
+markers = [
+    "slow: marks tests that need LLM API, GPU, or HuggingFace downloads (deselect with '-m \"not slow\"')",
+    "integration: marks tests that clone repos or build indexes (moderate runtime)",
 ]
 
 [tool.black]

--- a/test/agent/test_agent_graph_vertex.py
+++ b/test/agent/test_agent_graph_vertex.py
@@ -29,6 +29,8 @@ from codeminer.graph.code_graph import CodeGraph
 from codeminer.llm.litellm_chat import LiteLLMChat
 from codeminer.ops.expand import ExpandContext
 
+pytestmark = pytest.mark.slow
+
 # ---------------------------------------------------------------------------
 # Real SCIP graph from httpie/cli repo
 # ---------------------------------------------------------------------------
@@ -120,7 +122,6 @@ def _register_graph_expand(registry: SkillRegistry, graph: CodeGraph) -> None:
     )
 
 
-@pytest.mark.integration
 class TestAgentGraphVertexAI:
     """End-to-end: LLM agent uses graph_expand on the real httpie graph."""
 

--- a/test/agent/test_extract_agent.py
+++ b/test/agent/test_extract_agent.py
@@ -1,8 +1,12 @@
 import argparse
 
+import pytest
+
 from codeminer.agent.extract_agent import KeywordExtractor
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.llm.litellm_chat import LiteLLMChat
+
+pytestmark = pytest.mark.slow
 
 args_dict = {
     "model": "vertex_ai/gemini-2.5-flash",

--- a/test/agent/test_roi_rerank.py
+++ b/test/agent/test_roi_rerank.py
@@ -1,12 +1,16 @@
 import argparse
 from pathlib import Path
 
+import pytest
+
 from codeminer.agent.rerank_agent import RerankAgent
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.graph.roi_subgraph import ROISubgraph
 from codeminer.index import BM25CodeIndexer
 from codeminer.llm.litellm_chat import LiteLLMChat
 from codeminer.ls_router import LSIndexer
+
+pytestmark = pytest.mark.slow
 
 # args_dict = {
 #     "model": "claude-sonnet-4-5-20250929",

--- a/test/agent/test_vertex_ai.py
+++ b/test/agent/test_vertex_ai.py
@@ -5,7 +5,11 @@ Simple test script for Vertex AI LLM generation using LiteLLMChat.
 
 import os
 
+import pytest
+
 from codeminer.llm.litellm_chat import LiteLLMChat, human_message
+
+pytestmark = pytest.mark.slow
 
 
 def test_vertex_ai_gemini():

--- a/test/agent/test_vllm_agent.py
+++ b/test/agent/test_vllm_agent.py
@@ -1,8 +1,12 @@
 import argparse
 
+import pytest
+
 from codeminer.agent.extract_agent import KeywordExtractor
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.llm.litellm_chat import LiteLLMChat
+
+pytestmark = pytest.mark.slow
 
 args_dict = {
     "model": "Qwen/Qwen2.5-Coder-7B",

--- a/test/chunker/test_cpp_chunker.py
+++ b/test/chunker/test_cpp_chunker.py
@@ -5,7 +5,11 @@ Regression tests for the C++ code chunker using the fmt repository.
 
 from pathlib import Path
 
+import pytest
+
 from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+
+pytestmark = pytest.mark.integration
 
 
 def _collect_chunks(repo_root: Path, chunk_depth: int):

--- a/test/chunker/test_go_chunker.py
+++ b/test/chunker/test_go_chunker.py
@@ -5,7 +5,11 @@ Regression tests for the Go code chunker.
 
 from pathlib import Path
 
+import pytest
+
 from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+
+pytestmark = pytest.mark.integration
 
 
 def _collect_chunks(repo_root: Path, chunk_depth: int, l2_level_exclusive: bool = True):

--- a/test/chunker/test_js_chunker.py
+++ b/test/chunker/test_js_chunker.py
@@ -5,7 +5,11 @@ Regression tests for the JavaScript/TypeScript code chunker.
 
 from pathlib import Path
 
+import pytest
+
 from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+
+pytestmark = pytest.mark.integration
 
 
 def _collect_chunks(repo_root: Path, chunk_depth: int):

--- a/test/chunker/test_python_chunker.py
+++ b/test/chunker/test_python_chunker.py
@@ -9,6 +9,8 @@ import pytest
 
 from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
 
+pytestmark = pytest.mark.integration
+
 
 def _collect_chunks(repo_root: Path, chunk_depth: int, l2_level_exclusive: bool = True):
     repo_config = RepoChunkingConfig(languages=["python"])

--- a/test/chunker/test_rust_chunker.py
+++ b/test/chunker/test_rust_chunker.py
@@ -5,7 +5,11 @@ Regression tests for the Rust code chunker.
 
 from pathlib import Path
 
+import pytest
+
 from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+
+pytestmark = pytest.mark.integration
 
 
 def _collect_chunks(repo_root: Path, chunk_depth: int):

--- a/test/dataset/test_gt_locate.py
+++ b/test/dataset/test_gt_locate.py
@@ -270,6 +270,7 @@ def _assert_valid_result(result):
     assert total_symbols == len(result["code_blocks"])
 
 
+@pytest.mark.integration
 class TestAnalyzeGoInstance:
     """Full pipeline test on a real Go instance from caddyserver/caddy."""
 
@@ -283,6 +284,7 @@ class TestAnalyzeGoInstance:
         assert result["base_commit"] == go_instance["base_commit"]
 
 
+@pytest.mark.integration
 class TestAnalyzeCppInstance:
     """Full pipeline test on a real C/C++ instance from redis/redis."""
 
@@ -294,6 +296,7 @@ class TestAnalyzeCppInstance:
         assert result["repo"] == cpp_instance["repo"]
 
 
+@pytest.mark.integration
 class TestAnalyzeRustInstance:
     """Full pipeline test on a real Rust instance from tokio-rs/axum."""
 
@@ -304,6 +307,7 @@ class TestAnalyzeRustInstance:
         assert result["instance_id"] == rust_instance["instance_id"]
 
 
+@pytest.mark.integration
 class TestAnalyzeTypescriptInstance:
     """Full pipeline test on a real TypeScript instance from preactjs/preact."""
 

--- a/test/graph/test_codegraph.py
+++ b/test/graph/test_codegraph.py
@@ -1,8 +1,12 @@
 import argparse
 from pathlib import Path
 
+import pytest
+
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.ls_router import LSIndexer
+
+pytestmark = pytest.mark.integration
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/graph/test_codegraph_multi.py
+++ b/test/graph/test_codegraph_multi.py
@@ -46,6 +46,8 @@ import pytest
 from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
 from codeminer.ls_router import LSIndexer
 
+pytestmark = pytest.mark.integration
+
 # ==============================================================================
 # Language configuration
 # ==============================================================================
@@ -335,10 +337,7 @@ def run_local(lang, repo_path=None):
         project_path = Path(repo_path).absolute()
     else:
         project_path = (
-            Path(__file__).parent.parent
-            / "scip"
-            / "simple_repos"
-            / cfg["default_repo"]
+            Path(__file__).parent.parent / "scip" / "simple_repos" / cfg["default_repo"]
         )
 
     if not project_path.exists():
@@ -444,9 +443,7 @@ def run_multi(lang, args):
             indexer = LSIndexer(repo_path, output_dir=output_path, language=lang)
 
             print("\n[Running CodeGraph pipeline...]")
-            graph = indexer.run_pipeline(
-                skip_level="graph", **cfg["pipeline_kwargs"]
-            )
+            graph = indexer.run_pipeline(skip_level="graph", **cfg["pipeline_kwargs"])
 
             if not graph:
                 print(f"\n❌ Failed to generate CodeGraph for {instance_id}")

--- a/test/graph/test_subgraph.py
+++ b/test/graph/test_subgraph.py
@@ -1,10 +1,14 @@
 import argparse
 from pathlib import Path
 
+import pytest
+
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.graph.roi_subgraph import ROISubgraph
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
+
+pytestmark = pytest.mark.integration
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/graph/test_traverse_graph.py
+++ b/test/graph/test_traverse_graph.py
@@ -3,6 +3,8 @@
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from codeminer.graph.traverse_graph import (
     RepoDependencySearcher,
     traverse_tree_structure,
@@ -18,6 +20,8 @@ from codeminer.types import (
     NODE_TYPE_METHOD,
     NODE_TYPE_SYMBOL,
 )
+
+pytestmark = pytest.mark.integration
 
 HTTPIE_REPO_URL = "https://github.com/httpie/cli.git"
 HTTPIE_REPO_PATH = Path("/tmp/httpie-cli")

--- a/test/graph/test_traverse_graph_swebench.py
+++ b/test/graph/test_traverse_graph_swebench.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 
 from codeminer.dataset.swebench import SwebenchDataset
+
+pytestmark = pytest.mark.integration
 from codeminer.graph.traverse_graph import traverse_tree_structure
 from codeminer.ls_router import LSIndexer
 from codeminer.types import (

--- a/test/index/sparse_idx/test_bm25_compability.py
+++ b/test/index/sparse_idx/test_bm25_compability.py
@@ -1,10 +1,14 @@
 import argparse
 from pathlib import Path
 
+import pytest
+
 from codeminer.code_chunker import CodeChunker
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
+
+pytestmark = pytest.mark.integration
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/index/sparse_idx/test_bm25_index.py
+++ b/test/index/sparse_idx/test_bm25_index.py
@@ -8,6 +8,8 @@ from codeminer.code_chunker import CodeChunker
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture(scope="module")
 def samplemod_repo():
@@ -142,7 +144,7 @@ def test_build_index_from_chunks(code_chunks, test_output_dir):
     ]
 
     for query in search_queries:
-        print(f"\nSearching for '{query}':")
+        print(f"\nSearching for {query!r}:")
         results = indexer.search(query, top_k=3, return_code_content=False)
 
         assert isinstance(results, list), "Search should return a list"
@@ -214,12 +216,12 @@ def test_search_with_filter_test(code_graph):
     # Search with filter_test=True
     results_filtered = indexer.search(query, top_k=20, filter_test=True)
 
-    print(f"\nUnfiltered results for '{query}': {len(results_unfiltered)}")
+    print(f"\nUnfiltered results for {query!r}: {len(results_unfiltered)}")
     for result in results_unfiltered:
         print(f"  {result.node_name}")
 
     print(
-        f"\nFiltered results for '{query}' (filter_test=True): {len(results_filtered)}"
+        f"\nFiltered results for {query!r} (filter_test=True): {len(results_filtered)}"
     )
     for result in results_filtered:
         print(f"  {result.node_name}")

--- a/test/index/sparse_idx/test_bm25_locbench.py
+++ b/test/index/sparse_idx/test_bm25_locbench.py
@@ -1,9 +1,13 @@
 import argparse
 from pathlib import Path
 
+import pytest
+
 from codeminer.dataset.locbench import LocbenchDataset
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
+
+pytestmark = pytest.mark.integration
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/index/test_dense_compatibility.py
+++ b/test/index/test_dense_compatibility.py
@@ -9,6 +9,8 @@ from codeminer.code_chunker import CodeChunker
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
 
+pytestmark = pytest.mark.integration
+
 
 def test_dense_compatibility(httpie_cli_repo, tmp_path_factory):
     """Test that all dense node IDs exist in BM25 graph nodes for httpie CLI."""

--- a/test/index/test_regex_idx.py
+++ b/test/index/test_regex_idx.py
@@ -5,8 +5,12 @@ Test RegexNodeIndex functionality using the httpie CLI repository.
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from codeminer import RegexNodeIndex
 from codeminer.ls_router import LSIndexer
+
+pytestmark = pytest.mark.integration
 
 HTTPIE_REPO_URL = "https://github.com/httpie/cli.git"
 HTTPIE_REPO_PATH = Path("/tmp/httpie-cli")

--- a/test/scip/test_scip_core_w_python.py
+++ b/test/scip/test_scip_core_w_python.py
@@ -35,8 +35,12 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+import pytest
+
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.ls_router import LSGraphDecoder
+
+pytestmark = pytest.mark.integration
 from codeminer.ls_router import LSIndexer
 
 # Default instances for testing

--- a/test/scip/test_scip_exclude.py
+++ b/test/scip/test_scip_exclude.py
@@ -1,9 +1,13 @@
 import argparse
 from pathlib import Path
 
+import pytest
+
 from codeminer.dataset.locbench import LocbenchDataset
 from codeminer.graph.traverse_graph import traverse_tree_structure
 from codeminer.ls_router import LSIndexer
+
+pytestmark = pytest.mark.integration
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/scip/test_scip_indexer.py
+++ b/test/scip/test_scip_indexer.py
@@ -6,6 +6,8 @@ import pytest
 
 from codeminer.ls_router import LSIndexer
 
+pytestmark = pytest.mark.integration
+
 HTTPIE_REPO_URL = "https://github.com/httpie/cli.git"
 HTTPIE_REPO_PATH = Path("/tmp/httpie-cli")
 
@@ -118,7 +120,8 @@ def test_python_repo_indexing(httpie_cli_repo, test_output_dir, tmp_path_factory
             print(f"  Symbol node {i+1}: {node}")
     else:
         pytest.skip(
-            "Failed to run indexing pipeline for test_python_repo, possibly due to missing dependencies"
+            "Failed to run indexing pipeline for test_python_repo,"
+            " possibly due to missing dependencies"
         )
 
 
@@ -180,7 +183,8 @@ def test_samplemod_repo_indexing(samplemod_repo, test_output_dir, tmp_path_facto
             print(f"  Symbol node {i+1}: {node}")
     else:
         pytest.skip(
-            "Failed to run indexing pipeline for samplemod_repo, possibly due to missing dependencies"
+            "Failed to run indexing pipeline for samplemod_repo,"
+            " possibly due to missing dependencies"
         )
 
 

--- a/test/scip/test_scip_multilingual.py
+++ b/test/scip/test_scip_multilingual.py
@@ -12,6 +12,8 @@ import pytest
 from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
 from codeminer.ls_router import LSIndexer
 
+pytestmark = pytest.mark.integration
+
 
 def _has_node(ig, expected_unified_name, node_type=None):
     """Check if any node has exactly this unified_name (strict match).
@@ -23,7 +25,9 @@ def _has_node(ig, expected_unified_name, node_type=None):
         if node_type in ("file", "directory"):
             matched = v["name"] == expected_unified_name
         else:
-            matched = (v.attributes().get("unified_name") or "") == expected_unified_name
+            matched = (
+                v.attributes().get("unified_name") or ""
+            ) == expected_unified_name
         if matched:
             if node_type is None or v["type"] == node_type:
                 return True
@@ -39,7 +43,9 @@ def _vertex_matches(v, expected):
 def _has_edge(ig, src_expected, tgt_expected, edge_type=None):
     """Check if an edge exists between nodes matching by unified_name or name."""
     for e in ig.es:
-        if _vertex_matches(ig.vs[e.source], src_expected) and _vertex_matches(ig.vs[e.target], tgt_expected):
+        if _vertex_matches(ig.vs[e.source], src_expected) and _vertex_matches(
+            ig.vs[e.target], tgt_expected
+        ):
             if edge_type is None or e["type"] == edge_type:
                 return True
     return False
@@ -62,8 +68,16 @@ _EXPECTED = {
             ("src/os.cc:fmt.file.write()", "method"),
         ],
         "edges": [
-            ("include/fmt/core.h", "include/fmt/core.h:fmt.to_string_view()", "contain"),
-            ("include/fmt/core.h:fmt.detail.make_arg()", "include/fmt/core.h:fmt.basic_format_arg", "reference"),
+            (
+                "include/fmt/core.h",
+                "include/fmt/core.h:fmt.to_string_view()",
+                "contain",
+            ),
+            (
+                "include/fmt/core.h:fmt.detail.make_arg()",
+                "include/fmt/core.h:fmt.basic_format_arg",
+                "reference",
+            ),
         ],
     },
     # astral-sh/ruff (astral-sh__ruff-15309)
@@ -72,15 +86,29 @@ _EXPECTED = {
             ("crates/ruff_linter/src/linter.rs", "file"),
             ("crates/ruff_linter/src/linter.rs:check_path()", "function"),
             ("crates/ruff_linter/src/directives.rs:extract_directives()", "function"),
-            ("crates/ruff_python_resolver/src/resolver.rs:resolve_import()", "function"),
+            (
+                "crates/ruff_python_resolver/src/resolver.rs:resolve_import()",
+                "function",
+            ),
             ("crates/ruff_linter/src/settings/types.rs:PythonVersion", "class"),
             ("crates/ruff_linter/src/line_width.rs:IndentWidth", "class"),
             ("crates/ruff_linter/src/source_kind.rs:SourceKind", "class"),
-            ("crates/ruff_linter/src/source_kind.rs:SourceKind.source_code()", "method"),
+            (
+                "crates/ruff_linter/src/source_kind.rs:SourceKind.source_code()",
+                "method",
+            ),
         ],
         "edges": [
-            ("crates/ruff_linter/src/linter.rs", "crates/ruff_linter/src/linter.rs:check_path()", "contain"),
-            ("crates/ruff_linter/src/linter.rs:check_path()", "crates/ruff_linter/src/settings/mod.rs:LinterSettings", "reference"),
+            (
+                "crates/ruff_linter/src/linter.rs",
+                "crates/ruff_linter/src/linter.rs:check_path()",
+                "contain",
+            ),
+            (
+                "crates/ruff_linter/src/linter.rs:check_path()",
+                "crates/ruff_linter/src/settings/mod.rs:LinterSettings",
+                "reference",
+            ),
         ],
     },
     # axios/axios (axios__axios-4731)
@@ -212,10 +240,10 @@ def test_run_pipeline_swebench_multilingual_instance(
     expected = _EXPECTED.get(language)
     if expected:
         for name, node_type in expected["nodes"]:
-            assert _has_node(ig, name, node_type), (
-                f"[{language}] missing node: '{name}' (type={node_type})"
-            )
+            assert _has_node(
+                ig, name, node_type
+            ), f"[{language}] missing node: {name!r} (type={node_type})"
         for src, tgt, edge_type in expected["edges"]:
-            assert _has_edge(ig, src, tgt, edge_type), (
-                f"[{language}] missing edge: '{src}' -> '{tgt}' ({edge_type})"
-            )
+            assert _has_edge(
+                ig, src, tgt, edge_type
+            ), f"[{language}] missing edge: {src!r} -> {tgt!r} ({edge_type})"

--- a/test/scip/test_scip_swebench.py
+++ b/test/scip/test_scip_swebench.py
@@ -1,8 +1,12 @@
 import argparse
 from pathlib import Path
 
+import pytest
+
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.ls_router import LSIndexer
+
+pytestmark = pytest.mark.integration
 
 args_dict = {
     "model": "gpt-4o",


### PR DESCRIPTION
## Summary
- Split the single monolithic CI job into **3 parallel jobs**: `unit`, `integration`, `slow`
- Added `@pytest.mark.slow` and `@pytest.mark.integration` markers to 26 test files
- Registered markers in `pyproject.toml`, added `pytest-xdist` to test deps

## Before (serial, ~36 min wall clock)
```
[single job] setup (3 min) → ALL 213 tests (33 min)
```

## After (parallel, ~18 min wall clock)
```
┌─ unit         pip install only → 146 tests (~10s)    = ~1 min
├─ integration  full toolchain   →  47 tests (~15 min) = ~18 min
└─ slow         LLM + embeddings →  20 tests (~15 min) = ~17 min
```

### Job breakdown
| Job | Tests | What it needs | Expected time |
|-----|-------|---------------|---------------|
| `unit` | 146 | Python + pip only | ~1 min |
| `integration` | 47 | + SCIP, Rust, clangd, npm, bear | ~18 min |
| `slow` | 20 | + Vertex AI creds, GPU embeddings | ~17 min |

### Key benefits
- **Unit tests give fast feedback** (~1 min) on logic regressions
- **Unit job never flakes** on network/API issues
- **Wall clock drops ~50%** from parallelism

## Test plan
- [x] `pytest -m "not slow and not integration"` — 146 tests pass in 10s locally
- [x] `pytest --collect-only -m "integration"` — 47 tests collected
- [x] `pytest --collect-only -m "slow"` — 20 tests collected
- [x] 146 + 47 + 20 = 213 (all tests accounted for)
- [ ] Verify all 3 CI jobs pass on this PR
