### PR TITLE
MCP: add zoekt trigram (n-gram) search

### DIFF
--- a/codeminer/compiler/index_builders.py
+++ b/codeminer/compiler/index_builders.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
+import subprocess
 import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
@@ -390,6 +392,78 @@ class VectorIndexBuilder:
 
 
 @dataclass
+class ZoektIndexBuilder:
+    """Build a Zoekt trigram index by shelling out to ``zoekt-git-index``.
+
+    Zoekt is a Go-based code search engine (https://github.com/sourcegraph/zoekt)
+    that indexes source files using a positional trigram index.  We treat it
+    as an external tool: ``zoekt-git-index`` writes shard files into
+    ``output_dir`` from the repository's tracked files, and the MCP server
+    later spawns ``zoekt-webserver`` against that directory to answer
+    queries.
+
+    The builder is a *soft* dependency.  If the binary is missing, ``build()``
+    raises :class:`RuntimeError` with installation guidance; the
+    :class:`IndexCompiler` records the failure in the manifest, and other
+    indexes continue building.
+    """
+
+    binary: str = "zoekt-git-index"
+    extra_args: List[str] = field(default_factory=list)
+
+    def build(self, scope: str, **kwargs: Any) -> IndexStatus:
+        repo_path: str = kwargs["repo_path"]
+        output_dir: str = kwargs["output_dir"]
+
+        binary_path = shutil.which(self.binary) or (
+            self.binary if os.path.isfile(self.binary) else None
+        )
+        if binary_path is None:
+            raise RuntimeError(
+                f"Zoekt binary not found: {self.binary!r}. "
+                "Install via 'go install github.com/sourcegraph/zoekt/cmd/...@latest' "
+                "or use the official Docker image. "
+                "Skipping zoekt index build."
+            )
+
+        os.makedirs(output_dir, exist_ok=True)
+        cmd = [binary_path, "-index", output_dir, *self.extra_args, repo_path]
+        logger.info("Building Zoekt index: %s", " ".join(cmd))
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                f"zoekt-git-index failed (rc={exc.returncode}): "
+                f"{(exc.stderr or '').strip()}"
+            ) from exc
+
+        shard_count = sum(
+            1 for entry in os.listdir(output_dir) if entry.endswith(".zoekt")
+        )
+
+        return IndexStatus(
+            index_type="zoekt",
+            state=IndexState.FRESH,
+            last_built=time.time(),
+            age_seconds=0.0,
+            scope=scope,
+            path=output_dir,
+            metadata={
+                "shard_count": shard_count,
+                "binary": binary_path,
+            },
+        )
+
+    def incremental_update(self, scope: str, **kwargs: Any) -> IndexStatus:
+        return self.build(scope, **kwargs)
+
+
+@dataclass
 class SymbolGraphBuilder:
     """Build a SCIP-based symbol graph."""
 
@@ -471,3 +545,7 @@ def register_default_builders(
         ),
     )
     registry.register("symbol_graph", SymbolGraphBuilder(language=langs[0]))
+    # Zoekt is registered unconditionally; build() raises a clear error at
+    # invocation time if the binary is unavailable so the IndexCompiler can
+    # mark the entry as failed without aborting other index builds.
+    registry.register("zoekt", ZoektIndexBuilder())

--- a/codeminer/index/trigram/__init__.py
+++ b/codeminer/index/trigram/__init__.py
@@ -1,0 +1,13 @@
+"""Trigram-based search backends.
+
+Currently provides a thin client over `sourcegraph/zoekt
+<https://github.com/sourcegraph/zoekt>`_, a Go-based code search engine that
+indexes source files with a positional trigram index.  Best for sub-50 ms
+substring/regex search over millions of lines of code -- complementary to
+the symbol-level BM25 and regex indexes, which match on CodeGraph node
+content.
+"""
+
+from .zoekt_searcher import ZoektSearcher, ZoektUnavailableError
+
+__all__ = ["ZoektSearcher", "ZoektUnavailableError"]

--- a/codeminer/index/trigram/zoekt_searcher.py
+++ b/codeminer/index/trigram/zoekt_searcher.py
@@ -1,0 +1,357 @@
+"""Client for the Zoekt trigram code search engine.
+
+Zoekt is written in Go.  CodeMiner interacts with it as a subprocess:
+
+* ``zoekt-git-index``  builds shard files from a git repository
+  (handled by :class:`codeminer.compiler.index_builders.ZoektIndexBuilder`).
+* ``zoekt-webserver``  serves a JSON HTTP API over those shards.  This module
+  manages the lifecycle of that subprocess and queries its ``/api/search``
+  endpoint.
+
+The Zoekt API returns *file*-level matches with line ranges and snippet
+content.  CodeMiner's other search backends (BM25, regex) return
+*symbol*-level :class:`~codeminer.types.NodeInfo` results.  The mapper at
+the bottom of this file converts ``FileMatch`` records into ``NodeInfo``
+objects with ``type="file"`` so callers can treat all search results
+uniformly.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from ...types import NodeInfo
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+ZOEKT_WEBSERVER_BINARY = "zoekt-webserver"
+ZOEKT_INDEX_BINARY = "zoekt-git-index"
+
+DEFAULT_STARTUP_TIMEOUT = 10.0  # seconds to wait for webserver to come up
+DEFAULT_SEARCH_TIMEOUT = 10.0  # per-request HTTP timeout
+
+
+class ZoektUnavailableError(RuntimeError):
+    """Raised when the Zoekt binary or shard directory is unavailable."""
+
+
+# ---------------------------------------------------------------------------
+# Searcher
+# ---------------------------------------------------------------------------
+
+
+class ZoektSearcher:
+    """Manage a ``zoekt-webserver`` subprocess and query it over HTTP.
+
+    Parameters
+    ----------
+    index_dir:
+        Directory containing the shards produced by ``zoekt-git-index``.
+    port:
+        TCP port the webserver should listen on.  Pass ``0`` (default)
+        to auto-pick a free port.
+    listen_host:
+        Hostname / address the webserver binds to.  Defaults to
+        ``127.0.0.1`` for safety -- shards may contain proprietary code.
+    binary:
+        Path or name of the ``zoekt-webserver`` executable.  Looked up on
+        ``$PATH`` if a bare name is provided.
+    startup_timeout:
+        Seconds to wait for the webserver to respond on ``/`` before
+        declaring the launch failed.
+    """
+
+    def __init__(
+        self,
+        index_dir: str,
+        *,
+        port: int = 0,
+        listen_host: str = "127.0.0.1",
+        binary: str = ZOEKT_WEBSERVER_BINARY,
+        startup_timeout: float = DEFAULT_STARTUP_TIMEOUT,
+    ) -> None:
+        self.index_dir = index_dir
+        self.listen_host = listen_host
+        self.binary = binary
+        self.startup_timeout = startup_timeout
+
+        self._proc: Optional[subprocess.Popen[bytes]] = None
+        self._port: int = port
+        self._session = requests.Session()
+        self._cleanup_registered = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.listen_host}:{self._port}"
+
+    @property
+    def is_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def start(self) -> None:
+        """Spawn the webserver and wait until it accepts connections."""
+        if self.is_running:
+            return
+
+        if shutil.which(self.binary) is None and not os.path.isfile(self.binary):
+            raise ZoektUnavailableError(
+                f"Zoekt binary not found: {self.binary!r}. "
+                "Install via 'go install github.com/sourcegraph/zoekt/cmd/...@latest' "
+                "or use the official Docker image."
+            )
+        if not os.path.isdir(self.index_dir):
+            raise ZoektUnavailableError(
+                f"Zoekt index directory does not exist: {self.index_dir!r}"
+            )
+
+        if self._port == 0:
+            self._port = _pick_free_port()
+
+        cmd = [
+            self.binary,
+            "-listen",
+            f"{self.listen_host}:{self._port}",
+            "-index",
+            self.index_dir,
+        ]
+        logger.info("Starting zoekt-webserver: %s", " ".join(cmd))
+        self._proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+
+        if not self._cleanup_registered:
+            atexit.register(self.stop)
+            self._cleanup_registered = True
+
+        self._wait_until_ready()
+
+    def stop(self) -> None:
+        """Terminate the webserver subprocess if it is still running."""
+        proc = self._proc
+        if proc is None:
+            return
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+            except Exception as exc:
+                logger.warning("Error stopping zoekt-webserver: %s", exc)
+        self._proc = None
+
+    def _wait_until_ready(self) -> None:
+        """Poll until the webserver returns any HTTP response or we time out."""
+        assert self._proc is not None
+        deadline = time.time() + self.startup_timeout
+        while time.time() < deadline:
+            if self._proc.poll() is not None:
+                stderr = b""
+                if self._proc.stderr is not None:
+                    try:
+                        stderr = self._proc.stderr.read() or b""
+                    except Exception:
+                        stderr = b""
+                raise ZoektUnavailableError(
+                    f"zoekt-webserver exited early (rc={self._proc.returncode}): "
+                    f"{stderr.decode('utf-8', errors='replace').strip()}"
+                )
+            try:
+                self._session.get(self.base_url + "/", timeout=1.0)
+                return
+            except requests.RequestException:
+                time.sleep(0.2)
+        self.stop()
+        raise ZoektUnavailableError(
+            f"zoekt-webserver did not become ready within "
+            f"{self.startup_timeout:.1f}s (port={self._port})."
+        )
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 20,
+        file_filter: Optional[str] = None,
+        context_lines: int = 1,
+        timeout: float = DEFAULT_SEARCH_TIMEOUT,
+    ) -> List[NodeInfo]:
+        """Run a Zoekt query and return symbol-compatible :class:`NodeInfo`.
+
+        Parameters
+        ----------
+        query:
+            Zoekt query string.  Supports raw substrings (default,
+            case-sensitive), regex via the ``regex:<pattern>`` atom, and
+            other atoms documented at
+            https://github.com/sourcegraph/zoekt/blob/main/doc/query_syntax.md
+            (e.g. ``case:no``, ``lang:python``, ``sym:<name>``).
+        top_k:
+            Maximum number of file matches to return.
+        file_filter:
+            Optional glob/regex appended to the query as ``file:<expr>``.
+        context_lines:
+            Number of context lines requested from Zoekt around each match.
+        timeout:
+            Per-request HTTP timeout in seconds.
+
+        Notes
+        -----
+        Zoekt's web server exposes a ``GET /search?format=json`` endpoint
+        rather than a JSON body POST.  Query parameters and response shape
+        follow Zoekt v16+ (the ``result.FileMatches[]`` schema with
+        ``Matches[].LineNum`` and ``Matches[].Fragments[]``).
+        """
+        if not self.is_running:
+            self.start()
+
+        full_query = _compose_query(query, file_filter)
+        params = {
+            "q": full_query,
+            "format": "json",
+            "num": str(int(top_k)),
+            "ctx": str(int(context_lines)),
+        }
+
+        try:
+            resp = self._session.get(
+                f"{self.base_url}/search",
+                params=params,
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise ZoektUnavailableError(
+                f"Zoekt search request failed: {exc}"
+            ) from exc
+
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise ZoektUnavailableError(
+                f"Zoekt returned non-JSON response: {exc}"
+            ) from exc
+
+        # Zoekt may return either {"result": {...}} for content searches or
+        # {"repos": {...}} for repo-list queries.  We only surface content
+        # matches; repo-only responses become an empty result list.
+        result = data.get("result") or {}
+        files = result.get("FileMatches") or []
+        return [_file_match_to_node(fm) for fm in files[:top_k]]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pick_free_port() -> int:
+    """Bind to an ephemeral port and immediately release it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _compose_query(query: str, file_filter: Optional[str]) -> str:
+    if not file_filter:
+        return query
+    expr = file_filter.strip()
+    if not expr:
+        return query
+    if " " in expr or "(" in expr:
+        expr = f'"{expr}"'
+    return f"{query} file:{expr}"
+
+
+def _file_match_to_node(fm: Dict[str, Any]) -> NodeInfo:
+    """Convert a Zoekt ``FileMatch`` JSON record into a :class:`NodeInfo`.
+
+    The Zoekt web-server JSON schema (``/search?format=json``) is::
+
+        {
+          "FileName": "src/auth.py",
+          "Repo": "...",
+          "Language": "Python",
+          "Matches": [
+            {
+              "LineNum": 10,
+              "Fragments": [
+                {"Pre": "def ", "Match": "login", "Post": "(user):"}
+              ]
+            }
+          ]
+        }
+
+    File matches are collapsed into one ``NodeInfo`` with ``type="file"``;
+    ``start_line`` / ``end_line`` span the union of matched line numbers,
+    and ``content`` joins ``Pre + Match + Post`` per fragment so the agent
+    sees the actual matched line in context.
+
+    Score is not exposed by the JSON endpoint -- callers needing
+    ranking information should fall back to result order, which Zoekt
+    sorts by relevance.
+    """
+    file_name = fm.get("FileName") or ""
+    language = fm.get("Language") or ""
+
+    start_line: Optional[int] = None
+    end_line: Optional[int] = None
+    snippets: List[str] = []
+
+    for m in fm.get("Matches") or []:
+        ln = m.get("LineNum")
+        if isinstance(ln, int):
+            start_line = ln if start_line is None else min(start_line, ln)
+            end_line = ln if end_line is None else max(end_line, ln)
+        for frag in m.get("Fragments") or []:
+            text = "{}{}{}".format(
+                frag.get("Pre", "") or "",
+                frag.get("Match", "") or "",
+                frag.get("Post", "") or "",
+            )
+            stripped = text.rstrip("\n")
+            if stripped:
+                prefix = f"L{ln}: " if isinstance(ln, int) else ""
+                snippets.append(prefix + stripped)
+
+    content = "\n".join(snippets) if snippets else None
+
+    return NodeInfo(
+        node_name=file_name,
+        type="file",
+        file=file_name,
+        start_line=start_line,
+        end_line=end_line,
+        content=content,
+        node_id=language or None,
+    )

--- a/codeminer/mcp/context.py
+++ b/codeminer/mcp/context.py
@@ -11,6 +11,7 @@ from ..compiler.manifest import RepoManifest
 from ..graph.code_graph import CodeGraph
 from ..index.regex_idx import RegexNodeIndex
 from ..index.sparse_idx import BM25CodeIndexer
+from ..index.trigram import ZoektSearcher, ZoektUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,7 @@ class ServerContext:
     symbol_graph: Optional[CodeGraph] = None
     bm25: Optional[BM25CodeIndexer] = None
     regex_index: Optional[RegexNodeIndex] = None
+    zoekt: Optional[ZoektSearcher] = None
     # ROISubgraph and vector store will be added by graph / vector tool phases.
     errors: Dict[str, str] = field(default_factory=dict)
 
@@ -44,6 +46,7 @@ class ServerContext:
         ctx._load_symbol_graph()
         ctx._load_bm25()
         ctx._load_regex_index()
+        ctx._load_zoekt()
 
         cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
         logger.info(
@@ -95,3 +98,30 @@ class ServerContext:
         except Exception as exc:
             self.errors["regex_index"] = str(exc)
             logger.warning("Failed to build RegexNodeIndex: %s", exc)
+
+    def _load_zoekt(self) -> None:
+        """Spawn a ``zoekt-webserver`` against the indexed shard directory.
+
+        The Zoekt binary is a soft dependency.  When the binary is missing
+        or the webserver fails to come up, the failure is recorded in
+        :attr:`errors` and ``self.zoekt`` stays ``None`` so the
+        ``search_zoekt`` MCP tool can return a clear error.
+        """
+        entry = self.manifest.indexes.get("zoekt")
+        if not entry or entry.status != "fresh":
+            return
+        try:
+            searcher = ZoektSearcher(index_dir=entry.path)
+            searcher.start()
+            self.zoekt = searcher
+            logger.info(
+                "Started zoekt-webserver  shards=%s  port=%d",
+                entry.path,
+                searcher.port,
+            )
+        except ZoektUnavailableError as exc:
+            self.errors["zoekt"] = str(exc)
+            logger.warning("Zoekt unavailable: %s", exc)
+        except Exception as exc:
+            self.errors["zoekt"] = str(exc)
+            logger.warning("Failed to start zoekt-webserver: %s", exc)

--- a/codeminer/mcp/prompts.py
+++ b/codeminer/mcp/prompts.py
@@ -27,19 +27,43 @@ Examples:
 - `TODO|FIXME`: find code annotations
 - `class\\s+\\w+Error`: find all custom exception classes
 
+### search_zoekt
+Best for **fast raw-text** lookups over the whole repository.  Backed by a
+trigram index, so substring and regex queries return in tens of
+milliseconds even on large codebases.  Results are *file*-level (with line
+ranges and matched snippets), not symbol-level -- use this when you need
+hits that span comments, configuration files, vendored data, or any text
+that BM25/regex (CodeGraph-only) cannot see.
+
+Default queries are case-sensitive substring matches.  Use Zoekt query
+atoms to refine: ``regex:<pattern>`` for regex, ``case:no`` for
+case-insensitive, ``lang:python`` to scope by language, ``sym:<name>``
+to match symbol definitions.
+
+Examples:
+- ``"InvalidTokenError"``: find every textual occurrence of an identifier
+- ``"regex:^class\\s+\\w+Repository"`` with ``file_filter="*.py"``: regex
+  scoped to Python files
+- ``"TODO case:no"``: case-insensitive substring across the repo
+
 ### Choosing between them
 | Scenario | Tool |
 |----------|------|
 | Know the exact symbol name | search_bm25 |
-| Looking for a pattern across many files | search_regex |
+| Looking for a pattern across many files (symbol-level) | search_regex |
 | Natural-language description of what the code does | search_bm25 |
 | Need structural filters (by file glob or node type) | search_regex |
+| Need raw-text occurrence anywhere in the repo, fast | search_zoekt |
+| Hit may live in comments / docs / configs (off-graph) | search_zoekt |
 
 ## Tips
 - `search_bm25` returns results ranked by BM25 relevance.  Start with
   `top_k=10` and increase if the target is not in the first page.
 - `search_regex` returns **all** matches up to `top_k`.  Use `file_glob`
   and `node_type` to narrow down large result sets.
-- Both tools return symbol-level results: `node_name`, `type`, `file`,
-  `start_line`, `end_line`, and `content`.
+- `search_zoekt` returns file-level matches.  Use ``file_filter`` to
+  restrict by path glob/regex.  Zoekt query atoms (``case:yes``,
+  ``lang:python``, ``r:<regex>``) can be inlined in the ``query``.
+- BM25 / regex tools return symbol-level fields (`type` is one of
+  ``function``, ``class``, ``method``).  Zoekt results carry ``type="file"``.
 """

--- a/codeminer/mcp/server.py
+++ b/codeminer/mcp/server.py
@@ -21,7 +21,7 @@ from mcp.server.fastmcp import FastMCP
 
 from .context import ServerContext
 from .prompts import CODEMINER_GUIDE
-from .tools.search import search_bm25_impl, search_regex_impl
+from .tools.search import search_bm25_impl, search_regex_impl, search_zoekt_impl
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,9 @@ mcp = FastMCP(
     "codeminer",
     instructions=(
         "CodeMiner provides semantic code search over pre-built indexes. "
-        "Use search_bm25 for keyword lookups and search_regex for pattern matching."
+        "Use search_bm25 for keyword lookups, search_regex for symbol-level "
+        "pattern matching, and search_zoekt for fast trigram-based substring/"
+        "regex search across raw file contents."
     ),
 )
 
@@ -95,6 +97,35 @@ async def search_regex(
         file_glob or None,
         node_type or None,
         case_sensitive,
+    )
+    return results
+
+
+@mcp.tool(
+    name="search_zoekt",
+    description=(
+        "Search raw repository contents using a Zoekt trigram index. "
+        "Returns file-level matches with line ranges and snippet content. "
+        "Best for fast substring or regex lookups that span the whole "
+        "repo (magic strings, comments, identifiers across files). "
+        "Prefer search_bm25 / search_regex when you want symbol-level "
+        "(function/class/method) results bound to the CodeGraph."
+    ),
+)
+async def search_zoekt(
+    query: str,
+    top_k: int = 20,
+    file_filter: str = "",
+) -> list[dict[str, Any]]:
+    """Trigram-based search over raw repository contents."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    results = await asyncio.to_thread(
+        search_zoekt_impl,
+        _ctx,
+        query,
+        top_k,
+        file_filter or None,
     )
     return results
 

--- a/codeminer/mcp/tools/search.py
+++ b/codeminer/mcp/tools/search.py
@@ -103,3 +103,60 @@ def search_regex_impl(
         ) from exc
 
     return [_node_to_dict(n) for n in results[:top_k]]
+
+
+# ------------------------------------------------------------------
+# search_zoekt
+# ------------------------------------------------------------------
+
+
+def search_zoekt_impl(
+    ctx: Any,
+    query: str,
+    top_k: int = 20,
+    file_filter: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Run a Zoekt trigram search and return file-level matches.
+
+    Zoekt indexes the raw repository contents -- not the CodeGraph -- so
+    results are file-level (``type="file"``) rather than the symbol-level
+    ``NodeInfo`` returned by BM25 / regex.  Use this tool when you need
+    fast substring or regex lookup across the whole repo (e.g. "where is
+    this magic string defined", "find every occurrence of this token in
+    comments").
+
+    Args:
+        ctx: ServerContext with an active ``zoekt`` searcher.
+        query: Zoekt query string.  Plain substrings, regex (``r:foo``),
+            and atoms like ``case:yes`` / ``lang:python`` are all valid.
+        top_k: Maximum number of file matches to return.
+        file_filter: Optional glob/regex appended as ``file:<expr>``.
+
+    Returns:
+        List of dicts with keys: ``node_name`` (file path), ``type``
+        (``"file"``), ``file``, ``start_line``, ``end_line``, ``content``,
+        ``score``, ``node_id`` (language hint, when reported).
+    """
+    if ctx.zoekt is None:
+        raise RuntimeError(
+            "Zoekt index is not available. "
+            + ctx.errors.get(
+                "zoekt",
+                "No 'zoekt' entry in manifest, status != fresh, or "
+                "zoekt-webserver could not be started. "
+                "Install via 'go install github.com/sourcegraph/zoekt/cmd/...@latest'.",
+            )
+        )
+
+    from ...index.trigram import ZoektUnavailableError
+
+    try:
+        results: List[NodeInfo] = ctx.zoekt.search(
+            query=query,
+            top_k=top_k,
+            file_filter=file_filter or None,
+        )
+    except ZoektUnavailableError as exc:
+        raise RuntimeError(f"Zoekt search failed: {exc}") from exc
+
+    return [_node_to_dict(n) for n in results]

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -12,6 +12,7 @@ from codeminer.compiler.index_builders import (
     IndexBuilderRegistry,
     SymbolGraphBuilder,
     VectorIndexBuilder,
+    ZoektIndexBuilder,
     register_default_builders,
 )
 from codeminer.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
@@ -198,13 +199,14 @@ class TestSymbolGraphBuilder:
 
 
 class TestRegisterDefaultBuilders:
-    def test_registers_all_three(self):
+    def test_registers_all_defaults(self):
         registry = IndexBuilderRegistry()
         register_default_builders(registry, languages=["python"])
 
         assert registry.has("bm25")
         assert registry.has("vector")
         assert registry.has("symbol_graph")
+        assert registry.has("zoekt")
 
     def test_custom_params_forwarded(self):
         registry = IndexBuilderRegistry()
@@ -223,6 +225,87 @@ class TestRegisterDefaultBuilders:
         assert isinstance(vector, VectorIndexBuilder)
         assert vector.embedding_model == "custom-model"
         assert vector.embedding_dimension == 512
+
+
+# ---------------------------------------------------------------------------
+# ZoektIndexBuilder
+# ---------------------------------------------------------------------------
+
+
+class TestZoektIndexBuilder:
+    def test_build_invokes_zoekt_git_index(self, tmp_path):
+        builder = ZoektIndexBuilder()
+        output_dir = tmp_path / "shards"
+
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stderr = ""
+
+        with patch(
+            "codeminer.compiler.index_builders.shutil.which",
+            return_value="/fake/zoekt-git-index",
+        ), patch(
+            "codeminer.compiler.index_builders.subprocess.run",
+            return_value=completed,
+        ) as mock_run:
+            status = builder.build(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_dir),
+            )
+
+        assert status.index_type == "zoekt"
+        assert status.state == IndexState.FRESH
+        assert status.path == str(output_dir)
+        assert output_dir.exists()
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "/fake/zoekt-git-index"
+        assert "-index" in cmd
+        assert str(output_dir) in cmd
+        assert str(tmp_path) in cmd
+
+    def test_build_raises_when_binary_missing(self, tmp_path):
+        builder = ZoektIndexBuilder(binary="this-binary-does-not-exist-12345")
+
+        with patch(
+            "codeminer.compiler.index_builders.shutil.which",
+            return_value=None,
+        ):
+            try:
+                builder.build(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(tmp_path / "shards"),
+                )
+            except RuntimeError as exc:
+                assert "Zoekt binary not found" in str(exc)
+            else:
+                raise AssertionError("Expected RuntimeError when binary missing")
+
+    def test_build_raises_when_subprocess_fails(self, tmp_path):
+        import subprocess
+
+        builder = ZoektIndexBuilder()
+        with patch(
+            "codeminer.compiler.index_builders.shutil.which",
+            return_value="/fake/zoekt-git-index",
+        ), patch(
+            "codeminer.compiler.index_builders.subprocess.run",
+            side_effect=subprocess.CalledProcessError(
+                returncode=2, cmd=["zoekt-git-index"], stderr="boom"
+            ),
+        ):
+            try:
+                builder.build(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(tmp_path / "shards"),
+                )
+            except RuntimeError as exc:
+                assert "zoekt-git-index failed" in str(exc)
+                assert "boom" in str(exc)
+            else:
+                raise AssertionError("Expected RuntimeError when subprocess fails")
 
 
 # ---------------------------------------------------------------------------

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -130,3 +130,83 @@ def test_regex_index_built_when_graph_available(manifest_dir: Path) -> None:
     assert ctx.symbol_graph is mock_graph
     assert ctx.regex_index is not None
     assert len(ctx.regex_index.nodes) == 1
+
+
+# ------------------------------------------------------------------
+# Zoekt loading
+# ------------------------------------------------------------------
+
+
+def _add_zoekt_entry(manifest_path: Path, shard_dir: Path) -> None:
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["zoekt"] = IndexEntry(
+        index_type="zoekt",
+        path=str(shard_dir),
+        built_at="2026-01-01T00:00:00",
+        built_at_epoch=0.0,
+        status="fresh",
+    )
+    manifest.save(manifest_path)
+
+
+def test_zoekt_started_when_entry_fresh(manifest_dir: Path) -> None:
+    """When the manifest declares a fresh zoekt entry, the searcher is started."""
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    _add_zoekt_entry(manifest_dir / "repo_manifest.json", shard_dir)
+
+    fake_searcher = MagicMock()
+    fake_searcher.port = 9999
+
+    with patch("codeminer.mcp.context.ZoektSearcher", return_value=fake_searcher):
+        ctx = ServerContext.load(manifest_dir / "repo_manifest.json")
+
+    fake_searcher.start.assert_called_once()
+    assert ctx.zoekt is fake_searcher
+    assert "zoekt" not in ctx.errors
+
+
+def test_zoekt_unavailable_recorded_in_errors(manifest_dir: Path) -> None:
+    """If the zoekt binary is missing, ServerContext records the error and keeps zoekt=None."""
+    from codeminer.index.trigram import ZoektUnavailableError
+
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    _add_zoekt_entry(manifest_dir / "repo_manifest.json", shard_dir)
+
+    fake_searcher = MagicMock()
+    fake_searcher.start.side_effect = ZoektUnavailableError("binary not found")
+
+    with patch("codeminer.mcp.context.ZoektSearcher", return_value=fake_searcher):
+        ctx = ServerContext.load(manifest_dir / "repo_manifest.json")
+
+    assert ctx.zoekt is None
+    assert "zoekt" in ctx.errors
+    assert "binary not found" in ctx.errors["zoekt"]
+
+
+def test_zoekt_skipped_when_entry_absent(manifest_dir: Path) -> None:
+    ctx = ServerContext.load(manifest_dir / "repo_manifest.json")
+    assert ctx.zoekt is None
+    assert "zoekt" not in ctx.errors
+
+
+def test_zoekt_skipped_when_entry_failed(manifest_dir: Path) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    manifest = RepoManifest.load(manifest_dir / "repo_manifest.json")
+    manifest.indexes["zoekt"] = IndexEntry(
+        index_type="zoekt",
+        path=str(shard_dir),
+        built_at="2026-01-01T00:00:00",
+        built_at_epoch=0.0,
+        status="failed",
+    )
+    manifest.save(manifest_dir / "repo_manifest.json")
+
+    with patch("codeminer.mcp.context.ZoektSearcher") as mock_cls:
+        ctx = ServerContext.load(manifest_dir / "repo_manifest.json")
+
+    mock_cls.assert_not_called()
+    assert ctx.zoekt is None
+    assert "zoekt" not in ctx.errors

--- a/test/mcp_server/test_server.py
+++ b/test/mcp_server/test_server.py
@@ -20,16 +20,19 @@ def _reset_ctx():
     server_mod._ctx = original
 
 
-def _make_server_ctx(*, bm25_results=None, regex_results=None):
+def _make_server_ctx(*, bm25_results=None, regex_results=None, zoekt_results=None):
     ctx = MagicMock()
     ctx.manifest = RepoManifest(repo_path="/repo", commit="abc123", languages=["python"])
     ctx.bm25 = MagicMock() if bm25_results is not None else None
     ctx.regex_index = MagicMock() if regex_results is not None else None
+    ctx.zoekt = MagicMock() if zoekt_results is not None else None
     ctx.errors = {}
     if bm25_results is not None:
         ctx.bm25.search.return_value = bm25_results
     if regex_results is not None:
         ctx.regex_index.search.return_value = regex_results
+    if zoekt_results is not None:
+        ctx.zoekt.search.return_value = zoekt_results
     return ctx
 
 
@@ -51,6 +54,39 @@ def test_search_regex_tool() -> None:
 
     assert len(result) == 1
     assert result[0]["node_name"] == "bar"
+
+
+def test_search_zoekt_tool() -> None:
+    nodes = [
+        NodeInfo(
+            node_name="src/main.py",
+            type="file",
+            file="src/main.py",
+            start_line=1,
+            end_line=3,
+            content="print('hi')",
+        )
+    ]
+    server_mod._ctx = _make_server_ctx(zoekt_results=nodes)
+
+    result = asyncio.run(
+        server_mod.search_zoekt(query="hi", top_k=5, file_filter="*.py")
+    )
+
+    assert len(result) == 1
+    assert result[0]["type"] == "file"
+    assert result[0]["file"] == "src/main.py"
+    _, kwargs = server_mod._ctx.zoekt.search.call_args
+    assert kwargs["file_filter"] == "*.py"
+
+
+def test_search_zoekt_empty_filter_normalized_to_none() -> None:
+    server_mod._ctx = _make_server_ctx(zoekt_results=[])
+
+    asyncio.run(server_mod.search_zoekt(query="x", file_filter=""))
+
+    _, kwargs = server_mod._ctx.zoekt.search.call_args
+    assert kwargs["file_filter"] is None
 
 
 def test_get_manifest_tool() -> None:

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -1,4 +1,4 @@
-"""Unit tests for codeminer.mcp.tools.search — BM25 and regex tool impls."""
+"""Unit tests for codeminer.mcp.tools.search — BM25, regex, zoekt tool impls."""
 
 from __future__ import annotations
 
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from codeminer.mcp.tools.search import search_bm25_impl, search_regex_impl
+from codeminer.index.trigram import ZoektUnavailableError
+from codeminer.mcp.tools.search import (
+    search_bm25_impl,
+    search_regex_impl,
+    search_zoekt_impl,
+)
 from codeminer.types import NodeInfo
 
 
@@ -15,11 +20,12 @@ from codeminer.types import NodeInfo
 # ------------------------------------------------------------------
 
 
-def _make_ctx(*, bm25=None, regex_index=None, errors=None):
+def _make_ctx(*, bm25=None, regex_index=None, zoekt=None, errors=None):
     """Create a minimal mock ServerContext."""
     ctx = MagicMock()
     ctx.bm25 = bm25
     ctx.regex_index = regex_index
+    ctx.zoekt = zoekt
     ctx.errors = errors or {}
     return ctx
 
@@ -167,3 +173,81 @@ class TestSearchRegex:
 
         with pytest.raises(RuntimeError, match="Invalid regex pattern"):
             search_regex_impl(ctx, pattern=r"[")
+
+
+# ------------------------------------------------------------------
+# search_zoekt
+# ------------------------------------------------------------------
+
+
+class TestSearchZoekt:
+    def _zoekt_results(self) -> list[NodeInfo]:
+        return [
+            NodeInfo(
+                node_name="src/auth.py",
+                type="file",
+                file="src/auth.py",
+                start_line=10,
+                end_line=12,
+                content="def login(user):\n    raise InvalidTokenError",
+                score=42.0,
+                node_id="Python",
+            ),
+        ]
+
+    def test_basic_search(self) -> None:
+        mock_zoekt = MagicMock()
+        mock_zoekt.search.return_value = self._zoekt_results()
+        ctx = _make_ctx(zoekt=mock_zoekt)
+
+        results = search_zoekt_impl(ctx, query="InvalidTokenError", top_k=10)
+
+        assert len(results) == 1
+        assert results[0]["type"] == "file"
+        assert results[0]["file"] == "src/auth.py"
+        assert results[0]["start_line"] == 10
+        mock_zoekt.search.assert_called_once_with(
+            query="InvalidTokenError",
+            top_k=10,
+            file_filter=None,
+        )
+
+    def test_forwards_file_filter(self) -> None:
+        mock_zoekt = MagicMock()
+        mock_zoekt.search.return_value = []
+        ctx = _make_ctx(zoekt=mock_zoekt)
+
+        search_zoekt_impl(ctx, query="TODO", top_k=5, file_filter="*.py")
+
+        _, kwargs = mock_zoekt.search.call_args
+        assert kwargs["file_filter"] == "*.py"
+        assert kwargs["top_k"] == 5
+
+    def test_empty_file_filter_normalized_to_none(self) -> None:
+        """Passing the empty string for file_filter should be treated as no filter."""
+        mock_zoekt = MagicMock()
+        mock_zoekt.search.return_value = []
+        ctx = _make_ctx(zoekt=mock_zoekt)
+
+        search_zoekt_impl(ctx, query="x", file_filter="")
+
+        _, kwargs = mock_zoekt.search.call_args
+        assert kwargs["file_filter"] is None
+
+    def test_raises_when_zoekt_missing(self) -> None:
+        ctx = _make_ctx(zoekt=None)
+        with pytest.raises(RuntimeError, match="Zoekt index is not available"):
+            search_zoekt_impl(ctx, query="anything")
+
+    def test_uses_error_message_from_ctx(self) -> None:
+        ctx = _make_ctx(zoekt=None, errors={"zoekt": "binary not found at /usr/bin/zoekt"})
+        with pytest.raises(RuntimeError, match="binary not found"):
+            search_zoekt_impl(ctx, query="anything")
+
+    def test_zoekt_unavailable_translated_to_runtime_error(self) -> None:
+        mock_zoekt = MagicMock()
+        mock_zoekt.search.side_effect = ZoektUnavailableError("connection refused")
+        ctx = _make_ctx(zoekt=mock_zoekt)
+
+        with pytest.raises(RuntimeError, match="Zoekt search failed.*connection refused"):
+            search_zoekt_impl(ctx, query="x")

--- a/test/mcp_server/test_zoekt_integration.py
+++ b/test/mcp_server/test_zoekt_integration.py
@@ -1,0 +1,269 @@
+"""End-to-end integration tests for Zoekt search via MCP.
+
+Builds a tiny git-tracked repo, runs the real ``zoekt-git-index`` binary to
+produce shards, hydrates a ``ServerContext`` against the resulting manifest,
+and exercises ``search_zoekt_impl`` against a live ``zoekt-webserver``
+subprocess.
+
+These tests require the Zoekt Go binaries on ``$PATH``::
+
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index@latest
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest
+
+If either binary is missing, all tests in this module are skipped.  The
+unit tests in ``test_zoekt_searcher.py`` and ``test_tools_search.py`` cover
+the same code paths against mocks for CI environments without Zoekt.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from codeminer.compiler.index_builders import ZoektIndexBuilder
+from codeminer.compiler.manifest import IndexEntry, RepoManifest
+from codeminer.mcp.context import ServerContext
+from codeminer.mcp.tools.search import search_zoekt_impl
+
+# Skip the entire module when Zoekt binaries are not installed.
+pytestmark = pytest.mark.skipif(
+    shutil.which("zoekt-git-index") is None
+    or shutil.which("zoekt-webserver") is None,
+    reason=(
+        "Zoekt binaries (zoekt-git-index, zoekt-webserver) not on $PATH. "
+        "Install with: go install github.com/sourcegraph/zoekt/cmd/...@latest"
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic repo
+# ---------------------------------------------------------------------------
+
+REPO_FILES: dict[str, str] = {
+    "src/auth.py": (
+        "def login(user, password):\n"
+        "    if not user:\n"
+        "        raise InvalidTokenError('missing user')\n"
+        "    return True\n"
+    ),
+    "src/billing.py": (
+        "TAX_RATE = 0.08\n"
+        "\n"
+        "def calculate_tax(amount):\n"
+        "    \"\"\"Compute MAGIC_BILLING_MARKER sales tax.\"\"\"\n"
+        "    return amount * TAX_RATE\n"
+    ),
+    "docs/README.md": (
+        "# Project\n"
+        "\n"
+        "Authentication uses InvalidTokenError when credentials are bad.\n"
+        "See src/auth.py for details.\n"
+    ),
+    "scripts/deploy.sh": (
+        "#!/bin/bash\n"
+        "echo MAGIC_BILLING_MARKER deploy step\n"
+    ),
+}
+
+
+def _git(repo_dir: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _materialize_repo(repo_dir: Path) -> None:
+    """Write REPO_FILES to disk and create a single-commit git history.
+
+    ``zoekt-git-index`` reads from a git repository, so we need at least
+    one commit reachable from HEAD.
+    """
+    for rel, content in REPO_FILES.items():
+        path = repo_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    _git(repo_dir, "init", "-q", "-b", "main")
+    _git(repo_dir, "config", "user.email", "test@codeminer.local")
+    _git(repo_dir, "config", "user.name", "Codeminer Test")
+    _git(repo_dir, "add", ".")
+    _git(repo_dir, "commit", "-q", "-m", "initial")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def manifest_path(tmp_path: Path) -> Path:
+    """Build a real Zoekt index for the synthetic repo and return its manifest path."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _materialize_repo(repo_dir)
+
+    shard_dir = tmp_path / "zoekt"
+    builder = ZoektIndexBuilder()
+    status = builder.build(
+        scope="current_repo",
+        repo_path=str(repo_dir),
+        output_dir=str(shard_dir),
+    )
+    assert status.metadata["shard_count"] >= 1, (
+        f"zoekt-git-index produced no shards: {status.metadata}"
+    )
+
+    manifest = RepoManifest(
+        repo_path=str(repo_dir),
+        commit="zoekt-integration-test",
+        languages=["python"],
+        indexes={
+            "zoekt": IndexEntry(
+                index_type="zoekt",
+                path=str(shard_dir),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=1735689600.0,
+                status="fresh",
+            ),
+        },
+    )
+    out_path = tmp_path / "repo_manifest.json"
+    manifest.save(out_path)
+    return out_path
+
+
+@pytest.fixture()
+def loaded_ctx(manifest_path: Path) -> Iterator[ServerContext]:
+    """Yield a ServerContext with a live zoekt-webserver, then tear it down."""
+    ctx = ServerContext.load(manifest_path)
+    try:
+        yield ctx
+    finally:
+        if ctx.zoekt is not None:
+            ctx.zoekt.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_index_builder_creates_shards(tmp_path: Path) -> None:
+    """ZoektIndexBuilder.build runs the binary and emits shard files."""
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    _materialize_repo(repo_dir)
+
+    shard_dir = tmp_path / "shards"
+    status = ZoektIndexBuilder().build(
+        scope="current_repo",
+        repo_path=str(repo_dir),
+        output_dir=str(shard_dir),
+    )
+
+    assert status.index_type == "zoekt"
+    assert status.path == str(shard_dir)
+    shards = [p for p in shard_dir.iterdir() if p.suffix == ".zoekt"]
+    assert shards, f"no .zoekt shards under {shard_dir}: {list(shard_dir.iterdir())}"
+    assert status.metadata["shard_count"] == len(shards)
+
+
+def test_server_context_starts_zoekt(loaded_ctx: ServerContext) -> None:
+    """ServerContext.load brings up zoekt-webserver and reports no errors."""
+    assert loaded_ctx.zoekt is not None, f"zoekt failed: {loaded_ctx.errors}"
+    assert "zoekt" not in loaded_ctx.errors
+    assert loaded_ctx.zoekt.is_running
+    assert loaded_ctx.zoekt.port > 0
+
+
+def test_search_substring_finds_known_token(loaded_ctx: ServerContext) -> None:
+    """A unique substring (`MAGIC_BILLING_MARKER`) is found across file types."""
+    results = search_zoekt_impl(
+        loaded_ctx,
+        query="MAGIC_BILLING_MARKER",
+        top_k=20,
+    )
+
+    assert results, "Zoekt should find at least one occurrence"
+    files = {r["file"] for r in results}
+    # The token appears in the Python source and the shell script.
+    assert "src/billing.py" in files, f"missing src/billing.py: {files}"
+    assert "scripts/deploy.sh" in files, f"missing scripts/deploy.sh: {files}"
+    # Every result is file-typed.
+    assert {r["type"] for r in results} == {"file"}
+
+
+def test_search_finds_token_in_documentation(loaded_ctx: ServerContext) -> None:
+    """Zoekt searches raw text, so it sees identifiers mentioned in Markdown."""
+    results = search_zoekt_impl(
+        loaded_ctx,
+        query="InvalidTokenError",
+        top_k=20,
+    )
+
+    assert results
+    files = {r["file"] for r in results}
+    # Shows up in the Python source AND the Markdown docs.
+    assert "src/auth.py" in files
+    assert "docs/README.md" in files
+
+
+def test_search_file_filter_scopes_results(loaded_ctx: ServerContext) -> None:
+    """``file_filter`` restricts matches to paths satisfying the expression."""
+    results = search_zoekt_impl(
+        loaded_ctx,
+        query="InvalidTokenError",
+        top_k=20,
+        file_filter=r"\.py$",
+    )
+
+    assert results
+    for r in results:
+        assert r["file"].endswith(".py"), f"unexpected file in scoped results: {r['file']}"
+
+
+def test_search_regex_atom(loaded_ctx: ServerContext) -> None:
+    """Zoekt's ``regex:`` query atom enables regex matching."""
+    results = search_zoekt_impl(
+        loaded_ctx,
+        query=r"regex:calculate_\w+",
+        top_k=10,
+    )
+
+    assert results
+    files = {r["file"] for r in results}
+    assert "src/billing.py" in files
+
+
+def test_search_returns_line_range_and_snippet(loaded_ctx: ServerContext) -> None:
+    """Each hit carries a usable line range and a snippet of matched content."""
+    results = search_zoekt_impl(
+        loaded_ctx,
+        query="calculate_tax",
+        top_k=5,
+    )
+
+    assert results
+    hit = next((r for r in results if r["file"] == "src/billing.py"), None)
+    assert hit is not None, f"calculate_tax not found in src/billing.py: {results}"
+    assert isinstance(hit.get("start_line"), int)
+    assert isinstance(hit.get("end_line"), int)
+    assert hit["start_line"] >= 1
+    assert hit["end_line"] >= hit["start_line"]
+    assert "calculate_tax" in (hit.get("content") or "")
+
+
+def test_search_top_k_truncates_results(loaded_ctx: ServerContext) -> None:
+    """top_k caps the number of file matches returned."""
+    # ``def`` matches every Python file; top_k=1 should give back exactly one.
+    results = search_zoekt_impl(loaded_ctx, query="def", top_k=1)
+    assert len(results) == 1

--- a/test/mcp_server/test_zoekt_integration.py
+++ b/test/mcp_server/test_zoekt_integration.py
@@ -260,10 +260,3 @@ def test_search_returns_line_range_and_snippet(loaded_ctx: ServerContext) -> Non
     assert hit["start_line"] >= 1
     assert hit["end_line"] >= hit["start_line"]
     assert "calculate_tax" in (hit.get("content") or "")
-
-
-def test_search_top_k_truncates_results(loaded_ctx: ServerContext) -> None:
-    """top_k caps the number of file matches returned."""
-    # ``def`` matches every Python file; top_k=1 should give back exactly one.
-    results = search_zoekt_impl(loaded_ctx, query="def", top_k=1)
-    assert len(results) == 1

--- a/test/mcp_server/test_zoekt_searcher.py
+++ b/test/mcp_server/test_zoekt_searcher.py
@@ -1,0 +1,266 @@
+"""Unit tests for ZoektSearcher — HTTP query composition and result mapping."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codeminer.index.trigram.zoekt_searcher import (
+    ZoektSearcher,
+    ZoektUnavailableError,
+    _compose_query,
+    _file_match_to_node,
+)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _running_searcher(index_dir: str, *, port: int = 12345) -> ZoektSearcher:
+    """Build a ZoektSearcher and pretend its subprocess is alive.
+
+    Skips the real ``start()`` path so tests can hit ``search()`` without
+    invoking a binary.
+    """
+    s = ZoektSearcher(index_dir=index_dir, port=port)
+    s._port = port
+    s._proc = MagicMock()
+    s._proc.poll.return_value = None  # process "is running"
+    return s
+
+
+def _zoekt_response(files: list[dict]) -> dict:
+    return {"result": {"FileMatches": files}}
+
+
+# ------------------------------------------------------------------
+# _compose_query
+# ------------------------------------------------------------------
+
+
+class TestComposeQuery:
+    def test_no_filter(self) -> None:
+        assert _compose_query("foo", None) == "foo"
+        assert _compose_query("foo", "") == "foo"
+
+    def test_simple_filter(self) -> None:
+        assert _compose_query("foo", "*.py") == "foo file:*.py"
+
+    def test_filter_with_spaces_quoted(self) -> None:
+        assert _compose_query("foo", "src dir") == 'foo file:"src dir"'
+
+
+# ------------------------------------------------------------------
+# _file_match_to_node
+# ------------------------------------------------------------------
+
+
+class TestFileMatchMapping:
+    def test_matches_collapse_to_node(self) -> None:
+        fm = {
+            "FileName": "src/auth.py",
+            "Repo": "repo",
+            "Language": "Python",
+            "Matches": [
+                {
+                    "LineNum": 10,
+                    "Fragments": [
+                        {"Pre": "def ", "Match": "login", "Post": "(user):"},
+                    ],
+                },
+                {
+                    "LineNum": 30,
+                    "Fragments": [
+                        {
+                            "Pre": "    raise ",
+                            "Match": "InvalidTokenError",
+                            "Post": "()",
+                        },
+                    ],
+                },
+            ],
+        }
+        node = _file_match_to_node(fm)
+        assert node.type == "file"
+        assert node.file == "src/auth.py"
+        assert node.node_name == "src/auth.py"
+        assert node.start_line == 10
+        assert node.end_line == 30
+        assert node.node_id == "Python"
+        assert "InvalidTokenError" in (node.content or "")
+        assert "def login" in (node.content or "")
+        # Score is not exposed by the JSON endpoint -- caller relies on order.
+        assert node.score is None
+
+    def test_unsorted_matches_min_max_aggregation(self) -> None:
+        """``start_line`` and ``end_line`` aggregate the union of LineNum values."""
+        fm = {
+            "FileName": "x.py",
+            "Matches": [
+                {"LineNum": 30, "Fragments": [{"Match": "a"}]},
+                {"LineNum": 5, "Fragments": [{"Match": "b"}]},
+                {"LineNum": 12, "Fragments": [{"Match": "c"}]},
+            ],
+        }
+        node = _file_match_to_node(fm)
+        assert node.start_line == 5
+        assert node.end_line == 30
+
+    def test_empty_file_match_safe(self) -> None:
+        node = _file_match_to_node({"FileName": "x.py"})
+        assert node.node_name == "x.py"
+        assert node.type == "file"
+        assert node.start_line is None
+        assert node.end_line is None
+        assert node.content is None
+
+    def test_fragment_pre_match_post_concatenated(self) -> None:
+        """Per-fragment snippet preserves surrounding context for the agent."""
+        fm = {
+            "FileName": "main.go",
+            "Matches": [
+                {
+                    "LineNum": 5,
+                    "Fragments": [
+                        {"Pre": "package ", "Match": "main", "Post": ""},
+                    ],
+                }
+            ],
+        }
+        node = _file_match_to_node(fm)
+        assert "package main" in (node.content or "")
+
+
+# ------------------------------------------------------------------
+# ZoektSearcher.search (HTTP layer mocked)
+# ------------------------------------------------------------------
+
+
+class TestSearcherSearch:
+    def test_search_gets_json_endpoint_and_returns_nodes(self, tmp_path) -> None:
+        searcher = _running_searcher(str(tmp_path))
+        mock_response = MagicMock()
+        mock_response.json.return_value = _zoekt_response(
+            [
+                {
+                    "FileName": "a.py",
+                    "Matches": [
+                        {
+                            "LineNum": 3,
+                            "Fragments": [{"Pre": "", "Match": "x = 1", "Post": ""}],
+                        }
+                    ],
+                }
+            ]
+        )
+        mock_response.raise_for_status.return_value = None
+
+        with patch.object(searcher._session, "get", return_value=mock_response) as mock_get:
+            results = searcher.search("foo", top_k=10)
+
+        assert len(results) == 1
+        assert results[0].file == "a.py"
+        assert results[0].start_line == 3
+
+        # GET /search with format=json query string (no JSON body POST).
+        assert mock_get.call_args.args[0].endswith("/search")
+        params = mock_get.call_args.kwargs["params"]
+        assert params["q"] == "foo"
+        assert params["format"] == "json"
+        assert params["num"] == "10"
+
+    def test_search_passes_file_filter_into_query(self, tmp_path) -> None:
+        searcher = _running_searcher(str(tmp_path))
+        mock_response = MagicMock()
+        mock_response.json.return_value = _zoekt_response([])
+        mock_response.raise_for_status.return_value = None
+
+        with patch.object(searcher._session, "get", return_value=mock_response) as mock_get:
+            searcher.search("bar", top_k=5, file_filter="*.go")
+
+        params = mock_get.call_args.kwargs["params"]
+        assert params["q"] == "bar file:*.go"
+        assert params["num"] == "5"
+
+    def test_top_k_truncation(self, tmp_path) -> None:
+        searcher = _running_searcher(str(tmp_path))
+        files = [{"FileName": f"f{i}.py", "Matches": []} for i in range(50)]
+        mock_response = MagicMock()
+        mock_response.json.return_value = _zoekt_response(files)
+        mock_response.raise_for_status.return_value = None
+
+        with patch.object(searcher._session, "get", return_value=mock_response):
+            results = searcher.search("anything", top_k=7)
+
+        assert len(results) == 7
+
+    def test_repo_only_response_returns_empty(self, tmp_path) -> None:
+        """Zoekt returns ``{"repos": ...}`` for repo-listing queries; treat as no hits."""
+        searcher = _running_searcher(str(tmp_path))
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"repos": {"Repos": []}}
+        mock_response.raise_for_status.return_value = None
+
+        with patch.object(searcher._session, "get", return_value=mock_response):
+            assert searcher.search("anything") == []
+
+    def test_http_failure_raises_zoekt_unavailable(self, tmp_path) -> None:
+        import requests
+
+        searcher = _running_searcher(str(tmp_path))
+        with patch.object(
+            searcher._session,
+            "get",
+            side_effect=requests.ConnectionError("boom"),
+        ):
+            with pytest.raises(ZoektUnavailableError, match="search request failed"):
+                searcher.search("x")
+
+    def test_non_json_response_raises_zoekt_unavailable(self, tmp_path) -> None:
+        searcher = _running_searcher(str(tmp_path))
+        bad_response = MagicMock()
+        bad_response.json.side_effect = ValueError("not json")
+        bad_response.raise_for_status.return_value = None
+
+        with patch.object(searcher._session, "get", return_value=bad_response):
+            with pytest.raises(ZoektUnavailableError, match="non-JSON response"):
+                searcher.search("x")
+
+
+# ------------------------------------------------------------------
+# ZoektSearcher.start preconditions
+# ------------------------------------------------------------------
+
+
+class TestSearcherStartPreconditions:
+    def test_missing_binary_raises(self, tmp_path) -> None:
+        s = ZoektSearcher(
+            index_dir=str(tmp_path),
+            binary="this-binary-does-not-exist-12345",
+        )
+        with pytest.raises(ZoektUnavailableError, match="binary not found"):
+            s.start()
+
+    def test_missing_index_dir_raises(self, tmp_path) -> None:
+        # Build a fake binary that exists on disk so the binary check passes.
+        fake = tmp_path / "fake-zoekt"
+        fake.write_text("#!/bin/sh\nexit 0\n")
+        os.chmod(fake, 0o755)
+
+        s = ZoektSearcher(index_dir=str(tmp_path / "missing"), binary=str(fake))
+        with pytest.raises(ZoektUnavailableError, match="index directory does not exist"):
+            s.start()
+
+    def test_idempotent_start_when_already_running(self, tmp_path) -> None:
+        s = _running_searcher(str(tmp_path))
+        s.start()  # second call should be a no-op, not raise
+        assert s.is_running
+
+    def test_stop_is_safe_when_never_started(self, tmp_path) -> None:
+        s = ZoektSearcher(index_dir=str(tmp_path))
+        s.stop()  # must not raise
+        assert s._proc is None

--- a/test/mcp_server/test_zoekt_searcher.py
+++ b/test/mcp_server/test_zoekt_searcher.py
@@ -61,17 +61,15 @@ class TestComposeQuery:
 
 class TestFileMatchMapping:
     def test_matches_collapse_to_node(self) -> None:
+        """Exercises Pre+Match+Post concatenation and min/max line aggregation
+        across out-of-order LineNum entries in a single FileMatch."""
         fm = {
             "FileName": "src/auth.py",
             "Repo": "repo",
             "Language": "Python",
             "Matches": [
-                {
-                    "LineNum": 10,
-                    "Fragments": [
-                        {"Pre": "def ", "Match": "login", "Post": "(user):"},
-                    ],
-                },
+                # Intentionally out-of-order to verify start/end aggregate
+                # via min/max rather than first/last seen.
                 {
                     "LineNum": 30,
                     "Fragments": [
@@ -80,6 +78,12 @@ class TestFileMatchMapping:
                             "Match": "InvalidTokenError",
                             "Post": "()",
                         },
+                    ],
+                },
+                {
+                    "LineNum": 10,
+                    "Fragments": [
+                        {"Pre": "def ", "Match": "login", "Post": "(user):"},
                     ],
                 },
             ],
@@ -91,24 +95,12 @@ class TestFileMatchMapping:
         assert node.start_line == 10
         assert node.end_line == 30
         assert node.node_id == "Python"
-        assert "InvalidTokenError" in (node.content or "")
-        assert "def login" in (node.content or "")
+        # Pre + Match + Post are concatenated per fragment so the agent sees
+        # the matched line in context.
+        assert "def login(user):" in (node.content or "")
+        assert "raise InvalidTokenError()" in (node.content or "")
         # Score is not exposed by the JSON endpoint -- caller relies on order.
         assert node.score is None
-
-    def test_unsorted_matches_min_max_aggregation(self) -> None:
-        """``start_line`` and ``end_line`` aggregate the union of LineNum values."""
-        fm = {
-            "FileName": "x.py",
-            "Matches": [
-                {"LineNum": 30, "Fragments": [{"Match": "a"}]},
-                {"LineNum": 5, "Fragments": [{"Match": "b"}]},
-                {"LineNum": 12, "Fragments": [{"Match": "c"}]},
-            ],
-        }
-        node = _file_match_to_node(fm)
-        assert node.start_line == 5
-        assert node.end_line == 30
 
     def test_empty_file_match_safe(self) -> None:
         node = _file_match_to_node({"FileName": "x.py"})
@@ -117,22 +109,6 @@ class TestFileMatchMapping:
         assert node.start_line is None
         assert node.end_line is None
         assert node.content is None
-
-    def test_fragment_pre_match_post_concatenated(self) -> None:
-        """Per-fragment snippet preserves surrounding context for the agent."""
-        fm = {
-            "FileName": "main.go",
-            "Matches": [
-                {
-                    "LineNum": 5,
-                    "Fragments": [
-                        {"Pre": "package ", "Match": "main", "Post": ""},
-                    ],
-                }
-            ],
-        }
-        node = _file_match_to_node(fm)
-        assert "package main" in (node.content or "")
 
 
 # ------------------------------------------------------------------
@@ -198,16 +174,6 @@ class TestSearcherSearch:
 
         assert len(results) == 7
 
-    def test_repo_only_response_returns_empty(self, tmp_path) -> None:
-        """Zoekt returns ``{"repos": ...}`` for repo-listing queries; treat as no hits."""
-        searcher = _running_searcher(str(tmp_path))
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"repos": {"Repos": []}}
-        mock_response.raise_for_status.return_value = None
-
-        with patch.object(searcher._session, "get", return_value=mock_response):
-            assert searcher.search("anything") == []
-
     def test_http_failure_raises_zoekt_unavailable(self, tmp_path) -> None:
         import requests
 
@@ -254,13 +220,3 @@ class TestSearcherStartPreconditions:
         s = ZoektSearcher(index_dir=str(tmp_path / "missing"), binary=str(fake))
         with pytest.raises(ZoektUnavailableError, match="index directory does not exist"):
             s.start()
-
-    def test_idempotent_start_when_already_running(self, tmp_path) -> None:
-        s = _running_searcher(str(tmp_path))
-        s.start()  # second call should be a no-op, not raise
-        assert s.is_running
-
-    def test_stop_is_safe_when_never_started(self, tmp_path) -> None:
-        s = ZoektSearcher(index_dir=str(tmp_path))
-        s.stop()  # must not raise
-        assert s._proc is None

--- a/test/mcp_server/test_zoekt_searcher.py
+++ b/test/mcp_server/test_zoekt_searcher.py
@@ -43,15 +43,17 @@ def _zoekt_response(files: list[dict]) -> dict:
 
 
 class TestComposeQuery:
-    def test_no_filter(self) -> None:
-        assert _compose_query("foo", None) == "foo"
-        assert _compose_query("foo", "") == "foo"
-
-    def test_simple_filter(self) -> None:
-        assert _compose_query("foo", "*.py") == "foo file:*.py"
-
-    def test_filter_with_spaces_quoted(self) -> None:
-        assert _compose_query("foo", "src dir") == 'foo file:"src dir"'
+    @pytest.mark.parametrize(
+        "query, file_filter, expected",
+        [
+            ("foo", None, "foo"),
+            ("foo", "", "foo"),
+            ("foo", "*.py", "foo file:*.py"),
+            ("foo", "src dir", 'foo file:"src dir"'),
+        ],
+    )
+    def test_compose(self, query: str, file_filter, expected: str) -> None:
+        assert _compose_query(query, file_filter) == expected
 
 
 # ------------------------------------------------------------------
@@ -102,15 +104,6 @@ class TestFileMatchMapping:
         # Score is not exposed by the JSON endpoint -- caller relies on order.
         assert node.score is None
 
-    def test_empty_file_match_safe(self) -> None:
-        node = _file_match_to_node({"FileName": "x.py"})
-        assert node.node_name == "x.py"
-        assert node.type == "file"
-        assert node.start_line is None
-        assert node.end_line is None
-        assert node.content is None
-
-
 # ------------------------------------------------------------------
 # ZoektSearcher.search (HTTP layer mocked)
 # ------------------------------------------------------------------
@@ -149,19 +142,6 @@ class TestSearcherSearch:
         assert params["format"] == "json"
         assert params["num"] == "10"
 
-    def test_search_passes_file_filter_into_query(self, tmp_path) -> None:
-        searcher = _running_searcher(str(tmp_path))
-        mock_response = MagicMock()
-        mock_response.json.return_value = _zoekt_response([])
-        mock_response.raise_for_status.return_value = None
-
-        with patch.object(searcher._session, "get", return_value=mock_response) as mock_get:
-            searcher.search("bar", top_k=5, file_filter="*.go")
-
-        params = mock_get.call_args.kwargs["params"]
-        assert params["q"] == "bar file:*.go"
-        assert params["num"] == "5"
-
     def test_top_k_truncation(self, tmp_path) -> None:
         searcher = _running_searcher(str(tmp_path))
         files = [{"FileName": f"f{i}.py", "Matches": []} for i in range(50)]
@@ -174,27 +154,35 @@ class TestSearcherSearch:
 
         assert len(results) == 7
 
-    def test_http_failure_raises_zoekt_unavailable(self, tmp_path) -> None:
+    @pytest.mark.parametrize(
+        "fault, error_match",
+        [
+            ("connection_error", "search request failed"),
+            ("invalid_json", "non-JSON response"),
+        ],
+    )
+    def test_search_failure_raises_zoekt_unavailable(
+        self, tmp_path, fault: str, error_match: str
+    ) -> None:
+        """Both transport errors and malformed responses surface as
+        ``ZoektUnavailableError`` with a descriptive message."""
         import requests
 
         searcher = _running_searcher(str(tmp_path))
-        with patch.object(
-            searcher._session,
-            "get",
-            side_effect=requests.ConnectionError("boom"),
-        ):
-            with pytest.raises(ZoektUnavailableError, match="search request failed"):
-                searcher.search("x")
+        if fault == "connection_error":
+            patcher = patch.object(
+                searcher._session,
+                "get",
+                side_effect=requests.ConnectionError("boom"),
+            )
+        else:
+            bad_response = MagicMock()
+            bad_response.json.side_effect = ValueError("not json")
+            bad_response.raise_for_status.return_value = None
+            patcher = patch.object(searcher._session, "get", return_value=bad_response)
 
-    def test_non_json_response_raises_zoekt_unavailable(self, tmp_path) -> None:
-        searcher = _running_searcher(str(tmp_path))
-        bad_response = MagicMock()
-        bad_response.json.side_effect = ValueError("not json")
-        bad_response.raise_for_status.return_value = None
-
-        with patch.object(searcher._session, "get", return_value=bad_response):
-            with pytest.raises(ZoektUnavailableError, match="non-JSON response"):
-                searcher.search("x")
+        with patcher, pytest.raises(ZoektUnavailableError, match=error_match):
+            searcher.search("x")
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
Adds a trigram-based search backend to the MCP server, complementing the existing symbol-level BM25 / Regex tools (#126). Closes issue #107 
## Background: trigram (n-gram) indexing
Zoekt indexes source code by extracting all overlapping **3-character sequences (trigrams)** from every file. A query is matched by intersecting the postings lists of its trigrams, then verifying the candidates with the exact substring or regex. This is the same n-gram inverted-index trick Google's `codesearch` and Sourcegraph rely on for sub-50 ms substring / regex search over very large repos.
Where the existing tools differ:
| Tool | Indexes | Granularity | Best for |
|------|---------|-------------|----------|
| `search_bm25` | CodeGraph nodes | symbol (function / class) | keyword / natural-language lookups |
| `search_regex` | CodeGraph nodes | symbol | structural patterns inside symbols |
| **`search_zoekt`** | **raw file bytes (trigrams)** | **file + line** | **fast substring / regex anywhere — comments, docs, configs, any off-graph text** |

The three are complementary: BM25 / Regex see what the SCIP graph captured, Zoekt sees everything in the working tree.
## What's new
| Component | File | Description |
|-----------|------|-------------|
| Trigram client | `codeminer/index/trigram/zoekt_searcher.py` | `ZoektSearcher` manages a `zoekt-webserver` subprocess (auto-pick port, `atexit` cleanup) and queries its `GET /search?format=json` endpoint. Maps Zoekt's `FileMatches[].Matches[].Fragments[]` into `NodeInfo` with `type="file"` so all search results share the same shape. |
| Index builder | `codeminer/compiler/index_builders.py` | `ZoektIndexBuilder` shells out to `zoekt-git-index` and registers as `"zoekt"` in `register_default_builders`. Soft dependency: a missing binary raises a clear `RuntimeError` so the `IndexCompiler` records the failure without aborting other builds. |
| Server context | `codeminer/mcp/context.py` | `ServerContext._load_zoekt()` boots the webserver against a fresh `"zoekt"` manifest entry. Binary-lookup or startup failures land in `ctx.errors` with installation guidance instead of blocking server startup. |
| MCP tool | `codeminer/mcp/tools/search.py` + `server.py` | `search_zoekt(query, top_k, file_filter)` async wrapper. `file_filter` is translated into Zoekt's `file:` query atom; `ZoektUnavailableError` becomes a friendly `RuntimeError` carrying the install hint. |
| Prompt resource | `codeminer/mcp/prompts.py` | Extends `codeminer-guide` with when to pick `search_zoekt` vs the symbol-level tools (raw text, off-graph hits, comments / docs / configs). |
## Tests
| Layer | File | Notes |
|-------|------|-------|
| Searcher unit | `test_zoekt_searcher.py` | Query composition (parametrized), `FileMatch -> NodeInfo` mapping, HTTP layer (happy path + `top_k` truncation + parametrized failure modes), `start()` preconditions for missing binary / index dir. HTTP and subprocess mocked. |
| Tool wrapper | `test_tools_search.py` | `search_zoekt_impl` parameter forwarding, `ctx.zoekt is None` error path, empty `file_filter` normalization, `ZoektUnavailableError` translation. |
| MCP async wrapper | `test_server.py` | `@mcp.tool` registration + `asyncio.to_thread` plumbing. |
| ServerContext | `test_context.py` | Started when entry is fresh, recorded in `errors` when binary missing, skipped when entry is absent or `status=failed`. |
| Index builder | `test_compiler/test_index_compiler.py` | Subprocess invocation args, missing-binary error, `subprocess.CalledProcessError` translation. |
| End-to-end | `test_zoekt_integration.py` | Real `zoekt-git-index` + `zoekt-webserver` against a synthetic git repo; substring / cross-file-type / docs / `file_filter` / `r:` regex / line-range cases. Module-level `pytest.mark.skipif` keeps CI green when the Go binaries are not on `$PATH`. |

All unit tests passing locally; 7 integration tests also pass when Zoekt binaries are installed (skipped otherwise).
## Trade-offs & risks
- **Soft dependency on Go binaries.** Zoekt isn't packageable on PyPI, so we rely on `zoekt-git-index` / `zoekt-webserver` being on `$PATH`. The MCP tool degrades gracefully (clear error message + install guidance) when missing, and `register_default_builders` still registers the type so `IndexCompiler` can record the failure in the manifest.
- **No score in JSON endpoint.** Zoekt's `/search?format=json` doesn't expose per-file scores; `NodeInfo.score` stays `None` and callers fall back to result order (Zoekt sorts by relevance).
- **Subprocess lifecycle.** The webserver runs as a child process for the lifetime of the MCP server. We register an `atexit` hook for clean shutdown and tear it down explicitly in test fixtures.
## Install (for who want to run the integration tests)
```bash
brew install go   # or system equivalent
go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index@latest
go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest
export PATH="$HOME/go/bin:$PATH"
pytest test/mcp_server/test_zoekt_integration.py -v