### PR TITLE
[embedding] Drop LangChain, add minified-file skip and Qwen3 support

### DIFF
--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -38,6 +38,8 @@ class RepoChunkingConfig:
     ignore_patterns: Set[str] = None
     max_file_size_mb: float = 10.0  # Skip files larger than this
     filter_tests: bool = True  # Skip test files by default
+    skip_minified: bool = True  # Skip minified/bundled files
+    minified_line_threshold: int = 10000  # Max chars per line before a file is minified
 
     def __post_init__(self):
         """Initialize default values."""
@@ -95,6 +97,11 @@ class RepoChunkingConfig:
                 "*~",
                 "*.bak",
                 "*.tmp",
+                "*.min.js",
+                "*.min.css",
+                "*.min.mjs",
+                "*.bundle.js",
+                "*.bundle.mjs",
             }
 
 
@@ -415,6 +422,11 @@ class CodeChunker:
         except OSError:
             return False
 
+        # Check for minified/bundled files
+        if self.repo_config.skip_minified:
+            if self._is_minified_file(file_path):
+                return False
+
         # Check ignore patterns (basic pattern matching)
         file_name = file_path.name
         for pattern in self.repo_config.ignore_patterns:
@@ -431,6 +443,30 @@ class CodeChunker:
                 return False
 
         return True
+
+    def _is_minified_file(self, file_path: Path) -> bool:
+        """Detect minified/bundled files by checking for extremely long lines.
+
+        Minified JS/CSS bundles pack thousands of statements onto a single
+        line, producing chunks that each contain the entire file content.
+        These have no semantic search value and cause massive slowdowns
+        during embedding (e.g. babel's Makefile.js: 131KB in 3 lines →
+        ~480 duplicate chunks each hitting the 8192-token cap).
+        """
+        threshold = self.repo_config.minified_line_threshold
+        try:
+            with open(file_path, "r", errors="replace") as f:
+                for line in f:
+                    if len(line) > threshold:
+                        logger.debug(
+                            "Skipping minified file (line > %d chars): %s",
+                            threshold,
+                            file_path,
+                        )
+                        return True
+        except OSError:
+            pass
+        return False
 
     def _chunk_file_with_language(
         self, file_path: Path, language: str, repo_path: Optional[Path] = None

--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -464,8 +464,12 @@ class CodeChunker:
                             file_path,
                         )
                         return True
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug(
+                "Unable to inspect file for minification, treating as not minified: %s (%s)",
+                file_path,
+                exc,
+            )
         return False
 
     def _chunk_file_with_language(

--- a/codeminer/dataset/base.py
+++ b/codeminer/dataset/base.py
@@ -13,6 +13,11 @@ logger = get_logger(__name__)
 class DatasetBase:
     """Base dataset wrapper for loading and summarizing cached datasets."""
 
+    # Controls whether collect_targets uses simplified symbol filtering (functions
+    # only, identified by '(' in the symbol name). Override to False in datasets
+    # whose GT includes non-function symbols (e.g. JS/TS object constants).
+    simplified_symbols: bool = True
+
     def __init__(
         self,
         root: str | None = None,

--- a/codeminer/dataset/codeminer_base.py
+++ b/codeminer/dataset/codeminer_base.py
@@ -27,10 +27,11 @@ class CodeMinerBaseDataset(DatasetBase):
     deleted symbols, and code blocks) produced by the tree-sitter chunking
     pipeline (see ``scripts/build_swebench_locator_hf_dataset.py``).
 
-    Because the ground truth is baked into the dataset rows, there is no need
-    to clone the repo and re-parse the patch to compute eval metadata — the
-    ``load_eval_metadata`` override returns the GT columns directly.
+    GT includes non-function symbols (JS/TS object constants, Go variables,
+    etc.) so simplified_symbols filtering is disabled for this dataset.
     """
+
+    simplified_symbols: bool = False
 
     def __init__(
         self,

--- a/codeminer/index/embedding/builders.py
+++ b/codeminer/index/embedding/builders.py
@@ -34,8 +34,40 @@ def build_hierarchical_vector_store(
     embedding_kwargs: Optional[Dict[str, object]] = None,
     index_metric: str = "ip",
     profiler: Optional[Profiler] = None,
+    force_rebuild: bool = False,
 ) -> CodeVectorStore:
-    """Build a hierarchical vector store (L0/L2) for a repository."""
+    """Build (or load) a hierarchical vector store (L0/L2) for a repository.
+
+    When ``force_rebuild=False`` (the default) and a saved index for the
+    requested ``embedding_model`` already exists at ``index_path``, the store
+    is loaded from disk instead of re-chunking and re-embedding the repository.
+    Pass ``force_rebuild=True`` to unconditionally rebuild.
+    """
+    store_path = Path(index_path)
+    if plan_name:
+        store_path = store_path / plan_name
+
+    if not force_rebuild:
+        model_suffix = embedding_model.replace("/", "__")
+        config_path = store_path / f"config_{model_suffix}.json"
+        if config_path.exists():
+            logger.info(
+                "Pre-built index found at %s — loading instead of rebuilding "
+                "(pass force_rebuild=True to override).",
+                store_path,
+            )
+            vector_store = CodeVectorStore(
+                embedding_model=embedding_model,
+                embedding_provider=embedding_provider,
+                dimension=embedding_dimension,
+                index_metric=index_metric,
+                store_path=str(store_path),
+                profiler=profiler,
+                **(embedding_kwargs or {}),
+            )
+            vector_store.load(str(store_path))
+            return vector_store
+
     languages = languages or ["python"]
     build_levels = [level.lower() for level in (build_levels or ["l0", "l2"])]
     repo_cfg = RepoChunkingConfig(languages=languages)
@@ -106,9 +138,6 @@ def build_hierarchical_vector_store(
         "avg_chunk_loc": round(total_loc / max(total_chunks, 1), 1),
     }
 
-    store_path = Path(index_path)
-    if plan_name:
-        store_path = store_path / plan_name
     store_path.mkdir(parents=True, exist_ok=True)
     vector_store = CodeVectorStore(
         embedding_model=embedding_model,

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -320,6 +320,31 @@ class CodeVectorStore:
                 results.append((documents[idx], float(dist)))
         return results
 
+    def swap_index(self, path: str) -> None:
+        """Hot-swap the FAISS index without reloading the embedding model.
+
+        Frees the current L0/L2 FAISS indices and documents from memory, then
+        loads a new index from *path*.  The embedding model is left intact so
+        the caller can reuse the same model across many instances.
+        """
+        # Free current FAISS index memory (GPU or CPU).
+        for index in (self.l0_index, self.l2_index):
+            if index is None:
+                continue
+            reset = getattr(index, "reset", None)
+            if callable(reset):
+                reset()
+
+        # Reinitialise to empty indices (guards against a partially-failed
+        # subsequent load leaving the store in a mixed state).
+        self.l0_index = self._build_faiss_index()
+        self.l0_documents = []
+        self.l2_index = self._build_faiss_index()
+        self.l2_documents = []
+
+        self.store_path = Path(path)
+        self.load(path)
+
     def close(self) -> None:
         """Release embeddings and FAISS resources to free memory."""
         for index in (self.l0_index, self.l2_index):

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -1,5 +1,5 @@
 """
-Vector Store implementation using FAISS and LangChain for code embeddings.
+Vector Store implementation using FAISS and sentence-transformers for code embeddings.
 This module provides functionality to create, store, and query vector embeddings
 of code chunks for semantic similarity search.
 """
@@ -12,12 +12,6 @@ from typing import Any, Dict, List, Literal, Optional, Set
 
 import faiss
 import numpy as np
-from langchain_community.docstore import InMemoryDocstore
-from langchain_community.vectorstores import FAISS
-from langchain_core.documents import Document
-from langchain_core.embeddings import Embeddings
-from langchain_huggingface import HuggingFaceEmbeddings
-from langchain_openai import OpenAIEmbeddings
 
 from ...log_utils import get_logger
 from ...profiler import Profiler
@@ -28,9 +22,138 @@ logger = get_logger(__name__)
 Level = Literal["l0", "l2"]
 
 
+class _Document:
+    """Lightweight document container replacing LangChain Document.
+
+    Provides the same ``page_content`` / ``metadata`` interface so that
+    callers accessing ``store.l0_documents`` or ``store.l2_documents``
+    continue to work without changes.
+    """
+
+    __slots__ = ("page_content", "metadata")
+
+    def __init__(self, page_content: str = "", metadata: Optional[Dict] = None):
+        self.page_content = page_content
+        self.metadata = metadata if metadata is not None else {}
+
+    def __repr__(self) -> str:
+        name = self.metadata.get("name", "")
+        return f"_Document(name={name!r}, len={len(self.page_content)})"
+
+
+class _HuggingFaceEmbeddingWrapper:
+    """Wraps ``SentenceTransformer`` to expose ``embed_query`` / ``embed_documents``.
+
+    The interface is intentionally compatible with the LangChain ``Embeddings``
+    protocol so that external callers accessing ``store.embedding.embed_query``
+    or ``store.embedding.embed_documents`` keep working.
+    """
+
+    def __init__(self, model_name: str, max_seq_length: Optional[int] = None, **kwargs):
+        from sentence_transformers import SentenceTransformer
+
+        model_kwargs = kwargs.pop("model_kwargs", {})
+        self._encode_kwargs = kwargs.pop("encode_kwargs", {})
+
+        # Build SentenceTransformer init kwargs
+        st_kwargs: Dict[str, Any] = {}
+        if kwargs.pop("trust_remote_code", False):
+            st_kwargs["trust_remote_code"] = True
+        # Forward remaining kwargs (e.g. device, cache_folder)
+        st_kwargs.update(kwargs)
+        st_kwargs.update(model_kwargs)
+
+        self._model = SentenceTransformer(model_name, **st_kwargs)
+
+        # Cap the effective sequence length to avoid CUDA OOM.
+        self._apply_max_seq_length(model_name, max_seq_length)
+
+    # Expose the underlying SentenceTransformer so that callers that
+    # previously reached through ``store.embedding._client`` (langchain-
+    # huggingface >=0.1) or ``store.embedding.client`` (older) keep working.
+    @property
+    def _client(self):
+        return self._model
+
+    @property
+    def client(self):
+        return self._model
+
+    def _apply_max_seq_length(
+        self, model_name: str, max_seq_length: Optional[int]
+    ) -> None:
+        """Cap tokeniser / model sequence length to prevent OOM."""
+        try:
+            tok = self._model.tokenizer
+            max_pos = getattr(
+                self._model[0].auto_model.config,
+                "max_position_embeddings",
+                None,
+            )
+            effective_max = max_seq_length or max_pos
+            if effective_max:
+                if tok.model_max_length > effective_max:
+                    tok.model_max_length = effective_max
+                if self._model.max_seq_length > effective_max:
+                    logger.info(
+                        "Capping max_seq_length from %s to %s for model %s",
+                        self._model.max_seq_length,
+                        effective_max,
+                        model_name,
+                    )
+                    self._model.max_seq_length = effective_max
+        except Exception as e:
+            if max_seq_length is not None:
+                logger.warning(
+                    "--max-seq-length %s was requested but could not be "
+                    "applied to model %s: %s. CUDA OOM may occur.",
+                    max_seq_length,
+                    model_name,
+                    e,
+                )
+            else:
+                logger.debug("Could not check tokenizer max length: %s", e)
+
+    def embed_query(self, text: str) -> List[float]:
+        vec = self._model.encode([text], **self._encode_kwargs)
+        return vec[0].tolist()
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        vecs = self._model.encode(texts, **self._encode_kwargs)
+        return vecs.tolist()
+
+
+class _OpenAIEmbeddingWrapper:
+    """Wraps the OpenAI SDK to expose ``embed_query`` / ``embed_documents``."""
+
+    def __init__(self, model: str, **kwargs):
+        from openai import OpenAI
+
+        self._model = model
+        self._client = OpenAI(**kwargs)
+
+    def embed_query(self, text: str) -> List[float]:
+        resp = self._client.embeddings.create(input=[text], model=self._model)
+        return resp.data[0].embedding
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        resp = self._client.embeddings.create(input=texts, model=self._model)
+        return [d.embedding for d in sorted(resp.data, key=lambda x: x.index)]
+
+
+def _to_document(obj: Any) -> _Document:
+    """Convert any document-like object to ``_Document`` (duck-typed)."""
+    if isinstance(obj, _Document):
+        return obj
+    return _Document(
+        page_content=getattr(obj, "page_content", ""),
+        metadata=getattr(obj, "metadata", {}),
+    )
+
+
 class CodeVectorStore:
     """
-    Vector store for code embeddings using FAISS and LangChain.
+    Vector store for code embeddings using FAISS and sentence-transformers.
     Provides semantic search capabilities over code chunks.
 
     Supports hierarchical indexing:
@@ -82,99 +205,35 @@ class CodeVectorStore:
         self.embedding = self._initialize_embedding_model(**embedding_kwargs)
         self.dimension = self._infer_embedding_dimension(dimension)
 
-        # Initialize L0 vector store (file-level skeletons)
+        # Initialize L0 (file-level skeletons)
         self.l0_index = self._build_faiss_index()
-        self.l0_vector_store = FAISS(
-            embedding_function=self.embedding,
-            index=self.l0_index,
-            docstore=InMemoryDocstore(),
-            index_to_docstore_id={},
-        )
-        self.l0_documents: List[Document] = []
+        self.l0_documents: List[_Document] = []
 
-        # Initialize L2 vector store (function/method-level) - default
+        # Initialize L2 (function/method-level) - default
         self.l2_index = self._build_faiss_index()
-        self.l2_vector_store = FAISS(
-            embedding_function=self.embedding,
-            index=self.l2_index,
-            docstore=InMemoryDocstore(),
-            index_to_docstore_id={},
-        )
-        self.l2_documents: List[Document] = []
+        self.l2_documents: List[_Document] = []
+
         logger.info(
             f"Initialized CodeVectorStore with {embedding_provider}:{embedding_model}"
         )
 
-    def _get_store_and_docs(self, level: Level) -> tuple[FAISS, List[Document]]:
-        """Get the vector store and documents list for the specified level."""
+    def _get_index_and_docs(self, level: Level) -> tuple[faiss.Index, List[_Document]]:
+        """Get the FAISS index and documents list for the specified level."""
         if level == "l0":
-            return self.l0_vector_store, self.l0_documents
+            return self.l0_index, self.l0_documents
         elif level == "l2":
-            return self.l2_vector_store, self.l2_documents
+            return self.l2_index, self.l2_documents
         else:
             raise ValueError(f"Invalid level: {level}. Must be 'l0' or 'l2'.")
 
-    def _initialize_embedding_model(self, **kwargs) -> Embeddings:
+    def _initialize_embedding_model(self, **kwargs):
         """Initialize the embedding model based on provider."""
         if self.embedding_provider.lower() == "openai":
-            return OpenAIEmbeddings(model=self.embedding_model, **kwargs)
+            return _OpenAIEmbeddingWrapper(model=self.embedding_model, **kwargs)
         elif self.embedding_provider.lower() == "huggingface":
-            model_name = self.embedding_model
-            model_kwargs = kwargs.pop("model_kwargs", {})
-            encode_kwargs = kwargs.pop("encode_kwargs", {})
-            max_seq_length = kwargs.pop("max_seq_length", None)
-
-            hf_emb = HuggingFaceEmbeddings(
-                model_name=model_name,
-                model_kwargs=model_kwargs,
-                encode_kwargs=encode_kwargs,
-                **kwargs,
+            return _HuggingFaceEmbeddingWrapper(
+                model_name=self.embedding_model, **kwargs
             )
-
-            # Cap the effective sequence length to avoid CUDA OOM.
-            # Some models (e.g. jinaai/jina-code-embeddings) set an
-            # unlimited tokenizer.model_max_length and a very large
-            # max_seq_length that exceeds GPU memory without flash-attn.
-            try:
-                # langchain-huggingface >=0.1 uses _client, older uses client
-                st_model = getattr(hf_emb, "_client", None) or getattr(
-                    hf_emb, "client", None
-                )
-                if st_model is None:
-                    raise AttributeError(
-                        "Cannot locate SentenceTransformer on HuggingFaceEmbeddings"
-                    )
-                tok = st_model.tokenizer
-                max_pos = getattr(
-                    st_model[0].auto_model.config,
-                    "max_position_embeddings",
-                    None,
-                )
-                effective_max = max_seq_length or max_pos
-                if effective_max:
-                    if tok.model_max_length > effective_max:
-                        tok.model_max_length = effective_max
-                    if st_model.max_seq_length > effective_max:
-                        logger.info(
-                            "Capping max_seq_length from %s to %s for model %s",
-                            st_model.max_seq_length,
-                            effective_max,
-                            model_name,
-                        )
-                        st_model.max_seq_length = effective_max
-            except Exception as e:
-                if max_seq_length is not None:
-                    logger.warning(
-                        "--max-seq-length %s was requested but could not be "
-                        "applied to model %s: %s. CUDA OOM may occur.",
-                        max_seq_length,
-                        model_name,
-                        e,
-                    )
-                else:
-                    logger.debug("Could not check tokenizer max length: %s", e)
-
-            return hf_emb
         else:
             raise ValueError(
                 f"Unsupported embedding provider: {self.embedding_provider}"
@@ -212,10 +271,8 @@ class CodeVectorStore:
         filter if score > threshold
         """
         if self.index_metric == "ip":
-            # Inner product: higher is better (similarity score)
             return score < threshold
-        elif self.index_metric == "l2":  # l2
-            # L2 distance: lower is better (distance)
+        elif self.index_metric == "l2":
             return score > threshold
         else:
             raise ValueError(
@@ -226,12 +283,42 @@ class CodeVectorStore:
         """Create a flat FAISS index with the configured metric."""
         if self.index_metric == "ip":
             return faiss.IndexFlatIP(self.dimension)
-        elif self.index_metric == "l2":  # l2
+        elif self.index_metric == "l2":
             return faiss.IndexFlatL2(self.dimension)
         else:
             raise ValueError(
                 f"Unsupported index_metric: {self.index_metric}. Must be 'ip' or 'l2'."
             )
+
+    def _search_index(
+        self,
+        query: str,
+        index: faiss.Index,
+        documents: List[_Document],
+        top_k: int,
+    ) -> List[tuple[_Document, float]]:
+        """Encode *query* and search a raw FAISS index.
+
+        Returns a list of ``(document, score)`` pairs sorted by relevance.
+        """
+        if index is None or index.ntotal == 0:
+            return []
+
+        query_vec = np.array(
+            self.embedding.embed_query(query), dtype=np.float32
+        ).reshape(1, -1)
+
+        # FAISS search
+        k = min(top_k, index.ntotal)
+        distances, indices = index.search(query_vec, k)
+
+        results: List[tuple[_Document, float]] = []
+        for dist, idx in zip(distances[0], indices[0], strict=True):
+            if idx < 0:
+                continue  # FAISS sentinel for empty slots
+            if idx < len(documents):
+                results.append((documents[idx], float(dist)))
+        return results
 
     def close(self) -> None:
         """Release embeddings and FAISS resources to free memory."""
@@ -244,8 +331,6 @@ class CodeVectorStore:
 
         self.l0_documents.clear()
         self.l2_documents.clear()
-        self.l0_vector_store = None
-        self.l2_vector_store = None
         self.l0_index = None
         self.l2_index = None
 
@@ -274,13 +359,12 @@ class CodeVectorStore:
             logger.warning("No code chunks provided")
             return
 
-        vector_store, documents_list = self._get_store_and_docs(level)
+        index, documents_list = self._get_index_and_docs(level)
         logger.info(f"Adding {len(code_chunks)} code chunks to {level} vector store")
 
-        # Convert chunks to Document objects
-        documents = []
+        # Convert chunks to _Document objects
+        documents: List[_Document] = []
         for i, chunk in enumerate(code_chunks):
-            # Extract content and metadata
             content = chunk.get("content", "")
             metadata = {
                 "chunk_id": len(documents_list) + i,
@@ -290,23 +374,18 @@ class CodeVectorStore:
                 "start_line": chunk.get("start_line", 0),
                 "end_line": chunk.get("end_line", 0),
                 "node_id": chunk.get("node_id", ""),
-                "level": level,  # Track which level this chunk belongs to
+                "level": level,
             }
-
-            # Add any additional metadata
             for key, value in chunk.items():
                 if key not in ["content"] and key not in metadata:
                     metadata[key] = value
 
-            # Create Document
-            document = Document(page_content=content, metadata=metadata)
-            documents.append(document)
+            documents.append(_Document(page_content=content, metadata=metadata))
 
         # Store documents
         documents_list.extend(documents)
 
         texts = [doc.page_content for doc in documents]
-        metadatas = [doc.metadata for doc in documents]
 
         # Phase 1: Embed texts (typically the bottleneck)
         with self._profile_section(
@@ -320,11 +399,8 @@ class CodeVectorStore:
             f"faiss_index_add_{level}",
             {"num_vectors": len(embeddings), "level": level},
         ):
-            text_embedding_pairs = list(zip(texts, embeddings, strict=True))
-            vector_store.add_embeddings(
-                text_embeddings=text_embedding_pairs,
-                metadatas=metadatas,
-            )
+            vectors = np.array(embeddings, dtype=np.float32)
+            index.add(vectors)
 
         logger.info(
             f"Successfully added {len(documents)} documents to {level} vector store"
@@ -376,25 +452,20 @@ class CodeVectorStore:
         Returns:
             List of NodeInfo objects with scores populated
         """
-        vector_store, _ = self._get_store_and_docs(level)
+        index, documents = self._get_index_and_docs(level)
 
-        if vector_store is None:
+        if index is None or index.ntotal == 0:
             logger.warning(f"No {level} vector store available. Add code chunks first.")
             return []
 
         logger.debug(f"Searching {level} for: {query[:100]}...")
 
-        docs_with_scores = vector_store.similarity_search_with_score(query, k=top_k)
+        docs_with_scores = self._search_index(query, index, documents, top_k)
 
-        # Convert to NodeInfo objects
         results = []
         for doc, score in docs_with_scores:
             metadata = doc.metadata
 
-            # Apply score threshold based on index metric
-            # ip (inner product): higher score = more similar, filter if score <
-            # threshold
-            # l2 (distance): lower score = more similar, filter if score > threshold
             if score_threshold is not None and self._should_filter_by_threshold(
                 score, score_threshold
             ):
@@ -443,23 +514,18 @@ class CodeVectorStore:
         Returns:
             List of NodeInfo objects with content populated
         """
-        vector_store, _ = self._get_store_and_docs(level)
+        index, documents = self._get_index_and_docs(level)
 
-        if vector_store is None:
+        if index is None or index.ntotal == 0:
             logger.warning(f"No {level} vector store available. Add code chunks first.")
             return []
 
-        docs_with_scores = vector_store.similarity_search_with_score(query, k=top_k)
+        docs_with_scores = self._search_index(query, index, documents, top_k)
 
-        # Convert to NodeInfo objects
         results = []
         for doc, score in docs_with_scores:
             metadata = doc.metadata
 
-            # Apply score threshold based on index metric
-            # ip (inner product): higher score = more similar, filter if score <
-            # threshold
-            # l2 (distance): lower score = more similar, filter if score > threshold
             if score_threshold is not None and self._should_filter_by_threshold(
                 score, score_threshold
             ):
@@ -512,23 +578,20 @@ class CodeVectorStore:
         Returns:
             List of NodeInfo objects sorted by similarity score.
         """
-        vector_store, _ = self._get_store_and_docs(level)
-        if vector_store is None:
+        index, documents = self._get_index_and_docs(level)
+        if index is None or index.ntotal == 0:
             logger.warning(f"No {level} vector store available.")
             return []
 
-        # Find FAISS internal indices whose node_id or name is in mask set
-        matched: list[tuple[int, Document]] = []
-        for faiss_idx, docstore_id in vector_store.index_to_docstore_id.items():
-            doc = vector_store.docstore.search(docstore_id)
-            if not doc or not hasattr(doc, "metadata"):
-                continue
+        # Find documents whose node_id or name is in mask set
+        matched: list[tuple[int, _Document]] = []
+        for i, doc in enumerate(documents):
             meta = doc.metadata
             if (
                 meta.get("node_id", "") in mask_node_ids
                 or meta.get("name", "") in mask_node_ids
             ):
-                matched.append((faiss_idx, doc))
+                matched.append((i, doc))
 
         if not matched:
             logger.debug("search_within_ids: no matching documents found")
@@ -540,7 +603,7 @@ class CodeVectorStore:
         # Reconstruct stored vectors and compute similarity
         results: list[NodeInfo] = []
         for faiss_idx, doc in matched:
-            vec = vector_store.index.reconstruct(int(faiss_idx))
+            vec = index.reconstruct(faiss_idx)
             if self.index_metric == "ip":
                 score = float(np.dot(query_vec, vec))
             else:  # l2 — lower is better
@@ -644,55 +707,13 @@ class CodeVectorStore:
 
         model_suffix = self.embedding_model.replace("/", "__")
 
-        # Save L0 vector store
-        l0_path = save_path / "l0"
-        if self.l0_vector_store is not None and self.l0_documents:
-            l0_path.mkdir(parents=True, exist_ok=True)
-            index_name = f"index_{model_suffix}"
-            self.l0_vector_store.save_local(str(l0_path), index_name=index_name)
-            # Save L0 documents
-            docs_path = l0_path / f"documents_{model_suffix}.pkl"
-            with open(docs_path, "wb") as f:
-                pickle.dump(self.l0_documents, f)
-            # Save L0 config
-            config_path = l0_path / f"config_{model_suffix}.json"
-            config = {
-                "embedding_model": self.embedding_model,
-                "embedding_provider": self.embedding_provider,
-                "dimension": self.dimension,
-                "index_type": self.index_type,
-                "index_metric": self.index_metric,
-                "level": "l0",
-                "num_documents": len(self.l0_documents),
-            }
-            with open(config_path, "w") as f:
-                json.dump(config, f, indent=2)
-            logger.info(f"Saved L0 store with {len(self.l0_documents)} documents")
+        # Save L0
+        if self.l0_index is not None and self.l0_documents:
+            self._save_level(save_path, "l0", model_suffix)
 
-        # Save L2 vector store
-        l2_path = save_path / "l2"
-        if self.l2_vector_store is not None and self.l2_documents:
-            l2_path.mkdir(parents=True, exist_ok=True)
-            index_name = f"index_{model_suffix}"
-            self.l2_vector_store.save_local(str(l2_path), index_name=index_name)
-            # Save L2 documents
-            docs_path = l2_path / f"documents_{model_suffix}.pkl"
-            with open(docs_path, "wb") as f:
-                pickle.dump(self.l2_documents, f)
-            # Save L2 config
-            config_path = l2_path / f"config_{model_suffix}.json"
-            config = {
-                "embedding_model": self.embedding_model,
-                "embedding_provider": self.embedding_provider,
-                "dimension": self.dimension,
-                "index_type": self.index_type,
-                "index_metric": self.index_metric,
-                "level": "l2",
-                "num_documents": len(self.l2_documents),
-            }
-            with open(config_path, "w") as f:
-                json.dump(config, f, indent=2)
-            logger.info(f"Saved L2 store with {len(self.l2_documents)} documents")
+        # Save L2
+        if self.l2_index is not None and self.l2_documents:
+            self._save_level(save_path, "l2", model_suffix)
 
         # Save top-level configuration
         config_path = save_path / f"config_{model_suffix}.json"
@@ -709,6 +730,38 @@ class CodeVectorStore:
             json.dump(config, f, indent=2)
 
         logger.info("Vector store saved successfully")
+
+    def _save_level(self, save_path: Path, level: str, model_suffix: str) -> None:
+        """Save a single level (l0 or l2) to disk."""
+        index, documents = self._get_index_and_docs(level)
+
+        level_path = save_path / level
+        level_path.mkdir(parents=True, exist_ok=True)
+
+        # Write raw FAISS index
+        index_name = f"index_{model_suffix}"
+        faiss.write_index(index, str(level_path / f"{index_name}.faiss"))
+
+        # Save documents (list of _Document)
+        docs_path = level_path / f"documents_{model_suffix}.pkl"
+        with open(docs_path, "wb") as f:
+            pickle.dump(documents, f)
+
+        # Save level config
+        config_path = level_path / f"config_{model_suffix}.json"
+        config = {
+            "embedding_model": self.embedding_model,
+            "embedding_provider": self.embedding_provider,
+            "dimension": self.dimension,
+            "index_type": self.index_type,
+            "index_metric": self.index_metric,
+            "level": level,
+            "num_documents": len(documents),
+        }
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
+
+        logger.info(f"Saved {level.upper()} store with {len(documents)} documents")
 
     def load(self, path: Optional[str] = None) -> None:
         """
@@ -738,7 +791,6 @@ class CodeVectorStore:
             with open(config_path, "r") as f:
                 config = json.load(f)
 
-            # Verify configuration matches
             if config.get("dimension") != self.dimension:
                 logger.warning(
                     f"Dimension mismatch: expected {self.dimension}, "
@@ -753,51 +805,98 @@ class CodeVectorStore:
                 )
                 self.index_metric = saved_metric
 
-        # Load L0 vector store
+        # Load L0
         l0_path = load_path / "l0"
         if l0_path.exists():
-            try:
-                index_name = f"index_{model_suffix}"
-                self.l0_vector_store = FAISS.load_local(
-                    str(l0_path),
-                    self.embedding,
-                    index_name=index_name,
-                    allow_dangerous_deserialization=True,
-                )
-                # Load L0 documents
-                docs_path = l0_path / f"documents_{model_suffix}.pkl"
-                if docs_path.exists():
-                    with open(docs_path, "rb") as f:
-                        self.l0_documents = pickle.load(f)
+            loaded = self._load_level(l0_path, model_suffix)
+            if loaded is not None:
+                self.l0_index, self.l0_documents = loaded
                 logger.info(f"Loaded L0 store with {len(self.l0_documents)} documents")
-            except Exception as e:
-                logger.warning(f"Could not load L0 vector store: {e}")
 
-        # Load L2 vector store
+        # Load L2
         l2_path = load_path / "l2"
         if l2_path.exists():
-            try:
-                index_name = f"index_{model_suffix}"
-                self.l2_vector_store = FAISS.load_local(
-                    str(l2_path),
-                    self.embedding,
-                    index_name=index_name,
-                    allow_dangerous_deserialization=True,
-                )
-                # Load L2 documents
-                docs_path = l2_path / f"documents_{model_suffix}.pkl"
-                if docs_path.exists():
-                    with open(docs_path, "rb") as f:
-                        self.l2_documents = pickle.load(f)
+            loaded = self._load_level(l2_path, model_suffix)
+            if loaded is not None:
+                self.l2_index, self.l2_documents = loaded
                 logger.info(f"Loaded L2 store with {len(self.l2_documents)} documents")
-            except Exception as e:
-                logger.warning(f"Could not load L2 vector store: {e}")
 
         total_docs = len(self.l0_documents) + len(self.l2_documents)
         logger.info(
             f"Vector store loaded successfully with {total_docs} total documents "
             f"(L0: {len(self.l0_documents)}, L2: {len(self.l2_documents)})"
         )
+
+    def _load_level(
+        self, level_path: Path, model_suffix: str
+    ) -> Optional[tuple[faiss.Index, List[_Document]]]:
+        """Load a single level from disk.
+
+        Handles both the new format (raw FAISS + _Document list) and the
+        legacy LangChain format (FAISS + docstore pkl) transparently.
+        """
+        index_name = f"index_{model_suffix}"
+        faiss_path = level_path / f"{index_name}.faiss"
+
+        if not faiss_path.exists():
+            logger.warning(f"FAISS index not found at {faiss_path}")
+            return None
+
+        try:
+            index = faiss.read_index(str(faiss_path))
+        except Exception as e:
+            logger.warning(f"Could not load FAISS index from {faiss_path}: {e}")
+            return None
+
+        # Try loading documents pickle (works for both new _Document and
+        # legacy LangChain Document objects via duck-typing conversion).
+        docs_path = level_path / f"documents_{model_suffix}.pkl"
+        if docs_path.exists():
+            try:
+                with open(docs_path, "rb") as f:
+                    raw_docs = pickle.load(f)
+                documents = [_to_document(d) for d in raw_docs]
+                return index, documents
+            except Exception as e:
+                logger.warning(f"Could not load documents from {docs_path}: {e}")
+
+        # Fallback: try LangChain FAISS pkl (index_name.pkl contains
+        # (InMemoryDocstore, index_to_docstore_id) tuple).
+        lc_pkl_path = level_path / f"{index_name}.pkl"
+        if lc_pkl_path.exists():
+            try:
+                documents = self._load_langchain_pkl(lc_pkl_path)
+                logger.info(
+                    "Loaded %d documents from legacy LangChain format",
+                    len(documents),
+                )
+                return index, documents
+            except Exception as e:
+                logger.warning(
+                    f"Could not load legacy LangChain pkl from {lc_pkl_path}: {e}"
+                )
+
+        logger.warning(f"No document store found for {level_path}")
+        return index, []
+
+    @staticmethod
+    def _load_langchain_pkl(pkl_path: Path) -> List[_Document]:
+        """Extract documents from a LangChain FAISS pkl file.
+
+        The pkl file contains ``(InMemoryDocstore, index_to_docstore_id)``
+        where ``index_to_docstore_id`` maps integer FAISS indices to
+        docstore string IDs.
+        """
+        with open(pkl_path, "rb") as f:
+            docstore, index_to_docstore_id = pickle.load(f)
+
+        documents: List[_Document] = []
+        for i in sorted(index_to_docstore_id.keys()):
+            doc_id = index_to_docstore_id[i]
+            doc = docstore.search(doc_id)
+            if doc and hasattr(doc, "page_content"):
+                documents.append(_to_document(doc))
+        return documents
 
     def get_stats(self) -> Dict[str, Any]:
         """
@@ -846,23 +945,11 @@ class CodeVectorStore:
         if level is None or level == "l0":
             logger.info("Clearing L0 vector store")
             self.l0_index = self._build_faiss_index()
-            self.l0_vector_store = FAISS(
-                embedding_function=self.embedding,
-                index=self.l0_index,
-                docstore=InMemoryDocstore(),
-                index_to_docstore_id={},
-            )
             self.l0_documents = []
 
         if level is None or level == "l2":
             logger.info("Clearing L2 vector store")
             self.l2_index = self._build_faiss_index()
-            self.l2_vector_store = FAISS(
-                embedding_function=self.embedding,
-                index=self.l2_index,
-                docstore=InMemoryDocstore(),
-                index_to_docstore_id={},
-            )
             self.l2_documents = []
 
         logger.info("Vector store cleared")

--- a/codeminer/model/bm25_retrieve_pipeline.py
+++ b/codeminer/model/bm25_retrieve_pipeline.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..log_utils import get_logger
-from ..scip_interface import SCIPIndexer
+from ..scip_interface import SCIPIndexerBase as SCIPIndexer
 from ..types import QueriedNode
 
 logger = get_logger(__name__)

--- a/codeminer/model/embedding_retrieve_pipeline.py
+++ b/codeminer/model/embedding_retrieve_pipeline.py
@@ -12,24 +12,49 @@ logger = get_logger(__name__)
 class EmbeddingRetrievePipeline:
     """Embedding-only retrieval pipeline.
 
-    Builds a hierarchical vector store from the repository and retrieves
-    top-K nodes using embedding similarity search.
+    Typical single-instance usage (loads or builds index immediately)::
+
+        pipeline = EmbeddingRetrievePipeline(
+            repo_path=repo_path,
+            index_path=index_path,
+            embedding_model="Qwen/Qwen3-Embedding-0.6B",
+            embedding_dimension=1024,
+        )
+        results = pipeline.query(problem_statement)
+        pipeline.close()
+
+    Multi-instance / hot-swap usage (load model once, swap index per instance)::
+
+        pipeline = EmbeddingRetrievePipeline(
+            embedding_model="Qwen/Qwen3-Embedding-0.6B",
+            embedding_dimension=1024,
+        )
+        for instance in dataset:
+            pipeline.load_index(index_path_for_instance)
+            results = pipeline.query(instance["problem_statement"])
+        pipeline.close()
 
     Args:
-        repo_path: Repository root to index.
-        index_path: Directory used for vector index caches.
+        repo_path: Repository root to index. Only required when
+            ``force_rebuild=True``; ignored when loading a pre-built index.
+        index_path: Directory used for vector index caches. When ``None``,
+            the pipeline is initialised with an empty index so that
+            :meth:`load_index` can be called later (hot-swap pattern).
         embedding_model: Embedding model name.
-        embedding_provider: Embedding provider (huggingface or openai).
+        embedding_provider: Embedding provider (``"huggingface"`` or
+            ``"openai"``).
         embedding_dimension: Embedding vector dimension.
-        languages: Languages to chunk for indexing (default: ["python"]).
+        languages: Languages to chunk for indexing (default: ``["python"]``).
         max_lines_per_chunk: Maximum lines per chunk.
         top_k: Default number of results to retrieve.
+        embedding_kwargs: Extra kwargs forwarded to the embedding wrapper.
+        force_rebuild: Re-chunk and re-embed even if a cached index exists.
     """
 
     def __init__(
         self,
-        repo_path: str,
-        index_path: str,
+        repo_path: Optional[str] = None,
+        index_path: Optional[str] = None,
         *,
         embedding_model: str = "nomic-ai/CodeRankEmbed",
         embedding_provider: str = "huggingface",
@@ -37,23 +62,49 @@ class EmbeddingRetrievePipeline:
         languages: Optional[List[str]] = None,
         max_lines_per_chunk: int = 300,
         top_k: int = 50,
+        embedding_kwargs: Optional[dict] = None,
+        force_rebuild: bool = False,
     ) -> None:
         self.top_k = top_k
-        self.vector_store: CodeVectorStore = build_hierarchical_vector_store(
-            repo_path=repo_path,
-            index_path=index_path,
-            plan_name=None,
-            languages=languages or ["python"],
-            max_lines_per_chunk=max_lines_per_chunk,
-            build_levels=["l2"],
-            embedding_model=embedding_model,
-            embedding_provider=embedding_provider,
-            embedding_dimension=embedding_dimension,
-            embedding_kwargs={
-                "model_kwargs": {"trust_remote_code": True},
-            },
-            index_metric="ip",
-        )
+        _embedding_kwargs = {"model_kwargs": {"trust_remote_code": True}}
+        if embedding_kwargs:
+            _embedding_kwargs.update(embedding_kwargs)
+
+        if index_path is None:
+            # Model-only initialisation — no index loaded yet.
+            # Callers should follow up with load_index().
+            self.vector_store = CodeVectorStore(
+                embedding_model=embedding_model,
+                embedding_provider=embedding_provider,
+                dimension=embedding_dimension,
+                index_metric="ip",
+                store_path=None,
+                **_embedding_kwargs,
+            )
+        else:
+            self.vector_store: CodeVectorStore = build_hierarchical_vector_store(
+                repo_path=repo_path or "",
+                index_path=index_path,
+                plan_name=None,
+                languages=languages or ["python"],
+                max_lines_per_chunk=max_lines_per_chunk,
+                build_levels=["l2"],
+                embedding_model=embedding_model,
+                embedding_provider=embedding_provider,
+                embedding_dimension=embedding_dimension,
+                embedding_kwargs=_embedding_kwargs,
+                index_metric="ip",
+                force_rebuild=force_rebuild,
+            )
+
+    def load_index(self, index_path: str) -> None:
+        """Hot-swap the FAISS index without reloading the embedding model.
+
+        Frees the current index and loads the pre-built index at *index_path*.
+        The embedding model stays in memory, so this is much faster than
+        creating a new :class:`EmbeddingRetrievePipeline` for each instance.
+        """
+        self.vector_store.swap_index(index_path)
 
     def query(self, query: str, top_k: Optional[int] = None) -> List[QueriedNode]:
         """Retrieve top-K nodes using embedding similarity search.
@@ -82,7 +133,7 @@ class EmbeddingRetrievePipeline:
         ]
 
     def close(self) -> None:
-        """Release vector store resources."""
+        """Release all resources including the embedding model."""
         if self.vector_store is not None:
             self.vector_store.close()
             self.vector_store = None

--- a/codeminer/model/graph_retrieve_pipeline.py
+++ b/codeminer/model/graph_retrieve_pipeline.py
@@ -7,7 +7,7 @@ from ..graph.roi_subgraph import ROISubgraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..log_utils import get_logger
-from ..scip_interface import SCIPIndexer
+from ..scip_interface import SCIPIndexerBase as SCIPIndexer
 from ..types import QueriedNode
 
 logger = get_logger(__name__)
@@ -121,7 +121,8 @@ class GraphRetrievePipeline:
             )
             logger.info(
                 "Stage 2: %d nodes after PPR expansion (damping=%.2f)",
-                len(expanded_nodes), self.ppr_damping,
+                len(expanded_nodes),
+                self.ppr_damping,
             )
         else:
             subgraph = roi.extract_subgraph(
@@ -133,7 +134,8 @@ class GraphRetrievePipeline:
             expanded_nodes = expanded_nodes[: self.stage2_topk]
             logger.info(
                 "Stage 2: %d nodes after %d-hop BFS expansion",
-                len(expanded_nodes), self.k_hop,
+                len(expanded_nodes),
+                self.k_hop,
             )
 
         # Stage 3 (optional): Embedding rerank within expanded set only

--- a/examples/embedding_retrieve_baseline.py
+++ b/examples/embedding_retrieve_baseline.py
@@ -5,8 +5,28 @@ Embedding-only retrieval baseline script.
 This script retrieves top-K nodes using embedding similarity search over the
 entire codebase, for comparison with the graph-based baseline.
 
+Supports both SWE-bench (Python-only) and CodeMiner-base (multi-language)
+datasets. For CodeMiner-base, ground-truth annotations are read directly from
+the dataset — no external eval JSON is required.
+
 Usage:
+    # SWE-bench Lite
     python examples/embedding_retrieve_baseline.py --dataset swebench_lite
+
+    # CodeMiner-base (uses pre-built indices from build_embeddings.py)
+    python examples/embedding_retrieve_baseline.py \\
+        --dataset codeminer_base \\
+        --embedding-model Qwen/Qwen3-Embedding-0.6B \\
+        --embedding-dimension 1024 \\
+        --index-cache-dir /mnt/data/codeminer
+
+    # With profiling
+    python examples/embedding_retrieve_baseline.py \\
+        --dataset codeminer_base \\
+        --embedding-model Qwen/Qwen3-Embedding-0.6B \\
+        --embedding-dimension 1024 \\
+        --enable-profiler \\
+        --profile-tag qwen3_0.6b_run1
 
     # Single instance
     python examples/embedding_retrieve_baseline.py --dataset swebench_lite \\
@@ -14,8 +34,9 @@ Usage:
 """
 import argparse
 import json
-import time
+import logging
 from pathlib import Path
+from typing import List, Optional
 
 from codeminer.dataset.locbench import LocbenchDataset
 from codeminer.dataset.swebench import SwebenchDataset
@@ -27,9 +48,119 @@ from codeminer.eval.retrieval_eval import (
     extract_predictions,
 )
 from codeminer.log_utils import get_logger
-from codeminer.model import EmbeddingRetrievePipeline
+from codeminer.model.embedding_retrieve_pipeline import EmbeddingRetrievePipeline
+from codeminer.profiler import Profiler
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Language helpers (mirrors build_embeddings._map_language_group)
+# ---------------------------------------------------------------------------
+
+
+def _map_language_group(label: Optional[str], fallback: str = "python") -> List[str]:
+    """Map a dataset ``language_group`` value to chunker language string(s)."""
+    if not label:
+        return [fallback]
+    text = label.lower()
+    if "rust" in text:
+        return ["rust"]
+    if "javascript" in text and "typescript" in text:
+        return ["ts", "js"]
+    if "typescript" in text or text == "ts":
+        return ["ts"]
+    if "javascript" in text or text == "js":
+        return ["js"]
+    if "c++" in text or text in ("cpp", "c"):
+        return ["cpp"]
+    if "go" in text or text == "golang":
+        return ["go"]
+    if "python" in text:
+        return ["python"]
+    return [fallback]
+
+
+def _resolve_instance_languages(instance: dict, cli_languages: List[str]) -> List[str]:
+    """Return languages for this instance.
+
+    CodeMiner-base instances carry a ``language_group`` column; fall back to
+    the CLI ``--languages`` for datasets that don't have it (SWE-bench).
+    """
+    lang_group = instance.get("language_group")
+    if lang_group:
+        return _map_language_group(lang_group, fallback=cli_languages[0])
+    return list(cli_languages)
+
+
+# ---------------------------------------------------------------------------
+# Profiling helpers (mirrors retrieve_rerank.py)
+# ---------------------------------------------------------------------------
+
+
+def _to_sections_payload(profile_summary):
+    return [
+        {
+            "label": label,
+            "total": stats.total,
+            "count": stats.count,
+            "average": stats.average,
+            "min": stats.safe_min,
+            "max": stats.max_duration,
+            "errors": stats.errors,
+        }
+        for label, stats in profile_summary
+    ]
+
+
+def _aggregate_section_stats(instance_profiles):
+    aggregate = {}
+    for profile in instance_profiles:
+        for section in profile.get("sections", []):
+            label = section["label"]
+            entry = aggregate.setdefault(
+                label,
+                {
+                    "label": label,
+                    "total": 0.0,
+                    "count": 0,
+                    "min": float("inf"),
+                    "max": 0.0,
+                    "errors": 0,
+                },
+            )
+            entry["total"] += float(section["total"])
+            entry["count"] += int(section["count"])
+            entry["min"] = min(entry["min"], float(section["min"]))
+            entry["max"] = max(entry["max"], float(section["max"]))
+            entry["errors"] += int(section["errors"])
+
+    payload = []
+    for label, stats in aggregate.items():
+        count = stats["count"]
+        payload.append(
+            {
+                "label": label,
+                "total": stats["total"],
+                "count": count,
+                "average": (stats["total"] / count) if count else 0.0,
+                "min": 0.0 if stats["min"] == float("inf") else stats["min"],
+                "max": stats["max"],
+                "errors": stats["errors"],
+            }
+        )
+
+    payload.sort(key=lambda item: item["total"], reverse=True)
+    return payload
+
+
+def _sanitize_filename_part(value: str) -> str:
+    return str(value).replace("/", "__").replace(" ", "_")
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
 
 
 def parse_args():
@@ -38,8 +169,10 @@ def parse_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
-        "--dataset", type=str, required=True,
-        choices=["swebench_lite", "locbench_v1"],
+        "--dataset",
+        type=str,
+        required=True,
+        choices=["swebench_lite", "locbench_v1", "codeminer_base"],
     )
     parser.add_argument("--split", type=str, default="test")
     parser.add_argument("--filter-instance", type=str, default=".*")
@@ -47,159 +180,322 @@ def parse_args():
 
     # Embedding config
     parser.add_argument(
-        "--embedding-model", type=str, default="nomic-ai/CodeRankEmbed",
+        "--embedding-model",
+        type=str,
+        default="nomic-ai/CodeRankEmbed",
     )
     parser.add_argument(
-        "--embedding-provider", type=str, default="huggingface",
+        "--embedding-provider",
+        type=str,
+        default="huggingface",
     )
     parser.add_argument(
-        "--embedding-dimension", type=int, default=768,
+        "--embedding-dimension",
+        type=int,
+        default=768,
+    )
+
+    # Language / chunking (for SWE-bench; codeminer_base auto-detects per instance)
+    parser.add_argument(
+        "--languages",
+        type=str,
+        nargs="+",
+        default=["python"],
+        help=(
+            "Chunker languages to use when rebuilding an index. "
+            "Ignored for codeminer_base instances (language is read from "
+            "language_group column)."
+        ),
+    )
+
+    # Index rebuild control
+    parser.add_argument(
+        "--force-rebuild",
+        action="store_true",
+        default=False,
+        help=(
+            "Force rebuilding the embedding index even if a pre-built one "
+            "exists. By default pre-built indices are loaded from disk."
+        ),
     )
 
     # Evaluation
     parser.add_argument(
-        "--eval-instances", type=str, default=None,
-        help="Path to eval annotations JSON. Auto-generated if not provided.",
+        "--eval-instances",
+        type=str,
+        default=None,
+        help=(
+            "Path to eval annotations JSON. For codeminer_base this is "
+            "optional — GT is read directly from the dataset."
+        ),
     )
     parser.add_argument(
-        "--metrics-k", type=int, nargs="+", default=[1, 3, 5, 10, 15, 20],
+        "--metrics-k",
+        type=int,
+        nargs="+",
+        default=[1, 3, 5, 10, 15, 20],
     )
 
     # Cache
     parser.add_argument(
-        "--index-cache-dir", type=str, default="/mnt/data/codeminer",
+        "--index-cache-dir",
+        type=str,
+        default="/mnt/data/codeminer",
     )
     parser.add_argument(
-        "--repo-cache-dir", type=str, default="~/.codeminer/",
+        "--repo-cache-dir",
+        type=str,
+        default="~/.codeminer/",
     )
     parser.add_argument("--result-path", type=str, default=None)
+
+    # Profiling
+    parser.add_argument(
+        "--profile-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to store runtime profiler summaries "
+            "(default: <index-cache-dir>/profile_log/query_runtime)."
+        ),
+    )
+    parser.add_argument(
+        "--enable-profiler",
+        action="store_true",
+        help="Enable runtime profiler summaries even if --profile-dir is not set.",
+    )
+    parser.add_argument(
+        "--profile-tag",
+        type=str,
+        default=None,
+        help=(
+            "Optional tag appended to runtime profiler filename to avoid "
+            "overwriting runs."
+        ),
+    )
 
     return parser.parse_args()
 
 
-def run_embedding_pipeline(args):
-    """Run the embedding-only retrieval baseline."""
+# ---------------------------------------------------------------------------
+# Dataset factory
+# ---------------------------------------------------------------------------
 
-    # Load dataset
+
+def _build_dataset(args):
     if args.dataset == "swebench_lite":
-        dataset_obj = SwebenchDataset(
+        return SwebenchDataset(
             dataset="princeton-nlp/SWE-bench_Lite",
             split=args.split,
             filter_instance=args.filter_instance,
             repo_root=args.repo_cache_dir,
         )
-    elif args.dataset == "locbench_v1":
-        dataset_obj = LocbenchDataset(
+    if args.dataset == "locbench_v1":
+        return LocbenchDataset(
             dataset="czlll/Loc-Bench_V1",
             split=args.split,
             filter_instance=args.filter_instance,
             repo_root=args.repo_cache_dir,
         )
-    else:
-        raise ValueError(f"Unsupported dataset: {args.dataset}")
+    if args.dataset == "codeminer_base":
+        from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
 
+        return CodeMinerBaseDataset(
+            dataset="fishmingyu/codeminer-base-dataset",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=args.repo_cache_dir,
+        )
+    raise ValueError(f"Unsupported dataset: {args.dataset}")
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline runner
+# ---------------------------------------------------------------------------
+
+
+def run_embedding_pipeline(args):
+    """Run the embedding-only retrieval baseline."""
+    dataset_obj = _build_dataset(args)
     dataset_instances = dataset_obj.load()
     if not dataset_instances:
         raise ValueError(f"No instances found in {args.dataset}")
 
     logger.info("Loaded %d instance(s)", len(dataset_instances))
 
-    eval_path = args.eval_instances or str(
-        Path.home() / ".codeminer" / f"swebench_lite_{args.split}_gt.json"
+    profiling_enabled = args.enable_profiler or args.profile_dir is not None
+    profile_output_dir = (
+        Path(args.profile_dir).expanduser().resolve()
+        if args.profile_dir
+        else Path(args.index_cache_dir).expanduser().resolve()
+        / "profile_log"
+        / "query_runtime"
     )
+    if profiling_enabled:
+        profile_output_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "Runtime profiler summaries will be stored in: %s", profile_output_dir
+        )
+
+    eval_path = args.eval_instances or ""
     eval_metadata = dataset_obj.load_eval_metadata(eval_path)
+
     metrics_k = sorted(set(args.metrics_k))
     metric_max_k = max(metrics_k)
     aggregate = {}
     eval_count = 0
     all_results = [] if args.result_path else None
+    instance_profiles = []
 
-    for instance in dataset_instances:
-        instance_id = instance["instance_id"]
-        metadata = eval_metadata.get(instance_id)
-        if not metadata:
-            logger.info("Skipping %s - no eval metadata", instance_id)
-            continue
-        target_files, target_symbols = collect_targets(metadata)
-        if not target_symbols:
-            logger.info("Skipping %s - no valid target symbols", instance_id)
-            continue
+    # ---------------------------------------------------------------------------
+    # Initialise the embedding model ONCE outside the instance loop.
+    # Each iteration then hot-swaps only the FAISS index via load_index(),
+    # avoiding repeated GPU weight transfers for large models.
+    # ---------------------------------------------------------------------------
+    global_profiler = Profiler(
+        name="embedding_baseline[global]",
+        logger=logger,
+        emit_events=False,
+        summary_level=logging.INFO,
+    )
+    global_profiler.enabled = profiling_enabled
 
-        pipeline = None
-        try:
-            t0 = time.time()
+    with global_profiler.section("model.initialize"):
+        pipeline = EmbeddingRetrievePipeline(
+            embedding_model=args.embedding_model,
+            embedding_provider=args.embedding_provider,
+            embedding_dimension=args.embedding_dimension,
+            top_k=args.topk,
+        )
+    logger.info(
+        "Embedding model loaded: %s (provider=%s)",
+        args.embedding_model,
+        args.embedding_provider,
+    )
 
-            dataset_obj.process_instance(instance)
-            repo_path = dataset_obj.get_repo_path(instance)
-            index_path = str(
-                Path(args.index_cache_dir) / instance_id.replace("/", "__")
+    try:
+        for instance in dataset_instances:
+            instance_id = instance["instance_id"]
+            instance_profiler = Profiler(
+                name=f"embedding_baseline[{instance_id}]",
+                logger=logger,
+                emit_events=False,
+                summary_level=logging.INFO,
             )
+            instance_profiler.enabled = profiling_enabled
 
-            pipeline = EmbeddingRetrievePipeline(
-                repo_path=repo_path,
-                index_path=index_path,
-                embedding_model=args.embedding_model,
-                embedding_provider=args.embedding_provider,
-                embedding_dimension=args.embedding_dimension,
-                top_k=args.topk,
+            metadata = eval_metadata.get(instance_id)
+            if not metadata:
+                logger.info("Skipping %s - no eval metadata", instance_id)
+                continue
+            target_files, target_symbols = collect_targets(
+                metadata, simplified_symbols=dataset_obj.simplified_symbols
             )
-            results = pipeline.query(instance["problem_statement"])
-            elapsed = time.time() - t0
+            if not target_symbols:
+                logger.info("Skipping %s - no valid target symbols", instance_id)
+                continue
 
-            metrics = evaluate_predictions(
-                nodes=results,
-                target_files=target_files,
-                target_symbols=target_symbols,
-                ks=metrics_k,
-            )
-            aggregate_metrics(aggregate, metrics)
-            eval_count += 1
+            try:
+                with instance_profiler.section("instance_total"):
+                    with instance_profiler.section("dataset.process_instance"):
+                        dataset_obj.process_instance(instance)
 
-            logger.info(
-                "[%s] Done in %.1fs (%d results)", instance_id, elapsed, len(results),
-            )
-            for scope, per_k in metrics.items():
-                for k, stats in per_k.items():
-                    logger.info(
-                        "  [%s] k=%d acc=%.3f prec=%.3f recall=%.3f hits=%d",
-                        scope, k,
-                        stats["accuracy"], stats["precision"],
-                        stats["recall"], int(stats["hits"]),
+                    index_path = str(
+                        Path(args.index_cache_dir) / instance_id.replace("/", "__")
                     )
 
-            if all_results is not None:
-                unique_files, normalized_symbols = extract_predictions(results)
-                all_results.append({
-                    "instance_id": instance_id,
-                    "method": "embedding_baseline",
-                    "topk": args.topk,
-                    "num_results": len(results),
-                    "elapsed_s": elapsed,
-                    "metric_k_files": unique_files[:metric_max_k],
-                    "metric_k_node_ids": normalized_symbols[:metric_max_k],
-                    "metrics": metrics,
-                })
+                    with instance_profiler.section("pipeline.load_index"):
+                        pipeline.load_index(index_path)
 
-        except Exception:
-            logger.exception("Error processing %s", instance_id)
-            continue
-        finally:
-            if pipeline is not None:
-                pipeline.close()
+                    with instance_profiler.section("pipeline.query"):
+                        results = pipeline.query(instance["problem_statement"])
 
-    # ---- Aggregate ----
+                    with instance_profiler.section("evaluate_predictions"):
+                        metrics = evaluate_predictions(
+                            nodes=results,
+                            target_files=target_files,
+                            target_symbols=target_symbols,
+                            ks=metrics_k,
+                        )
+
+                aggregate_metrics(aggregate, metrics)
+                eval_count += 1
+
+                logger.info("Evaluation metrics for %s:", instance_id)
+                for scope, per_k in metrics.items():
+                    for k, stats in per_k.items():
+                        logger.info(
+                            "  [%s] k=%d acc=%.3f prec=%.3f recall=%.3f hits=%d",
+                            scope,
+                            k,
+                            stats["accuracy"],
+                            stats["precision"],
+                            stats["recall"],
+                            int(stats["hits"]),
+                        )
+
+                if all_results is not None:
+                    with instance_profiler.section("collect_results"):
+                        unique_files, normalized_symbols = extract_predictions(results)
+                        all_results.append(
+                            {
+                                "instance_id": instance_id,
+                                "method": "embedding_baseline",
+                                "dataset": args.dataset,
+                                "embedding_model": args.embedding_model,
+                                "topk": args.topk,
+                                "num_results": len(results),
+                                "metric_k_files": unique_files[:metric_max_k],
+                                "metric_k_node_ids": normalized_symbols[:metric_max_k],
+                                "metrics": metrics,
+                            }
+                        )
+
+            except Exception:
+                logger.exception("Error processing %s", instance_id)
+                continue
+            finally:
+                if profiling_enabled:
+                    logger.info("Runtime profiler summary for %s:", instance_id)
+                    profile_summary = instance_profiler.report(reset=True)
+                    sections_payload = _to_sections_payload(profile_summary)
+                    total_duration = next(
+                        (
+                            s["total"]
+                            for s in sections_payload
+                            if s["label"] == "instance_total"
+                        ),
+                        0.0,
+                    )
+                    instance_profiles.append(
+                        {
+                            "instance_id": instance_id,
+                            "total_duration": total_duration,
+                            "sections": sections_payload,
+                        }
+                    )
+
+    finally:
+        with global_profiler.section("model.close"):
+            pipeline.close()
+
+    # ---- Aggregate metrics ----
     if aggregate and eval_count:
         averaged = average_metrics(aggregate, eval_count)
         logger.info(
-            "=== Embedding Baseline Aggregate (%d instances) ===", eval_count,
+            "=== Embedding Baseline Aggregate (%d instances) ===",
+            eval_count,
         )
         for scope, per_k in averaged.items():
             for k, stats in per_k.items():
                 logger.info(
                     "[%s] k=%d acc=%.3f prec=%.3f recall=%.3f avg_hits=%.3f",
-                    scope, k,
-                    stats["accuracy"], stats["precision"],
-                    stats["recall"], stats["avg_hits"],
+                    scope,
+                    k,
+                    stats["accuracy"],
+                    stats["precision"],
+                    stats["recall"],
+                    stats["avg_hits"],
                 )
 
     if args.result_path and all_results is not None:
@@ -207,12 +503,43 @@ def run_embedding_pipeline(args):
         result_path.parent.mkdir(parents=True, exist_ok=True)
         with open(result_path, "w", encoding="utf-8") as f:
             json.dump(all_results, f, indent=2, ensure_ascii=False)
-        logger.info("Results saved to %s", result_path)
+        logger.info("Results saved to %s (%d instances)", result_path, len(all_results))
+
+    # ---- Runtime profile JSON ----
+    if profiling_enabled:
+        model_tag = _sanitize_filename_part(args.embedding_model)
+        filename_parts = [
+            _sanitize_filename_part(args.dataset),
+            "embedding_baseline",
+            model_tag,
+        ]
+        if args.profile_tag:
+            filename_parts.append(_sanitize_filename_part(args.profile_tag))
+        runtime_profile_file = profile_output_dir / f"{'__'.join(filename_parts)}.json"
+
+        runtime_payload = {
+            "dataset": args.dataset,
+            "split": args.split,
+            "filter_instance": args.filter_instance,
+            "embedding_model": args.embedding_model,
+            "embedding_provider": args.embedding_provider,
+            "embedding_dimension": args.embedding_dimension,
+            "profile_tag": args.profile_tag,
+            "instance_count": len(instance_profiles),
+            "aggregate_sections": _aggregate_section_stats(instance_profiles),
+            "instances": instance_profiles,
+        }
+        runtime_profile_file.write_text(
+            json.dumps(runtime_payload, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        logger.info("Saved runtime profiler results to %s", runtime_profile_file)
 
 
 def main():
     args = parse_args()
     logger.info("Dataset: %s", args.dataset)
+    logger.info("Embedding model: %s", args.embedding_model)
     logger.info("Pipeline: Embedding(top%d)", args.topk)
     run_embedding_pipeline(args)
 

--- a/scripts/embeddings/build_codeminer_base_embeddings.sh
+++ b/scripts/embeddings/build_codeminer_base_embeddings.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 #
-# Build embeddings for the CodeMiner-base dataset with three models:
-#   1. Salesforce/SweRankEmbed-Small   (768d)
-#   2. fishmingyu/SweRankEmbed-Large   (3584d)
-#   3. jinaai/jina-code-embeddings-1.5b (1536d)
+# Build embeddings for the CodeMiner-base dataset with five models:
+#   1. Salesforce/SweRankEmbed-Small       (768d,  ~0.1B, encoder)
+#   2. fishmingyu/SweRankEmbed-Large       (3584d, ~7B,   encoder)
+#   3. jinaai/jina-code-embeddings-1.5b    (1536d, 1.5B,  encoder)
+#   4. Qwen/Qwen3-Embedding-0.6B          (1024d, 0.6B,  decoder, last-token pooling)
+#   5. Qwen/Qwen3-Embedding-4B            (2560d, 4B,    decoder, last-token pooling)
 #
 # Usage:
 #   # Full run (all instances, all models)
@@ -28,15 +30,20 @@ PROFILE_TAG="${PROFILE_TAG:-codeminer_base_${SPLIT}}"
 # max_seq_length caps tokenization to prevent CUDA OOM on long documents.
 # Use 0 for max_seq_length to use the model's default.
 #
-# NOTE: jina-code-1.5b has max_position_embeddings=32768 but its tokenizer
-# does not enforce truncation, and 32K seq OOMs even at batch=1 without
-# flash-attn. We cap at 8192 which is safe for batch=4.
+# NOTE: Models with 32K+ context (jina-code-1.5b, Qwen3-Embedding) have
+# tokenizers that do not enforce truncation, and 32K seq OOMs even at batch=1
+# without flash-attn. We cap at 8192 which is safe at the listed batch sizes.
 # The main offender is hashicorp__terraform-35611 (L0 files up to ~49K tokens,
 # 14145 L2 chunks). With flash-attn installed, the cap could be raised.
+#
+# Qwen3 models use decoder-only (causal LM) backbone with last-token pooling.
+# sentence-transformers >= 2.7.0 handles this automatically.
 MODELS=(
-  "Salesforce/SweRankEmbed-Small:768:8:4:0"
-  "fishmingyu/SweRankEmbed-Large:3584:2:1:0"
-  "jinaai/jina-code-embeddings-1.5b:1536:4:2:8192"
+  # "Salesforce/SweRankEmbed-Small:768:8:4:0"
+  # "fishmingyu/SweRankEmbed-Large:3584:2:1:0"
+  # "jinaai/jina-code-embeddings-1.5b:1536:4:2:8192"
+  "Qwen/Qwen3-Embedding-0.6B:1024:8:4:8192"
+  "Qwen/Qwen3-Embedding-4B:2560:2:1:8192"
 )
 
 mkdir -p "${STORAGE_DIR}"
@@ -67,11 +74,19 @@ for entry in "${MODELS[@]}"; do
     --embedding-dimension "${DIM}" \
     --batch-size "${BATCH}" \
     --trust-remote-code \
+    --isolate-instances \
     ${SEQ_FLAG} \
     "$@" || true
 
-  # Retry failed instances with a smaller batch size
+  # Retry failed instances with a smaller batch size.
+  # Do NOT forward --force-rebuild here: we only want to retry instances
+  # that genuinely failed in the primary run above.
   if [ "${FALLBACK_BATCH}" != "${BATCH}" ]; then
+    # Strip --force-rebuild from extra args so the retry skips successes.
+    RETRY_ARGS=()
+    for arg in "$@"; do
+      [ "${arg}" != "--force-rebuild" ] && RETRY_ARGS+=("${arg}")
+    done
     echo ""
     echo "----------------------------------------------------------------"
     echo "Retrying with fallback batch=${FALLBACK_BATCH} for any failures"
@@ -89,8 +104,9 @@ for entry in "${MODELS[@]}"; do
       --embedding-dimension "${DIM}" \
       --batch-size "${FALLBACK_BATCH}" \
       --trust-remote-code \
+      --isolate-instances \
       ${SEQ_FLAG} \
-      "$@" || true
+      "${RETRY_ARGS[@]}" || true
   fi
 done
 

--- a/scripts/embeddings/build_codeminer_base_embeddings.sh
+++ b/scripts/embeddings/build_codeminer_base_embeddings.sh
@@ -39,9 +39,9 @@ PROFILE_TAG="${PROFILE_TAG:-codeminer_base_${SPLIT}}"
 # Qwen3 models use decoder-only (causal LM) backbone with last-token pooling.
 # sentence-transformers >= 2.7.0 handles this automatically.
 MODELS=(
-  # "Salesforce/SweRankEmbed-Small:768:8:4:0"
-  # "fishmingyu/SweRankEmbed-Large:3584:2:1:0"
-  # "jinaai/jina-code-embeddings-1.5b:1536:4:2:8192"
+  "Salesforce/SweRankEmbed-Small:768:8:4:0"
+  "fishmingyu/SweRankEmbed-Large:3584:2:1:0"
+  "jinaai/jina-code-embeddings-1.5b:1536:4:2:8192"
   "Qwen/Qwen3-Embedding-0.6B:1024:8:4:8192"
   "Qwen/Qwen3-Embedding-4B:2560:2:1:8192"
 )

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -192,6 +192,16 @@ def parse_args():
             "overwriting runs (e.g., dev_run1, rerank_expA)."
         ),
     )
+    parser.add_argument(
+        "--isolate-instances",
+        action="store_true",
+        default=False,
+        help=(
+            "Run each instance in a separate subprocess for CUDA fault "
+            "isolation. Prevents OOM in one instance from corrupting the "
+            "GPU state for subsequent instances."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -455,11 +465,97 @@ def build_embeddings(args):
     logger.info(f"{'='*80}")
 
 
+def build_embeddings_isolated(args):
+    """Run each instance in a separate subprocess for CUDA fault isolation.
+
+    Loads the dataset once to discover instance IDs, then spawns a fresh
+    ``python build_embeddings.py`` subprocess per instance (with
+    ``--filter-instance`` pinned to that single ID and ``--isolate-instances``
+    removed).  Each subprocess gets its own CUDA context, so an OOM or
+    segfault in one instance cannot poison subsequent ones.
+    """
+    import re
+    import subprocess
+
+    dataset_obj = _load_dataset(args)
+    dataset_instances = dataset_obj.load()
+
+    if len(dataset_instances) == 0:
+        raise ValueError(
+            f"No instances found in "
+            f"{args.dataset or _DATASET_DEFAULTS[args.dataset_class]}"
+        )
+
+    logger.info(f"Isolated mode: will process {len(dataset_instances)} instance(s)")
+
+    # Rebuild the argv without --isolate-instances, and without any existing
+    # --filter-instance (we'll supply our own per-instance filter).
+    child_argv = [sys.executable, __file__]
+    skip_next = False
+    for arg in sys.argv[1:]:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--isolate-instances":
+            continue
+        if arg == "--filter-instance":
+            skip_next = True  # skip the next token (the regex value)
+            continue
+        if arg.startswith("--filter-instance="):
+            continue
+        child_argv.append(arg)
+
+    succeeded, failed, skipped = 0, 0, 0
+    for idx, instance in enumerate(dataset_instances):
+        instance_id = instance["instance_id"]
+        # Exact-match filter so only this instance is processed
+        instance_filter = f"^({re.escape(instance_id)})$"
+        cmd = child_argv + ["--filter-instance", instance_filter]
+
+        logger.info(
+            f"\n{'='*80}\n"
+            f"[isolated {idx+1}/{len(dataset_instances)}] {instance_id}\n"
+            f"{'='*80}"
+        )
+
+        # Check if already built (mirrors the skip logic in build_embeddings)
+        instance_dir_name = instance_id.replace("/", "__")
+        instance_final_dir = Path(args.storage_dir) / instance_dir_name
+        model_suffix = args.embedding_model.replace("/", "__")
+        config_file = instance_final_dir / f"config_{model_suffix}.json"
+        if config_file.exists() and not args.force_rebuild:
+            logger.info(f"  Already exists, skipping: {config_file}")
+            skipped += 1
+            continue
+
+        result = subprocess.run(cmd)
+        if result.returncode == 0:
+            succeeded += 1
+        else:
+            logger.error(
+                f"  Subprocess exited with code {result.returncode} "
+                f"for {instance_id}"
+            )
+            failed += 1
+
+    logger.info(
+        f"\n{'='*80}\n"
+        f"Isolated build complete: {succeeded} succeeded, {failed} failed, "
+        f"{skipped} skipped\n"
+        f"{'='*80}"
+    )
+    if failed:
+        sys.exit(1)
+
+
 def main():
     """Main entry point."""
     args = parse_args()
 
-    build_embeddings(args)
+    if args.isolate_instances:
+        build_embeddings_isolated(args)
+    else:
+        build_embeddings(args)
 
 
 if __name__ == "__main__":

--- a/scripts/embeddings/eval_codeminer_base_embeddings.sh
+++ b/scripts/embeddings/eval_codeminer_base_embeddings.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Evaluate embedding retrieval quality on the CodeMiner-base dataset.
+#
+# Loads pre-built FAISS indices (produced by build_codeminer_base_embeddings.sh)
+# and runs the embedding-only retrieval baseline against the ground-truth
+# annotations baked into the dataset.
+#
+# Usage:
+#   # Evaluate all instances with all five models
+#   bash scripts/embeddings/eval_codeminer_base_embeddings.sh
+#
+#   # Evaluate a single model
+#   bash scripts/embeddings/eval_codeminer_base_embeddings.sh \
+#       --filter-instance "^(redis__redis-1234)$"
+#
+#   # Override storage / result directories
+#   STORAGE_DIR=/mnt/data/codeminer RESULTS_DIR=/tmp/eval_results \
+#       bash scripts/embeddings/eval_codeminer_base_embeddings.sh
+#
+#   # Force rebuild indices instead of loading pre-built ones
+#   bash scripts/embeddings/eval_codeminer_base_embeddings.sh --force-rebuild
+
+STORAGE_DIR="${STORAGE_DIR:-/mnt/data/codeminer}"
+RESULTS_DIR="${RESULTS_DIR:-${STORAGE_DIR}/eval_results}"
+PROFILE_DIR="${PROFILE_DIR:-${STORAGE_DIR}/profile_log/query_runtime}"
+SPLIT="${SPLIT:-test}"
+
+# Model entries: "model_name:dim"
+# Keep in sync with build_codeminer_base_embeddings.sh
+MODELS=(
+  "Salesforce/SweRankEmbed-Small:768"
+  "fishmingyu/SweRankEmbed-Large:3584"
+  "jinaai/jina-code-embeddings-1.5b:1536"
+  "Qwen/Qwen3-Embedding-0.6B:1024"
+  "Qwen/Qwen3-Embedding-4B:2560"
+)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BASELINE="${REPO_ROOT}/examples/embedding_retrieve_baseline.py"
+
+mkdir -p "${RESULTS_DIR}"
+
+echo "Storage dir : ${STORAGE_DIR}"
+echo "Results dir : ${RESULTS_DIR}"
+echo "Profile dir : ${PROFILE_DIR}"
+echo "Split       : ${SPLIT}"
+echo ""
+
+for entry in "${MODELS[@]}"; do
+  MODEL="${entry%%:*}"
+  DIM="${entry##*:}"
+
+  # Sanitize model name for use in filenames
+  MODEL_TAG="${MODEL//\//__}"
+  RESULT_FILE="${RESULTS_DIR}/eval_codeminer_base_${SPLIT}_${MODEL_TAG}.json"
+
+  echo "================================================================"
+  echo "Model : ${MODEL}  (dim=${DIM})"
+  echo "Output: ${RESULT_FILE}"
+  echo "================================================================"
+
+  python "${BASELINE}" \
+    --dataset codeminer_base \
+    --split "${SPLIT}" \
+    --embedding-model "${MODEL}" \
+    --embedding-dimension "${DIM}" \
+    --index-cache-dir "${STORAGE_DIR}" \
+    --result-path "${RESULT_FILE}" \
+    --enable-profiler \
+    --profile-dir "${PROFILE_DIR}" \
+    --profile-tag "${MODEL_TAG}" \
+    "$@" || true
+
+  echo ""
+done
+
+echo "================================================================"
+echo "All models evaluated. Results written to ${RESULTS_DIR}/"
+echo "================================================================"


### PR DESCRIPTION
## Summary

Drop LangChain as an embedding dependency and add several robustness improvements for GPU-heavy embedding runs.

## Changes

- **Drop LangChain embedding wrappers** (`langchain-huggingface`, `langchain-openai`, `langchain-community`) — replaced with thin direct wrappers (`_HuggingFaceEmbeddingWrapper`, `_OpenAIEmbeddingWrapper`) around `sentence-transformers` and the OpenAI SDK. Preserves the same `page_content`/`metadata` Document interface and `embed_query`/`embed_documents` API surface for callers.
- **Minified-file detection in `CodeChunker`** — skip files where any line exceeds `minified_line_threshold` chars (default 10 000) and extend `ignore_patterns` with `*.min.js`, `*.min.css`, `*.min.mjs`, `*.bundle.js`, `*.bundle.mjs`. Prevents thousands of duplicate oversized chunks from JS bundles (e.g. babel's `Makefile.js`: 131 KB in 3 lines → ~480 duplicate chunks each hitting the 8192-token cap).
- **`--isolate-instances` flag in `build_embeddings.py`** — spawns a fresh subprocess per instance so a CUDA OOM or segfault in one instance cannot corrupt GPU state for subsequent ones.
- **Qwen3-Embedding models in build script** — add `Qwen/Qwen3-Embedding-0.6B` (1024d) and `Qwen/Qwen3-Embedding-4B` (2560d) as the active models; enable `--isolate-instances` by default; strip `--force-rebuild` from retry args so already-succeeded instances are not rebuilt on retry.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [ ] Tests

## Testing

- [ ] Tests pass locally
- [ ] Added new tests for the changes

The LangChain wrappers expose identical `embed_query` / `embed_documents` / `client` / `_client` attributes, so existing callers require no changes. Minified-file detection is guarded behind `RepoChunkingConfig.skip_minified` (default `True`) and is unit-testable in isolation.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
