### PR TITLE
diag(eval): query-leak diagnostic tools + short-paraphrase generator (refs #130)

### DIFF
--- a/docs/diagnose_query_leak.md
+++ b/docs/diagnose_query_leak.md
@@ -1,0 +1,85 @@
+# Diagnosing semantic / lexical leak in synthesized retrieval queries
+
+Tooling that operationalizes the Tier-1 and Tier-3 checks proposed in
+[issue #130](https://github.com/sysevol-ai/CodeMiner/issues/130).
+
+## Why
+
+Running `examples/eval_synthesized_queries.py` with `Salesforce/SweRankEmbed-Small`
+against the current 96 synthesized behavioral queries scores file-recall@10 = 0.92
+and symbol-recall@10 = 0.73. The score is saturated relative to the same embedder
+on calibration data (0.39–0.77 on `codeminer-dataset-base`), suggesting the
+synthesizer prompt is leaking domain vocabulary into the query. The scripts below
+let us measure how much.
+
+## `scripts/diagnose_query_leak.py`
+
+Per-query leak detector and slicer. Stdlib only, runs on a queries directory
+plus the `--result-path` JSON of an `eval_synthesized_queries.py` run.
+
+```bash
+# All three Tier-3 checks at once
+python scripts/diagnose_query_leak.py \
+    --queries synthesis_output/ \
+    --eval-result eval_results/synthesized_embedding__Salesforce__SweRankEmbed-Small.json \
+    --metrics-k 1 5 10 \
+    --emit-leak-report eval_results/leak_signals.json \
+    --emit-masked-queries synthesis_output_masked/
+```
+
+The script reports:
+
+1. **Leak prevalence**: `fn_leak` (GT filename in query), `sym_leak` (last sub-token
+   of a GT symbol in query), `path_leak` (any path-segment token in query),
+   `any_leak` (union).
+2. **Length distribution**: ≤30 / 31–60 / >60 words.
+3. **Recall slices** (when `--eval-result` is provided):
+   - Leaked vs clean — quantifies how much of recall is carried by literal token leak.
+   - Length-stratified — answers whether the 0.92 file-recall lives entirely in the
+     long-prose bucket.
+4. **Masked emission** (when `--emit-masked-queries` is set): writes a parallel
+   queries directory where any GT-derived token has been replaced with `[MASK]`.
+   Feed it through `eval_synthesized_queries.py --queries-dir synthesis_output_masked/`
+   to obtain the **lexical-leak ceiling**: the drop relative to the unmasked run is
+   the maximum recall attributable to literal vocabulary overlap.
+
+## `scripts/synthesize_q2_short.py`
+
+Tier-1 short-paraphrase generator. Per query, an LLM rewrites the long behavioral
+description as a 5–30 word symptom-style query under the constraint that **no
+banned token** (anything derived from a GT file path or GT symbol) may appear.
+
+```bash
+python scripts/synthesize_q2_short.py \
+    --input-dir synthesis_output/ \
+    --output-dir synthesis_output_q2_short/ \
+    --model vertex_ai/gemini-2.5-flash
+```
+
+Output entries carry `query_type = "behavioral_short"` and a new
+`rewritten_from_query_id` pointer. The directory is drop-in for re-running:
+
+```bash
+python examples/eval_synthesized_queries.py \
+    --pipeline embedding \
+    --queries-dir synthesis_output_q2_short/ \
+    --embedding-model Salesforce/SweRankEmbed-Small \
+    --embedding-dimension 768 \
+    --result-path eval_results/synthesized_embedding__short.json
+```
+
+## Recommended sequence for the issue
+
+1. Run the existing eval with `--result-path` set (so the JSON is on disk).
+2. Run `diagnose_query_leak.py` — read the leaked-vs-clean and length-stratified
+   slices first. If the 0.92 lives entirely in `>60 w` and `any_leak=True`, the
+   diagnosis is confirmed.
+3. Run the masked re-eval: any drop is a hard lower bound on lexical-leak
+   contribution.
+4. Generate `_behavioral_q2` short variants and re-eval. Predicted drop per #130:
+   file-recall@10: 0.92 → ~0.65, symbol-recall@10: 0.73 → ~0.40.
+
+## Field-name compatibility
+
+Both scripts accept either `gt_files`/`gt_symbols` (older synthesized artifacts)
+or `target_files`/`target_symbols` (current synthesizer output).

--- a/scripts/diagnose_query_leak.py
+++ b/scripts/diagnose_query_leak.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Diagnose vocabulary / lexical leak in synthesized retrieval queries.
+
+Operationalizes the Tier-3 checks from issue #130:
+
+- Per-query leak signals (`fn_leak`, `sym_leak`, `path_leak`, `any_leak`).
+- Recall slices by leaked-vs-clean and by length bucket (≤30 / 30–60 / >60 words).
+- Optional emission of a masked query variant — any token appearing in any GT
+  symbol or path is stripped — that the user can re-feed through
+  ``examples/eval_synthesized_queries.py``.
+
+Inputs:
+
+- ``--queries`` : a directory or single JSON file in the same format the
+  synthesizer emits / ``eval_synthesized_queries.py`` consumes.
+- ``--eval-result`` (optional) : the ``--result-path`` JSON produced by
+  ``eval_synthesized_queries.py``. When present, recall slices are reported.
+
+Outputs:
+
+- A printed table to stdout.
+- ``--emit-masked-queries DIR`` : write per-instance masked query JSONs ready
+  for a re-run.
+- ``--emit-leak-report PATH`` : write the per-query leak signals as JSON.
+
+The script is deliberately dependency-free (stdlib only) so it can be run
+without an environment install.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+
+# ---------------------------------------------------------------------------
+# Field-name normalization — synthesizer emits target_*, older artifacts use gt_*.
+# ---------------------------------------------------------------------------
+
+
+def _gt_files(entry: Dict[str, Any]) -> List[str]:
+    return list(entry.get("gt_files") or entry.get("target_files") or [])
+
+
+def _gt_symbols(entry: Dict[str, Any]) -> List[str]:
+    return list(entry.get("gt_symbols") or entry.get("target_symbols") or [])
+
+
+def _query_text(entry: Dict[str, Any]) -> str:
+    return str(entry.get("query") or entry.get("question") or "")
+
+
+def _query_id(entry: Dict[str, Any]) -> str:
+    return str(entry.get("query_id") or entry.get("instance_id") or "")
+
+
+# ---------------------------------------------------------------------------
+# Tokenization (case-insensitive, snake/camel split).
+# ---------------------------------------------------------------------------
+
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9]*")
+
+
+def _camel_split(token: str) -> List[str]:
+    """Split CamelCase / snake_case into lowercase sub-tokens."""
+    parts: List[str] = []
+    for part in token.replace("-", "_").split("_"):
+        if not part:
+            continue
+        # Split on lower->Upper boundaries.
+        sub = re.findall(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|\d+", part)
+        parts.extend(s.lower() for s in sub if s)
+    return parts
+
+
+def _tokenize_query(text: str) -> Set[str]:
+    return {m.group(0).lower() for m in _WORD_RE.finditer(text)}
+
+
+def _tokens_from_symbol(symbol: str) -> List[str]:
+    """All meaningful sub-tokens from a symbol id.
+
+    Splits on ``.`` / ``::`` / ``/`` / ``\\`` and then on snake / camel case.
+    Single-character tokens are dropped.
+    """
+    raw = re.split(r"[./:\\#]+", symbol)
+    out: List[str] = []
+    for chunk in raw:
+        for tok in _camel_split(chunk):
+            if len(tok) > 1:
+                out.append(tok)
+    return out
+
+
+def _tokens_from_path(path: str) -> List[str]:
+    parts = re.split(r"[\\/]+", path)
+    if parts:
+        parts[-1] = re.sub(r"\.[A-Za-z0-9]+$", "", parts[-1])  # drop extension
+    out: List[str] = []
+    for part in parts:
+        for tok in _camel_split(part):
+            if len(tok) > 1:
+                out.append(tok)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Leak detection.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LeakSignals:
+    fn_leak: bool
+    sym_leak: bool
+    path_leak: bool
+
+    @property
+    def any_leak(self) -> bool:
+        return self.fn_leak or self.sym_leak or self.path_leak
+
+
+def detect_leaks(entry: Dict[str, Any]) -> LeakSignals:
+    """Match the three leak signals from issue #130."""
+    query_text = _query_text(entry)
+    qtokens = _tokenize_query(query_text)
+    qlower = query_text.lower()
+
+    fn_leak = False
+    for f in _gt_files(entry):
+        base = Path(f).name.lower()
+        if base and base in qlower:
+            fn_leak = True
+            break
+
+    sym_leak = False
+    for s in _gt_symbols(entry):
+        sym_tokens = _tokens_from_symbol(s)
+        if not sym_tokens:
+            continue
+        # Last sub-token is the most distinctive.
+        last_part = re.split(r"[./:#\\]+", s)[-1]
+        # If any case-split sub-token of the last part appears in the query, flag.
+        if any(tok in qtokens for tok in _camel_split(last_part) if len(tok) > 1):
+            sym_leak = True
+            break
+
+    path_leak = False
+    for f in _gt_files(entry):
+        if any(tok in qtokens for tok in _tokens_from_path(f)):
+            path_leak = True
+            break
+
+    return LeakSignals(fn_leak=fn_leak, sym_leak=sym_leak, path_leak=path_leak)
+
+
+# ---------------------------------------------------------------------------
+# Length stratification.
+# ---------------------------------------------------------------------------
+
+
+def length_bucket(text: str) -> str:
+    n = len(text.split())
+    if n <= 30:
+        return "<=30"
+    if n <= 60:
+        return "31-60"
+    return ">60"
+
+
+# ---------------------------------------------------------------------------
+# Masked-query emission.
+# ---------------------------------------------------------------------------
+
+
+def mask_query(
+    text: str, ban_tokens: Iterable[str], placeholder: str = "[MASK]"
+) -> str:
+    """Replace each banned sub-token (case-insensitive, word-boundary) with placeholder."""
+    bans = {t.lower() for t in ban_tokens if t and len(t) > 1}
+    if not bans:
+        return text
+    # Single regex; \b only matches word boundaries on ASCII letters/digits.
+    pattern = re.compile(
+        r"\b("
+        + "|".join(re.escape(t) for t in sorted(bans, key=len, reverse=True))
+        + r")\b",
+        re.IGNORECASE,
+    )
+    return pattern.sub(placeholder, text)
+
+
+def make_masked_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of the entry with the query string masked of GT vocabulary."""
+    bans: Set[str] = set()
+    for s in _gt_symbols(entry):
+        bans.update(_tokens_from_symbol(s))
+    for f in _gt_files(entry):
+        bans.update(_tokens_from_path(f))
+
+    new_entry = dict(entry)
+    new_entry["query"] = mask_query(_query_text(entry), bans)
+    qid = new_entry.get("query_id")
+    if qid:
+        new_entry["query_id"] = f"{qid}_masked"
+    new_entry["masked_from_query_id"] = entry.get("query_id")
+    new_entry["masked_banned_tokens"] = sorted(bans)
+    return new_entry
+
+
+# ---------------------------------------------------------------------------
+# Loading queries + eval results.
+# ---------------------------------------------------------------------------
+
+
+def load_queries(path: Path) -> List[Dict[str, Any]]:
+    """Accept either a directory of per-instance JSONs or a single file."""
+    if path.is_dir():
+        out: List[Dict[str, Any]] = []
+        for f in sorted(path.glob("*.json")):
+            with open(f, encoding="utf-8") as fh:
+                data = json.load(fh)
+            if isinstance(data, list):
+                out.extend(data)
+            elif isinstance(data, dict):
+                out.append(data)
+        return out
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    return data if isinstance(data, list) else [data]
+
+
+def load_eval_results(path: Path) -> Dict[str, Dict[str, Any]]:
+    """Index ``eval_synthesized_queries.py --result-path`` JSON by query_id."""
+    with open(path, encoding="utf-8") as fh:
+        records = json.load(fh)
+    return {str(r.get("query_id") or r.get("instance_id")): r for r in records}
+
+
+# ---------------------------------------------------------------------------
+# Recall extraction from result records.
+# ---------------------------------------------------------------------------
+
+
+def _scope_recall_at_k(record: Dict[str, Any], scope: str, k: int) -> Optional[float]:
+    metrics = record.get("metrics") or {}
+    bucket = metrics.get(scope) or {}
+    cell = bucket.get(str(k)) or bucket.get(k)
+    if not cell:
+        return None
+    val = cell.get("recall")
+    return float(val) if val is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Reporting.
+# ---------------------------------------------------------------------------
+
+
+def _mean(values: Sequence[float]) -> float:
+    vs = [v for v in values if v is not None]
+    return sum(vs) / len(vs) if vs else 0.0
+
+
+def _format_table(
+    title: str, header: Sequence[str], rows: Sequence[Sequence[str]]
+) -> str:
+    cols = list(zip(header, *rows, strict=False))
+    widths = [max(len(str(c)) for c in col) for col in cols]
+    sep = "+-" + "-+-".join("-" * w for w in widths) + "-+"
+
+    def fmt_row(row: Sequence[Any]) -> str:
+        cells = " | ".join(str(c).ljust(w) for c, w in zip(row, widths, strict=False))
+        return f"| {cells} |"
+
+    lines = [f"\n### {title}", sep, fmt_row(header), sep]
+    for r in rows:
+        lines.append(fmt_row(r))
+    lines.append(sep)
+    return "\n".join(lines)
+
+
+def report(
+    entries: List[Dict[str, Any]],
+    results: Optional[Dict[str, Dict[str, Any]]],
+    ks: Sequence[int],
+) -> str:
+    """Build the printable diagnostic report."""
+    out: List[str] = []
+
+    # 1. Per-query leak signals (always available).
+    leaks = [detect_leaks(e) for e in entries]
+    n = len(entries)
+    n_fn = sum(1 for L in leaks if L.fn_leak)
+    n_sym = sum(1 for L in leaks if L.sym_leak)
+    n_path = sum(1 for L in leaks if L.path_leak)
+    n_any = sum(1 for L in leaks if L.any_leak)
+
+    out.append(
+        _format_table(
+            f"Leak signals — {n} queries",
+            ["signal", "count", "prevalence"],
+            [
+                ("fn_leak", n_fn, f"{n_fn / max(n, 1):.0%}"),
+                ("sym_leak", n_sym, f"{n_sym / max(n, 1):.0%}"),
+                ("path_leak", n_path, f"{n_path / max(n, 1):.0%}"),
+                ("any_leak", n_any, f"{n_any / max(n, 1):.0%}"),
+            ],
+        )
+    )
+
+    # 2. Length distribution.
+    buckets: Counter[str] = Counter(length_bucket(_query_text(e)) for e in entries)
+    out.append(
+        _format_table(
+            "Query length distribution (words)",
+            ["bucket", "count", "share"],
+            [
+                (b, buckets.get(b, 0), f"{buckets.get(b, 0) / max(n, 1):.0%}")
+                for b in ("<=30", "31-60", ">60")
+            ],
+        )
+    )
+
+    # 3. Recall slices — only when eval results are supplied.
+    if results:
+        # Slice A: leaked vs clean.
+        scope_rows = []
+        for scope in ("files", "symbols"):
+            for k in ks:
+                lk, cl = [], []
+                for e, L in zip(entries, leaks, strict=False):
+                    rec = results.get(_query_id(e))
+                    if not rec:
+                        continue
+                    r = _scope_recall_at_k(rec, scope, k)
+                    if r is None:
+                        continue
+                    (lk if L.any_leak else cl).append(r)
+                scope_rows.append(
+                    (
+                        scope,
+                        k,
+                        f"{_mean(lk):.3f} ({len(lk)})",
+                        f"{_mean(cl):.3f} ({len(cl)})",
+                        f"{_mean(lk) - _mean(cl):+.3f}",
+                    )
+                )
+        out.append(
+            _format_table(
+                "Recall@k — leaked vs clean",
+                ["scope", "k", "leaked", "clean", "delta"],
+                scope_rows,
+            )
+        )
+
+        # Slice B: length bucket.
+        bucket_rows = []
+        for scope in ("files", "symbols"):
+            for k in ks:
+                cells: Dict[str, List[float]] = defaultdict(list)
+                for e in entries:
+                    rec = results.get(_query_id(e))
+                    if not rec:
+                        continue
+                    r = _scope_recall_at_k(rec, scope, k)
+                    if r is None:
+                        continue
+                    cells[length_bucket(_query_text(e))].append(r)
+                bucket_rows.append(
+                    (
+                        scope,
+                        k,
+                        f"{_mean(cells['<=30']):.3f} ({len(cells['<=30'])})",
+                        f"{_mean(cells['31-60']):.3f} ({len(cells['31-60'])})",
+                        f"{_mean(cells['>60']):.3f} ({len(cells['>60'])})",
+                    )
+                )
+        out.append(
+            _format_table(
+                "Recall@k — length-stratified",
+                ["scope", "k", "<=30 w", "31-60 w", ">60 w"],
+                bucket_rows,
+            )
+        )
+
+    return "\n".join(out) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--queries",
+        required=True,
+        type=Path,
+        help="Synthesized queries: directory of per-instance JSONs or a single file.",
+    )
+    p.add_argument(
+        "--eval-result",
+        type=Path,
+        default=None,
+        help="--result-path JSON from eval_synthesized_queries.py (enables recall slices).",
+    )
+    p.add_argument(
+        "--metrics-k",
+        type=int,
+        nargs="+",
+        default=[1, 5, 10],
+        help="Which k values to slice recall at.",
+    )
+    p.add_argument(
+        "--emit-masked-queries",
+        type=Path,
+        default=None,
+        help="If set, write per-instance masked JSONs into this directory.",
+    )
+    p.add_argument(
+        "--emit-leak-report",
+        type=Path,
+        default=None,
+        help="If set, write per-query leak signals (JSON list) to this path.",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    entries = load_queries(args.queries.expanduser().resolve())
+    if not entries:
+        print("No queries loaded — check --queries path.", file=sys.stderr)
+        return 1
+
+    results = (
+        load_eval_results(args.eval_result.expanduser().resolve())
+        if args.eval_result
+        else None
+    )
+
+    print(report(entries, results, args.metrics_k))
+
+    if args.emit_leak_report:
+        out_path = args.emit_leak_report.expanduser().resolve()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = [
+            {
+                "query_id": _query_id(e),
+                "instance_id": e.get("instance_id"),
+                "n_words": len(_query_text(e).split()),
+                "length_bucket": length_bucket(_query_text(e)),
+                "leak": {
+                    "fn_leak": L.fn_leak,
+                    "sym_leak": L.sym_leak,
+                    "path_leak": L.path_leak,
+                    "any_leak": L.any_leak,
+                },
+            }
+            for e, L in zip(entries, (detect_leaks(e) for e in entries), strict=False)
+        ]
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2, ensure_ascii=False)
+        print(f"Leak report → {out_path}")
+
+    if args.emit_masked_queries:
+        out_dir = args.emit_masked_queries.expanduser().resolve()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        per_instance: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for e in entries:
+            per_instance[str(e.get("instance_id") or "unknown")].append(
+                make_masked_entry(e)
+            )
+        for inst_id, items in per_instance.items():
+            safe = inst_id.replace("/", "__")
+            with open(out_dir / f"{safe}.json", "w", encoding="utf-8") as fh:
+                json.dump(items, fh, indent=2, ensure_ascii=False)
+        print(
+            f"Masked queries → {out_dir} ({sum(len(v) for v in per_instance.values())} entries)"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/synthesize_q2_short.py
+++ b/scripts/synthesize_q2_short.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Generate short, domain-vocab-stripped query variants — issue #130 Tier-1.
+
+For each ``_behavioral_q1`` query in the input directory, ask an LLM to rewrite
+it as a 5–30 word symptom-style query that:
+
+- Does **not** reuse any noun from the GT file path, module name, or function name.
+- Uses synonyms where possible (\"linter\" → \"static checker\", \"VOTable\" → \"that XML
+  table format\", etc.).
+- Reads like a one-sentence bug report a developer would file on GitHub.
+
+The output mirrors the input schema, with ``query_id`` re-suffixed ``_behavioral_q2``
+and a new ``rewritten_from_query_id`` pointer. The emitted directory can be passed
+straight to ``examples/eval_synthesized_queries.py --queries-dir`` for re-eval.
+
+Predicted result per #130: file-recall@10 drops from 0.92 → ~0.65, symbol-recall@10
+from 0.73 → ~0.40.
+
+Usage
+-----
+
+    python scripts/synthesize_q2_short.py \\
+        --input-dir synthesis_output/ \\
+        --output-dir synthesis_output_q2_short/ \\
+        --model vertex_ai/gemini-2.5-flash
+
+    # Single-instance smoke test
+    python scripts/synthesize_q2_short.py \\
+        --input-dir synthesis_output/ \\
+        --output-dir /tmp/q2_test/ \\
+        --filter-instance "astral-sh__ruff-15309" \\
+        --model vertex_ai/gemini-2.5-flash
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+from pydantic import BaseModel, Field  # noqa: E402
+
+from codeminer.llm.litellm_chat import (  # noqa: E402
+    LiteLLMChat,
+    human_message,
+    system_message,
+)
+from codeminer.log_utils import get_logger  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema for the structured output.
+# ---------------------------------------------------------------------------
+
+
+class ShortQueryRewrite(BaseModel):
+    """One-shot short rewrite of a behavioral query."""
+
+    rewritten_query: str = Field(
+        description="A 5–30 word symptom-style developer query reusing no banned tokens.",
+    )
+    banned_tokens_used: List[str] = Field(
+        default_factory=list,
+        description="Banned tokens that still slipped into the rewrite (for QA).",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field-name compatibility helpers (mirror diagnose_query_leak.py).
+# ---------------------------------------------------------------------------
+
+
+def _gt_files(entry: Dict[str, Any]) -> List[str]:
+    return list(entry.get("gt_files") or entry.get("target_files") or [])
+
+
+def _gt_symbols(entry: Dict[str, Any]) -> List[str]:
+    return list(entry.get("gt_symbols") or entry.get("target_symbols") or [])
+
+
+def _query_text(entry: Dict[str, Any]) -> str:
+    return str(entry.get("query") or entry.get("question") or "")
+
+
+# ---------------------------------------------------------------------------
+# Banned-token extraction (lifted from diagnose_query_leak.py).
+# ---------------------------------------------------------------------------
+
+
+def _camel_split(token: str) -> List[str]:
+    parts: List[str] = []
+    for part in token.replace("-", "_").split("_"):
+        if not part:
+            continue
+        sub = re.findall(r"[A-Z]+(?=[A-Z][a-z])|[A-Z]?[a-z]+|[A-Z]+|\d+", part)
+        parts.extend(s.lower() for s in sub if s)
+    return parts
+
+
+def _tokens_from_symbol(symbol: str) -> List[str]:
+    raw = re.split(r"[./:\\#]+", symbol)
+    return [t for chunk in raw for t in _camel_split(chunk) if len(t) > 1]
+
+
+def _tokens_from_path(path: str) -> List[str]:
+    parts = re.split(r"[\\/]+", path)
+    if parts:
+        parts[-1] = re.sub(r"\.[A-Za-z0-9]+$", "", parts[-1])
+    return [t for part in parts for t in _camel_split(part) if len(t) > 1]
+
+
+def banned_tokens(entry: Dict[str, Any]) -> List[str]:
+    """All sub-tokens drawn from GT file paths and GT symbol identifiers."""
+    bans = set()
+    for s in _gt_symbols(entry):
+        bans.update(_tokens_from_symbol(s))
+    for f in _gt_files(entry):
+        bans.update(_tokens_from_path(f))
+    return sorted(bans)
+
+
+# ---------------------------------------------------------------------------
+# Prompting.
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """\
+You rewrite verbose technical bug descriptions as short, symptom-style developer
+queries — the kind of one-sentence question a real engineer would file on GitHub
+or post on Stack Overflow.
+
+Constraints (must hold):
+- 5 to 30 words.
+- Do NOT use any of the BANNED_TOKENS (case-insensitive). Use plain English
+  synonyms instead. If a banned token names a domain concept, paraphrase it.
+- Describe the symptom, not the implementation. Avoid pointing at file paths,
+  class names, or function names.
+- Keep the rewrite grounded in the same defect — do not invent new behaviour.
+- Output only the rewritten query and a list of any banned tokens that slipped
+  through (should normally be empty).
+"""
+
+
+def build_user_prompt(query: str, bans: Sequence[str]) -> str:
+    return (
+        f"ORIGINAL_QUERY:\n{query}\n\n"
+        f"BANNED_TOKENS:\n{', '.join(bans) if bans else '(none)'}\n\n"
+        "Produce a single short rewrite obeying every constraint."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-entry rewrite.
+# ---------------------------------------------------------------------------
+
+
+def rewrite_entry(
+    llm: LiteLLMChat,
+    entry: Dict[str, Any],
+    max_retries: int = 2,
+) -> Optional[Dict[str, Any]]:
+    bans = banned_tokens(entry)
+    structured = llm.with_structured_output(ShortQueryRewrite)
+    messages = [
+        system_message(SYSTEM_PROMPT),
+        human_message(build_user_prompt(_query_text(entry), bans)),
+    ]
+    last_err: Optional[Exception] = None
+    for attempt in range(max_retries + 1):
+        try:
+            result = structured.invoke(messages)
+            new_entry = dict(entry)
+            qid = entry.get("query_id") or entry.get("instance_id") or "unknown"
+            base_qid = re.sub(r"_behavioral_q\d+$", "", str(qid))
+            new_entry["query_id"] = f"{base_qid}_behavioral_q2"
+            new_entry["query"] = result.rewritten_query
+            new_entry["query_type"] = "behavioral_short"
+            new_entry["rewritten_from_query_id"] = qid
+            new_entry["banned_tokens"] = bans
+            new_entry["banned_tokens_leaked"] = result.banned_tokens_used
+            new_entry["n_words"] = len(result.rewritten_query.split())
+            return new_entry
+        except Exception as exc:
+            last_err = exc
+            logger.warning(
+                "Rewrite attempt %d failed for %s: %s",
+                attempt + 1,
+                entry.get("query_id"),
+                exc,
+            )
+            time.sleep(1.0 * (attempt + 1))
+    logger.error(
+        "Giving up on %s after %d retries: %s",
+        entry.get("query_id"),
+        max_retries,
+        last_err,
+    )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# IO helpers.
+# ---------------------------------------------------------------------------
+
+
+def load_input(path: Path) -> Dict[str, List[Dict[str, Any]]]:
+    """Return {instance_id: [entries]} from a directory of per-instance JSONs."""
+    out: Dict[str, List[Dict[str, Any]]] = {}
+    if path.is_dir():
+        for f in sorted(path.glob("*.json")):
+            with open(f, encoding="utf-8") as fh:
+                data = json.load(fh)
+            entries = data if isinstance(data, list) else [data]
+            if not entries:
+                continue
+            inst = str(entries[0].get("instance_id") or f.stem)
+            out.setdefault(inst, []).extend(entries)
+    else:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        entries = data if isinstance(data, list) else [data]
+        for e in entries:
+            out.setdefault(str(e.get("instance_id") or "unknown"), []).append(e)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--input-dir",
+        required=True,
+        type=Path,
+        help="Directory of per-instance synthesized query JSONs (q1 inputs).",
+    )
+    p.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Where to write per-instance q2 short variant JSONs.",
+    )
+    p.add_argument(
+        "--model",
+        default="vertex_ai/gemini-2.5-flash",
+        help="litellm model id used for the rewrite.",
+    )
+    p.add_argument(
+        "--temperature",
+        type=float,
+        default=0.3,
+        help="Sampling temperature — small >0 keeps phrasing varied without drift.",
+    )
+    p.add_argument("--max-tokens", type=int, default=256)
+    p.add_argument(
+        "--filter-instance",
+        type=str,
+        default=".*",
+        help="Regex over instance_id to restrict the rewrite set.",
+    )
+    p.add_argument(
+        "--only-q1",
+        action="store_true",
+        default=True,
+        help="Only rewrite entries whose query_id ends in _behavioral_q1.",
+    )
+    p.add_argument(
+        "--all-queries",
+        dest="only_q1",
+        action="store_false",
+        help="Rewrite every input entry, regardless of query_type.",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    in_dir = args.input_dir.expanduser().resolve()
+    out_dir = args.output_dir.expanduser().resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    grouped = load_input(in_dir)
+    pat = re.compile(args.filter_instance)
+    grouped = {k: v for k, v in grouped.items() if pat.search(k)}
+    if not grouped:
+        print("No instances matched --filter-instance.", file=sys.stderr)
+        return 1
+    total = sum(len(v) for v in grouped.values())
+    logger.info("Loaded %d entries across %d instances", total, len(grouped))
+
+    llm = LiteLLMChat(
+        model=args.model, temperature=args.temperature, max_tokens=args.max_tokens
+    )
+
+    n_done = 0
+    n_failed = 0
+    for inst, entries in grouped.items():
+        rewritten: List[Dict[str, Any]] = []
+        for entry in entries:
+            qid = str(entry.get("query_id") or "")
+            if args.only_q1 and not qid.endswith("_behavioral_q1"):
+                continue
+            new_entry = rewrite_entry(llm, entry)
+            if new_entry is None:
+                n_failed += 1
+                continue
+            rewritten.append(new_entry)
+            n_done += 1
+            logger.info(
+                "[%s] q1(%d w) → q2(%d w) leaked=%s",
+                new_entry["query_id"],
+                len(_query_text(entry).split()),
+                new_entry["n_words"],
+                new_entry["banned_tokens_leaked"],
+            )
+        if not rewritten:
+            continue
+        safe = inst.replace("/", "__")
+        out_path = out_dir / f"{safe}.json"
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(rewritten, fh, indent=2, ensure_ascii=False)
+    logger.info("Done — %d rewritten, %d failed", n_done, n_failed)
+    print(f"Wrote {n_done} rewritten queries to {out_dir} ({n_failed} failed)")
+    return 0 if n_done > 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Operationalizes the Tier-1 and Tier-3 diagnostics proposed in #130 as
standalone, runnable tools. No changes to the existing eval pipeline — the
scripts plug in to ``examples/eval_synthesized_queries.py`` via its existing
``--queries-dir`` / ``--result-path`` interface.

- **``scripts/diagnose_query_leak.py``** — stdlib-only. Reads synthesized
  queries + the eval result JSON and reports leak-signal prevalence, length
  distribution, recall slices (leaked-vs-clean, length-stratified), and emits
  a masked-query variant for re-eval.
- **``scripts/synthesize_q2_short.py``** — LLM rewriter that emits 5–30 word
  ``_behavioral_q2`` symptom-style variants under a no-domain-vocab constraint.
- **``docs/diagnose_query_leak.md``** — usage + recommended sequence.

## Why

Per #130, the current SweRankEmbed-Small numbers on the 96 synthesized queries
(file-recall@10 = 0.92) are score-saturated vs. ``codeminer-dataset-base``
(0.68–0.77). The discussion converged on **semantic-vocabulary leak** — the
synthesizer prompt is conditioned on GT context, so paraphrases inherit
domain terminology. These two scripts let us measure the effect cleanly:

1. ``diagnose_query_leak.py`` (no LLM): leak prevalence + the recall slices
   that confirm or refute the leak diagnosis.
2. ``synthesize_q2_short.py`` (one LLM call per query): short variants whose
   re-eval drop is the headline calibration number.

Predicted result per the issue: file-recall@10 0.92 → ~0.65,
symbol-recall@10 0.73 → ~0.40.

## Test plan

- [x] Diagnostic script runs on a 2-query fixture and prints all three tables.
- [x] ``--emit-masked-queries`` writes valid JSONs with sub-tokens of GT
      symbols and path segments replaced by ``[MASK]``.
- [x] ``--emit-leak-report`` writes per-query leak signals.
- [x] Both scripts handle the synthesizer's ``target_files``/``target_symbols``
      schema **and** the older ``gt_files``/``gt_symbols`` schema.
- [ ] Run end-to-end on the 96-query corpus (deferred — needs ``synthesis_output/``
      data; instructions in ``docs/diagnose_query_leak.md``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)