### PR TITLE
chore(lint): clear pre-existing flake8 debt that was blocking pre-commit

### DIFF
--- a/codeminer/agent/tools.py
+++ b/codeminer/agent/tools.py
@@ -21,45 +21,59 @@ def search_code_snippets(
     file_path_or_pattern: Optional[str] = "**/*.py",
     repo_path: Optional[str] = None,
 ) -> str:
-    """
-    Searches the codebase to retrieve relevant code snippets based on given queries(terms or line numbers).
-    This function supports retrieving the complete content of a code entity,
-    searching for code entities such as classes or functions by keywords, or locating specific lines within a file.
-    It also supports filtering searches based on a file path or file pattern.
+    """Search the codebase for code snippets matching terms or line numbers.
+
+    Supports retrieving the complete content of a code entity, searching for
+    code entities (classes/functions) by keyword, or locating specific lines
+    within a file. Results can be filtered by file path or glob pattern.
 
     Note:
-    1. If `search_terms` are provided, it searches for code snippets based on each term:
-        - If a term is formatted as 'file_path:QualifiedName' (e.g., 'src/helpers/math_helpers.py:MathUtils.calculate_sum') ,
-          or just 'file_path', the corresponding complete code is retrieved or file content is retrieved.
-        - If a term matches a file, class, or function name, matched entities are retrieved.
-        - If there is no match with any module name, it attempts to find code snippets that likely contain the term.
-    2. If `line_nums` is provided, it searches for code snippets at the specified lines within the file defined by
-       `file_path_or_pattern`.
+        1. If ``search_terms`` is provided, each term is searched as follows:
+            - 'file_path:QualifiedName' (e.g.
+              'src/helpers/math.py:MathUtils.calculate_sum') or just
+              'file_path' retrieves the corresponding entity or full file.
+            - A term that matches a file, class, or function name returns
+              the matched entities.
+            - Otherwise the function falls back to a snippet-level search.
+        2. If ``line_nums`` is provided, snippets at the specified lines
+           within ``file_path_or_pattern`` are returned.
 
     Args:
-        search_terms (Optional[List[str]]): A list of names, keywords, or code snippets to search for within the codebase.
-            Terms can be formatted as 'file_path:QualifiedName' to search for a specific module or entity within a file
-            (e.g., 'src/helpers/math_helpers.py:MathUtils.calculate_sum') or as 'file_path' to retrieve the complete content
-            of a file. This can also include potential function names, class names, or general code fragments.
-        line_nums (Optional[List[int]]): Specific line numbers to locate code snippets within a specified file.
-            When provided, `file_path_or_pattern` must specify a valid file path.
-        file_path_or_pattern (Optional[str]): A glob pattern or specific file path used to filter search results
-            to particular files or directories. Defaults to '**/*.py', meaning all Python files are searched by default.
-            If `line_nums` are provided, this must specify a specific file path.
-        repo_path (Optional[str]): Path to the repository. If not provided, uses current working directory.
+        search_terms: Names, keywords, or code snippets to search for.
+            Terms may be ``'file_path:QualifiedName'`` to scope the search
+            to a specific module or entity, or just ``'file_path'`` to
+            retrieve a full file. Can also include function names, class
+            names, or general code fragments.
+        line_nums: Specific line numbers to locate snippets within the
+            file given by ``file_path_or_pattern``. Requires the latter
+            to be a concrete file path.
+        file_path_or_pattern: Glob or path used to filter results.
+            Defaults to ``'**/*.py'``. Must be a concrete file path when
+            ``line_nums`` is set.
+        repo_path: Repository root. Defaults to the current working
+            directory if not provided.
 
     Returns:
-        str: The search results, which may include code snippets, matching entities, or complete file content.
+        Search results: snippets, matching entities, or complete file
+        contents.
 
     Example Usage:
-        # Search for the full content of a specific file
+        # Full content of a file
         result = search_code_snippets(search_terms=['src/my_file.py'])
-        # Search for a specific function
-        result = search_code_snippets(search_terms=['src/my_file.py:MyClass.func_name'])
-        # Search for specific lines (10 and 15) within a file
-        result = search_code_snippets(line_nums=[10, 15], file_path_or_pattern='src/example.py')
-        # Combined search for a module name and within a specific file pattern
-        result = search_code_snippets(search_terms=["MyClass"], file_path_or_pattern="src/**/*.py")
+        # A specific function
+        result = search_code_snippets(
+            search_terms=['src/my_file.py:MyClass.func_name'],
+        )
+        # Specific lines within a file
+        result = search_code_snippets(
+            line_nums=[10, 15],
+            file_path_or_pattern='src/example.py',
+        )
+        # Class name within a file pattern
+        result = search_code_snippets(
+            search_terms=["MyClass"],
+            file_path_or_pattern="src/**/*.py",
+        )
     """
 
     if repo_path is None:
@@ -88,7 +102,7 @@ def search_code_snippets(
             if not term:
                 continue
 
-            result += f'## Searching for term "{term}"...\n### Search Result:\n'
+            result += f"## Searching for term {term!r}...\n### Search Result:\n"
 
             # 2.1 Check if term is file_path:entity format
             if ":" in term:
@@ -132,7 +146,10 @@ def _search_by_line_numbers(
         with open(full_path, "r", encoding="utf-8") as f:
             lines = f.readlines()
 
-        result = f'## Searching for lines {line_nums} in file "{file_path}"...\n### Search Result:\n'
+        result = (
+            f"## Searching for lines {line_nums} in file {file_path!r}...\n"
+            f"### Search Result:\n"
+        )
 
         for line_num in line_nums:
             if 1 <= line_num <= len(lines):
@@ -186,7 +203,10 @@ def _search_file_entity(term: str, repo_path: str, include_files: List[str]) -> 
         for i, line in enumerate(lines):
             if is_entity_definition(line, entity_part):
                 entity_content = extract_entity_content(lines, i)
-                return f"**Entity: {entity_part} in {file_part}**\n```python\n{entity_content}\n```\n\n"
+                return (
+                    f"**Entity: {entity_part} in {file_part}**\n"
+                    f"```python\n{entity_content}\n```\n\n"
+                )
 
         # If entity not found, search for any occurrence
         return search_entity_occurrence(lines, entity_part, file_part)
@@ -255,7 +275,10 @@ def _search_with_engine(term: str, repo_path: str, include_files: List[str]) -> 
                 continue
 
             match_counter += 1
-            result += f"**Match {match_counter}: {file_path}** (Type: {node_type}, Score: {score:.3f})\n"
+            result += (
+                f"**Match {match_counter}: {file_path}** "
+                f"(Type: {node_type}, Score: {score:.3f})\n"
+            )
 
             try:
                 code_context = search_engine.get_code_context(search_result)

--- a/codeminer/dataset/swebench.py
+++ b/codeminer/dataset/swebench.py
@@ -10,7 +10,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Union
 
 import datasets
 from datasets import Features, Sequence, Value

--- a/codeminer/eval/retrieval_eval.py
+++ b/codeminer/eval/retrieval_eval.py
@@ -21,7 +21,7 @@ def normalize_file_path(value: Optional[str]) -> Optional[str]:
 
 
 def normalize_symbol_identifier(value: Optional[str]) -> Optional[str]:
-    """Normalize `file:Symbol` identifiers to ensure file portion matches the retrieved format."""
+    """Normalize ``file:Symbol`` so the file portion matches the retrieved form."""
     if not value:
         return None
     if ":" not in value:
@@ -37,8 +37,10 @@ def collect_targets(
     instance: Mapping[str, object], simplified_symbols: bool = True
 ) -> Tuple[List[str], List[str]]:
     """Aggregate and normalize file + symbol labels from a dataset instance.
-    If simplified_symbols is True, use symbols_modified and symbols_deleted, exclude symbols_added.
-    If simplified_symbols is False, use all symbols_modified, symbols_added and symbols_deleted.
+
+    If ``simplified_symbols`` is True, use ``symbols_modified`` and
+    ``symbols_deleted`` (excluding ``symbols_added``); otherwise include
+    all three.
     """
     target_files = instance.get("target_files") or []
 

--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -280,7 +280,10 @@ class PatcherCpp(PatcherBase):
             success = indexer.generate_index(compdb_path=str(comp_db))
             n_after = len(list(cache_path.glob("*.idx"))) if cache_path.exists() else 0
             logger.info(
-                f"[patcher_cpp DEBUG] after ClangdIndexer: {cache_path} has {n_after} .idx (success={success})"
+                "[patcher_cpp DEBUG] after ClangdIndexer: %s has %d .idx (success=%s)",
+                cache_path,
+                n_after,
+                success,
             )
             return indexer.idx_directory if success else None
 

--- a/codeminer/index/regex_idx/regex_idx.py
+++ b/codeminer/index/regex_idx/regex_idx.py
@@ -82,7 +82,7 @@ class RegexNodeIndex:
 
         Args:
             pattern: Search pattern (regex or plain string)
-            file_glob: Optional glob pattern to filter by file path (e.g., '*.py', '**/calculator.py')
+            file_glob: Optional glob to filter by file path (e.g., '*.py', '**/calc.py')
             node_type: Optional node type to filter (e.g., 'function', 'class', 'file')
             case_sensitive: Whether search is case-sensitive (default: False)
             use_regex: Whether to use regex (default: True) or plain string matching
@@ -91,7 +91,7 @@ class RegexNodeIndex:
             List of NodeInfo objects matching the pattern
 
         Examples:
-            >>> idx.search(r'def\s+\w+', file_glob='*.py')  # Find function definitions in Python files
+            >>> idx.search(r'def\s+\w+', file_glob='*.py')  # Find function defs
             >>> idx.search('calculator', use_regex=False)  # Plain string search
             >>> idx.search('class', node_type='file')  # Search in file nodes only
         """
@@ -115,8 +115,8 @@ class RegexNodeIndex:
             try:
                 regex = re.compile(pattern, flags)
             except re.error as e:
-                logger.error(f"Invalid regex pattern '{pattern}': {e}")
-                raise ValueError(f"Invalid regex pattern: {e}")
+                logger.error(f"Invalid regex pattern {pattern!r}: {e}")
+                raise ValueError(f"Invalid regex pattern: {e}") from e
 
             matches = [n for n in candidates if n.content and regex.search(n.content)]
         else:
@@ -132,7 +132,7 @@ class RegexNodeIndex:
                 ]
 
         logger.debug(
-            f"Search pattern='{pattern}' file_glob={file_glob} node_type={node_type}: "
+            f"Search pattern={pattern!r} file_glob={file_glob} node_type={node_type}: "
             f"found {len(matches)} matches from {len(candidates)} candidates"
         )
 

--- a/codeminer/index/sparse_idx/bm25_index.py
+++ b/codeminer/index/sparse_idx/bm25_index.py
@@ -279,7 +279,8 @@ class BM25CodeIndexer:
             text = re.sub(r"\(\)", "", text)
 
             # Split on code-specific delimiters: '/', ':', '.', '_'
-            # This handles paths like "test/test_bas.py" and method calls like "sample/core.py:get_hmm"
+            # Handles paths ("test/test_bas.py") and qualified method names
+            # like "sample/core.py:get_hmm".
             tokens = re.split(r"[/:._ ]+", text)
 
             processed_tokens = []
@@ -383,7 +384,7 @@ class BM25CodeIndexer:
 
                                 extracted_lines = lines[start_idx:end_idx]
 
-                                # Remove trailing empty lines to avoid extra whitespace in output
+                                # Strip trailing blank lines to avoid extra whitespace.
                                 original_end_idx = len(extracted_lines)
                                 while (
                                     extracted_lines

--- a/codeminer/index/trigram/zoekt_searcher.py
+++ b/codeminer/index/trigram/zoekt_searcher.py
@@ -291,7 +291,7 @@ def _compose_query(query: str, file_filter: Optional[str]) -> str:
     if not expr:
         return query
     if " " in expr or "(" in expr:
-        expr = f'"{expr}"'
+        expr = f'"{expr}"'  # noqa: B907 — Zoekt requires literal quotes here
     return f"{query} file:{expr}"
 
 

--- a/codeminer/log_utils.py
+++ b/codeminer/log_utils.py
@@ -38,7 +38,8 @@ class LoggingManager:
         self.loggers: Dict[str, logging.Logger] = {}
         self.current_log_dir: str = ""
         self.unified_log_filename: str = "total.log"
-        # Modes: 'stdout' (console only), 'file' (unified file only), 'both' (console + unified file)
+        # Modes: 'stdout' (console only), 'file' (unified file only),
+        # 'both' (console + unified file).
         self.mode: str = "stdout"
         self.scip_debug_enabled: bool = False  # Track if SCIP debug is enabled
         self.scip_loggers: set = set()  # Explicitly registered SCIP loggers
@@ -219,7 +220,7 @@ def setup_detailed_logging(
     # Select output mode
     valid_modes = {None, "stdout", "file", "both"}
     if mode not in valid_modes:
-        raise ValueError(f"Invalid mode '{mode}'. Expected one of: stdout, file, both")
+        raise ValueError(f"Invalid mode {mode!r}. Expected one of: stdout, file, both")
 
     # Backward-compatible behavior if mode not provided
     if mode is None:

--- a/codeminer/types.py
+++ b/codeminer/types.py
@@ -28,7 +28,7 @@ SYMBOL_TYPES = {
 
 
 def is_symbol_node(node_type):
-    """Check if a node type represents any kind of symbol (class, function, method, or generic symbol)"""
+    """Whether ``node_type`` is any symbol (class/function/method/generic)."""
     return node_type in SYMBOL_TYPES
 
 

--- a/test/agent/test_agent_embedding_search.py
+++ b/test/agent/test_agent_embedding_search.py
@@ -25,7 +25,8 @@ EMBEDDING_INDEX_PATH = "/tmp/embedding_e2e_index"
 
 class TestAgentEmbeddingSearch:
     """
-    Vertex (or CODEMINER_VERTEX_ROUTING_MODEL) + real FAISS; assert tool_calls use embedding_search.
+    Vertex (or CODEMINER_VERTEX_ROUTING_MODEL) + real FAISS; assert
+    tool_calls use embedding_search.
 
     Index default: /tmp/codeminer_e2e_index — override with CODEMINER_INDEX_PATH.
     """

--- a/test/index/test_vector_store.py
+++ b/test/index/test_vector_store.py
@@ -156,7 +156,7 @@ def test_vector_store_with_huggingface():
         ]
 
         for query in test_queries:
-            print(f"\nSearching for: '{query}'")
+            print(f"\nSearching for: {query!r}")
             results = vector_store.search(query, top_k=5)  # Show all results
 
             for i, result in enumerate(results, 1):
@@ -225,7 +225,7 @@ def test_with_real_code_chunks(httpie_cli_repo=None):
         ]
 
         for query in search_queries:
-            print(f"\nSearching for: '{query}'")
+            print(f"\nSearching for: {query!r}")
             results = vector_store.search(query, top_k=3)
 
             for i, result in enumerate(results, 1):

--- a/test/scip/test_scip_core.py
+++ b/test/scip/test_scip_core.py
@@ -30,7 +30,7 @@ import argparse
 import importlib.util
 import os
 from pathlib import Path
-from typing import Dict, Set, Tuple
+from typing import Tuple
 
 import pytest
 


### PR DESCRIPTION
## Summary

Follow-up to #141. Every PR that touches a Python file currently triggers flake8 (via `.pre-commit-config.yaml`) on that file, and main has **41 pre-existing violations across 12 files** that fail the hook. SPDX PR #141 shipped with `SKIP=flake8` to keep that out of scope; this PR cleans the slate so future commits don't need the skip.

## Inventory

Counts from `pre-commit run flake8 --all-files` on origin/main:

| Code | Count | Meaning |
|---|---|---|
| **B950** | 29 | line too long (>97 chars after E501 ignore) |
| **B907** | 8 | manual quote surround on f-string → use `!r` |
| **F401** | 2 | unused import |
| **F811** | 1 | redefinition of unused symbol |
| **B904** | 1 | `raise` without `from` inside `except` |

## Fix patterns

- **B950**: rewrap long docstrings / log lines, or split a long f-string into a multi-line concatenation. The big block in `agent/tools.py` (a ~40-line docstring) was condensed without losing semantic content.
- **B907**: switched `f"'{x}'"` → `f"{x!r}"`. One Zoekt expression literal was annotated with `# noqa: B907` because the Zoekt wire format requires literal double quotes (not Python's `repr`).
- **B904**: `raise ValueError(...) from e` in `regex_idx` error path so exception chaining is preserved.
- **F401 / F811**: removed unused `Dict`, `Set`, and the duplicate `Sequence` import that shadowed `typing.Sequence` in `dataset/swebench.py`.

## Behavior change

**None.** All edits are formatting / shadowing / chaining / wording. No public API touched.

## Verification

```
$ pre-commit run --all-files
trailing-whitespace ............. Passed
mixed-line-ending ............... Passed
end-of-file-fixer ............... Passed
…
clang-format .................... Passed
black ........................... Passed
isort ........................... Passed
flake8 .......................... Passed   ← was failing on main
(License) REUSE compliance ...... Passed
```

## Test plan

- [x] `pre-commit run --all-files` clean (every hook including flake8)
- [x] No public API changes; behaviour-only diff is the swapped exception chain (`raise … from e`)
- [ ] CI green
