### PR TITLE
docs: add mkdocs-material for project wiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ key.cfg
 logs/
 uv.lock
 hf_dataset/
+site/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+# CodeMiner
+
+A code analysis agent with graph-enhancement for multi-language codebases.
+
+## Overview
+
+CodeMiner provides tools for structural code analysis, symbol-level change detection, and graph-based code intelligence. It supports **Python, Go, Rust, C/C++, JavaScript, and TypeScript**.
+
+### Key Components
+
+| Component | Description |
+|-----------|-------------|
+| [GT Locator](gt_locator.md) | Extract symbol-level ground truth from SWE-bench patches |
+| [Incremental Graph](incremental_graph.md) | Update CodeGraph in-place without full re-indexing |
+| [Regex Index](regex_index.md) | Fast regex search across CodeGraph nodes |
+| [SCIP Index](scip_index.md) | Code intelligence via the SCIP protocol |
+| [Graph Cache](graph_cache_usage.md) | Caching system for SCIP indexing |
+
+### Guides
+
+- [Collecting SWE-bench Instances](collect_swebench.md) — sample representative instances across languages
+- [Uploading to HuggingFace](upload_dataset_to_huggingface.md) — build and publish the dataset
+
+## Quick Start
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Serving Docs Locally
+
+```bash
+pip install mkdocs-material
+mkdocs serve
+```
+
+Then open [http://localhost:8000](http://localhost:8000).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,64 @@
+site_name: CodeMiner
+site_description: A code analysis agent with graph-enhancement
+repo_url: https://github.com/sysevol-ai/CodeMiner
+repo_name: sysevol-ai/CodeMiner
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+nav:
+  - Home: index.md
+  - Guides:
+      - SWE-bench Collection: collect_swebench.md
+      - Upload to HuggingFace: upload_dataset_to_huggingface.md
+  - Components:
+      - GT Locator: gt_locator.md
+      - Incremental Graph: incremental_graph.md
+      - Regex Index: regex_index.md
+      - SCIP Index: scip_index.md
+      - Graph Cache: graph_cache_usage.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "mypy>=0.950",
     "flake8>=4.0.1",
     "flake8-bugbear>=24.4.0",
+    "mkdocs-material>=9.5.0",
 ]
 test = ["pytest>=6.0.0", "pytest-cov>=3.0.0", "pytest-xdist>=3.0.0"]
 


### PR DESCRIPTION
## Summary
- Add mkdocs-material setup with organized nav (Guides + Components), dark/light theme toggle, and search
- Add `docs/index.md` landing page linking all existing documentation
- Add `mkdocs-material` to dev dependencies and `site/` to `.gitignore`

## Test plan
- [x] Run `mkdocs serve` and verify all pages render correctly at localhost:8000
- [x] Verify dark/light theme toggle works
- [ ] Verify search functionality
