### PR TITLE
MCP: add BM25 + Regex search server 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ logs/
 uv.lock
 hf_dataset/
 site/
+.venv/
+.cursor/
+*.bak

--- a/codeminer/mcp/__init__.py
+++ b/codeminer/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""CodeMiner MCP server - exposes backbone capabilities over stdio."""

--- a/codeminer/mcp/__main__.py
+++ b/codeminer/mcp/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as ``python -m codeminer.mcp <manifest>``."""
+
+from .server import main
+
+main()

--- a/codeminer/mcp/context.py
+++ b/codeminer/mcp/context.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 from ..compiler.manifest import RepoManifest
 from ..graph.code_graph import CodeGraph

--- a/codeminer/mcp/context.py
+++ b/codeminer/mcp/context.py
@@ -1,0 +1,97 @@
+"""ServerContext - loads a RepoManifest and hydrates index objects from disk."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..compiler.manifest import RepoManifest
+from ..graph.code_graph import CodeGraph
+from ..index.regex_idx import RegexNodeIndex
+from ..index.sparse_idx import BM25CodeIndexer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ServerContext:
+    """Runtime context for the MCP server.
+
+    Holds the loaded manifest and hydrated index objects.  Missing or
+    failed indexes stay ``None``; tools check at call time and return
+    descriptive errors.
+    """
+
+    manifest: RepoManifest
+    symbol_graph: Optional[CodeGraph] = None
+    bm25: Optional[BM25CodeIndexer] = None
+    regex_index: Optional[RegexNodeIndex] = None
+    # ROISubgraph and vector store will be added by graph / vector tool phases.
+    errors: Dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, manifest_path: str | Path) -> ServerContext:
+        """Load a manifest and hydrate all available indexes.
+
+        Each index is loaded independently; a failure in one does not
+        block the others.  Failed indexes are recorded in ``errors``.
+        """
+        manifest = RepoManifest.load(manifest_path)
+        ctx = cls(manifest=manifest)
+
+        ctx._load_symbol_graph()
+        ctx._load_bm25()
+        ctx._load_regex_index()
+
+        cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
+        logger.info(
+            "ServerContext ready  repo=%s  commit=%s  capabilities=%s  errors=%s",
+            manifest.repo_path,
+            manifest.commit[:8] if manifest.commit else "N/A",
+            cap_summary or "none",
+            list(ctx.errors) or "none",
+        )
+        return ctx
+
+    # ------------------------------------------------------------------
+    # Private loaders
+    # ------------------------------------------------------------------
+
+    def _load_symbol_graph(self) -> None:
+        entry = self.manifest.indexes.get("symbol_graph")
+        if not entry or entry.status != "fresh":
+            return
+        try:
+            graph_path = Path(entry.path)
+            pkl = graph_path / "graph.pkl" if graph_path.is_dir() else graph_path
+            self.symbol_graph = CodeGraph.load_graph(str(pkl))
+            logger.info("Loaded symbol_graph from %s", pkl)
+        except Exception as exc:
+            self.errors["symbol_graph"] = str(exc)
+            logger.warning("Failed to load symbol_graph: %s", exc)
+
+    def _load_bm25(self) -> None:
+        entry = self.manifest.indexes.get("bm25")
+        if not entry or entry.status != "fresh":
+            return
+        try:
+            indexer = BM25CodeIndexer()
+            indexer.load_index(entry.path)
+            self.bm25 = indexer
+            logger.info("Loaded BM25 index from %s", entry.path)
+        except Exception as exc:
+            self.errors["bm25"] = str(exc)
+            logger.warning("Failed to load BM25 index: %s", exc)
+
+    def _load_regex_index(self) -> None:
+        """Regex index piggybacks on symbol_graph; no separate manifest entry."""
+        if self.symbol_graph is None:
+            return
+        try:
+            self.regex_index = RegexNodeIndex(self.symbol_graph)
+            logger.info("Built RegexNodeIndex (%d nodes)", len(self.regex_index.nodes))
+        except Exception as exc:
+            self.errors["regex_index"] = str(exc)
+            logger.warning("Failed to build RegexNodeIndex: %s", exc)

--- a/codeminer/mcp/prompts.py
+++ b/codeminer/mcp/prompts.py
@@ -1,0 +1,45 @@
+"""MCP prompt resource - guidance for calling agents."""
+
+CODEMINER_GUIDE = """\
+# CodeMiner Tools Guide
+
+CodeMiner provides **semantic code search** over pre-built indexes. Results are
+structured at the symbol level (functions, classes, methods) with precise file
+locations and source content, not raw line-level grep output.
+
+## When to use each tool
+
+### search_bm25
+Best for **keyword / exact-name** lookups.  Use when you know (or can guess)
+the function name, class name, error string, or specific identifier you are
+looking for.
+
+Examples:
+- "find the function `calculate_tax`"
+- "where is `DatabaseConnectionError` raised"
+
+### search_regex
+Best for **pattern-based** searches across the code graph.  Supports full Python
+regex syntax plus optional file-glob and node-type filters.
+
+Examples:
+- `def\\s+test_` with `file_glob="**/test_*.py"`: find all test functions
+- `TODO|FIXME`: find code annotations
+- `class\\s+\\w+Error`: find all custom exception classes
+
+### Choosing between them
+| Scenario | Tool |
+|----------|------|
+| Know the exact symbol name | search_bm25 |
+| Looking for a pattern across many files | search_regex |
+| Natural-language description of what the code does | search_bm25 |
+| Need structural filters (by file glob or node type) | search_regex |
+
+## Tips
+- `search_bm25` returns results ranked by BM25 relevance.  Start with
+  `top_k=10` and increase if the target is not in the first page.
+- `search_regex` returns **all** matches up to `top_k`.  Use `file_glob`
+  and `node_type` to narrow down large result sets.
+- Both tools return symbol-level results: `node_name`, `type`, `file`,
+  `start_line`, `end_line`, and `content`.
+"""

--- a/codeminer/mcp/server.py
+++ b/codeminer/mcp/server.py
@@ -1,0 +1,184 @@
+"""CodeMiner MCP server - stdio transport.
+
+Usage::
+
+    codeminer-mcp --manifest /path/to/repo_manifest.json
+
+Or as a module::
+
+    python -m codeminer.mcp.server --manifest /path/to/repo_manifest.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from typing import Any, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from .context import ServerContext
+from .prompts import CODEMINER_GUIDE
+from .tools.search import search_bm25_impl, search_regex_impl
+
+logger = logging.getLogger(__name__)
+
+# Global context is set once at startup before the event loop runs tools.
+_ctx: Optional[ServerContext] = None
+
+mcp = FastMCP(
+    "codeminer",
+    instructions=(
+        "CodeMiner provides semantic code search over pre-built indexes. "
+        "Use search_bm25 for keyword lookups and search_regex for pattern matching."
+    ),
+)
+
+
+# ------------------------------------------------------------------
+# Tools
+# ------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="search_bm25",
+    description=(
+        "Search for code symbols using BM25 keyword retrieval. "
+        "Returns functions, classes, and methods ranked by relevance "
+        "with source content. Best for exact-name or keyword lookups. "
+        "Prefer this over search_regex when you know the symbol name "
+        "or have a natural-language description of what the code does."
+    ),
+)
+async def search_bm25(
+    query: str,
+    top_k: int = 20,
+    filter_test: bool = False,
+) -> list[dict[str, Any]]:
+    """BM25 keyword search over indexed code symbols."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    results = await asyncio.to_thread(
+        search_bm25_impl, _ctx, query, top_k, filter_test
+    )
+    return results
+
+
+@mcp.tool(
+    name="search_regex",
+    description=(
+        "Search code graph nodes by regex pattern (grep-like). "
+        "Supports file glob filtering and node type filtering. "
+        "Returns matching functions, classes, and methods with source content. "
+        "Best for pattern-based searches across the codebase. "
+        "Prefer search_bm25 when you know the exact name; "
+        "prefer this when you need structural pattern matching."
+    ),
+)
+async def search_regex(
+    pattern: str,
+    top_k: int = 20,
+    file_glob: str = "",
+    node_type: str = "",
+    case_sensitive: bool = False,
+) -> list[dict[str, Any]]:
+    """Regex pattern search over code graph nodes."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    results = await asyncio.to_thread(
+        search_regex_impl,
+        _ctx,
+        pattern,
+        top_k,
+        file_glob or None,
+        node_type or None,
+        case_sensitive,
+    )
+    return results
+
+
+@mcp.tool(
+    name="get_manifest",
+    description=(
+        "Return metadata about the indexed repository: path, commit, "
+        "languages, available indexes, and capabilities."
+    ),
+)
+async def get_manifest() -> str:
+    """Return the repo manifest as JSON."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    return _ctx.manifest.to_dict()
+
+
+# ------------------------------------------------------------------
+# Prompt resource
+# ------------------------------------------------------------------
+
+
+@mcp.prompt(
+    name="codeminer-guide",
+    description="Guidance on how to use CodeMiner search tools effectively.",
+)
+async def codeminer_guide() -> str:
+    return CODEMINER_GUIDE
+
+
+# ------------------------------------------------------------------
+# CLI entry point
+# ------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="codeminer-mcp",
+        description="Start the CodeMiner MCP server (stdio transport).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "manifest",
+        nargs="?",
+        type=str,
+        help="Path to repo_manifest.json produced by IndexCompiler.",
+    )
+    parser.add_argument(
+        "--manifest",
+        dest="manifest_flag",
+        type=str,
+        help="Path to repo_manifest.json produced by IndexCompiler.",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point: ``codeminer-mcp --manifest <manifest_path>``."""
+    global _ctx
+    args = _parse_args(argv)
+    manifest_path = args.manifest_flag or args.manifest
+    if manifest_path is None:
+        raise SystemExit("manifest path is required (use --manifest <path>)")
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        stream=sys.stderr,
+    )
+
+    logger.info("Loading manifest from %s", manifest_path)
+    _ctx = ServerContext.load(manifest_path)
+    logger.info("Starting MCP server (stdio)")
+
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/codeminer/mcp/tools/__init__.py
+++ b/codeminer/mcp/tools/__init__.py
@@ -1,0 +1,1 @@
+"""MCP tool implementations."""

--- a/codeminer/mcp/tools/search.py
+++ b/codeminer/mcp/tools/search.py
@@ -1,0 +1,105 @@
+"""Search MCP tools - BM25 and regex wrappers over backbone indexes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from ...types import NodeInfo
+
+
+def _node_to_dict(node: NodeInfo) -> Dict[str, Any]:
+    """Serialize a NodeInfo to a JSON-friendly dict, dropping None fields."""
+    d = node.model_dump(exclude_none=True)
+    return d
+
+
+# ------------------------------------------------------------------
+# search_bm25
+# ------------------------------------------------------------------
+
+
+def search_bm25_impl(
+    ctx: Any,
+    query: str,
+    top_k: int = 20,
+    filter_test: bool = False,
+) -> List[Dict[str, Any]]:
+    """Run BM25 keyword search over indexed code symbols.
+
+    Args:
+        ctx: ServerContext with a loaded ``bm25`` index.
+        query: Natural-language or keyword query.
+        top_k: Maximum number of results to return.
+        filter_test: If True, exclude results from test files.
+
+    Returns:
+        List of dicts with keys: node_name, type, file, start_line,
+        end_line, content, score.
+    """
+    if ctx.bm25 is None:
+        raise RuntimeError(
+            "BM25 index is not available. "
+            + ctx.errors.get("bm25", "No 'bm25' entry in manifest or status != fresh.")
+        )
+
+    results: List[NodeInfo] = ctx.bm25.search(
+        query=query,
+        top_k=top_k,
+        return_code_content=True,
+        wrap_with_ln=False,
+        filter_test=filter_test,
+    )
+    return [_node_to_dict(n) for n in results]
+
+
+# ------------------------------------------------------------------
+# search_regex
+# ------------------------------------------------------------------
+
+
+def search_regex_impl(
+    ctx: Any,
+    pattern: str,
+    top_k: int = 20,
+    file_glob: Optional[str] = None,
+    node_type: Optional[str] = None,
+    case_sensitive: bool = False,
+) -> List[Dict[str, Any]]:
+    """Search code graph nodes by regex pattern (grep-like).
+
+    Args:
+        ctx: ServerContext with a loaded ``regex_index``.
+        pattern: Regex pattern to match against node content.
+        top_k: Maximum number of results to return.
+        file_glob: Optional glob to restrict by file path (e.g. ``*.py``).
+        node_type: Optional filter by node type (function, class, method, file).
+        case_sensitive: Whether the search is case-sensitive.
+
+    Returns:
+        List of dicts with keys: node_name, type, file, start_line,
+        end_line, content.
+    """
+    if ctx.regex_index is None:
+        raise RuntimeError(
+            "Regex index is not available. "
+            + ctx.errors.get(
+                "regex_index",
+                "Requires a loaded symbol_graph (no 'symbol_graph' entry in manifest or load failed).",
+            )
+        )
+
+    try:
+        results: List[NodeInfo] = ctx.regex_index.search(
+            pattern=pattern,
+            file_glob=file_glob,
+            node_type=node_type,
+            case_sensitive=case_sensitive,
+            use_regex=True,
+        )
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Invalid regex pattern {pattern!r}: {exc}. "
+            "See https://docs.python.org/3/library/re.html for syntax."
+        ) from exc
+
+    return [_node_to_dict(n) for n in results[:top_k]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,11 @@ dependencies = [
     "PyStemmer>=3.0.0",                 # For stemmer (faster than NLTK)
     # "vllm>=0.10.2" removed — use vLLM OpenAI-compatible server via litellm
     "requests>=2.25.0",                 # For HTTP requests (health checks, etc.)
+    "mcp>=1.0.0",                        # Model Context Protocol SDK (stdio server)
 ]
+
+[project.scripts]
+codeminer-mcp = "codeminer.mcp.server:main"
 
 [project.optional-dependencies]
 dev = [

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -1,0 +1,132 @@
+"""Unit tests for codeminer.mcp.context.ServerContext."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codeminer.compiler.manifest import IndexEntry, RepoManifest
+from codeminer.mcp.context import ServerContext
+
+
+@pytest.fixture()
+def manifest_dir(tmp_path: Path) -> Path:
+    """Create a minimal manifest on disk with a BM25 index."""
+    bm25_dir = tmp_path / "bm25"
+    bm25_dir.mkdir()
+    (bm25_dir / "documents.json").write_text(
+        json.dumps([{"page_content": "def foo(): pass", "metadata": {"node_name": "foo", "type": "function"}}])
+    )
+    (bm25_dir / "bm25_metadata.json").write_text(
+        json.dumps({"project_root": str(tmp_path), "max_k": 10, "language": "english"})
+    )
+
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        commit="abc123",
+        languages=["python"],
+        indexes={
+            "bm25": IndexEntry(
+                index_type="bm25",
+                path=str(bm25_dir),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=1735689600.0,
+                status="fresh",
+            ),
+        },
+    )
+    manifest.derive_capabilities()
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest.save(manifest_path)
+    return tmp_path
+
+
+def test_load_with_bm25_only(manifest_dir: Path) -> None:
+    """ServerContext loads BM25 when symbol_graph is absent."""
+    ctx = ServerContext.load(manifest_dir / "repo_manifest.json")
+
+    assert ctx.bm25 is not None
+    assert ctx.symbol_graph is None
+    assert ctx.regex_index is None
+    assert "symbol_graph" not in ctx.errors
+
+
+def test_load_missing_bm25_path(tmp_path: Path) -> None:
+    """BM25 load failure is recorded in errors, not raised."""
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        indexes={
+            "bm25": IndexEntry(
+                index_type="bm25",
+                path=str(tmp_path / "nonexistent"),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=0.0,
+                status="fresh",
+            ),
+        },
+    )
+    manifest.save(tmp_path / "repo_manifest.json")
+
+    ctx = ServerContext.load(tmp_path / "repo_manifest.json")
+    assert ctx.bm25 is None
+    assert "bm25" in ctx.errors
+
+
+def test_skip_non_fresh_index(tmp_path: Path) -> None:
+    """Indexes with status != 'fresh' are skipped."""
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        indexes={
+            "bm25": IndexEntry(
+                index_type="bm25",
+                path=str(tmp_path / "bm25"),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=0.0,
+                status="failed",
+            ),
+        },
+    )
+    manifest.save(tmp_path / "repo_manifest.json")
+
+    ctx = ServerContext.load(tmp_path / "repo_manifest.json")
+    assert ctx.bm25 is None
+    assert "bm25" not in ctx.errors
+
+
+def test_regex_index_built_when_graph_available(manifest_dir: Path) -> None:
+    """RegexNodeIndex is built when symbol_graph loads successfully."""
+    graph_dir = manifest_dir / "symbol_graph"
+    graph_dir.mkdir()
+
+    mock_graph = MagicMock()
+    mock_vs = [MagicMock()]
+    mock_vs[0].index = 0
+    mock_vs[0].__getitem__ = lambda self, key: "my_func" if key == "name" else None
+    mock_vs[0].attributes.return_value = {
+        "type": "function",
+        "file": "main.py",
+        "start_line": 1,
+        "end_line": 5,
+    }
+    mock_graph.get_graph.return_value.vs = mock_vs
+    mock_graph.get_node_content.return_value = "def my_func(): pass"
+
+    manifest = RepoManifest.load(manifest_dir / "repo_manifest.json")
+    manifest.indexes["symbol_graph"] = IndexEntry(
+        index_type="symbol_graph",
+        path=str(graph_dir / "graph.pkl"),
+        built_at="2026-01-01T00:00:00",
+        built_at_epoch=0.0,
+        status="fresh",
+    )
+    manifest.save(manifest_dir / "repo_manifest.json")
+
+    with patch("codeminer.mcp.context.CodeGraph.load_graph", return_value=mock_graph):
+        ctx = ServerContext.load(manifest_dir / "repo_manifest.json")
+
+    assert ctx.symbol_graph is mock_graph
+    assert ctx.regex_index is not None
+    assert len(ctx.regex_index.nodes) == 1

--- a/test/mcp_server/test_integration.py
+++ b/test/mcp_server/test_integration.py
@@ -1,0 +1,197 @@
+"""End-to-end integration tests for the MCP server.
+
+Builds a tiny synthetic repo (a few Python files), constructs a real BM25
+index and a real CodeGraph + RegexNodeIndex on it, writes a real manifest,
+loads everything through ``ServerContext``, and exercises the search tool
+implementations against the loaded indexes.
+
+These tests do not depend on any external indexer binary (no scip-python,
+no Go / clangd) and are safe to run in CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codeminer.compiler.manifest import IndexEntry, RepoManifest
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.index.sparse_idx import BM25CodeIndexer
+from codeminer.mcp.context import ServerContext
+from codeminer.mcp.tools.search import search_bm25_impl, search_regex_impl
+
+
+# Synthetic repo: three small Python files with predictable symbols so that
+# both keyword (BM25) and regex search have something to match.
+REPO_FILES: dict[str, str] = {
+    "billing/tax.py": (
+        "def calculate_tax(amount):\n"
+        "    \"\"\"Compute sales tax for a given amount.\"\"\"\n"
+        "    return amount * 0.08\n"
+    ),
+    "billing/exceptions.py": (
+        "class TaxError(Exception):\n"
+        "    \"\"\"Raised when tax computation fails.\"\"\"\n"
+        "    pass\n"
+    ),
+    "auth/session.py": (
+        "def authenticate_user(username, password):\n"
+        "    \"\"\"Return True if credentials are valid.\"\"\"\n"
+        "    return False\n"
+    ),
+}
+
+
+def _build_synthetic_repo(repo_dir: Path) -> CodeGraph:
+    """Materialize REPO_FILES under repo_dir and build a matching CodeGraph.
+
+    The graph is constructed by hand (no SCIP / LSP) so the test is
+    self-contained.  Each function/class becomes one symbol vertex and
+    each source file becomes one file vertex.
+    """
+    for rel_path, content in REPO_FILES.items():
+        path = repo_dir / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    graph = CodeGraph(project_root=str(repo_dir))
+
+    # File nodes
+    for rel_path in REPO_FILES:
+        graph._add_vertex(rel_path, {"type": "file"})
+
+    # Symbol nodes (start_line / end_line are 1-based inclusive to match
+    # CodeGraph.get_node_content's slicing convention).
+    symbols = [
+        ("billing/tax.py:calculate_tax", "function", "billing/tax.py", 1, 3),
+        ("billing/exceptions.py:TaxError", "class", "billing/exceptions.py", 1, 3),
+        ("auth/session.py:authenticate_user", "function", "auth/session.py", 1, 3),
+    ]
+    for name, node_type, file, start_line, end_line in symbols:
+        graph._add_vertex(
+            name,
+            {
+                "type": node_type,
+                "file": file,
+                "start_line": start_line,
+                "end_line": end_line,
+            },
+        )
+
+    return graph
+
+
+@pytest.fixture()
+def manifest_path(tmp_path: Path) -> Path:
+    """Build a real BM25 + symbol_graph manifest from a synthetic repo."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    graph = _build_synthetic_repo(repo_dir)
+
+    # Persist the symbol graph
+    graph_dir = tmp_path / "symbol_graph"
+    graph_dir.mkdir()
+    graph_pkl = graph_dir / "graph.pkl"
+    graph.save_graph(str(graph_pkl))
+
+    # Build and persist the BM25 index from the same graph
+    bm25_dir = tmp_path / "bm25"
+    bm25_dir.mkdir()
+    indexer = BM25CodeIndexer()
+    indexer.build_index_from_graph(graph)
+    indexer.save_index(str(bm25_dir))
+
+    manifest = RepoManifest(
+        repo_path=str(repo_dir),
+        commit="integration-test",
+        languages=["python"],
+        indexes={
+            "bm25": IndexEntry(
+                index_type="bm25",
+                path=str(bm25_dir),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=1735689600.0,
+                status="fresh",
+            ),
+            "symbol_graph": IndexEntry(
+                index_type="symbol_graph",
+                path=str(graph_pkl),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=1735689600.0,
+                status="fresh",
+            ),
+        },
+    )
+    manifest.derive_capabilities()
+    out_path = tmp_path / "repo_manifest.json"
+    manifest.save(out_path)
+    return out_path
+
+
+def test_server_context_loads_real_indexes(manifest_path: Path) -> None:
+    """ServerContext.load hydrates BM25, symbol_graph, and the regex index."""
+    ctx = ServerContext.load(manifest_path)
+
+    assert ctx.bm25 is not None, f"BM25 failed to load: {ctx.errors}"
+    assert ctx.symbol_graph is not None, f"symbol_graph failed: {ctx.errors}"
+    assert ctx.regex_index is not None, f"regex index failed: {ctx.errors}"
+    assert ctx.errors == {}
+
+
+def test_search_bm25_finds_known_symbol(manifest_path: Path) -> None:
+    """A keyword query for a known symbol returns it in the top results."""
+    ctx = ServerContext.load(manifest_path)
+    results = search_bm25_impl(ctx, query="calculate tax", top_k=10)
+
+    assert results, "BM25 should return at least one hit"
+    names = [r["node_name"] for r in results]
+    assert any("calculate_tax" in n for n in names), (
+        f"calculate_tax not found in BM25 results: {names}"
+    )
+
+
+def test_search_regex_finds_function_definitions(manifest_path: Path) -> None:
+    """Regex search returns function-typed nodes only when filtered."""
+    ctx = ServerContext.load(manifest_path)
+    results = search_regex_impl(
+        ctx,
+        pattern=r"def\s+\w+",
+        top_k=10,
+        node_type="function",
+    )
+
+    assert results, "Regex should match at least one function"
+    names = [r["node_name"] for r in results]
+    assert any("calculate_tax" in n for n in names)
+    assert any("authenticate_user" in n for n in names)
+    # No class nodes should leak through the node_type filter
+    types = {r["type"] for r in results}
+    assert types == {"function"}, f"Unexpected types: {types}"
+
+
+def test_search_regex_file_glob_filter(manifest_path: Path) -> None:
+    """file_glob restricts results to a subdirectory."""
+    ctx = ServerContext.load(manifest_path)
+    results = search_regex_impl(
+        ctx,
+        pattern=r".",
+        top_k=20,
+        file_glob="billing/*",
+    )
+
+    assert results
+    files = {r.get("file") for r in results}
+    # All hits must be inside billing/
+    for f in files:
+        if f is not None:
+            assert f.startswith("billing/"), f"Unexpected file: {f}"
+
+
+def test_search_regex_invalid_pattern_raises_friendly_error(
+    manifest_path: Path,
+) -> None:
+    """Invalid regex patterns surface as a descriptive RuntimeError."""
+    ctx = ServerContext.load(manifest_path)
+    with pytest.raises(RuntimeError, match="Invalid regex pattern"):
+        search_regex_impl(ctx, pattern="[unclosed")

--- a/test/mcp_server/test_server.py
+++ b/test/mcp_server/test_server.py
@@ -1,0 +1,86 @@
+"""Unit tests for the MCP server tool registration and async wrappers."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.compiler.manifest import RepoManifest
+from codeminer.mcp import server as server_mod
+from codeminer.types import NodeInfo
+
+
+@pytest.fixture(autouse=True)
+def _reset_ctx():
+    """Ensure _ctx is cleaned up after each test."""
+    original = server_mod._ctx
+    yield
+    server_mod._ctx = original
+
+
+def _make_server_ctx(*, bm25_results=None, regex_results=None):
+    ctx = MagicMock()
+    ctx.manifest = RepoManifest(repo_path="/repo", commit="abc123", languages=["python"])
+    ctx.bm25 = MagicMock() if bm25_results is not None else None
+    ctx.regex_index = MagicMock() if regex_results is not None else None
+    ctx.errors = {}
+    if bm25_results is not None:
+        ctx.bm25.search.return_value = bm25_results
+    if regex_results is not None:
+        ctx.regex_index.search.return_value = regex_results
+    return ctx
+
+
+def test_search_bm25_tool() -> None:
+    nodes = [NodeInfo(node_name="foo", type="function", file="a.py", content="def foo(): pass")]
+    server_mod._ctx = _make_server_ctx(bm25_results=nodes)
+
+    result = asyncio.run(server_mod.search_bm25(query="foo", top_k=5, filter_test=False))
+
+    assert len(result) == 1
+    assert result[0]["node_name"] == "foo"
+
+
+def test_search_regex_tool() -> None:
+    nodes = [NodeInfo(node_name="bar", type="class", file="b.py", content="class bar: ...")]
+    server_mod._ctx = _make_server_ctx(regex_results=nodes)
+
+    result = asyncio.run(server_mod.search_regex(pattern="class", top_k=10))
+
+    assert len(result) == 1
+    assert result[0]["node_name"] == "bar"
+
+
+def test_get_manifest_tool() -> None:
+    server_mod._ctx = _make_server_ctx(bm25_results=[])
+
+    result = asyncio.run(server_mod.get_manifest())
+
+    assert result["repo"]["path"] == "/repo"
+    assert result["repo"]["commit"] == "abc123"
+
+
+def test_search_bm25_raises_without_ctx() -> None:
+    server_mod._ctx = None
+    with pytest.raises(RuntimeError, match="Server not initialized"):
+        asyncio.run(server_mod.search_bm25(query="x"))
+
+
+def test_parse_args_basic() -> None:
+    args = server_mod._parse_args(["/tmp/manifest.json"])
+    assert args.manifest == "/tmp/manifest.json"
+    assert args.manifest_flag is None
+    assert args.log_level == "INFO"
+
+
+def test_parse_args_with_manifest_flag() -> None:
+    args = server_mod._parse_args(["--manifest", "/tmp/manifest.json"])
+    assert args.manifest is None
+    assert args.manifest_flag == "/tmp/manifest.json"
+
+
+def test_parse_args_with_log_level() -> None:
+    args = server_mod._parse_args(["/tmp/m.json", "--log-level", "DEBUG"])
+    assert args.log_level == "DEBUG"

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -1,0 +1,169 @@
+"""Unit tests for codeminer.mcp.tools.search — BM25 and regex tool impls."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.mcp.tools.search import search_bm25_impl, search_regex_impl
+from codeminer.types import NodeInfo
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_ctx(*, bm25=None, regex_index=None, errors=None):
+    """Create a minimal mock ServerContext."""
+    ctx = MagicMock()
+    ctx.bm25 = bm25
+    ctx.regex_index = regex_index
+    ctx.errors = errors or {}
+    return ctx
+
+
+def _sample_nodes() -> list[NodeInfo]:
+    return [
+        NodeInfo(
+            node_name="calculate_tax",
+            type="function",
+            file="billing/tax.py",
+            start_line=10,
+            end_line=25,
+            content="def calculate_tax(amount): ...",
+            score=0.0,
+        ),
+        NodeInfo(
+            node_name="TaxError",
+            type="class",
+            file="billing/exceptions.py",
+            start_line=1,
+            end_line=5,
+            content="class TaxError(Exception): ...",
+            score=0.0,
+        ),
+    ]
+
+
+# ------------------------------------------------------------------
+# search_bm25
+# ------------------------------------------------------------------
+
+
+class TestSearchBM25:
+    def test_basic_search(self) -> None:
+        nodes = _sample_nodes()
+        mock_bm25 = MagicMock()
+        mock_bm25.search.return_value = nodes
+        ctx = _make_ctx(bm25=mock_bm25)
+
+        results = search_bm25_impl(ctx, query="tax", top_k=10, filter_test=False)
+
+        assert len(results) == 2
+        assert results[0]["node_name"] == "calculate_tax"
+        assert results[0]["type"] == "function"
+        assert results[0]["file"] == "billing/tax.py"
+        mock_bm25.search.assert_called_once_with(
+            query="tax",
+            top_k=10,
+            return_code_content=True,
+            wrap_with_ln=False,
+            filter_test=False,
+        )
+
+    def test_forwards_filter_test(self) -> None:
+        mock_bm25 = MagicMock()
+        mock_bm25.search.return_value = []
+        ctx = _make_ctx(bm25=mock_bm25)
+
+        search_bm25_impl(ctx, query="test", top_k=5, filter_test=True)
+
+        _, kwargs = mock_bm25.search.call_args
+        assert kwargs["filter_test"] is True
+
+    def test_raises_when_index_missing(self) -> None:
+        ctx = _make_ctx(bm25=None)
+        with pytest.raises(RuntimeError, match="BM25 index is not available"):
+            search_bm25_impl(ctx, query="anything")
+
+    def test_none_fields_excluded(self) -> None:
+        node = NodeInfo(node_name="foo", type="function")
+        mock_bm25 = MagicMock()
+        mock_bm25.search.return_value = [node]
+        ctx = _make_ctx(bm25=mock_bm25)
+
+        results = search_bm25_impl(ctx, query="foo")
+        assert "file" not in results[0]
+        assert "score" not in results[0]
+
+
+# ------------------------------------------------------------------
+# search_regex
+# ------------------------------------------------------------------
+
+
+class TestSearchRegex:
+    def test_basic_search(self) -> None:
+        nodes = _sample_nodes()[:1]
+        mock_regex = MagicMock()
+        mock_regex.search.return_value = nodes
+        ctx = _make_ctx(regex_index=mock_regex)
+
+        results = search_regex_impl(ctx, pattern=r"def\s+\w+", top_k=10)
+
+        assert len(results) == 1
+        assert results[0]["node_name"] == "calculate_tax"
+        mock_regex.search.assert_called_once_with(
+            pattern=r"def\s+\w+",
+            file_glob=None,
+            node_type=None,
+            case_sensitive=False,
+            use_regex=True,
+        )
+
+    def test_forwards_filters(self) -> None:
+        mock_regex = MagicMock()
+        mock_regex.search.return_value = []
+        ctx = _make_ctx(regex_index=mock_regex)
+
+        search_regex_impl(
+            ctx,
+            pattern="class",
+            top_k=5,
+            file_glob="*.py",
+            node_type="class",
+            case_sensitive=True,
+        )
+
+        _, kwargs = mock_regex.search.call_args
+        assert kwargs["file_glob"] == "*.py"
+        assert kwargs["node_type"] == "class"
+        assert kwargs["case_sensitive"] is True
+
+    def test_top_k_truncation(self) -> None:
+        many_nodes = [
+            NodeInfo(node_name=f"func_{i}", type="function", content="x")
+            for i in range(50)
+        ]
+        mock_regex = MagicMock()
+        mock_regex.search.return_value = many_nodes
+        ctx = _make_ctx(regex_index=mock_regex)
+
+        results = search_regex_impl(ctx, pattern="x", top_k=10)
+        assert len(results) == 10
+
+    def test_raises_when_index_missing(self) -> None:
+        ctx = _make_ctx(regex_index=None)
+        with pytest.raises(RuntimeError, match="Regex index is not available"):
+            search_regex_impl(ctx, pattern="anything")
+
+    def test_invalid_regex_translated_to_runtime_error(self) -> None:
+        """Invalid regex from RegexNodeIndex.search bubbles up as a friendly RuntimeError."""
+        mock_regex = MagicMock()
+        mock_regex.search.side_effect = ValueError("bad escape at position 0")
+        ctx = _make_ctx(regex_index=mock_regex)
+
+        with pytest.raises(RuntimeError, match="Invalid regex pattern"):
+            search_regex_impl(ctx, pattern=r"[")


### PR DESCRIPTION
## Summary

Implements the BM25 + Regex search part of the MCP server.

## What's new

| Component | File | Description |
|-----------|------|-------------|
| Server context | `codeminer/mcp/context.py` | Loads `RepoManifest` and hydrates `BM25CodeIndexer`, `CodeGraph`, and `RegexNodeIndex`; failed indexes go into `ctx.errors` instead of blocking startup. |
| Search tools | `codeminer/mcp/tools/search.py` | `search_bm25_impl`, `search_regex_impl` — thin wrappers over `BM25CodeIndexer.search` / `RegexNodeIndex.search`. Invalid regex `ValueError` is translated into a friendly `RuntimeError`. |
| MCP server | `codeminer/mcp/server.py` | FastMCP stdio server that registers `search_bm25`, `search_regex`, and `get_manifest` tools. Sync backbone calls are wrapped in `asyncio.to_thread`. |
| Prompt resource | `codeminer/mcp/prompts.py` | `codeminer-guide` prompt explaining when to pick BM25 vs regex. |
| CLI | `codeminer/mcp/__main__.py` | `codeminer-mcp <manifest>` (also accepts `--manifest <path>`). |
| Dependencies | `pyproject.toml` | `mcp>=1.0.0` runtime dep + `codeminer-mcp` console script. |

## Tests (25 passed)

- **Unit**: `ServerContext` loaders, search tool impls, FastMCP async tool wrappers — all with mocked backbone.
- **Integration**: builds a synthetic 3-file repo, a real BM25 index and `CodeGraph + RegexNodeIndex`, exercises the tools end-to-end through `ServerContext`.


## checklist

| Roadmap item | Status |
|---|---|
| `ServerContext` hydrates BM25 + symbol_graph + regex | ✅ |
| `search_bm25` delegates to `BM25CodeIndexer.search` | ✅ |
| `search_regex` delegates to `RegexNodeIndex.search` | ✅ |
| `asyncio.to_thread` for sync backbone | ✅ |
| Invalid regex translated to descriptive error | ✅ |
| Unit tests with mocked backbone + missing-ctx error path | ✅ |
| Integration test with a real small-repo manifest | ✅ |

### notice

#123 adds `search_semantic` over the same `codeminer/mcp/` directory. The two PRs touch the same files but every overlap is **additive** :

- `ServerContext` fields are independent (`vector` vs `bm25` / `symbol_graph` / `regex_index`)
- Tool functions are independent (`search_semantic` vs `search_bm25` / `search_regex`)
- `pyproject.toml` `mcp>=1.0.0` dep + `codeminer-mcp` script are written identically on both sides


