### PR TITLE
[agent] Phase 1: token usage tracking + allow_skills filter (refs #109, closes #110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 my_project/
 *.json
 graph.png
+graph.pkl
 build/
 *.egg-info/
 *.scip

--- a/codeminer/agent/agent_types.py
+++ b/codeminer/agent/agent_types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from ..llm.usage import TokenUsage, UsageRecord
+
 
 @dataclass
 class ToolCallRecord:
@@ -27,3 +29,5 @@ class AgentResult:
     messages: List[Dict[str, Any]] = field(default_factory=list)
     total_turns: int = 0
     total_duration_ms: float = 0.0
+    usage: Optional[TokenUsage] = None
+    usage_records: List[UsageRecord] = field(default_factory=list)

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -12,6 +12,7 @@ import time
 from typing import Any, Dict, List, Optional, Set
 
 from ..llm.litellm_chat import LiteLLMChat
+from ..llm.usage import UsageTracker
 from ..log_utils import get_logger
 from .agent_types import AgentResult, ToolCallRecord
 from .skills.registry import SkillRegistry
@@ -60,6 +61,7 @@ class AgentRunner:
         max_tokens: int = 512,
         system_prompt: Optional[str] = None,
         max_turns: int = 10,
+        allow_skills: Optional[Set[str]] = None,
         exclude_skills: Optional[Set[str]] = None,
         manifest: Optional[Any] = None,
         session_ctx: Optional[Any] = None,
@@ -79,6 +81,7 @@ class AgentRunner:
         self.session_ctx = session_ctx
 
         # Resource guard: filter unavailable skills and collect warnings
+        allow = set(allow_skills) if allow_skills is not None else None
         exclude = set(exclude_skills) if exclude_skills else set()
         resource_warnings: List[str] = []
 
@@ -90,7 +93,7 @@ class AgentRunner:
             exclude |= report.unavailable
             resource_warnings = report.warnings
 
-        self.tools = registry_to_tools(self.registry, exclude=exclude)
+        self.tools = registry_to_tools(self.registry, allow=allow, exclude=exclude)
 
         # Build system prompt with optional resource warnings
         base_prompt = system_prompt or _DEFAULT_SYSTEM_PROMPT
@@ -112,12 +115,16 @@ class AgentRunner:
             {"role": "user", "content": query},
         ]
         all_tool_calls: List[ToolCallRecord] = []
+        usage_tracker = UsageTracker()
         start = time.monotonic()
 
         for turn in range(max_turns):
             logger.debug("agent turn %d/%d", turn + 1, max_turns)
 
-            call_kwargs: Dict[str, Any] = {}
+            call_kwargs: Dict[str, Any] = {
+                "usage_tracker": usage_tracker,
+                "usage_turn": turn + 1,
+            }
             if self.tools:
                 call_kwargs["tools"] = self.tools
 
@@ -140,6 +147,8 @@ class AgentRunner:
                     messages=messages,
                     total_turns=turn + 1,
                     total_duration_ms=elapsed,
+                    usage=usage_tracker.totals(),
+                    usage_records=list(usage_tracker.records),
                 )
 
             # Execute each tool call
@@ -172,6 +181,8 @@ class AgentRunner:
             messages=messages,
             total_turns=max_turns,
             total_duration_ms=elapsed,
+            usage=usage_tracker.totals(),
+            usage_records=list(usage_tracker.records),
         )
 
     # ------------------------------------------------------------------

--- a/codeminer/agent/tool_schema.py
+++ b/codeminer/agent/tool_schema.py
@@ -59,13 +59,16 @@ def skill_to_tool_schema(meta: SkillMetadata) -> Dict[str, Any]:
 def registry_to_tools(
     registry: Optional[SkillRegistry] = None,
     *,
+    allow: Optional[Set[str]] = None,
     exclude: Optional[Set[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Convert all skills in the registry to OpenAI tool schemas.
 
     Args:
         registry: Registry to read from; defaults to the singleton.
-        exclude: Skill IDs to skip (e.g. internal-only skills).
+        allow: If provided, only skills in this set are included (allowlist,
+            applied first). If ``None``, all registered skills are eligible.
+        exclude: Skill IDs to skip (denylist, applied after ``allow``).
 
     Returns:
         List of tool dicts ready for ``litellm.completion(tools=...)``.
@@ -75,6 +78,8 @@ def registry_to_tools(
     tools: List[Dict[str, Any]] = []
 
     for skill_id, meta in reg.list_skills().items():
+        if allow is not None and skill_id not in allow:
+            continue
         if skill_id in exclude:
             continue
         tools.append(skill_to_tool_schema(meta))

--- a/codeminer/llm/litellm_chat.py
+++ b/codeminer/llm/litellm_chat.py
@@ -85,7 +85,19 @@ class LiteLLMChat:
         return self._call_raw(msg_dicts, **overrides)
 
     def _call_raw(self, messages: List[Dict[str, Any]], **overrides: Any) -> Any:
-        """Like ``_call`` but accepts raw message dicts (for tool-calling flows)."""
+        """Like ``_call`` but accepts raw message dicts (for tool-calling flows).
+
+        Accepts two optional control kwargs (not forwarded to litellm):
+
+        - ``usage_tracker``: a :class:`codeminer.llm.usage.UsageTracker`. If
+          provided, the response's token usage and cost are recorded.
+        - ``usage_turn``: turn index attached to the recorded usage entry.
+        """
+        import time as _time
+
+        usage_tracker = overrides.pop("usage_tracker", None)
+        usage_turn = overrides.pop("usage_turn", None)
+
         kwargs: Dict[str, Any] = {
             "model": self.model,
             "messages": messages,
@@ -102,7 +114,19 @@ class LiteLLMChat:
         # Drop None values so litellm uses its defaults
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
-        return litellm.completion(**kwargs)
+        start = _time.monotonic()
+        response = litellm.completion(**kwargs)
+        duration_ms = (_time.monotonic() - start) * 1000
+
+        if usage_tracker is not None:
+            usage_tracker.record_response(
+                response,
+                model=self.model,
+                duration_ms=duration_ms,
+                turn=usage_turn,
+            )
+
+        return response
 
 
 # ---------------------------------------------------------------------------

--- a/codeminer/llm/usage.py
+++ b/codeminer/llm/usage.py
@@ -1,0 +1,149 @@
+"""Token usage and cost tracking for LLM calls.
+
+Wraps the native ``response.usage`` field that litellm exposes on
+every ``completion()`` response and (when supported by the provider)
+the cost estimate from ``litellm.completion_cost``.
+
+Usage::
+
+    from codeminer.llm.usage import UsageTracker
+
+    tracker = UsageTracker()
+    llm._call_raw(messages, usage_tracker=tracker, _model=llm.model)
+    print(tracker.totals())  # TokenUsage(prompt=..., completion=..., total=..., cost_usd=...)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+from ..log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class TokenUsage:
+    """Cumulative token counts (plus optional USD cost)."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost_usd: Optional[float] = None
+
+    def add(self, other: "TokenUsage") -> "TokenUsage":
+        """Return a new TokenUsage that is the sum of ``self`` and ``other``."""
+        merged_cost: Optional[float]
+        if self.cost_usd is None and other.cost_usd is None:
+            merged_cost = None
+        else:
+            merged_cost = (self.cost_usd or 0.0) + (other.cost_usd or 0.0)
+        return TokenUsage(
+            prompt_tokens=self.prompt_tokens + other.prompt_tokens,
+            completion_tokens=self.completion_tokens + other.completion_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+            cost_usd=merged_cost,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+            "cost_usd": self.cost_usd,
+        }
+
+
+@dataclass
+class UsageRecord:
+    """A single ``_call_raw`` invocation's usage."""
+
+    model: str
+    usage: TokenUsage
+    duration_ms: float = 0.0
+    turn: Optional[int] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "usage": self.usage.to_dict(),
+            "duration_ms": self.duration_ms,
+            "turn": self.turn,
+        }
+
+
+class UsageTracker:
+    """Collects per-call usage and returns a running total."""
+
+    def __init__(self) -> None:
+        self.records: List[UsageRecord] = []
+
+    def record_response(
+        self,
+        response: Any,
+        *,
+        model: str,
+        duration_ms: float = 0.0,
+        turn: Optional[int] = None,
+    ) -> UsageRecord:
+        """Extract ``response.usage`` + ``completion_cost`` into a ``UsageRecord``.
+
+        Safe to call on any litellm response; missing fields default to zero and
+        cost falls back to ``None`` if the provider/model is unpriced.
+        """
+        usage = _extract_token_usage(response)
+        usage.cost_usd = _safe_completion_cost(response, model)
+        record = UsageRecord(
+            model=model, usage=usage, duration_ms=duration_ms, turn=turn
+        )
+        self.records.append(record)
+        return record
+
+    def totals(self) -> TokenUsage:
+        """Sum all records into a single ``TokenUsage``."""
+        total = TokenUsage()
+        for rec in self.records:
+            total = total.add(rec.usage)
+        return total
+
+
+def _extract_token_usage(response: Any) -> TokenUsage:
+    """Pull ``prompt_tokens``/``completion_tokens``/``total_tokens`` off a response.
+
+    litellm normalizes provider responses to an OpenAI-compatible shape; the
+    ``usage`` attribute is usually a pydantic model with ``prompt_tokens`` /
+    ``completion_tokens`` / ``total_tokens`` but can also be a plain dict.
+    """
+    usage_obj = getattr(response, "usage", None)
+    if usage_obj is None:
+        return TokenUsage()
+
+    def _read(name: str) -> int:
+        if hasattr(usage_obj, name):
+            val = getattr(usage_obj, name)
+        elif isinstance(usage_obj, dict):
+            val = usage_obj.get(name, 0)
+        else:
+            val = 0
+        try:
+            return int(val or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    return TokenUsage(
+        prompt_tokens=_read("prompt_tokens"),
+        completion_tokens=_read("completion_tokens"),
+        total_tokens=_read("total_tokens"),
+    )
+
+
+def _safe_completion_cost(response: Any, model: str) -> Optional[float]:
+    """Best-effort USD cost via ``litellm.completion_cost``; ``None`` on failure."""
+    try:
+        import litellm
+
+        return float(litellm.completion_cost(completion_response=response, model=model))
+    except Exception as exc:  # litellm raises for unpriced models/providers
+        logger.debug("completion_cost unavailable for %s: %s", model, exc)
+        return None

--- a/examples/skill_agent_eval.py
+++ b/examples/skill_agent_eval.py
@@ -65,7 +65,8 @@ LOCAGENT_LITE_SUBSET_DOC = (
 )
 
 
-# Output Schema 
+# Output Schema
+
 
 @dataclass
 class CodeSymbol:
@@ -105,9 +106,11 @@ class SkillEvalReport:
     eval_mode: str = "agent"
     locagent_lite_subset: bool = False
     gt_symbols_mode: str = "simplified"
+    total_usage: Optional[Dict[str, Any]] = None
 
 
 # QueriedNode -> CodeSymbol conversion
+
 
 def queried_node_to_symbol(node: QueriedNode) -> CodeSymbol:
     """Convert a QueriedNode to CodeSymbol."""
@@ -123,6 +126,7 @@ def queried_node_to_symbol(node: QueriedNode) -> CodeSymbol:
 
 
 # Core evaluation logic
+
 
 def build_bm25_index(
     repo_path: str, languages: List[str], max_k: int = 128
@@ -177,12 +181,16 @@ def run_agent_with_bm25(
     top_k: int = 10,
     max_turns: int = 3,
     repo_path: str = ".",
+    allow_skills: Optional[List[str]] = None,
 ) -> tuple[List[QueriedNode], List[str], Optional[Dict[str, Any]]]:
     """
-    Run AgentRunner with BM25 search skill.
+    Run AgentRunner with the configured skill allowlist.
 
     Uses the full AgentRunner pipeline with LLM tool-calling to let the
-    model decide when and how to use the bm25_search skill.
+    model decide when and how to use the allowed skills. In Phase 1 only
+    the ``bm25_search`` skill has its context wired up here; skills that
+    require a different context (embedding_search, graph_expand, ...)
+    will be enabled by the Phase 2 context_builder.
 
     Returns:
         Tuple of (results, execution_log, usage_stats)
@@ -191,7 +199,8 @@ def run_agent_with_bm25(
     from codeminer.compiler.params import SessionContext
 
     execution_log = []
-    usage_stats = {}
+    usage_stats: Dict[str, Any] = {}
+    allow_set = set(allow_skills or ["bm25_search"])
 
     try:
         skills_dir = os.path.join(_PROJECT_ROOT, "codeminer", "agent", "skills")
@@ -216,17 +225,18 @@ def run_agent_with_bm25(
         )
 
         registry = SkillRegistry()
-        all_skills = set(registry.list_skills())
-        exclude_skills = all_skills - {"bm25_search"}
 
         runner = AgentRunner(
             llm=llm,
             registry=registry,
             max_turns=max_turns,
-            exclude_skills=exclude_skills,
+            allow_skills=allow_set,
             session_ctx=session_ctx,
         )
-        execution_log.append(f"Created AgentRunner (max_turns={max_turns})")
+        execution_log.append(
+            f"Created AgentRunner (max_turns={max_turns}, "
+            f"allow_skills={sorted(allow_set)})"
+        )
 
         # Run the agent
         result = runner.run(query)
@@ -248,6 +258,7 @@ def run_agent_with_bm25(
             "total_turns": result.total_turns,
             "total_duration_ms": result.total_duration_ms,
             "tool_call_count": len(result.tool_calls),
+            "token_usage": result.usage.to_dict() if result.usage else None,
         }
 
         return all_results, execution_log, usage_stats
@@ -286,7 +297,9 @@ def evaluate_instance(
         # Step 2: Build BM25 index
         execution_log.append("Building BM25 index...")
         bm25_index = build_bm25_index(repo_path, args.languages, max_k=128)
-        execution_log.append(f"BM25 index built with {len(bm25_index.documents)} documents")
+        execution_log.append(
+            f"BM25 index built with {len(bm25_index.documents)} documents"
+        )
 
         simplified_gt = args.gt_symbols != "full"
 
@@ -312,7 +325,7 @@ def evaluate_instance(
         else:
             if llm is None:
                 raise RuntimeError("eval_mode=agent requires an LLM")
-            execution_log.append("Running agent with BM25 search...")
+            execution_log.append(f"Running agent with skills={args.skills}...")
             results, search_log, usage = run_agent_with_bm25(
                 query=problem_statement,
                 bm25_index=bm25_index,
@@ -320,6 +333,7 @@ def evaluate_instance(
                 top_k=args.topk,
                 max_turns=args.max_turns,
                 repo_path=repo_path,
+                allow_skills=args.skills,
             )
             execution_log.extend(search_log)
 
@@ -345,7 +359,8 @@ def evaluate_instance(
         if gt_empty:
             logger.warning(
                 "%s: GT has no target_files/target_symbols (HF rows often lack these). "
-                "Retrieval metrics are not meaningful without --eval-instances (gt_locate JSON).",
+                "Retrieval metrics are not meaningful without --eval-instances "
+                "(gt_locate JSON).",
                 instance_id,
             )
 
@@ -399,6 +414,7 @@ def evaluate_instance(
 
 
 # Main evaluation loop
+
 
 def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
     """Run evaluation on the dataset."""
@@ -483,7 +499,9 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
     metric_count = 0
 
     for idx, instance in enumerate(instances):
-        logger.info(f"\n[{idx + 1}/{len(instances)}] Evaluating {instance['instance_id']}")
+        logger.info(
+            f"\n[{idx + 1}/{len(instances)}] Evaluating {instance['instance_id']}"
+        )
 
         result = evaluate_instance(
             instance, dataset, llm, args, eval_metadata=eval_lookup
@@ -496,17 +514,37 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
             metric_count += 1
 
     # Compute average metrics (only over instances that produced metrics)
-    avg_metrics = (
-        average_metrics(aggregate, metric_count) if metric_count else {}
-    )
+    avg_metrics = average_metrics(aggregate, metric_count) if metric_count else {}
 
     # Build report
-    skill_ids = (
-        ["bm25_search"] if args.eval_mode == "agent" else ["bm25_baseline"]
-    )
-    report_model = (
-        args.model if args.eval_mode == "agent" else "bm25_baseline"
-    )
+    skill_ids = list(args.skills) if args.eval_mode == "agent" else ["bm25_baseline"]
+    report_model = args.model if args.eval_mode == "agent" else "bm25_baseline"
+
+    # Aggregate token usage across all instances (agent mode only).
+    total_usage: Optional[Dict[str, Any]] = None
+    if args.eval_mode == "agent":
+        prompt_total = 0
+        completion_total = 0
+        total_total = 0
+        cost_total: Optional[float] = None
+        for r in results:
+            if not r.get("success"):
+                continue
+            usage = r.get("loc_result", {}).get("usage") or {}
+            tu = usage.get("token_usage") or {}
+            prompt_total += int(tu.get("prompt_tokens") or 0)
+            completion_total += int(tu.get("completion_tokens") or 0)
+            total_total += int(tu.get("total_tokens") or 0)
+            c = tu.get("cost_usd")
+            if c is not None:
+                cost_total = (cost_total or 0.0) + float(c)
+        total_usage = {
+            "prompt_tokens": prompt_total,
+            "completion_tokens": completion_total,
+            "total_tokens": total_total,
+            "cost_usd": cost_total,
+        }
+
     report = SkillEvalReport(
         dataset=args.dataset,
         model=report_model,
@@ -517,12 +555,14 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
         eval_mode=args.eval_mode,
         locagent_lite_subset=args.locagent_lite_subset,
         gt_symbols_mode=args.gt_symbols,
+        total_usage=total_usage,
     )
 
     return report
 
 
 # CLI
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -651,6 +691,16 @@ def parse_args() -> argparse.Namespace:
         default=50,
         help="Default top_k for BM25 skill in agent mode (passed to RetrieveContext)",
     )
+    parser.add_argument(
+        "--skills",
+        type=str,
+        nargs="+",
+        default=["bm25_search"],
+        help=(
+            "Skill IDs the agent is allowed to use (allowlist). Phase 1 only "
+            "wires BM25 context; skills that need other contexts require Phase 2."
+        ),
+    )
 
     # Evaluation args
     parser.add_argument(
@@ -698,6 +748,18 @@ def main() -> None:
     logger.info("Evaluation complete!")
     logger.info(f"{'=' * 60}")
     logger.info(f"Results saved to: {result_path}")
+
+    if report.total_usage:
+        tu = report.total_usage
+        cost_str = f"${tu['cost_usd']:.4f}" if tu.get("cost_usd") is not None else "n/a"
+        logger.info(
+            "\nTotal token usage: prompt=%d completion=%d total=%d cost=%s",
+            tu.get("prompt_tokens", 0),
+            tu.get("completion_tokens", 0),
+            tu.get("total_tokens", 0),
+            cost_str,
+        )
+
     logger.info(f"\nAggregate Metrics:")
 
     def _metric_k_key(scope: str, k: int) -> Any:

--- a/test/agent/test_runner_allow_skills.py
+++ b/test/agent/test_runner_allow_skills.py
@@ -1,0 +1,140 @@
+"""Tests for ``allow_skills`` / ``allow`` filtering on AgentRunner + tool_schema."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.skills.core import (
+    SkillInputSpec,
+    SkillMetadata,
+    SkillOutputSpec,
+    SkillType,
+)
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.agent.tool_schema import registry_to_tools
+from codeminer.llm.litellm_chat import LiteLLMChat
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+def _register(reg: SkillRegistry, skill_id: str) -> None:
+    reg.register(
+        SkillMetadata(
+            skill_id=skill_id,
+            skill_type=SkillType.CUSTOM,
+            inputs=[SkillInputSpec(name="q", type_hint="str", required=True)],
+            outputs=SkillOutputSpec(type_hint="str"),
+            executor_fn=lambda q, _sid=skill_id: f"{_sid}: {q}",
+        )
+    )
+
+
+@pytest.fixture()
+def three_skill_registry():
+    """Registry with three distinct skills: a, b, c."""
+    reg = SkillRegistry()
+    for sid in ("a", "b", "c"):
+        _register(reg, sid)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# registry_to_tools ``allow`` / ``exclude`` filtering
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryToToolsAllow:
+    def test_allow_none_returns_all(self, three_skill_registry):
+        tools = registry_to_tools(three_skill_registry)
+        names = {t["function"]["name"] for t in tools}
+        assert names == {"a", "b", "c"}
+
+    def test_allow_subset(self, three_skill_registry):
+        tools = registry_to_tools(three_skill_registry, allow={"a", "b"})
+        names = {t["function"]["name"] for t in tools}
+        assert names == {"a", "b"}
+
+    def test_allow_empty_set_returns_nothing(self, three_skill_registry):
+        """An empty allow set is still a set, not None → excludes everything."""
+        tools = registry_to_tools(three_skill_registry, allow=set())
+        assert tools == []
+
+    def test_allow_unknown_skill_is_ignored(self, three_skill_registry):
+        tools = registry_to_tools(three_skill_registry, allow={"a", "does_not_exist"})
+        names = {t["function"]["name"] for t in tools}
+        assert names == {"a"}
+
+    def test_exclude_applied_after_allow(self, three_skill_registry):
+        """exclude wins when a skill is in both allow and exclude."""
+        tools = registry_to_tools(
+            three_skill_registry, allow={"a", "b", "c"}, exclude={"b"}
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert names == {"a", "c"}
+
+    def test_exclude_only(self, three_skill_registry):
+        tools = registry_to_tools(three_skill_registry, exclude={"c"})
+        names = {t["function"]["name"] for t in tools}
+        assert names == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# AgentRunner ``allow_skills`` wiring
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRunnerAllowSkills:
+    def test_allow_skills_filters_tools(self, three_skill_registry):
+        """Runner's tool schema list only contains allowed skills."""
+        llm = MagicMock(spec=LiteLLMChat)
+        runner = AgentRunner(llm, three_skill_registry, allow_skills={"a", "b"})
+        names = {t["function"]["name"] for t in runner.tools}
+        assert names == {"a", "b"}
+        assert len(runner.tools) == 2
+
+    def test_allow_skills_none_includes_all(self, three_skill_registry):
+        llm = MagicMock(spec=LiteLLMChat)
+        runner = AgentRunner(llm, three_skill_registry)
+        names = {t["function"]["name"] for t in runner.tools}
+        assert names == {"a", "b", "c"}
+
+    def test_allow_skills_single(self, three_skill_registry):
+        llm = MagicMock(spec=LiteLLMChat)
+        runner = AgentRunner(llm, three_skill_registry, allow_skills={"c"})
+        assert len(runner.tools) == 1
+        assert runner.tools[0]["function"]["name"] == "c"
+
+    def test_allow_and_exclude_combined(self, three_skill_registry):
+        """exclude is applied on top of allow; overlap is excluded."""
+        llm = MagicMock(spec=LiteLLMChat)
+        runner = AgentRunner(
+            llm,
+            three_skill_registry,
+            allow_skills={"a", "b", "c"},
+            exclude_skills={"a"},
+        )
+        names = {t["function"]["name"] for t in runner.tools}
+        assert names == {"b", "c"}
+
+    def test_allow_skills_empty_set_yields_no_tools(self, three_skill_registry):
+        llm = MagicMock(spec=LiteLLMChat)
+        runner = AgentRunner(llm, three_skill_registry, allow_skills=set())
+        assert runner.tools == []
+
+    def test_allow_skills_unknown_id_ignored(self, three_skill_registry):
+        llm = MagicMock(spec=LiteLLMChat)
+        runner = AgentRunner(llm, three_skill_registry, allow_skills={"a", "ghost"})
+        names = {t["function"]["name"] for t in runner.tools}
+        assert names == {"a"}

--- a/test/agent/test_runner_allow_skills.py
+++ b/test/agent/test_runner_allow_skills.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from codeminer.agent.resource_guard import PreflightReport
 from codeminer.agent.runner import AgentRunner
 from codeminer.agent.skills.core import (
     SkillInputSpec,
@@ -136,5 +137,94 @@ class TestAgentRunnerAllowSkills:
     def test_allow_skills_unknown_id_ignored(self, three_skill_registry):
         llm = MagicMock(spec=LiteLLMChat)
         runner = AgentRunner(llm, three_skill_registry, allow_skills={"a", "ghost"})
+        names = {t["function"]["name"] for t in runner.tools}
+        assert names == {"a"}
+
+
+# ---------------------------------------------------------------------------
+# allow_skills × ResourceGuard interaction
+# ---------------------------------------------------------------------------
+
+
+class TestAllowSkillsWithResourceGuard:
+    """Pin the current behaviour when a user-allowed skill is marked
+    unavailable by the ResourceGuard: the guard's ``unavailable`` set is
+    unioned into ``exclude``, which is applied **after** ``allow``, so the
+    skill is silently dropped from ``runner.tools``.
+    """
+
+    def test_guard_unavailable_overrides_allow(self, three_skill_registry):
+        """A skill in ``allow_skills`` but marked unavailable by the guard
+        is excluded (exclude wins over allow)."""
+        fake_guard = MagicMock()
+        fake_guard.preflight.return_value = PreflightReport(
+            available={"a", "c"},
+            unavailable={"b"},
+            warnings=["Skill 'b' unavailable: missing indexes [bm25]"],
+        )
+
+        with patch(
+            "codeminer.agent.resource_guard.ResourceGuard",
+            return_value=fake_guard,
+        ):
+            llm = MagicMock(spec=LiteLLMChat)
+            runner = AgentRunner(
+                llm,
+                three_skill_registry,
+                allow_skills={"a", "b"},
+                manifest=MagicMock(name="manifest"),
+            )
+
+        names = {t["function"]["name"] for t in runner.tools}
+        # 'b' is silently dropped even though the user allowed it.
+        assert names == {"a"}
+        # Warning from the guard is surfaced in the system prompt.
+        assert "missing indexes" in runner.system_prompt
+
+    def test_guard_all_unavailable_with_allow_yields_empty(self, three_skill_registry):
+        """Every allowed skill is unavailable → no tools at all."""
+        fake_guard = MagicMock()
+        fake_guard.preflight.return_value = PreflightReport(
+            unavailable={"a", "b", "c"},
+            warnings=["all unavailable"],
+        )
+
+        with patch(
+            "codeminer.agent.resource_guard.ResourceGuard",
+            return_value=fake_guard,
+        ):
+            llm = MagicMock(spec=LiteLLMChat)
+            runner = AgentRunner(
+                llm,
+                three_skill_registry,
+                allow_skills={"a", "b"},
+                manifest=MagicMock(name="manifest"),
+            )
+
+        assert runner.tools == []
+
+    def test_guard_does_not_expand_allow(self, three_skill_registry):
+        """A skill marked ``available`` by the guard but NOT in
+        ``allow_skills`` stays filtered out — the guard cannot widen the
+        allowlist."""
+        fake_guard = MagicMock()
+        fake_guard.preflight.return_value = PreflightReport(
+            available={"a", "b", "c"},
+            unavailable=set(),
+            warnings=[],
+        )
+
+        with patch(
+            "codeminer.agent.resource_guard.ResourceGuard",
+            return_value=fake_guard,
+        ):
+            llm = MagicMock(spec=LiteLLMChat)
+            runner = AgentRunner(
+                llm,
+                three_skill_registry,
+                allow_skills={"a"},
+                manifest=MagicMock(name="manifest"),
+            )
+
         names = {t["function"]["name"] for t in runner.tools}
         assert names == {"a"}

--- a/test/agent/test_runner_usage.py
+++ b/test/agent/test_runner_usage.py
@@ -1,0 +1,343 @@
+"""Tests for token-usage tracking in AgentRunner / LiteLLMChat / UsageTracker."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.skills.core import (
+    SkillInputSpec,
+    SkillMetadata,
+    SkillOutputSpec,
+    SkillType,
+)
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.llm.litellm_chat import LiteLLMChat
+from codeminer.llm.usage import (
+    TokenUsage,
+    UsageRecord,
+    UsageTracker,
+    _extract_token_usage,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_runner.py patterns)
+# ---------------------------------------------------------------------------
+
+
+def _make_response(
+    content=None,
+    tool_calls=None,
+    prompt_tokens=0,
+    completion_tokens=0,
+    total_tokens=None,
+):
+    """Build a fake litellm response with a ``usage`` field."""
+    if total_tokens is None:
+        total_tokens = prompt_tokens + completion_tokens
+    msg = SimpleNamespace(
+        role="assistant",
+        content=content,
+        tool_calls=tool_calls,
+    )
+    choice = SimpleNamespace(message=msg)
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+    )
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _make_tool_call(tc_id, name, arguments_json):
+    return SimpleNamespace(
+        id=tc_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments_json),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+@pytest.fixture()
+def echo_registry():
+    reg = SkillRegistry()
+    reg.register(
+        SkillMetadata(
+            skill_id="echo",
+            skill_type=SkillType.CUSTOM,
+            inputs=[SkillInputSpec(name="text", type_hint="str", required=True)],
+            outputs=SkillOutputSpec(type_hint="str"),
+            executor_fn=lambda text: f"echo: {text}",
+        )
+    )
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# TokenUsage / UsageTracker unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenUsage:
+    def test_add_both_with_cost(self):
+        a = TokenUsage(10, 20, 30, cost_usd=0.01)
+        b = TokenUsage(5, 5, 10, cost_usd=0.02)
+        c = a.add(b)
+        assert c.prompt_tokens == 15
+        assert c.completion_tokens == 25
+        assert c.total_tokens == 40
+        assert c.cost_usd == pytest.approx(0.03)
+
+    def test_add_missing_cost_left(self):
+        a = TokenUsage(10, 20, 30)
+        b = TokenUsage(5, 5, 10, cost_usd=0.02)
+        assert a.add(b).cost_usd == pytest.approx(0.02)
+
+    def test_add_both_missing_cost(self):
+        a = TokenUsage(10, 20, 30)
+        b = TokenUsage(5, 5, 10)
+        assert a.add(b).cost_usd is None
+
+    def test_to_dict(self):
+        d = TokenUsage(1, 2, 3, cost_usd=0.5).to_dict()
+        assert d == {
+            "prompt_tokens": 1,
+            "completion_tokens": 2,
+            "total_tokens": 3,
+            "cost_usd": 0.5,
+        }
+
+
+class TestExtractTokenUsage:
+    def test_object_usage(self):
+        resp = _make_response(prompt_tokens=10, completion_tokens=20)
+        u = _extract_token_usage(resp)
+        assert u.prompt_tokens == 10
+        assert u.completion_tokens == 20
+        assert u.total_tokens == 30
+
+    def test_dict_usage(self):
+        resp = SimpleNamespace(
+            usage={
+                "prompt_tokens": 4,
+                "completion_tokens": 6,
+                "total_tokens": 10,
+            }
+        )
+        u = _extract_token_usage(resp)
+        assert u.prompt_tokens == 4
+        assert u.completion_tokens == 6
+        assert u.total_tokens == 10
+
+    def test_missing_usage(self):
+        resp = SimpleNamespace()
+        u = _extract_token_usage(resp)
+        assert u == TokenUsage()
+
+
+class TestUsageTracker:
+    def test_record_and_totals(self):
+        tracker = UsageTracker()
+        with patch("codeminer.llm.usage._safe_completion_cost", return_value=None):
+            tracker.record_response(
+                _make_response(prompt_tokens=10, completion_tokens=20),
+                model="gpt-4o",
+                duration_ms=123.4,
+                turn=1,
+            )
+            tracker.record_response(
+                _make_response(prompt_tokens=5, completion_tokens=5),
+                model="gpt-4o",
+                turn=2,
+            )
+
+        assert len(tracker.records) == 2
+        assert isinstance(tracker.records[0], UsageRecord)
+        assert tracker.records[0].turn == 1
+        assert tracker.records[0].duration_ms == pytest.approx(123.4)
+
+        total = tracker.totals()
+        assert total.prompt_tokens == 15
+        assert total.completion_tokens == 25
+        assert total.total_tokens == 40
+        assert total.cost_usd is None
+
+    def test_cost_aggregation_when_available(self):
+        tracker = UsageTracker()
+        with patch(
+            "codeminer.llm.usage._safe_completion_cost",
+            side_effect=[0.001, 0.002],
+        ):
+            tracker.record_response(
+                _make_response(prompt_tokens=10, completion_tokens=20),
+                model="gpt-4o",
+            )
+            tracker.record_response(
+                _make_response(prompt_tokens=10, completion_tokens=20),
+                model="gpt-4o",
+            )
+        assert tracker.totals().cost_usd == pytest.approx(0.003)
+
+    def test_completion_cost_failure_is_none(self):
+        """If litellm.completion_cost raises, cost_usd is None — not a crash."""
+        tracker = UsageTracker()
+        with patch("litellm.completion_cost", side_effect=RuntimeError("unpriced")):
+            tracker.record_response(
+                _make_response(prompt_tokens=3, completion_tokens=4),
+                model="fake-model",
+            )
+        assert tracker.records[0].usage.cost_usd is None
+        assert tracker.totals().total_tokens == 7
+
+
+# ---------------------------------------------------------------------------
+# LiteLLMChat._call_raw usage_tracker wiring
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMChatUsageTracker:
+    def test_usage_tracker_receives_record(self):
+        chat = LiteLLMChat(model="gpt-4o")
+        tracker = UsageTracker()
+        fake_response = _make_response(
+            content="ok", prompt_tokens=7, completion_tokens=8
+        )
+
+        with (
+            patch(
+                "codeminer.llm.litellm_chat.litellm.completion",
+                return_value=fake_response,
+            ),
+            patch("codeminer.llm.usage._safe_completion_cost", return_value=None),
+        ):
+            resp = chat._call_raw(
+                [{"role": "user", "content": "hi"}],
+                usage_tracker=tracker,
+                usage_turn=1,
+            )
+
+        assert resp is fake_response
+        assert len(tracker.records) == 1
+        rec = tracker.records[0]
+        assert rec.model == "gpt-4o"
+        assert rec.turn == 1
+        assert rec.usage.prompt_tokens == 7
+        assert rec.usage.completion_tokens == 8
+        assert rec.usage.total_tokens == 15
+        assert rec.duration_ms >= 0.0
+
+    def test_usage_tracker_not_forwarded_to_litellm(self):
+        """usage_tracker/usage_turn must not leak into litellm.completion kwargs."""
+        chat = LiteLLMChat(model="gpt-4o")
+        tracker = UsageTracker()
+        with (
+            patch("codeminer.llm.litellm_chat.litellm.completion") as mock_completion,
+            patch("codeminer.llm.usage._safe_completion_cost", return_value=None),
+        ):
+            mock_completion.return_value = _make_response(content="ok")
+            chat._call_raw(
+                [{"role": "user", "content": "hi"}],
+                usage_tracker=tracker,
+                usage_turn=3,
+            )
+            kwargs = mock_completion.call_args.kwargs
+            assert "usage_tracker" not in kwargs
+            assert "usage_turn" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# AgentRunner populates AgentResult.usage
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRunnerUsage:
+    def test_usage_populated_direct_answer(self):
+        """Single LLM call with no tools → usage.total_tokens matches response."""
+        llm = MagicMock(spec=LiteLLMChat)
+
+        def _call_raw(messages, **kwargs):
+            tracker = kwargs.get("usage_tracker")
+            resp = _make_response(
+                content="Final answer", prompt_tokens=100, completion_tokens=50
+            )
+            if tracker is not None:
+                with patch(
+                    "codeminer.llm.usage._safe_completion_cost",
+                    return_value=None,
+                ):
+                    tracker.record_response(
+                        resp, model="test-model", turn=kwargs.get("usage_turn")
+                    )
+            return resp
+
+        llm._call_raw.side_effect = _call_raw
+
+        runner = AgentRunner(llm, SkillRegistry())
+        result = runner.run("hello")
+
+        assert result.answer == "Final answer"
+        assert result.usage is not None
+        assert result.usage.prompt_tokens == 100
+        assert result.usage.completion_tokens == 50
+        assert result.usage.total_tokens == 150
+        assert len(result.usage_records) == 1
+        assert result.usage_records[0].turn == 1
+
+    def test_usage_aggregates_across_turns(self, echo_registry):
+        """Two-turn run aggregates prompt/completion tokens from both responses."""
+        llm = MagicMock(spec=LiteLLMChat)
+        tc = _make_tool_call("call_1", "echo", '{"text": "hi"}')
+        responses = [
+            _make_response(tool_calls=[tc], prompt_tokens=40, completion_tokens=10),
+            _make_response(content="Done", prompt_tokens=60, completion_tokens=20),
+        ]
+        call_count = {"i": 0}
+
+        def _call_raw(messages, **kwargs):
+            tracker = kwargs.get("usage_tracker")
+            resp = responses[call_count["i"]]
+            call_count["i"] += 1
+            if tracker is not None:
+                with patch(
+                    "codeminer.llm.usage._safe_completion_cost",
+                    return_value=None,
+                ):
+                    tracker.record_response(
+                        resp, model="test-model", turn=kwargs.get("usage_turn")
+                    )
+            return resp
+
+        llm._call_raw.side_effect = _call_raw
+
+        runner = AgentRunner(llm, echo_registry)
+        result = runner.run("echo hi")
+
+        assert result.total_turns == 2
+        assert result.usage is not None
+        assert result.usage.prompt_tokens == 100
+        assert result.usage.completion_tokens == 30
+        assert result.usage.total_tokens == 130
+        assert len(result.usage_records) == 2
+        assert [r.turn for r in result.usage_records] == [1, 2]
+
+    def test_call_raw_receives_usage_tracker_kwarg(self):
+        """Runner always forwards usage_tracker + usage_turn to _call_raw."""
+        llm = MagicMock(spec=LiteLLMChat)
+        llm._call_raw.return_value = _make_response(content="ok")
+
+        runner = AgentRunner(llm, SkillRegistry())
+        runner.run("test")
+
+        assert llm._call_raw.called
+        kwargs = llm._call_raw.call_args.kwargs
+        assert "usage_tracker" in kwargs
+        assert kwargs["usage_turn"] == 1

--- a/test/agent/test_runner_usage.py
+++ b/test/agent/test_runner_usage.py
@@ -341,3 +341,40 @@ class TestAgentRunnerUsage:
         kwargs = llm._call_raw.call_args.kwargs
         assert "usage_tracker" in kwargs
         assert kwargs["usage_turn"] == 1
+
+    def test_usage_populated_on_max_turns_exhausted(self, echo_registry):
+        """If the LLM never stops calling tools, the max_turns-exhausted
+        return path must still populate ``usage`` / ``usage_records``.
+        """
+        llm = MagicMock(spec=LiteLLMChat)
+
+        def _call_raw(messages, **kwargs):
+            # Always return a tool_call → never reach the terminal branch.
+            tracker = kwargs.get("usage_tracker")
+            tc = _make_tool_call("call_x", "echo", '{"text": "loop"}')
+            resp = _make_response(tool_calls=[tc], prompt_tokens=7, completion_tokens=3)
+            if tracker is not None:
+                with patch(
+                    "codeminer.llm.usage._safe_completion_cost",
+                    return_value=None,
+                ):
+                    tracker.record_response(
+                        resp, model="test-model", turn=kwargs.get("usage_turn")
+                    )
+            return resp
+
+        llm._call_raw.side_effect = _call_raw
+
+        runner = AgentRunner(llm, echo_registry, max_turns=2)
+        result = runner.run("loop forever")
+
+        # Exhausted the budget — answer falls back to last assistant content.
+        assert result.total_turns == 2
+        assert llm._call_raw.call_count == 2
+        # Crucial assertion: usage on the max-turns return path.
+        assert result.usage is not None
+        assert result.usage.prompt_tokens == 14  # 2 × 7
+        assert result.usage.completion_tokens == 6  # 2 × 3
+        assert result.usage.total_tokens == 20
+        assert len(result.usage_records) == 2
+        assert [r.turn for r in result.usage_records] == [1, 2]


### PR DESCRIPTION
## Summary
Phase 1 of issue #109: token-usage tracking threaded end-to-end through `LiteLLMChat` → `AgentRunner` → `AgentResult`, plus an `allow_skills` allowlist on `AgentRunner` and `registry_to_tools` that resolves #110.

Refs #109 (phase 1 only — phases 2-4 remain open)
Closes #110

## Changes
- **New `codeminer/llm/usage.py`** — `TokenUsage`, `UsageRecord`, `UsageTracker` built on `litellm.completion_cost` + `response.usage`. `cost_usd` falls back to `None` for unpriced models instead of crashing.
- **`LiteLLMChat._call_raw`** now accepts optional `usage_tracker` / `usage_turn` control kwargs and records each response. These are popped before the call, so they never leak into `litellm.completion` kwargs.
- **`AgentRunner`**
  - Instantiates a `UsageTracker` per `run()` and passes `usage_turn` on every call.
  - Aggregates per-turn usage into `AgentResult.usage` + `AgentResult.usage_records` — on **both** the terminal return path and the `max_turns`-exhausted path.
  - Gains `allow_skills: set[str] | None`. Allowlist is applied **before** the existing `exclude_skills` (denylist). Empty set yields no tools; unknown IDs are silently skipped.
  - Interaction with `ResourceGuard`: the guard's `unavailable` set is unioned into `exclude`, so a user-allowed skill is dropped if the guard marks it unavailable (current behaviour is now pinned by tests).
- **`registry_to_tools`** gains a matching `allow=` parameter with the same precedence — fixes #110.
- **`examples/skill_agent_eval.py`**
  - New repeatable `--skills` flag (default `bm25_search`), threaded through `run_agent_with_bm25` → `AgentRunner(allow_skills=...)`.
  - Aggregated `total_usage` (prompt / completion / total / cost_usd) on `SkillEvalReport`, logged at the end of the run.
- **`.gitignore`** — ignore `graph.pkl` alongside the existing `graph.png`.
- **Tests** — `test/agent/test_runner_usage.py` (16 tests) and `test/agent/test_runner_allow_skills.py` (15 tests).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally — `pytest test/agent/test_runner_usage.py test/agent/test_runner_allow_skills.py` → **31 passed**
- [x] Added new tests for the changes
  - `TokenUsage.add` with/without `cost_usd`
  - `_extract_token_usage` for object-shaped + dict-shaped `response.usage`
  - `UsageTracker.totals()` aggregation across calls, incl. `completion_cost` failure → `None`
  - `LiteLLMChat._call_raw` records into tracker and does **not** forward `usage_tracker` / `usage_turn` into `litellm.completion`
  - `AgentRunner` populates `result.usage` on direct-answer, multi-turn tool-calling, **and `max_turns`-exhausted** return paths
  - `registry_to_tools` / `AgentRunner`: `allow=None` → all, `allow={}` → none, unknown IDs ignored, `exclude` wins on overlap
  - `AgentRunner` × `ResourceGuard`: guard-unavailable skill is dropped even when in `allow_skills`; guard cannot widen the allowlist; guard warnings appear in the system prompt

## Checklist
- [x] My code follows the project's style guidelines (pre-commit: black, isort, flake8 — all passed)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
