### PR TITLE
fix(rerank): graceful OOM recovery in QwenRerankerWrapper

### DIFF
--- a/codeminer/index/rerank/cross_encoder.py
+++ b/codeminer/index/rerank/cross_encoder.py
@@ -239,26 +239,65 @@ class QwenRerankerWrapper:
         )
 
     def score(self, query: str, docs: List[str]) -> List[float]:
+        """Score (query, doc) pairs as P(yes-token) at the last position.
+
+        Defends against CUDA OOM on long-context instances (long L2 chunks
+        from large repos like prometheus, jq, ruff) by halving the batch
+        size on each ``OutOfMemoryError`` and retrying the same chunk. At
+        batch=1, a single still-OOMing doc is assigned score 0.0 so the
+        rest of the candidates still get ranked instead of poisoning the
+        whole run.
+        """
         if not docs:
             return []
         import torch
 
+        pair_texts = [self._format_pair(query, d) for d in docs]
         out: List[float] = []
-        with torch.inference_mode():
-            for start in range(0, len(docs), self.batch_size):
-                batch_docs = docs[start : start + self.batch_size]
-                pair_texts = [self._format_pair(query, d) for d in batch_docs]
-                inputs = self._build_input_ids(pair_texts)
-                inputs = {k: v.to(self._device) for k, v in inputs.items()}
+        i = 0
+        batch_size = self.batch_size
 
-                logits = self._model(**inputs).logits  # (B, T, V)
-                last = logits[:, -1, :]  # (B, V)
-                yes_no = torch.stack(
-                    [last[:, self._yes_id], last[:, self._no_id]], dim=-1
-                )
-                probs = torch.softmax(yes_no.float(), dim=-1)
-                out.extend(probs[:, 0].tolist())  # P(yes)
+        with torch.inference_mode():
+            while i < len(pair_texts):
+                chunk = pair_texts[i : i + batch_size]
+                try:
+                    out.extend(self._score_chunk(chunk))
+                    i += len(chunk)
+                except torch.cuda.OutOfMemoryError:
+                    torch.cuda.empty_cache()
+                    if batch_size > 1:
+                        new_bs = max(1, batch_size // 2)
+                        logger.warning(
+                            "QwenRerankerWrapper OOM at batch=%d; halving "
+                            "to %d and retrying (%d docs remaining)",
+                            batch_size,
+                            new_bs,
+                            len(pair_texts) - i,
+                        )
+                        batch_size = new_bs
+                        continue
+                    logger.error(
+                        "QwenRerankerWrapper OOM at batch=1 on doc %d "
+                        "(content len=%d); assigning score 0.0 and "
+                        "continuing",
+                        i,
+                        len(docs[i]) if i < len(docs) else 0,
+                    )
+                    out.append(0.0)
+                    i += 1
         return out
+
+    def _score_chunk(self, pair_texts: List[str]) -> List[float]:
+        """Single forward pass + yes/no-token softmax for a batch."""
+        import torch
+
+        inputs = self._build_input_ids(pair_texts)
+        inputs = {k: v.to(self._device) for k, v in inputs.items()}
+        logits = self._model(**inputs).logits  # (B, T, V)
+        last = logits[:, -1, :]  # (B, V)
+        yes_no = torch.stack([last[:, self._yes_id], last[:, self._no_id]], dim=-1)
+        probs = torch.softmax(yes_no.float(), dim=-1)
+        return probs[:, 0].tolist()
 
     def close(self) -> None:
         # Best-effort teardown; never raise from close() but keep cleanup

--- a/examples/codeminer_base_rerank_matrix.py
+++ b/examples/codeminer_base_rerank_matrix.py
@@ -653,6 +653,19 @@ def run_sweep(args):
 
                         except Exception:
                             logger.exception("  Error processing %s", instance_id)
+                            # Clear CUDA cache so a transient OOM/error in
+                            # one instance can't poison the context for the
+                            # rest of the sweep.
+                            try:
+                                import torch
+
+                                if torch.cuda.is_available():
+                                    torch.cuda.empty_cache()
+                            except Exception:
+                                logger.debug(
+                                    "post-error cuda empty_cache failed",
+                                    exc_info=True,
+                                )
                             continue
                         finally:
                             if profiling_enabled:


### PR DESCRIPTION
## Summary

Follow-up to #128. Cross-encoder cascade runs at K=100 with Qwen3-Reranker-8B were aborting mid-sweep when a long-context instance (`prometheus__prometheus-11859`, `jqlang__jq-*`, `astral-sh__ruff-15443`) tripped CUDA OOM during a batch=8 forward pass. Once the first OOM hit, the CUDA context was left in a partial state and subsequent allocations failed with "unknown error", poisoning the rest of the run — one cell finished with only **36 of 100 instances scored**.

Two layers of defense:

1. **`QwenRerankerWrapper.score`** now traps `torch.cuda.OutOfMemoryError` and halves the batch size on each hit, retrying the same chunk. If batch=1 still OOMs (one pathologically long doc), that single doc is assigned score 0.0 so the rest of the candidates still get ranked. Refactored the forward pass into a small `_score_chunk` helper so the retry loop stays readable.

2. **`examples/codeminer_base_rerank_matrix.py`** now calls `torch.cuda.empty_cache()` in the per-instance `except` handler. Limits the blast radius if any error path leaves CUDA in a partial state, so one bad instance can't take down the rest of a 100-instance sweep.

With these in place, `CROSS_ENCODER_BATCH_SIZE=8` is safe again as a default for K=100 + 8B reranker — the wrapper degrades to a smaller batch locally on the few problematic instances and keeps the rest at full throughput.

## Test plan

- [x] Rerun the K=100 cells that previously failed (`Qwen3-Emb-4B × Qwen3-RR-8B`, `jina × Qwen3-RR-{4B, 8B}`) at `CROSS_ENCODER_BATCH_SIZE=8`. All should land 100 (or 100-minus-truly-oversized) instances instead of cascading into 36.
- [x] Watch the log for `QwenRerankerWrapper OOM at batch=8; halving to 4 and retrying` lines on the long-context instances — confirms the retry path actually fires.
- [x] `pytest -m "not slow and not integration" -x` — unit suite green.
