### PR TITLE
CI, dataset fixes, and documentation updates

### DIFF
--- a/codeminer/dataset/gt_locate.py
+++ b/codeminer/dataset/gt_locate.py
@@ -28,12 +28,12 @@ Output Format:
         "target_files":     ["astropy/coordinates/builtin_frames/itrs.py", ...],
         "code_blocks": [
             {
-                "file_path": "astropy/coordinates/builtin_frames/itrs.py",
-                "symbol": "ITRS",
+                "change_type": "modified",
                 "start_line": 10,
                 "end_line": 50,
-                "symbol_type": "class",
-                "change_type": "modified"
+                "file_path": "astropy/coordinates/builtin_frames/itrs.py",
+                "symbol": "ITRS",
+                "symbol_type": "class"
             },
             ...
         ],
@@ -116,12 +116,12 @@ def _chunk_to_code_block(chunk: CodeChunk, change_type: str) -> Dict[str, Any]:
     """Convert a CodeChunk to a ground-truth code block dict with 1-based lines."""
     file_path, _, symbol = chunk.node_id.partition(":")
     return {
-        "file_path": file_path,
-        "symbol": symbol or chunk.name,
+        "change_type": change_type,
         "start_line": chunk.start_line + 1,  # 0-based -> 1-based
         "end_line": chunk.end_line + 1,  # 0-based -> 1-based
+        "file_path": file_path,
+        "symbol": symbol or chunk.name,
         "symbol_type": chunk.chunk_type,
-        "change_type": change_type,
     }
 
 

--- a/docs/collect_swebench.md
+++ b/docs/collect_swebench.md
@@ -1,0 +1,132 @@
+# Collecting SWE-bench Instances
+
+This guide covers how to use the `collect_swebench.sh` script to sample representative SWE-bench instances across multiple languages.
+
+## What It Does
+
+The collection pipeline:
+
+1. Loads SWE-bench datasets (Python from SWE-bench Lite, others from SWE-bench Multilingual)
+2. Selects top repositories per language by instance count
+3. Samples instances per repo with patch-size diversity
+4. Classifies difficulty (low/medium/high) using a Claude agent
+5. Extracts ground-truth code blocks from patches via tree-sitter
+6. Filters out instances exceeding a GT code block threshold
+7. Saves all artifacts to the output directory
+
+## Prerequisites
+
+1. **Install the project:**
+
+   ```bash
+   pip install -e .
+   ```
+
+2. **Authenticate for difficulty classification** — the pipeline uses `claude_agent_sdk` to call Claude. Choose one method:
+
+   ```bash
+   # Option A: log in via the Claude client (no API key needed)
+   claude login
+
+   # Option B: set an API key
+   export ANTHROPIC_API_KEY="sk-ant-..."
+   ```
+
+## Quick Start
+
+Run the wrapper script with default settings:
+
+```bash
+scripts/collect_swebench.sh
+```
+
+This samples from all 5 languages (`Python`, `Rust`, `TypeScript/JavaScript`, `C++/C`, `Go`) and writes output to `~/.codeminer/swebench_sampling/`.
+
+## Environment Variables
+
+The shell wrapper accepts these environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CACHE_DIR` | `~/.codeminer` | Root cache directory (datasets, repo clones) |
+| `OUTPUT_DIR` | `$CACHE_DIR/swebench_sampling` | Output directory for sampling artifacts |
+
+Example:
+
+```bash
+CACHE_DIR=/data/codeminer OUTPUT_DIR=/data/output scripts/collect_swebench.sh
+```
+
+## Python Script Options
+
+For finer control, call `collect_swebench.py` directly:
+
+```bash
+PYTHONPATH=. python scripts/collect_swebench.py [OPTIONS]
+```
+
+### All Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--languages` | All 5 | Space- or comma-separated language list |
+| `--split` | `test` | Dataset split |
+| `--filter-instance` | `.*` | Regex filter for instance IDs |
+| `--repos-per-language` | `5` | Max repos to select per language |
+| `--instances-per-repo` | `4` | Target instances per repo |
+| `--total-instances` | `100` | Target total instances (adaptive allocation) |
+| `--min-instances` | `3` | Minimum instances a repo must have to be selected |
+| `--max-gt-code-blocks` | `10` | Exclude instances with more GT blocks than this |
+| `--difficulty-model` | `opus` | Model for difficulty classification |
+| `--shallow-clone` / `--no-shallow-clone` | `true` | Use shallow git clones for repos |
+| `--cache-dir` | `~/.codeminer` | Root cache directory |
+| `--repo-cache-dir` | same as `--cache-dir` | Separate directory for repo clones |
+| `--output-dir` | `$cache-dir/swebench_sampling` | Output directory |
+| `--multilingual-csv-path` | bundled | Path to `swebench_multilingual_repos.csv` |
+| `--print-sample` | `5` | Print first N instances to stdout |
+| `--save-sampled` | — | Extra path to save sampled instances JSON |
+
+### Examples
+
+**Sample only Go and Rust, 50 total instances:**
+
+```bash
+PYTHONPATH=. python scripts/collect_swebench.py \
+  --languages Go Rust \
+  --total-instances 50 \
+  --output-dir output/go-rust
+```
+
+**Sample with a specific instance filter:**
+
+```bash
+PYTHONPATH=. python scripts/collect_swebench.py \
+  --filter-instance "redis.*" \
+  --languages "C++/C" \
+  --output-dir output/redis-only
+```
+
+## Output Artifacts
+
+The pipeline writes the following files to the output directory:
+
+| File | Description |
+|------|-------------|
+| `selected_instances.json` | Full instance data with GT fields — input for the HuggingFace upload script |
+| `selected_repos.json` | Selected repositories grouped by language |
+| `selected_instances.csv` | Summary CSV with key fields (language, repo, difficulty, etc.) |
+| `difficulty_cache.json` | Cached difficulty classifications (avoids re-calling the LLM) |
+| `gt_locator_cache.json` | Cached ground-truth extraction results |
+
+The `selected_instances.json` file is the primary output — pass it to `build_swebench_locator_hf_dataset.py` to upload to HuggingFace (see [upload_dataset_to_huggingface.md](upload_dataset_to_huggingface.md)).
+
+## Caching
+
+The pipeline caches aggressively to avoid redundant work on reruns:
+
+- **Dataset cache** (`~/.codeminer/`) — HuggingFace dataset downloads
+- **Repo clones** (`cache-dir`) — shallow git clones of target repos
+- **Difficulty cache** (`difficulty_cache.json`) — LLM difficulty classifications
+- **GT cache** (`gt_locator_cache.json`) — ground-truth extraction results
+
+To force a fresh run, delete the relevant cache files or use a new output directory.

--- a/docs/upload_dataset_to_huggingface.md
+++ b/docs/upload_dataset_to_huggingface.md
@@ -1,0 +1,112 @@
+# Uploading the Dataset to HuggingFace
+
+This guide covers how to build and upload the SWE-bench locator dataset to HuggingFace Hub.
+
+## Prerequisites
+
+1. **Install dependencies** — the project already includes the `datasets` library (`>=4.0.0`):
+
+   ```bash
+   pip install -e .
+   ```
+
+2. **Authenticate with HuggingFace Hub** — choose one method:
+
+   ```bash
+   # Option A: interactive login (stores token in ~/.cache/huggingface/)
+   hf login
+
+   # Option B: environment variable
+   export HF_TOKEN="hf_your_token_here"
+   ```
+
+   You need a **write** token. Create one at https://huggingface.co/settings/tokens.
+
+3. **Prepare the input file** — you need a `selected_instances.json` file with ground-truth fields already computed (output of the GT extraction + difficulty classification pipeline).
+
+## Upload Command
+
+```bash
+python scripts/build_swebench_locator_hf_dataset.py \
+  --selected-instances path/to/selected_instances.json \
+  --output-dir output/dataset \
+  --push-to-hub "your-org/your-dataset-name"
+```
+
+### All Options
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--selected-instances` | Yes | — | Path to `selected_instances.json` with GT fields |
+| `--output-dir` | Yes | — | Local output directory for Parquet files |
+| `--split` | No | `test` | Dataset split name |
+| `--push-to-hub` | No | — | HuggingFace Hub repo ID (e.g. `org/dataset-name`) |
+| `--private` | No | `false` | Make the Hub dataset private |
+| `--output-jsonl` | No | — | Also export a JSONL file |
+| `--output-parquet` | No | — | Also export an extra Parquet file |
+
+### Examples
+
+**Local-only build (no upload):**
+
+```bash
+python scripts/build_swebench_locator_hf_dataset.py \
+  --selected-instances data/selected_instances.json \
+  --output-dir output/swebench-locator
+```
+
+## What Gets Uploaded
+
+The script creates a HuggingFace `DatasetDict` with a single split (default: `test`) containing these fields per instance:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `instance_id` | string | Unique SWE-bench identifier |
+| `repo` | string | GitHub repository (e.g. `redis/redis`) |
+| `base_commit` | string | Base commit hash |
+| `patch` | string | The gold patch |
+| `problem_statement` | string | Issue description |
+| `language_group` | string | Language (e.g. `Go`, `C++/C`, `Rust`, `TypeScript/JavaScript`) |
+| `difficulty_level` | string | `low`, `medium`, or `high` |
+| `target_files` | list[string] | Files modified by the patch |
+| `gt_code_blocks` | list[dict] | Ground-truth code blocks (see below) |
+| `gt_code_blocks_count` | int | Number of GT code blocks |
+| `gt_symbols_modified` | list[string] | Modified symbol names |
+| `gt_symbols_deleted` | list[string] | Deleted symbol names |
+| `gt_target_files` | list[string] | Target files from GT extraction |
+
+Each entry in `gt_code_blocks` contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `file_path` | string | Path to the file |
+| `symbol` | string | Symbol name (function, class, etc.) |
+| `symbol_type` | string | Type of symbol (`function`, `method`, `class`, `struct`, etc.) |
+| `change_type` | string | `modified`, `added`, or `deleted` |
+| `start_line` | int | Start line (1-based) |
+| `end_line` | int | End line (1-based) |
+
+> Note: `changed_loc` and `total_in_repo` fields are dropped from the output automatically.
+
+## Output
+
+After running, you'll see a summary like:
+
+```
+Loaded 50 instance(s) from data/selected_instances.json
+Saved Parquet (50 rows) to output/swebench-locator/test-00000-of-00001.parquet
+Pushed dataset to https://huggingface.co/datasets/sysevol-ai/swebench-locator
+Summary: total=50  gt_nonempty=48  by_language={'Go': 14, 'C++/C': 12, 'Rust': 7, 'TypeScript/JavaScript': 17}
+```
+
+The dataset will be available at `https://huggingface.co/datasets/<your-org>/<your-dataset-name>`.
+
+## Updating an Existing Dataset
+
+Simply re-run the same command with `--push-to-hub` pointing to the existing repo. The `push_to_hub()` call will overwrite the split with the new data.
+
+## Troubleshooting
+
+- **`401 Unauthorized`** — run `hf login` or check your `HF_TOKEN`.
+- **`403 Forbidden`** — your token may lack write permission, or you don't have push access to the target org/repo.
+- **`No instances found`** — the input JSON is empty or malformed. Ensure it's a JSON array of instance dicts.

--- a/scripts/build_swebench_locator_hf_dataset.py
+++ b/scripts/build_swebench_locator_hf_dataset.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import datasets
+import pyarrow as pa
 
 from codeminer.log_utils import get_logger
 
@@ -98,7 +99,47 @@ def main() -> None:
     if not rows:
         raise ValueError("No instances found in input file.")
 
+    # Build the Arrow table directly so we control struct field order for
+    # gt_code_blocks (Arrow/Parquet sorts struct fields alphabetically by
+    # default when inferring from Python dicts).
+    _CODE_BLOCK_FIELDS = [
+        "change_type",
+        "start_line",
+        "end_line",
+        "file_path",
+        "symbol",
+        "symbol_type",
+    ]
+
+    def _reorder_code_blocks(blocks: list) -> list:
+        """Return code_block dicts with keys in the canonical order."""
+        return [{k: b[k] for k in _CODE_BLOCK_FIELDS} for b in blocks]
+
+    for row in rows:
+        if row.get("gt_code_blocks"):
+            row["gt_code_blocks"] = _reorder_code_blocks(row["gt_code_blocks"])
+
+    # Let HF infer schema, then rebuild the gt_code_blocks column with
+    # an explicit struct type to lock in the field order.
     ds = datasets.Dataset.from_list(rows)
+    table = ds.data
+    code_block_type = pa.struct(
+        [
+            ("change_type", pa.string()),
+            ("start_line", pa.int64()),
+            ("end_line", pa.int64()),
+            ("file_path", pa.string()),
+            ("symbol", pa.string()),
+            ("symbol_type", pa.string()),
+        ]
+    )
+    idx = table.schema.get_field_index("gt_code_blocks")
+    old_col = table.column(idx)
+    new_col = old_col.cast(pa.list_(code_block_type))
+    table = table.set_column(
+        idx, pa.field("gt_code_blocks", pa.list_(code_block_type)), new_col
+    )
+    ds = datasets.Dataset(table)
 
     # Save Parquet (default) — HF Hub native format
     output_dir = Path(args.output_dir).expanduser()


### PR DESCRIPTION
## Summary
Split CI into parallel jobs, fix gt_code_blocks field ordering in Parquet output, and add documentation for SWE-bench data collection and HuggingFace upload workflows.

## Changes
- Split CI into 3 parallel jobs to cut wall-clock time in half
- Reorder code_block fields in `gt_locate.py` to canonical order (`change_type` first)
- Enforce struct field order in Parquet output via explicit Arrow schema cast (Arrow/Parquet sorts struct fields alphabetically by default)
- Add docs for SWE-bench collection pipeline and HuggingFace dataset upload

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published