### PR TITLE
Improve CI: DRY config, local caching, composite action, CLAUDE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for reporting a bug! Please fill out the sections below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Run `pytest test/...`
+        2. Observe error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error Output
+      description: Paste the full error traceback or log output.
+      render: shell
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of CodeMiner is affected?
+      options:
+        - agent
+        - chunking
+        - graph
+        - index
+        - dataset
+        - scip
+        - llm
+        - ops
+        - compiler
+        - eval
+        - ci
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Python version, OS, GPU, relevant package versions.
+      placeholder: "Python 3.12, Ubuntu 22.04, CUDA 12.x"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Describe the feature you'd like to see in CodeMiner.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Why is it needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this feature work? Include API sketches, CLI examples, or diagrams if helpful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you consider?
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of CodeMiner does this relate to?
+      options:
+        - agent
+        - chunking
+        - graph
+        - index
+        - dataset
+        - scip
+        - llm
+        - ops
+        - compiler
+        - eval
+        - ci
+        - other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,59 @@
+name: RFC / Design Proposal
+description: Propose a significant design change or architectural decision
+labels: ["rfc"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for proposals that require team discussion before implementation.
+        Examples: new retrieval strategies, graph schema changes, evaluation methodology, API redesigns.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph overview of the proposal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this change needed? What's the current limitation?
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Detailed Design
+      description: |
+        Describe the proposed changes in detail.
+        Include: affected modules, new/changed APIs, data flow, schema changes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tradeoffs
+    attributes:
+      label: Trade-offs & Risks
+      description: What are the downsides? What could go wrong? Migration concerns?
+
+  - type: textarea
+    id: milestones
+    attributes:
+      label: Implementation Plan
+      description: Break the work into phases or milestones if applicable.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: How large is this change?
+      options:
+        - "Small — single module, < 1 week"
+        - "Medium — multiple modules, 1-2 weeks"
+        - "Large — cross-cutting, > 2 weeks"
+    validations:
+      required: true

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,126 @@
+name: "Setup CodeMiner Environment"
+description: "Shared environment setup for CI jobs (conda, scip, toolchains)"
+
+inputs:
+  python-version:
+    description: "Python version for conda"
+    required: false
+    default: "3.12"
+  install-rust:
+    description: "Install Rust toolchain + rust-analyzer"
+    required: false
+    default: "true"
+  install-clangd:
+    description: "Install clangd"
+    required: false
+    default: "false"
+  install-scip-typescript:
+    description: "Install scip-typescript and yarn"
+    required: false
+    default: "true"
+  install-bear:
+    description: "Install bear build tool"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up codeminer conda env
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        activate-environment: codeminer-test
+        python-version: ${{ inputs.python-version }}
+        auto-activate-base: false
+        remove-profiles: false
+
+    - name: Create scip env
+      shell: bash -l {0}
+      run: |
+        if ! conda env list | grep -q 'scip-env'; then
+          conda env create --quiet --solver=libmamba --file codeminer/scip_interface/scip-environment.yml
+        fi
+
+    - name: Build and install scip-python
+      shell: bash -l {0}
+      run: |
+        git submodule update --init --recursive third_party/scip-python
+        conda run -n scip-env bash -lc "
+          set -euo pipefail
+          cd third_party/scip-python
+          npm ci
+          cd packages/pyright-scip
+          npm ci
+          npm run build
+          npm install -g .
+        "
+
+    - name: Install dependencies
+      shell: bash -l {0}
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[test]"
+
+    - name: Install Rust toolchain + rust-analyzer
+      if: inputs.install-rust == 'true'
+      shell: bash -l {0}
+      run: |
+        if ! command -v rustup >/dev/null 2>&1; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        fi
+        if [ -f "$HOME/.cargo/env" ]; then
+          . "$HOME/.cargo/env"
+        fi
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        rustup toolchain install stable nightly
+        rustup component add rust-analyzer --toolchain nightly
+
+    - name: Install clangd
+      if: inputs.install-clangd == 'true'
+      shell: bash -l {0}
+      run: |
+        if ! command -v clangd >/dev/null 2>&1; then
+          if command -v apt-get >/dev/null 2>&1; then
+            if command -v sudo >/dev/null 2>&1; then
+              sudo apt-get update && sudo apt-get install -y clangd
+            elif [ "$(id -u)" = "0" ]; then
+              apt-get update && apt-get install -y clangd
+            else
+              echo "WARN: cannot install clangd without sudo/root"
+            fi
+          else
+            echo "WARN: apt-get not available; skipping clangd install"
+          fi
+        fi
+        clangd --version || true
+
+    - name: Install scip-typescript
+      if: inputs.install-scip-typescript == 'true'
+      shell: bash -l {0}
+      run: |
+        npm config set prefix "$HOME/.npm-global"
+        export PATH="$HOME/.npm-global/bin:$PATH"
+        npm install -g @sourcegraph/scip-typescript yarn
+        echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+
+    - name: Install bear (best effort)
+      if: inputs.install-bear == 'true'
+      shell: bash -l {0}
+      run: |
+        if command -v bear >/dev/null 2>&1; then
+          bear --version || true
+          exit 0
+        fi
+        if command -v apt-get >/dev/null 2>&1; then
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y bear
+          elif [ "$(id -u)" = "0" ]; then
+            apt-get update
+            apt-get install -y bear
+          else
+            echo "WARN: apt-get available but no sudo/root; cannot install bear"
+          fi
+        else
+          echo "WARN: apt-get not available; skipping bear install"
+        fi

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,89 @@
+# Auto-label PRs based on changed file paths
+# See https://github.com/actions/labeler
+
+# ── Domains ──────────────────────────────────────────────────────────
+agent:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/agent/**
+          - test/agent/**
+
+chunking:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/code_chunking/**
+          - test/chunker/**
+
+graph:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/graph/**
+          - test/graph/**
+
+index:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/index/**
+          - test/index/**
+
+dataset:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/dataset/**
+          - test/dataset/**
+
+scip:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/scip_interface/**
+          - codeminer/ls_index/**
+          - test/scip/**
+
+llm:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/llm/**
+
+ops:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/ops/**
+          - test/ops/**
+
+compiler:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/compiler/**
+          - test/compiler/**
+
+eval:
+  - changed-files:
+      - any-glob-to-any-file:
+          - codeminer/eval/**
+
+# ── Cross-cutting ────────────────────────────────────────────────────
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**.md"
+          - docs/**
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - test/**
+          - conftest.py
+          - pyproject.toml
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - requirements*.txt
+          - setup.py
+          - setup.cfg
+          - pyproject.toml

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,17 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,11 @@ jobs:
 
       - name: Run unit tests
         shell: bash -l {0}
-        run: pytest -n auto -m "not slow and not integration" -x --tb=short
+        run: pytest -n auto -m "not slow and not integration and not integration_serial" -x --tb=short
 
   # =============================================================
-  # Job 2 — Integration tests  (clone repos, SCIP, chunkers, ~15 min)
+  # Job 2 — Integration tests  (read-only, parallel-safe, ~2 min)
+  #   Chunkers, fixture-based SCIP — uses xdist for parallelism
   # =============================================================
   integration:
     needs: [preflight, unit]
@@ -128,15 +129,45 @@ jobs:
           install-clangd: "true"
           install-bear: "true"
 
-      - name: Run integration tests
+      - name: Run integration tests (parallel)
         shell: bash -l {0}
-        run: pytest -m "integration" --tb=short
+        run: pytest -n auto -m "integration" --tb=short
 
   # =============================================================
-  # Job 3 — Slow tests  (LLM API, GPU embeddings, ~15 min)
+  # Job 3 — Integration serial  (mutates repos, ~25 min)
+  #   SCIP indexing, process_instance, git checkout/apply
+  # =============================================================
+  integration-serial:
+    needs: [preflight, integration]
+    if: needs.preflight.outputs.should-run == 'true'
+    runs-on: self-hosted
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
+      npm_config_cache: ${{ github.workspace }}/../.cache/npm
+    steps:
+      - name: Prepare temp HOME
+        run: |
+          mkdir -p "$RUNNER_TEMP/home"
+          echo "HOME=$RUNNER_TEMP/home" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-clangd: "true"
+          install-bear: "true"
+
+      - name: Run integration serial tests
+        shell: bash -l {0}
+        run: pytest -m "integration_serial" --tb=short
+
+  # =============================================================
+  # Job 4 — Slow tests  (LLM API, GPU embeddings, ~15 min)
   # =============================================================
   slow:
-    needs: [preflight, integration]
+    needs: [preflight, integration-serial]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,19 @@ on:
     branches:
       - main
       - master
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
   pull_request:
     branches:
       - "*"
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
   workflow_dispatch:
     inputs:
       skip_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,11 @@ jobs:
           mkdir -p "$RUNNER_TEMP/home"
           echo "HOME=$RUNNER_TEMP/home" >> "$GITHUB_ENV"
 
+      - name: Setup GCP credentials
+        run: |
+          mkdir -p "$HOME/.config/gcloud"
+          echo '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}' > "$HOME/.config/gcloud/application_default_credentials.json"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # =============================================================
   # Preflight — evaluate skip condition once for all jobs
@@ -152,4 +156,4 @@ jobs:
 
       - name: Run slow tests (LLM + embedding)
         shell: bash -l {0}
-        run: pytest -n auto -m "slow" --tb=short
+        run: pytest -m "slow" --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
   # Job 4 — Slow tests  (LLM API, GPU embeddings, ~15 min)
   # =============================================================
   slow:
-    needs: [preflight, integration-serial]
+    needs: [preflight, unit]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,49 @@ on:
 permissions:
   contents: read
 
-# ---------------------------------------------------------------
-# Shared skip condition used by every job.
-# ---------------------------------------------------------------
-# Allows skipping via:
-#   - workflow_dispatch input
-#   - [skip tests] in commit message
-#   - [skip tests] in PR title or skip-tests label
-
 jobs:
+  # =============================================================
+  # Preflight — evaluate skip condition once for all jobs
+  # =============================================================
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - name: Evaluate skip condition
+        id: check
+        run: |
+          SKIP=false
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ github.event.inputs.skip_tests }}" == "true" ]]; then
+              SKIP=true
+            fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ contains(github.event.head_commit.message, '[skip tests]') }}" == "true" ]]; then
+              SKIP=true
+            fi
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if [[ "${{ contains(github.event.pull_request.title, '[skip tests]') }}" == "true" ]] || \
+               [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-tests') }}" == "true" ]]; then
+              SKIP=true
+            fi
+          fi
+          if [[ "$SKIP" == "true" ]]; then
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # =============================================================
   # Job 1 — Unit tests  (pure logic, mocks only, ~1 min)
   # =============================================================
   unit:
-    if: ${{ !((github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_tests == 'true' || github.event.inputs.skip_tests == true)) || (github.event_name == 'push' && contains(github.event.head_commit.message, '[skip tests]')) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.title, '[skip tests]') || contains(github.event.pull_request.labels.*.name, 'skip-tests')))) }}
+    needs: preflight
+    if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
+      npm_config_cache: ${{ github.workspace }}/../.cache/npm
     steps:
       - name: Prepare temp HOME
         run: |
@@ -75,8 +103,12 @@ jobs:
   # Job 2 — Integration tests  (clone repos, SCIP, chunkers, ~15 min)
   # =============================================================
   integration:
-    if: ${{ !((github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_tests == 'true' || github.event.inputs.skip_tests == true)) || (github.event_name == 'push' && contains(github.event.head_commit.message, '[skip tests]')) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.title, '[skip tests]') || contains(github.event.pull_request.labels.*.name, 'skip-tests')))) }}
+    needs: preflight
+    if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
+      npm_config_cache: ${{ github.workspace }}/../.cache/npm
     steps:
       - name: Prepare temp HOME
         run: |
@@ -86,100 +118,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up codeminer conda env
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
         with:
-          activate-environment: codeminer-test
-          python-version: "3.12"
-          auto-activate-base: false
-          remove-profiles: false
-
-      - name: Create scip env (empty conda env for SCIP indexer)
-        shell: bash -l {0}
-        run: |
-          if ! conda env list | grep -q 'scip-env'; then
-            conda env create --quiet --solver=libmamba --file codeminer/scip_interface/scip-environment.yml
-          fi
-
-      - name: Build and install scip-python (local fork) into scip env
-        shell: bash -l {0}
-        run: |
-          git submodule update --init --recursive third_party/scip-python
-          conda run -n scip-env bash -lc "
-            set -euo pipefail
-            cd third_party/scip-python
-            npm ci
-            cd packages/pyright-scip
-            npm ci
-            npm run build
-            npm install -g .
-          "
-
-      - name: Install dependencies
-        shell: bash -l {0}
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[test]"
-
-      - name: Install Rust toolchain + rust-analyzer
-        shell: bash -l {0}
-        run: |
-          if ! command -v rustup >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          fi
-          if [ -f "$HOME/.cargo/env" ]; then
-            . "$HOME/.cargo/env"
-          fi
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          rustup toolchain install stable nightly
-          rustup component add rust-analyzer --toolchain nightly
-
-      - name: Install clangd
-        shell: bash -l {0}
-        run: |
-          if ! command -v clangd >/dev/null 2>&1; then
-            if command -v apt-get >/dev/null 2>&1; then
-              if command -v sudo >/dev/null 2>&1; then
-                sudo apt-get update && sudo apt-get install -y clangd
-              elif [ "$(id -u)" = "0" ]; then
-                apt-get update && apt-get install -y clangd
-              else
-                echo "WARN: cannot install clangd without sudo/root"
-              fi
-            else
-              echo "WARN: apt-get not available; skipping clangd install"
-            fi
-          fi
-          clangd --version || true
-
-      - name: Install scip-typescript
-        shell: bash -l {0}
-        run: |
-          npm config set prefix "$HOME/.npm-global"
-          export PATH="$HOME/.npm-global/bin:$PATH"
-          npm install -g @sourcegraph/scip-typescript yarn
-          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
-
-      - name: Install bear (best effort)
-        shell: bash -l {0}
-        run: |
-          if command -v bear >/dev/null 2>&1; then
-            bear --version || true
-            exit 0
-          fi
-          if command -v apt-get >/dev/null 2>&1; then
-            if command -v sudo >/dev/null 2>&1; then
-              sudo apt-get update
-              sudo apt-get install -y bear
-            elif [ "$(id -u)" = "0" ]; then
-              apt-get update
-              apt-get install -y bear
-            else
-              echo "WARN: apt-get available but no sudo/root; cannot install bear"
-            fi
-          else
-            echo "WARN: apt-get not available; skipping bear install"
-          fi
+          install-clangd: "true"
+          install-bear: "true"
 
       - name: Run integration tests
         shell: bash -l {0}
@@ -189,8 +132,12 @@ jobs:
   # Job 3 — Slow tests  (LLM API, GPU embeddings, ~15 min)
   # =============================================================
   slow:
-    if: ${{ !((github.event_name == 'workflow_dispatch' && (github.event.inputs.skip_tests == 'true' || github.event.inputs.skip_tests == true)) || (github.event_name == 'push' && contains(github.event.head_commit.message, '[skip tests]')) || (github.event_name == 'pull_request' && (contains(github.event.pull_request.title, '[skip tests]') || contains(github.event.pull_request.labels.*.name, 'skip-tests')))) }}
+    needs: preflight
+    if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
+      npm_config_cache: ${{ github.workspace }}/../.cache/npm
     steps:
       - name: Prepare temp HOME
         run: |
@@ -200,61 +147,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up codeminer conda env
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          activate-environment: codeminer-test
-          python-version: "3.12"
-          auto-activate-base: false
-          remove-profiles: false
-
-      - name: Create scip env (empty conda env for SCIP indexer)
-        shell: bash -l {0}
-        run: |
-          if ! conda env list | grep -q 'scip-env'; then
-            conda env create --quiet --solver=libmamba --file codeminer/scip_interface/scip-environment.yml
-          fi
-
-      - name: Build and install scip-python (local fork) into scip env
-        shell: bash -l {0}
-        run: |
-          git submodule update --init --recursive third_party/scip-python
-          conda run -n scip-env bash -lc "
-            set -euo pipefail
-            cd third_party/scip-python
-            npm ci
-            cd packages/pyright-scip
-            npm ci
-            npm run build
-            npm install -g .
-          "
-
-      - name: Install dependencies
-        shell: bash -l {0}
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[test]"
-
-      - name: Install Rust toolchain + rust-analyzer
-        shell: bash -l {0}
-        run: |
-          if ! command -v rustup >/dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          fi
-          if [ -f "$HOME/.cargo/env" ]; then
-            . "$HOME/.cargo/env"
-          fi
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          rustup toolchain install stable nightly
-          rustup component add rust-analyzer --toolchain nightly
-
-      - name: Install scip-typescript
-        shell: bash -l {0}
-        run: |
-          npm config set prefix "$HOME/.npm-global"
-          export PATH="$HOME/.npm-global/bin:$PATH"
-          npm install -g @sourcegraph/scip-typescript yarn
-          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
 
       - name: Run slow tests (LLM + embedding)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Run integration tests
         shell: bash -l {0}
-        run: pytest -n auto -m "integration" --tb=short
+        run: pytest -m "integration" --tb=short
 
   # =============================================================
   # Job 3 — Slow tests  (LLM API, GPU embeddings, ~15 min)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
     needs: [preflight, integration]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
+    timeout-minutes: 45
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
       npm_config_cache: ${{ github.workspace }}/../.cache/npm
@@ -149,6 +150,12 @@ jobs:
         run: |
           mkdir -p "$RUNNER_TEMP/home"
           echo "HOME=$RUNNER_TEMP/home" >> "$GITHUB_ENV"
+
+      - name: Persist codeminer cache across runs
+        run: |
+          CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
+          mkdir -p "$CACHE_DIR"
+          ln -sfn "$CACHE_DIR" "$HOME/.codeminer"
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -161,7 +168,7 @@ jobs:
 
       - name: Run integration serial tests
         shell: bash -l {0}
-        run: pytest -m "integration_serial" --tb=short
+        run: pytest -m "integration_serial" -v --tb=short
 
   # =============================================================
   # Job 4 — Slow tests  (LLM API, GPU embeddings, ~15 min)
@@ -173,11 +180,18 @@ jobs:
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
       npm_config_cache: ${{ github.workspace }}/../.cache/npm
+      VERTEXAI_PROJECT: ${{ vars.VERTEXAI_PROJECT }}
     steps:
       - name: Prepare temp HOME
         run: |
           mkdir -p "$RUNNER_TEMP/home"
           echo "HOME=$RUNNER_TEMP/home" >> "$GITHUB_ENV"
+
+      - name: Persist codeminer cache across runs
+        run: |
+          CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
+          mkdir -p "$CACHE_DIR"
+          ln -sfn "$CACHE_DIR" "$HOME/.codeminer"
 
       - name: Setup GCP credentials
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,13 @@ jobs:
 
       - name: Run unit tests
         shell: bash -l {0}
-        run: pytest -m "not slow and not integration" -x --tb=short
+        run: pytest -n auto -m "not slow and not integration" -x --tb=short
 
   # =============================================================
   # Job 2 — Integration tests  (clone repos, SCIP, chunkers, ~15 min)
   # =============================================================
   integration:
-    needs: preflight
+    needs: [preflight, unit]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
     env:
@@ -126,13 +126,13 @@ jobs:
 
       - name: Run integration tests
         shell: bash -l {0}
-        run: pytest -m "integration" --tb=short
+        run: pytest -n auto -m "integration" --tb=short
 
   # =============================================================
   # Job 3 — Slow tests  (LLM API, GPU embeddings, ~15 min)
   # =============================================================
   slow:
-    needs: preflight
+    needs: [preflight, integration]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
     env:
@@ -152,4 +152,4 @@ jobs:
 
       - name: Run slow tests (LLM + embedding)
         shell: bash -l {0}
-        run: pytest -m "slow" --tb=short
+        run: pytest -n auto -m "slow" --tb=short

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+CodeMiner is a code analysis agent with graph-enhanced search. It parses
+multi-language codebases with tree-sitter, builds semantic graphs (igraph),
+and provides hybrid retrieval (BM25 + FAISS/Milvus embeddings + LLM re-ranking)
+via litellm. Python 3.10+.
+
+## Package structure
+
+```
+codeminer/
+  code_chunking/   # Tree-sitter chunkers: Python, Go, Rust, C++, JS/TS
+  graph/           # CodeGraph (igraph), ROI subgraph, incremental patchers
+  dataset/         # SWE-bench loading, ground-truth extraction, query synthesis
+  index/           # BM25 sparse index, FAISS embedding search, regex node index
+  agent/           # Keyword extraction, re-ranking, resource guards, tool runners
+  llm/             # litellm-based chat interface
+  scip_interface/  # SCIP indexing bindings (proto, shell scripts)
+  ls_index/        # Language server index (clangd, rust-analyzer, scip-typescript)
+  ops/             # Graph operations (expand, traverse)
+  eval/            # Evaluation utilities
+  compiler/        # Build / compilation integration
+  plans/           # Plan generation and management
+test/              # Mirrors package structure; uses pytest markers
+scripts/           # CLI entry points: dataset collection, embedding, evaluation
+third_party/       # Git submodules (scip-python)
+```
+
+## Dev commands
+
+```bash
+make dev          # pip install -e ".[dev,test]"
+make test         # pytest
+make scip         # Install SCIP toolchain (rust-analyzer, scip-clang, TS, Python)
+make install      # pip install -e .
+```
+
+Pre-commit hooks: black (line-length 88), isort, flake8+bugbear, clang-format for C/C++.
+
+## Testing
+
+Three pytest marker tiers:
+
+| Marker | Scope | Duration |
+|--------|-------|----------|
+| _(none)_ | Unit — pure logic, mocks only | ~1 min |
+| `integration` | Repo cloning, SCIP indexing, chunkers | ~15 min |
+| `slow` | LLM API calls, GPU embeddings | ~15 min |
+
+```bash
+pytest -m "not slow and not integration" -x   # unit only
+pytest -m integration                          # integration only
+pytest -m slow                                 # slow only
+```
+
+- Test fixtures cache repos to `/tmp/codeminer-gt-test/`
+- HuggingFace dataset cache: `~/.codeminer/`
+
+## Key conventions
+
+- **Line numbering**: `CodeChunk.start_line`/`end_line` are **0-based** (tree-sitter).
+  `CodeLocation.start_line`/`end_line` are **1-based** (output/HuggingFace).
+  `_chunk_to_code_block()` in `dataset/gt_locate.py` does the +1 conversion.
+- **`.c` files** use the `cpp` chunker (not a separate C chunker).
+- **Chunking granularity**: L0 = file, L1 = top-level symbols, L2 = nested/methods.
+- **Symbol chunk types**: `function`, `method`, `class`, `struct`, `type`,
+  `interface`, `object`, `enum`, `trait`, `impl`, `var`, `const`, `static`,
+  `declaration`, `macro`, `variable`.
+
+## CI
+
+Three parallel jobs on a self-hosted runner (see `.github/workflows/ci.yml`):
+
+1. **unit** — fast, no external deps
+2. **integration** — needs SCIP, clangd, rust-analyzer, bear
+3. **slow** — needs LLM API keys, GPU
+
+Skip mechanisms:
+- `paths-ignore`: `**.md`, `docs/**`, `LICENSE`, `.gitignore`
+- `[skip tests]` in commit message or PR title
+- `skip-tests` label on PR
+- `workflow_dispatch` with `skip_tests: true`

--- a/codeminer/agent/skills/graph_expand/executor.py
+++ b/codeminer/agent/skills/graph_expand/executor.py
@@ -13,7 +13,7 @@ def create_executor(context: Any) -> Callable[..., List[Any]]:
         that carries the loaded ``CodeGraph``.
     """
     from ....graph.roi_subgraph import ROISubgraph
-    from ....ops.expand import _nodeinfo_to_queried
+    from ....ops.expand import nodeinfo_to_queried
 
     def execute(
         seed_nodes: List[Any],
@@ -68,6 +68,6 @@ def create_executor(context: Any) -> Callable[..., List[Any]]:
                 node_types=node_types,
             )
 
-        return _nodeinfo_to_queried(node_infos)[:top_k]
+        return nodeinfo_to_queried(node_infos)[:top_k]
 
     return execute

--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -183,7 +183,7 @@ class PatcherCpp(PatcherBase):
             logger.warning("clangd incremental indexing failed")
             return stats
 
-        from ..ls_index.clangd_decode import ClangdGraphDecoder
+        from codeminer.ls_index.clangd_decode import ClangdGraphDecoder
 
         with self.profiler.section("cpp.parse_idx"):
             decoder = ClangdGraphDecoder(
@@ -243,7 +243,7 @@ class PatcherCpp(PatcherBase):
 
         if idx_dir is None:
             logger.info("No .idx cache, running full clangd index")
-            from ..ls_index.clangd_indexer import ClangdIndexer
+            from codeminer.ls_index.clangd_indexer import ClangdIndexer
 
             indexer = ClangdIndexer(project_root=str(self.project_root))
             success = indexer.generate_index(compdb_path=str(comp_db))
@@ -378,7 +378,7 @@ class PatcherCpp(PatcherBase):
         changed_files: list[str],
     ) -> tuple[int, int]:
         """Add symbols and edges from .idx data for changed files."""
-        from ..ls_index.clangd_decode import (
+        from codeminer.ls_index.clangd_decode import (
             KIND_MACRO,
             REF_KIND_DEFINITION,
             REF_KIND_REFERENCE,

--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -163,8 +163,8 @@ class SubgraphMgr(ABC):
         if hasattr(g, "file_to_vertices") and file_path in g.file_to_vertices:
             vids = set(g.file_to_vertices[file_path])
         else:
+            from ...types import NODE_TYPE_FILE as NTF
             from ..code_graph import is_symbol_node
-            from ..types import NODE_TYPE_FILE as NTF
 
             vids = set()
             for v in g.graph.vs:

--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -163,7 +163,7 @@ class SubgraphMgr(ABC):
         if hasattr(g, "file_to_vertices") and file_path in g.file_to_vertices:
             vids = set(g.file_to_vertices[file_path])
         else:
-            from ..graph.code_graph import is_symbol_node
+            from ..code_graph import is_symbol_node
             from ..types import NODE_TYPE_FILE as NTF
 
             vids = set()

--- a/codeminer/scip_interface/scip_indexer_python.py
+++ b/codeminer/scip_interface/scip_indexer_python.py
@@ -208,11 +208,11 @@ class SCIPPythonIndexer(SCIPIndexerBase):
             )
 
             if self.conda_env_name in result.stdout:
-                logger.info(f"Conda environment '{self.conda_env_name}' already exists")
+                logger.info(f"Conda environment {self.conda_env_name!r} already exists")
                 return True
 
             if self.env_file.exists():
-                logger.info(f"Creating conda environment '{self.conda_env_name}'...")
+                logger.info(f"Creating conda environment {self.conda_env_name!r}...")
 
                 create_cmd = [
                     "conda",
@@ -237,7 +237,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                     )
 
                 logger.info(
-                    f"Conda environment '{self.conda_env_name}' created successfully"
+                    f"Conda environment {self.conda_env_name!r} created successfully"
                 )
                 return True
             else:
@@ -257,6 +257,25 @@ class SCIPPythonIndexer(SCIPIndexerBase):
             )
             return False
 
+    def _get_conda_env_bin(self) -> Optional[str]:
+        """Return the bin directory for the scip conda environment."""
+        try:
+            result = subprocess.run(
+                ["conda", "info", "--envs", "--json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            import json
+
+            envs = json.loads(result.stdout).get("envs", [])
+            for env_path in envs:
+                if env_path.endswith(f"/{self.conda_env_name}"):
+                    return str(Path(env_path) / "bin")
+        except Exception:
+            pass
+        return None
+
     def _run_in_conda_env(
         self, cmd: list, cwd: Optional[Union[str, Path]] = None
     ) -> bool:
@@ -275,10 +294,23 @@ class SCIPPythonIndexer(SCIPIndexerBase):
 
             logger.info(f"Running in conda environment: {cmd}")
 
+            # Prepend scip-env bin to PATH so scip-python's internal
+            # pip3/python3 calls resolve to the clean scip-env, not
+            # the host environment (which may have hundreds of packages
+            # that cause ENOBUFS in pip show).
+            env = None
+            scip_bin = self._get_conda_env_bin()
+            if scip_bin:
+                import os
+
+                env = os.environ.copy()
+                env["PATH"] = f"{scip_bin}:{env.get('PATH', '')}"
+
             subprocess.run(
                 conda_cmd,
                 check=True,
                 cwd=cwd if cwd else self.project_root,
+                env=env,
             )
             return True
         except subprocess.CalledProcessError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "flake8-bugbear>=24.4.0",
     "mkdocs-material>=9.5.0",
 ]
-test = ["pytest>=6.0.0", "pytest-cov>=3.0.0", "pytest-xdist>=3.0.0"]
+test = ["pytest>=6.0.0", "pytest-cov>=3.0.0", "pytest-xdist>=3.0.0", "filelock>=3.0.0"]
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,8 @@ norecursedirs = [
 ]
 markers = [
     "slow: marks tests that need LLM API, GPU, or HuggingFace downloads (deselect with '-m \"not slow\"')",
-    "integration: marks tests that clone repos or build indexes (moderate runtime)",
+    "integration: marks tests that use external repos but are read-only / parallel-safe (chunkers, fixture-based SCIP)",
+    "integration_serial: marks tests that mutate shared repos (process_instance, git checkout/apply) and must run sequentially",
 ]
 
 [tool.black]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from filelock import FileLock
 
 HTTPIE_REPO_URL = "https://github.com/httpie/cli.git"
 HTTPIE_REPO_PATH = Path("/tmp/httpie-cli")
@@ -73,33 +74,50 @@ def ensure_repo_checkout(repo_url: str, repo_path: Path, ref: str) -> Path:
     return repo_path
 
 
+def _locked_repo_checkout(
+    tmp_path_factory, repo_url: str, repo_path: Path, ref: str
+) -> Path:
+    """Acquire a cross-worker filelock before cloning/checking out a repo."""
+    lock_path = tmp_path_factory.getbasetemp().parent / f"{repo_path.name}.lock"
+    with FileLock(str(lock_path)):
+        return ensure_repo_checkout(repo_url, repo_path, ref)
+
+
 @pytest.fixture(scope="session")
-def httpie_cli_repo():
+def httpie_cli_repo(tmp_path_factory):
     """Provide a pinned checkout of the httpie/cli repository."""
-    return ensure_repo_checkout(HTTPIE_REPO_URL, HTTPIE_REPO_PATH, HTTPIE_REPO_REF)
-
-
-@pytest.fixture(scope="session")
-def express_repo():
-    """Provide a pinned checkout of the express repository."""
-    return ensure_repo_checkout(EXPRESS_REPO_URL, EXPRESS_REPO_PATH, EXPRESS_REPO_REF)
-
-
-@pytest.fixture(scope="session")
-def fmt_repo():
-    """Provide a pinned checkout of the fmt repository."""
-    return ensure_repo_checkout(FMT_REPO_URL, FMT_REPO_PATH, FMT_REPO_REF)
-
-
-@pytest.fixture(scope="session")
-def arrayvec_repo():
-    """Provide a pinned checkout of the arrayvec repository."""
-    return ensure_repo_checkout(
-        ARRAYVEC_REPO_URL, ARRAYVEC_REPO_PATH, ARRAYVEC_REPO_REF
+    return _locked_repo_checkout(
+        tmp_path_factory, HTTPIE_REPO_URL, HTTPIE_REPO_PATH, HTTPIE_REPO_REF
     )
 
 
 @pytest.fixture(scope="session")
-def gjson_repo():
+def express_repo(tmp_path_factory):
+    """Provide a pinned checkout of the express repository."""
+    return _locked_repo_checkout(
+        tmp_path_factory, EXPRESS_REPO_URL, EXPRESS_REPO_PATH, EXPRESS_REPO_REF
+    )
+
+
+@pytest.fixture(scope="session")
+def fmt_repo(tmp_path_factory):
+    """Provide a pinned checkout of the fmt repository."""
+    return _locked_repo_checkout(
+        tmp_path_factory, FMT_REPO_URL, FMT_REPO_PATH, FMT_REPO_REF
+    )
+
+
+@pytest.fixture(scope="session")
+def arrayvec_repo(tmp_path_factory):
+    """Provide a pinned checkout of the arrayvec repository."""
+    return _locked_repo_checkout(
+        tmp_path_factory, ARRAYVEC_REPO_URL, ARRAYVEC_REPO_PATH, ARRAYVEC_REPO_REF
+    )
+
+
+@pytest.fixture(scope="session")
+def gjson_repo(tmp_path_factory):
     """Provide a pinned checkout of the gjson repository."""
-    return ensure_repo_checkout(GJSON_REPO_URL, GJSON_REPO_PATH, GJSON_REPO_REF)
+    return _locked_repo_checkout(
+        tmp_path_factory, GJSON_REPO_URL, GJSON_REPO_PATH, GJSON_REPO_REF
+    )

--- a/test/dataset/conftest.py
+++ b/test/dataset/conftest.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 import pytest
+from filelock import FileLock
 
 from codeminer.dataset.gt_locate import GTLocator
 from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
@@ -19,6 +20,28 @@ REPO_FIXTURES = {
     "rust": "tokio-rs/axum",
     "typescript": "preactjs/preact",
 }
+
+
+class LockedGTLocator:
+    """Wraps GTLocator so analyze_instance acquires a per-repo filelock.
+
+    This prevents xdist workers from running git checkout / git apply on the
+    same repo directory simultaneously.
+    """
+
+    def __init__(self, locator: GTLocator, lock_dir: Path):
+        self._locator = locator
+        self._lock_dir = lock_dir
+        self._lock_dir.mkdir(parents=True, exist_ok=True)
+
+    def analyze_instance(self, instance, **kwargs):
+        repo_name = instance["repo"].replace("/", "_")
+        lock_path = self._lock_dir / f"{repo_name}.lock"
+        with FileLock(str(lock_path)):
+            return self._locator.analyze_instance(instance, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._locator, name)
 
 
 @pytest.fixture(scope="session")
@@ -40,10 +63,12 @@ def _first_instance_for_repo(dataset, repo: str):
 
 
 @pytest.fixture(scope="session")
-def gt_locator():
-    """Shared GTLocator with a persistent work directory."""
+def gt_locator(tmp_path_factory):
+    """Shared GTLocator with a persistent work directory and per-repo locking."""
     GT_TEST_WORK_DIR.mkdir(parents=True, exist_ok=True)
-    return GTLocator(work_dir=str(GT_TEST_WORK_DIR))
+    locator = GTLocator(work_dir=str(GT_TEST_WORK_DIR))
+    lock_dir = tmp_path_factory.getbasetemp().parent / "gt-locks"
+    return LockedGTLocator(locator, lock_dir)
 
 
 @pytest.fixture(scope="session")

--- a/test/dataset/test_gt_locate.py
+++ b/test/dataset/test_gt_locate.py
@@ -270,7 +270,7 @@ def _assert_valid_result(result):
     assert total_symbols == len(result["code_blocks"])
 
 
-@pytest.mark.integration
+@pytest.mark.integration_serial
 class TestAnalyzeGoInstance:
     """Full pipeline test on a real Go instance from caddyserver/caddy."""
 
@@ -284,7 +284,7 @@ class TestAnalyzeGoInstance:
         assert result["base_commit"] == go_instance["base_commit"]
 
 
-@pytest.mark.integration
+@pytest.mark.integration_serial
 class TestAnalyzeCppInstance:
     """Full pipeline test on a real C/C++ instance from redis/redis."""
 
@@ -296,7 +296,7 @@ class TestAnalyzeCppInstance:
         assert result["repo"] == cpp_instance["repo"]
 
 
-@pytest.mark.integration
+@pytest.mark.integration_serial
 class TestAnalyzeRustInstance:
     """Full pipeline test on a real Rust instance from tokio-rs/axum."""
 
@@ -307,7 +307,7 @@ class TestAnalyzeRustInstance:
         assert result["instance_id"] == rust_instance["instance_id"]
 
 
-@pytest.mark.integration
+@pytest.mark.integration_serial
 class TestAnalyzeTypescriptInstance:
     """Full pipeline test on a real TypeScript instance from preactjs/preact."""
 

--- a/test/graph/incremental/test_graph_patcher.py
+++ b/test/graph/incremental/test_graph_patcher.py
@@ -34,6 +34,8 @@ from codeminer.graph.incremental.graph_patcher import GraphPatcher
 from codeminer.graph.incremental.lsp_client import LSPClient
 from codeminer.ls_router import LSIndexer
 
+pytestmark = pytest.mark.integration
+
 
 def test_ls_indexer_graph_patch_import():
     """Smoke test: LSIndexer.graph_patch lazy imports resolve correctly."""

--- a/test/graph/incremental/test_graph_patcher.py
+++ b/test/graph/incremental/test_graph_patcher.py
@@ -34,7 +34,7 @@ from codeminer.graph.incremental.graph_patcher import GraphPatcher
 from codeminer.graph.incremental.lsp_client import LSPClient
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 
 def test_ls_indexer_graph_patch_import():

--- a/test/graph/test_codegraph_multi.py
+++ b/test/graph/test_codegraph_multi.py
@@ -46,7 +46,7 @@ import pytest
 from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 # ==============================================================================
 # Language configuration

--- a/test/graph/test_subgraph.py
+++ b/test/graph/test_subgraph.py
@@ -8,7 +8,7 @@ from codeminer.graph.roi_subgraph import ROISubgraph
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/graph/test_traverse_graph_swebench.py
+++ b/test/graph/test_traverse_graph_swebench.py
@@ -4,7 +4,7 @@ import pytest
 
 from codeminer.dataset.swebench import SwebenchDataset
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 from codeminer.graph.traverse_graph import traverse_tree_structure
 from codeminer.ls_router import LSIndexer
 from codeminer.types import (

--- a/test/index/sparse_idx/test_bm25_compability.py
+++ b/test/index/sparse_idx/test_bm25_compability.py
@@ -8,7 +8,7 @@ from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/index/sparse_idx/test_bm25_index.py
+++ b/test/index/sparse_idx/test_bm25_index.py
@@ -8,7 +8,7 @@ from codeminer.code_chunker import CodeChunker
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 
 @pytest.fixture(scope="module")

--- a/test/index/sparse_idx/test_bm25_locbench.py
+++ b/test/index/sparse_idx/test_bm25_locbench.py
@@ -7,7 +7,7 @@ from codeminer.dataset.locbench import LocbenchDataset
 from codeminer.index import BM25CodeIndexer
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/scip/test_scip_axios.py
+++ b/test/scip/test_scip_axios.py
@@ -17,7 +17,7 @@ from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
 from codeminer.ls_router import LSIndexer
 from codeminer.types import is_symbol_node
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 
 def _pick_axios_instance() -> dict:

--- a/test/scip/test_scip_core_w_python.py
+++ b/test/scip/test_scip_core_w_python.py
@@ -40,7 +40,7 @@ import pytest
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.ls_router import LSGraphDecoder
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 from codeminer.ls_router import LSIndexer
 
 # Default instances for testing

--- a/test/scip/test_scip_exclude.py
+++ b/test/scip/test_scip_exclude.py
@@ -7,7 +7,7 @@ from codeminer.dataset.locbench import LocbenchDataset
 from codeminer.graph.traverse_graph import traverse_tree_structure
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 args_dict = {
     "model": "gpt-4o",

--- a/test/scip/test_scip_multilingual.py
+++ b/test/scip/test_scip_multilingual.py
@@ -12,7 +12,7 @@ import pytest
 from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 
 def _has_node(ig, expected_unified_name, node_type=None):

--- a/test/scip/test_scip_swebench.py
+++ b/test/scip/test_scip_swebench.py
@@ -6,7 +6,7 @@ import pytest
 from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.ls_router import LSIndexer
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.integration_serial
 
 args_dict = {
     "model": "gpt-4o",


### PR DESCRIPTION
## Summary

Overhaul the CI pipeline for reliability, speed, and correctness. Fixes broken imports, a scip-python ENOBUFS bug producing empty indexes, restructures CI into 4 jobs with proper dependency chains, adds persistent caching, Vertex AI credentials, auto-labeling, and issue templates.

## Changes

### CI pipeline restructure
- Extract composite action `.github/actions/setup-env` for DRY environment setup (conda, pip, SCIP toolchain, clangd, bear)
- Split monolithic CI into 4 jobs: `unit`, `integration` (parallel-safe, xdist), `integration-serial` (repo-mutating, sequential), `slow` (LLM/GPU)
- Decouple slow tests from integration — slow tests depend only on `unit`, not `integration-serial`
- Add `paths-ignore` for docs-only changes, `[skip tests]` in commit message/PR title, `skip-tests` label, and `workflow_dispatch` skip
- Add concurrency group to cancel in-progress runs on same branch

### Caching & performance
- Persistent `~/.codeminer` cache via symlink to `../.cache/codeminer` — cloned repos, SCIP indexes, and graph caches survive across CI runs
- Local pip/npm caches (`../.cache/pip`, `../.cache/npm`)
- `timeout-minutes: 45` on integration-serial to prevent infinite hangs

### Slow test (LLM/GPU) support
- Setup GCP credentials from `GOOGLE_APPLICATION_CREDENTIALS_JSON` secret
- Set `VERTEXAI_PROJECT` from repo variable for Vertex AI tests

### scip-python ENOBUFS fix
- Root cause: `scip-python` calls `pip3`/`python3` which resolve to the host environment (297 packages) instead of the clean `scip-env` (3 packages). The enormous `pip3 show -f` command exceeds OS buffer limits, silently producing empty SCIP indexes (metadata only, zero documents)
- Fix: prepend `scip-env/bin` to `PATH` in `_run_in_conda_env()` so pip3/python3 resolve to the clean scip-env

### Auto-labeling
- `actions/labeler@v5` workflow to auto-label PRs by domain (agent, chunking, graph, index, dataset, scip, llm, ops, compiler, eval) and cross-cutting concerns (ci, documentation, tests, dependencies)

### Issue templates
- Structured YAML forms: bug report, feature request, RFC/design proposal
- Component dropdown matching auto-labeler categories

### Bug fixes
- Fix import paths in `executor.py` and `patcher_cpp.py`
- Fix relative import depth for types in `subgraph_mgr.py`
- Mark `graph_patcher` tests as `integration_serial`

### Test infrastructure
- Add pytest-xdist parallelization for unit and integration tests
- Add filelock to `conftest.py` fixtures to prevent race conditions during parallel test collection
- Reclassify test markers: `integration` (read-only, parallel-safe) vs `integration_serial` (mutates repos)

### Documentation
- Add `CLAUDE.md` with project structure, dev commands, testing tiers, key conventions

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Tests
- [x] Documentation update

## Testing
- [x] Tests pass locally
- [x] Unit tests: ✅ passing
- [x] Integration tests (parallel): ✅ passing
- [x] Integration serial tests: ✅ passing (26 min)
- [x] Slow tests: ✅ passing
- [ ] Integration serial with scip-python fix: pending (next CI run)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Setup required
- Add repo variable `VERTEXAI_PROJECT` = `ucsd-cse-stable-gcp` in **Settings > Secrets and variables > Actions > Variables**
