### PR TITLE
[docs] update docs for scip-index, added docs for incremental-graph & GTLocator

### DIFF
--- a/docs/gt_locator.md
+++ b/docs/gt_locator.md
@@ -1,0 +1,85 @@
+# GTLocator
+
+Extract symbol-level ground truth changes (functions, classes, methods) from SWE-bench unified diff patches. Identifies which symbols were modified, added, or deleted.
+
+Supports Python, Go, Rust, C/C++, JavaScript, and TypeScript.
+
+## How It Works
+
+1. Clone repo and checkout `base_commit`
+2. Extract symbols from affected files using tree-sitter chunkers
+3. Apply patch
+4. Extract symbols again
+5. Compare before/after to classify changes as modified, added, or deleted
+
+**Change detection** uses three-level filtering:
+- Set difference → added/deleted symbols
+- Line count change → modified (cheapest check)
+- Line range overlap + content diff → modified (only when lengths match)
+
+## Prerequisites
+
+- `tree-sitter-language-pack` (bundled with CodeMiner, provides parsers for all supported languages)
+- `git` (for cloning and checking out repos)
+
+## Usage
+
+```python
+from codeminer.dataset.gt_locate import GTLocator
+
+locator = GTLocator(work_dir="/data/repos")
+
+result = locator.analyze_instance({
+    "instance_id": "django__django-12345",
+    "repo": "django/django",
+    "base_commit": "abc123",
+    "patch": "--- a/file.py\n+++ b/file.py\n@@ -10,3 +10,5 @@\n...",
+})
+```
+
+**Parameters:**
+
+- `work_dir` (str, optional): Directory for cloning repos. Default: `~/.codeminer/tmp` (auto-cleaned on `cleanup()`)
+- `language` (str, optional): Force a specific language instead of auto-detecting from file extensions
+
+**Output:**
+```python
+{
+    "instance_id": "django__django-12345",
+    "target_files": ["django/db/models/query.py"],
+    "code_blocks": [{
+        "file_path": "django/db/models/query.py",
+        "symbol": "QuerySet.filter()",
+        "start_line": 100,    # 1-based
+        "end_line": 120,
+        "symbol_type": "method",
+        "change_type": "modified",
+    }],
+    "symbols_modified": ["django/db/models/query.py:QuerySet.filter()"],
+    "symbols_added": [],
+    "symbols_deleted": [],
+    "error": None,
+}
+```
+
+**Symbol naming**: `file:func()`, `file:Class`, `file:Class.method()`. Line numbers in output are 1-based.
+
+### Lightweight Usage
+
+```python
+# Just extract affected file paths from a patch (no clone needed)
+files = locator.get_target_files(patch_content)
+# ["django/db/models/query.py", "django/db/models/manager.py"]
+
+# Extract changed line ranges from a patch
+ranges = locator.get_changed_line_ranges(patch_content)
+# {"django/db/models/query.py": [(100, 105), (200, 210)]}
+```
+
+### Batch Processing
+
+```python
+from codeminer.dataset.gt_locate import build_gt_metadata
+
+results = build_gt_metadata(dataset, work_dir="/data/repos", keep_repos=True)
+```

--- a/docs/incremental_graph.md
+++ b/docs/incremental_graph.md
@@ -1,0 +1,80 @@
+# Incremental Graph Patching
+
+Update an existing `CodeGraph` in-place when code changes, avoiding full re-indexing. Uses LSP language servers to detect symbol changes and reconnect reference edges.
+
+## How It Works
+
+Given a base commit (matching the current graph) and a target commit:
+
+1. **Detect changes** — `git diff -U0` identifies modified/added/deleted/renamed files and changed line ranges
+2. **Round 1 (Vertices)** — delete old symbols, create new ones, shift line numbers for unaffected symbols
+3. **Round 2 (Edges)** — reconnect reference edges using LSP `references` (incoming) and `semantic_tokens` + `definition` (outgoing)
+
+The two-round design ensures all vertices exist before any edges are created.
+
+### Symbol Classification
+
+For modified files, each symbol is classified by comparing old graph data against new LSP results and git hunks: `deleted`, `added`, `affected` (overlaps changed lines), `shifted` (line offset but content unchanged), or `unchanged`. Only `affected` and `added` symbols trigger edge reconnection in Round 2.
+
+### LSP Interaction
+
+Each language uses a specific language server, started via stdio by `LSPClient`:
+
+| Language | Server | Install |
+|----------|--------|---------|
+| Python | `basedpyright-langserver` | `pip install basedpyright` |
+| Rust | `rust-analyzer` | `rustup component add rust-analyzer` |
+| TypeScript/JS | `typescript-language-server` | `npm install -g typescript-language-server` |
+| Go | `gopls` | `go install golang.org/x/tools/gopls@latest` |
+| C/C++ | `clangd` | `apt install clangd` |
+
+The patcher queries three LSP methods to rebuild the graph:
+
+1. **`textDocument/documentSymbol`** — get the hierarchical symbol tree of a file (used in Round 1 to discover new/changed symbols)
+2. **`textDocument/references`** — find all call-sites of a symbol across the project (used in Round 2 to reconnect incoming edges)
+3. **`textDocument/semanticTokens`** + **`textDocument/definition`** — scan tokens in changed line ranges, then resolve each cross-file token to its definition (used in Round 2 to reconnect outgoing edges)
+
+`LSPClient` auto-resolves server binaries from PATH / conda / venv / npm-global.
+
+**C/C++ special case**: clangd's background indexer is natively incremental — it only re-indexes changed translation units, producing updated `.idx` files. So `patcher_cpp.py` simply triggers a clangd background-index run on the changed files and rebuilds the graph from the new `.idx` data, without the LSP query flow above.
+
+## Prerequisites
+
+- An existing `CodeGraph` (built via `LSIndexer.run_pipeline()`, see [scip_index](scip_index.md))
+- The corresponding language server installed (see table above)
+- The project must be a git repository with both the base and target commits reachable
+
+## Usage
+
+```python
+from codeminer.ls_router import LSIndexer
+from codeminer.graph.code_graph import CodeGraph
+
+# Load a graph built at commit v1.0
+graph = CodeGraph.load_graph("/cache/project/graph.pkl")
+
+# Patch it to HEAD
+indexer = LSIndexer("/path/to/project", language="rust")
+result = indexer.graph_patch(graph, base_commit="v1.0", target_commit="HEAD")
+
+graph.save_graph("/cache/project/graph.pkl")
+```
+
+**Supported languages:** Python, Rust, TypeScript/JS, Go, C/C++.
+
+### Return Value
+
+`graph_patch` returns a stats dict:
+
+```python
+{
+    "files_modified": 1,
+    "vertices_created": 2,
+    "vertices_deleted": 0,
+    "vertices_shifted": 3,
+    "refs_incoming": 5,
+    "refs_outgoing": 3,
+    "nodes_before": 45,
+    "nodes_after": 47,
+}
+```

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -12,12 +12,16 @@ Besides `scip-python`, multilingual indexing requires extra tooling:
   - `npm`
   - `yarn` for repos using Yarn workspaces (optional but commonly needed)
   - `pnpm` for pnpm workspaces (optional)
-- C/C++ (`scip-clang`):
-  - `scip-clang`
+- C/C++ (`clangd`):
+  - `clangd` (`apt install clangd`)
   - `cmake` for CMake-based projects
   - `bear` for Make/Autotools projects (e.g., repositories without CMake compile DB)
+  - Requires `compile_commands.json` (auto-generated from CMake or `bear -- make` if missing)
 - Rust (`rust-analyzer`):
-  - stable toolchain with `rust-analyzer` component
+  - nightly toolchain with `rust-analyzer` component (auto-set via `RUSTUP_TOOLCHAIN=nightly`)
+- Go (`scip-go`):
+  - `go install github.com/sourcegraph/scip-go/cmd/scip-go@latest`
+  - Project must contain `go.mod`
 
 Example installs:
 ```bash
@@ -120,6 +124,39 @@ result = indexer.run_pipeline(
 )
 ```
 
+#### Language-Specific Options
+
+**Rust:**
+```python
+graph = indexer.run_pipeline(
+    config_path="/path/to/config.json",       # cargo customization
+    exclude_vendored_libraries=True,          # exclude vendored deps
+)
+```
+Requires `Cargo.toml`.
+
+**TypeScript / JavaScript:**
+```python
+graph = indexer.run_pipeline(
+    yarn_workspaces=True,       # or pnpm_workspaces / npm_workspaces
+)
+```
+Auto-detects workspace type, installs dependencies, and patches tsconfig to enable `allowJs: true` for JS files. If no `tsconfig.json`/`jsconfig.json` exists, `--infer-tsconfig` is enabled automatically.
+
+**Go:**
+```python
+graph = indexer.run_pipeline()  # no language-specific options
+```
+Requires `go.mod`.
+
+**C/C++:**
+```python
+graph = indexer.run_pipeline(
+    compdb_path="/path/to/compile_commands.json",  # optional, auto-discovered
+)
+```
+Uses clangd background indexing (`.idx` files). Auto-generates `compile_commands.json` from CMake or `bear -- make` if missing.
+
 #### Advanced Features
 
 **Cache Management:**
@@ -147,8 +184,21 @@ indexer = LSIndexer(
 )
 ```
 
+### LSGraphDecoder
 
-#### FAQ
+Build a graph directly from an existing decoded index:
+
+```python
+from codeminer.ls_router import LSGraphDecoder
+
+decoder = LSGraphDecoder("index.decoded", project_root="/path/to/repo", language="rust")
+graph = decoder.decode()
+
+# C/C++: pass the .idx directory
+decoder = LSGraphDecoder(".cache/clangd/index/", project_root="/path/to/repo", language="cpp")
+```
+
+### FAQ
 If the following error occurs:
 ```
 FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
@@ -157,4 +207,13 @@ FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaS
 Please increase the memory space for node.js
 ``` bash
 export NODE_OPTIONS="--max-old-space-size=16384"
+```
+
+If `compile_commands.json` is missing for C/C++ projects:
+```bash
+# CMake
+cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+# Make
+bear -- make
 ```


### PR DESCRIPTION
## Summary
Add documentation for `incremental-graph` and `GTLocator` modules, and update existing `scip-index` docs with Go support, language-specific options, and LSGraphDecoder usage.

## Changes
- Add `docs/incremental_graph.md`: documents the two-round LSP-based incremental graph patching system (symbol classification, LSP interaction per language, usage)
- Add `docs/gt_locator.md`: documents the GTLocator for extracting symbol-level ground truth changes from SWE-bench patches
- Update `docs/scip_index.md`: add Go prerequisites, language-specific options (Rust/TS/Go/C++), LSGraphDecoder section, fix C/C++ tooling (scip-clang → clangd), additional FAQ entries

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published