### PR TITLE
[profiling] graph-RAG profiling harness scaffolding

### DIFF
--- a/codeminer/model/graph_retrieve_pipeline.py
+++ b/codeminer/model/graph_retrieve_pipeline.py
@@ -73,6 +73,10 @@ class GraphRetrievePipeline:
         self.use_ppr = use_ppr
         self.ppr_damping = ppr_damping
         self.use_embedding_rerank = use_embedding_rerank
+        # Populated by query(): BM25 stage-1 results from the most recent
+        # query. Surfaced so callers can compute correctness signals such as
+        # bm25_seed_recall@k without re-running BM25.
+        self.last_bm25_seeds: List[Any] = []
 
         pname = project_name or Path(index_path).name
 
@@ -136,6 +140,7 @@ class GraphRetrievePipeline:
         with _section(profiler, "query.bm25_seed", {"top_k": self.stage1_topk}):
             bm25_results = self.bm25_index.search(query, top_k=self.stage1_topk)
             seed_names = [r.node_name for r in bm25_results]
+        self.last_bm25_seeds = list(bm25_results)
         logger.info("Stage 1: %d seed nodes from BM25", len(seed_names))
 
         # Stage 2: Graph expansion

--- a/codeminer/model/graph_retrieve_pipeline.py
+++ b/codeminer/model/graph_retrieve_pipeline.py
@@ -1,16 +1,27 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from ..graph.roi_subgraph import ROISubgraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..log_utils import get_logger
+from ..profiler import Profiler
 from ..scip_interface import SCIPIndexerBase as SCIPIndexer
 from ..types import QueriedNode
 
 logger = get_logger(__name__)
+
+
+def _section(
+    profiler: Optional[Profiler], label: str, metadata: Optional[Dict[str, Any]] = None
+):
+    """Open a profiler section if profiler is provided, otherwise a no-op."""
+    if profiler is None:
+        return nullcontext()
+    return profiler.section(label, metadata)
 
 
 class GraphRetrievePipeline:
@@ -54,6 +65,7 @@ class GraphRetrievePipeline:
         languages: Optional[List[str]] = None,
         max_lines_per_chunk: int = 300,
         project_name: Optional[str] = None,
+        profiler: Optional[Profiler] = None,
     ) -> None:
         self.stage1_topk = stage1_topk
         self.stage2_topk = stage2_topk
@@ -65,106 +77,132 @@ class GraphRetrievePipeline:
         pname = project_name or Path(index_path).name
 
         # Build CodeGraph via SCIP indexing
-        repo_indexer = SCIPIndexer(repo_path, output_dir=index_path)
-        self.code_graph = repo_indexer.run_pipeline(
-            project_name=pname, skip_level="graph"
-        )
-        if self.code_graph is None:
-            raise RuntimeError(f"Failed to build code graph for {repo_path!r}")
+        with _section(profiler, "index.graph_build", {"repo": pname}):
+            repo_indexer = SCIPIndexer(repo_path, output_dir=index_path)
+            self.code_graph = repo_indexer.run_pipeline(
+                project_name=pname, skip_level="graph"
+            )
+            if self.code_graph is None:
+                raise RuntimeError(f"Failed to build code graph for {repo_path!r}")
 
         # Build BM25 index from graph
-        self.bm25_index = BM25CodeIndexer(max_k=stage1_topk, language="english")
-        self.bm25_index.build_index_from_graph(self.code_graph)
+        with _section(profiler, "index.bm25_build", {"max_k": stage1_topk}):
+            self.bm25_index = BM25CodeIndexer(max_k=stage1_topk, language="english")
+            self.bm25_index.build_index_from_graph(self.code_graph)
 
         # Build vector store for Stage 3 if requested
         self.vector_store: Optional[CodeVectorStore] = None
         if use_embedding_rerank:
-            self.vector_store = build_hierarchical_vector_store(
-                repo_path=repo_path,
-                index_path=index_path,
-                plan_name=None,
-                languages=languages or ["python"],
-                max_lines_per_chunk=max_lines_per_chunk,
-                build_levels=["l2"],
-                embedding_model=embedding_model,
-                embedding_provider=embedding_provider,
-                embedding_dimension=embedding_dimension,
-                embedding_kwargs={
-                    "model_kwargs": {"trust_remote_code": True},
-                    "encode_kwargs": {"batch_size": 4},
-                },
-                index_metric="ip",
-            )
+            with _section(
+                profiler,
+                "index.vector_store_build",
+                {"model": embedding_model, "dim": embedding_dimension},
+            ):
+                self.vector_store = build_hierarchical_vector_store(
+                    repo_path=repo_path,
+                    index_path=index_path,
+                    plan_name=None,
+                    languages=languages or ["python"],
+                    max_lines_per_chunk=max_lines_per_chunk,
+                    build_levels=["l2"],
+                    embedding_model=embedding_model,
+                    embedding_provider=embedding_provider,
+                    embedding_dimension=embedding_dimension,
+                    embedding_kwargs={
+                        "model_kwargs": {"trust_remote_code": True},
+                        "encode_kwargs": {"batch_size": 4},
+                    },
+                    index_metric="ip",
+                    profiler=profiler,
+                )
 
-    def query(self, query: str) -> List[QueriedNode]:
+    def query(
+        self,
+        query: str,
+        profiler: Optional[Profiler] = None,
+    ) -> List[QueriedNode]:
         """Run the three-stage graph retrieval pipeline.
 
         Args:
             query: The search query (e.g., problem statement).
+            profiler: Optional profiler. When provided, stages are recorded as
+                ``query.bm25_seed``, ``query.graph_expand``,
+                ``query.embedding_rerank``.
 
         Returns:
             List of QueriedNode results.
         """
         # Stage 1: BM25 seed selection
-        bm25_results = self.bm25_index.search(query, top_k=self.stage1_topk)
-        seed_names = [r.node_name for r in bm25_results]
+        with _section(profiler, "query.bm25_seed", {"top_k": self.stage1_topk}):
+            bm25_results = self.bm25_index.search(query, top_k=self.stage1_topk)
+            seed_names = [r.node_name for r in bm25_results]
         logger.info("Stage 1: %d seed nodes from BM25", len(seed_names))
 
         # Stage 2: Graph expansion
-        roi = ROISubgraph(self.code_graph)
-        if self.use_ppr:
-            expanded_nodes = roi.expand_ppr(
-                seed_names,
-                top_k=self.stage2_topk,
-                damping=self.ppr_damping,
-                filter_tests=True,
-            )
-            logger.info(
-                "Stage 2: %d nodes after PPR expansion (damping=%.2f)",
-                len(expanded_nodes),
-                self.ppr_damping,
-            )
-        else:
-            subgraph = roi.extract_subgraph(
-                seed_names, k_hop=self.k_hop, direction="both"
-            )
-            expanded_nodes = roi.get_filtered_subgraph_nodes(
-                subgraph, exclude_nodes=None, filter_tests=True
-            )
-            expanded_nodes = expanded_nodes[: self.stage2_topk]
-            logger.info(
-                "Stage 2: %d nodes after %d-hop BFS expansion",
-                len(expanded_nodes),
-                self.k_hop,
-            )
+        with _section(
+            profiler,
+            "query.graph_expand",
+            {"mode": "ppr" if self.use_ppr else "bfs", "top_k": self.stage2_topk},
+        ):
+            roi = ROISubgraph(self.code_graph)
+            if self.use_ppr:
+                expanded_nodes = roi.expand_ppr(
+                    seed_names,
+                    top_k=self.stage2_topk,
+                    damping=self.ppr_damping,
+                    filter_tests=True,
+                )
+                logger.info(
+                    "Stage 2: %d nodes after PPR expansion (damping=%.2f)",
+                    len(expanded_nodes),
+                    self.ppr_damping,
+                )
+            else:
+                subgraph = roi.extract_subgraph(
+                    seed_names, k_hop=self.k_hop, direction="both"
+                )
+                expanded_nodes = roi.get_filtered_subgraph_nodes(
+                    subgraph, exclude_nodes=None, filter_tests=True
+                )
+                expanded_nodes = expanded_nodes[: self.stage2_topk]
+                logger.info(
+                    "Stage 2: %d nodes after %d-hop BFS expansion",
+                    len(expanded_nodes),
+                    self.k_hop,
+                )
 
         # Stage 3 (optional): Embedding rerank within expanded set only
         if self.use_embedding_rerank and expanded_nodes and self.vector_store:
-            mask_ids: set = set()
-            for node in expanded_nodes:
-                if node.node_name:
-                    mask_ids.add(node.node_name)
-                if node.node_id:
-                    mask_ids.add(node.node_id)
-            # Search ONLY within the graph-expanded node set — do NOT search
-            # the full FAISS index globally.  This is the key design: graph
-            # expansion reduces the corpus, then embedding ranks within it.
-            reranked = self.vector_store.search_within_ids(
-                query, mask_node_ids=mask_ids, top_k=self.stage2_topk
-            )
-            results = [
-                QueriedNode(
-                    node_name=n.node_name,
-                    type=n.type,
-                    file=n.file,
-                    node_id=n.node_id or n.node_name,
-                    start_line=n.start_line,
-                    end_line=n.end_line,
-                    score=n.score,
-                    content=n.content,
+            with _section(
+                profiler,
+                "query.embedding_rerank",
+                {"candidates": len(expanded_nodes)},
+            ):
+                mask_ids: set = set()
+                for node in expanded_nodes:
+                    if node.node_name:
+                        mask_ids.add(node.node_name)
+                    if node.node_id:
+                        mask_ids.add(node.node_id)
+                # Search ONLY within the graph-expanded node set — do NOT search
+                # the full FAISS index globally.  This is the key design: graph
+                # expansion reduces the corpus, then embedding ranks within it.
+                reranked = self.vector_store.search_within_ids(
+                    query, mask_node_ids=mask_ids, top_k=self.stage2_topk
                 )
-                for n in reranked
-            ]
+                results = [
+                    QueriedNode(
+                        node_name=n.node_name,
+                        type=n.type,
+                        file=n.file,
+                        node_id=n.node_id or n.node_name,
+                        start_line=n.start_line,
+                        end_line=n.end_line,
+                        score=n.score,
+                        content=n.content,
+                    )
+                    for n in reranked
+                ]
             logger.info("Stage 3: %d nodes after embedding rerank", len(results))
         else:
             # ROISubgraph returns node_id=None; use node_name as node_id since

--- a/codeminer/profiler.py
+++ b/codeminer/profiler.py
@@ -10,20 +10,53 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .log_utils import get_logger
 
-__all__ = ["Profiler", "RangeStats"]
+__all__ = ["Profiler", "RangeStats", "percentile_from_sorted"]
+
+
+def percentile_from_sorted(sorted_values: List[float], p: float) -> float:
+    """Linear-interpolated percentile from a pre-sorted list."""
+    if not sorted_values:
+        return 0.0
+    if p <= 0:
+        return float(sorted_values[0])
+    if p >= 100:
+        return float(sorted_values[-1])
+    n = len(sorted_values)
+    rank = (p / 100.0) * (n - 1)
+    lo = int(rank)
+    hi = min(lo + 1, n - 1)
+    frac = rank - lo
+    return float(sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac)
 
 
 @dataclass
 class RangeStats:
-    """Aggregate timing statistics captured for a profiler section."""
+    """Aggregate timing statistics captured for a profiler section.
+
+    Optional per-call sample lists (``samples``, ``rss_deltas``, ``gpu_peaks``)
+    are populated only when the owning ``Profiler`` is configured with
+    ``record_samples`` and/or ``record_memory``. When empty, the percentile and
+    memory accessors return zero so consumers can ignore them safely.
+    """
 
     total: float = 0.0
     count: int = 0
     max_duration: float = 0.0
     min_duration: float = field(default_factory=lambda: float("inf"))
     errors: int = 0
+    samples: List[float] = field(default_factory=list)
+    rss_deltas: List[int] = field(default_factory=list)
+    gpu_peaks: List[int] = field(default_factory=list)
 
-    def update(self, duration: float, had_error: bool) -> None:
+    def update(
+        self,
+        duration: float,
+        had_error: bool,
+        *,
+        sample: bool = False,
+        rss_delta: Optional[int] = None,
+        gpu_peak: Optional[int] = None,
+    ) -> None:
         self.total += duration
         self.count += 1
         if duration > self.max_duration:
@@ -32,6 +65,12 @@ class RangeStats:
             self.min_duration = duration
         if had_error:
             self.errors += 1
+        if sample:
+            self.samples.append(duration)
+        if rss_delta is not None:
+            self.rss_deltas.append(int(rss_delta))
+        if gpu_peak is not None:
+            self.gpu_peaks.append(int(gpu_peak))
 
     @property
     def average(self) -> float:
@@ -44,6 +83,39 @@ class RangeStats:
         if self.min_duration == float("inf"):
             return 0.0
         return self.min_duration
+
+    def percentile(self, p: float) -> float:
+        """Linear-interpolated percentile over recorded duration samples."""
+        if not self.samples:
+            return 0.0
+        return percentile_from_sorted(sorted(self.samples), p)
+
+    def percentiles(self, *ps: float) -> Dict[float, float]:
+        """Compute multiple percentiles in one sort pass."""
+        if not self.samples:
+            return {p: 0.0 for p in ps}
+        ordered = sorted(self.samples)
+        return {p: percentile_from_sorted(ordered, p) for p in ps}
+
+    @property
+    def rss_delta_max(self) -> int:
+        return max(self.rss_deltas) if self.rss_deltas else 0
+
+    @property
+    def rss_delta_avg(self) -> float:
+        if not self.rss_deltas:
+            return 0.0
+        return sum(self.rss_deltas) / len(self.rss_deltas)
+
+    @property
+    def gpu_peak_max(self) -> int:
+        return max(self.gpu_peaks) if self.gpu_peaks else 0
+
+    @property
+    def gpu_peak_avg(self) -> float:
+        if not self.gpu_peaks:
+            return 0.0
+        return sum(self.gpu_peaks) / len(self.gpu_peaks)
 
 
 class Profiler:
@@ -74,6 +146,8 @@ class Profiler:
         range_level: int = logging.DEBUG,
         summary_level: int = logging.INFO,
         indent: int = 2,
+        record_samples: bool = False,
+        record_memory: bool = False,
     ) -> None:
         self.name = name
         self.enabled = enabled
@@ -81,11 +155,57 @@ class Profiler:
         self.range_level = range_level
         self.summary_level = summary_level
         self.indent = indent
+        self.record_samples = record_samples
+        self.record_memory = record_memory
         self.logger = logger or get_logger(name)
 
         self._thread_state = threading.local()
         self._lock = threading.Lock()
         self._stats: Dict[str, RangeStats] = {}
+
+        self._psutil_process = None
+        self._torch_cuda = None
+        if self.record_memory:
+            try:
+                import psutil
+
+                self._psutil_process = psutil.Process()
+            except Exception:
+                self._psutil_process = None
+            try:
+                import torch
+
+                if torch.cuda.is_available():
+                    self._torch_cuda = torch.cuda
+            except Exception:
+                self._torch_cuda = None
+
+    # --------------------------------------------------------------------- #
+    # Memory snapshot helpers
+    # --------------------------------------------------------------------- #
+    def _rss_now(self) -> Optional[int]:
+        if self._psutil_process is None:
+            return None
+        try:
+            return int(self._psutil_process.memory_info().rss)
+        except Exception:
+            return None
+
+    def _gpu_reset_peak(self) -> None:
+        if self._torch_cuda is None:
+            return
+        try:
+            self._torch_cuda.reset_peak_memory_stats()
+        except Exception:
+            pass
+
+    def _gpu_peak(self) -> Optional[int]:
+        if self._torch_cuda is None:
+            return None
+        try:
+            return int(self._torch_cuda.max_memory_allocated())
+        except Exception:
+            return None
 
     # --------------------------------------------------------------------- #
     # Public API
@@ -208,13 +328,22 @@ class Profiler:
         label: str,
         duration: float,
         had_error: bool,
+        *,
+        rss_delta: Optional[int] = None,
+        gpu_peak: Optional[int] = None,
     ) -> None:
         with self._lock:
             stats = self._stats.get(label)
             if stats is None:
                 stats = RangeStats()
                 self._stats[label] = stats
-            stats.update(duration, had_error)
+            stats.update(
+                duration,
+                had_error,
+                sample=self.record_samples,
+                rss_delta=rss_delta,
+                gpu_peak=gpu_peak,
+            )
 
     def _get_stack(self) -> list:
         stack = getattr(self._thread_state, "stack", None)
@@ -289,6 +418,7 @@ class _ProfilerRange(ContextDecorator):
         "duration",
         "depth",
         "had_error",
+        "_rss_start",
     )
 
     def __init__(
@@ -304,6 +434,7 @@ class _ProfilerRange(ContextDecorator):
         self.duration: float = 0.0
         self.depth: int = 0
         self.had_error: bool = False
+        self._rss_start: Optional[int] = None
 
     def __enter__(self) -> "_ProfilerRange":
         if not self._profiler.enabled:
@@ -314,6 +445,10 @@ class _ProfilerRange(ContextDecorator):
         stack = self._profiler._get_stack()
         self.depth = len(stack)
         stack.append(self)
+
+        if self._profiler.record_memory:
+            self._rss_start = self._profiler._rss_now()
+            self._profiler._gpu_reset_peak()
 
         self.start_time = self._profiler._now()
         self._profiler._log_range_start(self.label, self.depth, self.metadata)
@@ -327,6 +462,14 @@ class _ProfilerRange(ContextDecorator):
         self.duration = end_time - self.start_time
         self.had_error = exc_type is not None
 
+        rss_delta: Optional[int] = None
+        gpu_peak: Optional[int] = None
+        if self._profiler.record_memory:
+            rss_end = self._profiler._rss_now()
+            if self._rss_start is not None and rss_end is not None:
+                rss_delta = rss_end - self._rss_start
+            gpu_peak = self._profiler._gpu_peak()
+
         stack = self._profiler._get_stack()
         if stack and stack[-1] is self:
             stack.pop()
@@ -338,7 +481,13 @@ class _ProfilerRange(ContextDecorator):
             except ValueError:
                 stack.clear()
 
-        self._profiler._record(self.label, self.duration, self.had_error)
+        self._profiler._record(
+            self.label,
+            self.duration,
+            self.had_error,
+            rss_delta=rss_delta,
+            gpu_peak=gpu_peak,
+        )
         self._profiler._log_range_stop(
             self.label,
             self.depth,

--- a/codeminer/profiler.py
+++ b/codeminer/profiler.py
@@ -191,14 +191,6 @@ class Profiler:
         except Exception:
             return None
 
-    def _gpu_reset_peak(self) -> None:
-        if self._torch_cuda is None:
-            return
-        try:
-            self._torch_cuda.reset_peak_memory_stats()
-        except Exception:
-            pass
-
     def _gpu_peak(self) -> Optional[int]:
         if self._torch_cuda is None:
             return None
@@ -419,6 +411,7 @@ class _ProfilerRange(ContextDecorator):
         "depth",
         "had_error",
         "_rss_start",
+        "_gpu_peak_start",
     )
 
     def __init__(
@@ -435,6 +428,7 @@ class _ProfilerRange(ContextDecorator):
         self.depth: int = 0
         self.had_error: bool = False
         self._rss_start: Optional[int] = None
+        self._gpu_peak_start: Optional[int] = None
 
     def __enter__(self) -> "_ProfilerRange":
         if not self._profiler.enabled:
@@ -448,7 +442,12 @@ class _ProfilerRange(ContextDecorator):
 
         if self._profiler.record_memory:
             self._rss_start = self._profiler._rss_now()
-            self._profiler._gpu_reset_peak()
+            # Snapshot the CUDA peak watermark on entry; the exit handler
+            # reports (max_memory_allocated() - start) so the delta composes
+            # under nesting. The previous approach reset the peak globally
+            # at every section enter, which silently under-reported any
+            # outer section that wrapped an inner memory-recording section.
+            self._gpu_peak_start = self._profiler._gpu_peak()
 
         self.start_time = self._profiler._now()
         self._profiler._log_range_start(self.label, self.depth, self.metadata)
@@ -468,7 +467,11 @@ class _ProfilerRange(ContextDecorator):
             rss_end = self._profiler._rss_now()
             if self._rss_start is not None and rss_end is not None:
                 rss_delta = rss_end - self._rss_start
-            gpu_peak = self._profiler._gpu_peak()
+            gpu_peak_end = self._profiler._gpu_peak()
+            if self._gpu_peak_start is not None and gpu_peak_end is not None:
+                # max(0, ...) guards against the rare case where another
+                # caller resets the peak counter while a section is open.
+                gpu_peak = max(0, gpu_peak_end - self._gpu_peak_start)
 
         stack = self._profiler._get_stack()
         if stack and stack[-1] is self:

--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -43,7 +43,7 @@ from codeminer.eval.retrieval_eval import (
 )
 from codeminer.log_utils import get_logger
 from codeminer.model import GraphRetrievePipeline
-from codeminer.profiler import Profiler
+from codeminer.profiler import Profiler, percentile_from_sorted
 
 logger = get_logger(__name__)
 
@@ -54,9 +54,15 @@ logger = get_logger(__name__)
 
 
 def _to_sections_payload(profile_summary):
-    """Convert ``Profiler.report()`` output to a JSON-serialisable list."""
-    return [
-        {
+    """Convert ``Profiler.report()`` output to a JSON-serialisable list.
+
+    When the profiler was configured with ``record_samples`` or
+    ``record_memory``, additional fields are included so the aggregator can
+    recompute global percentiles / memory rollups across instances.
+    """
+    payload = []
+    for label, stats in profile_summary:
+        entry = {
             "label": label,
             "total": stats.total,
             "count": stats.count,
@@ -65,12 +71,31 @@ def _to_sections_payload(profile_summary):
             "max": stats.max_duration,
             "errors": stats.errors,
         }
-        for label, stats in profile_summary
-    ]
+        if stats.samples:
+            pct = stats.percentiles(50.0, 95.0, 99.0)
+            entry["p50"] = pct[50.0]
+            entry["p95"] = pct[95.0]
+            entry["p99"] = pct[99.0]
+            entry["samples"] = list(stats.samples)
+        if stats.rss_deltas:
+            entry["rss_delta_avg"] = stats.rss_delta_avg
+            entry["rss_delta_max"] = stats.rss_delta_max
+            entry["rss_deltas"] = list(stats.rss_deltas)
+        if stats.gpu_peaks:
+            entry["gpu_peak_avg"] = stats.gpu_peak_avg
+            entry["gpu_peak_max"] = stats.gpu_peak_max
+            entry["gpu_peaks"] = list(stats.gpu_peaks)
+        payload.append(entry)
+    return payload
 
 
 def _aggregate_section_stats(instance_profiles):
-    """Sum per-instance section payloads into a single aggregate list."""
+    """Sum per-instance section payloads into a single aggregate list.
+
+    When per-call sample lists are present, concatenate them and recompute
+    global p50/p95/p99 in one sort pass per section; memory lists are rolled
+    up the same way for ``rss_delta_*`` and ``gpu_peak_*``.
+    """
     aggregate = {}
     for profile in instance_profiles:
         for section in profile.get("sections", []):
@@ -84,6 +109,9 @@ def _aggregate_section_stats(instance_profiles):
                     "min": float("inf"),
                     "max": 0.0,
                     "errors": 0,
+                    "samples": [],
+                    "rss_deltas": [],
+                    "gpu_peaks": [],
                 },
             )
             entry["total"] += float(section["total"])
@@ -91,24 +119,62 @@ def _aggregate_section_stats(instance_profiles):
             entry["min"] = min(entry["min"], float(section["min"]))
             entry["max"] = max(entry["max"], float(section["max"]))
             entry["errors"] += int(section["errors"])
+            entry["samples"].extend(section.get("samples", []))
+            entry["rss_deltas"].extend(section.get("rss_deltas", []))
+            entry["gpu_peaks"].extend(section.get("gpu_peaks", []))
 
     payload = []
     for label, stats in aggregate.items():
         count = stats["count"]
-        payload.append(
-            {
-                "label": label,
-                "total": stats["total"],
-                "count": count,
-                "average": (stats["total"] / count) if count else 0.0,
-                "min": 0.0 if stats["min"] == float("inf") else stats["min"],
-                "max": stats["max"],
-                "errors": stats["errors"],
-            }
-        )
+        item = {
+            "label": label,
+            "total": stats["total"],
+            "count": count,
+            "average": (stats["total"] / count) if count else 0.0,
+            "min": 0.0 if stats["min"] == float("inf") else stats["min"],
+            "max": stats["max"],
+            "errors": stats["errors"],
+        }
+        if stats["samples"]:
+            ordered = sorted(stats["samples"])
+            item["p50"] = percentile_from_sorted(ordered, 50.0)
+            item["p95"] = percentile_from_sorted(ordered, 95.0)
+            item["p99"] = percentile_from_sorted(ordered, 99.0)
+            item["sample_count"] = len(ordered)
+        if stats["rss_deltas"]:
+            rss = stats["rss_deltas"]
+            item["rss_delta_avg"] = sum(rss) / len(rss)
+            item["rss_delta_max"] = max(rss)
+        if stats["gpu_peaks"]:
+            gpu = stats["gpu_peaks"]
+            item["gpu_peak_avg"] = sum(gpu) / len(gpu)
+            item["gpu_peak_max"] = max(gpu)
+        payload.append(item)
 
     payload.sort(key=lambda item: item["total"], reverse=True)
     return payload
+
+
+def _compute_bm25_seed_recall(seeds, target_files, ks):
+    """Compute bm25_seed_recall@k for each k in ``ks``.
+
+    Uses the same file-extraction logic as the main retrieval evaluator
+    (``extract_predictions``), so the recall numbers are directly comparable
+    against ``files@k`` reported for the full pipeline output.
+
+    Returns dict of {int(k): float} with recall in [0, 1]. Empty if no
+    target files (instance has no GT files to recall against).
+    """
+    if not target_files:
+        return {}
+    seed_files, _ = extract_predictions(seeds)
+    target_set = set(target_files)
+    out = {}
+    denom = len(target_set)
+    for k in ks:
+        topk = set(seed_files[:k])
+        out[int(k)] = (len(topk & target_set) / denom) if denom else 0.0
+    return out
 
 
 def _split_sections_by_phase(sections):
@@ -280,6 +346,24 @@ def parse_args():
         default=None,
         help="Optional tag appended to profiler filename.",
     )
+    parser.add_argument(
+        "--record-samples",
+        action="store_true",
+        help=(
+            "Retain per-call durations so the harness can emit p50/p95/p99 "
+            "per section (per-instance and aggregate). No effect unless "
+            "--enable-profiler is also set."
+        ),
+    )
+    parser.add_argument(
+        "--record-memory",
+        action="store_true",
+        help=(
+            "Capture RSS delta (psutil) and peak GPU memory (torch.cuda) "
+            "per section. GPU fields are populated only when CUDA is "
+            "available; otherwise the RSS deltas are emitted alone."
+        ),
+    )
 
     return parser.parse_args()
 
@@ -308,21 +392,24 @@ def run_graph_pipeline(args):
 
     # Profiler setup ---------------------------------------------------------
     profiling_enabled = args.enable_profiler or args.profile_dir is not None
-    if profiling_enabled:
-        profile_output_dir = (
+
+    def _resolve_profile_dir() -> Path:
+        base = (
             Path(args.profile_dir).expanduser().resolve()
             if args.profile_dir
             else Path(args.index_cache_dir).expanduser().resolve()
             / "profile_log"
             / "graph_rag"
         )
-        profile_output_dir.mkdir(parents=True, exist_ok=True)
-        logger.info("Profiler summaries will be stored in: %s", profile_output_dir)
-    else:
-        profile_output_dir = None
+        base.mkdir(parents=True, exist_ok=True)
+        return base
+
+    if profiling_enabled:
+        logger.info("Profiler summaries will be stored in: %s", _resolve_profile_dir())
 
     instance_index_profiles = []
     instance_query_profiles = []
+    instance_seed_recalls = []
 
     # Load dataset
     if args.dataset == "swebench_lite":
@@ -378,12 +465,16 @@ def run_graph_pipeline(args):
                 logger=logger,
                 emit_events=False,
                 summary_level=logging.INFO,
+                record_samples=args.record_samples,
+                record_memory=args.record_memory,
             )
             query_profiler = Profiler(
                 name=f"graph_rag[query][{instance_id}]",
                 logger=logger,
                 emit_events=False,
                 summary_level=logging.INFO,
+                record_samples=args.record_samples,
+                record_memory=args.record_memory,
             )
         try:
             t0 = time.time()
@@ -417,6 +508,22 @@ def run_graph_pipeline(args):
             else:
                 results = pipeline.query(instance["problem_statement"])
             elapsed = time.time() - t0
+
+            # bm25_seed_recall@k — saturation-guard signal. Compares the
+            # stage-1 BM25 seeds against GT files at every k in --metrics-k,
+            # using the same file-extraction logic as the main evaluator so
+            # the numbers line up with files@k for the full pipeline.
+            seed_recall = _compute_bm25_seed_recall(
+                pipeline.last_bm25_seeds, target_files, metrics_k
+            )
+            if seed_recall:
+                instance_seed_recalls.append(
+                    {"instance_id": instance_id, "recall_at_k": seed_recall}
+                )
+                logger.info(
+                    "  [bm25_seed] %s",
+                    " ".join(f"r@{k}={v:.3f}" for k, v in seed_recall.items()),
+                )
 
             if profiling_enabled:
                 index_summary = index_profiler.report()
@@ -533,7 +640,21 @@ def run_graph_pipeline(args):
                 args.embedding_model if rerank_strategy == "embedding" else None
             ),
             "rerank_model": args.rerank_model,
+            "record_samples": args.record_samples,
+            "record_memory": args.record_memory,
         }
+        # Aggregate bm25_seed_recall@k by averaging per-instance recall at each k.
+        # Each instance contributes one observation per k (the recall for that
+        # instance's GT set), so the aggregate is a plain mean across instances.
+        aggregate_seed_recall = {}
+        for k in metrics_k:
+            values = [
+                entry["recall_at_k"][int(k)]
+                for entry in instance_seed_recalls
+                if int(k) in entry["recall_at_k"]
+            ]
+            if values:
+                aggregate_seed_recall[int(k)] = sum(values) / len(values)
         profile_payload = {
             "config": config_payload,
             "instances_profiled": len(instance_query_profiles),
@@ -545,6 +666,11 @@ def run_graph_pipeline(args):
                 "per_instance": instance_query_profiles,
                 "aggregate_sections": _aggregate_section_stats(instance_query_profiles),
             },
+            "bm25_seed_recall": {
+                "per_instance": instance_seed_recalls,
+                "aggregate": aggregate_seed_recall,
+                "instances_with_targets": len(instance_seed_recalls),
+            },
         }
         tag_part = (
             f"__{_sanitize_filename_part(args.profile_tag)}" if args.profile_tag else ""
@@ -553,10 +679,17 @@ def run_graph_pipeline(args):
         profile_filename = (
             f"graph_rag_{args.dataset}_{expansion}_" f"{rerank_strategy}{tag_part}.json"
         )
-        profile_path = profile_output_dir / profile_filename
+        profile_path = _resolve_profile_dir() / profile_filename
         with open(profile_path, "w", encoding="utf-8") as f:
             json.dump(profile_payload, f, indent=2, ensure_ascii=False)
         logger.info("Profiler summary saved to %s", profile_path)
+        if aggregate_seed_recall:
+            logger.info(
+                "=== bm25_seed_recall (avg over %d instance(s)) ===",
+                len(instance_seed_recalls),
+            )
+            for k in sorted(aggregate_seed_recall):
+                logger.info("  r@%d = %.3f", k, aggregate_seed_recall[k])
 
 
 def main():

--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -177,31 +177,49 @@ def _compute_bm25_seed_recall(seeds, target_files, ks):
     return out
 
 
-def _split_sections_by_phase(sections):
-    """Split a flat section list into ``index_time`` and ``query_time`` buckets.
+def _filter_index_sections(sections):
+    """Return only the sections that belong in the ``index_time`` bucket.
 
-    Index-time sections include any label produced during pipeline initialisation
-    (``index.*`` plus the inner labels emitted by ``build_hierarchical_vector_store``
-    and ``CodeVectorStore`` — ``chunking_*``, ``embedding_encode_*``,
-    ``faiss_index_add_*``). Query-time sections are everything matching
-    ``query.*``.
+    Anything starting with ``query.`` should never appear in the index
+    profile, but if it does (e.g. a future label addition wires through
+    the wrong profiler), log a warning rather than silently dropping so
+    the leak is visible in CI rather than ghosting from the JSON.
     """
-    index_prefixes = (
-        "index.",
-        "chunking_",
-        "embedding_encode_",
-        "faiss_index_add_",
-    )
-    index_sections, query_sections = [], []
+    keep, leaked = [], []
     for section in sections:
-        label = section["label"]
-        if label.startswith("query."):
-            query_sections.append(section)
-        elif label.startswith(index_prefixes):
-            index_sections.append(section)
+        if section["label"].startswith("query."):
+            leaked.append(section["label"])
         else:
-            index_sections.append(section)
-    return index_sections, query_sections
+            keep.append(section)
+    if leaked:
+        logger.warning(
+            "Dropping %d query.* section(s) leaked into index profile: %s",
+            len(leaked),
+            leaked,
+        )
+    return keep
+
+
+def _filter_query_sections(sections):
+    """Return only the sections that belong in the ``query_time`` bucket.
+
+    Only ``query.*`` labels survive. Anything else — an ``index.*`` label
+    routed through the query profiler, or any unrecognised prefix added in
+    a future phase — is logged rather than silently discarded.
+    """
+    keep, leaked = [], []
+    for section in sections:
+        if section["label"].startswith("query."):
+            keep.append(section)
+        else:
+            leaked.append(section["label"])
+    if leaked:
+        logger.warning(
+            "Dropping %d non-query.* section(s) leaked into query profile: %s",
+            len(leaked),
+            leaked,
+        )
+    return keep
 
 
 def _sanitize_filename_part(value):
@@ -531,10 +549,10 @@ def run_graph_pipeline(args):
                 index_sections = _to_sections_payload(index_summary)
                 query_sections = _to_sections_payload(query_summary)
                 # Internal labels emitted by builders/vector_store land in
-                # the index profiler — split by phase here so any cross-talk
-                # stays in the right bucket.
-                index_only, _query_leak = _split_sections_by_phase(index_sections)
-                _index_leak, query_only = _split_sections_by_phase(query_sections)
+                # the index profiler — filter each side so any cross-talk
+                # is logged rather than silently bucketed.
+                index_only = _filter_index_sections(index_sections)
+                query_only = _filter_query_sections(query_sections)
                 instance_index_profiles.append(
                     {"instance_id": instance_id, "sections": index_only}
                 )

--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -172,8 +172,12 @@ def _compute_bm25_seed_recall(seeds, target_files, ks):
     out = {}
     denom = len(target_set)
     for k in ks:
-        topk = set(seed_files[:k])
-        out[int(k)] = (len(topk & target_set) / denom) if denom else 0.0
+        # Normalise k to int up front so both the slice and the output key
+        # use the same value — argparse hands us ints today, but downstream
+        # callers (sweep scripts) may pass floats / numpy scalars.
+        ik = int(k)
+        topk = set(seed_files[:ik])
+        out[ik] = (len(topk & target_set) / denom) if denom else 0.0
     return out
 
 
@@ -306,7 +310,7 @@ def parse_args():
         "--metrics-k",
         type=int,
         nargs="+",
-        default=[1, 3, 5, 10, 15, 20],
+        default=[1, 5, 10],
     )
 
     # Cache
@@ -434,8 +438,9 @@ def run_graph_pipeline(args):
         base.mkdir(parents=True, exist_ok=True)
         return base
 
-    if profiling_enabled:
-        logger.info("Profiler summaries will be stored in: %s", _resolve_profile_dir())
+    profile_dir = _resolve_profile_dir() if profiling_enabled else None
+    if profile_dir is not None:
+        logger.info("Profiler summaries will be stored in: %s", profile_dir)
 
     instance_index_profiles = []
     instance_query_profiles = []
@@ -465,8 +470,10 @@ def run_graph_pipeline(args):
 
     logger.info("Loaded %d instance(s)", len(dataset_instances))
 
+    # GT files are dataset-specific; derive the default from --dataset so a
+    # Loc-Bench run can't silently align against the SWE-bench ground truth.
     eval_path = args.eval_instances or str(
-        Path.home() / ".codeminer" / f"swebench_lite_{args.split}_gt.json"
+        Path.home() / ".codeminer" / f"{args.dataset}_{args.split}_gt.json"
     )
     eval_metadata = dataset_obj.load_eval_metadata(eval_path)
     metrics_k = sorted(set(args.metrics_k))
@@ -711,9 +718,9 @@ def run_graph_pipeline(args):
         # loosens we don't want to write outside the resolved profile dir.
         dataset_part = _sanitize_filename_part(args.dataset)
         profile_filename = (
-            f"graph_rag_{dataset_part}_{expansion}_" f"{rerank_strategy}{tag_part}.json"
+            f"graph_rag_{dataset_part}_{expansion}_{rerank_strategy}{tag_part}.json"
         )
-        profile_path = _resolve_profile_dir() / profile_filename
+        profile_path = profile_dir / profile_filename
         with open(profile_path, "w", encoding="utf-8") as f:
             json.dump(profile_payload, f, indent=2, ensure_ascii=False)
         logger.info("Profiler summary saved to %s", profile_path)

--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -28,6 +28,7 @@ Usage:
 """
 import argparse
 import json
+import logging
 import time
 from pathlib import Path
 
@@ -42,8 +43,103 @@ from codeminer.eval.retrieval_eval import (
 )
 from codeminer.log_utils import get_logger
 from codeminer.model import GraphRetrievePipeline
+from codeminer.profiler import Profiler
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Profiling helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_sections_payload(profile_summary):
+    """Convert ``Profiler.report()`` output to a JSON-serialisable list."""
+    return [
+        {
+            "label": label,
+            "total": stats.total,
+            "count": stats.count,
+            "average": stats.average,
+            "min": stats.safe_min,
+            "max": stats.max_duration,
+            "errors": stats.errors,
+        }
+        for label, stats in profile_summary
+    ]
+
+
+def _aggregate_section_stats(instance_profiles):
+    """Sum per-instance section payloads into a single aggregate list."""
+    aggregate = {}
+    for profile in instance_profiles:
+        for section in profile.get("sections", []):
+            label = section["label"]
+            entry = aggregate.setdefault(
+                label,
+                {
+                    "label": label,
+                    "total": 0.0,
+                    "count": 0,
+                    "min": float("inf"),
+                    "max": 0.0,
+                    "errors": 0,
+                },
+            )
+            entry["total"] += float(section["total"])
+            entry["count"] += int(section["count"])
+            entry["min"] = min(entry["min"], float(section["min"]))
+            entry["max"] = max(entry["max"], float(section["max"]))
+            entry["errors"] += int(section["errors"])
+
+    payload = []
+    for label, stats in aggregate.items():
+        count = stats["count"]
+        payload.append(
+            {
+                "label": label,
+                "total": stats["total"],
+                "count": count,
+                "average": (stats["total"] / count) if count else 0.0,
+                "min": 0.0 if stats["min"] == float("inf") else stats["min"],
+                "max": stats["max"],
+                "errors": stats["errors"],
+            }
+        )
+
+    payload.sort(key=lambda item: item["total"], reverse=True)
+    return payload
+
+
+def _split_sections_by_phase(sections):
+    """Split a flat section list into ``index_time`` and ``query_time`` buckets.
+
+    Index-time sections include any label produced during pipeline initialisation
+    (``index.*`` plus the inner labels emitted by ``build_hierarchical_vector_store``
+    and ``CodeVectorStore`` — ``chunking_*``, ``embedding_encode_*``,
+    ``faiss_index_add_*``). Query-time sections are everything matching
+    ``query.*``.
+    """
+    index_prefixes = (
+        "index.",
+        "chunking_",
+        "embedding_encode_",
+        "faiss_index_add_",
+    )
+    index_sections, query_sections = [], []
+    for section in sections:
+        label = section["label"]
+        if label.startswith("query."):
+            query_sections.append(section)
+        elif label.startswith(index_prefixes):
+            index_sections.append(section)
+        else:
+            index_sections.append(section)
+    return index_sections, query_sections
+
+
+def _sanitize_filename_part(value):
+    return str(value).replace("/", "__").replace(" ", "_")
 
 
 def parse_args():
@@ -142,11 +238,91 @@ def parse_args():
     )
     parser.add_argument("--result-path", type=str, default=None)
 
+    # Rerank strategy (forward-compatible flag; cross-encoder backends
+    # are introduced in PR #128 and not yet available on main).
+    parser.add_argument(
+        "--rerank-strategy",
+        type=str,
+        choices=["none", "embedding", "cross-encoder"],
+        default=None,
+        help=(
+            "Rerank strategy for Stage 3. 'none' disables rerank, "
+            "'embedding' uses FAISS within the expanded set (legacy), "
+            "'cross-encoder' requires PR #128 (Qwen3-Reranker / "
+            "STCrossEncoderWrapper) and currently raises NotImplementedError."
+        ),
+    )
+    parser.add_argument(
+        "--rerank-model",
+        type=str,
+        default=None,
+        help="Cross-encoder rerank model id (used when rerank-strategy=cross-encoder).",
+    )
+
+    # Profiling
+    parser.add_argument(
+        "--enable-profiler",
+        action="store_true",
+        help="Enable runtime profiler summaries.",
+    )
+    parser.add_argument(
+        "--profile-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to store runtime profiler summaries "
+            "(default: <index-cache-dir>/profile_log/graph_rag)."
+        ),
+    )
+    parser.add_argument(
+        "--profile-tag",
+        type=str,
+        default=None,
+        help="Optional tag appended to profiler filename.",
+    )
+
     return parser.parse_args()
+
+
+def _resolve_rerank_strategy(args):
+    """Combine legacy ``--embedding`` flag with ``--rerank-strategy``.
+
+    Returns one of: ``"none"``, ``"embedding"``, ``"cross-encoder"``.
+    """
+    if args.rerank_strategy is not None:
+        if args.rerank_strategy == "cross-encoder":
+            raise NotImplementedError(
+                "rerank-strategy='cross-encoder' requires the rerank "
+                "wrappers from PR #128 (codeminer/index/rerank/cross_encoder.py). "
+                "That PR has not landed on main yet."
+            )
+        return args.rerank_strategy
+    return "embedding" if args.embedding else "none"
 
 
 def run_graph_pipeline(args):
     """Run the graph-based retrieval baseline."""
+
+    rerank_strategy = _resolve_rerank_strategy(args)
+    use_embedding_rerank = rerank_strategy == "embedding"
+
+    # Profiler setup ---------------------------------------------------------
+    profiling_enabled = args.enable_profiler or args.profile_dir is not None
+    if profiling_enabled:
+        profile_output_dir = (
+            Path(args.profile_dir).expanduser().resolve()
+            if args.profile_dir
+            else Path(args.index_cache_dir).expanduser().resolve()
+            / "profile_log"
+            / "graph_rag"
+        )
+        profile_output_dir.mkdir(parents=True, exist_ok=True)
+        logger.info("Profiler summaries will be stored in: %s", profile_output_dir)
+    else:
+        profile_output_dir = None
+
+    instance_index_profiles = []
+    instance_query_profiles = []
 
     # Load dataset
     if args.dataset == "swebench_lite":
@@ -194,6 +370,21 @@ def run_graph_pipeline(args):
             continue
 
         pipeline = None
+        index_profiler = None
+        query_profiler = None
+        if profiling_enabled:
+            index_profiler = Profiler(
+                name=f"graph_rag[index][{instance_id}]",
+                logger=logger,
+                emit_events=False,
+                summary_level=logging.INFO,
+            )
+            query_profiler = Profiler(
+                name=f"graph_rag[query][{instance_id}]",
+                logger=logger,
+                emit_events=False,
+                summary_level=logging.INFO,
+            )
         try:
             t0 = time.time()
 
@@ -211,14 +402,38 @@ def run_graph_pipeline(args):
                 k_hop=args.k_hop,
                 use_ppr=args.ppr,
                 ppr_damping=args.ppr_damping,
-                use_embedding_rerank=args.embedding,
+                use_embedding_rerank=use_embedding_rerank,
                 embedding_model=args.embedding_model,
                 embedding_provider=args.embedding_provider,
                 embedding_dimension=args.embedding_dimension,
                 project_name=instance_id.replace("/", "__"),
+                profiler=index_profiler,
             )
-            results = pipeline.query(instance["problem_statement"])
+            if query_profiler is not None:
+                with query_profiler.section("query.total"):
+                    results = pipeline.query(
+                        instance["problem_statement"], profiler=query_profiler
+                    )
+            else:
+                results = pipeline.query(instance["problem_statement"])
             elapsed = time.time() - t0
+
+            if profiling_enabled:
+                index_summary = index_profiler.report()
+                query_summary = query_profiler.report()
+                index_sections = _to_sections_payload(index_summary)
+                query_sections = _to_sections_payload(query_summary)
+                # Internal labels emitted by builders/vector_store land in
+                # the index profiler — split by phase here so any cross-talk
+                # stays in the right bucket.
+                index_only, _query_leak = _split_sections_by_phase(index_sections)
+                _index_leak, query_only = _split_sections_by_phase(query_sections)
+                instance_index_profiles.append(
+                    {"instance_id": instance_id, "sections": index_only}
+                )
+                instance_query_profiles.append(
+                    {"instance_id": instance_id, "sections": query_only}
+                )
 
             metrics = evaluate_predictions(
                 nodes=results,
@@ -260,7 +475,8 @@ def run_graph_pipeline(args):
                         "k_hop": args.k_hop,
                         "use_ppr": args.ppr,
                         "ppr_damping": args.ppr_damping,
-                        "embedding_rerank": args.embedding,
+                        "embedding_rerank": use_embedding_rerank,
+                        "rerank_strategy": rerank_strategy,
                         "num_results": len(results),
                         "elapsed_s": elapsed,
                         "metric_k_files": unique_files[:metric_max_k],
@@ -302,6 +518,46 @@ def run_graph_pipeline(args):
             json.dump(all_results, f, indent=2, ensure_ascii=False)
         logger.info("Results saved to %s", result_path)
 
+    if profiling_enabled:
+        config_payload = {
+            "dataset": args.dataset,
+            "split": args.split,
+            "filter_instance": args.filter_instance,
+            "expansion": "ppr" if args.ppr else "bfs",
+            "stage1_topk": args.stage1_topk,
+            "stage2_topk": args.stage2_topk,
+            "k_hop": args.k_hop,
+            "ppr_damping": args.ppr_damping,
+            "rerank_strategy": rerank_strategy,
+            "embedding_model": (
+                args.embedding_model if rerank_strategy == "embedding" else None
+            ),
+            "rerank_model": args.rerank_model,
+        }
+        profile_payload = {
+            "config": config_payload,
+            "instances_profiled": len(instance_query_profiles),
+            "index_time": {
+                "per_instance": instance_index_profiles,
+                "aggregate_sections": _aggregate_section_stats(instance_index_profiles),
+            },
+            "query_time": {
+                "per_instance": instance_query_profiles,
+                "aggregate_sections": _aggregate_section_stats(instance_query_profiles),
+            },
+        }
+        tag_part = (
+            f"__{_sanitize_filename_part(args.profile_tag)}" if args.profile_tag else ""
+        )
+        expansion = "ppr" if args.ppr else "bfs"
+        profile_filename = (
+            f"graph_rag_{args.dataset}_{expansion}_" f"{rerank_strategy}{tag_part}.json"
+        )
+        profile_path = profile_output_dir / profile_filename
+        with open(profile_path, "w", encoding="utf-8") as f:
+            json.dump(profile_payload, f, indent=2, ensure_ascii=False)
+        logger.info("Profiler summary saved to %s", profile_path)
+
 
 def main():
     args = parse_args()
@@ -311,11 +567,17 @@ def main():
         if args.ppr
         else f"Graph({args.k_hop}-hop, max {args.stage2_topk})"
     )
+    rerank_strategy = _resolve_rerank_strategy(args)
+    rerank_desc = {
+        "none": "",
+        "embedding": "-> Embedding rerank",
+        "cross-encoder": "-> Cross-encoder rerank (PR #128)",
+    }[rerank_strategy]
     logger.info(
         "Pipeline: BM25(top%d) -> %s %s",
         args.stage1_topk,
         stage2_desc,
-        "-> Embedding rerank" if args.embedding else "",
+        rerank_desc,
     )
     run_graph_pipeline(args)
 

--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -336,6 +336,10 @@ def parse_args():
             "STCrossEncoderWrapper) and currently raises NotImplementedError."
         ),
     )
+    # Forward-compat: wired in PR #128. Currently echoed only into the
+    # profiler `config` payload (no rerank backend reads it), so it is
+    # safe to pass but has no runtime effect until the cross-encoder
+    # wrapper lands.
     parser.add_argument(
         "--rerank-model",
         type=str,
@@ -383,7 +387,15 @@ def parse_args():
         ),
     )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    # Surface unsupported rerank strategies at parse time, before any
+    # dataset load / profiler-dir creation, with argparse's exit code 2
+    # rather than a stack trace mid-pipeline.
+    try:
+        _resolve_rerank_strategy(args)
+    except NotImplementedError as exc:
+        parser.error(str(exc))
+    return args
 
 
 def _resolve_rerank_strategy(args):
@@ -694,8 +706,12 @@ def run_graph_pipeline(args):
             f"__{_sanitize_filename_part(args.profile_tag)}" if args.profile_tag else ""
         )
         expansion = "ppr" if args.ppr else "bfs"
+        # Sanitize args.dataset for symmetry with profile_tag — today
+        # `choices=` constrains it to safe values, but if that ever
+        # loosens we don't want to write outside the resolved profile dir.
+        dataset_part = _sanitize_filename_part(args.dataset)
         profile_filename = (
-            f"graph_rag_{args.dataset}_{expansion}_" f"{rerank_strategy}{tag_part}.json"
+            f"graph_rag_{dataset_part}_{expansion}_" f"{rerank_strategy}{tag_part}.json"
         )
         profile_path = _resolve_profile_dir() / profile_filename
         with open(profile_path, "w", encoding="utf-8") as f:

--- a/test/examples/test_graph_retrieve_baseline.py
+++ b/test/examples/test_graph_retrieve_baseline.py
@@ -107,6 +107,29 @@ def test_resolve_strategy_cross_encoder_raises(runner):
         runner._resolve_rerank_strategy(_args(rerank_strategy="cross-encoder"))
 
 
+def test_parse_args_rejects_cross_encoder_at_parse_time(runner, monkeypatch, capsys):
+    """The cross-encoder NotImplementedError should be surfaced by parse_args
+    via parser.error (exit code 2) before any dataset-load side effects, not
+    deep inside run_graph_pipeline."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "graph_retrieve_baseline.py",
+            "--dataset",
+            "swebench_lite",
+            "--rerank-strategy",
+            "cross-encoder",
+        ],
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        runner.parse_args()
+    assert exc_info.value.code == 2, (
+        "expected argparse exit code 2, got " f"{exc_info.value.code}"
+    )
+    err = capsys.readouterr().err
+    assert "PR #128" in err, f"expected error mentioning PR #128, got: {err!r}"
+
+
 # ---------------------------------------------------------------------------
 # _aggregate_section_stats
 # ---------------------------------------------------------------------------

--- a/test/examples/test_graph_retrieve_baseline.py
+++ b/test/examples/test_graph_retrieve_baseline.py
@@ -1,0 +1,361 @@
+"""Unit tests for the pure helpers in ``examples/graph_retrieve_baseline.py``.
+
+Phase 1 review called out that the runner's helpers had no tests, so as
+the harness grows (Phase 2 added percentile / memory rollups) regressions
+would land silently. The helpers covered here are pure functions:
+
+- ``_resolve_rerank_strategy``: legacy ``--embedding`` ↔ new
+  ``--rerank-strategy`` precedence and the cross-encoder NotImplementedError
+  fence (until PR #128 lands).
+- ``_aggregate_section_stats``: sums per-instance section payloads, with
+  optional sample / memory roll-ups added in Phase 2.
+- ``_filter_index_sections`` / ``_filter_query_sections``: replace the
+  prior ``_split_sections_by_phase`` helper that silently dropped
+  unexpected labels into the wrong bucket — these now log a warning so
+  future leaks are visible.
+
+The runner script is not part of the ``codeminer`` package (see
+``pyproject.toml``: ``include = ["codeminer*"]``), so we load it via
+``importlib.util`` rather than polluting ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_RUNNER_PATH = (
+    Path(__file__).resolve().parents[2] / "examples" / "graph_retrieve_baseline.py"
+)
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location(
+        "graph_retrieve_baseline_under_test", _RUNNER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def runner():
+    return _load_runner()
+
+
+@pytest.fixture
+def runner_caplog(runner, caplog):
+    """``caplog`` that actually sees warnings emitted via ``runner.logger``.
+
+    The project's ``get_logger`` sets ``propagate=False`` and installs its
+    own handler. caplog attaches to the root logger, so without temporarily
+    re-enabling propagation it never sees these records.
+    """
+    original = runner.logger.propagate
+    runner.logger.propagate = True
+    try:
+        yield caplog
+    finally:
+        runner.logger.propagate = original
+
+
+# ---------------------------------------------------------------------------
+# _resolve_rerank_strategy
+# ---------------------------------------------------------------------------
+
+
+def _args(rerank_strategy=None, embedding=False):
+    return SimpleNamespace(rerank_strategy=rerank_strategy, embedding=embedding)
+
+
+def test_resolve_strategy_legacy_embedding_off(runner):
+    """Neither flag set → 'none' (default behaviour)."""
+    assert runner._resolve_rerank_strategy(_args()) == "none"
+
+
+def test_resolve_strategy_legacy_embedding_on(runner):
+    """``--embedding`` alone resolves to 'embedding' (legacy path)."""
+    assert runner._resolve_rerank_strategy(_args(embedding=True)) == "embedding"
+
+
+def test_resolve_strategy_explicit_overrides_legacy(runner):
+    """``--rerank-strategy`` wins over legacy ``--embedding``.
+
+    A user who passes ``--embedding --rerank-strategy=none`` clearly meant
+    'none', not 'embedding'. Without this precedence, the legacy default
+    would silently re-enable rerank.
+    """
+    assert (
+        runner._resolve_rerank_strategy(_args(rerank_strategy="none", embedding=True))
+        == "none"
+    )
+
+
+def test_resolve_strategy_explicit_embedding(runner):
+    assert (
+        runner._resolve_rerank_strategy(_args(rerank_strategy="embedding"))
+        == "embedding"
+    )
+
+
+def test_resolve_strategy_cross_encoder_raises(runner):
+    """Cross-encoder is wired but not implemented until PR #128 lands."""
+    with pytest.raises(NotImplementedError, match="PR #128"):
+        runner._resolve_rerank_strategy(_args(rerank_strategy="cross-encoder"))
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_section_stats
+# ---------------------------------------------------------------------------
+
+
+def _section(
+    label,
+    total,
+    count=1,
+    *,
+    section_min=None,
+    section_max=None,
+    errors=0,
+    samples=None,
+    rss_deltas=None,
+    gpu_peaks=None,
+):
+    if section_min is None:
+        section_min = total / count if count else 0.0
+    if section_max is None:
+        section_max = total / count if count else 0.0
+    entry = {
+        "label": label,
+        "total": total,
+        "count": count,
+        "average": (total / count) if count else 0.0,
+        "min": section_min,
+        "max": section_max,
+        "errors": errors,
+    }
+    if samples is not None:
+        entry["samples"] = samples
+    if rss_deltas is not None:
+        entry["rss_deltas"] = rss_deltas
+    if gpu_peaks is not None:
+        entry["gpu_peaks"] = gpu_peaks
+    return entry
+
+
+def test_aggregate_empty(runner):
+    assert runner._aggregate_section_stats([]) == []
+
+
+def test_aggregate_sums_across_instances(runner):
+    """Two instances, same label: totals/counts add, min/max collapse correctly."""
+    instances = [
+        {
+            "instance_id": "a",
+            "sections": [
+                _section("query.bm25_seed", total=2.0, count=1),
+                _section("query.graph_expand", total=10.0, count=1),
+            ],
+        },
+        {
+            "instance_id": "b",
+            "sections": [
+                _section("query.bm25_seed", total=4.0, count=1),
+                _section("query.graph_expand", total=8.0, count=1),
+            ],
+        },
+    ]
+    out = runner._aggregate_section_stats(instances)
+    by_label = {s["label"]: s for s in out}
+
+    assert by_label["query.bm25_seed"]["total"] == pytest.approx(6.0)
+    assert by_label["query.bm25_seed"]["count"] == 2
+    assert by_label["query.bm25_seed"]["average"] == pytest.approx(3.0)
+    assert by_label["query.bm25_seed"]["min"] == pytest.approx(2.0)
+    assert by_label["query.bm25_seed"]["max"] == pytest.approx(4.0)
+
+    assert by_label["query.graph_expand"]["total"] == pytest.approx(18.0)
+    assert by_label["query.graph_expand"]["count"] == 2
+    assert by_label["query.graph_expand"]["min"] == pytest.approx(8.0)
+    assert by_label["query.graph_expand"]["max"] == pytest.approx(10.0)
+
+
+def test_aggregate_sorted_by_total_desc(runner):
+    instances = [
+        {
+            "instance_id": "a",
+            "sections": [
+                _section("cheap", total=1.0),
+                _section("expensive", total=100.0),
+                _section("medium", total=10.0),
+            ],
+        }
+    ]
+    out = runner._aggregate_section_stats(instances)
+    assert [s["label"] for s in out] == ["expensive", "medium", "cheap"]
+
+
+def test_aggregate_concatenates_samples_and_recomputes_percentiles(runner):
+    """Phase-2 sample roll-up: per-instance samples concatenate, p50/p95/p99
+    are recomputed globally so the aggregate matches what a single global
+    profiler would have reported."""
+    instances = [
+        {
+            "instance_id": "a",
+            "sections": [
+                _section(
+                    "query.bm25_seed",
+                    total=10.0,
+                    count=10,
+                    samples=[float(x) for x in range(1, 11)],  # 1..10
+                )
+            ],
+        },
+        {
+            "instance_id": "b",
+            "sections": [
+                _section(
+                    "query.bm25_seed",
+                    total=10.0,
+                    count=10,
+                    samples=[float(x) for x in range(11, 21)],  # 11..20
+                )
+            ],
+        },
+    ]
+    out = runner._aggregate_section_stats(instances)
+    [agg] = out
+    assert agg["sample_count"] == 20
+    # Linear-interpolation percentiles over 1..20:
+    #   p50 ≈ 10.5, p95 ≈ 19.05, p99 ≈ 19.81
+    assert agg["p50"] == pytest.approx(10.5, rel=1e-3)
+    assert agg["p95"] == pytest.approx(19.05, rel=1e-3)
+    assert agg["p99"] == pytest.approx(19.81, rel=1e-3)
+
+
+def test_aggregate_rolls_up_memory_when_present(runner):
+    instances = [
+        {
+            "instance_id": "a",
+            "sections": [
+                _section(
+                    "index.graph_build",
+                    total=1.0,
+                    rss_deltas=[10.0, 20.0],
+                    gpu_peaks=[100.0],
+                )
+            ],
+        },
+        {
+            "instance_id": "b",
+            "sections": [
+                _section(
+                    "index.graph_build",
+                    total=1.0,
+                    rss_deltas=[30.0],
+                    gpu_peaks=[200.0, 50.0],
+                )
+            ],
+        },
+    ]
+    [agg] = runner._aggregate_section_stats(instances)
+    assert agg["rss_delta_avg"] == pytest.approx(20.0)  # (10+20+30)/3
+    assert agg["rss_delta_max"] == pytest.approx(30.0)
+    assert agg["gpu_peak_avg"] == pytest.approx((100 + 200 + 50) / 3)
+    assert agg["gpu_peak_max"] == pytest.approx(200.0)
+
+
+def test_aggregate_skips_memory_rollup_when_absent(runner):
+    """Sections without samples/memory don't grow the schema with empty fields."""
+    instances = [
+        {
+            "instance_id": "a",
+            "sections": [_section("query.bm25_seed", total=1.0)],
+        }
+    ]
+    [agg] = runner._aggregate_section_stats(instances)
+    for absent in (
+        "p50",
+        "p95",
+        "p99",
+        "sample_count",
+        "rss_delta_avg",
+        "rss_delta_max",
+        "gpu_peak_avg",
+        "gpu_peak_max",
+    ):
+        assert absent not in agg, f"unexpected key {absent!r} in {agg}"
+
+
+# ---------------------------------------------------------------------------
+# _filter_index_sections / _filter_query_sections
+# ---------------------------------------------------------------------------
+
+
+def test_filter_index_keeps_index_and_inner_labels(runner):
+    sections = [
+        {"label": "index.graph_build"},
+        {"label": "chunking_python"},
+        {"label": "embedding_encode_batch"},
+        {"label": "faiss_index_add_l2"},
+    ]
+    out = runner._filter_index_sections(sections)
+    assert [s["label"] for s in out] == [s["label"] for s in sections]
+
+
+def test_filter_index_warns_on_query_leak(runner, runner_caplog):
+    sections = [
+        {"label": "index.graph_build"},
+        {"label": "query.bm25_seed"},  # leaked
+    ]
+    with runner_caplog.at_level("WARNING"):
+        out = runner._filter_index_sections(sections)
+    assert [s["label"] for s in out] == ["index.graph_build"]
+    assert any(
+        "query.bm25_seed" in rec.getMessage() for rec in runner_caplog.records
+    ), (
+        "expected leak warning; got "
+        f"{[r.getMessage() for r in runner_caplog.records]}"
+    )
+
+
+def test_filter_query_keeps_query_only(runner):
+    sections = [
+        {"label": "query.bm25_seed"},
+        {"label": "query.graph_expand"},
+        {"label": "query.embedding_rerank"},
+    ]
+    out = runner._filter_query_sections(sections)
+    assert [s["label"] for s in out] == [s["label"] for s in sections]
+
+
+def test_filter_query_warns_on_index_leak(runner, runner_caplog):
+    sections = [
+        {"label": "query.bm25_seed"},
+        {"label": "index.graph_build"},  # leaked
+        {"label": "chunking_python"},  # leaked
+    ]
+    with runner_caplog.at_level("WARNING"):
+        out = runner._filter_query_sections(sections)
+    assert [s["label"] for s in out] == ["query.bm25_seed"]
+    assert runner_caplog.records, "expected at least one warning record"
+    msg = runner_caplog.records[-1].getMessage()
+    assert "index.graph_build" in msg and "chunking_python" in msg
+
+
+def test_filter_query_drops_unrecognised_labels_with_warning(runner, runner_caplog):
+    """Future label additions that don't follow the query.* convention surface
+    as warnings rather than disappearing into the wrong bucket."""
+    sections = [
+        {"label": "query.bm25_seed"},
+        {"label": "fancy_new_phase_3_label"},
+    ]
+    with runner_caplog.at_level("WARNING"):
+        out = runner._filter_query_sections(sections)
+    assert [s["label"] for s in out] == ["query.bm25_seed"]
+    assert any(
+        "fancy_new_phase_3_label" in rec.getMessage() for rec in runner_caplog.records
+    )

--- a/test/examples/test_graph_retrieve_baseline.py
+++ b/test/examples/test_graph_retrieve_baseline.py
@@ -382,3 +382,74 @@ def test_filter_query_drops_unrecognised_labels_with_warning(runner, runner_capl
     assert any(
         "fancy_new_phase_3_label" in rec.getMessage() for rec in runner_caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# _compute_bm25_seed_recall
+# ---------------------------------------------------------------------------
+
+
+def _seed(node_id):
+    """Minimal duck-typed stand-in for the NodeInfo / QueriedNode seeds the
+    pipeline hands to ``_compute_bm25_seed_recall`` — only ``node_id`` is read
+    by ``extract_predictions``."""
+    return SimpleNamespace(node_id=node_id)
+
+
+def test_seed_recall_empty_targets_returns_empty(runner):
+    """Instance has no GT files → no recall to report."""
+    seeds = [_seed("a.py:foo()"), _seed("b.py:bar()")]
+    assert runner._compute_bm25_seed_recall(seeds, [], [1, 5, 10]) == {}
+
+
+def test_seed_recall_partial_then_full_hit(runner):
+    """First seed misses the GT file, the second hits it; recall climbs
+    from 0/1 at k=1 to 1/1 at k=2 and stays at 1.0 for larger k."""
+    seeds = [_seed("other.py:x()"), _seed("target.py:hit()")]
+    target_files = ["target.py"]
+    out = runner._compute_bm25_seed_recall(seeds, target_files, [1, 2, 5])
+    assert out == {1: 0.0, 2: 1.0, 5: 1.0}
+
+
+def test_seed_recall_multi_target_partial(runner):
+    """Two GT files, three seeds — only one GT file in top-1, both by top-2."""
+    seeds = [
+        _seed("hit_a.py:foo()"),
+        _seed("hit_b.py:bar()"),
+        _seed("miss.py:baz()"),
+    ]
+    out = runner._compute_bm25_seed_recall(seeds, ["hit_a.py", "hit_b.py"], [1, 2, 3])
+    assert out == {1: 0.5, 2: 1.0, 3: 1.0}
+
+
+def test_seed_recall_returns_int_keys(runner):
+    """Keys must be ``int`` even when ``ks`` is supplied as floats / numpy
+    scalars — the aggregator downstream keys into the dict via ``int(k)`` so a
+    str/float key would silently produce zeros."""
+    seeds = [_seed("a.py:foo()")]
+    out = runner._compute_bm25_seed_recall(seeds, ["a.py"], [1.0, 2, 3.0])
+    assert list(out.keys()) == [1, 2, 3]
+    assert all(isinstance(k, int) for k in out.keys())
+
+
+def test_seed_recall_normalizes_file_paths(runner):
+    """Seeds emitted as ``./pkg/mod.py:sym()`` should match a GT entry
+    ``pkg/mod.py`` because ``extract_predictions`` strips the leading ``./``
+    via ``normalize_file_path``."""
+    seeds = [_seed("./pkg/mod.py:foo()")]
+    out = runner._compute_bm25_seed_recall(seeds, ["pkg/mod.py"], [1])
+    assert out == {1: 1.0}
+
+
+def test_seed_recall_dedupes_seeds_before_k_slice(runner):
+    """``extract_predictions`` collapses duplicate files; the top-1 slice
+    should therefore see the second distinct file at k=2, not a re-count of
+    the first."""
+    seeds = [
+        _seed("dup.py:a()"),
+        _seed("dup.py:b()"),
+        _seed("target.py:c()"),
+    ]
+    # k=2 covers the two unique files {dup.py, target.py}, hitting target.py
+    out = runner._compute_bm25_seed_recall(seeds, ["target.py"], [1, 2])
+    assert out == {1: 0.0, 2: 1.0}


### PR DESCRIPTION
Adds opt-in Profiler instrumentation around the three-stage graph retrieval pipeline (BM25 seed -> graph expand -> optional embedding rerank). When `--enable-profiler` is set, per-instance Profilers capture index-time and query-time sections separately and emit a JSON summary with `index_time` and `query_time` top-level keys.

Sections recorded:
- `index.graph_build`, `index.bm25_build`, `index.vector_store_build` (plus inner `chunking_*`, `embedding_encode_*`, `faiss_index_add_*` emitted by `build_hierarchical_vector_store` / `CodeVectorStore`)
- `query.bm25_seed`, `query.graph_expand`, `query.embedding_rerank`, `query.total`

CLI additions: `--enable-profiler`, `--profile-dir`, `--profile-tag`, `--rerank-strategy {none,embedding,cross-encoder}`, `--rerank-model`. The legacy `--embedding` flag still works.

`--rerank-strategy=cross-encoder` is wired but rejected at parse time (argparse exit code 2) with a pointer to PR #128 until the cross-encoder backends land.

Phase 2 (memory + percentiles + bm25_seed_recall) is also in this branch:
- `RangeStats` percentiles via optional sample retention (`--record-samples`)
- per-section RSS deltas (psutil) and peak GPU memory (torch.cuda) via `--record-memory`
- `bm25_seed_recall@k` per instance + aggregate, computed against GT files

## Summary

Section-level profiling harness for graph-RAG that's free when off and isolates index-time vs query-time costs per dataset instance, with optional sample / memory rollups for percentile and OOM analysis. Forward-compat hooks for the cross-encoder rerank arrive in PR #128.

## Changes

- Per-instance index/query Profilers wired through `GraphRetrievePipeline.__init__` and `query()` (`nullcontext()` shim keeps the off-path zero-cost)
- `_filter_index_sections` / `_filter_query_sections` route sections by phase and `logger.warning` on any unexpected leak (replaces the prior `_split_sections_by_phase` whose `elif` was dead and silently dropped non-`query.*` labels)
- `_to_sections_payload` / `_aggregate_section_stats` carry through samples / `rss_deltas` / `gpu_peaks` so the aggregator recomputes global p50/p95/p99 and memory rollups in one sort pass
- JSON payload: `{config, instances_profiled, index_time, query_time, bm25_seed_recall}` written to `<profile-dir>/graph_rag_<dataset>_<expansion>_<strategy>[__<tag>].json`
- `test/examples/test_graph_retrieve_baseline.py` covers the pure helpers (resolve / aggregate / filter / parse_args fail-fast)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement (profiling harness — measure, don't optimize yet)
- [x] Tests

## Testing
- [x] Tests pass locally (`pytest test/examples/test_graph_retrieve_baseline.py` — 17 passed)
- [x] Added new tests for the changes

## Phases
- [x] Phase 1: graph-RAG harness — section instrumentation
- [x] Phase 2: memory + percentiles + bm25_seed_recall
- [ ] Phase 3
- [ ] Phase 4
- [ ] Phase 5
- [ ] Phase 6
