### PR TITLE
feat(graph): line-range query primitive + typed API + multi-edge anchor schema (closes #125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Run unit tests
         shell: bash -l {0}
-        run: pytest -n auto -m "not slow and not integration and not integration_serial" -x --tb=short
+        run: pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short
 
   # =============================================================
   # Job 2 — Integration tests  (read-only, parallel-safe, ~2 min)
@@ -160,7 +160,11 @@ jobs:
       - name: Purge stale SCIP Python caches (one-time)
         run: |
           CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
-          MARKER="$CACHE_DIR/.scip-cache-v3"
+          # Cleanup orphan v3 marker from an earlier graph-index iteration —
+          # #120's _SCHEMA_VERSION check now handles graph.pkl invalidation,
+          # so the ci.yml marker bump is no longer needed.
+          rm -f "$CACHE_DIR/.scip-cache-v3"
+          MARKER="$CACHE_DIR/.scip-cache-v2"
           if [ ! -f "$MARKER" ]; then
             echo "Purging stale SCIP Python graph caches..."
             find "$CACHE_DIR" -name "graph.pkl" -delete 2>/dev/null || true
@@ -290,6 +294,50 @@ jobs:
           pytest test/scip/test_scip_core.py -v --tb=short
 
   # =============================================================
+  # Job 5 — Graph cache consumer tests (~5 min)
+  #
+  # Reads graph.pkl written by integration-serial (specifically
+  # test_scip_multilingual) and runs query / range / anchor checks against
+  # it via skip_level="graph". Mirrors scip-core's job-level dependency on
+  # integration-serial — runs in a separate job so the cached pickle is
+  # always fresh from the most recent decoder.
+  # =============================================================
+  graph-consumer:
+    needs: [preflight, integration-serial]
+    if: needs.preflight.outputs.should-run == 'true'
+    runs-on: self-hosted
+    timeout-minutes: 15
+    env:
+      PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
+      npm_config_cache: ${{ github.workspace }}/../.cache/npm
+    steps:
+      - name: Prepare temp HOME
+        run: |
+          mkdir -p "$RUNNER_TEMP/home"
+          echo "HOME=$RUNNER_TEMP/home" >> "$GITHUB_ENV"
+
+      - name: Persist codeminer cache across runs
+        run: |
+          CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
+          mkdir -p "$CACHE_DIR"
+          ln -sfn "$CACHE_DIR" "$HOME/.codeminer"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-clangd: "true"
+          install-bear: "true"
+
+      - name: Run graph consumer tests
+        shell: bash -l {0}
+        run: pytest -m "integration_serial_consumer" -v --tb=short
+
+  # =============================================================
   # Job 4 — Slow tests  (LLM API, GPU embeddings, ~15 min)
   # =============================================================
   slow:
@@ -315,7 +363,11 @@ jobs:
       - name: Purge stale SCIP Python caches (one-time)
         run: |
           CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
-          MARKER="$CACHE_DIR/.scip-cache-v3"
+          # Cleanup orphan v3 marker from an earlier graph-index iteration —
+          # #120's _SCHEMA_VERSION check now handles graph.pkl invalidation,
+          # so the ci.yml marker bump is no longer needed.
+          rm -f "$CACHE_DIR/.scip-cache-v3"
+          MARKER="$CACHE_DIR/.scip-cache-v2"
           if [ ! -f "$MARKER" ]; then
             echo "Purging stale SCIP Python graph caches..."
             find "$CACHE_DIR" -name "graph.pkl" -delete 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,15 +222,16 @@ jobs:
           install-clangd: "true"
           install-bear: "true"
 
-      - name: Install C++ build deps (libigraph, re2, cmake)
+      - name: Install C++ build deps (re2, cmake)
         shell: bash -l {0}
         timeout-minutes: 5
+        # libigraph is vendored via FetchContent in core/CMakeLists.txt
+        # (see comment there) so we only need re2 + cmake from the system.
         run: |
           set -eu
           NEED=()
           command -v pkg-config >/dev/null 2>&1 || NEED+=(pkg-config)
           command -v cmake      >/dev/null 2>&1 || NEED+=(cmake)
-          pkg-config --exists igraph 2>/dev/null || NEED+=(libigraph-dev)
           pkg-config --exists re2    2>/dev/null || NEED+=(libre2-dev)
           if [ ${#NEED[@]} -eq 0 ]; then
             echo "[deps] all present — skipping apt"
@@ -243,6 +244,19 @@ jobs:
       - name: Install pybind11
         shell: bash -l {0}
         run: python -m pip install pybind11
+
+      - name: Cache build/core
+        uses: actions/cache@v4
+        with:
+          path: build/core
+          # Reuse the build dir whenever core sources, CMakeLists, and the
+          # vendored c-igraph pin are unchanged. c-igraph compile is the
+          # bulk of the build cost (~30s on cold cache); cmake's own
+          # incremental cache handles partial rebuilds when only our .cpp
+          # files change.
+          key: core-${{ runner.os }}-${{ hashFiles('core/**/*.cpp','core/**/*.h','core/CMakeLists.txt','core/bindings/*.cpp') }}
+          restore-keys: |
+            core-${{ runner.os }}-
 
       - name: Build core/ (pybind)
         shell: bash -l {0}
@@ -260,10 +274,11 @@ jobs:
         # Force the dynamic loader to resolve libstdc++ against the same
         # GCC that compiled our pybind .so.  Any conda env on the runner
         # may carry an older libstdc++ whose GLIBCXX_* tags don't cover
-        # the symbols our build references; libigraph/libre2 also drag
-        # libstdc++ in transitively so a runtime override is required.
-        # `gcc -print-file-name` yields the distro-appropriate path on
-        # any Linux host (Ubuntu, RHEL, Arch, ...).
+        # the symbols our build references.
+        #
+        # (No libigraph PRELOAD needed: c-igraph is vendored privately
+        # into codeminer_core.so via --exclude-libs,ALL, so it cannot
+        # clash with the c-igraph that Python's `igraph` wheel bundles.)
         run: |
           SYS_STDCPP="$(gcc -print-file-name=libstdc++.so.6 2>/dev/null || true)"
           if [ -e "$SYS_STDCPP" ]; then

--- a/codeminer/graph/code_graph.py
+++ b/codeminer/graph/code_graph.py
@@ -26,17 +26,60 @@ from ..types import (
 #
 # v2 (main): adds file_to_vertices index + new pickle keys
 # v3 (this branch): edges carry anchor_file / anchor_line; range indexes
-#                   (file_nodes / file_edge_anchors) pickled with graph
+#                   (file_nodes / file_edge_anchors) pickled with graph;
+#                   unified_to_names aux dict (display -> identity names)
 _SCHEMA_VERSION = 3
 
 
-@dataclass
-class RangeQueryResult:
-    """Result of CodeGraph.query_range — three lists of igraph ids."""
+@dataclass(slots=True)
+class NodeRef:
+    """Resolved vertex record returned by range/symbol queries.
 
-    defined: List[int] = field(default_factory=list)   # node ids
-    outgoing: List[int] = field(default_factory=list)  # edge ids, anchor in range
-    incoming: List[int] = field(default_factory=list)  # edge ids, target def in range
+    Carries identity (`name`), display (`unified_name`), span, and kind so
+    consumers don't poke `graph.vs[vid][...]` directly.
+    """
+
+    vid: int
+    name: str
+    unified_name: str
+    file: str
+    start_line: int
+    end_line: int
+    kind: str
+
+
+@dataclass(slots=True)
+class EdgeRef:
+    """Resolved edge record returned by range queries.
+
+    `anchor_file`/`anchor_line` are populated only for REFERENCE edges
+    (see anchor invariants in `query_range` docstring).
+    """
+
+    eid: int
+    source_vid: int
+    target_vid: int
+    edge_kind: str
+    anchor_file: Optional[str] = None
+    anchor_line: Optional[int] = None
+
+
+@dataclass(slots=True)
+class RangeQueryResult:
+    """Result of CodeGraph.query_range — typed records, not raw ids.
+
+    Anchor invariants (also enforced in `query_range`'s docstring):
+        (i)   anchor_file == source vertex's file (anchor lives at the call
+              site, never the target).
+        (ii)  anchor_file/anchor_line are meaningful only on REFERENCE edges;
+              CONTAIN edges leave both fields None.
+        (iii) outgoing ∩ incoming = ∅ for any single query (call site and
+              target are in distinct scopes by definition).
+    """
+
+    defined: List[NodeRef] = field(default_factory=list)
+    outgoing: List[EdgeRef] = field(default_factory=list)
+    incoming: List[EdgeRef] = field(default_factory=list)
 
 
 class CodeGraph:
@@ -63,6 +106,11 @@ class CodeGraph:
         # _file_edge_anchors[file] -> sorted list of (anchor_line, eid).
         self._file_nodes: Dict[str, List[Tuple[int, int, int]]] = {}
         self._file_edge_anchors: Dict[str, List[Tuple[int, int]]] = {}
+
+        # Aux: unified_name (display, may collide) -> list of identity names.
+        # Populated by build_range_indexes(). Pickled with the graph.
+        # Consumers disambiguate via file context (this layer just lists candidates).
+        self._unified_to_names: Dict[str, List[str]] = {}
 
     def add_file_node(self, file_path):
         """
@@ -209,31 +257,19 @@ class CodeGraph:
                 # Scope is still active
                 break
 
-    def add_containment_edge(
-        self,
-        target_symbol,
-        anchor_file: Optional[str] = None,
-        anchor_line: Optional[int] = None,
-    ):
+    def add_containment_edge(self, target_symbol):
         """
         Add a containment edge from current scope to a symbol.
 
+        CONTAIN edges deliberately carry no anchor — containment is a
+        structural relation, not a call/reference site. (See anchor invariant
+        ii on `query_range`.)
+
         Args:
-            target_symbol: Symbol being contained
-            anchor_file: File where the contained symbol is declared (optional)
-            anchor_line: 0-based line of the declaration (optional)
+            target_symbol: Symbol being contained.
         """
         # Use the current scope directly (not parent scope)
-        parent_scope = self.current_scope
-        if anchor_file is None:
-            anchor_file = self.current_file
-        self._add_edge(
-            parent_scope,
-            target_symbol,
-            EDGE_TYPE_CONTAIN,
-            anchor_file=anchor_file,
-            anchor_line=anchor_line,
-        )
+        self._add_edge(self.current_scope, target_symbol, EDGE_TYPE_CONTAIN)
 
     def _add_vertex(self, name, attributes=None):
         """
@@ -280,10 +316,18 @@ class CodeGraph:
         """
         Add an edge between two vertices.
 
-        Multiple edges between the same `(source, target)` pair are allowed —
-        each call creates a new edge. Pass `anchor_file` / `anchor_line` to
-        record where the reference originated (e.g., the line of a call site);
-        these are used by `build_range_indexes()` to support range queries.
+        Anchored edges (those carrying ``anchor_file`` / ``anchor_line``) are
+        intentionally multi-edge — each call site keeps its own edge so range
+        queries can address them individually. Pass ``anchor_file`` /
+        ``anchor_line`` to record where the reference originated (e.g., the
+        line of a call site); these feed ``build_range_indexes()``.
+
+        Structural edges WITHOUT anchor info (CONTAIN edges, file/dir
+        containment, etc.) are deduped by ``(source, target)`` — repeating
+        them adds no information and would inflate the graph for languages
+        like Rust where SCIP records the same containment site twice (struct
+        decl + impl block). The C++ ``batch_add_edges`` does the same dedup
+        for parity.
 
         Args:
             source_name: Name of the source vertex
@@ -293,7 +337,7 @@ class CodeGraph:
             anchor_line: 0-based line number of the call/reference site (optional)
 
         Returns:
-            Edge ID of the newly created edge.
+            Edge ID of the newly created (or already-existing) edge.
         """
         # Make sure both vertices exist
         source_id = (
@@ -307,7 +351,22 @@ class CodeGraph:
             else self.name_to_vertex[target_name]
         )
 
-        # Add edge — multi-edges allowed; no dedup.
+        # Structural edges (no anchor) — dedup by (source, target). Mirrors the
+        # C++ `batch_add_edges` structural dedup (see core/code_graph.cpp).
+        is_structural = anchor_file is None and anchor_line is None
+        if is_structural:
+            for eid in self.graph.incident(source_id, mode="out"):
+                edge = self.graph.es[eid]
+                if edge.target == target_id and edge["type"] == edge_type:
+                    eattrs = edge.attributes()
+                    if (
+                        eattrs.get("anchor_file") is None
+                        and eattrs.get("anchor_line") is None
+                    ):
+                        return eid
+
+        # Add edge — multi-edges allowed for anchored edges; structural have
+        # been deduped above.
         self.graph.add_edges([(source_id, target_id)])
         edge_id = self.graph.ecount() - 1
 
@@ -357,48 +416,128 @@ class CodeGraph:
             edges[f].sort()
         self._file_edge_anchors = dict(edges)
 
+        unified: Dict[str, List[str]] = defaultdict(list)
+        for vid in range(self.graph.vcount()):
+            v = self.graph.vs[vid]
+            uname = v.attributes().get("unified_name")
+            if uname:
+                unified[uname].append(v["name"])
+        self._unified_to_names = dict(unified)
+
     def query_range(
-        self, file: str, start_line: int, end_line: int
+        self,
+        file: str,
+        start_line: int,
+        end_line: int,
+        kinds: Optional[set] = None,
+        depth: int = 1,
     ) -> RangeQueryResult:
         """Query the graph by source-file line range (LSP-aligned).
 
-        Returns three lists of igraph ids:
-        - `defined`: vids whose def range overlaps `[start_line, end_line]`
-          (overlap semantics — matches IDE outline behavior; nested scopes
-          are all returned).
-        - `outgoing`: eids whose `anchor_file == file` and
-          `anchor_line ∈ [start_line, end_line]` — call sites / references
-          originating inside the range.
-        - `incoming`: eids pointing into any node in `defined` — references
-          *to* symbols defined in the range, regardless of where they
-          originate. No separate index; uses `igraph.incident(mode='in')`.
+        Args:
+            file: source file (graph-relative path).
+            start_line, end_line: inclusive 0-based line span.
+            kinds: edge kinds to include in `outgoing` AND `incoming`.
+                Defaults to `{EDGE_TYPE_REFERENCE}` — CONTAIN edges have no
+                meaningful anchor and are excluded by default. Pass an
+                explicit set (e.g. `{EDGE_TYPE_REFERENCE, EDGE_TYPE_CONTAIN}`)
+                to opt in.
+            depth: reserved for future multi-hop expansion. Only `depth=1`
+                is supported in v1; raises NotImplementedError otherwise.
 
-        Build `build_range_indexes()` must have been called once (decoder
-        and patcher hooks do this automatically; loaded graphs carry the
-        indexes in their pickle).
+        Returns: RangeQueryResult with typed `NodeRef`/`EdgeRef` records.
+
+        Anchor invariants:
+            (i)   anchor_file == source.file (anchor lives at the call site,
+                  never the target).
+            (ii)  anchor_* is meaningful only on EDGE_TYPE_REFERENCE; CONTAIN
+                  edges leave both fields None.
+            (iii) outgoing ∩ incoming = ∅ for any single query (call site
+                  and target are in distinct scopes by definition).
         """
-        # defined: brute-force overlap scan over per-file node list.
-        # Per-file symbol counts are typically 10–1000; this stays well
-        # under 0.1 ms even on the largest files.
-        nodes = self._file_nodes.get(file, [])
-        defined = [vid for s, e, vid in nodes if s <= end_line and e >= start_line]
+        if depth != 1:
+            raise NotImplementedError(
+                f"query_range supports only depth=1 in v1; got depth={depth}"
+            )
+        if kinds is None:
+            kinds = {EDGE_TYPE_REFERENCE}
 
-        # outgoing: bisect on the sorted (anchor_line, eid) list.
-        # The (line, -1) / (line, +inf) sentinel pairs ensure we capture
-        # all edges on the boundary lines regardless of eid ordering.
+        # defined: brute-force overlap on per-file node list.
+        nodes = self._file_nodes.get(file, [])
+        defined_vids = [vid for s, e, vid in nodes if s <= end_line and e >= start_line]
+        defined = [self._build_node_ref(vid) for vid in defined_vids]
+
+        # outgoing: bisect on sorted (anchor_line, eid) list, then filter by kind.
         arr = self._file_edge_anchors.get(file, [])
         lo = bisect.bisect_left(arr, (start_line, -1))
         hi = bisect.bisect_right(arr, (end_line, float("inf")))
-        outgoing = [eid for _, eid in arr[lo:hi]]
+        outgoing: List[EdgeRef] = []
+        for _, eid in arr[lo:hi]:
+            edge = self.graph.es[eid]
+            if edge["type"] in kinds:
+                outgoing.append(self._build_edge_ref(eid))
 
-        # incoming: use igraph's adjacency directly — no separate index.
-        incoming: List[int] = []
-        for vid in defined:
-            incoming.extend(self.graph.incident(vid, mode="in"))
+        # incoming: walk igraph adjacency directly; carry target_vid so the
+        # consumer can map the inbound edge back to which defined node it hit.
+        incoming: List[EdgeRef] = []
+        for vid in defined_vids:
+            for eid in self.graph.incident(vid, mode="in"):
+                edge = self.graph.es[eid]
+                if edge["type"] in kinds:
+                    incoming.append(self._build_edge_ref(eid))
 
-        return RangeQueryResult(
-            defined=defined, outgoing=outgoing, incoming=incoming
+        return RangeQueryResult(defined=defined, outgoing=outgoing, incoming=incoming)
+
+    def _build_node_ref(self, vid: int) -> NodeRef:
+        v = self.graph.vs[vid]
+        attrs = v.attributes()
+        return NodeRef(
+            vid=vid,
+            name=v["name"],
+            unified_name=attrs.get("unified_name", ""),
+            file=attrs.get("file", ""),
+            start_line=attrs.get("start_line", 0),
+            end_line=attrs.get("end_line", 0),
+            kind=attrs.get("type", ""),
         )
+
+    def _build_edge_ref(self, eid: int) -> EdgeRef:
+        edge = self.graph.es[eid]
+        attrs = edge.attributes()
+        return EdgeRef(
+            eid=eid,
+            source_vid=edge.source,
+            target_vid=edge.target,
+            edge_kind=edge["type"],
+            anchor_file=attrs.get("anchor_file"),
+            anchor_line=attrs.get("anchor_line"),
+        )
+
+    def query_range_by_symbol(
+        self,
+        name: str,
+        kinds: Optional[set] = None,
+        depth: int = 1,
+    ) -> RangeQueryResult:
+        """Range-query by symbol identity (`name`).
+
+        Resolves `name` -> vid -> `(file, start_line, end_line)` and forwards
+        to `query_range`. `name` is the globally-unique identity attribute
+        (semi-raw SCIP symbol), not the `unified_name` display.
+
+        Returns an empty RangeQueryResult if the symbol is unknown or has
+        no associated file/range (e.g. a SCIP reference-only vertex).
+        """
+        vid = self.name_to_vertex.get(name)
+        if vid is None:
+            return RangeQueryResult()
+        attrs = self.graph.vs[vid].attributes()
+        f = attrs.get("file")
+        s = attrs.get("start_line")
+        e = attrs.get("end_line")
+        if f is None or s is None or e is None:
+            return RangeQueryResult()
+        return self.query_range(f, s, e, kinds=kinds, depth=depth)
 
     # ------------------------------------------------------------------
 
@@ -426,6 +565,7 @@ class CodeGraph:
             "name_to_vertex": self.name_to_vertex,
             "file_nodes": self._file_nodes,
             "file_edge_anchors": self._file_edge_anchors,
+            "unified_to_names": self._unified_to_names,
         }
 
         with open(output_path, "wb") as f:
@@ -462,6 +602,7 @@ class CodeGraph:
         graph_instance.name_to_vertex = data.get("name_to_vertex", {})
         graph_instance._file_nodes = data.get("file_nodes", {})
         graph_instance._file_edge_anchors = data.get("file_edge_anchors", {})
+        graph_instance._unified_to_names = data.get("unified_to_names", {})
 
         return graph_instance
 

--- a/codeminer/graph/code_graph.py
+++ b/codeminer/graph/code_graph.py
@@ -1,4 +1,8 @@
+import bisect
 import pickle
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
 
 import igraph as ig
 import matplotlib.pyplot as plt
@@ -19,7 +23,20 @@ from ..types import (
 # Bump when the persisted graph schema changes (vertex/edge attributes,
 # top-level pickle keys). load_graph() refuses mismatching pickles so stale
 # caches surface as a loud error instead of silent attribute drift.
-_SCHEMA_VERSION = 2
+#
+# v2 (main): adds file_to_vertices index + new pickle keys
+# v3 (this branch): edges carry anchor_file / anchor_line; range indexes
+#                   (file_nodes / file_edge_anchors) pickled with graph
+_SCHEMA_VERSION = 3
+
+
+@dataclass
+class RangeQueryResult:
+    """Result of CodeGraph.query_range — three lists of igraph ids."""
+
+    defined: List[int] = field(default_factory=list)   # node ids
+    outgoing: List[int] = field(default_factory=list)  # edge ids, anchor in range
+    incoming: List[int] = field(default_factory=list)  # edge ids, target def in range
 
 
 class CodeGraph:
@@ -39,6 +56,13 @@ class CodeGraph:
         self.symbol_ranges = {}
         # Map symbol names to vertex IDs
         self.name_to_vertex = {}
+
+        # Range indexes — per-file, populated by build_range_indexes() after the
+        # graph is fully built or after a patcher batch. Pickled with the graph.
+        # _file_nodes[file] -> list of (start_line, end_line, vid), unsorted.
+        # _file_edge_anchors[file] -> sorted list of (anchor_line, eid).
+        self._file_nodes: Dict[str, List[Tuple[int, int, int]]] = {}
+        self._file_edge_anchors: Dict[str, List[Tuple[int, int]]] = {}
 
     def add_file_node(self, file_path):
         """
@@ -99,7 +123,14 @@ class CodeGraph:
                 },
             )
 
-    def add_symbol_reference(self, symbol, module_path=None, symbol_type=None):
+    def add_symbol_reference(
+        self,
+        symbol,
+        module_path=None,
+        symbol_type=None,
+        anchor_file: Optional[str] = None,
+        anchor_line: Optional[int] = None,
+    ):
         """
         Add a reference to a symbol.
 
@@ -108,6 +139,8 @@ class CodeGraph:
             module_path: Path of the module containing the symbol (optional)
             symbol_type: Type of symbol
                 (NODE_TYPE_CLASS, NODE_TYPE_METHOD, NODE_TYPE_FUNCTION) (optional)
+            anchor_file: File where the reference site is located (optional)
+            anchor_line: 0-based line of the reference site (optional)
         """
         # If the symbol doesn't exist, create it without range info
         if symbol not in self.name_to_vertex:
@@ -115,8 +148,16 @@ class CodeGraph:
             node_type = symbol_type if symbol_type else NODE_TYPE_SYMBOL
             self._add_vertex(symbol, {"type": node_type, "file": file_attr})
 
-        # Add reference edge
-        self._add_edge(self.current_scope, symbol, EDGE_TYPE_REFERENCE)
+        # Add reference edge with anchor info (defaults: current file)
+        if anchor_file is None:
+            anchor_file = self.current_file
+        self._add_edge(
+            self.current_scope,
+            symbol,
+            EDGE_TYPE_REFERENCE,
+            anchor_file=anchor_file,
+            anchor_line=anchor_line,
+        )
 
     def update_current_scope(self, symbol, start_line=None, end_line=None):
         """
@@ -168,16 +209,31 @@ class CodeGraph:
                 # Scope is still active
                 break
 
-    def add_containment_edge(self, target_symbol):
+    def add_containment_edge(
+        self,
+        target_symbol,
+        anchor_file: Optional[str] = None,
+        anchor_line: Optional[int] = None,
+    ):
         """
         Add a containment edge from current scope to a symbol.
 
         Args:
             target_symbol: Symbol being contained
+            anchor_file: File where the contained symbol is declared (optional)
+            anchor_line: 0-based line of the declaration (optional)
         """
         # Use the current scope directly (not parent scope)
         parent_scope = self.current_scope
-        self._add_edge(parent_scope, target_symbol, EDGE_TYPE_CONTAIN)
+        if anchor_file is None:
+            anchor_file = self.current_file
+        self._add_edge(
+            parent_scope,
+            target_symbol,
+            EDGE_TYPE_CONTAIN,
+            anchor_file=anchor_file,
+            anchor_line=anchor_line,
+        )
 
     def _add_vertex(self, name, attributes=None):
         """
@@ -213,17 +269,31 @@ class CodeGraph:
 
         return vertex_id
 
-    def _add_edge(self, source_name, target_name, edge_type):
+    def _add_edge(
+        self,
+        source_name,
+        target_name,
+        edge_type,
+        anchor_file: Optional[str] = None,
+        anchor_line: Optional[int] = None,
+    ):
         """
         Add an edge between two vertices.
+
+        Multiple edges between the same `(source, target)` pair are allowed —
+        each call creates a new edge. Pass `anchor_file` / `anchor_line` to
+        record where the reference originated (e.g., the line of a call site);
+        these are used by `build_range_indexes()` to support range queries.
 
         Args:
             source_name: Name of the source vertex
             target_name: Name of the target vertex
             edge_type: Type of the edge (e.g., "reference", "contain")
+            anchor_file: File containing the call/reference site (optional)
+            anchor_line: 0-based line number of the call/reference site (optional)
 
         Returns:
-            Edge ID
+            Edge ID of the newly created edge.
         """
         # Make sure both vertices exist
         source_id = (
@@ -237,21 +307,100 @@ class CodeGraph:
             else self.name_to_vertex[target_name]
         )
 
-        # Check if the edge already exists
-        if self.graph.are_adjacent(source_id, target_id):
-            # Edge already exists, return its ID
-            edge_id = self.graph.get_eid(source_id, target_id, error=False)
-            if edge_id is not None:
-                return edge_id
-
-        # Add edge
+        # Add edge — multi-edges allowed; no dedup.
         self.graph.add_edges([(source_id, target_id)])
         edge_id = self.graph.ecount() - 1
 
-        # Set edge type
+        # Set edge attributes
         self.graph.es[edge_id]["type"] = edge_type
+        if anchor_file is not None:
+            self.graph.es[edge_id]["anchor_file"] = anchor_file
+        if anchor_line is not None:
+            self.graph.es[edge_id]["anchor_line"] = anchor_line
 
         return edge_id
+
+    # ------------------------------------------------------------------
+    # Range indexes (LSP-aligned line-range queries)
+    # ------------------------------------------------------------------
+
+    def build_range_indexes(self) -> None:
+        """Rebuild per-file line-range indexes from current graph state.
+
+        Call this after the graph is fully constructed by a decoder, and
+        again after any incremental patcher batch. The two indexes are
+        pickled with the graph by `save_graph`, so subsequent `load_graph`
+        calls do not need to rebuild.
+
+        Cost: O(V + E) — one linear pass over vertices and edges.
+        """
+        nodes: Dict[str, List[Tuple[int, int, int]]] = defaultdict(list)
+        for vid in range(self.graph.vcount()):
+            v = self.graph.vs[vid]
+            attrs = v.attributes()
+            f = attrs.get("file")
+            s = attrs.get("start_line")
+            e = attrs.get("end_line")
+            if f and s is not None and e is not None:
+                nodes[f].append((s, e, vid))
+        self._file_nodes = dict(nodes)
+
+        edges: Dict[str, List[Tuple[int, int]]] = defaultdict(list)
+        for eid in range(self.graph.ecount()):
+            edge = self.graph.es[eid]
+            attrs = edge.attributes()
+            f = attrs.get("anchor_file")
+            line = attrs.get("anchor_line")
+            if f and line is not None:
+                edges[f].append((line, eid))
+        for f in edges:
+            edges[f].sort()
+        self._file_edge_anchors = dict(edges)
+
+    def query_range(
+        self, file: str, start_line: int, end_line: int
+    ) -> RangeQueryResult:
+        """Query the graph by source-file line range (LSP-aligned).
+
+        Returns three lists of igraph ids:
+        - `defined`: vids whose def range overlaps `[start_line, end_line]`
+          (overlap semantics — matches IDE outline behavior; nested scopes
+          are all returned).
+        - `outgoing`: eids whose `anchor_file == file` and
+          `anchor_line ∈ [start_line, end_line]` — call sites / references
+          originating inside the range.
+        - `incoming`: eids pointing into any node in `defined` — references
+          *to* symbols defined in the range, regardless of where they
+          originate. No separate index; uses `igraph.incident(mode='in')`.
+
+        Build `build_range_indexes()` must have been called once (decoder
+        and patcher hooks do this automatically; loaded graphs carry the
+        indexes in their pickle).
+        """
+        # defined: brute-force overlap scan over per-file node list.
+        # Per-file symbol counts are typically 10–1000; this stays well
+        # under 0.1 ms even on the largest files.
+        nodes = self._file_nodes.get(file, [])
+        defined = [vid for s, e, vid in nodes if s <= end_line and e >= start_line]
+
+        # outgoing: bisect on the sorted (anchor_line, eid) list.
+        # The (line, -1) / (line, +inf) sentinel pairs ensure we capture
+        # all edges on the boundary lines regardless of eid ordering.
+        arr = self._file_edge_anchors.get(file, [])
+        lo = bisect.bisect_left(arr, (start_line, -1))
+        hi = bisect.bisect_right(arr, (end_line, float("inf")))
+        outgoing = [eid for _, eid in arr[lo:hi]]
+
+        # incoming: use igraph's adjacency directly — no separate index.
+        incoming: List[int] = []
+        for vid in defined:
+            incoming.extend(self.graph.incident(vid, mode="in"))
+
+        return RangeQueryResult(
+            defined=defined, outgoing=outgoing, incoming=incoming
+        )
+
+    # ------------------------------------------------------------------
 
     def add_root_node(self, project_root):
         """Add the root node to the graph"""
@@ -275,6 +424,8 @@ class CodeGraph:
             "graph": self.graph,  # igraph objects are picklable
             "symbol_ranges": self.symbol_ranges,
             "name_to_vertex": self.name_to_vertex,
+            "file_nodes": self._file_nodes,
+            "file_edge_anchors": self._file_edge_anchors,
         }
 
         with open(output_path, "wb") as f:
@@ -309,6 +460,8 @@ class CodeGraph:
         graph_instance.graph = data["graph"]
         graph_instance.symbol_ranges = data.get("symbol_ranges", {})
         graph_instance.name_to_vertex = data.get("name_to_vertex", {})
+        graph_instance._file_nodes = data.get("file_nodes", {})
+        graph_instance._file_edge_anchors = data.get("file_edge_anchors", {})
 
         return graph_instance
 

--- a/codeminer/graph/code_graph.py
+++ b/codeminer/graph/code_graph.py
@@ -390,8 +390,11 @@ class CodeGraph:
         for e in self.graph.es:
             attrs = e.attributes()
             key = (
-                e.source, e.target, attrs.get("type"),
-                attrs.get("anchor_file"), attrs.get("anchor_line"),
+                e.source,
+                e.target,
+                attrs.get("type"),
+                attrs.get("anchor_file"),
+                attrs.get("anchor_line"),
             )
             # Earlier eid wins on duplicate keys; igraph batch paths can
             # produce parallel edges with identical keys before this index
@@ -494,9 +497,12 @@ class CodeGraph:
         defined = [self._build_node_ref(vid) for vid in defined_vids]
 
         # outgoing: bisect on sorted (anchor_line, eid) list, then filter by kind.
+        # Use bisect_left for the upper bound: bisect_right would include
+        # `(end_line+1, 0)` (eid==0 entries at the line just past the query),
+        # leaking an off-anchor edge into the slice.
         arr = self._file_edge_anchors.get(file, [])
         lo = bisect.bisect_left(arr, (start_line, -1))
-        hi = bisect.bisect_right(arr, (end_line + 1, 0))
+        hi = bisect.bisect_left(arr, (end_line + 1, 0))
         outgoing: List[EdgeRef] = []
         for _, eid in arr[lo:hi]:
             edge = self.graph.es[eid]

--- a/codeminer/graph/code_graph.py
+++ b/codeminer/graph/code_graph.py
@@ -73,8 +73,9 @@ class RangeQueryResult:
               site, never the target).
         (ii)  anchor_file/anchor_line are meaningful only on REFERENCE edges;
               CONTAIN edges leave both fields None.
-        (iii) outgoing ∩ incoming = ∅ for any single query (call site and
-              target are in distinct scopes by definition).
+        (iii) outgoing ∩ incoming = ∅ — query_range filters self-edges
+              (source == target) out of `incoming` so a recursive call
+              site appears once, in `outgoing`.
     """
 
     defined: List[NodeRef] = field(default_factory=list)
@@ -111,6 +112,13 @@ class CodeGraph:
         # Populated by build_range_indexes(). Pickled with the graph.
         # Consumers disambiguate via file context (this layer just lists candidates).
         self._unified_to_names: Dict[str, List[str]] = {}
+
+        # Edge dedup index: (src_id, tgt_id, type, anchor_file, anchor_line) -> eid.
+        # Populated lazily on first _add_edge / invalidated to None when callers
+        # delete edges or vertices (igraph compacts eids on delete, so cached
+        # eids would point at wrong edges). Lookup via _ensure_edge_index().
+        # Not pickled — rebuilt on demand after load.
+        self._edge_index: Optional[Dict[Tuple, int]] = None
 
     def add_file_node(self, file_path):
         """
@@ -351,21 +359,15 @@ class CodeGraph:
             else self.name_to_vertex[target_name]
         )
 
-        # Dedup by (src, tgt, type, anchor_file, anchor_line). Structural
-        # edges (no anchor) collapse on (src, tgt, type). Mirrors C++
-        # add_edge / batch_add_edges.
-        is_structural = anchor_file is None and anchor_line is None
-        for eid in self.graph.incident(source_id, mode="out"):
-            edge = self.graph.es[eid]
-            if edge.target != target_id or edge["type"] != edge_type:
-                continue
-            eattrs = edge.attributes()
-            if is_structural:
-                if eattrs.get("anchor_file") is None and eattrs.get("anchor_line") is None:
-                    return eid
-            elif (eattrs.get("anchor_file") == anchor_file
-                  and eattrs.get("anchor_line") == anchor_line):
-                return eid
+        # Dedup by (src, tgt, type, anchor_file, anchor_line) via O(1) hash
+        # lookup. Structural edges (no anchor) collapse on (src, tgt, type).
+        # Mirrors C++ add_edge / batch_add_edges.
+        if self._edge_index is None:
+            self._rebuild_edge_index()
+        key = (source_id, target_id, edge_type, anchor_file, anchor_line)
+        existing = self._edge_index.get(key)
+        if existing is not None:
+            return existing
 
         self.graph.add_edges([(source_id, target_id)])
         edge_id = self.graph.ecount() - 1
@@ -377,7 +379,31 @@ class CodeGraph:
         if anchor_line is not None:
             self.graph.es[edge_id]["anchor_line"] = anchor_line
 
+        self._edge_index[key] = edge_id
         return edge_id
+
+    def _rebuild_edge_index(self) -> None:
+        """Rebuild the edge dedup index by walking all current edges. O(E).
+        Called lazily after construct/load and after any operation that
+        invalidates eids (delete_edges / delete_vertices)."""
+        idx: Dict[Tuple, int] = {}
+        for e in self.graph.es:
+            attrs = e.attributes()
+            key = (
+                e.source, e.target, attrs.get("type"),
+                attrs.get("anchor_file"), attrs.get("anchor_line"),
+            )
+            # Earlier eid wins on duplicate keys; igraph batch paths can
+            # produce parallel edges with identical keys before this index
+            # existed, so first-write semantics keeps the index stable.
+            idx.setdefault(key, e.index)
+        self._edge_index = idx
+
+    def _invalidate_edge_index(self) -> None:
+        """Mark the edge index stale. Next _add_edge will rebuild it.
+        Call after any igraph delete_edges/delete_vertices — eids shift on
+        delete and cached values would point at wrong edges."""
+        self._edge_index = None
 
     # ------------------------------------------------------------------
     # Range indexes (LSP-aligned line-range queries)
@@ -470,7 +496,7 @@ class CodeGraph:
         # outgoing: bisect on sorted (anchor_line, eid) list, then filter by kind.
         arr = self._file_edge_anchors.get(file, [])
         lo = bisect.bisect_left(arr, (start_line, -1))
-        hi = bisect.bisect_right(arr, (end_line, float("inf")))
+        hi = bisect.bisect_right(arr, (end_line + 1, 0))
         outgoing: List[EdgeRef] = []
         for _, eid in arr[lo:hi]:
             edge = self.graph.es[eid]
@@ -479,10 +505,14 @@ class CodeGraph:
 
         # incoming: walk igraph adjacency directly; carry target_vid so the
         # consumer can map the inbound edge back to which defined node it hit.
+        # Self-edges (recursion) are emitted by `outgoing` already, so skip
+        # them here to keep outgoing ∩ incoming = ∅ (invariant iii).
         incoming: List[EdgeRef] = []
         for vid in defined_vids:
             for eid in self.graph.incident(vid, mode="in"):
                 edge = self.graph.es[eid]
+                if edge.source == edge.target:
+                    continue
                 if edge["type"] in kinds:
                     incoming.append(self._build_edge_ref(eid))
 

--- a/codeminer/graph/code_graph.py
+++ b/codeminer/graph/code_graph.py
@@ -351,22 +351,22 @@ class CodeGraph:
             else self.name_to_vertex[target_name]
         )
 
-        # Structural edges (no anchor) — dedup by (source, target). Mirrors the
-        # C++ `batch_add_edges` structural dedup (see core/code_graph.cpp).
+        # Dedup by (src, tgt, type, anchor_file, anchor_line). Structural
+        # edges (no anchor) collapse on (src, tgt, type). Mirrors C++
+        # add_edge / batch_add_edges.
         is_structural = anchor_file is None and anchor_line is None
-        if is_structural:
-            for eid in self.graph.incident(source_id, mode="out"):
-                edge = self.graph.es[eid]
-                if edge.target == target_id and edge["type"] == edge_type:
-                    eattrs = edge.attributes()
-                    if (
-                        eattrs.get("anchor_file") is None
-                        and eattrs.get("anchor_line") is None
-                    ):
-                        return eid
+        for eid in self.graph.incident(source_id, mode="out"):
+            edge = self.graph.es[eid]
+            if edge.target != target_id or edge["type"] != edge_type:
+                continue
+            eattrs = edge.attributes()
+            if is_structural:
+                if eattrs.get("anchor_file") is None and eattrs.get("anchor_line") is None:
+                    return eid
+            elif (eattrs.get("anchor_file") == anchor_file
+                  and eattrs.get("anchor_line") == anchor_line):
+                return eid
 
-        # Add edge — multi-edges allowed for anchored edges; structural have
-        # been deduped above.
         self.graph.add_edges([(source_id, target_id)])
         edge_id = self.graph.ecount() - 1
 

--- a/codeminer/graph/incremental/change_mgr.py
+++ b/codeminer/graph/incremental/change_mgr.py
@@ -89,11 +89,13 @@ def get_changed_line_ranges(
     file_path: str,
     base_commit: str,
     target_commit: str = "HEAD",
-) -> list[tuple[int, int]]:
+) -> list[tuple[int, int, int, int]]:
     """Get changed line ranges between two commits for a single file.
 
-    Uses ``git diff -U0`` to extract exact changed line ranges in the
-    target (new) version of the file.
+    Uses ``git diff -U0`` to extract both the OLD and NEW side of each hunk
+    so callers can compare line counts (case 3 vs case 4 in the patcher
+    classification): if ``(old_end - old_start) == (new_end - new_start)``,
+    the body length is preserved and the patcher's fast path is safe.
 
     Args:
         project_root: Path to the git repository root.
@@ -102,7 +104,10 @@ def get_changed_line_ranges(
         target_commit: Target commit hash or ref (default HEAD).
 
     Returns:
-        List of (start_line, end_line) tuples (0-indexed, inclusive).
+        List of (old_start, old_end, new_start, new_end) tuples
+        (0-indexed, inclusive). For pure-insertion hunks the old side
+        collapses to a marker (old_start == old_end); for pure-deletion
+        hunks the new side collapses similarly.
     """
     try:
         output = subprocess.check_output(
@@ -123,14 +128,34 @@ def get_changed_line_ranges(
         logger.debug(f"git diff failed for {file_path}")
         return []
 
-    ranges = []
-    for match in re.finditer(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", output):
-        start = int(match.group(1)) - 1  # Convert to 0-indexed
-        count = int(match.group(2)) if match.group(2) else 1
-        if count == 0:
-            # Pure deletion: mark the deletion point
-            ranges.append((max(0, start - 1), max(0, start - 1)))
-            continue
-        end = start + count - 1
-        ranges.append((start, end))
+    ranges: list[tuple[int, int, int, int]] = []
+    pattern = r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@"
+    for match in re.finditer(pattern, output):
+        old_start_1 = int(match.group(1))
+        old_count = int(match.group(2)) if match.group(2) else 1
+        new_start_1 = int(match.group(3))
+        new_count = int(match.group(4)) if match.group(4) else 1
+
+        old_start_0 = old_start_1 - 1
+        new_start_0 = new_start_1 - 1
+
+        # Preserve the historical "deletion marker" quirk: pure-deletion
+        # hunks (new_count==0) land at max(0, new_start_0 - 1) on the new
+        # side, since there's no actual new line to point at.
+        if new_count == 0:
+            new_marker = max(0, new_start_0 - 1)
+            new_s, new_e = new_marker, new_marker
+        else:
+            new_s = new_start_0
+            new_e = new_start_0 + new_count - 1
+
+        # Mirror semantics for pure-insertion hunks on the old side.
+        if old_count == 0:
+            old_marker = max(0, old_start_0 - 1)
+            old_s, old_e = old_marker, old_marker
+        else:
+            old_s = old_start_0
+            old_e = old_start_0 + old_count - 1
+
+        ranges.append((old_s, old_e, new_s, new_e))
     return ranges

--- a/codeminer/graph/incremental/graph_patcher.py
+++ b/codeminer/graph/incremental/graph_patcher.py
@@ -30,6 +30,7 @@ def _create_patcher(
     language: str,
     project_root: str,
     code_graph: Optional[CodeGraph],
+    mode: str = "symbol",
 ) -> PatcherBase:
     """Factory: create language-specific patcher."""
     from .patcher_cpp import PatcherCpp
@@ -51,7 +52,7 @@ def _create_patcher(
     cls = PATCHER_MAP.get(language)
     if cls is None:
         raise ValueError(f"Unsupported language: {language}")
-    return cls(project_root, code_graph or CodeGraph(project_root))
+    return cls(project_root, code_graph or CodeGraph(project_root), mode=mode)
 
 
 class GraphPatcher:
@@ -75,10 +76,14 @@ class GraphPatcher:
         project_root: str,
         code_graph: Optional[CodeGraph],
         language: str,
+        mode: str = "symbol",
     ):
         self.project_root = project_root
         self.language = language
-        self._impl: PatcherBase = _create_patcher(language, project_root, code_graph)
+        self.mode = mode
+        self._impl: PatcherBase = _create_patcher(
+            language, project_root, code_graph, mode=mode
+        )
 
     @property
     def code_graph(self) -> CodeGraph:
@@ -126,8 +131,12 @@ class GraphPatcher:
         file_path: str,
         base_commit: str,
         target_commit: str = "HEAD",
-    ) -> list[tuple[int, int]]:
-        """Get line ranges changed between two commits."""
+    ) -> list[tuple[int, int, int, int]]:
+        """Get line ranges changed between two commits.
+
+        Each hunk is reported as (old_start, old_end, new_start, new_end)
+        in 0-indexed inclusive form so callers can compare line counts.
+        """
         return change_mgr.get_changed_line_ranges(
             project_root, file_path, base_commit, target_commit
         )

--- a/codeminer/graph/incremental/lsp_client.py
+++ b/codeminer/graph/incremental/lsp_client.py
@@ -9,6 +9,7 @@ Supports the subset of LSP needed for incremental graph updates:
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
 import select
@@ -36,6 +37,15 @@ _LSP_PROFILE_FH = None
 _LSP_PROFILE_PATH: str | None = None
 
 
+@atexit.register
+def _close_profile_fh() -> None:
+    if _LSP_PROFILE_FH is not None:
+        try:
+            _LSP_PROFILE_FH.close()
+        except Exception:
+            pass
+
+
 def _profile_log(method: str, abs_file: str, line, character, elapsed_s: float, n_results) -> None:
     """Append one call to the file at ``$LSP_PROFILE_PATH``.
 
@@ -51,7 +61,7 @@ def _profile_log(method: str, abs_file: str, line, character, elapsed_s: float, 
             try:
                 _LSP_PROFILE_FH.close()
             except Exception:
-                pass
+                pass  # stale FH; close failures are harmless here
         _LSP_PROFILE_FH = None
         _LSP_PROFILE_PATH = path
         if path:
@@ -69,7 +79,7 @@ def _profile_log(method: str, abs_file: str, line, character, elapsed_s: float, 
                         "ms": round(elapsed_s * 1000, 2), "n": n_results}) + "\n"
         )
     except Exception:
-        pass
+        pass  # best-effort profile write — never break real work
 
 # LSP SymbolKind integer → human-readable name
 SYMBOL_KIND_NAMES = {

--- a/codeminer/graph/incremental/lsp_client.py
+++ b/codeminer/graph/incremental/lsp_client.py
@@ -23,6 +23,54 @@ from ...log_utils import get_logger
 
 logger = get_logger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Per-call profiling (env-controlled, zero overhead when off)
+#
+# Enable by setting ``LSP_PROFILE_PATH=/path/to/calls.jsonl``. Each call to
+# definition / references / semantic_tokens_* writes one line:
+#   {"m": method, "f": abs_file, "l": line, "c": char, "ms": elapsed_ms, "n": result_count}
+# Aggregate offline to find slow positions.
+# ---------------------------------------------------------------------------
+_LSP_PROFILE_FH = None
+_LSP_PROFILE_PATH: str | None = None
+
+
+def _profile_log(method: str, abs_file: str, line, character, elapsed_s: float, n_results) -> None:
+    """Append one call to the file at ``$LSP_PROFILE_PATH``.
+
+    Re-reads the env var each call and reopens the file when the path
+    changes — so a single Python process can cleanly switch profile
+    files between strategies (chain runner sets a fresh path per
+    (step, strategy) and expects the next calls to land in the new file).
+    """
+    global _LSP_PROFILE_FH, _LSP_PROFILE_PATH
+    path = os.environ.get("LSP_PROFILE_PATH")
+    if path != _LSP_PROFILE_PATH:
+        if _LSP_PROFILE_FH is not None:
+            try:
+                _LSP_PROFILE_FH.close()
+            except Exception:
+                pass
+        _LSP_PROFILE_FH = None
+        _LSP_PROFILE_PATH = path
+        if path:
+            try:
+                _LSP_PROFILE_FH = open(path, "a", buffering=1)  # line-buffered
+            except Exception:
+                _LSP_PROFILE_FH = None
+    if _LSP_PROFILE_FH is None:
+        return
+    try:
+        _LSP_PROFILE_FH.write(
+            json.dumps({"t": round(time.time(), 3),
+                        "m": method, "f": abs_file,
+                        "l": line, "c": character,
+                        "ms": round(elapsed_s * 1000, 2), "n": n_results}) + "\n"
+        )
+    except Exception:
+        pass
+
 # LSP SymbolKind integer → human-readable name
 SYMBOL_KIND_NAMES = {
     1: "File",
@@ -141,6 +189,11 @@ class LSPClient:
         # Populated during start() from server capabilities
         self.semantic_tokens_legend: Optional[dict] = None
         self.supports_semantic_tokens_range: bool = False
+
+        # Active $/progress tokens (set by _handle_progress, cleared by
+        # 'end' notifications). wait_until_idle() polls this for emptiness
+        # to know when LSP background work has finished.
+        self._active_progress: dict = {}
 
         # Pending request tracking: limit in-flight requests to avoid
         # overwhelming the LSP server (clangd hangs after ~570 queued requests)
@@ -341,13 +394,17 @@ class LSPClient:
     # ── LSP queries ───────────────────────────────────────────
 
     def document_symbol(
-        self, file_path: str, retries: int = 5, retry_delay: float = 5.0
+        self, file_path: str, retries: int = 0, retry_delay: float = 0.5
     ) -> list[dict]:
         """Get hierarchical document symbols for a file.
 
-        Some LSP servers (e.g. rust-analyzer) return null while the workspace
-        is still loading.  We retry a few times to wait for readiness.
+        Default ``retries=0`` — null is a legitimate "no symbols" answer
+        per LSP spec. Previous default of 5 retries × 5s sleep wasted up
+        to 25s/call when servers returned null. If the server is still
+        loading at warmup time, callers should wait at the call-site,
+        not inside this primitive.
         """
+        t0 = time.monotonic()
         self.open_document(file_path)
         abs_path = self._abs_path(file_path)
         uri = Path(abs_path).as_uri()
@@ -358,8 +415,12 @@ class LSPClient:
                 {
                     "textDocument": {"uri": uri},
                 },
+                timeout=10,  # longest non-empty observed: 138ms
             )
             if result is not None:
+                _profile_log("documentSymbol", file_path, None, None,
+                             time.monotonic() - t0,
+                             len(result) if isinstance(result, list) else 0)
                 return result
             if attempt < retries:
                 logger.debug(
@@ -368,21 +429,43 @@ class LSPClient:
                 )
                 time.sleep(retry_delay)
 
+        _profile_log("documentSymbol", file_path, None, None,
+                     time.monotonic() - t0, 0)
         return []
 
-    def references(
+    def references(self, *args, **kwargs):
+        t0 = time.monotonic()
+        out = self._references_inner(*args, **kwargs)
+        _profile_log("references", args[0] if args else kwargs.get("file_path"),
+                     args[1] if len(args) > 1 else kwargs.get("line"),
+                     args[2] if len(args) > 2 else kwargs.get("character"),
+                     time.monotonic() - t0, len(out) if out else 0)
+        return out
+
+    def _references_inner(
         self,
         file_path: str,
         line: int,
         character: int,
         include_declaration: bool = False,
-        timeout: float = 30,
-        retries: int = 3,
+        timeout: float = 10,
+        retries: int = 0,
     ) -> list[dict]:
         """Find all references to the symbol at the given position.
 
-        Retries on transient errors (e.g. 'content modified' from VFS updates).
-        Checks response buffer for late-arriving responses from prior attempts.
+        Default ``timeout=10``. Across 25 v8 trials there were 0 references
+        calls that took >10s and returned a non-empty result (longest
+        non-empty was 9.6s). Calls hitting 30s were always rust-analyzer /
+        basedpyright pathological hangs returning n=0. Cap at 10s to fail
+        fast on hangs while keeping all legitimate slow calls.
+
+        Default ``retries=0``. Per LSP 3.17 spec, null is a legitimate
+        response meaning "no references at this position". Retrying on
+        null wastes 9s (3×3s sleep) per call; with N callers many calls
+        return null and the cumulative cost was the dominant patcher
+        bottleneck. Caller-side warmup handles "server still loading".
+        Checks response buffer for late-arriving responses from prior
+        attempts.
         """
         self.open_document(file_path)
         abs_path = self._abs_path(file_path)
@@ -424,25 +507,47 @@ class LSPClient:
                     f"references failed for {file_path}:{line} ({reason}), "
                     f"retrying ({attempt + 1}/{retries})"
                 )
-                time.sleep(3)
-        logger.warning(
-            f"references failed for {file_path}:{line} " f"after {retries} retries"
-        )
+                time.sleep(0.5)
+        if retries > 0:
+            logger.warning(
+                f"references failed for {file_path}:{line} after {retries} retries"
+            )
         return []
 
-    def definition(
+    def definition(self, *args, **kwargs):
+        t0 = time.monotonic()
+        out = self._definition_inner(*args, **kwargs)
+        _profile_log("definition", args[0] if args else kwargs.get("file_path"),
+                     args[1] if len(args) > 1 else kwargs.get("line"),
+                     args[2] if len(args) > 2 else kwargs.get("character"),
+                     time.monotonic() - t0, len(out) if out else 0)
+        return out
+
+    def _definition_inner(
         self,
         file_path: str,
         line: int,
         character: int,
-        timeout: float = 30,
-        retries: int = 3,
+        timeout: float = 10,
+        retries: int = 0,
     ) -> list[dict]:
         """Go to definition of the symbol at the given position.
 
         Returns a list of Location or LocationLink objects.
-        Retries on transient errors (e.g. 'content modified' from VFS updates).
-        Checks response buffer for late-arriving responses from prior attempts.
+
+        Default ``timeout=10``: longest non-empty definition across 25 v8
+        trials was 1.9s. Hits at 30s were all rust-analyzer / basedpyright
+        timeouts on pathological positions returning n=0.
+
+        Default ``retries=0`` because the most common cause of a null
+        response is "no definition at this position" (a legitimate answer
+        for whitespace, comments, or already-resolved tokens) — NOT a
+        transient error. The previous default of 3 retries × 3s sleep
+        wasted ~9s per null token; on xarray bin=30 that pushed
+        ``reconnect_outgoing`` from a few seconds to 39s. Callers that
+        want to wait for server warmup should retry at the call-site,
+        not inside this primitive. Checks response buffer for
+        late-arriving responses from prior attempts.
         """
         self.open_document(file_path)
         abs_path = self._abs_path(file_path)
@@ -488,22 +593,30 @@ class LSPClient:
                     f"definition failed for {file_path}:{line}:{character} ({reason}), "
                     f"retrying ({attempt + 1}/{retries})"
                 )
-                time.sleep(3)
-        logger.warning(
-            f"definition failed for {file_path}:{line}:{character} "
-            f"after {retries} retries"
-        )
+                time.sleep(0.5)
+        if retries > 0:
+            logger.warning(
+                f"definition failed for {file_path}:{line}:{character} "
+                f"after {retries} retries"
+            )
         return []
 
     def semantic_tokens_full(
-        self, file_path: str, timeout: float = 60
+        self, file_path: str, timeout: float = 15
     ) -> Optional[dict]:
         """Get semantic tokens for the entire file.
 
         Returns raw response with ``data`` field (delta-encoded integers).
         Use ``decode_semantic_tokens()`` to decode.
         Returns None on timeout or error (details logged by _request).
+
+        Default timeout 15s: a server that needs longer is pathological
+        (basedpyright on sklearn's test_pls.py used to take 60s). The
+        patcher tolerates None — that file simply skips outgoing-ref
+        discovery for this run. 60s × N pathological files dominated
+        runtime before this cap.
         """
+        t0 = time.monotonic()
         self.open_document(file_path)
         abs_path = self._abs_path(file_path)
         uri = Path(abs_path).as_uri()
@@ -514,9 +627,12 @@ class LSPClient:
             },
             timeout=timeout,
         )
+        n_tokens = 0
         if result is not None:
             n_tokens = len(result.get("data", [])) // 5
             logger.debug(f"semanticTokens for {file_path}: {n_tokens} tokens")
+        _profile_log("semanticTokens/full", file_path, None, None,
+                     time.monotonic() - t0, n_tokens)
         return result
 
     def semantic_tokens_range(
@@ -531,6 +647,7 @@ class LSPClient:
         Faster than full for large files when only a small range is needed.
         Returns None if not supported or on error.
         """
+        t0 = time.monotonic()
         self.open_document(file_path)
         abs_path = self._abs_path(file_path)
         uri = Path(abs_path).as_uri()
@@ -545,12 +662,16 @@ class LSPClient:
             },
             timeout=timeout,
         )
+        n_tokens = 0
         if result is not None:
             n_tokens = len(result.get("data", [])) // 5
             logger.debug(
                 f"semanticTokens/range for {file_path} "
                 f"L{start_line}-{end_line}: {n_tokens} tokens"
             )
+        _profile_log("semanticTokens/range", file_path,
+                     start_line, end_line,
+                     time.monotonic() - t0, n_tokens)
         return result
 
     def decode_semantic_tokens(
@@ -803,14 +924,19 @@ class LSPClient:
                         )
                         continue
 
-                # Skip server notifications that we don't need
-                # (these would otherwise clog the message loop)
+                # Server notifications we don't return upstream.
                 if "method" in message and "id" not in message:
+                    if message["method"] == "$/progress":
+                        # Track LSP background work (rust-analyzer indexing,
+                        # gopls workspace setup, basedpyright analysis...)
+                        # so callers can wait_until_idle() before timed
+                        # regions instead of guessing with sleeps.
+                        self._handle_progress(message.get("params", {}))
+                        continue
                     skip_methods = {
                         "window/logMessage",
                         "window/showMessage",
                         "textDocument/publishDiagnostics",
-                        "$/progress",
                     }
                     if message["method"] in skip_methods:
                         continue
@@ -818,6 +944,67 @@ class LSPClient:
                 return message
 
         return None
+
+    # ── progress / idleness tracking ─────────────────────────────────
+    # Servers signal background work via ``$/progress`` notifications:
+    #   begin → report* → end
+    # We track active tokens; ``wait_until_idle`` polls for empty.
+
+    def _handle_progress(self, params: dict) -> None:
+        token = params.get("token")
+        if token is None:
+            return
+        kind = (params.get("value") or {}).get("kind")
+        if kind == "begin":
+            self._active_progress[token] = time.monotonic()
+        elif kind == "end":
+            self._active_progress.pop(token, None)
+        # report: keep the token active
+
+    def drain_notifications(self, timeout_s: float = 0.5) -> int:
+        """Drain any pending notifications without waiting for a response.
+
+        Returns the number of messages drained. Used by ``wait_until_idle``
+        to keep the progress map fresh while polling.
+        """
+        n = 0
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            ready, _, _ = select.select([self.process.stdout], [], [], min(remaining, 0.05))
+            if not ready:
+                break
+            msg = self._read_message(timeout=remaining)
+            if msg is None:
+                break
+            n += 1
+            # We don't dispatch unmatched responses here; just count and
+            # let _handle_progress (called inside _read_message) update state.
+        return n
+
+    def wait_until_idle(self, max_wait_s: float = 60.0, idle_grace_s: float = 1.0) -> bool:
+        """Wait until no ``$/progress`` tokens are active for ``idle_grace_s``.
+
+        Returns True if the server became idle within ``max_wait_s``,
+        False on timeout. Useful before timed regions so background
+        indexing (rust-analyzer cache priming, gopls workspace load,
+        basedpyright type analysis) doesn't bleed into measurements.
+        """
+        deadline = time.monotonic() + max_wait_s
+        idle_since: Optional[float] = None
+        while time.monotonic() < deadline:
+            self.drain_notifications(timeout_s=0.2)
+            if not self._active_progress:
+                if idle_since is None:
+                    idle_since = time.monotonic()
+                elif time.monotonic() - idle_since >= idle_grace_s:
+                    return True
+            else:
+                idle_since = None
+            time.sleep(0.1)
+        return False
 
     def _request(self, method: str, params: Any, timeout: float = 30) -> Any:
         """Send a request and wait for the matching response.

--- a/codeminer/graph/incremental/patcher_base.py
+++ b/codeminer/graph/incremental/patcher_base.py
@@ -350,6 +350,12 @@ class PatcherBase(SubgraphMgr):
             f"edges {edges_before}→{edges_after} (Δ{edges_after - edges_before:+d})"
         )
 
+        # Rebuild line-range indexes after each patcher batch so range
+        # queries reflect the post-patch graph state. Cost is O(V+E),
+        # negligible relative to the patch itself.
+        with self.profiler.section("patch_files.build_range_indexes"):
+            self.code_graph.build_range_indexes()
+
         # Profiler summary
         self.profiler.report(reset=True)
 
@@ -797,19 +803,28 @@ class PatcherBase(SubgraphMgr):
 
         remapped = 0
 
-        # Incoming: always safe to remap
+        # Incoming: always safe to remap. Severed entries are 6-tuples
+        # `(src, tgt, src_uname, tgt_uname, anchor_file, anchor_line)` —
+        # one entry per anchored call site. Anchor is threaded through to
+        # _add_edge so the rebuilt edge carries the same anchor metadata.
         for entry in severed_incoming:
-            src_name, _, _, tgt_uname = entry
+            src_name, _, _, tgt_uname, anchor_file, anchor_line = entry
             if not tgt_uname:
                 continue
             new_target = uname_to_new.get(tgt_uname)
             if new_target and src_name in self.code_graph.name_to_vertex:
-                self.code_graph._add_edge(src_name, new_target, EDGE_TYPE_REFERENCE)
+                self.code_graph._add_edge(
+                    src_name,
+                    new_target,
+                    EDGE_TYPE_REFERENCE,
+                    anchor_file=anchor_file,
+                    anchor_line=anchor_line,
+                )
                 remapped += 1
 
-        # Outgoing: skip if source body changed
+        # Outgoing: skip if source body changed.
         for entry in severed_outgoing:
-            src_name, tgt_name, src_uname, tgt_uname = entry
+            src_name, tgt_name, src_uname, tgt_uname, anchor_file, anchor_line = entry
 
             if src_uname:
                 if src_uname in changed_unames:
@@ -828,7 +843,13 @@ class PatcherBase(SubgraphMgr):
                 resolved_tgt = None
 
             if new_src and resolved_tgt:
-                self.code_graph._add_edge(new_src, resolved_tgt, EDGE_TYPE_REFERENCE)
+                self.code_graph._add_edge(
+                    new_src,
+                    resolved_tgt,
+                    EDGE_TYPE_REFERENCE,
+                    anchor_file=anchor_file,
+                    anchor_line=anchor_line,
+                )
                 remapped += 1
 
         return remapped
@@ -895,10 +916,14 @@ class PatcherBase(SubgraphMgr):
         severed_incoming: list[tuple],
         severed_outgoing: list[tuple],
     ) -> set[str]:
-        """Get set of vertex names whose edges were remapped."""
+        """Get set of vertex names whose edges were remapped.
+
+        Severed entries are 6-tuples since the multi-edge fix:
+        `(src, tgt, src_uname, tgt_uname, anchor_file, anchor_line)`.
+        """
         remapped_unames = set()
         for entry in severed_incoming:
-            _, _, _, tgt_uname = entry
+            _, _, _, tgt_uname, _, _ = entry
             if tgt_uname:
                 for vname in new_vertices:
                     vid = self.code_graph.name_to_vertex.get(vname)
@@ -911,7 +936,7 @@ class PatcherBase(SubgraphMgr):
                         if u == tgt_uname:
                             remapped_unames.add(vname)
         for entry in severed_outgoing:
-            _, _, src_uname, _ = entry
+            _, _, src_uname, _, _, _ = entry
             if src_uname:
                 for vname in new_vertices:
                     vid = self.code_graph.name_to_vertex.get(vname)

--- a/codeminer/graph/incremental/patcher_base.py
+++ b/codeminer/graph/incremental/patcher_base.py
@@ -66,8 +66,23 @@ class PatcherBase(SubgraphMgr):
         project_root: str,
         code_graph: CodeGraph,
         lsp_client: Optional[LSPClient] = None,
+        mode: str = "symbol",
     ):
+        """``mode`` is one of:
+
+        - ``"symbol"`` (default): the actual symbol-level incremental patcher.
+        - ``"naive"``: file-granularity baseline used by the sequential
+          benchmark (issue #129). For modified files, every old symbol is
+          classified as deleted and every new symbol as added — no shifted /
+          affected / unchanged / invisible buckets. Untouched files are still
+          left alone. Only the classifier behaviour changes; the rest of the
+          pipeline (LSP queries, edge reconnection) is identical to symbol
+          mode, which is exactly what makes it the right A/B comparison.
+        """
         super().__init__(project_root, code_graph, lsp_client)
+        if mode not in ("symbol", "naive"):
+            raise ValueError(f"unknown patcher mode: {mode!r}")
+        self.mode = mode
         self.profiler = Profiler()
 
     # ═══════════════════════════════════════════════════════════
@@ -225,6 +240,23 @@ class PatcherBase(SubgraphMgr):
     # Top-level patch entry point
     # ═══════════════════════════════════════════════════════════
 
+    def _should_skip_path(self, path: str) -> bool:
+        """Override to exclude language-specific files (e.g. _test.go) so
+        the patcher mirrors the SCIP/clangd decoder's file scope. Default
+        keeps every file."""
+        return False
+
+    def _filter_changed_files(self, changed_files: dict) -> dict:
+        """Apply ``_should_skip_path`` to every entry in ``changed_files``."""
+        skip = self._should_skip_path
+        return {
+            "modified": [p for p in changed_files.get("modified", []) if not skip(p)],
+            "added":    [p for p in changed_files.get("added",    []) if not skip(p)],
+            "deleted":  [p for p in changed_files.get("deleted",  []) if not skip(p)],
+            "renamed":  [(o, n) for o, n in changed_files.get("renamed", [])
+                         if not skip(n) and not skip(o)],
+        }
+
     def patch_files(
         self,
         changed_files: dict,
@@ -241,6 +273,11 @@ class PatcherBase(SubgraphMgr):
         Returns:
             Stats dict.
         """
+        # Drop files the language excludes from indexing (e.g. _test.go for
+        # Go, where SCIP-go skips test files by design — see
+        # scip_decode_go.py).
+        changed_files = self._filter_changed_files(changed_files)
+
         # Auto-start LSP if not already running
         if self.lsp_client is None:
             self.start_lsp()
@@ -356,8 +393,13 @@ class PatcherBase(SubgraphMgr):
         with self.profiler.section("patch_files.build_range_indexes"):
             self.code_graph.build_range_indexes()
 
-        # Profiler summary
-        self.profiler.report(reset=True)
+        # Profiler summary — also stash structured timings on the patcher so
+        # benchmarks can read them without parsing logs.
+        report = self.profiler.report(reset=True)
+        total_stats["profile"] = {
+            label: {"total_s": st.total, "count": st.count}
+            for label, st in report
+        }
 
         return total_stats
 
@@ -519,60 +561,28 @@ class PatcherBase(SubgraphMgr):
 
         # SHIFTED
         for uname in classified["shifted"]:
-            old = old_symbols[uname]
-            new = new_symbols[uname]
-            old_vname = old["vertex_name"]
-            new_vname = f"{uname}:{new['start_line']}"
-            self.rename_vertex(
-                old_vname,
-                new_vname,
-                {
-                    "start_line": new["start_line"],
-                    "end_line": new["end_line"],
-                },
+            self._process_shifted(
+                uname=uname,
+                old=old_symbols[uname],
+                new=new_symbols[uname],
+                file_path=file_path,
+                file_stats=file_stats,
             )
-            self._update_selection_range(old_vname, new_vname, new)
-            file_stats["vertices_shifted"] += 1
 
-        # AFFECTED (rename/update vertex, collect ranges for Round 2)
+        # AFFECTED — fast (preserved) / slow (rebuilt) split per uname
         affected_vnames = []
         affected_changed_ranges = []
         for uname in classified["affected"]:
-            old = old_symbols[uname]
-            new = new_symbols[uname]
-            old_vname = old["vertex_name"]
-            new_vname = f"{uname}:{new['start_line']}"
-
-            if old_vname != new_vname:
-                self.rename_vertex(
-                    old_vname,
-                    new_vname,
-                    {
-                        "start_line": new["start_line"],
-                        "end_line": new["end_line"],
-                    },
-                )
-            else:
-                vid = self.code_graph.name_to_vertex.get(new_vname)
-                if vid is not None:
-                    self.code_graph.graph.vs[vid]["end_line"] = new["end_line"]
-                    self.code_graph.symbol_ranges[new_vname] = (
-                        new["start_line"],
-                        new["end_line"],
-                    )
-
-            self._update_selection_range(old_vname, new_vname, new)
-            affected_vnames.append(new_vname)
-
-            sym_start, sym_end = new["start_line"], new["end_line"]
-            changed = [
-                (max(h_start, sym_start), min(h_end, sym_end))
-                for h_start, h_end in hunks
-                if h_start <= sym_end and h_end >= sym_start
-            ]
-            affected_changed_ranges.append(
-                changed if changed else [(sym_start, sym_end)]
+            new_vname, changed = self._process_affected(
+                uname=uname,
+                old=old_symbols[uname],
+                new=new_symbols[uname],
+                hunks=hunks,
+                file_path=file_path,
+                file_stats=file_stats,
             )
+            affected_vnames.append(new_vname)
+            affected_changed_ranges.append(changed)
 
         # ADDED (create vertices, collect for Round 2)
         added_vnames = []
@@ -612,7 +622,8 @@ class PatcherBase(SubgraphMgr):
             f"add={len(classified['added'])} "
             f"affected={len(classified['affected'])} "
             f"shifted={len(classified['shifted'])} "
-            f"unchanged={len(classified['unchanged'])}"
+            f"unchanged={len(classified['unchanged'])} "
+            f"invisible={len(classified.get('invisible', []))}"
         )
 
         return {
@@ -644,6 +655,12 @@ class PatcherBase(SubgraphMgr):
         affected_changed_ranges = ctx["affected_changed_ranges"]
         added_vnames = ctx["added_vnames"]
 
+        # Stage all reference edges through one EdgeBatch and flush at the
+        # end of this file's processing. Avoids ~5000 single-edge
+        # ``add_edges`` calls per patch (Python↔C round-trip dominated).
+        from .subgraph_mgr import EdgeBatch
+        batch = EdgeBatch(self.code_graph)
+
         # Affected: outgoing refs for changed lines
         if affected_vnames:
             flat_vnames = []
@@ -662,6 +679,7 @@ class PatcherBase(SubgraphMgr):
                     flat_vnames,
                     ref_stats,
                     line_ranges=flat_ranges,
+                    batch=batch,
                 )
             edge_stats["refs_outgoing"] = ref_stats["outgoing_added"]
 
@@ -682,7 +700,7 @@ class PatcherBase(SubgraphMgr):
 
             ref_stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
             with self.profiler.section("lsp_incoming_refs"):
-                self.reconnect_incoming(file_path, added_vnames, ref_stats)
+                self.reconnect_incoming(file_path, added_vnames, ref_stats, batch=batch)
             with self.profiler.section("lsp_outgoing_refs"):
                 effective_ranges = (
                     added_ranges if len(added_ranges) == len(added_vnames) else None
@@ -692,9 +710,13 @@ class PatcherBase(SubgraphMgr):
                     added_vnames,
                     ref_stats,
                     line_ranges=effective_ranges,
+                    batch=batch,
                 )
             edge_stats["refs_incoming"] = ref_stats["incoming_added"]
             edge_stats["refs_outgoing"] += ref_stats["outgoing_added"]
+
+        with self.profiler.section("edge_batch_flush"):
+            batch.flush()
 
         return edge_stats
 
@@ -706,17 +728,64 @@ class PatcherBase(SubgraphMgr):
         self,
         old_symbols: dict[str, dict],
         new_symbols: dict[str, dict],
-        hunks: list[tuple[int, int]],
+        hunks: list[tuple[int, int, int, int]],
     ) -> dict[str, list[str]]:
-        """Classify each symbol as deleted/added/affected/shifted/unchanged."""
+        """Classify each symbol as deleted/added/affected/shifted/unchanged.
+
+        ``hunks`` is a list of (old_start, old_end, new_start, new_end).
+        Common-symbol overlap uses the new-file side; old-only-symbol
+        overlap uses the old-file side.
+
+        old_set − new_set is split into:
+          - deleted: old uname whose old-side range overlaps a hunk
+          - invisible: old uname outside every hunk. The base graph
+            indexer (e.g. SCIP) saw this symbol but ``documentSymbol``
+            cannot (typically macro-expanded enum variants). Since the
+            location wasn't touched, leave the vertex untouched.
+        """
 
         def overlaps_any_hunk(start, end):
-            return any(start <= h_end and end >= h_start for h_start, h_end in hunks)
+            return any(
+                start <= h_new_e and end >= h_new_s
+                for (_old_s, _old_e, h_new_s, h_new_e) in hunks
+            )
+
+        def overlaps_any_hunk_old(start, end):
+            return any(
+                start <= h_old_e and end >= h_old_s
+                for (h_old_s, h_old_e, _new_s, _new_e) in hunks
+            )
 
         old_set = set(old_symbols.keys())
         new_set = set(new_symbols.keys())
 
-        deleted = sorted(old_set - new_set)
+        # Naive mode (issue #129 baseline): in a modified file, drop every
+        # old symbol and rebuild every new one. No symbol-level diff. The
+        # rest of the pipeline (reconnect_outgoing / reconnect_incoming) then
+        # issues LSP queries for *every* new symbol — by design, since the
+        # whole point of naive mode is to bound how much LSP traffic the
+        # symbol-level diff is saving.
+        if getattr(self, "mode", "symbol") == "naive":
+            return {
+                "deleted":   sorted(old_set),
+                "added":     sorted(new_set),
+                "affected":  [],
+                "shifted":   [],
+                "unchanged": [],
+                "invisible": [],
+            }
+
+        deleted = []
+        invisible = []
+        for uname in sorted(old_set - new_set):
+            old = old_symbols[uname]
+            sl = old["start_line"]
+            el = old.get("end_line", sl)
+            if overlaps_any_hunk_old(sl, el):
+                deleted.append(uname)
+            else:
+                invisible.append(uname)
+
         added = sorted(new_set - old_set)
         common = old_set & new_set
 
@@ -757,7 +826,162 @@ class PatcherBase(SubgraphMgr):
             "affected": affected,
             "shifted": shifted,
             "unchanged": unchanged,
+            "invisible": invisible,
         }
+
+    # ═══════════════════════════════════════════════════════════
+    # Per-classification processing helpers
+    # ═══════════════════════════════════════════════════════════
+
+    def _process_shifted(
+        self,
+        uname: str,
+        old: dict,
+        new: dict,
+        file_path: str,
+        file_stats: dict,
+    ) -> None:
+        """Apply a *shifted* symbol update: body unchanged, start_line moved.
+
+        Steps (order matters):
+          1. Rebase outgoing anchored REFERENCE edges from the OLD vname by
+             ``shift = new.start_line - old.start_line`` so range queries
+             keep matching the moved call sites.
+          2. Rename the vertex to the new ``"{uname}:{new_start}"`` form
+             and refresh ``start_line``/``end_line`` attrs.
+          3. Update the selection range index for downstream LSP probes.
+        """
+        old_vname = old["vertex_name"]
+        new_vname = f"{uname}:{new['start_line']}"
+
+        shift = new["start_line"] - old["start_line"]
+        if shift:
+            self.shift_outgoing_anchor_lines(
+                vertex_name=old_vname,
+                anchor_file=file_path,
+                old_start=old["start_line"],
+                old_end=old["end_line"],
+                shift=shift,
+            )
+
+        self.rename_vertex(
+            old_vname,
+            new_vname,
+            {
+                "start_line": new["start_line"],
+                "end_line": new["end_line"],
+            },
+        )
+        self._update_selection_range(old_vname, new_vname, new)
+        file_stats["vertices_shifted"] += 1
+
+    def _process_affected(
+        self,
+        uname: str,
+        old: dict,
+        new: dict,
+        hunks: list[tuple[int, int, int, int]],
+        file_path: str,
+        file_stats: dict,
+    ) -> tuple[str, list[tuple[int, int]]]:
+        """Apply an *affected* symbol update — body has hunks overlapping it.
+
+        Two paths, decided per-symbol:
+
+        - **Fast (case 3, body length preserved)**: every hunk overlapping
+          the body has equal old/new line counts. Surgical:
+            1. Delete outgoing REFERENCE edges with anchors in the OLD
+               changed regions (anchors there are stale).
+            2. Uniform-shift remaining body anchors by ``delta = new.start
+               - old.start`` (file-level shift).
+            3. Rename / refresh attrs.
+          Round 2 then reconnects only the changed regions.
+
+        - **Slow (case 4, body length changed)**: at least one hunk's
+          line count changed. Internal anchor positions are non-uniform,
+          so we wipe ALL outgoing reference edges and let Round 2
+          reconnect the full body.
+
+        Returns ``(new_vname, ranges_for_round_2)`` where ranges are in
+        NEW-file coordinates.
+        """
+        old_vname = old["vertex_name"]
+        new_vname = f"{uname}:{new['start_line']}"
+        old_start, old_end = old["start_line"], old["end_line"]
+        new_start, new_end = new["start_line"], new["end_line"]
+
+        overlapping_old: list[tuple[int, int]] = []
+        overlapping_new: list[tuple[int, int]] = []
+        all_preserving = True
+        for h_old_s, h_old_e, h_new_s, h_new_e in hunks:
+            body_overlap_old = h_old_s <= old_end and h_old_e >= old_start
+            body_overlap_new = h_new_s <= new_end and h_new_e >= new_start
+            if not body_overlap_old and not body_overlap_new:
+                continue
+            old_count = h_old_e - h_old_s + 1
+            new_count = h_new_e - h_new_s + 1
+            if old_count != new_count:
+                all_preserving = False
+            if body_overlap_old:
+                overlapping_old.append(
+                    (max(h_old_s, old_start), min(h_old_e, old_end))
+                )
+            if body_overlap_new:
+                overlapping_new.append(
+                    (max(h_new_s, new_start), min(h_new_e, new_end))
+                )
+
+        if all_preserving:
+            # Fast path: surgical anchor cleanup + uniform shift.
+            if overlapping_old:
+                self.delete_outgoing_in_anchor_ranges(
+                    vertex_name=old_vname,
+                    anchor_file=file_path,
+                    ranges=overlapping_old,
+                )
+            delta = new_start - old_start
+            if delta:
+                self.shift_outgoing_anchor_lines(
+                    vertex_name=old_vname,
+                    anchor_file=file_path,
+                    old_start=old_start,
+                    old_end=old_end,
+                    shift=delta,
+                )
+            file_stats["vertices_affected_preserved"] = (
+                file_stats.get("vertices_affected_preserved", 0) + 1
+            )
+        else:
+            # Slow path: clear all outgoing refs; Round 2 rebuilds.
+            self.delete_outgoing_reference_edges(old_vname)
+            file_stats["vertices_affected_rebuilt"] = (
+                file_stats.get("vertices_affected_rebuilt", 0) + 1
+            )
+
+        # Rename or refresh in place.
+        if old_vname != new_vname:
+            self.rename_vertex(
+                old_vname,
+                new_vname,
+                {"start_line": new_start, "end_line": new_end},
+            )
+        else:
+            vid = self.code_graph.name_to_vertex.get(new_vname)
+            if vid is not None:
+                self.code_graph.graph.vs[vid]["end_line"] = new_end
+                self.code_graph.symbol_ranges[new_vname] = (new_start, new_end)
+
+        self._update_selection_range(old_vname, new_vname, new)
+
+        # Round 2 ranges in NEW coords. Slow path always does the full body.
+        if all_preserving:
+            ranges_for_r2 = (
+                overlapping_new if overlapping_new else [(new_start, new_end)]
+            )
+        else:
+            ranges_for_r2 = [(new_start, new_end)]
+
+        return new_vname, ranges_for_r2
 
     # ═══════════════════════════════════════════════════════════
     # Remap severed edges
@@ -765,14 +989,44 @@ class PatcherBase(SubgraphMgr):
 
     _STRUCTURAL_NODE_TYPES = frozenset({"file", "directory"})
 
+    @staticmethod
+    def _rebase_anchor_line(
+        anchor_file: Optional[str],
+        anchor_line: Optional[int],
+        anchor_shifts: Optional[dict],
+    ) -> Optional[int]:
+        """Apply per-file shift table to a recorded anchor line.
+
+        ``anchor_shifts`` maps file → list of ``(old_start, old_end, delta)``
+        triples. If a triple covers ``anchor_line`` the delta is added; the
+        first matching triple wins. Returns the (possibly unchanged) line.
+        """
+        if anchor_line is None or not anchor_shifts or not anchor_file:
+            return anchor_line
+        shifts = anchor_shifts.get(anchor_file)
+        if not shifts:
+            return anchor_line
+        for old_start, old_end, delta in shifts:
+            if old_start <= anchor_line <= old_end:
+                return anchor_line + delta
+        return anchor_line
+
     def _remap_severed_edges(
         self,
         new_vertices: list[str],
         severed_incoming: list[tuple],
         severed_outgoing: list[tuple],
         changed_line_ranges: list[tuple[int, int]] | None = None,
+        anchor_shifts: Optional[dict] = None,
     ) -> int:
-        """Remap severed reference edges to new vertex names."""
+        """Remap severed reference edges to new vertex names.
+
+        ``anchor_shifts``: optional ``{file: [(old_start, old_end, delta)]}``
+        table built from sibling-file patches that already shifted symbols
+        by the time this remap runs. Severed entries' ``anchor_line`` is
+        rebased through the table before the rebuilt edge is written, so
+        the new edge lands on the post-patch line numbering.
+        """
         uname_to_new = {}
         for vname in new_vertices:
             if vname in self.code_graph.name_to_vertex:
@@ -780,6 +1034,17 @@ class PatcherBase(SubgraphMgr):
                 uname = v.attributes().get("unified_name")
                 if uname:
                     uname_to_new[uname] = vname
+
+        # Global uname → current vname map covers cross-file renames that
+        # happened earlier in this batch (e.g. caller's file was patched
+        # before the current target's). Used as a fallback when the
+        # severed entry's src_name is stale.
+        global_uname_to_vname: dict[str, str] = {}
+        g_vs = self.code_graph.graph.vs
+        for vid in range(self.code_graph.graph.vcount()):
+            un = g_vs[vid].attributes().get("unified_name")
+            if un and un not in global_uname_to_vname:
+                global_uname_to_vname[un] = g_vs[vid]["name"]
 
         changed_unames = set()
         if changed_line_ranges:
@@ -808,17 +1073,32 @@ class PatcherBase(SubgraphMgr):
         # one entry per anchored call site. Anchor is threaded through to
         # _add_edge so the rebuilt edge carries the same anchor metadata.
         for entry in severed_incoming:
-            src_name, _, _, tgt_uname, anchor_file, anchor_line = entry
+            src_name, _, src_uname, tgt_uname, anchor_file, anchor_line = entry
             if not tgt_uname:
                 continue
             new_target = uname_to_new.get(tgt_uname)
-            if new_target and src_name in self.code_graph.name_to_vertex:
+            if not new_target:
+                continue
+
+            # Resolve src: prefer the recorded vname, fall back to the
+            # uname index when the src has been renamed (R1).
+            if src_name in self.code_graph.name_to_vertex:
+                resolved_src = src_name
+            elif src_uname:
+                resolved_src = global_uname_to_vname.get(src_uname)
+            else:
+                resolved_src = None
+
+            if resolved_src:
+                rebased_line = self._rebase_anchor_line(
+                    anchor_file, anchor_line, anchor_shifts
+                )
                 self.code_graph._add_edge(
-                    src_name,
+                    resolved_src,
                     new_target,
                     EDGE_TYPE_REFERENCE,
                     anchor_file=anchor_file,
-                    anchor_line=anchor_line,
+                    anchor_line=rebased_line,
                 )
                 remapped += 1
 
@@ -843,12 +1123,15 @@ class PatcherBase(SubgraphMgr):
                 resolved_tgt = None
 
             if new_src and resolved_tgt:
+                rebased_line = self._rebase_anchor_line(
+                    anchor_file, anchor_line, anchor_shifts
+                )
                 self.code_graph._add_edge(
                     new_src,
                     resolved_tgt,
                     EDGE_TYPE_REFERENCE,
                     anchor_file=anchor_file,
-                    anchor_line=anchor_line,
+                    anchor_line=rebased_line,
                 )
                 remapped += 1
 

--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -307,7 +307,7 @@ class PatcherCpp(PatcherBase):
                     idx.unlink()
                     deleted += 1
                 except OSError:
-                    pass
+                    pass  # stale .idx; unlink failure is harmless
         if header_changed:
             # Header changes can affect any TU. Delete all .idx files for
             # source-file TUs so clangd rebuilds them. Header-only .idx
@@ -323,7 +323,7 @@ class PatcherCpp(PatcherBase):
                         idx.unlink()
                         deleted += 1
                     except OSError:
-                        pass
+                        pass  # stale .idx; unlink failure is harmless
         if deleted:
             logger.info(
                 f"Pre-invalidated {deleted} .idx file(s) for affected TUs "

--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -45,7 +45,8 @@ class PatcherCpp(PatcherBase):
             "macro",
         }
 
-    def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+    def _build_unified_name(self, file_path, name, parent_unified_part, kind,
+                            parent_kind: int = 0):
         node_type = self._classify_symbol_type(kind)
         clean_name = name.replace("::", ".")
 
@@ -95,7 +96,8 @@ class PatcherCpp(PatcherBase):
             + [new for _, new in changed_files.get("renamed", [])]
         )
 
-        # Delete old subgraphs
+        # Delete old subgraphs (severed edges are discarded — cpp recovers
+        # them by re-reading .idx data, see _apply_idx_data below).
         for path in changed_files.get("deleted", []):
             with self.profiler.section("delete_subgraph"):
                 self.delete_file_subgraph(path)
@@ -228,8 +230,22 @@ class PatcherCpp(PatcherBase):
                     logger.debug(f"Failed to parse {candidate}: {exc}")
                     continue
         if comp_db is None:
-            logger.warning("No valid compile_commands.json found")
-            return None
+            # Autotools / fresh-checkout case: compile_commands.json hasn't
+            # been generated yet. Trigger ClangdIndexer's auto-generate
+            # path (cmake/bear -- make) to produce one, then resume.
+            logger.info(
+                "No compile_commands.json — calling ClangdIndexer's "
+                "auto-generate (cmake / bear -- make) to produce one"
+            )
+            from codeminer.ls_index.clangd_indexer import ClangdIndexer
+
+            indexer = ClangdIndexer(project_root=str(self.project_root))
+            generated = indexer._auto_generate_compdb()
+            if generated is None or not indexer._is_valid_compdb(generated):
+                logger.warning("Auto-generate compile_commands failed")
+                return None
+            comp_db = generated
+            logger.info(f"Auto-generated compile_commands at {comp_db}")
 
         candidates = [
             Path(self.project_root) / ".cache" / "clangd" / "index",
@@ -237,7 +253,10 @@ class PatcherCpp(PatcherBase):
         ]
         idx_dir = None
         for d in candidates:
-            if d.exists() and any(d.glob("*.idx")):
+            exists = d.exists()
+            n_idx = len(list(d.glob("*.idx"))) if exists else 0
+            logger.info(f"[patcher_cpp DEBUG] candidate {d}: exists={exists} idx_count={n_idx}")
+            if exists and n_idx > 0:
                 idx_dir = d
                 break
 
@@ -245,8 +264,13 @@ class PatcherCpp(PatcherBase):
             logger.info("No .idx cache, running full clangd index")
             from codeminer.ls_index.clangd_indexer import ClangdIndexer
 
+            cache_path = Path(self.project_root) / ".cache" / "clangd" / "index"
+            n_before = len(list(cache_path.glob("*.idx"))) if cache_path.exists() else 0
+            logger.info(f"[patcher_cpp DEBUG] before ClangdIndexer: {cache_path} has {n_before} .idx")
             indexer = ClangdIndexer(project_root=str(self.project_root))
             success = indexer.generate_index(compdb_path=str(comp_db))
+            n_after = len(list(cache_path.glob("*.idx"))) if cache_path.exists() else 0
+            logger.info(f"[patcher_cpp DEBUG] after ClangdIndexer: {cache_path} has {n_after} .idx (success={success})")
             return indexer.idx_directory if success else None
 
         pre_mtime = max(
@@ -258,6 +282,59 @@ class PatcherCpp(PatcherBase):
             f"C++ incremental: {pre_count} .idx in {idx_dir}, "
             f"didOpen {len(changed_files)} files"
         )
+
+        # Force-invalidate .idx files for affected TUs so clangd's startup
+        # background-index loader sees them as missing → MUST rebuild.
+        #
+        # Why this is needed: clangd 18.1.3 only verifies the *main file*
+        # digest when loading existing shards. If a header file changes
+        # but the .cc TU's source content didn't, clangd considers the
+        # TU shard valid and skips reindex — leaving header symbol
+        # changes invisible. By deleting .idx files we eliminate the
+        # "shard valid" optimization and force a real reindex, matching
+        # what `clear_indexer_cache` does for full rebuild but only for
+        # the affected files.
+        HEADER_EXTS = (".h", ".hpp", ".hxx", ".hh")
+        TU_EXTS = (".c", ".cc", ".cpp", ".cxx")
+        deleted = 0
+        header_changed = False
+        for changed_file in changed_files:
+            name = Path(changed_file).name
+            if name.endswith(HEADER_EXTS):
+                header_changed = True
+            for idx in idx_dir.glob(f"{name}.*.idx"):
+                try:
+                    idx.unlink()
+                    deleted += 1
+                except OSError:
+                    pass
+        if header_changed:
+            # Header changes can affect any TU. Delete all .idx files for
+            # source-file TUs so clangd rebuilds them. Header-only .idx
+            # are kept as-is — they'll be regenerated as a side effect of
+            # indexing the TUs that include them.
+            for idx in idx_dir.glob("*.idx"):
+                # match files like "format.cc.HASH.idx" or "foo.c.HASH.idx"
+                stem = idx.name
+                # strip ".HASH.idx" tail
+                base = stem.rsplit(".", 2)[0]  # "format.cc"
+                if base.endswith(TU_EXTS):
+                    try:
+                        idx.unlink()
+                        deleted += 1
+                    except OSError:
+                        pass
+        if deleted:
+            logger.info(
+                f"Pre-invalidated {deleted} .idx file(s) for affected TUs "
+                f"(header-changed={header_changed})"
+            )
+            # Update pre_mtime/count for the polling logic below.
+            pre_mtime = max(
+                (f.stat().st_mtime for f in idx_dir.glob("*.idx")),
+                default=0,
+            )
+            pre_count = len(list(idx_dir.glob("*.idx")))
 
         cmd = [
             clangd,
@@ -273,6 +350,22 @@ class PatcherCpp(PatcherBase):
             stderr=subprocess.PIPE,
             cwd=str(self.project_root),
         )
+
+        # Drain stdout/stderr in background threads. Without this clangd
+        # blocks on its first reply once the pipe buffer fills (~64KB),
+        # which silently halts the BackgroundIndex queue.
+        def _drain(stream):
+            try:
+                while True:
+                    chunk = stream.read1(65536) if hasattr(stream, "read1") else stream.read(4096)
+                    if not chunk:
+                        return
+            except Exception:
+                return
+
+        import threading
+        threading.Thread(target=_drain, args=(process.stdout,), daemon=True).start()
+        threading.Thread(target=_drain, args=(process.stderr,), daemon=True).start()
 
         def lsp_send(msg):
             content = json.dumps(msg).encode()
@@ -326,6 +419,16 @@ class PatcherCpp(PatcherBase):
                     }
                 )
 
+            # Poll for clangd to update .idx after didOpen.
+            # Two exit conditions:
+            #   (a) success: clangd touched .idx (cur > pre) AND has been
+            #       quiet for ``idle_after_change`` seconds
+            #   (b) no-op:   clangd never updates .idx (e.g. didOpen on
+            #       a header file in fmt — header isn't its own TU). Bail
+            #       after ``idle_no_change`` seconds; further waiting is
+            #       pure overhead.
+            idle_after_change = 5
+            idle_no_change = 5
             stable = 0
             last_mtime = pre_mtime
             for _ in range(120):
@@ -339,9 +442,9 @@ class PatcherCpp(PatcherBase):
                     stable = 0
                 else:
                     stable += 1
-                    if stable >= 5 and cur_mtime > pre_mtime:
+                    if cur_mtime > pre_mtime and stable >= idle_after_change:
                         break
-                    if stable >= 30:
+                    if cur_mtime <= pre_mtime and stable >= idle_no_change:
                         break
 
             post_count = len(list(idx_dir.glob("*.idx")))
@@ -377,13 +480,21 @@ class PatcherCpp(PatcherBase):
         decoder,
         changed_files: list[str],
     ) -> tuple[int, int]:
-        """Add symbols and edges from .idx data for changed files."""
+        """Add symbols and edges from .idx data for changed files.
+
+        Edges go through ``EdgeBatch`` (one ``add_edges`` call instead of
+        thousands of single-edge inserts). On redis-scale graphs (~95k
+        edges) this drops graph rebuild from ~50s/step to seconds because
+        each ``CodeGraph._add_edge`` does an O(out-degree) dedup walk plus
+        a Python↔C round-trip — quadratic at thousands of edges per patch.
+        """
         from codeminer.ls_index.clangd_decode import (
             KIND_MACRO,
             REF_KIND_DEFINITION,
             REF_KIND_REFERENCE,
             ZERO_SYMBOL_ID,
         )
+        from .subgraph_mgr import EdgeBatch
 
         changed_set = set(changed_files)
         new_vertices = 0
@@ -430,6 +541,11 @@ class PatcherCpp(PatcherBase):
                 self.code_graph.graph.vs[vid]["file"] = rel_file
                 new_vertices += 1
 
+        # All edge inserts go through one batch. EdgeBatch.stage rejects
+        # duplicates; on caller contract violation (vertex missing) it
+        # transparently falls back to _add_edge.
+        batch = EdgeBatch(self.code_graph)
+
         contained = set()
         for sym_id in changed_sym_ids:
             if sym_id not in self.code_graph.name_to_vertex:
@@ -442,9 +558,7 @@ class PatcherCpp(PatcherBase):
                         and container_id != ZERO_SYMBOL_ID
                         and container_id in self.code_graph.name_to_vertex
                     ):
-                        self.code_graph._add_edge(
-                            container_id, sym_id, EDGE_TYPE_CONTAIN
-                        )
+                        batch.stage(container_id, sym_id, EDGE_TYPE_CONTAIN)
                         contained.add(sym_id)
                         break
 
@@ -456,7 +570,7 @@ class PatcherCpp(PatcherBase):
             vid = self.code_graph.name_to_vertex[sym_id]
             file_path = self.code_graph.graph.vs[vid].attributes().get("file")
             if file_path and file_path in self.code_graph.name_to_vertex:
-                self.code_graph._add_edge(file_path, sym_id, EDGE_TYPE_CONTAIN)
+                batch.stage(file_path, sym_id, EDGE_TYPE_CONTAIN)
 
         for sym_id, ref_list in decoder._refs.items():
             if sym_id not in self.code_graph.name_to_vertex:
@@ -470,7 +584,28 @@ class PatcherCpp(PatcherBase):
                 if container_id not in self.code_graph.name_to_vertex:
                     continue
                 if sym_id in changed_sym_ids or container_id in changed_sym_ids:
-                    self.code_graph._add_edge(container_id, sym_id, EDGE_TYPE_REFERENCE)
+                    # Carry call-site anchor metadata through (matches
+                    # what clangd_decode does on full rebuild) — otherwise
+                    # the patcher's reference edges land with anchor_*=None
+                    # and miss range-query indexes.
+                    loc = ref.get("location") or {}
+                    anchor_uri = loc.get("file")
+                    anchor_file = (
+                        decoder._file_uri_to_relative(anchor_uri)
+                        if anchor_uri else None
+                    )
+                    start = loc.get("start")
+                    anchor_line = start[0] if start else None
+                    batch.stage(
+                        container_id,
+                        sym_id,
+                        EDGE_TYPE_REFERENCE,
+                        anchor_file=anchor_file,
+                        anchor_line=anchor_line,
+                    )
                     new_refs += 1
+
+        with self.profiler.section("cpp.edge_batch_flush"):
+            batch.flush()
 
         return new_vertices, new_refs

--- a/codeminer/graph/incremental/patcher_go.py
+++ b/codeminer/graph/incremental/patcher_go.py
@@ -17,6 +17,12 @@ class PatcherGo(PatcherBase):
     def _language_id(self):
         return "go"
 
+    def _should_skip_path(self, path: str) -> bool:
+        """SCIP-go skips ``*_test.go`` files (see scip_decode_go.py:92).
+        Match that so patcher graphs and rebuild graphs share the same
+        file scope."""
+        return path.endswith("_test.go")
+
     def _get_crossfile_token_types(self):
         return {
             "type",

--- a/codeminer/graph/incremental/patcher_python.py
+++ b/codeminer/graph/incremental/patcher_python.py
@@ -10,6 +10,14 @@ class PatcherPython(PatcherBase):
     """Python incremental patcher. Matches SCIPPythonGraphDecoder naming."""
 
     def get_lsp_command(self):
+        # ty 0.0.33 is faster on small queries but hangs on some larger
+        # workspaces (observed on xarray bin=300, 36min+ no response).
+        # basedpyright is slower but reliable; default to it. Override via
+        # ``CODEMINER_PYTHON_LSP_CMD=ty\ server`` to experiment with ty.
+        import os
+        cmd = os.environ.get("CODEMINER_PYTHON_LSP_CMD")
+        if cmd:
+            return cmd.split()
         return ["basedpyright-langserver", "--stdio"]
 
     def _language_id(self):

--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -65,6 +65,100 @@ _INCOMING_REF_TYPES = frozenset(
 )
 
 
+class EdgeBatch:
+    """Stage edges across many reconnect calls, flush in one igraph op.
+
+    Per-edge ``CodeGraph._add_edge`` does an O(out-degree) dedup walk plus a
+    Python↔C round-trip per edge — at thousands of edges per patch this is
+    the second-largest non-LSP cost. The batch:
+
+      1. Builds an index of existing edges keyed by
+         ``(src_id, tgt_id, type, anchor_file, anchor_line)`` once.
+      2. ``stage(src_name, tgt_name, type, anchor_file, anchor_line)`` resolves
+         names to ids, dedups against existing + already-staged, queues into
+         a list.
+      3. ``flush()`` issues a single ``graph.add_edges(pairs, attributes=...)``
+         call and clears the queue.
+
+    Falls back to ``CodeGraph._add_edge`` when staging would be wrong (vertex
+    creation needed) — keeps the contract simple: callers pass *names* of
+    vertices they expect to already exist.
+    """
+
+    def __init__(self, code_graph):
+        self.cg = code_graph
+        self.pairs: list[tuple[int, int]] = []
+        self.types: list[str] = []
+        self.anchor_files: list = []
+        self.anchor_lines: list = []
+        self._staged_keys: set = set()
+        self._existing: dict = self._build_existing_index()
+
+    def _build_existing_index(self) -> dict:
+        idx = {}
+        es = self.cg.graph.es
+        for eid in range(self.cg.graph.ecount()):
+            e = es[eid]
+            attrs = e.attributes()
+            key = (
+                e.source,
+                e.target,
+                attrs.get("type"),
+                attrs.get("anchor_file"),
+                attrs.get("anchor_line"),
+            )
+            idx[key] = eid
+        return idx
+
+    def stage(self, source_name: str, target_name: str, edge_type: str,
+              anchor_file=None, anchor_line=None) -> bool:
+        """Stage an edge. Returns True if newly staged, False if dedup hit.
+
+        Caller guarantees both vertices already exist (no implicit creation).
+        """
+        cg = self.cg
+        src = cg.name_to_vertex.get(source_name)
+        tgt = cg.name_to_vertex.get(target_name)
+        if src is None or tgt is None:
+            # Caller-violated contract — fall back to the safe path that
+            # creates vertices on demand.
+            cg._add_edge(source_name, target_name, edge_type,
+                         anchor_file=anchor_file, anchor_line=anchor_line)
+            return True
+        key = (src, tgt, edge_type, anchor_file, anchor_line)
+        if key in self._existing or key in self._staged_keys:
+            return False
+        self._staged_keys.add(key)
+        self.pairs.append((src, tgt))
+        self.types.append(edge_type)
+        self.anchor_files.append(anchor_file)
+        self.anchor_lines.append(anchor_line)
+        return True
+
+    def flush(self) -> int:
+        n = len(self.pairs)
+        if not n:
+            return 0
+        old_ecount = self.cg.graph.ecount()
+        self.cg.graph.add_edges(self.pairs)
+        # Bulk attribute set: one Python-level loop, but no add_edges calls.
+        for i in range(n):
+            eid = old_ecount + i
+            self.cg.graph.es[eid]["type"] = self.types[i]
+            af = self.anchor_files[i]
+            if af is not None:
+                self.cg.graph.es[eid]["anchor_file"] = af
+            al = self.anchor_lines[i]
+            if al is not None:
+                self.cg.graph.es[eid]["anchor_line"] = al
+        self.pairs.clear()
+        self.types.clear()
+        self.anchor_files.clear()
+        self.anchor_lines.clear()
+        self._staged_keys.clear()
+        return n
+
+
 class SubgraphMgr(ABC):
     """Manages incremental subgraph operations on a CodeGraph.
 
@@ -364,6 +458,89 @@ class SubgraphMgr(ABC):
             g.graph.delete_edges(to_delete)
         return len(to_delete)
 
+    def delete_outgoing_in_anchor_ranges(
+        self,
+        vertex_name: str,
+        anchor_file: str,
+        ranges: list[tuple[int, int]],
+    ) -> int:
+        """Delete outgoing REFERENCE edges from ``vertex_name`` whose
+        ``(anchor_file, anchor_line)`` falls inside any of the given ranges.
+
+        Used by the patcher's affected-symbol path to surgically remove only
+        the outgoing edges whose call sites lie in the changed body region,
+        keeping anchors in unchanged regions intact. CONTAIN edges (no
+        anchor) are never touched. Edges with no ``anchor_line`` set are
+        also skipped.
+
+        Returns the count of edges deleted.
+        """
+        g = self.code_graph
+        vid = g.name_to_vertex.get(vertex_name)
+        if vid is None or not ranges:
+            return 0
+
+        to_delete = []
+        for eid in g.graph.incident(vid, mode="out"):
+            edge = g.graph.es[eid]
+            if edge["type"] != EDGE_TYPE_REFERENCE:
+                continue
+            attrs = edge.attributes()
+            if attrs.get("anchor_file") != anchor_file:
+                continue
+            line = attrs.get("anchor_line")
+            if line is None:
+                continue
+            for start, end in ranges:
+                if start <= line <= end:
+                    to_delete.append(eid)
+                    break
+        if to_delete:
+            g.graph.delete_edges(to_delete)
+        return len(to_delete)
+
+    def shift_outgoing_anchor_lines(
+        self,
+        vertex_name: str,
+        anchor_file: str,
+        old_start: int,
+        old_end: int,
+        shift: int,
+    ) -> int:
+        """Shift ``anchor_line`` on outgoing REFERENCE edges from
+        ``vertex_name`` whose ``(anchor_file, anchor_line)`` falls inside
+        ``[old_start, old_end]`` by ``shift``.
+
+        Used by the patcher's shifted-symbol path: when a symbol moves up
+        or down by N lines but its body is unmodified, every anchor in its
+        old body region needs the same uniform shift to stay aligned with
+        the new line numbering.
+
+        Returns the count of edges modified. ``shift=0`` is a no-op.
+        """
+        if shift == 0:
+            return 0
+        g = self.code_graph
+        vid = g.name_to_vertex.get(vertex_name)
+        if vid is None:
+            return 0
+
+        moved = 0
+        for eid in g.graph.incident(vid, mode="out"):
+            edge = g.graph.es[eid]
+            if edge["type"] != EDGE_TYPE_REFERENCE:
+                continue
+            attrs = edge.attributes()
+            if attrs.get("anchor_file") != anchor_file:
+                continue
+            line = attrs.get("anchor_line")
+            if line is None:
+                continue
+            if old_start <= line <= old_end:
+                edge["anchor_line"] = line + shift
+                moved += 1
+        return moved
+
     def rename_vertex(self, old_name: str, new_name: str, new_attrs: dict = None):
         """Rename a vertex without deleting it. All edges preserved."""
         g = self.code_graph
@@ -401,6 +578,11 @@ class SubgraphMgr(ABC):
     def rebuild_file_subgraph(self, file_path: str, symbols: list[dict]) -> list[str]:
         """Add file vertex + symbol vertices + containment edges.
 
+        Also keeps ``file_to_vertices`` consistent for this file so callers
+        can use ``match_location_to_*`` immediately without an explicit
+        ``build_indexes()`` step. Other index dicts (``unified_name_to_vertex``)
+        are still rebuilt by the caller via ``build_indexes()`` at batch end.
+
         Returns list of created vertex names.
         """
         g = self.code_graph
@@ -411,6 +593,14 @@ class SubgraphMgr(ABC):
             if parent_dir not in g.name_to_vertex:
                 g.add_directory_node(parent_dir)
             g._add_edge(parent_dir, file_path, EDGE_TYPE_CONTAIN)
+
+        # Seed file_to_vertices for this file so match_location_to_* works
+        # without a follow-up build_indexes(). Vertices created by
+        # _process_symbol_tree below get appended via _track_file_vertex.
+        if not hasattr(g, "file_to_vertices") or g.file_to_vertices is None:
+            g.file_to_vertices = {}
+        file_vid = g.name_to_vertex[file_path]
+        g.file_to_vertices.setdefault(file_path, set()).add(file_vid)
 
         return self._process_symbol_tree(
             symbols,
@@ -457,6 +647,10 @@ class SubgraphMgr(ABC):
                 },
             )
             g.symbol_ranges[vertex_name] = (start_line, end_line)
+            # Keep file_to_vertices consistent for live callers.
+            if hasattr(g, "file_to_vertices") and g.file_to_vertices is not None:
+                vid = g.name_to_vertex[vertex_name]
+                g.file_to_vertices.setdefault(file_path, set()).add(vid)
 
             sel_start = sel_range.get("start", {})
             sel_end = sel_range.get("end", {})
@@ -500,6 +694,7 @@ class SubgraphMgr(ABC):
         file_path: str,
         vertex_names: list[str],
         stats: dict,
+        batch: "EdgeBatch | None" = None,
     ):
         """For each vertex, call LSP references to find external callers."""
         if not self.lsp_client:
@@ -528,8 +723,19 @@ class SubgraphMgr(ABC):
                 ref_line = loc.get("range", {}).get("start", {}).get("line", 0)
                 ref_scope = self.match_location_to_scope(ref_file, ref_line)
                 if ref_scope:
-                    self.code_graph._add_edge(ref_scope, vname, EDGE_TYPE_REFERENCE)
-                    stats["incoming_added"] += 1
+                    if batch is not None:
+                        if batch.stage(ref_scope, vname, EDGE_TYPE_REFERENCE,
+                                       anchor_file=ref_file, anchor_line=ref_line):
+                            stats["incoming_added"] += 1
+                    else:
+                        self.code_graph._add_edge(
+                            ref_scope,
+                            vname,
+                            EDGE_TYPE_REFERENCE,
+                            anchor_file=ref_file,
+                            anchor_line=ref_line,
+                        )
+                        stats["incoming_added"] += 1
                 else:
                     stats["unmatched"] += 1
 
@@ -539,6 +745,7 @@ class SubgraphMgr(ABC):
         vertex_names: list[str],
         stats: dict,
         line_ranges: list[tuple[int, int]] | None = None,
+        batch: "EdgeBatch | None" = None,
     ):
         """Use semanticTokens + definition to find outgoing refs."""
         if not self.lsp_client:
@@ -580,16 +787,13 @@ class SubgraphMgr(ABC):
                     abs_file, t["line"], t["character"]
                 )
 
-        # Retry empty definitions — server may still be analyzing new files.
-        # Only retry the ones that returned [] (not the ones that succeeded).
+        # Retry empty definitions once with NO sleep — null is a legitimate
+        # "no definition here" answer per LSP spec, but on cold servers a
+        # second pass occasionally resolves more. The previous 3s sleep
+        # added per-file overhead with ~zero real benefit (most empties
+        # remain empty on retry).
         empty_keys = [k for k, v in seen_text.items() if v == []]
         if empty_keys:
-            logger.debug(
-                f"{len(empty_keys)}/{len(seen_text)} definitions returned "
-                f"empty for {file_path}, retrying after 3s"
-            )
-            time.sleep(3)
-            # Build text → token mapping for retry
             text_to_token = {}
             for t in ref_tokens:
                 if t["text"] not in text_to_token:
@@ -609,8 +813,10 @@ class SubgraphMgr(ABC):
                     f"Retry resolved {resolved}/{len(empty_keys)} " "empty definitions"
                 )
 
-        # Build edges
-        added_edges = set()
+        # Build edges. Each call site becomes its own anchored edge so the
+        # multi-edge schema preserves call-site identity for range queries.
+        # _add_edge dedups on (src, tgt, type, anchor_file, anchor_line),
+        # so identical anchors collapse but distinct call sites stay distinct.
         for ref_token in ref_tokens:
             defn_list = seen_text.get(ref_token["text"])
             if not defn_list:
@@ -637,11 +843,20 @@ class SubgraphMgr(ABC):
             target_vertex = self.match_location_to_vertex(target_file, target_line)
 
             if scope and target_vertex:
-                edge_key = (scope, target_vertex)
-                if edge_key not in added_edges:
-                    self.code_graph._add_edge(scope, target_vertex, EDGE_TYPE_REFERENCE)
+                if batch is not None:
+                    if batch.stage(scope, target_vertex, EDGE_TYPE_REFERENCE,
+                                   anchor_file=file_path,
+                                   anchor_line=ref_token["line"]):
+                        stats["outgoing_added"] += 1
+                else:
+                    self.code_graph._add_edge(
+                        scope,
+                        target_vertex,
+                        EDGE_TYPE_REFERENCE,
+                        anchor_file=file_path,
+                        anchor_line=ref_token["line"],
+                    )
                     stats["outgoing_added"] += 1
-                    added_edges.add(edge_key)
             else:
                 stats["unmatched"] += 1
 
@@ -685,21 +900,14 @@ class SubgraphMgr(ABC):
             logger.debug(f"Using semanticTokens/full for {file_path} ({reason})")
             tokens_response = self.lsp_client.semantic_tokens_full(abs_file)
 
-        # Retry once if still empty
-        if tokens_response is None or not tokens_response.get("data"):
-            logger.debug(
-                f"semanticTokens returned "
-                f"{'None' if tokens_response is None else 'empty'} "
-                f"for {file_path}, retrying after 5s"
-            )
-            time.sleep(5)
-            tokens_response = self.lsp_client.semantic_tokens_full(abs_file)
-            if tokens_response and tokens_response.get("data"):
-                logger.debug(f"semanticTokens retry succeeded for {file_path}")
-
+        # No retry: null/empty semanticTokens is a legitimate response per
+        # LSP spec. On pathological files (e.g. basedpyright hanging on
+        # sklearn's test_pls.py for 60s) a retry pays the full server
+        # timeout twice. The cache entry below ensures repeat callers
+        # within this patcher run skip immediately.
         if not tokens_response or not tokens_response.get("data"):
             logger.warning(
-                f"semanticTokens failed for {file_path} after retry, "
+                f"semanticTokens failed for {file_path}, "
                 "skipping outgoing reference discovery"
             )
             self._semantic_tokens_cache[file_path] = None
@@ -729,36 +937,40 @@ class SubgraphMgr(ABC):
 
         Level 1: Exact (file, start_line) match.
         Level 2: Innermost enclosing scope.
+
+        Uses ``file_to_vertices`` to constrain the scan to one file's
+        vertices instead of the whole graph (5985 calls × 31k vertices
+        was a 500s+ hot loop on ruff).
         """
-        candidates = [
-            vname
-            for vname, (start, _) in self.code_graph.symbol_ranges.items()
-            if self._vertex_file(vname) == file_path and start == line
-        ]
+        g = self.code_graph
+        vids = getattr(g, "file_to_vertices", {}).get(file_path, ())
+        candidates = []
+        for vid in vids:
+            vname = g.graph.vs[vid]["name"]
+            sr = g.symbol_ranges.get(vname)
+            if sr and sr[0] == line:
+                candidates.append(vname)
         if len(candidates) == 1:
             return candidates[0]
         return self.match_location_to_scope(file_path, line)
 
     def match_location_to_scope(self, file_path: str, line: int) -> Optional[str]:
         """Find the innermost scope vertex containing (file, line)."""
+        g = self.code_graph
+        vids = getattr(g, "file_to_vertices", {}).get(file_path, ())
         candidates = []
-        for vname, (start, end) in self.code_graph.symbol_ranges.items():
-            if self._vertex_file(vname) == file_path and start <= line <= end:
-                candidates.append((vname, end - start))
+        for vid in vids:
+            vname = g.graph.vs[vid]["name"]
+            sr = g.symbol_ranges.get(vname)
+            if sr and sr[0] <= line <= sr[1]:
+                candidates.append((vname, sr[1] - sr[0]))
 
         if not candidates:
-            if file_path in self.code_graph.name_to_vertex:
+            if file_path in g.name_to_vertex:
                 return file_path
             return None
 
         return min(candidates, key=lambda x: x[1])[0]
-
-    def _vertex_file(self, vname: str) -> Optional[str]:
-        """Get the file attribute of a vertex by name."""
-        vid = self.code_graph.name_to_vertex.get(vname)
-        if vid is None:
-            return None
-        return self.code_graph.graph.vs[vid].attributes().get("file")
 
     def clear_cache(self):
         """Clear semantic tokens cache between patch_files runs."""

--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -13,7 +13,6 @@ patcher_lang subclasses must implement.
 
 from __future__ import annotations
 
-import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
@@ -110,8 +109,14 @@ class EdgeBatch:
             idx[key] = eid
         return idx
 
-    def stage(self, source_name: str, target_name: str, edge_type: str,
-              anchor_file=None, anchor_line=None) -> bool:
+    def stage(
+        self,
+        source_name: str,
+        target_name: str,
+        edge_type: str,
+        anchor_file=None,
+        anchor_line=None,
+    ) -> bool:
         """Stage an edge. Returns True if newly staged, False if dedup hit.
 
         Caller guarantees both vertices already exist (no implicit creation).
@@ -122,8 +127,13 @@ class EdgeBatch:
         if src is None or tgt is None:
             # Caller-violated contract — fall back to the safe path that
             # creates vertices on demand.
-            cg._add_edge(source_name, target_name, edge_type,
-                         anchor_file=anchor_file, anchor_line=anchor_line)
+            cg._add_edge(
+                source_name,
+                target_name,
+                edge_type,
+                anchor_file=anchor_file,
+                anchor_line=anchor_line,
+            )
             return True
         key = (src, tgt, edge_type, anchor_file, anchor_line)
         if key in self._existing or key in self._staged_keys:
@@ -156,6 +166,10 @@ class EdgeBatch:
         self.anchor_files.clear()
         self.anchor_lines.clear()
         self._staged_keys.clear()
+        # Bulk add bypassed CodeGraph._add_edge, so any cached edge index is
+        # now missing the just-flushed edges. Drop it; the next _add_edge
+        # will rebuild lazily and see the batched edges.
+        self.cg._invalidate_edge_index()
         return n
 
 
@@ -731,8 +745,13 @@ class SubgraphMgr(ABC):
                 ref_scope = self.match_location_to_scope(ref_file, ref_line)
                 if ref_scope:
                     if batch is not None:
-                        if batch.stage(ref_scope, vname, EDGE_TYPE_REFERENCE,
-                                       anchor_file=ref_file, anchor_line=ref_line):
+                        if batch.stage(
+                            ref_scope,
+                            vname,
+                            EDGE_TYPE_REFERENCE,
+                            anchor_file=ref_file,
+                            anchor_line=ref_line,
+                        ):
                             stats["incoming_added"] += 1
                     else:
                         self.code_graph._add_edge(
@@ -851,9 +870,13 @@ class SubgraphMgr(ABC):
 
             if scope and target_vertex:
                 if batch is not None:
-                    if batch.stage(scope, target_vertex, EDGE_TYPE_REFERENCE,
-                                   anchor_file=file_path,
-                                   anchor_line=ref_token["line"]):
+                    if batch.stage(
+                        scope,
+                        target_vertex,
+                        EDGE_TYPE_REFERENCE,
+                        anchor_file=file_path,
+                        anchor_line=ref_token["line"],
+                    ):
                         stats["outgoing_added"] += 1
                 else:
                     self.code_graph._add_edge(

--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -185,40 +185,49 @@ class SubgraphMgr(ABC):
 
         severed_incoming = []
         severed_outgoing = []
-        seen_outgoing = set()
         for vid in vids:
             v = g.graph.vs[vid]
             v_uname = v.attributes().get("unified_name") or ""
-            # Outgoing reference edges
+            # Outgoing: one entry per anchored call site (NO (src,tgt) dedup).
+            # Multi-edge schema means (src, tgt) may have N edges, one per
+            # call site; remap path needs each anchor preserved.
             for eid in g.graph.incident(vid, mode="out"):
                 edge = g.graph.es[eid]
-                if edge["type"] == EDGE_TYPE_REFERENCE:
-                    tv = g.graph.vs[edge.target]
-                    key = (v["name"], tv["name"])
-                    if key not in seen_outgoing:
-                        seen_outgoing.add(key)
-                        severed_outgoing.append(
-                            (
-                                v["name"],
-                                tv["name"],
-                                v_uname,
-                                tv.attributes().get("unified_name") or "",
-                            )
-                        )
-            # Incoming reference edges from outside
+                if edge["type"] != EDGE_TYPE_REFERENCE:
+                    continue
+                if edge.target in vids:
+                    continue
+                tv = g.graph.vs[edge.target]
+                eattrs = edge.attributes()
+                severed_outgoing.append(
+                    (
+                        v["name"],
+                        tv["name"],
+                        v_uname,
+                        tv.attributes().get("unified_name") or "",
+                        eattrs.get("anchor_file"),
+                        eattrs.get("anchor_line"),
+                    )
+                )
+            # Incoming: similarly per-anchor.
             for eid in g.graph.incident(vid, mode="in"):
                 edge = g.graph.es[eid]
-                if edge["type"] == EDGE_TYPE_REFERENCE:
-                    sv = g.graph.vs[edge.source]
-                    if edge.source not in vids:
-                        severed_incoming.append(
-                            (
-                                sv["name"],
-                                v["name"],
-                                sv.attributes().get("unified_name") or "",
-                                v_uname,
-                            )
-                        )
+                if edge["type"] != EDGE_TYPE_REFERENCE:
+                    continue
+                if edge.source in vids:
+                    continue
+                sv = g.graph.vs[edge.source]
+                eattrs = edge.attributes()
+                severed_incoming.append(
+                    (
+                        sv["name"],
+                        v["name"],
+                        sv.attributes().get("unified_name") or "",
+                        v_uname,
+                        eattrs.get("anchor_file"),
+                        eattrs.get("anchor_line"),
+                    )
+                )
 
         deleted_names = [g.graph.vs[vid]["name"] for vid in vids]
         g.graph.delete_vertices(sorted(vids))
@@ -253,32 +262,43 @@ class SubgraphMgr(ABC):
         for vid in vids:
             v = g.graph.vs[vid]
             v_uname = v.attributes().get("unified_name") or ""
+            # Outgoing: one entry per anchored call site (multi-edge aware).
             for eid in g.graph.incident(vid, mode="out"):
                 edge = g.graph.es[eid]
-                if edge["type"] == EDGE_TYPE_REFERENCE:
-                    tv = g.graph.vs[edge.target]
-                    if edge.target not in vids:
-                        severed_outgoing.append(
-                            (
-                                v["name"],
-                                tv["name"],
-                                v_uname,
-                                tv.attributes().get("unified_name") or "",
-                            )
-                        )
+                if edge["type"] != EDGE_TYPE_REFERENCE:
+                    continue
+                if edge.target in vids:
+                    continue
+                tv = g.graph.vs[edge.target]
+                eattrs = edge.attributes()
+                severed_outgoing.append(
+                    (
+                        v["name"],
+                        tv["name"],
+                        v_uname,
+                        tv.attributes().get("unified_name") or "",
+                        eattrs.get("anchor_file"),
+                        eattrs.get("anchor_line"),
+                    )
+                )
             for eid in g.graph.incident(vid, mode="in"):
                 edge = g.graph.es[eid]
-                if edge["type"] == EDGE_TYPE_REFERENCE:
-                    sv = g.graph.vs[edge.source]
-                    if edge.source not in vids:
-                        severed_incoming.append(
-                            (
-                                sv["name"],
-                                v["name"],
-                                sv.attributes().get("unified_name") or "",
-                                v_uname,
-                            )
-                        )
+                if edge["type"] != EDGE_TYPE_REFERENCE:
+                    continue
+                if edge.source in vids:
+                    continue
+                sv = g.graph.vs[edge.source]
+                eattrs = edge.attributes()
+                severed_incoming.append(
+                    (
+                        sv["name"],
+                        v["name"],
+                        sv.attributes().get("unified_name") or "",
+                        v_uname,
+                        eattrs.get("anchor_file"),
+                        eattrs.get("anchor_line"),
+                    )
+                )
 
         deleted_names = [g.graph.vs[vid]["name"] for vid in vids]
         g.graph.delete_vertices(sorted(vids))
@@ -303,6 +323,43 @@ class SubgraphMgr(ABC):
             for eid in g.graph.incident(vid, mode="out")
             if g.graph.es[eid]["type"] == EDGE_TYPE_REFERENCE
         ]
+        if to_delete:
+            g.graph.delete_edges(to_delete)
+        return len(to_delete)
+
+    def delete_edges_by_anchor(
+        self,
+        source_name: str,
+        target_name: str,
+        edge_type: str,
+        anchor_file: str,
+        anchor_line: int,
+    ) -> int:
+        """Delete edges matching `(src, tgt, type, anchor_file, anchor_line)`.
+
+        Multi-edge aware: if the (src, tgt) pair has multiple edges (one per
+        call site), only the edge whose anchor matches is removed. Returns
+        the count of edges deleted.
+        """
+        g = self.code_graph
+        src_vid = g.name_to_vertex.get(source_name)
+        tgt_vid = g.name_to_vertex.get(target_name)
+        if src_vid is None or tgt_vid is None:
+            return 0
+
+        to_delete = []
+        for eid in g.graph.incident(src_vid, mode="out"):
+            edge = g.graph.es[eid]
+            if edge.target != tgt_vid:
+                continue
+            if edge["type"] != edge_type:
+                continue
+            attrs = edge.attributes()
+            if (
+                attrs.get("anchor_file") == anchor_file
+                and attrs.get("anchor_line") == anchor_line
+            ):
+                to_delete.append(eid)
         if to_delete:
             g.graph.delete_edges(to_delete)
         return len(to_delete)

--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -325,6 +325,7 @@ class SubgraphMgr(ABC):
 
         deleted_names = [g.graph.vs[vid]["name"] for vid in vids]
         g.graph.delete_vertices(sorted(vids))
+        g._invalidate_edge_index()
         self._rebuild_indexes()
         for n in deleted_names:
             g.symbol_ranges.pop(n, None)
@@ -396,6 +397,7 @@ class SubgraphMgr(ABC):
 
         deleted_names = [g.graph.vs[vid]["name"] for vid in vids]
         g.graph.delete_vertices(sorted(vids))
+        g._invalidate_edge_index()
         self._rebuild_indexes()
         for n in deleted_names:
             g.symbol_ranges.pop(n, None)
@@ -419,6 +421,7 @@ class SubgraphMgr(ABC):
         ]
         if to_delete:
             g.graph.delete_edges(to_delete)
+            g._invalidate_edge_index()
         return len(to_delete)
 
     def delete_edges_by_anchor(
@@ -456,6 +459,7 @@ class SubgraphMgr(ABC):
                 to_delete.append(eid)
         if to_delete:
             g.graph.delete_edges(to_delete)
+            g._invalidate_edge_index()
         return len(to_delete)
 
     def delete_outgoing_in_anchor_ranges(
@@ -497,6 +501,7 @@ class SubgraphMgr(ABC):
                     break
         if to_delete:
             g.graph.delete_edges(to_delete)
+            g._invalidate_edge_index()
         return len(to_delete)
 
     def shift_outgoing_anchor_lines(
@@ -539,6 +544,8 @@ class SubgraphMgr(ABC):
             if old_start <= line <= old_end:
                 edge["anchor_line"] = line + shift
                 moved += 1
+        if moved:
+            g._invalidate_edge_index()
         return moved
 
     def rename_vertex(self, old_name: str, new_name: str, new_attrs: dict = None):

--- a/codeminer/graph/roi_subgraph.py
+++ b/codeminer/graph/roi_subgraph.py
@@ -146,7 +146,7 @@ class ROISubgraph:
             try:
                 # Convert node name to node ID
                 if node_name not in self.code_graph.name_to_vertex:
-                    logger.warning(f"Node name '{node_name}' not found in graph")
+                    logger.warning(f"Node name {node_name!r} not found in graph")
                     continue
 
                 node_id = self.code_graph.name_to_vertex[node_name]
@@ -199,7 +199,8 @@ class ROISubgraph:
         start_line equals end_line (unless explicitly included).
 
         Args:
-            subgraph: An igraph Graph object (from extract_subgraph or extract_roi_from_search_results)
+            subgraph: An igraph Graph object (from extract_subgraph or
+                extract_roi_from_search_results)
             node_types: Optional list of node types to include (None for all types)
 
         Returns:
@@ -266,6 +267,12 @@ class ROISubgraph:
         """
         Get neighbors of a node, optionally filtered by edge type and direction.
 
+        Iterates over edges (not unique neighbors) so multi-edges between
+        the same pair — possible after the anchor-aware schema upgrade —
+        are each inspected for type filtering. Returned neighbor list may
+        contain duplicates only if multiple matching edges exist between
+        the same pair; callers using sets handle this naturally.
+
         Args:
             node_id: ID of the node
             edge_types: Optional list of edge types to filter by
@@ -274,45 +281,44 @@ class ROISubgraph:
         Returns:
             List of neighbor node IDs
         """
-        # Get neighbors based on direction
+        # Map direction to the edge-set we should iterate over.
         if direction == "forward":
-            neighbors = self.full_graph.successors(node_id)
+            edge_ids = self.full_graph.incident(node_id, mode="out")
         elif direction == "backward":
-            neighbors = self.full_graph.predecessors(node_id)
-        else:  # direction == "both"
-            neighbors = self.full_graph.neighbors(node_id)
+            edge_ids = self.full_graph.incident(node_id, mode="in")
+        else:  # "both"
+            edge_ids = self.full_graph.incident(node_id, mode="all")
 
-        # If no edge type filter, return all neighbors
+        # No edge-type filter: return unique neighbors directly.
         if not edge_types:
-            return neighbors
+            seen = set()
+            result = []
+            for eid in edge_ids:
+                e = self.full_graph.es[eid]
+                neighbor = e.target if e.source == node_id else e.source
+                if neighbor not in seen:
+                    seen.add(neighbor)
+                    result.append(neighbor)
+            return result
 
-        # Filter neighbors by edge type
-        filtered_neighbors = []
-        for neighbor in neighbors:
-            # Get edge between node and neighbor based on direction
+        # With edge-type filter: include each neighbor at most once but only
+        # if at least one of the edges between them passes the type filter.
+        filtered_neighbors: List[int] = []
+        seen = set()
+        for eid in edge_ids:
             try:
-                edge_id = None
-                if direction == "forward":
-                    edge_id = self.full_graph.get_eid(node_id, neighbor, error=False)
-                elif direction == "backward":
-                    edge_id = self.full_graph.get_eid(neighbor, node_id, error=False)
-                else:  # direction == "both"
-                    edge_id = self.full_graph.get_eid(node_id, neighbor, error=False)
-                    if edge_id is None:
-                        # Try the reverse direction
-                        edge_id = self.full_graph.get_eid(
-                            neighbor, node_id, error=False
-                        )
-
-                if (
-                    edge_id is not None
-                    and "type" in self.full_graph.es[edge_id].attributes()
-                ):
-                    edge_type = self.full_graph.es[edge_id]["type"]
-                    if edge_type in edge_types:
-                        filtered_neighbors.append(neighbor)
-            except Exception as e:
-                logger.error(f"Error getting edge type: {e}")
+                e = self.full_graph.es[eid]
+                if "type" not in e.attributes():
+                    continue
+                if e["type"] not in edge_types:
+                    continue
+                neighbor = e.target if e.source == node_id else e.source
+                if neighbor in seen:
+                    continue
+                seen.add(neighbor)
+                filtered_neighbors.append(neighbor)
+            except Exception as exc:
+                logger.error(f"Error inspecting edge {eid}: {exc}")
                 continue
 
         return filtered_neighbors

--- a/codeminer/graph/traverse_graph.py
+++ b/codeminer/graph/traverse_graph.py
@@ -31,7 +31,12 @@ class RepoDependencySearcher:
         etype_filter=None,
         ignore_test_file=True,
     ):
-        """Get neighbors of a node with filtering options"""
+        """Get neighbors of a node with filtering options.
+
+        Iterates over edges (not unique neighbors) so multi-edges between
+        the same pair — possible after the anchor-aware schema upgrade —
+        are each surfaced with their own type.
+        """
         nodes, edges = [], []
 
         if nid not in self.code_graph.name_to_vertex:
@@ -39,18 +44,28 @@ class RepoDependencySearcher:
 
         vertex_id = self.code_graph.name_to_vertex[nid]
 
+        # Pick incident edge sets for the requested direction(s).
         if direction == "forward":
-            neighbor_ids = self.graph.successors(vertex_id)
+            edge_ids = self.graph.incident(vertex_id, mode="out")
         elif direction == "backward":
-            neighbor_ids = self.graph.predecessors(vertex_id)
+            edge_ids = self.graph.incident(vertex_id, mode="in")
         else:
-            neighbor_ids = self.graph.neighbors(vertex_id)
+            edge_ids = self.graph.incident(vertex_id, mode="all")
 
-        for neighbor_id in neighbor_ids:
+        for eid in edge_ids:
+            edge = self.graph.es[eid]
+            # The "other" end depends on direction; for "all" we infer per-edge.
+            if edge.source == vertex_id:
+                neighbor_id = edge.target
+                edge_dir = "forward"
+            else:
+                neighbor_id = edge.source
+                edge_dir = "backward"
+
             neighbor_vertex = self.graph.vs[neighbor_id]
             neighbor_nid = neighbor_vertex["name"]
 
-            # Apply filters
+            # Node-type filter
             if ntype_filter and (
                 "type" not in neighbor_vertex.attributes()
                 or neighbor_vertex["type"] not in ntype_filter
@@ -59,25 +74,15 @@ class RepoDependencySearcher:
             if ignore_test_file and is_test_file(neighbor_nid):
                 continue
 
-            # Get edge information
-            if direction == "forward":
-                edge_id = self.graph.get_eid(vertex_id, neighbor_id, error=False)
-                if edge_id is not None:
-                    edge = self.graph.es[edge_id]
-                    etype = edge["type"] if "type" in edge.attributes() else "unknown"
-                    if etype_filter and etype not in etype_filter:
-                        continue
-                    edges.append((nid, neighbor_nid, 0, {"type": etype}))
-                    nodes.append(neighbor_nid)
-            elif direction == "backward":
-                edge_id = self.graph.get_eid(neighbor_id, vertex_id, error=False)
-                if edge_id is not None:
-                    edge = self.graph.es[edge_id]
-                    etype = edge["type"] if "type" in edge.attributes() else "unknown"
-                    if etype_filter and etype not in etype_filter:
-                        continue
-                    edges.append((neighbor_nid, nid, 0, {"type": etype}))
-                    nodes.append(neighbor_nid)
+            etype = edge["type"] if "type" in edge.attributes() else "unknown"
+            if etype_filter and etype not in etype_filter:
+                continue
+
+            if edge_dir == "forward":
+                edges.append((nid, neighbor_nid, 0, {"type": etype}))
+            else:
+                edges.append((neighbor_nid, nid, 0, {"type": etype}))
+            nodes.append(neighbor_nid)
 
         return nodes, edges
 
@@ -147,10 +152,12 @@ def traverse_tree_structure(
 
         vertex_id = code_graph.name_to_vertex[node]
 
-        # Downstream traversal
+        # Downstream traversal — iterate edges directly so multi-edges
+        # between the same pair are each surfaced with their own type.
         if "downstream" == edirection or (node == root and direction == "both"):
-            neighbor_ids = code_graph.graph.successors(vertex_id)
-            for neighbor_id in neighbor_ids:
+            for eid in code_graph.graph.incident(vertex_id, mode="out"):
+                edge = code_graph.graph.es[eid]
+                neighbor_id = edge.target
                 neighbor_vertex = code_graph.graph.vs[neighbor_id]
                 neighbor = neighbor_vertex["name"]
                 neigh_type = (
@@ -162,33 +169,24 @@ def traverse_tree_structure(
                 if is_ntype_not_valid(neigh_type):
                     continue
 
-                # Get edge type
-                edge_id = code_graph.graph.get_eid(vertex_id, neighbor_id, error=False)
-                if edge_id is not None:
-                    etype = (
-                        code_graph.graph.es[edge_id]["type"]
-                        if "type" in code_graph.graph.es[edge_id].attributes()
-                        else "unknown"
-                    )
-                    if is_etype_not_valid(etype):
-                        continue
-                    if not is_test_file(neighbor):
-                        if (node, etype, neighbor) not in traversed_edges:
-                            traversed_edges.add((node, etype, neighbor))
-                            # Separate by edge type: "contain" vs others
-                            if etype == "contain":
-                                contain_neighbors.append(
-                                    (neighbor, etype, "downstream")
-                                )
-                            else:
-                                reference_neighbors.append(
-                                    (neighbor, etype, "downstream")
-                                )
+                etype = edge["type"] if "type" in edge.attributes() else "unknown"
+                if is_etype_not_valid(etype):
+                    continue
+                if is_test_file(neighbor):
+                    continue
+                if (node, etype, neighbor) in traversed_edges:
+                    continue
+                traversed_edges.add((node, etype, neighbor))
+                if etype == "contain":
+                    contain_neighbors.append((neighbor, etype, "downstream"))
+                else:
+                    reference_neighbors.append((neighbor, etype, "downstream"))
 
         # Upstream traversal
         if "upstream" == edirection or (node == root and direction == "both"):
-            neighbor_ids = code_graph.graph.predecessors(vertex_id)
-            for neighbor_id in neighbor_ids:
+            for eid in code_graph.graph.incident(vertex_id, mode="in"):
+                edge = code_graph.graph.es[eid]
+                neighbor_id = edge.source
                 neighbor_vertex = code_graph.graph.vs[neighbor_id]
                 neighbor = neighbor_vertex["name"]
                 neigh_type = (
@@ -200,26 +198,18 @@ def traverse_tree_structure(
                 if is_ntype_not_valid(neigh_type):
                     continue
 
-                # Get edge type
-                edge_id = code_graph.graph.get_eid(neighbor_id, vertex_id, error=False)
-                if edge_id is not None:
-                    etype = (
-                        code_graph.graph.es[edge_id]["type"]
-                        if "type" in code_graph.graph.es[edge_id].attributes()
-                        else "unknown"
-                    )
-                    if is_etype_not_valid(etype):
-                        continue
-                    if not is_test_file(neighbor):
-                        if (neighbor, etype, node) not in traversed_edges:
-                            traversed_edges.add((neighbor, etype, node))
-                            # Separate by edge type: "contain" vs others
-                            if etype == "contain":
-                                contain_neighbors.append((neighbor, etype, "upstream"))
-                            else:
-                                reference_neighbors.append(
-                                    (neighbor, etype, "upstream")
-                                )
+                etype = edge["type"] if "type" in edge.attributes() else "unknown"
+                if is_etype_not_valid(etype):
+                    continue
+                if is_test_file(neighbor):
+                    continue
+                if (neighbor, etype, node) in traversed_edges:
+                    continue
+                traversed_edges.add((neighbor, etype, node))
+                if etype == "contain":
+                    contain_neighbors.append((neighbor, etype, "upstream"))
+                else:
+                    reference_neighbors.append((neighbor, etype, "upstream"))
 
         # Combine: containment first, then references
         all_neighbors = contain_neighbors + reference_neighbors

--- a/codeminer/ls_index/clangd_decode.py
+++ b/codeminer/ls_index/clangd_decode.py
@@ -21,7 +21,7 @@ import logging
 import struct
 import zlib
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from ..code_chunking import CppCodeChunker
 from ..graph.code_graph import CodeGraph
@@ -372,8 +372,13 @@ class ClangdGraphDecoder:
 
         # Buffered edges for batch insert — filled by _queue_edge during the
         # three _add_*_edges passes, flushed once at the end of _build_graph.
-        # Preserves CodeGraph._add_edge's first-wins dedup semantics.
-        self._pending_edges: Dict[Tuple[int, int], str] = {}
+        # Each entry: (src_id, tgt_id, edge_type, anchor_file, anchor_line).
+        # Multi-edges between the same (src, tgt) pair are allowed so each
+        # call site survives as its own edge (matches CodeGraph._add_edge's
+        # post-anchor-schema behavior).
+        self._pending_edges: List[
+            Tuple[int, int, str, Optional[str], Optional[int]]
+        ] = []
 
         # Code chunker for range detection
         self._chunker = CppCodeChunker()
@@ -649,39 +654,46 @@ class ClangdGraphDecoder:
     # under 1% of wall time.
     # ------------------------------------------------------------------
 
-    def _queue_edge(self, src_name: str, tgt_name: str, edge_type: str) -> None:
+    def _queue_edge(
+        self,
+        src_name: str,
+        tgt_name: str,
+        edge_type: str,
+        anchor_file: Optional[str] = None,
+        anchor_line: Optional[int] = None,
+    ) -> None:
         """Buffer an edge for the batch flush.
 
-        Mirrors CodeGraph._add_edge's first-wins dedup on (src, tgt): if a
-        pair was already queued with any type, subsequent calls are no-ops
-        so the earlier edge's type survives.
+        Multi-edges between the same `(src, tgt)` pair are allowed; each
+        call site (or relation) becomes its own edge. Pass `anchor_file` /
+        `anchor_line` for reference edges that need range-query support.
         """
         n2v = self.code_graph.name_to_vertex
         src_id = n2v.get(src_name)
         tgt_id = n2v.get(tgt_name)
         if src_id is None or tgt_id is None:
             return
-        key = (src_id, tgt_id)
-        if key not in self._pending_edges:
-            self._pending_edges[key] = edge_type
+        self._pending_edges.append(
+            (src_id, tgt_id, edge_type, anchor_file, anchor_line)
+        )
 
     def _flush_edges(self) -> None:
         """Insert all queued edges in one batched igraph call."""
         if not self._pending_edges:
             return
         g = self.code_graph.graph
-        # Skip pairs that already exist on the graph (edges added during
-        # _add_symbol_nodes via _ensure_file_hierarchy go through the serial
-        # _add_edge path).
-        existing = set(map(tuple, g.get_edgelist()))
-        pairs, types = [], []
-        for pair, etype in self._pending_edges.items():
-            if pair in existing:
-                continue
-            pairs.append(pair)
-            types.append(etype)
-        if pairs:
-            g.add_edges(pairs, attributes={"type": types})
+        pairs = [(s, t) for s, t, *_ in self._pending_edges]
+        types = [e[2] for e in self._pending_edges]
+        anchor_files = [e[3] for e in self._pending_edges]
+        anchor_lines = [e[4] for e in self._pending_edges]
+        g.add_edges(
+            pairs,
+            attributes={
+                "type": types,
+                "anchor_file": anchor_files,
+                "anchor_line": anchor_lines,
+            },
+        )
         self._pending_edges.clear()
 
     def _ensure_file_hierarchy(self, relative_path: str):
@@ -828,7 +840,14 @@ class ClangdGraphDecoder:
                 self._queue_edge(file_path, sym_name, EDGE_TYPE_CONTAIN)
 
     def _add_reference_edges(self):
-        """Add reference edges from refs with Reference kind."""
+        """Add reference edges from refs with Reference kind.
+
+        Each ref carries a ``location`` (file URI + (line, col)) — extract it
+        as ``anchor_file`` / ``anchor_line`` so range queries can find call
+        sites. Note that with multi-edge support (no `_add_edge` dedup),
+        repeated calls between the same `(container, sym)` pair create one
+        edge per call site instead of being collapsed into one.
+        """
         for sym_id, ref_list in self._refs.items():
             sym_name = self._resolve_sym_id(sym_id)
             if not sym_name:
@@ -847,7 +866,22 @@ class ClangdGraphDecoder:
                         container_name
                         and container_name in self.code_graph.name_to_vertex
                     ):
-                        self._queue_edge(container_name, sym_name, EDGE_TYPE_REFERENCE)
+                        loc = ref.get("location") or {}
+                        anchor_file_uri = loc.get("file")
+                        anchor_file = (
+                            self._file_uri_to_relative(anchor_file_uri)
+                            if anchor_file_uri
+                            else None
+                        )
+                        start = loc.get("start")
+                        anchor_line = start[0] if start else None
+                        self._queue_edge(
+                            container_name,
+                            sym_name,
+                            EDGE_TYPE_REFERENCE,
+                            anchor_file=anchor_file,
+                            anchor_line=anchor_line,
+                        )
 
     def _add_relation_edges(self):
         """Add edges from rela chunk (inheritance, override)."""

--- a/codeminer/ls_index/clangd_indexer.py
+++ b/codeminer/ls_index/clangd_indexer.py
@@ -224,6 +224,11 @@ class ClangdIndexer:
                 graph: CodeGraph = decoder.decode()
             duration = section.duration
 
+            # Build line-range indexes once the graph is fully assembled.
+            # Must happen before save_graph so the indexes are persisted.
+            with self.profiler.section("process_index.build_range_indexes"):
+                graph.build_range_indexes()
+
             if output_file:
                 with self.profiler.section("process_index.save_graph") as save_section:
                     graph.save_graph(output_file)

--- a/codeminer/scip_interface/scip_decode_core.py
+++ b/codeminer/scip_interface/scip_decode_core.py
@@ -21,6 +21,10 @@ logger = get_logger(__name__)
 
 try:
     # Primary import path — codeminer_core must be on sys.path / installed.
+    # Note: `codeminer/__init__.py` also pre-imports this module so that the
+    # extension's bundled libigraph wins the dynamic-linker race against the
+    # system libigraph that Python's `igraph` package brings in. The try here
+    # remains the source of truth for the optional-dependency contract.
     import codeminer_core as _cpp  # type: ignore[import-not-found]
 except ImportError as _import_err:  # pragma: no cover — optional dep
     _cpp = None
@@ -77,25 +81,41 @@ def _build_code_graph(
             ranges[v["name"]] = (v["start_line"], v["end_line"])
 
     # --- Edges ---
+    # Multi-edges between the same `(src, tgt)` pair are allowed (one per
+    # call site). The current C++ binding emits 5-tuples
+    # `(src, tgt, type, anchor_file_or_None, anchor_line_or_None)` so range
+    # queries work on graphs produced by this backend. The 3-tuple branch
+    # below is kept for backward compatibility with older binary builds.
     if edges:
-        # Dedupe by (src, tgt) only (type-agnostic), matching serial
-        # CodeGraph._add_edge's `are_adjacent` check.
-        seen = set()
         pairs: List = []
         types: List[str] = []
-        for src, tgt, etype in edges:
-            key = (src, tgt)
-            if key in seen:
-                continue
-            seen.add(key)
+        anchor_files: List[Optional[str]] = []
+        anchor_lines: List[Optional[int]] = []
+        for edge in edges:
+            # Standard format is 5-tuple; legacy 3-tuple is tolerated.
+            if len(edge) >= 5:
+                src, tgt, etype, a_file, a_line = edge[:5]
+            else:
+                src, tgt, etype = edge[:3]
+                a_file = None
+                a_line = None
             src_id = n2v.get(src)
             tgt_id = n2v.get(tgt)
             if src_id is None or tgt_id is None:
                 continue
             pairs.append((src_id, tgt_id))
             types.append(etype)
+            anchor_files.append(a_file)
+            anchor_lines.append(a_line)
         if pairs:
-            g.add_edges(pairs, attributes={"type": types})
+            g.add_edges(
+                pairs,
+                attributes={
+                    "type": types,
+                    "anchor_file": anchor_files,
+                    "anchor_line": anchor_lines,
+                },
+            )
 
     return code_graph
 

--- a/codeminer/scip_interface/scip_decode_go.py
+++ b/codeminer/scip_interface/scip_decode_go.py
@@ -411,7 +411,9 @@ class SCIPGoGraphDecoder:
 
         # Handle reference (not a definition)
         else:
-            self.code_graph.add_symbol_reference(symbol_key, file_path, symbol_type)
+            self.code_graph.add_symbol_reference(
+                symbol_key, file_path, symbol_type, anchor_line=line
+            )
             if symbol_key in self.code_graph.name_to_vertex:
                 vid = self.code_graph.name_to_vertex[symbol_key]
                 if not self.code_graph.graph.vs[vid].attributes().get("unified_name"):

--- a/codeminer/scip_interface/scip_decode_python.py
+++ b/codeminer/scip_interface/scip_decode_python.py
@@ -325,7 +325,11 @@ class SCIPPythonGraphDecoder:
 
                 if symbol_roles == 8:
                     self.code_graph._add_edge(
-                        self.code_graph.current_scope, file_path, EDGE_TYPE_REFERENCE
+                        self.code_graph.current_scope,
+                        file_path,
+                        EDGE_TYPE_REFERENCE,
+                        anchor_file=self.code_graph.current_file,
+                        anchor_line=line,
                     )
                 return
 
@@ -373,7 +377,10 @@ class SCIPPythonGraphDecoder:
         # Handle reference (symbol_roles == 8)
         elif symbol_roles == 8:
             self.code_graph.add_symbol_reference(
-                unified_symbol, module_path, symbol_type
+                unified_symbol,
+                module_path,
+                symbol_type,
+                anchor_line=line,
             )
 
     def save_graph(self, output_path):

--- a/codeminer/scip_interface/scip_decode_rust.py
+++ b/codeminer/scip_interface/scip_decode_rust.py
@@ -548,7 +548,9 @@ class SCIPRustGraphDecoder:
 
         # Handle reference (not a definition)
         else:
-            self.code_graph.add_symbol_reference(unified_symbol, file_path, symbol_type)
+            self.code_graph.add_symbol_reference(
+                unified_symbol, file_path, symbol_type, anchor_line=line
+            )
             if unified_symbol in self.code_graph.name_to_vertex:
                 vid = self.code_graph.name_to_vertex[unified_symbol]
                 if not self.code_graph.graph.vs[vid].attributes().get("unified_name"):

--- a/codeminer/scip_interface/scip_decode_ts.py
+++ b/codeminer/scip_interface/scip_decode_ts.py
@@ -452,7 +452,7 @@ class SCIPTypeScriptGraphDecoder:
                         self.code_graph.current_scope,
                         file_path,
                         EDGE_TYPE_REFERENCE,
-                        anchor_file=file_path,
+                        anchor_file=self.code_graph.current_file,
                         anchor_line=line,
                     )
                 return

--- a/codeminer/scip_interface/scip_decode_ts.py
+++ b/codeminer/scip_interface/scip_decode_ts.py
@@ -286,24 +286,42 @@ class SCIPTypeScriptGraphDecoder:
         else:
             sym_with_bt = original_symbol.split(" ")[-1]
 
-        # --- Extract file path from backtick boundaries ---
-        # SCIP format: `file/path.js`/SymbolDescriptor
-        all_bt_segments = re.findall(r"`([^`]+)`", sym_with_bt)
-
-        if all_bt_segments:
-            if len(all_bt_segments) == 1:
-                module_path = all_bt_segments[0]
-            else:
-                # Multi-segment: first segment may use dots for slashes
-                first = re.sub(r"\.(ts|tsx|js|jsx)$", "", all_bt_segments[0])
-                first = first.replace(".", "/")
-                module_path = first + "/" + "/".join(all_bt_segments[1:])
-
-            # Everything after the last closing backtick is the descriptor
-            last_bt_end = sym_with_bt.rfind("`") + 1
-            symbol_descriptor = sym_with_bt[last_bt_end:].lstrip("/")
+        # --- Extract file path + symbol descriptor from backtick boundaries ---
+        # SCIP TS descriptor shape:
+        #   [dir/prefix/]`filename`[/<nested-symbol-segments>]<kind-suffix>
+        # where:
+        #   * the optional `dir/prefix/` outside the first backtick is the
+        #     containing directory (e.g. "examples/"),
+        #   * the FIRST backtick wraps the filename (".js"/".ts" etc. need
+        #     escaping due to the dot),
+        #   * subsequent backticks wrap nested-name segments that contain
+        #     special characters (quotes, dots, colons),
+        #   * the trailing kind suffix is one of `:` / `#` / `().` / `.`.
+        # The previous implementation took only backtick-extracted segments
+        # for module_path and dropped the outside-backtick prefix, which
+        # collapsed e.g. ``examples/`server.js`/'Content-Type'0`:`` and
+        # ``sandbox/`server.js`/'Content-Type'0`:`` into the same id.
+        first_bt_open = sym_with_bt.find("`")
+        if first_bt_open >= 0:
+            first_bt_close = sym_with_bt.find("`", first_bt_open + 1)
         else:
-            # Fallback: no backticks — use the document file path
+            first_bt_close = -1
+
+        if first_bt_open >= 0 and first_bt_close > first_bt_open:
+            # `dir_prefix/` (without trailing slash); empty if symbol begins
+            # with a backtick.
+            dir_prefix = sym_with_bt[:first_bt_open].rstrip("/")
+            file_part = sym_with_bt[first_bt_open + 1 : first_bt_close]
+            module_path = (
+                f"{dir_prefix}/{file_part}" if dir_prefix else file_part
+            )
+            # Everything after the file's closing backtick is the symbol
+            # descriptor; strip any inner backticks (they only escape special
+            # chars within name segments).
+            tail = sym_with_bt[first_bt_close + 1 :].lstrip("/")
+            symbol_descriptor = tail.replace("`", "")
+        else:
+            # No backticks — fall back to the document file path.
             module_path = file_path or "unknown"
             symbol_descriptor = symbol.replace("`", "")
 
@@ -431,7 +449,11 @@ class SCIPTypeScriptGraphDecoder:
             if not (symbol_roles & 1):
                 if self.code_graph.current_scope != file_path:
                     self.code_graph._add_edge(
-                        self.code_graph.current_scope, file_path, EDGE_TYPE_REFERENCE
+                        self.code_graph.current_scope,
+                        file_path,
+                        EDGE_TYPE_REFERENCE,
+                        anchor_file=file_path,
+                        anchor_line=line,
                     )
                 return
 
@@ -501,7 +523,9 @@ class SCIPTypeScriptGraphDecoder:
         # Handle reference (not a definition)
         # Use bitwise check instead of exact match to handle all reference types
         else:
-            self.code_graph.add_symbol_reference(unified_symbol, file_path, symbol_type)
+            self.code_graph.add_symbol_reference(
+                unified_symbol, file_path, symbol_type, anchor_line=line
+            )
             # Set unified_name for reference-only nodes (first occurrence wins)
             if unified_symbol in self.code_graph.name_to_vertex:
                 vid = self.code_graph.name_to_vertex[unified_symbol]

--- a/codeminer/scip_interface/scip_indexer_base.py
+++ b/codeminer/scip_interface/scip_indexer_base.py
@@ -378,6 +378,11 @@ class SCIPIndexerBase(ABC):
                 graph: CodeGraph = decoder.decode()
             duration = section.duration
 
+            # Build line-range indexes once the graph is fully assembled.
+            # Must happen before save_graph so the indexes are persisted.
+            with self.profiler.section("process_index.build_range_indexes"):
+                graph.build_range_indexes()
+
             if output_file:
                 with self.profiler.section("process_index.save_graph") as save_section:
                     output_path = Path(output_file)

--- a/codeminer/scip_interface/scip_indexer_ts.py
+++ b/codeminer/scip_interface/scip_indexer_ts.py
@@ -148,6 +148,31 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
         if not package_json.exists():
             return
 
+        # Indexer-only experiment: skip install if lockfile unchanged from
+        # the cached prior install. Saves ~30s per cold-start on monorepos
+        # like docusaurus where yarn install does a no-op integrity check.
+        import hashlib
+        sentinel = self.project_root / ".codeminer_install_cache"
+        node_modules = self.project_root / "node_modules"
+        lockfile = None
+        for name in ("yarn.lock", "package-lock.json", "pnpm-lock.yaml",
+                     "bun.lock", "bun.lockb"):
+            if (self.project_root / name).exists():
+                lockfile = self.project_root / name
+                break
+        if lockfile and node_modules.is_dir() and sentinel.exists():
+            cur_h = hashlib.sha1(lockfile.read_bytes()).hexdigest()
+            try:
+                saved_h = sentinel.read_text().strip()
+                if cur_h == saved_h:
+                    logger.info(
+                        "Skipping install: %s unchanged (cached)",
+                        lockfile.name,
+                    )
+                    return
+            except Exception:
+                pass
+
         needs_pnpm = (self.project_root / "pnpm-lock.yaml").exists() or (
             self.project_root / "pnpm-workspace.yaml"
         ).exists()
@@ -213,6 +238,22 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
                 text=True,
                 timeout=timeout_sec,
             )
+            # Cache: write lockfile hash so next call can skip if unchanged
+            import hashlib
+            sentinel = self.project_root / ".codeminer_install_cache"
+            lockfile = None
+            for name in ("yarn.lock", "package-lock.json", "pnpm-lock.yaml",
+                         "bun.lock", "bun.lockb"):
+                if (self.project_root / name).exists():
+                    lockfile = self.project_root / name
+                    break
+            if lockfile:
+                try:
+                    sentinel.write_text(
+                        hashlib.sha1(lockfile.read_bytes()).hexdigest()
+                    )
+                except Exception:
+                    pass
             return
         except FileNotFoundError:
             logger.warning(

--- a/codeminer/scip_interface/scip_indexer_ts.py
+++ b/codeminer/scip_interface/scip_indexer_ts.py
@@ -248,12 +248,15 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
                     lockfile = self.project_root / name
                     break
             if lockfile:
+                # Best-effort: cache write is non-fatal; next run will retry.
                 try:
                     sentinel.write_text(
                         hashlib.sha1(lockfile.read_bytes()).hexdigest()
                     )
-                except Exception:
-                    pass
+                except Exception as cache_err:
+                    logger.debug(
+                        "skip-cache write failed (%s); continuing", cache_err
+                    )
             return
         except FileNotFoundError:
             logger.warning(

--- a/codeminer/scip_interface/scip_indexer_ts.py
+++ b/codeminer/scip_interface/scip_indexer_ts.py
@@ -171,7 +171,7 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
                     )
                     return
             except Exception:
-                pass
+                pass  # missing/corrupt sentinel; fall through to install
 
         needs_pnpm = (self.project_root / "pnpm-lock.yaml").exists() or (
             self.project_root / "pnpm-workspace.yaml"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(codeminer_core LANGUAGES CXX)
+project(codeminer_core LANGUAGES CXX C)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -7,8 +7,39 @@ option(CODEMINER_ENABLE_DEBUG "Enable debug-friendly flags for codeminer targets
 option(CODEMINER_ENABLE_O3 "Enable -O3 optimization for codeminer targets" ON)
 option(CODEMINER_BUILD_PYBIND "Build pybind11 Python extension module" ON)
 
+# -------------------------------------------------------------------------
+# Vendored c-igraph
+# -------------------------------------------------------------------------
+# We deliberately do NOT link system libigraph. Reason: Python's `igraph`
+# package (PyPI wheel) bundles its own c-igraph inside _igraph.abi3.so and
+# exports a few interop symbols (igraph_rng_Python_*). When codeminer_core
+# also links system libigraph.so.3, the two c-igraphs fight over the
+# global symbol table at process load time and the parity test segfaults
+# inside libigraph. Vendoring c-igraph here + --exclude-libs,ALL on the
+# pybind module keeps our copy private to codeminer_core.so so no symbol
+# clash is possible. Each .so owns an independent c-igraph instance.
+include(FetchContent)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+set(IGRAPH_OPENMP_SUPPORT OFF CACHE BOOL "" FORCE)
+set(IGRAPH_USE_INTERNAL_BLAS ON CACHE BOOL "" FORCE)
+set(IGRAPH_USE_INTERNAL_LAPACK ON CACHE BOOL "" FORCE)
+set(IGRAPH_USE_INTERNAL_ARPACK ON CACHE BOOL "" FORCE)
+set(IGRAPH_USE_INTERNAL_GLPK ON CACHE BOOL "" FORCE)
+set(IGRAPH_USE_INTERNAL_GMP ON CACHE BOOL "" FORCE)
+set(IGRAPH_USE_INTERNAL_PLFIT ON CACHE BOOL "" FORCE)
+set(IGRAPH_GRAPHML_SUPPORT OFF CACHE BOOL "" FORCE)
+set(IGRAPH_ENABLE_TLS OFF CACHE BOOL "" FORCE)
+set(IGRAPH_WARNINGS_AS_ERRORS OFF CACHE BOOL "" FORCE)
+
+FetchContent_Declare(
+    igraph
+    GIT_REPOSITORY https://github.com/igraph/igraph.git
+    GIT_TAG        0.10.15
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(igraph)
+
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(IGRAPH REQUIRED igraph)
 pkg_check_modules(RE2 REQUIRED re2)
 
 add_library(codeminer_core STATIC
@@ -26,14 +57,15 @@ target_compile_features(codeminer_core PUBLIC cxx_std_17)
 target_include_directories(codeminer_core
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${IGRAPH_INCLUDE_DIRS}
         ${RE2_INCLUDE_DIRS}
 )
 
-target_link_directories(codeminer_core PRIVATE ${IGRAPH_LIBRARY_DIRS} ${RE2_LIBRARY_DIRS})
-target_link_libraries(codeminer_core PUBLIC ${IGRAPH_LIBRARIES} ${RE2_LIBRARIES})
-
-target_compile_options(codeminer_core PRIVATE ${IGRAPH_CFLAGS_OTHER})
+target_link_directories(codeminer_core PRIVATE ${RE2_LIBRARY_DIRS})
+target_link_libraries(codeminer_core
+    PUBLIC
+        igraph
+        ${RE2_LIBRARIES}
+)
 
 add_executable(scip_decode_test
     tests/scip_decode_test.cpp
@@ -83,9 +115,19 @@ if(CODEMINER_BUILD_PYBIND)
     # Statically link libstdc++ and libgcc_s so the pybind module does
     # not depend on the runtime Python env's bundled libstdc++, which
     # may lack the GLIBCXX symbols our system GCC references.
+    #
+    # --exclude-libs,ALL hides every symbol coming from a static library
+    # (vendored c-igraph, codeminer_core, RE2, ...) from the .so's
+    # dynamic symbol table. Combined with vendored c-igraph above, this
+    # makes our c-igraph fully private and prevents clashes with the
+    # c-igraph that Python's `igraph` wheel bundles in _igraph.abi3.so.
+    # The PYBIND11_MODULE entry symbol (PyInit_codeminer_core) is
+    # defined directly in bindings/pybind_module.cpp (not from a static
+    # archive), so it stays visible.
     target_link_options(codeminer_core_py PRIVATE
         $<$<CXX_COMPILER_ID:GNU>:-static-libstdc++>
         $<$<CXX_COMPILER_ID:GNU>:-static-libgcc>
+        $<$<CXX_COMPILER_ID:GNU>:LINKER:--exclude-libs,ALL>
     )
     if(CODEMINER_ENABLE_O3)
         target_compile_options(codeminer_core_py PRIVATE -O3)

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -3,14 +3,16 @@
 // Exposes a single function `decode_scip(index_file, project_root, language)`
 // that returns a `DecodedGraph` struct with two flat Python lists:
 //   - vertices: list of dicts {name,type,file,start_line,end_line,unified_name}
-//   - edges:    list of tuples (source_name, target_name, type)
+//   - edges:    list of 5-tuples (source_name, target_name, type,
+//                                 anchor_file_or_None, anchor_line_or_None)
 //
-// The Python-side wrapper (scip_decode_cpp.py) builds a CodeGraph from this.
+// The Python-side wrapper (scip_decode_core.py) builds a CodeGraph from this.
+// Anchor info is included so range-query indexes (`build_range_indexes`) on
+// the Python side can resolve call-site lines emitted by the C++ decoders.
+//
 // We keep the binding lean (no custom class for CodeGraph) so that
 // serialization cost across the C++/Python boundary is just one igraph vcount +
-// ecount worth of tuples/dicts. Measured overhead on sympy (48K/221K) is ~1-2s,
-// dominated by the Python-side list construction — not worth optimizing further
-// since the Python serial decoder already reaches minutes on this input.
+// ecount worth of tuples/dicts.
 
 #include "scip_decode.h"
 
@@ -83,12 +85,20 @@ py::dict decode_scip(const std::string &index_file,
   }
 
   // Flatten edges: resolve vertex ids → names for portability.
+  // 5-tuple = (src, tgt, type, anchor_file_or_None, anchor_line_or_None).
+  // The Python wrapper (scip_decode_core.py) handles either 3- or 5-tuple
+  // for forward compatibility.
   py::list edge_list;
   const auto &cpp_edges = graph.edges();
   for (const auto &e : cpp_edges) {
     const std::string &src_name = vertices[e.source].name;
     const std::string &tgt_name = vertices[e.target].name;
-    edge_list.append(py::make_tuple(src_name, tgt_name, e.type));
+    py::object anchor_file =
+        e.anchor_file.has_value() ? py::cast(*e.anchor_file) : py::none();
+    py::object anchor_line =
+        e.anchor_line.has_value() ? py::cast(*e.anchor_line) : py::none();
+    edge_list.append(py::make_tuple(src_name, tgt_name, e.type, anchor_file,
+                                     anchor_line));
   }
 
   py::dict result;
@@ -119,7 +129,9 @@ Returns:
     dict with:
       - "vertices": list of dicts with keys
           name, type, file, start_line, end_line, unified_name
-      - "edges": list of tuples (source_name, target_name, edge_type)
+      - "edges": list of 5-tuples
+          (source_name, target_name, edge_type,
+           anchor_file_or_None, anchor_line_or_None)
       - "project_root": the effective project_root used.
 )pbdoc");
 }

--- a/core/code_graph.cpp
+++ b/core/code_graph.cpp
@@ -239,8 +239,8 @@ void CodeGraph::add_symbol_node(const std::string &symbol, int line,
 
 void CodeGraph::add_symbol_reference(
     const std::string &symbol, const std::optional<std::string> &module_path,
-    const std::string &symbol_type, std::optional<int> anchor_line,
-    std::optional<std::string> anchor_file) {
+    const std::string &symbol_type, std::optional<std::string> anchor_file,
+    std::optional<int> anchor_line) {
   const bool already_exists =
       name_to_vertex_.find(symbol) != name_to_vertex_.end();
   VertexId id = ensure_vertex(symbol);

--- a/core/code_graph.cpp
+++ b/core/code_graph.cpp
@@ -303,36 +303,41 @@ igraph_integer_t CodeGraph::add_edge(const std::string &source,
   VertexId source_id = ensure_vertex(source);
   VertexId target_id = ensure_vertex(target);
 
-  // Structural edges (no anchor) — dedup by (source, target, type) to mirror
-  // the Python `CodeGraph._add_edge` and the `batch_add_edges` structural
-  // dedup. CONTAIN edges from rust struct + impl pairs would otherwise
-  // become duplicates after the anchor strip on CONTAIN edges.
-  // Anchored edges are intentionally multi-edge (one per call site).
+  // Dedup by (src, tgt, type, anchor_file, anchor_line). Structural edges
+  // (no anchor) collapse on (src, tgt, type). Mirrors Python _add_edge.
   const bool is_structural =
       !anchor_file.has_value() && !anchor_line.has_value();
-  if (is_structural) {
-    igraph_vector_int_t out_eids;
-    igraph_vector_int_init(&out_eids, 0);
-    if (igraph_incident(&graph_, &out_eids, source_id, IGRAPH_OUT) ==
-        IGRAPH_SUCCESS) {
-      const igraph_integer_t n = igraph_vector_int_size(&out_eids);
-      for (igraph_integer_t i = 0; i < n; ++i) {
-        igraph_integer_t eid =
-            static_cast<igraph_integer_t>(VECTOR(out_eids)[i]);
-        if (static_cast<std::size_t>(eid) >= edges_.size()) {
-          continue;
-        }
-        const EdgeData &existing = edges_[eid];
-        if (existing.target == target_id && existing.type == edge_type &&
-            !existing.anchor_file.has_value() &&
+  igraph_vector_int_t out_eids;
+  igraph_vector_int_init(&out_eids, 0);
+  if (igraph_incident(&graph_, &out_eids, source_id, IGRAPH_OUT) ==
+      IGRAPH_SUCCESS) {
+    const igraph_integer_t n = igraph_vector_int_size(&out_eids);
+    for (igraph_integer_t i = 0; i < n; ++i) {
+      igraph_integer_t eid =
+          static_cast<igraph_integer_t>(VECTOR(out_eids)[i]);
+      if (static_cast<std::size_t>(eid) >= edges_.size()) {
+        continue;
+      }
+      const EdgeData &existing = edges_[eid];
+      if (existing.target != target_id || existing.type != edge_type) {
+        continue;
+      }
+      if (is_structural) {
+        if (!existing.anchor_file.has_value() &&
             !existing.anchor_line.has_value()) {
+          igraph_vector_int_destroy(&out_eids);
+          return eid;
+        }
+      } else {
+        if (existing.anchor_file == anchor_file &&
+            existing.anchor_line == anchor_line) {
           igraph_vector_int_destroy(&out_eids);
           return eid;
         }
       }
     }
-    igraph_vector_int_destroy(&out_eids);
   }
+  igraph_vector_int_destroy(&out_eids);
 
   if (igraph_add_edge(&graph_, source_id, target_id) != IGRAPH_SUCCESS) {
     throw std::runtime_error("Failed to add edge to graph");
@@ -420,37 +425,51 @@ void CodeGraph::batch_add_edges(
     return;
   }
 
-  // Anchored edges (those carrying an anchor_file/anchor_line) are
-  // intentionally multi-edge — each call site keeps its own edge so
-  // range queries can address them individually.
-  //
-  // Structural edges WITHOUT anchor info (file/dir containment,
-  // inheritance, etc.) are deduped by (source, target). Without this,
-  // every parallel decoder worker would re-emit the file/dir hierarchy
-  // it traversed, producing N duplicates of "root → src/" etc. — the
-  // serial Python decoder avoids this via decoder-level
-  // ``indexed_directories`` tracking that the per-worker SubgraphBuilder
-  // can't share, so dedup at merge time keeps parity.
+  // Structural edges (no anchor) dedup on (src, tgt). Without this,
+  // parallel workers re-emit shared file/dir hierarchy as duplicates.
+  // Anchored edges dedup on (src, tgt, type, anchor_file, anchor_line)
+  // so cross-side reconnect in the Python patcher can't double-add.
   struct StructuralKey {
     VertexId source;
     VertexId target;
-
-    bool operator==(const StructuralKey &other) const {
-      return source == other.source && target == other.target;
+    bool operator==(const StructuralKey &o) const {
+      return source == o.source && target == o.target;
     }
   };
-
   struct StructuralKeyHash {
-    std::size_t operator()(const StructuralKey &key) const {
-      return std::hash<VertexId>{}(key.source) ^
-             (std::hash<VertexId>{}(key.target) << 1);
+    std::size_t operator()(const StructuralKey &k) const {
+      return std::hash<VertexId>{}(k.source) ^
+             (std::hash<VertexId>{}(k.target) << 1);
+    }
+  };
+  struct AnchoredKey {
+    VertexId source;
+    VertexId target;
+    std::string type;
+    std::optional<std::string> anchor_file;
+    std::optional<int> anchor_line;
+    bool operator==(const AnchoredKey &o) const {
+      return source == o.source && target == o.target && type == o.type &&
+             anchor_file == o.anchor_file && anchor_line == o.anchor_line;
+    }
+  };
+  struct AnchoredKeyHash {
+    std::size_t operator()(const AnchoredKey &k) const {
+      std::size_t h = std::hash<VertexId>{}(k.source);
+      h ^= std::hash<VertexId>{}(k.target) << 1;
+      h ^= std::hash<std::string>{}(k.type) << 2;
+      if (k.anchor_file.has_value())
+        h ^= std::hash<std::string>{}(*k.anchor_file) << 3;
+      if (k.anchor_line.has_value())
+        h ^= std::hash<int>{}(*k.anchor_line) << 4;
+      return h;
     }
   };
 
   std::unordered_set<StructuralKey, StructuralKeyHash> seen_structural;
+  std::unordered_set<AnchoredKey, AnchoredKeyHash> seen_anchored;
 
-  // Pre-seed with existing structural edges already on the graph (added
-  // through the serial `add_edge` path before this batch).
+  // Pre-seed with edges already on the graph from prior add_edge calls.
   igraph_integer_t current_ecount = igraph_ecount(&graph_);
   for (igraph_integer_t i = 0; i < current_ecount; ++i) {
     if (i < static_cast<igraph_integer_t>(edges_.size())) {
@@ -458,6 +477,10 @@ void CodeGraph::batch_add_edges(
       if (!existing.anchor_file.has_value() &&
           !existing.anchor_line.has_value()) {
         seen_structural.insert(StructuralKey{existing.source, existing.target});
+      } else {
+        seen_anchored.insert(AnchoredKey{existing.source, existing.target,
+                                         existing.type, existing.anchor_file,
+                                         existing.anchor_line});
       }
     }
   }
@@ -493,11 +516,15 @@ void CodeGraph::batch_add_edges(
     if (is_structural) {
       StructuralKey key{source_id, target_id};
       if (seen_structural.find(key) != seen_structural.end()) {
-        log_debug("Structural edge from '" + source + "' to '" + target +
-                  "' already exists, skipping");
         continue;
       }
       seen_structural.insert(key);
+    } else {
+      AnchoredKey key{source_id, target_id, type, anchor_file, anchor_line};
+      if (seen_anchored.find(key) != seen_anchored.end()) {
+        continue;
+      }
+      seen_anchored.insert(key);
     }
 
     VECTOR(edge_vector)[edge_idx * 2] = source_id;

--- a/core/code_graph.cpp
+++ b/core/code_graph.cpp
@@ -239,17 +239,24 @@ void CodeGraph::add_symbol_node(const std::string &symbol, int line,
 
 void CodeGraph::add_symbol_reference(
     const std::string &symbol, const std::optional<std::string> &module_path,
-    const std::string &symbol_type) {
+    const std::string &symbol_type, std::optional<int> anchor_line,
+    std::optional<std::string> anchor_file) {
   const bool already_exists =
       name_to_vertex_.find(symbol) != name_to_vertex_.end();
   VertexId id = ensure_vertex(symbol);
   std::optional<std::string> file_attr =
       already_exists ? std::nullopt : module_path;
   apply_vertex_update(id, symbol_type, file_attr, std::nullopt, std::nullopt);
-  add_edge(current_scope_, symbol, EDGE_TYPE_REFERENCE);
+  if (!anchor_file.has_value() && !current_file_.empty()) {
+    anchor_file = current_file_;
+  }
+  add_edge(current_scope_, symbol, EDGE_TYPE_REFERENCE, anchor_file,
+           anchor_line);
 }
 
 void CodeGraph::add_containment_edge(const std::string &target_symbol) {
+  // CONTAIN edges deliberately carry no anchor — containment is structural,
+  // not a call/reference site. See anchor invariant ii on the Python side.
   add_edge(current_scope_, target_symbol, EDGE_TYPE_CONTAIN);
 }
 
@@ -288,22 +295,45 @@ void CodeGraph::exit_scopes_by_line(int current_line) {
 
 igraph_integer_t CodeGraph::add_edge(const std::string &source,
                                      const std::string &target,
-                                     const std::string &edge_type) {
+                                     const std::string &edge_type,
+                                     std::optional<std::string> anchor_file,
+                                     std::optional<int> anchor_line) {
   log_debug("Adding edge from '" + source + "' to '" + target + "' type '" +
             edge_type + "'");
   VertexId source_id = ensure_vertex(source);
   VertexId target_id = ensure_vertex(target);
 
-  igraph_integer_t eid = -1;
-  if (igraph_get_eid(&graph_, &eid, source_id, target_id, /*directed=*/1,
-                     /*error=*/0) == IGRAPH_SUCCESS &&
-      eid >= 0) {
-    log_debug("Edge already exists; returning eid " + std::to_string(eid) +
-              " without updating type");
-    return eid;
+  // Structural edges (no anchor) — dedup by (source, target, type) to mirror
+  // the Python `CodeGraph._add_edge` and the `batch_add_edges` structural
+  // dedup. CONTAIN edges from rust struct + impl pairs would otherwise
+  // become duplicates after the anchor strip on CONTAIN edges.
+  // Anchored edges are intentionally multi-edge (one per call site).
+  const bool is_structural =
+      !anchor_file.has_value() && !anchor_line.has_value();
+  if (is_structural) {
+    igraph_vector_int_t out_eids;
+    igraph_vector_int_init(&out_eids, 0);
+    if (igraph_incident(&graph_, &out_eids, source_id, IGRAPH_OUT) ==
+        IGRAPH_SUCCESS) {
+      const igraph_integer_t n = igraph_vector_int_size(&out_eids);
+      for (igraph_integer_t i = 0; i < n; ++i) {
+        igraph_integer_t eid =
+            static_cast<igraph_integer_t>(VECTOR(out_eids)[i]);
+        if (static_cast<std::size_t>(eid) >= edges_.size()) {
+          continue;
+        }
+        const EdgeData &existing = edges_[eid];
+        if (existing.target == target_id && existing.type == edge_type &&
+            !existing.anchor_file.has_value() &&
+            !existing.anchor_line.has_value()) {
+          igraph_vector_int_destroy(&out_eids);
+          return eid;
+        }
+      }
+    }
+    igraph_vector_int_destroy(&out_eids);
   }
 
-  log_debug("Edge not present; creating new edge");
   if (igraph_add_edge(&graph_, source_id, target_id) != IGRAPH_SUCCESS) {
     throw std::runtime_error("Failed to add edge to graph");
   }
@@ -313,7 +343,8 @@ igraph_integer_t CodeGraph::add_edge(const std::string &source,
   if (static_cast<std::size_t>(igraph_ecount(&graph_)) > edges_.size()) {
     edges_.resize(static_cast<std::size_t>(igraph_ecount(&graph_)));
   }
-  edges_[new_eid] = EdgeData{source_id, target_id, edge_type};
+  edges_[new_eid] = EdgeData{source_id, target_id, edge_type,
+                             std::move(anchor_file), anchor_line};
   return new_eid;
 }
 
@@ -382,36 +413,52 @@ void CodeGraph::batch_upsert_nodes(const std::vector<VertexData> &nodes) {
 }
 
 void CodeGraph::batch_add_edges(
-    const std::vector<std::tuple<std::string, std::string, std::string>>
-        &edges) {
+    const std::vector<
+        std::tuple<std::string, std::string, std::string,
+                   std::optional<std::string>, std::optional<int>>> &edges) {
   if (edges.empty()) {
     return;
   }
 
-  // Build edge list for igraph, deduplicating using a set
-  struct EdgeKey {
+  // Anchored edges (those carrying an anchor_file/anchor_line) are
+  // intentionally multi-edge — each call site keeps its own edge so
+  // range queries can address them individually.
+  //
+  // Structural edges WITHOUT anchor info (file/dir containment,
+  // inheritance, etc.) are deduped by (source, target). Without this,
+  // every parallel decoder worker would re-emit the file/dir hierarchy
+  // it traversed, producing N duplicates of "root → src/" etc. — the
+  // serial Python decoder avoids this via decoder-level
+  // ``indexed_directories`` tracking that the per-worker SubgraphBuilder
+  // can't share, so dedup at merge time keeps parity.
+  struct StructuralKey {
     VertexId source;
     VertexId target;
 
-    bool operator==(const EdgeKey &other) const {
+    bool operator==(const StructuralKey &other) const {
       return source == other.source && target == other.target;
     }
   };
 
-  struct EdgeKeyHash {
-    std::size_t operator()(const EdgeKey &key) const {
+  struct StructuralKeyHash {
+    std::size_t operator()(const StructuralKey &key) const {
       return std::hash<VertexId>{}(key.source) ^
              (std::hash<VertexId>{}(key.target) << 1);
     }
   };
 
-  std::unordered_set<EdgeKey, EdgeKeyHash> existing_edges;
+  std::unordered_set<StructuralKey, StructuralKeyHash> seen_structural;
 
-  // Collect existing edges to avoid duplicates
+  // Pre-seed with existing structural edges already on the graph (added
+  // through the serial `add_edge` path before this batch).
   igraph_integer_t current_ecount = igraph_ecount(&graph_);
   for (igraph_integer_t i = 0; i < current_ecount; ++i) {
     if (i < static_cast<igraph_integer_t>(edges_.size())) {
-      existing_edges.insert(EdgeKey{edges_[i].source, edges_[i].target});
+      const auto &existing = edges_[i];
+      if (!existing.anchor_file.has_value() &&
+          !existing.anchor_line.has_value()) {
+        seen_structural.insert(StructuralKey{existing.source, existing.target});
+      }
     }
   }
 
@@ -423,9 +470,7 @@ void CodeGraph::batch_add_edges(
   new_edge_data.reserve(edges.size());
 
   igraph_integer_t edge_idx = 0;
-  for (const auto &[source, target, type] : edges) {
-    // Verify vertices exist (they should have been created by
-    // batch_upsert_nodes)
+  for (const auto &[source, target, type, anchor_file, anchor_line] : edges) {
     auto source_it = name_to_vertex_.find(source);
     auto target_it = name_to_vertex_.find(target);
 
@@ -443,39 +488,36 @@ void CodeGraph::batch_add_edges(
     VertexId source_id = source_it->second;
     VertexId target_id = target_it->second;
 
-    EdgeKey key{source_id, target_id};
-
-    // Check if edge already exists in our local set
-    if (existing_edges.find(key) != existing_edges.end()) {
-      log_debug("Edge from '" + source + "' to '" + target +
-                "' already exists, skipping");
-      continue;
+    const bool is_structural =
+        !anchor_file.has_value() && !anchor_line.has_value();
+    if (is_structural) {
+      StructuralKey key{source_id, target_id};
+      if (seen_structural.find(key) != seen_structural.end()) {
+        log_debug("Structural edge from '" + source + "' to '" + target +
+                  "' already exists, skipping");
+        continue;
+      }
+      seen_structural.insert(key);
     }
 
-    // Mark as existing to prevent duplicates within this batch
-    existing_edges.insert(key);
-
-    // Add to edge vector
     VECTOR(edge_vector)[edge_idx * 2] = source_id;
     VECTOR(edge_vector)[edge_idx * 2 + 1] = target_id;
     edge_idx++;
 
-    new_edge_data.push_back(EdgeData{source_id, target_id, type});
+    new_edge_data.push_back(
+        EdgeData{source_id, target_id, type, anchor_file, anchor_line});
     log_debug("Batch adding edge from '" + source + "' to '" + target +
               "' type '" + type + "'");
   }
 
-  // Resize the vector to actual number of edges to add (excluding duplicates)
   igraph_vector_int_resize(&edge_vector, edge_idx * 2);
 
-  // Batch add edges to igraph
   if (edge_idx > 0) {
     if (igraph_add_edges(&graph_, &edge_vector, nullptr) != IGRAPH_SUCCESS) {
       igraph_vector_int_destroy(&edge_vector);
       throw std::runtime_error("Failed to batch add edges to graph");
     }
 
-    // Resize edges_ and store edge data
     igraph_integer_t new_ecount = igraph_ecount(&graph_);
     if (static_cast<std::size_t>(new_ecount) > edges_.size()) {
       edges_.resize(static_cast<std::size_t>(new_ecount));
@@ -644,7 +686,21 @@ void CodeGraph::save_graph(const std::string &output_path) const {
     out << "      \"id\": " << i << ",\n";
     out << "      \"source\": " << e.source << ",\n";
     out << "      \"target\": " << e.target << ",\n";
-    out << "      \"type\": " << escape_json(e.type) << "\n";
+    out << "      \"type\": " << escape_json(e.type) << ",\n";
+    out << "      \"anchor_file\": ";
+    if (e.anchor_file.has_value()) {
+      out << escape_json(*e.anchor_file);
+    } else {
+      out << "null";
+    }
+    out << ",\n";
+    out << "      \"anchor_line\": ";
+    if (e.anchor_line.has_value()) {
+      out << *e.anchor_line;
+    } else {
+      out << "null";
+    }
+    out << "\n";
     out << "    }";
     if (i + 1 < edges_.size()) {
       out << ",";

--- a/core/code_graph.h
+++ b/core/code_graph.h
@@ -69,8 +69,8 @@ public:
       const std::string &symbol,
       const std::optional<std::string> &module_path = std::nullopt,
       const std::string &symbol_type = NODE_TYPE_SYMBOL,
-      std::optional<int> anchor_line = std::nullopt,
-      std::optional<std::string> anchor_file = std::nullopt);
+      std::optional<std::string> anchor_file = std::nullopt,
+      std::optional<int> anchor_line = std::nullopt);
 
   // CONTAIN edges deliberately carry no anchor — containment is a structural
   // relation, not a call/reference site. (See anchor invariant ii on
@@ -81,9 +81,11 @@ public:
                             std::optional<int> end_line = std::nullopt);
   void exit_scopes_by_line(int current_line);
 
-  // Multi-edges between the same `(source, target)` pair are allowed —
-  // each call creates a new edge. Pass `anchor_file` / `anchor_line` to
-  // record the call-site location for range-query support.
+  // Edges between `(source, target)` collapse on the full key
+  // `(source, target, edge_type, anchor_file, anchor_line)`. Distinct
+  // anchors yield distinct multi-edges; an identical key returns the
+  // existing eid. Pass `anchor_file` / `anchor_line` to record the
+  // call-site location for range-query support.
   igraph_integer_t
   add_edge(const std::string &source, const std::string &target,
            const std::string &edge_type,
@@ -92,10 +94,10 @@ public:
 
   void batch_upsert_nodes(const std::vector<VertexData> &nodes);
   // Each entry: (source, target, type, anchor_file, anchor_line).
-  // Edges with anchor info are inserted as multi-edges (no dedup);
-  // structural edges without anchor info are deduped by (source, target)
-  // to mirror the per-decoder ``indexed_directories`` tracking that the
-  // serial Python decoders apply at decoder scope.
+  // Identical `(source, target, type, anchor_file, anchor_line)` collapses
+  // to a single edge; multi-edges across distinct anchors are allowed.
+  // Mirrors the per-decoder ``indexed_directories`` tracking the serial
+  // Python decoders apply at decoder scope.
   void batch_add_edges(
       const std::vector<
           std::tuple<std::string, std::string, std::string,

--- a/core/code_graph.h
+++ b/core/code_graph.h
@@ -40,6 +40,11 @@ public:
     VertexId source;
     VertexId target;
     std::string type;
+    // Optional call-site location (LSP-aligned line-range query support).
+    // Set for reference edges that carry `occurrence.range` info; nullopt
+    // for structural edges (file/dir containment, inheritance).
+    std::optional<std::string> anchor_file;
+    std::optional<int> anchor_line;
   };
 
   CodeGraph();
@@ -63,22 +68,38 @@ public:
   void add_symbol_reference(
       const std::string &symbol,
       const std::optional<std::string> &module_path = std::nullopt,
-      const std::string &symbol_type = NODE_TYPE_SYMBOL);
+      const std::string &symbol_type = NODE_TYPE_SYMBOL,
+      std::optional<int> anchor_line = std::nullopt,
+      std::optional<std::string> anchor_file = std::nullopt);
 
+  // CONTAIN edges deliberately carry no anchor — containment is a structural
+  // relation, not a call/reference site. (See anchor invariant ii on
+  // CodeGraph::query_range in the Python side.)
   void add_containment_edge(const std::string &target_symbol);
   void update_current_scope(const std::string &symbol,
                             std::optional<int> start_line = std::nullopt,
                             std::optional<int> end_line = std::nullopt);
   void exit_scopes_by_line(int current_line);
 
-  igraph_integer_t add_edge(const std::string &source,
-                            const std::string &target,
-                            const std::string &edge_type);
+  // Multi-edges between the same `(source, target)` pair are allowed —
+  // each call creates a new edge. Pass `anchor_file` / `anchor_line` to
+  // record the call-site location for range-query support.
+  igraph_integer_t
+  add_edge(const std::string &source, const std::string &target,
+           const std::string &edge_type,
+           std::optional<std::string> anchor_file = std::nullopt,
+           std::optional<int> anchor_line = std::nullopt);
 
   void batch_upsert_nodes(const std::vector<VertexData> &nodes);
+  // Each entry: (source, target, type, anchor_file, anchor_line).
+  // Edges with anchor info are inserted as multi-edges (no dedup);
+  // structural edges without anchor info are deduped by (source, target)
+  // to mirror the per-decoder ``indexed_directories`` tracking that the
+  // serial Python decoders apply at decoder scope.
   void batch_add_edges(
-      const std::vector<std::tuple<std::string, std::string, std::string>>
-          &edges);
+      const std::vector<
+          std::tuple<std::string, std::string, std::string,
+                     std::optional<std::string>, std::optional<int>>> &edges);
 
   std::optional<VertexData>
   get_node_info_by_name(const std::string &node_name) const;

--- a/core/scip_decode_base.cpp
+++ b/core/scip_decode_base.cpp
@@ -251,7 +251,9 @@ void SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) {
   //   - Later REFERENCE leaves existing attrs alone (matches serial
   //     add_symbol_reference's "only create if missing").
   std::unordered_map<std::string, Subgraph::Node> merged_nodes;
-  std::vector<std::tuple<std::string, std::string, std::string>> all_edges;
+  std::vector<std::tuple<std::string, std::string, std::string,
+                          std::optional<std::string>, std::optional<int>>>
+      all_edges;
 
   std::size_t estimated = 0;
   for (const auto &sg : subgraphs)
@@ -281,7 +283,8 @@ void SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) {
       // else: subsequent ref on existing node — leave attrs alone.
     }
     for (const auto &e : sg.edges) {
-      all_edges.emplace_back(e.source, e.target, e.type);
+      all_edges.emplace_back(e.source, e.target, e.type, e.anchor_file,
+                              e.anchor_line);
     }
   }
 

--- a/core/scip_decode_common.cpp
+++ b/core/scip_decode_common.cpp
@@ -81,8 +81,8 @@ void SubgraphBuilder::add_symbol_node(const std::string &symbol, int line,
 
 void SubgraphBuilder::add_symbol_reference(
     const std::string &symbol, const std::optional<std::string> &module_path,
-    const std::string &symbol_type, std::optional<int> anchor_line,
-    std::optional<std::string> anchor_file) {
+    const std::string &symbol_type, std::optional<std::string> anchor_file,
+    std::optional<int> anchor_line) {
   // Serial CodeGraph.add_symbol_reference: only populates attrs on FIRST
   // add. Subsequent refs leave the node alone (defs still overwrite via
   // add_symbol_node).

--- a/core/scip_decode_common.cpp
+++ b/core/scip_decode_common.cpp
@@ -81,7 +81,8 @@ void SubgraphBuilder::add_symbol_node(const std::string &symbol, int line,
 
 void SubgraphBuilder::add_symbol_reference(
     const std::string &symbol, const std::optional<std::string> &module_path,
-    const std::string &symbol_type) {
+    const std::string &symbol_type, std::optional<int> anchor_line,
+    std::optional<std::string> anchor_file) {
   // Serial CodeGraph.add_symbol_reference: only populates attrs on FIRST
   // add. Subsequent refs leave the node alone (defs still overwrite via
   // add_symbol_node).
@@ -95,17 +96,28 @@ void SubgraphBuilder::add_symbol_reference(
                  std::nullopt, std::nullopt);
     node.is_definition = false;
   }
-  add_edge(current_scope_, symbol, EDGE_TYPE_REFERENCE);
+  // Default anchor_file to the current document so range queries can
+  // route reference edges to the file they originate from.
+  if (!anchor_file.has_value() && !current_file_.empty()) {
+    anchor_file = current_file_;
+  }
+  add_edge(current_scope_, symbol, EDGE_TYPE_REFERENCE, anchor_file,
+           anchor_line);
 }
 
 void SubgraphBuilder::add_containment_edge(const std::string &target_symbol) {
+  // CONTAIN edges carry no anchor — see anchor invariant ii on the Python
+  // CodeGraph::query_range docstring.
   add_edge(current_scope_, target_symbol, EDGE_TYPE_CONTAIN);
 }
 
 void SubgraphBuilder::add_edge(const std::string &source,
                                const std::string &target,
-                               const std::string &edge_type) {
-  subgraph_.edges.push_back(Subgraph::Edge{source, target, edge_type});
+                               const std::string &edge_type,
+                               std::optional<std::string> anchor_file,
+                               std::optional<int> anchor_line) {
+  subgraph_.edges.push_back(Subgraph::Edge{
+      source, target, edge_type, std::move(anchor_file), anchor_line});
 }
 
 void SubgraphBuilder::set_unified_name(const std::string &symbol,

--- a/core/scip_decode_common.h
+++ b/core/scip_decode_common.h
@@ -63,8 +63,8 @@ public:
   add_symbol_reference(const std::string &symbol,
                        const std::optional<std::string> &module_path,
                        const std::string &symbol_type,
-                       std::optional<int> anchor_line = std::nullopt,
-                       std::optional<std::string> anchor_file = std::nullopt);
+                       std::optional<std::string> anchor_file = std::nullopt,
+                       std::optional<int> anchor_line = std::nullopt);
 
   // CONTAIN edges carry no anchor — see CodeGraph::add_containment_edge.
   void add_containment_edge(const std::string &target_symbol);

--- a/core/scip_decode_common.h
+++ b/core/scip_decode_common.h
@@ -19,6 +19,12 @@ struct Subgraph {
     std::string source;
     std::string target;
     std::string type;
+    // Optional call-site location (LSP-aligned line-range query support).
+    // Set for reference edges threaded with `occurrence.range`; nullopt for
+    // structural edges (file/dir containment, inheritance) where there is
+    // no meaningful anchor.
+    std::optional<std::string> anchor_file;
+    std::optional<int> anchor_line;
   };
 
   struct Node {
@@ -51,14 +57,21 @@ public:
   // Reference — mirrors serial CodeGraph.add_symbol_reference:
   //   attributes are set only the FIRST time the name is seen; subsequent
   //   references leave existing attrs alone (defs via add_symbol_node are
-  //   the only thing that overwrites).
-  void add_symbol_reference(const std::string &symbol,
-                            const std::optional<std::string> &module_path,
-                            const std::string &symbol_type);
+  //   the only thing that overwrites). Pass `anchor_line` for the call-site
+  //   line; `anchor_file` defaults to the current document.
+  void
+  add_symbol_reference(const std::string &symbol,
+                       const std::optional<std::string> &module_path,
+                       const std::string &symbol_type,
+                       std::optional<int> anchor_line = std::nullopt,
+                       std::optional<std::string> anchor_file = std::nullopt);
 
+  // CONTAIN edges carry no anchor — see CodeGraph::add_containment_edge.
   void add_containment_edge(const std::string &target_symbol);
   void add_edge(const std::string &source, const std::string &target,
-                const std::string &edge_type);
+                const std::string &edge_type,
+                std::optional<std::string> anchor_file = std::nullopt,
+                std::optional<int> anchor_line = std::nullopt);
 
   // Set unified_name on a node. When `only_if_missing`, preserves an
   // already-set value (matches serial "first-ref-wins for unified_name"

--- a/core/scip_decode_go.cpp
+++ b/core/scip_decode_go.cpp
@@ -291,7 +291,7 @@ void SCIPGoDecoder::process_symbol(const std::string &symbol,
       builder.add_edge(builder.current_scope(), key, EDGE_TYPE_CONTAIN);
     }
   } else {
-    builder.add_symbol_reference(key, file_path, type);
+    builder.add_symbol_reference(key, file_path, type, /*anchor_line=*/line);
     builder.set_unified_name(key, unified_name(key, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/core/scip_decode_go.cpp
+++ b/core/scip_decode_go.cpp
@@ -291,7 +291,9 @@ void SCIPGoDecoder::process_symbol(const std::string &symbol,
       builder.add_edge(builder.current_scope(), key, EDGE_TYPE_CONTAIN);
     }
   } else {
-    builder.add_symbol_reference(key, file_path, type, /*anchor_line=*/line);
+    builder.add_symbol_reference(key, file_path, type,
+                                  /*anchor_file=*/std::nullopt,
+                                  /*anchor_line=*/line);
     builder.set_unified_name(key, unified_name(key, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/core/scip_decode_python.cpp
+++ b/core/scip_decode_python.cpp
@@ -206,7 +206,9 @@ void SCIPPythonDecoder::process_symbol(const std::string &symbol, int line,
       std::replace(module_dir.begin(), module_dir.end(), '.', '/');
       std::string file = module_dir + ".py";
       if (is_reference) {
-        builder.add_edge(builder.current_scope(), file, EDGE_TYPE_REFERENCE);
+        builder.add_edge(builder.current_scope(), file, EDGE_TYPE_REFERENCE,
+                          /*anchor_file=*/builder.current_file(),
+                          /*anchor_line=*/line);
       }
     }
     return;
@@ -226,7 +228,8 @@ void SCIPPythonDecoder::process_symbol(const std::string &symbol, int line,
                             symbol_type);
     builder.add_edge(builder.current_scope(), unified, EDGE_TYPE_CONTAIN);
   } else if (is_reference) {
-    builder.add_symbol_reference(unified, module_path, symbol_type);
+    builder.add_symbol_reference(unified, module_path, symbol_type,
+                                  /*anchor_line=*/line);
   }
 }
 

--- a/core/scip_decode_python.cpp
+++ b/core/scip_decode_python.cpp
@@ -229,6 +229,7 @@ void SCIPPythonDecoder::process_symbol(const std::string &symbol, int line,
     builder.add_edge(builder.current_scope(), unified, EDGE_TYPE_CONTAIN);
   } else if (is_reference) {
     builder.add_symbol_reference(unified, module_path, symbol_type,
+                                  /*anchor_file=*/std::nullopt,
                                   /*anchor_line=*/line);
   }
 }

--- a/core/scip_decode_rust.cpp
+++ b/core/scip_decode_rust.cpp
@@ -451,7 +451,7 @@ void SCIPRustDecoder::process_symbol(const std::string &symbol,
       builder.add_edge(builder.current_scope(), unified, EDGE_TYPE_CONTAIN);
     }
   } else {
-    builder.add_symbol_reference(unified, file_path, type);
+    builder.add_symbol_reference(unified, file_path, type, /*anchor_line=*/line);
     builder.set_unified_name(unified, unified_name(unified, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/core/scip_decode_rust.cpp
+++ b/core/scip_decode_rust.cpp
@@ -451,7 +451,9 @@ void SCIPRustDecoder::process_symbol(const std::string &symbol,
       builder.add_edge(builder.current_scope(), unified, EDGE_TYPE_CONTAIN);
     }
   } else {
-    builder.add_symbol_reference(unified, file_path, type, /*anchor_line=*/line);
+    builder.add_symbol_reference(unified, file_path, type,
+                                  /*anchor_file=*/std::nullopt,
+                                  /*anchor_line=*/line);
     builder.set_unified_name(unified, unified_name(unified, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/core/scip_decode_ts.cpp
+++ b/core/scip_decode_ts.cpp
@@ -171,29 +171,40 @@ std::string SCIPTSDecoder::unify_symbol_name(const std::string &cleaned_symbol,
                       : original_symbol.substr(last_sp + 1);
   }
 
+  // SCIP TS descriptor shape:
+  //   [dir/prefix/]`filename`[/<nested-symbol-segments>]<kind-suffix>
+  // The optional dir prefix lives OUTSIDE the first backtick block — the
+  // previous implementation discarded it, collapsing e.g.
+  //   `examples/`server.js`/'Content-Type'0`:` and
+  //   `sandbox/`server.js`/'Content-Type'0`:`
+  // into the same symbol id. This block mirrors the Python decoder's fix:
+  // include the outside-backtick prefix in module_path; descriptor is the
+  // tail after the first backtick block (subsequent backticks stripped).
   std::string module_path;
   std::string descriptor;
-  auto bt_segments = all_backtick_segments(sym_with_bt);
-  if (!bt_segments.empty()) {
-    if (bt_segments.size() == 1) {
-      module_path = bt_segments[0];
-    } else {
-      // First segment might use dots for slashes
-      static const re2::RE2 ext_strip(R"re2(\.(ts|tsx|js|jsx)$)re2");
-      std::string first = bt_segments[0];
-      re2::RE2::Replace(&first, ext_strip, "");
-      std::replace(first.begin(), first.end(), '.', '/');
-      std::ostringstream oss;
-      oss << first;
-      for (std::size_t i = 1; i < bt_segments.size(); ++i)
-        oss << '/' << bt_segments[i];
-      module_path = oss.str();
-    }
-    auto last_bt = sym_with_bt.rfind('`');
-    std::string tail = sym_with_bt.substr(last_bt + 1);
+  auto first_bt_open = sym_with_bt.find('`');
+  auto first_bt_close =
+      first_bt_open == std::string::npos
+          ? std::string::npos
+          : sym_with_bt.find('`', first_bt_open + 1);
+
+  if (first_bt_open != std::string::npos &&
+      first_bt_close != std::string::npos &&
+      first_bt_close > first_bt_open) {
+    std::string dir_prefix = sym_with_bt.substr(0, first_bt_open);
+    while (!dir_prefix.empty() && dir_prefix.back() == '/')
+      dir_prefix.pop_back();
+    std::string file_part = sym_with_bt.substr(
+        first_bt_open + 1, first_bt_close - first_bt_open - 1);
+    if (!dir_prefix.empty())
+      module_path = dir_prefix + "/" + file_part;
+    else
+      module_path = file_part;
+
+    std::string tail = sym_with_bt.substr(first_bt_close + 1);
     while (!tail.empty() && tail.front() == '/')
       tail.erase(tail.begin());
-    descriptor = tail;
+    descriptor = strip_backticks(tail);
   } else {
     module_path = file_path.empty() ? std::string("unknown") : file_path;
     descriptor = strip_backticks(cleaned_symbol);
@@ -396,7 +407,9 @@ void SCIPTSDecoder::process_symbol(const std::string &symbol, int line,
   bool is_simple_symbol = unified.find('#') == std::string::npos;
   if (is_index_file && is_simple_symbol && !(symbol_roles & 1)) {
     if (builder.current_scope() != file_path) {
-      builder.add_edge(builder.current_scope(), file_path, EDGE_TYPE_REFERENCE);
+      builder.add_edge(builder.current_scope(), file_path, EDGE_TYPE_REFERENCE,
+                        /*anchor_file=*/file_path,
+                        /*anchor_line=*/line);
     }
     return;
   }
@@ -417,7 +430,7 @@ void SCIPTSDecoder::process_symbol(const std::string &symbol, int line,
     builder.set_unified_name(unified, unified_name(unified, file_path, type));
     builder.add_edge(builder.current_scope(), unified, EDGE_TYPE_CONTAIN);
   } else {
-    builder.add_symbol_reference(unified, file_path, type);
+    builder.add_symbol_reference(unified, file_path, type, /*anchor_line=*/line);
     builder.set_unified_name(unified, unified_name(unified, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/core/scip_decode_ts.cpp
+++ b/core/scip_decode_ts.cpp
@@ -430,7 +430,9 @@ void SCIPTSDecoder::process_symbol(const std::string &symbol, int line,
     builder.set_unified_name(unified, unified_name(unified, file_path, type));
     builder.add_edge(builder.current_scope(), unified, EDGE_TYPE_CONTAIN);
   } else {
-    builder.add_symbol_reference(unified, file_path, type, /*anchor_line=*/line);
+    builder.add_symbol_reference(unified, file_path, type,
+                                  /*anchor_file=*/std::nullopt,
+                                  /*anchor_line=*/line);
     builder.set_unified_name(unified, unified_name(unified, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ markers = [
     "slow: marks tests that need LLM API, GPU, or HuggingFace downloads (deselect with '-m \"not slow\"')",
     "integration: marks tests that use external repos but are read-only / parallel-safe (chunkers, fixture-based SCIP)",
     "integration_serial: marks tests that mutate shared repos (process_instance, git checkout/apply) and must run sequentially",
+    "integration_serial_consumer: marks tests that consume graph.pkl written by integration_serial (run in a separate job after integration-serial via job-level needs, mirroring scip-core)",
 ]
 
 [tool.black]

--- a/test/graph/incremental/test_graph_patcher.py
+++ b/test/graph/incremental/test_graph_patcher.py
@@ -801,8 +801,10 @@ class TestSWEBenchGo:
         assert stats["vertices_created"] > 0
 
         unames_after = _get_unified_names(g)
-        # Modified files' symbols should exist
+        # Modified files' symbols should exist (SCIP-Go skips _test.go).
         for f in changed["modified"]:
+            if f.endswith("_test.go"):
+                continue
             file_syms = [u for u in unames_after if u.startswith(f + ":")]
             assert len(file_syms) > 0, f"Modified file {f} should have symbols"
 
@@ -830,62 +832,60 @@ class TestSWEBenchGo:
         assert total_refs > 0, f"Expected reference edges for Go, got {total_refs}"
 
         # ── Strict cross-file edge assertions (10+) ──
-        # Go SCIP edge source is file vertex (name), target has unified_name
-        # connpolicy.go → values.go
         assert _has_ref_edge(
             g,
-            "modules/caddytls/connpolicy.go",
+            "modules/caddytls/connpolicy.go:ConnectionPolicy.buildStandardTLSConfig()",
             "modules/caddytls/values.go:CipherSuiteID()",
-        ), "connpolicy.go → CipherSuiteID()"
+        ), "connpolicy.go:buildStandardTLSConfig → values.go:CipherSuiteID()"
         assert _has_ref_edge(
             g,
-            "modules/caddytls/connpolicy.go",
+            "modules/caddytls/connpolicy.go:ConnectionPolicy.buildStandardTLSConfig()",
             "modules/caddytls/values.go:SupportedCurves",
-        ), "connpolicy.go → SupportedCurves"
+        ), "connpolicy.go:buildStandardTLSConfig → values.go:SupportedCurves"
         assert _has_ref_edge(
             g,
-            "modules/caddytls/connpolicy.go",
+            "modules/caddytls/connpolicy.go:ConnectionPolicy.buildStandardTLSConfig()",
             "modules/caddytls/values.go:SupportedProtocols",
-        ), "connpolicy.go → SupportedProtocols"
+        ), "connpolicy.go:buildStandardTLSConfig → values.go:SupportedProtocols"
         assert _has_ref_edge(
             g,
-            "modules/caddytls/connpolicy.go",
+            "modules/caddytls/connpolicy.go:setDefaultTLSParams()",
             "modules/caddytls/values.go:getOptimalDefaultCipherSuites()",
-        ), "connpolicy.go → getOptimalDefaultCipherSuites()"
+        ), "connpolicy.go:setDefaultTLSParams → values.go:getOptimalDefaultCipherSuites()"
         # builtins.go → values.go (unmodified file referencing values.go)
         assert _has_ref_edge(
             g,
-            "caddyconfig/httpcaddyfile/builtins.go",
+            "caddyconfig/httpcaddyfile/builtins.go:parseTLS()",
             "modules/caddytls/values.go:SupportedProtocols",
-        ), "builtins.go → SupportedProtocols"
+        ), "builtins.go:parseTLS → values.go:SupportedProtocols"
         assert _has_ref_edge(
             g,
-            "caddyconfig/httpcaddyfile/builtins.go",
+            "caddyconfig/httpcaddyfile/builtins.go:parseTLS()",
             "modules/caddytls/values.go:SupportedCurves",
-        ), "builtins.go → SupportedCurves"
+        ), "builtins.go:parseTLS → values.go:SupportedCurves"
         assert _has_ref_edge(
             g,
-            "caddyconfig/httpcaddyfile/builtins.go",
+            "caddyconfig/httpcaddyfile/builtins.go:parseTLS()",
             "modules/caddytls/values.go:CipherSuiteNameSupported()",
-        ), "builtins.go → CipherSuiteNameSupported()"
+        ), "builtins.go:parseTLS → values.go:CipherSuiteNameSupported()"
         # automation.go → values.go
         assert _has_ref_edge(
             g,
-            "modules/caddytls/automation.go",
+            "modules/caddytls/automation.go:AutomationPolicy.Provision()",
             "modules/caddytls/values.go:supportedCertKeyTypes",
-        ), "automation.go → supportedCertKeyTypes"
+        ), "automation.go:Provision → values.go:supportedCertKeyTypes"
         # replacer.go → values.go
         assert _has_ref_edge(
             g,
-            "modules/caddyhttp/replacer.go",
+            "modules/caddyhttp/replacer.go:getReqTLSReplacement()",
             "modules/caddytls/values.go:ProtocolName()",
-        ), "replacer.go → ProtocolName()"
+        ), "replacer.go:getReqTLSReplacement → values.go:ProtocolName()"
         # fastcgi → values.go
         assert _has_ref_edge(
             g,
-            "modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go",
+            "modules/caddyhttp/reverseproxy/fastcgi/fastcgi.go:Transport.buildEnv()",
             "modules/caddytls/values.go:SupportedCipherSuites()",
-        ), "fastcgi.go → SupportedCipherSuites()"
+        ), "fastcgi.go:Transport.buildEnv → values.go:SupportedCipherSuites()"
 
 
 class TestSWEBenchRust:

--- a/test/graph/incremental/test_patcher_multiedge.py
+++ b/test/graph/incremental/test_patcher_multiedge.py
@@ -8,8 +8,25 @@ anchor so the remap path can re-create one edge per call site.
 """
 
 from codeminer.graph.code_graph import CodeGraph
+from codeminer.graph.incremental.patcher_base import PatcherBase
 from codeminer.graph.incremental.subgraph_mgr import SubgraphMgr
 from codeminer.types import EDGE_TYPE_REFERENCE
+
+
+class _StubPatcher(PatcherBase):
+    """Minimal PatcherBase subclass for unit tests on its protected methods."""
+
+    def get_lsp_command(self):
+        return ["echo"]
+
+    def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+        return f"{file_path}:{name}"
+
+    def _get_crossfile_token_types(self):
+        return set()
+
+    def flatten_symbols(self, file_path, lsp_symbols):
+        return self._flatten_symbols_default(file_path, lsp_symbols)
 
 
 class _NoopMgr(SubgraphMgr):
@@ -206,3 +223,867 @@ def test_delete_vertices_by_file_skips_internal_edges():
         f"expected exactly 1 external severance entry, got {len(external)}: "
         f"{external}"
     )
+
+
+# ---------------------------------------------------------------------------
+# P1: delete_outgoing_in_anchor_ranges
+# ---------------------------------------------------------------------------
+def _setup_outgoing_with_anchors(anchor_lines, anchor_files=None):
+    """Build a graph with one source `Foo` (in a.py) carrying multiple
+    outgoing REFERENCE edges to `Tgt` (in b.py), each at a distinct anchor."""
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    g.add_file_node("b.py")
+    g._add_vertex(
+        "a.py:Foo",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 10,
+            "end_line": 50,
+            "unified_name": "a.py:Foo",
+        },
+    )
+    g._add_vertex(
+        "b.py:Tgt",
+        {
+            "type": "function",
+            "file": "b.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "b.py:Tgt",
+        },
+    )
+    if anchor_files is None:
+        anchor_files = ["a.py"] * len(anchor_lines)
+    for af, al in zip(anchor_files, anchor_lines, strict=False):
+        g._add_edge(
+            "a.py:Foo",
+            "b.py:Tgt",
+            EDGE_TYPE_REFERENCE,
+            anchor_file=af,
+            anchor_line=al,
+        )
+    g.build_range_indexes()
+    return g
+
+
+def _outgoing_ref_anchor_lines(g, src_name):
+    src = g.name_to_vertex[src_name]
+    out_eids = g.graph.incident(src, mode="out")
+    return sorted(
+        g.graph.es[e].attributes().get("anchor_line")
+        for e in out_eids
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    )
+
+
+def test_delete_outgoing_in_anchor_ranges_single_range():
+    """Delete only edges whose anchor_line falls within the given range."""
+    g = _setup_outgoing_with_anchors([5, 15, 25, 50])
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    removed = mgr.delete_outgoing_in_anchor_ranges(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        ranges=[(10, 30)],
+    )
+    assert removed == 2, f"expected 2 deletions (lines 15 and 25), got {removed}"
+    survivors = _outgoing_ref_anchor_lines(g, "a.py:Foo")
+    assert survivors == [5, 50], f"unexpected survivors: {survivors}"
+
+
+def test_delete_outgoing_in_anchor_ranges_respects_anchor_file():
+    """Edges in the same line range but a different anchor_file must stay.
+    All three distinct anchors fall in [10, 20] numerically, but only the
+    a.py ones should be deleted; b.py:15 must survive."""
+    g = _setup_outgoing_with_anchors(
+        [12, 15, 18],
+        anchor_files=["a.py", "b.py", "a.py"],
+    )
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    removed = mgr.delete_outgoing_in_anchor_ranges(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        ranges=[(10, 20)],
+    )
+    assert removed == 2, f"expected 2 a.py edges deleted, got {removed}"
+    src = g.name_to_vertex["a.py:Foo"]
+    out_eids = g.graph.incident(src, mode="out")
+    surviving = [
+        g.graph.es[e].attributes()
+        for e in out_eids
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    assert len(surviving) == 1
+    assert surviving[0].get("anchor_file") == "b.py"
+    assert surviving[0].get("anchor_line") == 15
+
+
+def test_delete_outgoing_in_anchor_ranges_only_reference():
+    """CONTAIN edges (no anchor) must NOT be touched."""
+    g = _setup_outgoing_with_anchors([15])
+    # Add a CONTAIN edge from Foo to a child symbol — no anchor, must survive.
+    g._add_vertex(
+        "a.py:Foo.helper",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 20,
+            "end_line": 25,
+            "unified_name": "a.py:Foo.helper",
+        },
+    )
+    from codeminer.types import EDGE_TYPE_CONTAIN
+    g._add_edge("a.py:Foo", "a.py:Foo.helper", EDGE_TYPE_CONTAIN)
+
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    removed = mgr.delete_outgoing_in_anchor_ranges(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        ranges=[(10, 30)],
+    )
+    assert removed == 1, f"expected 1 ref edge deleted, got {removed}"
+
+    src = g.name_to_vertex["a.py:Foo"]
+    out_eids = g.graph.incident(src, mode="out")
+    contain_count = sum(
+        1 for e in out_eids if g.graph.es[e]["type"] == EDGE_TYPE_CONTAIN
+    )
+    assert contain_count == 1, "CONTAIN edge must be preserved"
+
+
+def test_delete_outgoing_in_anchor_ranges_multiple_ranges():
+    """Multiple ranges: edge in any range gets deleted; edges outside all stay."""
+    g = _setup_outgoing_with_anchors([3, 12, 18, 22, 35, 50])
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    removed = mgr.delete_outgoing_in_anchor_ranges(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        ranges=[(10, 15), (20, 25)],
+    )
+    assert removed == 2, f"expected 2 (lines 12 and 22), got {removed}"
+    survivors = _outgoing_ref_anchor_lines(g, "a.py:Foo")
+    assert survivors == [3, 18, 35, 50], f"unexpected survivors: {survivors}"
+
+
+# ---------------------------------------------------------------------------
+# P2: shift_outgoing_anchor_lines
+# ---------------------------------------------------------------------------
+def test_shift_outgoing_anchor_lines_basic():
+    """Uniform positive shift over the symbol's old body range."""
+    g = _setup_outgoing_with_anchors([12, 18, 25])
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    moved = mgr.shift_outgoing_anchor_lines(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        old_start=10,
+        old_end=30,
+        shift=5,
+    )
+    assert moved == 3, f"expected 3 anchor shifts, got {moved}"
+    assert _outgoing_ref_anchor_lines(g, "a.py:Foo") == [17, 23, 30]
+
+
+def test_shift_outgoing_anchor_lines_negative():
+    """Negative shift moves anchors back. Anchors outside the old range stay."""
+    g = _setup_outgoing_with_anchors([5, 22, 28, 40])
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    moved = mgr.shift_outgoing_anchor_lines(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        old_start=20,
+        old_end=30,
+        shift=-3,
+    )
+    assert moved == 2, f"expected 2 (lines 22 and 28), got {moved}"
+    assert _outgoing_ref_anchor_lines(g, "a.py:Foo") == [5, 19, 25, 40]
+
+
+def test_shift_outgoing_anchor_lines_respects_anchor_file():
+    """Anchors with same line range but different anchor_file must not shift."""
+    g = _setup_outgoing_with_anchors(
+        [12, 15, 18],
+        anchor_files=["a.py", "b.py", "a.py"],
+    )
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    moved = mgr.shift_outgoing_anchor_lines(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        old_start=10,
+        old_end=20,
+        shift=100,
+    )
+    assert moved == 2, f"expected 2 (a.py edges only), got {moved}"
+    src = g.name_to_vertex["a.py:Foo"]
+    pairs = sorted(
+        (
+            g.graph.es[e].attributes().get("anchor_file"),
+            g.graph.es[e].attributes().get("anchor_line"),
+        )
+        for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    )
+    assert pairs == [("a.py", 112), ("a.py", 118), ("b.py", 15)]
+
+
+def test_shift_outgoing_anchor_lines_only_reference():
+    """CONTAIN edges (no anchor) stay untouched."""
+    g = _setup_outgoing_with_anchors([15])
+    g._add_vertex(
+        "a.py:Foo.helper",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 20,
+            "end_line": 25,
+            "unified_name": "a.py:Foo.helper",
+        },
+    )
+    from codeminer.types import EDGE_TYPE_CONTAIN
+    g._add_edge("a.py:Foo", "a.py:Foo.helper", EDGE_TYPE_CONTAIN)
+
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    moved = mgr.shift_outgoing_anchor_lines(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        old_start=10,
+        old_end=30,
+        shift=5,
+    )
+    assert moved == 1
+    src = g.name_to_vertex["a.py:Foo"]
+    contain_count = sum(
+        1
+        for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_CONTAIN
+    )
+    assert contain_count == 1, "CONTAIN edge must stay"
+
+
+def test_shift_outgoing_anchor_lines_zero_shift_noop():
+    """shift=0 is a no-op: nothing moves, nothing reported."""
+    g = _setup_outgoing_with_anchors([12, 18])
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    moved = mgr.shift_outgoing_anchor_lines(
+        vertex_name="a.py:Foo",
+        anchor_file="a.py",
+        old_start=10,
+        old_end=30,
+        shift=0,
+    )
+    assert moved == 0
+    assert _outgoing_ref_anchor_lines(g, "a.py:Foo") == [12, 18]
+
+
+# ---------------------------------------------------------------------------
+# P3: reconnect_outgoing / reconnect_incoming must anchor each new edge
+# ---------------------------------------------------------------------------
+class _FakeLSPDefRefs:
+    """Stub lsp_client with canned definition() / references() responses."""
+
+    def __init__(self, project_root, definitions=None, references=None):
+        self.project_root = project_root
+        self._defs = definitions or {}      # text → list[loc]
+        self._refs = references or {}       # (file, line) → list[loc]
+
+    def definition(self, abs_file, line, character):
+        # Look up by token text — but we don't have text here, so the
+        # caller-side override of _get_semantic_tokens is responsible for
+        # routing. Here we just return whatever is keyed by line.
+        return self._defs.get(line, [])
+
+    def references(self, abs_file, line, character, include_declaration=False):
+        rel = abs_file.split(self.project_root + "/")[-1]
+        return self._refs.get((rel, line, character), [])
+
+
+class _ReconnectMgr(_NoopMgr):
+    """Override LSP semantic-token fetch to feed canned tokens."""
+
+    canned_tokens = []
+    def_by_text = {}
+
+    def _get_semantic_tokens(self, abs_file, file_path, line_ranges=None):
+        return self.canned_tokens
+
+    def _set_definitions(self, defs_by_text):
+        self.def_by_text = defs_by_text
+
+
+def _build_caller_target_graph(project_root="/tmp/recproj"):
+    g = CodeGraph(project_root=project_root)
+    g.add_file_node("caller.py")
+    g.add_file_node("tgt.py")
+    g._add_vertex(
+        "caller.py:Foo",
+        {
+            "type": "function",
+            "file": "caller.py",
+            "start_line": 10,
+            "end_line": 30,
+            "unified_name": "caller.py:Foo",
+        },
+    )
+    g._add_vertex(
+        "tgt.py:Bar",
+        {
+            "type": "function",
+            "file": "tgt.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "tgt.py:Bar",
+        },
+    )
+    g.build_range_indexes()
+    return g
+
+
+def test_reconnect_outgoing_anchors_each_call_site():
+    """After fix: 2 call sites to same target produce 2 anchored edges,
+    each carrying its own (anchor_file, anchor_line)."""
+    project_root = "/tmp/recproj"
+    g = _build_caller_target_graph(project_root)
+    mgr = _ReconnectMgr(project_root=project_root, code_graph=g)
+    mgr.canned_tokens = [
+        {"line": 12, "character": 8, "text": "Bar"},
+        {"line": 18, "character": 8, "text": "Bar"},
+    ]
+
+    # Single LSP definition response — both tokens resolve to same target.
+    fake_lsp = _FakeLSPDefRefs(project_root)
+    fake_lsp._defs = {
+        12: [{"targetUri": f"file://{project_root}/tgt.py",
+              "targetSelectionRange": {"start": {"line": 1, "character": 0}}}],
+        18: [{"targetUri": f"file://{project_root}/tgt.py",
+              "targetSelectionRange": {"start": {"line": 1, "character": 0}}}],
+    }
+    # _get_semantic_tokens dedups by text BEFORE calling lsp.definition;
+    # but the dedup uses text as the key. Stub: same text "Bar" → only one
+    # definition lookup. So return the line-1 target either way.
+    fake_lsp.definition = lambda abs_file, line, character: [{
+        "targetUri": f"file://{project_root}/tgt.py",
+        "targetSelectionRange": {"start": {"line": 1, "character": 0}},
+    }]
+    mgr.lsp_client = fake_lsp
+
+    stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
+    mgr.reconnect_outgoing(
+        "caller.py", ["caller.py:Foo"], stats, line_ranges=[(10, 30)]
+    )
+
+    assert stats["outgoing_added"] == 2, (
+        f"expected 2 anchored edges (one per call site), "
+        f"got {stats['outgoing_added']}"
+    )
+    src = g.name_to_vertex["caller.py:Foo"]
+    ref_eids = [
+        e for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    assert len(ref_eids) == 2, f"graph has {len(ref_eids)} ref edges"
+    pairs = sorted(
+        (g.graph.es[e].attributes().get("anchor_file"),
+         g.graph.es[e].attributes().get("anchor_line"))
+        for e in ref_eids
+    )
+    assert pairs == [("caller.py", 12), ("caller.py", 18)], (
+        f"anchor metadata not threaded through; got {pairs}"
+    )
+
+
+def test_reconnect_outgoing_same_anchor_collapses():
+    """If two tokens have IDENTICAL (line, character), _add_edge collapses
+    them — same call site, can't be two distinct edges. One edge survives,
+    anchored at that single line."""
+    project_root = "/tmp/recproj"
+    g = _build_caller_target_graph(project_root)
+    mgr = _ReconnectMgr(project_root=project_root, code_graph=g)
+    mgr.canned_tokens = [
+        {"line": 12, "character": 8, "text": "Bar"},
+        {"line": 12, "character": 8, "text": "Bar"},
+    ]
+    fake_lsp = _FakeLSPDefRefs(project_root)
+    fake_lsp.definition = lambda abs_file, line, character: [{
+        "targetUri": f"file://{project_root}/tgt.py",
+        "targetSelectionRange": {"start": {"line": 1, "character": 0}},
+    }]
+    mgr.lsp_client = fake_lsp
+    stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
+    mgr.reconnect_outgoing(
+        "caller.py", ["caller.py:Foo"], stats, line_ranges=[(10, 30)]
+    )
+    src = g.name_to_vertex["caller.py:Foo"]
+    ref_eids = [
+        e for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    # Same anchor → _add_edge dedup collapses to 1 edge.
+    assert len(ref_eids) == 1, f"expected 1 edge (same anchor), got {len(ref_eids)}"
+
+
+def test_reconnect_incoming_anchors_caller_site():
+    """reconnect_incoming must anchor the new edge on the caller site."""
+    project_root = "/tmp/recproj"
+    g = CodeGraph(project_root=project_root)
+    g.add_file_node("caller.py")
+    g.add_file_node("tgt.py")
+    g._add_vertex(
+        "caller.py:Caller",
+        {
+            "type": "function",
+            "file": "caller.py",
+            "start_line": 5,
+            "end_line": 15,
+            "unified_name": "caller.py:Caller",
+        },
+    )
+    g._add_vertex(
+        "tgt.py:Bar",
+        {
+            "type": "function",
+            "file": "tgt.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "tgt.py:Bar",
+        },
+    )
+    # match_location_to_scope reads symbol_ranges (populated by decoder /
+    # patcher in normal flow); do it explicitly here.
+    g.symbol_ranges["caller.py:Caller"] = (5, 15)
+    g.symbol_ranges["tgt.py:Bar"] = (1, 5)
+    g.build_range_indexes()
+
+    fake_lsp = _FakeLSPDefRefs(project_root)
+    # references() must return list of LSP locations for any (file,line,char).
+    fake_lsp.references = lambda abs_file, line, character, include_declaration=False: [
+        {
+            "uri": f"file://{project_root}/caller.py",
+            "range": {"start": {"line": 7, "character": 4}},
+        }
+    ]
+    mgr = _NoopMgr(project_root=project_root, code_graph=g, lsp_client=fake_lsp)
+    # selection ranges populated for the target so reconnect_incoming finds it
+    mgr.symbol_selection_ranges["tgt.py:Bar"] = (1, 4, 1, 7)
+    # match_location_to_scope reads file_to_vertices, populated by build_indexes()
+    mgr.build_indexes()
+
+    stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
+    mgr.reconnect_incoming("tgt.py", ["tgt.py:Bar"], stats)
+
+    assert stats["incoming_added"] == 1, f"expected 1 incoming edge, got {stats}"
+    src = g.name_to_vertex["caller.py:Caller"]
+    ref_eids = [
+        e for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    assert len(ref_eids) == 1
+    attrs = g.graph.es[ref_eids[0]].attributes()
+    assert attrs.get("anchor_file") == "caller.py", (
+        f"anchor_file should be the caller site file; got {attrs}"
+    )
+    assert attrs.get("anchor_line") == 7, (
+        f"anchor_line should be the call line; got {attrs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# P5: shifted branch must rebase outgoing anchors via shift_outgoing_anchor_lines
+# ---------------------------------------------------------------------------
+def test_shifted_rebases_outgoing_anchor_lines():
+    """When a symbol shifts (body unchanged but start_line moves), the
+    patcher's shifted branch must shift every outgoing reference anchor by
+    `new_start - old_start` so range queries still match."""
+    project_root = "/tmp/shftproj"
+    g = _setup_outgoing_with_anchors([12, 18, 25])  # Foo body 10-30
+    patcher = _StubPatcher(project_root=project_root, code_graph=g)
+    patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
+
+    file_stats = {
+        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
+        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "refs_unmatched": 0,
+    }
+    patcher._process_shifted(
+        uname="a.py:Foo",
+        old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
+        new={"start_line": 15, "end_line": 35,
+             "sel_range": {"start": {"line": 15, "character": 4},
+                           "end": {"line": 15, "character": 7}}},
+        file_path="a.py",
+        file_stats=file_stats,
+    )
+
+    # Vertex renamed.
+    new_vname = "a.py:Foo:15"
+    assert new_vname in g.name_to_vertex, "vertex should be renamed"
+    assert "a.py:Foo" not in g.name_to_vertex, "old vname should be gone"
+
+    # Outgoing anchors shifted by +5.
+    src = g.name_to_vertex[new_vname]
+    anchor_lines = sorted(
+        g.graph.es[e].attributes().get("anchor_line")
+        for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    )
+    assert anchor_lines == [17, 23, 30], (
+        f"anchors should shift +5 to [17,23,30]; got {anchor_lines}"
+    )
+    assert file_stats["vertices_shifted"] == 1
+
+
+def test_affected_preserved_clears_in_range_outgoing():
+    """Case 3 (preserved): hunk modifies a single line inside body but
+    line count is preserved. Edges anchored in the changed range must be
+    deleted; edges outside are kept (will be picked up by Round 2 LSP)."""
+    project_root = "/tmp/affproj"
+    g = _setup_outgoing_with_anchors([12, 18, 25])  # Foo body 10-30
+    patcher = _StubPatcher(project_root=project_root, code_graph=g)
+    patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
+
+    file_stats = {
+        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
+        "vertices_affected_preserved": 0, "vertices_affected_rebuilt": 0,
+        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "refs_unmatched": 0,
+    }
+    # Hunk: line 18 (old) → line 18 (new). 1 line in / 1 line out → preserved.
+    hunks = [(18, 18, 18, 18)]
+    _new_vname, new_ranges = patcher._process_affected(
+        uname="a.py:Foo",
+        old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
+        new={"start_line": 10, "end_line": 30,
+             "sel_range": {"start": {"line": 10, "character": 4},
+                           "end": {"line": 10, "character": 7}}},
+        hunks=hunks,
+        file_path="a.py",
+        file_stats=file_stats,
+    )
+
+    new_vname = "a.py:Foo:10"
+    src = g.name_to_vertex[new_vname]
+    surviving = sorted(
+        g.graph.es[e].attributes().get("anchor_line")
+        for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    )
+    assert surviving == [12, 25], (
+        f"only line-18 anchor should be cleared; got {surviving}"
+    )
+    # Round 2 needs to know which lines to query in the NEW coordinate
+    # system; for this hunk that's line 18.
+    assert (18, 18) in new_ranges, f"new_changed_ranges missing 18; got {new_ranges}"
+    assert file_stats["vertices_affected_preserved"] == 1
+
+
+def test_affected_length_changed_clears_all_outgoing():
+    """Case 4 (length_changed): hunk inserts lines into the body. Net line
+    count not preserved, fast-path anchor shift is unsafe → delete every
+    outgoing reference edge from this vertex; Round 2 rebuilds them."""
+    project_root = "/tmp/affproj"
+    g = _setup_outgoing_with_anchors([12, 18, 25])  # Foo body 10-30
+    patcher = _StubPatcher(project_root=project_root, code_graph=g)
+    patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
+
+    file_stats = {
+        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
+        "vertices_affected_preserved": 0, "vertices_affected_rebuilt": 0,
+        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "refs_unmatched": 0,
+    }
+    # Hunk: 1 line at old 18 becomes 4 lines at new 18-21. Length changed.
+    hunks = [(18, 18, 18, 21)]
+    _new_vname, new_ranges = patcher._process_affected(
+        uname="a.py:Foo",
+        old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
+        new={"start_line": 10, "end_line": 33,
+             "sel_range": {"start": {"line": 10, "character": 4},
+                           "end": {"line": 10, "character": 7}}},
+        hunks=hunks,
+        file_path="a.py",
+        file_stats=file_stats,
+    )
+
+    new_vname = "a.py:Foo:10"
+    src = g.name_to_vertex[new_vname]
+    surviving = [
+        e for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    assert len(surviving) == 0, (
+        "case 4 must clear ALL outgoing ref edges; got "
+        f"{[g.graph.es[e].attributes() for e in surviving]}"
+    )
+    # Round 2 reconnects over the entire new body.
+    assert new_ranges == [(10, 33)], (
+        f"slow path should report full new body; got {new_ranges}"
+    )
+    assert file_stats["vertices_affected_rebuilt"] == 1
+
+
+def test_affected_preserved_with_start_line_shift_uniform_rebase():
+    """Case 3 + symbol shifted by file-level insertion: anchors outside the
+    changed range shift by `delta = new.start - old.start`; in-range
+    anchors are deleted."""
+    project_root = "/tmp/affproj"
+    g = _setup_outgoing_with_anchors([12, 18, 25])  # Foo body 10-30
+    patcher = _StubPatcher(project_root=project_root, code_graph=g)
+    patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
+
+    file_stats = {
+        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
+        "vertices_affected_preserved": 0, "vertices_affected_rebuilt": 0,
+        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "refs_unmatched": 0,
+    }
+    # 5 lines inserted at top of file → symbol shifts +5; old hunk modifies
+    # what was old line 18 (now new line 23). Length preserved.
+    hunks = [(18, 18, 23, 23)]
+    _new_vname, new_ranges = patcher._process_affected(
+        uname="a.py:Foo",
+        old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
+        new={"start_line": 15, "end_line": 35,
+             "sel_range": {"start": {"line": 15, "character": 4},
+                           "end": {"line": 15, "character": 7}}},
+        hunks=hunks,
+        file_path="a.py",
+        file_stats=file_stats,
+    )
+
+    new_vname = "a.py:Foo:15"
+    src = g.name_to_vertex[new_vname]
+    surviving = sorted(
+        g.graph.es[e].attributes().get("anchor_line")
+        for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    )
+    # 12 → 17, 25 → 30; anchor at 18 is in changed region → deleted.
+    assert surviving == [17, 30], (
+        f"expected [17, 30] (uniform +5 shift, line-18 deleted); got {surviving}"
+    )
+    assert (23, 23) in new_ranges
+    assert file_stats["vertices_affected_preserved"] == 1
+
+
+# ---------------------------------------------------------------------------
+# P7: severed_incoming uname fallback when src vname has been renamed
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# P8: severed remap rebase anchor_line via per-file shift table
+# ---------------------------------------------------------------------------
+def test_remap_severed_anchor_line_rebased_by_shift_table():
+    """When the severed entry's src file has been shifted (e.g. from an
+    earlier sibling-file patch in the same batch), anchor_line must be
+    rebased by the shift table before the rebuilt edge is written."""
+    project_root = "/tmp/r2proj"
+    g = CodeGraph(project_root=project_root)
+    g.add_file_node("caller.py")
+    g.add_file_node("tgt.py")
+    g._add_vertex(
+        "caller.py:Caller",
+        {
+            "type": "function",
+            "file": "caller.py",
+            "start_line": 5,
+            "end_line": 15,
+            "unified_name": "caller.py:Caller",
+        },
+    )
+    g._add_vertex(
+        "tgt.py:Bar:1",
+        {
+            "type": "function",
+            "file": "tgt.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "tgt.py:Bar",
+        },
+    )
+    g.symbol_ranges["caller.py:Caller"] = (5, 15)
+    g.symbol_ranges["tgt.py:Bar:1"] = (1, 5)
+    g.build_range_indexes()
+
+    patcher = _StubPatcher(project_root=project_root, code_graph=g)
+
+    # Severed entry was recorded with anchor_line=7 (pre-shift). The src
+    # file has since been shifted by +5 in [5, 15] → new anchor should be 12.
+    severed_incoming = [
+        (
+            "caller.py:Caller", "tgt.py:Bar",
+            "caller.py:Caller", "tgt.py:Bar",
+            "caller.py", 7,
+        )
+    ]
+    anchor_shifts = {
+        "caller.py": [(5, 15, 5)],   # (old_start, old_end, delta)
+    }
+
+    remapped = patcher._remap_severed_edges(
+        new_vertices=["tgt.py:Bar:1"],
+        severed_incoming=severed_incoming,
+        severed_outgoing=[],
+        anchor_shifts=anchor_shifts,
+    )
+    assert remapped == 1
+    src = g.name_to_vertex["caller.py:Caller"]
+    ref_eids = [
+        e for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    assert len(ref_eids) == 1
+    attrs = g.graph.es[ref_eids[0]].attributes()
+    assert attrs.get("anchor_line") == 12, (
+        f"anchor_line should rebase 7 + 5 = 12; got {attrs}"
+    )
+
+
+def test_remap_severed_anchor_line_no_shift_table_keeps_anchor():
+    """No shift table → anchors remain at their recorded line (back-compat)."""
+    project_root = "/tmp/r2proj"
+    g = CodeGraph(project_root=project_root)
+    g.add_file_node("caller.py")
+    g.add_file_node("tgt.py")
+    g._add_vertex(
+        "caller.py:Caller",
+        {
+            "type": "function",
+            "file": "caller.py",
+            "start_line": 5,
+            "end_line": 15,
+            "unified_name": "caller.py:Caller",
+        },
+    )
+    g._add_vertex(
+        "tgt.py:Bar:1",
+        {
+            "type": "function",
+            "file": "tgt.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "tgt.py:Bar",
+        },
+    )
+    g.symbol_ranges["caller.py:Caller"] = (5, 15)
+    g.symbol_ranges["tgt.py:Bar:1"] = (1, 5)
+    g.build_range_indexes()
+
+    patcher = _StubPatcher(project_root=project_root, code_graph=g)
+    remapped = patcher._remap_severed_edges(
+        new_vertices=["tgt.py:Bar:1"],
+        severed_incoming=[(
+            "caller.py:Caller", "tgt.py:Bar",
+            "caller.py:Caller", "tgt.py:Bar",
+            "caller.py", 7,
+        )],
+        severed_outgoing=[],
+    )
+    assert remapped == 1
+    src = g.name_to_vertex["caller.py:Caller"]
+    ref_eids = [
+        e for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    attrs = g.graph.es[ref_eids[0]].attributes()
+    assert attrs.get("anchor_line") == 7, "no shift table → anchor unchanged"
+
+
+def test_remap_severed_incoming_uname_fallback():
+    """If the caller's vname was renamed in this batch, severed_incoming
+    must still remap via src_uname instead of silently dropping the entry."""
+    project_root = "/tmp/r1proj"
+    g = CodeGraph(project_root=project_root)
+    g.add_file_node("caller.py")
+    g.add_file_node("tgt.py")
+    # Caller already RENAMED to its new vname (simulating a sibling file
+    # patch that ran before this one in the same batch).
+    g._add_vertex(
+        "caller.py:Caller:5",
+        {
+            "type": "function",
+            "file": "caller.py",
+            "start_line": 5,
+            "end_line": 15,
+            "unified_name": "caller.py:Caller",
+        },
+    )
+    # Target rebuilt under a new vname, with same unified_name.
+    g._add_vertex(
+        "tgt.py:Bar:1",
+        {
+            "type": "function",
+            "file": "tgt.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "tgt.py:Bar",
+        },
+    )
+    g.symbol_ranges["caller.py:Caller:5"] = (5, 15)
+    g.symbol_ranges["tgt.py:Bar:1"] = (1, 5)
+    g.build_range_indexes()
+
+    patcher = _StubPatcher(project_root=project_root, code_graph=g)
+    # Severed incoming entry recorded earlier when the OLD caller.py:Caller
+    # vname was still in the graph.
+    severed_incoming = [
+        (
+            "caller.py:Caller",     # src_name (STALE — already renamed)
+            "tgt.py:Bar",           # tgt_name
+            "caller.py:Caller",     # src_uname (stable)
+            "tgt.py:Bar",           # tgt_uname
+            "caller.py",
+            7,
+        )
+    ]
+
+    remapped = patcher._remap_severed_edges(
+        new_vertices=["tgt.py:Bar:1"],
+        severed_incoming=severed_incoming,
+        severed_outgoing=[],
+    )
+
+    # Without the uname fallback this returns 0 and the edge is lost.
+    assert remapped == 1, (
+        "uname fallback should resurrect the edge when src_name is stale; "
+        f"remapped={remapped}"
+    )
+    src = g.name_to_vertex["caller.py:Caller:5"]
+    ref_eids = [
+        e for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    assert len(ref_eids) == 1
+    attrs = g.graph.es[ref_eids[0]].attributes()
+    assert attrs.get("anchor_file") == "caller.py"
+    assert attrs.get("anchor_line") == 7
+
+
+def test_shifted_zero_shift_is_attribute_only_update():
+    """Defensive: if start_line did not actually change, no shift call;
+    only attrs (e.g. end_line) get refreshed."""
+    project_root = "/tmp/shftproj"
+    g = _setup_outgoing_with_anchors([12, 18])  # Foo body 10-30
+    patcher = _StubPatcher(project_root=project_root, code_graph=g)
+    patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
+
+    file_stats = {
+        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
+        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "refs_unmatched": 0,
+    }
+    patcher._process_shifted(
+        uname="a.py:Foo",
+        old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
+        new={"start_line": 10, "end_line": 32,
+             "sel_range": {"start": {"line": 10, "character": 4},
+                           "end": {"line": 10, "character": 7}}},
+        file_path="a.py",
+        file_stats=file_stats,
+    )
+
+    # Anchors unchanged.
+    src = g.name_to_vertex["a.py:Foo:10"]  # renamed because start in vname
+    anchor_lines = sorted(
+        g.graph.es[e].attributes().get("anchor_line")
+        for e in g.graph.incident(src, mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    )
+    assert anchor_lines == [12, 18]

--- a/test/graph/incremental/test_patcher_multiedge.py
+++ b/test/graph/incremental/test_patcher_multiedge.py
@@ -1,0 +1,208 @@
+"""Multi-edge correctness: edit one call site, verify only one edge is removed.
+
+#125 review correctness risk: dropping `are_adjacent` dedup means a
+`(src, tgt)` pair now carries multiple edges (one per anchor). Patcher
+deletion logic must remove edges by `(src, tgt, type, anchor_line)`, not
+by source/target alone. Severance reporting must surface one record per
+anchor so the remap path can re-create one edge per call site.
+"""
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.graph.incremental.subgraph_mgr import SubgraphMgr
+from codeminer.types import EDGE_TYPE_REFERENCE
+
+
+class _NoopMgr(SubgraphMgr):
+    """Minimal concrete SubgraphMgr to test the deletion / severance API."""
+
+    def _build_unified_name(self, file_path, name, parent_unified_part, kind):
+        return f"{file_path}:{name}"
+
+    def _get_crossfile_token_types(self):
+        return set()
+
+
+def _setup_two_calls_one_target():
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("caller.py")
+    g._add_vertex(
+        "caller_fn",
+        {
+            "type": "function",
+            "file": "caller.py",
+            "start_line": 1,
+            "end_line": 20,
+            "unified_name": "caller.py:caller_fn",
+        },
+    )
+    g._add_vertex(
+        "Target",
+        {
+            "type": "function",
+            "file": "target.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "target.py:Target",
+        },
+    )
+    # Two call sites to the same target, anchored at lines 5 and 10.
+    g._add_edge(
+        "caller_fn",
+        "Target",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="caller.py",
+        anchor_line=5,
+    )
+    g._add_edge(
+        "caller_fn",
+        "Target",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="caller.py",
+        anchor_line=10,
+    )
+    g.build_range_indexes()
+    return g
+
+
+def test_two_anchors_produce_two_edges():
+    """Sanity: multi-edge schema preserves both call sites as distinct edges."""
+    g = _setup_two_calls_one_target()
+    src = g.name_to_vertex["caller_fn"]
+    out_eids = g.graph.incident(src, mode="out")
+    ref_eids = [e for e in out_eids if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE]
+    assert (
+        len(ref_eids) == 2
+    ), f"expected 2 multi-edges (one per anchor), got {len(ref_eids)}"
+
+
+def test_delete_one_anchor_keeps_other():
+    """Simulate: anchor at line 5 is removed, anchor at line 10 survives.
+
+    The patcher path under test is `subgraph_mgr.delete_edges_by_anchor`.
+    Verify the line-10 edge remains intact afterwards.
+    """
+    g = _setup_two_calls_one_target()
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    removed = mgr.delete_edges_by_anchor(
+        source_name="caller_fn",
+        target_name="Target",
+        edge_type=EDGE_TYPE_REFERENCE,
+        anchor_file="caller.py",
+        anchor_line=5,
+    )
+    assert removed == 1
+
+    src = g.name_to_vertex["caller_fn"]
+    out_eids = g.graph.incident(src, mode="out")
+    ref_eids = [e for e in out_eids if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE]
+    assert len(ref_eids) == 1, f"expected 1 surviving edge, got {len(ref_eids)}"
+    surviving = g.graph.es[ref_eids[0]].attributes()
+    assert (
+        surviving.get("anchor_line") == 10
+    ), f"wrong edge survived; anchor_line={surviving.get('anchor_line')}"
+
+
+def test_severed_edges_carry_anchor_per_site():
+    """When a vertex is deleted, severed_outgoing must carry one entry per
+    anchor (no (src, tgt) dedup), so remap can re-create one edge per site."""
+    g = _setup_two_calls_one_target()
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    result = mgr.delete_vertices_by_name(["caller_fn"])
+    severed = result["severed_outgoing_refs"]
+    target_entries = [s for s in severed if s[1] == "Target"]
+    assert len(target_entries) == 2, (
+        f"expected 2 severed entries (per-anchor), got {len(target_entries)}: "
+        f"{target_entries}"
+    )
+    # Each entry must be a 6-tuple with (anchor_file, anchor_line) at the tail.
+    for entry in target_entries:
+        assert (
+            len(entry) == 6
+        ), f"severed entry expected 6-tuple, got {len(entry)}-tuple: {entry}"
+        anchor_file = entry[4]
+        anchor_line = entry[5]
+        assert anchor_file == "caller.py"
+        assert anchor_line in (
+            5,
+            10,
+        ), f"unexpected anchor_line {anchor_line}; expected 5 or 10"
+    # Both anchor lines surface (distinct call sites).
+    anchor_lines = sorted(e[5] for e in target_entries)
+    assert anchor_lines == [
+        5,
+        10,
+    ], f"expected per-anchor entries for lines [5, 10]; got {anchor_lines}"
+
+
+def test_delete_vertices_by_file_skips_internal_edges():
+    """Severed edges should NOT include edges where both endpoints are
+    inside the file being deleted — those are cascaded by vertex deletion."""
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    # Two symbols in the same file with an internal reference edge.
+    g._add_vertex(
+        "a.py:Foo",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "a.py:Foo",
+        },
+    )
+    g._add_vertex(
+        "a.py:Bar",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 10,
+            "end_line": 15,
+            "unified_name": "a.py:Bar",
+        },
+    )
+    # Foo -> Bar internal reference (anchor in a.py)
+    g._add_edge(
+        "a.py:Foo",
+        "a.py:Bar",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="a.py",
+        anchor_line=3,
+    )
+    # External vertex referencing into a.py:Bar — this severance IS expected.
+    g.add_file_node("b.py")
+    g._add_vertex(
+        "b.py:caller",
+        {
+            "type": "function",
+            "file": "b.py",
+            "start_line": 1,
+            "end_line": 10,
+            "unified_name": "b.py:caller",
+        },
+    )
+    g._add_edge(
+        "b.py:caller",
+        "a.py:Bar",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="b.py",
+        anchor_line=2,
+    )
+    g.build_range_indexes()
+
+    mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
+    result = mgr.delete_file_subgraph("a.py")
+
+    # Internal Foo->Bar edge is cascaded; should NOT appear in either list.
+    severed_out = result["severed_outgoing_refs"]
+    internal = [s for s in severed_out if s[0] == "a.py:Foo" and s[1] == "a.py:Bar"]
+    assert (
+        len(internal) == 0
+    ), f"internal a.py:Foo->a.py:Bar leaked into severed_outgoing: {internal}"
+
+    # External b.py:caller -> a.py:Bar IS an external severance, must surface.
+    severed_in = result["severed_incoming_refs"]
+    external = [s for s in severed_in if s[0] == "b.py:caller" and s[1] == "a.py:Bar"]
+    assert len(external) == 1, (
+        f"expected exactly 1 external severance entry, got {len(external)}: "
+        f"{external}"
+    )

--- a/test/graph/incremental/test_patcher_multiedge.py
+++ b/test/graph/incremental/test_patcher_multiedge.py
@@ -334,6 +334,7 @@ def test_delete_outgoing_in_anchor_ranges_only_reference():
         },
     )
     from codeminer.types import EDGE_TYPE_CONTAIN
+
     g._add_edge("a.py:Foo", "a.py:Foo.helper", EDGE_TYPE_CONTAIN)
 
     mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
@@ -440,6 +441,7 @@ def test_shift_outgoing_anchor_lines_only_reference():
         },
     )
     from codeminer.types import EDGE_TYPE_CONTAIN
+
     g._add_edge("a.py:Foo", "a.py:Foo.helper", EDGE_TYPE_CONTAIN)
 
     mgr = _NoopMgr(project_root="/tmp/x", code_graph=g)
@@ -483,8 +485,8 @@ class _FakeLSPDefRefs:
 
     def __init__(self, project_root, definitions=None, references=None):
         self.project_root = project_root
-        self._defs = definitions or {}      # text → list[loc]
-        self._refs = references or {}       # (file, line) → list[loc]
+        self._defs = definitions or {}  # text → list[loc]
+        self._refs = references or {}  # (file, line) → list[loc]
 
     def definition(self, abs_file, line, character):
         # Look up by token text — but we don't have text here, so the
@@ -552,18 +554,28 @@ def test_reconnect_outgoing_anchors_each_call_site():
     # Single LSP definition response — both tokens resolve to same target.
     fake_lsp = _FakeLSPDefRefs(project_root)
     fake_lsp._defs = {
-        12: [{"targetUri": f"file://{project_root}/tgt.py",
-              "targetSelectionRange": {"start": {"line": 1, "character": 0}}}],
-        18: [{"targetUri": f"file://{project_root}/tgt.py",
-              "targetSelectionRange": {"start": {"line": 1, "character": 0}}}],
+        12: [
+            {
+                "targetUri": f"file://{project_root}/tgt.py",
+                "targetSelectionRange": {"start": {"line": 1, "character": 0}},
+            }
+        ],
+        18: [
+            {
+                "targetUri": f"file://{project_root}/tgt.py",
+                "targetSelectionRange": {"start": {"line": 1, "character": 0}},
+            }
+        ],
     }
     # _get_semantic_tokens dedups by text BEFORE calling lsp.definition;
     # but the dedup uses text as the key. Stub: same text "Bar" → only one
     # definition lookup. So return the line-1 target either way.
-    fake_lsp.definition = lambda abs_file, line, character: [{
-        "targetUri": f"file://{project_root}/tgt.py",
-        "targetSelectionRange": {"start": {"line": 1, "character": 0}},
-    }]
+    fake_lsp.definition = lambda abs_file, line, character: [
+        {
+            "targetUri": f"file://{project_root}/tgt.py",
+            "targetSelectionRange": {"start": {"line": 1, "character": 0}},
+        }
+    ]
     mgr.lsp_client = fake_lsp
 
     stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
@@ -577,18 +589,22 @@ def test_reconnect_outgoing_anchors_each_call_site():
     )
     src = g.name_to_vertex["caller.py:Foo"]
     ref_eids = [
-        e for e in g.graph.incident(src, mode="out")
+        e
+        for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     ]
     assert len(ref_eids) == 2, f"graph has {len(ref_eids)} ref edges"
     pairs = sorted(
-        (g.graph.es[e].attributes().get("anchor_file"),
-         g.graph.es[e].attributes().get("anchor_line"))
+        (
+            g.graph.es[e].attributes().get("anchor_file"),
+            g.graph.es[e].attributes().get("anchor_line"),
+        )
         for e in ref_eids
     )
-    assert pairs == [("caller.py", 12), ("caller.py", 18)], (
-        f"anchor metadata not threaded through; got {pairs}"
-    )
+    assert pairs == [
+        ("caller.py", 12),
+        ("caller.py", 18),
+    ], f"anchor metadata not threaded through; got {pairs}"
 
 
 def test_reconnect_outgoing_same_anchor_collapses():
@@ -603,10 +619,12 @@ def test_reconnect_outgoing_same_anchor_collapses():
         {"line": 12, "character": 8, "text": "Bar"},
     ]
     fake_lsp = _FakeLSPDefRefs(project_root)
-    fake_lsp.definition = lambda abs_file, line, character: [{
-        "targetUri": f"file://{project_root}/tgt.py",
-        "targetSelectionRange": {"start": {"line": 1, "character": 0}},
-    }]
+    fake_lsp.definition = lambda abs_file, line, character: [
+        {
+            "targetUri": f"file://{project_root}/tgt.py",
+            "targetSelectionRange": {"start": {"line": 1, "character": 0}},
+        }
+    ]
     mgr.lsp_client = fake_lsp
     stats = {"incoming_added": 0, "outgoing_added": 0, "unmatched": 0}
     mgr.reconnect_outgoing(
@@ -614,7 +632,8 @@ def test_reconnect_outgoing_same_anchor_collapses():
     )
     src = g.name_to_vertex["caller.py:Foo"]
     ref_eids = [
-        e for e in g.graph.incident(src, mode="out")
+        e
+        for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     ]
     # Same anchor → _add_edge dedup collapses to 1 edge.
@@ -673,17 +692,18 @@ def test_reconnect_incoming_anchors_caller_site():
     assert stats["incoming_added"] == 1, f"expected 1 incoming edge, got {stats}"
     src = g.name_to_vertex["caller.py:Caller"]
     ref_eids = [
-        e for e in g.graph.incident(src, mode="out")
+        e
+        for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     ]
     assert len(ref_eids) == 1
     attrs = g.graph.es[ref_eids[0]].attributes()
-    assert attrs.get("anchor_file") == "caller.py", (
-        f"anchor_file should be the caller site file; got {attrs}"
-    )
-    assert attrs.get("anchor_line") == 7, (
-        f"anchor_line should be the call line; got {attrs}"
-    )
+    assert (
+        attrs.get("anchor_file") == "caller.py"
+    ), f"anchor_file should be the caller site file; got {attrs}"
+    assert (
+        attrs.get("anchor_line") == 7
+    ), f"anchor_line should be the call line; got {attrs}"
 
 
 # ---------------------------------------------------------------------------
@@ -699,16 +719,25 @@ def test_shifted_rebases_outgoing_anchor_lines():
     patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
 
     file_stats = {
-        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
-        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "vertices_deleted": 0,
+        "vertices_created": 0,
+        "vertices_shifted": 0,
+        "refs_incoming": 0,
+        "refs_outgoing": 0,
+        "refs_remapped": 0,
         "refs_unmatched": 0,
     }
     patcher._process_shifted(
         uname="a.py:Foo",
         old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
-        new={"start_line": 15, "end_line": 35,
-             "sel_range": {"start": {"line": 15, "character": 4},
-                           "end": {"line": 15, "character": 7}}},
+        new={
+            "start_line": 15,
+            "end_line": 35,
+            "sel_range": {
+                "start": {"line": 15, "character": 4},
+                "end": {"line": 15, "character": 7},
+            },
+        },
         file_path="a.py",
         file_stats=file_stats,
     )
@@ -725,9 +754,11 @@ def test_shifted_rebases_outgoing_anchor_lines():
         for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     )
-    assert anchor_lines == [17, 23, 30], (
-        f"anchors should shift +5 to [17,23,30]; got {anchor_lines}"
-    )
+    assert anchor_lines == [
+        17,
+        23,
+        30,
+    ], f"anchors should shift +5 to [17,23,30]; got {anchor_lines}"
     assert file_stats["vertices_shifted"] == 1
 
 
@@ -741,9 +772,14 @@ def test_affected_preserved_clears_in_range_outgoing():
     patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
 
     file_stats = {
-        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
-        "vertices_affected_preserved": 0, "vertices_affected_rebuilt": 0,
-        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "vertices_deleted": 0,
+        "vertices_created": 0,
+        "vertices_shifted": 0,
+        "vertices_affected_preserved": 0,
+        "vertices_affected_rebuilt": 0,
+        "refs_incoming": 0,
+        "refs_outgoing": 0,
+        "refs_remapped": 0,
         "refs_unmatched": 0,
     }
     # Hunk: line 18 (old) → line 18 (new). 1 line in / 1 line out → preserved.
@@ -751,9 +787,14 @@ def test_affected_preserved_clears_in_range_outgoing():
     _new_vname, new_ranges = patcher._process_affected(
         uname="a.py:Foo",
         old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
-        new={"start_line": 10, "end_line": 30,
-             "sel_range": {"start": {"line": 10, "character": 4},
-                           "end": {"line": 10, "character": 7}}},
+        new={
+            "start_line": 10,
+            "end_line": 30,
+            "sel_range": {
+                "start": {"line": 10, "character": 4},
+                "end": {"line": 10, "character": 7},
+            },
+        },
         hunks=hunks,
         file_path="a.py",
         file_stats=file_stats,
@@ -766,9 +807,10 @@ def test_affected_preserved_clears_in_range_outgoing():
         for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     )
-    assert surviving == [12, 25], (
-        f"only line-18 anchor should be cleared; got {surviving}"
-    )
+    assert surviving == [
+        12,
+        25,
+    ], f"only line-18 anchor should be cleared; got {surviving}"
     # Round 2 needs to know which lines to query in the NEW coordinate
     # system; for this hunk that's line 18.
     assert (18, 18) in new_ranges, f"new_changed_ranges missing 18; got {new_ranges}"
@@ -785,9 +827,14 @@ def test_affected_length_changed_clears_all_outgoing():
     patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
 
     file_stats = {
-        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
-        "vertices_affected_preserved": 0, "vertices_affected_rebuilt": 0,
-        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "vertices_deleted": 0,
+        "vertices_created": 0,
+        "vertices_shifted": 0,
+        "vertices_affected_preserved": 0,
+        "vertices_affected_rebuilt": 0,
+        "refs_incoming": 0,
+        "refs_outgoing": 0,
+        "refs_remapped": 0,
         "refs_unmatched": 0,
     }
     # Hunk: 1 line at old 18 becomes 4 lines at new 18-21. Length changed.
@@ -795,9 +842,14 @@ def test_affected_length_changed_clears_all_outgoing():
     _new_vname, new_ranges = patcher._process_affected(
         uname="a.py:Foo",
         old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
-        new={"start_line": 10, "end_line": 33,
-             "sel_range": {"start": {"line": 10, "character": 4},
-                           "end": {"line": 10, "character": 7}}},
+        new={
+            "start_line": 10,
+            "end_line": 33,
+            "sel_range": {
+                "start": {"line": 10, "character": 4},
+                "end": {"line": 10, "character": 7},
+            },
+        },
         hunks=hunks,
         file_path="a.py",
         file_stats=file_stats,
@@ -806,7 +858,8 @@ def test_affected_length_changed_clears_all_outgoing():
     new_vname = "a.py:Foo:10"
     src = g.name_to_vertex[new_vname]
     surviving = [
-        e for e in g.graph.incident(src, mode="out")
+        e
+        for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     ]
     assert len(surviving) == 0, (
@@ -814,9 +867,9 @@ def test_affected_length_changed_clears_all_outgoing():
         f"{[g.graph.es[e].attributes() for e in surviving]}"
     )
     # Round 2 reconnects over the entire new body.
-    assert new_ranges == [(10, 33)], (
-        f"slow path should report full new body; got {new_ranges}"
-    )
+    assert new_ranges == [
+        (10, 33)
+    ], f"slow path should report full new body; got {new_ranges}"
     assert file_stats["vertices_affected_rebuilt"] == 1
 
 
@@ -830,9 +883,14 @@ def test_affected_preserved_with_start_line_shift_uniform_rebase():
     patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
 
     file_stats = {
-        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
-        "vertices_affected_preserved": 0, "vertices_affected_rebuilt": 0,
-        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "vertices_deleted": 0,
+        "vertices_created": 0,
+        "vertices_shifted": 0,
+        "vertices_affected_preserved": 0,
+        "vertices_affected_rebuilt": 0,
+        "refs_incoming": 0,
+        "refs_outgoing": 0,
+        "refs_remapped": 0,
         "refs_unmatched": 0,
     }
     # 5 lines inserted at top of file → symbol shifts +5; old hunk modifies
@@ -841,9 +899,14 @@ def test_affected_preserved_with_start_line_shift_uniform_rebase():
     _new_vname, new_ranges = patcher._process_affected(
         uname="a.py:Foo",
         old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
-        new={"start_line": 15, "end_line": 35,
-             "sel_range": {"start": {"line": 15, "character": 4},
-                           "end": {"line": 15, "character": 7}}},
+        new={
+            "start_line": 15,
+            "end_line": 35,
+            "sel_range": {
+                "start": {"line": 15, "character": 4},
+                "end": {"line": 15, "character": 7},
+            },
+        },
         hunks=hunks,
         file_path="a.py",
         file_stats=file_stats,
@@ -857,9 +920,10 @@ def test_affected_preserved_with_start_line_shift_uniform_rebase():
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     )
     # 12 → 17, 25 → 30; anchor at 18 is in changed region → deleted.
-    assert surviving == [17, 30], (
-        f"expected [17, 30] (uniform +5 shift, line-18 deleted); got {surviving}"
-    )
+    assert surviving == [
+        17,
+        30,
+    ], f"expected [17, 30] (uniform +5 shift, line-18 deleted); got {surviving}"
     assert (23, 23) in new_ranges
     assert file_stats["vertices_affected_preserved"] == 1
 
@@ -908,13 +972,16 @@ def test_remap_severed_anchor_line_rebased_by_shift_table():
     # file has since been shifted by +5 in [5, 15] → new anchor should be 12.
     severed_incoming = [
         (
-            "caller.py:Caller", "tgt.py:Bar",
-            "caller.py:Caller", "tgt.py:Bar",
-            "caller.py", 7,
+            "caller.py:Caller",
+            "tgt.py:Bar",
+            "caller.py:Caller",
+            "tgt.py:Bar",
+            "caller.py",
+            7,
         )
     ]
     anchor_shifts = {
-        "caller.py": [(5, 15, 5)],   # (old_start, old_end, delta)
+        "caller.py": [(5, 15, 5)],  # (old_start, old_end, delta)
     }
 
     remapped = patcher._remap_severed_edges(
@@ -926,14 +993,15 @@ def test_remap_severed_anchor_line_rebased_by_shift_table():
     assert remapped == 1
     src = g.name_to_vertex["caller.py:Caller"]
     ref_eids = [
-        e for e in g.graph.incident(src, mode="out")
+        e
+        for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     ]
     assert len(ref_eids) == 1
     attrs = g.graph.es[ref_eids[0]].attributes()
-    assert attrs.get("anchor_line") == 12, (
-        f"anchor_line should rebase 7 + 5 = 12; got {attrs}"
-    )
+    assert (
+        attrs.get("anchor_line") == 12
+    ), f"anchor_line should rebase 7 + 5 = 12; got {attrs}"
 
 
 def test_remap_severed_anchor_line_no_shift_table_keeps_anchor():
@@ -969,17 +1037,23 @@ def test_remap_severed_anchor_line_no_shift_table_keeps_anchor():
     patcher = _StubPatcher(project_root=project_root, code_graph=g)
     remapped = patcher._remap_severed_edges(
         new_vertices=["tgt.py:Bar:1"],
-        severed_incoming=[(
-            "caller.py:Caller", "tgt.py:Bar",
-            "caller.py:Caller", "tgt.py:Bar",
-            "caller.py", 7,
-        )],
+        severed_incoming=[
+            (
+                "caller.py:Caller",
+                "tgt.py:Bar",
+                "caller.py:Caller",
+                "tgt.py:Bar",
+                "caller.py",
+                7,
+            )
+        ],
         severed_outgoing=[],
     )
     assert remapped == 1
     src = g.name_to_vertex["caller.py:Caller"]
     ref_eids = [
-        e for e in g.graph.incident(src, mode="out")
+        e
+        for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     ]
     attrs = g.graph.es[ref_eids[0]].attributes()
@@ -1025,10 +1099,10 @@ def test_remap_severed_incoming_uname_fallback():
     # vname was still in the graph.
     severed_incoming = [
         (
-            "caller.py:Caller",     # src_name (STALE — already renamed)
-            "tgt.py:Bar",           # tgt_name
-            "caller.py:Caller",     # src_uname (stable)
-            "tgt.py:Bar",           # tgt_uname
+            "caller.py:Caller",  # src_name (STALE — already renamed)
+            "tgt.py:Bar",  # tgt_name
+            "caller.py:Caller",  # src_uname (stable)
+            "tgt.py:Bar",  # tgt_uname
             "caller.py",
             7,
         )
@@ -1047,7 +1121,8 @@ def test_remap_severed_incoming_uname_fallback():
     )
     src = g.name_to_vertex["caller.py:Caller:5"]
     ref_eids = [
-        e for e in g.graph.incident(src, mode="out")
+        e
+        for e in g.graph.incident(src, mode="out")
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     ]
     assert len(ref_eids) == 1
@@ -1065,16 +1140,25 @@ def test_shifted_zero_shift_is_attribute_only_update():
     patcher.symbol_selection_ranges["a.py:Foo"] = (10, 4, 10, 7)
 
     file_stats = {
-        "vertices_deleted": 0, "vertices_created": 0, "vertices_shifted": 0,
-        "refs_incoming": 0, "refs_outgoing": 0, "refs_remapped": 0,
+        "vertices_deleted": 0,
+        "vertices_created": 0,
+        "vertices_shifted": 0,
+        "refs_incoming": 0,
+        "refs_outgoing": 0,
+        "refs_remapped": 0,
         "refs_unmatched": 0,
     }
     patcher._process_shifted(
         uname="a.py:Foo",
         old={"vertex_name": "a.py:Foo", "start_line": 10, "end_line": 30},
-        new={"start_line": 10, "end_line": 32,
-             "sel_range": {"start": {"line": 10, "character": 4},
-                           "end": {"line": 10, "character": 7}}},
+        new={
+            "start_line": 10,
+            "end_line": 32,
+            "sel_range": {
+                "start": {"line": 10, "character": 4},
+                "end": {"line": 10, "character": 7},
+            },
+        },
         file_path="a.py",
         file_stats=file_stats,
     )
@@ -1087,3 +1171,65 @@ def test_shifted_zero_shift_is_attribute_only_update():
         if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
     )
     assert anchor_lines == [12, 18]
+
+
+def test_edge_batch_flush_invalidates_edge_index():
+    """Regression: EdgeBatch.flush bypasses CodeGraph._add_edge; if it leaves
+    a stale _edge_index in place, a follow-up _add_edge for one of the
+    flushed keys will think the edge doesn't exist and create a duplicate.
+    """
+    from codeminer.graph.incremental.subgraph_mgr import EdgeBatch
+
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    g._add_vertex(
+        "src",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 0,
+            "end_line": 9,
+            "unified_name": "a.py:src",
+        },
+    )
+    g._add_vertex(
+        "tgt",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 10,
+            "end_line": 19,
+            "unified_name": "a.py:tgt",
+        },
+    )
+
+    # Force the lazy _edge_index to materialise via a normal _add_edge.
+    g._add_edge("src", "tgt", EDGE_TYPE_REFERENCE, anchor_file="a.py", anchor_line=1)
+    assert g._edge_index is not None  # built lazily on the call above
+
+    # Stage and flush a *different* anchor via EdgeBatch.
+    batch = EdgeBatch(g)
+    staged = batch.stage(
+        "src", "tgt", EDGE_TYPE_REFERENCE, anchor_file="a.py", anchor_line=2
+    )
+    assert staged is True
+    batch.flush()
+
+    ref_eids_before = [
+        e
+        for e in g.graph.incident(g.name_to_vertex["src"], mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    assert len(ref_eids_before) == 2
+
+    # Re-add the flushed key via _add_edge — must dedup, not duplicate.
+    g._add_edge("src", "tgt", EDGE_TYPE_REFERENCE, anchor_file="a.py", anchor_line=2)
+    ref_eids_after = [
+        e
+        for e in g.graph.incident(g.name_to_vertex["src"], mode="out")
+        if g.graph.es[e]["type"] == EDGE_TYPE_REFERENCE
+    ]
+    assert len(ref_eids_after) == 2, (
+        "EdgeBatch.flush left _edge_index stale: a follow-up _add_edge "
+        "for the same anchor created a duplicate"
+    )

--- a/test/graph/incremental/test_reference_resolver.py
+++ b/test/graph/incremental/test_reference_resolver.py
@@ -73,6 +73,8 @@ def _make_decoder():
     g._add_edge("src/main.rs", "src/main.rs:main():0", EDGE_TYPE_CONTAIN)
 
     decoder = PatcherRust("/tmp/test", g)
+    # match_location_to_* needs file_to_vertices, populated by build_indexes()
+    decoder.build_indexes()
     return decoder, g
 
 

--- a/test/graph/test_anchor_invariants.py
+++ b/test/graph/test_anchor_invariants.py
@@ -1,0 +1,70 @@
+"""Anchor invariants: CONTAIN edges carry no anchor; REFERENCE edges always do.
+
+See `CodeGraph.query_range` docstring for the three anchor invariants.
+"""
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE
+
+
+def test_contain_edge_has_no_anchor():
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    g._add_vertex(
+        "Foo",
+        {
+            "type": "class",
+            "file": "a.py",
+            "start_line": 1,
+            "end_line": 30,
+            "unified_name": "a.py:Foo",
+        },
+    )
+    g.update_current_scope("Foo", 1, 30)
+    g.add_symbol_node(
+        "Foo.bar",
+        line=5,
+        scope_start_line=5,
+        scope_end_line=15,
+        symbol_type="method",
+    )
+    g.add_containment_edge("Foo.bar")
+
+    found = False
+    for e in g.graph.es:
+        if e["type"] == EDGE_TYPE_CONTAIN:
+            attrs = e.attributes()
+            assert (
+                attrs.get("anchor_file") is None
+            ), f"CONTAIN edges must not carry anchor_file; got {attrs.get('anchor_file')!r}"
+            assert (
+                attrs.get("anchor_line") is None
+            ), f"CONTAIN edges must not carry anchor_line; got {attrs.get('anchor_line')!r}"
+            found = True
+    assert found, "test setup did not produce a CONTAIN edge"
+
+
+def test_reference_edge_carries_anchor():
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    g._add_vertex(
+        "Foo",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 1,
+            "end_line": 10,
+            "unified_name": "a.py:Foo",
+        },
+    )
+    g.update_current_scope("Foo", 1, 10)
+    g.add_symbol_reference("Bar", anchor_file="a.py", anchor_line=5)
+
+    found = False
+    for e in g.graph.es:
+        if e["type"] == EDGE_TYPE_REFERENCE:
+            attrs = e.attributes()
+            assert attrs.get("anchor_file") == "a.py"
+            assert attrs.get("anchor_line") == 5
+            found = True
+    assert found, "test setup did not produce a REFERENCE edge"

--- a/test/graph/test_range_queries.py
+++ b/test/graph/test_range_queries.py
@@ -1,0 +1,322 @@
+"""Unit tests for CodeGraph.query_range and the per-file range indexes.
+
+Covers the surface introduced for the LSP-aligned graph_expand redesign:
+
+- `defined` query uses overlap semantics (matches IDE outline behavior),
+  including nested scopes
+- `outgoing` returns edges with anchor inside the query range
+- `incoming` returns edges into nodes whose def is inside the range,
+  regardless of where the anchors come from
+- multi-edges between the same `(src, tgt)` pair are preserved
+- `build_range_indexes` is idempotent
+- `save_graph` / `load_graph` round-trips the indexes
+- old pickles raise on load (forces re-decode rather than silent drift)
+"""
+
+from __future__ import annotations
+
+import pickle
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from codeminer.graph.code_graph import _SCHEMA_VERSION, CodeGraph, RangeQueryResult
+from codeminer.types import EDGE_TYPE_REFERENCE
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _build_simple_graph() -> CodeGraph:
+    """Two functions in foo.py, with cross-references in both directions.
+
+    foo.py:bar  defined lines 5–20, references baz at line 12
+    foo.py:baz  defined lines 25–40, references bar at line 28
+    """
+    g = CodeGraph()
+    g.add_file_node("foo.py")
+    g.add_symbol_node("foo.py:bar", 10, 5, 20, "function")
+    g.add_symbol_node("foo.py:baz", 30, 25, 40, "function")
+
+    g.update_current_scope("foo.py:bar", 5, 20)
+    g.add_symbol_reference("foo.py:baz", anchor_line=12)
+
+    g.update_current_scope("foo.py:baz", 25, 40)
+    g.add_symbol_reference("foo.py:bar", anchor_line=28)
+
+    g.build_range_indexes()
+    return g
+
+
+def _build_nested_graph() -> CodeGraph:
+    """Class with two nested methods, all overlapping the outer class scope.
+
+    foo.py:Outer        class lines 1–100
+    foo.py:Outer.meth1  method lines 10–30
+    foo.py:Outer.meth2  method lines 50–80
+    """
+    g = CodeGraph()
+    g.add_file_node("foo.py")
+    g.add_symbol_node("foo.py:Outer", 1, 1, 100, "class")
+    g.add_symbol_node("foo.py:Outer.meth1", 10, 10, 30, "method")
+    g.add_symbol_node("foo.py:Outer.meth2", 50, 50, 80, "method")
+    g.build_range_indexes()
+    return g
+
+
+def _build_multi_edge_graph() -> CodeGraph:
+    """Same `bar` symbol called twice from different lines inside `caller`."""
+    g = CodeGraph()
+    g.add_file_node("foo.py")
+    g.add_symbol_node("foo.py:bar", 5, 5, 6, "function")
+    g.add_symbol_node("foo.py:caller", 10, 10, 100, "function")
+
+    g.update_current_scope("foo.py:caller", 10, 100)
+    g.add_symbol_reference("foo.py:bar", anchor_line=15)
+    g.add_symbol_reference("foo.py:bar", anchor_line=42)
+    g.add_symbol_reference("foo.py:bar", anchor_line=88)
+
+    g.build_range_indexes()
+    return g
+
+
+# ---------------------------------------------------------------------------
+# `defined` query
+# ---------------------------------------------------------------------------
+
+
+def test_defined_overlap_partial_left():
+    g = _build_simple_graph()
+    bar_vid = g.name_to_vertex["foo.py:bar"]
+
+    # Range starts before bar's def (5) but ends inside it.
+    r = g.query_range("foo.py", 1, 10)
+    assert [n.vid for n in r.defined] == [bar_vid]
+
+
+def test_defined_overlap_partial_right():
+    g = _build_simple_graph()
+    bar_vid = g.name_to_vertex["foo.py:bar"]
+
+    # Range starts inside bar's def and ends after it.
+    r = g.query_range("foo.py", 18, 22)
+    assert [n.vid for n in r.defined] == [bar_vid]
+
+
+def test_defined_overlap_fully_inside():
+    g = _build_simple_graph()
+    bar_vid = g.name_to_vertex["foo.py:bar"]
+
+    # Range fully inside bar's def — should still match.
+    r = g.query_range("foo.py", 8, 15)
+    assert [n.vid for n in r.defined] == [bar_vid]
+
+
+def test_defined_no_overlap():
+    g = _build_simple_graph()
+    r = g.query_range("foo.py", 100, 200)
+    assert r.defined == []
+
+
+def test_defined_includes_nested_scopes():
+    """Outer class, inner method, and outer scope all match a range that
+    covers them — IDE outline behavior."""
+    g = _build_nested_graph()
+
+    # Range 12–25 overlaps Outer (1–100) AND Outer.meth1 (10–30).
+    r = g.query_range("foo.py", 12, 25)
+    names = {n.name for n in r.defined}
+    assert names == {"foo.py:Outer", "foo.py:Outer.meth1"}
+
+
+def test_defined_unknown_file():
+    g = _build_simple_graph()
+    r = g.query_range("does_not_exist.py", 0, 9999)
+    assert r.defined == []
+    assert r.outgoing == []
+    assert r.incoming == []
+
+
+# ---------------------------------------------------------------------------
+# `outgoing` query
+# ---------------------------------------------------------------------------
+
+
+def test_outgoing_anchor_inside_range():
+    g = _build_simple_graph()
+
+    # Reference bar -> baz is anchored at line 12.
+    r = g.query_range("foo.py", 10, 15)
+    assert len(r.outgoing) == 1
+    edge_ref = r.outgoing[0]
+    assert edge_ref.edge_kind == EDGE_TYPE_REFERENCE
+    assert edge_ref.anchor_line == 12
+    assert edge_ref.anchor_file == "foo.py"
+
+
+def test_outgoing_excludes_anchors_outside_range():
+    g = _build_simple_graph()
+
+    # Range 0–10 misses both anchors (12 and 28).
+    r = g.query_range("foo.py", 0, 10)
+    assert r.outgoing == []
+
+
+def test_outgoing_boundary_inclusive():
+    g = _build_simple_graph()
+
+    # Boundary case: start_line == anchor.
+    r = g.query_range("foo.py", 12, 13)
+    assert len(r.outgoing) == 1
+
+    # Boundary case: end_line == anchor.
+    r = g.query_range("foo.py", 11, 12)
+    assert len(r.outgoing) == 1
+
+
+# ---------------------------------------------------------------------------
+# `incoming` query
+# ---------------------------------------------------------------------------
+
+
+def test_incoming_returns_edges_into_defined_nodes():
+    g = _build_simple_graph()
+
+    # Range covers bar's def — incoming should include the baz->bar edge.
+    r = g.query_range("foo.py", 5, 20)
+    assert len(r.incoming) == 1
+    edge_ref = r.incoming[0]
+    bar_vid = g.name_to_vertex["foo.py:bar"]
+    assert edge_ref.target_vid == bar_vid
+
+
+def test_incoming_no_definitions_in_range():
+    g = _build_simple_graph()
+
+    # Range with no symbol defs — no incoming.
+    r = g.query_range("foo.py", 100, 200)
+    assert r.incoming == []
+
+
+# ---------------------------------------------------------------------------
+# Multi-edge handling (no `_add_edge` dedup)
+# ---------------------------------------------------------------------------
+
+
+def test_multi_edge_same_pair_preserved():
+    g = _build_multi_edge_graph()
+
+    # caller calls bar three times → three distinct edges
+    caller_vid = g.name_to_vertex["foo.py:caller"]
+    bar_vid = g.name_to_vertex["foo.py:bar"]
+    edges = [
+        g.graph.es[eid]
+        for eid in g.graph.incident(caller_vid, mode="out")
+        if g.graph.es[eid].target == bar_vid
+    ]
+    assert len(edges) == 3
+    anchor_lines = sorted(e["anchor_line"] for e in edges)
+    assert anchor_lines == [15, 42, 88]
+
+
+def test_multi_edge_outgoing_per_call_site():
+    g = _build_multi_edge_graph()
+
+    # Range covers only the line-42 anchor.
+    r = g.query_range("foo.py", 40, 50)
+    assert len(r.outgoing) == 1
+    assert r.outgoing[0].anchor_line == 42
+
+    # Range covering all three.
+    r = g.query_range("foo.py", 10, 100)
+    assert len(r.outgoing) == 3
+
+
+# ---------------------------------------------------------------------------
+# build_range_indexes idempotency + persistence roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_build_range_indexes_is_idempotent():
+    g = _build_simple_graph()
+    snapshot_nodes = dict(g._file_nodes)
+    snapshot_edges = dict(g._file_edge_anchors)
+
+    g.build_range_indexes()
+    g.build_range_indexes()
+
+    assert g._file_nodes == snapshot_nodes
+    assert g._file_edge_anchors == snapshot_edges
+
+
+def test_save_load_graph_roundtrip():
+    g = _build_simple_graph()
+
+    with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+        path = f.name
+
+    try:
+        g.save_graph(path)
+        g2 = CodeGraph.load_graph(path)
+
+        # Indexes survive pickle.
+        assert g2._file_nodes == g._file_nodes
+        assert g2._file_edge_anchors == g._file_edge_anchors
+
+        # Same query produces same result.
+        r1 = g.query_range("foo.py", 8, 15)
+        r2 = g2.query_range("foo.py", 8, 15)
+        assert r1.defined == r2.defined
+        assert r1.outgoing == r2.outgoing
+        assert r1.incoming == r2.incoming
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_load_legacy_pickle_raises():
+    """Old pickles (schema_version != current) must raise on load to force a
+    re-decode rather than silently returning a graph with empty / stale
+    range indexes."""
+    g = CodeGraph()
+    g.add_file_node("foo.py")
+    g.add_symbol_node("foo.py:bar", 10, 5, 20, "function")
+    # Intentionally do not call build_range_indexes; mimic an old pickle by
+    # hand-crafting the data dict without the new fields.
+
+    legacy_data = {
+        # No "schema_version" key — load_graph treats as None and raises
+        "project_root": None,
+        "graph": g.graph,
+        "symbol_ranges": g.symbol_ranges,
+        "name_to_vertex": g.name_to_vertex,
+    }
+    with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+        path = f.name
+    try:
+        with open(path, "wb") as fh:
+            pickle.dump(legacy_data, fh)
+
+        with pytest.raises(ValueError, match="schema_version"):
+            CodeGraph.load_graph(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+def test_query_range_returns_range_query_result():
+    g = _build_simple_graph()
+    r = g.query_range("foo.py", 0, 0)
+    assert isinstance(r, RangeQueryResult)
+    assert isinstance(r.defined, list)
+    assert isinstance(r.outgoing, list)
+    assert isinstance(r.incoming, list)
+
+
+def test_schema_version_constant_exposed():
+    assert _SCHEMA_VERSION >= 3

--- a/test/graph/test_range_queries.py
+++ b/test/graph/test_range_queries.py
@@ -200,6 +200,28 @@ def test_incoming_no_definitions_in_range():
     assert r.incoming == []
 
 
+def test_recursion_self_edge_not_in_both_outgoing_and_incoming():
+    """Invariant (iii): outgoing ∩ incoming = ∅ even for recursive calls.
+
+    A recursive function `f` defined at lines 5–20 with a self-reference at
+    line 12 produces a single REFERENCE edge whose source == target == f.
+    Without filtering, that edge appears in `outgoing` (anchor in range)
+    AND `incoming` (target def in range). The implementation drops self-
+    edges from `incoming` so the recursion shows up exactly once.
+    """
+    g = CodeGraph()
+    g.add_file_node("foo.py")
+    g.add_symbol_node("foo.py:f", 10, 5, 20, "function")
+    g.update_current_scope("foo.py:f", 5, 20)
+    g.add_symbol_reference("foo.py:f", anchor_line=12)
+    g.build_range_indexes()
+
+    r = g.query_range("foo.py", 5, 20)
+    assert len(r.outgoing) == 1
+    assert r.outgoing[0].anchor_line == 12
+    assert r.incoming == []
+
+
 # ---------------------------------------------------------------------------
 # Multi-edge handling (no `_add_edge` dedup)
 # ---------------------------------------------------------------------------

--- a/test/graph/test_range_queries_simple_repos.py
+++ b/test/graph/test_range_queries_simple_repos.py
@@ -1,0 +1,372 @@
+"""Per-language precise tests for range queries on test/scip/simple_repos.
+
+Mirrors the algorithmic tests in ``test_range_queries.py`` (overlap modes,
+nested scopes, multi-edge same-pair, boundary inclusivity) but runs against
+real source decoded by each language's SCIP indexer — verifying that the
+anchor-line threading works end-to-end per language.
+
+Source-level facts these tests rely on (verify by reading the file):
+
+- ``rust_simple/src/math_utils.rs::add`` defined at lines 4–6
+- ``rust_simple/src/shapes.rs`` has ``impl Shape for Rectangle`` (lines 39–51)
+  containing nested method definitions ``area`` / ``perimeter`` / ``name``
+- ``typescript_simple/src/main.ts`` calls ``add`` three times from module
+  scope (lines 8, 9, 10) — exact multi-edge fixture
+
+Each test skips cleanly if the SCIP tool for its language isn't installed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration_serial
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.ls_router import LSIndexer
+from codeminer.types import NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+
+SIMPLE_REPOS = Path(__file__).resolve().parent.parent / "scip" / "simple_repos"
+
+
+_SCIP_TOOLS = {
+    "rust": "rust-analyzer",
+    "ts": "scip-typescript",
+    "go": "scip-go",
+    "cpp": "clangd",
+}
+
+
+def _skip_if_no_scip(language: str) -> None:
+    tool = _SCIP_TOOLS.get(language)
+    if tool and not shutil.which(tool):
+        pytest.skip(f"SCIP tool {tool!r} not installed")
+
+
+def _ensure_cpp_compdb(repo: Path) -> None:
+    compdb = repo / "build" / "compile_commands.json"
+    if compdb.exists():
+        return
+    subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(repo),
+            "-B",
+            str(repo / "build"),
+            "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _build_graph(language: str, repo_subdir: str, tmp_path: Path) -> CodeGraph:
+    """Build a fresh CodeGraph for ``simple_repos/<repo_subdir>``."""
+    src = SIMPLE_REPOS / repo_subdir
+    if not src.exists():
+        pytest.skip(f"{repo_subdir} not found in simple_repos")
+
+    if language == "cpp":
+        _ensure_cpp_compdb(src)
+
+    output_dir = tmp_path / repo_subdir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    indexer = LSIndexer(
+        project_root=src,
+        output_dir=output_dir,
+        language=language,
+        decoder_backend="serial",
+    )
+    kwargs = {"infer_tsconfig": True} if language == "ts" else {}
+    graph = indexer.run_pipeline(
+        skip_level=None,  # full rebuild — no cache pollution from prior schemas
+        report_profile=False,
+        **kwargs,
+    )
+    assert graph is not None, f"run_pipeline returned None for {repo_subdir}"
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Per-language session-scoped graphs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rust_graph(tmp_path_factory) -> CodeGraph:
+    _skip_if_no_scip("rust")
+    return _build_graph(
+        "rust", "rust_simple", tmp_path_factory.mktemp("rust_simple_idx")
+    )
+
+
+@pytest.fixture(scope="module")
+def ts_graph(tmp_path_factory) -> CodeGraph:
+    _skip_if_no_scip("ts")
+    return _build_graph("ts", "typescript_simple", tmp_path_factory.mktemp("ts_idx"))
+
+
+@pytest.fixture(scope="module")
+def go_graph(tmp_path_factory) -> CodeGraph:
+    _skip_if_no_scip("go")
+    return _build_graph("go", "go_simple", tmp_path_factory.mktemp("go_idx"))
+
+
+@pytest.fixture(scope="module")
+def cpp_graph(tmp_path_factory) -> CodeGraph:
+    _skip_if_no_scip("cpp")
+    return _build_graph("cpp", "cpp_simple", tmp_path_factory.mktemp("cpp_idx"))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_symbol_in_file(g, file_substr: str, name_substr: str):
+    """Return (start_line, end_line, vid, file_path) for the first symbol
+    whose ``file`` ends with ``file_substr`` and ``name`` contains
+    ``name_substr``. Skips nodes without a real def range."""
+    for vid in range(g.graph.vcount()):
+        v = g.graph.vs[vid]
+        attrs = v.attributes()
+        f = attrs.get("file")
+        name = attrs.get("name", "")
+        if not f or not f.endswith(file_substr):
+            continue
+        if name_substr not in name:
+            continue
+        s = attrs.get("start_line")
+        e = attrs.get("end_line")
+        ntype = attrs.get("type")
+        if (
+            s is None
+            or e is None
+            or s == e
+            or ntype not in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_CLASS)
+        ):
+            continue
+        return s, e, vid, f
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Overlap modes — Rust math_utils.rs::add (lines 4-6)
+# ---------------------------------------------------------------------------
+
+
+def test_rust_defined_overlap_partial_left(rust_graph):
+    """Range starts before def, ends inside → match (left overlap).
+
+    Picks a function whose def start_line is far enough into the file to
+    leave room for a `s - 2` query window (some SCIP backends include
+    leading doc comments in the enclosing_range, making the file's first
+    function start at line 0 or 1).
+    """
+    g = rust_graph
+    # Walk math_utils.rs symbols and pick one with start_line ≥ 2.
+    file = next((f for f in g._file_nodes if f.endswith("math_utils.rs")), None)
+    if file is None:
+        pytest.skip("math_utils.rs not in graph")
+    picked = None
+    for s, e, vid in g._file_nodes[file]:
+        if s < 2 or s == e:
+            continue
+        ntype = g.graph.vs[vid].attributes().get("type")
+        if ntype in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_CLASS):
+            picked = (s, e, vid)
+            break
+    if picked is None:
+        pytest.skip("no symbol in math_utils.rs with start_line ≥ 2")
+    s, e, vid = picked
+
+    r = g.query_range(file, s - 2, s)
+    assert vid in [n.vid for n in r.defined]
+
+
+def test_rust_defined_overlap_partial_right(rust_graph):
+    """Range starts inside def, ends after → match (right overlap)."""
+    target = _find_symbol_in_file(rust_graph, "math_utils.rs", "add")
+    assert target is not None
+    s, e, vid, file = target
+    r = rust_graph.query_range(file, e, e + 5)
+    assert vid in [n.vid for n in r.defined]
+
+
+def test_rust_defined_overlap_fully_inside(rust_graph):
+    """Range fully inside def → match."""
+    target = _find_symbol_in_file(rust_graph, "math_utils.rs", "factorial")
+    if target is None:
+        # fallback to add if factorial not present
+        target = _find_symbol_in_file(rust_graph, "math_utils.rs", "add")
+    assert target is not None
+    s, e, vid, file = target
+    if e - s < 2:
+        pytest.skip(f"def range {s}-{e} too tight for fully-inside test")
+    r = rust_graph.query_range(file, s + 1, max(s + 1, e - 1))
+    assert vid in [n.vid for n in r.defined]
+
+
+def test_rust_defined_no_overlap(rust_graph):
+    """Range with no overlap returns no definitions for the same file."""
+    target = _find_symbol_in_file(rust_graph, "math_utils.rs", "add")
+    assert target is not None
+    s, e, vid, file = target
+    # Pick a range guaranteed past add() but before tests mod (line ~48)
+    r = rust_graph.query_range(file, e + 1, e + 1)
+    # vid must NOT appear in defined for a single-line range past def end
+    assert vid not in [n.vid for n in r.defined]
+
+
+# ---------------------------------------------------------------------------
+# Nested scopes — Rust shapes.rs has impl Shape for Rectangle with nested methods
+# ---------------------------------------------------------------------------
+
+
+def test_rust_defined_includes_nested_scopes(rust_graph):
+    """Querying a range inside an impl block returns both the outer block
+    (or struct) and the inner methods that overlap."""
+    g = rust_graph
+    rect_impl = _find_symbol_in_file(g, "shapes.rs", "Rectangle")
+    if rect_impl is None:
+        pytest.skip("Rectangle symbol not found in shapes.rs")
+
+    # Find one inner method (area / perimeter / new / width)
+    inner_method = None
+    for cand in ("area", "perimeter", "name", "new", "width", "height"):
+        m = _find_symbol_in_file(g, "shapes.rs", cand)
+        if m is None:
+            continue
+        # Inner means its range is contained in (or overlaps) Rectangle's range
+        inner_method = m
+        break
+    if inner_method is None:
+        pytest.skip("no nested method found in shapes.rs")
+
+    inner_s, inner_e, inner_vid, file = inner_method
+    r = g.query_range(file, inner_s, inner_e)
+    # The inner method itself must appear
+    assert inner_vid in [n.vid for n in r.defined]
+    # Plus an outer scope (Rectangle / impl / file-level structure)
+    assert len(r.defined) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Multi-edge — TypeScript main.ts calls add() 3× from module scope
+# ---------------------------------------------------------------------------
+
+
+def test_ts_multi_edge_three_calls_to_add(ts_graph):
+    """In TS main.ts the import ``add`` is called from module scope at
+    lines 8, 9, 10. Without the dedup removal these would collapse to one
+    edge; with multi-edge, all three should appear."""
+    g = ts_graph
+    add_target = _find_symbol_in_file(g, "math.ts", "add")
+    if add_target is None:
+        pytest.skip("add not found in math.ts")
+
+    _, _, add_vid, _ = add_target
+    incoming_eids = g.graph.incident(add_vid, mode="in")
+
+    # Filter to anchors in main.ts
+    main_anchored = [
+        eid
+        for eid in incoming_eids
+        if (g.graph.es[eid].attributes().get("anchor_file") or "").endswith("main.ts")
+    ]
+    # main.ts has at least 3 module-scope calls + 1 inside wrapper() = ≥ 4
+    assert len(main_anchored) >= 3, (
+        f"expected ≥ 3 incoming edges from main.ts to add, got {len(main_anchored)}: "
+        f"{[g.graph.es[e]['anchor_line'] for e in main_anchored]}"
+    )
+
+
+def test_ts_multi_edge_query_range_distinguishes_call_sites(ts_graph):
+    """Querying a tight range around lines 8-10 of main.ts should return
+    the three add-call edges; querying a single line should return one."""
+    g = ts_graph
+    main_path = next((f for f in g._file_edge_anchors if f.endswith("main.ts")), None)
+    if main_path is None:
+        pytest.skip("main.ts not in edge_anchor_index")
+
+    # Find the 3 lines with add() calls — each should have ≥ 1 anchor.
+    arr = g._file_edge_anchors[main_path]
+    add_target = _find_symbol_in_file(g, "math.ts", "add")
+    assert add_target is not None
+    _, _, add_vid, _ = add_target
+
+    add_call_lines = sorted(
+        line for line, eid in arr if g.graph.es[eid].target == add_vid
+    )
+    assert (
+        len(add_call_lines) >= 3
+    ), f"expected ≥ 3 anchors in main.ts pointing at add, got {add_call_lines}"
+
+    # Query range that covers the first three add-calls only.
+    lo, hi = add_call_lines[0], add_call_lines[2]
+    r = g.query_range(main_path, lo, hi)
+    add_outgoing = [e for e in r.outgoing if e.target_vid == add_vid]
+    assert len(add_outgoing) >= 3, (
+        f"query_range({main_path}, {lo}, {hi}) returned only "
+        f"{len(add_outgoing)} edges into add"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Boundary inclusivity — anchor exactly on start/end_line
+# ---------------------------------------------------------------------------
+
+
+def test_rust_outgoing_boundary_inclusive(rust_graph):
+    """Anchor lines exactly equal to query start_line / end_line are included."""
+    g = rust_graph
+    main_path = next((f for f in g._file_edge_anchors if f.endswith("main.rs")), None)
+    if main_path is None or not g._file_edge_anchors[main_path]:
+        pytest.skip("main.rs has no anchored edges")
+
+    # Pick the first anchored line — query single-line range exactly at it.
+    first_line = g._file_edge_anchors[main_path][0][0]
+    r = g.query_range(main_path, first_line, first_line)
+    assert (
+        len(r.outgoing) >= 1
+    ), f"single-line query at exactly the anchor line {first_line} returned 0 edges"
+
+
+# ---------------------------------------------------------------------------
+# Per-language smoke: indexes built + persisted with v3 schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    ["rust_graph", "ts_graph", "go_graph", "cpp_graph"],
+)
+def test_per_language_indexes_and_roundtrip(fixture_name, request, tmp_path):
+    """Cheap smoke per language: indexes built, anchor cross-check, pickle
+    round-trip lossless."""
+    g = request.getfixturevalue(fixture_name)
+    assert len(g._file_nodes) > 0
+    # Edge anchors may be empty if a language's repo has only contain edges,
+    # but for our fixture set at least one language always has references.
+    if not g._file_edge_anchors:
+        return  # acceptable per-language; cross-language test elsewhere asserts
+
+    # Spot-check anchor consistency.
+    for file, arr in list(g._file_edge_anchors.items())[:1]:
+        for line, eid in arr[:5]:
+            edge = g.graph.es[eid]
+            assert edge["anchor_file"] == file
+            assert edge["anchor_line"] == line
+
+    # Round-trip.
+    out = tmp_path / "graph.pkl"
+    g.save_graph(str(out))
+    reloaded = CodeGraph.load_graph(str(out))
+    assert reloaded._file_nodes == g._file_nodes
+    assert reloaded._file_edge_anchors == g._file_edge_anchors

--- a/test/graph/test_range_queries_swebench.py
+++ b/test/graph/test_range_queries_swebench.py
@@ -1,0 +1,528 @@
+"""Integration test: build range indexes on real SWE-bench repos (serial).
+
+Parametrized over 5 languages following the ``test_scip_multilingual`` pattern:
+
+- python via ``SwebenchDataset`` (astropy-12907)
+- rust / ts / go / cpp via ``SwebenchMultilingualDataset``
+
+Verifies the new line-range query surface end-to-end: SCIP decode → CodeGraph
+→ build_range_indexes → query_range on real source. Forces a fresh graph
+build (``skip_level="decode"``) so we never load a cached graph.pkl from a
+prior schema version.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration_serial
+
+from codeminer.graph.code_graph import CodeGraph, EdgeRef, NodeRef
+from codeminer.ls_router import LSIndexer
+from codeminer.types import (
+    EDGE_TYPE_CONTAIN,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+)
+
+# ---------------------------------------------------------------------------
+# Per-language tooling probes (skip cleanly on machines without indexers)
+# ---------------------------------------------------------------------------
+
+
+def _tool_for(language: str) -> str:
+    return {
+        "python": "scip-python",
+        "rust": "rust-analyzer",
+        "ts": "scip-typescript",
+        "go": "scip-go",
+        "cpp": "clangd",
+    }[language]
+
+
+def _tools_ready(language: str) -> bool:
+    return bool(shutil.which(_tool_for(language)))
+
+
+# ---------------------------------------------------------------------------
+# Per-language instance lookup (mirrors test_scip_multilingual.py)
+# ---------------------------------------------------------------------------
+
+
+_REPO_KEYWORDS = {
+    "cpp": ["fmtlib/", "google/", "gabime/", "nlohmann/", "catchorg/"],
+    "rust": ["BurntSushi/", "tokio-rs/", "clap-rs/", "rust-lang/", "image-rs/"],
+    "ts": ["axios/", "expressjs/", "facebook/", "lodash/", "vuejs/"],
+    "go": ["caddyserver/", "gin-gonic/", "gohugoio/", "hashicorp/", "prometheus/"],
+}
+
+
+def _pick_python_instance() -> tuple:
+    """Return (dataset_obj, instance) for the pinned Python case (astropy)."""
+    from codeminer.dataset.swebench import SwebenchDataset
+
+    dataset_obj = SwebenchDataset(
+        dataset="princeton-nlp/SWE-bench_Lite",
+        split="test",
+        filter_instance="^(astropy__astropy-12907)$",
+    )
+    rows = dataset_obj.load()
+    return dataset_obj, dict(next(iter(rows)))
+
+
+def _pick_multilingual_instance(language: str) -> tuple:
+    """Return (dataset_obj, instance) for a SWE-bench_Multilingual instance."""
+    from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
+
+    dataset_obj = SwebenchMultilingualDataset(split="test", filter_instance=".*")
+    rows = dataset_obj.load()
+    for row in rows:
+        if any(k in row["repo"] for k in _REPO_KEYWORDS[language]):
+            return dataset_obj, dict(row)
+    raise RuntimeError(f"No SWE-bench_Multilingual instance for {language}")
+
+
+def _ensure_cpp_compdb(repo: Path) -> None:
+    """Generate compile_commands.json for clangd if missing."""
+    compdb = repo / "build" / "compile_commands.json"
+    if compdb.exists():
+        return
+    subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(repo),
+            "-B",
+            str(repo / "build"),
+            "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-language indexed_repo fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", params=["python", "rust", "ts", "go", "cpp"])
+def language(request) -> str:
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def indexed_repo(language) -> CodeGraph:
+    """Build a fresh CodeGraph at the current schema (v3+) for ``language``.
+
+    Uses ``skip_level="decode"`` so SCIP indexing + protoc decode are reused
+    from cache, but the graph itself is rebuilt via the serial decoder so it
+    carries edge anchors and the new range indexes get persisted.
+    """
+    if not _tools_ready(language):
+        pytest.skip(f"SCIP tool {_tool_for(language)!r} not installed")
+
+    if language == "python":
+        dataset_obj, instance = _pick_python_instance()
+    else:
+        try:
+            dataset_obj, instance = _pick_multilingual_instance(language)
+        except Exception as exc:
+            pytest.skip(
+                f"SWE-bench_Multilingual unavailable / no matching instance: {exc}"
+            )
+
+    dataset_obj.process_instance(instance)
+    repo_path = Path(dataset_obj.get_repo_path(instance))
+    if language == "cpp":
+        _ensure_cpp_compdb(repo_path)
+
+    output_dir = Path.home() / ".codeminer" / instance["instance_id"]
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    kwargs = {"infer_tsconfig": True} if language == "ts" else {}
+    indexer = LSIndexer(
+        project_root=repo_path,
+        output_dir=output_dir,
+        language=language,
+        decoder_backend="serial",
+    )
+    graph = indexer.run_pipeline(
+        skip_level="decode",
+        report_profile=False,
+        **kwargs,
+    )
+    assert graph is not None, f"run_pipeline returned None for {language}"
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Index integrity (per-language)
+# ---------------------------------------------------------------------------
+
+
+def test_range_indexes_populated_after_pipeline(indexed_repo, language):
+    """`process_index` must call `build_range_indexes()` and the persisted
+    graph must carry non-empty indexes for both nodes and edges, in every
+    language we support."""
+    g = indexed_repo
+
+    assert len(g._file_nodes) > 0, f"node_line_index has no files ({language})"
+    assert len(g._file_edge_anchors) > 0, (
+        f"edge_anchor_index has no files for {language} — anchor info "
+        f"isn't being threaded through the {language} decoder"
+    )
+
+    # Per-file node entries are well-formed.
+    sample_file = next(iter(g._file_nodes))
+    nodes = g._file_nodes[sample_file]
+    for entry in nodes:
+        assert len(entry) == 3
+        s, e, vid = entry
+        assert isinstance(s, int) and isinstance(e, int) and isinstance(vid, int)
+        assert s <= e
+        assert 0 <= vid < g.graph.vcount()
+
+    # Edge anchor entries are sorted by line, eids are valid.
+    sample_anchor_file = next(iter(g._file_edge_anchors))
+    arr = g._file_edge_anchors[sample_anchor_file]
+    assert [line for line, _ in arr] == sorted(line for line, _ in arr)
+    for _, eid in arr:
+        assert 0 <= eid < g.graph.ecount()
+
+
+def test_edge_anchor_lines_match_edge_attributes(indexed_repo):
+    """Cross-check: each (line, eid) in the anchor index agrees with the
+    edge's stored ``anchor_file`` / ``anchor_line`` attributes."""
+    g = indexed_repo
+    checked = 0
+    for file, arr in g._file_edge_anchors.items():
+        for line, eid in arr:
+            edge = g.graph.es[eid]
+            assert edge["anchor_file"] == file
+            assert edge["anchor_line"] == line
+            checked += 1
+            if checked >= 50:
+                return
+
+
+# ---------------------------------------------------------------------------
+# query_range correctness on real symbols
+# ---------------------------------------------------------------------------
+
+
+def _pick_symbol_node(g, file_path: str, min_span: int = 5):
+    """Find a function/method/class in ``file_path`` with a span ≥ ``min_span``."""
+    for s, e, vid in g._file_nodes.get(file_path, []):
+        if (e - s) < min_span:
+            continue
+        ntype = g.graph.vs[vid].attributes().get("type")
+        if ntype in (NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_CLASS):
+            return s, e, vid
+    return None
+
+
+def _pick_file_with_symbols(g) -> str | None:
+    """Find any source file with at least one function-shaped symbol."""
+    for f in g._file_nodes:
+        if _pick_symbol_node(g, f, min_span=3) is not None:
+            return f
+    return None
+
+
+def test_query_range_returns_self_for_symbol_def_range(indexed_repo, language):
+    """Querying a symbol's own def range must return that symbol in `defined`."""
+    g = indexed_repo
+    target_file = _pick_file_with_symbols(g)
+    if target_file is None:
+        pytest.skip(f"no function-shaped symbol found in {language} graph")
+
+    picked = _pick_symbol_node(g, target_file, min_span=5)
+    if picked is None:
+        pytest.skip(f"no symbol with span ≥ 5 in {target_file}")
+
+    s, e, vid = picked
+    r = g.query_range(target_file, s, e)
+    defined_vids = [n.vid for n in r.defined]
+    assert vid in defined_vids, (
+        f"[{language}] {g.graph.vs[vid]['name']} (vid={vid}, lines {s}-{e}) "
+        f"missing from defined={defined_vids}"
+    )
+
+
+def test_outgoing_edges_anchor_inside_query_range(indexed_repo):
+    """Every edge returned by ``outgoing`` has anchor_line in range and
+    anchor_file matches. Picks the densest file so the spot-check window
+    is non-trivial."""
+    g = indexed_repo
+    target_file, arr = max(g._file_edge_anchors.items(), key=lambda kv: len(kv[1]))
+    assert len(arr) >= 5, f"densest file has < 5 anchors ({len(arr)} in {target_file})"
+    mid = len(arr) // 2
+    line_lo = arr[max(mid - 2, 0)][0]
+    line_hi = arr[min(mid + 2, len(arr) - 1)][0]
+    if line_lo == line_hi:
+        line_hi = line_lo + 1
+
+    r = g.query_range(target_file, line_lo, line_hi)
+    assert len(r.outgoing) > 0
+    for edge_ref in r.outgoing:
+        assert edge_ref.anchor_file == target_file
+        assert line_lo <= edge_ref.anchor_line <= line_hi
+
+
+def test_incoming_edges_target_def_inside_query_range(indexed_repo, language):
+    """For a popular symbol, every edge returned by ``incoming`` must point
+    to a node whose def overlaps the queried range."""
+    g = indexed_repo
+
+    target_file = None
+    target = None
+    for f, nodes in g._file_nodes.items():
+        for s, e, vid in nodes:
+            if (e - s) < 3:
+                continue
+            in_count = len(g.graph.incident(vid, mode="in"))
+            if in_count > 2:
+                target_file = f
+                target = (s, e, vid)
+                break
+        if target:
+            break
+
+    if target is None:
+        pytest.skip(f"[{language}] no symbol with > 2 incoming edges found")
+
+    s, e, vid = target
+    r = g.query_range(target_file, s, e)
+    assert len(r.incoming) > 0
+
+    defined_vids = {n.vid for n in r.defined}
+    for edge_ref in r.incoming:
+        assert edge_ref.target_vid in defined_vids
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def test_pickled_graph_loads_and_indexes_intact(indexed_repo, tmp_path):
+    """save_graph + load_graph round-trips the indexes; verifies the pickle
+    written by run_pipeline is at the current schema and reloads cleanly."""
+    out = tmp_path / "graph.pkl"
+    indexed_repo.save_graph(str(out))
+    reloaded = CodeGraph.load_graph(str(out))
+
+    assert reloaded._file_nodes == indexed_repo._file_nodes
+    assert reloaded._file_edge_anchors == indexed_repo._file_edge_anchors
+
+    sample_file = next(iter(indexed_repo._file_nodes))
+    r1 = indexed_repo.query_range(sample_file, 1, 9999)
+    r2 = reloaded.query_range(sample_file, 1, 9999)
+    assert r1.defined == r2.defined
+    assert r1.outgoing == r2.outgoing
+    assert r1.incoming == r2.incoming
+
+
+def test_unified_to_names_populated_on_real_repo(indexed_repo, language):
+    """On a real SWE-bench graph (across all 5 languages), the unified_name
+    aux index is populated and every candidate identity is a real vertex.
+
+    Catches: the aux build path is skipped, the indexer doesn't call
+    build_range_indexes, or the index falls out of sync with name_to_vertex.
+    """
+    graph = indexed_repo
+
+    assert graph._unified_to_names, (
+        f"[{language}] _unified_to_names empty on a real graph — "
+        f"build_range_indexes likely not called by the indexer pipeline"
+    )
+
+    # Every entry's identity name must resolve to a real vertex
+    for unified, candidates in graph._unified_to_names.items():
+        assert (
+            candidates
+        ), f"[{language}] empty candidate list for unified_name={unified!r}"
+        for name in candidates:
+            assert name in graph.name_to_vertex, (
+                f"[{language}] _unified_to_names[{unified!r}] -> {name!r} "
+                f"missing from name_to_vertex"
+            )
+
+    # Spot-check: the inverse mapping is consistent — every vertex with a
+    # non-empty unified_name appears in the aux index under that key.
+    for vid in range(graph.graph.vcount()):
+        v = graph.graph.vs[vid]
+        u = v.attributes().get("unified_name")
+        if u:
+            assert v["name"] in graph._unified_to_names.get(u, []), (
+                f"[{language}] vertex {v['name']} (unified={u!r}) missing "
+                f"from _unified_to_names[{u!r}]"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Typed return shape (NodeRef / EdgeRef) + outgoing-default invariant
+# ---------------------------------------------------------------------------
+
+
+def test_query_range_returns_typed_records_on_real_repo(indexed_repo, language):
+    """On a real SWE-bench graph, query_range returns NodeRef/EdgeRef records
+    (not raw vid/eid ints) and outgoing default excludes CONTAIN edges."""
+    g = indexed_repo
+
+    # Pick a file with both nodes and anchored reference edges so the query
+    # covers all three result lists.
+    target_file = None
+    for f in g._file_edge_anchors:
+        if f in g._file_nodes:
+            target_file = f
+            break
+    if target_file is None:
+        pytest.skip(f"[{language}] no file has both nodes and anchored edges")
+
+    # Query a window covering the densest stretch of anchors in the file.
+    arr = g._file_edge_anchors[target_file]
+    if not arr:
+        pytest.skip(f"[{language}] no anchored edges in {target_file}")
+    line_lo = arr[0][0]
+    line_hi = arr[-1][0]
+
+    res = g.query_range(target_file, line_lo, line_hi)
+
+    # All defined entries are NodeRef
+    for n in res.defined:
+        assert isinstance(
+            n, NodeRef
+        ), f"[{language}] expected NodeRef, got {type(n).__name__}"
+    # All edge entries are EdgeRef
+    for e in res.outgoing:
+        assert isinstance(
+            e, EdgeRef
+        ), f"[{language}] outgoing has {type(e).__name__}, expected EdgeRef"
+    for e in res.incoming:
+        assert isinstance(
+            e, EdgeRef
+        ), f"[{language}] incoming has {type(e).__name__}, expected EdgeRef"
+
+    # Default `kinds` filters CONTAIN edges out of `outgoing`.
+    for e in res.outgoing:
+        assert (
+            e.edge_kind != EDGE_TYPE_CONTAIN
+        ), f"[{language}] CONTAIN edge leaked into outgoing default: {e}"
+
+
+# ---------------------------------------------------------------------------
+# query_range_by_symbol on a real repo
+# ---------------------------------------------------------------------------
+
+
+def test_query_range_by_symbol_returns_self_on_real_repo(indexed_repo, language):
+    """Pick a real symbol from a real repo and verify query_range_by_symbol
+    returns a result that includes that symbol in `defined`."""
+    g = indexed_repo
+
+    # Find any vertex with a real def range and known identity name.
+    target_file = _pick_file_with_symbols(g)
+    if target_file is None:
+        pytest.skip(f"[{language}] no function-shaped symbol found")
+
+    picked = _pick_symbol_node(g, target_file, min_span=3)
+    if picked is None:
+        pytest.skip(f"[{language}] no symbol with span >= 3 in {target_file}")
+
+    s, e, vid = picked
+    name = g.graph.vs[vid]["name"]
+
+    res = g.query_range_by_symbol(name)
+    defined_vids = [n.vid for n in res.defined]
+    assert vid in defined_vids, (
+        f"[{language}] {name} (vid={vid}) not in its own range query "
+        f"(defined={defined_vids})"
+    )
+
+
+def test_query_range_by_symbol_unknown_is_empty(indexed_repo, language):
+    """Unknown symbol returns an empty RangeQueryResult (does not raise)."""
+    g = indexed_repo
+    res = g.query_range_by_symbol("__definitely_not_a_real_symbol_42__")
+    assert res.defined == [] and res.outgoing == [] and res.incoming == [], (
+        f"[{language}] expected empty result, got "
+        f"defined={res.defined}, outgoing={res.outgoing}, incoming={res.incoming}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor invariant ii — CONTAIN edges carry no anchor on a real repo
+# ---------------------------------------------------------------------------
+
+
+def test_incoming_default_is_reference_on_real_repo(indexed_repo, language):
+    """On a real graph, incoming default kinds excludes CONTAIN — pick a node
+    with known CONTAIN parents and verify default query excludes them."""
+    graph = indexed_repo
+
+    # Find a method-like node with a CONTAIN parent edge.
+    target_vid = None
+    for vid in range(graph.graph.vcount()):
+        v = graph.graph.vs[vid]
+        attrs = v.attributes()
+        if attrs.get("type") not in ("method", "function"):
+            continue
+        f = attrs.get("file")
+        s = attrs.get("start_line")
+        e = attrs.get("end_line")
+        if f is None or s is None or e is None:
+            continue
+        # Verify it has at least one inbound CONTAIN edge.
+        in_eids = graph.graph.incident(vid, mode="in")
+        if any(graph.graph.es[eid]["type"] == EDGE_TYPE_CONTAIN for eid in in_eids):
+            target_vid = vid
+            break
+
+    if target_vid is None:
+        pytest.skip(f"[{language}] no method/function with CONTAIN parent found")
+
+    v = graph.graph.vs[target_vid]
+    res = graph.query_range(
+        v.attributes()["file"],
+        v.attributes()["start_line"],
+        v.attributes()["end_line"],
+    )
+
+    # Default kinds: incoming must contain ZERO contain edges (the parent
+    # CONTAIN that exists structurally is filtered out).
+    in_kinds = {e.edge_kind for e in res.incoming}
+    assert EDGE_TYPE_CONTAIN not in in_kinds, (
+        f"[{language}] incoming default leaked CONTAIN edge into query result: "
+        f"kinds={in_kinds}"
+    )
+
+
+def test_contain_edges_have_no_anchor_on_real_repo(indexed_repo, language):
+    """Every CONTAIN edge in a real per-language graph must have
+    anchor_file=None and anchor_line=None (anchor invariant ii)."""
+    g = indexed_repo
+    contain_count = 0
+    leaked = []
+    for e in g.graph.es:
+        if e["type"] != EDGE_TYPE_CONTAIN:
+            continue
+        contain_count += 1
+        attrs = e.attributes()
+        if attrs.get("anchor_file") is not None or attrs.get("anchor_line") is not None:
+            leaked.append(
+                (e.source, e.target, attrs.get("anchor_file"), attrs.get("anchor_line"))
+            )
+            if len(leaked) >= 5:
+                break
+    assert contain_count > 0, f"[{language}] graph has no CONTAIN edges"
+    assert (
+        not leaked
+    ), f"[{language}] CONTAIN edges leaked anchor data (first 5): {leaked}"

--- a/test/graph/test_range_queries_swebench.py
+++ b/test/graph/test_range_queries_swebench.py
@@ -6,9 +6,10 @@ Parametrized over 5 languages following the ``test_scip_multilingual`` pattern:
 - rust / ts / go / cpp via ``SwebenchMultilingualDataset``
 
 Verifies the new line-range query surface end-to-end: SCIP decode → CodeGraph
-→ build_range_indexes → query_range on real source. Forces a fresh graph
-build (``skip_level="decode"``) so we never load a cached graph.pkl from a
-prior schema version.
+→ build_range_indexes → query_range on real source. Uses ``skip_level="graph"``
+to fast-path off cached ``graph.pkl`` when present; ``CodeGraph.load_graph``
+raises ``ValueError`` on schema mismatch which ``run_pipeline`` catches and
+falls back to rebuilding from the cached SCIP decode.
 """
 
 from __future__ import annotations
@@ -19,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.integration_serial
+pytestmark = pytest.mark.integration_serial_consumer
 
 from codeminer.graph.code_graph import CodeGraph, EdgeRef, NodeRef
 from codeminer.ls_router import LSIndexer
@@ -119,11 +120,12 @@ def language(request) -> str:
 
 @pytest.fixture(scope="module")
 def indexed_repo(language) -> CodeGraph:
-    """Build a fresh CodeGraph at the current schema (v3+) for ``language``.
+    """Load (or build) a CodeGraph at the current schema for ``language``.
 
-    Uses ``skip_level="decode"`` so SCIP indexing + protoc decode are reused
-    from cache, but the graph itself is rebuilt via the serial decoder so it
-    carries edge anchors and the new range indexes get persisted.
+    Uses ``skip_level="graph"`` to load a cached ``graph.pkl`` when present
+    (fast path). ``load_graph`` raises ``ValueError`` if the cached pickle's
+    schema differs from ``_SCHEMA_VERSION``; ``run_pipeline`` catches the
+    error and falls back to rebuilding from cached SCIP decode.
     """
     if not _tools_ready(language):
         pytest.skip(f"SCIP tool {_tool_for(language)!r} not installed")
@@ -154,7 +156,7 @@ def indexed_repo(language) -> CodeGraph:
         decoder_backend="serial",
     )
     graph = indexer.run_pipeline(
-        skip_level="decode",
+        skip_level="graph",
         report_profile=False,
         **kwargs,
     )

--- a/test/graph/test_range_query_api.py
+++ b/test/graph/test_range_query_api.py
@@ -272,3 +272,72 @@ def test_query_range_by_symbol_no_range_returns_empty():
     g.build_range_indexes()
     res = g.query_range_by_symbol("ref_only")
     assert res.defined == [] and res.outgoing == [] and res.incoming == []
+
+
+def test_query_range_excludes_anchor_at_end_line_plus_one():
+    """Regression: bisect upper bound must not leak in `(end_line+1, eid=0)`.
+
+    Previously the upper bound used `bisect_right(arr, (end_line+1, 0))`,
+    which considers `(end_line+1, 0)` to compare equal-or-less and thus
+    *includes* it. Trigger condition: anchored edge at `end_line+1` whose
+    eid is 0 — i.e. it is the very first edge ever added. With `bisect_left`
+    the entry is correctly excluded.
+    """
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    # Define two scopes in a.py: caller spans lines 0-4, neighbor at line 5.
+    g._add_vertex(
+        "caller",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 0,
+            "end_line": 4,
+            "unified_name": "a.py:caller",
+        },
+    )
+    g._add_vertex(
+        "neighbor",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 5,
+            "end_line": 9,
+            "unified_name": "a.py:neighbor",
+        },
+    )
+    g._add_vertex(
+        "Target",
+        {
+            "type": "function",
+            "file": "b.py",
+            "start_line": 0,
+            "end_line": 1,
+            "unified_name": "b.py:Target",
+        },
+    )
+
+    # Add the offending anchor FIRST so it lands at eid 0 — this is the
+    # narrow trigger the buggy bound used to leak.
+    g._add_edge(
+        "neighbor",
+        "Target",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="a.py",
+        anchor_line=5,  # exactly query end_line + 1
+    )
+    # An in-range anchor for sanity (lands inside [0,4]).
+    g._add_edge(
+        "caller",
+        "Target",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="a.py",
+        anchor_line=2,
+    )
+    g.build_range_indexes()
+
+    res = g.query_range("a.py", 0, 4)
+    anchor_lines = sorted(e.anchor_line for e in res.outgoing)
+    assert anchor_lines == [2], (
+        "Outgoing slice leaked an anchor at end_line+1: " f"{anchor_lines}"
+    )

--- a/test/graph/test_range_query_api.py
+++ b/test/graph/test_range_query_api.py
@@ -1,0 +1,274 @@
+"""Tests for the typed NodeRef / EdgeRef record shape returned by query_range."""
+
+from codeminer.graph.code_graph import CodeGraph, EdgeRef, NodeRef, RangeQueryResult
+from codeminer.types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE
+
+
+def test_noderef_has_required_fields():
+    ref = NodeRef(
+        vid=1,
+        name="scip-python python pkg 1.0 mod/foo.py:Foo#bar()",
+        unified_name="mod/foo.py:Foo.bar",
+        file="mod/foo.py",
+        start_line=10,
+        end_line=20,
+        kind="method",
+    )
+    assert ref.vid == 1
+    assert ref.unified_name == "mod/foo.py:Foo.bar"
+    assert ref.kind == "method"
+
+
+def test_edgeref_has_required_fields():
+    ref = EdgeRef(
+        eid=42,
+        source_vid=1,
+        target_vid=2,
+        edge_kind="reference",
+        anchor_file="mod/foo.py",
+        anchor_line=15,
+    )
+    assert ref.eid == 42
+    assert ref.edge_kind == "reference"
+    assert ref.anchor_line == 15
+
+
+def test_unified_to_names_built_after_index():
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    g._add_vertex(
+        "name1",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "a.py:foo",
+        },
+    )
+    g._add_vertex(
+        "name2",
+        {
+            "type": "function",
+            "file": "b.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "b.py:foo",
+        },
+    )
+    g.build_range_indexes()
+    # Distinct identities, distinct unified_names — each maps to its identity
+    assert g._unified_to_names.get("a.py:foo") == ["name1"]
+    assert g._unified_to_names.get("b.py:foo") == ["name2"]
+
+
+def test_unified_to_names_collision():
+    """When two identities share the same unified_name, both surface as candidates."""
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    # Two distinct identity names but same unified_name "foo" (cross-file collision).
+    g._add_vertex(
+        "ident_a",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "foo",
+        },
+    )
+    g._add_vertex(
+        "ident_b",
+        {
+            "type": "function",
+            "file": "b.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "foo",
+        },
+    )
+    g.build_range_indexes()
+    candidates = g._unified_to_names.get("foo", [])
+    assert sorted(candidates) == ["ident_a", "ident_b"]
+
+
+def test_unified_to_names_round_trip(tmp_path):
+    """Pickle round-trip preserves _unified_to_names (schema v3 amended)."""
+    g = CodeGraph(project_root=str(tmp_path))
+    g.add_file_node("a.py")
+    g._add_vertex(
+        "identity",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 1,
+            "end_line": 5,
+            "unified_name": "a.py:foo",
+        },
+    )
+    g.build_range_indexes()
+
+    p = tmp_path / "g.pkl"
+    g.save_graph(str(p))
+    loaded = CodeGraph.load_graph(str(p))
+    assert loaded._unified_to_names.get("a.py:foo") == ["identity"]
+
+
+def test_unified_to_names_legacy_v3_pickle_tolerated(tmp_path):
+    """A v3 pickle saved BEFORE this aux index existed must still load —
+    the absent key is tolerated by load_graph's `data.get(...)` default."""
+    import pickle
+
+    import igraph as ig
+
+    from codeminer.graph.code_graph import _SCHEMA_VERSION
+
+    legacy = {
+        "schema_version": _SCHEMA_VERSION,
+        "project_root": str(tmp_path),
+        "graph": ig.Graph(directed=True),
+        "symbol_ranges": {},
+        "name_to_vertex": {},
+        "file_nodes": {},
+        "file_edge_anchors": {},
+        # Note: no "unified_to_names" key — simulating a pre-amend v3 pickle.
+    }
+    p = tmp_path / "legacy.pkl"
+    with open(p, "wb") as f:
+        pickle.dump(legacy, f)
+
+    loaded = CodeGraph.load_graph(str(p))
+    assert loaded._unified_to_names == {}
+
+
+def _make_simple_graph():
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    g._add_vertex(
+        "Foo",
+        {
+            "type": "class",
+            "file": "a.py",
+            "start_line": 1,
+            "end_line": 30,
+            "unified_name": "a.py:Foo",
+        },
+    )
+    g._add_vertex(
+        "Foo.bar",
+        {
+            "type": "method",
+            "file": "a.py",
+            "start_line": 5,
+            "end_line": 15,
+            "unified_name": "a.py:Foo.bar",
+        },
+    )
+    g._add_vertex(
+        "Helper",
+        {
+            "type": "function",
+            "file": "b.py",
+            "start_line": 1,
+            "end_line": 10,
+            "unified_name": "b.py:Helper",
+        },
+    )
+    # Foo CONTAINS Foo.bar (no anchor — invariant ii).
+    g._add_edge("Foo", "Foo.bar", EDGE_TYPE_CONTAIN)
+    # Foo.bar -> Helper, anchor at line 8 inside Foo.bar.
+    g._add_edge(
+        "Foo.bar", "Helper", EDGE_TYPE_REFERENCE, anchor_file="a.py", anchor_line=8
+    )
+    g.build_range_indexes()
+    return g
+
+
+def test_query_range_returns_noderefs():
+    g = _make_simple_graph()
+    res = g.query_range("a.py", 6, 9)
+    assert all(isinstance(r, NodeRef) for r in res.defined)
+    names = {r.unified_name for r in res.defined}
+    assert names == {"a.py:Foo", "a.py:Foo.bar"}
+
+
+def test_outgoing_default_is_reference_only():
+    """CONTAIN edges have no meaningful anchor; outgoing default filters them out."""
+    g = _make_simple_graph()
+    res = g.query_range("a.py", 6, 9)
+    edge_kinds = {e.edge_kind for e in res.outgoing}
+    assert edge_kinds <= {
+        EDGE_TYPE_REFERENCE
+    }, f"outgoing leaked non-reference edges: {edge_kinds}"
+
+
+def test_outgoing_kinds_opt_in():
+    g = _make_simple_graph()
+    res = g.query_range("a.py", 0, 30, kinds={EDGE_TYPE_REFERENCE, EDGE_TYPE_CONTAIN})
+    # opt-in returns at least the reference edge.
+    assert len(res.outgoing) >= 1
+
+
+def test_incoming_default_is_reference_only():
+    """Like outgoing, incoming defaults to REFERENCE-only — CONTAIN inbound
+    (e.g. 'Foo CONTAINS Foo.bar') is filtered out of the typical query."""
+    g = _make_simple_graph()
+    # Range covering Foo.bar; the inbound CONTAIN edge from Foo is incoming
+    # to Foo.bar but should not surface by default.
+    res = g.query_range("a.py", 6, 9)
+    edge_kinds = {e.edge_kind for e in res.incoming}
+    assert edge_kinds <= {
+        EDGE_TYPE_REFERENCE
+    }, f"incoming leaked non-reference edges: {edge_kinds}"
+
+
+def test_incoming_kinds_opt_in():
+    g = _make_simple_graph()
+    res = g.query_range("a.py", 6, 9, kinds={EDGE_TYPE_REFERENCE, EDGE_TYPE_CONTAIN})
+    # opt-in: the CONTAIN inbound from Foo to Foo.bar surfaces.
+    contain_inbound = [e for e in res.incoming if e.edge_kind == EDGE_TYPE_CONTAIN]
+    assert len(contain_inbound) >= 1
+
+
+def test_incoming_returns_edgerefs_with_target_vid():
+    g = _make_simple_graph()
+    res = g.query_range("a.py", 0, 30)
+    for edge in res.incoming:
+        assert isinstance(edge, EdgeRef)
+        assert edge.target_vid is not None
+
+
+def test_depth_only_one_supported():
+    import pytest
+
+    g = _make_simple_graph()
+    res = g.query_range("a.py", 0, 30, depth=1)
+    assert isinstance(res, RangeQueryResult)
+    with pytest.raises(NotImplementedError):
+        g.query_range("a.py", 0, 30, depth=2)
+
+
+def test_query_range_by_symbol_uses_identity():
+    """query_range_by_symbol resolves the identity `name` (not unified_name)
+    and returns the symbol in `defined`."""
+    g = _make_simple_graph()
+    res = g.query_range_by_symbol("Foo.bar")
+    unified_names = {n.unified_name for n in res.defined}
+    assert "a.py:Foo.bar" in unified_names
+
+
+def test_query_range_by_symbol_unknown_returns_empty():
+    g = _make_simple_graph()
+    res = g.query_range_by_symbol("DoesNotExist")
+    assert res.defined == [] and res.outgoing == [] and res.incoming == []
+
+
+def test_query_range_by_symbol_no_range_returns_empty():
+    """A vertex without start_line/end_line (e.g. a SCIP reference-only
+    vertex) yields an empty result, not a crash."""
+    g = CodeGraph(project_root="/tmp/x")
+    # Add a vertex with no file/start_line/end_line attributes.
+    g._add_vertex("ref_only", {"type": "function"})
+    g.build_range_indexes()
+    res = g.query_range_by_symbol("ref_only")
+    assert res.defined == [] and res.outgoing == [] and res.incoming == []

--- a/test/scip/test_scip_core.py
+++ b/test/scip/test_scip_core.py
@@ -41,8 +41,23 @@ if importlib.util.find_spec("codeminer_core") is None:
         allow_module_level=True,
     )
 
+# Library load-order ritual: codeminer_core links system libigraph while
+# Python's `igraph` package bundles its own; whichever is loaded first wins
+# the dynamic-linker race for shared symbols. We have to load codeminer_core
+# BEFORE anything that transitively imports `igraph` (CodeGraph, ROISubgraph,
+# the patcher tree, …) or `decode_scip` segfaults inside libigraph. The
+# integration-serial CI job sequences fixtures so this order falls out
+# naturally; in unit-test runs we have to enforce it explicitly here.
+import codeminer_core  # noqa: E402, F401
+
 
 _COMPARED_ATTRS = ("type", "file", "start_line", "end_line", "unified_name")
+
+# Edge attributes compared for parity. `anchor_file` / `anchor_line` were
+# added in schema v3 to support LSP-aligned line-range queries; both serial
+# and core decoders thread the SCIP `occurrence.range` start line through
+# reference edges.
+_EDGE_COMPARED_ATTRS = ("type", "anchor_file", "anchor_line")
 
 
 _MULTILINGUAL_KEYWORDS = {
@@ -97,16 +112,34 @@ def _pick_instance(language: str) -> Tuple[object, dict]:
     raise RuntimeError(f"No SWE-bench_Multilingual instance for {language}")
 
 
-def _graph_signature(
-    graph,
-) -> Tuple[Set[str], Set[Tuple[str, str, str]], Dict[str, Dict]]:
+def _graph_signature(graph):
+    """Return (names, edge_multiset, vertex_attrs).
+
+    ``edge_multiset`` is a sorted list of
+    ``(src_name, tgt_name, type, anchor_file, anchor_line)`` so multi-edges
+    between the same `(src, tgt)` pair (one per call site) are preserved
+    and order-independent comparison still works.
+    """
     names = set(graph.vs["name"])
     i2n = {v.index: v["name"] for v in graph.vs}
-    edges = {(i2n[e.source], i2n[e.target], e["type"]) for e in graph.es}
-    attrs = {
-        v["name"]: {k: v.attributes().get(k) for k in _COMPARED_ATTRS} for v in graph.vs
+    edges_list = []
+    for e in graph.es:
+        attrs = e.attributes()
+        edges_list.append(
+            (
+                i2n[e.source],
+                i2n[e.target],
+                attrs.get("type"),
+                attrs.get("anchor_file"),
+                attrs.get("anchor_line"),
+            )
+        )
+    edges_list.sort(key=lambda t: (t[0], t[1], t[2] or "", t[3] or "", t[4] or -1))
+    vertex_attrs = {
+        v["name"]: {k: v.attributes().get(k) for k in _COMPARED_ATTRS}
+        for v in graph.vs
     }
-    return names, edges, attrs
+    return names, edges_list, vertex_attrs
 
 
 def _assert_graph_parity(ref, cand, tag: str) -> None:
@@ -120,11 +153,49 @@ def _assert_graph_parity(ref, cand, tag: str) -> None:
         f"missing={sorted(ref_names - cand_names)[:3]}, "
         f"extra={sorted(cand_names - ref_names)[:3]}"
     )
-    assert ref_edges == cand_edges, (
-        f"[{tag}] edge sets differ: "
-        f"ref-only={len(ref_edges - cand_edges)}, "
-        f"cand-only={len(cand_edges - ref_edges)}"
-    )
+
+    if ref_edges != cand_edges:
+        # Build category breakdown for a useful failure message.
+        from collections import Counter
+
+        ref_set = set(ref_edges)
+        cand_set = set(cand_edges)
+        ref_only = ref_set - cand_set
+        cand_only = cand_set - ref_set
+        per_field = {field: 0 for field in _EDGE_COMPARED_ATTRS}
+        # Count mismatches grouped by which field disagrees, on a sample.
+        for e in list(ref_only)[:200]:
+            for c in list(cand_only)[:200]:
+                if e[0] == c[0] and e[1] == c[1]:
+                    if e[2] != c[2]:
+                        per_field["type"] += 1
+                    if e[3] != c[3]:
+                        per_field["anchor_file"] += 1
+                    if e[4] != c[4]:
+                        per_field["anchor_line"] += 1
+                    break
+
+        # Multi-edge multiplicity diff: same edge tuple appearing more / fewer
+        # times. Surfaces dedup mismatches between serial and core.
+        ref_counts = Counter(ref_edges)
+        cand_counts = Counter(cand_edges)
+        mult_diff = []
+        for e in set(ref_counts) | set(cand_counts):
+            r = ref_counts.get(e, 0)
+            c = cand_counts.get(e, 0)
+            if r != c:
+                mult_diff.append((e, r, c))
+
+        sample = mult_diff[:5]
+        raise AssertionError(
+            f"[{tag}] edge sets differ "
+            f"(ref={len(ref_edges)} cand={len(cand_edges)}): "
+            f"ref-only={len(ref_only)}, cand-only={len(cand_only)}, "
+            f"multiplicity-mismatches={len(mult_diff)}, "
+            f"sample-field-mismatches={per_field}, "
+            f"sample-multi-diff={sample}"
+        )
+
     per_attr = {
         a: sum(1 for n in ref_names if ref_attrs[n].get(a) != cand_attrs[n].get(a))
         for a in _COMPARED_ATTRS
@@ -159,7 +230,32 @@ def _run_parity(language: str) -> None:
 
     from codeminer.graph.code_graph import CodeGraph
 
-    serial_graph = CodeGraph.load_graph(str(graph_pkl))
+    # Rebuild the serial graph in-place if the cached pickle is at an older
+    # schema than what we now expect. The expensive ``index.decoded`` file is
+    # reused via ``skip_level="decode"``. Without this, a CodeGraph schema
+    # bump silently breaks all parity runs until each cache is manually
+    # cleared.
+    try:
+        serial_graph = CodeGraph.load_graph(str(graph_pkl))
+    except ValueError as exc:
+        if "schema_version" not in str(exc):
+            raise
+        from codeminer.ls_router import LSIndexer
+
+        rebuild_indexer = LSIndexer(
+            project_root=repo_path,
+            output_dir=output_dir,
+            language=language,
+            decoder_backend="serial",
+        )
+        kwargs = {"infer_tsconfig": True} if language == "ts" else {}
+        rebuilt = rebuild_indexer.run_pipeline(
+            skip_level="decode", report_profile=False, **kwargs
+        )
+        assert rebuilt is not None, (
+            f"[{language}] failed to rebuild serial graph after stale-schema load"
+        )
+        serial_graph = CodeGraph.load_graph(str(graph_pkl))
 
     # Core decoder: reuse index.decoded, don't clobber graph.pkl (serial's).
     from codeminer.ls_router import LSIndexer


### PR DESCRIPTION
## Summary

Implements RFC #125 (line-range query primitive on `CodeGraph`) and addresses
@fishmingyu's review feedback in full. Lands the typed query API, anchor-aware
edge schema, multi-edge correctness in the incremental patcher, and the C++
decoder mirror that keeps both backends in lockstep.

## Architecture

The PR adds a **range-keyed** query layer on top of the existing symbol-keyed
graph (consumers have spans — LSP hovers, BM25 hits, code chunks — not symbols).

**Edge schema.** `REFERENCE` edges gain `anchor_file` / `anchor_line` (the
call site that produced them); multiple edges per `(src, tgt)` pair are
allowed, one per call site. `CONTAIN` edges leave anchor `None` and are still
deduped by `(src, tgt, type)` to avoid inflation when SCIP records the same
containment twice (Rust's `struct + impl`).

**Derived indexes.** `build_range_indexes()` scans the graph once and
produces three pickled dicts: `_file_nodes` (for `defined`),
`_file_edge_anchors` (for `outgoing`), `_unified_to_names` (display →
identity reverse lookup). Built only in Python; both serial Python and C++
pybind decoder paths converge through this function — no C++ reimplementation
to drift.

**Query API.** `query_range(file, s, e)` and `query_range_by_symbol(name)`
return typed `NodeRef`/`EdgeRef` records. Default `kinds = {REFERENCE}`
(applies to both `outgoing` and `incoming`); `depth = 1` only in v1,
reserved for future multi-hop expansion.

**Patcher.** Vertex deletion now reports per-anchor 6-tuple severance
entries; `_remap_severed_edges` threads the anchor back through `_add_edge`
on reconnect, preserving multi-edge structure across edits (the failure mode
@fishmingyu flagged). The hot path (whole-symbol wipe + LSP re-add) is
multi-edge-safe by construction.

**C++ mirror.** `add_containment_edge` strips anchor on both Python and C++
sides; serial `add_edge` deduplicates structural edges like `batch_add_edges`
already does. `test_scip_core.py` asserts 5-tuple edge multiset equivalence
(including anchor) on real SWE-bench repos.

## API surface

### Typed records

```python
@dataclass(slots=True)
class NodeRef:
    vid: int
    name: str            # identity (globally unique)
    unified_name: str    # display (may collide)
    file: str
    start_line: int
    end_line: int
    kind: str


@dataclass(slots=True)
class EdgeRef:
    eid: int
    source_vid: int
    target_vid: int
    edge_kind: str
    anchor_file: Optional[str] = None
    anchor_line: Optional[int] = None
```

### Query entry points

```python
class CodeGraph:
    def query_range(
        self, file: str, start_line: int, end_line: int,
        kinds: Optional[set] = None, depth: int = 1,
    ) -> RangeQueryResult: ...

    def query_range_by_symbol(
        self, name: str,
        kinds: Optional[set] = None, depth: int = 1,
    ) -> RangeQueryResult: ...
```

- `defined`: nodes whose def range overlaps the query range
- `outgoing`: edges whose anchor falls in the query range
- `incoming`: edges pointing into any `defined` node
- `kinds` defaults to `{EDGE_TYPE_REFERENCE}` (CONTAIN excluded by default;
  applies to both `outgoing` and `incoming`)
- `depth=1` only in v1; reserved for future multi-hop expansion
- `query_range_by_symbol` resolves identity `name` → vid → range and forwards
  to `query_range`

### Three anchor invariants

Documented on `RangeQueryResult` and `query_range`:

> (i)&nbsp;&nbsp; `anchor_file == source.file` (anchor lives at the call site, never the target)
> (ii)&nbsp; `anchor_*` is meaningful only on `EDGE_TYPE_REFERENCE`; CONTAIN edges leave both fields `None`
> (iii) `outgoing ∩ incoming = ∅` for any single query (call site and target are in distinct scopes by definition)

## Changes

- Schema v3 in-place amendment with three new pickled indexes
- `RangeQueryResult` returns typed `NodeRef` / `EdgeRef` records
- New `query_range` and `query_range_by_symbol` APIs with `kinds` / `depth` params
- Three anchor invariants documented in `query_range` docstring
- Multi-edge correctness in the incremental patcher (severance, remap, surgical delete)
- C++ side mirrors Python: `add_containment_edge` strips anchor; serial `add_edge` dedupes structural
- `codeminer_core` build infra: c-igraph vendored via FetchContent, `build/core` CI cache, anchor-aware `test_scip_core` parity
- pre-commit cleanups in `roi_subgraph.py` + `traverse_graph.py`

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
