### PR TITLE
ci(license): enforce REUSE/SPDX compliance via pre-commit hook + CI gate

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 Language:        Cpp
 # BasedOnStyle:  LLVM

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Set sane defaults; normalize text with LF checkout unless specified otherwise.
 * text=auto
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Bug Report
 description: Report a bug or unexpected behavior
 labels: ["type/bug", "status/triage"]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Feature Request
 description: Propose a new feature or enhancement
 labels: ["type/feature", "status/triage"]

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: RFC / Design Proposal
 description: Propose a significant design change or architectural decision
 labels: ["type/feature", "status/triage"]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ## Summary
 <!-- Provide a brief description of the changes in this PR -->
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: "Setup CodeMiner Environment"
 description: "Shared environment setup for CI jobs (conda, scip, toolchains)"
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Auto-label PRs based on changed file paths.
 # Labels follow the prefix-based taxonomy defined in .github/labels.yml.
 # See https://github.com/actions/labeler

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Source-of-truth label taxonomy for CodeMiner.
 #
 # Four orthogonal dimensions — each issue picks at most one label per prefix:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Label PRs
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: CI
 
 on:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Sync labels
 
 on:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REUSE / SPDX compliance gate.
+#
+# Lives in its own workflow (not folded into ci.yml) so that it is *not*
+# subject to ci.yml's `paths-ignore` filter for **.md / docs/** / LICENSE /
+# .gitignore — a doc-only PR can still introduce a file without an SPDX
+# header, and we want that caught.
+name: REUSE
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reuse-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reuse:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: REUSE compliance check
+        uses: fsfe/reuse-action@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [submodule "third_party/scip-python"]
 	path = third_party/scip-python
 	url = https://github.com/fishmingyu/scip-python.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,9 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-bugbear]
+
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v6.2.0
+    hooks:
+      - id: reuse
+        name: (License) REUSE compliance (SPDX headers)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # CLAUDE.md
 
 CodeMiner is a code analysis agent with graph-enhanced search. It parses

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 .PHONY: install scip dev test
 
 install:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # CodeMiner
 
 An LLM-adapted code indexing and retrieval system for multi-language codebases.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,31 @@
+version = 1
+
+# Files we cannot (or should not) annotate with inline SPDX headers:
+#   - prompt templates loaded verbatim as model input
+#   - meta / convention files where Apache 2.0 itself reserves the format
+#     (NOTICE) or where comments are awkward (.gitignore, .flake8)
+# Their licensing is declared here, per the REUSE 3.3 specification.
+
+[[annotations]]
+path = "NOTICE"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "CodeMiner Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".gitignore"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "CodeMiner Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".flake8"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "CodeMiner Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = "codeminer/model/prompts/*.txt"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "CodeMiner Contributors"
+SPDX-License-Identifier = "Apache-2.0"

--- a/codeminer/__init__.py
+++ b/codeminer/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .agent import KeywordExtractor, RerankAgent
 from .code_chunker import CodeChunker, RepoChunkingConfig
 from .graph.code_graph import CodeGraph

--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Agent package consolidating agent utilities and implementations."""
 
 from .agent_types import AgentResult, ToolCallRecord

--- a/codeminer/agent/agent_types.py
+++ b/codeminer/agent/agent_types.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Data types for the agent runner."""
 
 from __future__ import annotations

--- a/codeminer/agent/extract_agent.py
+++ b/codeminer/agent/extract_agent.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Keyword extraction agent for problem statements.
 This module extracts key terms from problem statements using llama_index.

--- a/codeminer/agent/rerank_agent.py
+++ b/codeminer/agent/rerank_agent.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Rerank agent for ranking code nodes based on relevance to a query.
 This module uses LLM APIs to rank NodeInfo objects and return QueriedNode objects.

--- a/codeminer/agent/resource_guard.py
+++ b/codeminer/agent/resource_guard.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Manifest-aware resource checking for the agent.
 
 Before the agent loop starts, ``ResourceGuard`` checks which skills can

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Lightweight agent runner using LLM tool calling.
 
 Implements a think → act → observe loop that lets an LLM decide which

--- a/codeminer/agent/skills/__init__.py
+++ b/codeminer/agent/skills/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Declarative skill definitions for Codeminer agents.
 

--- a/codeminer/agent/skills/bm25_search/config.yaml
+++ b/codeminer/agent/skills/bm25_search/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: bm25_search
 skill_type: retrieval
 operator: bm25.topk

--- a/codeminer/agent/skills/bm25_search/executor.py
+++ b/codeminer/agent/skills/bm25_search/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, List

--- a/codeminer/agent/skills/bm25_search/skill.md
+++ b/codeminer/agent/skills/bm25_search/skill.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # BM25 Search
 
 ## When to Use

--- a/codeminer/agent/skills/code_to_query/config.yaml
+++ b/codeminer/agent/skills/code_to_query/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: code_to_query
 skill_type: transform
 operator: code-to-query.transform

--- a/codeminer/agent/skills/code_to_query/executor.py
+++ b/codeminer/agent/skills/code_to_query/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, List

--- a/codeminer/agent/skills/code_to_query/skill.md
+++ b/codeminer/agent/skills/code_to_query/skill.md
@@ -1,1 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 Use to transform code snippets into search queries. Useful for finding similar code or understanding code context.

--- a/codeminer/agent/skills/core.py
+++ b/codeminer/agent/skills/core.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Core data structures for skill definitions.
 

--- a/codeminer/agent/skills/embedding_rerank/config.yaml
+++ b/codeminer/agent/skills/embedding_rerank/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: embedding_rerank
 skill_type: rerank
 operator: embedding.rerank

--- a/codeminer/agent/skills/embedding_rerank/executor.py
+++ b/codeminer/agent/skills/embedding_rerank/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, List

--- a/codeminer/agent/skills/embedding_rerank/skill.md
+++ b/codeminer/agent/skills/embedding_rerank/skill.md
@@ -1,1 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 Use for fast embedding-based reranking. Less accurate than LLM rerank but much faster. Good for large candidate sets where LLM rerank would be too slow.

--- a/codeminer/agent/skills/embedding_search/config.yaml
+++ b/codeminer/agent/skills/embedding_search/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: embedding_search
 skill_type: retrieval
 operator: faiss.retrieve

--- a/codeminer/agent/skills/embedding_search/executor.py
+++ b/codeminer/agent/skills/embedding_search/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, List, Optional, Set

--- a/codeminer/agent/skills/embedding_search/skill.md
+++ b/codeminer/agent/skills/embedding_search/skill.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Embedding Search
 
 ## When to Use

--- a/codeminer/agent/skills/graph_expand/config.yaml
+++ b/codeminer/agent/skills/graph_expand/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: graph_expand
 skill_type: expand
 operator: graph.walk

--- a/codeminer/agent/skills/graph_expand/executor.py
+++ b/codeminer/agent/skills/graph_expand/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, List, Optional

--- a/codeminer/agent/skills/graph_expand/skill.md
+++ b/codeminer/agent/skills/graph_expand/skill.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # graph_expand
 
 Expand seed code blocks along the symbol graph to discover structurally related symbols in bulk.

--- a/codeminer/agent/skills/hybrid_search/config.yaml
+++ b/codeminer/agent/skills/hybrid_search/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: hybrid_search
 skill_type: aggregate
 operator: hybrid.retrieve

--- a/codeminer/agent/skills/hybrid_search/executor.py
+++ b/codeminer/agent/skills/hybrid_search/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, List, Optional, Tuple

--- a/codeminer/agent/skills/hybrid_search/skill.md
+++ b/codeminer/agent/skills/hybrid_search/skill.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Hybrid Search
 
 ## When to Use

--- a/codeminer/agent/skills/llm_rerank/config.yaml
+++ b/codeminer/agent/skills/llm_rerank/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: llm_rerank
 skill_type: rerank
 operator: llm.rerank

--- a/codeminer/agent/skills/llm_rerank/executor.py
+++ b/codeminer/agent/skills/llm_rerank/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, List

--- a/codeminer/agent/skills/llm_rerank/skill.md
+++ b/codeminer/agent/skills/llm_rerank/skill.md
@@ -1,1 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 Use for high-quality reranking when precision matters most. Uses LLM to judge relevance. Slower but more accurate than embedding rerank. Best after initial retrieval to refine top results.

--- a/codeminer/agent/skills/loader.py
+++ b/codeminer/agent/skills/loader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Skill package loader.
 

--- a/codeminer/agent/skills/query_transform/config.yaml
+++ b/codeminer/agent/skills/query_transform/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: query_transform
 skill_type: transform
 operator: query.transform

--- a/codeminer/agent/skills/query_transform/executor.py
+++ b/codeminer/agent/skills/query_transform/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, Dict

--- a/codeminer/agent/skills/query_transform/skill.md
+++ b/codeminer/agent/skills/query_transform/skill.md
@@ -1,1 +1,7 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 Use to expand/reformulate a user query using keyword extraction. Improves retrieval recall by generating additional search terms.

--- a/codeminer/agent/skills/regex_search/config.yaml
+++ b/codeminer/agent/skills/regex_search/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 skill_id: regex_search
 skill_type: retrieval
 operator: regex.retrieve

--- a/codeminer/agent/skills/regex_search/executor.py
+++ b/codeminer/agent/skills/regex_search/executor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Any, Callable, List, Optional

--- a/codeminer/agent/skills/regex_search/skill.md
+++ b/codeminer/agent/skills/regex_search/skill.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Regex Search
 
 ## When to Use

--- a/codeminer/agent/skills/registry.py
+++ b/codeminer/agent/skills/registry.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Skill registry and ``@skill`` decorator.
 

--- a/codeminer/agent/tool_schema.py
+++ b/codeminer/agent/tool_schema.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Convert SkillMetadata to OpenAI function-calling tool schemas.
 
 This module bridges the SkillRegistry to LLM tool-calling APIs.

--- a/codeminer/agent/tools.py
+++ b/codeminer/agent/tools.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from typing import List, Optional
 

--- a/codeminer/agent/utils.py
+++ b/codeminer/agent/utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import fnmatch
 from pathlib import Path
 from typing import List, Tuple

--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Code chunking module with both file-level and repository-level functionality.
 This file maintains backward compatibility with the old API and adds repository processing.

--- a/codeminer/code_chunking/README.md
+++ b/codeminer/code_chunking/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Code Chunking
 
 Tree-sitter based code chunkers that split source files into semantic chunks

--- a/codeminer/code_chunking/__init__.py
+++ b/codeminer/code_chunking/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Code chunking module for splitting source code files into semantic chunks.
 """

--- a/codeminer/code_chunking/base.py
+++ b/codeminer/code_chunking/base.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Base code chunker class with common functionality.
 """

--- a/codeminer/code_chunking/cpp_chunker.py
+++ b/codeminer/code_chunking/cpp_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 C++ specific code chunker implementation.
 """

--- a/codeminer/code_chunking/go_chunker.py
+++ b/codeminer/code_chunking/go_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Go-specific code chunker implementation.
 """

--- a/codeminer/code_chunking/js_chunker.py
+++ b/codeminer/code_chunking/js_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 JavaScript/TypeScript code chunker implementation.
 """

--- a/codeminer/code_chunking/python_chunker.py
+++ b/codeminer/code_chunking/python_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Python-specific code chunker implementation.
 """

--- a/codeminer/code_chunking/rust_chunker.py
+++ b/codeminer/code_chunking/rust_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Rust-specific code chunker implementation.
 """

--- a/codeminer/compiler/__init__.py
+++ b/codeminer/compiler/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Compiler infrastructure for Codeminer.
 

--- a/codeminer/compiler/index_builders.py
+++ b/codeminer/compiler/index_builders.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Index builder protocol, registry, and concrete implementations.
 

--- a/codeminer/compiler/index_compiler.py
+++ b/codeminer/compiler/index_compiler.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Index Compiler — Phase 1 of the two-phase compilation architecture.
 

--- a/codeminer/compiler/manifest.py
+++ b/codeminer/compiler/manifest.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Repo manifest — the linking protocol between index compilation (Phase 1)
 and query compilation (Phase 2).

--- a/codeminer/compiler/params.py
+++ b/codeminer/compiler/params.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Layered parameter resolution for skill execution.
 

--- a/codeminer/compiler/resources.py
+++ b/codeminer/compiler/resources.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Index resource management for the skill compiler.
 

--- a/codeminer/compiler/skill_context.py
+++ b/codeminer/compiler/skill_context.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Skill-aware context construction.
 
 The agent eval scripts used to chunk repos and instantiate ``BM25CodeIndexer``
@@ -210,9 +214,7 @@ def build_skill_contexts(
                     embedding_model=embedding_model,
                     embedding_dimension=embedding_dimension,
                 )
-            logger.info(
-                "Building missing indexes %s under %s", missing, cache_dir
-            )
+            logger.info("Building missing indexes %s under %s", missing, cache_dir)
             _run_compiler(
                 repo_path,
                 missing,
@@ -258,9 +260,7 @@ def _package_contexts(
     """
     contexts: Dict[str, Any] = {}
 
-    needs_retrieve = bool(
-        skill_types & {SkillType.RETRIEVAL, SkillType.AGGREGATE}
-    )
+    needs_retrieve = bool(skill_types & {SkillType.RETRIEVAL, SkillType.AGGREGATE})
     if needs_retrieve:
         from ..ops.retrieve import RetrieveContext
 

--- a/codeminer/dataset/__init__.py
+++ b/codeminer/dataset/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .base import DatasetBase
 from .codeminer_base import CodeMinerBaseDataset
 from .local_json import LocalJsonDataset

--- a/codeminer/dataset/base.py
+++ b/codeminer/dataset/base.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import json

--- a/codeminer/dataset/codeminer_base.py
+++ b/codeminer/dataset/codeminer_base.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import argparse

--- a/codeminer/dataset/collect/data/swebench_multilingual_repos.csv.license
+++ b/codeminer/dataset/collect/data/swebench_multilingual_repos.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0

--- a/codeminer/dataset/collect/difficulty_classifier.py
+++ b/codeminer/dataset/collect/difficulty_classifier.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Agent-based difficulty classification for SWE-bench instances.
 
 Uses a Claude agent to analyze the problem statement and patch content to

--- a/codeminer/dataset/collect/swebench_sample.py
+++ b/codeminer/dataset/collect/swebench_sample.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SWE-bench sampling utilities.
 

--- a/codeminer/dataset/gt_locate.py
+++ b/codeminer/dataset/gt_locate.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Analyze SWE-bench patches to extract symbol-level changes.
 

--- a/codeminer/dataset/local_json.py
+++ b/codeminer/dataset/local_json.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import json

--- a/codeminer/dataset/locbench.py
+++ b/codeminer/dataset/locbench.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import argparse

--- a/codeminer/dataset/swebench.py
+++ b/codeminer/dataset/swebench.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import argparse

--- a/codeminer/dataset/swebench_multilingual.py
+++ b/codeminer/dataset/swebench_multilingual.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import argparse

--- a/codeminer/dataset/synthesize/__init__.py
+++ b/codeminer/dataset/synthesize/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Query synthesis tools for SWE-bench multiplexed indexing."""
 
 from codeminer.dataset.utils import (

--- a/codeminer/dataset/synthesize/_agent.py
+++ b/codeminer/dataset/synthesize/_agent.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared agent runner for the query synthesis pipeline."""
 
 from __future__ import annotations

--- a/codeminer/dataset/synthesize/_types.py
+++ b/codeminer/dataset/synthesize/_types.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Shared data classes for the query synthesis pipeline."""
 
 from __future__ import annotations

--- a/codeminer/dataset/synthesize/context_loader.py
+++ b/codeminer/dataset/synthesize/context_loader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Context loading for query synthesis — graph sampling + agent exploration."""
 
 from __future__ import annotations

--- a/codeminer/dataset/synthesize/query_curator.py
+++ b/codeminer/dataset/synthesize/query_curator.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Query generation (curation) for the synthesis pipeline."""
 
 from __future__ import annotations

--- a/codeminer/dataset/synthesize/query_synthesizer.py
+++ b/codeminer/dataset/synthesize/query_synthesizer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Query synthesis facade for SWE-bench instances.
 

--- a/codeminer/dataset/synthesize/verifier.py
+++ b/codeminer/dataset/synthesize/verifier.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Query verification for the synthesis pipeline."""
 
 from __future__ import annotations

--- a/codeminer/dataset/utils.py
+++ b/codeminer/dataset/utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Utility types and functions for code search QA dataset generation.
 

--- a/codeminer/eval/retrieval_eval.py
+++ b/codeminer/eval/retrieval_eval.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Utility functions for evaluating retrieval outputs against labeled targets."""
 
 from __future__ import annotations

--- a/codeminer/graph/__init__.py
+++ b/codeminer/graph/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Graph-related modules for CodeMiner."""
 
 from .code_graph import CodeGraph

--- a/codeminer/graph/code_graph.py
+++ b/codeminer/graph/code_graph.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import bisect
 import pickle
 from collections import defaultdict

--- a/codeminer/graph/incremental/__init__.py
+++ b/codeminer/graph/incremental/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """LSP-based incremental patching for CodeGraph updates."""
 
 from .graph_patcher import GraphPatcher

--- a/codeminer/graph/incremental/change_mgr.py
+++ b/codeminer/graph/incremental/change_mgr.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Change manager: git-based change detection for incremental updates."""
 
 from __future__ import annotations

--- a/codeminer/graph/incremental/graph_patcher.py
+++ b/codeminer/graph/incremental/graph_patcher.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """GraphPatcher: thin router for incremental CodeGraph updates.
 
 Dispatches to language-specific patchers (patcher_*.py).

--- a/codeminer/graph/incremental/lsp_client.py
+++ b/codeminer/graph/incremental/lsp_client.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Production LSP JSON-RPC client for graph-patching.
 
 Supports the subset of LSP needed for incremental graph updates:
@@ -46,7 +50,9 @@ def _close_profile_fh() -> None:
             pass
 
 
-def _profile_log(method: str, abs_file: str, line, character, elapsed_s: float, n_results) -> None:
+def _profile_log(
+    method: str, abs_file: str, line, character, elapsed_s: float, n_results
+) -> None:
     """Append one call to the file at ``$LSP_PROFILE_PATH``.
 
     Re-reads the env var each call and reopens the file when the path
@@ -73,13 +79,22 @@ def _profile_log(method: str, abs_file: str, line, character, elapsed_s: float, 
         return
     try:
         _LSP_PROFILE_FH.write(
-            json.dumps({"t": round(time.time(), 3),
-                        "m": method, "f": abs_file,
-                        "l": line, "c": character,
-                        "ms": round(elapsed_s * 1000, 2), "n": n_results}) + "\n"
+            json.dumps(
+                {
+                    "t": round(time.time(), 3),
+                    "m": method,
+                    "f": abs_file,
+                    "l": line,
+                    "c": character,
+                    "ms": round(elapsed_s * 1000, 2),
+                    "n": n_results,
+                }
+            )
+            + "\n"
         )
     except Exception:
         pass  # best-effort profile write — never break real work
+
 
 # LSP SymbolKind integer → human-readable name
 SYMBOL_KIND_NAMES = {
@@ -428,9 +443,14 @@ class LSPClient:
                 timeout=10,  # longest non-empty observed: 138ms
             )
             if result is not None:
-                _profile_log("documentSymbol", file_path, None, None,
-                             time.monotonic() - t0,
-                             len(result) if isinstance(result, list) else 0)
+                _profile_log(
+                    "documentSymbol",
+                    file_path,
+                    None,
+                    None,
+                    time.monotonic() - t0,
+                    len(result) if isinstance(result, list) else 0,
+                )
                 return result
             if attempt < retries:
                 logger.debug(
@@ -439,17 +459,20 @@ class LSPClient:
                 )
                 time.sleep(retry_delay)
 
-        _profile_log("documentSymbol", file_path, None, None,
-                     time.monotonic() - t0, 0)
+        _profile_log("documentSymbol", file_path, None, None, time.monotonic() - t0, 0)
         return []
 
     def references(self, *args, **kwargs):
         t0 = time.monotonic()
         out = self._references_inner(*args, **kwargs)
-        _profile_log("references", args[0] if args else kwargs.get("file_path"),
-                     args[1] if len(args) > 1 else kwargs.get("line"),
-                     args[2] if len(args) > 2 else kwargs.get("character"),
-                     time.monotonic() - t0, len(out) if out else 0)
+        _profile_log(
+            "references",
+            args[0] if args else kwargs.get("file_path"),
+            args[1] if len(args) > 1 else kwargs.get("line"),
+            args[2] if len(args) > 2 else kwargs.get("character"),
+            time.monotonic() - t0,
+            len(out) if out else 0,
+        )
         return out
 
     def _references_inner(
@@ -527,10 +550,14 @@ class LSPClient:
     def definition(self, *args, **kwargs):
         t0 = time.monotonic()
         out = self._definition_inner(*args, **kwargs)
-        _profile_log("definition", args[0] if args else kwargs.get("file_path"),
-                     args[1] if len(args) > 1 else kwargs.get("line"),
-                     args[2] if len(args) > 2 else kwargs.get("character"),
-                     time.monotonic() - t0, len(out) if out else 0)
+        _profile_log(
+            "definition",
+            args[0] if args else kwargs.get("file_path"),
+            args[1] if len(args) > 1 else kwargs.get("line"),
+            args[2] if len(args) > 2 else kwargs.get("character"),
+            time.monotonic() - t0,
+            len(out) if out else 0,
+        )
         return out
 
     def _definition_inner(
@@ -641,8 +668,14 @@ class LSPClient:
         if result is not None:
             n_tokens = len(result.get("data", [])) // 5
             logger.debug(f"semanticTokens for {file_path}: {n_tokens} tokens")
-        _profile_log("semanticTokens/full", file_path, None, None,
-                     time.monotonic() - t0, n_tokens)
+        _profile_log(
+            "semanticTokens/full",
+            file_path,
+            None,
+            None,
+            time.monotonic() - t0,
+            n_tokens,
+        )
         return result
 
     def semantic_tokens_range(
@@ -679,9 +712,14 @@ class LSPClient:
                 f"semanticTokens/range for {file_path} "
                 f"L{start_line}-{end_line}: {n_tokens} tokens"
             )
-        _profile_log("semanticTokens/range", file_path,
-                     start_line, end_line,
-                     time.monotonic() - t0, n_tokens)
+        _profile_log(
+            "semanticTokens/range",
+            file_path,
+            start_line,
+            end_line,
+            time.monotonic() - t0,
+            n_tokens,
+        )
         return result
 
     def decode_semantic_tokens(
@@ -983,7 +1021,9 @@ class LSPClient:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break
-            ready, _, _ = select.select([self.process.stdout], [], [], min(remaining, 0.05))
+            ready, _, _ = select.select(
+                [self.process.stdout], [], [], min(remaining, 0.05)
+            )
             if not ready:
                 break
             msg = self._read_message(timeout=remaining)
@@ -994,7 +1034,9 @@ class LSPClient:
             # let _handle_progress (called inside _read_message) update state.
         return n
 
-    def wait_until_idle(self, max_wait_s: float = 60.0, idle_grace_s: float = 1.0) -> bool:
+    def wait_until_idle(
+        self, max_wait_s: float = 60.0, idle_grace_s: float = 1.0
+    ) -> bool:
         """Wait until no ``$/progress`` tokens are active for ``idle_grace_s``.
 
         Returns True if the server became idle within ``max_wait_s``,

--- a/codeminer/graph/incremental/patcher_base.py
+++ b/codeminer/graph/incremental/patcher_base.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """PatcherBase: incremental orchestration for CodeGraph updates.
 
 Handles the high-level patch flow (classify, remap, patch) while
@@ -251,10 +255,13 @@ class PatcherBase(SubgraphMgr):
         skip = self._should_skip_path
         return {
             "modified": [p for p in changed_files.get("modified", []) if not skip(p)],
-            "added":    [p for p in changed_files.get("added",    []) if not skip(p)],
-            "deleted":  [p for p in changed_files.get("deleted",  []) if not skip(p)],
-            "renamed":  [(o, n) for o, n in changed_files.get("renamed", [])
-                         if not skip(n) and not skip(o)],
+            "added": [p for p in changed_files.get("added", []) if not skip(p)],
+            "deleted": [p for p in changed_files.get("deleted", []) if not skip(p)],
+            "renamed": [
+                (o, n)
+                for o, n in changed_files.get("renamed", [])
+                if not skip(n) and not skip(o)
+            ],
         }
 
     def patch_files(
@@ -397,8 +404,7 @@ class PatcherBase(SubgraphMgr):
         # benchmarks can read them without parsing logs.
         report = self.profiler.report(reset=True)
         total_stats["profile"] = {
-            label: {"total_s": st.total, "count": st.count}
-            for label, st in report
+            label: {"total_s": st.total, "count": st.count} for label, st in report
         }
 
         return total_stats
@@ -659,6 +665,7 @@ class PatcherBase(SubgraphMgr):
         # end of this file's processing. Avoids ~5000 single-edge
         # ``add_edges`` calls per patch (Python↔C round-trip dominated).
         from .subgraph_mgr import EdgeBatch
+
         batch = EdgeBatch(self.code_graph)
 
         # Affected: outgoing refs for changed lines
@@ -767,10 +774,10 @@ class PatcherBase(SubgraphMgr):
         # symbol-level diff is saving.
         if getattr(self, "mode", "symbol") == "naive":
             return {
-                "deleted":   sorted(old_set),
-                "added":     sorted(new_set),
-                "affected":  [],
-                "shifted":   [],
+                "deleted": sorted(old_set),
+                "added": sorted(new_set),
+                "affected": [],
+                "shifted": [],
                 "unchanged": [],
                 "invisible": [],
             }
@@ -923,13 +930,9 @@ class PatcherBase(SubgraphMgr):
             if old_count != new_count:
                 all_preserving = False
             if body_overlap_old:
-                overlapping_old.append(
-                    (max(h_old_s, old_start), min(h_old_e, old_end))
-                )
+                overlapping_old.append((max(h_old_s, old_start), min(h_old_e, old_end)))
             if body_overlap_new:
-                overlapping_new.append(
-                    (max(h_new_s, new_start), min(h_new_e, new_end))
-                )
+                overlapping_new.append((max(h_new_s, new_start), min(h_new_e, new_end)))
 
         if all_preserving:
             # Fast path: surgical anchor cleanup + uniform shift.

--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """C/C++-specific incremental patcher.
 
 Uses clangd .idx files instead of LSP queries for incremental updates.
@@ -45,8 +49,9 @@ class PatcherCpp(PatcherBase):
             "macro",
         }
 
-    def _build_unified_name(self, file_path, name, parent_unified_part, kind,
-                            parent_kind: int = 0):
+    def _build_unified_name(
+        self, file_path, name, parent_unified_part, kind, parent_kind: int = 0
+    ):
         node_type = self._classify_symbol_type(kind)
         clean_name = name.replace("::", ".")
 
@@ -255,7 +260,9 @@ class PatcherCpp(PatcherBase):
         for d in candidates:
             exists = d.exists()
             n_idx = len(list(d.glob("*.idx"))) if exists else 0
-            logger.info(f"[patcher_cpp DEBUG] candidate {d}: exists={exists} idx_count={n_idx}")
+            logger.info(
+                f"[patcher_cpp DEBUG] candidate {d}: exists={exists} idx_count={n_idx}"
+            )
             if exists and n_idx > 0:
                 idx_dir = d
                 break
@@ -266,11 +273,15 @@ class PatcherCpp(PatcherBase):
 
             cache_path = Path(self.project_root) / ".cache" / "clangd" / "index"
             n_before = len(list(cache_path.glob("*.idx"))) if cache_path.exists() else 0
-            logger.info(f"[patcher_cpp DEBUG] before ClangdIndexer: {cache_path} has {n_before} .idx")
+            logger.info(
+                f"[patcher_cpp DEBUG] before ClangdIndexer: {cache_path} has {n_before} .idx"
+            )
             indexer = ClangdIndexer(project_root=str(self.project_root))
             success = indexer.generate_index(compdb_path=str(comp_db))
             n_after = len(list(cache_path.glob("*.idx"))) if cache_path.exists() else 0
-            logger.info(f"[patcher_cpp DEBUG] after ClangdIndexer: {cache_path} has {n_after} .idx (success={success})")
+            logger.info(
+                f"[patcher_cpp DEBUG] after ClangdIndexer: {cache_path} has {n_after} .idx (success={success})"
+            )
             return indexer.idx_directory if success else None
 
         pre_mtime = max(
@@ -357,13 +368,18 @@ class PatcherCpp(PatcherBase):
         def _drain(stream):
             try:
                 while True:
-                    chunk = stream.read1(65536) if hasattr(stream, "read1") else stream.read(4096)
+                    chunk = (
+                        stream.read1(65536)
+                        if hasattr(stream, "read1")
+                        else stream.read(4096)
+                    )
                     if not chunk:
                         return
             except Exception:
                 return
 
         import threading
+
         threading.Thread(target=_drain, args=(process.stdout,), daemon=True).start()
         threading.Thread(target=_drain, args=(process.stderr,), daemon=True).start()
 
@@ -494,6 +510,7 @@ class PatcherCpp(PatcherBase):
             REF_KIND_REFERENCE,
             ZERO_SYMBOL_ID,
         )
+
         from .subgraph_mgr import EdgeBatch
 
         changed_set = set(changed_files)
@@ -592,7 +609,8 @@ class PatcherCpp(PatcherBase):
                     anchor_uri = loc.get("file")
                     anchor_file = (
                         decoder._file_uri_to_relative(anchor_uri)
-                        if anchor_uri else None
+                        if anchor_uri
+                        else None
                     )
                     start = loc.get("start")
                     anchor_line = start[0] if start else None

--- a/codeminer/graph/incremental/patcher_go.py
+++ b/codeminer/graph/incremental/patcher_go.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Go-specific incremental patcher."""
 
 from __future__ import annotations

--- a/codeminer/graph/incremental/patcher_python.py
+++ b/codeminer/graph/incremental/patcher_python.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Python-specific incremental patcher."""
 
 from __future__ import annotations
@@ -15,6 +19,7 @@ class PatcherPython(PatcherBase):
         # basedpyright is slower but reliable; default to it. Override via
         # ``CODEMINER_PYTHON_LSP_CMD=ty\ server`` to experiment with ty.
         import os
+
         cmd = os.environ.get("CODEMINER_PYTHON_LSP_CMD")
         if cmd:
             return cmd.split()

--- a/codeminer/graph/incremental/patcher_rust.py
+++ b/codeminer/graph/incremental/patcher_rust.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Rust-specific incremental patcher."""
 
 from __future__ import annotations

--- a/codeminer/graph/incremental/patcher_ts.py
+++ b/codeminer/graph/incremental/patcher_ts.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """TypeScript/JavaScript-specific incremental patcher."""
 
 from __future__ import annotations

--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """SubgraphMgr: manages incremental subgraph operations on CodeGraph.
 
 Handles:

--- a/codeminer/graph/roi_subgraph.py
+++ b/codeminer/graph/roi_subgraph.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from collections import deque
 from typing import List, Optional, Set
 

--- a/codeminer/graph/traverse_graph.py
+++ b/codeminer/graph/traverse_graph.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Revised from:
 # https://github.com/All-Hands-AI/openhands-aci/blob/main/openhands_aci/indexing/locagent/repo/dependency_graph/traverse_graph.py
 

--- a/codeminer/incremental/__init__.py
+++ b/codeminer/incremental/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Incremental indexing layer for CodeMiner.
 

--- a/codeminer/incremental/chunk_store.py
+++ b/codeminer/incremental/chunk_store.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Per-file versioned code chunk store for incremental indexing.
 

--- a/codeminer/incremental/embeddings_cache.py
+++ b/codeminer/incremental/embeddings_cache.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Content-hash keyed embedding vector cache.
 

--- a/codeminer/incremental/git_diff.py
+++ b/codeminer/incremental/git_diff.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Git diff detection for incremental indexing.
 

--- a/codeminer/incremental/index_updater.py
+++ b/codeminer/incremental/index_updater.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Incremental index update orchestrator.
 

--- a/codeminer/incremental/state.py
+++ b/codeminer/incremental/state.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Persistent incremental indexing state.
 

--- a/codeminer/index/__init__.py
+++ b/codeminer/index/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Index-related components: sparse, dense, and regex."""
 
 from .embedding import CodeVectorStore, create_code_vector_store

--- a/codeminer/index/embedding/__init__.py
+++ b/codeminer/index/embedding/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Embedding module for CodeMiner.
 Provides vector storage and semantic search capabilities for code chunks.

--- a/codeminer/index/embedding/builders.py
+++ b/codeminer/index/embedding/builders.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Reusable embedding builders for hierarchical pipelines."""
 
 from contextlib import nullcontext

--- a/codeminer/index/embedding/prompt_registry.py
+++ b/codeminer/index/embedding/prompt_registry.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Per-model prompt registry for sentence-transformer embedders.
 
 These embedders are trained with **asymmetric** query/document encoding —

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Vector Store implementation using FAISS and sentence-transformers for code embeddings.
 This module provides functionality to create, store, and query vector embeddings

--- a/codeminer/index/regex_idx/__init__.py
+++ b/codeminer/index/regex_idx/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .regex_idx import RegexNodeIndex
 
 __all__ = ["RegexNodeIndex"]

--- a/codeminer/index/regex_idx/regex_idx.py
+++ b/codeminer/index/regex_idx/regex_idx.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Regex-based in-memory index for CodeGraph nodes.
 """

--- a/codeminer/index/rerank/__init__.py
+++ b/codeminer/index/rerank/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Cross-encoder rerankers (pairwise (query, doc) → relevance score).
 
 Two backends:

--- a/codeminer/index/rerank/cross_encoder.py
+++ b/codeminer/index/rerank/cross_encoder.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Cross-encoder reranker wrappers.
 
 Two backends share a common ``score(query, docs) -> List[float]`` interface:

--- a/codeminer/index/sparse_idx/__init__.py
+++ b/codeminer/index/sparse_idx/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Sparse indexing module for CodeMiner."""
 
 from .bm25_index import BM25CodeIndexer

--- a/codeminer/index/sparse_idx/bm25_index.py
+++ b/codeminer/index/sparse_idx/bm25_index.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 import re

--- a/codeminer/index/trigram/__init__.py
+++ b/codeminer/index/trigram/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Trigram-based search backends.
 
 Currently provides a thin client over `sourcegraph/zoekt

--- a/codeminer/index/trigram/zoekt_searcher.py
+++ b/codeminer/index/trigram/zoekt_searcher.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Client for the Zoekt trigram code search engine.
 
 Zoekt is written in Go.  CodeMiner interacts with it as a subprocess:
@@ -251,9 +255,7 @@ class ZoektSearcher:
             )
             resp.raise_for_status()
         except requests.RequestException as exc:
-            raise ZoektUnavailableError(
-                f"Zoekt search request failed: {exc}"
-            ) from exc
+            raise ZoektUnavailableError(f"Zoekt search request failed: {exc}") from exc
 
         try:
             data = resp.json()

--- a/codeminer/llm/__init__.py
+++ b/codeminer/llm/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """LLM module for CodeMiner."""
 
 from .litellm_chat import ChatMessage, LiteLLMChat, human_message, system_message

--- a/codeminer/llm/litellm_chat.py
+++ b/codeminer/llm/litellm_chat.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Lightweight LLM chat wrapper around LiteLLM.
 

--- a/codeminer/llm/usage.py
+++ b/codeminer/llm/usage.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Token usage and cost tracking for LLM calls.
 
 Wraps the native ``response.usage`` field that litellm exposes on

--- a/codeminer/log_utils.py
+++ b/codeminer/log_utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 from typing import Dict, Optional

--- a/codeminer/ls_index/__init__.py
+++ b/codeminer/ls_index/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Language-Server Index Module (non-SCIP)
 

--- a/codeminer/ls_index/clangd_decode.py
+++ b/codeminer/ls_index/clangd_decode.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Clangd .idx decoder: parse binary RIFF .idx files and build CodeGraph.
 

--- a/codeminer/ls_index/clangd_indexer.py
+++ b/codeminer/ls_index/clangd_indexer.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Indexer for C/C++ projects using clangd.
 Uses clangd's background indexer to generate .idx files, then

--- a/codeminer/ls_router.py
+++ b/codeminer/ls_router.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unified language-server router for indexing and decoding across all languages.
 

--- a/codeminer/mcp/README.md
+++ b/codeminer/mcp/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # CodeMiner MCP Server
 
 Model Context Protocol (MCP) server for CodeMiner's semantic search capabilities.

--- a/codeminer/mcp/__init__.py
+++ b/codeminer/mcp/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """CodeMiner MCP server - exposes backbone capabilities over stdio.
 
 Provides MCP tools for semantic indexing, CodeGraph, and hybrid retrieval

--- a/codeminer/mcp/__main__.py
+++ b/codeminer/mcp/__main__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Allow running as ``python -m codeminer.mcp <manifest>``."""
 
 from .server import main

--- a/codeminer/mcp/context.py
+++ b/codeminer/mcp/context.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """ServerContext - loads a RepoManifest and hydrates index objects from disk.
 
 Holds vector, symbol_graph, BM25, regex, and Zoekt indexes. Each loads

--- a/codeminer/mcp/prompts.py
+++ b/codeminer/mcp/prompts.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MCP prompt resource - guidance for calling agents."""
 
 CODEMINER_GUIDE = """\

--- a/codeminer/mcp/server.py
+++ b/codeminer/mcp/server.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """CodeMiner MCP server - stdio transport.
 
 Exposes vector (semantic), BM25, regex, and Zoekt trigram search over a

--- a/codeminer/mcp/tools/__init__.py
+++ b/codeminer/mcp/tools/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """MCP tool implementations.
 
 Each tool is a thin wrapper delegating to existing backbone APIs

--- a/codeminer/mcp/tools/search.py
+++ b/codeminer/mcp/tools/search.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Search MCP tools - vector (semantic), BM25, regex, and Zoekt wrappers
 over backbone indexes."""
 

--- a/codeminer/model/__init__.py
+++ b/codeminer/model/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Model module for CodeMiner."""
 
 from .agentless_pipeline import AgentlessPipeline

--- a/codeminer/model/agentless_pipeline.py
+++ b/codeminer/model/agentless_pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from pathlib import Path
 from typing import List, Optional

--- a/codeminer/model/bm25_retrieve_pipeline.py
+++ b/codeminer/model/bm25_retrieve_pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/codeminer/model/embedding_retrieve_pipeline.py
+++ b/codeminer/model/embedding_retrieve_pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import List, Optional

--- a/codeminer/model/graph_retrieve_pipeline.py
+++ b/codeminer/model/graph_retrieve_pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from contextlib import nullcontext

--- a/codeminer/model/retrieve_rerank_pipeline.py
+++ b/codeminer/model/retrieve_rerank_pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import os

--- a/codeminer/ops/expand.py
+++ b/codeminer/ops/expand.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/codeminer/ops/rerank.py
+++ b/codeminer/ops/rerank.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/codeminer/ops/retrieve.py
+++ b/codeminer/ops/retrieve.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/codeminer/ops/transform.py
+++ b/codeminer/ops/transform.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/codeminer/profiler.py
+++ b/codeminer/profiler.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import logging

--- a/codeminer/scip_interface/__init__.py
+++ b/codeminer/scip_interface/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SCIP Interface Module
 

--- a/codeminer/scip_interface/scip-environment.yml
+++ b/codeminer/scip_interface/scip-environment.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: scip-env
 channels:
   - defaults

--- a/codeminer/scip_interface/scip.proto
+++ b/codeminer/scip_interface/scip.proto
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // An index contains one or more pieces of information about a given piece of
 // source code or software artifact. Complementary information can be merged
 // together from multiple sources to provide a unified code intelligence

--- a/codeminer/scip_interface/scip_decode_core.py
+++ b/codeminer/scip_interface/scip_decode_core.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Thin Python wrapper around the `codeminer_core` pybind11 extension.
 
 Exposes a `SCIPDecoderCore` that produces a fully-populated `CodeGraph`

--- a/codeminer/scip_interface/scip_decode_go.py
+++ b/codeminer/scip_interface/scip_decode_go.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SCIP decoder for Go projects.
 

--- a/codeminer/scip_interface/scip_decode_python.py
+++ b/codeminer/scip_interface/scip_decode_python.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SCIP decoder for Python projects.
 

--- a/codeminer/scip_interface/scip_decode_rust.py
+++ b/codeminer/scip_interface/scip_decode_rust.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SCIP decoder for Rust projects.
 

--- a/codeminer/scip_interface/scip_decode_ts.py
+++ b/codeminer/scip_interface/scip_decode_ts.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import re
 from pathlib import Path
 
@@ -312,9 +316,7 @@ class SCIPTypeScriptGraphDecoder:
             # with a backtick.
             dir_prefix = sym_with_bt[:first_bt_open].rstrip("/")
             file_part = sym_with_bt[first_bt_open + 1 : first_bt_close]
-            module_path = (
-                f"{dir_prefix}/{file_part}" if dir_prefix else file_part
-            )
+            module_path = f"{dir_prefix}/{file_part}" if dir_prefix else file_part
             # Everything after the file's closing backtick is the symbol
             # descriptor; strip any inner backticks (they only escape special
             # chars within name segments).

--- a/codeminer/scip_interface/scip_indexer_base.py
+++ b/codeminer/scip_interface/scip_indexer_base.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Base class for SCIP indexers across different languages.
 """

--- a/codeminer/scip_interface/scip_indexer_go.py
+++ b/codeminer/scip_interface/scip_indexer_go.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SCIP indexer for Go projects using scip-go.
 """

--- a/codeminer/scip_interface/scip_indexer_python.py
+++ b/codeminer/scip_interface/scip_indexer_python.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SCIP indexer for Python projects using scip-python (via conda environment).
 """

--- a/codeminer/scip_interface/scip_indexer_rust.py
+++ b/codeminer/scip_interface/scip_indexer_rust.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SCIP indexer for Rust projects using rust-analyzer.
 """

--- a/codeminer/scip_interface/scip_indexer_ts.py
+++ b/codeminer/scip_interface/scip_indexer_ts.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 SCIP indexer for TypeScript and JavaScript projects using scip-typescript.
 """
@@ -152,11 +157,17 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
         # the cached prior install. Saves ~30s per cold-start on monorepos
         # like docusaurus where yarn install does a no-op integrity check.
         import hashlib
+
         sentinel = self.project_root / ".codeminer_install_cache"
         node_modules = self.project_root / "node_modules"
         lockfile = None
-        for name in ("yarn.lock", "package-lock.json", "pnpm-lock.yaml",
-                     "bun.lock", "bun.lockb"):
+        for name in (
+            "yarn.lock",
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "bun.lock",
+            "bun.lockb",
+        ):
             if (self.project_root / name).exists():
                 lockfile = self.project_root / name
                 break
@@ -240,23 +251,25 @@ class SCIPTypeScriptIndexer(SCIPIndexerBase):
             )
             # Cache: write lockfile hash so next call can skip if unchanged
             import hashlib
+
             sentinel = self.project_root / ".codeminer_install_cache"
             lockfile = None
-            for name in ("yarn.lock", "package-lock.json", "pnpm-lock.yaml",
-                         "bun.lock", "bun.lockb"):
+            for name in (
+                "yarn.lock",
+                "package-lock.json",
+                "pnpm-lock.yaml",
+                "bun.lock",
+                "bun.lockb",
+            ):
                 if (self.project_root / name).exists():
                     lockfile = self.project_root / name
                     break
             if lockfile:
                 # Best-effort: cache write is non-fatal; next run will retry.
                 try:
-                    sentinel.write_text(
-                        hashlib.sha1(lockfile.read_bytes()).hexdigest()
-                    )
+                    sentinel.write_text(hashlib.sha1(lockfile.read_bytes()).hexdigest())
                 except Exception as cache_err:
-                    logger.debug(
-                        "skip-cache write failed (%s); continuing", cache_err
-                    )
+                    logger.debug("skip-cache write failed (%s); continuing", cache_err)
             return
         except FileNotFoundError:
             logger.warning(

--- a/codeminer/scip_interface/scip_install.sh
+++ b/codeminer/scip_interface/scip_install.sh
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 npm install -g @sourcegraph/scip-python

--- a/codeminer/search.py
+++ b/codeminer/search.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/codeminer/types.py
+++ b/codeminer/types.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Optional
 
 from pydantic import BaseModel

--- a/codeminer/utils.py
+++ b/codeminer/utils.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
 def is_test_file(nid):
     """Check if a node ID belongs to a test file."""
     if ":" in nid:

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.15)
 project(codeminer_core LANGUAGES CXX C)
 

--- a/core/README.md
+++ b/core/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Codeminer Core (C++)
 
 This directory contains a C++ implementation of the high-traffic pieces of the Python `codeminer` graph pipeline. The goal is to mirror the behaviour of `codeminer.graph.code_graph.CodeGraph` and `codeminer.scip_interface.scip_decode.SCIPGraphDecoder` while leveraging the libigraph C API for better throughput on large `.decoded` index files.

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // Pybind11 bindings for codeminer::core SCIP decoders.
 //
 // Exposes a single function `decode_scip(index_file, project_root, language)`
@@ -97,8 +101,8 @@ py::dict decode_scip(const std::string &index_file,
         e.anchor_file.has_value() ? py::cast(*e.anchor_file) : py::none();
     py::object anchor_line =
         e.anchor_line.has_value() ? py::cast(*e.anchor_line) : py::none();
-    edge_list.append(py::make_tuple(src_name, tgt_name, e.type, anchor_file,
-                                     anchor_line));
+    edge_list.append(
+        py::make_tuple(src_name, tgt_name, e.type, anchor_file, anchor_line));
   }
 
   py::dict result;

--- a/core/code_graph.cpp
+++ b/core/code_graph.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "code_graph.h"
 
 #include <cstdlib>
@@ -313,8 +317,7 @@ igraph_integer_t CodeGraph::add_edge(const std::string &source,
       IGRAPH_SUCCESS) {
     const igraph_integer_t n = igraph_vector_int_size(&out_eids);
     for (igraph_integer_t i = 0; i < n; ++i) {
-      igraph_integer_t eid =
-          static_cast<igraph_integer_t>(VECTOR(out_eids)[i]);
+      igraph_integer_t eid = static_cast<igraph_integer_t>(VECTOR(out_eids)[i]);
       if (static_cast<std::size_t>(eid) >= edges_.size()) {
         continue;
       }

--- a/core/code_graph.h
+++ b/core/code_graph.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include <igraph/igraph.h>

--- a/core/scip_decode.h
+++ b/core/scip_decode.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 // Umbrella header for the core SCIP decoders. Individual language decoders

--- a/core/scip_decode_base.cpp
+++ b/core/scip_decode_base.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "scip_decode_base.h"
 
 #include <algorithm>
@@ -252,7 +256,7 @@ void SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) {
   //     add_symbol_reference's "only create if missing").
   std::unordered_map<std::string, Subgraph::Node> merged_nodes;
   std::vector<std::tuple<std::string, std::string, std::string,
-                          std::optional<std::string>, std::optional<int>>>
+                         std::optional<std::string>, std::optional<int>>>
       all_edges;
 
   std::size_t estimated = 0;
@@ -284,7 +288,7 @@ void SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) {
     }
     for (const auto &e : sg.edges) {
       all_edges.emplace_back(e.source, e.target, e.type, e.anchor_file,
-                              e.anchor_line);
+                             e.anchor_line);
     }
   }
 

--- a/core/scip_decode_base.h
+++ b/core/scip_decode_base.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "code_graph.h"

--- a/core/scip_decode_common.cpp
+++ b/core/scip_decode_common.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "scip_decode_common.h"
 
 #include <utility>

--- a/core/scip_decode_common.h
+++ b/core/scip_decode_common.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "code_graph.h"

--- a/core/scip_decode_go.cpp
+++ b/core/scip_decode_go.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "scip_decode_go.h"
 
 #include <algorithm>
@@ -292,8 +296,8 @@ void SCIPGoDecoder::process_symbol(const std::string &symbol,
     }
   } else {
     builder.add_symbol_reference(key, file_path, type,
-                                  /*anchor_file=*/std::nullopt,
-                                  /*anchor_line=*/line);
+                                 /*anchor_file=*/std::nullopt,
+                                 /*anchor_line=*/line);
     builder.set_unified_name(key, unified_name(key, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/core/scip_decode_go.h
+++ b/core/scip_decode_go.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "scip_decode_base.h"

--- a/core/scip_decode_python.cpp
+++ b/core/scip_decode_python.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "scip_decode_python.h"
 
 #include <algorithm>
@@ -207,8 +211,8 @@ void SCIPPythonDecoder::process_symbol(const std::string &symbol, int line,
       std::string file = module_dir + ".py";
       if (is_reference) {
         builder.add_edge(builder.current_scope(), file, EDGE_TYPE_REFERENCE,
-                          /*anchor_file=*/builder.current_file(),
-                          /*anchor_line=*/line);
+                         /*anchor_file=*/builder.current_file(),
+                         /*anchor_line=*/line);
       }
     }
     return;
@@ -229,8 +233,8 @@ void SCIPPythonDecoder::process_symbol(const std::string &symbol, int line,
     builder.add_edge(builder.current_scope(), unified, EDGE_TYPE_CONTAIN);
   } else if (is_reference) {
     builder.add_symbol_reference(unified, module_path, symbol_type,
-                                  /*anchor_file=*/std::nullopt,
-                                  /*anchor_line=*/line);
+                                 /*anchor_file=*/std::nullopt,
+                                 /*anchor_line=*/line);
   }
 }
 

--- a/core/scip_decode_python.h
+++ b/core/scip_decode_python.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "scip_decode_base.h"

--- a/core/scip_decode_rust.cpp
+++ b/core/scip_decode_rust.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "scip_decode_rust.h"
 
 #include <algorithm>
@@ -452,8 +456,8 @@ void SCIPRustDecoder::process_symbol(const std::string &symbol,
     }
   } else {
     builder.add_symbol_reference(unified, file_path, type,
-                                  /*anchor_file=*/std::nullopt,
-                                  /*anchor_line=*/line);
+                                 /*anchor_file=*/std::nullopt,
+                                 /*anchor_line=*/line);
     builder.set_unified_name(unified, unified_name(unified, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/core/scip_decode_rust.h
+++ b/core/scip_decode_rust.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "scip_decode_base.h"

--- a/core/scip_decode_ts.cpp
+++ b/core/scip_decode_ts.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "scip_decode_ts.h"
 
 #include <algorithm>
@@ -183,14 +187,12 @@ std::string SCIPTSDecoder::unify_symbol_name(const std::string &cleaned_symbol,
   std::string module_path;
   std::string descriptor;
   auto first_bt_open = sym_with_bt.find('`');
-  auto first_bt_close =
-      first_bt_open == std::string::npos
-          ? std::string::npos
-          : sym_with_bt.find('`', first_bt_open + 1);
+  auto first_bt_close = first_bt_open == std::string::npos
+                            ? std::string::npos
+                            : sym_with_bt.find('`', first_bt_open + 1);
 
   if (first_bt_open != std::string::npos &&
-      first_bt_close != std::string::npos &&
-      first_bt_close > first_bt_open) {
+      first_bt_close != std::string::npos && first_bt_close > first_bt_open) {
     std::string dir_prefix = sym_with_bt.substr(0, first_bt_open);
     while (!dir_prefix.empty() && dir_prefix.back() == '/')
       dir_prefix.pop_back();
@@ -408,8 +410,8 @@ void SCIPTSDecoder::process_symbol(const std::string &symbol, int line,
   if (is_index_file && is_simple_symbol && !(symbol_roles & 1)) {
     if (builder.current_scope() != file_path) {
       builder.add_edge(builder.current_scope(), file_path, EDGE_TYPE_REFERENCE,
-                        /*anchor_file=*/file_path,
-                        /*anchor_line=*/line);
+                       /*anchor_file=*/file_path,
+                       /*anchor_line=*/line);
     }
     return;
   }
@@ -431,8 +433,8 @@ void SCIPTSDecoder::process_symbol(const std::string &symbol, int line,
     builder.add_edge(builder.current_scope(), unified, EDGE_TYPE_CONTAIN);
   } else {
     builder.add_symbol_reference(unified, file_path, type,
-                                  /*anchor_file=*/std::nullopt,
-                                  /*anchor_line=*/line);
+                                 /*anchor_file=*/std::nullopt,
+                                 /*anchor_line=*/line);
     builder.set_unified_name(unified, unified_name(unified, file_path, type),
                              /*only_if_missing=*/true);
   }

--- a/core/scip_decode_ts.h
+++ b/core/scip_decode_ts.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #pragma once
 
 #include "scip_decode_base.h"

--- a/core/tests/scip_decode_repo.cpp
+++ b/core/tests/scip_decode_repo.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "scip_decode.h"
 
 #include <array>

--- a/core/tests/scip_decode_test.cpp
+++ b/core/tests/scip_decode_test.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "scip_decode.h"
 
 #include <cassert>

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # CI/CD
 
 GitHub Actions pipeline that runs on every push to `main` and on all pull requests.

--- a/docs/collect_swebench.md
+++ b/docs/collect_swebench.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Collecting SWE-bench Instances
 
 This guide covers how to use the `collect_swebench.sh` script to sample representative SWE-bench instances across multiple languages.

--- a/docs/diagnose_query_leak.md
+++ b/docs/diagnose_query_leak.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Diagnosing semantic / lexical leak in synthesized retrieval queries
 
 Tooling that operationalizes the Tier-1 and Tier-3 checks proposed in

--- a/docs/graph_cache_usage.md
+++ b/docs/graph_cache_usage.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Graph Cache Mechanism
 
 The SCIP indexer now includes a comprehensive caching system with configurable skip levels to optimize repeated indexing operations.

--- a/docs/gt_locator.md
+++ b/docs/gt_locator.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # GTLocator
 
 Extract symbol-level ground truth changes (functions, classes, methods) from SWE-bench unified diff patches. Identifies which symbols were modified, added, or deleted.

--- a/docs/incremental_graph/incremental_interactive.html
+++ b/docs/incremental_graph/incremental_interactive.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/docs/incremental_graph/index.md
+++ b/docs/incremental_graph/index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Incremental Graph Patching
 
 Update an existing `CodeGraph` in-place when code changes, avoiding full re-indexing. Uses LSP language servers to detect symbol changes and reconnect reference edges.

--- a/docs/incremental_graph/interactive.md
+++ b/docs/incremental_graph/interactive.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Incremental Graph - Interactive Demo
 
 <style>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # CodeMiner
 
 A code analysis agent with graph-enhancement for multi-language codebases.

--- a/docs/regex_index.md
+++ b/docs/regex_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Regex Node Index
 
 An in-memory index for fast regex-based searching across CodeGraph nodes (similar to grep).

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 ## Use SCIP to get the index
 
 [SCIP](https://github.com/sourcegraph/scip/tree/main) is a code intelligence protocol for index, which has powerful support for multiple languages, e.g. python, C++, etc.

--- a/docs/upload_dataset_to_huggingface.md
+++ b/docs/upload_dataset_to_huggingface.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Uploading the Dataset to HuggingFace
 
 This guide covers how to build and upload the SWE-bench locator dataset to HuggingFace Hub.

--- a/examples/agentless.py
+++ b/examples/agentless.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This script demonstrates the usage of AgentlessPipeline on SWE-bench or LocBench
 datasets.

--- a/examples/bm25_retrieve_baseline.py
+++ b/examples/bm25_retrieve_baseline.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 BM25-only retrieval baseline script.
 

--- a/examples/codeminer_base_rerank_matrix.py
+++ b/examples/codeminer_base_rerank_matrix.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Codeminer-base × embedding-rerank matrix sweep.
 

--- a/examples/embedding_retrieve_baseline.py
+++ b/examples/embedding_retrieve_baseline.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Embedding-only retrieval baseline script.
 

--- a/examples/eval.sh
+++ b/examples/eval.sh
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 python examples/retrieve_rerank.py     \
     --dataset swebench_lite     \
     --top-k 100     \

--- a/examples/eval_synthesized_queries.py
+++ b/examples/eval_synthesized_queries.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Evaluate synthesized behavioral queries against retrieval backends.
 

--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Graph-based retrieval baseline script.
 

--- a/examples/retrieve_rerank.py
+++ b/examples/retrieve_rerank.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 This script demonstrates RetrieveRerankPipeline on SWE-bench or LocBench
 datasets. Before running the pipeline, start a vLLM server for the rerank

--- a/examples/roadmap_semantic_search_mcp.md
+++ b/examples/roadmap_semantic_search_mcp.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Roadmap: `search_semantic` MCP tool
 
 This only covers the embedding/vector part. Graph tools and manifest schema changes can be tracked separately with hengjia if needed.

--- a/examples/selected_instance.csv.license
+++ b/examples/selected_instance.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0

--- a/examples/skill_agent.py
+++ b/examples/skill_agent.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 End-to-end example of the skill agent pipeline.
 

--- a/examples/skill_agent_eval.py
+++ b/examples/skill_agent_eval.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Skill-agent evaluation driver on SWE-bench.
 
@@ -318,12 +323,8 @@ def evaluate_instance(
         # In bm25_baseline mode we still go through the compiler so the
         # build path stays single-source; we just read the BM25 index back
         # out for the direct-query call.
-        skill_ids = (
-            list(args.skills) if args.eval_mode == "agent" else ["bm25_search"]
-        )
-        execution_log.append(
-            f"Building contexts for skills={skill_ids}..."
-        )
+        skill_ids = list(args.skills) if args.eval_mode == "agent" else ["bm25_search"]
+        execution_log.append(f"Building contexts for skills={skill_ids}...")
         contexts = build_skill_contexts(
             repo_path=repo_path,
             skill_ids=skill_ids,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 site_name: CodeMiner
 site_description: A code analysis agent with graph-enhancement
 repo_url: https://github.com/sysevol-ai/CodeMiner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/scripts/build_swebench_locator_hf_dataset.py
+++ b/scripts/build_swebench_locator_hf_dataset.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Build a HuggingFace-ready SWE-bench locator dataset from selected instances."""
 
 from __future__ import annotations

--- a/scripts/build_swebench_locator_hf_dataset.sh
+++ b/scripts/build_swebench_locator_hf_dataset.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/collect_swebench.py
+++ b/scripts/collect_swebench.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Collect representative SWE-bench instances and save sampling artifacts.
 """

--- a/scripts/collect_swebench.sh
+++ b/scripts/collect_swebench.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/diagnose_query_leak.py
+++ b/scripts/diagnose_query_leak.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Diagnose vocabulary / lexical leak in synthesized retrieval queries.
 
 Operationalizes the Tier-3 checks from issue #130:

--- a/scripts/embeddings/EMBEDDING_PROMPTS.md
+++ b/scripts/embeddings/EMBEDDING_PROMPTS.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Embedding query/document prompt cheat sheet
 
 Sentence-transformer code retrievers are trained with **asymmetric**

--- a/scripts/embeddings/RERANK_EXPERIMENTS.md
+++ b/scripts/embeddings/RERANK_EXPERIMENTS.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Rerank experiments runbook
 
 How to run, name, and find output for the codeminer-base retrieval / rerank

--- a/scripts/embeddings/build_codeminer_base_embeddings.sh
+++ b/scripts/embeddings/build_codeminer_base_embeddings.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 #
 # Build embeddings for the CodeMiner-base dataset with five models:

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Build and cache hierarchical embedding indices for SWE-bench or CodeMiner-base instances.
 Each instance's embedding will be stored in <storage-dir>/{instance_id}/

--- a/scripts/embeddings/build_swebench_dev_embeddings.sh
+++ b/scripts/embeddings/build_swebench_dev_embeddings.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 STORAGE_DIR="${STORAGE_DIR:-/mnt/data/codeminer}"

--- a/scripts/embeddings/eval_codeminer_base_embeddings.sh
+++ b/scripts/embeddings/eval_codeminer_base_embeddings.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 #
 # Evaluate embedding retrieval quality on the CodeMiner-base dataset.

--- a/scripts/embeddings/eval_codeminer_base_rerank_matrix.sh
+++ b/scripts/embeddings/eval_codeminer_base_rerank_matrix.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 #
 # Run a (small × large) embedding-rerank matrix sweep on the CodeMiner-base

--- a/scripts/embeddings/profile_dataset_stats.py
+++ b/scripts/embeddings/profile_dataset_stats.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Compute chunk count and LOC statistics for codeminer-base dataset instances.
 

--- a/scripts/embeddings/profile_embedding_models.sh
+++ b/scripts/embeddings/profile_embedding_models.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # Profile build time for multiple embedding models on a single instance.

--- a/scripts/eval_graph_baselines.sh
+++ b/scripts/eval_graph_baselines.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 echo "=== Graph Baseline ==="

--- a/scripts/eval_swebench_dev_rerank_bge.sh
+++ b/scripts/eval_swebench_dev_rerank_bge.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # Run retrieval + embedding rerank evaluation on SWE-bench Lite dev split using

--- a/scripts/eval_swebench_dev_rerank_qwen.sh
+++ b/scripts/eval_swebench_dev_rerank_qwen.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # Run retrieval + rerank evaluation on SWE-bench Lite dev split using Qwen2.5-Coder-7B.

--- a/scripts/eval_swebench_dev_retrieve.sh
+++ b/scripts/eval_swebench_dev_retrieve.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 # Run retrieval-only evaluation on SWE-bench Lite dev split using the original

--- a/scripts/mcp_benchmark_codeminer_base.py
+++ b/scripts/mcp_benchmark_codeminer_base.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 MCP server benchmark on the CodeMiner base dataset.
 
@@ -22,7 +26,6 @@ from codeminer.compiler.manifest import IndexEntry, RepoManifest
 from codeminer.index.embedding.vector_store import CodeVectorStore
 from codeminer.mcp.context import ServerContext
 from codeminer.mcp.tools.search import search_semantic
-
 
 CODEMINER_DATA = Path("/mnt/data/codeminer")
 # Model + dim defaults: Salesforce/SweRankEmbed-Small has 100/100 prebuilt
@@ -76,7 +79,7 @@ def _make_relative(file_path: str, instance_id: str, repo: str = "") -> str:
     for marker in candidates:
         for i, part in enumerate(parts):
             if part == marker:
-                return "/".join(parts[i + 1:])
+                return "/".join(parts[i + 1 :])
     return file_path
 
 
@@ -170,9 +173,7 @@ async def benchmark_instance(
     start_time = time.time()
 
     try:
-        results = await search_semantic(
-            ctx=ctx, query=query, top_k=top_k, level="l2"
-        )
+        results = await search_semantic(ctx=ctx, query=query, top_k=top_k, level="l2")
         elapsed = time.time() - start_time
     except Exception as e:
         return {

--- a/scripts/start_vllm_server.py
+++ b/scripts/start_vllm_server.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Script to start vLLM server with OpenAI-compatible API.
 

--- a/scripts/swebench_graph_index.py
+++ b/scripts/swebench_graph_index.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Build SCIP graph indexes for multiple benchmark sources.
 

--- a/scripts/swebench_test_acc.py
+++ b/scripts/swebench_test_acc.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
 
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import json
 from pathlib import Path

--- a/scripts/synthesize_q2_short.py
+++ b/scripts/synthesize_q2_short.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Generate short, domain-vocab-stripped query variants — issue #130 Tier-1.
 
 For each ``_behavioral_q1`` query in the input directory, ask an LLM to rewrite

--- a/scripts/synthesize_swebench.py
+++ b/scripts/synthesize_swebench.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Synthesize natural-language queries from collected SWE-bench instances.
 

--- a/scripts/synthesize_swebench.sh
+++ b/scripts/synthesize_swebench.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/setup-scip.sh
+++ b/setup-scip.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 SCIP_CLANG_VERSION="${SCIP_CLANG_VERSION:-v0.3.2}"

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 *.jpg
 *.jsonl
 *.npy

--- a/test/agent/test_agent_embedding_search.py
+++ b/test/agent/test_agent_embedding_search.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Agent integration tests: AgentRunner must invoke embedding_search.
 

--- a/test/agent/test_agent_graph_vertex.py
+++ b/test/agent/test_agent_graph_vertex.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration test: AgentRunner + graph_expand skill + Vertex AI backend.
 
 Uses the real httpie/cli repo (from conftest.py) with SCIP-python to

--- a/test/agent/test_bm25_search_agent.py
+++ b/test/agent/test_bm25_search_agent.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Agent integration tests for bm25_search skill.
 

--- a/test/agent/test_bm25_search_e2e.py
+++ b/test/agent/test_bm25_search_e2e.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 End-to-end smoke test for the bm25_search skill.
 

--- a/test/agent/test_bm25_search_skill.py
+++ b/test/agent/test_bm25_search_skill.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for the bm25_search skill executor and loader.
 

--- a/test/agent/test_embedding_search_e2e.py
+++ b/test/agent/test_embedding_search_e2e.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 End-to-end smoke test for the embedding_search skill.
 

--- a/test/agent/test_embedding_search_skill.py
+++ b/test/agent/test_embedding_search_skill.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for the embedding_search skill executor and loader.
 

--- a/test/agent/test_extract_agent.py
+++ b/test/agent/test_extract_agent.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 import pytest

--- a/test/agent/test_roi_rerank.py
+++ b/test/agent/test_roi_rerank.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from pathlib import Path
 

--- a/test/agent/test_runner.py
+++ b/test/agent/test_runner.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the agent runner (codeminer.agent.runner)."""
 
 from __future__ import annotations

--- a/test/agent/test_runner_allow_skills.py
+++ b/test/agent/test_runner_allow_skills.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for ``allow_skills`` / ``allow`` filtering on AgentRunner + tool_schema."""
 
 from __future__ import annotations

--- a/test/agent/test_runner_usage.py
+++ b/test/agent/test_runner_usage.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for token-usage tracking in AgentRunner / LiteLLMChat / UsageTracker."""
 
 from __future__ import annotations

--- a/test/agent/test_tool_schema.py
+++ b/test/agent/test_tool_schema.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for tool schema generation (codeminer.agent.tool_schema)."""
 
 from __future__ import annotations

--- a/test/agent/test_vertex_ai.py
+++ b/test/agent/test_vertex_ai.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Simple test script for Vertex AI LLM generation using LiteLLMChat.
 """

--- a/test/agent/test_vllm_agent.py
+++ b/test/agent/test_vllm_agent.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 import pytest

--- a/test/chunker/test_cpp_chunker.py
+++ b/test/chunker/test_cpp_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Regression tests for the C++ code chunker using the fmt repository.
 """

--- a/test/chunker/test_go_chunker.py
+++ b/test/chunker/test_go_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Regression tests for the Go code chunker.
 """

--- a/test/chunker/test_js_chunker.py
+++ b/test/chunker/test_js_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Regression tests for the JavaScript/TypeScript code chunker.
 """

--- a/test/chunker/test_python_chunker.py
+++ b/test/chunker/test_python_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Regression tests for the Python code chunker using the httpie CLI repository.
 """

--- a/test/chunker/test_rust_chunker.py
+++ b/test/chunker/test_rust_chunker.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Regression tests for the Rust code chunker.
 """

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for concrete index builders and the IndexCompiler."""
 
 from __future__ import annotations
@@ -241,13 +245,16 @@ class TestZoektIndexBuilder:
         completed.returncode = 0
         completed.stderr = ""
 
-        with patch(
-            "codeminer.compiler.index_builders.shutil.which",
-            return_value="/fake/zoekt-git-index",
-        ), patch(
-            "codeminer.compiler.index_builders.subprocess.run",
-            return_value=completed,
-        ) as mock_run:
+        with (
+            patch(
+                "codeminer.compiler.index_builders.shutil.which",
+                return_value="/fake/zoekt-git-index",
+            ),
+            patch(
+                "codeminer.compiler.index_builders.subprocess.run",
+                return_value=completed,
+            ) as mock_run,
+        ):
             status = builder.build(
                 scope="current_repo",
                 repo_path=str(tmp_path),
@@ -286,13 +293,16 @@ class TestZoektIndexBuilder:
         import subprocess
 
         builder = ZoektIndexBuilder()
-        with patch(
-            "codeminer.compiler.index_builders.shutil.which",
-            return_value="/fake/zoekt-git-index",
-        ), patch(
-            "codeminer.compiler.index_builders.subprocess.run",
-            side_effect=subprocess.CalledProcessError(
-                returncode=2, cmd=["zoekt-git-index"], stderr="boom"
+        with (
+            patch(
+                "codeminer.compiler.index_builders.shutil.which",
+                return_value="/fake/zoekt-git-index",
+            ),
+            patch(
+                "codeminer.compiler.index_builders.subprocess.run",
+                side_effect=subprocess.CalledProcessError(
+                    returncode=2, cmd=["zoekt-git-index"], stderr="boom"
+                ),
             ),
         ):
             try:

--- a/test/compiler/test_manifest.py
+++ b/test/compiler/test_manifest.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the repo manifest and ManifestIndexStateStore."""
 
 from __future__ import annotations

--- a/test/compiler/test_params.py
+++ b/test/compiler/test_params.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the layered parameter resolution system."""
 
 from __future__ import annotations

--- a/test/compiler/test_resources.py
+++ b/test/compiler/test_resources.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for index resource management."""
 
 from __future__ import annotations

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for ``codeminer.compiler.skill_context``.
 
 The function under test orchestrates: skill → index_type union → build/load
@@ -39,9 +43,7 @@ def _make_meta(
     *,
     index_types: List[str] = (),
 ) -> SkillMetadata:
-    reqs = [
-        compiler_resources.IndexRequirement(index_type=t) for t in index_types
-    ]
+    reqs = [compiler_resources.IndexRequirement(index_type=t) for t in index_types]
     return SkillMetadata(
         skill_id=skill_id,
         skill_type=skill_type,
@@ -84,9 +86,7 @@ def test_required_types_empty(registry):
 
 
 def test_required_types_single(registry):
-    got = skill_context.required_index_types(
-        ["bm25_search"], skill_registry=registry
-    )
+    got = skill_context.required_index_types(["bm25_search"], skill_registry=registry)
     assert got == {"bm25"}
 
 
@@ -176,9 +176,7 @@ def test_build_returns_expand_for_graph_expand(registry, mocked_build, tmp_path)
     assert contexts["expand"].code_graph is not None
 
 
-def test_build_returns_both_keys_for_mixed_skills(
-    registry, mocked_build, tmp_path
-):
+def test_build_returns_both_keys_for_mixed_skills(registry, mocked_build, tmp_path):
     contexts = skill_context.build_skill_contexts(
         repo_path=str(tmp_path),
         skill_ids=["bm25_search", "embedding_search", "graph_expand"],
@@ -207,9 +205,7 @@ def test_sibling_skill_with_no_requirement_still_gets_context(
     assert "retrieve" in contexts
 
 
-def test_transform_skill_alone_returns_empty_dict(
-    registry, mocked_build, tmp_path
-):
+def test_transform_skill_alone_returns_empty_dict(registry, mocked_build, tmp_path):
     """``query_transform`` is TRANSFORM type with no index requirements.
     Currently no transform context is plumbed through — the dict stays
     empty rather than fabricating a useless entry."""
@@ -222,9 +218,7 @@ def test_transform_skill_alone_returns_empty_dict(
     assert contexts == {}
 
 
-def test_already_built_index_is_not_rebuilt(
-    registry, mocked_build, tmp_path
-):
+def test_already_built_index_is_not_rebuilt(registry, mocked_build, tmp_path):
     """If ``cache_dir/<index_type>`` already has a file, the compiler is
     not invoked for that type. Loading still happens."""
     cache = tmp_path / "cache"
@@ -242,9 +236,7 @@ def test_already_built_index_is_not_rebuilt(
     assert mocked_build["loaded"] == ["bm25"]
 
 
-def test_missing_index_triggers_build(
-    registry, mocked_build, tmp_path
-):
+def test_missing_index_triggers_build(registry, mocked_build, tmp_path):
     """Empty cache → compiler is invoked for the missing type."""
     skill_context.build_skill_contexts(
         repo_path=str(tmp_path),
@@ -256,9 +248,7 @@ def test_missing_index_triggers_build(
     assert mocked_build["loaded"] == ["bm25"]
 
 
-def test_rebuild_forces_full_recompile(
-    registry, mocked_build, tmp_path
-):
+def test_rebuild_forces_full_recompile(registry, mocked_build, tmp_path):
     """Even with all dirs populated, ``rebuild=True`` rebuilds everything."""
     cache = tmp_path / "cache"
     for t in ("bm25", "vector"):
@@ -276,9 +266,7 @@ def test_rebuild_forces_full_recompile(
     assert mocked_build["compile"] == [("bm25", "vector")]
 
 
-def test_partial_cache_only_rebuilds_missing(
-    registry, mocked_build, tmp_path
-):
+def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):
     """bm25 already built, vector missing → only vector is rebuilt."""
     cache = tmp_path / "cache"
     bm25_dir = cache / "bm25"

--- a/test/compiler/test_skill_loader.py
+++ b/test/compiler/test_skill_loader.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the skill package loader."""
 
 from __future__ import annotations

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Pytest fixtures shared across test modules."""
 
 import shutil

--- a/test/dataset/conftest.py
+++ b/test/dataset/conftest.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Pytest fixtures for dataset tests using real SWE-bench Multilingual data."""
 
 import os

--- a/test/dataset/test_gt_locate.py
+++ b/test/dataset/test_gt_locate.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tests for codeminer.dataset.gt_locate.
 

--- a/test/examples/test_graph_retrieve_baseline.py
+++ b/test/examples/test_graph_retrieve_baseline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for the pure helpers in ``examples/graph_retrieve_baseline.py``.
 
 Phase 1 review called out that the runner's helpers had no tests, so as

--- a/test/graph/incremental/test_graph_patcher.py
+++ b/test/graph/incremental/test_graph_patcher.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration tests for SCIP cold-start → incremental graph patch pipeline.
 
 Part 1: simple_repos — controlled environment.

--- a/test/graph/incremental/test_lsp_decoder.py
+++ b/test/graph/incremental/test_lsp_decoder.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for LSP message decoding across all 4 message types.
 
 Tests the full decode pipeline for each LSP message format:

--- a/test/graph/incremental/test_patcher_multiedge.py
+++ b/test/graph/incremental/test_patcher_multiedge.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Multi-edge correctness: edit one call site, verify only one edge is removed.
 
 #125 review correctness risk: dropping `are_adjacent` dedup means a

--- a/test/graph/incremental/test_reference_resolver.py
+++ b/test/graph/incremental/test_reference_resolver.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for LSPDecoderBase location matching logic (used by reference reconnection)."""
 
 from codeminer.graph.code_graph import CodeGraph

--- a/test/graph/incremental/test_subgraph_removal.py
+++ b/test/graph/incremental/test_subgraph_removal.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for SubgraphMgr subgraph deletion and index building."""
 
 from codeminer.graph.code_graph import CodeGraph

--- a/test/graph/test_anchor_invariants.py
+++ b/test/graph/test_anchor_invariants.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Anchor invariants: CONTAIN edges carry no anchor; REFERENCE edges always do.
 
 See `CodeGraph.query_range` docstring for the three anchor invariants.

--- a/test/graph/test_codegraph.py
+++ b/test/graph/test_codegraph.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from pathlib import Path
 

--- a/test/graph/test_range_queries.py
+++ b/test/graph/test_range_queries.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for CodeGraph.query_range and the per-file range indexes.
 
 Covers the surface introduced for the LSP-aligned graph_expand redesign:

--- a/test/graph/test_range_queries_simple_repos.py
+++ b/test/graph/test_range_queries_simple_repos.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Per-language precise tests for range queries on test/scip/simple_repos.
 
 Mirrors the algorithmic tests in ``test_range_queries.py`` (overlap modes,

--- a/test/graph/test_range_queries_swebench.py
+++ b/test/graph/test_range_queries_swebench.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Integration test: build range indexes on real SWE-bench repos (serial).
 
 Parametrized over 5 languages following the ``test_scip_multilingual`` pattern:

--- a/test/graph/test_range_query_api.py
+++ b/test/graph/test_range_query_api.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for the typed NodeRef / EdgeRef record shape returned by query_range."""
 
 from codeminer.graph.code_graph import CodeGraph, EdgeRef, NodeRef, RangeQueryResult

--- a/test/graph/test_subgraph.py
+++ b/test/graph/test_subgraph.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from pathlib import Path
 

--- a/test/graph/test_traverse_graph.py
+++ b/test/graph/test_traverse_graph.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test script for traverse_graph functionality using the httpie CLI repository."""
 
 import subprocess

--- a/test/graph/test_traverse_graph_swebench.py
+++ b/test/graph/test_traverse_graph_swebench.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 
 import pytest

--- a/test/incremental/test_cache_seeding.py
+++ b/test/incremental/test_cache_seeding.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tests for Phase 1: Embeddings cache seeding from first build.
 

--- a/test/incremental/test_chunk_store.py
+++ b/test/incremental/test_chunk_store.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for IncrementalChunkStore.
 """

--- a/test/incremental/test_delta_faiss.py
+++ b/test/incremental/test_delta_faiss.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tests for Phase 4: Delta FAISS update optimization.
 

--- a/test/incremental/test_e2e_real_faiss.py
+++ b/test/incremental/test_e2e_real_faiss.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 End-to-end integration tests with real FAISS (no mocked vector store).
 

--- a/test/incremental/test_embeddings_cache.py
+++ b/test/incremental/test_embeddings_cache.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for EmbeddingsCache.
 """

--- a/test/incremental/test_git_diff.py
+++ b/test/incremental/test_git_diff.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for GitDiffDetector.
 

--- a/test/incremental/test_incremental_pipeline.py
+++ b/test/incremental/test_incremental_pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration tests for the incremental indexing pipeline.
 

--- a/test/incremental/test_l0_incremental.py
+++ b/test/incremental/test_l0_incremental.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tests for Phase 2: Incremental L0 (file skeleton) updates.
 

--- a/test/incremental/test_persistence_migration.py
+++ b/test/incremental/test_persistence_migration.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tests for Phase 5: Persistence migration from pickle to JSON + NPZ.
 

--- a/test/incremental/test_state.py
+++ b/test/incremental/test_state.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tests for Phase 3: IncrementalState commit SHA state management.
 

--- a/test/index/sparse_idx/test_bm25_compability.py
+++ b/test/index/sparse_idx/test_bm25_compability.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from pathlib import Path
 

--- a/test/index/sparse_idx/test_bm25_index.py
+++ b/test/index/sparse_idx/test_bm25_index.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import subprocess
 from pathlib import Path

--- a/test/index/sparse_idx/test_bm25_locbench.py
+++ b/test/index/sparse_idx/test_bm25_locbench.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from pathlib import Path
 

--- a/test/index/sparse_idx/test_bm25_unified_name.py
+++ b/test/index/sparse_idx/test_bm25_unified_name.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for BM25 indexed-text contract on non-Python decoders.
 
 The decoders attach two name attributes per symbol vertex:

--- a/test/index/test_dense_compatibility.py
+++ b/test/index/test_dense_compatibility.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test to check if all dense chunk node_ids exist in BM25 graph nodes."""
 
 import warnings

--- a/test/index/test_regex_idx.py
+++ b/test/index/test_regex_idx.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Test RegexNodeIndex functionality on a small Python repo.
 
 Uses pallets/flask pinned to a tagged release. Flask was previously httpie/cli,

--- a/test/index/test_vector_store.py
+++ b/test/index/test_vector_store.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Test script for the CodeVectorStore functionality.
 Demonstrates how to use the vector store for semantic search over code chunks.

--- a/test/mcp/test_mcp_e2e.py
+++ b/test/mcp/test_mcp_e2e.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 End-to-end MCP server tests with real embedding indexes.
 
@@ -6,13 +10,14 @@ from codeminer-base-dataset at /mnt/data/codeminer.
 """
 
 import asyncio
-import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from codeminer.compiler.manifest import RepoManifest, IndexEntry
-from codeminer.mcp.context import ServerContext
+import pytest
+
 import codeminer.mcp.server as server_module
+from codeminer.compiler.manifest import IndexEntry, RepoManifest
+from codeminer.mcp.context import ServerContext
 
 # Test data from codeminer-base-dataset
 CODEMINER_DATA = Path("/mnt/data/codeminer")
@@ -84,7 +89,6 @@ class TestMCPServerE2E:
                 print(f"  L0: {stats.get('l0_documents', 0)}")
                 print(f"  L2: {stats.get('l2_documents', 0)}")
 
-    
     def test_mcp_semantic_search(self, test_manifest_path):
         """Test MCP semantic_search tool with real query."""
         # Initialize server
@@ -96,11 +100,13 @@ class TestMCPServerE2E:
         # Known query for astropy separability issue
         query = "function that calculates model separability matrix"
 
-        results = asyncio.run(server_module.semantic_search(
-            query=query,
-            top_k=10,
-            level="l2",
-        ))
+        results = asyncio.run(
+            server_module.semantic_search(
+                query=query,
+                top_k=10,
+                level="l2",
+            )
+        )
 
         # Validate results
         assert isinstance(results, list)
@@ -133,7 +139,6 @@ class TestMCPServerE2E:
             print(f"   File: {Path(r['file']).name}")
             print()
 
-    
     def test_mcp_vs_direct_call_equivalence(self, test_manifest_path):
         """
         Verify MCP layer produces identical results to direct API call.
@@ -165,9 +170,9 @@ class TestMCPServerE2E:
             with patch.object(server_module, "mcp", mock_mcp):
                 server_module.init_server(test_manifest_path)
 
-        mcp_results = asyncio.run(server_module.semantic_search(
-            query=query, top_k=top_k, level="l2"
-        ))
+        mcp_results = asyncio.run(
+            server_module.semantic_search(query=query, top_k=top_k, level="l2")
+        )
 
         # Should have same number of results
         assert len(mcp_results) == len(direct_results)
@@ -187,7 +192,6 @@ class TestMCPServerE2E:
         print("Scores match: ✓")
         print("MCP adds no transformation overhead: ✓")
 
-    
     def test_mcp_server_status(self, test_manifest_path):
         """Test server_status resource returns correct info."""
         mock_mcp = MagicMock()

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for MCP server entry point.
 

--- a/test/mcp/test_search_semantic.py
+++ b/test/mcp/test_search_semantic.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Unit tests for search_semantic MCP tool.
 
@@ -5,8 +9,9 @@ Tests the tool wrapper logic with mocked CodeVectorStore.
 """
 
 import asyncio
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 from codeminer.compiler.manifest import RepoManifest
 from codeminer.mcp.context import ServerContext
@@ -71,7 +76,6 @@ def test_search_semantic_normal_path(mock_context):
     )
 
 
-
 def test_search_semantic_missing_index(mock_context):
     """Test search_semantic when vector index is not loaded."""
     mock_context.vector = None
@@ -82,7 +86,6 @@ def test_search_semantic_missing_index(mock_context):
     assert isinstance(results, dict)
     assert "error" in results
     assert "not loaded" in results["error"].lower()
-
 
 
 def test_search_semantic_score_threshold_forwarding(mock_context):
@@ -98,7 +101,6 @@ def test_search_semantic_score_threshold_forwarding(mock_context):
     assert call_args.kwargs["score_threshold"] == 0.7
 
 
-
 def test_search_semantic_default_parameters(mock_context):
     """Test search_semantic with default parameters."""
     mock_context.vector.search_with_content = Mock(return_value=[])
@@ -110,7 +112,6 @@ def test_search_semantic_default_parameters(mock_context):
     assert call_args.kwargs["top_k"] == 10
     assert call_args.kwargs["level"] == "l2"  # Default to "l2" if not specified
     assert call_args.kwargs["score_threshold"] is None
-
 
 
 def test_search_semantic_empty_results(mock_context):

--- a/test/mcp/test_search_semantic_integration.py
+++ b/test/mcp/test_search_semantic_integration.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration tests for search_semantic with real embedding indexes.
 
@@ -5,13 +9,13 @@ Uses pre-built indexes from /mnt/data/codeminer (Turquoise-T's dataset).
 """
 
 import asyncio
-import pytest
 from pathlib import Path
 
-from codeminer.compiler.manifest import RepoManifest, IndexEntry
+import pytest
+
+from codeminer.compiler.manifest import IndexEntry, RepoManifest
 from codeminer.mcp.context import ServerContext
 from codeminer.mcp.tools.search import search_semantic
-
 
 # Test data directory
 CODEMINER_DATA = Path("/mnt/data/codeminer")
@@ -68,15 +72,16 @@ class TestSearchSemanticIntegration:
 
         return ctx
 
-    
     def test_search_semantic_real_query(self, real_context):
         """Test semantic search with a real query on astropy code."""
-        results = asyncio.run(search_semantic(
-            real_context,
-            query="find coordinate transformation functions",
-            top_k=5,
-            level="l2",
-        ))
+        results = asyncio.run(
+            search_semantic(
+                real_context,
+                query="find coordinate transformation functions",
+                top_k=5,
+                level="l2",
+            )
+        )
 
         # Basic validation
         assert isinstance(results, list)
@@ -97,25 +102,24 @@ class TestSearchSemanticIntegration:
         # Print results for manual inspection
         print("\n=== Search Results ===")
         for i, r in enumerate(results):
-            print(
-                f"{i+1}. {r['node_name']} (score: {r['score']:.3f})"
-            )
+            print(f"{i+1}. {r['node_name']} (score: {r['score']:.3f})")
             print(f"   File: {r['file']}")
             print(f"   Type: {r['type']}")
             print()
 
-    
     def test_search_semantic_score_threshold(self, real_context):
         """Test score threshold filtering with real index."""
         # Search without threshold
-        all_results = asyncio.run(search_semantic(
-            real_context, query="unit test", top_k=20
-        ))
+        all_results = asyncio.run(
+            search_semantic(real_context, query="unit test", top_k=20)
+        )
 
         # Search with threshold
-        filtered_results = asyncio.run(search_semantic(
-            real_context, query="unit test", top_k=20, score_threshold=0.5
-        ))
+        filtered_results = asyncio.run(
+            search_semantic(
+                real_context, query="unit test", top_k=20, score_threshold=0.5
+            )
+        )
 
         # Filtered should have fewer or equal results
         assert len(filtered_results) <= len(all_results)
@@ -124,15 +128,14 @@ class TestSearchSemanticIntegration:
         for r in filtered_results:
             assert r["score"] >= 0.5
 
-    
     def test_search_semantic_performance(self, real_context):
         """Test that search completes in reasonable time."""
         import time
 
         start = time.time()
-        results = asyncio.run(search_semantic(
-            real_context, query="coordinate transformation", top_k=10
-        ))
+        results = asyncio.run(
+            search_semantic(real_context, query="coordinate transformation", top_k=10)
+        )
         elapsed = time.time() - start
 
         # Should complete within 2 seconds (generous threshold)

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for codeminer.mcp.context.ServerContext."""
 
 from __future__ import annotations
@@ -18,7 +22,14 @@ def manifest_dir(tmp_path: Path) -> Path:
     bm25_dir = tmp_path / "bm25"
     bm25_dir.mkdir()
     (bm25_dir / "documents.json").write_text(
-        json.dumps([{"page_content": "def foo(): pass", "metadata": {"node_name": "foo", "type": "function"}}])
+        json.dumps(
+            [
+                {
+                    "page_content": "def foo(): pass",
+                    "metadata": {"node_name": "foo", "type": "function"},
+                }
+            ]
+        )
     )
     (bm25_dir / "bm25_metadata.json").write_text(
         json.dumps({"project_root": str(tmp_path), "max_k": 10, "language": "english"})

--- a/test/mcp_server/test_integration.py
+++ b/test/mcp_server/test_integration.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """End-to-end integration tests for the MCP server.
 
 Builds a tiny synthetic repo (a few Python files), constructs a real BM25
@@ -21,23 +25,22 @@ from codeminer.index.sparse_idx import BM25CodeIndexer
 from codeminer.mcp.context import ServerContext
 from codeminer.mcp.tools.search import search_bm25_impl, search_regex_impl
 
-
 # Synthetic repo: three small Python files with predictable symbols so that
 # both keyword (BM25) and regex search have something to match.
 REPO_FILES: dict[str, str] = {
     "billing/tax.py": (
         "def calculate_tax(amount):\n"
-        "    \"\"\"Compute sales tax for a given amount.\"\"\"\n"
+        '    """Compute sales tax for a given amount."""\n'
         "    return amount * 0.08\n"
     ),
     "billing/exceptions.py": (
         "class TaxError(Exception):\n"
-        "    \"\"\"Raised when tax computation fails.\"\"\"\n"
+        '    """Raised when tax computation fails."""\n'
         "    pass\n"
     ),
     "auth/session.py": (
         "def authenticate_user(username, password):\n"
-        "    \"\"\"Return True if credentials are valid.\"\"\"\n"
+        '    """Return True if credentials are valid."""\n'
         "    return False\n"
     ),
 }
@@ -146,9 +149,9 @@ def test_search_bm25_finds_known_symbol(manifest_path: Path) -> None:
 
     assert results, "BM25 should return at least one hit"
     names = [r["node_name"] for r in results]
-    assert any("calculate_tax" in n for n in names), (
-        f"calculate_tax not found in BM25 results: {names}"
-    )
+    assert any(
+        "calculate_tax" in n for n in names
+    ), f"calculate_tax not found in BM25 results: {names}"
 
 
 def test_search_regex_finds_function_definitions(manifest_path: Path) -> None:

--- a/test/mcp_server/test_server.py
+++ b/test/mcp_server/test_server.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for the MCP server tool registration and async wrappers."""
 
 from __future__ import annotations
@@ -22,7 +26,9 @@ def _reset_ctx():
 
 def _make_server_ctx(*, bm25_results=None, regex_results=None, zoekt_results=None):
     ctx = MagicMock()
-    ctx.manifest = RepoManifest(repo_path="/repo", commit="abc123", languages=["python"])
+    ctx.manifest = RepoManifest(
+        repo_path="/repo", commit="abc123", languages=["python"]
+    )
     ctx.bm25 = MagicMock() if bm25_results is not None else None
     ctx.regex_index = MagicMock() if regex_results is not None else None
     ctx.zoekt = MagicMock() if zoekt_results is not None else None
@@ -37,17 +43,25 @@ def _make_server_ctx(*, bm25_results=None, regex_results=None, zoekt_results=Non
 
 
 def test_search_bm25_tool() -> None:
-    nodes = [NodeInfo(node_name="foo", type="function", file="a.py", content="def foo(): pass")]
+    nodes = [
+        NodeInfo(
+            node_name="foo", type="function", file="a.py", content="def foo(): pass"
+        )
+    ]
     server_mod._ctx = _make_server_ctx(bm25_results=nodes)
 
-    result = asyncio.run(server_mod.search_bm25(query="foo", top_k=5, filter_test=False))
+    result = asyncio.run(
+        server_mod.search_bm25(query="foo", top_k=5, filter_test=False)
+    )
 
     assert len(result) == 1
     assert result[0]["node_name"] == "foo"
 
 
 def test_search_regex_tool() -> None:
-    nodes = [NodeInfo(node_name="bar", type="class", file="b.py", content="class bar: ...")]
+    nodes = [
+        NodeInfo(node_name="bar", type="class", file="b.py", content="class bar: ...")
+    ]
     server_mod._ctx = _make_server_ctx(regex_results=nodes)
 
     result = asyncio.run(server_mod.search_regex(pattern="class", top_k=10))

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for codeminer.mcp.tools.search — BM25, regex, zoekt tool impls."""
 
 from __future__ import annotations
@@ -13,7 +17,6 @@ from codeminer.mcp.tools.search import (
     search_zoekt_impl,
 )
 from codeminer.types import NodeInfo
-
 
 # ------------------------------------------------------------------
 # Fixtures
@@ -240,7 +243,9 @@ class TestSearchZoekt:
             search_zoekt_impl(ctx, query="anything")
 
     def test_uses_error_message_from_ctx(self) -> None:
-        ctx = _make_ctx(zoekt=None, errors={"zoekt": "binary not found at /usr/bin/zoekt"})
+        ctx = _make_ctx(
+            zoekt=None, errors={"zoekt": "binary not found at /usr/bin/zoekt"}
+        )
         with pytest.raises(RuntimeError, match="binary not found"):
             search_zoekt_impl(ctx, query="anything")
 
@@ -249,5 +254,7 @@ class TestSearchZoekt:
         mock_zoekt.search.side_effect = ZoektUnavailableError("connection refused")
         ctx = _make_ctx(zoekt=mock_zoekt)
 
-        with pytest.raises(RuntimeError, match="Zoekt search failed.*connection refused"):
+        with pytest.raises(
+            RuntimeError, match="Zoekt search failed.*connection refused"
+        ):
             search_zoekt_impl(ctx, query="x")

--- a/test/mcp_server/test_zoekt_integration.py
+++ b/test/mcp_server/test_zoekt_integration.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """End-to-end integration tests for Zoekt search via MCP.
 
 Builds a tiny git-tracked repo, runs the real ``zoekt-git-index`` binary to
@@ -31,8 +35,7 @@ from codeminer.mcp.tools.search import search_zoekt_impl
 
 # Skip the entire module when Zoekt binaries are not installed.
 pytestmark = pytest.mark.skipif(
-    shutil.which("zoekt-git-index") is None
-    or shutil.which("zoekt-webserver") is None,
+    shutil.which("zoekt-git-index") is None or shutil.which("zoekt-webserver") is None,
     reason=(
         "Zoekt binaries (zoekt-git-index, zoekt-webserver) not on $PATH. "
         "Install with: go install github.com/sourcegraph/zoekt/cmd/...@latest"
@@ -55,7 +58,7 @@ REPO_FILES: dict[str, str] = {
         "TAX_RATE = 0.08\n"
         "\n"
         "def calculate_tax(amount):\n"
-        "    \"\"\"Compute MAGIC_BILLING_MARKER sales tax.\"\"\"\n"
+        '    """Compute MAGIC_BILLING_MARKER sales tax."""\n'
         "    return amount * TAX_RATE\n"
     ),
     "docs/README.md": (
@@ -64,10 +67,7 @@ REPO_FILES: dict[str, str] = {
         "Authentication uses InvalidTokenError when credentials are bad.\n"
         "See src/auth.py for details.\n"
     ),
-    "scripts/deploy.sh": (
-        "#!/bin/bash\n"
-        "echo MAGIC_BILLING_MARKER deploy step\n"
-    ),
+    "scripts/deploy.sh": ("#!/bin/bash\n" "echo MAGIC_BILLING_MARKER deploy step\n"),
 }
 
 
@@ -118,9 +118,9 @@ def manifest_path(tmp_path: Path) -> Path:
         repo_path=str(repo_dir),
         output_dir=str(shard_dir),
     )
-    assert status.metadata["shard_count"] >= 1, (
-        f"zoekt-git-index produced no shards: {status.metadata}"
-    )
+    assert (
+        status.metadata["shard_count"] >= 1
+    ), f"zoekt-git-index produced no shards: {status.metadata}"
 
     manifest = RepoManifest(
         repo_path=str(repo_dir),
@@ -228,7 +228,9 @@ def test_search_file_filter_scopes_results(loaded_ctx: ServerContext) -> None:
 
     assert results
     for r in results:
-        assert r["file"].endswith(".py"), f"unexpected file in scoped results: {r['file']}"
+        assert r["file"].endswith(
+            ".py"
+        ), f"unexpected file in scoped results: {r['file']}"
 
 
 def test_search_regex_atom(loaded_ctx: ServerContext) -> None:

--- a/test/mcp_server/test_zoekt_searcher.py
+++ b/test/mcp_server/test_zoekt_searcher.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Unit tests for ZoektSearcher — HTTP query composition and result mapping."""
 
 from __future__ import annotations
@@ -13,7 +17,6 @@ from codeminer.index.trigram.zoekt_searcher import (
     _compose_query,
     _file_match_to_node,
 )
-
 
 # ------------------------------------------------------------------
 # Helpers
@@ -104,6 +107,7 @@ class TestFileMatchMapping:
         # Score is not exposed by the JSON endpoint -- caller relies on order.
         assert node.score is None
 
+
 # ------------------------------------------------------------------
 # ZoektSearcher.search (HTTP layer mocked)
 # ------------------------------------------------------------------
@@ -128,7 +132,9 @@ class TestSearcherSearch:
         )
         mock_response.raise_for_status.return_value = None
 
-        with patch.object(searcher._session, "get", return_value=mock_response) as mock_get:
+        with patch.object(
+            searcher._session, "get", return_value=mock_response
+        ) as mock_get:
             results = searcher.search("foo", top_k=10)
 
         assert len(results) == 1
@@ -206,5 +212,7 @@ class TestSearcherStartPreconditions:
         os.chmod(fake, 0o755)
 
         s = ZoektSearcher(index_dir=str(tmp_path / "missing"), binary=str(fake))
-        with pytest.raises(ZoektUnavailableError, match="index directory does not exist"):
+        with pytest.raises(
+            ZoektUnavailableError, match="index directory does not exist"
+        ):
             s.start()

--- a/test/ops/test_expand.py
+++ b/test/ops/test_expand.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Tests for graph expansion ops (codeminer.ops.expand)."""
 
 from __future__ import annotations

--- a/test/scip/simple_repos/cpp_simple/CMakeLists.txt
+++ b/test/scip/simple_repos/cpp_simple/CMakeLists.txt
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.10)
 project(TestCppSimple VERSION 1.0.0 LANGUAGES CXX)
 

--- a/test/scip/simple_repos/cpp_simple/include/math_utils.h
+++ b/test/scip/simple_repos/cpp_simple/include/math_utils.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef MATH_UTILS_H
 #define MATH_UTILS_H
 

--- a/test/scip/simple_repos/cpp_simple/include/shape.h
+++ b/test/scip/simple_repos/cpp_simple/include/shape.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef SHAPE_H
 #define SHAPE_H
 

--- a/test/scip/simple_repos/cpp_simple/src/main.cpp
+++ b/test/scip/simple_repos/cpp_simple/src/main.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "math_utils.h"
 #include "shape.h"
 #include <iostream>

--- a/test/scip/simple_repos/cpp_simple/src/math_utils.cpp
+++ b/test/scip/simple_repos/cpp_simple/src/math_utils.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "math_utils.h"
 
 namespace MathUtils {

--- a/test/scip/simple_repos/cpp_simple/src/shape.cpp
+++ b/test/scip/simple_repos/cpp_simple/src/shape.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 #include "shape.h"
 
 // Rectangle implementation

--- a/test/scip/simple_repos/go_simple/calculator.go
+++ b/test/scip/simple_repos/go_simple/calculator.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 // Calculator performs arithmetic operations.

--- a/test/scip/simple_repos/go_simple/duplicates.go
+++ b/test/scip/simple_repos/go_simple/duplicates.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 // Process is a package-level function.

--- a/test/scip/simple_repos/go_simple/go.mod
+++ b/test/scip/simple_repos/go_simple/go.mod
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module github.com/test/go_simple
 
 go 1.22

--- a/test/scip/simple_repos/go_simple/greet.go
+++ b/test/scip/simple_repos/go_simple/greet.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import "fmt"

--- a/test/scip/simple_repos/go_simple/main.go
+++ b/test/scip/simple_repos/go_simple/main.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import "fmt"

--- a/test/scip/simple_repos/rust_simple/Cargo.lock.license
+++ b/test/scip/simple_repos/rust_simple/Cargo.lock.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0

--- a/test/scip/simple_repos/rust_simple/Cargo.toml
+++ b/test/scip/simple_repos/rust_simple/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "test_rust_simple"
 version = "0.1.0"

--- a/test/scip/simple_repos/rust_simple/src/main.rs
+++ b/test/scip/simple_repos/rust_simple/src/main.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 mod math_utils;
 mod shapes;
 

--- a/test/scip/simple_repos/rust_simple/src/math_utils.rs
+++ b/test/scip/simple_repos/rust_simple/src/math_utils.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /// Math utility module providing basic mathematical operations
 
 /// Add two integers

--- a/test/scip/simple_repos/rust_simple/src/shapes.rs
+++ b/test/scip/simple_repos/rust_simple/src/shapes.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /// Shape module providing geometry abstractions
 use std::f64::consts::PI;
 

--- a/test/scip/simple_repos/typescript_simple/src/main.ts
+++ b/test/scip/simple_repos/typescript_simple/src/main.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Main entry point that uses math functions
  */

--- a/test/scip/simple_repos/typescript_simple/src/math.ts
+++ b/test/scip/simple_repos/typescript_simple/src/math.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Math utility functions
  */

--- a/test/scip/test_scip_axios.py
+++ b/test/scip/test_scip_axios.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration test for axios/axios SCIP indexing — verify start_line values
 for convertValue and toFormData in lib/helpers/toFormData.js.

--- a/test/scip/test_scip_core.py
+++ b/test/scip/test_scip_core.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """C++ ``core/`` decoder parity test (pybind11).
 
 For each language with a C++ decoder (python, go, rust, ts):
@@ -49,7 +53,6 @@ if importlib.util.find_spec("codeminer_core") is None:
 # integration-serial CI job sequences fixtures so this order falls out
 # naturally; in unit-test runs we have to enforce it explicitly here.
 import codeminer_core  # noqa: E402, F401
-
 
 _COMPARED_ATTRS = ("type", "file", "start_line", "end_line", "unified_name")
 
@@ -136,8 +139,7 @@ def _graph_signature(graph):
         )
     edges_list.sort(key=lambda t: (t[0], t[1], t[2] or "", t[3] or "", t[4] or -1))
     vertex_attrs = {
-        v["name"]: {k: v.attributes().get(k) for k in _COMPARED_ATTRS}
-        for v in graph.vs
+        v["name"]: {k: v.attributes().get(k) for k in _COMPARED_ATTRS} for v in graph.vs
     }
     return names, edges_list, vertex_attrs
 
@@ -252,9 +254,9 @@ def _run_parity(language: str) -> None:
         rebuilt = rebuild_indexer.run_pipeline(
             skip_level="decode", report_profile=False, **kwargs
         )
-        assert rebuilt is not None, (
-            f"[{language}] failed to rebuild serial graph after stale-schema load"
-        )
+        assert (
+            rebuilt is not None
+        ), f"[{language}] failed to rebuild serial graph after stale-schema load"
         serial_graph = CodeGraph.load_graph(str(graph_pkl))
 
     # Core decoder: reuse index.decoded, don't clobber graph.pkl (serial's).

--- a/test/scip/test_scip_core_w_python.py
+++ b/test/scip/test_scip_core_w_python.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Test correctness of C++ SCIP decoder. (compare with Python decoder)
 

--- a/test/scip/test_scip_exclude.py
+++ b/test/scip/test_scip_exclude.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from pathlib import Path
 

--- a/test/scip/test_scip_indexer.py
+++ b/test/scip/test_scip_indexer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import subprocess
 import tempfile
 from pathlib import Path

--- a/test/scip/test_scip_multilingual.py
+++ b/test/scip/test_scip_multilingual.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Integration tests for multilingual SCIP indexing via unified run_pipeline().
 """

--- a/test/scip/test_scip_swebench.py
+++ b/test/scip/test_scip_swebench.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

Companion to **#141** (bulk SPDX annotation). With every file now carrying a SPDX header (or covered by `REUSE.toml`), this PR closes the loop by gating regressions on two levels.

1. **Local: pre-commit hook** — `fsfe/reuse-tool` v6.2.0 added to `.pre-commit-config.yaml`. New files without `SPDX-FileCopyrightText` / `SPDX-License-Identifier`, or files referencing a license not in `LICENSES/`, fail the commit locally.

2. **CI: dedicated REUSE workflow** — `.github/workflows/reuse.yml` runs `fsfe/reuse-action@v5` on every push / PR.

   Intentionally **split from `ci.yml`** so the workflow-level `paths-ignore: ["**.md", "docs/**", "LICENSE", ".gitignore"]` on `ci.yml` does **not** bypass the license check. A doc-only PR that introduces an unannotated markdown file is still caught.

   Lightweight: ~10 s on `ubuntu-latest`, separate from the self-hosted runners used by the rest of CI.

## Depends on

> **#141 must merge first** so the repo is already REUSE-compliant before this gate activates. Otherwise this CI job would immediately fail on every PR because the existing files on `main` lack headers.

## Verification

```
$ pre-commit run reuse --all-files
(License) REUSE compliance (SPDX headers)................................Passed
```

## Test plan

- [x] `fsfe/reuse-tool` pre-commit hook installs and passes locally
- [x] `reuse.yml` workflow YAML is valid (check-yaml hook pre-commit pass)
- [ ] CI workflow runs green on this PR after #141 merges
- [ ] After both PRs merge, a deliberate "remove SPDX header" test PR is blocked by the new gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)