### PR TITLE
[refactor] decompose query synthesizer & move incremental_graph to graph/incremental

### DIFF
--- a/codeminer/dataset/synthesize/__init__.py
+++ b/codeminer/dataset/synthesize/__init__.py
@@ -9,11 +9,18 @@ from codeminer.dataset.utils import (
     get_prompt_for_query_type,
 )
 
-from .query_synthesizer import ClaudeQuerySynthesizer, QuerySynthesisResult
+from ._types import QuerySynthesisResult
+from .context_loader import ContextLoader
+from .query_curator import QueryCurator
+from .query_synthesizer import ClaudeQuerySynthesizer
+from .verifier import Verifier
 
 __all__ = [
     "ClaudeQuerySynthesizer",
+    "ContextLoader",
+    "QueryCurator",
     "QuerySynthesisResult",
+    "Verifier",
     "CodeLocation",
     "CodeSearchDataset",
     "CodeSearchQuery",

--- a/codeminer/dataset/synthesize/_agent.py
+++ b/codeminer/dataset/synthesize/_agent.py
@@ -1,0 +1,115 @@
+"""Shared agent runner for the query synthesis pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from typing import List, Optional
+
+from claude_agent_sdk import ClaudeAgentOptions, query
+
+from codeminer.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+class AgentRunner:
+    """Thin wrapper around the Claude Agent SDK for running LLM calls.
+
+    Each synthesis module (ContextLoader, QueryCurator, Verifier) gets its
+    own ``AgentRunner`` instance, potentially with different ``allowed_tools``
+    configurations.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = "opus",
+        max_turns: int = 10,
+        system_prompt: str = "",
+        allowed_tools: Optional[List[str]] = None,
+        permission_mode: str = "bypassPermissions",
+    ) -> None:
+        self.model = model
+        self.max_turns = max_turns
+        self.system_prompt = system_prompt
+        self.allowed_tools = allowed_tools or []
+        self.permission_mode = permission_mode
+
+    def run(self, prompt: str, *, cwd: Optional[str] = None) -> str:
+        """Synchronous agent call (delegates to async via ``asyncio.run``)."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.run_async(prompt, cwd=cwd))
+        raise RuntimeError(
+            "Running inside an active event loop. Use run_async instead."
+        )
+
+    async def run_async(self, prompt: str, *, cwd: Optional[str] = None) -> str:
+        """Asynchronous agent call — streams messages from Claude."""
+        options = ClaudeAgentOptions(
+            max_turns=self.max_turns,
+            system_prompt=self.system_prompt,
+            allowed_tools=self.allowed_tools,
+            permission_mode=self.permission_mode,
+            model=self.model,
+            cwd=cwd,
+        )
+        text_chunks: List[str] = []
+        query_gen = query(prompt=prompt, options=options)
+
+        try:
+            async for message in query_gen:
+                msg_type = message.__class__.__name__
+                logger.debug(f"Agent message type: {msg_type}")
+
+                if msg_type == "ResultMessage":
+                    result = getattr(message, "result", None)
+                    if result and isinstance(result, str):
+                        return result.strip()
+                    return "\n".join(text_chunks).strip()
+
+                if msg_type == "ErrorMessage":
+                    error_msg = getattr(message, "error", "Unknown error")
+                    logger.error(f"Agent error message: {error_msg}")
+                    raise RuntimeError(f"Agent returned error: {error_msg}")
+
+                if msg_type == "AssistantMessage":
+                    content = getattr(message, "content", None)
+                    if not content:
+                        continue
+                    block_texts: List[str] = []
+                    for block in content:
+                        text = getattr(block, "text", None)
+                        if isinstance(text, str) and text.strip():
+                            block_texts.append(text.strip())
+                    if block_texts:
+                        text_chunks.append("\n".join(block_texts))
+        finally:
+            await query_gen.aclose()
+
+        return "\n".join(text_chunks).strip()
+
+    @staticmethod
+    def extract_json(text: str) -> str:
+        """Extract the first valid JSON object from *text*."""
+        text = text.strip()
+        if not text:
+            return text
+
+        fenced = re.search(r"```(?:json)?\s*(\{[\s\S]*\})\s*```", text)
+        if fenced:
+            text = fenced.group(1).strip()
+
+        decoder = json.JSONDecoder()
+        for idx, ch in enumerate(text):
+            if ch != "{":
+                continue
+            try:
+                _obj, end = decoder.raw_decode(text[idx:])
+                return text[idx : idx + end]
+            except json.JSONDecodeError:
+                continue
+        return text

--- a/codeminer/dataset/synthesize/_types.py
+++ b/codeminer/dataset/synthesize/_types.py
@@ -1,0 +1,137 @@
+"""Shared data classes for the query synthesis pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from codeminer.dataset.utils import CodeLocation
+from codeminer.types import (
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NodeInfo,
+)
+
+
+class QuerySynthesisResult(BaseModel):
+    """Structured output for synthesized queries."""
+
+    question: str = Field(
+        description="Single natural-language question describing the issue."
+    )
+    focus: Optional[str] = Field(
+        default=None,
+        description="Optional short phrase highlighting the behavior focus.",
+    )
+    hints: Optional[List[str]] = Field(
+        default=None,
+        description="Optional progressive hints that could help locate the code.",
+    )
+
+
+class TargetDiscoveryResult(BaseModel):
+    """Structured output for repository target discovery."""
+
+    target_files: List[str] = Field(default_factory=list)
+    target_symbols: List[str] = Field(default_factory=list)
+    target_symbol_nodes: List[NodeInfo] = Field(default_factory=list)
+    rationale: Optional[str] = Field(default=None)
+
+
+class BehavioralSelectionResult(BaseModel):
+    """Structured output for behavior-first synthesis from sampled code blocks."""
+
+    question: str = Field(description="Natural-language behavioral question.")
+    focus: Optional[str] = Field(default=None)
+    required_block_ids: List[str] = Field(default_factory=list)
+    rationale: Optional[str] = Field(default=None)
+
+
+@dataclass
+class RepoSnapshot:
+    root: Path
+    top_level: List[str]
+    languages: List[Tuple[str, int]]
+    agent_summary: Optional[str] = None
+
+    def format_summary(self) -> str:
+        parts: List[str] = []
+        if self.top_level:
+            parts.append("Top-level entries: " + ", ".join(self.top_level))
+        if self.languages:
+            lang_summary = ", ".join(
+                f"{ext} ({count})" for ext, count in self.languages
+            )
+            parts.append(f"File extensions (top): {lang_summary}")
+        if self.agent_summary:
+            parts.append(f"Agent exploration summary:\n{self.agent_summary}")
+        return "\n\n".join(parts)
+
+
+@dataclass
+class SampledCodeBlock:
+    block_id: str
+    node_id: int
+    node_name: str
+    file_path: str
+    node_type: str
+    start_line: int
+    end_line: int
+    content: str
+    char_count: int
+    line_count: int
+
+    def to_node_info(self, *, include_content: bool = True) -> NodeInfo:
+        return NodeInfo(
+            node_name=self.node_name,
+            type=self.node_type,
+            file=self.file_path,
+            start_line=self.start_line,
+            end_line=self.end_line,
+            content=self.content if include_content else None,
+        )
+
+    def to_code_location(self) -> CodeLocation:
+        symbol_type = None
+        if self.node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
+            symbol_type = "function"
+        elif self.node_type == NODE_TYPE_CLASS:
+            symbol_type = "class"
+        return CodeLocation(
+            file_path=self.file_path,
+            symbol_type=symbol_type,
+            start_line=self.start_line,
+            end_line=self.end_line,
+        )
+
+
+@dataclass
+class BehavioralContext:
+    core_block: SampledCodeBlock
+    candidate_blocks: List[SampledCodeBlock]
+    neighborhood_blocks: List[SampledCodeBlock]
+
+
+def format_prompt_block(
+    block: SampledCodeBlock,
+    *,
+    is_core: bool = False,
+    max_block_chars: int = 1800,
+) -> str:
+    """Format a SampledCodeBlock for inclusion in an LLM prompt."""
+    content = block.content
+    if len(content) > max_block_chars:
+        content = (
+            content[:max_block_chars] + "\n# ... truncated for synthesis context ..."
+        )
+    core_tag = " **CORE**" if is_core else ""
+    return (
+        f"[{block.block_id}]{core_tag} type={block.node_type} "
+        f"lines={block.start_line}-{block.end_line} "
+        f"chars={block.char_count}\n"
+        f"{content}"
+    )

--- a/codeminer/dataset/synthesize/context_loader.py
+++ b/codeminer/dataset/synthesize/context_loader.py
@@ -1,0 +1,463 @@
+"""Context loading for query synthesis — graph sampling + agent exploration."""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import ValidationError
+
+from codeminer.dataset.swebench import SwebenchDataset
+from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
+from codeminer.graph.roi_subgraph import ROISubgraph
+from codeminer.log_utils import get_logger
+from codeminer.ls_router import LSIndexer
+from codeminer.types import (
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    is_symbol_node,
+)
+from codeminer.utils import is_test_file
+
+from ._agent import AgentRunner
+from ._types import (
+    BehavioralContext,
+    RepoSnapshot,
+    SampledCodeBlock,
+    TargetDiscoveryResult,
+)
+
+logger = get_logger(__name__)
+
+
+class ContextLoader:
+    """Load and prepare code context for query synthesis.
+
+    Responsibilities:
+      - Check out the target repo at a specific commit.
+      - Snapshot the repo structure (top-level entries, file extensions).
+      - Build a SCIP code graph via ``LSIndexer``.
+      - Sample candidate code blocks from the graph.
+      - Select a core block and its k-hop neighborhood.
+      - Optionally explore the repo with the agent for richer context.
+      - Discover target files/symbols for non-behavioral queries.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: AgentRunner,
+        max_top_level: int = 40,
+        max_extensions: int = 8,
+        min_block_chars: int = 100,
+        max_candidate_blocks: int = 24,
+        max_neighbor_blocks: int = 8,
+        neighbor_k_hop: int = 1,
+        sampling_seed: Optional[int] = None,
+    ) -> None:
+        self.agent = agent
+        self.max_top_level = max_top_level
+        self.max_extensions = max_extensions
+        self.min_block_chars = min_block_chars
+        self.max_candidate_blocks = max_candidate_blocks
+        self.max_neighbor_blocks = max_neighbor_blocks
+        self.neighbor_k_hop = neighbor_k_hop
+        self.sampling_seed = sampling_seed
+
+    # ------------------------------------------------------------------
+    # Checkout & snapshot
+    # ------------------------------------------------------------------
+
+    def checkout_instance(
+        self,
+        instance: Dict[str, Any],
+        *,
+        repo_root: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+    ) -> str:
+        """Clone/fetch the repo and checkout ``base_commit``.  Returns repo path."""
+        dataset_cls = (
+            SwebenchMultilingualDataset
+            if instance.get("language_group")
+            else SwebenchDataset
+        )
+        dataset = dataset_cls(root=cache_dir, repo_root=repo_root, log=False)
+        dataset.process_instance(instance, repo_root=repo_root)
+        return dataset.get_repo_path(instance, repo_root=repo_root)
+
+    def snapshot_repo(self, repo_path: str) -> RepoSnapshot:
+        """Collect lightweight repo metadata (top-level entries, extensions)."""
+        root = Path(repo_path)
+        top_level = sorted(
+            [entry.name for entry in root.iterdir() if not entry.name.startswith(".")]
+        )[: self.max_top_level]
+
+        extensions = self._collect_extensions(root)
+        return RepoSnapshot(
+            root=root,
+            top_level=top_level,
+            languages=extensions,
+        )
+
+    def checkout_and_snapshot(
+        self,
+        instance: Dict[str, Any],
+        *,
+        repo_root: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+    ) -> Tuple[str, RepoSnapshot]:
+        """Convenience: checkout + snapshot in one call."""
+        repo_path = self.checkout_instance(
+            instance, repo_root=repo_root, cache_dir=cache_dir
+        )
+        snapshot = self.snapshot_repo(repo_path)
+        return repo_path, snapshot
+
+    # ------------------------------------------------------------------
+    # Agent-based repo exploration (new)
+    # ------------------------------------------------------------------
+
+    async def explore_repo_with_agent_async(
+        self, snapshot: RepoSnapshot
+    ) -> RepoSnapshot:
+        """Use the agent (with file tools) to explore the repo and produce
+        a richer context summary.  Mutates and returns *snapshot*."""
+        prompt = (
+            "You are exploring a code repository to build context for generating "
+            "code-search evaluation queries.\n\n"
+            f"Repo structure:\n{snapshot.format_summary()}\n\n"
+            "Please:\n"
+            "1. Read the README (if present) and summarize the project purpose.\n"
+            "2. Identify the main source directories and their roles.\n"
+            "3. List the key modules/packages and briefly describe each.\n"
+            "4. Note any important architectural patterns.\n\n"
+            "Return a concise summary (under 800 chars)."
+        )
+        try:
+            summary = await self.agent.run_async(prompt, cwd=str(snapshot.root))
+            snapshot.agent_summary = summary.strip()[:800] if summary else None
+        except Exception as exc:
+            logger.warning("Agent repo exploration failed: %s", exc)
+        return snapshot
+
+    def explore_repo_with_agent(self, snapshot: RepoSnapshot) -> RepoSnapshot:
+        """Synchronous wrapper for :meth:`explore_repo_with_agent_async`."""
+        import asyncio
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.explore_repo_with_agent_async(snapshot))
+        raise RuntimeError(
+            "Running inside an active event loop. Use explore_repo_with_agent_async."
+        )
+
+    # ------------------------------------------------------------------
+    # Graph-based behavioral context
+    # ------------------------------------------------------------------
+
+    def prepare_behavioral_context(
+        self,
+        instance: Dict[str, Any],
+        repo_path: str,
+        *,
+        cache_dir: Optional[str] = None,
+        query_index: int = 0,
+    ) -> Optional[BehavioralContext]:
+        """Build a ``BehavioralContext`` by indexing the repo, sampling blocks,
+        and selecting a core block with its neighborhood."""
+        graph = self.load_code_graph(
+            instance=instance,
+            repo_path=repo_path,
+            cache_dir=cache_dir,
+        )
+        if graph is None:
+            return None
+
+        candidates = self.sample_candidate_blocks(graph, instance)
+        if not candidates:
+            return None
+
+        core_block = self.pick_core_block(candidates, graph, query_index=query_index)
+        neighborhood = self.collect_neighborhood_blocks(
+            graph=graph,
+            core_block=core_block,
+            candidate_blocks=candidates,
+        )
+        return BehavioralContext(
+            core_block=core_block,
+            candidate_blocks=candidates,
+            neighborhood_blocks=neighborhood,
+        )
+
+    def load_code_graph(
+        self,
+        instance: Dict[str, Any],
+        repo_path: str,
+        *,
+        cache_dir: Optional[str] = None,
+    ):
+        """Build SCIP code graph via ``LSIndexer``.  Returns ``CodeGraph`` or ``None``."""
+        language = self.infer_language(instance)
+        repo_name = (instance.get("repo") or "repo").replace("/", "__")
+        graph_cache_root = (
+            Path(cache_dir).expanduser() / "scip_graph_cache"
+            if cache_dir
+            else Path("/tmp") / "scip_graph_cache"
+        )
+        output_dir = graph_cache_root / repo_name
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            indexer = LSIndexer(
+                project_root=repo_path,
+                output_dir=output_dir,
+                language=language,
+            )
+            return indexer.run_pipeline(skip_level="graph", report_profile=False)
+        except Exception as exc:
+            logger.warning(
+                "Failed to build code graph for %s (%s): %s",
+                instance.get("instance_id", "unknown"),
+                language,
+                exc,
+            )
+            return None
+
+    @staticmethod
+    def infer_language(instance: Dict[str, Any]) -> str:
+        """Infer the primary language from instance metadata."""
+        language_group = (instance.get("language_group") or "").lower()
+        if "rust" in language_group:
+            return "rust"
+        if "javascript" in language_group or "typescript" in language_group:
+            return "ts"
+        if "c++" in language_group or language_group == "c":
+            return "cpp"
+        return "python"
+
+    def sample_candidate_blocks(
+        self,
+        code_graph,
+        instance: Dict[str, Any],
+    ) -> List[SampledCodeBlock]:
+        """Sample symbol nodes from the graph as candidate code blocks."""
+        graph = code_graph.get_graph()
+        blocks: List[SampledCodeBlock] = []
+
+        for node in graph.vs:
+            attrs = node.attributes()
+            node_type = attrs.get("type", "")
+            if not is_symbol_node(node_type):
+                continue
+
+            file_path = attrs.get("file")
+            if not file_path or is_test_file(file_path):
+                continue
+
+            start_line = attrs.get("start_line")
+            end_line = attrs.get("end_line")
+            if (
+                not isinstance(start_line, int)
+                or not isinstance(end_line, int)
+                or end_line <= start_line
+            ):
+                continue
+
+            content = code_graph.get_node_content(node.index)
+            if not content:
+                continue
+            content = content.strip()
+            if len(content) < self.min_block_chars:
+                continue
+
+            line_count = content.count("\n") + 1
+            block = SampledCodeBlock(
+                block_id=f"blk_{len(blocks) + 1:03d}",
+                node_id=node.index,
+                node_name=node["name"],
+                file_path=file_path,
+                node_type=node_type,
+                start_line=start_line,
+                end_line=end_line,
+                content=content,
+                char_count=len(content),
+                line_count=line_count,
+            )
+            blocks.append(block)
+
+        if not blocks:
+            return []
+
+        run_id = instance.get("synthesis_run_id")
+        if self.sampling_seed is None:
+            rng = random.Random()
+        else:
+            seed_input = (
+                f"{self.sampling_seed}:"
+                f"{instance.get('instance_id') or instance.get('repo') or 'seed'}:"
+                f"{run_id or 0}"
+            )
+            seed = int(hashlib.md5(seed_input.encode("utf-8")).hexdigest()[:8], 16)
+            rng = random.Random(seed)
+        if len(blocks) > self.max_candidate_blocks:
+            blocks = rng.sample(blocks, self.max_candidate_blocks)
+
+        return sorted(blocks, key=lambda blk: blk.char_count, reverse=True)
+
+    @staticmethod
+    def pick_core_block(
+        blocks: List[SampledCodeBlock], code_graph, *, query_index: int = 0
+    ) -> SampledCodeBlock:
+        """Select the core block by scoring char_count + 20 * degree."""
+        graph = code_graph.get_graph()
+        scored = sorted(
+            blocks,
+            key=lambda blk: blk.char_count + 20 * graph.degree(blk.node_id),
+            reverse=True,
+        )
+        return scored[min(query_index, len(scored) - 1)]
+
+    def collect_neighborhood_blocks(
+        self,
+        *,
+        graph,
+        core_block: SampledCodeBlock,
+        candidate_blocks: List[SampledCodeBlock],
+    ) -> List[SampledCodeBlock]:
+        """Collect k-hop neighbors of *core_block* from the code graph."""
+        try:
+            roi = ROISubgraph(graph)
+            subgraph = roi.extract_subgraph(
+                [core_block.node_name],
+                k_hop=self.neighbor_k_hop,
+                direction="both",
+            )
+            nodes = roi.get_filtered_subgraph_nodes(
+                subgraph,
+                exclude_nodes=[core_block.node_name],
+                filter_tests=True,
+                node_types=[NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_CLASS],
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to collect neighborhood for core block %s: %s",
+                core_block.node_name,
+                exc,
+            )
+            nodes = []
+
+        by_name = {blk.node_name: blk for blk in candidate_blocks}
+        neighborhood: List[SampledCodeBlock] = []
+        for node in nodes:
+            matched = by_name.get(node.node_name)
+            if matched is None:
+                continue
+            if matched.block_id == core_block.block_id:
+                continue
+            neighborhood.append(matched)
+            if len(neighborhood) >= self.max_neighbor_blocks:
+                break
+
+        if not neighborhood:
+            for blk in candidate_blocks:
+                if blk.block_id == core_block.block_id:
+                    continue
+                neighborhood.append(blk)
+                if len(neighborhood) >= self.max_neighbor_blocks:
+                    break
+
+        return neighborhood
+
+    # ------------------------------------------------------------------
+    # Non-behavioral target discovery
+    # ------------------------------------------------------------------
+
+    def discover_targets(
+        self,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+    ) -> TargetDiscoveryResult:
+        """Synchronous target discovery."""
+        import asyncio
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.discover_targets_async(instance, snapshot))
+        raise RuntimeError(
+            "Running inside an active event loop. Use discover_targets_async."
+        )
+
+    async def discover_targets_async(
+        self,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+    ) -> TargetDiscoveryResult:
+        """Ask the agent to explore the repo and identify target files/symbols."""
+        context_parts = ["Repo summary:\n" + snapshot.format_summary()]
+        context_parts.append(
+            "Explore the repository and identify likely implementation targets.\n"
+            "Return strict JSON with keys: target_files (array of relative file paths), "
+            "target_symbols (array of symbol identifiers in repository-native format), "
+            "rationale (string or null). Keep arrays concise (<= 8)."
+        )
+
+        raw_payload = await self.agent.run_async(
+            "\n\n".join(context_parts),
+            cwd=str(snapshot.root),
+        )
+        payload = self.agent.extract_json(raw_payload)
+        try:
+            return TargetDiscoveryResult.model_validate_json(payload)
+        except ValidationError:
+            heuristic = self._parse_discovery_from_text(raw_payload)
+            if heuristic.target_files or heuristic.target_symbols:
+                return heuristic
+            logger.warning("Target discovery returned non-JSON payload; continuing.")
+            return TargetDiscoveryResult()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _collect_extensions(self, root: Path) -> List[Tuple[str, int]]:
+        counts: Dict[str, int] = {}
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            if self._is_hidden(path):
+                continue
+            ext = path.suffix.lower() or "no_ext"
+            counts[ext] = counts.get(ext, 0) + 1
+        sorted_counts = sorted(counts.items(), key=lambda item: item[1], reverse=True)
+        return sorted_counts[: self.max_extensions]
+
+    @staticmethod
+    def _is_hidden(path: Path) -> bool:
+        return any(part.startswith(".") for part in path.parts)
+
+    @staticmethod
+    def _parse_discovery_from_text(text: str) -> TargetDiscoveryResult:
+        if not text:
+            return TargetDiscoveryResult()
+        file_pattern = r"\b[\w./-]+\.(?:py|rs|js|ts|go|java|cpp|c|h|hpp)\b"
+        files = list(dict.fromkeys(re.findall(file_pattern, text)))
+        symbol_patterns = [
+            r"\b[\w./-]+\.(?:py|rs|js|ts|go|java|cpp|c|h|hpp):[A-Za-z_][\w.:]*(?:\(\))?\b",
+            r"\b[\w/]+#[A-Za-z_]\w*(?:\(\))?\b",
+            r"\b[\w/]+/[A-Za-z_]\w*(?:\(\))?\b",
+        ]
+        symbols: List[str] = []
+        for pattern in symbol_patterns:
+            symbols.extend(re.findall(pattern, text))
+        symbols = list(dict.fromkeys(symbols))
+        return TargetDiscoveryResult(
+            target_files=files[:8],
+            target_symbols=symbols[:8],
+            rationale="parsed from non-JSON discovery output",
+        )

--- a/codeminer/dataset/synthesize/query_curator.py
+++ b/codeminer/dataset/synthesize/query_curator.py
@@ -1,0 +1,591 @@
+"""Query generation (curation) for the synthesis pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import random
+import re
+from typing import Any, Dict, List, Optional
+
+from pydantic import ValidationError
+
+from codeminer.dataset.utils import QueryType, get_prompt_for_query_type
+from codeminer.log_utils import get_logger
+
+from ._agent import AgentRunner
+from ._types import (
+    BehavioralContext,
+    BehavioralSelectionResult,
+    QuerySynthesisResult,
+    RepoSnapshot,
+    TargetDiscoveryResult,
+    format_prompt_block,
+)
+
+logger = get_logger(__name__)
+
+
+class QueryCurator:
+    """Generate natural-language queries from code context.
+
+    Supports multiple modes via ``query_type``:
+      - BEHAVIORAL: pure natural language, no code identifiers
+      - MODULE_HINT: may mention module/package names
+      - FILE_HINT: may mention file paths
+      - SYMBOL_HINT: may mention specific function/class names
+      - REASONING: requires reasoning about code relationships
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: AgentRunner,
+        query_type: QueryType = QueryType.BEHAVIORAL,
+        system_prompt: Optional[str] = None,
+        max_block_chars_in_prompt: int = 1800,
+        behavioral_consensus_runs: int = 3,
+    ) -> None:
+        self.agent = agent
+        self.query_type = query_type
+        self.max_block_chars_in_prompt = max_block_chars_in_prompt
+        self.behavioral_consensus_runs = max(1, behavioral_consensus_runs)
+
+        base_prompt = (
+            "You are a codebase assistant helping create "
+            "code search evaluation queries. "
+        )
+        level_prompt = get_prompt_for_query_type(self.query_type)
+        self.system_prompt = system_prompt or (base_prompt + level_prompt)
+        # Push system prompt into the agent runner
+        self.agent.system_prompt = self.system_prompt
+
+    # ------------------------------------------------------------------
+    # Behavioral query generation
+    # ------------------------------------------------------------------
+
+    def generate_behavioral(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+        run_index: int = 0,
+    ) -> Dict[str, Any]:
+        """Generate a single behavioral question (sync)."""
+        prompt = self._build_behavioral_prompt(
+            instance=instance,
+            snapshot=snapshot,
+            behavioral_context=behavioral_context,
+            run_index=run_index,
+        )
+        payload = self.agent.run(prompt, cwd=str(snapshot.root))
+        return self._parse_behavioral_payload(payload, behavioral_context)
+
+    async def generate_behavioral_async(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+        run_index: int = 0,
+    ) -> Dict[str, Any]:
+        """Generate a single behavioral question (async)."""
+        prompt = self._build_behavioral_prompt(
+            instance=instance,
+            snapshot=snapshot,
+            behavioral_context=behavioral_context,
+            run_index=run_index,
+        )
+        payload = await self.agent.run_async(prompt, cwd=str(snapshot.root))
+        return self._parse_behavioral_payload(payload, behavioral_context)
+
+    def generate_with_consensus(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        """Run N behavioral generation passes and aggregate via majority vote (sync).
+
+        Returns consensus result dict.  Verification is done separately by
+        the Verifier.
+        """
+        runs = []
+        for idx in range(self.behavioral_consensus_runs):
+            runs.append(
+                self.generate_behavioral(
+                    instance=instance,
+                    snapshot=snapshot,
+                    behavioral_context=behavioral_context,
+                    run_index=idx,
+                )
+            )
+        result = self._aggregate_consensus(runs, behavioral_context)
+        result["_runs"] = runs  # pass runs through for the verifier
+        return result
+
+    async def generate_with_consensus_async(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        """Run N behavioral generation passes and aggregate (async)."""
+        runs = []
+        for idx in range(self.behavioral_consensus_runs):
+            runs.append(
+                await self.generate_behavioral_async(
+                    instance=instance,
+                    snapshot=snapshot,
+                    behavioral_context=behavioral_context,
+                    run_index=idx,
+                )
+            )
+        result = self._aggregate_consensus(runs, behavioral_context)
+        result["_runs"] = runs
+        return result
+
+    # ------------------------------------------------------------------
+    # Non-behavioral query generation
+    # ------------------------------------------------------------------
+
+    def generate_question(
+        self,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        *,
+        ground_truth: Optional[Dict[str, Any]] = None,
+        discovered_targets: Optional[TargetDiscoveryResult] = None,
+    ) -> Dict[str, Any]:
+        """Generate a question at the configured query type (sync)."""
+        user_content = self._build_question_prompt(
+            instance, snapshot, ground_truth, discovered_targets
+        )
+        payload = self.agent.run(user_content, cwd=str(snapshot.root))
+        return self._parse_question_payload(payload, discovered_targets)
+
+    async def generate_question_async(
+        self,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        *,
+        ground_truth: Optional[Dict[str, Any]] = None,
+        discovered_targets: Optional[TargetDiscoveryResult] = None,
+    ) -> Dict[str, Any]:
+        """Generate a question at the configured query type (async)."""
+        user_content = self._build_question_prompt(
+            instance, snapshot, ground_truth, discovered_targets
+        )
+        payload = await self.agent.run_async(user_content, cwd=str(snapshot.root))
+        return self._parse_question_payload(payload, discovered_targets)
+
+    # ------------------------------------------------------------------
+    # Private: behavioral prompt & parsing
+    # ------------------------------------------------------------------
+
+    def _build_behavioral_prompt(
+        self,
+        *,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        behavioral_context: BehavioralContext,
+        run_index: int = 0,
+    ) -> str:
+        core = behavioral_context.core_block
+        neighborhood = list(behavioral_context.neighborhood_blocks)
+        if neighborhood:
+            seed_src = (
+                f"{instance.get('instance_id', 'unknown')}:"
+                f"{instance.get('synthesis_run_id', 0)}:{run_index}"
+            )
+            seed = int(hashlib.md5(seed_src.encode("utf-8")).hexdigest()[:8], 16)
+            random.Random(seed).shuffle(neighborhood)
+
+        core_block_text = format_prompt_block(
+            core, is_core=True, max_block_chars=self.max_block_chars_in_prompt
+        )
+
+        context_block_text = ""
+        if neighborhood:
+            context_block_text = "\n\n".join(
+                format_prompt_block(
+                    block, max_block_chars=self.max_block_chars_in_prompt
+                )
+                for block in neighborhood
+            )
+
+        parts = [
+            "You are generating a behavioral code-search query from sampled code blocks.\n",
+            "=== PRIMARY TARGET (CORE BLOCK) ===\n"
+            "Your question MUST describe the behavior of this block.\n\n"
+            f"{core_block_text}",
+        ]
+
+        if context_block_text:
+            parts.append(
+                "=== CONTEXT BLOCKS (for understanding only) ===\n"
+                "These help you understand the codebase but are NOT the primary focus.\n\n"
+                f"{context_block_text}"
+            )
+
+        parts.append(
+            f"Repository summary:\n{snapshot.format_summary()}\n\n"
+            f"Source instance id: {instance.get('instance_id', 'unknown')}\n"
+            f"Verification pass: {run_index + 1}\n\n"
+            "RULES:\n"
+            f"1) The question MUST describe what the CORE BLOCK"
+            f" ({core.block_id}) does behaviorally.\n"
+            "2) The question MUST NOT mention function names, class names,"
+            " signatures, or file paths.\n"
+            "3) Pick required blocks (IDs) needed to answer the question. "
+            f"Always include {core.block_id}.\n"
+            "4) In your rationale, explain how your question relates to"
+            " the CORE BLOCK's behavior.\n"
+            "5) Return strict JSON only with keys:"
+            " question, focus, required_block_ids, rationale."
+        )
+
+        return "\n\n".join(parts)
+
+    def _parse_behavioral_payload(
+        self,
+        payload: str,
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        blob = self.agent.extract_json(payload)
+        try:
+            parsed = BehavioralSelectionResult.model_validate_json(blob)
+            question = parsed.question.strip()
+            focus = parsed.focus
+            selected_ids = parsed.required_block_ids
+        except ValidationError:
+            question = self._coerce_question_text(blob)
+            focus = None
+            selected_ids = []
+
+        question = self._sanitize_question(question)
+        if not question:
+            question = self._fallback_question(None)
+        if not question.endswith("?"):
+            question = question.rstrip(".") + "?"
+
+        pool = {
+            blk.block_id: blk
+            for blk in [behavioral_context.core_block]
+            + behavioral_context.neighborhood_blocks
+        }
+        selected_blocks = [
+            pool[block_id] for block_id in selected_ids if block_id in pool
+        ]
+        if behavioral_context.core_block.block_id not in {
+            blk.block_id for blk in selected_blocks
+        }:
+            selected_blocks.insert(0, behavioral_context.core_block)
+
+        return {
+            "question": question,
+            "focus": focus,
+            "hints": None,
+            "selected_blocks": selected_blocks,
+            "core_block_id": behavioral_context.core_block.block_id,
+            "selected_block_ids": [blk.block_id for blk in selected_blocks],
+        }
+
+    def _aggregate_consensus(
+        self,
+        runs: List[Dict[str, Any]],
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        if not runs:
+            return {
+                "question": self._fallback_question(None),
+                "focus": None,
+                "hints": None,
+                "selected_blocks": [behavioral_context.core_block],
+                "core_block_id": behavioral_context.core_block.block_id,
+                "selected_block_ids": [behavioral_context.core_block.block_id],
+            }
+
+        vote_counts: Dict[str, int] = {}
+        for run in runs:
+            for block in run.get("selected_blocks", []):
+                vote_counts[block.block_id] = vote_counts.get(block.block_id, 0) + 1
+
+        core_id = behavioral_context.core_block.block_id
+        majority = math.ceil(len(runs) / 2)
+
+        pool = {
+            blk.block_id: blk
+            for blk in [behavioral_context.core_block]
+            + behavioral_context.neighborhood_blocks
+        }
+        selected_blocks = [
+            pool[block_id]
+            for block_id, votes in sorted(
+                vote_counts.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+            if votes >= majority and block_id in pool
+        ]
+        if not selected_blocks:
+            selected_blocks = [behavioral_context.core_block]
+        if core_id not in {blk.block_id for blk in selected_blocks}:
+            selected_blocks.insert(0, behavioral_context.core_block)
+
+        best_run = max(
+            runs,
+            key=lambda run: sum(
+                vote_counts.get(blk.block_id, 0)
+                for blk in run.get("selected_blocks", [])
+            ),
+        )
+        return {
+            "question": best_run.get("question") or self._fallback_question(None),
+            "focus": best_run.get("focus"),
+            "hints": None,
+            "selected_blocks": selected_blocks,
+            "core_block_id": behavioral_context.core_block.block_id,
+            "selected_block_ids": [blk.block_id for blk in selected_blocks],
+        }
+
+    # ------------------------------------------------------------------
+    # Private: non-behavioral prompt & parsing
+    # ------------------------------------------------------------------
+
+    def _build_question_prompt(
+        self,
+        instance: Dict[str, Any],
+        snapshot: RepoSnapshot,
+        ground_truth: Optional[Dict[str, Any]],
+        discovered_targets: Optional[TargetDiscoveryResult],
+    ) -> str:
+        problem_statement = (instance.get("problem_statement") or "").strip()
+        synthesis_run_id = instance.get("synthesis_run_id")
+
+        constraint_clause = self._build_constraint_clause(
+            problem_statement, ground_truth
+        )
+
+        context_parts = ["Repo summary:\n" + snapshot.format_summary()]
+
+        if synthesis_run_id is not None:
+            context_parts.append(
+                "Diversity run id: "
+                f"{synthesis_run_id}. Produce a distinct query focus from other runs."
+            )
+
+        if ground_truth and self.query_type in (
+            QueryType.FILE_HINT,
+            QueryType.SYMBOL_HINT,
+            QueryType.REASONING,
+        ):
+            gt_info = []
+            if ground_truth.get("target_files"):
+                gt_info.append(
+                    f"Target files: {', '.join(ground_truth['target_files'])}"
+                )
+            if ground_truth.get("symbols_modified"):
+                gt_info.append(
+                    f"Modified symbols: {', '.join(ground_truth['symbols_modified'][:5])}"
+                )
+            if gt_info:
+                context_parts.append(
+                    "Ground truth info (use as appropriate):\n" + "\n".join(gt_info)
+                )
+        elif discovered_targets and self.query_type in (
+            QueryType.FILE_HINT,
+            QueryType.SYMBOL_HINT,
+            QueryType.REASONING,
+        ):
+            discovered_info = []
+            if discovered_targets.target_files:
+                discovered_info.append(
+                    "Discovered files: "
+                    + ", ".join(discovered_targets.target_files[:8])
+                )
+            if discovered_targets.target_symbols:
+                discovered_info.append(
+                    "Discovered symbols: "
+                    + ", ".join(discovered_targets.target_symbols[:8])
+                )
+            if discovered_info:
+                context_parts.append(
+                    "Repository exploration targets:\n" + "\n".join(discovered_info)
+                )
+
+        context_parts.append(f"Constraints:\n{constraint_clause}")
+        context_parts.append(
+            "Output JSON with keys: question (string), focus (string or null), "
+            "hints (array of strings or null). Return only JSON."
+        )
+
+        return "\n\n".join(context_parts)
+
+    def _parse_question_payload(
+        self,
+        payload: str,
+        discovered_targets: Optional[TargetDiscoveryResult],
+    ) -> Dict[str, Any]:
+        payload = self.agent.extract_json(payload)
+
+        try:
+            result = QuerySynthesisResult.model_validate_json(payload)
+            question = result.question.strip()
+            focus = result.focus
+            hints = result.hints
+        except ValidationError:
+            question = self._coerce_question_text(payload)
+            focus = None
+            hints = None
+
+        if self.query_type == QueryType.BEHAVIORAL:
+            question = self._sanitize_question(question)
+
+        if not question:
+            question = self._fallback_question(discovered_targets)
+        if not question.endswith("?"):
+            question = question.rstrip(".") + "?"
+
+        return {"question": question, "focus": focus, "hints": hints}
+
+    # ------------------------------------------------------------------
+    # Private: constraint clause
+    # ------------------------------------------------------------------
+
+    def _build_constraint_clause(
+        self,
+        problem_statement: str,
+        ground_truth: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        level = self.query_type
+
+        if level == QueryType.BEHAVIORAL:
+            avoid_terms = self._extract_avoid_terms(problem_statement)
+            if avoid_terms:
+                return (
+                    "STRICT: You MUST NOT mention any of these identifiers: "
+                    + ", ".join(sorted(avoid_terms))
+                    + ". Focus purely on observable behavior."
+                )
+            return (
+                "STRICT: Avoid ALL code identifiers, file paths, and technical names."
+            )
+
+        elif level == QueryType.MODULE_HINT:
+            return (
+                "You MAY mention module or package names (e.g., 'the caching module') "
+                "but AVOID specific file paths or function/class names."
+            )
+
+        elif level == QueryType.FILE_HINT:
+            if ground_truth:
+                files = ground_truth.get("target_files", [])
+                if files:
+                    return (
+                        f"You SHOULD mention relevant file paths from: {', '.join(files)}. "
+                        "But AVOID mentioning specific function or class names."
+                    )
+            return "You MAY mention specific file paths but AVOID function/class names."
+
+        elif level == QueryType.SYMBOL_HINT:
+            if ground_truth:
+                symbols = ground_truth.get("symbols_modified", []) + ground_truth.get(
+                    "symbols_added", []
+                )
+                if symbols:
+                    return (
+                        f"You SHOULD mention relevant symbols from: {', '.join(symbols[:5])}. "
+                        "Be specific about which function/class/method is involved."
+                    )
+            return "You MAY and SHOULD mention specific function/class/method names."
+
+        elif level == QueryType.REASONING:
+            if ground_truth:
+                symbols = ground_truth.get("symbols_modified", []) + ground_truth.get(
+                    "symbols_added", []
+                )
+                if symbols:
+                    return (
+                        f"Mention some symbols from: {', '.join(symbols[:3])}. "
+                        "But frame the question to require understanding of call chains, "
+                        "inheritance, or control flow. Ask 'what calls X', 'which classes "
+                        "inherit from Y', or 'how does A interact with B'."
+                    )
+            return (
+                "Frame the question to require reasoning about code relationships "
+                "(call chains, inheritance, data flow)."
+            )
+
+        return "Focus on the behavior being described."
+
+    # ------------------------------------------------------------------
+    # Private: text helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_avoid_terms(text: str) -> List[str]:
+        if not text:
+            return []
+        file_like = re.findall(
+            r"\b[\w/\.-]+\.(?:py|js|ts|rs|go|java|cpp|c|h|hpp)\b", text
+        )
+        func_like = re.findall(r"\b[A-Za-z_]\w*\(\)", text)
+        names = set(file_like + func_like)
+        return [name for name in names if len(name) > 2]
+
+    @staticmethod
+    def _sanitize_question(text: str) -> str:
+        text = re.sub(r"`[^`]+`", "", text)
+        text = re.sub(
+            r"\b[\w/\.-]+\.(?:py|js|ts|rs|go|java|cpp|c|h|hpp)\b",
+            "a module",
+            text,
+        )
+        text = re.sub(r"\b[A-Za-z_]\w*\(\)", "a function", text)
+        text = re.sub(r"\s{2,}", " ", text).strip()
+        return text
+
+    @staticmethod
+    def _coerce_question_text(text: str) -> str:
+        if not text:
+            return ""
+        stripped = text.strip()
+        if not stripped:
+            return ""
+        for line in stripped.splitlines():
+            candidate = line.strip().strip("-* ").strip()
+            if not candidate:
+                continue
+            candidate = re.sub(r"^(question|query)\s*:\s*", "", candidate, flags=re.I)
+            if len(candidate) >= 12:
+                if "?" in candidate:
+                    return candidate.split("?", 1)[0].strip() + "?"
+                return candidate
+        return ""
+
+    @staticmethod
+    def _fallback_question(
+        discovered_targets: Optional[TargetDiscoveryResult],
+    ) -> str:
+        first_file = (
+            discovered_targets.target_files[0]
+            if discovered_targets and discovered_targets.target_files
+            else None
+        )
+        first_symbol = (
+            discovered_targets.target_symbols[0]
+            if discovered_targets and discovered_targets.target_symbols
+            else None
+        )
+        # Default behavioral fallback
+        if first_file:
+            return f"What logic in {first_file} is responsible for this behavior?"
+        if first_symbol:
+            return f"How does {first_symbol} implement this behavior?"
+        return (
+            "Which code path controls this behavior, and why can an automatic "
+            "rewrite change runtime semantics?"
+        )

--- a/codeminer/dataset/synthesize/query_synthesizer.py
+++ b/codeminer/dataset/synthesize/query_synthesizer.py
@@ -1,8 +1,10 @@
 """
-Query synthesis agent for SWE-bench instances.
+Query synthesis facade for SWE-bench instances.
 
-This agent checks out the target repo commit, summarizes the repo, and uses the
-Claude code agent to produce natural-language queries at different query types.
+Orchestrates the three-stage pipeline:
+  1. **ContextLoader** — checkout repo, build code graph, sample blocks
+  2. **QueryCurator** — generate natural-language queries at various modes
+  3. **Verifier** — verify query quality and target alignment
 
 Query Types:
 - BEHAVIORAL: Pure natural language, no code identifiers
@@ -14,144 +16,26 @@ Query Types:
 
 from __future__ import annotations
 
-import asyncio
-import hashlib
-import json
-import math
-import random
-import re
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
-from claude_agent_sdk import ClaudeAgentOptions, query
-from pydantic import BaseModel, Field, ValidationError
-
-from codeminer.dataset.swebench import SwebenchDataset
-from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
-from codeminer.dataset.utils import (
-    CodeLocation,
-    GroundTruth,
-    QueryType,
-    get_prompt_for_query_type,
-)
-from codeminer.graph.roi_subgraph import ROISubgraph
+from codeminer.dataset.utils import CodeLocation, GroundTruth, QueryType
 from codeminer.log_utils import get_logger
-from codeminer.ls_router import LSIndexer
-from codeminer.types import (
-    NODE_TYPE_CLASS,
-    NODE_TYPE_FUNCTION,
-    NODE_TYPE_METHOD,
-    NodeInfo,
-    is_symbol_node,
-)
-from codeminer.utils import is_test_file
+from codeminer.types import NodeInfo
+
+from ._agent import AgentRunner
+from ._types import RepoSnapshot, SampledCodeBlock, TargetDiscoveryResult
+from .context_loader import ContextLoader
+from .query_curator import QueryCurator
+from .verifier import Verifier
 
 logger = get_logger(__name__)
 
 
-class QuerySynthesisResult(BaseModel):
-    """Structured output for synthesized queries."""
-
-    question: str = Field(
-        description="Single natural-language question describing the issue."
-    )
-    focus: Optional[str] = Field(
-        default=None,
-        description="Optional short phrase highlighting the behavior focus.",
-    )
-    hints: Optional[List[str]] = Field(
-        default=None,
-        description="Optional progressive hints that could help locate the code.",
-    )
-
-
-class TargetDiscoveryResult(BaseModel):
-    """Structured output for repository target discovery."""
-
-    target_files: List[str] = Field(default_factory=list)
-    target_symbols: List[str] = Field(default_factory=list)
-    target_symbol_nodes: List[NodeInfo] = Field(default_factory=list)
-    rationale: Optional[str] = Field(default=None)
-
-
-class BehavioralSelectionResult(BaseModel):
-    """Structured output for behavior-first synthesis from sampled code blocks."""
-
-    question: str = Field(description="Natural-language behavioral question.")
-    focus: Optional[str] = Field(default=None)
-    required_block_ids: List[str] = Field(default_factory=list)
-    rationale: Optional[str] = Field(default=None)
-
-
-@dataclass
-class RepoSnapshot:
-    root: Path
-    top_level: List[str]
-    languages: List[Tuple[str, int]]
-
-    def format_summary(self) -> str:
-        parts: List[str] = []
-        if self.top_level:
-            parts.append("Top-level entries: " + ", ".join(self.top_level))
-        if self.languages:
-            lang_summary = ", ".join(
-                f"{ext} ({count})" for ext, count in self.languages
-            )
-            parts.append(f"File extensions (top): {lang_summary}")
-        return "\n\n".join(parts)
-
-
-@dataclass
-class SampledCodeBlock:
-    block_id: str
-    node_id: int
-    node_name: str
-    file_path: str
-    node_type: str
-    start_line: int
-    end_line: int
-    content: str
-    char_count: int
-    line_count: int
-
-    def to_node_info(self, *, include_content: bool = True) -> NodeInfo:
-        return NodeInfo(
-            node_name=self.node_name,
-            type=self.node_type,
-            file=self.file_path,
-            start_line=self.start_line,
-            end_line=self.end_line,
-            content=self.content if include_content else None,
-        )
-
-    def to_code_location(self) -> CodeLocation:
-        symbol_type = None
-        if self.node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
-            symbol_type = "function"
-        elif self.node_type == NODE_TYPE_CLASS:
-            symbol_type = "class"
-        return CodeLocation(
-            file_path=self.file_path,
-            symbol_type=symbol_type,
-            start_line=self.start_line,
-            end_line=self.end_line,
-        )
-
-
-@dataclass
-class BehavioralContext:
-    core_block: SampledCodeBlock
-    candidate_blocks: List[SampledCodeBlock]
-    neighborhood_blocks: List[SampledCodeBlock]
-
-
 class ClaudeQuerySynthesizer:
-    """
-    Synthesize natural-language queries using a Claude-backed LLM.
+    """Synthesize natural-language queries using a Claude-backed LLM.
 
-    Supports multiple query types for generating queries with varying
-    amounts of code context revealed.
+    Thin facade that wires together :class:`ContextLoader`,
+    :class:`QueryCurator`, and :class:`Verifier`.
     """
 
     def __init__(
@@ -178,28 +62,6 @@ class ClaudeQuerySynthesizer:
         num_queries: int = 1,
         verification_mode: str = "lenient",
     ) -> None:
-        self.model = model
-        self.max_turns = max_turns
-        self.allowed_tools = allowed_tools or []
-        self.permission_mode = permission_mode
-        self.max_readme_chars = max_readme_chars
-        self.max_metadata_chars = max_metadata_chars
-        self.max_top_level = max_top_level
-        self.max_extensions = max_extensions
-        self.min_block_chars = min_block_chars
-        self.max_candidate_blocks = max_candidate_blocks
-        self.max_neighbor_blocks = max_neighbor_blocks
-        self.neighbor_k_hop = neighbor_k_hop
-        self.max_block_chars_in_prompt = max_block_chars_in_prompt
-        self.sampling_seed = sampling_seed
-        self.behavioral_consensus_runs = max(1, behavioral_consensus_runs)
-        self.num_queries = max(1, num_queries)
-        if verification_mode not in ("strict", "lenient", "none"):
-            raise ValueError(
-                f"verification_mode must be strict, lenient, or none; got {verification_mode!r}"
-            )
-        self.verification_mode = verification_mode
-
         # Parse query type (difficulty_level is a deprecated alias).
         if difficulty_level is not None:
             query_type = difficulty_level
@@ -208,13 +70,55 @@ class ClaudeQuerySynthesizer:
         else:
             self.query_type = query_type
 
-        # Build system prompt based on query type
-        base_prompt = (
-            "You are a codebase assistant helping create "
-            "code search evaluation queries. "
+        self.num_queries = max(1, num_queries)
+
+        # --- Agent runners with per-stage tool configs ---
+        context_agent = AgentRunner(
+            model=model,
+            max_turns=max_turns,
+            allowed_tools=["Read", "Glob", "Grep", "Bash"],
+            permission_mode=permission_mode,
         )
-        level_prompt = get_prompt_for_query_type(self.query_type)
-        self.system_prompt = system_prompt or (base_prompt + level_prompt)
+        curator_agent = AgentRunner(
+            model=model,
+            max_turns=max_turns,
+            allowed_tools=allowed_tools or [],
+            permission_mode=permission_mode,
+        )
+        verifier_agent = AgentRunner(
+            model=model,
+            max_turns=max_turns,
+            allowed_tools=[],
+            permission_mode=permission_mode,
+        )
+
+        # --- Sub-modules ---
+        self._loader = ContextLoader(
+            agent=context_agent,
+            max_top_level=max_top_level,
+            max_extensions=max_extensions,
+            min_block_chars=min_block_chars,
+            max_candidate_blocks=max_candidate_blocks,
+            max_neighbor_blocks=max_neighbor_blocks,
+            neighbor_k_hop=neighbor_k_hop,
+            sampling_seed=sampling_seed,
+        )
+        self._curator = QueryCurator(
+            agent=curator_agent,
+            query_type=self.query_type,
+            system_prompt=system_prompt,
+            max_block_chars_in_prompt=max_block_chars_in_prompt,
+            behavioral_consensus_runs=behavioral_consensus_runs,
+        )
+        self._verifier = Verifier(
+            agent=verifier_agent,
+            verification_mode=verification_mode,
+            max_block_chars_in_prompt=max_block_chars_in_prompt,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def synthesize_query(
         self,
@@ -225,30 +129,22 @@ class ClaudeQuerySynthesizer:
         ground_truth: Optional[Dict[str, Any]] = None,
         query_index: int = 0,
     ) -> Dict[str, Any]:
-        """
-        Synthesize a query for a single instance.
-
-        Args:
-            instance: SWE-bench instance dictionary
-            repo_root: Root directory for repository storage
-            cache_dir: Cache directory for datasets
-            ground_truth: Optional pre-computed ground truth from gt_locate.py
-
-        Returns:
-            Dictionary with query and metadata in CodeSearchQuery format
-        """
-        repo_path = self._checkout_instance(
+        repo_path, snapshot = self._loader.checkout_and_snapshot(
             instance, repo_root=repo_root, cache_dir=cache_dir
         )
-        snapshot = self._snapshot_repo(repo_path)
-        behavioral_context = self._prepare_behavioral_context(
+        behavioral_context = self._loader.prepare_behavioral_context(
             instance, repo_path, cache_dir=cache_dir, query_index=query_index
         )
+
         if self.query_type == QueryType.BEHAVIORAL and behavioral_context is not None:
-            result = self._generate_behavioral_question_with_consensus(
+            result = self._curator.generate_with_consensus(
                 instance=instance,
                 snapshot=snapshot,
                 behavioral_context=behavioral_context,
+            )
+            runs = result.pop("_runs", [])
+            result = self._verifier.verify(
+                result, runs, behavioral_context, cwd=str(snapshot.root)
             )
             gt = self._build_ground_truth_from_blocks(
                 result.get("selected_blocks") or [behavioral_context.core_block]
@@ -260,8 +156,8 @@ class ClaudeQuerySynthesizer:
                 result.get("selected_blocks") or [behavioral_context.core_block]
             )
         else:
-            discovered = self._discover_targets(instance, snapshot)
-            result = self._generate_question(
+            discovered = self._loader.discover_targets(instance, snapshot)
+            result = self._curator.generate_question(
                 instance,
                 snapshot,
                 ground_truth=ground_truth,
@@ -274,37 +170,15 @@ class ClaudeQuerySynthesizer:
             )
             target_symbol_nodes = self._build_symbol_nodes_from_ground_truth(gt)
 
-        instance_id = instance.get("instance_id", "unknown")
-        query_id = f"{instance_id}_{self.query_type.value}_q{query_index + 1}"
-
-        return {
-            "query_id": query_id,
-            "instance_id": instance_id,
-            "repo": instance.get("repo"),
-            "base_commit": instance.get("base_commit"),
-            "query": result["question"],
-            "query_type": self.query_type.value,
-            "difficulty": self.query_type.value,
-            "ground_truth": gt.to_dict() if gt else None,
-            "target_files": gt.to_dict()["target_files"] if gt else [],
-            "target_symbols": gt.to_dict()["target_symbols"] if gt else [],
-            "target_symbol_nodes": [
-                self._dump_node_info(node) for node in target_symbol_nodes
-            ],
-            "focus": result.get("focus"),
-            "hints": result.get("hints"),
-            "repo_snapshot": snapshot.format_summary(),
-            "discovered_target_files": discovered.target_files,
-            "discovered_target_symbols": discovered.target_symbols,
-            "discovered_target_symbol_nodes": [
-                self._dump_node_info(node) for node in discovered.target_symbol_nodes
-            ],
-            "discovery_rationale": discovered.rationale,
-            "core_block_id": result.get("core_block_id"),
-            "selected_block_ids": result.get("selected_block_ids"),
-            "verification_passed": result.get("verification_passed"),
-            "verification_block_id": result.get("verification_block_id"),
-        }
+        return self._build_output(
+            instance=instance,
+            result=result,
+            gt=gt,
+            discovered=discovered,
+            target_symbol_nodes=target_symbol_nodes,
+            snapshot=snapshot,
+            query_index=query_index,
+        )
 
     async def synthesize_query_async(
         self,
@@ -315,30 +189,22 @@ class ClaudeQuerySynthesizer:
         ground_truth: Optional[Dict[str, Any]] = None,
         query_index: int = 0,
     ) -> Dict[str, Any]:
-        """
-        Synthesize a query for a single instance (async version).
-
-        Args:
-            instance: SWE-bench instance dictionary
-            repo_root: Root directory for repository storage
-            cache_dir: Cache directory for datasets
-            ground_truth: Optional pre-computed ground truth from gt_locate.py
-
-        Returns:
-            Dictionary with query and metadata in CodeSearchQuery format
-        """
-        repo_path = self._checkout_instance(
+        repo_path, snapshot = self._loader.checkout_and_snapshot(
             instance, repo_root=repo_root, cache_dir=cache_dir
         )
-        snapshot = self._snapshot_repo(repo_path)
-        behavioral_context = self._prepare_behavioral_context(
+        behavioral_context = self._loader.prepare_behavioral_context(
             instance, repo_path, cache_dir=cache_dir, query_index=query_index
         )
+
         if self.query_type == QueryType.BEHAVIORAL and behavioral_context is not None:
-            result = await self._generate_behavioral_question_with_consensus_async(
+            result = await self._curator.generate_with_consensus_async(
                 instance=instance,
                 snapshot=snapshot,
                 behavioral_context=behavioral_context,
+            )
+            runs = result.pop("_runs", [])
+            result = await self._verifier.verify_async(
+                result, runs, behavioral_context, cwd=str(snapshot.root)
             )
             gt = self._build_ground_truth_from_blocks(
                 result.get("selected_blocks") or [behavioral_context.core_block]
@@ -350,8 +216,8 @@ class ClaudeQuerySynthesizer:
                 result.get("selected_blocks") or [behavioral_context.core_block]
             )
         else:
-            discovered = await self._discover_targets_async(instance, snapshot)
-            result = await self._generate_question_async(
+            discovered = await self._loader.discover_targets_async(instance, snapshot)
+            result = await self._curator.generate_question_async(
                 instance,
                 snapshot,
                 ground_truth=ground_truth,
@@ -364,37 +230,15 @@ class ClaudeQuerySynthesizer:
             )
             target_symbol_nodes = self._build_symbol_nodes_from_ground_truth(gt)
 
-        instance_id = instance.get("instance_id", "unknown")
-        query_id = f"{instance_id}_{self.query_type.value}_q{query_index + 1}"
-
-        return {
-            "query_id": query_id,
-            "instance_id": instance_id,
-            "repo": instance.get("repo"),
-            "base_commit": instance.get("base_commit"),
-            "query": result["question"],
-            "query_type": self.query_type.value,
-            "difficulty": self.query_type.value,
-            "ground_truth": gt.to_dict() if gt else None,
-            "target_files": gt.to_dict()["target_files"] if gt else [],
-            "target_symbols": gt.to_dict()["target_symbols"] if gt else [],
-            "target_symbol_nodes": [
-                self._dump_node_info(node) for node in target_symbol_nodes
-            ],
-            "focus": result.get("focus"),
-            "hints": result.get("hints"),
-            "repo_snapshot": snapshot.format_summary(),
-            "discovered_target_files": discovered.target_files,
-            "discovered_target_symbols": discovered.target_symbols,
-            "discovered_target_symbol_nodes": [
-                self._dump_node_info(node) for node in discovered.target_symbol_nodes
-            ],
-            "discovery_rationale": discovered.rationale,
-            "core_block_id": result.get("core_block_id"),
-            "selected_block_ids": result.get("selected_block_ids"),
-            "verification_passed": result.get("verification_passed"),
-            "verification_block_id": result.get("verification_block_id"),
-        }
+        return self._build_output(
+            instance=instance,
+            result=result,
+            gt=gt,
+            discovered=discovered,
+            target_symbol_nodes=target_symbol_nodes,
+            snapshot=snapshot,
+            query_index=query_index,
+        )
 
     def synthesize_queries(
         self,
@@ -472,763 +316,59 @@ class ClaudeQuerySynthesizer:
                     )
         return results
 
-    def _checkout_instance(
-        self,
-        instance: Dict[str, Any],
-        *,
-        repo_root: Optional[str] = None,
-        cache_dir: Optional[str] = None,
-    ) -> str:
-        dataset_cls = (
-            SwebenchMultilingualDataset
-            if instance.get("language_group")
-            else SwebenchDataset
-        )
-        dataset = dataset_cls(root=cache_dir, repo_root=repo_root, log=False)
-        dataset.process_instance(instance, repo_root=repo_root)
-        return dataset.get_repo_path(instance, repo_root=repo_root)
+    # ------------------------------------------------------------------
+    # Output assembly
+    # ------------------------------------------------------------------
 
-    def _snapshot_repo(self, repo_path: str) -> RepoSnapshot:
-        root = Path(repo_path)
-        top_level = sorted(
-            [entry.name for entry in root.iterdir() if not entry.name.startswith(".")]
-        )[: self.max_top_level]
-
-        extensions = self._collect_extensions(root)
-        return RepoSnapshot(
-            root=root,
-            top_level=top_level,
-            languages=extensions,
-        )
-
-    def _collect_extensions(self, root: Path) -> List[Tuple[str, int]]:
-        counts: Dict[str, int] = {}
-        for path in root.rglob("*"):
-            if not path.is_file():
-                continue
-            if self._is_hidden(path):
-                continue
-            ext = path.suffix.lower() or "no_ext"
-            counts[ext] = counts.get(ext, 0) + 1
-        sorted_counts = sorted(counts.items(), key=lambda item: item[1], reverse=True)
-        return sorted_counts[: self.max_extensions]
-
-    def _is_hidden(self, path: Path) -> bool:
-        return any(part.startswith(".") for part in path.parts)
-
-    def _prepare_behavioral_context(
-        self,
-        instance: Dict[str, Any],
-        repo_path: str,
-        *,
-        cache_dir: Optional[str] = None,
-        query_index: int = 0,
-    ) -> Optional[BehavioralContext]:
-        graph = self._load_or_build_code_graph(
-            instance=instance,
-            repo_path=repo_path,
-            cache_dir=cache_dir,
-        )
-        if graph is None:
-            return None
-
-        candidates = self._sample_candidate_blocks(graph, instance)
-        if not candidates:
-            return None
-
-        core_block = self._pick_core_block(candidates, graph, query_index=query_index)
-        neighborhood = self._collect_neighborhood_blocks(
-            graph=graph,
-            core_block=core_block,
-            candidate_blocks=candidates,
-        )
-        return BehavioralContext(
-            core_block=core_block,
-            candidate_blocks=candidates,
-            neighborhood_blocks=neighborhood,
-        )
-
-    def _load_or_build_code_graph(
-        self,
-        instance: Dict[str, Any],
-        repo_path: str,
-        *,
-        cache_dir: Optional[str] = None,
-    ):
-        language = self._infer_instance_language(instance)
-        repo_name = (instance.get("repo") or "repo").replace("/", "__")
-        graph_cache_root = (
-            Path(cache_dir).expanduser() / "scip_graph_cache"
-            if cache_dir
-            else Path("/tmp") / "scip_graph_cache"
-        )
-        output_dir = graph_cache_root / repo_name
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        try:
-            indexer = LSIndexer(
-                project_root=repo_path,
-                output_dir=output_dir,
-                language=language,
-            )
-            return indexer.run_pipeline(skip_level="graph", report_profile=False)
-        except Exception as exc:
-            logger.warning(
-                "Failed to build code graph for %s (%s): %s",
-                instance.get("instance_id", "unknown"),
-                language,
-                exc,
-            )
-            return None
-
-    def _infer_instance_language(self, instance: Dict[str, Any]) -> str:
-        language_group = (instance.get("language_group") or "").lower()
-        if "rust" in language_group:
-            return "rust"
-        if "javascript" in language_group or "typescript" in language_group:
-            return "ts"
-        if "c++" in language_group or language_group == "c":
-            return "cpp"
-        return "python"
-
-    def _sample_candidate_blocks(
-        self,
-        code_graph,
-        instance: Dict[str, Any],
-    ) -> List[SampledCodeBlock]:
-        graph = code_graph.get_graph()
-        blocks: List[SampledCodeBlock] = []
-
-        for node in graph.vs:
-            attrs = node.attributes()
-            node_type = attrs.get("type", "")
-            if not is_symbol_node(node_type):
-                continue
-
-            file_path = attrs.get("file")
-            if not file_path or is_test_file(file_path):
-                continue
-
-            start_line = attrs.get("start_line")
-            end_line = attrs.get("end_line")
-            if (
-                not isinstance(start_line, int)
-                or not isinstance(end_line, int)
-                or end_line <= start_line
-            ):
-                continue
-
-            content = code_graph.get_node_content(node.index)
-            if not content:
-                continue
-            content = content.strip()
-            if len(content) < self.min_block_chars:
-                continue
-
-            line_count = content.count("\n") + 1
-            block = SampledCodeBlock(
-                block_id=f"blk_{len(blocks) + 1:03d}",
-                node_id=node.index,
-                node_name=node["name"],
-                file_path=file_path,
-                node_type=node_type,
-                start_line=start_line,
-                end_line=end_line,
-                content=content,
-                char_count=len(content),
-                line_count=line_count,
-            )
-            blocks.append(block)
-
-        if not blocks:
-            return []
-
-        run_id = instance.get("synthesis_run_id")
-        if self.sampling_seed is None:
-            rng = random.Random()
-        else:
-            seed_input = (
-                f"{self.sampling_seed}:"
-                f"{instance.get('instance_id') or instance.get('repo') or 'seed'}:"
-                f"{run_id or 0}"
-            )
-            seed = int(hashlib.md5(seed_input.encode("utf-8")).hexdigest()[:8], 16)
-            rng = random.Random(seed)
-        if len(blocks) > self.max_candidate_blocks:
-            blocks = rng.sample(blocks, self.max_candidate_blocks)
-
-        return sorted(blocks, key=lambda blk: blk.char_count, reverse=True)
-
-    def _pick_core_block(
-        self, blocks: List[SampledCodeBlock], code_graph, *, query_index: int = 0
-    ) -> SampledCodeBlock:
-        graph = code_graph.get_graph()
-        scored = sorted(
-            blocks,
-            key=lambda blk: blk.char_count + 20 * graph.degree(blk.node_id),
-            reverse=True,
-        )
-        return scored[min(query_index, len(scored) - 1)]
-
-    def _collect_neighborhood_blocks(
-        self,
-        *,
-        graph,
-        core_block: SampledCodeBlock,
-        candidate_blocks: List[SampledCodeBlock],
-    ) -> List[SampledCodeBlock]:
-        try:
-            roi = ROISubgraph(graph)
-            subgraph = roi.extract_subgraph(
-                [core_block.node_name],
-                k_hop=self.neighbor_k_hop,
-                direction="both",
-            )
-            nodes = roi.get_filtered_subgraph_nodes(
-                subgraph,
-                exclude_nodes=[core_block.node_name],
-                filter_tests=True,
-                node_types=[NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_CLASS],
-            )
-        except Exception as exc:
-            logger.warning(
-                "Failed to collect neighborhood for core block %s: %s",
-                core_block.node_name,
-                exc,
-            )
-            nodes = []
-
-        by_name = {blk.node_name: blk for blk in candidate_blocks}
-        neighborhood: List[SampledCodeBlock] = []
-        for node in nodes:
-            matched = by_name.get(node.node_name)
-            if matched is None:
-                continue
-            if matched.block_id == core_block.block_id:
-                continue
-            neighborhood.append(matched)
-            if len(neighborhood) >= self.max_neighbor_blocks:
-                break
-
-        if not neighborhood:
-            for blk in candidate_blocks:
-                if blk.block_id == core_block.block_id:
-                    continue
-                neighborhood.append(blk)
-                if len(neighborhood) >= self.max_neighbor_blocks:
-                    break
-
-        return neighborhood
-
-    def _generate_behavioral_question(
+    def _build_output(
         self,
         *,
         instance: Dict[str, Any],
-        snapshot: RepoSnapshot,
-        behavioral_context: BehavioralContext,
-        run_index: int = 0,
-    ) -> Dict[str, Any]:
-        prompt = self._build_behavioral_prompt(
-            instance=instance,
-            snapshot=snapshot,
-            behavioral_context=behavioral_context,
-            run_index=run_index,
-        )
-        payload = self._run_agent(prompt, cwd=str(snapshot.root))
-        return self._parse_behavioral_payload(payload, behavioral_context)
-
-    async def _generate_behavioral_question_async(
-        self,
-        *,
-        instance: Dict[str, Any],
-        snapshot: RepoSnapshot,
-        behavioral_context: BehavioralContext,
-        run_index: int = 0,
-    ) -> Dict[str, Any]:
-        prompt = self._build_behavioral_prompt(
-            instance=instance,
-            snapshot=snapshot,
-            behavioral_context=behavioral_context,
-            run_index=run_index,
-        )
-        payload = await self._run_agent_async(prompt, cwd=str(snapshot.root))
-        return self._parse_behavioral_payload(payload, behavioral_context)
-
-    def _generate_behavioral_question_with_consensus(
-        self,
-        *,
-        instance: Dict[str, Any],
-        snapshot: RepoSnapshot,
-        behavioral_context: BehavioralContext,
-    ) -> Dict[str, Any]:
-        runs = []
-        for idx in range(self.behavioral_consensus_runs):
-            runs.append(
-                self._generate_behavioral_question(
-                    instance=instance,
-                    snapshot=snapshot,
-                    behavioral_context=behavioral_context,
-                    run_index=idx,
-                )
-            )
-        result = self._aggregate_behavioral_consensus(runs, behavioral_context)
-        return self._apply_verification(
-            result, runs, behavioral_context, cwd=str(snapshot.root)
-        )
-
-    async def _generate_behavioral_question_with_consensus_async(
-        self,
-        *,
-        instance: Dict[str, Any],
-        snapshot: RepoSnapshot,
-        behavioral_context: BehavioralContext,
-    ) -> Dict[str, Any]:
-        runs = []
-        for idx in range(self.behavioral_consensus_runs):
-            runs.append(
-                await self._generate_behavioral_question_async(
-                    instance=instance,
-                    snapshot=snapshot,
-                    behavioral_context=behavioral_context,
-                    run_index=idx,
-                )
-            )
-        result = self._aggregate_behavioral_consensus(runs, behavioral_context)
-        return await self._apply_verification_async(
-            result, runs, behavioral_context, cwd=str(snapshot.root)
-        )
-
-    def _aggregate_behavioral_consensus(
-        self,
-        runs: List[Dict[str, Any]],
-        behavioral_context: BehavioralContext,
-    ) -> Dict[str, Any]:
-        if not runs:
-            return {
-                "question": self._fallback_question(None),
-                "focus": None,
-                "hints": None,
-                "selected_blocks": [behavioral_context.core_block],
-                "core_block_id": behavioral_context.core_block.block_id,
-                "selected_block_ids": [behavioral_context.core_block.block_id],
-            }
-
-        vote_counts: Dict[str, int] = {}
-        for run in runs:
-            for block in run.get("selected_blocks", []):
-                vote_counts[block.block_id] = vote_counts.get(block.block_id, 0) + 1
-
-        core_id = behavioral_context.core_block.block_id
-        majority = math.ceil(len(runs) / 2)
-
-        pool = {
-            blk.block_id: blk
-            for blk in [behavioral_context.core_block]
-            + behavioral_context.neighborhood_blocks
-        }
-        selected_blocks = [
-            pool[block_id]
-            for block_id, votes in sorted(
-                vote_counts.items(),
-                key=lambda item: (-item[1], item[0]),
-            )
-            if votes >= majority and block_id in pool
-        ]
-        if not selected_blocks:
-            selected_blocks = [behavioral_context.core_block]
-        if core_id not in {blk.block_id for blk in selected_blocks}:
-            selected_blocks.insert(0, behavioral_context.core_block)
-
-        best_run = max(
-            runs,
-            key=lambda run: sum(
-                vote_counts.get(blk.block_id, 0)
-                for blk in run.get("selected_blocks", [])
-            ),
-        )
-        return {
-            "question": best_run.get("question") or self._fallback_question(None),
-            "focus": best_run.get("focus"),
-            "hints": None,
-            "selected_blocks": selected_blocks,
-            "core_block_id": behavioral_context.core_block.block_id,
-            "selected_block_ids": [blk.block_id for blk in selected_blocks],
-        }
-
-    # Patterns that indicate chain-of-thought leaks or meta-language rather
-    # than genuine behavioral queries.
-    _BAD_QUERY_PATTERNS = re.compile(
-        r"(?i)"
-        r"(?:^let me |^I (?:will|need to|want to|should|can) |"
-        r"examine (?:the |this )?(?:core )?block|"
-        r"look (?:at|into) (?:the |this )?(?:core )?block|"
-        r"understand (?:the |its |this )?(?:full )?content|"
-        r"(?:core|context|sampled|candidate) block|"
-        r"blk_\d+|"
-        r"^(?:now|first|next),? (?:let|I)|"
-        r"read (?:the |this )?(?:source |code )?(?:more )?closely)"
-    )
-    _MIN_QUERY_LENGTH = 60
-
-    @classmethod
-    def _validate_query_quality(cls, question: str) -> Tuple[bool, str]:
-        """Check whether *question* is a valid behavioral query.
-
-        Returns ``(is_valid, reason)`` where *reason* explains the failure
-        when *is_valid* is ``False``.
-        """
-        if not question or not question.strip():
-            return False, "empty question"
-        q = question.strip()
-        if len(q) < cls._MIN_QUERY_LENGTH:
-            return False, f"too short ({len(q)} chars, need >= {cls._MIN_QUERY_LENGTH})"
-        m = cls._BAD_QUERY_PATTERNS.search(q)
-        if m:
-            return False, f"meta-language detected: {m.group()!r}"
-        return True, ""
-
-    def _pick_best_valid_question(
-        self,
         result: Dict[str, Any],
-        runs: List[Dict[str, Any]],
-    ) -> bool:
-        """Try to replace *result*'s question with a valid one from *runs*.
-
-        Mutates *result* in place and returns ``True`` if a valid question was
-        found, ``False`` otherwise.
-        """
-        for run in runs:
-            alt_q = run.get("question", "")
-            if not alt_q or alt_q == result["question"]:
-                continue
-            ok, _ = self._validate_query_quality(alt_q)
-            if ok:
-                result["question"] = alt_q
-                result["focus"] = run.get("focus")
-                return True
-        return False
-
-    def _apply_verification(
-        self,
-        result: Dict[str, Any],
-        runs: List[Dict[str, Any]],
-        behavioral_context: BehavioralContext,
-        *,
-        cwd: str,
-    ) -> Dict[str, Any]:
-        """Run quality check + post-consensus verification (sync)."""
-        # ---- Quality gate: reject degenerate questions first ----
-        ok, reason = self._validate_query_quality(result["question"])
-        if not ok:
-            logger.warning(
-                "Query quality check failed (%s): %r", reason, result["question"]
-            )
-            if not self._pick_best_valid_question(result, runs):
-                result["verification_passed"] = False
-                result["verification_block_id"] = None
-                return result
-
-        if self.verification_mode == "none":
-            result["verification_passed"] = None
-            result["verification_block_id"] = None
-            return result
-
-        vr = self._verify_question_alignment(
-            result["question"], behavioral_context, cwd=cwd
-        )
-        if vr["passed"]:
-            result["verification_passed"] = True
-            result["verification_block_id"] = vr["block_id"]
-            return result
-
-        # Verification failed — try alternate runs in strict mode
-        if self.verification_mode == "strict":
-            ranked_runs = sorted(
-                runs,
-                key=lambda r: r.get("question", "") != result["question"],
-            )
-            for alt_run in ranked_runs:
-                alt_q = alt_run.get("question", "")
-                if not alt_q or alt_q == result["question"]:
-                    continue
-                alt_ok, _ = self._validate_query_quality(alt_q)
-                if not alt_ok:
-                    continue
-                alt_vr = self._verify_question_alignment(
-                    alt_q, behavioral_context, cwd=cwd
-                )
-                if alt_vr["passed"]:
-                    result["question"] = alt_q
-                    result["focus"] = alt_run.get("focus")
-                    result["verification_passed"] = True
-                    result["verification_block_id"] = alt_vr["block_id"]
-                    return result
-
-        # All attempts failed or lenient mode — keep best question, mark failed
-        result["verification_passed"] = False
-        result["verification_block_id"] = vr["block_id"]
-        return result
-
-    async def _apply_verification_async(
-        self,
-        result: Dict[str, Any],
-        runs: List[Dict[str, Any]],
-        behavioral_context: BehavioralContext,
-        *,
-        cwd: str,
-    ) -> Dict[str, Any]:
-        """Run quality check + post-consensus verification (async)."""
-        # ---- Quality gate: reject degenerate questions first ----
-        ok, reason = self._validate_query_quality(result["question"])
-        if not ok:
-            logger.warning(
-                "Query quality check failed (%s): %r", reason, result["question"]
-            )
-            if not self._pick_best_valid_question(result, runs):
-                result["verification_passed"] = False
-                result["verification_block_id"] = None
-                return result
-
-        if self.verification_mode == "none":
-            result["verification_passed"] = None
-            result["verification_block_id"] = None
-            return result
-
-        vr = await self._verify_question_alignment_async(
-            result["question"], behavioral_context, cwd=cwd
-        )
-        if vr["passed"]:
-            result["verification_passed"] = True
-            result["verification_block_id"] = vr["block_id"]
-            return result
-
-        # Verification failed — try alternate runs in strict mode
-        if self.verification_mode == "strict":
-            ranked_runs = sorted(
-                runs,
-                key=lambda r: r.get("question", "") != result["question"],
-            )
-            for alt_run in ranked_runs:
-                alt_q = alt_run.get("question", "")
-                if not alt_q or alt_q == result["question"]:
-                    continue
-                alt_ok, _ = self._validate_query_quality(alt_q)
-                if not alt_ok:
-                    continue
-                alt_vr = await self._verify_question_alignment_async(
-                    alt_q, behavioral_context, cwd=cwd
-                )
-                if alt_vr["passed"]:
-                    result["question"] = alt_q
-                    result["focus"] = alt_run.get("focus")
-                    result["verification_passed"] = True
-                    result["verification_block_id"] = alt_vr["block_id"]
-                    return result
-
-        # All attempts failed or lenient mode — keep best question, mark failed
-        result["verification_passed"] = False
-        result["verification_block_id"] = vr["block_id"]
-        return result
-
-    def _build_verification_prompt(
-        self,
-        question: str,
-        behavioral_context: BehavioralContext,
-    ) -> str:
-        """Build a blind verification prompt (no core label) to check alignment."""
-        all_blocks = [behavioral_context.core_block] + list(
-            behavioral_context.neighborhood_blocks
-        )
-        block_text = "\n\n".join(
-            self._format_prompt_block(block, is_core=False) for block in all_blocks
-        )
-        return (
-            "Given the following code-search question, identify which code block "
-            "the question is primarily about.\n\n"
-            f"Question: {question!r}\n\n"
-            f"Code blocks:\n{block_text}\n\n"
-            "Which block does this question primarily describe? "
-            "Return strict JSON with keys: block_id (string), confidence (high|medium|low)."
-        )
-
-    def _verify_question_alignment(
-        self,
-        question: str,
-        behavioral_context: BehavioralContext,
-        *,
-        cwd: str,
-    ) -> Dict[str, Any]:
-        """Verify that a generated question aligns with the core block (sync)."""
-        prompt = self._build_verification_prompt(question, behavioral_context)
-        payload = self._run_agent(prompt, cwd=cwd)
-        return self._parse_verification_result(payload, behavioral_context)
-
-    async def _verify_question_alignment_async(
-        self,
-        question: str,
-        behavioral_context: BehavioralContext,
-        *,
-        cwd: str,
-    ) -> Dict[str, Any]:
-        """Verify that a generated question aligns with the core block (async)."""
-        prompt = self._build_verification_prompt(question, behavioral_context)
-        payload = await self._run_agent_async(prompt, cwd=cwd)
-        return self._parse_verification_result(payload, behavioral_context)
-
-    def _parse_verification_result(
-        self,
-        payload: str,
-        behavioral_context: BehavioralContext,
-    ) -> Dict[str, Any]:
-        """Parse verification LLM response into block_id + confidence."""
-        blob = self._extract_json_blob(payload)
-        core_id = behavioral_context.core_block.block_id
-        try:
-            data = json.loads(blob)
-            block_id = data.get("block_id", "")
-            confidence = data.get("confidence", "low")
-        except (json.JSONDecodeError, AttributeError):
-            logger.warning("Verification returned non-JSON; assuming failed.")
-            return {"block_id": "", "confidence": "low", "passed": False}
-
-        passed = block_id == core_id
-        if not passed:
-            logger.warning(
-                "Verification mismatch: question maps to %s, expected %s (confidence=%s)",
-                block_id,
-                core_id,
-                confidence,
-            )
-        else:
-            logger.info(
-                "Verification passed: question maps to core block %s (confidence=%s)",
-                core_id,
-                confidence,
-            )
-        return {"block_id": block_id, "confidence": confidence, "passed": passed}
-
-    def _build_behavioral_prompt(
-        self,
-        *,
-        instance: Dict[str, Any],
+        gt: Optional[GroundTruth],
+        discovered: TargetDiscoveryResult,
+        target_symbol_nodes: List[NodeInfo],
         snapshot: RepoSnapshot,
-        behavioral_context: BehavioralContext,
-        run_index: int = 0,
-    ) -> str:
-        core = behavioral_context.core_block
-        neighborhood = list(behavioral_context.neighborhood_blocks)
-        if neighborhood:
-            seed_src = (
-                f"{instance.get('instance_id', 'unknown')}:"
-                f"{instance.get('synthesis_run_id', 0)}:{run_index}"
-            )
-            seed = int(hashlib.md5(seed_src.encode("utf-8")).hexdigest()[:8], 16)
-            random.Random(seed).shuffle(neighborhood)
-
-        core_block_text = self._format_prompt_block(core, is_core=True)
-
-        context_block_text = ""
-        if neighborhood:
-            context_block_text = "\n\n".join(
-                self._format_prompt_block(block) for block in neighborhood
-            )
-
-        parts = [
-            "You are generating a behavioral code-search query from sampled code blocks.\n",
-            "=== PRIMARY TARGET (CORE BLOCK) ===\n"
-            "Your question MUST describe the behavior of this block.\n\n"
-            f"{core_block_text}",
-        ]
-
-        if context_block_text:
-            parts.append(
-                "=== CONTEXT BLOCKS (for understanding only) ===\n"
-                "These help you understand the codebase but are NOT the primary focus.\n\n"
-                f"{context_block_text}"
-            )
-
-        parts.append(
-            f"Repository summary:\n{snapshot.format_summary()}\n\n"
-            f"Source instance id: {instance.get('instance_id', 'unknown')}\n"
-            f"Verification pass: {run_index + 1}\n\n"
-            "RULES:\n"
-            f"1) The question MUST describe what the CORE BLOCK"
-            f" ({core.block_id}) does behaviorally.\n"
-            "2) The question MUST NOT mention function names, class names,"
-            " signatures, or file paths.\n"
-            "3) Pick required blocks (IDs) needed to answer the question. "
-            f"Always include {core.block_id}.\n"
-            "4) In your rationale, explain how your question relates to"
-            " the CORE BLOCK's behavior.\n"
-            "5) Return strict JSON only with keys:"
-            " question, focus, required_block_ids, rationale."
-        )
-
-        return "\n\n".join(parts)
-
-    def _format_prompt_block(
-        self, block: SampledCodeBlock, *, is_core: bool = False
-    ) -> str:
-        content = block.content
-        if len(content) > self.max_block_chars_in_prompt:
-            content = (
-                content[: self.max_block_chars_in_prompt]
-                + "\n# ... truncated for synthesis context ..."
-            )
-        core_tag = " **CORE**" if is_core else ""
-        return (
-            f"[{block.block_id}]{core_tag} type={block.node_type} "
-            f"lines={block.start_line}-{block.end_line} "
-            f"chars={block.char_count}\n"
-            f"{content}"
-        )
-
-    def _parse_behavioral_payload(
-        self,
-        payload: str,
-        behavioral_context: BehavioralContext,
+        query_index: int,
     ) -> Dict[str, Any]:
-        blob = self._extract_json_blob(payload)
-        try:
-            parsed = BehavioralSelectionResult.model_validate_json(blob)
-            question = parsed.question.strip()
-            focus = parsed.focus
-            selected_ids = parsed.required_block_ids
-        except ValidationError:
-            question = self._coerce_question_text(blob)
-            focus = None
-            selected_ids = []
-
-        question = self._sanitize_question(question)
-        if not question:
-            question = self._fallback_question(None)
-        if not question.endswith("?"):
-            question = question.rstrip(".") + "?"
-
-        pool = {
-            blk.block_id: blk
-            for blk in [behavioral_context.core_block]
-            + behavioral_context.neighborhood_blocks
-        }
-        selected_blocks = [
-            pool[block_id] for block_id in selected_ids if block_id in pool
-        ]
-        if behavioral_context.core_block.block_id not in {
-            blk.block_id for blk in selected_blocks
-        }:
-            selected_blocks.insert(0, behavioral_context.core_block)
+        instance_id = instance.get("instance_id", "unknown")
+        query_id = f"{instance_id}_{self.query_type.value}_q{query_index + 1}"
 
         return {
-            "question": question,
-            "focus": focus,
-            "hints": None,
-            "selected_blocks": selected_blocks,
-            "core_block_id": behavioral_context.core_block.block_id,
-            "selected_block_ids": [blk.block_id for blk in selected_blocks],
+            "query_id": query_id,
+            "instance_id": instance_id,
+            "repo": instance.get("repo"),
+            "base_commit": instance.get("base_commit"),
+            "query": result["question"],
+            "query_type": self.query_type.value,
+            "difficulty": self.query_type.value,
+            "ground_truth": gt.to_dict() if gt else None,
+            "target_files": gt.to_dict()["target_files"] if gt else [],
+            "target_symbols": gt.to_dict()["target_symbols"] if gt else [],
+            "target_symbol_nodes": [
+                self._dump_node_info(node) for node in target_symbol_nodes
+            ],
+            "focus": result.get("focus"),
+            "hints": result.get("hints"),
+            "repo_snapshot": snapshot.format_summary(),
+            "discovered_target_files": discovered.target_files,
+            "discovered_target_symbols": discovered.target_symbols,
+            "discovered_target_symbol_nodes": [
+                self._dump_node_info(node) for node in discovered.target_symbol_nodes
+            ],
+            "discovery_rationale": discovered.rationale,
+            "core_block_id": result.get("core_block_id"),
+            "selected_block_ids": result.get("selected_block_ids"),
+            "verification_passed": result.get("verification_passed"),
+            "verification_block_id": result.get("verification_block_id"),
         }
 
+    # ------------------------------------------------------------------
+    # Ground truth helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
     def _build_discovery_from_blocks(
-        self,
         blocks: List[SampledCodeBlock],
     ) -> TargetDiscoveryResult:
         files = list(dict.fromkeys(block.file_path for block in blocks))
@@ -1236,12 +376,14 @@ class ClaudeQuerySynthesizer:
         return TargetDiscoveryResult(
             target_files=files,
             target_symbols=symbols,
-            target_symbol_nodes=self._build_symbol_nodes_from_blocks(blocks),
+            target_symbol_nodes=[
+                block.to_node_info(include_content=True) for block in blocks
+            ],
             rationale="graph-sampled behavioral blocks",
         )
 
+    @staticmethod
     def _build_ground_truth_from_blocks(
-        self,
         blocks: List[SampledCodeBlock],
     ) -> Optional[GroundTruth]:
         if not blocks:
@@ -1250,11 +392,14 @@ class ClaudeQuerySynthesizer:
         primary_locations: List[CodeLocation] = []
         for block in blocks:
             loc = block.to_code_location()
-            loc.symbol = self._extract_symbol_name(block.node_name, block.file_path)
+            loc.symbol = ClaudeQuerySynthesizer._extract_symbol_name(
+                block.node_name, block.file_path
+            )
             primary_locations.append(loc)
         return GroundTruth(primary_locations=primary_locations)
 
-    def _extract_symbol_name(self, node_name: str, file_path: str) -> Optional[str]:
+    @staticmethod
+    def _extract_symbol_name(node_name: str, file_path: str) -> Optional[str]:
         if ":" in node_name:
             prefix, symbol = node_name.split(":", 1)
             if prefix.endswith(file_path) or prefix == file_path:
@@ -1262,14 +407,14 @@ class ClaudeQuerySynthesizer:
             return symbol.rstrip("()") or None
         return node_name.rstrip("()") or None
 
+    @staticmethod
     def _build_symbol_nodes_from_blocks(
-        self,
         blocks: List[SampledCodeBlock],
     ) -> List[NodeInfo]:
         return [block.to_node_info(include_content=True) for block in blocks]
 
+    @staticmethod
     def _build_symbol_nodes_from_ground_truth(
-        self,
         gt: Optional[GroundTruth],
     ) -> List[NodeInfo]:
         if gt is None:
@@ -1287,34 +432,23 @@ class ClaudeQuerySynthesizer:
             )
         return nodes
 
-    def _dump_node_info(self, node: NodeInfo) -> Dict[str, Any]:
+    @staticmethod
+    def _dump_node_info(node: NodeInfo) -> Dict[str, Any]:
         return node.model_dump(exclude_none=True)
 
+    @staticmethod
     def _build_ground_truth(
-        self,
         instance: Dict[str, Any],
         ground_truth: Optional[Dict[str, Any]] = None,
         discovered_targets: Optional[TargetDiscoveryResult] = None,
     ) -> Optional[GroundTruth]:
-        """
-        Build a GroundTruth object from instance data and/or pre-computed ground truth.
-
-        Args:
-            instance: SWE-bench instance dictionary
-            ground_truth: Optional pre-computed ground truth from gt_locate.py
-
-        Returns:
-            GroundTruth object or None if no ground truth available
-        """
         primary_locations: List[CodeLocation] = []
 
         if ground_truth:
-            # Use pre-computed ground truth from gt_locate.py
             target_files = ground_truth.get("target_files", [])
             symbols_modified = ground_truth.get("symbols_modified", [])
             symbols_added = ground_truth.get("symbols_added", [])
 
-            # Add modified symbols as primary locations
             for symbol_id in symbols_modified + symbols_added:
                 if ":" in symbol_id:
                     file_path, symbol = symbol_id.split(":", 1)
@@ -1328,7 +462,6 @@ class ClaudeQuerySynthesizer:
                         )
                     )
 
-            # If no symbols, add file-level locations
             if not primary_locations:
                 for file_path in target_files:
                     primary_locations.append(CodeLocation(file_path=file_path))
@@ -1357,7 +490,6 @@ class ClaudeQuerySynthesizer:
                         )
                     )
 
-        # Fallback: extract from patch if no ground truth provided
         if not primary_locations and instance.get("patch"):
             from codeminer.dataset.gt_locate import GTLocator
 
@@ -1370,489 +502,3 @@ class ClaudeQuerySynthesizer:
             return None
 
         return GroundTruth(primary_locations=primary_locations)
-
-    def _build_constraint_clause(
-        self,
-        problem_statement: str,
-        ground_truth: Optional[Dict[str, Any]] = None,
-    ) -> str:
-        """
-        Build constraint clause based on query type.
-
-        For harder levels (BEHAVIORAL, MODULE_HINT), we restrict what can be mentioned.
-        For easier levels (FILE_HINT, SYMBOL_HINT), we allow and even encourage specifics.
-        For REASONING level, we require mentioning some symbols but asking about relationships.
-        """
-        level = self.query_type
-
-        if level == QueryType.BEHAVIORAL:
-            avoid_terms = self._extract_avoid_terms(problem_statement)
-            if avoid_terms:
-                return (
-                    "STRICT: You MUST NOT mention any of these identifiers: "
-                    + ", ".join(sorted(avoid_terms))
-                    + ". Focus purely on observable behavior."
-                )
-            return (
-                "STRICT: Avoid ALL code identifiers, file paths, and technical names."
-            )
-
-        elif level == QueryType.MODULE_HINT:
-            return (
-                "You MAY mention module or package names (e.g., 'the caching module') "
-                "but AVOID specific file paths or function/class names."
-            )
-
-        elif level == QueryType.FILE_HINT:
-            if ground_truth:
-                files = ground_truth.get("target_files", [])
-                if files:
-                    return (
-                        f"You SHOULD mention relevant file paths from: {', '.join(files)}. "
-                        "But AVOID mentioning specific function or class names."
-                    )
-            return "You MAY mention specific file paths but AVOID function/class names."
-
-        elif level == QueryType.SYMBOL_HINT:
-            if ground_truth:
-                symbols = ground_truth.get("symbols_modified", []) + ground_truth.get(
-                    "symbols_added", []
-                )
-                if symbols:
-                    return (
-                        f"You SHOULD mention relevant symbols from: {', '.join(symbols[:5])}. "
-                        "Be specific about which function/class/method is involved."
-                    )
-            return "You MAY and SHOULD mention specific function/class/method names."
-
-        elif level == QueryType.REASONING:
-            if ground_truth:
-                symbols = ground_truth.get("symbols_modified", []) + ground_truth.get(
-                    "symbols_added", []
-                )
-                if symbols:
-                    return (
-                        f"Mention some symbols from: {', '.join(symbols[:3])}. "
-                        "But frame the question to require understanding of call chains, "
-                        "inheritance, or control flow. Ask 'what calls X', 'which classes "
-                        "inherit from Y', or 'how does A interact with B'."
-                    )
-            return (
-                "Frame the question to require reasoning about code relationships "
-                "(call chains, inheritance, data flow)."
-            )
-
-        return "Focus on the behavior being described."
-
-    def _generate_question(
-        self,
-        instance: Dict[str, Any],
-        snapshot: RepoSnapshot,
-        ground_truth: Optional[Dict[str, Any]] = None,
-        discovered_targets: Optional[TargetDiscoveryResult] = None,
-    ) -> Dict[str, Any]:
-        """
-        Generate a question at the configured query type.
-
-        Returns a dict with 'question', 'focus', and optionally 'hints'.
-        """
-        problem_statement = (instance.get("problem_statement") or "").strip()
-        synthesis_run_id = instance.get("synthesis_run_id")
-
-        constraint_clause = self._build_constraint_clause(
-            problem_statement, ground_truth
-        )
-
-        # Build context based on query type
-        context_parts = ["Repo summary:\n" + snapshot.format_summary()]
-
-        if synthesis_run_id is not None:
-            context_parts.append(
-                "Diversity run id: "
-                f"{synthesis_run_id}. Produce a distinct query focus from other runs."
-            )
-
-        # Add ground truth info for levels that need it
-        if ground_truth and self.query_type in (
-            QueryType.FILE_HINT,
-            QueryType.SYMBOL_HINT,
-            QueryType.REASONING,
-        ):
-            gt_info = []
-            if ground_truth.get("target_files"):
-                gt_info.append(
-                    f"Target files: {', '.join(ground_truth['target_files'])}"
-                )
-            if ground_truth.get("symbols_modified"):
-                gt_info.append(
-                    f"Modified symbols: {', '.join(ground_truth['symbols_modified'][:5])}"
-                )
-            if gt_info:
-                context_parts.append(
-                    "Ground truth info (use as appropriate):\n" + "\n".join(gt_info)
-                )
-        elif discovered_targets and self.query_type in (
-            QueryType.FILE_HINT,
-            QueryType.SYMBOL_HINT,
-            QueryType.REASONING,
-        ):
-            discovered_info = []
-            if discovered_targets.target_files:
-                discovered_info.append(
-                    "Discovered files: "
-                    + ", ".join(discovered_targets.target_files[:8])
-                )
-            if discovered_targets.target_symbols:
-                discovered_info.append(
-                    "Discovered symbols: "
-                    + ", ".join(discovered_targets.target_symbols[:8])
-                )
-            if discovered_info:
-                context_parts.append(
-                    "Repository exploration targets:\n" + "\n".join(discovered_info)
-                )
-
-        context_parts.append(f"Constraints:\n{constraint_clause}")
-        context_parts.append(
-            "Output JSON with keys: question (string), focus (string or null), "
-            "hints (array of strings or null). Return only JSON."
-        )
-
-        user_content = "\n\n".join(context_parts)
-
-        payload = self._run_agent(user_content, cwd=str(snapshot.root))
-        payload = self._extract_json_blob(payload)
-
-        try:
-            result = QuerySynthesisResult.model_validate_json(payload)
-            question = result.question.strip()
-            focus = result.focus
-            hints = result.hints
-        except ValidationError:
-            question = self._coerce_question_text(payload)
-            focus = None
-            hints = None
-
-        # Only sanitize for BEHAVIORAL level
-        if self.query_type == QueryType.BEHAVIORAL:
-            question = self._sanitize_question(question)
-
-        if not question:
-            question = self._fallback_question(discovered_targets)
-        if not question.endswith("?"):
-            question = question.rstrip(".") + "?"
-
-        return {"question": question, "focus": focus, "hints": hints}
-
-    async def _generate_question_async(
-        self,
-        instance: Dict[str, Any],
-        snapshot: RepoSnapshot,
-        ground_truth: Optional[Dict[str, Any]] = None,
-        discovered_targets: Optional[TargetDiscoveryResult] = None,
-    ) -> Dict[str, Any]:
-        """
-        Generate a question at the configured query type (async version).
-
-        Returns a dict with 'question', 'focus', and optionally 'hints'.
-        """
-        problem_statement = (instance.get("problem_statement") or "").strip()
-        synthesis_run_id = instance.get("synthesis_run_id")
-
-        constraint_clause = self._build_constraint_clause(
-            problem_statement, ground_truth
-        )
-
-        # Build context based on query type
-        context_parts = ["Repo summary:\n" + snapshot.format_summary()]
-
-        if synthesis_run_id is not None:
-            context_parts.append(
-                "Diversity run id: "
-                f"{synthesis_run_id}. Produce a distinct query focus from other runs."
-            )
-
-        # Add ground truth info for levels that need it
-        if ground_truth and self.query_type in (
-            QueryType.FILE_HINT,
-            QueryType.SYMBOL_HINT,
-            QueryType.REASONING,
-        ):
-            gt_info = []
-            if ground_truth.get("target_files"):
-                gt_info.append(
-                    f"Target files: {', '.join(ground_truth['target_files'])}"
-                )
-            if ground_truth.get("symbols_modified"):
-                gt_info.append(
-                    f"Modified symbols: {', '.join(ground_truth['symbols_modified'][:5])}"
-                )
-            if gt_info:
-                context_parts.append(
-                    "Ground truth info (use as appropriate):\n" + "\n".join(gt_info)
-                )
-        elif discovered_targets and self.query_type in (
-            QueryType.FILE_HINT,
-            QueryType.SYMBOL_HINT,
-            QueryType.REASONING,
-        ):
-            discovered_info = []
-            if discovered_targets.target_files:
-                discovered_info.append(
-                    "Discovered files: "
-                    + ", ".join(discovered_targets.target_files[:8])
-                )
-            if discovered_targets.target_symbols:
-                discovered_info.append(
-                    "Discovered symbols: "
-                    + ", ".join(discovered_targets.target_symbols[:8])
-                )
-            if discovered_info:
-                context_parts.append(
-                    "Repository exploration targets:\n" + "\n".join(discovered_info)
-                )
-
-        context_parts.append(f"Constraints:\n{constraint_clause}")
-        context_parts.append(
-            "Output JSON with keys: question (string), focus (string or null), "
-            "hints (array of strings or null). Return only JSON."
-        )
-
-        user_content = "\n\n".join(context_parts)
-
-        payload = await self._run_agent_async(user_content, cwd=str(snapshot.root))
-        payload = self._extract_json_blob(payload)
-
-        try:
-            result = QuerySynthesisResult.model_validate_json(payload)
-            question = result.question.strip()
-            focus = result.focus
-            hints = result.hints
-        except ValidationError:
-            question = self._coerce_question_text(payload)
-            focus = None
-            hints = None
-
-        # Only sanitize for BEHAVIORAL level
-        if self.query_type == QueryType.BEHAVIORAL:
-            question = self._sanitize_question(question)
-
-        if not question:
-            question = self._fallback_question(discovered_targets)
-        if not question.endswith("?"):
-            question = question.rstrip(".") + "?"
-
-        return {"question": question, "focus": focus, "hints": hints}
-
-    def _discover_targets(
-        self,
-        instance: Dict[str, Any],
-        snapshot: RepoSnapshot,
-    ) -> TargetDiscoveryResult:
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(self._discover_targets_async(instance, snapshot))
-        raise RuntimeError(
-            "Running inside an active event loop. Use synthesize_query_async instead."
-        )
-
-    async def _discover_targets_async(
-        self,
-        instance: Dict[str, Any],
-        snapshot: RepoSnapshot,
-    ) -> TargetDiscoveryResult:
-        context_parts = ["Repo summary:\n" + snapshot.format_summary()]
-        context_parts.append(
-            "Explore the repository and identify likely implementation targets.\n"
-            "Return strict JSON with keys: target_files (array of relative file paths), "
-            "target_symbols (array of symbol identifiers in repository-native format), "
-            "rationale (string or null). Keep arrays concise (<= 8)."
-        )
-
-        raw_payload = await self._run_agent_async(
-            "\n\n".join(context_parts),
-            cwd=str(snapshot.root),
-        )
-        payload = self._extract_json_blob(raw_payload)
-        try:
-            return TargetDiscoveryResult.model_validate_json(payload)
-        except ValidationError:
-            heuristic = self._parse_discovery_from_text(raw_payload)
-            if heuristic.target_files or heuristic.target_symbols:
-                return heuristic
-            logger.warning("Target discovery returned non-JSON payload; continuing.")
-            return TargetDiscoveryResult()
-
-    def _run_agent(self, prompt: str, *, cwd: Optional[str] = None) -> str:
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            return asyncio.run(self._run_agent_async(prompt, cwd=cwd))
-        raise RuntimeError(
-            "Running inside an active event loop. Use synthesize_query_async instead."
-        )
-
-    async def _run_agent_async(self, prompt: str, *, cwd: Optional[str] = None) -> str:
-        options = ClaudeAgentOptions(
-            max_turns=self.max_turns,
-            system_prompt=self.system_prompt,
-            allowed_tools=self.allowed_tools,
-            permission_mode=self.permission_mode,
-            model=self.model,
-            cwd=cwd,
-        )
-        text_chunks: List[str] = []
-        query_gen = query(prompt=prompt, options=options)
-
-        try:
-            async for message in query_gen:
-                msg_type = message.__class__.__name__
-                logger.debug(f"Agent message type: {msg_type}")
-
-                if msg_type == "ResultMessage":
-                    # Get result directly from ResultMessage
-                    result = getattr(message, "result", None)
-                    if result and isinstance(result, str):
-                        return result.strip()
-                    # If no result in ResultMessage, return accumulated text
-                    return "\n".join(text_chunks).strip()
-
-                if msg_type == "ErrorMessage":
-                    error_msg = getattr(message, "error", "Unknown error")
-                    logger.error(f"Agent error message: {error_msg}")
-                    raise RuntimeError(f"Agent returned error: {error_msg}")
-
-                if msg_type == "AssistantMessage":
-                    content = getattr(message, "content", None)
-                    if not content:
-                        continue
-                    block_texts: List[str] = []
-                    for block in content:
-                        text = getattr(block, "text", None)
-                        if isinstance(text, str) and text.strip():
-                            block_texts.append(text.strip())
-                    if block_texts:
-                        text_chunks.append("\n".join(block_texts))
-        finally:
-            # Ensure generator is properly closed
-            await query_gen.aclose()
-
-        return "\n".join(text_chunks).strip()
-
-    def _extract_json_blob(self, text: str) -> str:
-        text = text.strip()
-        if not text:
-            return text
-
-        fenced = re.search(r"```(?:json)?\s*(\{[\s\S]*\})\s*```", text)
-        if fenced:
-            text = fenced.group(1).strip()
-
-        decoder = json.JSONDecoder()
-        for idx, ch in enumerate(text):
-            if ch != "{":
-                continue
-            try:
-                _obj, end = decoder.raw_decode(text[idx:])
-                return text[idx : idx + end]
-            except json.JSONDecodeError:
-                continue
-        return text
-
-    def _extract_avoid_terms(self, text: str) -> List[str]:
-        if not text:
-            return []
-        file_like = re.findall(
-            r"\b[\w/\.-]+\.(?:py|js|ts|rs|go|java|cpp|c|h|hpp)\b", text
-        )
-        func_like = re.findall(r"\b[A-Za-z_]\w*\(\)", text)
-        names = set(file_like + func_like)
-        return [name for name in names if len(name) > 2]
-
-    def _sanitize_question(self, text: str) -> str:
-        text = re.sub(r"`[^`]+`", "", text)
-        text = re.sub(
-            r"\b[\w/\.-]+\.(?:py|js|ts|rs|go|java|cpp|c|h|hpp)\b",
-            "a module",
-            text,
-        )
-        text = re.sub(r"\b[A-Za-z_]\w*\(\)", "a function", text)
-        text = re.sub(r"\s{2,}", " ", text).strip()
-        return text
-
-    def _coerce_question_text(self, text: str) -> str:
-        if not text:
-            return ""
-        stripped = text.strip()
-        if not stripped:
-            return ""
-        for line in stripped.splitlines():
-            candidate = line.strip().strip("-* ").strip()
-            if not candidate:
-                continue
-            candidate = re.sub(r"^(question|query)\s*:\s*", "", candidate, flags=re.I)
-            if len(candidate) >= 12:
-                if "?" in candidate:
-                    return candidate.split("?", 1)[0].strip() + "?"
-                return candidate
-        return ""
-
-    def _fallback_question(
-        self, discovered_targets: Optional[TargetDiscoveryResult]
-    ) -> str:
-        first_file = (
-            discovered_targets.target_files[0]
-            if discovered_targets and discovered_targets.target_files
-            else None
-        )
-        first_symbol = (
-            discovered_targets.target_symbols[0]
-            if discovered_targets and discovered_targets.target_symbols
-            else None
-        )
-        if self.query_type == QueryType.BEHAVIORAL:
-            return (
-                "Which code path controls this behavior, and why can an automatic "
-                "rewrite change runtime semantics?"
-            )
-        if self.query_type == QueryType.MODULE_HINT:
-            module_hint = (
-                first_file.split("/", 1)[0]
-                if first_file and "/" in first_file
-                else "the relevant module"
-            )
-            return f"In {module_hint}, where is the logic that governs this behavior?"
-        if self.query_type == QueryType.FILE_HINT and first_file:
-            return f"What logic in {first_file} is responsible for this behavior?"
-        if self.query_type == QueryType.SYMBOL_HINT and first_symbol:
-            return f"How does {first_symbol} implement this behavior?"
-        if self.query_type == QueryType.REASONING:
-            if first_symbol:
-                return (
-                    "What callers or control-flow paths around "
-                    f"{first_symbol} determine this behavior?"
-                )
-            if first_file:
-                return f"What interactions in {first_file} determine this behavior?"
-        return "Where in the codebase is the logic responsible for this behavior?"
-
-    def _parse_discovery_from_text(self, text: str) -> TargetDiscoveryResult:
-        if not text:
-            return TargetDiscoveryResult()
-        file_pattern = r"\b[\w./-]+\.(?:py|rs|js|ts|go|java|cpp|c|h|hpp)\b"
-        files = list(dict.fromkeys(re.findall(file_pattern, text)))
-        symbol_patterns = [
-            r"\b[\w./-]+\.(?:py|rs|js|ts|go|java|cpp|c|h|hpp):[A-Za-z_][\w.:]*(?:\(\))?\b",
-            r"\b[\w/]+#[A-Za-z_]\w*(?:\(\))?\b",
-            r"\b[\w/]+/[A-Za-z_]\w*(?:\(\))?\b",
-        ]
-        symbols: List[str] = []
-        for pattern in symbol_patterns:
-            symbols.extend(re.findall(pattern, text))
-        symbols = list(dict.fromkeys(symbols))
-        return TargetDiscoveryResult(
-            target_files=files[:8],
-            target_symbols=symbols[:8],
-            rationale="parsed from non-JSON discovery output",
-        )

--- a/codeminer/dataset/synthesize/verifier.py
+++ b/codeminer/dataset/synthesize/verifier.py
@@ -1,0 +1,294 @@
+"""Query verification for the synthesis pipeline."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Tuple
+
+from codeminer.log_utils import get_logger
+
+from ._agent import AgentRunner
+from ._types import BehavioralContext, format_prompt_block
+
+logger = get_logger(__name__)
+
+
+class Verifier:
+    """Verify synthesized queries for quality and target alignment.
+
+    Two checks:
+      1. **Format compliance** — regex/length checks ensuring the query
+         matches its mode (e.g., behavioral queries contain no code
+         identifiers, questions are not too short, no chain-of-thought
+         leaks).
+      2. **Target alignment** — a blind LLM test: given the question and
+         all blocks (unlabeled), does the LLM identify the core block?
+    """
+
+    # Patterns that indicate chain-of-thought leaks or meta-language.
+    _BAD_QUERY_PATTERNS = re.compile(
+        r"(?i)"
+        r"(?:^let me |^I (?:will|need to|want to|should|can) |"
+        r"examine (?:the |this )?(?:core )?block|"
+        r"look (?:at|into) (?:the |this )?(?:core )?block|"
+        r"understand (?:the |its |this )?(?:full )?content|"
+        r"(?:core|context|sampled|candidate) block|"
+        r"blk_\d+|"
+        r"^(?:now|first|next),? (?:let|I)|"
+        r"read (?:the |this )?(?:source |code )?(?:more )?closely)"
+    )
+    _MIN_QUERY_LENGTH = 60
+
+    def __init__(
+        self,
+        *,
+        agent: AgentRunner,
+        verification_mode: str = "lenient",
+        max_block_chars_in_prompt: int = 1800,
+    ) -> None:
+        if verification_mode not in ("strict", "lenient", "none"):
+            raise ValueError(
+                f"verification_mode must be strict, lenient, or none; got {verification_mode!r}"
+            )
+        self.agent = agent
+        self.verification_mode = verification_mode
+        self.max_block_chars_in_prompt = max_block_chars_in_prompt
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def verify(
+        self,
+        result: Dict[str, Any],
+        runs: List[Dict[str, Any]],
+        behavioral_context: BehavioralContext,
+        *,
+        cwd: str,
+    ) -> Dict[str, Any]:
+        """Run quality check + post-consensus verification (sync).
+
+        Mutates and returns *result* with ``verification_passed`` and
+        ``verification_block_id`` keys added.
+        """
+        ok, reason = self.validate_query_quality(result["question"])
+        if not ok:
+            logger.warning(
+                "Query quality check failed (%s): %r", reason, result["question"]
+            )
+            if not self._pick_best_valid_question(result, runs):
+                result["verification_passed"] = False
+                result["verification_block_id"] = None
+                return result
+
+        if self.verification_mode == "none":
+            result["verification_passed"] = None
+            result["verification_block_id"] = None
+            return result
+
+        vr = self._verify_alignment(result["question"], behavioral_context, cwd=cwd)
+        if vr["passed"]:
+            result["verification_passed"] = True
+            result["verification_block_id"] = vr["block_id"]
+            return result
+
+        if self.verification_mode == "strict":
+            ranked_runs = sorted(
+                runs,
+                key=lambda r: r.get("question", "") != result["question"],
+            )
+            for alt_run in ranked_runs:
+                alt_q = alt_run.get("question", "")
+                if not alt_q or alt_q == result["question"]:
+                    continue
+                alt_ok, _ = self.validate_query_quality(alt_q)
+                if not alt_ok:
+                    continue
+                alt_vr = self._verify_alignment(alt_q, behavioral_context, cwd=cwd)
+                if alt_vr["passed"]:
+                    result["question"] = alt_q
+                    result["focus"] = alt_run.get("focus")
+                    result["verification_passed"] = True
+                    result["verification_block_id"] = alt_vr["block_id"]
+                    return result
+
+        result["verification_passed"] = False
+        result["verification_block_id"] = vr["block_id"]
+        return result
+
+    async def verify_async(
+        self,
+        result: Dict[str, Any],
+        runs: List[Dict[str, Any]],
+        behavioral_context: BehavioralContext,
+        *,
+        cwd: str,
+    ) -> Dict[str, Any]:
+        """Run quality check + post-consensus verification (async)."""
+        ok, reason = self.validate_query_quality(result["question"])
+        if not ok:
+            logger.warning(
+                "Query quality check failed (%s): %r", reason, result["question"]
+            )
+            if not self._pick_best_valid_question(result, runs):
+                result["verification_passed"] = False
+                result["verification_block_id"] = None
+                return result
+
+        if self.verification_mode == "none":
+            result["verification_passed"] = None
+            result["verification_block_id"] = None
+            return result
+
+        vr = await self._verify_alignment_async(
+            result["question"], behavioral_context, cwd=cwd
+        )
+        if vr["passed"]:
+            result["verification_passed"] = True
+            result["verification_block_id"] = vr["block_id"]
+            return result
+
+        if self.verification_mode == "strict":
+            ranked_runs = sorted(
+                runs,
+                key=lambda r: r.get("question", "") != result["question"],
+            )
+            for alt_run in ranked_runs:
+                alt_q = alt_run.get("question", "")
+                if not alt_q or alt_q == result["question"]:
+                    continue
+                alt_ok, _ = self.validate_query_quality(alt_q)
+                if not alt_ok:
+                    continue
+                alt_vr = await self._verify_alignment_async(
+                    alt_q, behavioral_context, cwd=cwd
+                )
+                if alt_vr["passed"]:
+                    result["question"] = alt_q
+                    result["focus"] = alt_run.get("focus")
+                    result["verification_passed"] = True
+                    result["verification_block_id"] = alt_vr["block_id"]
+                    return result
+
+        result["verification_passed"] = False
+        result["verification_block_id"] = vr["block_id"]
+        return result
+
+    # ------------------------------------------------------------------
+    # Quality validation (static — usable without an agent)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def validate_query_quality(cls, question: str) -> Tuple[bool, str]:
+        """Check whether *question* is a valid behavioral query.
+
+        Returns ``(is_valid, reason)``.
+        """
+        if not question or not question.strip():
+            return False, "empty question"
+        q = question.strip()
+        if len(q) < cls._MIN_QUERY_LENGTH:
+            return False, f"too short ({len(q)} chars, need >= {cls._MIN_QUERY_LENGTH})"
+        m = cls._BAD_QUERY_PATTERNS.search(q)
+        if m:
+            return False, f"meta-language detected: {m.group()!r}"
+        return True, ""
+
+    # ------------------------------------------------------------------
+    # Private
+    # ------------------------------------------------------------------
+
+    def _pick_best_valid_question(
+        self,
+        result: Dict[str, Any],
+        runs: List[Dict[str, Any]],
+    ) -> bool:
+        """Try to replace *result*'s question with a valid one from *runs*."""
+        for run in runs:
+            alt_q = run.get("question", "")
+            if not alt_q or alt_q == result["question"]:
+                continue
+            ok, _ = self.validate_query_quality(alt_q)
+            if ok:
+                result["question"] = alt_q
+                result["focus"] = run.get("focus")
+                return True
+        return False
+
+    def _build_verification_prompt(
+        self,
+        question: str,
+        behavioral_context: BehavioralContext,
+    ) -> str:
+        """Build a blind verification prompt (no core label)."""
+        all_blocks = [behavioral_context.core_block] + list(
+            behavioral_context.neighborhood_blocks
+        )
+        block_text = "\n\n".join(
+            format_prompt_block(
+                block, is_core=False, max_block_chars=self.max_block_chars_in_prompt
+            )
+            for block in all_blocks
+        )
+        return (
+            "Given the following code-search question, identify which code block "
+            "the question is primarily about.\n\n"
+            f"Question: {question!r}\n\n"
+            f"Code blocks:\n{block_text}\n\n"
+            "Which block does this question primarily describe? "
+            "Return strict JSON with keys: block_id (string), confidence (high|medium|low)."
+        )
+
+    def _verify_alignment(
+        self,
+        question: str,
+        behavioral_context: BehavioralContext,
+        *,
+        cwd: str,
+    ) -> Dict[str, Any]:
+        prompt = self._build_verification_prompt(question, behavioral_context)
+        payload = self.agent.run(prompt, cwd=cwd)
+        return self._parse_verification_result(payload, behavioral_context)
+
+    async def _verify_alignment_async(
+        self,
+        question: str,
+        behavioral_context: BehavioralContext,
+        *,
+        cwd: str,
+    ) -> Dict[str, Any]:
+        prompt = self._build_verification_prompt(question, behavioral_context)
+        payload = await self.agent.run_async(prompt, cwd=cwd)
+        return self._parse_verification_result(payload, behavioral_context)
+
+    def _parse_verification_result(
+        self,
+        payload: str,
+        behavioral_context: BehavioralContext,
+    ) -> Dict[str, Any]:
+        blob = self.agent.extract_json(payload)
+        core_id = behavioral_context.core_block.block_id
+        try:
+            data = json.loads(blob)
+            block_id = data.get("block_id", "")
+            confidence = data.get("confidence", "low")
+        except (json.JSONDecodeError, AttributeError):
+            logger.warning("Verification returned non-JSON; assuming failed.")
+            return {"block_id": "", "confidence": "low", "passed": False}
+
+        passed = block_id == core_id
+        if not passed:
+            logger.warning(
+                "Verification mismatch: question maps to %s, expected %s (confidence=%s)",
+                block_id,
+                core_id,
+                confidence,
+            )
+        else:
+            logger.info(
+                "Verification passed: question maps to core block %s (confidence=%s)",
+                core_id,
+                confidence,
+            )
+        return {"block_id": block_id, "confidence": confidence, "passed": passed}

--- a/codeminer/graph/__init__.py
+++ b/codeminer/graph/__init__.py
@@ -1,11 +1,15 @@
 """Graph-related modules for CodeMiner."""
 
 from .code_graph import CodeGraph
+from .incremental import GraphPatcher, LSPClient, PatcherBase
 from .roi_subgraph import ROISubgraph
 from .traverse_graph import traverse_tree_structure
 
 __all__ = [
     "CodeGraph",
-    "traverse_tree_structure",
+    "GraphPatcher",
+    "LSPClient",
+    "PatcherBase",
     "ROISubgraph",
+    "traverse_tree_structure",
 ]

--- a/codeminer/graph/incremental/__init__.py
+++ b/codeminer/graph/incremental/__init__.py
@@ -1,4 +1,5 @@
 """LSP-based incremental patching for CodeGraph updates."""
+
 from .graph_patcher import GraphPatcher
 from .lsp_client import LSPClient
 from .patcher_base import PatcherBase

--- a/codeminer/graph/incremental/change_mgr.py
+++ b/codeminer/graph/incremental/change_mgr.py
@@ -1,4 +1,5 @@
 """Change manager: git-based change detection for incremental updates."""
+
 from __future__ import annotations
 
 import re
@@ -6,7 +7,7 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
-from ..log_utils import get_logger
+from ...log_utils import get_logger
 
 logger = get_logger(__name__)
 
@@ -43,8 +44,11 @@ def detect_changed_files(
     try:
         output = subprocess.check_output(
             [
-                "git", "diff", "--name-status",
-                _shorten_ref(base_commit), _shorten_ref(target_commit),
+                "git",
+                "diff",
+                "--name-status",
+                _shorten_ref(base_commit),
+                _shorten_ref(target_commit),
             ],
             cwd=project_root,
             text=True,
@@ -103,9 +107,13 @@ def get_changed_line_ranges(
     try:
         output = subprocess.check_output(
             [
-                "git", "diff", "-U0",
-                _shorten_ref(base_commit), _shorten_ref(target_commit),
-                "--", file_path,
+                "git",
+                "diff",
+                "-U0",
+                _shorten_ref(base_commit),
+                _shorten_ref(target_commit),
+                "--",
+                file_path,
             ],
             cwd=project_root,
             text=True,
@@ -116,9 +124,7 @@ def get_changed_line_ranges(
         return []
 
     ranges = []
-    for match in re.finditer(
-        r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", output
-    ):
+    for match in re.finditer(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", output):
         start = int(match.group(1)) - 1  # Convert to 0-indexed
         count = int(match.group(2)) if match.group(2) else 1
         if count == 0:

--- a/codeminer/graph/incremental/graph_patcher.py
+++ b/codeminer/graph/incremental/graph_patcher.py
@@ -3,12 +3,13 @@
 Dispatches to language-specific patchers (patcher_*.py).
 Maintains backward-compatible API.
 """
+
 from __future__ import annotations
 
 from typing import Optional
 
-from ..graph.code_graph import CodeGraph
-from ..log_utils import get_logger
+from ...log_utils import get_logger
+from ..code_graph import CodeGraph
 from . import change_mgr
 from .patcher_base import PatcherBase
 
@@ -77,9 +78,7 @@ class GraphPatcher:
     ):
         self.project_root = project_root
         self.language = language
-        self._impl: PatcherBase = _create_patcher(
-            language, project_root, code_graph
-        )
+        self._impl: PatcherBase = _create_patcher(language, project_root, code_graph)
 
     @property
     def code_graph(self) -> CodeGraph:

--- a/codeminer/graph/incremental/lsp_client.py
+++ b/codeminer/graph/incremental/lsp_client.py
@@ -6,6 +6,7 @@ Supports the subset of LSP needed for incremental graph updates:
   - textDocument/definition
   - textDocument/semanticTokens/full
 """
+
 from __future__ import annotations
 
 import json
@@ -18,17 +19,31 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
-from ..log_utils import get_logger
+from ...log_utils import get_logger
 
 logger = get_logger(__name__)
 
 # LSP SymbolKind integer → human-readable name
 SYMBOL_KIND_NAMES = {
-    1: "File", 2: "Module", 3: "Namespace", 4: "Package",
-    5: "Class", 6: "Method", 7: "Property", 8: "Field",
-    9: "Constructor", 10: "Enum", 11: "Interface", 12: "Function",
-    13: "Variable", 14: "Constant", 22: "Enum", 23: "Struct",
-    24: "Event", 25: "Operator", 26: "TypeParameter",
+    1: "File",
+    2: "Module",
+    3: "Namespace",
+    4: "Package",
+    5: "Class",
+    6: "Method",
+    7: "Property",
+    8: "Field",
+    9: "Constructor",
+    10: "Enum",
+    11: "Interface",
+    12: "Function",
+    13: "Variable",
+    14: "Constant",
+    22: "Enum",
+    23: "Struct",
+    24: "Event",
+    25: "Operator",
+    26: "TypeParameter",
 }
 
 # Default LSP server commands per language
@@ -50,11 +65,11 @@ LSP_COMMANDS_ALT = {
 
 # Common locations to search for LSP binaries not on PATH
 _EXTRA_BIN_DIRS = [
-    lambda: Path(sys.executable).parent,       # conda/venv bin
-    lambda: Path.home() / "go" / "bin",        # Go binaries
-    lambda: Path.home() / ".cargo" / "bin",    # Rust binaries
+    lambda: Path(sys.executable).parent,  # conda/venv bin
+    lambda: Path.home() / "go" / "bin",  # Go binaries
+    lambda: Path.home() / ".cargo" / "bin",  # Rust binaries
     lambda: Path.home() / ".npm-global" / "bin",  # npm global
-    lambda: Path.home() / ".local" / "bin",    # pip --user
+    lambda: Path.home() / ".local" / "bin",  # pip --user
 ]
 
 
@@ -76,6 +91,7 @@ def resolve_lsp_binary(binary: str) -> Optional[str]:
             logger.debug(f"Failed to check {binary} at {candidate}: {exc}")
             continue
     return None
+
 
 # File extension → LSP languageId
 _EXT_TO_LANG_ID = {
@@ -138,7 +154,6 @@ class LSPClient:
         # Track the last error from _request so callers can decide whether
         # to retry (transient errors like -32801) or not (permanent errors).
         self._last_error: Optional[dict] = None
-
 
     # ── Lifecycle ─────────────────────────────────────────────
 
@@ -210,15 +225,12 @@ class LSPClient:
 
         # Extract semantic tokens legend from server capabilities
         if result:
-            sem_provider = (
-                result.get("capabilities", {})
-                .get("semanticTokensProvider", {})
+            sem_provider = result.get("capabilities", {}).get(
+                "semanticTokensProvider", {}
             )
             if isinstance(sem_provider, dict):
                 self.semantic_tokens_legend = sem_provider.get("legend")
-                self.supports_semantic_tokens_range = bool(
-                    sem_provider.get("range")
-                )
+                self.supports_semantic_tokens_range = bool(sem_provider.get("range"))
 
         # Wait for server readiness (unless skipped for warm-up)
         if not skip_probe:
@@ -264,14 +276,17 @@ class LSPClient:
             logger.warning(f"Cannot open {abs_path}: file not found")
             return
 
-        self._notify("textDocument/didOpen", {
-            "textDocument": {
-                "uri": uri,
-                "languageId": self._detect_language_id(abs_path),
-                "version": 1,
-                "text": text,
+        self._notify(
+            "textDocument/didOpen",
+            {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": self._detect_language_id(abs_path),
+                    "version": 1,
+                    "text": text,
+                },
             },
-        })
+        )
         self._opened_files.add(uri)
 
     def close_document(self, file_path: str):
@@ -280,9 +295,12 @@ class LSPClient:
         uri = Path(abs_path).as_uri()
         if uri not in self._opened_files:
             return
-        self._notify("textDocument/didClose", {
-            "textDocument": {"uri": uri},
-        })
+        self._notify(
+            "textDocument/didClose",
+            {
+                "textDocument": {"uri": uri},
+            },
+        )
         self._opened_files.discard(uri)
 
     def wait_for_analysis(
@@ -304,10 +322,14 @@ class LSPClient:
         while time.time() - start < max_wait:
             t0 = time.time()
             try:
-                self._request("textDocument/hover", {
-                    "textDocument": {"uri": uri},
-                    "position": {"line": 0, "character": 0},
-                }, timeout=5)
+                self._request(
+                    "textDocument/hover",
+                    {
+                        "textDocument": {"uri": uri},
+                        "position": {"line": 0, "character": 0},
+                    },
+                    timeout=5,
+                )
             except Exception as exc:
                 logger.debug(f"Analysis probe failed: {exc}")
             elapsed = time.time() - t0
@@ -330,12 +352,13 @@ class LSPClient:
         abs_path = self._abs_path(file_path)
         uri = Path(abs_path).as_uri()
 
-
-
         for attempt in range(retries + 1):
-            result = self._request("textDocument/documentSymbol", {
-                "textDocument": {"uri": uri},
-            })
+            result = self._request(
+                "textDocument/documentSymbol",
+                {
+                    "textDocument": {"uri": uri},
+                },
+            )
             if result is not None:
                 return result
             if attempt < retries:
@@ -392,15 +415,18 @@ class LSPClient:
                 )
                 return []
             if attempt < retries:
-                reason = self._last_error.get("message", "unknown") if self._last_error else "null result"
+                reason = (
+                    self._last_error.get("message", "unknown")
+                    if self._last_error
+                    else "null result"
+                )
                 logger.debug(
                     f"references failed for {file_path}:{line} ({reason}), "
                     f"retrying ({attempt + 1}/{retries})"
                 )
                 time.sleep(3)
         logger.warning(
-            f"references failed for {file_path}:{line} "
-            f"after {retries} retries"
+            f"references failed for {file_path}:{line} " f"after {retries} retries"
         )
         return []
 
@@ -453,7 +479,11 @@ class LSPClient:
                 )
                 return []
             if attempt < retries:
-                reason = self._last_error.get("message", "unknown") if self._last_error else "null result"
+                reason = (
+                    self._last_error.get("message", "unknown")
+                    if self._last_error
+                    else "null result"
+                )
                 logger.debug(
                     f"definition failed for {file_path}:{line}:{character} ({reason}), "
                     f"retrying ({attempt + 1}/{retries})"
@@ -465,7 +495,9 @@ class LSPClient:
         )
         return []
 
-    def semantic_tokens_full(self, file_path: str, timeout: float = 60) -> Optional[dict]:
+    def semantic_tokens_full(
+        self, file_path: str, timeout: float = 60
+    ) -> Optional[dict]:
         """Get semantic tokens for the entire file.
 
         Returns raw response with ``data`` field (delta-encoded integers).
@@ -475,9 +507,13 @@ class LSPClient:
         self.open_document(file_path)
         abs_path = self._abs_path(file_path)
         uri = Path(abs_path).as_uri()
-        result = self._request("textDocument/semanticTokens/full", {
-            "textDocument": {"uri": uri},
-        }, timeout=timeout)
+        result = self._request(
+            "textDocument/semanticTokens/full",
+            {
+                "textDocument": {"uri": uri},
+            },
+            timeout=timeout,
+        )
         if result is not None:
             n_tokens = len(result.get("data", [])) // 5
             logger.debug(f"semanticTokens for {file_path}: {n_tokens} tokens")
@@ -498,13 +534,17 @@ class LSPClient:
         self.open_document(file_path)
         abs_path = self._abs_path(file_path)
         uri = Path(abs_path).as_uri()
-        result = self._request("textDocument/semanticTokens/range", {
-            "textDocument": {"uri": uri},
-            "range": {
-                "start": {"line": start_line, "character": 0},
-                "end": {"line": end_line + 1, "character": 0},
+        result = self._request(
+            "textDocument/semanticTokens/range",
+            {
+                "textDocument": {"uri": uri},
+                "range": {
+                    "start": {"line": start_line, "character": 0},
+                    "end": {"line": end_line + 1, "character": 0},
+                },
             },
-        }, timeout=timeout)
+            timeout=timeout,
+        )
         if result is not None:
             n_tokens = len(result.get("data", [])) // 5
             logger.debug(
@@ -557,7 +597,11 @@ class LSPClient:
                 current_char += delta_char
 
             # Decode type
-            type_name = token_types[type_idx] if type_idx < len(token_types) else f"type_{type_idx}"
+            type_name = (
+                token_types[type_idx]
+                if type_idx < len(token_types)
+                else f"type_{type_idx}"
+            )
 
             # Decode modifiers (bitmask)
             mods = []
@@ -569,16 +613,18 @@ class LSPClient:
             text = ""
             if current_line < len(lines):
                 line_text = lines[current_line]
-                text = line_text[current_char:current_char + length]
+                text = line_text[current_char : current_char + length]
 
-            tokens.append({
-                "line": current_line,
-                "character": current_char,
-                "length": length,
-                "token_type": type_name,
-                "modifiers": mods,
-                "text": text,
-            })
+            tokens.append(
+                {
+                    "line": current_line,
+                    "character": current_char,
+                    "length": length,
+                    "token_type": type_name,
+                    "modifiers": mods,
+                    "text": text,
+                }
+            )
 
         return tokens
 
@@ -624,34 +670,47 @@ class LSPClient:
             logger.debug(f"Probing server readiness with {probe_file}")
             self.open_document(str(probe_file))
             # documentSymbol verifies basic server readiness (syntax analysis)
-            self._request("textDocument/documentSymbol", {
-                "textDocument": {"uri": probe_file.as_uri()},
-            }, timeout=60)
+            self._request(
+                "textDocument/documentSymbol",
+                {
+                    "textDocument": {"uri": probe_file.as_uri()},
+                },
+                timeout=60,
+            )
             # Poll references to wait for cross-file semantic analysis.
             # Servers like rust-analyzer need extra time for project loading;
             # references returns [] until the project is fully indexed.
-    
 
-            symbols = self._request("textDocument/documentSymbol", {
-                "textDocument": {"uri": probe_file.as_uri()},
-            }, timeout=10) or []
+            symbols = (
+                self._request(
+                    "textDocument/documentSymbol",
+                    {
+                        "textDocument": {"uri": probe_file.as_uri()},
+                    },
+                    timeout=10,
+                )
+                or []
+            )
             if symbols:
                 # Use the first symbol's position to probe references
                 first_sym = symbols[0]
                 sel = first_sym.get("selectionRange", first_sym.get("range", {}))
                 probe_pos = sel.get("start", {"line": 0, "character": 0})
                 for _ in range(15):
-                    result = self._request("textDocument/references", {
-                        "textDocument": {"uri": probe_file.as_uri()},
-                        "position": probe_pos,
-                        "context": {"includeDeclaration": True},
-                    }, timeout=10)
+                    result = self._request(
+                        "textDocument/references",
+                        {
+                            "textDocument": {"uri": probe_file.as_uri()},
+                            "position": probe_pos,
+                            "context": {"includeDeclaration": True},
+                        },
+                        timeout=10,
+                    )
                     if result:
                         break
                     time.sleep(1)
         else:
             # No source files found, just wait briefly
-    
 
             time.sleep(2)
 
@@ -662,7 +721,7 @@ class LSPClient:
         try:
             self.process.stdin.write(header + content)
             self.process.stdin.flush()
-        except (BrokenPipeError, OSError) as e:
+        except OSError as e:
             logger.error(f"LSP server pipe broken: {e}")
             raise
 
@@ -677,7 +736,11 @@ class LSPClient:
             if not ready:
                 continue
 
-            chunk = self.process.stdout.read1(65536) if hasattr(self.process.stdout, 'read1') else self.process.stdout.read(1)
+            chunk = (
+                self.process.stdout.read1(65536)
+                if hasattr(self.process.stdout, "read1")
+                else self.process.stdout.read(1)
+            )
             if not chunk:
                 return None
             buf += chunk
@@ -699,7 +762,7 @@ class LSPClient:
 
                 if content_length is None:
                     # Malformed header, skip
-                    buf = buf[header_end + 4:]
+                    buf = buf[header_end + 4 :]
                     continue
 
                 body_start = header_end + 4
@@ -721,19 +784,23 @@ class LSPClient:
                     server_method = message["method"]
                     if server_method == "window/workDoneProgress/create":
                         # Acknowledge progress token creation
-                        self._send({
-                            "jsonrpc": "2.0",
-                            "id": message["id"],
-                            "result": None,
-                        })
+                        self._send(
+                            {
+                                "jsonrpc": "2.0",
+                                "id": message["id"],
+                                "result": None,
+                            }
+                        )
                         continue
                     elif server_method == "client/registerCapability":
                         # Acknowledge dynamic capability registration
-                        self._send({
-                            "jsonrpc": "2.0",
-                            "id": message["id"],
-                            "result": None,
-                        })
+                        self._send(
+                            {
+                                "jsonrpc": "2.0",
+                                "id": message["id"],
+                                "result": None,
+                            }
+                        )
                         continue
 
                 # Skip server notifications that we don't need
@@ -768,12 +835,14 @@ class LSPClient:
         msg_id = self._next_id
         self._next_id += 1
         self._pending_ids.add(msg_id)
-        self._send({
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "method": method,
-            "params": params,
-        })
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "method": method,
+                "params": params,
+            }
+        )
 
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
@@ -831,12 +900,14 @@ class LSPClient:
     #   -32801 ContentModified: server VFS changed, will resolve after apply
     #   -32802 ServerCancelled: server cancelled (spec says retrigger)
     # All other codes are permanent (bad request, not supported, etc.).
-    _RETRYABLE_ERROR_CODES = frozenset({
-        -1,      # Timeout (internal)
-        -2,      # Null result (server may still be analyzing)
-        -32801,  # ContentModified
-        -32802,  # ServerCancelled
-    })
+    _RETRYABLE_ERROR_CODES = frozenset(
+        {
+            -1,  # Timeout (internal)
+            -2,  # Null result (server may still be analyzing)
+            -32801,  # ContentModified
+            -32802,  # ServerCancelled
+        }
+    )
 
     def _is_retryable_error(self) -> bool:
         """Check if the last _request error is transient (worth retrying).

--- a/codeminer/graph/incremental/patcher_base.py
+++ b/codeminer/graph/incremental/patcher_base.py
@@ -4,15 +4,16 @@ Handles the high-level patch flow (classify, remap, patch) while
 delegating subgraph operations to SubgraphMgr and language-specific
 behavior to patcher_lang subclasses.
 """
+
 from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Optional
 
-from ..graph.code_graph import CodeGraph
-from ..log_utils import get_logger
-from ..profiler import Profiler
-from ..types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE
+from ...log_utils import get_logger
+from ...profiler import Profiler
+from ...types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE
+from ..code_graph import CodeGraph
 from . import change_mgr
 from .lsp_client import LSPClient
 from .subgraph_mgr import SubgraphMgr
@@ -42,21 +43,23 @@ class PatcherBase(SubgraphMgr):
 
     # Subclasses override: which LSP SymbolKinds to include in classification.
     # Default covers most languages. C++ overrides completely.
-    GRAPH_SYMBOL_KINDS = frozenset({
-        2,   # Module
-        5,   # Class
-        6,   # Method
-        8,   # Field
-        9,   # Constructor
-        10,  # Enum
-        11,  # Interface
-        12,  # Function
-        13,  # Variable
-        14,  # Constant
-        22,  # Enum (alt)
-        23,  # Struct
-        25,  # Operator
-    })
+    GRAPH_SYMBOL_KINDS = frozenset(
+        {
+            2,  # Module
+            5,  # Class
+            6,  # Method
+            8,  # Field
+            9,  # Constructor
+            10,  # Enum
+            11,  # Interface
+            12,  # Function
+            13,  # Variable
+            14,  # Constant
+            22,  # Enum (alt)
+            23,  # Struct
+            25,  # Operator
+        }
+    )
 
     def __init__(
         self,
@@ -126,7 +129,7 @@ class PatcherBase(SubgraphMgr):
         Language patchers call this from their flatten_symbols() method.
         """
         result = {}
-        for sym in (symbols or []):
+        for sym in symbols or []:
             name = sym.get("name", "")
             kind = sym.get("kind", 0)
 
@@ -143,9 +146,7 @@ class PatcherBase(SubgraphMgr):
                     uname = self._build_unified_name(
                         file_path, name, parent_uname, kind
                     )
-                    child_parent = (
-                        uname.split(":", 1)[1] if ":" in uname else name
-                    )
+                    child_parent = uname.split(":", 1)[1] if ":" in uname else name
                 for child in sym.get("children", []):
                     child_result = self._flatten_symbols_default(
                         file_path, [child], child_parent
@@ -158,9 +159,7 @@ class PatcherBase(SubgraphMgr):
             start = range_data.get("start", {}).get("line", 0)
             end = range_data.get("end", {}).get("line", start)
 
-            uname = self._build_unified_name(
-                file_path, name, parent_uname, kind
-            )
+            uname = self._build_unified_name(file_path, name, parent_uname, kind)
             entry = {
                 "kind": kind,
                 "start_line": start,
@@ -176,9 +175,7 @@ class PatcherBase(SubgraphMgr):
                 elif kind in (5, 10, 23) and existing["kind"] not in (5, 10, 23):
                     result[uname] = entry
                 else:
-                    if (end - start) > (
-                        existing["end_line"] - existing["start_line"]
-                    ):
+                    if (end - start) > (existing["end_line"] - existing["start_line"]):
                         result[uname] = entry
             else:
                 result[uname] = entry
@@ -189,9 +186,7 @@ class PatcherBase(SubgraphMgr):
             if kind == 2:
                 child_parent = parent_uname  # skip module
             else:
-                child_parent = (
-                    uname.split(":", 1)[1] if ":" in uname else name
-                )
+                child_parent = uname.split(":", 1)[1] if ":" in uname else name
             for child in sym.get("children", []):
                 child_result = self._flatten_symbols_default(
                     file_path, [child], child_parent
@@ -213,9 +208,7 @@ class PatcherBase(SubgraphMgr):
         if resolved:
             cmd = [resolved] + cmd[1:]
 
-        self.lsp_client = LSPClient(
-            cmd, str(self.project_root), self._language_id()
-        )
+        self.lsp_client = LSPClient(cmd, str(self.project_root), self._language_id())
         self.lsp_client.start(skip_probe=skip_probe)
 
     def stop_lsp(self):
@@ -256,12 +249,17 @@ class PatcherBase(SubgraphMgr):
         self.build_indexes()
 
         total_stats = {
-            "files_deleted": 0, "files_modified": 0,
-            "files_added": 0, "files_renamed": 0,
-            "vertices_deleted": 0, "vertices_created": 0,
+            "files_deleted": 0,
+            "files_modified": 0,
+            "files_added": 0,
+            "files_renamed": 0,
+            "vertices_deleted": 0,
+            "vertices_created": 0,
             "vertices_shifted": 0,
-            "refs_incoming": 0, "refs_outgoing": 0,
-            "refs_remapped": 0, "refs_unmatched": 0,
+            "refs_incoming": 0,
+            "refs_outgoing": 0,
+            "refs_remapped": 0,
+            "refs_unmatched": 0,
         }
 
         # Clear stale caches from previous patch_files calls
@@ -362,14 +360,19 @@ class PatcherBase(SubgraphMgr):
     # ═══════════════════════════════════════════════════════════
 
     def _rebuild_prepare_vertices(
-        self, file_path: str, is_new: bool = False,
+        self,
+        file_path: str,
+        is_new: bool = False,
         line_ranges: list[tuple[int, int]] | None = None,
     ) -> dict:
         """Round 1 for full rebuild: delete old + build new vertices + remap."""
         file_stats = {
-            "vertices_deleted": 0, "vertices_created": 0,
-            "refs_incoming": 0, "refs_outgoing": 0,
-            "refs_remapped": 0, "refs_unmatched": 0,
+            "vertices_deleted": 0,
+            "vertices_created": 0,
+            "refs_incoming": 0,
+            "refs_outgoing": 0,
+            "refs_remapped": 0,
+            "refs_unmatched": 0,
         }
 
         severed_in = []
@@ -378,9 +381,7 @@ class PatcherBase(SubgraphMgr):
         if not is_new:
             with self.profiler.section("delete_subgraph"):
                 result = self.delete_file_subgraph(file_path)
-                file_stats["vertices_deleted"] = len(
-                    result["deleted_vertex_names"]
-                )
+                file_stats["vertices_deleted"] = len(result["deleted_vertex_names"])
                 severed_in = result["severed_incoming_refs"]
                 severed_out = result["severed_outgoing_refs"]
 
@@ -392,7 +393,9 @@ class PatcherBase(SubgraphMgr):
 
         with self.profiler.section("remap_edges"):
             remapped = self._remap_severed_edges(
-                new_vertices, severed_in, severed_out,
+                new_vertices,
+                severed_in,
+                severed_out,
                 changed_line_ranges=line_ranges,
             )
             file_stats["refs_remapped"] = remapped
@@ -405,17 +408,23 @@ class PatcherBase(SubgraphMgr):
         }
 
     def _rebuild_connect_edges(
-        self, file_path: str, ctx: dict,
+        self,
+        file_path: str,
+        ctx: dict,
         line_ranges: list[tuple[int, int]] | None = None,
     ) -> dict:
         """Round 2 for full rebuild: connect edges via LSP."""
         edge_stats = {
-            "refs_incoming": 0, "refs_outgoing": 0, "refs_unmatched": 0,
+            "refs_incoming": 0,
+            "refs_outgoing": 0,
+            "refs_unmatched": 0,
         }
         new_vertices = ctx["new_vertices"]
 
         remapped_unames = self._get_remapped_unames(
-            new_vertices, ctx["severed_in"], ctx["severed_out"],
+            new_vertices,
+            ctx["severed_in"],
+            ctx["severed_out"],
         )
         new_only = [v for v in new_vertices if v not in remapped_unames]
 
@@ -426,7 +435,8 @@ class PatcherBase(SubgraphMgr):
 
         if line_ranges:
             outgoing_ranges = self._compute_outgoing_ranges(
-                new_vertices, line_ranges,
+                new_vertices,
+                line_ranges,
             )
         else:
             outgoing_ranges = []
@@ -439,7 +449,9 @@ class PatcherBase(SubgraphMgr):
 
         with self.profiler.section("lsp_outgoing_refs"):
             self.reconnect_outgoing(
-                file_path, new_vertices, ref_stats,
+                file_path,
+                new_vertices,
+                ref_stats,
                 line_ranges=outgoing_ranges,
             )
 
@@ -452,7 +464,6 @@ class PatcherBase(SubgraphMgr):
     # Single file: symbol-level incremental (modified)
     # ═══════════════════════════════════════════════════════════
 
-
     def _incremental_prepare_vertices(
         self, file_path: str, base_commit: str
     ) -> Optional[dict]:
@@ -462,9 +473,13 @@ class PatcherBase(SubgraphMgr):
         if no hunks were found (file unchanged at line level).
         """
         file_stats = {
-            "vertices_deleted": 0, "vertices_created": 0,
-            "vertices_shifted": 0, "refs_incoming": 0,
-            "refs_outgoing": 0, "refs_remapped": 0, "refs_unmatched": 0,
+            "vertices_deleted": 0,
+            "vertices_created": 0,
+            "vertices_shifted": 0,
+            "refs_incoming": 0,
+            "refs_outgoing": 0,
+            "refs_remapped": 0,
+            "refs_unmatched": 0,
         }
 
         with self.profiler.section("git_diff"):
@@ -488,9 +503,7 @@ class PatcherBase(SubgraphMgr):
             return ctx
 
         with self.profiler.section("classify_symbols"):
-            classified = self._classify_symbols(
-                old_symbols, new_symbols, hunks
-            )
+            classified = self._classify_symbols(old_symbols, new_symbols, hunks)
 
         # DELETED
         for uname in classified["deleted"]:
@@ -504,10 +517,14 @@ class PatcherBase(SubgraphMgr):
             new = new_symbols[uname]
             old_vname = old["vertex_name"]
             new_vname = f"{uname}:{new['start_line']}"
-            self.rename_vertex(old_vname, new_vname, {
-                "start_line": new["start_line"],
-                "end_line": new["end_line"],
-            })
+            self.rename_vertex(
+                old_vname,
+                new_vname,
+                {
+                    "start_line": new["start_line"],
+                    "end_line": new["end_line"],
+                },
+            )
             self._update_selection_range(old_vname, new_vname, new)
             file_stats["vertices_shifted"] += 1
 
@@ -521,16 +538,21 @@ class PatcherBase(SubgraphMgr):
             new_vname = f"{uname}:{new['start_line']}"
 
             if old_vname != new_vname:
-                self.rename_vertex(old_vname, new_vname, {
-                    "start_line": new["start_line"],
-                    "end_line": new["end_line"],
-                })
+                self.rename_vertex(
+                    old_vname,
+                    new_vname,
+                    {
+                        "start_line": new["start_line"],
+                        "end_line": new["end_line"],
+                    },
+                )
             else:
                 vid = self.code_graph.name_to_vertex.get(new_vname)
                 if vid is not None:
                     self.code_graph.graph.vs[vid]["end_line"] = new["end_line"]
                     self.code_graph.symbol_ranges[new_vname] = (
-                        new["start_line"], new["end_line"]
+                        new["start_line"],
+                        new["end_line"],
                     )
 
             self._update_selection_range(old_vname, new_vname, new)
@@ -553,26 +575,26 @@ class PatcherBase(SubgraphMgr):
             vname = f"{uname}:{new['start_line']}"
             node_type = self._classify_symbol_type(new["kind"])
 
-            self.code_graph._add_vertex(vname, {
-                "type": node_type,
-                "file": file_path,
-                "start_line": new["start_line"],
-                "end_line": new["end_line"],
-                "unified_name": uname,
-            })
-            self.code_graph.symbol_ranges[vname] = (
-                new["start_line"], new["end_line"]
+            self.code_graph._add_vertex(
+                vname,
+                {
+                    "type": node_type,
+                    "file": file_path,
+                    "start_line": new["start_line"],
+                    "end_line": new["end_line"],
+                    "unified_name": uname,
+                },
             )
+            self.code_graph.symbol_ranges[vname] = (new["start_line"], new["end_line"])
 
             parent_uname = new.get("parent_uname")
             parent_vname = (
                 self._find_vertex_by_unified_name(parent_uname, file_path)
-                if parent_uname else file_path
+                if parent_uname
+                else file_path
             )
             if parent_vname:
-                self.code_graph._add_edge(
-                    parent_vname, vname, EDGE_TYPE_CONTAIN
-                )
+                self.code_graph._add_edge(parent_vname, vname, EDGE_TYPE_CONTAIN)
 
             self._store_selection_range(vname, new)
             added_vnames.append(vname)
@@ -596,15 +618,15 @@ class PatcherBase(SubgraphMgr):
             "hunks": hunks,
         }
 
-    def _incremental_connect_edges(
-        self, file_path: str, ctx: dict
-    ) -> dict:
+    def _incremental_connect_edges(self, file_path: str, ctx: dict) -> dict:
         """Round 2: connect reference edges using LSP queries.
 
         Called after all files' vertices have been prepared.
         """
         edge_stats = {
-            "refs_incoming": 0, "refs_outgoing": 0, "refs_unmatched": 0,
+            "refs_incoming": 0,
+            "refs_outgoing": 0,
+            "refs_unmatched": 0,
         }
 
         if ctx.get("fallback_rebuild"):
@@ -621,18 +643,18 @@ class PatcherBase(SubgraphMgr):
             flat_vnames = []
             flat_ranges = []
             for vname, ranges in zip(
-                affected_vnames, affected_changed_ranges
+                affected_vnames, affected_changed_ranges, strict=False
             ):
                 for r in ranges:
                     flat_vnames.append(vname)
                     flat_ranges.append(r)
 
-            ref_stats = {
-                "incoming_added": 0, "outgoing_added": 0, "unmatched": 0
-            }
+            ref_stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
             with self.profiler.section("lsp_outgoing_refs"):
                 self.reconnect_outgoing(
-                    file_path, flat_vnames, ref_stats,
+                    file_path,
+                    flat_vnames,
+                    ref_stats,
                     line_ranges=flat_ranges,
                 )
             edge_stats["refs_outgoing"] = ref_stats["outgoing_added"]
@@ -652,19 +674,17 @@ class PatcherBase(SubgraphMgr):
                         el = v.attributes().get("end_line", sl)
                         added_ranges.append((sl, el))
 
-            ref_stats = {
-                "incoming_added": 0, "outgoing_added": 0, "unmatched": 0
-            }
+            ref_stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
             with self.profiler.section("lsp_incoming_refs"):
                 self.reconnect_incoming(file_path, added_vnames, ref_stats)
             with self.profiler.section("lsp_outgoing_refs"):
                 effective_ranges = (
-                    added_ranges
-                    if len(added_ranges) == len(added_vnames)
-                    else None
+                    added_ranges if len(added_ranges) == len(added_vnames) else None
                 )
                 self.reconnect_outgoing(
-                    file_path, added_vnames, ref_stats,
+                    file_path,
+                    added_vnames,
+                    ref_stats,
                     line_ranges=effective_ranges,
                 )
             edge_stats["refs_incoming"] = ref_stats["incoming_added"]
@@ -685,10 +705,7 @@ class PatcherBase(SubgraphMgr):
         """Classify each symbol as deleted/added/affected/shifted/unchanged."""
 
         def overlaps_any_hunk(start, end):
-            return any(
-                start <= h_end and end >= h_start
-                for h_start, h_end in hunks
-            )
+            return any(start <= h_end and end >= h_start for h_start, h_end in hunks)
 
         old_set = set(old_symbols.keys())
         new_set = set(new_symbols.keys())
@@ -717,8 +734,7 @@ class PatcherBase(SubgraphMgr):
         demote = []
         for uname in affected:
             children_in_affected = [
-                u for u in affected
-                if u != uname and u.startswith(uname + ".")
+                u for u in affected if u != uname and u.startswith(uname + ".")
             ]
             if children_in_affected and not overlaps_any_hunk(
                 new_symbols[uname]["start_line"],
@@ -754,9 +770,7 @@ class PatcherBase(SubgraphMgr):
         uname_to_new = {}
         for vname in new_vertices:
             if vname in self.code_graph.name_to_vertex:
-                v = self.code_graph.graph.vs[
-                    self.code_graph.name_to_vertex[vname]
-                ]
+                v = self.code_graph.graph.vs[self.code_graph.name_to_vertex[vname]]
                 uname = v.attributes().get("unified_name")
                 if uname:
                     uname_to_new[uname] = vname
@@ -772,8 +786,11 @@ class PatcherBase(SubgraphMgr):
                     if sym_start <= cl_end and cl_start <= sym_end:
                         vid = self.code_graph.name_to_vertex.get(vname)
                         if vid is not None:
-                            uname = self.code_graph.graph.vs[vid].attributes(
-                            ).get("unified_name")
+                            uname = (
+                                self.code_graph.graph.vs[vid]
+                                .attributes()
+                                .get("unified_name")
+                            )
                             if uname:
                                 changed_unames.add(uname)
                         break
@@ -787,9 +804,7 @@ class PatcherBase(SubgraphMgr):
                 continue
             new_target = uname_to_new.get(tgt_uname)
             if new_target and src_name in self.code_graph.name_to_vertex:
-                self.code_graph._add_edge(
-                    src_name, new_target, EDGE_TYPE_REFERENCE
-                )
+                self.code_graph._add_edge(src_name, new_target, EDGE_TYPE_REFERENCE)
                 remapped += 1
 
         # Outgoing: skip if source body changed
@@ -802,9 +817,7 @@ class PatcherBase(SubgraphMgr):
                 new_src = uname_to_new.get(src_uname)
             else:
                 new_src = (
-                    src_name
-                    if src_name in self.code_graph.name_to_vertex
-                    else None
+                    src_name if src_name in self.code_graph.name_to_vertex else None
                 )
 
             if tgt_name in self.code_graph.name_to_vertex:
@@ -815,9 +828,7 @@ class PatcherBase(SubgraphMgr):
                 resolved_tgt = None
 
             if new_src and resolved_tgt:
-                self.code_graph._add_edge(
-                    new_src, resolved_tgt, EDGE_TYPE_REFERENCE
-                )
+                self.code_graph._add_edge(new_src, resolved_tgt, EDGE_TYPE_REFERENCE)
                 remapped += 1
 
         return remapped
@@ -859,9 +870,7 @@ class PatcherBase(SubgraphMgr):
                 merged.append((start, end))
         return merged
 
-    def _find_vertex_by_unified_name(
-        self, uname: str, file_path: str
-    ) -> Optional[str]:
+    def _find_vertex_by_unified_name(self, uname: str, file_path: str) -> Optional[str]:
         """Find a vertex name by unified_name, preferring same file."""
         idx = getattr(self.code_graph, "unified_name_to_vertex", {})
         vids = idx.get(uname, [])
@@ -894,8 +903,10 @@ class PatcherBase(SubgraphMgr):
                 for vname in new_vertices:
                     vid = self.code_graph.name_to_vertex.get(vname)
                     if vid is not None:
-                        u = self.code_graph.graph.vs[vid].attributes().get(
-                            "unified_name"
+                        u = (
+                            self.code_graph.graph.vs[vid]
+                            .attributes()
+                            .get("unified_name")
                         )
                         if u == tgt_uname:
                             remapped_unames.add(vname)
@@ -905,16 +916,16 @@ class PatcherBase(SubgraphMgr):
                 for vname in new_vertices:
                     vid = self.code_graph.name_to_vertex.get(vname)
                     if vid is not None:
-                        u = self.code_graph.graph.vs[vid].attributes().get(
-                            "unified_name"
+                        u = (
+                            self.code_graph.graph.vs[vid]
+                            .attributes()
+                            .get("unified_name")
                         )
                         if u == src_uname:
                             remapped_unames.add(vname)
         return remapped_unames
 
-    def _update_selection_range(
-        self, old_vname: str, new_vname: str, new_meta: dict
-    ):
+    def _update_selection_range(self, old_vname: str, new_vname: str, new_meta: dict):
         """Update symbol_selection_ranges for a shifted/affected symbol."""
         sel = new_meta["sel_range"]
         sel_start = sel.get("start", {})
@@ -944,8 +955,13 @@ class PatcherBase(SubgraphMgr):
     def _merge_stats(total: dict, file_stats: dict):
         """Merge file-level stats into total stats."""
         for key in (
-            "vertices_deleted", "vertices_created", "vertices_shifted",
-            "refs_incoming", "refs_outgoing", "refs_remapped", "refs_unmatched",
+            "vertices_deleted",
+            "vertices_created",
+            "vertices_shifted",
+            "refs_incoming",
+            "refs_outgoing",
+            "refs_remapped",
+            "refs_unmatched",
         ):
             if key in file_stats:
                 total[key] = total.get(key, 0) + file_stats[key]

--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -2,6 +2,7 @@
 
 Uses clangd .idx files instead of LSP queries for incremental updates.
 """
+
 from __future__ import annotations
 
 import json
@@ -10,8 +11,9 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from ..log_utils import get_logger
-from ..types import (
+
+from ...log_utils import get_logger
+from ...types import (
     EDGE_TYPE_CONTAIN,
     EDGE_TYPE_REFERENCE,
     NODE_TYPE_FUNCTION,
@@ -33,8 +35,14 @@ class PatcherCpp(PatcherBase):
 
     def _get_crossfile_token_types(self):
         return {
-            "type", "class", "struct", "enum", "function", "method",
-            "namespace", "macro",
+            "type",
+            "class",
+            "struct",
+            "enum",
+            "function",
+            "method",
+            "namespace",
+            "macro",
         }
 
     def _build_unified_name(self, file_path, name, parent_unified_part, kind):
@@ -62,11 +70,16 @@ class PatcherCpp(PatcherBase):
     def patch_files(self, changed_files, **kwargs):
         """C++ incremental: delete old subgraphs, reindex via .idx, rebuild."""
         total_stats = {
-            "files_deleted": 0, "files_modified": 0,
-            "files_added": 0, "files_renamed": 0,
-            "vertices_deleted": 0, "vertices_created": 0,
-            "refs_incoming": 0, "refs_outgoing": 0,
-            "refs_remapped": 0, "refs_unmatched": 0,
+            "files_deleted": 0,
+            "files_modified": 0,
+            "files_added": 0,
+            "files_renamed": 0,
+            "vertices_deleted": 0,
+            "vertices_created": 0,
+            "refs_incoming": 0,
+            "refs_outgoing": 0,
+            "refs_remapped": 0,
+            "refs_unmatched": 0,
         }
 
         # Rebuild indexes for delete_file_subgraph
@@ -106,9 +119,7 @@ class PatcherCpp(PatcherBase):
             total_stats["vertices_created"] = stats["vertices_created"]
             total_stats["refs_outgoing"] = stats["refs_added"]
 
-        total_stats["files_modified"] = len(
-            changed_files.get("modified", [])
-        )
+        total_stats["files_modified"] = len(changed_files.get("modified", []))
         total_stats["files_added"] = len(changed_files.get("added", []))
         total_stats["files_renamed"] = len(changed_files.get("renamed", []))
 
@@ -195,9 +206,7 @@ class PatcherCpp(PatcherBase):
         )
         return stats
 
-    def _reindex_changed_files(
-        self, changed_files: list[str]
-    ) -> Path | None:
+    def _reindex_changed_files(self, changed_files: list[str]) -> Path | None:
         """Run clangd background-index, preserving .idx cache."""
         clangd = shutil.which("clangd")
         if not clangd:
@@ -235,12 +244,14 @@ class PatcherCpp(PatcherBase):
         if idx_dir is None:
             logger.info("No .idx cache, running full clangd index")
             from ..ls_index.clangd_indexer import ClangdIndexer
+
             indexer = ClangdIndexer(project_root=str(self.project_root))
             success = indexer.generate_index(compdb_path=str(comp_db))
             return indexer.idx_directory if success else None
 
         pre_mtime = max(
-            (f.stat().st_mtime for f in idx_dir.glob("*.idx")), default=0,
+            (f.stat().st_mtime for f in idx_dir.glob("*.idx")),
+            default=0,
         )
         pre_count = len(list(idx_dir.glob("*.idx")))
         logger.info(
@@ -249,13 +260,18 @@ class PatcherCpp(PatcherBase):
         )
 
         cmd = [
-            clangd, "--background-index",
+            clangd,
+            "--background-index",
             f"--compile-commands-dir={comp_db.parent}",
-            "--background-index-priority=normal", "--log=error",
+            "--background-index-priority=normal",
+            "--log=error",
         ]
         process = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, cwd=str(self.project_root),
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(self.project_root),
         )
 
         def lsp_send(msg):
@@ -265,18 +281,26 @@ class PatcherCpp(PatcherBase):
             process.stdin.flush()
 
         try:
-            lsp_send({
-                "jsonrpc": "2.0", "id": 1, "method": "initialize",
-                "params": {
-                    "processId": os.getpid(),
-                    "rootUri": Path(self.project_root).as_uri(),
-                    "capabilities": {},
-                },
-            })
+            lsp_send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "processId": os.getpid(),
+                        "rootUri": Path(self.project_root).as_uri(),
+                        "capabilities": {},
+                    },
+                }
+            )
             time.sleep(1)
-            lsp_send({
-                "jsonrpc": "2.0", "method": "initialized", "params": {},
-            })
+            lsp_send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "initialized",
+                    "params": {},
+                }
+            )
             time.sleep(0.5)
 
             for fpath in changed_files:
@@ -287,18 +311,20 @@ class PatcherCpp(PatcherBase):
                     text = abs_path.read_text(errors="replace")
                 except Exception:
                     continue
-                lsp_send({
-                    "jsonrpc": "2.0",
-                    "method": "textDocument/didOpen",
-                    "params": {
-                        "textDocument": {
-                            "uri": abs_path.as_uri(),
-                            "languageId": "cpp",
-                            "version": 1,
-                            "text": text,
-                        }
-                    },
-                })
+                lsp_send(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "textDocument/didOpen",
+                        "params": {
+                            "textDocument": {
+                                "uri": abs_path.as_uri(),
+                                "languageId": "cpp",
+                                "version": 1,
+                                "text": text,
+                            }
+                        },
+                    }
+                )
 
             stable = 0
             last_mtime = pre_mtime
@@ -319,20 +345,26 @@ class PatcherCpp(PatcherBase):
                         break
 
             post_count = len(list(idx_dir.glob("*.idx")))
-            logger.info(
-                f"C++ incremental done: {pre_count}→{post_count} .idx files"
-            )
+            logger.info(f"C++ incremental done: {pre_count}→{post_count} .idx files")
 
         finally:
             try:
-                lsp_send({
-                    "jsonrpc": "2.0", "id": 99,
-                    "method": "shutdown", "params": None,
-                })
+                lsp_send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 99,
+                        "method": "shutdown",
+                        "params": None,
+                    }
+                )
                 time.sleep(0.5)
-                lsp_send({
-                    "jsonrpc": "2.0", "method": "exit", "params": None,
-                })
+                lsp_send(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "exit",
+                        "params": None,
+                    }
+                )
                 process.wait(timeout=5)
             except Exception:
                 process.kill()
@@ -347,10 +379,10 @@ class PatcherCpp(PatcherBase):
     ) -> tuple[int, int]:
         """Add symbols and edges from .idx data for changed files."""
         from ..ls_index.clangd_decode import (
+            KIND_MACRO,
             REF_KIND_DEFINITION,
             REF_KIND_REFERENCE,
             ZERO_SYMBOL_ID,
-            KIND_MACRO,
         )
 
         changed_set = set(changed_files)
@@ -380,7 +412,8 @@ class PatcherCpp(PatcherBase):
             scope_start, scope_end = decoder._find_range(rel_file, line)
 
             self.code_graph.add_symbol_node(
-                sym_id, line,
+                sym_id,
+                line,
                 scope_start_line=scope_start,
                 scope_end_line=scope_end,
                 symbol_type=node_type,
@@ -391,9 +424,9 @@ class PatcherCpp(PatcherBase):
                 unified_display = qualified_name.replace("::", ".")
                 if node_type in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD):
                     unified_display = f"{unified_display}()"
-                self.code_graph.graph.vs[vid]["unified_name"] = (
-                    f"{rel_file}:{unified_display}"
-                )
+                self.code_graph.graph.vs[vid][
+                    "unified_name"
+                ] = f"{rel_file}:{unified_display}"
                 self.code_graph.graph.vs[vid]["file"] = rel_file
                 new_vertices += 1
 
@@ -423,9 +456,7 @@ class PatcherCpp(PatcherBase):
             vid = self.code_graph.name_to_vertex[sym_id]
             file_path = self.code_graph.graph.vs[vid].attributes().get("file")
             if file_path and file_path in self.code_graph.name_to_vertex:
-                self.code_graph._add_edge(
-                    file_path, sym_id, EDGE_TYPE_CONTAIN
-                )
+                self.code_graph._add_edge(file_path, sym_id, EDGE_TYPE_CONTAIN)
 
         for sym_id, ref_list in decoder._refs.items():
             if sym_id not in self.code_graph.name_to_vertex:
@@ -438,13 +469,8 @@ class PatcherCpp(PatcherBase):
                     continue
                 if container_id not in self.code_graph.name_to_vertex:
                     continue
-                if (
-                    sym_id in changed_sym_ids
-                    or container_id in changed_sym_ids
-                ):
-                    self.code_graph._add_edge(
-                        container_id, sym_id, EDGE_TYPE_REFERENCE
-                    )
+                if sym_id in changed_sym_ids or container_id in changed_sym_ids:
+                    self.code_graph._add_edge(container_id, sym_id, EDGE_TYPE_REFERENCE)
                     new_refs += 1
 
         return new_vertices, new_refs

--- a/codeminer/graph/incremental/patcher_go.py
+++ b/codeminer/graph/incremental/patcher_go.py
@@ -1,9 +1,10 @@
 """Go-specific incremental patcher."""
+
 from __future__ import annotations
 
 import re
 
-from ..types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from ...types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
 from .patcher_base import PatcherBase
 
 
@@ -18,7 +19,11 @@ class PatcherGo(PatcherBase):
 
     def _get_crossfile_token_types(self):
         return {
-            "type", "function", "method", "namespace", "interface",
+            "type",
+            "function",
+            "method",
+            "namespace",
+            "interface",
             "property",
         }
 

--- a/codeminer/graph/incremental/patcher_python.py
+++ b/codeminer/graph/incremental/patcher_python.py
@@ -1,29 +1,31 @@
-"""TypeScript/JavaScript-specific incremental patcher."""
+"""Python-specific incremental patcher."""
+
 from __future__ import annotations
 
-from ..types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from ...types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
 from .patcher_base import PatcherBase
 
 
-class PatcherTS(PatcherBase):
-    """TS/JS incremental patcher. Matches SCIPTypeScriptGraphDecoder naming."""
+class PatcherPython(PatcherBase):
+    """Python incremental patcher. Matches SCIPPythonGraphDecoder naming."""
 
     def get_lsp_command(self):
-        return ["typescript-language-server", "--stdio"]
+        return ["basedpyright-langserver", "--stdio"]
 
     def _language_id(self):
-        return "typescript"
+        return "python"
 
     def _get_crossfile_token_types(self):
         return {
-            "type", "class", "enum", "function", "method",
-            "namespace", "interface", "variable", "property",
+            "type",
+            "class",
+            "function",
+            "method",
+            "namespace",
+            "property",
         }
 
     def _build_unified_name(self, file_path, name, parent_unified_part, kind):
-        if name in ("<constructor>", "constructor"):
-            name = "constructor"
-
         node_type = self._classify_symbol_type(kind)
 
         if parent_unified_part:

--- a/codeminer/graph/incremental/patcher_rust.py
+++ b/codeminer/graph/incremental/patcher_rust.py
@@ -1,9 +1,10 @@
 """Rust-specific incremental patcher."""
+
 from __future__ import annotations
 
 import re
 
-from ..types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from ...types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
 from .patcher_base import PatcherBase
 
 
@@ -18,8 +19,15 @@ class PatcherRust(PatcherBase):
 
     def _get_crossfile_token_types(self):
         return {
-            "type", "struct", "enum", "function", "method",
-            "namespace", "macro", "interface", "property",
+            "type",
+            "struct",
+            "enum",
+            "function",
+            "method",
+            "namespace",
+            "macro",
+            "interface",
+            "property",
         }
 
     # ── Unified name construction ──────────────────────────
@@ -46,13 +54,13 @@ class PatcherRust(PatcherBase):
                 elif ch == ">":
                     depth -= 1
                     if depth == 0:
-                        text = text[i + 1:].strip()
+                        text = text[i + 1 :].strip()
                         break
 
         for_idx = _find_toplevel_for(text)
         if for_idx >= 0:
             trait_part = text[:for_idx].strip()
-            type_part = text[for_idx + 4:].strip()
+            type_part = text[for_idx + 4 :].strip()
             trait_part = re.sub(r"<['\\a-z_,\s]+>", "", trait_part)
             if trait_part:
                 return f"{type_part}<{trait_part}>"
@@ -65,9 +73,7 @@ class PatcherRust(PatcherBase):
         node_type = self._classify_symbol_type(kind)
 
         if parent_unified_part and parent_unified_part.startswith("impl"):
-            parent_unified_part = self._normalize_impl_name(
-                parent_unified_part
-            )
+            parent_unified_part = self._normalize_impl_name(parent_unified_part)
 
         if name.startswith("impl"):
             name = self._normalize_impl_name(name)
@@ -101,7 +107,7 @@ def _find_toplevel_for(text: str) -> int:
             depth += 1
         elif ch == ">":
             depth -= 1
-        elif depth == 0 and text[i:i + 5] == " for ":
+        elif depth == 0 and text[i : i + 5] == " for ":
             return i + 1
         i += 1
     return -1

--- a/codeminer/graph/incremental/patcher_ts.py
+++ b/codeminer/graph/incremental/patcher_ts.py
@@ -1,26 +1,37 @@
-"""Python-specific incremental patcher."""
+"""TypeScript/JavaScript-specific incremental patcher."""
+
 from __future__ import annotations
 
-from ..types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from ...types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
 from .patcher_base import PatcherBase
 
 
-class PatcherPython(PatcherBase):
-    """Python incremental patcher. Matches SCIPPythonGraphDecoder naming."""
+class PatcherTS(PatcherBase):
+    """TS/JS incremental patcher. Matches SCIPTypeScriptGraphDecoder naming."""
 
     def get_lsp_command(self):
-        return ["basedpyright-langserver", "--stdio"]
+        return ["typescript-language-server", "--stdio"]
 
     def _language_id(self):
-        return "python"
+        return "typescript"
 
     def _get_crossfile_token_types(self):
         return {
-            "type", "class", "function", "method", "namespace",
+            "type",
+            "class",
+            "enum",
+            "function",
+            "method",
+            "namespace",
+            "interface",
+            "variable",
             "property",
         }
 
     def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+        if name in ("<constructor>", "constructor"):
+            name = "constructor"
+
         node_type = self._classify_symbol_type(kind)
 
         if parent_unified_part:

--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -10,6 +10,7 @@ Uses composition — holds a reference to CodeGraph and LSPClient.
 Language-specific behavior is delegated via abstract methods that
 patcher_lang subclasses must implement.
 """
+
 from __future__ import annotations
 
 import time
@@ -17,9 +18,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
 
-from ..graph.code_graph import CodeGraph
-from ..log_utils import get_logger
-from ..types import (
+from ...log_utils import get_logger
+from ...types import (
     EDGE_TYPE_CONTAIN,
     EDGE_TYPE_REFERENCE,
     NODE_TYPE_CLASS,
@@ -29,35 +29,40 @@ from ..types import (
     NODE_TYPE_METHOD,
     NODE_TYPE_SYMBOL,
 )
+from ..code_graph import CodeGraph
 from .lsp_client import LSPClient, uri_to_relpath
 
 logger = get_logger(__name__)
 
 # LSP SymbolKind integer → NODE_TYPE_* default mapping
 LSP_KIND_TO_NODE_TYPE = {
-    2: NODE_TYPE_CLASS,       # Module
-    3: NODE_TYPE_CLASS,       # Namespace
-    5: NODE_TYPE_CLASS,       # Class
-    6: NODE_TYPE_METHOD,      # Method
-    7: NODE_TYPE_FIELD,       # Property
-    8: NODE_TYPE_FIELD,       # Field
-    9: NODE_TYPE_METHOD,      # Constructor
-    10: NODE_TYPE_CLASS,      # Enum
-    11: NODE_TYPE_CLASS,      # Interface
-    12: NODE_TYPE_FUNCTION,   # Function
-    13: NODE_TYPE_FIELD,      # Variable
-    14: NODE_TYPE_FIELD,      # Constant
-    22: NODE_TYPE_CLASS,      # Enum (alt)
-    23: NODE_TYPE_CLASS,      # Struct
-    25: NODE_TYPE_FUNCTION,   # Operator
+    2: NODE_TYPE_CLASS,  # Module
+    3: NODE_TYPE_CLASS,  # Namespace
+    5: NODE_TYPE_CLASS,  # Class
+    6: NODE_TYPE_METHOD,  # Method
+    7: NODE_TYPE_FIELD,  # Property
+    8: NODE_TYPE_FIELD,  # Field
+    9: NODE_TYPE_METHOD,  # Constructor
+    10: NODE_TYPE_CLASS,  # Enum
+    11: NODE_TYPE_CLASS,  # Interface
+    12: NODE_TYPE_FUNCTION,  # Function
+    13: NODE_TYPE_FIELD,  # Variable
+    14: NODE_TYPE_FIELD,  # Constant
+    22: NODE_TYPE_CLASS,  # Enum (alt)
+    23: NODE_TYPE_CLASS,  # Struct
+    25: NODE_TYPE_FUNCTION,  # Operator
 }
 
 # Symbol types worth querying for cross-file incoming references.
 # Variables, fields, and parameters are file-local — querying references
 # for them causes LSP servers to scan the entire workspace, which is slow.
-_INCOMING_REF_TYPES = frozenset({
-    NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD,
-})
+_INCOMING_REF_TYPES = frozenset(
+    {
+        NODE_TYPE_CLASS,
+        NODE_TYPE_FUNCTION,
+        NODE_TYPE_METHOD,
+    }
+)
 
 
 class SubgraphMgr(ABC):
@@ -158,8 +163,9 @@ class SubgraphMgr(ABC):
         if hasattr(g, "file_to_vertices") and file_path in g.file_to_vertices:
             vids = set(g.file_to_vertices[file_path])
         else:
-            from ..types import NODE_TYPE_FILE as NTF
             from ..graph.code_graph import is_symbol_node
+            from ..types import NODE_TYPE_FILE as NTF
+
             vids = set()
             for v in g.graph.vs:
                 attrs = v.attributes()
@@ -191,22 +197,28 @@ class SubgraphMgr(ABC):
                     key = (v["name"], tv["name"])
                     if key not in seen_outgoing:
                         seen_outgoing.add(key)
-                        severed_outgoing.append((
-                            v["name"], tv["name"],
-                            v_uname,
-                            tv.attributes().get("unified_name") or "",
-                        ))
+                        severed_outgoing.append(
+                            (
+                                v["name"],
+                                tv["name"],
+                                v_uname,
+                                tv.attributes().get("unified_name") or "",
+                            )
+                        )
             # Incoming reference edges from outside
             for eid in g.graph.incident(vid, mode="in"):
                 edge = g.graph.es[eid]
                 if edge["type"] == EDGE_TYPE_REFERENCE:
                     sv = g.graph.vs[edge.source]
                     if edge.source not in vids:
-                        severed_incoming.append((
-                            sv["name"], v["name"],
-                            sv.attributes().get("unified_name") or "",
-                            v_uname,
-                        ))
+                        severed_incoming.append(
+                            (
+                                sv["name"],
+                                v["name"],
+                                sv.attributes().get("unified_name") or "",
+                                v_uname,
+                            )
+                        )
 
         deleted_names = [g.graph.vs[vid]["name"] for vid in vids]
         g.graph.delete_vertices(sorted(vids))
@@ -246,21 +258,27 @@ class SubgraphMgr(ABC):
                 if edge["type"] == EDGE_TYPE_REFERENCE:
                     tv = g.graph.vs[edge.target]
                     if edge.target not in vids:
-                        severed_outgoing.append((
-                            v["name"], tv["name"],
-                            v_uname,
-                            tv.attributes().get("unified_name") or "",
-                        ))
+                        severed_outgoing.append(
+                            (
+                                v["name"],
+                                tv["name"],
+                                v_uname,
+                                tv.attributes().get("unified_name") or "",
+                            )
+                        )
             for eid in g.graph.incident(vid, mode="in"):
                 edge = g.graph.es[eid]
                 if edge["type"] == EDGE_TYPE_REFERENCE:
                     sv = g.graph.vs[edge.source]
                     if edge.source not in vids:
-                        severed_incoming.append((
-                            sv["name"], v["name"],
-                            sv.attributes().get("unified_name") or "",
-                            v_uname,
-                        ))
+                        severed_incoming.append(
+                            (
+                                sv["name"],
+                                v["name"],
+                                sv.attributes().get("unified_name") or "",
+                                v_uname,
+                            )
+                        )
 
         deleted_names = [g.graph.vs[vid]["name"] for vid in vids]
         g.graph.delete_vertices(sorted(vids))
@@ -281,16 +299,15 @@ class SubgraphMgr(ABC):
         if vid is None:
             return 0
         to_delete = [
-            eid for eid in g.graph.incident(vid, mode="out")
+            eid
+            for eid in g.graph.incident(vid, mode="out")
             if g.graph.es[eid]["type"] == EDGE_TYPE_REFERENCE
         ]
         if to_delete:
             g.graph.delete_edges(to_delete)
         return len(to_delete)
 
-    def rename_vertex(
-        self, old_name: str, new_name: str, new_attrs: dict = None
-    ):
+    def rename_vertex(self, old_name: str, new_name: str, new_attrs: dict = None):
         """Rename a vertex without deleting it. All edges preserved."""
         g = self.code_graph
         if old_name == new_name and not new_attrs:
@@ -324,9 +341,7 @@ class SubgraphMgr(ABC):
     # Subgraph construction (from LSP documentSymbol)
     # ═══════════════════════════════════════════════════════════
 
-    def rebuild_file_subgraph(
-        self, file_path: str, symbols: list[dict]
-    ) -> list[str]:
+    def rebuild_file_subgraph(self, file_path: str, symbols: list[dict]) -> list[str]:
         """Add file vertex + symbol vertices + containment edges.
 
         Returns list of created vertex names.
@@ -341,7 +356,8 @@ class SubgraphMgr(ABC):
             g._add_edge(parent_dir, file_path, EDGE_TYPE_CONTAIN)
 
         return self._process_symbol_tree(
-            symbols, file_path,
+            symbols,
+            file_path,
             parent_vertex_name=file_path,
             parent_unified_part="",
         )
@@ -373,13 +389,16 @@ class SubgraphMgr(ABC):
             vertex_name = f"{unified_name}:{start_line}"
             node_type = self._classify_symbol_type(kind)
 
-            g._add_vertex(vertex_name, {
-                "type": node_type,
-                "file": file_path,
-                "start_line": start_line,
-                "end_line": end_line,
-                "unified_name": unified_name,
-            })
+            g._add_vertex(
+                vertex_name,
+                {
+                    "type": node_type,
+                    "file": file_path,
+                    "start_line": start_line,
+                    "end_line": end_line,
+                    "unified_name": unified_name,
+                },
+            )
             g.symbol_ranges[vertex_name] = (start_line, end_line)
 
             sel_start = sel_range.get("start", {})
@@ -404,11 +423,14 @@ class SubgraphMgr(ABC):
 
             children = sym.get("children", [])
             if children:
-                created.extend(self._process_symbol_tree(
-                    children, file_path,
-                    parent_vertex_name=vertex_name,
-                    parent_unified_part=child_parent_part,
-                ))
+                created.extend(
+                    self._process_symbol_tree(
+                        children,
+                        file_path,
+                        parent_vertex_name=vertex_name,
+                        parent_unified_part=child_parent_part,
+                    )
+                )
 
         return created
 
@@ -430,9 +452,7 @@ class SubgraphMgr(ABC):
         for vname in vertex_names:
             vid = self.code_graph.name_to_vertex.get(vname)
             if vid is not None:
-                node_type = self.code_graph.graph.vs[vid].attributes().get(
-                    "type", ""
-                )
+                node_type = self.code_graph.graph.vs[vid].attributes().get("type", "")
                 if node_type not in _INCOMING_REF_TYPES:
                     continue
 
@@ -445,17 +465,13 @@ class SubgraphMgr(ABC):
                 abs_file, sel_line, sel_char, include_declaration=False
             )
             for loc in refs:
-                ref_file = uri_to_relpath(
-                    loc.get("uri", ""), str(self.project_root)
-                )
+                ref_file = uri_to_relpath(loc.get("uri", ""), str(self.project_root))
                 if ref_file is None:
                     continue
                 ref_line = loc.get("range", {}).get("start", {}).get("line", 0)
                 ref_scope = self.match_location_to_scope(ref_file, ref_line)
                 if ref_scope:
-                    self.code_graph._add_edge(
-                        ref_scope, vname, EDGE_TYPE_REFERENCE
-                    )
+                    self.code_graph._add_edge(ref_scope, vname, EDGE_TYPE_REFERENCE)
                     stats["incoming_added"] += 1
                 else:
                     stats["unmatched"] += 1
@@ -473,7 +489,9 @@ class SubgraphMgr(ABC):
         abs_file = str(self.project_root / file_path)
 
         ref_tokens = self._get_semantic_tokens(
-            abs_file, file_path, line_ranges=line_ranges,
+            abs_file,
+            file_path,
+            line_ranges=line_ranges,
         )
         if not ref_tokens:
             return
@@ -481,7 +499,7 @@ class SubgraphMgr(ABC):
         # Map range → vertex for scope resolution
         range_to_vertex = {}
         if line_ranges and len(line_ranges) == len(vertex_names):
-            for vname, (start, end) in zip(vertex_names, line_ranges):
+            for vname, (start, end) in zip(vertex_names, line_ranges, strict=False):
                 range_to_vertex[(start, end)] = vname
 
         # Filter to line ranges if semanticTokens/range wasn't used
@@ -531,8 +549,7 @@ class SubgraphMgr(ABC):
                         resolved += 1
             if resolved:
                 logger.debug(
-                    f"Retry resolved {resolved}/{len(empty_keys)} "
-                    "empty definitions"
+                    f"Retry resolved {resolved}/{len(empty_keys)} " "empty definitions"
                 )
 
         # Build edges
@@ -548,9 +565,7 @@ class SubgraphMgr(ABC):
             if target_file is None:
                 continue
 
-            target_range = defn.get(
-                "targetSelectionRange", defn.get("range", {})
-            )
+            target_range = defn.get("targetSelectionRange", defn.get("range", {}))
             target_line = target_range.get("start", {}).get("line", 0)
 
             scope = None
@@ -560,20 +575,14 @@ class SubgraphMgr(ABC):
                         scope = vname
                         break
             if scope is None:
-                scope = self.match_location_to_scope(
-                    file_path, ref_token["line"]
-                )
+                scope = self.match_location_to_scope(file_path, ref_token["line"])
 
-            target_vertex = self.match_location_to_vertex(
-                target_file, target_line
-            )
+            target_vertex = self.match_location_to_vertex(target_file, target_line)
 
             if scope and target_vertex:
                 edge_key = (scope, target_vertex)
                 if edge_key not in added_edges:
-                    self.code_graph._add_edge(
-                        scope, target_vertex, EDGE_TYPE_REFERENCE
-                    )
+                    self.code_graph._add_edge(scope, target_vertex, EDGE_TYPE_REFERENCE)
                     stats["outgoing_added"] += 1
                     added_edges.add(edge_key)
             else:
@@ -603,7 +612,9 @@ class SubgraphMgr(ABC):
             min_line = min(s for s, _ in line_ranges)
             max_line = max(e for _, e in line_ranges)
             tokens_response = self.lsp_client.semantic_tokens_range(
-                abs_file, min_line, max_line,
+                abs_file,
+                min_line,
+                max_line,
             )
 
         # Fall back to full
@@ -614,9 +625,7 @@ class SubgraphMgr(ABC):
                 reason = "server does not support range"
             else:
                 reason = "range returned empty"
-            logger.debug(
-                f"Using semanticTokens/full for {file_path} ({reason})"
-            )
+            logger.debug(f"Using semanticTokens/full for {file_path} ({reason})")
             tokens_response = self.lsp_client.semantic_tokens_full(abs_file)
 
         # Retry once if still empty
@@ -639,15 +648,14 @@ class SubgraphMgr(ABC):
             self._semantic_tokens_cache[file_path] = None
             return None
 
-        tokens = self.lsp_client.decode_semantic_tokens(
-            tokens_response, abs_file
-        )
+        tokens = self.lsp_client.decode_semantic_tokens(tokens_response, abs_file)
         if not tokens:
             return None
 
         crossfile_types = self._get_crossfile_token_types()
         filtered = [
-            t for t in tokens
+            t
+            for t in tokens
             if "declaration" not in t["modifiers"]
             and "definition" not in t["modifiers"]
             and t["token_type"] in crossfile_types
@@ -659,9 +667,7 @@ class SubgraphMgr(ABC):
     # Location matching
     # ═══════════════════════════════════════════════════════════
 
-    def match_location_to_vertex(
-        self, file_path: str, line: int
-    ) -> Optional[str]:
+    def match_location_to_vertex(self, file_path: str, line: int) -> Optional[str]:
         """Match an LSP location to an existing graph vertex.
 
         Level 1: Exact (file, start_line) match.
@@ -676,9 +682,7 @@ class SubgraphMgr(ABC):
             return candidates[0]
         return self.match_location_to_scope(file_path, line)
 
-    def match_location_to_scope(
-        self, file_path: str, line: int
-    ) -> Optional[str]:
+    def match_location_to_scope(self, file_path: str, line: int) -> Optional[str]:
         """Find the innermost scope vertex containing (file, line)."""
         candidates = []
         for vname, (start, end) in self.code_graph.symbol_ranges.items():

--- a/codeminer/ls_router.py
+++ b/codeminer/ls_router.py
@@ -51,9 +51,7 @@ def _normalize_language(language: Optional[str]) -> str:
     key = language.lower()
     if key not in LANGUAGE_ALIASES:
         supported = ", ".join(sorted(set(LANGUAGE_ALIASES.keys())))
-        raise ValueError(
-            f"Unsupported language: '{language}'. Supported: {supported}"
-        )
+        raise ValueError(f"Unsupported language: {language!r}. Supported: {supported}")
     return LANGUAGE_ALIASES[key]
 
 
@@ -194,7 +192,7 @@ class LSIndexer:
         Returns:
             Statistics dict from the patcher.
         """
-        from .incremental_graph.graph_patcher import GraphPatcher, LANGUAGE_EXTENSIONS
+        from .graph.incremental.graph_patcher import LANGUAGE_EXTENSIONS, GraphPatcher
 
         patcher = GraphPatcher(
             project_root=str(self.project_root),

--- a/codeminer/ls_router.py
+++ b/codeminer/ls_router.py
@@ -194,7 +194,7 @@ class LSIndexer:
         Returns:
             Statistics dict from the patcher.
         """
-        from .incremental.graph_patcher import GraphPatcher
+        from .incremental_graph.graph_patcher import GraphPatcher, LANGUAGE_EXTENSIONS
 
         patcher = GraphPatcher(
             project_root=str(self.project_root),
@@ -202,7 +202,6 @@ class LSIndexer:
             language=self.language,
             profiler=self.profiler,
         )
-        from .incremental.graph_patcher import LANGUAGE_EXTENSIONS
 
         changed = patcher.detect_changed_files(
             str(self.project_root),

--- a/test/graph/incremental/test_graph_patcher.py
+++ b/test/graph/incremental/test_graph_patcher.py
@@ -15,10 +15,11 @@ Requirements:
     - Network access for cloning SWE-bench repos (first run only)
 
 Usage:
-    pytest test/incremental_graph/test_graph_patcher.py -v
-    pytest test/incremental_graph/test_graph_patcher.py -k simple -v
-    pytest test/incremental_graph/test_graph_patcher.py -k swebench -v
+    pytest test/graph/incremental/test_graph_patcher.py -v
+    pytest test/graph/incremental/test_graph_patcher.py -k simple -v
+    pytest test/graph/incremental/test_graph_patcher.py -k swebench -v
 """
+
 from __future__ import annotations
 
 import os
@@ -29,14 +30,15 @@ from pathlib import Path
 import pytest
 
 from codeminer.graph.code_graph import CodeGraph
+from codeminer.graph.incremental.graph_patcher import GraphPatcher
+from codeminer.graph.incremental.lsp_client import LSPClient
 from codeminer.ls_router import LSIndexer
-from codeminer.incremental_graph.lsp_client import LSPClient
-from codeminer.incremental_graph.graph_patcher import GraphPatcher
+
 
 def test_ls_indexer_graph_patch_import():
     """Smoke test: LSIndexer.graph_patch lazy imports resolve correctly."""
     assert hasattr(LSIndexer, "graph_patch")
-    from codeminer.incremental_graph.graph_patcher import LANGUAGE_EXTENSIONS
+    from codeminer.graph.incremental.graph_patcher import LANGUAGE_EXTENSIONS
 
     assert isinstance(LANGUAGE_EXTENSIONS, dict)
 
@@ -72,7 +74,7 @@ def _skip_if_no_scip(language: str):
     """Skip if SCIP indexer for this language is not available."""
     tool = _SCIP_TOOLS.get(language)
     if tool and not shutil.which(tool):
-        pytest.skip(f"SCIP tool '{tool}' not installed")
+        pytest.skip(f"SCIP tool {tool!r} not installed")
 
 
 def _skip_if_no_lsp(language: str):
@@ -82,8 +84,10 @@ def _skip_if_no_lsp(language: str):
 
 def _git(*args, cwd):
     return subprocess.check_output(
-        ["git"] + list(args), cwd=str(cwd),
-        text=True, stderr=subprocess.DEVNULL,
+        ["git"] + list(args),
+        cwd=str(cwd),
+        text=True,
+        stderr=subprocess.DEVNULL,
     ).strip()
 
 
@@ -181,9 +185,15 @@ def _ensure_swebench_repo(repo_name: str, base_commit: str) -> Path:
         cache_dir.mkdir(parents=True, exist_ok=True)
         repo_dir = cache_dir / dirname
         subprocess.run(
-            ["git", "clone", "--quiet",
-             f"https://github.com/{repo_name}.git", str(repo_dir)],
-            check=True, capture_output=True,
+            [
+                "git",
+                "clone",
+                "--quiet",
+                f"https://github.com/{repo_name}.git",
+                str(repo_dir),
+            ],
+            check=True,
+            capture_output=True,
         )
     # Checkout base commit (use short hash to avoid issues with partial clones)
     short = base_commit[:12]
@@ -229,8 +239,12 @@ class TestSimpleRust:
         assert "src/math_utils.rs:add()" in unames
         assert "src/math_utils.rs:is_prime()" in unames
         assert "src/shapes.rs:Rectangle" in unames
-        assert _has_ref_edge(g, "src/main.rs:test_math_utils()", "src/math_utils.rs:add()")
-        assert _has_ref_edge(g, "src/main.rs:test_math_utils()", "src/math_utils.rs:is_prime()")
+        assert _has_ref_edge(
+            g, "src/main.rs:test_math_utils()", "src/math_utils.rs:add()"
+        )
+        assert _has_ref_edge(
+            g, "src/main.rs:test_math_utils()", "src/math_utils.rs:is_prime()"
+        )
         assert _has_ref_edge(g, "src/main.rs:test_shapes()", "src/shapes.rs:Rectangle")
 
         base = _git("rev-parse", "HEAD", cwd=rust_repo)
@@ -277,7 +291,10 @@ class TestSimpleRust:
 
         patcher = GraphPatcher(str(rust_repo), g, "rust")
         changed = GraphPatcher.detect_changed_files(
-            str(rust_repo), base, "HEAD", extensions={".rs"},
+            str(rust_repo),
+            base,
+            "HEAD",
+            extensions={".rs"},
         )
         patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
 
@@ -291,18 +308,22 @@ class TestSimpleRust:
         assert edges_add > 0, "modify: add() edges survive"
         # remove: vertex gone
         assert "src/math_utils.rs:is_prime()" not in unames, "remove: is_prime gone"
-        assert _count_ref_edges_involving(g, "src/math_utils.rs:is_prime()") == 0, \
-            "remove: is_prime edges gone"
+        assert (
+            _count_ref_edges_involving(g, "src/math_utils.rs:is_prime()") == 0
+        ), "remove: is_prime edges gone"
         # shift: multiply survives with edge
         assert "src/math_utils.rs:multiply()" in unames, "shift: multiply survives"
-        assert _has_ref_edge(g, "src/main.rs:test_math_utils()", "src/math_utils.rs:multiply()"), \
-            "shift: multiply edge survives"
+        assert _has_ref_edge(
+            g, "src/main.rs:test_math_utils()", "src/math_utils.rs:multiply()"
+        ), "shift: multiply edge survives"
         # cross-file: main→subtract
-        assert _has_ref_edge(g, "src/main.rs:main()", "src/math_utils.rs:subtract()"), \
-            "cross-file: main→subtract"
+        assert _has_ref_edge(
+            g, "src/main.rs:main()", "src/math_utils.rs:subtract()"
+        ), "cross-file: main→subtract"
         # shapes edges unchanged
-        assert _has_ref_edge(g, "src/main.rs:test_shapes()", "src/shapes.rs:Rectangle"), \
-            "unchanged: shapes edge survives"
+        assert _has_ref_edge(
+            g, "src/main.rs:test_shapes()", "src/shapes.rs:Rectangle"
+        ), "unchanged: shapes edge survives"
 
 
 class TestSimpleTypeScript:
@@ -323,7 +344,10 @@ class TestSimpleTypeScript:
     def test_graph_patch(self, ts_repo, tmp_path):
         """One commit: add + remove + modify + cross-file."""
         g = _build_graph_with_scip(
-            ts_repo, "ts", tmp_path / "scip_out", infer_tsconfig=True,
+            ts_repo,
+            "ts",
+            tmp_path / "scip_out",
+            infer_tsconfig=True,
         )
 
         unames = _get_unified_names(g)
@@ -353,7 +377,11 @@ class TestSimpleTypeScript:
         content = content.replace("return a + b;", "const r = a + b;\n    return r;")
 
         # 3. Add divide
-        content += "\nexport function divide(a: number, b: number): number {\n    return a / b;\n}\n"
+        content += (
+            "\nexport function divide("
+            "a: number, b: number): number {\n"
+            "    return a / b;\n}\n"
+        )
         math_file.write_text(content)
 
         # 4. Cross-file call
@@ -370,7 +398,10 @@ class TestSimpleTypeScript:
 
         patcher = GraphPatcher(str(ts_repo), g, "ts")
         changed = GraphPatcher.detect_changed_files(
-            str(ts_repo), base, "HEAD", extensions={".ts", ".tsx", ".js", ".jsx"},
+            str(ts_repo),
+            base,
+            "HEAD",
+            extensions={".ts", ".tsx", ".js", ".jsx"},
         )
         patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
 
@@ -378,8 +409,12 @@ class TestSimpleTypeScript:
         assert "src/math.ts:divide()" in unames, "add: divide vertex"
         assert "src/math.ts:subtract()" not in unames, "remove: subtract gone"
         assert "src/math.ts:add()" in unames, "modify: add survives"
-        assert _has_ref_edge(g, "src/main.ts:wrapper()", "src/math.ts:add()"), "modify: edge survives"
-        assert _has_ref_edge(g, "src/main.ts", "src/math.ts:divide()"), "cross-file: main→divide"
+        assert _has_ref_edge(
+            g, "src/main.ts:wrapper()", "src/math.ts:add()"
+        ), "modify: edge survives"
+        assert _has_ref_edge(
+            g, "src/main.ts", "src/math.ts:divide()"
+        ), "cross-file: main→divide"
 
 
 class TestSimpleCpp:
@@ -395,9 +430,16 @@ class TestSimpleCpp:
         dst = tmp_path / "cpp_simple"
         shutil.copytree(src, dst)
         subprocess.run(
-            ["cmake", "-S", str(dst), "-B", str(dst / "build"),
-             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"],
-            check=True, capture_output=True,
+            [
+                "cmake",
+                "-S",
+                str(dst),
+                "-B",
+                str(dst / "build"),
+                "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+            ],
+            check=True,
+            capture_output=True,
         )
         compdb = dst / "build" / "compile_commands.json"
         link = dst / "compile_commands.json"
@@ -413,8 +455,12 @@ class TestSimpleCpp:
         unames = _get_unified_names(g)
         assert "src/math_utils.cpp:MathUtils.add()" in unames
         assert "src/math_utils.cpp:MathUtils.isPrime()" in unames
-        assert _has_ref_edge(g, "src/main.cpp:testMathUtils()", "src/math_utils.cpp:MathUtils.add()")
-        assert _has_ref_edge(g, "src/main.cpp:testShapes()", "include/shape.h:Rectangle")
+        assert _has_ref_edge(
+            g, "src/main.cpp:testMathUtils()", "src/math_utils.cpp:MathUtils.add()"
+        )
+        assert _has_ref_edge(
+            g, "src/main.cpp:testShapes()", "include/shape.h:Rectangle"
+        )
 
         base = _git("rev-parse", "HEAD", cwd=cpp_repo)
         math_file = cpp_repo / "src" / "math_utils.cpp"
@@ -465,20 +511,28 @@ class TestSimpleCpp:
 
         patcher = GraphPatcher(str(cpp_repo), g, "cpp")
         changed = GraphPatcher.detect_changed_files(
-            str(cpp_repo), base, "HEAD",
+            str(cpp_repo),
+            base,
+            "HEAD",
             extensions={".cpp", ".cc", ".c", ".h", ".hpp"},
         )
         stats = patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
         assert stats["vertices_created"] > 0
 
         unames = _get_unified_names(g)
-        assert "src/math_utils.cpp:MathUtils.subtract()" in unames, "add: subtract vertex"
-        assert "src/math_utils.cpp:MathUtils.isPrime()" not in unames, "remove: isPrime gone"
+        assert (
+            "src/math_utils.cpp:MathUtils.subtract()" in unames
+        ), "add: subtract vertex"
+        assert (
+            "src/math_utils.cpp:MathUtils.isPrime()" not in unames
+        ), "remove: isPrime gone"
         assert "src/math_utils.cpp:MathUtils.add()" in unames, "modify: add survives"
-        assert _has_ref_edge(g, "src/main.cpp:main()", "src/math_utils.cpp:MathUtils.subtract()"), \
-            "cross-file: main→subtract"
-        assert _has_ref_edge(g, "src/main.cpp:testShapes()", "include/shape.h:Rectangle"), \
-            "unchanged: shapes survives"
+        assert _has_ref_edge(
+            g, "src/main.cpp:main()", "src/math_utils.cpp:MathUtils.subtract()"
+        ), "cross-file: main→subtract"
+        assert _has_ref_edge(
+            g, "src/main.cpp:testShapes()", "include/shape.h:Rectangle"
+        ), "unchanged: shapes survives"
 
 
 class TestSimpleGo:
@@ -530,27 +584,29 @@ class TestSimpleGo:
         # 2. Modify Add body
         content = content.replace(
             "result := a + b",
-            "result := a + b\n\tfmt.Println(\"Adding:\", a, b)",
+            'result := a + b\n\tfmt.Println("Adding:", a, b)',
         )
         if '"fmt"' not in content:
             content = content.replace("package main", 'package main\n\nimport "fmt"')
 
         # 3. Add Multiply
-        content += """
-// Multiply multiplies two integers.
-func (c *Calculator) Multiply(a, b int) int {
-	result := a * b
-	c.History = append(c.History, result)
-	return result
-}
-"""
+        content += (
+            "\n// Multiply multiplies two integers.\n"
+            "func (c *Calculator) Multiply(a, b int) int {\n"
+            "    result := a * b\n"
+            "    c.History = append(c.History, result)\n"
+            "    return result\n"
+            "}\n"
+        )
         calc_file.write_text(content)
 
         # 4. Cross-file call
         main_content = main_file.read_text()
         main_content = main_content.replace(
             'fmt.Println("Result:", result)',
-            'fmt.Println("Result:", result)\n\tprod := calc.Multiply(3, 7)\n\tfmt.Println("Product:", prod)',
+            'fmt.Println("Result:", result)\n'
+            "\tprod := calc.Multiply(3, 7)\n"
+            '\tfmt.Println("Product:", prod)',
         )
         main_file.write_text(main_content)
 
@@ -559,13 +615,18 @@ func (c *Calculator) Multiply(a, b int) int {
 
         patcher = GraphPatcher(str(go_repo), g, "go")
         changed = GraphPatcher.detect_changed_files(
-            str(go_repo), base, "HEAD", extensions={".go"},
+            str(go_repo),
+            base,
+            "HEAD",
+            extensions={".go"},
         )
         patcher.patch_files(changed, earlier_commit=base, later_commit="HEAD")
 
         unames = _get_unified_names(g)
         assert "calculator.go:Calculator.Multiply()" in unames, "add: Multiply vertex"
-        assert "calculator.go:Calculator.LastResult()" not in unames, "remove: LastResult gone"
+        assert (
+            "calculator.go:Calculator.LastResult()" not in unames
+        ), "remove: LastResult gone"
         assert "calculator.go:Calculator.Add()" in unames, "modify: Add survives"
         assert "greet.go:Greet()" in unames, "unchanged: Greet survives"
 
@@ -605,8 +666,14 @@ class TestSWEBenchCpp:
             pytest.skip(f"Cannot clone repo: {e}")
             return None  # unreachable; satisfies linter
         subprocess.run(
-            ["cmake", "-S", str(repo), "-B", str(repo / "build"),
-             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"],
+            [
+                "cmake",
+                "-S",
+                str(repo),
+                "-B",
+                str(repo / "build"),
+                "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+            ],
             capture_output=True,
         )
         return repo
@@ -615,17 +682,25 @@ class TestSWEBenchCpp:
         earlier = _get_earlier_commit(repo_dir, self.LATER, self.N_BACK)
 
         _git("checkout", "-f", earlier, cwd=repo_dir)
-        g = _build_graph_with_scip(repo_dir, "cpp", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
+        g = _build_graph_with_scip(
+            repo_dir,
+            "cpp",
+            Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"),
+        )
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
-            str(repo_dir), earlier, self.LATER,
+            str(repo_dir),
+            earlier,
+            self.LATER,
             extensions={".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx"},
         )
         assert len(changed["modified"]) > 0
 
         patcher = GraphPatcher(str(repo_dir), g, "cpp")
-        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        stats = patcher.patch_files(
+            changed, earlier_commit=earlier, later_commit=self.LATER[:12]
+        )
         assert stats["files_modified"] >= 1
         assert stats["vertices_created"] > 0
 
@@ -643,30 +718,34 @@ class TestSWEBenchCpp:
         assert "include/fmt/format.h:fmt.detail.vformat_to()" in unames_after
 
         # .idx incremental should have produced refs
-        assert stats.get("refs_outgoing", 0) > 0, \
-            f"Expected C++ .idx refs, got {stats}"
+        assert stats.get("refs_outgoing", 0) > 0, f"Expected C++ .idx refs, got {stats}"
 
         # ── Strict cross-file edge assertions (format.h → core.h) ──
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "include/fmt/format.h:fmt.detail.for_each_codepoint()",
-            "include/fmt/core.h:fmt.string_view"), \
-            "for_each_codepoint() → string_view"
-        assert _has_ref_edge(g,
+            "include/fmt/core.h:fmt.string_view",
+        ), "for_each_codepoint() → string_view"
+        assert _has_ref_edge(
+            g,
             "include/fmt/format.h:fmt.detail.compute_width()",
-            "include/fmt/core.h:fmt.string_view"), \
-            "compute_width() → string_view"
-        assert _has_ref_edge(g,
+            "include/fmt/core.h:fmt.string_view",
+        ), "compute_width() → string_view"
+        assert _has_ref_edge(
+            g,
             "include/fmt/format.h:fmt.detail.write_bytes()",
-            "include/fmt/core.h:fmt.string_view"), \
-            "write_bytes() → string_view"
-        assert _has_ref_edge(g,
+            "include/fmt/core.h:fmt.string_view",
+        ), "write_bytes() → string_view"
+        assert _has_ref_edge(
+            g,
             "include/fmt/format.h:fmt.vformat()",
-            "include/fmt/core.h:fmt.string_view"), \
-            "vformat() → string_view"
-        assert _has_ref_edge(g,
+            "include/fmt/core.h:fmt.string_view",
+        ), "vformat() → string_view"
+        assert _has_ref_edge(
+            g,
             "include/fmt/format.h:fmt.system_error()",
-            "include/fmt/core.h:fmt.string_view"), \
-            "system_error() → string_view"
+            "include/fmt/core.h:fmt.string_view",
+        ), "system_error() → string_view"
 
 
 class TestSWEBenchGo:
@@ -697,16 +776,25 @@ class TestSWEBenchGo:
         patcher = GraphPatcher(str(repo_dir), None, "go")
         patcher.start_lsp()
 
-        g = _build_graph_with_scip(repo_dir, "go", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
+        g = _build_graph_with_scip(
+            repo_dir,
+            "go",
+            Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"),
+        )
         patcher.code_graph = g
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
-            str(repo_dir), earlier, self.LATER, extensions={".go"},
+            str(repo_dir),
+            earlier,
+            self.LATER,
+            extensions={".go"},
         )
         assert len(changed["modified"]) >= 1
 
-        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        stats = patcher.patch_files(
+            changed, earlier_commit=earlier, later_commit=self.LATER[:12]
+        )
         assert stats["files_modified"] >= 1
         assert stats["vertices_created"] > 0
 
@@ -718,65 +806,84 @@ class TestSWEBenchGo:
 
         # ── Strict vertex assertions (5+) ──
         assert "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler" in unames_after
-        assert "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.ServeHTTP()" in unames_after
-        assert "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.Provision()" in unames_after
-        assert "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.VerboseLogs" in unames_after, \
-            "VerboseLogs field (added in this range) should exist"
-        assert "modules/caddyhttp/reverseproxy/selectionpolicies.go:LeastConnSelection" in unames_after
+        assert (
+            "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.ServeHTTP()"
+            in unames_after
+        )
+        assert (
+            "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.Provision()"
+            in unames_after
+        )
+        assert (
+            "modules/caddyhttp/reverseproxy/reverseproxy.go:Handler.VerboseLogs"
+            in unames_after
+        ), "VerboseLogs field (added in this range) should exist"
+        assert (
+            "modules/caddyhttp/reverseproxy/selectionpolicies.go:LeastConnSelection"
+            in unames_after
+        )
 
         # Check that LSP discovered at least some reference edges
         total_refs = stats.get("refs_incoming", 0) + stats.get("refs_outgoing", 0)
-        assert total_refs > 0, \
-            f"Expected reference edges for Go, got {total_refs}"
+        assert total_refs > 0, f"Expected reference edges for Go, got {total_refs}"
 
         # ── Strict cross-file edge assertions (10+) ──
         # Go SCIP edge source is file vertex (name), target has unified_name
         # connpolicy.go → values.go
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "modules/caddytls/connpolicy.go",
-            "modules/caddytls/values.go:CipherSuiteID()"), \
-            "connpolicy.go → CipherSuiteID()"
-        assert _has_ref_edge(g,
+            "modules/caddytls/values.go:CipherSuiteID()",
+        ), "connpolicy.go → CipherSuiteID()"
+        assert _has_ref_edge(
+            g,
             "modules/caddytls/connpolicy.go",
-            "modules/caddytls/values.go:SupportedCurves"), \
-            "connpolicy.go → SupportedCurves"
-        assert _has_ref_edge(g,
+            "modules/caddytls/values.go:SupportedCurves",
+        ), "connpolicy.go → SupportedCurves"
+        assert _has_ref_edge(
+            g,
             "modules/caddytls/connpolicy.go",
-            "modules/caddytls/values.go:SupportedProtocols"), \
-            "connpolicy.go → SupportedProtocols"
-        assert _has_ref_edge(g,
+            "modules/caddytls/values.go:SupportedProtocols",
+        ), "connpolicy.go → SupportedProtocols"
+        assert _has_ref_edge(
+            g,
             "modules/caddytls/connpolicy.go",
-            "modules/caddytls/values.go:getOptimalDefaultCipherSuites()"), \
-            "connpolicy.go → getOptimalDefaultCipherSuites()"
+            "modules/caddytls/values.go:getOptimalDefaultCipherSuites()",
+        ), "connpolicy.go → getOptimalDefaultCipherSuites()"
         # builtins.go → values.go (unmodified file referencing values.go)
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "caddyconfig/httpcaddyfile/builtins.go",
-            "modules/caddytls/values.go:SupportedProtocols"), \
-            "builtins.go → SupportedProtocols"
-        assert _has_ref_edge(g,
+            "modules/caddytls/values.go:SupportedProtocols",
+        ), "builtins.go → SupportedProtocols"
+        assert _has_ref_edge(
+            g,
             "caddyconfig/httpcaddyfile/builtins.go",
-            "modules/caddytls/values.go:SupportedCurves"), \
-            "builtins.go → SupportedCurves"
-        assert _has_ref_edge(g,
+            "modules/caddytls/values.go:SupportedCurves",
+        ), "builtins.go → SupportedCurves"
+        assert _has_ref_edge(
+            g,
             "caddyconfig/httpcaddyfile/builtins.go",
-            "modules/caddytls/values.go:CipherSuiteNameSupported()"), \
-            "builtins.go → CipherSuiteNameSupported()"
+            "modules/caddytls/values.go:CipherSuiteNameSupported()",
+        ), "builtins.go → CipherSuiteNameSupported()"
         # automation.go → values.go
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "modules/caddytls/automation.go",
-            "modules/caddytls/values.go:supportedCertKeyTypes"), \
-            "automation.go → supportedCertKeyTypes"
+            "modules/caddytls/values.go:supportedCertKeyTypes",
+        ), "automation.go → supportedCertKeyTypes"
         # replacer.go → values.go
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "modules/caddyhttp/replacer.go",
-            "modules/caddytls/values.go:ProtocolName()"), \
-            "replacer.go → ProtocolName()"
+            "modules/caddytls/values.go:ProtocolName()",
+        ), "replacer.go → ProtocolName()"
         # fastcgi → values.go
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go",
-            "modules/caddytls/values.go:SupportedCipherSuites()"), \
-            "fastcgi.go → SupportedCipherSuites()"
-
+            "modules/caddytls/values.go:SupportedCipherSuites()",
+        ), "fastcgi.go → SupportedCipherSuites()"
 
 
 class TestSWEBenchRust:
@@ -805,16 +912,25 @@ class TestSWEBenchRust:
         patcher = GraphPatcher(str(repo_dir), None, "rust")
         patcher.start_lsp()
 
-        g = _build_graph_with_scip(repo_dir, "rust", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
+        g = _build_graph_with_scip(
+            repo_dir,
+            "rust",
+            Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"),
+        )
         patcher.code_graph = g
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
-            str(repo_dir), earlier, self.LATER, extensions={".rs"},
+            str(repo_dir),
+            earlier,
+            self.LATER,
+            extensions={".rs"},
         )
         assert len(changed["modified"]) >= 1
 
-        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        stats = patcher.patch_files(
+            changed, earlier_commit=earlier, later_commit=self.LATER[:12]
+        )
         assert stats["files_modified"] >= 1
         assert stats["vertices_created"] > 0
 
@@ -826,8 +942,7 @@ class TestSWEBenchRust:
 
         # Edges should be preserved or rediscovered
         total_refs = stats.get("refs_incoming", 0) + stats.get("refs_outgoing", 0)
-        assert total_refs > 0, \
-            f"Expected reference edges for Rust, got {total_refs}"
+        assert total_refs > 0, f"Expected reference edges for Rust, got {total_refs}"
         # Overall edges
 
         # ── Strict vertex assertions ──
@@ -840,48 +955,57 @@ class TestSWEBenchRust:
 
         # ── Strict cross-file edge assertions (10+) ──
         # object_without_hash_method() uses Checker, Diagnostic, StmtClassDef
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}object_without_hash_method()",
-            "crates/ruff_linter/src/checkers/ast/mod.rs:Checker"), \
-            "object_without_hash_method() → Checker"
-        assert _has_ref_edge(g,
+            "crates/ruff_linter/src/checkers/ast/mod.rs:Checker",
+        ), "object_without_hash_method() → Checker"
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}object_without_hash_method()",
-            "crates/ruff_diagnostics/src/diagnostic.rs:Diagnostic"), \
-            "object_without_hash_method() → Diagnostic"
-        assert _has_ref_edge(g,
+            "crates/ruff_diagnostics/src/diagnostic.rs:Diagnostic",
+        ), "object_without_hash_method() → Diagnostic"
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}object_without_hash_method()",
-            "crates/ruff_diagnostics/src/diagnostic.rs:Diagnostic.new()"), \
-            "object_without_hash_method() → Diagnostic.new()"
-        assert _has_ref_edge(g,
+            "crates/ruff_diagnostics/src/diagnostic.rs:Diagnostic.new()",
+        ), "object_without_hash_method() → Diagnostic.new()"
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}object_without_hash_method()",
-            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef"), \
-            "object_without_hash_method() → StmtClassDef"
-        assert _has_ref_edge(g,
+            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef",
+        ), "object_without_hash_method() → StmtClassDef"
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}object_without_hash_method()",
-            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef.name"), \
-            "object_without_hash_method() → StmtClassDef.name"
-        assert _has_ref_edge(g,
+            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef.name",
+        ), "object_without_hash_method() → StmtClassDef.name"
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}object_without_hash_method()",
-            "crates/ruff_linter/src/checkers/ast/mod.rs:Checker.diagnostics"), \
-            "object_without_hash_method() → Checker.diagnostics"
+            "crates/ruff_linter/src/checkers/ast/mod.rs:Checker.diagnostics",
+        ), "object_without_hash_method() → Checker.diagnostics"
         # EqHash.from_class() uses any_member_declaration, ClassMemberKind
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}EqHash.from_class()",
-            "crates/ruff_python_semantic/src/analyze/class.rs:any_member_declaration()"), \
-            "EqHash.from_class() → any_member_declaration()"
-        assert _has_ref_edge(g,
+            "crates/ruff_python_semantic/src/analyze/class.rs:any_member_declaration()",
+        ), "EqHash.from_class() → any_member_declaration()"
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}EqHash.from_class()",
-            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef"), \
-            "EqHash.from_class() → StmtClassDef"
-        assert _has_ref_edge(g,
+            "crates/ruff_python_ast/src/nodes.rs:StmtClassDef",
+        ), "EqHash.from_class() → StmtClassDef"
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}EqHash.from_class()",
-            "crates/ruff_python_semantic/src/analyze/class.rs:ClassMemberDeclaration.kind()"), \
-            "EqHash.from_class() → ClassMemberDeclaration.kind()"
-        assert _has_ref_edge(g,
+            "crates/ruff_python_semantic/src/analyze/class.rs:ClassMemberDeclaration.kind()",
+        ), "EqHash.from_class() → ClassMemberDeclaration.kind()"
+        assert _has_ref_edge(
+            g,
             f"{eq_prefix}object_without_hash_method()",
-            "crates/ruff_python_ast/src/nodes.rs:Identifier<Ranged>.range()"), \
-            "object_without_hash_method() → Identifier.range()"
-
+            "crates/ruff_python_ast/src/nodes.rs:Identifier<Ranged>.range()",
+        ), "object_without_hash_method() → Identifier.range()"
 
 
 class TestSWEBenchPython:
@@ -910,16 +1034,25 @@ class TestSWEBenchPython:
         patcher = GraphPatcher(str(repo_dir), None, "python")
         patcher.start_lsp()
 
-        g = _build_graph_with_scip(repo_dir, "python", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"))
+        g = _build_graph_with_scip(
+            repo_dir,
+            "python",
+            Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"),
+        )
         patcher.code_graph = g
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
-            str(repo_dir), earlier, self.LATER, extensions={".py"},
+            str(repo_dir),
+            earlier,
+            self.LATER,
+            extensions={".py"},
         )
         assert len(changed["modified"]) >= 1
 
-        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        stats = patcher.patch_files(
+            changed, earlier_commit=earlier, later_commit=self.LATER[:12]
+        )
         assert stats["files_modified"] >= 1
         assert stats["vertices_created"] > 0
 
@@ -931,8 +1064,7 @@ class TestSWEBenchPython:
 
         # Edges should be preserved or rediscovered
         total_refs = stats.get("refs_incoming", 0) + stats.get("refs_outgoing", 0)
-        assert total_refs > 0, \
-            f"Expected reference edges for Python, got {total_refs}"
+        assert total_refs > 0, f"Expected reference edges for Python, got {total_refs}"
         # Overall edges
 
         # ── Strict vertex assertions (5+) ──
@@ -946,63 +1078,72 @@ class TestSWEBenchPython:
         assert "sklearn/naive_bayes.py:MultinomialNB" in unames_after
 
         # _check_fit_data was renamed to _check_test_data
-        assert "sklearn/cluster/k_means_.py:KMeans._check_fit_data()" not in unames_after, \
-            "_check_fit_data should be removed after patch"
-        assert "sklearn/cluster/k_means_.py:KMeans._check_test_data()" in unames_after, \
-            "_check_test_data (renamed) should exist after patch"
+        assert (
+            "sklearn/cluster/k_means_.py:KMeans._check_fit_data()" not in unames_after
+        ), "_check_fit_data should be removed after patch"
+        assert (
+            "sklearn/cluster/k_means_.py:KMeans._check_test_data()" in unames_after
+        ), "_check_test_data (renamed) should exist after patch"
 
         # ── Strict cross-file edge assertions (10+) ──
         # k_means_.py → utils
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "sklearn/cluster/k_means_.py:k_means()",
-            "sklearn/utils/validation.py:check_array()"), \
-            "k_means() → check_array()"
-        assert _has_ref_edge(g,
+            "sklearn/utils/validation.py:check_array()",
+        ), "k_means() → check_array()"
+        assert _has_ref_edge(
+            g,
             "sklearn/cluster/k_means_.py:k_means()",
-            "sklearn/utils/validation.py:check_random_state()"), \
-            "k_means() → check_random_state()"
-        assert _has_ref_edge(g,
+            "sklearn/utils/validation.py:check_random_state()",
+        ), "k_means() → check_random_state()"
+        assert _has_ref_edge(
+            g,
             "sklearn/cluster/k_means_.py:k_means()",
-            "sklearn/utils/extmath.py:row_norms()"), \
-            "k_means() → row_norms()"
-        assert _has_ref_edge(g,
+            "sklearn/utils/extmath.py:row_norms()",
+        ), "k_means() → row_norms()"
+        assert _has_ref_edge(
+            g,
             "sklearn/cluster/k_means_.py:KMeans.fit()",
-            "sklearn/utils/validation.py:check_random_state()"), \
-            "KMeans.fit() → check_random_state()"
-        assert _has_ref_edge(g,
+            "sklearn/utils/validation.py:check_random_state()",
+        ), "KMeans.fit() → check_random_state()"
+        assert _has_ref_edge(
+            g,
             "sklearn/cluster/k_means_.py:KMeans.transform()",
-            "sklearn/utils/validation.py:check_is_fitted()"), \
-            "KMeans.transform() → check_is_fitted()"
+            "sklearn/utils/validation.py:check_is_fitted()",
+        ), "KMeans.transform() → check_is_fitted()"
         # k_means_.py → metrics
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "sklearn/cluster/k_means_.py:KMeans._transform()",
-            "sklearn/metrics/pairwise.py:euclidean_distances()"), \
-            "KMeans._transform() → euclidean_distances()"
+            "sklearn/metrics/pairwise.py:euclidean_distances()",
+        ), "KMeans._transform() → euclidean_distances()"
         # k_means_.py inheritance → base
-        assert _has_ref_edge(g,
-            "sklearn/cluster/k_means_.py:KMeans",
-            "sklearn/base.py:BaseEstimator"), \
-            "KMeans → BaseEstimator (inheritance)"
+        assert _has_ref_edge(
+            g, "sklearn/cluster/k_means_.py:KMeans", "sklearn/base.py:BaseEstimator"
+        ), "KMeans → BaseEstimator (inheritance)"
         # naive_bayes.py → utils
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "sklearn/naive_bayes.py:GaussianNB.fit()",
-            "sklearn/utils/validation.py:check_X_y()"), \
-            "GaussianNB.fit() → check_X_y()"
-        assert _has_ref_edge(g,
+            "sklearn/utils/validation.py:check_X_y()",
+        ), "GaussianNB.fit() → check_X_y()"
+        assert _has_ref_edge(
+            g,
             "sklearn/naive_bayes.py:BaseDiscreteNB.fit()",
-            "sklearn/utils/validation.py:check_X_y()"), \
-            "BaseDiscreteNB.fit() → check_X_y()"
-        assert _has_ref_edge(g,
-            "sklearn/naive_bayes.py:BaseNB",
-            "sklearn/base.py:BaseEstimator"), \
-            "BaseNB → BaseEstimator (inheritance)"
+            "sklearn/utils/validation.py:check_X_y()",
+        ), "BaseDiscreteNB.fit() → check_X_y()"
+        assert _has_ref_edge(
+            g, "sklearn/naive_bayes.py:BaseNB", "sklearn/base.py:BaseEstimator"
+        ), "BaseNB → BaseEstimator (inheritance)"
 
         # _check_fit_data was deleted — its edges should be gone
         check_fit_edges = _count_ref_edges_involving(
-            g, "sklearn/cluster/k_means_.py:KMeans._check_fit_data()")
-        assert check_fit_edges == 0, \
-            f"_check_fit_data edges should be gone, got {check_fit_edges}"
-
+            g, "sklearn/cluster/k_means_.py:KMeans._check_fit_data()"
+        )
+        assert (
+            check_fit_edges == 0
+        ), f"_check_fit_data edges should be gone, got {check_fit_edges}"
 
 
 class TestSWEBenchTypeScript:
@@ -1032,18 +1173,25 @@ class TestSWEBenchTypeScript:
         patcher.start_lsp()
 
         g = _build_graph_with_scip(
-            repo_dir, "ts", Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"), infer_tsconfig=True,
+            repo_dir,
+            "ts",
+            Path.home() / ".codeminer" / "scip_cache" / self.REPO.replace("/", "_"),
+            infer_tsconfig=True,
         )
         patcher.code_graph = g
 
         _git("checkout", "-f", self.LATER[:12], cwd=repo_dir)
         changed = GraphPatcher.detect_changed_files(
-            str(repo_dir), earlier, self.LATER,
+            str(repo_dir),
+            earlier,
+            self.LATER,
             extensions={".ts", ".tsx", ".js", ".jsx"},
         )
         assert len(changed["modified"]) >= 1
 
-        stats = patcher.patch_files(changed, earlier_commit=earlier, later_commit=self.LATER[:12])
+        stats = patcher.patch_files(
+            changed, earlier_commit=earlier, later_commit=self.LATER[:12]
+        )
         assert stats["files_modified"] >= 1
         assert stats["vertices_created"] > 0
 
@@ -1057,8 +1205,7 @@ class TestSWEBenchTypeScript:
 
         # Edges should be preserved or rediscovered
         total_refs = stats.get("refs_incoming", 0) + stats.get("refs_outgoing", 0)
-        assert total_refs > 0, \
-            f"Expected reference edges for TS, got {total_refs}"
+        assert total_refs > 0, f"Expected reference edges for TS, got {total_refs}"
         # Overall edges
 
         # ── Strict vertex assertions (5+) ──
@@ -1072,46 +1219,41 @@ class TestSWEBenchTypeScript:
         # ── Strict cross-file edge assertions (10+) ──
         # portals.js imports { createElement, render } from 'preact'
         # SCIP resolves 'preact' to the .d.ts declarations with preact/ prefix
-        assert _has_ref_edge(g,
-            "compat/src/portals.js:Portal()",
-            "src/index.d.ts:preact/render()"), \
-            "Portal() → preact/render()"
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g, "compat/src/portals.js:Portal()", "src/index.d.ts:preact/render()"
+        ), "Portal() → preact/render()"
+        assert _has_ref_edge(
+            g,
             "compat/src/portals.js:createPortal()",
-            "src/index.d.ts:preact/createElement()"), \
-            "createPortal() → preact/createElement()"
+            "src/index.d.ts:preact/createElement()",
+        ), "createPortal() → preact/createElement()"
 
         # children.js: import { diff, unmount, applyRef } from './index'
-        assert _has_ref_edge(g,
-            "src/diff/children.js:diffChildren()",
-            "src/diff/index.js:diff()"), \
-            "diffChildren → diff()"
-        assert _has_ref_edge(g,
-            "src/diff/children.js:diffChildren()",
-            "src/diff/index.js:unmount()"), \
-            "diffChildren → unmount()"
+        assert _has_ref_edge(
+            g, "src/diff/children.js:diffChildren()", "src/diff/index.js:diff()"
+        ), "diffChildren → diff()"
+        assert _has_ref_edge(
+            g, "src/diff/children.js:diffChildren()", "src/diff/index.js:unmount()"
+        ), "diffChildren → unmount()"
 
         # children.js: import { getDomSibling } from '../component'
-        assert _has_ref_edge(g,
-            "src/diff/children.js:diffChildren()",
-            "src/component.js:getDomSibling()"), \
-            "diffChildren → getDomSibling()"
+        assert _has_ref_edge(
+            g, "src/diff/children.js:diffChildren()", "src/component.js:getDomSibling()"
+        ), "diffChildren → getDomSibling()"
 
         # children.js: import { createVNode, Fragment } from '../create-element'
-        assert _has_ref_edge(g,
+        assert _has_ref_edge(
+            g,
             "src/diff/children.js:diffChildren()",
-            "src/create-element.js:createVNode()"), \
-            "diffChildren → createVNode()"
+            "src/create-element.js:createVNode()",
+        ), "diffChildren → createVNode()"
 
         # children.js: import { removeNode } from '../util'
-        assert _has_ref_edge(g,
-            "src/diff/children.js:diffChildren()",
-            "src/util.js:removeNode()"), \
-            "diffChildren → removeNode()"
+        assert _has_ref_edge(
+            g, "src/diff/children.js:diffChildren()", "src/util.js:removeNode()"
+        ), "diffChildren → removeNode()"
 
         # children.js: import { EMPTY_OBJ, EMPTY_ARR } from '../constants'
-        assert _has_ref_edge(g,
-            "src/diff/children.js:diffChildren()",
-            "src/constants.js:EMPTY_OBJ"), \
-            "diffChildren → EMPTY_OBJ"
-
+        assert _has_ref_edge(
+            g, "src/diff/children.js:diffChildren()", "src/constants.js:EMPTY_OBJ"
+        ), "diffChildren → EMPTY_OBJ"

--- a/test/graph/incremental/test_lsp_decoder.py
+++ b/test/graph/incremental/test_lsp_decoder.py
@@ -8,16 +8,17 @@ Tests the full decode pipeline for each LSP message format:
 
 Uses mock LSP responses (no actual LSP server needed).
 """
-from codeminer.graph.code_graph import CodeGraph
-from codeminer.incremental_graph.patcher_rust import PatcherRust
-from codeminer.incremental_graph.patcher_ts import PatcherTS
-from codeminer.incremental_graph.patcher_go import PatcherGo
-from codeminer.incremental_graph.patcher_python import PatcherPython
 
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.graph.incremental.patcher_go import PatcherGo
+from codeminer.graph.incremental.patcher_python import PatcherPython
+from codeminer.graph.incremental.patcher_rust import PatcherRust
+from codeminer.graph.incremental.patcher_ts import PatcherTS
 
 # ═══════════════════════════════════════════════════════════════
 # Helpers: mock LSP responses
 # ═══════════════════════════════════════════════════════════════
+
 
 def _sym(name, kind, start, end, children=None):
     """Build a documentSymbol response dict."""
@@ -53,6 +54,7 @@ def _semantic_tokens_data(tokens_spec):
 # 1. documentSymbol decoding
 # ═══════════════════════════════════════════════════════════════
 
+
 class TestDocumentSymbol:
     """Test documentSymbol → rebuild_file_subgraph → graph vertices."""
 
@@ -60,8 +62,8 @@ class TestDocumentSymbol:
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
         symbols = [
-            _sym("add", 12, 0, 5),      # Function
-            _sym("multiply", 12, 7, 12), # Function
+            _sym("add", 12, 0, 5),  # Function
+            _sym("multiply", 12, 7, 12),  # Function
         ]
         created = p.rebuild_file_subgraph("src/math.rs", symbols)
 
@@ -74,10 +76,16 @@ class TestDocumentSymbol:
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
         symbols = [
-            _sym("Router", 23, 5, 50, children=[
-                _sym("handle", 6, 10, 30),
-                _sym("new", 6, 35, 45),
-            ]),
+            _sym(
+                "Router",
+                23,
+                5,
+                50,
+                children=[
+                    _sym("handle", 6, 10, 30),
+                    _sym("new", 6, 35, 45),
+                ],
+            ),
             _sym("run", 12, 55, 60),
         ]
         created = p.rebuild_file_subgraph("src/lib.rs", symbols)
@@ -102,9 +110,15 @@ class TestDocumentSymbol:
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
         symbols = [
-            _sym("impl Violation for EqWithoutHash", 19, 50, 80, children=[
-                _sym("message", 6, 55, 70),
-            ]),
+            _sym(
+                "impl Violation for EqWithoutHash",
+                19,
+                50,
+                80,
+                children=[
+                    _sym("message", 6, 55, 70),
+                ],
+            ),
         ]
         created = p.rebuild_file_subgraph("src/rules.rs", symbols)
 
@@ -115,10 +129,16 @@ class TestDocumentSymbol:
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
         symbols = [
-            _sym("tests", 2, 40, 80, children=[  # Module
-                _sym("test_add", 12, 42, 50),
-                _sym("test_mul", 12, 52, 60),
-            ]),
+            _sym(
+                "tests",
+                2,
+                40,
+                80,
+                children=[  # Module
+                    _sym("test_add", 12, 42, 50),
+                    _sym("test_mul", 12, 52, 60),
+                ],
+            ),
         ]
         created = p.rebuild_file_subgraph("src/math.rs", symbols)
 
@@ -139,10 +159,16 @@ class TestDocumentSymbol:
         g = CodeGraph(project_root="/tmp")
         p = PatcherTS("/tmp", g)
         symbols = [
-            _sym("Axios", 5, 0, 100, children=[
-                _sym("<constructor>", 9, 10, 30),
-                _sym("request", 6, 35, 80),
-            ]),
+            _sym(
+                "Axios",
+                5,
+                0,
+                100,
+                children=[
+                    _sym("<constructor>", 9, 10, 30),
+                    _sym("request", 6, 35, 80),
+                ],
+            ),
         ]
         created = p.rebuild_file_subgraph("index.ts", symbols)
 
@@ -154,10 +180,16 @@ class TestDocumentSymbol:
         g = CodeGraph(project_root="/tmp")
         p = PatcherPython("/tmp", g)
         symbols = [
-            _sym("KMeans", 5, 10, 200, children=[
-                _sym("fit", 6, 20, 80),
-                _sym("predict", 6, 90, 150),
-            ]),
+            _sym(
+                "KMeans",
+                5,
+                10,
+                200,
+                children=[
+                    _sym("fit", 6, 20, 80),
+                    _sym("predict", 6, 90, 150),
+                ],
+            ),
         ]
         created = p.rebuild_file_subgraph("cluster.py", symbols)
 
@@ -173,30 +205,43 @@ class TestDocumentSymbol:
 
         vname = "src/main.rs:main():0"
         assert vname in p.symbol_selection_ranges
-        assert p.symbol_selection_ranges[vname][0] == 0   # start line
-        assert p.symbol_selection_ranges[vname][1] == 4   # start char
+        assert p.symbol_selection_ranges[vname][0] == 0  # start line
+        assert p.symbol_selection_ranges[vname][1] == 4  # start char
 
 
 # ═══════════════════════════════════════════════════════════════
 # 2. semanticTokens decoding
 # ═══════════════════════════════════════════════════════════════
 
+
 class _MockClient:
     """Mock LSP client with semantic tokens legend."""
+
     semantic_tokens_legend = {
         "tokenTypes": [
-            "namespace", "type", "class", "function", "method",
-            "property", "variable", "parameter", "keyword",
+            "namespace",
+            "type",
+            "class",
+            "function",
+            "method",
+            "property",
+            "variable",
+            "parameter",
+            "keyword",
         ],
         "tokenModifiers": [
-            "declaration", "definition", "readonly",
+            "declaration",
+            "definition",
+            "readonly",
         ],
     }
+
     def _abs_path(self, p):
         return p
 
     def decode_semantic_tokens(self, response, file_path):
-        from codeminer.incremental_graph.lsp_client import LSPClient
+        from codeminer.graph.incremental.lsp_client import LSPClient
+
         return LSPClient.decode_semantic_tokens(self, response, file_path)
 
 
@@ -210,11 +255,13 @@ class TestSemanticTokensDecode:
         client = _MockClient()
         client._abs_path = lambda p: str(src)
 
-        response = _semantic_tokens_data([
-            (0, 0, 2, 8, 0),   # L0:0 "fn" keyword
-            (0, 3, 3, 3, 2),   # L0:3 "add" function, definition
-            (0, 4, 1, 7, 1),   # L0:7 "a" parameter, declaration
-        ])
+        response = _semantic_tokens_data(
+            [
+                (0, 0, 2, 8, 0),  # L0:0 "fn" keyword
+                (0, 3, 3, 3, 2),  # L0:3 "add" function, definition
+                (0, 4, 1, 7, 1),  # L0:7 "a" parameter, declaration
+            ]
+        )
 
         tokens = client.decode_semantic_tokens(response, str(src))
 
@@ -234,10 +281,12 @@ class TestSemanticTokensDecode:
         client = _MockClient()
         client._abs_path = lambda p: str(src)
 
-        response = _semantic_tokens_data([
-            (0, 4, 3, 0, 0),   # L0:4 "std" namespace
-            (1, 3, 4, 3, 2),   # L1:3 "main" function, definition
-        ])
+        response = _semantic_tokens_data(
+            [
+                (0, 4, 3, 0, 0),  # L0:4 "std" namespace
+                (1, 3, 4, 3, 2),  # L1:3 "main" function, definition
+            ]
+        )
 
         tokens = client.decode_semantic_tokens(response, str(src))
 
@@ -271,16 +320,26 @@ class TestSemanticTokensDecode:
 # 3. definition response → vertex matching
 # ═══════════════════════════════════════════════════════════════
 
+
 class TestDefinitionDecode:
 
     def test_match_exact_line(self):
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
-        p.rebuild_file_subgraph("src/lib.rs", [
-            _sym("Router", 23, 5, 50, children=[
-                _sym("handle", 6, 10, 30),
-            ]),
-        ])
+        p.rebuild_file_subgraph(
+            "src/lib.rs",
+            [
+                _sym(
+                    "Router",
+                    23,
+                    5,
+                    50,
+                    children=[
+                        _sym("handle", 6, 10, 30),
+                    ],
+                ),
+            ],
+        )
 
         result = p.match_location_to_vertex("src/lib.rs", 10)
         assert result == "src/lib.rs:Router.handle():10"
@@ -288,11 +347,20 @@ class TestDefinitionDecode:
     def test_match_within_scope(self):
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
-        p.rebuild_file_subgraph("src/lib.rs", [
-            _sym("Router", 23, 5, 50, children=[
-                _sym("handle", 6, 10, 30),
-            ]),
-        ])
+        p.rebuild_file_subgraph(
+            "src/lib.rs",
+            [
+                _sym(
+                    "Router",
+                    23,
+                    5,
+                    50,
+                    children=[
+                        _sym("handle", 6, 10, 30),
+                    ],
+                ),
+            ],
+        )
 
         result = p.match_location_to_vertex("src/lib.rs", 20)
         assert result == "src/lib.rs:Router.handle():10"
@@ -300,11 +368,20 @@ class TestDefinitionDecode:
     def test_match_class_scope(self):
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
-        p.rebuild_file_subgraph("src/lib.rs", [
-            _sym("Router", 23, 5, 50, children=[
-                _sym("handle", 6, 10, 30),
-            ]),
-        ])
+        p.rebuild_file_subgraph(
+            "src/lib.rs",
+            [
+                _sym(
+                    "Router",
+                    23,
+                    5,
+                    50,
+                    children=[
+                        _sym("handle", 6, 10, 30),
+                    ],
+                ),
+            ],
+        )
 
         result = p.match_location_to_scope("src/lib.rs", 40)
         assert result == "src/lib.rs:Router:5"
@@ -312,9 +389,12 @@ class TestDefinitionDecode:
     def test_fallback_to_file(self):
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
-        p.rebuild_file_subgraph("src/lib.rs", [
-            _sym("run", 12, 5, 10),
-        ])
+        p.rebuild_file_subgraph(
+            "src/lib.rs",
+            [
+                _sym("run", 12, 5, 10),
+            ],
+        )
 
         result = p.match_location_to_scope("src/lib.rs", 20)
         assert result == "src/lib.rs"
@@ -338,15 +418,19 @@ class TestDefinitionDecode:
 # 4. references response → scope matching
 # ═══════════════════════════════════════════════════════════════
 
+
 class TestReferencesDecode:
 
     def test_scope_inside_function(self):
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
-        p.rebuild_file_subgraph("src/main.rs", [
-            _sym("main", 12, 0, 20),
-            _sym("helper", 12, 25, 40),
-        ])
+        p.rebuild_file_subgraph(
+            "src/main.rs",
+            [
+                _sym("main", 12, 0, 20),
+                _sym("helper", 12, 25, 40),
+            ],
+        )
 
         assert p.match_location_to_scope("src/main.rs", 5) == "src/main.rs:main():0"
         assert p.match_location_to_scope("src/main.rs", 30) == "src/main.rs:helper():25"
@@ -354,22 +438,40 @@ class TestReferencesDecode:
     def test_scope_at_file_level(self):
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
-        p.rebuild_file_subgraph("src/main.rs", [
-            _sym("main", 12, 5, 20),
-        ])
+        p.rebuild_file_subgraph(
+            "src/main.rs",
+            [
+                _sym("main", 12, 5, 20),
+            ],
+        )
 
         assert p.match_location_to_scope("src/main.rs", 2) == "src/main.rs"
 
     def test_innermost_scope_wins(self):
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
-        p.rebuild_file_subgraph("src/lib.rs", [
-            _sym("Router", 23, 0, 100, children=[
-                _sym("handle", 6, 10, 50, children=[
-                    _sym("inner", 12, 20, 30),
-                ]),
-            ]),
-        ])
+        p.rebuild_file_subgraph(
+            "src/lib.rs",
+            [
+                _sym(
+                    "Router",
+                    23,
+                    0,
+                    100,
+                    children=[
+                        _sym(
+                            "handle",
+                            6,
+                            10,
+                            50,
+                            children=[
+                                _sym("inner", 12, 20, 30),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
 
         scope = p.match_location_to_scope("src/lib.rs", 25)
         assert scope == "src/lib.rs:Router.handle().inner():20"
@@ -379,16 +481,23 @@ class TestReferencesDecode:
 # 5. flatten_symbols (documentSymbol → classify-ready dict)
 # ═══════════════════════════════════════════════════════════════
 
+
 class TestFlattenSymbols:
 
     def test_filters_local_variables(self):
         g = CodeGraph(project_root="/tmp")
         p = PatcherRust("/tmp", g)
         symbols = [
-            _sym("add", 12, 0, 10, children=[
-                _sym("result", 13, 2, 2),       # Variable inside function
-            ]),
-            _sym("MAX_SIZE", 14, 12, 12),        # Constant at top level
+            _sym(
+                "add",
+                12,
+                0,
+                10,
+                children=[
+                    _sym("result", 13, 2, 2),  # Variable inside function
+                ],
+            ),
+            _sym("MAX_SIZE", 14, 12, 12),  # Constant at top level
         ]
         result = p.flatten_symbols("src/lib.rs", symbols)
 

--- a/test/graph/incremental/test_reference_resolver.py
+++ b/test/graph/incremental/test_reference_resolver.py
@@ -1,4 +1,5 @@
 """Tests for LSPDecoderBase location matching logic (used by reference reconnection)."""
+
 from codeminer.graph.code_graph import CodeGraph
 from codeminer.types import (
     EDGE_TYPE_CONTAIN,
@@ -10,42 +11,64 @@ from codeminer.types import (
 
 def _make_decoder():
     """Create a concrete decoder with a mock graph (no actual LSP client needed)."""
-    from codeminer.incremental_graph.patcher_rust import PatcherRust
+    from codeminer.graph.incremental.patcher_rust import PatcherRust
 
     g = CodeGraph(project_root="/tmp/test")
 
     # Build a graph with known symbol_ranges
     g.add_file_node("src/lib.rs")
-    g._add_vertex("src/lib.rs:Router:5", {
-        "type": NODE_TYPE_CLASS, "file": "src/lib.rs",
-        "start_line": 5, "end_line": 50,
-        "unified_name": "src/lib.rs:Router",
-    })
+    g._add_vertex(
+        "src/lib.rs:Router:5",
+        {
+            "type": NODE_TYPE_CLASS,
+            "file": "src/lib.rs",
+            "start_line": 5,
+            "end_line": 50,
+            "unified_name": "src/lib.rs:Router",
+        },
+    )
     g.symbol_ranges["src/lib.rs:Router:5"] = (5, 50)
     g._add_edge("src/lib.rs", "src/lib.rs:Router:5", EDGE_TYPE_CONTAIN)
 
-    g._add_vertex("src/lib.rs:Router.handle():10", {
-        "type": NODE_TYPE_METHOD, "file": "src/lib.rs",
-        "start_line": 10, "end_line": 30,
-        "unified_name": "src/lib.rs:Router.handle()",
-    })
+    g._add_vertex(
+        "src/lib.rs:Router.handle():10",
+        {
+            "type": NODE_TYPE_METHOD,
+            "file": "src/lib.rs",
+            "start_line": 10,
+            "end_line": 30,
+            "unified_name": "src/lib.rs:Router.handle()",
+        },
+    )
     g.symbol_ranges["src/lib.rs:Router.handle():10"] = (10, 30)
-    g._add_edge("src/lib.rs:Router:5", "src/lib.rs:Router.handle():10", EDGE_TYPE_CONTAIN)
+    g._add_edge(
+        "src/lib.rs:Router:5", "src/lib.rs:Router.handle():10", EDGE_TYPE_CONTAIN
+    )
 
-    g._add_vertex("src/lib.rs:Router.new():35", {
-        "type": NODE_TYPE_METHOD, "file": "src/lib.rs",
-        "start_line": 35, "end_line": 45,
-        "unified_name": "src/lib.rs:Router.new()",
-    })
+    g._add_vertex(
+        "src/lib.rs:Router.new():35",
+        {
+            "type": NODE_TYPE_METHOD,
+            "file": "src/lib.rs",
+            "start_line": 35,
+            "end_line": 45,
+            "unified_name": "src/lib.rs:Router.new()",
+        },
+    )
     g.symbol_ranges["src/lib.rs:Router.new():35"] = (35, 45)
     g._add_edge("src/lib.rs:Router:5", "src/lib.rs:Router.new():35", EDGE_TYPE_CONTAIN)
 
     g.add_file_node("src/main.rs")
-    g._add_vertex("src/main.rs:main():0", {
-        "type": NODE_TYPE_FUNCTION, "file": "src/main.rs",
-        "start_line": 0, "end_line": 20,
-        "unified_name": "src/main.rs:main()",
-    })
+    g._add_vertex(
+        "src/main.rs:main():0",
+        {
+            "type": NODE_TYPE_FUNCTION,
+            "file": "src/main.rs",
+            "start_line": 0,
+            "end_line": 20,
+            "unified_name": "src/main.rs:main()",
+        },
+    )
     g.symbol_ranges["src/main.rs:main():0"] = (0, 20)
     g._add_edge("src/main.rs", "src/main.rs:main():0", EDGE_TYPE_CONTAIN)
 

--- a/test/graph/incremental/test_subgraph_removal.py
+++ b/test/graph/incremental/test_subgraph_removal.py
@@ -1,6 +1,7 @@
 """Tests for SubgraphMgr subgraph deletion and index building."""
+
 from codeminer.graph.code_graph import CodeGraph
-from codeminer.incremental_graph.patcher_rust import PatcherRust
+from codeminer.graph.incremental.patcher_rust import PatcherRust
 from codeminer.types import (
     EDGE_TYPE_CONTAIN,
     EDGE_TYPE_REFERENCE,
@@ -35,31 +36,56 @@ def _build_two_file_graph():
     g.add_file_node("src/main.rs")
     g._add_edge(ROOT_NODE, "src/main.rs", EDGE_TYPE_CONTAIN)
 
-    g.add_symbol_node("main_fn", line=0, scope_start_line=0, scope_end_line=10,
-                       symbol_type=NODE_TYPE_FUNCTION)
+    g.add_symbol_node(
+        "main_fn",
+        line=0,
+        scope_start_line=0,
+        scope_end_line=10,
+        symbol_type=NODE_TYPE_FUNCTION,
+    )
     g.graph.vs[g.name_to_vertex["main_fn"]]["file"] = "src/main.rs"
     g._add_edge("src/main.rs", "main_fn", EDGE_TYPE_CONTAIN)
 
-    g.add_symbol_node("Config", line=12, scope_start_line=12, scope_end_line=20,
-                       symbol_type=NODE_TYPE_CLASS)
+    g.add_symbol_node(
+        "Config",
+        line=12,
+        scope_start_line=12,
+        scope_end_line=20,
+        symbol_type=NODE_TYPE_CLASS,
+    )
     g.graph.vs[g.name_to_vertex["Config"]]["file"] = "src/main.rs"
     g._add_edge("src/main.rs", "Config", EDGE_TYPE_CONTAIN)
 
     g.add_file_node("src/lib.rs")
     g._add_edge(ROOT_NODE, "src/lib.rs", EDGE_TYPE_CONTAIN)
 
-    g.add_symbol_node("run_fn", line=0, scope_start_line=0, scope_end_line=5,
-                       symbol_type=NODE_TYPE_FUNCTION)
+    g.add_symbol_node(
+        "run_fn",
+        line=0,
+        scope_start_line=0,
+        scope_end_line=5,
+        symbol_type=NODE_TYPE_FUNCTION,
+    )
     g.graph.vs[g.name_to_vertex["run_fn"]]["file"] = "src/lib.rs"
     g._add_edge("src/lib.rs", "run_fn", EDGE_TYPE_CONTAIN)
 
-    g.add_symbol_node("Router", line=7, scope_start_line=7, scope_end_line=30,
-                       symbol_type=NODE_TYPE_CLASS)
+    g.add_symbol_node(
+        "Router",
+        line=7,
+        scope_start_line=7,
+        scope_end_line=30,
+        symbol_type=NODE_TYPE_CLASS,
+    )
     g.graph.vs[g.name_to_vertex["Router"]]["file"] = "src/lib.rs"
     g._add_edge("src/lib.rs", "Router", EDGE_TYPE_CONTAIN)
 
-    g.add_symbol_node("handle_fn", line=8, scope_start_line=8, scope_end_line=25,
-                       symbol_type=NODE_TYPE_METHOD)
+    g.add_symbol_node(
+        "handle_fn",
+        line=8,
+        scope_start_line=8,
+        scope_end_line=25,
+        symbol_type=NODE_TYPE_METHOD,
+    )
     g.graph.vs[g.name_to_vertex["handle_fn"]]["file"] = "src/lib.rs"
     g._add_edge("Router", "handle_fn", EDGE_TYPE_CONTAIN)
 
@@ -115,8 +141,12 @@ class TestBuildIndexes:
 
     def test_build_unified_name_index_one_to_many(self):
         g = CodeGraph()
-        g._add_vertex("scip_key_1", {"type": NODE_TYPE_FUNCTION, "unified_name": "f.rs:new()"})
-        g._add_vertex("scip_key_2", {"type": NODE_TYPE_FUNCTION, "unified_name": "f.rs:new()"})
+        g._add_vertex(
+            "scip_key_1", {"type": NODE_TYPE_FUNCTION, "unified_name": "f.rs:new()"}
+        )
+        g._add_vertex(
+            "scip_key_2", {"type": NODE_TYPE_FUNCTION, "unified_name": "f.rs:new()"}
+        )
         mgr = _make_mgr(g)
         mgr.build_indexes()
 
@@ -132,7 +162,11 @@ class TestDeleteFileSubgraph:
         initial_vcount = g.graph.vcount()
         result = mgr.delete_file_subgraph("src/main.rs")
 
-        assert set(result["deleted_vertex_names"]) == {"src/main.rs", "main_fn", "Config"}
+        assert set(result["deleted_vertex_names"]) == {
+            "src/main.rs",
+            "main_fn",
+            "Config",
+        }
         assert g.graph.vcount() == initial_vcount - 3
 
     def test_delete_cleans_name_to_vertex(self):
@@ -236,7 +270,11 @@ class TestDeleteFileSubgraph:
         mgr = _make_mgr(g)
         result = mgr.delete_file_subgraph("src/main.rs")
 
-        assert set(result["deleted_vertex_names"]) == {"src/main.rs", "main_fn", "Config"}
+        assert set(result["deleted_vertex_names"]) == {
+            "src/main.rs",
+            "main_fn",
+            "Config",
+        }
 
     def test_name_to_vertex_consistency_after_delete(self):
         g = _build_two_file_graph()

--- a/test/incremental_graph/test_graph_patcher.py
+++ b/test/incremental_graph/test_graph_patcher.py
@@ -33,6 +33,14 @@ from codeminer.ls_router import LSIndexer
 from codeminer.incremental_graph.lsp_client import LSPClient
 from codeminer.incremental_graph.graph_patcher import GraphPatcher
 
+def test_ls_indexer_graph_patch_import():
+    """Smoke test: LSIndexer.graph_patch lazy imports resolve correctly."""
+    assert hasattr(LSIndexer, "graph_patch")
+    from codeminer.incremental_graph.graph_patcher import LANGUAGE_EXTENSIONS
+
+    assert isinstance(LANGUAGE_EXTENSIONS, dict)
+
+
 SIMPLE_REPOS = Path(__file__).resolve().parent.parent / "scip" / "simple_repos"
 REPO_CACHE_DIRS = [
     Path.home() / ".codeminer" / "repos",

--- a/test/scip/test_scip_axios.py
+++ b/test/scip/test_scip_axios.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""
+Integration test for axios/axios SCIP indexing — verify start_line values
+for convertValue and toFormData in lib/helpers/toFormData.js.
+
+These functions live in the same file and their graph node start_line values
+should match the actual source (SCIP enclosing_range is 0-based).
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
+from codeminer.ls_router import LSIndexer
+from codeminer.types import is_symbol_node
+
+pytestmark = pytest.mark.integration
+
+
+def _pick_axios_instance() -> dict:
+    """Pick the axios__axios-4738 instance from SWE-bench Multilingual."""
+    dataset_obj = SwebenchMultilingualDataset(
+        split="test", filter_instance="axios__axios-4738"
+    )
+    rows = dataset_obj.load()
+    if len(rows) == 0:
+        raise RuntimeError("axios__axios-4738 not found in SWE-bench_Multilingual")
+    return dict(rows[0])
+
+
+def _find_node_by_symbol(ig, symbol_name, file_path=None, node_type=None):
+    """Find a graph node whose symbol name ends with *symbol_name*.
+
+    Matches against the last segment of unified_name (after the last ':')
+    to avoid false matches against file paths in the name.
+    """
+    for v in ig.vs:
+        attrs = v.attributes()
+        unified = attrs.get("unified_name") or ""
+        # Extract symbol portion: everything after the last ':'
+        symbol_part = unified.rsplit(":", 1)[-1] if ":" in unified else unified
+        # Also try the node name
+        name = v["name"]
+        name_part = name.rsplit(":", 1)[-1] if ":" in name else name
+
+        # Match symbol name (strip trailing parens for comparison)
+        symbol_clean = symbol_part.rstrip("()")
+        name_clean = name_part.rstrip("()")
+
+        if symbol_name not in (symbol_clean, name_clean):
+            continue
+
+        # Optional file path filter
+        if file_path is not None:
+            node_file = attrs.get("file", "")
+            if file_path not in node_file:
+                continue
+
+        # Optional type filter
+        if node_type is not None and attrs.get("type") != node_type:
+            continue
+
+        return v
+    return None
+
+
+def _find_nodes_in_file(ig, file_path):
+    """Return all symbol nodes in a given file path."""
+    results = []
+    for v in ig.vs:
+        attrs = v.attributes()
+        if not is_symbol_node(attrs.get("type", "")):
+            continue
+        node_file = attrs.get("file", "")
+        if file_path in node_file:
+            results.append(v)
+    return results
+
+
+@pytest.fixture(scope="module")
+def axios_graph(tmp_path_factory):
+    """Build the SCIP code graph for the axios/axios repo."""
+    if not shutil.which("scip-typescript"):
+        pytest.skip("scip-typescript not available in PATH")
+
+    try:
+        instance = _pick_axios_instance()
+    except Exception as exc:
+        pytest.skip(f"SWE-bench_Multilingual unavailable: {exc}")
+
+    dataset_obj = SwebenchMultilingualDataset(split="test", filter_instance=".*")
+    dataset_obj.process_instance(instance)
+    repo_path = Path(dataset_obj.get_repo_path(instance))
+
+    # Verify the correct commit is checked out
+    expected_commit = instance["base_commit"]
+    actual_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert actual_commit.startswith(expected_commit) or expected_commit.startswith(
+        actual_commit
+    ), (
+        f"Commit mismatch: expected {expected_commit}, got {actual_commit}. "
+        f"process_instance may have failed to checkout the correct commit."
+    )
+
+    tmp_path = tmp_path_factory.mktemp("scip_axios")
+    indexer = LSIndexer(
+        project_root=repo_path,
+        output_dir=tmp_path,
+        language="ts",
+    )
+    graph = indexer.run_pipeline(
+        skip_level="graph", report_profile=False, infer_tsconfig=True
+    )
+    assert graph is not None, "run_pipeline returned None for axios"
+    return graph, repo_path
+
+
+def test_dump_toFormData_file_nodes(axios_graph):
+    """Diagnostic: dump all symbol nodes in lib/helpers/toFormData.js to
+    understand what the SCIP decoder produced."""
+    graph, repo_path = axios_graph
+    ig = graph.graph
+
+    nodes = _find_nodes_in_file(ig, "toFormData.js")
+    print(f"\n=== All symbol nodes in toFormData.js ({len(nodes)} found) ===")
+    for v in sorted(nodes, key=lambda v: v.attributes().get("start_line") or 0):
+        attrs = v.attributes()
+        print(
+            f"  name={v['name']!r}\n"
+            f"    unified_name={attrs.get('unified_name')!r}\n"
+            f"    type={attrs.get('type')!r}\n"
+            f"    file={attrs.get('file')!r}\n"
+            f"    start_line={attrs.get('start_line')}, end_line={attrs.get('end_line')}"
+        )
+    assert len(nodes) > 0, "No symbol nodes found in toFormData.js"
+
+
+def test_toFormData_start_line(axios_graph):
+    """toFormData should start at line 48 (0-based) in lib/helpers/toFormData.js."""
+    graph, repo_path = axios_graph
+    ig = graph.graph
+
+    # Match by symbol name in the correct file
+    node = _find_node_by_symbol(ig, "toFormData", file_path="toFormData.js")
+    toFormData_nodes = [
+        (v["name"], v.attributes().get("type"), v.attributes().get("start_line"))
+        for v in ig.vs
+        if "toFormData" in v["name"]
+    ]
+    assert node is not None, (
+        "toFormData function node not found in toFormData.js; "
+        f"all toFormData nodes: {toFormData_nodes}"
+    )
+
+    attrs = node.attributes()
+    start_line = attrs.get("start_line")
+    end_line = attrs.get("end_line")
+    file_path = attrs.get("file")
+
+    print(f"toFormData: file={file_path}, start_line={start_line}, end_line={end_line}")
+    print(f"  node name: {node['name']}")
+    print(f"  unified_name: {attrs.get('unified_name')}")
+    print(f"  type: {attrs.get('type')}")
+
+    assert start_line is not None, "toFormData has no start_line"
+    assert end_line is not None, "toFormData has no end_line"
+    assert file_path is not None, "toFormData has no file attribute"
+
+    # Verify start_line matches expected position (0-based from SCIP).
+    # toFormData starts at line 48 in 1-based editors, i.e. line 47 in 0-based.
+    assert start_line == 47, (
+        f"toFormData start_line expected 47 (0-based), got {start_line}; "
+        f"this may indicate a line-numbering convention mismatch"
+    )
+
+
+def test_graph_start_line_vs_source(axios_graph):
+    """Cross-check that graph start_line values can correctly index into
+    the source file — verifying the 0-based vs 1-based convention."""
+    graph, repo_path = axios_graph
+    ig = graph.graph
+
+    for symbol_name in ("convertValue", "toFormData"):
+        node = _find_node_by_symbol(ig, symbol_name, file_path="toFormData.js")
+        if node is None:
+            print(f"  {symbol_name}: node not found, skipping")
+            continue
+
+        attrs = node.attributes()
+        start_line = attrs.get("start_line")
+        file_path = attrs.get("file")
+        if start_line is None or file_path is None:
+            continue
+
+        source_file = repo_path / file_path
+        if not source_file.exists():
+            continue
+
+        lines = source_file.read_text().splitlines()
+
+        # If start_line is 0-based, lines[start_line] should contain the symbol
+        if start_line < len(lines):
+            line_0based = lines[start_line]
+            print(
+                f"{symbol_name}: line[{start_line}] (0-based) = {line_0based.strip()!r}"
+            )
+
+        # If start_line is 1-based, lines[start_line - 1] should contain the symbol
+        if start_line - 1 >= 0 and start_line - 1 < len(lines):
+            line_1based = lines[start_line - 1]
+            print(
+                f"{symbol_name}: line[{start_line - 1}] (1-based interp) = "
+                f"{line_1based.strip()!r}"
+            )
+
+        # At least one interpretation should have the function keyword or name
+        found_0 = start_line < len(lines) and (
+            symbol_name in lines[start_line]
+            or "function" in lines[start_line]
+            or "const" in lines[start_line]
+        )
+        found_1 = (
+            start_line - 1 >= 0
+            and start_line - 1 < len(lines)
+            and (
+                symbol_name in lines[start_line - 1]
+                or "function" in lines[start_line - 1]
+                or "const" in lines[start_line - 1]
+            )
+        )
+        assert found_0 or found_1, (
+            f"{symbol_name}: neither 0-based line[{start_line}] nor "
+            f"1-based line[{start_line - 1}] contains the function definition. "
+            f"Graph start_line={start_line}, file={file_path}"
+        )
+        if found_0 and not found_1:
+            print(f"  => {symbol_name} start_line is 0-based")
+        elif found_1 and not found_0:
+            print(f"  => {symbol_name} start_line is 1-based")
+        else:
+            print(f"  => {symbol_name} ambiguous (both lines match)")


### PR DESCRIPTION
## Summary
Refactor the query synthesis pipeline and reorganize the incremental graph module under `codeminer/graph/`.

## Changes
- **Decompose query synthesizer** into a three-stage pipeline:
  - `ContextLoader` — checkout repo, build code graph, sample blocks
  - `QueryCurator` — generate natural-language queries at various modes
  - `Verifier` — verify query quality and target alignment
  - Shared types extracted to `_types.py`, agent runner to `_agent.py`
  - `ClaudeQuerySynthesizer` becomes a thin facade orchestrating the pipeline
- **Move `incremental_graph` → `graph/incremental`**: relocate `codeminer/incremental_graph/` under `codeminer/graph/incremental/` to better reflect the module hierarchy
  - Update all parent-relative imports (`..` → `...`)
  - Re-export `GraphPatcher`, `LSPClient`, `PatcherBase` from `graph/__init__.py`
  - Mirror test structure: `test/incremental_graph/` → `test/graph/incremental/`
  - Fix pre-existing flake8 warnings (B014, B905, B907, B950, W191)
- **Add SCIP test for axios** (js/ts) in `test/scip/test_scip_axios.py`

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
  - `pytest test/scip/test_scip_axios.py` — axios js/ts SCIP indexing
  - `pytest test/graph/incremental/` — all incremental graph tests with updated imports
  - Import verification: `from codeminer.graph.incremental import GraphPatcher` ✓

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published