### PR TITLE
Rewrite README with project overview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Purge stale SCIP Python caches (one-time)
         run: |
           CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
-          MARKER="$CACHE_DIR/.scip-cache-v2"
+          MARKER="$CACHE_DIR/.scip-cache-v3"
           if [ ! -f "$MARKER" ]; then
             echo "Purging stale SCIP Python graph caches..."
             find "$CACHE_DIR" -name "graph.pkl" -delete 2>/dev/null || true
@@ -208,7 +208,7 @@ jobs:
       - name: Purge stale SCIP Python caches (one-time)
         run: |
           CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
-          MARKER="$CACHE_DIR/.scip-cache-v2"
+          MARKER="$CACHE_DIR/.scip-cache-v3"
           if [ ! -f "$MARKER" ]; then
             echo "Purging stale SCIP Python graph caches..."
             find "$CACHE_DIR" -name "graph.pkl" -delete 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,18 @@ jobs:
           mkdir -p "$CACHE_DIR"
           ln -sfn "$CACHE_DIR" "$HOME/.codeminer"
 
+      - name: Purge stale SCIP Python caches (one-time)
+        run: |
+          CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
+          MARKER="$CACHE_DIR/.scip-cache-v2"
+          if [ ! -f "$MARKER" ]; then
+            echo "Purging stale SCIP Python graph caches..."
+            find "$CACHE_DIR" -name "graph.pkl" -delete 2>/dev/null || true
+            find "$CACHE_DIR" -name "index.scip" -delete 2>/dev/null || true
+            find "$CACHE_DIR" -name "index.decoded" -delete 2>/dev/null || true
+            touch "$MARKER"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -192,6 +204,18 @@ jobs:
           CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
           mkdir -p "$CACHE_DIR"
           ln -sfn "$CACHE_DIR" "$HOME/.codeminer"
+
+      - name: Purge stale SCIP Python caches (one-time)
+        run: |
+          CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
+          MARKER="$CACHE_DIR/.scip-cache-v2"
+          if [ ! -f "$MARKER" ]; then
+            echo "Purging stale SCIP Python graph caches..."
+            find "$CACHE_DIR" -name "graph.pkl" -delete 2>/dev/null || true
+            find "$CACHE_DIR" -name "index.scip" -delete 2>/dev/null || true
+            find "$CACHE_DIR" -name "index.decoded" -delete 2>/dev/null || true
+            touch "$MARKER"
+          fi
 
       - name: Setup GCP credentials
         run: |

--- a/README.md
+++ b/README.md
@@ -1,26 +1,53 @@
 # CodeMiner
 
-## Setup
+An LLM-adapted code indexing and retrieval system for multi-language codebases.
 
-Install Python environment with conda:
+CodeMiner builds LSP-oriented symbol graphs and lightweight indexes from multi-language codebases, designed for efficient retrieval by LLM-based code agents. It supports **Python, Go, Rust, C/C++, JavaScript, and TypeScript**.
+
+## Quick Start
+
 ```bash
 conda create -n codeminer python=3.10
 conda activate codeminer
 pip install -e .
-```
 
-Optional: enable SCIP-based code indexing:
-```bash
+# Enable SCIP/LSP-based code intelligence
 make scip
 ```
-The setup script installs `rust-analyzer`, `scip-clang`, `@sourcegraph/scip-typescript`, and `@sourcegraph/scip-python`.
 
-## Contribute
+## Key Capabilities
 
-Install pre-commit hooks:
+- **LSP-oriented symbol graphs** -- structural code intelligence via SCIP protocol and language servers (scip-python, rust-analyzer, clangd, gopls, scip-typescript)
+- **Incremental graph patching** -- update CodeGraph in-place via LSP without full re-indexing, enabling fast iteration on evolving codebases
+- **Lightweight hybrid retrieval** -- BM25 sparse, regex, and FAISS/Milvus dense indexes with LLM re-ranking
+- **Tree-sitter chunking** at file, symbol, and method granularity
+- **SWE-bench integration** -- ground-truth extraction, multi-language dataset collection, and evaluation
+
+## Development
+
 ```bash
-pip install pre-commit
-pre-commit install
+make dev          # install with dev + test deps
+make test         # run all tests
 ```
 
-Code formatting (black, isort) and linting (flake8) will run automatically before each commit.
+Tests use three pytest marker tiers:
+
+```bash
+pytest -m "not slow and not integration" -x   # unit (~1 min)
+pytest -m integration                          # integration (~15 min)
+pytest -m slow                                 # LLM/GPU (~15 min)
+```
+
+Pre-commit hooks (black, isort, flake8) are configured -- run `pre-commit install` after cloning.
+
+## Documentation
+
+Full docs are served via [mkdocs-material](https://squidfunk.github.io/mkdocs-material/). To run locally:
+
+```bash
+mkdocs serve
+```
+
+## License
+
+MIT

--- a/codeminer/scip_interface/scip_indexer_base.py
+++ b/codeminer/scip_interface/scip_indexer_base.py
@@ -230,6 +230,16 @@ class SCIPIndexerBase(ABC):
                 logger.info(f"Saved processed SCIP index to {output_path}")
                 logger.info(f"⏱️  Graph saving took: {save_duration:.2f} seconds")
 
+            n_nodes = graph.graph.vcount()
+            n_edges = graph.graph.ecount()
+            logger.info(
+                f"✅ Graph created successfully ({n_nodes} nodes, {n_edges} edges)"
+            )
+            if n_nodes <= 1:
+                logger.warning(
+                    "⚠️  Graph has no symbol nodes — the SCIP index may be empty. "
+                    "Check that the indexer produced valid output."
+                )
             logger.info(f"⏱️  Index processing took: {duration:.2f} seconds")
             return graph
 

--- a/codeminer/scip_interface/scip_indexer_python.py
+++ b/codeminer/scip_interface/scip_indexer_python.py
@@ -271,9 +271,14 @@ class SCIPPythonIndexer(SCIPIndexerBase):
             envs = json.loads(result.stdout).get("envs", [])
             for env_path in envs:
                 if env_path.endswith(f"/{self.conda_env_name}"):
-                    return str(Path(env_path) / "bin")
-        except Exception:
-            pass
+                    bin_dir = str(Path(env_path) / "bin")
+                    logger.debug(f"Found scip-env bin directory: {bin_dir}")
+                    return bin_dir
+        except Exception as e:
+            logger.warning(f"Failed to locate scip-env bin directory: {e}")
+        logger.warning(
+            "Could not find scip-env bin directory, will fall back to conda run"
+        )
         return None
 
     def _run_in_conda_env(
@@ -290,28 +295,33 @@ class SCIPPythonIndexer(SCIPIndexerBase):
             bool: True if command succeeded, False otherwise
         """
         try:
-            conda_cmd = ["conda", "run", "-n", self.conda_env_name] + cmd
+            import os
 
-            logger.info(f"Running in conda environment: {cmd}")
-
-            # Prepend scip-env bin to PATH so scip-python's internal
-            # pip3/python3 calls resolve to the clean scip-env, not
-            # the host environment (which may have hundreds of packages
-            # that cause ENOBUFS in pip show).
-            env = None
             scip_bin = self._get_conda_env_bin()
-            if scip_bin:
-                import os
+            work_dir = cwd if cwd else self.project_root
 
+            if scip_bin:
+                # Run directly with scip-env/bin on PATH instead of
+                # using `conda run`, which resets PATH during activation
+                # and causes pip3 to resolve to the wrong environment.
                 env = os.environ.copy()
                 env["PATH"] = f"{scip_bin}:{env.get('PATH', '')}"
-
-            subprocess.run(
-                conda_cmd,
-                check=True,
-                cwd=cwd if cwd else self.project_root,
-                env=env,
-            )
+                logger.info(f"Running with scip-env PATH ({scip_bin}): {cmd}")
+                subprocess.run(
+                    cmd,
+                    check=True,
+                    cwd=work_dir,
+                    env=env,
+                )
+            else:
+                # Fallback: use conda run (may have PATH issues)
+                conda_cmd = ["conda", "run", "-n", self.conda_env_name] + cmd
+                logger.info(f"Running via conda run (fallback): {cmd}")
+                subprocess.run(
+                    conda_cmd,
+                    check=True,
+                    cwd=work_dir,
+                )
             return True
         except subprocess.CalledProcessError as e:
             logger.error(f"Error running command in conda environment: {e}")

--- a/codeminer/scip_interface/scip_indexer_python.py
+++ b/codeminer/scip_interface/scip_indexer_python.py
@@ -85,7 +85,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
 
         if cwd:
             cmd.append("--cwd")
-            cmd.append(str(Path(cwd).absolute()))
+            cmd.append(str(Path(cwd).resolve()))
 
         if project_name:
             cmd.extend(["--project-name", project_name])
@@ -298,7 +298,8 @@ class SCIPPythonIndexer(SCIPIndexerBase):
             import os
 
             scip_bin = self._get_conda_env_bin()
-            work_dir = cwd if cwd else self.project_root
+            # Resolve symlinks so subprocess cwd matches real paths
+            work_dir = Path(cwd if cwd else self.project_root).resolve()
 
             if scip_bin:
                 # Run directly with scip-env/bin on PATH instead of


### PR DESCRIPTION
## Summary
- Rewrite README with project overview highlighting CodeMiner's core value: LSP-oriented symbol graphs, incremental graph patching, and lightweight hybrid retrieval
- Add one-time cache purge step to CI for stale SCIP Python caches
- **Fix scip-python empty indexes in CI**: bypass `conda run` (which resets PATH) and run scip-python directly with scip-env/bin on PATH, so pip3 resolves to the clean scip-env instead of the host environment

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Verify integration-serial CI tests pass (6 previously failing tests)
- [x] Verify cache purge runs once then skips on subsequent CI runs
