### PR TITLE
Add Incremental Graph Update Module (`incremental_graph`)

### DIFF
--- a/codeminer/incremental_graph/__init__.py
+++ b/codeminer/incremental_graph/__init__.py
@@ -1,0 +1,10 @@
+"""LSP-based incremental patching for CodeGraph updates."""
+from .graph_patcher import GraphPatcher
+from .lsp_client import LSPClient
+from .patcher_base import PatcherBase
+
+__all__ = [
+    "GraphPatcher",
+    "LSPClient",
+    "PatcherBase",
+]

--- a/codeminer/incremental_graph/change_mgr.py
+++ b/codeminer/incremental_graph/change_mgr.py
@@ -1,0 +1,130 @@
+"""Change manager: git-based change detection for incremental updates."""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from ..log_utils import get_logger
+
+logger = get_logger(__name__)
+
+_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def _shorten_ref(ref: str) -> str:
+    """Shorten a git ref to 12 chars only if it is a full 40-char hex SHA."""
+    if _FULL_SHA_RE.fullmatch(ref):
+        return ref[:12]
+    return ref
+
+
+def detect_changed_files(
+    project_root: str,
+    base_commit: str,
+    target_commit: str = "HEAD",
+    extensions: Optional[set[str]] = None,
+) -> dict:
+    """Detect changed files between two commits using git diff.
+
+    Args:
+        project_root: Path to the git repository root.
+        base_commit: Base commit hash or ref.
+        target_commit: Target commit hash or ref (default HEAD).
+        extensions: Only include files with these extensions.
+
+    Returns:
+        Dict with keys: modified, added, deleted, renamed.
+        Each value is a list of relative file paths (renamed is list of
+        (old_path, new_path) tuples).
+    """
+    result = {"modified": [], "added": [], "deleted": [], "renamed": []}
+    try:
+        output = subprocess.check_output(
+            [
+                "git", "diff", "--name-status",
+                _shorten_ref(base_commit), _shorten_ref(target_commit),
+            ],
+            cwd=project_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError as e:
+        logger.error(f"git diff failed: {e}")
+        return result
+
+    for line in output.strip().splitlines():
+        parts = line.split("\t")
+        if not parts:
+            continue
+
+        status = parts[0]
+        if status == "M" and len(parts) >= 2:
+            path = parts[1]
+            if extensions is None or Path(path).suffix in extensions:
+                result["modified"].append(path)
+        elif status == "A" and len(parts) >= 2:
+            path = parts[1]
+            if extensions is None or Path(path).suffix in extensions:
+                result["added"].append(path)
+        elif status == "D" and len(parts) >= 2:
+            path = parts[1]
+            if extensions is None or Path(path).suffix in extensions:
+                result["deleted"].append(path)
+        elif status.startswith("R") and len(parts) >= 3:
+            old_path, new_path = parts[1], parts[2]
+            if extensions is None or Path(new_path).suffix in extensions:
+                result["renamed"].append((old_path, new_path))
+
+    return result
+
+
+def get_changed_line_ranges(
+    project_root: str,
+    file_path: str,
+    base_commit: str,
+    target_commit: str = "HEAD",
+) -> list[tuple[int, int]]:
+    """Get changed line ranges between two commits for a single file.
+
+    Uses ``git diff -U0`` to extract exact changed line ranges in the
+    target (new) version of the file.
+
+    Args:
+        project_root: Path to the git repository root.
+        file_path: Relative path to the file within the repo.
+        base_commit: Base commit hash or ref.
+        target_commit: Target commit hash or ref (default HEAD).
+
+    Returns:
+        List of (start_line, end_line) tuples (0-indexed, inclusive).
+    """
+    try:
+        output = subprocess.check_output(
+            [
+                "git", "diff", "-U0",
+                _shorten_ref(base_commit), _shorten_ref(target_commit),
+                "--", file_path,
+            ],
+            cwd=project_root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        logger.debug(f"git diff failed for {file_path}")
+        return []
+
+    ranges = []
+    for match in re.finditer(
+        r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", output
+    ):
+        start = int(match.group(1)) - 1  # Convert to 0-indexed
+        count = int(match.group(2)) if match.group(2) else 1
+        if count == 0:
+            # Pure deletion: mark the deletion point
+            ranges.append((max(0, start - 1), max(0, start - 1)))
+            continue
+        end = start + count - 1
+        ranges.append((start, end))
+    return ranges

--- a/codeminer/incremental_graph/graph_patcher.py
+++ b/codeminer/incremental_graph/graph_patcher.py
@@ -1,0 +1,134 @@
+"""GraphPatcher: thin router for incremental CodeGraph updates.
+
+Dispatches to language-specific patchers (patcher_*.py).
+Maintains backward-compatible API.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from ..graph.code_graph import CodeGraph
+from ..log_utils import get_logger
+from . import change_mgr
+from .patcher_base import PatcherBase
+
+logger = get_logger(__name__)
+
+# Language → file extensions
+LANGUAGE_EXTENSIONS = {
+    "rust": {".rs"},
+    "python": {".py"},
+    "typescript": {".ts", ".tsx", ".js", ".jsx"},
+    "ts": {".ts", ".tsx", ".js", ".jsx"},
+    "go": {".go"},
+    "cpp": {".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx"},
+}
+
+
+def _create_patcher(
+    language: str,
+    project_root: str,
+    code_graph: Optional[CodeGraph],
+) -> PatcherBase:
+    """Factory: create language-specific patcher."""
+    from .patcher_cpp import PatcherCpp
+    from .patcher_go import PatcherGo
+    from .patcher_python import PatcherPython
+    from .patcher_rust import PatcherRust
+    from .patcher_ts import PatcherTS
+
+    PATCHER_MAP = {
+        "rust": PatcherRust,
+        "python": PatcherPython,
+        "typescript": PatcherTS,
+        "ts": PatcherTS,
+        "go": PatcherGo,
+        "cpp": PatcherCpp,
+        "c": PatcherCpp,
+    }
+
+    cls = PATCHER_MAP.get(language)
+    if cls is None:
+        raise ValueError(f"Unsupported language: {language}")
+    return cls(project_root, code_graph or CodeGraph(project_root))
+
+
+class GraphPatcher:
+    """Orchestrates incremental graph updates using LSP.
+
+    Thin router that delegates to language-specific PatcherBase subclasses.
+
+    Usage::
+
+        graph = CodeGraph.load_graph("graph.pkl")
+        patcher = GraphPatcher("/path/to/project", graph, "rust")
+        changed = GraphPatcher.detect_changed_files(
+            "/path/to/project", "abc123", "HEAD"
+        )
+        stats = patcher.patch_files(changed)
+        graph.save_graph("graph.pkl")
+    """
+
+    def __init__(
+        self,
+        project_root: str,
+        code_graph: Optional[CodeGraph],
+        language: str,
+    ):
+        self.project_root = project_root
+        self.language = language
+        self._impl: PatcherBase = _create_patcher(
+            language, project_root, code_graph
+        )
+
+    @property
+    def code_graph(self) -> CodeGraph:
+        return self._impl.code_graph
+
+    @code_graph.setter
+    def code_graph(self, value: CodeGraph):
+        self._impl.code_graph = value
+
+    @property
+    def profiler(self):
+        return self._impl.profiler
+
+    # ── Delegated methods ─────────────────────────────────
+
+    def start_lsp(self, skip_probe: bool = False):
+        """Start the LSP server for warm-up."""
+        self._impl.start_lsp(skip_probe=skip_probe)
+
+    def stop_lsp(self):
+        """Stop the LSP server."""
+        self._impl.stop_lsp()
+
+    def patch_files(self, changed_files: dict, **kwargs) -> dict:
+        """Apply incremental patch for all changed files."""
+        return self._impl.patch_files(changed_files, **kwargs)
+
+    # ── Static utilities (backward-compatible) ────────────
+
+    @staticmethod
+    def detect_changed_files(
+        project_root: str,
+        base_commit: str,
+        target_commit: str = "HEAD",
+        extensions: Optional[set[str]] = None,
+    ) -> dict:
+        """Detect changed files between two commits."""
+        return change_mgr.detect_changed_files(
+            project_root, base_commit, target_commit, extensions
+        )
+
+    @staticmethod
+    def get_changed_line_ranges(
+        project_root: str,
+        file_path: str,
+        base_commit: str,
+        target_commit: str = "HEAD",
+    ) -> list[tuple[int, int]]:
+        """Get line ranges changed between two commits."""
+        return change_mgr.get_changed_line_ranges(
+            project_root, file_path, base_commit, target_commit
+        )

--- a/codeminer/incremental_graph/lsp_client.py
+++ b/codeminer/incremental_graph/lsp_client.py
@@ -1,0 +1,926 @@
+"""Production LSP JSON-RPC client for graph-patching.
+
+Supports the subset of LSP needed for incremental graph updates:
+  - textDocument/documentSymbol
+  - textDocument/references
+  - textDocument/definition
+  - textDocument/semanticTokens/full
+"""
+from __future__ import annotations
+
+import json
+import os
+import select
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from ..log_utils import get_logger
+
+logger = get_logger(__name__)
+
+# LSP SymbolKind integer → human-readable name
+SYMBOL_KIND_NAMES = {
+    1: "File", 2: "Module", 3: "Namespace", 4: "Package",
+    5: "Class", 6: "Method", 7: "Property", 8: "Field",
+    9: "Constructor", 10: "Enum", 11: "Interface", 12: "Function",
+    13: "Variable", 14: "Constant", 22: "Enum", 23: "Struct",
+    24: "Event", 25: "Operator", 26: "TypeParameter",
+}
+
+# Default LSP server commands per language
+LSP_COMMANDS = {
+    "python": ["basedpyright-langserver", "--stdio"],
+    "rust": ["rust-analyzer"],
+    "typescript": ["typescript-language-server", "--stdio"],
+    "ts": ["typescript-language-server", "--stdio"],
+    "go": ["gopls", "serve"],
+    "cpp": ["clangd"],
+    "c": ["clangd"],
+    "c++": ["clangd"],
+}
+
+# Alternative LSP servers (e.g. pylsp supports semanticTokens, pyright does not)
+LSP_COMMANDS_ALT = {
+    "python": ["pylsp"],
+}
+
+# Common locations to search for LSP binaries not on PATH
+_EXTRA_BIN_DIRS = [
+    lambda: Path(sys.executable).parent,       # conda/venv bin
+    lambda: Path.home() / "go" / "bin",        # Go binaries
+    lambda: Path.home() / ".cargo" / "bin",    # Rust binaries
+    lambda: Path.home() / ".npm-global" / "bin",  # npm global
+    lambda: Path.home() / ".local" / "bin",    # pip --user
+]
+
+
+def resolve_lsp_binary(binary: str) -> Optional[str]:
+    """Find the full path to an LSP binary.
+
+    Searches: PATH (via shutil.which) → common install locations.
+    Returns resolved path or None.
+    """
+    resolved = shutil.which(binary)
+    if resolved:
+        return resolved
+    for dir_fn in _EXTRA_BIN_DIRS:
+        try:
+            candidate = dir_fn() / binary
+            if candidate.exists():
+                return str(candidate)
+        except Exception as exc:
+            logger.debug(f"Failed to check {binary} at {candidate}: {exc}")
+            continue
+    return None
+
+# File extension → LSP languageId
+_EXT_TO_LANG_ID = {
+    ".py": "python",
+    ".rs": "rust",
+    ".go": "go",
+    ".ts": "typescript",
+    ".tsx": "typescriptreact",
+    ".js": "javascript",
+    ".jsx": "javascriptreact",
+    ".c": "c",
+    ".h": "c",
+    ".cpp": "cpp",
+    ".cc": "cpp",
+    ".cxx": "cpp",
+    ".hpp": "cpp",
+    ".hxx": "cpp",
+}
+
+
+class LSPClient:
+    """Synchronous LSP client that communicates with a language server via stdio.
+
+    Usage::
+
+        with LSPClient(["rust-analyzer"], "/path/to/project", "rust") as client:
+            symbols = client.document_symbol("src/main.rs")
+            refs = client.references("src/main.rs", 10, 4)
+    """
+
+    def __init__(
+        self,
+        command: list[str],
+        project_root: str,
+        language: str,
+        init_options: Optional[dict] = None,
+    ):
+        self.command = command
+        self.project_root = Path(project_root).resolve()
+        self.root_uri = self.project_root.as_uri()
+        self.language = language
+        self.init_options = init_options
+        self.process: Optional[subprocess.Popen] = None
+        self._next_id = 1
+        self._opened_files: set[str] = set()
+
+        # Populated during start() from server capabilities
+        self.semantic_tokens_legend: Optional[dict] = None
+        self.supports_semantic_tokens_range: bool = False
+
+        # Pending request tracking: limit in-flight requests to avoid
+        # overwhelming the LSP server (clangd hangs after ~570 queued requests)
+        self._pending_ids: set[int] = set()
+        self._max_pending: int = 10
+
+        # Buffer for out-of-order responses: when _request reads a response
+        # for a different request ID, it stores it here instead of discarding.
+        self._response_buffer: dict[int, dict] = {}
+
+        # Track the last error from _request so callers can decide whether
+        # to retry (transient errors like -32801) or not (permanent errors).
+        self._last_error: Optional[dict] = None
+
+
+    # ── Lifecycle ─────────────────────────────────────────────
+
+    def start(self, skip_probe: bool = False) -> dict:
+        """Start the LSP server and send initialize/initialized.
+
+        Args:
+            skip_probe: If True, skip the blocking readiness probe.
+                Use this when starting early for warm-up — the server
+                will analyze the project in the background.
+        """
+        logger.info(f"Starting LSP server: {' '.join(self.command)}")
+        env = os.environ.copy()
+        # Bypass rustup toolchain override so our installed rust-analyzer
+        # is used instead of the project's pinned toolchain version.
+        if self.language == "rust":
+            env["RUSTUP_TOOLCHAIN"] = "nightly"
+        self.process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(self.project_root),
+            env=env,
+        )
+
+        # Build capabilities we request
+        capabilities = {
+            "textDocument": {
+                "documentSymbol": {
+                    "hierarchicalDocumentSymbolSupport": True,
+                },
+                "references": {},
+                "definition": {
+                    "linkSupport": True,
+                },
+                "semanticTokens": {
+                    "requests": {"full": True},
+                    "tokenTypes": [],
+                    "tokenModifiers": [],
+                    "formats": ["relative"],
+                },
+            },
+            "window": {
+                "workDoneProgress": True,
+            },
+        }
+
+        # Language-specific initialization options
+        init_opts = dict(self.init_options) if self.init_options else {}
+        if self.language == "go":
+            # gopls disables semanticTokens by default — enable it
+            init_opts.setdefault("semanticTokens", True)
+
+        params = {
+            "processId": os.getpid(),
+            "rootUri": self.root_uri,
+            "rootPath": str(self.project_root),
+            "capabilities": capabilities,
+            "workspaceFolders": [
+                {"uri": self.root_uri, "name": self.project_root.name}
+            ],
+        }
+        if init_opts:
+            params["initializationOptions"] = init_opts
+
+        result = self._request("initialize", params, timeout=120)
+        self._notify("initialized", {})
+
+        # Extract semantic tokens legend from server capabilities
+        if result:
+            sem_provider = (
+                result.get("capabilities", {})
+                .get("semanticTokensProvider", {})
+            )
+            if isinstance(sem_provider, dict):
+                self.semantic_tokens_legend = sem_provider.get("legend")
+                self.supports_semantic_tokens_range = bool(
+                    sem_provider.get("range")
+                )
+
+        # Wait for server readiness (unless skipped for warm-up)
+        if not skip_probe:
+            self._wait_for_ready()
+
+        logger.info("LSP server initialized successfully")
+        return result or {}
+
+    def shutdown(self):
+        """Gracefully shut down the LSP server."""
+        if self.process is None:
+            return
+        try:
+            self._request("shutdown", None, timeout=10)
+            self._notify("exit", None)
+            self.process.wait(timeout=5)
+        except Exception:
+            if self.process:
+                self.process.kill()
+                self.process.wait()
+        finally:
+            self.process = None
+            self._opened_files.clear()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc):
+        self.shutdown()
+
+    # ── Document management ───────────────────────────────────
+
+    def open_document(self, file_path: str):
+        """Send textDocument/didOpen for a file (idempotent)."""
+        abs_path = self._abs_path(file_path)
+        uri = Path(abs_path).as_uri()
+        if uri in self._opened_files:
+            return
+        try:
+            text = Path(abs_path).read_text(errors="replace")
+        except FileNotFoundError:
+            logger.warning(f"Cannot open {abs_path}: file not found")
+            return
+
+        self._notify("textDocument/didOpen", {
+            "textDocument": {
+                "uri": uri,
+                "languageId": self._detect_language_id(abs_path),
+                "version": 1,
+                "text": text,
+            },
+        })
+        self._opened_files.add(uri)
+
+    def close_document(self, file_path: str):
+        """Send textDocument/didClose for a file."""
+        abs_path = self._abs_path(file_path)
+        uri = Path(abs_path).as_uri()
+        if uri not in self._opened_files:
+            return
+        self._notify("textDocument/didClose", {
+            "textDocument": {"uri": uri},
+        })
+        self._opened_files.discard(uri)
+
+    def wait_for_analysis(
+        self,
+        file_path: str,
+        max_wait: float = 15.0,
+        poll_interval: float = 0.5,
+    ):
+        """Wait for the LSP server to finish analyzing a file.
+
+        After didOpen/didChange, servers like pyright need time to
+        re-analyze before references() returns correct results.
+        We poll with a lightweight hover request until it responds
+        quickly, indicating analysis is complete.
+        """
+        abs_path = self._abs_path(file_path)
+        uri = Path(abs_path).as_uri()
+        start = time.time()
+        while time.time() - start < max_wait:
+            t0 = time.time()
+            try:
+                self._request("textDocument/hover", {
+                    "textDocument": {"uri": uri},
+                    "position": {"line": 0, "character": 0},
+                }, timeout=5)
+            except Exception as exc:
+                logger.debug(f"Analysis probe failed: {exc}")
+            elapsed = time.time() - t0
+            # If hover responds in < 1s, server is likely done analyzing
+            if elapsed < 1.0:
+                return
+            time.sleep(poll_interval)
+
+    # ── LSP queries ───────────────────────────────────────────
+
+    def document_symbol(
+        self, file_path: str, retries: int = 5, retry_delay: float = 5.0
+    ) -> list[dict]:
+        """Get hierarchical document symbols for a file.
+
+        Some LSP servers (e.g. rust-analyzer) return null while the workspace
+        is still loading.  We retry a few times to wait for readiness.
+        """
+        self.open_document(file_path)
+        abs_path = self._abs_path(file_path)
+        uri = Path(abs_path).as_uri()
+
+
+
+        for attempt in range(retries + 1):
+            result = self._request("textDocument/documentSymbol", {
+                "textDocument": {"uri": uri},
+            })
+            if result is not None:
+                return result
+            if attempt < retries:
+                logger.debug(
+                    f"documentSymbol returned null for {file_path}, "
+                    f"retrying in {retry_delay}s ({attempt + 1}/{retries})"
+                )
+                time.sleep(retry_delay)
+
+        return []
+
+    def references(
+        self,
+        file_path: str,
+        line: int,
+        character: int,
+        include_declaration: bool = False,
+        timeout: float = 30,
+        retries: int = 3,
+    ) -> list[dict]:
+        """Find all references to the symbol at the given position.
+
+        Retries on transient errors (e.g. 'content modified' from VFS updates).
+        Checks response buffer for late-arriving responses from prior attempts.
+        """
+        self.open_document(file_path)
+        abs_path = self._abs_path(file_path)
+        uri = Path(abs_path).as_uri()
+        params = {
+            "textDocument": {"uri": uri},
+            "position": {"line": line, "character": character},
+            "context": {"includeDeclaration": include_declaration},
+        }
+        prior_ids = []
+        for attempt in range(retries + 1):
+            # Check if a prior attempt's response arrived late
+            for pid in prior_ids:
+                if pid in self._response_buffer:
+                    message = self._response_buffer.pop(pid)
+                    if "error" not in message and message.get("result") is not None:
+                        logger.debug(f"references: using buffered response id={pid}")
+                        return message["result"]
+
+            result = self._request("textDocument/references", params, timeout=timeout)
+            if result is not None:
+                if attempt > 0:
+                    logger.debug(f"references retry succeeded on attempt {attempt + 1}")
+                return result
+            # Record this attempt's id for buffer check on next retry
+            prior_ids.append(self._next_id - 1)
+            if not self._is_retryable_error():
+                logger.warning(
+                    f"references failed for {file_path}:{line} (permanent error)"
+                )
+                return []
+            if attempt < retries:
+                reason = self._last_error.get("message", "unknown") if self._last_error else "null result"
+                logger.debug(
+                    f"references failed for {file_path}:{line} ({reason}), "
+                    f"retrying ({attempt + 1}/{retries})"
+                )
+                time.sleep(3)
+        logger.warning(
+            f"references failed for {file_path}:{line} "
+            f"after {retries} retries"
+        )
+        return []
+
+    def definition(
+        self,
+        file_path: str,
+        line: int,
+        character: int,
+        timeout: float = 30,
+        retries: int = 3,
+    ) -> list[dict]:
+        """Go to definition of the symbol at the given position.
+
+        Returns a list of Location or LocationLink objects.
+        Retries on transient errors (e.g. 'content modified' from VFS updates).
+        Checks response buffer for late-arriving responses from prior attempts.
+        """
+        self.open_document(file_path)
+        abs_path = self._abs_path(file_path)
+        uri = Path(abs_path).as_uri()
+        params = {
+            "textDocument": {"uri": uri},
+            "position": {"line": line, "character": character},
+        }
+        prior_ids = []
+        for attempt in range(retries + 1):
+            # Check if a prior attempt's response arrived late
+            for pid in prior_ids:
+                if pid in self._response_buffer:
+                    message = self._response_buffer.pop(pid)
+                    if "error" not in message and message.get("result") is not None:
+                        logger.debug(f"definition: using buffered response id={pid}")
+                        result = message["result"]
+                        if isinstance(result, dict):
+                            return [result]
+                        return result
+
+            result = self._request("textDocument/definition", params, timeout=timeout)
+            if result is not None:
+                if attempt > 0:
+                    logger.debug(f"definition retry succeeded on attempt {attempt + 1}")
+                if isinstance(result, dict):
+                    return [result]
+                return result
+            prior_ids.append(self._next_id - 1)
+            if not self._is_retryable_error():
+                logger.warning(
+                    f"definition failed for {file_path}:{line}:{character} "
+                    f"(permanent error)"
+                )
+                return []
+            if attempt < retries:
+                reason = self._last_error.get("message", "unknown") if self._last_error else "null result"
+                logger.debug(
+                    f"definition failed for {file_path}:{line}:{character} ({reason}), "
+                    f"retrying ({attempt + 1}/{retries})"
+                )
+                time.sleep(3)
+        logger.warning(
+            f"definition failed for {file_path}:{line}:{character} "
+            f"after {retries} retries"
+        )
+        return []
+
+    def semantic_tokens_full(self, file_path: str, timeout: float = 60) -> Optional[dict]:
+        """Get semantic tokens for the entire file.
+
+        Returns raw response with ``data`` field (delta-encoded integers).
+        Use ``decode_semantic_tokens()`` to decode.
+        Returns None on timeout or error (details logged by _request).
+        """
+        self.open_document(file_path)
+        abs_path = self._abs_path(file_path)
+        uri = Path(abs_path).as_uri()
+        result = self._request("textDocument/semanticTokens/full", {
+            "textDocument": {"uri": uri},
+        }, timeout=timeout)
+        if result is not None:
+            n_tokens = len(result.get("data", [])) // 5
+            logger.debug(f"semanticTokens for {file_path}: {n_tokens} tokens")
+        return result
+
+    def semantic_tokens_range(
+        self,
+        file_path: str,
+        start_line: int,
+        end_line: int,
+        timeout: float = 30,
+    ) -> Optional[dict]:
+        """Get semantic tokens for a specific line range.
+
+        Faster than full for large files when only a small range is needed.
+        Returns None if not supported or on error.
+        """
+        self.open_document(file_path)
+        abs_path = self._abs_path(file_path)
+        uri = Path(abs_path).as_uri()
+        result = self._request("textDocument/semanticTokens/range", {
+            "textDocument": {"uri": uri},
+            "range": {
+                "start": {"line": start_line, "character": 0},
+                "end": {"line": end_line + 1, "character": 0},
+            },
+        }, timeout=timeout)
+        if result is not None:
+            n_tokens = len(result.get("data", [])) // 5
+            logger.debug(
+                f"semanticTokens/range for {file_path} "
+                f"L{start_line}-{end_line}: {n_tokens} tokens"
+            )
+        return result
+
+    def decode_semantic_tokens(
+        self, tokens_response: dict, file_path: str
+    ) -> list[dict]:
+        """Decode semantic tokens response into a list of token dicts.
+
+        Each token dict has: line, character, length, token_type, modifiers, text.
+        """
+        if not tokens_response or "data" not in tokens_response:
+            return []
+        if not self.semantic_tokens_legend:
+            logger.warning("No semantic tokens legend available")
+            return []
+
+        data = tokens_response["data"]
+        token_types = self.semantic_tokens_legend.get("tokenTypes", [])
+        token_modifiers = self.semantic_tokens_legend.get("tokenModifiers", [])
+
+        # Read file content for extracting token text
+        abs_path = self._abs_path(file_path)
+        try:
+            lines = Path(abs_path).read_text(errors="replace").splitlines()
+        except FileNotFoundError:
+            lines = []
+
+        tokens = []
+        current_line = 0
+        current_char = 0
+
+        for i in range(0, len(data), 5):
+            if i + 4 >= len(data):
+                break
+            delta_line = data[i]
+            delta_char = data[i + 1]
+            length = data[i + 2]
+            type_idx = data[i + 3]
+            mod_bits = data[i + 4]
+
+            if delta_line > 0:
+                current_line += delta_line
+                current_char = delta_char
+            else:
+                current_char += delta_char
+
+            # Decode type
+            type_name = token_types[type_idx] if type_idx < len(token_types) else f"type_{type_idx}"
+
+            # Decode modifiers (bitmask)
+            mods = []
+            for bit_idx, mod_name in enumerate(token_modifiers):
+                if mod_bits & (1 << bit_idx):
+                    mods.append(mod_name)
+
+            # Extract text from source
+            text = ""
+            if current_line < len(lines):
+                line_text = lines[current_line]
+                text = line_text[current_char:current_char + length]
+
+            tokens.append({
+                "line": current_line,
+                "character": current_char,
+                "length": length,
+                "token_type": type_name,
+                "modifiers": mods,
+                "text": text,
+            })
+
+        return tokens
+
+    # ── Internal ──────────────────────────────────────────────
+
+    def _abs_path(self, file_path: str) -> str:
+        """Convert relative file path to absolute."""
+        p = Path(file_path)
+        if p.is_absolute():
+            return str(p)
+        return str(self.project_root / file_path)
+
+    def _detect_language_id(self, file_path: str) -> str:
+        ext = Path(file_path).suffix
+        return _EXT_TO_LANG_ID.get(ext, "text")
+
+    def _wait_for_ready(self):
+        """Wait for the LSP server to become ready.
+
+        Strategy: send a probe documentSymbol on a known file. If it returns,
+        the server is ready. Falls back to a short sleep if no file is available.
+        """
+        # Find a file to probe — use extensions matching the configured language
+        _LANG_PROBE_EXTS = {
+            "python": [".py"],
+            "rust": [".rs"],
+            "typescript": [".ts", ".tsx", ".js"],
+            "ts": [".ts", ".tsx", ".js"],
+            "go": [".go"],
+            "cpp": [".cpp", ".cc", ".c", ".h"],
+            "c": [".c", ".h"],
+            "c++": [".cpp", ".cc", ".h"],
+        }
+        probe_file = None
+        probe_exts = _LANG_PROBE_EXTS.get(self.language, [])
+        for ext in probe_exts:
+            candidates = list(self.project_root.glob(f"**/*{ext}"))
+            if candidates:
+                probe_file = candidates[0]
+                break
+
+        if probe_file:
+            logger.debug(f"Probing server readiness with {probe_file}")
+            self.open_document(str(probe_file))
+            # documentSymbol verifies basic server readiness (syntax analysis)
+            self._request("textDocument/documentSymbol", {
+                "textDocument": {"uri": probe_file.as_uri()},
+            }, timeout=60)
+            # Poll references to wait for cross-file semantic analysis.
+            # Servers like rust-analyzer need extra time for project loading;
+            # references returns [] until the project is fully indexed.
+    
+
+            symbols = self._request("textDocument/documentSymbol", {
+                "textDocument": {"uri": probe_file.as_uri()},
+            }, timeout=10) or []
+            if symbols:
+                # Use the first symbol's position to probe references
+                first_sym = symbols[0]
+                sel = first_sym.get("selectionRange", first_sym.get("range", {}))
+                probe_pos = sel.get("start", {"line": 0, "character": 0})
+                for _ in range(15):
+                    result = self._request("textDocument/references", {
+                        "textDocument": {"uri": probe_file.as_uri()},
+                        "position": probe_pos,
+                        "context": {"includeDeclaration": True},
+                    }, timeout=10)
+                    if result:
+                        break
+                    time.sleep(1)
+        else:
+            # No source files found, just wait briefly
+    
+
+            time.sleep(2)
+
+    def _send(self, message: dict):
+        """Send a JSON-RPC message to the server."""
+        content = json.dumps(message).encode("utf-8")
+        header = f"Content-Length: {len(content)}\r\n\r\n".encode("utf-8")
+        try:
+            self.process.stdin.write(header + content)
+            self.process.stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            logger.error(f"LSP server pipe broken: {e}")
+            raise
+
+    def _read_message(self, timeout: float = 30) -> Optional[dict]:
+        """Read one JSON-RPC message from the server's stdout."""
+        deadline = time.monotonic() + timeout
+        buf = b""
+
+        while time.monotonic() < deadline:
+            remaining = max(0.1, deadline - time.monotonic())
+            ready, _, _ = select.select([self.process.stdout], [], [], remaining)
+            if not ready:
+                continue
+
+            chunk = self.process.stdout.read1(65536) if hasattr(self.process.stdout, 'read1') else self.process.stdout.read(1)
+            if not chunk:
+                return None
+            buf += chunk
+
+            # Try to parse a complete message from buffer
+            while True:
+                # Find header/body boundary
+                header_end = buf.find(b"\r\n\r\n")
+                if header_end == -1:
+                    break
+
+                # Parse Content-Length
+                header_text = buf[:header_end].decode("utf-8", errors="replace")
+                content_length = None
+                for line in header_text.split("\r\n"):
+                    if line.lower().startswith("content-length:"):
+                        content_length = int(line.split(":", 1)[1].strip())
+                        break
+
+                if content_length is None:
+                    # Malformed header, skip
+                    buf = buf[header_end + 4:]
+                    continue
+
+                body_start = header_end + 4
+                body_end = body_start + content_length
+                if len(buf) < body_end:
+                    # Need more data
+                    break
+
+                body = buf[body_start:body_end]
+                buf = buf[body_end:]
+
+                try:
+                    message = json.loads(body.decode("utf-8"))
+                except json.JSONDecodeError:
+                    continue
+
+                # Auto-respond to server-initiated requests
+                if "id" in message and "method" in message:
+                    server_method = message["method"]
+                    if server_method == "window/workDoneProgress/create":
+                        # Acknowledge progress token creation
+                        self._send({
+                            "jsonrpc": "2.0",
+                            "id": message["id"],
+                            "result": None,
+                        })
+                        continue
+                    elif server_method == "client/registerCapability":
+                        # Acknowledge dynamic capability registration
+                        self._send({
+                            "jsonrpc": "2.0",
+                            "id": message["id"],
+                            "result": None,
+                        })
+                        continue
+
+                # Skip server notifications that we don't need
+                # (these would otherwise clog the message loop)
+                if "method" in message and "id" not in message:
+                    skip_methods = {
+                        "window/logMessage",
+                        "window/showMessage",
+                        "textDocument/publishDiagnostics",
+                        "$/progress",
+                    }
+                    if message["method"] in skip_methods:
+                        continue
+
+                return message
+
+        return None
+
+    def _request(self, method: str, params: Any, timeout: float = 30) -> Any:
+        """Send a request and wait for the matching response.
+
+        Enforces a maximum number of in-flight (pending) requests to prevent
+        overwhelming the LSP server.  When the limit is reached, drains
+        pending responses before sending a new request.
+
+        Out-of-order responses are buffered (not discarded) so that
+        concurrent request patterns do not lose data.
+        """
+        # Drain pending responses if we're at the limit
+        self._drain_pending()
+
+        msg_id = self._next_id
+        self._next_id += 1
+        self._pending_ids.add(msg_id)
+        self._send({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "method": method,
+            "params": params,
+        })
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            # Check buffer first — another _request may have read our response
+            if msg_id in self._response_buffer:
+                message = self._response_buffer.pop(msg_id)
+                self._pending_ids.discard(msg_id)
+                if "error" in message:
+                    self._last_error = message["error"]
+                    logger.warning(f"LSP error for {method}: {message['error']}")
+                    return None
+                result = message.get("result")
+                if result is None:
+                    self._last_error = {"code": -2, "message": "null result"}
+                else:
+                    self._last_error = None
+                return result
+
+            remaining = max(0.1, deadline - time.monotonic())
+            message = self._read_message(timeout=remaining)
+            if message is None:
+                self._last_error = {"code": -1, "message": "timeout"}
+                logger.warning(f"LSP request {method} timed out (id={msg_id})")
+                return None
+            resp_id = message.get("id")
+            if resp_id is not None:
+                self._pending_ids.discard(resp_id)
+            if resp_id == msg_id:
+                if "error" in message:
+                    self._last_error = message["error"]
+                    logger.warning(f"LSP error for {method}: {message['error']}")
+                    return None
+                result = message.get("result")
+                if result is None:
+                    # Server returned null — may still be analyzing
+                    self._last_error = {"code": -2, "message": "null result"}
+                else:
+                    self._last_error = None
+                return result
+            # Not our response — buffer it for later retrieval
+            if resp_id is not None:
+                self._response_buffer[resp_id] = message
+                # Evict oldest entries if buffer grows too large
+                _MAX_RESPONSE_BUFFER = 100
+                if len(self._response_buffer) > _MAX_RESPONSE_BUFFER:
+                    oldest = min(self._response_buffer.keys())
+                    del self._response_buffer[oldest]
+
+        self._last_error = {"code": -1, "message": "timeout"}
+        logger.warning(f"LSP request {method} timed out after {timeout}s")
+        return None
+
+    # LSP error codes that are transient (server busy/updating, worth retrying).
+    # Based on LSP 3.17 spec and Neovim's handling (PR #14622, #30999):
+    #   -32801 ContentModified: server VFS changed, will resolve after apply
+    #   -32802 ServerCancelled: server cancelled (spec says retrigger)
+    # All other codes are permanent (bad request, not supported, etc.).
+    _RETRYABLE_ERROR_CODES = frozenset({
+        -1,      # Timeout (internal)
+        -2,      # Null result (server may still be analyzing)
+        -32801,  # ContentModified
+        -32802,  # ServerCancelled
+    })
+
+    def _is_retryable_error(self) -> bool:
+        """Check if the last _request error is transient (worth retrying).
+
+        Transient: timeout (code=-1), ContentModified (-32801),
+                   ServerCancelled (-32802), null result (code=-2,
+                   server may still be analyzing).
+        Permanent: everything else.
+        """
+        if self._last_error is None:
+            return False  # no error info at all
+        code = self._last_error.get("code", 0)
+        return code in self._RETRYABLE_ERROR_CODES
+
+    def _drain_pending(self):
+        """If too many requests are pending, block until responses arrive."""
+        max_iterations = 100
+        iterations = 0
+        while len(self._pending_ids) >= self._max_pending:
+            iterations += 1
+            if iterations > max_iterations:
+                logger.warning(
+                    f"_drain_pending exceeded {max_iterations} iterations, "
+                    f"clearing {len(self._pending_ids)} pending requests"
+                )
+                self._pending_ids.clear()
+                break
+
+            if self.process and self.process.poll() is not None:
+                logger.warning("LSP server process died, clearing pending requests")
+                self._pending_ids.clear()
+                break
+
+            message = self._read_message(timeout=30.0)
+            if message is None:
+                # No response — server may be busy processing.
+                # Do NOT discard pending IDs or send new requests.
+                # Just keep waiting.
+                continue
+            resp_id = message.get("id")
+            if resp_id is not None:
+                self._pending_ids.discard(resp_id)
+
+    def _notify(self, method: str, params: Any):
+        """Send a notification (no response expected)."""
+        msg = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            msg["params"] = params
+        self._send(msg)
+
+    # ── Class methods ─────────────────────────────────────────
+
+    @staticmethod
+    def get_lsp_command(language: str) -> Optional[list[str]]:
+        """Get the default LSP server command for a language."""
+        cmd = LSP_COMMANDS.get(language)
+        if not cmd:
+            return None
+        binary = cmd[0]
+        resolved = shutil.which(binary)
+        if not resolved:
+            # Check inside the running Python environment's bin dir
+            env_bin = Path(sys.executable).parent / binary
+            if env_bin.exists():
+                resolved = str(env_bin)
+        if resolved:
+            return [resolved] + cmd[1:]
+        return cmd
+
+    @staticmethod
+    def check_lsp_available(language: str) -> bool:
+        """Check if the LSP server binary is available."""
+        cmd = LSP_COMMANDS.get(language)
+        if not cmd:
+            return False
+        return resolve_lsp_binary(cmd[0]) is not None
+
+
+def uri_to_relpath(uri: str, project_root: str) -> Optional[str]:
+    """Convert a file:// URI to a path relative to the project root."""
+    if not uri.startswith("file://"):
+        return None
+    abs_path = uri[7:]  # strip file://
+    try:
+        return str(Path(abs_path).relative_to(project_root))
+    except ValueError:
+        return abs_path

--- a/codeminer/incremental_graph/patcher_base.py
+++ b/codeminer/incremental_graph/patcher_base.py
@@ -1,0 +1,966 @@
+"""PatcherBase: incremental orchestration for CodeGraph updates.
+
+Handles the high-level patch flow (classify, remap, patch) while
+delegating subgraph operations to SubgraphMgr and language-specific
+behavior to patcher_lang subclasses.
+"""
+from __future__ import annotations
+
+from abc import abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from ..graph.code_graph import CodeGraph
+from ..log_utils import get_logger
+from ..profiler import Profiler
+from ..types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE
+from . import change_mgr
+from .lsp_client import LSPClient
+from .subgraph_mgr import SubgraphMgr
+
+logger = get_logger(__name__)
+
+
+class PatcherBase(SubgraphMgr):
+    """Base class for language-specific incremental patchers.
+
+    Inherits SubgraphMgr for subgraph operations. Adds:
+    - patch_files: top-level entry point
+    - _rebuild_prepare_vertices / _rebuild_connect_edges: full rebuild for added/renamed
+    - _incremental_prepare_vertices / _incremental_connect_edges: symbol-level diff
+    - _classify_symbols, _remap_severed_edges, etc.
+
+    Subclasses must implement:
+    - _build_unified_name: construct unified_name from LSP symbol info
+    - _get_crossfile_token_types: which semanticToken types to query
+    - get_lsp_command: LSP server command
+
+    Subclasses may override:
+    - flatten_symbols: convert LSP documentSymbol to flat dict (default provided)
+    - get_old_symbols: extract old symbols from graph (default provided)
+    - GRAPH_SYMBOL_KINDS: which SymbolKinds to process (default provided)
+    """
+
+    # Subclasses override: which LSP SymbolKinds to include in classification.
+    # Default covers most languages. C++ overrides completely.
+    GRAPH_SYMBOL_KINDS = frozenset({
+        2,   # Module
+        5,   # Class
+        6,   # Method
+        8,   # Field
+        9,   # Constructor
+        10,  # Enum
+        11,  # Interface
+        12,  # Function
+        13,  # Variable
+        14,  # Constant
+        22,  # Enum (alt)
+        23,  # Struct
+        25,  # Operator
+    })
+
+    def __init__(
+        self,
+        project_root: str,
+        code_graph: CodeGraph,
+        lsp_client: Optional[LSPClient] = None,
+    ):
+        super().__init__(project_root, code_graph, lsp_client)
+        self.profiler = Profiler()
+
+    # ═══════════════════════════════════════════════════════════
+    # Abstract methods — language-specific
+    # ═══════════════════════════════════════════════════════════
+
+    @abstractmethod
+    def get_lsp_command(self) -> list[str]:
+        """Return the LSP server command for this language."""
+
+    @abstractmethod
+    def flatten_symbols(
+        self, file_path: str, lsp_symbols: list[dict]
+    ) -> dict[str, dict]:
+        """Convert LSP documentSymbol to flat {unified_name: metadata} dict.
+
+        Must filter by GRAPH_SYMBOL_KINDS and handle language-specific
+        naming (e.g. Rust impl blocks, Go pointer receivers).
+        """
+
+    def get_old_symbols(self, file_path: str) -> dict[str, dict]:
+        """Extract existing definition vertices from the graph for a file.
+
+        Default implementation: returns symbols with valid start_line
+        (skips SCIP reference-only vertices).
+        Override for language-specific filtering.
+        """
+        g = self.code_graph
+        result = {}
+        vids = getattr(g, "file_to_vertices", {}).get(file_path, set())
+        for vid in vids:
+            v = g.graph.vs[vid]
+            attrs = v.attributes()
+            uname = attrs.get("unified_name")
+            if not uname:
+                continue
+            sl = attrs.get("start_line")
+            if sl is None:
+                continue  # SCIP reference vertex, not a definition
+            result[uname] = {
+                "vertex_name": v["name"],
+                "start_line": sl,
+                "end_line": attrs.get("end_line", sl),
+            }
+        return result
+
+    def _flatten_symbols_default(
+        self,
+        file_path: str,
+        symbols: list[dict],
+        parent_uname: str = "",
+    ) -> dict[str, dict]:
+        """Default flatten logic shared by most languages.
+
+        Recursively walks documentSymbol tree, computing unified_name
+        for each symbol. Filters by GRAPH_SYMBOL_KINDS and skips
+        parameters/local variables.
+
+        Language patchers call this from their flatten_symbols() method.
+        """
+        result = {}
+        for sym in (symbols or []):
+            name = sym.get("name", "")
+            kind = sym.get("kind", 0)
+
+            # Variable/Constant inside functions are params/locals — skip
+            if kind in (13, 14) and parent_uname and parent_uname.endswith("()"):
+                continue
+
+            # For kinds not tracked (e.g. kind=19 impl blocks), skip the
+            # entry but still recurse into children (impl methods are tracked).
+            if kind not in self.GRAPH_SYMBOL_KINDS:
+                if kind == 2:
+                    child_parent = parent_uname
+                else:
+                    uname = self._build_unified_name(
+                        file_path, name, parent_uname, kind
+                    )
+                    child_parent = (
+                        uname.split(":", 1)[1] if ":" in uname else name
+                    )
+                for child in sym.get("children", []):
+                    child_result = self._flatten_symbols_default(
+                        file_path, [child], child_parent
+                    )
+                    result.update(child_result)
+                continue
+
+            range_data = sym.get("range", {})
+            sel_range = sym.get("selectionRange", range_data)
+            start = range_data.get("start", {}).get("line", 0)
+            end = range_data.get("end", {}).get("line", start)
+
+            uname = self._build_unified_name(
+                file_path, name, parent_uname, kind
+            )
+            entry = {
+                "kind": kind,
+                "start_line": start,
+                "end_line": end,
+                "sel_range": sel_range,
+                "parent_uname": parent_uname or None,
+            }
+            # Dedup: prefer struct/class/enum over impl blocks
+            if uname in result:
+                existing = result[uname]
+                if existing["kind"] in (5, 10, 23) and kind not in (5, 10, 23):
+                    pass  # keep existing definition
+                elif kind in (5, 10, 23) and existing["kind"] not in (5, 10, 23):
+                    result[uname] = entry
+                else:
+                    if (end - start) > (
+                        existing["end_line"] - existing["start_line"]
+                    ):
+                        result[uname] = entry
+            else:
+                result[uname] = entry
+
+            # Recurse into children.
+            # Module (kind=2, e.g. Rust `mod tests`) is transparent — SCIP
+            # doesn't include module name in the symbol path.
+            if kind == 2:
+                child_parent = parent_uname  # skip module
+            else:
+                child_parent = (
+                    uname.split(":", 1)[1] if ":" in uname else name
+                )
+            for child in sym.get("children", []):
+                child_result = self._flatten_symbols_default(
+                    file_path, [child], child_parent
+                )
+                result.update(child_result)
+
+        return result
+
+    # ═══════════════════════════════════════════════════════════
+    # LSP lifecycle
+    # ═══════════════════════════════════════════════════════════
+
+    def start_lsp(self, skip_probe: bool = False):
+        """Start the LSP server, resolving binary path."""
+        from .lsp_client import resolve_lsp_binary
+
+        cmd = self.get_lsp_command()
+        resolved = resolve_lsp_binary(cmd[0])
+        if resolved:
+            cmd = [resolved] + cmd[1:]
+
+        self.lsp_client = LSPClient(
+            cmd, str(self.project_root), self._language_id()
+        )
+        self.lsp_client.start(skip_probe=skip_probe)
+
+    def stop_lsp(self):
+        """Stop the LSP server."""
+        if self.lsp_client:
+            self.lsp_client.shutdown()
+            self.lsp_client = None
+
+    def _language_id(self) -> str:
+        """Return the LSP language ID. Override if needed."""
+        return "unknown"
+
+    # ═══════════════════════════════════════════════════════════
+    # Top-level patch entry point
+    # ═══════════════════════════════════════════════════════════
+
+    def patch_files(
+        self,
+        changed_files: dict,
+        earlier_commit: str = None,
+        later_commit: str = None,
+    ) -> dict:
+        """Apply incremental patch for all changed files.
+
+        Args:
+            changed_files: dict with modified/added/deleted/renamed lists.
+            earlier_commit: base commit (required for modified files).
+            later_commit: target commit.
+
+        Returns:
+            Stats dict.
+        """
+        # Auto-start LSP if not already running
+        if self.lsp_client is None:
+            self.start_lsp()
+
+        # Rebuild indexes (vertex IDs may have changed from previous patch)
+        self.build_indexes()
+
+        total_stats = {
+            "files_deleted": 0, "files_modified": 0,
+            "files_added": 0, "files_renamed": 0,
+            "vertices_deleted": 0, "vertices_created": 0,
+            "vertices_shifted": 0,
+            "refs_incoming": 0, "refs_outgoing": 0,
+            "refs_remapped": 0, "refs_unmatched": 0,
+        }
+
+        # Clear stale caches from previous patch_files calls
+        self._semantic_tokens_cache.clear()
+
+        nodes_before = self.code_graph.graph.vcount()
+        edges_before = self.code_graph.graph.ecount()
+
+        # ── Round 1: Build all vertices ──────────────────────────
+        # Process deletions, then build vertices for added/renamed/modified.
+        # No edge connections yet — ensures all vertices exist first.
+
+        # 1a. Deletions
+        for path in changed_files.get("deleted", []):
+            with self.profiler.section("delete_subgraph"):
+                self.delete_file_subgraph(path)
+            total_stats["files_deleted"] += 1
+
+        # 1b. Renames: delete old
+        for old_path, _ in changed_files.get("renamed", []):
+            with self.profiler.section("delete_subgraph"):
+                self.delete_file_subgraph(old_path)
+
+        # 1c. Added files: build vertices
+        add_contexts = []
+        for path in changed_files.get("added", []):
+            ctx = self._rebuild_prepare_vertices(path, is_new=True)
+            add_contexts.append((path, ctx))
+            self._merge_stats(total_stats, ctx["file_stats"])
+            total_stats["files_added"] += 1
+
+        # 1d. Renamed files: build vertices for new path
+        rename_contexts = []
+        for _, new_path in changed_files.get("renamed", []):
+            ctx = self._rebuild_prepare_vertices(new_path, is_new=True)
+            rename_contexts.append((new_path, ctx))
+            self._merge_stats(total_stats, ctx["file_stats"])
+            total_stats["files_renamed"] += 1
+
+        # 1e. Modified files: classify + build vertices
+        modified = changed_files.get("modified", [])
+        if modified and not earlier_commit:
+            raise ValueError("earlier_commit required for modified files")
+        mod_contexts = []
+        for path in modified:
+            ctx = self._incremental_prepare_vertices(path, earlier_commit)
+            if ctx is not None:
+                mod_contexts.append((path, ctx))
+                self._merge_stats(total_stats, ctx["file_stats"])
+            total_stats["files_modified"] += 1
+
+        # ── Round 2: Connect all edges ───────────────────────────
+        # All vertices from all files now exist.
+
+        for path, ctx in add_contexts:
+            edge_stats = self._rebuild_connect_edges(path, ctx)
+            self._merge_stats(total_stats, edge_stats)
+
+        for path, ctx in rename_contexts:
+            edge_stats = self._rebuild_connect_edges(path, ctx)
+            self._merge_stats(total_stats, edge_stats)
+
+        for path, ctx in mod_contexts:
+            edge_stats = self._incremental_connect_edges(path, ctx)
+            self._merge_stats(total_stats, edge_stats)
+
+        nodes_after = self.code_graph.graph.vcount()
+        edges_after = self.code_graph.graph.ecount()
+        total_stats["nodes_before"] = nodes_before
+        total_stats["nodes_after"] = nodes_after
+        total_stats["edges_before"] = edges_before
+        total_stats["edges_after"] = edges_after
+
+        commit_info = ""
+        if earlier_commit and later_commit:
+            total_stats["commit_earlier"] = earlier_commit
+            total_stats["commit_later"] = later_commit
+            commit_info = f"commits {earlier_commit[:12]}..{later_commit[:12]}, "
+
+        total_changed = sum(
+            len(changed_files.get(k, []))
+            for k in ("deleted", "added", "renamed", "modified")
+        )
+        logger.info(
+            f"Incremental patch summary: {commit_info}"
+            f"{total_changed} files changed, "
+            f"nodes {nodes_before}→{nodes_after} (Δ{nodes_after - nodes_before:+d}), "
+            f"edges {edges_before}→{edges_after} (Δ{edges_after - edges_before:+d})"
+        )
+
+        # Profiler summary
+        report = self.profiler.report(reset=True)
+        if report:
+            total_time = sum(s.total for _, s in report)
+            lines = [
+                f"[graph_patcher_{self._language_id()}] profiler summary: "
+                f"{total_time:.3f}s total across {len(report)} section(s)"
+            ]
+            for label, s in report:
+                avg = s.total / s.count if s.count else 0
+                lines.append(
+                    f"  {label:<40s} total={s.total:>7.3f}s "
+                    f"count={s.count:>3d} avg={avg:>7.3f}s "
+                    f"min={s.min_duration:>7.3f}s max={s.max_duration:>7.3f}s"
+                )
+            logger.info("\n".join(lines))
+
+        return total_stats
+
+    # ═══════════════════════════════════════════════════════════
+    # Single file: full rebuild (added/renamed)
+    # ═══════════════════════════════════════════════════════════
+
+    def _rebuild_prepare_vertices(
+        self, file_path: str, is_new: bool = False,
+        line_ranges: list[tuple[int, int]] | None = None,
+    ) -> dict:
+        """Round 1 for full rebuild: delete old + build new vertices + remap."""
+        file_stats = {
+            "vertices_deleted": 0, "vertices_created": 0,
+            "refs_incoming": 0, "refs_outgoing": 0,
+            "refs_remapped": 0, "refs_unmatched": 0,
+        }
+
+        severed_in = []
+        severed_out = []
+
+        if not is_new:
+            with self.profiler.section("delete_subgraph"):
+                result = self.delete_file_subgraph(file_path)
+                file_stats["vertices_deleted"] = len(
+                    result["deleted_vertex_names"]
+                )
+                severed_in = result["severed_incoming_refs"]
+                severed_out = result["severed_outgoing_refs"]
+
+        with self.profiler.section("lsp_document_symbol"):
+            abs_file = str(self.project_root / file_path)
+            symbols = self.lsp_client.document_symbol(abs_file)
+            new_vertices = self.rebuild_file_subgraph(file_path, symbols)
+            file_stats["vertices_created"] = len(new_vertices)
+
+        with self.profiler.section("remap_edges"):
+            remapped = self._remap_severed_edges(
+                new_vertices, severed_in, severed_out,
+                changed_line_ranges=line_ranges,
+            )
+            file_stats["refs_remapped"] = remapped
+
+        return {
+            "file_stats": file_stats,
+            "new_vertices": new_vertices,
+            "severed_in": severed_in,
+            "severed_out": severed_out,
+        }
+
+    def _rebuild_connect_edges(
+        self, file_path: str, ctx: dict,
+        line_ranges: list[tuple[int, int]] | None = None,
+    ) -> dict:
+        """Round 2 for full rebuild: connect edges via LSP."""
+        edge_stats = {
+            "refs_incoming": 0, "refs_outgoing": 0, "refs_unmatched": 0,
+        }
+        new_vertices = ctx["new_vertices"]
+
+        remapped_unames = self._get_remapped_unames(
+            new_vertices, ctx["severed_in"], ctx["severed_out"],
+        )
+        new_only = [v for v in new_vertices if v not in remapped_unames]
+
+        ref_stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
+        if new_only:
+            with self.profiler.section("lsp_incoming_refs"):
+                self.reconnect_incoming(file_path, new_only, ref_stats)
+
+        if line_ranges:
+            outgoing_ranges = self._compute_outgoing_ranges(
+                new_vertices, line_ranges,
+            )
+        else:
+            outgoing_ranges = []
+            for vname in new_vertices:
+                sr = self.code_graph.symbol_ranges.get(vname)
+                if sr:
+                    outgoing_ranges.append(sr)
+            if not outgoing_ranges:
+                outgoing_ranges = None
+
+        with self.profiler.section("lsp_outgoing_refs"):
+            self.reconnect_outgoing(
+                file_path, new_vertices, ref_stats,
+                line_ranges=outgoing_ranges,
+            )
+
+        edge_stats["refs_incoming"] = ref_stats["incoming_added"]
+        edge_stats["refs_outgoing"] = ref_stats["outgoing_added"]
+        edge_stats["refs_unmatched"] = ref_stats["unmatched"]
+        return edge_stats
+
+    # ═══════════════════════════════════════════════════════════
+    # Single file: symbol-level incremental (modified)
+    # ═══════════════════════════════════════════════════════════
+
+
+    def _incremental_prepare_vertices(
+        self, file_path: str, base_commit: str
+    ) -> Optional[dict]:
+        """Round 1: classify symbols and build/delete/shift vertices.
+
+        Returns a context dict for Round 2 (edge connection), or None
+        if no hunks were found (file unchanged at line level).
+        """
+        file_stats = {
+            "vertices_deleted": 0, "vertices_created": 0,
+            "vertices_shifted": 0, "refs_incoming": 0,
+            "refs_outgoing": 0, "refs_remapped": 0, "refs_unmatched": 0,
+        }
+
+        with self.profiler.section("git_diff"):
+            hunks = change_mgr.get_changed_line_ranges(
+                str(self.project_root), file_path, base_commit
+            )
+        if not hunks:
+            return None
+
+        abs_file = str(self.project_root / file_path)
+        with self.profiler.section("lsp_document_symbol"):
+            raw_symbols = self.lsp_client.document_symbol(abs_file)
+            new_symbols = self.flatten_symbols(file_path, raw_symbols)
+        old_symbols = self.get_old_symbols(file_path)
+
+        if not old_symbols:
+            # No old symbols (SCIP didn't index this file) — fall back to
+            # full rebuild but still in two rounds so cross-file edges work.
+            ctx = self._rebuild_prepare_vertices(file_path, is_new=False)
+            ctx["fallback_rebuild"] = True
+            return ctx
+
+        with self.profiler.section("classify_symbols"):
+            classified = self._classify_symbols(
+                old_symbols, new_symbols, hunks
+            )
+
+        # DELETED
+        for uname in classified["deleted"]:
+            old = old_symbols[uname]
+            self.delete_vertices_by_name([old["vertex_name"]])
+            file_stats["vertices_deleted"] += 1
+
+        # SHIFTED
+        for uname in classified["shifted"]:
+            old = old_symbols[uname]
+            new = new_symbols[uname]
+            old_vname = old["vertex_name"]
+            new_vname = f"{uname}:{new['start_line']}"
+            self.rename_vertex(old_vname, new_vname, {
+                "start_line": new["start_line"],
+                "end_line": new["end_line"],
+            })
+            self._update_selection_range(old_vname, new_vname, new)
+            file_stats["vertices_shifted"] += 1
+
+        # AFFECTED (rename/update vertex, collect ranges for Round 2)
+        affected_vnames = []
+        affected_changed_ranges = []
+        for uname in classified["affected"]:
+            old = old_symbols[uname]
+            new = new_symbols[uname]
+            old_vname = old["vertex_name"]
+            new_vname = f"{uname}:{new['start_line']}"
+
+            if old_vname != new_vname:
+                self.rename_vertex(old_vname, new_vname, {
+                    "start_line": new["start_line"],
+                    "end_line": new["end_line"],
+                })
+            else:
+                vid = self.code_graph.name_to_vertex.get(new_vname)
+                if vid is not None:
+                    self.code_graph.graph.vs[vid]["end_line"] = new["end_line"]
+                    self.code_graph.symbol_ranges[new_vname] = (
+                        new["start_line"], new["end_line"]
+                    )
+
+            self._update_selection_range(old_vname, new_vname, new)
+            affected_vnames.append(new_vname)
+
+            sym_start, sym_end = new["start_line"], new["end_line"]
+            changed = [
+                (max(h_start, sym_start), min(h_end, sym_end))
+                for h_start, h_end in hunks
+                if h_start <= sym_end and h_end >= sym_start
+            ]
+            affected_changed_ranges.append(
+                changed if changed else [(sym_start, sym_end)]
+            )
+
+        # ADDED (create vertices, collect for Round 2)
+        added_vnames = []
+        for uname in classified["added"]:
+            new = new_symbols[uname]
+            vname = f"{uname}:{new['start_line']}"
+            node_type = self._classify_symbol_type(new["kind"])
+
+            self.code_graph._add_vertex(vname, {
+                "type": node_type,
+                "file": file_path,
+                "start_line": new["start_line"],
+                "end_line": new["end_line"],
+                "unified_name": uname,
+            })
+            self.code_graph.symbol_ranges[vname] = (
+                new["start_line"], new["end_line"]
+            )
+
+            parent_uname = new.get("parent_uname")
+            parent_vname = (
+                self._find_vertex_by_unified_name(parent_uname, file_path)
+                if parent_uname else file_path
+            )
+            if parent_vname:
+                self.code_graph._add_edge(
+                    parent_vname, vname, EDGE_TYPE_CONTAIN
+                )
+
+            self._store_selection_range(vname, new)
+            added_vnames.append(vname)
+            file_stats["vertices_created"] += 1
+
+        logger.info(
+            f"Incremental patch {file_path}: "
+            f"del={len(classified['deleted'])} "
+            f"add={len(classified['added'])} "
+            f"affected={len(classified['affected'])} "
+            f"shifted={len(classified['shifted'])} "
+            f"unchanged={len(classified['unchanged'])}"
+        )
+
+        return {
+            "file_stats": file_stats,
+            "classified": classified,
+            "affected_vnames": affected_vnames,
+            "affected_changed_ranges": affected_changed_ranges,
+            "added_vnames": added_vnames,
+            "hunks": hunks,
+        }
+
+    def _incremental_connect_edges(
+        self, file_path: str, ctx: dict
+    ) -> dict:
+        """Round 2: connect reference edges using LSP queries.
+
+        Called after all files' vertices have been prepared.
+        """
+        edge_stats = {
+            "refs_incoming": 0, "refs_outgoing": 0, "refs_unmatched": 0,
+        }
+
+        if ctx.get("fallback_rebuild"):
+            # Fallback: old_symbols was empty, used _rebuild_prepare_vertices.
+            # Now connect edges via _rebuild_connect_edges.
+            return self._rebuild_connect_edges(file_path, ctx)
+
+        affected_vnames = ctx["affected_vnames"]
+        affected_changed_ranges = ctx["affected_changed_ranges"]
+        added_vnames = ctx["added_vnames"]
+
+        # Affected: outgoing refs for changed lines
+        if affected_vnames:
+            flat_vnames = []
+            flat_ranges = []
+            for vname, ranges in zip(
+                affected_vnames, affected_changed_ranges
+            ):
+                for r in ranges:
+                    flat_vnames.append(vname)
+                    flat_ranges.append(r)
+
+            ref_stats = {
+                "incoming_added": 0, "outgoing_added": 0, "unmatched": 0
+            }
+            with self.profiler.section("lsp_outgoing_refs"):
+                self.reconnect_outgoing(
+                    file_path, flat_vnames, ref_stats,
+                    line_ranges=flat_ranges,
+                )
+            edge_stats["refs_outgoing"] = ref_stats["outgoing_added"]
+
+        # Added: incoming + outgoing refs
+        if added_vnames:
+            added_ranges = []
+            for vname in added_vnames:
+                sr = self.code_graph.symbol_ranges.get(vname)
+                if sr:
+                    added_ranges.append(sr)
+                else:
+                    vid = self.code_graph.name_to_vertex.get(vname)
+                    if vid is not None:
+                        v = self.code_graph.graph.vs[vid]
+                        sl = v.attributes().get("start_line", 0)
+                        el = v.attributes().get("end_line", sl)
+                        added_ranges.append((sl, el))
+
+            ref_stats = {
+                "incoming_added": 0, "outgoing_added": 0, "unmatched": 0
+            }
+            with self.profiler.section("lsp_incoming_refs"):
+                self.reconnect_incoming(file_path, added_vnames, ref_stats)
+            with self.profiler.section("lsp_outgoing_refs"):
+                effective_ranges = (
+                    added_ranges
+                    if len(added_ranges) == len(added_vnames)
+                    else None
+                )
+                self.reconnect_outgoing(
+                    file_path, added_vnames, ref_stats,
+                    line_ranges=effective_ranges,
+                )
+            edge_stats["refs_incoming"] = ref_stats["incoming_added"]
+            edge_stats["refs_outgoing"] += ref_stats["outgoing_added"]
+
+        return edge_stats
+
+    # ═══════════════════════════════════════════════════════════
+    # Symbol classification
+    # ═══════════════════════════════════════════════════════════
+
+    def _classify_symbols(
+        self,
+        old_symbols: dict[str, dict],
+        new_symbols: dict[str, dict],
+        hunks: list[tuple[int, int]],
+    ) -> dict[str, list[str]]:
+        """Classify each symbol as deleted/added/affected/shifted/unchanged."""
+
+        def overlaps_any_hunk(start, end):
+            return any(
+                start <= h_end and end >= h_start
+                for h_start, h_end in hunks
+            )
+
+        old_set = set(old_symbols.keys())
+        new_set = set(new_symbols.keys())
+
+        deleted = sorted(old_set - new_set)
+        added = sorted(new_set - old_set)
+        common = old_set & new_set
+
+        affected = []
+        shifted = []
+        unchanged = []
+
+        for uname in sorted(common):
+            new = new_symbols[uname]
+            if overlaps_any_hunk(new["start_line"], new["end_line"]):
+                affected.append(uname)
+            else:
+                old = old_symbols[uname]
+                if old["start_line"] != new["start_line"]:
+                    shifted.append(uname)
+                else:
+                    unchanged.append(uname)
+
+        # Leaf-priority: if a parent (struct) is affected only because
+        # a child (method) is affected, demote parent to shifted.
+        demote = []
+        for uname in affected:
+            children_in_affected = [
+                u for u in affected
+                if u != uname and u.startswith(uname + ".")
+            ]
+            if children_in_affected and not overlaps_any_hunk(
+                new_symbols[uname]["start_line"],
+                new_symbols[uname]["start_line"],
+            ):
+                demote.append(uname)
+        for uname in demote:
+            affected.remove(uname)
+            shifted.append(uname)
+
+        return {
+            "deleted": deleted,
+            "added": added,
+            "affected": affected,
+            "shifted": shifted,
+            "unchanged": unchanged,
+        }
+
+    # ═══════════════════════════════════════════════════════════
+    # Remap severed edges
+    # ═══════════════════════════════════════════════════════════
+
+    _STRUCTURAL_NODE_TYPES = frozenset({"file", "directory"})
+
+    def _remap_severed_edges(
+        self,
+        new_vertices: list[str],
+        severed_incoming: list[tuple],
+        severed_outgoing: list[tuple],
+        changed_line_ranges: list[tuple[int, int]] | None = None,
+    ) -> int:
+        """Remap severed reference edges to new vertex names."""
+        uname_to_new = {}
+        for vname in new_vertices:
+            if vname in self.code_graph.name_to_vertex:
+                v = self.code_graph.graph.vs[
+                    self.code_graph.name_to_vertex[vname]
+                ]
+                uname = v.attributes().get("unified_name")
+                if uname:
+                    uname_to_new[uname] = vname
+
+        changed_unames = set()
+        if changed_line_ranges:
+            for vname in new_vertices:
+                sr = self.code_graph.symbol_ranges.get(vname)
+                if sr is None:
+                    continue
+                sym_start, sym_end = sr
+                for cl_start, cl_end in changed_line_ranges:
+                    if sym_start <= cl_end and cl_start <= sym_end:
+                        vid = self.code_graph.name_to_vertex.get(vname)
+                        if vid is not None:
+                            uname = self.code_graph.graph.vs[vid].attributes(
+                            ).get("unified_name")
+                            if uname:
+                                changed_unames.add(uname)
+                        break
+
+        remapped = 0
+
+        # Incoming: always safe to remap
+        for entry in severed_incoming:
+            src_name, _, _, tgt_uname = entry
+            if not tgt_uname:
+                continue
+            new_target = uname_to_new.get(tgt_uname)
+            if new_target and src_name in self.code_graph.name_to_vertex:
+                self.code_graph._add_edge(
+                    src_name, new_target, EDGE_TYPE_REFERENCE
+                )
+                remapped += 1
+
+        # Outgoing: skip if source body changed
+        for entry in severed_outgoing:
+            src_name, tgt_name, src_uname, tgt_uname = entry
+
+            if src_uname:
+                if src_uname in changed_unames:
+                    continue
+                new_src = uname_to_new.get(src_uname)
+            else:
+                new_src = (
+                    src_name
+                    if src_name in self.code_graph.name_to_vertex
+                    else None
+                )
+
+            if tgt_name in self.code_graph.name_to_vertex:
+                resolved_tgt = tgt_name
+            elif tgt_uname:
+                resolved_tgt = uname_to_new.get(tgt_uname)
+            else:
+                resolved_tgt = None
+
+            if new_src and resolved_tgt:
+                self.code_graph._add_edge(
+                    new_src, resolved_tgt, EDGE_TYPE_REFERENCE
+                )
+                remapped += 1
+
+        return remapped
+
+    # ═══════════════════════════════════════════════════════════
+    # Helpers
+    # ═══════════════════════════════════════════════════════════
+
+    def _compute_outgoing_ranges(
+        self,
+        new_vertices: list[str],
+        changed_line_ranges: list[tuple[int, int]] | None,
+    ) -> list[tuple[int, int]] | None:
+        """Expand changed line ranges to cover affected function bodies."""
+        if not changed_line_ranges:
+            return changed_line_ranges
+
+        expanded = list(changed_line_ranges)
+        for vname in new_vertices:
+            sr = self.code_graph.symbol_ranges.get(vname)
+            if sr is None:
+                continue
+            sym_start, sym_end = sr
+            overlaps = any(
+                sym_start <= cl_end and cl_start <= sym_end
+                for cl_start, cl_end in changed_line_ranges
+            )
+            if overlaps:
+                expanded.append((sym_start, sym_end))
+
+        if not expanded:
+            return changed_line_ranges
+        expanded.sort()
+        merged = [expanded[0]]
+        for start, end in expanded[1:]:
+            if start <= merged[-1][1] + 1:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+        return merged
+
+    def _find_vertex_by_unified_name(
+        self, uname: str, file_path: str
+    ) -> Optional[str]:
+        """Find a vertex name by unified_name, preferring same file."""
+        idx = getattr(self.code_graph, "unified_name_to_vertex", {})
+        vids = idx.get(uname, [])
+        if not vids:
+            for vname, (_, _) in self.code_graph.symbol_ranges.items():
+                vid = self.code_graph.name_to_vertex.get(vname)
+                if vid is not None:
+                    v = self.code_graph.graph.vs[vid]
+                    if v.attributes().get("unified_name") == uname:
+                        return vname
+            return None
+
+        for vid in vids:
+            v = self.code_graph.graph.vs[vid]
+            if v.attributes().get("file") == file_path:
+                return v["name"]
+        return self.code_graph.graph.vs[vids[0]]["name"]
+
+    def _get_remapped_unames(
+        self,
+        new_vertices: list[str],
+        severed_incoming: list[tuple],
+        severed_outgoing: list[tuple],
+    ) -> set[str]:
+        """Get set of vertex names whose edges were remapped."""
+        remapped_unames = set()
+        for entry in severed_incoming:
+            _, _, _, tgt_uname = entry
+            if tgt_uname:
+                for vname in new_vertices:
+                    vid = self.code_graph.name_to_vertex.get(vname)
+                    if vid is not None:
+                        u = self.code_graph.graph.vs[vid].attributes().get(
+                            "unified_name"
+                        )
+                        if u == tgt_uname:
+                            remapped_unames.add(vname)
+        for entry in severed_outgoing:
+            _, _, src_uname, _ = entry
+            if src_uname:
+                for vname in new_vertices:
+                    vid = self.code_graph.name_to_vertex.get(vname)
+                    if vid is not None:
+                        u = self.code_graph.graph.vs[vid].attributes().get(
+                            "unified_name"
+                        )
+                        if u == src_uname:
+                            remapped_unames.add(vname)
+        return remapped_unames
+
+    def _update_selection_range(
+        self, old_vname: str, new_vname: str, new_meta: dict
+    ):
+        """Update symbol_selection_ranges for a shifted/affected symbol."""
+        sel = new_meta["sel_range"]
+        sel_start = sel.get("start", {})
+        sel_end = sel.get("end", {})
+        self.symbol_selection_ranges[new_vname] = (
+            sel_start.get("line", new_meta["start_line"]),
+            sel_start.get("character", 0),
+            sel_end.get("line", new_meta["start_line"]),
+            sel_end.get("character", 0),
+        )
+        if new_vname != old_vname and old_vname in self.symbol_selection_ranges:
+            del self.symbol_selection_ranges[old_vname]
+
+    def _store_selection_range(self, vname: str, meta: dict):
+        """Store symbol_selection_ranges for a new vertex."""
+        sel = meta["sel_range"]
+        sel_start = sel.get("start", {})
+        sel_end = sel.get("end", {})
+        self.symbol_selection_ranges[vname] = (
+            sel_start.get("line", meta["start_line"]),
+            sel_start.get("character", 0),
+            sel_end.get("line", meta["start_line"]),
+            sel_end.get("character", 0),
+        )
+
+    @staticmethod
+    def _merge_stats(total: dict, file_stats: dict):
+        """Merge file-level stats into total stats."""
+        for key in (
+            "vertices_deleted", "vertices_created", "vertices_shifted",
+            "refs_incoming", "refs_outgoing", "refs_remapped", "refs_unmatched",
+        ):
+            if key in file_stats:
+                total[key] = total.get(key, 0) + file_stats[key]

--- a/codeminer/incremental_graph/patcher_base.py
+++ b/codeminer/incremental_graph/patcher_base.py
@@ -7,7 +7,6 @@ behavior to patcher_lang subclasses.
 from __future__ import annotations
 
 from abc import abstractmethod
-from pathlib import Path
 from typing import Optional
 
 from ..graph.code_graph import CodeGraph

--- a/codeminer/incremental_graph/patcher_base.py
+++ b/codeminer/incremental_graph/patcher_base.py
@@ -354,21 +354,7 @@ class PatcherBase(SubgraphMgr):
         )
 
         # Profiler summary
-        report = self.profiler.report(reset=True)
-        if report:
-            total_time = sum(s.total for _, s in report)
-            lines = [
-                f"[graph_patcher_{self._language_id()}] profiler summary: "
-                f"{total_time:.3f}s total across {len(report)} section(s)"
-            ]
-            for label, s in report:
-                avg = s.total / s.count if s.count else 0
-                lines.append(
-                    f"  {label:<40s} total={s.total:>7.3f}s "
-                    f"count={s.count:>3d} avg={avg:>7.3f}s "
-                    f"min={s.min_duration:>7.3f}s max={s.max_duration:>7.3f}s"
-                )
-            logger.info("\n".join(lines))
+        self.profiler.report(reset=True)
 
         return total_stats
 

--- a/codeminer/incremental_graph/patcher_cpp.py
+++ b/codeminer/incremental_graph/patcher_cpp.py
@@ -1,0 +1,453 @@
+"""C/C++-specific incremental patcher.
+
+Uses clangd .idx files instead of LSP queries for incremental updates.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+from ..graph.code_graph import CodeGraph
+from ..log_utils import get_logger
+from ..types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+)
+from .patcher_base import PatcherBase
+
+logger = get_logger(__name__)
+
+
+class PatcherCpp(PatcherBase):
+    """C/C++ incremental patcher using clangd .idx files."""
+
+    def get_lsp_command(self):
+        return ["clangd"]
+
+    def _language_id(self):
+        return "cpp"
+
+    def _get_crossfile_token_types(self):
+        return {
+            "type", "class", "struct", "enum", "function", "method",
+            "namespace", "macro",
+        }
+
+    def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+        node_type = self._classify_symbol_type(kind)
+        clean_name = name.replace("::", ".")
+
+        if parent_unified_part:
+            display = f"{parent_unified_part}.{clean_name}"
+        else:
+            display = clean_name
+
+        if node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+            if not display.endswith("()"):
+                display = f"{display}()"
+
+        return f"{file_path}:{display}"
+
+    def flatten_symbols(self, file_path, lsp_symbols):
+        return self._flatten_symbols_default(file_path, lsp_symbols)
+
+    # ═══════════════════════════════════════════════════════════
+    # Override patch_files: C++ uses .idx path, not LSP
+    # ═══════════════════════════════════════════════════════════
+
+    def patch_files(self, changed_files, **kwargs):
+        """C++ incremental: delete old subgraphs, reindex via .idx, rebuild."""
+        total_stats = {
+            "files_deleted": 0, "files_modified": 0,
+            "files_added": 0, "files_renamed": 0,
+            "vertices_deleted": 0, "vertices_created": 0,
+            "refs_incoming": 0, "refs_outgoing": 0,
+            "refs_remapped": 0, "refs_unmatched": 0,
+        }
+
+        # Rebuild indexes for delete_file_subgraph
+        self.build_indexes()
+
+        nodes_before = self.code_graph.graph.vcount()
+        edges_before = self.code_graph.graph.ecount()
+
+        # Collect all changed file paths
+        all_changed = (
+            changed_files.get("modified", [])
+            + changed_files.get("added", [])
+            + [new for _, new in changed_files.get("renamed", [])]
+        )
+
+        # Delete old subgraphs
+        for path in changed_files.get("deleted", []):
+            with self.profiler.section("delete_subgraph"):
+                self.delete_file_subgraph(path)
+            total_stats["files_deleted"] += 1
+
+        for old_path, _ in changed_files.get("renamed", []):
+            with self.profiler.section("delete_subgraph"):
+                self.delete_file_subgraph(old_path)
+
+        for path in changed_files.get("modified", []):
+            with self.profiler.section("delete_subgraph"):
+                self.delete_file_subgraph(path)
+
+        for path in changed_files.get("added", []):
+            with self.profiler.section("delete_subgraph"):
+                self.delete_file_subgraph(path)
+
+        # Reindex and rebuild via .idx
+        if all_changed:
+            stats = self._incremental_update_idx(all_changed)
+            total_stats["vertices_created"] = stats["vertices_created"]
+            total_stats["refs_outgoing"] = stats["refs_added"]
+
+        total_stats["files_modified"] = len(
+            changed_files.get("modified", [])
+        )
+        total_stats["files_added"] = len(changed_files.get("added", []))
+        total_stats["files_renamed"] = len(changed_files.get("renamed", []))
+
+        nodes_after = self.code_graph.graph.vcount()
+        edges_after = self.code_graph.graph.ecount()
+        total_stats["nodes_before"] = nodes_before
+        total_stats["nodes_after"] = nodes_after
+        total_stats["edges_before"] = edges_before
+        total_stats["edges_after"] = edges_after
+
+        earlier = kwargs.get("earlier_commit", "")
+        later = kwargs.get("later_commit", "")
+        commit_info = ""
+        if earlier and later:
+            total_stats["commit_earlier"] = earlier
+            total_stats["commit_later"] = later
+            commit_info = f"commits {earlier[:12]}..{later[:12]}, "
+
+        total_changed = sum(
+            len(changed_files.get(k, []))
+            for k in ("deleted", "added", "renamed", "modified")
+        )
+        logger.info(
+            f"Incremental patch summary: {commit_info}"
+            f"{total_changed} files changed, "
+            f"nodes {nodes_before}→{nodes_after} "
+            f"(Δ{nodes_after - nodes_before:+d}), "
+            f"edges {edges_before}→{edges_after} "
+            f"(Δ{edges_after - edges_before:+d})"
+        )
+
+        report = self.profiler.report(reset=True)
+        if report:
+            total_time = sum(s.total for _, s in report)
+            lines = [
+                f"[graph_patcher_cpp] profiler summary: "
+                f"{total_time:.3f}s total across {len(report)} section(s)"
+            ]
+            for label, s in report:
+                avg = s.total / s.count if s.count else 0
+                lines.append(
+                    f"  {label:<40s} total={s.total:>7.3f}s "
+                    f"count={s.count:>3d} avg={avg:>7.3f}s "
+                    f"min={s.min_duration:>7.3f}s max={s.max_duration:>7.3f}s"
+                )
+            logger.info("\n".join(lines))
+
+        return total_stats
+
+    # ═══════════════════════════════════════════════════════════
+    # .idx-based incremental update
+    # ═══════════════════════════════════════════════════════════
+
+    def _incremental_update_idx(self, changed_files: list[str]) -> dict:
+        """Reindex via clangd .idx, then rebuild graph for changed files."""
+        stats = {"vertices_created": 0, "refs_added": 0}
+
+        with self.profiler.section("cpp.reindex"):
+            idx_dir = self._reindex_changed_files(changed_files)
+        if idx_dir is None:
+            logger.warning("clangd incremental indexing failed")
+            return stats
+
+        from ..ls_index.clangd_decode import ClangdGraphDecoder
+
+        with self.profiler.section("cpp.parse_idx"):
+            decoder = ClangdGraphDecoder(
+                idx_directory=str(idx_dir),
+                project_root=str(self.project_root),
+            )
+            decoder._collect_all_idx()
+            decoder._build_id_to_display()
+
+        decoder.code_graph = self.code_graph
+
+        with self.profiler.section("cpp.rebuild_graph"):
+            v_count, r_count = self._apply_idx_data(decoder, changed_files)
+            stats["vertices_created"] = v_count
+            stats["refs_added"] = r_count
+
+        logger.info(
+            f"C++ .idx incremental: {len(changed_files)} files, "
+            f"+{v_count} vertices, {r_count} refs"
+        )
+        return stats
+
+    def _reindex_changed_files(
+        self, changed_files: list[str]
+    ) -> Path | None:
+        """Run clangd background-index, preserving .idx cache."""
+        clangd = shutil.which("clangd")
+        if not clangd:
+            return None
+
+        comp_db = None
+        for candidate in [
+            Path(self.project_root) / "compile_commands.json",
+            Path(self.project_root) / "build" / "compile_commands.json",
+        ]:
+            # Skip empty/trivial files (bare "[]" is ~3 bytes)
+            if candidate.exists() and candidate.stat().st_size > 4:
+                try:
+                    data = json.loads(candidate.read_text())
+                    if isinstance(data, list) and len(data) > 0:
+                        comp_db = candidate
+                        break
+                except Exception as exc:
+                    logger.debug(f"Failed to parse {candidate}: {exc}")
+                    continue
+        if comp_db is None:
+            logger.warning("No valid compile_commands.json found")
+            return None
+
+        candidates = [
+            Path(self.project_root) / ".cache" / "clangd" / "index",
+            comp_db.parent / ".cache" / "clangd" / "index",
+        ]
+        idx_dir = None
+        for d in candidates:
+            if d.exists() and any(d.glob("*.idx")):
+                idx_dir = d
+                break
+
+        if idx_dir is None:
+            logger.info("No .idx cache, running full clangd index")
+            from ..ls_index.clangd_indexer import ClangdIndexer
+            indexer = ClangdIndexer(project_root=str(self.project_root))
+            success = indexer.generate_index(compdb_path=str(comp_db))
+            return indexer.idx_directory if success else None
+
+        pre_mtime = max(
+            (f.stat().st_mtime for f in idx_dir.glob("*.idx")), default=0,
+        )
+        pre_count = len(list(idx_dir.glob("*.idx")))
+        logger.info(
+            f"C++ incremental: {pre_count} .idx in {idx_dir}, "
+            f"didOpen {len(changed_files)} files"
+        )
+
+        cmd = [
+            clangd, "--background-index",
+            f"--compile-commands-dir={comp_db.parent}",
+            "--background-index-priority=normal", "--log=error",
+        ]
+        process = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, cwd=str(self.project_root),
+        )
+
+        def lsp_send(msg):
+            content = json.dumps(msg).encode()
+            header = f"Content-Length: {len(content)}\r\n\r\n".encode()
+            process.stdin.write(header + content)
+            process.stdin.flush()
+
+        try:
+            lsp_send({
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {
+                    "processId": os.getpid(),
+                    "rootUri": Path(self.project_root).as_uri(),
+                    "capabilities": {},
+                },
+            })
+            time.sleep(1)
+            lsp_send({
+                "jsonrpc": "2.0", "method": "initialized", "params": {},
+            })
+            time.sleep(0.5)
+
+            for fpath in changed_files:
+                abs_path = Path(self.project_root) / fpath
+                if not abs_path.is_file():
+                    continue
+                try:
+                    text = abs_path.read_text(errors="replace")
+                except Exception:
+                    continue
+                lsp_send({
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didOpen",
+                    "params": {
+                        "textDocument": {
+                            "uri": abs_path.as_uri(),
+                            "languageId": "cpp",
+                            "version": 1,
+                            "text": text,
+                        }
+                    },
+                })
+
+            stable = 0
+            last_mtime = pre_mtime
+            for _ in range(120):
+                time.sleep(1)
+                cur_mtime = max(
+                    (f.stat().st_mtime for f in idx_dir.glob("*.idx")),
+                    default=0,
+                )
+                if cur_mtime > last_mtime:
+                    last_mtime = cur_mtime
+                    stable = 0
+                else:
+                    stable += 1
+                    if stable >= 5 and cur_mtime > pre_mtime:
+                        break
+                    if stable >= 30:
+                        break
+
+            post_count = len(list(idx_dir.glob("*.idx")))
+            logger.info(
+                f"C++ incremental done: {pre_count}→{post_count} .idx files"
+            )
+
+        finally:
+            try:
+                lsp_send({
+                    "jsonrpc": "2.0", "id": 99,
+                    "method": "shutdown", "params": None,
+                })
+                time.sleep(0.5)
+                lsp_send({
+                    "jsonrpc": "2.0", "method": "exit", "params": None,
+                })
+                process.wait(timeout=5)
+            except Exception:
+                process.kill()
+                process.wait()
+
+        return idx_dir
+
+    def _apply_idx_data(
+        self,
+        decoder,
+        changed_files: list[str],
+    ) -> tuple[int, int]:
+        """Add symbols and edges from .idx data for changed files."""
+        from ..ls_index.clangd_decode import (
+            REF_KIND_DEFINITION,
+            REF_KIND_REFERENCE,
+            ZERO_SYMBOL_ID,
+            KIND_MACRO,
+        )
+
+        changed_set = set(changed_files)
+        new_vertices = 0
+        new_refs = 0
+
+        changed_sym_ids = set()
+        for sym_id, sym in decoder._symbols.items():
+            if sym.get("kind", 0) == KIND_MACRO:
+                continue
+            def_info = decoder._resolve_definition(sym_id)
+            if not def_info["file"]:
+                continue
+            rel_file = decoder._file_uri_to_relative(def_info["file"])
+            if rel_file in changed_set:
+                changed_sym_ids.add(sym_id)
+
+        for sym_id in changed_sym_ids:
+            sym = decoder._symbols[sym_id]
+            def_info = decoder._resolve_definition(sym_id)
+            rel_file = decoder._file_uri_to_relative(def_info["file"])
+            decoder._ensure_file_hierarchy(rel_file)
+
+            node_type = decoder._kind_to_node_type(sym.get("kind", 0))
+            qualified_name = decoder._sym_id_to_display_name(sym_id)
+            line = def_info["line"]
+            scope_start, scope_end = decoder._find_range(rel_file, line)
+
+            self.code_graph.add_symbol_node(
+                sym_id, line,
+                scope_start_line=scope_start,
+                scope_end_line=scope_end,
+                symbol_type=node_type,
+            )
+
+            if sym_id in self.code_graph.name_to_vertex:
+                vid = self.code_graph.name_to_vertex[sym_id]
+                unified_display = qualified_name.replace("::", ".")
+                if node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+                    unified_display = f"{unified_display}()"
+                self.code_graph.graph.vs[vid]["unified_name"] = (
+                    f"{rel_file}:{unified_display}"
+                )
+                self.code_graph.graph.vs[vid]["file"] = rel_file
+                new_vertices += 1
+
+        contained = set()
+        for sym_id in changed_sym_ids:
+            if sym_id not in self.code_graph.name_to_vertex:
+                continue
+            for ref in decoder._refs.get(sym_id, []):
+                if ref["kind"] & REF_KIND_DEFINITION:
+                    container_id = ref.get("container", "")
+                    if (
+                        container_id
+                        and container_id != ZERO_SYMBOL_ID
+                        and container_id in self.code_graph.name_to_vertex
+                    ):
+                        self.code_graph._add_edge(
+                            container_id, sym_id, EDGE_TYPE_CONTAIN
+                        )
+                        contained.add(sym_id)
+                        break
+
+        for sym_id in changed_sym_ids:
+            if sym_id in contained:
+                continue
+            if sym_id not in self.code_graph.name_to_vertex:
+                continue
+            vid = self.code_graph.name_to_vertex[sym_id]
+            file_path = self.code_graph.graph.vs[vid].attributes().get("file")
+            if file_path and file_path in self.code_graph.name_to_vertex:
+                self.code_graph._add_edge(
+                    file_path, sym_id, EDGE_TYPE_CONTAIN
+                )
+
+        for sym_id, ref_list in decoder._refs.items():
+            if sym_id not in self.code_graph.name_to_vertex:
+                continue
+            for ref in ref_list:
+                if not (ref["kind"] & REF_KIND_REFERENCE):
+                    continue
+                container_id = ref.get("container", "")
+                if not container_id or container_id == ZERO_SYMBOL_ID:
+                    continue
+                if container_id not in self.code_graph.name_to_vertex:
+                    continue
+                if (
+                    sym_id in changed_sym_ids
+                    or container_id in changed_sym_ids
+                ):
+                    self.code_graph._add_edge(
+                        container_id, sym_id, EDGE_TYPE_REFERENCE
+                    )
+                    new_refs += 1
+
+        return new_vertices, new_refs

--- a/codeminer/incremental_graph/patcher_cpp.py
+++ b/codeminer/incremental_graph/patcher_cpp.py
@@ -10,9 +10,6 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from typing import Optional
-
-from ..graph.code_graph import CodeGraph
 from ..log_utils import get_logger
 from ..types import (
     EDGE_TYPE_CONTAIN,

--- a/codeminer/incremental_graph/patcher_go.py
+++ b/codeminer/incremental_graph/patcher_go.py
@@ -1,0 +1,45 @@
+"""Go-specific incremental patcher."""
+from __future__ import annotations
+
+import re
+
+from ..types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from .patcher_base import PatcherBase
+
+
+class PatcherGo(PatcherBase):
+    """Go incremental patcher. Matches SCIPGoGraphDecoder naming."""
+
+    def get_lsp_command(self):
+        return ["gopls", "serve"]
+
+    def _language_id(self):
+        return "go"
+
+    def _get_crossfile_token_types(self):
+        return {
+            "type", "function", "method", "namespace", "interface",
+            "property",
+        }
+
+    def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+        node_type = self._classify_symbol_type(kind)
+
+        # gopls returns method names as "(*ReceiverType).MethodName"
+        # Strip parens and leading * to match SCIP format "Type.Method()"
+        m = re.match(r"^\(\*?([^)]+)\)\.(.+)$", name)
+        if m:
+            display = f"{m.group(1)}.{m.group(2)}"
+        elif parent_unified_part:
+            display = f"{parent_unified_part}.{name}"
+        else:
+            display = name
+
+        if node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+            if not display.endswith("()"):
+                display = f"{display}()"
+
+        return f"{file_path}:{display}"
+
+    def flatten_symbols(self, file_path, lsp_symbols):
+        return self._flatten_symbols_default(file_path, lsp_symbols)

--- a/codeminer/incremental_graph/patcher_python.py
+++ b/codeminer/incremental_graph/patcher_python.py
@@ -1,0 +1,38 @@
+"""Python-specific incremental patcher."""
+from __future__ import annotations
+
+from ..types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from .patcher_base import PatcherBase
+
+
+class PatcherPython(PatcherBase):
+    """Python incremental patcher. Matches SCIPPythonGraphDecoder naming."""
+
+    def get_lsp_command(self):
+        return ["basedpyright-langserver", "--stdio"]
+
+    def _language_id(self):
+        return "python"
+
+    def _get_crossfile_token_types(self):
+        return {
+            "type", "class", "function", "method", "namespace",
+            "property",
+        }
+
+    def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+        node_type = self._classify_symbol_type(kind)
+
+        if parent_unified_part:
+            display = f"{parent_unified_part}.{name}"
+        else:
+            display = name
+
+        if node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+            if not display.endswith("()"):
+                display = f"{display}()"
+
+        return f"{file_path}:{display}"
+
+    def flatten_symbols(self, file_path, lsp_symbols):
+        return self._flatten_symbols_default(file_path, lsp_symbols)

--- a/codeminer/incremental_graph/patcher_rust.py
+++ b/codeminer/incremental_graph/patcher_rust.py
@@ -1,0 +1,107 @@
+"""Rust-specific incremental patcher."""
+from __future__ import annotations
+
+import re
+
+from ..types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from .patcher_base import PatcherBase
+
+
+class PatcherRust(PatcherBase):
+    """Rust incremental patcher. Matches SCIPRustGraphDecoder naming."""
+
+    def get_lsp_command(self):
+        return ["rust-analyzer"]
+
+    def _language_id(self):
+        return "rust"
+
+    def _get_crossfile_token_types(self):
+        return {
+            "type", "struct", "enum", "function", "method",
+            "namespace", "macro", "interface", "property",
+        }
+
+    # ── Unified name construction ──────────────────────────
+
+    @staticmethod
+    def _normalize_impl_name(impl_name: str) -> str:
+        """Convert LSP impl block name to SCIP-compatible type display.
+
+        "impl EqHash"                        → "EqHash"
+        "impl Violation for EqWithoutHash"   → "EqWithoutHash<Violation>"
+        "impl<'a> From<io::Error> for Error" → "Error<From<io::Error>>"
+        """
+        text = impl_name.strip()
+        if not text.startswith("impl"):
+            return text
+        text = text[4:].strip()
+
+        # Strip leading lifetime/generic params
+        if text.startswith("<"):
+            depth = 0
+            for i, ch in enumerate(text):
+                if ch == "<":
+                    depth += 1
+                elif ch == ">":
+                    depth -= 1
+                    if depth == 0:
+                        text = text[i + 1:].strip()
+                        break
+
+        for_idx = _find_toplevel_for(text)
+        if for_idx >= 0:
+            trait_part = text[:for_idx].strip()
+            type_part = text[for_idx + 4:].strip()
+            trait_part = re.sub(r"<['\\'a-z_,\s]+>", "", trait_part)
+            if trait_part:
+                return f"{type_part}<{trait_part}>"
+            return type_part
+        else:
+            text = re.sub(r"<['\\'a-z_,\s]+>", "", text)
+            return text
+
+    def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+        node_type = self._classify_symbol_type(kind)
+
+        if parent_unified_part and parent_unified_part.startswith("impl"):
+            parent_unified_part = self._normalize_impl_name(
+                parent_unified_part
+            )
+
+        if name.startswith("impl"):
+            name = self._normalize_impl_name(name)
+
+        if parent_unified_part:
+            display = f"{parent_unified_part}.{name}"
+        else:
+            display = name
+
+        if node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+            if not display.endswith("()"):
+                display = f"{display}()"
+
+        return f"{file_path}:{display}"
+
+    # ── Symbol flattening ──────────────────────────────────
+
+    def flatten_symbols(self, file_path, lsp_symbols):
+        return self._flatten_symbols_default(file_path, lsp_symbols)
+
+    # ── Rust doesn't override get_old_symbols ──────────────
+
+
+def _find_toplevel_for(text: str) -> int:
+    """Find start index of top-level 'for ' keyword (not inside <>)."""
+    depth = 0
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth -= 1
+        elif depth == 0 and text[i:i + 5] == " for ":
+            return i + 1
+        i += 1
+    return -1

--- a/codeminer/incremental_graph/patcher_rust.py
+++ b/codeminer/incremental_graph/patcher_rust.py
@@ -53,12 +53,12 @@ class PatcherRust(PatcherBase):
         if for_idx >= 0:
             trait_part = text[:for_idx].strip()
             type_part = text[for_idx + 4:].strip()
-            trait_part = re.sub(r"<['\\'a-z_,\s]+>", "", trait_part)
+            trait_part = re.sub(r"<['\\a-z_,\s]+>", "", trait_part)
             if trait_part:
                 return f"{type_part}<{trait_part}>"
             return type_part
         else:
-            text = re.sub(r"<['\\'a-z_,\s]+>", "", text)
+            text = re.sub(r"<['\\a-z_,\s]+>", "", text)
             return text
 
     def _build_unified_name(self, file_path, name, parent_unified_part, kind):

--- a/codeminer/incremental_graph/patcher_ts.py
+++ b/codeminer/incremental_graph/patcher_ts.py
@@ -1,0 +1,41 @@
+"""TypeScript/JavaScript-specific incremental patcher."""
+from __future__ import annotations
+
+from ..types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from .patcher_base import PatcherBase
+
+
+class PatcherTS(PatcherBase):
+    """TS/JS incremental patcher. Matches SCIPTypeScriptGraphDecoder naming."""
+
+    def get_lsp_command(self):
+        return ["typescript-language-server", "--stdio"]
+
+    def _language_id(self):
+        return "typescript"
+
+    def _get_crossfile_token_types(self):
+        return {
+            "type", "class", "enum", "function", "method",
+            "namespace", "interface", "variable", "property",
+        }
+
+    def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+        if name in ("<constructor>", "constructor"):
+            name = "constructor"
+
+        node_type = self._classify_symbol_type(kind)
+
+        if parent_unified_part:
+            display = f"{parent_unified_part}.{name}"
+        else:
+            display = name
+
+        if node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+            if not display.endswith("()"):
+                display = f"{display}()"
+
+        return f"{file_path}:{display}"
+
+    def flatten_symbols(self, file_path, lsp_symbols):
+        return self._flatten_symbols_default(file_path, lsp_symbols)

--- a/codeminer/incremental_graph/subgraph_mgr.py
+++ b/codeminer/incremental_graph/subgraph_mgr.py
@@ -1,0 +1,704 @@
+"""SubgraphMgr: manages incremental subgraph operations on CodeGraph.
+
+Handles:
+- Subgraph deletion (file-level, vertex-level)
+- Subgraph construction from LSP documentSymbol
+- Cross-file reference edge reconnection (incoming + outgoing)
+- Vertex renaming and index maintenance
+
+Uses composition — holds a reference to CodeGraph and LSPClient.
+Language-specific behavior is delegated via abstract methods that
+patcher_lang subclasses must implement.
+"""
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from ..graph.code_graph import CodeGraph
+from ..log_utils import get_logger
+from ..types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FIELD,
+    NODE_TYPE_FILE,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NODE_TYPE_SYMBOL,
+)
+from .lsp_client import LSPClient, uri_to_relpath
+
+logger = get_logger(__name__)
+
+# LSP SymbolKind integer → NODE_TYPE_* default mapping
+LSP_KIND_TO_NODE_TYPE = {
+    2: NODE_TYPE_CLASS,       # Module
+    3: NODE_TYPE_CLASS,       # Namespace
+    5: NODE_TYPE_CLASS,       # Class
+    6: NODE_TYPE_METHOD,      # Method
+    7: NODE_TYPE_FIELD,       # Property
+    8: NODE_TYPE_FIELD,       # Field
+    9: NODE_TYPE_METHOD,      # Constructor
+    10: NODE_TYPE_CLASS,      # Enum
+    11: NODE_TYPE_CLASS,      # Interface
+    12: NODE_TYPE_FUNCTION,   # Function
+    13: NODE_TYPE_FIELD,      # Variable
+    14: NODE_TYPE_FIELD,      # Constant
+    22: NODE_TYPE_CLASS,      # Enum (alt)
+    23: NODE_TYPE_CLASS,      # Struct
+    25: NODE_TYPE_FUNCTION,   # Operator
+}
+
+# Symbol types worth querying for cross-file incoming references.
+# Variables, fields, and parameters are file-local — querying references
+# for them causes LSP servers to scan the entire workspace, which is slow.
+_INCOMING_REF_TYPES = frozenset({
+    NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD,
+})
+
+
+class SubgraphMgr(ABC):
+    """Manages incremental subgraph operations on a CodeGraph.
+
+    Abstract methods that language-specific patchers must implement:
+        - _build_unified_name: construct unified_name matching SCIP format
+        - _get_crossfile_token_types: which semantic token types to query
+    """
+
+    def __init__(
+        self,
+        project_root: str,
+        code_graph: CodeGraph,
+        lsp_client: Optional[LSPClient] = None,
+    ):
+        self.project_root = Path(project_root).resolve()
+        self.code_graph = code_graph
+        self.lsp_client = lsp_client
+        # selectionRange for each vertex (for incoming ref queries)
+        self.symbol_selection_ranges: dict[str, tuple[int, int, int, int]] = {}
+        # Cache semanticTokens per file (avoid duplicate LSP calls)
+        self._semantic_tokens_cache: dict[str, list[dict] | None] = {}
+
+    # ═══════════════════════════════════════════════════════════
+    # Abstract methods — language-specific
+    # ═══════════════════════════════════════════════════════════
+
+    @abstractmethod
+    def _build_unified_name(
+        self,
+        file_path: str,
+        name: str,
+        parent_unified_part: str,
+        kind: int,
+    ) -> str:
+        """Construct unified_name matching the SCIP decoder's format.
+
+        Args:
+            file_path: Relative file path.
+            name: Symbol name from LSP documentSymbol.
+            parent_unified_part: Display part of parent's unified_name.
+            kind: LSP SymbolKind integer.
+
+        Returns:
+            e.g. "src/lib.rs:Router.handle()"
+        """
+
+    @abstractmethod
+    def _get_crossfile_token_types(self) -> set[str]:
+        """Semantic token types that may reference cross-file symbols."""
+
+    def _classify_symbol_type(self, kind: int) -> str:
+        """Map LSP SymbolKind to NODE_TYPE_*. Override for language-specific."""
+        return LSP_KIND_TO_NODE_TYPE.get(kind, NODE_TYPE_SYMBOL)
+
+    # ═══════════════════════════════════════════════════════════
+    # Index maintenance
+    # ═══════════════════════════════════════════════════════════
+
+    def build_indexes(self):
+        """Build unified_name and file_to_vertices indexes."""
+        g = self.code_graph
+        g.unified_name_to_vertex = {}
+        for v in g.graph.vs:
+            un = v.attributes().get("unified_name")
+            if un:
+                g.unified_name_to_vertex.setdefault(un, []).append(v.index)
+
+        g.file_to_vertices = {}
+        for v in g.graph.vs:
+            attrs = v.attributes()
+            node_type = attrs.get("type")
+            name = v["name"]
+            if node_type == NODE_TYPE_FILE:
+                g.file_to_vertices.setdefault(name, set()).add(v.index)
+            else:
+                f = attrs.get("file")
+                if f:
+                    g.file_to_vertices.setdefault(f, set()).add(v.index)
+
+    # ═══════════════════════════════════════════════════════════
+    # Subgraph deletion
+    # ═══════════════════════════════════════════════════════════
+
+    def delete_file_subgraph(self, file_path: str) -> dict:
+        """Remove file vertex + all symbol vertices for a file.
+
+        Records severed reference edges for later remap.
+
+        Returns:
+            dict with deleted_vertex_names, severed_incoming_refs,
+            severed_outgoing_refs.
+        """
+        g = self.code_graph
+
+        # Collect vertex IDs
+        if hasattr(g, "file_to_vertices") and file_path in g.file_to_vertices:
+            vids = set(g.file_to_vertices[file_path])
+        else:
+            from ..types import NODE_TYPE_FILE as NTF
+            from ..graph.code_graph import is_symbol_node
+            vids = set()
+            for v in g.graph.vs:
+                attrs = v.attributes()
+                if attrs.get("type") == NTF and v["name"] == file_path:
+                    vids.add(v.index)
+                elif attrs.get("file") == file_path and is_symbol_node(
+                    attrs.get("type", "")
+                ):
+                    vids.add(v.index)
+
+        if not vids:
+            return {
+                "deleted_vertex_names": [],
+                "severed_incoming_refs": [],
+                "severed_outgoing_refs": [],
+            }
+
+        severed_incoming = []
+        severed_outgoing = []
+        seen_outgoing = set()
+        for vid in vids:
+            v = g.graph.vs[vid]
+            v_uname = v.attributes().get("unified_name") or ""
+            # Outgoing reference edges
+            for eid in g.graph.incident(vid, mode="out"):
+                edge = g.graph.es[eid]
+                if edge["type"] == EDGE_TYPE_REFERENCE:
+                    tv = g.graph.vs[edge.target]
+                    key = (v["name"], tv["name"])
+                    if key not in seen_outgoing:
+                        seen_outgoing.add(key)
+                        severed_outgoing.append((
+                            v["name"], tv["name"],
+                            v_uname,
+                            tv.attributes().get("unified_name") or "",
+                        ))
+            # Incoming reference edges from outside
+            for eid in g.graph.incident(vid, mode="in"):
+                edge = g.graph.es[eid]
+                if edge["type"] == EDGE_TYPE_REFERENCE:
+                    sv = g.graph.vs[edge.source]
+                    if edge.source not in vids:
+                        severed_incoming.append((
+                            sv["name"], v["name"],
+                            sv.attributes().get("unified_name") or "",
+                            v_uname,
+                        ))
+
+        deleted_names = [g.graph.vs[vid]["name"] for vid in vids]
+        g.graph.delete_vertices(sorted(vids))
+        self._rebuild_indexes()
+        for n in deleted_names:
+            g.symbol_ranges.pop(n, None)
+
+        return {
+            "deleted_vertex_names": deleted_names,
+            "severed_incoming_refs": severed_incoming,
+            "severed_outgoing_refs": severed_outgoing,
+        }
+
+    def delete_vertices_by_name(self, names: list) -> dict:
+        """Delete specific vertices by name. Records severed edges."""
+        g = self.code_graph
+        vids = set()
+        for n in names:
+            vid = g.name_to_vertex.get(n)
+            if vid is not None:
+                vids.add(vid)
+
+        if not vids:
+            return {
+                "deleted_vertex_names": [],
+                "severed_incoming_refs": [],
+                "severed_outgoing_refs": [],
+            }
+
+        severed_incoming = []
+        severed_outgoing = []
+        for vid in vids:
+            v = g.graph.vs[vid]
+            v_uname = v.attributes().get("unified_name") or ""
+            for eid in g.graph.incident(vid, mode="out"):
+                edge = g.graph.es[eid]
+                if edge["type"] == EDGE_TYPE_REFERENCE:
+                    tv = g.graph.vs[edge.target]
+                    if edge.target not in vids:
+                        severed_outgoing.append((
+                            v["name"], tv["name"],
+                            v_uname,
+                            tv.attributes().get("unified_name") or "",
+                        ))
+            for eid in g.graph.incident(vid, mode="in"):
+                edge = g.graph.es[eid]
+                if edge["type"] == EDGE_TYPE_REFERENCE:
+                    sv = g.graph.vs[edge.source]
+                    if edge.source not in vids:
+                        severed_incoming.append((
+                            sv["name"], v["name"],
+                            sv.attributes().get("unified_name") or "",
+                            v_uname,
+                        ))
+
+        deleted_names = [g.graph.vs[vid]["name"] for vid in vids]
+        g.graph.delete_vertices(sorted(vids))
+        self._rebuild_indexes()
+        for n in deleted_names:
+            g.symbol_ranges.pop(n, None)
+
+        return {
+            "deleted_vertex_names": deleted_names,
+            "severed_incoming_refs": severed_incoming,
+            "severed_outgoing_refs": severed_outgoing,
+        }
+
+    def delete_outgoing_reference_edges(self, vertex_name: str) -> int:
+        """Delete only outgoing REFERENCE edges from a vertex."""
+        g = self.code_graph
+        vid = g.name_to_vertex.get(vertex_name)
+        if vid is None:
+            return 0
+        to_delete = [
+            eid for eid in g.graph.incident(vid, mode="out")
+            if g.graph.es[eid]["type"] == EDGE_TYPE_REFERENCE
+        ]
+        if to_delete:
+            g.graph.delete_edges(to_delete)
+        return len(to_delete)
+
+    def rename_vertex(
+        self, old_name: str, new_name: str, new_attrs: dict = None
+    ):
+        """Rename a vertex without deleting it. All edges preserved."""
+        g = self.code_graph
+        if old_name == new_name and not new_attrs:
+            return
+        vid = g.name_to_vertex.get(old_name)
+        if vid is None:
+            return
+
+        if old_name != new_name:
+            del g.name_to_vertex[old_name]
+            g.name_to_vertex[new_name] = vid
+            g.graph.vs[vid]["name"] = new_name
+            if old_name in g.symbol_ranges:
+                g.symbol_ranges[new_name] = g.symbol_ranges.pop(old_name)
+
+        if new_attrs:
+            for key, value in new_attrs.items():
+                g.graph.vs[vid][key] = value
+            sl = new_attrs.get("start_line")
+            el = new_attrs.get("end_line")
+            if sl is not None and el is not None:
+                g.symbol_ranges[new_name] = (sl, el)
+
+    def _rebuild_indexes(self):
+        """Rebuild all indexes after vertex deletion (IDs shift)."""
+        g = self.code_graph
+        g.name_to_vertex = {v["name"]: v.index for v in g.graph.vs}
+        self.build_indexes()
+
+    # ═══════════════════════════════════════════════════════════
+    # Subgraph construction (from LSP documentSymbol)
+    # ═══════════════════════════════════════════════════════════
+
+    def rebuild_file_subgraph(
+        self, file_path: str, symbols: list[dict]
+    ) -> list[str]:
+        """Add file vertex + symbol vertices + containment edges.
+
+        Returns list of created vertex names.
+        """
+        g = self.code_graph
+        g.add_file_node(file_path)
+
+        parent_dir = str(Path(file_path).parent)
+        if parent_dir != ".":
+            if parent_dir not in g.name_to_vertex:
+                g.add_directory_node(parent_dir)
+            g._add_edge(parent_dir, file_path, EDGE_TYPE_CONTAIN)
+
+        return self._process_symbol_tree(
+            symbols, file_path,
+            parent_vertex_name=file_path,
+            parent_unified_part="",
+        )
+
+    def _process_symbol_tree(
+        self,
+        symbols: list[dict],
+        file_path: str,
+        parent_vertex_name: str,
+        parent_unified_part: str,
+    ) -> list[str]:
+        """Recursively process documentSymbol children into graph vertices."""
+        created = []
+        if not symbols:
+            return created
+
+        g = self.code_graph
+        for sym in symbols:
+            name = sym.get("name", "")
+            kind = sym.get("kind", 0)
+            range_data = sym.get("range", {})
+            sel_range = sym.get("selectionRange", range_data)
+            start_line = range_data.get("start", {}).get("line", 0)
+            end_line = range_data.get("end", {}).get("line", start_line)
+
+            unified_name = self._build_unified_name(
+                file_path, name, parent_unified_part, kind
+            )
+            vertex_name = f"{unified_name}:{start_line}"
+            node_type = self._classify_symbol_type(kind)
+
+            g._add_vertex(vertex_name, {
+                "type": node_type,
+                "file": file_path,
+                "start_line": start_line,
+                "end_line": end_line,
+                "unified_name": unified_name,
+            })
+            g.symbol_ranges[vertex_name] = (start_line, end_line)
+
+            sel_start = sel_range.get("start", {})
+            sel_end = sel_range.get("end", {})
+            self.symbol_selection_ranges[vertex_name] = (
+                sel_start.get("line", start_line),
+                sel_start.get("character", 0),
+                sel_end.get("line", start_line),
+                sel_end.get("character", 0),
+            )
+
+            g._add_edge(parent_vertex_name, vertex_name, EDGE_TYPE_CONTAIN)
+            created.append(vertex_name)
+
+            # Module (kind=2, e.g. Rust `mod tests`) is transparent —
+            # SCIP doesn't include module name in symbol path.
+            if kind == 2:
+                child_parent_part = parent_unified_part  # skip module
+            else:
+                parts = unified_name.split(":", 1)
+                child_parent_part = parts[1] if len(parts) > 1 else name
+
+            children = sym.get("children", [])
+            if children:
+                created.extend(self._process_symbol_tree(
+                    children, file_path,
+                    parent_vertex_name=vertex_name,
+                    parent_unified_part=child_parent_part,
+                ))
+
+        return created
+
+    # ═══════════════════════════════════════════════════════════
+    # Reference edge reconnection
+    # ═══════════════════════════════════════════════════════════
+
+    def reconnect_incoming(
+        self,
+        file_path: str,
+        vertex_names: list[str],
+        stats: dict,
+    ):
+        """For each vertex, call LSP references to find external callers."""
+        if not self.lsp_client:
+            return
+        abs_file = str(self.project_root / file_path)
+
+        for vname in vertex_names:
+            vid = self.code_graph.name_to_vertex.get(vname)
+            if vid is not None:
+                node_type = self.code_graph.graph.vs[vid].attributes().get(
+                    "type", ""
+                )
+                if node_type not in _INCOMING_REF_TYPES:
+                    continue
+
+            sel = self.symbol_selection_ranges.get(vname)
+            if sel is None:
+                continue
+            sel_line, sel_char, _, _ = sel
+
+            refs = self.lsp_client.references(
+                abs_file, sel_line, sel_char, include_declaration=False
+            )
+            for loc in refs:
+                ref_file = uri_to_relpath(
+                    loc.get("uri", ""), str(self.project_root)
+                )
+                if ref_file is None:
+                    continue
+                ref_line = loc.get("range", {}).get("start", {}).get("line", 0)
+                ref_scope = self.match_location_to_scope(ref_file, ref_line)
+                if ref_scope:
+                    self.code_graph._add_edge(
+                        ref_scope, vname, EDGE_TYPE_REFERENCE
+                    )
+                    stats["incoming_added"] += 1
+                else:
+                    stats["unmatched"] += 1
+
+    def reconnect_outgoing(
+        self,
+        file_path: str,
+        vertex_names: list[str],
+        stats: dict,
+        line_ranges: list[tuple[int, int]] | None = None,
+    ):
+        """Use semanticTokens + definition to find outgoing refs."""
+        if not self.lsp_client:
+            return
+        abs_file = str(self.project_root / file_path)
+
+        ref_tokens = self._get_semantic_tokens(
+            abs_file, file_path, line_ranges=line_ranges,
+        )
+        if not ref_tokens:
+            return
+
+        # Map range → vertex for scope resolution
+        range_to_vertex = {}
+        if line_ranges and len(line_ranges) == len(vertex_names):
+            for vname, (start, end) in zip(vertex_names, line_ranges):
+                range_to_vertex[(start, end)] = vname
+
+        # Filter to line ranges if semanticTokens/range wasn't used
+        if line_ranges:
+            filtered = []
+            for t in ref_tokens:
+                for start, end in line_ranges:
+                    if start <= t["line"] <= end:
+                        filtered.append(t)
+                        break
+            ref_tokens = filtered
+            if not ref_tokens:
+                return
+
+        # Deduplicate by text for definition lookup
+        seen_text = {}
+        for t in ref_tokens:
+            key = t["text"]
+            if key not in seen_text:
+                seen_text[key] = self.lsp_client.definition(
+                    abs_file, t["line"], t["character"]
+                )
+
+        # Retry empty definitions — server may still be analyzing new files.
+        # Only retry the ones that returned [] (not the ones that succeeded).
+        empty_keys = [k for k, v in seen_text.items() if v == []]
+        if empty_keys:
+            logger.debug(
+                f"{len(empty_keys)}/{len(seen_text)} definitions returned "
+                f"empty for {file_path}, retrying after 3s"
+            )
+            time.sleep(3)
+            # Build text → token mapping for retry
+            text_to_token = {}
+            for t in ref_tokens:
+                if t["text"] not in text_to_token:
+                    text_to_token[t["text"]] = t
+            resolved = 0
+            for key in empty_keys:
+                tok = text_to_token.get(key)
+                if tok:
+                    result = self.lsp_client.definition(
+                        abs_file, tok["line"], tok["character"]
+                    )
+                    if result:
+                        seen_text[key] = result
+                        resolved += 1
+            if resolved:
+                logger.debug(
+                    f"Retry resolved {resolved}/{len(empty_keys)} "
+                    "empty definitions"
+                )
+
+        # Build edges
+        added_edges = set()
+        for ref_token in ref_tokens:
+            defn_list = seen_text.get(ref_token["text"])
+            if not defn_list:
+                continue
+
+            defn = defn_list[0]
+            target_uri = defn.get("targetUri", defn.get("uri", ""))
+            target_file = uri_to_relpath(target_uri, str(self.project_root))
+            if target_file is None:
+                continue
+
+            target_range = defn.get(
+                "targetSelectionRange", defn.get("range", {})
+            )
+            target_line = target_range.get("start", {}).get("line", 0)
+
+            scope = None
+            if range_to_vertex:
+                for (start, end), vname in range_to_vertex.items():
+                    if start <= ref_token["line"] <= end:
+                        scope = vname
+                        break
+            if scope is None:
+                scope = self.match_location_to_scope(
+                    file_path, ref_token["line"]
+                )
+
+            target_vertex = self.match_location_to_vertex(
+                target_file, target_line
+            )
+
+            if scope and target_vertex:
+                edge_key = (scope, target_vertex)
+                if edge_key not in added_edges:
+                    self.code_graph._add_edge(
+                        scope, target_vertex, EDGE_TYPE_REFERENCE
+                    )
+                    stats["outgoing_added"] += 1
+                    added_edges.add(edge_key)
+            else:
+                stats["unmatched"] += 1
+
+    def _get_semantic_tokens(
+        self,
+        abs_file: str,
+        file_path: str,
+        line_ranges: list[tuple[int, int]] | None = None,
+    ) -> list[dict] | None:
+        """Get filtered semantic tokens, with caching.
+
+        Prefers semanticTokens/range when available, falls back to full.
+        """
+        if file_path in self._semantic_tokens_cache:
+            cached = self._semantic_tokens_cache[file_path]
+            return list(cached) if cached is not None else None
+
+        if not self.lsp_client:
+            return None
+
+        tokens_response = None
+
+        # Try range first
+        if line_ranges and self.lsp_client.supports_semantic_tokens_range:
+            min_line = min(s for s, _ in line_ranges)
+            max_line = max(e for _, e in line_ranges)
+            tokens_response = self.lsp_client.semantic_tokens_range(
+                abs_file, min_line, max_line,
+            )
+
+        # Fall back to full
+        if tokens_response is None or not tokens_response.get("data"):
+            if not line_ranges:
+                reason = "no line_ranges"
+            elif not self.lsp_client.supports_semantic_tokens_range:
+                reason = "server does not support range"
+            else:
+                reason = "range returned empty"
+            logger.debug(
+                f"Using semanticTokens/full for {file_path} ({reason})"
+            )
+            tokens_response = self.lsp_client.semantic_tokens_full(abs_file)
+
+        # Retry once if still empty
+        if tokens_response is None or not tokens_response.get("data"):
+            logger.debug(
+                f"semanticTokens returned "
+                f"{'None' if tokens_response is None else 'empty'} "
+                f"for {file_path}, retrying after 5s"
+            )
+            time.sleep(5)
+            tokens_response = self.lsp_client.semantic_tokens_full(abs_file)
+            if tokens_response and tokens_response.get("data"):
+                logger.debug(f"semanticTokens retry succeeded for {file_path}")
+
+        if not tokens_response or not tokens_response.get("data"):
+            logger.warning(
+                f"semanticTokens failed for {file_path} after retry, "
+                "skipping outgoing reference discovery"
+            )
+            self._semantic_tokens_cache[file_path] = None
+            return None
+
+        tokens = self.lsp_client.decode_semantic_tokens(
+            tokens_response, abs_file
+        )
+        if not tokens:
+            return None
+
+        crossfile_types = self._get_crossfile_token_types()
+        filtered = [
+            t for t in tokens
+            if "declaration" not in t["modifiers"]
+            and "definition" not in t["modifiers"]
+            and t["token_type"] in crossfile_types
+        ]
+        self._semantic_tokens_cache[file_path] = filtered
+        return list(filtered)
+
+    # ═══════════════════════════════════════════════════════════
+    # Location matching
+    # ═══════════════════════════════════════════════════════════
+
+    def match_location_to_vertex(
+        self, file_path: str, line: int
+    ) -> Optional[str]:
+        """Match an LSP location to an existing graph vertex.
+
+        Level 1: Exact (file, start_line) match.
+        Level 2: Innermost enclosing scope.
+        """
+        candidates = [
+            vname
+            for vname, (start, _) in self.code_graph.symbol_ranges.items()
+            if self._vertex_file(vname) == file_path and start == line
+        ]
+        if len(candidates) == 1:
+            return candidates[0]
+        return self.match_location_to_scope(file_path, line)
+
+    def match_location_to_scope(
+        self, file_path: str, line: int
+    ) -> Optional[str]:
+        """Find the innermost scope vertex containing (file, line)."""
+        candidates = []
+        for vname, (start, end) in self.code_graph.symbol_ranges.items():
+            if self._vertex_file(vname) == file_path and start <= line <= end:
+                candidates.append((vname, end - start))
+
+        if not candidates:
+            if file_path in self.code_graph.name_to_vertex:
+                return file_path
+            return None
+
+        return min(candidates, key=lambda x: x[1])[0]
+
+    def _vertex_file(self, vname: str) -> Optional[str]:
+        """Get the file attribute of a vertex by name."""
+        vid = self.code_graph.name_to_vertex.get(vname)
+        if vid is None:
+            return None
+        return self.code_graph.graph.vs[vid].attributes().get("file")
+
+    def clear_cache(self):
+        """Clear semantic tokens cache between patch_files runs."""
+        self._semantic_tokens_cache.clear()

--- a/codeminer/ls_index/clangd_decode.py
+++ b/codeminer/ls_index/clangd_decode.py
@@ -670,6 +670,9 @@ class ClangdGraphDecoder:
             # Skip symbols defined outside the project root
             if relative_file.startswith("/"):
                 continue
+            # Skip vendored/third-party code
+            if "third_party/" in relative_file:
+                continue
 
             # Ensure file hierarchy exists
             self._ensure_file_hierarchy(relative_file)

--- a/codeminer/ls_router.py
+++ b/codeminer/ls_router.py
@@ -167,6 +167,40 @@ class LSIndexer:
     def clear_cache(self, level: str = "all") -> bool:
         return self._delegate.clear_cache(level=level)
 
+    def graph_patch(
+        self,
+        graph: "CodeGraph",
+        base_commit: str,
+        target_commit: str = "HEAD",
+    ) -> dict:
+        """Incrementally update graph using LSP graph-patching.
+
+        Args:
+            graph: Existing CodeGraph to update in place.
+            base_commit: Git commit hash the graph was built from.
+            target_commit: Git commit hash to patch to (default HEAD).
+
+        Returns:
+            Statistics dict from the patcher.
+        """
+        from .incremental.graph_patcher import GraphPatcher
+
+        patcher = GraphPatcher(
+            project_root=str(self.project_root),
+            code_graph=graph,
+            language=self.language,
+            profiler=self.profiler,
+        )
+        from .incremental.graph_patcher import LANGUAGE_EXTENSIONS
+
+        changed = patcher.detect_changed_files(
+            str(self.project_root),
+            base_commit,
+            target_commit,
+            extensions=LANGUAGE_EXTENSIONS.get(self.language),
+        )
+        return patcher.patch_files(changed)
+
 
 # ── LSGraphDecoder ─────────────────────────────────────────────────────────
 

--- a/codeminer/scip_interface/scip_decode_python.py
+++ b/codeminer/scip_interface/scip_decode_python.py
@@ -77,7 +77,27 @@ class SCIPPythonGraphDecoder:
         for document in document_blocks:
             self._process_document(document)
 
+        self._fix_unified_names()
         return self.code_graph
+
+    def _fix_unified_names(self):
+        """Replace module-derived file paths in unified_name with actual file paths.
+
+        During decode, unified_name is built from SCIP's module path
+        (e.g. ``sklearn.cluster.k_means_`` → ``sklearn/cluster/k_means_.py``).
+        This can produce incorrect paths for ``__init__.py`` packages.
+        The vertex ``file`` attribute (from SCIP document ``relative_path``)
+        is always correct, so we use it to fix the file path portion.
+        """
+        for v in self.code_graph.graph.vs:
+            name = v["name"]
+            file_path = v.attributes().get("file", "")
+            node_type = v.attributes().get("type", "")
+            if node_type in ("file", "directory"):
+                v["unified_name"] = name
+            elif file_path and ":" in name:
+                symbol_part = name.split(":", 1)[1]
+                v["unified_name"] = f"{file_path}:{symbol_part}"
 
     def _process_document(self, document_text):
         """
@@ -293,8 +313,8 @@ class SCIPPythonGraphDecoder:
         symbol_type = self._classify_symbol_type(unified_symbol, cleaned_symbol)
 
         # Handle __init__ symbols - convert to file reference
-        if "/__init__" in unified_symbol:
-            module_match = re.search(r"(.+)/(?:__init__)", unified_symbol)
+        if "/__init__" in cleaned_symbol:
+            module_match = re.search(r"(.+)/(?:__init__)", cleaned_symbol)
             if module_match:
                 module_path = module_match.group(1)
                 file_path = module_path.replace(".", "/") + ".py"

--- a/codeminer/scip_interface/scip_decode_rust.py
+++ b/codeminer/scip_interface/scip_decode_rust.py
@@ -392,15 +392,17 @@ class SCIPRustGraphDecoder:
             Unified symbol name in SCIP format (crate/module/Type#method or crate/module/function)
         """
         # Extract the actual symbol part (after version or URL)
-        parts = symbol.split(" ")
-        if len(parts) < 4:
+        # Format: "rust-analyzer cargo <crate_name> <version> <symbol_path>"
+        # Split into at most 5 parts so that symbol_path (which may contain
+        # spaces in generics like `<B, E>`) stays intact.
+        parts = symbol.split(" ", 4)
+        if len(parts) < 5:
             return None
 
         # Extract crate name for scoping
-        # Format: "rust-analyzer cargo <crate_name> <version> <symbol_path>"
         crate_prefix = parts[2] if parts[1] == "cargo" else None
 
-        symbol_part = parts[-1].rstrip(".")
+        symbol_part = parts[4].rstrip(".")
 
         # Clean up trailing markers
         unified = symbol_part.rstrip("#/()")
@@ -429,8 +431,7 @@ class SCIPRustGraphDecoder:
                 # Distinguish field vs method using original SCIP symbol:
                 # method ends with "()." (e.g. "impl#[Type]method().")
                 # field ends with "."  (e.g. "Type#field.")
-                original_part = original_symbol.split(" ")[-1] if original_symbol else ""
-                if original_part.endswith("()."):
+                if original_symbol and original_symbol.endswith("()."):
                     return NODE_TYPE_METHOD
                 else:
                     return NODE_TYPE_FIELD

--- a/test/incremental_graph/test_graph_patcher.py
+++ b/test/incremental_graph/test_graph_patcher.py
@@ -1,0 +1,1121 @@
+"""Integration tests for SCIP cold-start → incremental graph patch pipeline.
+
+Part 1: simple_repos — controlled environment.
+Part 2: SWE-bench repos — real commit ranges with detect_changed_files.
+
+Flow per test:
+    1. SCIP cold-start (LSIndexer.run_pipeline) builds the initial CodeGraph
+    2. Apply code changes (manual edit or real commit range)
+    3. GraphPatcher incrementally updates the graph
+    4. Assert vertex additions / removals via unified_name
+
+Requirements:
+    - SCIP toolchain: rust-analyzer, scip-typescript, scip-python, scip-go, clangd
+    - LSP servers: rust-analyzer, typescript-language-server, pyright-langserver, gopls, clangd
+    - Network access for cloning SWE-bench repos (first run only)
+
+Usage:
+    pytest test/incremental_graph/test_graph_patcher.py -v
+    pytest test/incremental_graph/test_graph_patcher.py -k simple -v
+    pytest test/incremental_graph/test_graph_patcher.py -k swebench -v
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.ls_router import LSIndexer
+from codeminer.incremental_graph.lsp_client import LSPClient
+from codeminer.incremental_graph.graph_patcher import GraphPatcher
+
+SIMPLE_REPOS = Path(__file__).resolve().parent.parent / "scip" / "simple_repos"
+REPO_CACHE_DIRS = [
+    Path.home() / ".codeminer" / "repos",
+]
+
+# Ensure LSP/SCIP tool directories are on PATH
+_EXTRA_PATHS = [
+    str(Path.home() / ".npm-global" / "bin"),
+    str(Path.home() / ".cargo" / "bin"),
+    str(Path.home() / "go" / "bin"),
+]
+for _p in _EXTRA_PATHS:
+    if _p not in os.environ.get("PATH", ""):
+        os.environ["PATH"] = _p + ":" + os.environ.get("PATH", "")
+
+# SCIP tool name per language (for availability checks)
+_SCIP_TOOLS = {
+    "rust": "rust-analyzer",
+    "ts": "scip-typescript",
+    "python": "scip-python",
+    "go": "scip-go",
+    "cpp": "clangd",
+}
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _skip_if_no_scip(language: str):
+    """Skip if SCIP indexer for this language is not available."""
+    tool = _SCIP_TOOLS.get(language)
+    if tool and not shutil.which(tool):
+        pytest.skip(f"SCIP tool '{tool}' not installed")
+
+
+def _skip_if_no_lsp(language: str):
+    if not LSPClient.check_lsp_available(language):
+        pytest.skip(f"LSP server for {language} not installed")
+
+
+def _git(*args, cwd):
+    return subprocess.check_output(
+        ["git"] + list(args), cwd=str(cwd),
+        text=True, stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+def _init_git(repo_dir: Path):
+    """Initialize a git repo and commit all files."""
+    _git("init", cwd=repo_dir)
+    _git("add", ".", cwd=repo_dir)
+    _git("commit", "-m", "initial", cwd=repo_dir)
+
+
+def _build_graph_with_scip(
+    project_root: Path,
+    language: str,
+    output_dir: Path,
+    **kwargs,
+) -> CodeGraph:
+    """Build a CodeGraph via SCIP cold-start (LSIndexer.run_pipeline).
+
+    Uses skip_level="graph" to reuse cached graph.pkl if available,
+    falling back to full pipeline if not.
+    """
+    indexer = LSIndexer(
+        project_root=project_root,
+        output_dir=output_dir,
+        language=language,
+    )
+    # Try loading cached graph first
+    graph = indexer.run_pipeline(skip_level="graph", report_profile=False, **kwargs)
+    if graph is None:
+        # No cache, do full pipeline
+        graph = indexer.run_pipeline(skip_level=None, report_profile=False, **kwargs)
+    assert graph is not None, f"SCIP run_pipeline returned None for {language}"
+    return graph
+
+
+def _get_unified_names(g: CodeGraph) -> set[str]:
+    """Collect all unified_name values from the graph (skipping None/empty)."""
+    result = set()
+    for v in g.graph.vs:
+        un = v.attributes().get("unified_name")
+        if un:
+            result.add(un)
+    return result
+
+
+def _get_vertex_label(v) -> str:
+    """Get the best identifier for a vertex: unified_name if set, else name."""
+    return v.attributes().get("unified_name") or v["name"]
+
+
+def _has_ref_edge(g: CodeGraph, src_label: str, tgt_label: str) -> bool:
+    """Check if a reference edge exists between vertices identified by label.
+
+    Label is matched against unified_name first, then name (for file vertices).
+    """
+    from codeminer.types import EDGE_TYPE_REFERENCE
+
+    for e in g.graph.es:
+        if e["type"] != EDGE_TYPE_REFERENCE:
+            continue
+        src_l = _get_vertex_label(g.graph.vs[e.source])
+        tgt_l = _get_vertex_label(g.graph.vs[e.target])
+        if src_l == src_label and tgt_l == tgt_label:
+            return True
+    return False
+
+
+def _count_ref_edges_involving(g: CodeGraph, label: str) -> int:
+    """Count reference edges where either end matches label exactly."""
+    from codeminer.types import EDGE_TYPE_REFERENCE
+
+    count = 0
+    for e in g.graph.es:
+        if e["type"] != EDGE_TYPE_REFERENCE:
+            continue
+        src_l = _get_vertex_label(g.graph.vs[e.source])
+        tgt_l = _get_vertex_label(g.graph.vs[e.target])
+        if src_l == label or tgt_l == label:
+            count += 1
+    return count
+
+
+def _ensure_swebench_repo(repo_name: str, base_commit: str) -> Path:
+    """Find or clone a repo and checkout base_commit."""
+    dirname = repo_name.replace("/", "_")
+
+    # Search existing cache directories first
+    for cache_dir in REPO_CACHE_DIRS:
+        repo_dir = cache_dir / dirname
+        if repo_dir.exists():
+            break
+    else:
+        # Clone to first cache dir
+        cache_dir = REPO_CACHE_DIRS[0]
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        repo_dir = cache_dir / dirname
+        subprocess.run(
+            ["git", "clone", "--quiet",
+             f"https://github.com/{repo_name}.git", str(repo_dir)],
+            check=True, capture_output=True,
+        )
+    # Checkout base commit (use short hash to avoid issues with partial clones)
+    short = base_commit[:12]
+    try:
+        _git("checkout", "-f", short, cwd=repo_dir)
+    except subprocess.CalledProcessError:
+        _git("fetch", "--all", cwd=repo_dir)
+        _git("checkout", "-f", short, cwd=repo_dir)
+    _git("clean", "-fd", cwd=repo_dir)
+    return repo_dir
+
+
+# ═════════════════════════════════════════════════════════════════════
+# Part 1: Simple Repos Integration Tests
+# ═════════════════════════════════════════════════════════════════════
+
+
+class TestSimpleRust:
+    """Comprehensive graph-patch test for Rust.
+
+    One SCIP build, multiple sequential patch rounds covering:
+    add / remove / modify-body / same-file-edge / cross-file / line-shift.
+    """
+
+    @pytest.fixture
+    def rust_repo(self, tmp_path):
+        _skip_if_no_scip("rust")
+        _skip_if_no_lsp("rust")
+        src = SIMPLE_REPOS / "rust_simple"
+        if not src.exists():
+            pytest.skip("rust_simple not found")
+        dst = tmp_path / "rust_simple"
+        shutil.copytree(src, dst)
+        _init_git(dst)
+        return dst
+
+    def test_graph_patch(self, rust_repo, tmp_path):
+        """One commit covers: add + modify + remove + shift + cross-file."""
+        g = _build_graph_with_scip(rust_repo, "rust", tmp_path / "scip_out")
+
+        # ── Cold-start verification ──
+        unames = _get_unified_names(g)
+        assert "src/math_utils.rs:add()" in unames
+        assert "src/math_utils.rs:is_prime()" in unames
+        assert "src/shapes.rs:Rectangle" in unames
+        assert _has_ref_edge(g, "src/main.rs:test_math_utils()", "src/math_utils.rs:add()")
+        assert _has_ref_edge(g, "src/main.rs:test_math_utils()", "src/math_utils.rs:is_prime()")
+        assert _has_ref_edge(g, "src/main.rs:test_shapes()", "src/shapes.rs:Rectangle")
+
+        base = _git("rev-parse", "HEAD", cwd=rust_repo)
+        math_file = rust_repo / "src" / "math_utils.rs"
+        main_file = rust_repo / "src" / "main.rs"
+
+        # ── Single commit: add subtract, modify add body, remove is_prime,
+        #    shift lines (comments at top), cross-file call ──
+
+        # 1. Remove is_prime (brace counting)
+        lines = math_file.read_text().splitlines(keepends=True)
+        new_lines, skip, depth = [], False, 0
+        for line in lines:
+            if not skip and "pub fn is_prime" in line:
+                skip, depth = True, 0
+            if skip:
+                depth += line.count("{") - line.count("}")
+                if depth <= 0 and "}" in line:
+                    skip = False
+                continue
+            new_lines.append(line)
+        content = "".join(new_lines)
+
+        # 2. Modify add() body
+        content = content.replace("a + b", "let r = a + b;\n    r")
+
+        # 3. Add comments at top (shifts all lines)
+        content = "// Shift comment 1\n// Shift comment 2\n" + content
+
+        # 4. Add subtract()
+        content += "\n\npub fn subtract(a: i32, b: i32) -> i32 {\n    a - b\n}\n"
+        math_file.write_text(content)
+
+        # 5. Cross-file call from main.rs
+        main_content = main_file.read_text()
+        main_content = main_content.replace(
+            "test_math_utils();",
+            "test_math_utils();\n    let _ = math_utils::subtract(10, 3);",
+        )
+        main_file.write_text(main_content)
+
+        _git("add", ".", cwd=rust_repo)
+        _git("commit", "-m", "add+modify+remove+shift", cwd=rust_repo)
+
+        patcher = GraphPatcher(str(rust_repo), g, "rust")
+        changed = GraphPatcher.detect_changed_files(
+            str(rust_repo), base, "HEAD", extensions={".rs"},
+        )
+        stats = patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
+
+        unames = _get_unified_names(g)
+
+        # add: new vertex
+        assert "src/math_utils.rs:subtract()" in unames, "add: subtract vertex"
+        # modify: vertex survives
+        assert "src/math_utils.rs:add()" in unames, "modify: add survives"
+        edges_add = _count_ref_edges_involving(g, "src/math_utils.rs:add()")
+        assert edges_add > 0, "modify: add() edges survive"
+        # remove: vertex gone
+        assert "src/math_utils.rs:is_prime()" not in unames, "remove: is_prime gone"
+        assert _count_ref_edges_involving(g, "src/math_utils.rs:is_prime()") == 0, \
+            "remove: is_prime edges gone"
+        # shift: multiply survives with edge
+        assert "src/math_utils.rs:multiply()" in unames, "shift: multiply survives"
+        assert _has_ref_edge(g, "src/main.rs:test_math_utils()", "src/math_utils.rs:multiply()"), \
+            "shift: multiply edge survives"
+        # cross-file: main→subtract
+        assert _has_ref_edge(g, "src/main.rs:main()", "src/math_utils.rs:subtract()"), \
+            "cross-file: main→subtract"
+        # shapes edges unchanged
+        assert _has_ref_edge(g, "src/main.rs:test_shapes()", "src/shapes.rs:Rectangle"), \
+            "unchanged: shapes edge survives"
+
+
+class TestSimpleTypeScript:
+    """Comprehensive graph-patch test for TypeScript."""
+
+    @pytest.fixture
+    def ts_repo(self, tmp_path):
+        _skip_if_no_scip("ts")
+        _skip_if_no_lsp("typescript")
+        src = SIMPLE_REPOS / "typescript_simple"
+        if not src.exists():
+            pytest.skip("typescript_simple not found")
+        dst = tmp_path / "typescript_simple"
+        shutil.copytree(src, dst)
+        _init_git(dst)
+        return dst
+
+    def test_graph_patch(self, ts_repo, tmp_path):
+        """One commit: add + remove + modify + cross-file."""
+        g = _build_graph_with_scip(
+            ts_repo, "ts", tmp_path / "scip_out", infer_tsconfig=True,
+        )
+
+        unames = _get_unified_names(g)
+        assert "src/math.ts:add()" in unames
+        assert "src/math.ts:subtract()" in unames
+        assert _has_ref_edge(g, "src/main.ts:wrapper()", "src/math.ts:add()")
+
+        base = _git("rev-parse", "HEAD", cwd=ts_repo)
+        math_file = ts_repo / "src" / "math.ts"
+        main_file = ts_repo / "src" / "main.ts"
+
+        # 1. Remove subtract (brace counting)
+        lines = math_file.read_text().splitlines(keepends=True)
+        new_lines, skip, depth = [], False, 0
+        for line in lines:
+            if not skip and "export function subtract" in line:
+                skip, depth = True, 0
+            if skip:
+                depth += line.count("{") - line.count("}")
+                if depth <= 0 and "}" in line:
+                    skip = False
+                continue
+            new_lines.append(line)
+        content = "".join(new_lines)
+
+        # 2. Modify add body
+        content = content.replace("return a + b;", "const r = a + b;\n    return r;")
+
+        # 3. Add divide
+        content += "\nexport function divide(a: number, b: number): number {\n    return a / b;\n}\n"
+        math_file.write_text(content)
+
+        # 4. Cross-file call
+        main_content = main_file.read_text()
+        main_content = main_content.replace(
+            "import { add, multiply, subtract, Calculator } from './math';",
+            "import { add, multiply, divide, Calculator } from './math';",
+        )
+        main_content += "\nconst q = divide(100, 4);\nconsole.log(q);\n"
+        main_file.write_text(main_content)
+
+        _git("add", ".", cwd=ts_repo)
+        _git("commit", "-m", "add+modify+remove", cwd=ts_repo)
+
+        patcher = GraphPatcher(str(ts_repo), g, "ts")
+        changed = GraphPatcher.detect_changed_files(
+            str(ts_repo), base, "HEAD", extensions={".ts", ".tsx", ".js", ".jsx"},
+        )
+        patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
+
+        unames = _get_unified_names(g)
+        assert "src/math.ts:divide()" in unames, "add: divide vertex"
+        assert "src/math.ts:subtract()" not in unames, "remove: subtract gone"
+        assert "src/math.ts:add()" in unames, "modify: add survives"
+        assert _has_ref_edge(g, "src/main.ts:wrapper()", "src/math.ts:add()"), "modify: edge survives"
+        assert _has_ref_edge(g, "src/main.ts", "src/math.ts:divide()"), "cross-file: main→divide"
+
+
+class TestSimpleCpp:
+    """Comprehensive graph-patch test for C++."""
+
+    @pytest.fixture
+    def cpp_repo(self, tmp_path):
+        _skip_if_no_scip("cpp")
+        _skip_if_no_lsp("cpp")
+        src = SIMPLE_REPOS / "cpp_simple"
+        if not src.exists():
+            pytest.skip("cpp_simple not found")
+        dst = tmp_path / "cpp_simple"
+        shutil.copytree(src, dst)
+        subprocess.run(
+            ["cmake", "-S", str(dst), "-B", str(dst / "build"),
+             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"],
+            check=True, capture_output=True,
+        )
+        compdb = dst / "build" / "compile_commands.json"
+        link = dst / "compile_commands.json"
+        if compdb.exists() and not link.exists():
+            os.symlink(str(compdb), str(link))
+        _init_git(dst)
+        return dst
+
+    def test_graph_patch(self, cpp_repo, tmp_path):
+        """One commit: add + remove + modify + cross-file."""
+        g = _build_graph_with_scip(cpp_repo, "cpp", tmp_path / "scip_out")
+
+        unames = _get_unified_names(g)
+        assert "src/math_utils.cpp:MathUtils.add()" in unames
+        assert "src/math_utils.cpp:MathUtils.isPrime()" in unames
+        assert _has_ref_edge(g, "src/main.cpp:testMathUtils()", "src/math_utils.cpp:MathUtils.add()")
+        assert _has_ref_edge(g, "src/main.cpp:testShapes()", "include/shape.h:Rectangle")
+
+        base = _git("rev-parse", "HEAD", cwd=cpp_repo)
+        math_file = cpp_repo / "src" / "math_utils.cpp"
+        header = cpp_repo / "include" / "math_utils.h"
+        main_file = cpp_repo / "src" / "main.cpp"
+
+        # 1. Remove isPrime (brace counting)
+        lines = math_file.read_text().splitlines(keepends=True)
+        new_lines, skip, depth = [], False, 0
+        for line in lines:
+            if not skip and "bool isPrime" in line:
+                skip, depth = True, 0
+            if skip:
+                depth += line.count("{") - line.count("}")
+                if depth <= 0 and "{" not in line and "}" in line:
+                    skip = False
+                    continue
+                continue
+            new_lines.append(line)
+        content = "".join(new_lines)
+
+        # 2. Modify add body
+        content = content.replace("return a + b;", "int r = a + b;\n    return r;")
+
+        # 3. Add subtract
+        content += "\nint MathUtils::subtract(int a, int b) {\n    return a - b;\n}\n"
+        math_file.write_text(content)
+
+        # 4. Header declaration
+        hcontent = header.read_text()
+        hcontent = hcontent.replace(
+            "} // namespace MathUtils",
+            "int subtract(int a, int b);\n\n} // namespace MathUtils",
+        )
+        header.write_text(hcontent)
+
+        # 5. Cross-file call
+        main_content = main_file.read_text()
+        main_content = main_content.replace(
+            "testMathUtils();",
+            "testMathUtils();\n    int d = MathUtils::subtract(10, 3);\n"
+            "    cout << d << endl;",
+        )
+        main_file.write_text(main_content)
+
+        _git("add", ".", cwd=cpp_repo)
+        _git("commit", "-m", "add+modify+remove", cwd=cpp_repo)
+
+        patcher = GraphPatcher(str(cpp_repo), g, "cpp")
+        changed = GraphPatcher.detect_changed_files(
+            str(cpp_repo), base, "HEAD",
+            extensions={".cpp", ".cc", ".c", ".h", ".hpp"},
+        )
+        stats = patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
+        assert stats["vertices_created"] > 0
+
+        unames = _get_unified_names(g)
+        assert "src/math_utils.cpp:MathUtils.subtract()" in unames, "add: subtract vertex"
+        assert "src/math_utils.cpp:MathUtils.isPrime()" not in unames, "remove: isPrime gone"
+        assert "src/math_utils.cpp:MathUtils.add()" in unames, "modify: add survives"
+        assert _has_ref_edge(g, "src/main.cpp:main()", "src/math_utils.cpp:MathUtils.subtract()"), \
+            "cross-file: main→subtract"
+        assert _has_ref_edge(g, "src/main.cpp:testShapes()", "include/shape.h:Rectangle"), \
+            "unchanged: shapes survives"
+
+
+class TestSimpleGo:
+    """Comprehensive graph-patch test for Go."""
+
+    @pytest.fixture
+    def go_repo(self, tmp_path):
+        _skip_if_no_scip("go")
+        _skip_if_no_lsp("go")
+        src = SIMPLE_REPOS / "go_simple"
+        if not src.exists():
+            pytest.skip("go_simple not found")
+        dst = tmp_path / "go_simple"
+        shutil.copytree(src, dst)
+        _init_git(dst)
+        return dst
+
+    def test_graph_patch(self, go_repo, tmp_path):
+        """One commit: add + remove + modify + cross-file."""
+        g = _build_graph_with_scip(go_repo, "go", tmp_path / "scip_out")
+
+        unames = _get_unified_names(g)
+        assert "calculator.go:Calculator" in unames
+        assert "calculator.go:Calculator.Add()" in unames
+        assert "calculator.go:Calculator.LastResult()" in unames
+        assert "greet.go:Greet()" in unames
+        assert "main.go:main()" in unames
+
+        base = _git("rev-parse", "HEAD", cwd=go_repo)
+        calc_file = go_repo / "calculator.go"
+        main_file = go_repo / "main.go"
+
+        # 1. Remove LastResult (brace counting)
+        lines = calc_file.read_text().splitlines(keepends=True)
+        new_lines, skip, depth = [], False, 0
+        for line in lines:
+            if not skip and "LastResult()" in line and "func" in line:
+                skip, depth = True, 0
+                while new_lines and new_lines[-1].strip().startswith("//"):
+                    new_lines.pop()
+            if skip:
+                depth += line.count("{") - line.count("}")
+                if depth <= 0 and "}" in line:
+                    skip = False
+                continue
+            new_lines.append(line)
+        content = "".join(new_lines)
+
+        # 2. Modify Add body
+        content = content.replace(
+            "result := a + b",
+            "result := a + b\n\tfmt.Println(\"Adding:\", a, b)",
+        )
+        if '"fmt"' not in content:
+            content = content.replace("package main", 'package main\n\nimport "fmt"')
+
+        # 3. Add Multiply
+        content += """
+// Multiply multiplies two integers.
+func (c *Calculator) Multiply(a, b int) int {
+	result := a * b
+	c.History = append(c.History, result)
+	return result
+}
+"""
+        calc_file.write_text(content)
+
+        # 4. Cross-file call
+        main_content = main_file.read_text()
+        main_content = main_content.replace(
+            'fmt.Println("Result:", result)',
+            'fmt.Println("Result:", result)\n\tprod := calc.Multiply(3, 7)\n\tfmt.Println("Product:", prod)',
+        )
+        main_file.write_text(main_content)
+
+        _git("add", ".", cwd=go_repo)
+        _git("commit", "-m", "add+modify+remove", cwd=go_repo)
+
+        patcher = GraphPatcher(str(go_repo), g, "go")
+        changed = GraphPatcher.detect_changed_files(
+            str(go_repo), base, "HEAD", extensions={".go"},
+        )
+        patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
+
+        unames = _get_unified_names(g)
+        assert "calculator.go:Calculator.Multiply()" in unames, "add: Multiply vertex"
+        assert "calculator.go:Calculator.LastResult()" not in unames, "remove: LastResult gone"
+        assert "calculator.go:Calculator.Add()" in unames, "modify: Add survives"
+        assert "greet.go:Greet()" in unames, "unchanged: Greet survives"
+
+
+# ═════════════════════════════════════════════════════════════════════
+# Part 2: SWE-bench Real-Commit Integration Tests
+# Uses actual commit ranges (no manual patches / HuggingFace).
+# Flow: checkout earlier~N → SCIP cold-start → checkout later
+#       → detect_changed_files → LSP graph-patch → assert symbols.
+# ═════════════════════════════════════════════════════════════════════
+
+
+def _get_earlier_commit(repo_dir: Path, later_commit: str, n_back: int) -> str:
+    """Get a commit N steps before later_commit."""
+    # Use short hash to avoid git issues with partial/blobless clones
+    short = later_commit[:12]
+    full = _git("rev-parse", f"{short}~{n_back}", cwd=repo_dir)
+    return full[:12]
+
+
+class TestSWEBenchCpp:
+    """fmtlib/fmt: instance fmt-2317 (from codeminer-base-dataset)."""
+
+    REPO = "fmtlib/fmt"
+    LATER = "ece4b4b33a96928e3d92f4965f6deeb8e3a6e6b0"
+    N_BACK = 5
+
+    @pytest.fixture(scope="class")
+    def repo_dir(self):
+        _skip_if_no_scip("cpp")
+        _skip_if_no_lsp("cpp")
+        if not shutil.which("cmake"):
+            pytest.skip("cmake not installed")
+        try:
+            repo = _ensure_swebench_repo(self.REPO, self.LATER)
+        except Exception as e:
+            pytest.skip(f"Cannot clone repo: {e}")
+        subprocess.run(
+            ["cmake", "-S", str(repo), "-B", str(repo / "build"),
+             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"],
+            capture_output=True,
+        )
+        return repo
+
+    def test_graph_patch(self, repo_dir, tmp_path):
+        earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
+
+        _git("checkout", "-f", earlier, cwd=repo_dir)
+        g = _build_graph_with_scip(repo_dir, "cpp", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
+
+        nodes_before = g.graph.vcount()
+
+        unames_before = _get_unified_names(g)
+
+        _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
+        changed = GraphPatcher.detect_changed_files(
+            str(repo_dir), earlier, self.LATER,
+            extensions={".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx"},
+        )
+        assert len(changed["modified"]) > 0
+
+        patcher = GraphPatcher(str(repo_dir), g, "cpp")
+        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        assert stats["files_modified"] >= 1
+        assert stats["vertices_created"] > 0
+
+        unames_after = _get_unified_names(g)
+        # Graph should still have reasonable size
+        assert g.graph.vcount() > 0
+        assert g.graph.ecount() > 0
+
+        # ── Strict vertex assertions (5+) ──
+        assert "include/fmt/core.h:fmt.basic_format_specs" in unames_after
+        assert "include/fmt/core.h:fmt.detail.specs_setter" in unames_after
+        assert "include/fmt/core.h:fmt.detail.specs_setter.on_zero()" in unames_after
+        assert "include/fmt/format.h:fmt.detail.write_nonfinite()" in unames_after
+        assert "include/fmt/format.h:fmt.detail.write_padded()" in unames_after
+        assert "include/fmt/format.h:fmt.detail.vformat_to()" in unames_after
+
+        # .idx incremental should have produced refs
+        assert stats.get("refs_outgoing", 0) > 0, \
+            f"Expected C++ .idx refs, got {stats}"
+
+        # ── Strict cross-file edge assertions (format.h → core.h) ──
+        assert _has_ref_edge(g,
+            "include/fmt/format.h:fmt.detail.for_each_codepoint()",
+            "include/fmt/core.h:fmt.string_view"), \
+            "for_each_codepoint() → string_view"
+        assert _has_ref_edge(g,
+            "include/fmt/format.h:fmt.detail.compute_width()",
+            "include/fmt/core.h:fmt.string_view"), \
+            "compute_width() → string_view"
+        assert _has_ref_edge(g,
+            "include/fmt/format.h:fmt.detail.write_bytes()",
+            "include/fmt/core.h:fmt.string_view"), \
+            "write_bytes() → string_view"
+        assert _has_ref_edge(g,
+            "include/fmt/format.h:fmt.vformat()",
+            "include/fmt/core.h:fmt.string_view"), \
+            "vformat() → string_view"
+        assert _has_ref_edge(g,
+            "include/fmt/format.h:fmt.system_error()",
+            "include/fmt/core.h:fmt.string_view"), \
+            "system_error() → string_view"
+
+
+class TestSWEBenchGo:
+    """caddyserver/caddy: instance caddy-5870 (from codeminer-base-dataset).
+    N_BACK=5 to include reverseproxy changes for richer edge testing.
+    """
+
+    REPO = "caddyserver/caddy"
+    LATER = "fae195ac7eb9cce1d81e43e5a0d34e9f3e4c7086"
+    N_BACK = 5
+
+    @pytest.fixture(scope="class")
+    def repo_dir(self):
+        _skip_if_no_scip("go")
+        _skip_if_no_lsp("go")
+        try:
+            return _ensure_swebench_repo(self.REPO, self.LATER)
+        except Exception as e:
+            pytest.skip(f"Cannot clone repo: {e}")
+
+    def test_graph_patch(self, repo_dir, tmp_path):
+        earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
+
+        _git("checkout", "-f", earlier, cwd=repo_dir)
+
+        # Start LSP early for warm-up (parallel with SCIP)
+        patcher = GraphPatcher(str(repo_dir), None, "go")
+        patcher.start_lsp()
+
+        g = _build_graph_with_scip(repo_dir, "go", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
+        patcher.code_graph = g
+
+        nodes_before = g.graph.vcount()
+
+        unames_before = _get_unified_names(g)
+
+        _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
+        changed = GraphPatcher.detect_changed_files(
+            str(repo_dir), earlier, self.LATER, extensions={".go"},
+        )
+        assert len(changed["modified"]) >= 1
+
+        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        assert stats["files_modified"] >= 1
+        assert stats["vertices_created"] > 0
+
+        unames_after = _get_unified_names(g)
+        # Modified files' symbols should exist
+        for f in changed["modified"]:
+            file_syms = [u for u in unames_after if u.startswith(f + ":")]
+            assert len(file_syms) > 0, f"Modified file {f} should have symbols"
+
+        # ── Strict vertex assertions (5+) ──
+        assert "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler" in unames_after
+        assert "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.ServeHTTP()" in unames_after
+        assert "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.Provision()" in unames_after
+        assert "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.VerboseLogs" in unames_after, \
+            "VerboseLogs field (added in this range) should exist"
+        assert "modules/caddyhttp/reverseproxy/selectionpolicies.go:LeastConnSelection" in unames_after
+
+        # Check that LSP discovered at least some reference edges
+        total_refs = stats.get("refs_incoming", 0) + stats.get("refs_outgoing", 0)
+        assert total_refs > 0, \
+            f"Expected reference edges for Go, got {total_refs}"
+
+        # ── Strict cross-file edge assertions (10+) ──
+        # Go SCIP edge source is file vertex (name), target has unified_name
+        # connpolicy.go → values.go
+        assert _has_ref_edge(g,
+            "modules/caddytls/connpolicy.go",
+            "modules/caddytls/values.go:CipherSuiteID()"), \
+            "connpolicy.go → CipherSuiteID()"
+        assert _has_ref_edge(g,
+            "modules/caddytls/connpolicy.go",
+            "modules/caddytls/values.go:SupportedCurves"), \
+            "connpolicy.go → SupportedCurves"
+        assert _has_ref_edge(g,
+            "modules/caddytls/connpolicy.go",
+            "modules/caddytls/values.go:SupportedProtocols"), \
+            "connpolicy.go → SupportedProtocols"
+        assert _has_ref_edge(g,
+            "modules/caddytls/connpolicy.go",
+            "modules/caddytls/values.go:getOptimalDefaultCipherSuites()"), \
+            "connpolicy.go → getOptimalDefaultCipherSuites()"
+        # builtins.go → values.go (unmodified file referencing values.go)
+        assert _has_ref_edge(g,
+            "caddyconfig/httpcaddyfile/builtins.go",
+            "modules/caddytls/values.go:SupportedProtocols"), \
+            "builtins.go → SupportedProtocols"
+        assert _has_ref_edge(g,
+            "caddyconfig/httpcaddyfile/builtins.go",
+            "modules/caddytls/values.go:SupportedCurves"), \
+            "builtins.go → SupportedCurves"
+        assert _has_ref_edge(g,
+            "caddyconfig/httpcaddyfile/builtins.go",
+            "modules/caddytls/values.go:CipherSuiteNameSupported()"), \
+            "builtins.go → CipherSuiteNameSupported()"
+        # automation.go → values.go
+        assert _has_ref_edge(g,
+            "modules/caddytls/automation.go",
+            "modules/caddytls/values.go:supportedCertKeyTypes"), \
+            "automation.go → supportedCertKeyTypes"
+        # replacer.go → values.go
+        assert _has_ref_edge(g,
+            "modules/caddyhttp/replacer.go",
+            "modules/caddytls/values.go:ProtocolName()"), \
+            "replacer.go → ProtocolName()"
+        # fastcgi → values.go
+        assert _has_ref_edge(g,
+            "modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go",
+            "modules/caddytls/values.go:SupportedCipherSuites()"), \
+            "fastcgi.go → SupportedCipherSuites()"
+
+
+
+class TestSWEBenchRust:
+    """astral-sh/ruff: instance ruff-15309 (from codeminer-base-dataset)."""
+
+    REPO = "astral-sh/ruff"
+    LATER = "75a24bbc67aa31b825b6326cfb6e6afdf3ca90d5"
+    N_BACK = 3
+
+    @pytest.fixture(scope="class")
+    def repo_dir(self):
+        _skip_if_no_scip("rust")
+        _skip_if_no_lsp("rust")
+        try:
+            return _ensure_swebench_repo(self.REPO, self.LATER)
+        except Exception as e:
+            pytest.skip(f"Cannot clone repo: {e}")
+
+    def test_graph_patch(self, repo_dir, tmp_path):
+        earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
+
+        _git("checkout", "-f", earlier, cwd=repo_dir)
+
+        # Start LSP early for warm-up (parallel with SCIP)
+        patcher = GraphPatcher(str(repo_dir), None, "rust")
+        patcher.start_lsp()
+
+        g = _build_graph_with_scip(repo_dir, "rust", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
+        patcher.code_graph = g
+
+
+        unames_before = _get_unified_names(g)
+
+        _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
+        changed = GraphPatcher.detect_changed_files(
+            str(repo_dir), earlier, self.LATER, extensions={".rs"},
+        )
+        assert len(changed["modified"]) >= 1
+
+        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        assert stats["files_modified"] >= 1
+        assert stats["vertices_created"] > 0
+
+        unames_after = _get_unified_names(g)
+        # Modified files' symbols should exist
+        for f in changed["modified"]:
+            file_syms = [u for u in unames_after if u.startswith(f + ":")]
+            assert len(file_syms) > 0, f"Modified file {f} should have symbols"
+
+        # Edges should be preserved or rediscovered
+        total_refs = stats.get("refs_incoming", 0) + stats.get("refs_outgoing", 0)
+        assert total_refs > 0, \
+            f"Expected reference edges for Rust, got {total_refs}"
+        # Overall edges
+
+        # ── Strict vertex assertions ──
+        eq_prefix = "crates/ruff_linter/src/rules/pylint/rules/eq_without_hash.rs:"
+        assert f"{eq_prefix}EqWithoutHash" in unames_after
+        assert f"{eq_prefix}object_without_hash_method()" in unames_after
+        assert f"{eq_prefix}EqHash" in unames_after
+        assert f"{eq_prefix}EqHash.from_class()" in unames_after
+        assert f"{eq_prefix}HasMethod" in unames_after
+
+        # ── Strict cross-file edge assertions (10+) ──
+        # object_without_hash_method() uses Checker, Diagnostic, StmtClassDef
+        assert _has_ref_edge(g,
+            f"{eq_prefix}object_without_hash_method()",
+            "crates/ruff_linter/src/checkers/ast/mod.rs:Checker"), \
+            "object_without_hash_method() → Checker"
+        assert _has_ref_edge(g,
+            f"{eq_prefix}object_without_hash_method()",
+            "crates/ruff_diagnostics/src/diagnostic.rs:Diagnostic"), \
+            "object_without_hash_method() → Diagnostic"
+        assert _has_ref_edge(g,
+            f"{eq_prefix}object_without_hash_method()",
+            "crates/ruff_diagnostics/src/diagnostic.rs:Diagnostic.new()"), \
+            "object_without_hash_method() → Diagnostic.new()"
+        assert _has_ref_edge(g,
+            f"{eq_prefix}object_without_hash_method()",
+            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef"), \
+            "object_without_hash_method() → StmtClassDef"
+        assert _has_ref_edge(g,
+            f"{eq_prefix}object_without_hash_method()",
+            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef.name"), \
+            "object_without_hash_method() → StmtClassDef.name"
+        assert _has_ref_edge(g,
+            f"{eq_prefix}object_without_hash_method()",
+            "crates/ruff_linter/src/checkers/ast/mod.rs:Checker.diagnostics"), \
+            "object_without_hash_method() → Checker.diagnostics"
+        # EqHash.from_class() uses any_member_declaration, ClassMemberKind
+        assert _has_ref_edge(g,
+            f"{eq_prefix}EqHash.from_class()",
+            "crates/ruff_python_semantic/src/analyze/class.rs:any_member_declaration()"), \
+            "EqHash.from_class() → any_member_declaration()"
+        assert _has_ref_edge(g,
+            f"{eq_prefix}EqHash.from_class()",
+            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef"), \
+            "EqHash.from_class() → StmtClassDef"
+        assert _has_ref_edge(g,
+            f"{eq_prefix}EqHash.from_class()",
+            "crates/ruff_python_semantic/src/analyze/class.rs:ClassMemberDeclaration.kind()"), \
+            "EqHash.from_class() → ClassMemberDeclaration.kind()"
+        assert _has_ref_edge(g,
+            f"{eq_prefix}object_without_hash_method()",
+            "crates/ruff_python_ast/src/nodes.rs:Identifier<Ranged>.range()"), \
+            "object_without_hash_method() → Identifier.range()"
+
+
+
+class TestSWEBenchPython:
+    """scikit-learn/scikit-learn: instance sklearn-10297 (from codeminer-base-dataset)."""
+
+    REPO = "scikit-learn/scikit-learn"
+    LATER = "b90661d6a46aa3619d3eec94d5281f5888add501"
+    N_BACK = 3
+
+    @pytest.fixture(scope="class")
+    def repo_dir(self):
+        _skip_if_no_scip("python")
+        _skip_if_no_lsp("python")
+        try:
+            return _ensure_swebench_repo(self.REPO, self.LATER)
+        except Exception as e:
+            pytest.skip(f"Cannot clone repo: {e}")
+
+    def test_graph_patch(self, repo_dir, tmp_path):
+        earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
+
+        _git("checkout", "-f", earlier, cwd=repo_dir)
+
+        # Start LSP early for warm-up (parallel with SCIP)
+        patcher = GraphPatcher(str(repo_dir), None, "python")
+        patcher.start_lsp()
+
+        g = _build_graph_with_scip(repo_dir, "python", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
+        patcher.code_graph = g
+
+
+        unames_before = _get_unified_names(g)
+
+        _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
+        changed = GraphPatcher.detect_changed_files(
+            str(repo_dir), earlier, self.LATER, extensions={".py"},
+        )
+        assert len(changed["modified"]) >= 1
+
+        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        assert stats["files_modified"] >= 1
+        assert stats["vertices_created"] > 0
+
+        unames_after = _get_unified_names(g)
+        # Modified files' symbols should exist
+        for f in changed["modified"]:
+            file_syms = [u for u in unames_after if u.startswith(f + ":")]
+            assert len(file_syms) > 0, f"Modified file {f} should have symbols"
+
+        # Edges should be preserved or rediscovered
+        total_refs = stats.get("refs_incoming", 0) + stats.get("refs_outgoing", 0)
+        assert total_refs > 0, \
+            f"Expected reference edges for Python, got {total_refs}"
+        # Overall edges
+
+        # ── Strict vertex assertions (5+) ──
+        assert "sklearn/cluster/k_means_.py:KMeans" in unames_after
+        assert "sklearn/cluster/k_means_.py:k_means()" in unames_after
+        assert "sklearn/cluster/k_means_.py:MiniBatchKMeans" in unames_after
+        assert "sklearn/cluster/k_means_.py:KMeans.fit()" in unames_after
+        assert "sklearn/cluster/k_means_.py:KMeans.predict()" in unames_after
+        assert "sklearn/naive_bayes.py:GaussianNB" in unames_after
+        assert "sklearn/naive_bayes.py:BaseDiscreteNB" in unames_after
+        assert "sklearn/naive_bayes.py:MultinomialNB" in unames_after
+
+        # _check_fit_data was renamed to _check_test_data
+        assert "sklearn/cluster/k_means_.py:KMeans._check_fit_data()" not in unames_after, \
+            "_check_fit_data should be removed after patch"
+        assert "sklearn/cluster/k_means_.py:KMeans._check_test_data()" in unames_after, \
+            "_check_test_data (renamed) should exist after patch"
+
+        # ── Strict cross-file edge assertions (10+) ──
+        # k_means_.py → utils
+        assert _has_ref_edge(g,
+            "sklearn/cluster/k_means_.py:k_means()",
+            "sklearn/utils/validation.py:check_array()"), \
+            "k_means() → check_array()"
+        assert _has_ref_edge(g,
+            "sklearn/cluster/k_means_.py:k_means()",
+            "sklearn/utils/validation.py:check_random_state()"), \
+            "k_means() → check_random_state()"
+        assert _has_ref_edge(g,
+            "sklearn/cluster/k_means_.py:k_means()",
+            "sklearn/utils/extmath.py:row_norms()"), \
+            "k_means() → row_norms()"
+        assert _has_ref_edge(g,
+            "sklearn/cluster/k_means_.py:KMeans.fit()",
+            "sklearn/utils/validation.py:check_random_state()"), \
+            "KMeans.fit() → check_random_state()"
+        assert _has_ref_edge(g,
+            "sklearn/cluster/k_means_.py:KMeans.transform()",
+            "sklearn/utils/validation.py:check_is_fitted()"), \
+            "KMeans.transform() → check_is_fitted()"
+        # k_means_.py → metrics
+        assert _has_ref_edge(g,
+            "sklearn/cluster/k_means_.py:KMeans._transform()",
+            "sklearn/metrics/pairwise.py:euclidean_distances()"), \
+            "KMeans._transform() → euclidean_distances()"
+        # k_means_.py inheritance → base
+        assert _has_ref_edge(g,
+            "sklearn/cluster/k_means_.py:KMeans",
+            "sklearn/base.py:BaseEstimator"), \
+            "KMeans → BaseEstimator (inheritance)"
+        # naive_bayes.py → utils
+        assert _has_ref_edge(g,
+            "sklearn/naive_bayes.py:GaussianNB.fit()",
+            "sklearn/utils/validation.py:check_X_y()"), \
+            "GaussianNB.fit() → check_X_y()"
+        assert _has_ref_edge(g,
+            "sklearn/naive_bayes.py:BaseDiscreteNB.fit()",
+            "sklearn/utils/validation.py:check_X_y()"), \
+            "BaseDiscreteNB.fit() → check_X_y()"
+        assert _has_ref_edge(g,
+            "sklearn/naive_bayes.py:BaseNB",
+            "sklearn/base.py:BaseEstimator"), \
+            "BaseNB → BaseEstimator (inheritance)"
+
+        # _check_fit_data was deleted — its edges should be gone
+        check_fit_edges = _count_ref_edges_involving(
+            g, "sklearn/cluster/k_means_.py:KMeans._check_fit_data()")
+        assert check_fit_edges == 0, \
+            f"_check_fit_data edges should be gone, got {check_fit_edges}"
+
+
+
+class TestSWEBenchTypeScript:
+    """preactjs/preact: instance preact-2896 (from codeminer-base-dataset)."""
+
+    REPO = "preactjs/preact"
+    LATER = "a9f7e676dc03b5008b8483e0937fc27c1af8287f"
+    N_BACK = 3
+
+    @pytest.fixture(scope="class")
+    def repo_dir(self):
+        _skip_if_no_scip("ts")
+        _skip_if_no_lsp("typescript")
+        try:
+            return _ensure_swebench_repo(self.REPO, self.LATER)
+        except Exception as e:
+            pytest.skip(f"Cannot clone repo: {e}")
+
+    def test_graph_patch(self, repo_dir, tmp_path):
+        earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
+
+        _git("checkout", "-f", earlier, cwd=repo_dir)
+
+        # Start LSP early for warm-up (parallel with SCIP)
+        patcher = GraphPatcher(str(repo_dir), None, "ts")
+        patcher.start_lsp()
+
+        g = _build_graph_with_scip(
+            repo_dir, "ts", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"), infer_tsconfig=True,
+        )
+        patcher.code_graph = g
+
+
+        unames_before = _get_unified_names(g)
+
+        _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
+        changed = GraphPatcher.detect_changed_files(
+            str(repo_dir), earlier, self.LATER,
+            extensions={".ts", ".tsx", ".js", ".jsx"},
+        )
+        assert len(changed["modified"]) >= 1
+
+        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        assert stats["files_modified"] >= 1
+        assert stats["vertices_created"] > 0
+
+        unames_after = _get_unified_names(g)
+        # Modified files' symbols should exist (except re-export-only files like index.js)
+        for f in changed["modified"]:
+            if f.endswith("index.js") or f.endswith("index.ts"):
+                continue  # Re-export files may have no symbols
+            file_syms = [u for u in unames_after if u.startswith(f + ":")]
+            assert len(file_syms) > 0, f"Modified file {f} should have symbols"
+
+        # Edges should be preserved or rediscovered
+        total_refs = stats.get("refs_incoming", 0) + stats.get("refs_outgoing", 0)
+        assert total_refs > 0, \
+            f"Expected reference edges for TS, got {total_refs}"
+        # Overall edges
+
+        # ── Strict vertex assertions (5+) ──
+        assert "compat/src/portals.js:Portal()" in unames_after
+        assert "compat/src/portals.js:createPortal()" in unames_after
+        assert "compat/src/portals.js:ContextProvider()" in unames_after
+        assert "src/diff/children.js:diffChildren()" in unames_after
+        assert "src/diff/children.js:toChildArray()" in unames_after
+        assert "src/diff/children.js:reorderChildren()" in unames_after
+
+        # ── Strict cross-file edge assertions (10+) ──
+        # portals.js imports { createElement, render } from 'preact'
+        # SCIP resolves 'preact' to the .d.ts declarations with preact/ prefix
+        assert _has_ref_edge(g,
+            "compat/src/portals.js:Portal()",
+            "src/index.d.ts:preact/render()"), \
+            "Portal() → preact/render()"
+        assert _has_ref_edge(g,
+            "compat/src/portals.js:createPortal()",
+            "src/index.d.ts:preact/createElement()"), \
+            "createPortal() → preact/createElement()"
+
+        # children.js: import { diff, unmount, applyRef } from './index'
+        assert _has_ref_edge(g,
+            "src/diff/children.js:diffChildren()",
+            "src/diff/index.js:diff()"), \
+            "diffChildren → diff()"
+        assert _has_ref_edge(g,
+            "src/diff/children.js:diffChildren()",
+            "src/diff/index.js:unmount()"), \
+            "diffChildren → unmount()"
+
+        # children.js: import { getDomSibling } from '../component'
+        assert _has_ref_edge(g,
+            "src/diff/children.js:diffChildren()",
+            "src/component.js:getDomSibling()"), \
+            "diffChildren → getDomSibling()"
+
+        # children.js: import { createVNode, Fragment } from '../create-element'
+        assert _has_ref_edge(g,
+            "src/diff/children.js:diffChildren()",
+            "src/create-element.js:createVNode()"), \
+            "diffChildren → createVNode()"
+
+        # children.js: import { removeNode } from '../util'
+        assert _has_ref_edge(g,
+            "src/diff/children.js:diffChildren()",
+            "src/util.js:removeNode()"), \
+            "diffChildren → removeNode()"
+
+        # children.js: import { EMPTY_OBJ, EMPTY_ARR } from '../constants'
+        assert _has_ref_edge(g,
+            "src/diff/children.js:diffChildren()",
+            "src/constants.js:EMPTY_OBJ"), \
+            "diffChildren → EMPTY_OBJ"
+

--- a/test/incremental_graph/test_graph_patcher.py
+++ b/test/incremental_graph/test_graph_patcher.py
@@ -271,7 +271,7 @@ class TestSimpleRust:
         changed = GraphPatcher.detect_changed_files(
             str(rust_repo), base, "HEAD", extensions={".rs"},
         )
-        stats = patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
+        patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
 
         unames = _get_unified_names(g)
 
@@ -595,6 +595,7 @@ class TestSWEBenchCpp:
             repo = _ensure_swebench_repo(self.REPO, self.LATER)
         except Exception as e:
             pytest.skip(f"Cannot clone repo: {e}")
+            return None  # unreachable; satisfies linter
         subprocess.run(
             ["cmake", "-S", str(repo), "-B", str(repo / "build"),
              "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"],
@@ -607,10 +608,6 @@ class TestSWEBenchCpp:
 
         _git("checkout", "-f", earlier, cwd=repo_dir)
         g = _build_graph_with_scip(repo_dir, "cpp", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
-
-        nodes_before = g.graph.vcount()
-
-        unames_before = _get_unified_names(g)
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
@@ -681,6 +678,7 @@ class TestSWEBenchGo:
             return _ensure_swebench_repo(self.REPO, self.LATER)
         except Exception as e:
             pytest.skip(f"Cannot clone repo: {e}")
+            return None  # unreachable; satisfies linter
 
     def test_graph_patch(self, repo_dir, tmp_path):
         earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
@@ -693,10 +691,6 @@ class TestSWEBenchGo:
 
         g = _build_graph_with_scip(repo_dir, "go", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
         patcher.code_graph = g
-
-        nodes_before = g.graph.vcount()
-
-        unames_before = _get_unified_names(g)
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
@@ -792,6 +786,7 @@ class TestSWEBenchRust:
             return _ensure_swebench_repo(self.REPO, self.LATER)
         except Exception as e:
             pytest.skip(f"Cannot clone repo: {e}")
+            return None  # unreachable; satisfies linter
 
     def test_graph_patch(self, repo_dir, tmp_path):
         earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
@@ -804,9 +799,6 @@ class TestSWEBenchRust:
 
         g = _build_graph_with_scip(repo_dir, "rust", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
         patcher.code_graph = g
-
-
-        unames_before = _get_unified_names(g)
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
@@ -899,6 +891,7 @@ class TestSWEBenchPython:
             return _ensure_swebench_repo(self.REPO, self.LATER)
         except Exception as e:
             pytest.skip(f"Cannot clone repo: {e}")
+            return None  # unreachable; satisfies linter
 
     def test_graph_patch(self, repo_dir, tmp_path):
         earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
@@ -911,9 +904,6 @@ class TestSWEBenchPython:
 
         g = _build_graph_with_scip(repo_dir, "python", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
         patcher.code_graph = g
-
-
-        unames_before = _get_unified_names(g)
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
@@ -1022,6 +1012,7 @@ class TestSWEBenchTypeScript:
             return _ensure_swebench_repo(self.REPO, self.LATER)
         except Exception as e:
             pytest.skip(f"Cannot clone repo: {e}")
+            return None  # unreachable; satisfies linter
 
     def test_graph_patch(self, repo_dir, tmp_path):
         earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
@@ -1036,9 +1027,6 @@ class TestSWEBenchTypeScript:
             repo_dir, "ts", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"), infer_tsconfig=True,
         )
         patcher.code_graph = g
-
-
-        unames_before = _get_unified_names(g)
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(

--- a/test/incremental_graph/test_lsp_decoder.py
+++ b/test/incremental_graph/test_lsp_decoder.py
@@ -8,20 +8,11 @@ Tests the full decode pipeline for each LSP message format:
 
 Uses mock LSP responses (no actual LSP server needed).
 """
-import pytest
-
 from codeminer.graph.code_graph import CodeGraph
 from codeminer.incremental_graph.patcher_rust import PatcherRust
 from codeminer.incremental_graph.patcher_ts import PatcherTS
 from codeminer.incremental_graph.patcher_go import PatcherGo
 from codeminer.incremental_graph.patcher_python import PatcherPython
-from codeminer.types import (
-    EDGE_TYPE_CONTAIN,
-    EDGE_TYPE_REFERENCE,
-    NODE_TYPE_CLASS,
-    NODE_TYPE_FUNCTION,
-    NODE_TYPE_METHOD,
-)
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/test/incremental_graph/test_lsp_decoder.py
+++ b/test/incremental_graph/test_lsp_decoder.py
@@ -1,0 +1,431 @@
+"""Tests for LSP message decoding across all 4 message types.
+
+Tests the full decode pipeline for each LSP message format:
+  - documentSymbol → rebuild_file_subgraph → vertices + containment edges
+  - semanticTokens → decode_semantic_tokens → filtered token list
+  - definition → location resolution → target vertex matching
+  - references → location resolution → incoming edge building
+
+Uses mock LSP responses (no actual LSP server needed).
+"""
+import pytest
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.incremental_graph.patcher_rust import PatcherRust
+from codeminer.incremental_graph.patcher_ts import PatcherTS
+from codeminer.incremental_graph.patcher_go import PatcherGo
+from codeminer.incremental_graph.patcher_python import PatcherPython
+from codeminer.types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Helpers: mock LSP responses
+# ═══════════════════════════════════════════════════════════════
+
+def _sym(name, kind, start, end, children=None):
+    """Build a documentSymbol response dict."""
+    sym = {
+        "name": name,
+        "kind": kind,
+        "range": {
+            "start": {"line": start, "character": 0},
+            "end": {"line": end, "character": 0},
+        },
+        "selectionRange": {
+            "start": {"line": start, "character": 4},
+            "end": {"line": start, "character": 4 + len(name)},
+        },
+    }
+    if children:
+        sym["children"] = children
+    return sym
+
+
+def _semantic_tokens_data(tokens_spec):
+    """Build semanticTokens response data from a list of token specs.
+
+    Each spec is (delta_line, delta_char, length, type_idx, mod_bits).
+    """
+    data = []
+    for spec in tokens_spec:
+        data.extend(spec)
+    return {"data": data}
+
+
+# ═══════════════════════════════════════════════════════════════
+# 1. documentSymbol decoding
+# ═══════════════════════════════════════════════════════════════
+
+class TestDocumentSymbol:
+    """Test documentSymbol → rebuild_file_subgraph → graph vertices."""
+
+    def test_rust_flat_functions(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        symbols = [
+            _sym("add", 12, 0, 5),      # Function
+            _sym("multiply", 12, 7, 12), # Function
+        ]
+        created = p.rebuild_file_subgraph("src/math.rs", symbols)
+
+        assert len(created) == 2
+        assert "src/math.rs:add():0" in created
+        assert "src/math.rs:multiply():7" in created
+        assert "src/math.rs" in g.name_to_vertex
+
+    def test_rust_struct_with_methods(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        symbols = [
+            _sym("Router", 23, 5, 50, children=[
+                _sym("handle", 6, 10, 30),
+                _sym("new", 6, 35, 45),
+            ]),
+            _sym("run", 12, 55, 60),
+        ]
+        created = p.rebuild_file_subgraph("src/lib.rs", symbols)
+
+        assert len(created) == 4
+        assert "src/lib.rs:Router:5" in created
+        assert "src/lib.rs:Router.handle():10" in created
+        assert "src/lib.rs:Router.new():35" in created
+        assert "src/lib.rs:run():55" in created
+
+        # Containment edges
+        assert g.graph.are_adjacent(
+            g.name_to_vertex["src/lib.rs"],
+            g.name_to_vertex["src/lib.rs:Router:5"],
+        )
+        assert g.graph.are_adjacent(
+            g.name_to_vertex["src/lib.rs:Router:5"],
+            g.name_to_vertex["src/lib.rs:Router.handle():10"],
+        )
+
+    def test_rust_impl_block_naming(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        symbols = [
+            _sym("impl Violation for EqWithoutHash", 19, 50, 80, children=[
+                _sym("message", 6, 55, 70),
+            ]),
+        ]
+        created = p.rebuild_file_subgraph("src/rules.rs", symbols)
+
+        assert "src/rules.rs:EqWithoutHash<Violation>.message():55" in created
+
+    def test_rust_mod_transparent(self):
+        """mod tests is transparent — children don't get 'tests.' prefix."""
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        symbols = [
+            _sym("tests", 2, 40, 80, children=[  # Module
+                _sym("test_add", 12, 42, 50),
+                _sym("test_mul", 12, 52, 60),
+            ]),
+        ]
+        created = p.rebuild_file_subgraph("src/math.rs", symbols)
+
+        assert "src/math.rs:test_add():42" in created
+        assert "src/math.rs:test_mul():52" in created
+
+    def test_go_pointer_receiver(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherGo("/tmp", g)
+        symbols = [
+            _sym("(*Handler).ServeHTTP", 6, 10, 50),
+        ]
+        created = p.rebuild_file_subgraph("server.go", symbols)
+
+        assert "server.go:Handler.ServeHTTP():10" in created
+
+    def test_ts_constructor(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherTS("/tmp", g)
+        symbols = [
+            _sym("Axios", 5, 0, 100, children=[
+                _sym("<constructor>", 9, 10, 30),
+                _sym("request", 6, 35, 80),
+            ]),
+        ]
+        created = p.rebuild_file_subgraph("index.ts", symbols)
+
+        assert "index.ts:Axios:0" in created
+        assert "index.ts:Axios.constructor():10" in created
+        assert "index.ts:Axios.request():35" in created
+
+    def test_python_class_method(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherPython("/tmp", g)
+        symbols = [
+            _sym("KMeans", 5, 10, 200, children=[
+                _sym("fit", 6, 20, 80),
+                _sym("predict", 6, 90, 150),
+            ]),
+        ]
+        created = p.rebuild_file_subgraph("cluster.py", symbols)
+
+        assert "cluster.py:KMeans:10" in created
+        assert "cluster.py:KMeans.fit():20" in created
+        assert "cluster.py:KMeans.predict():90" in created
+
+    def test_selection_range_stored(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        symbols = [_sym("main", 12, 0, 10)]
+        p.rebuild_file_subgraph("src/main.rs", symbols)
+
+        vname = "src/main.rs:main():0"
+        assert vname in p.symbol_selection_ranges
+        assert p.symbol_selection_ranges[vname][0] == 0   # start line
+        assert p.symbol_selection_ranges[vname][1] == 4   # start char
+
+
+# ═══════════════════════════════════════════════════════════════
+# 2. semanticTokens decoding
+# ═══════════════════════════════════════════════════════════════
+
+class _MockClient:
+    """Mock LSP client with semantic tokens legend."""
+    semantic_tokens_legend = {
+        "tokenTypes": [
+            "namespace", "type", "class", "function", "method",
+            "property", "variable", "parameter", "keyword",
+        ],
+        "tokenModifiers": [
+            "declaration", "definition", "readonly",
+        ],
+    }
+    def _abs_path(self, p):
+        return p
+
+    def decode_semantic_tokens(self, response, file_path):
+        from codeminer.incremental_graph.lsp_client import LSPClient
+        return LSPClient.decode_semantic_tokens(self, response, file_path)
+
+
+class TestSemanticTokensDecode:
+    """Test semanticTokens response → decoded token list."""
+
+    def test_basic_decode(self, tmp_path):
+        src = tmp_path / "test.rs"
+        src.write_text("fn add(a: i32) {\n    a + 1\n}\n")
+
+        client = _MockClient()
+        client._abs_path = lambda p: str(src)
+
+        response = _semantic_tokens_data([
+            (0, 0, 2, 8, 0),   # L0:0 "fn" keyword
+            (0, 3, 3, 3, 2),   # L0:3 "add" function, definition
+            (0, 4, 1, 7, 1),   # L0:7 "a" parameter, declaration
+        ])
+
+        tokens = client.decode_semantic_tokens(response, str(src))
+
+        assert len(tokens) == 3
+        assert tokens[0]["token_type"] == "keyword"
+        assert tokens[0]["text"] == "fn"
+        assert tokens[1]["token_type"] == "function"
+        assert tokens[1]["text"] == "add"
+        assert "definition" in tokens[1]["modifiers"]
+        assert tokens[2]["token_type"] == "parameter"
+        assert "declaration" in tokens[2]["modifiers"]
+
+    def test_multiline_tokens(self, tmp_path):
+        src = tmp_path / "test.rs"
+        src.write_text("use std::io;\nfn main() {}\n")
+
+        client = _MockClient()
+        client._abs_path = lambda p: str(src)
+
+        response = _semantic_tokens_data([
+            (0, 4, 3, 0, 0),   # L0:4 "std" namespace
+            (1, 3, 4, 3, 2),   # L1:3 "main" function, definition
+        ])
+
+        tokens = client.decode_semantic_tokens(response, str(src))
+
+        assert len(tokens) == 2
+        assert tokens[0]["line"] == 0
+        assert tokens[0]["text"] == "std"
+        assert tokens[1]["line"] == 1
+        assert tokens[1]["text"] == "main"
+
+    def test_crossfile_types_rust(self):
+        p = PatcherRust("/tmp", CodeGraph())
+        types = p._get_crossfile_token_types()
+        assert "function" in types
+        assert "method" in types
+        assert "property" in types
+        assert "keyword" not in types
+        assert "parameter" not in types
+
+    def test_crossfile_types_ts_includes_variable(self):
+        p = PatcherTS("/tmp", CodeGraph())
+        types = p._get_crossfile_token_types()
+        assert "variable" in types
+
+    def test_crossfile_types_python_excludes_variable(self):
+        p = PatcherPython("/tmp", CodeGraph())
+        types = p._get_crossfile_token_types()
+        assert "variable" not in types
+
+
+# ═══════════════════════════════════════════════════════════════
+# 3. definition response → vertex matching
+# ═══════════════════════════════════════════════════════════════
+
+class TestDefinitionDecode:
+
+    def test_match_exact_line(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        p.rebuild_file_subgraph("src/lib.rs", [
+            _sym("Router", 23, 5, 50, children=[
+                _sym("handle", 6, 10, 30),
+            ]),
+        ])
+
+        result = p.match_location_to_vertex("src/lib.rs", 10)
+        assert result == "src/lib.rs:Router.handle():10"
+
+    def test_match_within_scope(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        p.rebuild_file_subgraph("src/lib.rs", [
+            _sym("Router", 23, 5, 50, children=[
+                _sym("handle", 6, 10, 30),
+            ]),
+        ])
+
+        result = p.match_location_to_vertex("src/lib.rs", 20)
+        assert result == "src/lib.rs:Router.handle():10"
+
+    def test_match_class_scope(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        p.rebuild_file_subgraph("src/lib.rs", [
+            _sym("Router", 23, 5, 50, children=[
+                _sym("handle", 6, 10, 30),
+            ]),
+        ])
+
+        result = p.match_location_to_scope("src/lib.rs", 40)
+        assert result == "src/lib.rs:Router:5"
+
+    def test_fallback_to_file(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        p.rebuild_file_subgraph("src/lib.rs", [
+            _sym("run", 12, 5, 10),
+        ])
+
+        result = p.match_location_to_scope("src/lib.rs", 20)
+        assert result == "src/lib.rs"
+
+    def test_cross_file(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        p.rebuild_file_subgraph("src/lib.rs", [_sym("Router", 23, 5, 50)])
+        p.rebuild_file_subgraph("src/main.rs", [_sym("main", 12, 0, 10)])
+
+        result = p.match_location_to_vertex("src/lib.rs", 5)
+        assert result == "src/lib.rs:Router:5"
+
+    def test_unknown_file(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        assert p.match_location_to_vertex("unknown.rs", 10) is None
+
+
+# ═══════════════════════════════════════════════════════════════
+# 4. references response → scope matching
+# ═══════════════════════════════════════════════════════════════
+
+class TestReferencesDecode:
+
+    def test_scope_inside_function(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        p.rebuild_file_subgraph("src/main.rs", [
+            _sym("main", 12, 0, 20),
+            _sym("helper", 12, 25, 40),
+        ])
+
+        assert p.match_location_to_scope("src/main.rs", 5) == "src/main.rs:main():0"
+        assert p.match_location_to_scope("src/main.rs", 30) == "src/main.rs:helper():25"
+
+    def test_scope_at_file_level(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        p.rebuild_file_subgraph("src/main.rs", [
+            _sym("main", 12, 5, 20),
+        ])
+
+        assert p.match_location_to_scope("src/main.rs", 2) == "src/main.rs"
+
+    def test_innermost_scope_wins(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        p.rebuild_file_subgraph("src/lib.rs", [
+            _sym("Router", 23, 0, 100, children=[
+                _sym("handle", 6, 10, 50, children=[
+                    _sym("inner", 12, 20, 30),
+                ]),
+            ]),
+        ])
+
+        scope = p.match_location_to_scope("src/lib.rs", 25)
+        assert scope == "src/lib.rs:Router.handle().inner():20"
+
+
+# ═══════════════════════════════════════════════════════════════
+# 5. flatten_symbols (documentSymbol → classify-ready dict)
+# ═══════════════════════════════════════════════════════════════
+
+class TestFlattenSymbols:
+
+    def test_filters_local_variables(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        symbols = [
+            _sym("add", 12, 0, 10, children=[
+                _sym("result", 13, 2, 2),       # Variable inside function
+            ]),
+            _sym("MAX_SIZE", 14, 12, 12),        # Constant at top level
+        ]
+        result = p.flatten_symbols("src/lib.rs", symbols)
+
+        assert "src/lib.rs:add()" in result
+        assert "src/lib.rs:result" not in result
+        assert "src/lib.rs:MAX_SIZE" in result
+
+    def test_struct_over_impl(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherRust("/tmp", g)
+        symbols = [
+            _sym("Config", 23, 5, 50),
+            _sym("impl Config", 19, 55, 80),
+        ]
+        result = p.flatten_symbols("src/config.rs", symbols)
+
+        assert "src/config.rs:Config" in result
+        assert result["src/config.rs:Config"]["start_line"] == 5
+        assert result["src/config.rs:Config"]["end_line"] == 50
+
+    def test_go_pointer_receiver(self):
+        g = CodeGraph(project_root="/tmp")
+        p = PatcherGo("/tmp", g)
+        symbols = [
+            _sym("Handler", 23, 0, 5),
+            _sym("(*Handler).ServeHTTP", 6, 10, 50),
+        ]
+        result = p.flatten_symbols("server.go", symbols)
+
+        assert "server.go:Handler" in result
+        assert "server.go:Handler.ServeHTTP()" in result

--- a/test/incremental_graph/test_reference_resolver.py
+++ b/test/incremental_graph/test_reference_resolver.py
@@ -1,12 +1,8 @@
 """Tests for LSPDecoderBase location matching logic (used by reference reconnection)."""
-import pytest
-
 from codeminer.graph.code_graph import CodeGraph
 from codeminer.types import (
     EDGE_TYPE_CONTAIN,
-    EDGE_TYPE_REFERENCE,
     NODE_TYPE_CLASS,
-    NODE_TYPE_FILE,
     NODE_TYPE_FUNCTION,
     NODE_TYPE_METHOD,
 )

--- a/test/incremental_graph/test_reference_resolver.py
+++ b/test/incremental_graph/test_reference_resolver.py
@@ -1,0 +1,111 @@
+"""Tests for LSPDecoderBase location matching logic (used by reference reconnection)."""
+import pytest
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FILE,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+)
+
+
+def _make_decoder():
+    """Create a concrete decoder with a mock graph (no actual LSP client needed)."""
+    from codeminer.incremental_graph.patcher_rust import PatcherRust
+
+    g = CodeGraph(project_root="/tmp/test")
+
+    # Build a graph with known symbol_ranges
+    g.add_file_node("src/lib.rs")
+    g._add_vertex("src/lib.rs:Router:5", {
+        "type": NODE_TYPE_CLASS, "file": "src/lib.rs",
+        "start_line": 5, "end_line": 50,
+        "unified_name": "src/lib.rs:Router",
+    })
+    g.symbol_ranges["src/lib.rs:Router:5"] = (5, 50)
+    g._add_edge("src/lib.rs", "src/lib.rs:Router:5", EDGE_TYPE_CONTAIN)
+
+    g._add_vertex("src/lib.rs:Router.handle():10", {
+        "type": NODE_TYPE_METHOD, "file": "src/lib.rs",
+        "start_line": 10, "end_line": 30,
+        "unified_name": "src/lib.rs:Router.handle()",
+    })
+    g.symbol_ranges["src/lib.rs:Router.handle():10"] = (10, 30)
+    g._add_edge("src/lib.rs:Router:5", "src/lib.rs:Router.handle():10", EDGE_TYPE_CONTAIN)
+
+    g._add_vertex("src/lib.rs:Router.new():35", {
+        "type": NODE_TYPE_METHOD, "file": "src/lib.rs",
+        "start_line": 35, "end_line": 45,
+        "unified_name": "src/lib.rs:Router.new()",
+    })
+    g.symbol_ranges["src/lib.rs:Router.new():35"] = (35, 45)
+    g._add_edge("src/lib.rs:Router:5", "src/lib.rs:Router.new():35", EDGE_TYPE_CONTAIN)
+
+    g.add_file_node("src/main.rs")
+    g._add_vertex("src/main.rs:main():0", {
+        "type": NODE_TYPE_FUNCTION, "file": "src/main.rs",
+        "start_line": 0, "end_line": 20,
+        "unified_name": "src/main.rs:main()",
+    })
+    g.symbol_ranges["src/main.rs:main():0"] = (0, 20)
+    g._add_edge("src/main.rs", "src/main.rs:main():0", EDGE_TYPE_CONTAIN)
+
+    decoder = PatcherRust("/tmp/test", g)
+    return decoder, g
+
+
+class TestMatchLocationToVertex:
+    def test_exact_start_line_match(self):
+        decoder, _ = _make_decoder()
+        result = decoder.match_location_to_vertex("src/lib.rs", 10)
+        assert result == "src/lib.rs:Router.handle():10"
+
+    def test_exact_match_class(self):
+        decoder, _ = _make_decoder()
+        result = decoder.match_location_to_vertex("src/lib.rs", 5)
+        assert result == "src/lib.rs:Router:5"
+
+    def test_no_exact_match_falls_to_scope(self):
+        decoder, _ = _make_decoder()
+        # Line 20 is inside Router.handle() (10-30)
+        result = decoder.match_location_to_vertex("src/lib.rs", 20)
+        assert result == "src/lib.rs:Router.handle():10"
+
+    def test_wrong_file_returns_none(self):
+        decoder, _ = _make_decoder()
+        result = decoder.match_location_to_vertex("nonexistent.rs", 10)
+        assert result is None
+
+
+class TestMatchLocationToScope:
+    def test_innermost_scope(self):
+        decoder, _ = _make_decoder()
+        # Line 15 is inside Router.handle() (10-30) which is inside Router (5-50)
+        # Should return the innermost: Router.handle()
+        result = decoder.match_location_to_scope("src/lib.rs", 15)
+        assert result == "src/lib.rs:Router.handle():10"
+
+    def test_outer_scope(self):
+        decoder, _ = _make_decoder()
+        # Line 48 is inside Router (5-50) but outside handle/new
+        result = decoder.match_location_to_scope("src/lib.rs", 48)
+        assert result == "src/lib.rs:Router:5"
+
+    def test_outside_all_scopes_fallback_to_file(self):
+        decoder, _ = _make_decoder()
+        # Line 55 is outside all symbol ranges
+        result = decoder.match_location_to_scope("src/lib.rs", 55)
+        assert result == "src/lib.rs"
+
+    def test_different_file(self):
+        decoder, _ = _make_decoder()
+        result = decoder.match_location_to_scope("src/main.rs", 5)
+        assert result == "src/main.rs:main():0"
+
+    def test_file_not_in_graph(self):
+        decoder, _ = _make_decoder()
+        result = decoder.match_location_to_scope("unknown.rs", 5)
+        assert result is None

--- a/test/incremental_graph/test_subgraph_removal.py
+++ b/test/incremental_graph/test_subgraph_removal.py
@@ -1,0 +1,262 @@
+"""Tests for SubgraphMgr subgraph deletion and index building."""
+import pytest
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.incremental_graph.patcher_rust import PatcherRust
+from codeminer.types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FILE,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    ROOT_NODE,
+)
+
+
+def _build_two_file_graph():
+    """Build a small graph with 2 files, cross-file references.
+
+    Structure:
+        . (root)
+        ├── src/main.rs  (file)
+        │   ├── main()     (function, lines 0-10)
+        │   └── Config     (class, lines 12-20)
+        └── src/lib.rs   (file)
+            ├── run()      (function, lines 0-5)
+            └── Router     (class, lines 7-30)
+                └── handle()  (method, lines 8-25)
+
+    Cross-file references:
+        main() → Router       (main.rs references lib.rs)
+        main() → run()        (main.rs references lib.rs)
+        handle() → Config     (lib.rs references main.rs)
+    """
+    g = CodeGraph(project_root="/tmp/test_project")
+    g.add_root_node(ROOT_NODE)
+
+    g.add_file_node("src/main.rs")
+    g._add_edge(ROOT_NODE, "src/main.rs", EDGE_TYPE_CONTAIN)
+
+    g.add_symbol_node("main_fn", line=0, scope_start_line=0, scope_end_line=10,
+                       symbol_type=NODE_TYPE_FUNCTION)
+    g.graph.vs[g.name_to_vertex["main_fn"]]["file"] = "src/main.rs"
+    g._add_edge("src/main.rs", "main_fn", EDGE_TYPE_CONTAIN)
+
+    g.add_symbol_node("Config", line=12, scope_start_line=12, scope_end_line=20,
+                       symbol_type=NODE_TYPE_CLASS)
+    g.graph.vs[g.name_to_vertex["Config"]]["file"] = "src/main.rs"
+    g._add_edge("src/main.rs", "Config", EDGE_TYPE_CONTAIN)
+
+    g.add_file_node("src/lib.rs")
+    g._add_edge(ROOT_NODE, "src/lib.rs", EDGE_TYPE_CONTAIN)
+
+    g.add_symbol_node("run_fn", line=0, scope_start_line=0, scope_end_line=5,
+                       symbol_type=NODE_TYPE_FUNCTION)
+    g.graph.vs[g.name_to_vertex["run_fn"]]["file"] = "src/lib.rs"
+    g._add_edge("src/lib.rs", "run_fn", EDGE_TYPE_CONTAIN)
+
+    g.add_symbol_node("Router", line=7, scope_start_line=7, scope_end_line=30,
+                       symbol_type=NODE_TYPE_CLASS)
+    g.graph.vs[g.name_to_vertex["Router"]]["file"] = "src/lib.rs"
+    g._add_edge("src/lib.rs", "Router", EDGE_TYPE_CONTAIN)
+
+    g.add_symbol_node("handle_fn", line=8, scope_start_line=8, scope_end_line=25,
+                       symbol_type=NODE_TYPE_METHOD)
+    g.graph.vs[g.name_to_vertex["handle_fn"]]["file"] = "src/lib.rs"
+    g._add_edge("Router", "handle_fn", EDGE_TYPE_CONTAIN)
+
+    g._add_edge("main_fn", "Router", EDGE_TYPE_REFERENCE)
+    g._add_edge("main_fn", "run_fn", EDGE_TYPE_REFERENCE)
+    g._add_edge("handle_fn", "Config", EDGE_TYPE_REFERENCE)
+
+    return g
+
+
+def _make_mgr(g):
+    """Create a PatcherRust (which is a SubgraphMgr) for testing."""
+    mgr = PatcherRust("/tmp/test_project", g)
+    return mgr
+
+
+class TestBuildIndexes:
+    def test_build_file_to_vertices_index(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+
+        assert "src/main.rs" in g.file_to_vertices
+        assert "src/lib.rs" in g.file_to_vertices
+
+        main_vids = g.file_to_vertices["src/main.rs"]
+        main_names = {g.graph.vs[vid]["name"] for vid in main_vids}
+        assert "src/main.rs" in main_names
+        assert "main_fn" in main_names
+        assert "Config" in main_names
+
+        lib_vids = g.file_to_vertices["src/lib.rs"]
+        lib_names = {g.graph.vs[vid]["name"] for vid in lib_vids}
+        assert "src/lib.rs" in lib_names
+        assert "run_fn" in lib_names
+        assert "Router" in lib_names
+        assert "handle_fn" in lib_names
+
+    def test_build_unified_name_index(self):
+        g = _build_two_file_graph()
+        g.graph.vs[g.name_to_vertex["main_fn"]]["unified_name"] = "src/main.rs:main()"
+        g.graph.vs[g.name_to_vertex["Config"]]["unified_name"] = "src/main.rs:Config"
+        g.graph.vs[g.name_to_vertex["Router"]]["unified_name"] = "src/lib.rs:Router"
+
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+
+        assert "src/main.rs:main()" in g.unified_name_to_vertex
+        assert g.unified_name_to_vertex["src/main.rs:main()"] == [
+            g.name_to_vertex["main_fn"]
+        ]
+        assert "src/lib.rs:Router" in g.unified_name_to_vertex
+
+    def test_build_unified_name_index_one_to_many(self):
+        g = CodeGraph()
+        g._add_vertex("scip_key_1", {"type": NODE_TYPE_FUNCTION, "unified_name": "f.rs:new()"})
+        g._add_vertex("scip_key_2", {"type": NODE_TYPE_FUNCTION, "unified_name": "f.rs:new()"})
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+
+        assert len(g.unified_name_to_vertex["f.rs:new()"]) == 2
+
+
+class TestDeleteFileSubgraph:
+    def test_delete_removes_correct_vertices(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+
+        initial_vcount = g.graph.vcount()
+        result = mgr.delete_file_subgraph("src/main.rs")
+
+        assert set(result["deleted_vertex_names"]) == {"src/main.rs", "main_fn", "Config"}
+        assert g.graph.vcount() == initial_vcount - 3
+
+    def test_delete_cleans_name_to_vertex(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+        mgr.delete_file_subgraph("src/main.rs")
+
+        assert "src/main.rs" not in g.name_to_vertex
+        assert "main_fn" not in g.name_to_vertex
+        assert "Config" not in g.name_to_vertex
+
+        for name, vid in g.name_to_vertex.items():
+            assert g.graph.vs[vid]["name"] == name
+
+    def test_delete_cleans_symbol_ranges(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+
+        assert "main_fn" in g.symbol_ranges
+        assert "Config" in g.symbol_ranges
+
+        mgr.delete_file_subgraph("src/main.rs")
+
+        assert "main_fn" not in g.symbol_ranges
+        assert "Config" not in g.symbol_ranges
+        assert "run_fn" in g.symbol_ranges
+        assert "Router" in g.symbol_ranges
+
+    def test_delete_reports_severed_outgoing_refs(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+        result = mgr.delete_file_subgraph("src/main.rs")
+
+        outgoing_names = {(e[0], e[1]) for e in result["severed_outgoing_refs"]}
+        assert ("main_fn", "Router") in outgoing_names
+        assert ("main_fn", "run_fn") in outgoing_names
+
+    def test_delete_reports_severed_incoming_refs(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+        result = mgr.delete_file_subgraph("src/main.rs")
+
+        incoming_names = {(e[0], e[1]) for e in result["severed_incoming_refs"]}
+        assert ("handle_fn", "Config") in incoming_names
+
+    def test_delete_preserves_remaining_graph(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+        mgr.delete_file_subgraph("src/main.rs")
+
+        assert "src/lib.rs" in g.name_to_vertex
+        assert "run_fn" in g.name_to_vertex
+        assert "Router" in g.name_to_vertex
+        assert "handle_fn" in g.name_to_vertex
+        assert ROOT_NODE in g.name_to_vertex
+
+        lib_vid = g.name_to_vertex["src/lib.rs"]
+        router_vid = g.name_to_vertex["Router"]
+        handle_vid = g.name_to_vertex["handle_fn"]
+        assert g.graph.are_adjacent(lib_vid, router_vid)
+        assert g.graph.are_adjacent(router_vid, handle_vid)
+
+    def test_delete_cleans_file_to_vertices_index(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+        mgr.delete_file_subgraph("src/main.rs")
+
+        assert "src/main.rs" not in g.file_to_vertices
+        assert "src/lib.rs" in g.file_to_vertices
+
+    def test_delete_cleans_unified_name_index(self):
+        g = _build_two_file_graph()
+        g.graph.vs[g.name_to_vertex["main_fn"]]["unified_name"] = "src/main.rs:main()"
+        g.graph.vs[g.name_to_vertex["Router"]]["unified_name"] = "src/lib.rs:Router"
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+
+        mgr.delete_file_subgraph("src/main.rs")
+
+        assert "src/main.rs:main()" not in g.unified_name_to_vertex
+        assert "src/lib.rs:Router" in g.unified_name_to_vertex
+
+    def test_delete_nonexistent_file(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        result = mgr.delete_file_subgraph("nonexistent.rs")
+
+        assert result["deleted_vertex_names"] == []
+        assert result["severed_incoming_refs"] == []
+        assert result["severed_outgoing_refs"] == []
+        assert g.graph.vcount() == 8
+
+    def test_delete_without_index(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        result = mgr.delete_file_subgraph("src/main.rs")
+
+        assert set(result["deleted_vertex_names"]) == {"src/main.rs", "main_fn", "Config"}
+
+    def test_name_to_vertex_consistency_after_delete(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+        mgr.delete_file_subgraph("src/main.rs")
+
+        for name, vid in g.name_to_vertex.items():
+            assert vid < g.graph.vcount(), f"vid {vid} out of range for {name}"
+            assert g.graph.vs[vid]["name"] == name
+
+    def test_delete_both_files(self):
+        g = _build_two_file_graph()
+        mgr = _make_mgr(g)
+        mgr.build_indexes()
+        mgr.delete_file_subgraph("src/main.rs")
+        mgr.delete_file_subgraph("src/lib.rs")
+
+        assert g.graph.vcount() == 1
+        assert ROOT_NODE in g.name_to_vertex

--- a/test/incremental_graph/test_subgraph_removal.py
+++ b/test/incremental_graph/test_subgraph_removal.py
@@ -1,13 +1,10 @@
 """Tests for SubgraphMgr subgraph deletion and index building."""
-import pytest
-
 from codeminer.graph.code_graph import CodeGraph
 from codeminer.incremental_graph.patcher_rust import PatcherRust
 from codeminer.types import (
     EDGE_TYPE_CONTAIN,
     EDGE_TYPE_REFERENCE,
     NODE_TYPE_CLASS,
-    NODE_TYPE_FILE,
     NODE_TYPE_FUNCTION,
     NODE_TYPE_METHOD,
     ROOT_NODE,


### PR DESCRIPTION
## Summary

Add a new `incremental_graph` module that incrementally updates SCIP(or LS)-built code graphs using LSP servers. Given a base graph from cold-start and a commit range, the module detects changed files, classifies symbol-level diffs (deleted/added/affected/shifted/unchanged), and uses LSP `documentSymbol`, `semanticTokens`, `definition`, and `references` to patch the graph without full re-indexing.

Supports 5 languages: `Rust`, `Go`, `Python`, `TypeScript/JavaScript`, and `C/C++`.

## Changes

### New Module Architecture

```
codeminer/incremental_graph/
├── graph_patcher.py      # Thin router — dispatches to language-specific patchers
├── patcher_base.py       # Core functions: symbol classify, remap, two-phase patch
├── subgraph_mgr.py       # Subgraph operations: vertex/edge CRUD, LSP reconnection
├── patcher_rust.py       # Rust: unified_name for impl blocks, mod transparency
├── patcher_python.py     # Python: basedpyright semanticTokens
├── patcher_go.py         # Go: pointer receiver naming, file-level edges
├── patcher_ts.py         # TS/JS: definition retry for .js import bindings
├── patcher_cpp.py        # C++: clangd .idx incremental path (no LSP definition)
├── lsp_client.py         # JSON-RPC LSP client with retry, buffer, parallel support
└── change_mgr.py         # Git operations: detect changed files, diff hunks
```

### Key Design Decisions

- **SCIP cold-start + LSP graph-patch**: SCIP builds the baseline graph; LSP incrementally patches it. No full re-indexing needed for each commit.
- **Symbol-level diff**: Instead of deleting and rebuilding entire file subgraphs, symbols are classified into 5 categories. Only affected/added symbols trigger LSP queries — shifted/unchanged symbols keep their edges untouched.
- **Two-phase patch for modified files**: Phase 1 builds all vertices (classify + delete + shift + add), Phase 2 connects edges (outgoing + incoming refs). This ensures target vertices exist before edge queries.
- **`semanticTokens/range` preferred**: Requests only the changed line ranges instead of the full file, avoiding file size limit (gopls's 100KB) and reducing data transfer.
- **C++ uses `.idx` path**: clangd's background indexer generates `.idx` files, which naturally supports incremental indexing; no LSP communication needed. 
- **Retry with error classification**: LSP errors classified as transient (`ContentModified`, `ServerCancelled`, null result) vs permanent (`no package metadata`, `MethodNotFound`). Only transient errors retry.

### LSP Servers — Installation & Configuration

| Language | LSP Server | Install Command | Binary Location |
|----------|-----------|----------------|-----------------|
| **Rust** | rust-analyzer | `rustup component add rust-analyzer --toolchain nightly` | `~/.cargo/bin/rust-analyzer` |
| **Python** | basedpyright | `pip install basedpyright` | `<env>/bin/basedpyright-langserver` |
| **Go** | gopls | `go install golang.org/x/tools/gopls@latest` | `~/go/bin/gopls` |
| **TypeScript/JS** | typescript-language-server | `npm install -g typescript-language-server typescript` | `~/.npm-global/bin/typescript-language-server` |

The module auto-discovers LSP binaries in standard locations (`~/.cargo/bin/`, `~/go/bin/`, conda env `bin/`, `~/.npm-global/bin/`). If not found, falls back to `PATH`.


### Known Limitations

- **Python `semanticTokens/range` unsupported**: basedpyright doesn't support range requests; falls back to `semanticTokens/full`. pyright doesn't support any kinds of `semanticTokens` (`semanticTokens/full` or `semanticTokens/range`, these are pylance features), so we used basedpyright.
- **TS `.js` definition delay**: typescript-language-server needs ~3s after `didOpen` before `definition()` returns correct results for `.js` files. The module detects this and retries.

## Type of Change

- [x] New feature
- [x] Tests

## Testing

| Category | Tests | What's Tested |
|----------|-------|---------------|
| **Simple Repos** (4) | Rust, TS, C++, Go | add/remove/modify function, cross-file edge, same-file edge, edge survival |
| **SWE-bench** (5) | fmtlib/fmt, caddy, ruff, scikit-learn, preact | Real-world repos from codeminer-base-dataset, 3-5 commit range |

```bash
# Run all incremental graph tests
pytest test/incremental_graph/test_graph_patcher.py -v

# Run only simple repo tests (fast, ~60s)
pytest test/incremental_graph/test_graph_patcher.py -k "Simple"

# Run only SWE-bench tests (~15min)
pytest test/incremental_graph/test_graph_patcher.py -k "SWEBench"

```

Tests automatically skip if the required LSP server or SCIP tool is not installed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
