### PR TITLE
Fix embedding language mapping and CUDA OOM for codeminer-base

### DIFF
--- a/codeminer/dataset/codeminer_base.py
+++ b/codeminer/dataset/codeminer_base.py
@@ -208,6 +208,19 @@ class CodeMinerBaseDataset(DatasetBase):
         os.chdir(repo_path)
 
         try:
+            # Ensure refspec fetches all branches (repos that renamed
+            # default branch may have a narrow refspec from the initial clone)
+            subprocess.run(
+                [
+                    "git",
+                    "config",
+                    "remote.origin.fetch",
+                    "+refs/heads/*:refs/remotes/origin/*",
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
             logger.info("Fetching updates from remote repository")
             subprocess.run(
                 ["git", "fetch", "--all"],

--- a/codeminer/index/embedding/builders.py
+++ b/codeminer/index/embedding/builders.py
@@ -85,14 +85,18 @@ def build_hierarchical_vector_store(
     if not l0_chunks and not l2_chunks:
         raise ValueError("No code chunks generated from repository.")
 
-    # Compute chunk / LOC statistics.
-    # L0 chunks (skeleton_mode) span entire files, so end_line+1 gives LOC.
+    # Compute chunk / LOC statistics by counting actual file lines on disk.
+    repo = Path(repo_path)
+    unique_files = {chunk.file for chunk in (l0_chunks + l2_chunks)}
     loc_by_file: Dict[str, int] = {}
-    for chunk in l0_chunks or l2_chunks:
-        prev = loc_by_file.get(chunk.file, -1)
-        if chunk.end_line > prev:
-            loc_by_file[chunk.file] = chunk.end_line
-    total_loc = sum(end + 1 for end in loc_by_file.values())  # 0-based
+    for rel_path in unique_files:
+        try:
+            loc_by_file[rel_path] = len(
+                (repo / rel_path).read_text(errors="replace").splitlines()
+            )
+        except OSError:
+            pass
+    total_loc = sum(loc_by_file.values())
     total_chunks = len(l0_chunks) + len(l2_chunks)
     chunk_stats = {
         "l0_chunks": len(l0_chunks),

--- a/codeminer/index/embedding/builders.py
+++ b/codeminer/index/embedding/builders.py
@@ -85,6 +85,23 @@ def build_hierarchical_vector_store(
     if not l0_chunks and not l2_chunks:
         raise ValueError("No code chunks generated from repository.")
 
+    # Compute chunk / LOC statistics.
+    # L0 chunks (skeleton_mode) span entire files, so end_line+1 gives LOC.
+    loc_by_file: Dict[str, int] = {}
+    for chunk in l0_chunks or l2_chunks:
+        prev = loc_by_file.get(chunk.file, -1)
+        if chunk.end_line > prev:
+            loc_by_file[chunk.file] = chunk.end_line
+    total_loc = sum(end + 1 for end in loc_by_file.values())  # 0-based
+    total_chunks = len(l0_chunks) + len(l2_chunks)
+    chunk_stats = {
+        "l0_chunks": len(l0_chunks),
+        "l2_chunks": len(l2_chunks),
+        "total_files": len(loc_by_file),
+        "total_loc": total_loc,
+        "avg_chunk_loc": round(total_loc / max(total_chunks, 1), 1),
+    }
+
     store_path = Path(index_path)
     if plan_name:
         store_path = store_path / plan_name
@@ -109,6 +126,7 @@ def build_hierarchical_vector_store(
         )
 
     vector_store.save(str(store_path))
+    vector_store.chunk_stats = chunk_stats
     return vector_store
 
 

--- a/codeminer/index/embedding/builders.py
+++ b/codeminer/index/embedding/builders.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Reusable embedding builders for hierarchical pipelines."""
 
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -10,6 +11,13 @@ from ...profiler import Profiler
 from .vector_store import CodeVectorStore
 
 logger = get_logger(__name__)
+
+
+def _profiler_section(profiler, label, metadata=None):
+    """Return an active profiler section context if profiling is enabled."""
+    if profiler is None:
+        return nullcontext()
+    return profiler.section(label, metadata)
 
 
 def build_hierarchical_vector_store(
@@ -60,7 +68,16 @@ def build_hierarchical_vector_store(
         if not cfg:
             continue
         chunker = CodeChunker(**cfg["chunker_kwargs"])
-        chunks_by_level[level] = chunker.chunk_repository(repo_path=repo_path)
+        with _profiler_section(
+            profiler,
+            f"chunking_{level}",
+            {"level": level, "language": languages[0]},
+        ):
+            chunks_by_level[level] = chunker.chunk_repository(repo_path=repo_path)
+        logger.info(
+            f"Chunked {len(chunks_by_level[level])} {level} chunks "
+            f"(lang={languages[0]})"
+        )
 
     l0_chunks = chunks_by_level.get("l0", [])
     l2_chunks = chunks_by_level.get("l2", [])

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -136,7 +136,14 @@ class CodeVectorStore:
             # unlimited tokenizer.model_max_length and a very large
             # max_seq_length that exceeds GPU memory without flash-attn.
             try:
-                st_model = hf_emb._client  # SentenceTransformer instance
+                # langchain-huggingface >=0.1 uses _client, older uses client
+                st_model = getattr(hf_emb, "_client", None) or getattr(
+                    hf_emb, "client", None
+                )
+                if st_model is None:
+                    raise AttributeError(
+                        "Cannot locate SentenceTransformer on HuggingFaceEmbeddings"
+                    )
                 tok = st_model.tokenizer
                 max_pos = getattr(
                     st_model[0].auto_model.config,
@@ -149,14 +156,23 @@ class CodeVectorStore:
                         tok.model_max_length = effective_max
                     if st_model.max_seq_length > effective_max:
                         logger.info(
-                            "Capping max_seq_length from %s to %s " "for model %s",
+                            "Capping max_seq_length from %s to %s for model %s",
                             st_model.max_seq_length,
                             effective_max,
                             model_name,
                         )
                         st_model.max_seq_length = effective_max
             except Exception as e:
-                logger.debug("Could not set max_seq_length: %s", e)
+                if max_seq_length is not None:
+                    logger.warning(
+                        "--max-seq-length %s was requested but could not be "
+                        "applied to model %s: %s. CUDA OOM may occur.",
+                        max_seq_length,
+                        model_name,
+                        e,
+                    )
+                else:
+                    logger.debug("Could not check tokenizer max length: %s", e)
 
             return hf_emb
         else:

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -259,13 +259,26 @@ class CodeVectorStore:
         # Store documents
         documents_list.extend(documents)
 
+        texts = [doc.page_content for doc in documents]
+        metadatas = [doc.metadata for doc in documents]
+
+        # Phase 1: Embed texts (typically the bottleneck)
         with self._profile_section(
-            f"vector_store_add_documents_{level}",
+            f"embedding_encode_{level}",
             {"num_documents": len(documents), "level": level},
         ):
-            vector_store.add_documents(
-                documents
-            )  # this part will majorly blocked by embedding time
+            embeddings = self.embedding.embed_documents(texts)
+
+        # Phase 2: Add pre-computed vectors to FAISS index
+        with self._profile_section(
+            f"faiss_index_add_{level}",
+            {"num_vectors": len(embeddings), "level": level},
+        ):
+            text_embedding_pairs = list(zip(texts, embeddings, strict=True))
+            vector_store.add_embeddings(
+                text_embeddings=text_embedding_pairs,
+                metadatas=metadatas,
+            )
 
         logger.info(
             f"Successfully added {len(documents)} documents to {level} vector store"
@@ -465,9 +478,10 @@ class CodeVectorStore:
             if not doc or not hasattr(doc, "metadata"):
                 continue
             meta = doc.metadata
-            if meta.get("node_id", "") in mask_node_ids or meta.get(
-                "name", ""
-            ) in mask_node_ids:
+            if (
+                meta.get("node_id", "") in mask_node_ids
+                or meta.get("name", "") in mask_node_ids
+            ):
                 matched.append((faiss_idx, doc))
 
         if not matched:
@@ -475,9 +489,7 @@ class CodeVectorStore:
             return []
 
         # Encode query
-        query_vec = np.array(
-            self.embedding.embed_query(query), dtype=np.float32
-        )
+        query_vec = np.array(self.embedding.embed_query(query), dtype=np.float32)
 
         # Reconstruct stored vectors and compute similarity
         results: list[NodeInfo] = []

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -122,13 +122,43 @@ class CodeVectorStore:
             model_name = self.embedding_model
             model_kwargs = kwargs.pop("model_kwargs", {})
             encode_kwargs = kwargs.pop("encode_kwargs", {})
+            max_seq_length = kwargs.pop("max_seq_length", None)
 
-            return HuggingFaceEmbeddings(
+            hf_emb = HuggingFaceEmbeddings(
                 model_name=model_name,
                 model_kwargs=model_kwargs,
                 encode_kwargs=encode_kwargs,
                 **kwargs,
             )
+
+            # Cap the effective sequence length to avoid CUDA OOM.
+            # Some models (e.g. jinaai/jina-code-embeddings) set an
+            # unlimited tokenizer.model_max_length and a very large
+            # max_seq_length that exceeds GPU memory without flash-attn.
+            try:
+                st_model = hf_emb._client  # SentenceTransformer instance
+                tok = st_model.tokenizer
+                max_pos = getattr(
+                    st_model[0].auto_model.config,
+                    "max_position_embeddings",
+                    None,
+                )
+                effective_max = max_seq_length or max_pos
+                if effective_max:
+                    if tok.model_max_length > effective_max:
+                        tok.model_max_length = effective_max
+                    if st_model.max_seq_length > effective_max:
+                        logger.info(
+                            "Capping max_seq_length from %s to %s " "for model %s",
+                            st_model.max_seq_length,
+                            effective_max,
+                            model_name,
+                        )
+                        st_model.max_seq_length = effective_max
+            except Exception as e:
+                logger.debug("Could not set max_seq_length: %s", e)
+
+            return hf_emb
         else:
             raise ValueError(
                 f"Unsupported embedding provider: {self.embedding_provider}"

--- a/scripts/embeddings/build_codeminer_base_embeddings.sh
+++ b/scripts/embeddings/build_codeminer_base_embeddings.sh
@@ -23,21 +23,35 @@ SPLIT="${SPLIT:-test}"
 FILTER="${FILTER:-.*}"
 PROFILE_TAG="${PROFILE_TAG:-codeminer_base_${SPLIT}}"
 
-# model:dimension:batch_size triples
-# SweRankEmbed-Large needs batch_size=2 to avoid CUDA OOM on H100 80GB
+# model:dimension:batch_size:fallback_batch_size:max_seq_length
+# Batch sizes and max_seq_length tuned for H100 80GB without flash-attn.
+# max_seq_length caps tokenization to prevent CUDA OOM on long documents.
+# Use 0 for max_seq_length to use the model's default.
+#
+# NOTE: jina-code-1.5b has max_position_embeddings=32768 but its tokenizer
+# does not enforce truncation, and 32K seq OOMs even at batch=1 without
+# flash-attn. We cap at 8192 which is safe for batch=4.
+# The main offender is hashicorp__terraform-35611 (L0 files up to ~49K tokens,
+# 14145 L2 chunks). With flash-attn installed, the cap could be raised.
 MODELS=(
-  "Salesforce/SweRankEmbed-Small:768:8"
-  "fishmingyu/SweRankEmbed-Large:3584:2"
-  "jinaai/jina-code-embeddings-1.5b:1536:8"
+  "Salesforce/SweRankEmbed-Small:768:8:4:0"
+  "fishmingyu/SweRankEmbed-Large:3584:2:1:0"
+  "jinaai/jina-code-embeddings-1.5b:1536:4:2:8192"
 )
 
 mkdir -p "${STORAGE_DIR}"
 
 for entry in "${MODELS[@]}"; do
-  IFS=':' read -r MODEL DIM BATCH <<< "${entry}"
+  IFS=':' read -r MODEL DIM BATCH FALLBACK_BATCH MAX_SEQ <<< "${entry}"
+
+  SEQ_FLAG=""
+  if [ "${MAX_SEQ}" != "0" ]; then
+    SEQ_FLAG="--max-seq-length ${MAX_SEQ}"
+  fi
+
   echo ""
   echo "================================================================"
-  echo "Building embeddings: ${MODEL} (dim=${DIM}, batch=${BATCH})"
+  echo "Building embeddings: ${MODEL} (dim=${DIM}, batch=${BATCH}, max_seq=${MAX_SEQ})"
   echo "  dataset=${DATASET}  split=${SPLIT}  filter=${FILTER}"
   echo "================================================================"
   python scripts/embeddings/build_embeddings.py \
@@ -53,7 +67,31 @@ for entry in "${MODELS[@]}"; do
     --embedding-dimension "${DIM}" \
     --batch-size "${BATCH}" \
     --trust-remote-code \
-    "$@"
+    ${SEQ_FLAG} \
+    "$@" || true
+
+  # Retry failed instances with a smaller batch size
+  if [ "${FALLBACK_BATCH}" != "${BATCH}" ]; then
+    echo ""
+    echo "----------------------------------------------------------------"
+    echo "Retrying with fallback batch=${FALLBACK_BATCH} for any failures"
+    echo "----------------------------------------------------------------"
+    python scripts/embeddings/build_embeddings.py \
+      --dataset-class codeminer_base \
+      --dataset "${DATASET}" \
+      --split "${SPLIT}" \
+      --filter-instance "${FILTER}" \
+      --storage-dir "${STORAGE_DIR}" \
+      --enable-profiler \
+      --profile-tag "${PROFILE_TAG}" \
+      --embedding-model "${MODEL}" \
+      --embedding-provider huggingface \
+      --embedding-dimension "${DIM}" \
+      --batch-size "${FALLBACK_BATCH}" \
+      --trust-remote-code \
+      ${SEQ_FLAG} \
+      "$@" || true
+  fi
 done
 
 echo ""

--- a/scripts/embeddings/build_codeminer_base_embeddings.sh
+++ b/scripts/embeddings/build_codeminer_base_embeddings.sh
@@ -23,21 +23,21 @@ SPLIT="${SPLIT:-test}"
 FILTER="${FILTER:-.*}"
 PROFILE_TAG="${PROFILE_TAG:-codeminer_base_${SPLIT}}"
 
-# model:dimension pairs
+# model:dimension:batch_size triples
+# SweRankEmbed-Large needs batch_size=2 to avoid CUDA OOM on H100 80GB
 MODELS=(
-  "Salesforce/SweRankEmbed-Small:768"
-  "fishmingyu/SweRankEmbed-Large:3584"
-  "jinaai/jina-code-embeddings-1.5b:1536"
+  "Salesforce/SweRankEmbed-Small:768:8"
+  "fishmingyu/SweRankEmbed-Large:3584:2"
+  "jinaai/jina-code-embeddings-1.5b:1536:8"
 )
 
 mkdir -p "${STORAGE_DIR}"
 
 for entry in "${MODELS[@]}"; do
-  MODEL="${entry%%:*}"
-  DIM="${entry##*:}"
+  IFS=':' read -r MODEL DIM BATCH <<< "${entry}"
   echo ""
   echo "================================================================"
-  echo "Building embeddings: ${MODEL} (dim=${DIM})"
+  echo "Building embeddings: ${MODEL} (dim=${DIM}, batch=${BATCH})"
   echo "  dataset=${DATASET}  split=${SPLIT}  filter=${FILTER}"
   echo "================================================================"
   python scripts/embeddings/build_embeddings.py \
@@ -51,6 +51,7 @@ for entry in "${MODELS[@]}"; do
     --embedding-model "${MODEL}" \
     --embedding-provider huggingface \
     --embedding-dimension "${DIM}" \
+    --batch-size "${BATCH}" \
     --trust-remote-code \
     "$@"
 done

--- a/scripts/embeddings/build_codeminer_base_embeddings.sh
+++ b/scripts/embeddings/build_codeminer_base_embeddings.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Build embeddings for the CodeMiner-base dataset with three models:
+#   1. Salesforce/SweRankEmbed-Small   (768d)
+#   2. fishmingyu/SweRankEmbed-Large   (3584d)
+#   3. jinaai/jina-code-embeddings-1.5b (1536d)
+#
+# Usage:
+#   # Full run (all instances, all models)
+#   bash scripts/embeddings/build_codeminer_base_embeddings.sh
+#
+#   # Single instance smoke test
+#   FILTER="^(astropy__astropy-12907)$" bash scripts/embeddings/build_codeminer_base_embeddings.sh
+#
+#   # Override storage / dataset
+#   STORAGE_DIR=/tmp/emb DATASET=fishmingyu/codeminer-base-dataset \
+#     bash scripts/embeddings/build_codeminer_base_embeddings.sh
+
+STORAGE_DIR="${STORAGE_DIR:-/mnt/data/codeminer}"
+DATASET="${DATASET:-fishmingyu/codeminer-base-dataset}"
+SPLIT="${SPLIT:-test}"
+FILTER="${FILTER:-.*}"
+PROFILE_TAG="${PROFILE_TAG:-codeminer_base_${SPLIT}}"
+
+# model:dimension pairs
+MODELS=(
+  "Salesforce/SweRankEmbed-Small:768"
+  "fishmingyu/SweRankEmbed-Large:3584"
+  "jinaai/jina-code-embeddings-1.5b:1536"
+)
+
+mkdir -p "${STORAGE_DIR}"
+
+for entry in "${MODELS[@]}"; do
+  MODEL="${entry%%:*}"
+  DIM="${entry##*:}"
+  echo ""
+  echo "================================================================"
+  echo "Building embeddings: ${MODEL} (dim=${DIM})"
+  echo "  dataset=${DATASET}  split=${SPLIT}  filter=${FILTER}"
+  echo "================================================================"
+  python scripts/embeddings/build_embeddings.py \
+    --dataset-class codeminer_base \
+    --dataset "${DATASET}" \
+    --split "${SPLIT}" \
+    --filter-instance "${FILTER}" \
+    --storage-dir "${STORAGE_DIR}" \
+    --enable-profiler \
+    --profile-tag "${PROFILE_TAG}" \
+    --embedding-model "${MODEL}" \
+    --embedding-provider huggingface \
+    --embedding-dimension "${DIM}" \
+    --trust-remote-code \
+    "$@"
+done
+
+echo ""
+echo "Done. Embeddings stored under ${STORAGE_DIR}"
+echo "Profile logs stored under ${STORAGE_DIR}/profile_log"

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -109,6 +109,16 @@ def parse_args():
         help="Batch size for embedding encoding",
     )
     parser.add_argument(
+        "--max-seq-length",
+        type=int,
+        default=None,
+        help=(
+            "Override the model's max sequence length for tokenization. "
+            "Use to prevent CUDA OOM on models with long context windows "
+            "when flash-attn is not installed (e.g. 8192 for jina-code-1.5b)."
+        ),
+    )
+    parser.add_argument(
         "--index-metric",
         type=str,
         default="ip",
@@ -195,26 +205,33 @@ _DATASET_DEFAULTS = {
 }
 
 
-def _map_language_group(label: Optional[str], fallback: str = "python") -> str:
-    """Map a dataset ``language_group`` value to a chunker language string.
+def _map_language_group(label: Optional[str], fallback: str = "python") -> List[str]:
+    """Map a dataset ``language_group`` value to chunker language string(s).
 
     Mirrors ``swebench_graph_index._map_language_label`` with an added Go
     mapping so the codeminer-base multilingual instances get the right chunker.
+
+    Returns a list because some language groups (e.g. "TypeScript/JavaScript")
+    cover multiple chunker languages with disjoint file extensions.
     """
     if not label:
-        return fallback
+        return [fallback]
     text = label.lower()
     if "rust" in text:
-        return "rust"
-    if "javascript" in text or "typescript" in text or text in ("ts", "js"):
-        return "ts"
+        return ["rust"]
+    if "javascript" in text and "typescript" in text:
+        return ["ts", "js"]
+    if "typescript" in text or text == "ts":
+        return ["ts"]
+    if "javascript" in text or text == "js":
+        return ["js"]
     if "c++" in text or text in ("cpp", "c"):
-        return "cpp"
+        return ["cpp"]
     if "go" in text or text == "golang":
-        return "go"
+        return ["go"]
     if "python" in text:
-        return "python"
-    return fallback
+        return ["python"]
+    return [fallback]
 
 
 def _resolve_languages(instance: dict, cli_languages: List[str]) -> List[str]:
@@ -225,7 +242,7 @@ def _resolve_languages(instance: dict, cli_languages: List[str]) -> List[str]:
     """
     lang_group = instance.get("language_group")
     if lang_group:
-        return [_map_language_group(lang_group, fallback=cli_languages[0])]
+        return _map_language_group(lang_group, fallback=cli_languages[0])
     return list(cli_languages)
 
 
@@ -335,6 +352,8 @@ def build_embeddings(args):
                 embedding_kwargs["model_kwargs"] = {"trust_remote_code": True}
             if args.batch_size:
                 embedding_kwargs["encode_kwargs"] = {"batch_size": args.batch_size}
+            if args.max_seq_length:
+                embedding_kwargs["max_seq_length"] = args.max_seq_length
 
             logger.info("Building hierarchical vector store...")
             plan_name = args.plan_name

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 """
-This script builds and caches hierarchical embedding indices for all SWE-bench Lite instances.
-Each instance's embedding will be stored in /mnt/data/codeminer/{instance_id}/
+Build and cache hierarchical embedding indices for SWE-bench or CodeMiner-base instances.
+Each instance's embedding will be stored in <storage-dir>/{instance_id}/
 
-Test Usage:
-    python scripts/build_embeddings.py \\
+Usage:
+    # SWE-bench Lite (default, Python-only)
+    python scripts/embeddings/build_embeddings.py \\
         --filter-instance "^(astropy__astropy-6938)$" \\
         --force-rebuild
+
+    # CodeMiner-base (multi-language, auto-detects language per instance)
+    python scripts/embeddings/build_embeddings.py \\
+        --dataset-class codeminer_base \\
+        --dataset fishmingyu/codeminer-base-dataset \\
+        --enable-profiler
 """
 
 import argparse
@@ -15,8 +22,8 @@ import json
 import logging
 import sys
 from pathlib import Path
+from typing import List, Optional
 
-from codeminer.dataset.swebench import SwebenchDataset
 from codeminer.index.embedding import build_hierarchical_vector_store
 from codeminer.log_utils import get_logger
 from codeminer.profiler import Profiler
@@ -36,10 +43,25 @@ def parse_args():
 
     # Dataset configuration
     parser.add_argument(
+        "--dataset-class",
+        type=str,
+        choices=["swebench", "codeminer_base"],
+        default="swebench",
+        help=(
+            "Dataset class to use. 'swebench' for SWE-bench Lite/Verified, "
+            "'codeminer_base' for the multi-language CodeMiner-base dataset "
+            "(auto-detects language per instance from 'language_group' column)."
+        ),
+    )
+    parser.add_argument(
         "--dataset",
         type=str,
-        default="princeton-nlp/SWE-bench_Lite",
-        help="Dataset name",
+        default=None,
+        help=(
+            "HuggingFace dataset name. Defaults to "
+            "'princeton-nlp/SWE-bench_Lite' for swebench, "
+            "'fishmingyu/codeminer-base-dataset' for codeminer_base."
+        ),
     )
     parser.add_argument(
         "--split",
@@ -163,23 +185,88 @@ def parse_args():
     return parser.parse_args()
 
 
+# ---------------------------------------------------------------------------
+# Language mapping (dataset language_group -> chunker language)
+# ---------------------------------------------------------------------------
+
+_DATASET_DEFAULTS = {
+    "swebench": "princeton-nlp/SWE-bench_Lite",
+    "codeminer_base": "fishmingyu/codeminer-base-dataset",
+}
+
+
+def _map_language_group(label: Optional[str], fallback: str = "python") -> str:
+    """Map a dataset ``language_group`` value to a chunker language string.
+
+    Mirrors ``swebench_graph_index._map_language_label`` with an added Go
+    mapping so the codeminer-base multilingual instances get the right chunker.
+    """
+    if not label:
+        return fallback
+    text = label.lower()
+    if "rust" in text:
+        return "rust"
+    if "javascript" in text or "typescript" in text or text in ("ts", "js"):
+        return "ts"
+    if "c++" in text or text in ("cpp", "c"):
+        return "cpp"
+    if "go" in text or text == "golang":
+        return "go"
+    if "python" in text:
+        return "python"
+    return fallback
+
+
+def _resolve_languages(instance: dict, cli_languages: List[str]) -> List[str]:
+    """Return the language list for a single instance.
+
+    If the instance has a ``language_group`` column (codeminer-base), derive
+    the chunker language from it.  Otherwise fall back to ``cli_languages``.
+    """
+    lang_group = instance.get("language_group")
+    if lang_group:
+        return [_map_language_group(lang_group, fallback=cli_languages[0])]
+    return list(cli_languages)
+
+
+def _load_dataset(args):
+    """Instantiate the dataset object based on ``--dataset-class``."""
+    dataset_name = args.dataset or _DATASET_DEFAULTS[args.dataset_class]
+
+    if args.dataset_class == "codeminer_base":
+        from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
+
+        return CodeMinerBaseDataset(
+            dataset=dataset_name,
+            split=args.split,
+            filter_instance=args.filter_instance,
+        )
+
+    from codeminer.dataset.swebench import SwebenchDataset
+
+    return SwebenchDataset(
+        dataset=dataset_name,
+        split=args.split,
+        filter_instance=args.filter_instance,
+    )
+
+
 def build_embeddings(args):
-    """Build hierarchical embedding indices for all SWE-bench Lite instances."""
+    """Build hierarchical embedding indices for dataset instances."""
 
     build_levels = [level.lower() for level in args.build_levels]
 
     # Load dataset
-    dataset_obj = SwebenchDataset(
-        dataset=args.dataset,
-        split=args.split,
-        filter_instance=args.filter_instance,
-    )
+    dataset_obj = _load_dataset(args)
     dataset_instances = dataset_obj.load()
 
     if len(dataset_instances) == 0:
-        raise ValueError(f"No instances found in {args.dataset}")
+        raise ValueError(
+            f"No instances found in {args.dataset or _DATASET_DEFAULTS[args.dataset_class]}"
+        )
 
     logger.info(f"Loaded {len(dataset_instances)} instance(s)")
+    logger.info(f"Dataset class: {args.dataset_class}")
     logger.info(f"Embeddings will be stored in: {args.storage_dir}")
 
     # Setup profile output directory
@@ -223,20 +310,24 @@ def build_embeddings(args):
             instance_final_dir = Path(args.storage_dir) / instance_dir_name
             instance_final_dir.mkdir(parents=True, exist_ok=True)
 
+            # Resolve per-instance language (uses language_group when available)
+            instance_languages = _resolve_languages(instance, args.languages)
+
             logger.info(f"Repository path: {repo_path}")
             logger.info(f"Target directory: {instance_final_dir}")
+            logger.info(f"Languages: {instance_languages}")
 
             # Check if embedding already exists (model-specific config)
             model_suffix = args.embedding_model.replace("/", "__")
             config_file = instance_final_dir / f"config_{model_suffix}.json"
             if config_file.exists() and not args.force_rebuild:
                 logger.info(
-                    f"✓ Embedding already exists at {instance_final_dir}, skipping..."
+                    f"Embedding already exists at {instance_final_dir}, skipping..."
                 )
                 continue
             elif config_file.exists() and args.force_rebuild:
                 logger.info(
-                    f" Embedding already exists but force-rebuild is enabled, rebuilding..."
+                    "Embedding already exists but force-rebuild is enabled, rebuilding..."
                 )
 
             embedding_kwargs = {}
@@ -252,7 +343,7 @@ def build_embeddings(args):
                     repo_path=repo_path,
                     index_path=str(instance_final_dir),
                     plan_name=plan_name,
-                    languages=list(args.languages),
+                    languages=instance_languages,
                     max_lines_per_chunk=args.max_lines_per_chunk,
                     build_levels=build_levels,
                     embedding_model=args.embedding_model,
@@ -285,6 +376,9 @@ def build_embeddings(args):
                     "instance_id": instance_id,
                     "repo": instance.get("repo", "unknown"),
                     "base_commit": instance.get("base_commit", "unknown"),
+                    "language_group": instance.get("language_group"),
+                    "languages": instance_languages,
+                    "dataset_class": args.dataset_class,
                     "embedding_model": args.embedding_model,
                     "embedding_provider": args.embedding_provider,
                     "embedding_dimension": args.embedding_dimension,
@@ -335,7 +429,7 @@ def build_embeddings(args):
     logger.info(f"\n{'='*80}")
     logger.info("Hierarchical embedding build complete!")
     logger.info(f"Processed {len(dataset_instances)} instance(s)")
-    if args.profile_dir:
+    if args.enable_profiler or args.profile_dir:
         logger.info(f"Profile logs stored in: {profile_output_dir}")
     logger.info(f"{'='*80}")
 

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -391,6 +391,7 @@ def build_embeddings(args):
                     for label, stats in profile_summary
                 ]
 
+                chunk_stats = getattr(vector_store, "chunk_stats", {})
                 profile_payload = {
                     "instance_id": instance_id,
                     "repo": instance.get("repo", "unknown"),
@@ -405,6 +406,7 @@ def build_embeddings(args):
                     "total_duration": sum(
                         section["total"] for section in sections_payload
                     ),
+                    "chunk_stats": chunk_stats,
                     "sections": sections_payload,
                 }
 

--- a/scripts/embeddings/build_swebench_dev_embeddings.sh
+++ b/scripts/embeddings/build_swebench_dev_embeddings.sh
@@ -18,7 +18,7 @@ PROFILE_TAG="${PROFILE_TAG:-${SPLIT}_emb_build}"
 mkdir -p "${STORAGE_DIR}"
 
 # echo "Building primary embeddings (${PRIMARY_MODEL})..."
-# python scripts/build_embeddings.py \
+# python scripts/embeddings/build_embeddings.py \
 #   --dataset "${DATASET}" \
 #   --split "${SPLIT}" \
 #   --storage-dir "${STORAGE_DIR}" \
@@ -29,7 +29,7 @@ mkdir -p "${STORAGE_DIR}"
 #   "$@"
 
 echo "Building secondary embeddings (${SECONDARY_MODEL})..."
-python scripts/build_embeddings.py \
+python scripts/embeddings/build_embeddings.py \
   --dataset "${DATASET}" \
   --split "${SPLIT}" \
   --storage-dir "${STORAGE_DIR}" \

--- a/scripts/embeddings/profile_dataset_stats.py
+++ b/scripts/embeddings/profile_dataset_stats.py
@@ -58,12 +58,17 @@ def compute_chunk_stats(repo_path, languages):
         stats[f"{level}_chunks"] = len(chunks)
 
         if level == "l0":
+            repo = Path(repo_path)
+            unique_files = {c.file for c in chunks}
             loc_by_file = {}
-            for c in chunks:
-                prev = loc_by_file.get(c.file, -1)
-                if c.end_line > prev:
-                    loc_by_file[c.file] = c.end_line
-            stats["total_loc"] = sum(end + 1 for end in loc_by_file.values())
+            for rel_path in unique_files:
+                try:
+                    loc_by_file[rel_path] = len(
+                        (repo / rel_path).read_text(errors="replace").splitlines()
+                    )
+                except OSError:
+                    pass
+            stats["total_loc"] = sum(loc_by_file.values())
             stats["total_files"] = len(loc_by_file)
 
     total_chunks = stats.get("l0_chunks", 0) + stats.get("l2_chunks", 0)
@@ -172,7 +177,8 @@ def main():
         # Re-chunk for detailed stats
         if args.rechunk:
             try:
-                repo_path = dataset_obj.process_instance(instance)
+                dataset_obj.process_instance(instance)
+                repo_path = dataset_obj.get_repo_path(instance)
                 chunk_stats = compute_chunk_stats(repo_path, instance_languages)
                 entry["chunk_stats"] = chunk_stats
                 logger.info(

--- a/scripts/embeddings/profile_dataset_stats.py
+++ b/scripts/embeddings/profile_dataset_stats.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Compute chunk count and LOC statistics for codeminer-base dataset instances.
+
+Reads existing embedding configs for document counts and optionally re-chunks
+repos to compute detailed statistics (total LOC, file counts, chunk sizes)
+without re-embedding.
+
+Usage:
+    # Quick: read existing configs only (no re-chunking)
+    python scripts/embeddings/profile_dataset_stats.py \
+        --storage-dir /mnt/data/codeminer
+
+    # Full: re-chunk repos to get LOC stats
+    python scripts/embeddings/profile_dataset_stats.py \
+        --storage-dir /mnt/data/codeminer \
+        --rechunk
+
+    # Output JSON summary
+    python scripts/embeddings/profile_dataset_stats.py \
+        --storage-dir /mnt/data/codeminer \
+        --rechunk \
+        --output /mnt/data/codeminer/dataset_stats.json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+from codeminer.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+# Import dataset loading helpers from build_embeddings
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from build_embeddings import _load_dataset, _resolve_languages  # noqa: E402
+
+
+def compute_chunk_stats(repo_path, languages):
+    """Chunk the repo at L0 and L2 and return a stats dict."""
+    repo_cfg = RepoChunkingConfig(languages=languages)
+    stats = {}
+
+    for level, depth, skeleton, l2_exclusive in [
+        ("l0", 0, True, False),
+        ("l2", 2, False, True),
+    ]:
+        chunker = CodeChunker(
+            language=languages[0],
+            repo_config=repo_cfg,
+            chunk_depth=depth,
+            skeleton_mode=skeleton,
+            l2_level_exclusive=l2_exclusive,
+        )
+        chunks = chunker.chunk_repository(repo_path=repo_path)
+        stats[f"{level}_chunks"] = len(chunks)
+
+        if level == "l0":
+            loc_by_file = {}
+            for c in chunks:
+                prev = loc_by_file.get(c.file, -1)
+                if c.end_line > prev:
+                    loc_by_file[c.file] = c.end_line
+            stats["total_loc"] = sum(end + 1 for end in loc_by_file.values())
+            stats["total_files"] = len(loc_by_file)
+
+    total_chunks = stats.get("l0_chunks", 0) + stats.get("l2_chunks", 0)
+    stats["avg_chunk_loc"] = round(stats.get("total_loc", 0) / max(total_chunks, 1), 1)
+    return stats
+
+
+def read_existing_configs(instance_dir):
+    """Read all config_*.json files in an instance directory."""
+    configs = {}
+    for cfg_path in Path(instance_dir).glob("config_*.json"):
+        with open(cfg_path) as f:
+            data = json.load(f)
+        model = data.get("embedding_model", cfg_path.stem)
+        configs[model] = {
+            "l0_documents": data.get("l0_documents", 0),
+            "l2_documents": data.get("l2_documents", 0),
+        }
+    return configs
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compute chunk/LOC stats for codeminer-base instances.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--dataset-class",
+        default="codeminer_base",
+        choices=["codeminer_base", "swebench"],
+    )
+    parser.add_argument("--dataset", default=None, help="HuggingFace dataset name")
+    parser.add_argument("--split", default="test")
+    parser.add_argument(
+        "--storage-dir",
+        default="/mnt/data/codeminer",
+        help="Base directory with embedding outputs",
+    )
+    parser.add_argument(
+        "--rechunk",
+        action="store_true",
+        help="Re-chunk repos to compute LOC stats (slower, needs repo access)",
+    )
+    parser.add_argument(
+        "--filter-instance",
+        default=".*",
+        help="Regex to filter instances",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Write JSON summary to this file",
+    )
+    parser.add_argument(
+        "--languages",
+        nargs="+",
+        default=["python"],
+        help="Fallback languages",
+    )
+    args = parser.parse_args()
+
+    # Load dataset
+    # Build a minimal args namespace for _load_dataset
+    import re
+    from types import SimpleNamespace
+
+    _DATASET_DEFAULTS = {
+        "swebench": "princeton-nlp/SWE-bench_Lite",
+        "codeminer_base": "fishmingyu/codeminer-base-dataset",
+    }
+    load_args = SimpleNamespace(
+        dataset_class=args.dataset_class,
+        dataset=args.dataset or _DATASET_DEFAULTS[args.dataset_class],
+        split=args.split,
+        filter_instance=args.filter_instance,
+    )
+    dataset_obj = _load_dataset(load_args)
+    dataset_instances = dataset_obj.load()
+
+    pattern = re.compile(args.filter_instance)
+    dataset_instances = [
+        inst
+        for inst in dataset_instances
+        if pattern.search(inst.get("instance_id", ""))
+    ]
+
+    storage_dir = Path(args.storage_dir)
+    results = []
+
+    for idx, instance in enumerate(dataset_instances):
+        instance_id = instance.get("instance_id", f"unknown_{idx}")
+        instance_dir = storage_dir / instance_id
+        instance_languages = _resolve_languages(instance, args.languages)
+
+        entry = {
+            "instance_id": instance_id,
+            "repo": instance.get("repo", "unknown"),
+            "language_group": instance.get("language_group"),
+            "languages": instance_languages,
+        }
+
+        # Read existing configs
+        if instance_dir.exists():
+            entry["embedding_configs"] = read_existing_configs(instance_dir)
+
+        # Re-chunk for detailed stats
+        if args.rechunk:
+            try:
+                repo_path = dataset_obj.process_instance(instance)
+                chunk_stats = compute_chunk_stats(repo_path, instance_languages)
+                entry["chunk_stats"] = chunk_stats
+                logger.info(
+                    "[%d/%d] %s: %d files, %d LOC, %d L0, %d L2 chunks",
+                    idx + 1,
+                    len(dataset_instances),
+                    instance_id,
+                    chunk_stats["total_files"],
+                    chunk_stats["total_loc"],
+                    chunk_stats["l0_chunks"],
+                    chunk_stats["l2_chunks"],
+                )
+            except Exception as e:
+                logger.error(
+                    "[%d/%d] %s: rechunk failed: %s",
+                    idx + 1,
+                    len(dataset_instances),
+                    instance_id,
+                    e,
+                )
+                entry["chunk_stats_error"] = str(e)
+        else:
+            logger.info(
+                "[%d/%d] %s: %d model configs found",
+                idx + 1,
+                len(dataset_instances),
+                instance_id,
+                len(entry.get("embedding_configs", {})),
+            )
+
+        results.append(entry)
+
+    # Print summary table
+    print(f"\n{'Instance':<45} {'Lang':<8} {'Files':>6} {'LOC':>8} {'L0':>6} {'L2':>6}")
+    print("-" * 85)
+    for r in results:
+        cs = r.get("chunk_stats", {})
+        cfg = r.get("embedding_configs", {})
+        # Use chunk_stats if available, else first config
+        l0 = cs.get("l0_chunks") or next((v["l0_documents"] for v in cfg.values()), "?")
+        l2 = cs.get("l2_chunks") or next((v["l2_documents"] for v in cfg.values()), "?")
+        files = cs.get("total_files", "?")
+        loc = cs.get("total_loc", "?")
+        lang = ",".join(r.get("languages", []))
+        print(f"{r['instance_id']:<45} {lang:<8} {files:>6} {loc:>8} {l0:>6} {l2:>6}")
+
+    # Write JSON output
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nSaved {len(results)} entries to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/embeddings/profile_embedding_models.sh
+++ b/scripts/embeddings/profile_embedding_models.sh
@@ -24,7 +24,7 @@ for entry in "${MODELS[@]}"; do
   MODEL="${entry%%:*}"
   DIM="${entry##*:}"
   echo "Profiling ${MODEL} (dim=${DIM}) on ${INSTANCE_ID}"
-  python scripts/build_embeddings.py \
+  python scripts/embeddings/build_embeddings.py \
     --dataset "${DATASET}" \
     --split "${SPLIT}" \
     --filter-instance "^(${INSTANCE_ID})$" \


### PR DESCRIPTION
## Summary
Fix embedding pipeline bugs causing incomplete indices for 9 codeminer-base instances: wrong language mapping for JS/TS repos, and CUDA OOM for jina-code-1.5b on long sequences.

## Changes
- **TypeScript/JavaScript language mapping**: `_map_language_group("TypeScript/JavaScript")` returned only `"ts"`, missing all `.js/.jsx/.mjs` files. Repos like axios (pure JS) and preact (mixed JS/TS) produced empty or incomplete indices. Now returns `["ts", "js"]`.
- **CUDA OOM for jina-code-1.5b**: The jina tokenizer sets `model_max_length=1e30` (unlimited), so inputs are never truncated. On repos with long files (e.g. hashicorp/terraform with ~49K-token L0 files), attention OOMs at 192 GB even at batch=1. Added `--max-seq-length` CLI arg and auto-cap when `tokenizer.model_max_length > max_position_embeddings`.
- **Build script hardening**: jina batch 8->4, fallback batch retry on OOM, `max_seq_length=8192` for jina.

### Affected instances (codeminer-base)
| Issue | Instances |
|---|---|
| Missing JS files (language mapping) | axios x4, preact x4 |
| CUDA OOM (jina tokenizer) | hashicorp/terraform-35611 |

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Verified axios/preact instances produce correct L0+L2 counts after rebuild
- [x] Benchmarked batch sizes on H100 80GB — batch=8 is max for SweRank-Small (OOM at 16+), batch=4 is max for jina (OOM on large repos at 8)
- [x] Verified max_seq_length=8192 caps tokenization and prevents OOM
- [ ] Tests pass locally
- [ ] Added new tests for the changes

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published