### PR TITLE
[baselines] Claude + Codex agentic loc-agent runners (refs #150)

### DIFF
--- a/codeminer/agent/claude_agent.py
+++ b/codeminer/agent/claude_agent.py
@@ -1,0 +1,534 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Claude Agent wrapper for code localization.
+
+This module provides a wrapper around the Claude Agent SDK to serve as
+a read-only code localization agent: given a repository and an issue/query,
+it identifies the relevant code locations (with symbol-level detail)
+without making any modifications.
+"""
+
+import asyncio
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from claude_agent_sdk import ClaudeAgentOptions, query
+
+from ..log_utils import get_logger
+
+# Canonical chunker-format rules for the `name` field. Shared with
+# codex_agent so both system prompts derive from a single source of truth.
+LOC_SYMBOL_NAMING_RULES = (
+    "Symbol naming follows the dataset's canonical chunker format. "
+    "Exactly one of three shapes:\n"
+    "    bare_function()              (free function/var, any lang)\n"
+    "    Class.method()               (method on class/type)\n"
+    "    ClassName                    (class/struct/type decl, NO parens)\n"
+    "  STRICT RULES:\n"
+    '  * Use "." (period) between class and method, NEVER "::" '
+    "(even for C++/Rust source). Convert `Type::method` -> `Type.method`.\n"
+    "  * STRIP all prefix qualifiers (namespace / module / package):\n"
+    "      C++   `fmt::detail::write_bytes()`         -> `write_bytes()`\n"
+    "      Rust  `crate::sys::expand_glob()`          -> `expand_glob()`\n"
+    "      Rust  `State::visit_token_kind()` -> `State.visit_token_kind()`\n"
+    "      Python `xarray.core.var.Variable.quantile()` -> `Variable.quantile()`\n"
+    "      Go    `logging.CookieFilter.Filter()`      -> `CookieFilter.Filter()`\n"
+    "      Go    `(*Server).ServeHTTP()`              -> `Server.ServeHTTP()`\n"
+    "  * STRIP parameter signatures: `Foo.bar(int x)` -> `Foo.bar()`.\n"
+    "  * Keep the IMMEDIATE enclosing class/type qualifier only "
+    '(at most one ".").\n'
+    "  * Be consistent across ALL symbols.\n"
+)
+
+
+# JSON Schema for structured output from the localization agent
+LOC_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "locations": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        # GT (from the codeminer code-chunking pipeline) is
+                        # exactly one of:
+                        #   bare_function()
+                        #   Class.method()
+                        #   ClassName             (no parens)
+                        # so the canonical form has 0 or 1 dot. The `::`
+                        # operator and parameter signatures are rejected
+                        # outright; namespace / module / package prefixes
+                        # are partially rejected (any 2+ dot form will be
+                        # forced into a single-dot form by schema retry).
+                        "pattern": (
+                            r"^[A-Za-z_][A-Za-z_0-9]*"
+                            r"(\.[A-Za-z_][A-Za-z_0-9]*)?"
+                            r"(\(\))?$"
+                        ),
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "function",
+                            "class",
+                            "method",
+                            "field",
+                            "module",
+                            "variable",
+                        ],
+                    },
+                    "file_path": {"type": "string"},
+                    "line_start": {"type": "integer"},
+                    "line_end": {"type": "integer"},
+                    "action": {
+                        "type": "string",
+                        "enum": ["modify", "add", "delete"],
+                    },
+                    "description": {"type": "string"},
+                },
+                "required": [
+                    "name",
+                    "type",
+                    "file_path",
+                    "line_start",
+                    "line_end",
+                    "action",
+                    "description",
+                ],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["locations"],
+    "additionalProperties": False,
+}
+
+
+@dataclass
+class CodeSymbol:
+    """A code symbol with its location, identified as relevant to an issue."""
+
+    name: str
+    type: str  # e.g. "function", "class", "method", "field"
+    file_path: str
+    line_start: int
+    line_end: int
+    action: str  # "modify", "add", "delete"
+    description: str = ""  # brief description of the change or relevance
+
+
+@dataclass
+class LocResult:
+    """Result from code localization."""
+
+    success: bool
+    repo_path: str
+    locations: List[CodeSymbol] = field(default_factory=list)
+    error_message: Optional[str] = None
+    execution_log: List[str] = field(default_factory=list)
+    usage: Optional[Dict[str, Any]] = None
+
+
+class ClaudeLocAgent:
+    """
+    Read-only code localization agent powered by Claude Agent SDK.
+
+    Given a repository path and an issue/query, this agent explores the
+    codebase and identifies the code locations (with symbol-level detail)
+    that are relevant or need modification — without actually making any changes.
+    """
+
+    def __init__(
+        self,
+        max_turns: int = 100,
+        system_prompt: Optional[str] = None,
+        allowed_tools: Optional[List[str]] = None,
+        permission_mode: str = "bypassPermissions",
+        model: str = "sonnet",
+    ):
+        self.logger = get_logger(__name__)
+        self.max_turns = max_turns
+        self.permission_mode = permission_mode
+        self.model = model
+
+        self.system_prompt = system_prompt or (
+            "You are an expert at code analysis and issue localization. "
+            "Your task is to identify the exact code locations in a repository "
+            "that are relevant to a given issue or query.\n\n"
+            "CRITICAL RULES:\n"
+            "- You are a READ-ONLY agent. DO NOT modify, create, or delete any files.\n"
+            "- Thoroughly explore the codebase using the available tools (Read, Glob, "
+            "Grep, Bash for git commands, etc.).\n"
+            "- Trace through call chains, imports, and dependencies to find ALL "
+            "relevant locations.\n"
+            "- For each relevant symbol (function, class, method, field, etc.), "
+            "identify its location and classify the action to be done on it "
+            'as "modify", "add", or "delete" based on what would be needed '
+            "to resolve the issue.\n"
+            "- At the END of your analysis, you MUST output a single fenced JSON "
+            "code block (```json ... ```) containing an array of symbol objects.\n"
+            "- Each symbol object must have these fields:\n"
+            '    "name", "type", "file_path", "line_start", "line_end", '
+            '"action", "description".\n'
+            "- " + LOC_SYMBOL_NAMING_RULES + ""
+            '- "type" is one of function/class/method/field; "action" is '
+            'one of modify/add/delete; "file_path" is relative to repo root.\n'
+            "- Order symbols by relevance (most relevant first).\n"
+            "\nIMPORTANT BUDGET CONSTRAINT:\n"
+            "- You have a LIMITED number of tool calls. Be efficient and focused.\n"
+            "- Start with targeted searches (grep for keywords from the issue), "
+            "NOT broad directory listings.\n"
+            "- Once you have identified the relevant files, read only the "
+            "necessary sections.\n"
+            "- Do NOT exhaustively explore every file. Focus on the most likely "
+            "locations first.\n"
+            "- You MUST output the JSON result block before running out of turns. "
+            "If you have a reasonable set of locations, output the JSON rather "
+            "than continuing to explore.\n"
+        )
+
+        # Read-only tool set — no Edit/Write/NotebookEdit
+        self.allowed_tools = allowed_tools or [
+            "Task",
+            "Bash",
+            "Glob",
+            "Grep",
+            "Read",
+        ]
+
+    async def locate_code(
+        self,
+        query_text: str,
+        repo_path: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> LocResult:
+        """
+        Locate relevant code positions for a given query in a repository.
+
+        Args:
+            query_text: The issue description or query to localize.
+            repo_path: Path to the repository root.
+            context: Additional context with keys like
+                     'issue_title', 'issue_body', 'diff', 'hints'.
+
+        Returns:
+            LocResult with identified code locations and symbol details.
+        """
+        if not os.path.isdir(repo_path):
+            return LocResult(
+                success=False,
+                repo_path=repo_path,
+                error_message=f"Repository path does not exist: {repo_path}",
+            )
+
+        full_prompt = self._prepare_prompt(query_text, context)
+
+        try:
+            options = ClaudeAgentOptions(
+                max_turns=self.max_turns,
+                system_prompt=self.system_prompt,
+                cwd=Path(repo_path),
+                allowed_tools=self.allowed_tools,
+                permission_mode=self.permission_mode,
+                model=self.model,
+                output_format={
+                    "type": "json_schema",
+                    "schema": LOC_OUTPUT_SCHEMA,
+                },
+            )
+
+            self.logger.info(f"Starting code localization in: {repo_path}")
+            self.logger.debug(f"Query: {query_text[:200]}...")
+
+            execution_log = []
+            structured_result = None
+            turn_count = 0
+            usage_info = {}
+            async for message in query(prompt=full_prompt, options=options):
+                msg_type = message.__class__.__name__
+
+                # Count AssistantMessage instances (includes sub-agent messages)
+                if msg_type == "AssistantMessage":
+                    turn_count += 1
+                    if turn_count % 10 == 0:
+                        self.logger.info(
+                            f"  ... {turn_count} assistant messages received"
+                        )
+
+                # Extract result from ResultMessage
+                if msg_type == "ResultMessage":
+                    # Prefer structured_output from output_format schema
+                    structured = getattr(message, "structured_output", None)
+                    if structured is not None:
+                        structured_result = structured
+                    if getattr(message, "result", None):
+                        execution_log.append(message.result)
+                    usage = getattr(message, "usage", None) or {}
+                    usage_info = {
+                        "num_turns": getattr(message, "num_turns", None),
+                        "total_cost_usd": getattr(message, "total_cost_usd", None),
+                        "duration_ms": getattr(message, "duration_ms", None),
+                        "input_tokens": usage.get("input_tokens", 0),
+                        "output_tokens": usage.get("output_tokens", 0),
+                        "cache_read_input_tokens": usage.get(
+                            "cache_read_input_tokens", 0
+                        ),
+                        "cache_creation_input_tokens": usage.get(
+                            "cache_creation_input_tokens", 0
+                        ),
+                    }
+                else:
+                    execution_log.append(str(message))
+
+            # Log usage summary
+            if usage_info:
+                self.logger.info(
+                    f"Usage: turns={usage_info['num_turns']}, "
+                    f"cost=${usage_info['total_cost_usd']:.4f}, "
+                    f"input={usage_info['input_tokens']}, "
+                    f"cache_read={usage_info['cache_read_input_tokens']}, "
+                    f"cache_create={usage_info['cache_creation_input_tokens']}, "
+                    f"output={usage_info['output_tokens']}"
+                )
+
+            # Check if agent was truncated by max_turns
+            sdk_turns = usage_info.get("num_turns")
+            if sdk_turns is not None and sdk_turns >= self.max_turns:
+                self.logger.warning(
+                    f"Agent reached max_turns limit ({self.max_turns}). "
+                    "Results may be incomplete."
+                )
+            else:
+                self.logger.info(
+                    f"Agent finished in {sdk_turns} SDK turns "
+                    f"({turn_count} assistant messages)."
+                )
+
+            # Parse locations: prefer structured output, fall back to regex
+            if structured_result is not None:
+                self.logger.info(
+                    "Parsing locations from structured_output (schema-validated)"
+                )
+                locations = self._parse_structured(structured_result)
+            else:
+                self.logger.info(
+                    "No structured_output found, falling back to regex parsing"
+                )
+                locations = self._parse_locations(execution_log)
+
+            return LocResult(
+                success=True,
+                repo_path=repo_path,
+                locations=locations,
+                execution_log=execution_log,
+                usage=usage_info or None,
+            )
+
+        except Exception as e:
+            error_msg = f"Error during code localization: {str(e)}"
+            self.logger.error(error_msg)
+            return LocResult(
+                success=False,
+                repo_path=repo_path,
+                error_message=error_msg,
+            )
+
+    def _prepare_prompt(
+        self, query_text: str, context: Optional[Dict[str, Any]]
+    ) -> str:
+        """
+        Build the full prompt for the localization task.
+
+        Args:
+            query_text: The main query / issue description.
+            context: Optional context dict with keys:
+                     'issue_title', 'issue_body', 'diff', 'hints'.
+
+        Returns:
+            Assembled prompt string.
+        """
+        parts = []
+
+        if context:
+            if "issue_title" in context:
+                parts.append(f"## Issue Title\n{context['issue_title']}\n")
+            if "issue_body" in context:
+                parts.append(f"## Issue Body\n{context['issue_body']}\n")
+            if "diff" in context:
+                parts.append(f"## Related Diff\n```diff\n{context['diff']}\n```\n")
+            if "hints" in context:
+                parts.append(f"## Hints\n{context['hints']}\n")
+
+        parts.append(f"## Query\n{query_text}")
+
+        parts.append(
+            "\n## Instructions\n"
+            "1. Explore the repository to understand its structure.\n"
+            "2. Identify ALL code symbols relevant to the query above.\n"
+            "3. For each relevant symbol, note the name, type, file path "
+            "(relative to repo root), line range, and what action is needed.\n"
+            "4. At the very end, output a single fenced JSON code block with "
+            "the results in this format:\n"
+            "```json\n"
+            "[\n"
+            "  {\n"
+            '    "name": "Foo.bar()",\n'
+            '    "type": "method",\n'
+            '    "file_path": "src/foo.cpp",\n'
+            '    "line_start": 42,\n'
+            '    "line_end": 55,\n'
+            '    "action": "modify",\n'
+            '    "description": "Needs to handle + in email"\n'
+            "  }\n"
+            "]\n"
+            "```\n"
+            "5. The `name` field must follow the canonical chunker format "
+            "described in your system instructions (no `::`, no namespace "
+            "prefix, no parameter signatures).\n"
+            "6. DO NOT modify any files. This is a read-only analysis task.\n"
+        )
+
+        return "\n".join(parts)
+
+    def _parse_structured(self, data: Any) -> List[CodeSymbol]:
+        """Parse CodeSymbol objects from structured_output (schema-validated JSON)."""
+        if isinstance(data, str):
+            try:
+                data = json.loads(data)
+            except json.JSONDecodeError:
+                self.logger.warning("structured_output is a string but not valid JSON.")
+                return []
+
+        items = []
+        if isinstance(data, dict) and isinstance(data.get("locations"), list):
+            items = data["locations"]
+        elif isinstance(data, list):
+            items = data
+        else:
+            self.logger.warning("Unexpected structured_output format: %s", type(data))
+            return []
+
+        symbols = []
+        for item in items:
+            if not isinstance(item, dict) or "name" not in item:
+                continue
+            symbols.append(
+                CodeSymbol(
+                    name=item.get("name", ""),
+                    type=item.get("type", ""),
+                    file_path=item.get("file_path", ""),
+                    line_start=int(item.get("line_start", 0)),
+                    line_end=int(item.get("line_end", 0)),
+                    action=item.get("action", ""),
+                    description=item.get("description", ""),
+                )
+            )
+        return symbols
+
+    def _parse_locations(self, execution_log: List[str]) -> List[CodeSymbol]:
+        """
+        Parse CodeSymbol objects from the agent's execution log.
+
+        Scans the log (last-to-first) for a fenced ```json code block
+        containing an array of symbol objects.
+
+        Args:
+            execution_log: List of stringified agent messages.
+
+        Returns:
+            Parsed list of CodeSymbol, or empty list on failure.
+        """
+        json_pattern = re.compile(r"```json\s*\n(.*?)\n\s*```", re.DOTALL)
+
+        for entry in reversed(execution_log):
+            match = json_pattern.search(entry)
+            if not match:
+                continue
+
+            try:
+                data = json.loads(match.group(1))
+            except json.JSONDecodeError:
+                self.logger.warning("Found JSON block but failed to parse it.")
+                continue
+
+            if not isinstance(data, list):
+                continue
+
+            symbols = []
+            for item in data:
+                if not isinstance(item, dict) or "name" not in item:
+                    continue
+                symbols.append(
+                    CodeSymbol(
+                        name=item.get("name", ""),
+                        type=item.get("type", ""),
+                        file_path=item.get("file_path", ""),
+                        line_start=int(item.get("line_start", 0)),
+                        line_end=int(item.get("line_end", 0)),
+                        action=item.get("action", ""),
+                        description=item.get("description", ""),
+                    )
+                )
+            return symbols
+
+        self.logger.warning("No valid JSON symbol block found in execution log.")
+        return []
+
+
+# Synchronous wrapper
+class SyncClaudeLocAgent:
+    """
+    Synchronous wrapper for ClaudeLocAgent.
+    """
+
+    def __init__(self, **kwargs):
+        self.agent = ClaudeLocAgent(**kwargs)
+        self.logger = get_logger(__name__)
+
+    def locate_code(
+        self,
+        query_text: str,
+        repo_path: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> LocResult:
+        """
+        Synchronous wrapper for locate_code.
+
+        Args:
+            query_text: The issue description or query.
+            repo_path: Path to the repository root.
+            context: Optional additional context.
+
+        Returns:
+            LocResult with identified code locations.
+        """
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                return loop.run_until_complete(
+                    self.agent.locate_code(
+                        query_text=query_text,
+                        repo_path=repo_path,
+                        context=context,
+                    )
+                )
+            finally:
+                loop.close()
+        except Exception as e:
+            error_msg = f"Error in synchronous code localization: {str(e)}"
+            self.logger.error(error_msg)
+            return LocResult(
+                success=False,
+                repo_path=repo_path,
+                error_message=error_msg,
+            )

--- a/codeminer/agent/codex_agent.py
+++ b/codeminer/agent/codex_agent.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Codex Agent wrapper for code localization.
+
+Mirror of ClaudeLocAgent using the official OpenAI Codex Python SDK
+(``openai-codex``, top-level module ``openai_codex``, from
+github.com/openai/codex sdk/python). Read-only: explores a repository to
+identify code locations relevant to an issue/query, without modifying
+files.
+
+The SDK speaks JSON-RPC v2 to a co-installed ``openai-codex-cli-bin``
+wheel that ships the platform-specific ``codex`` binary -- no system
+PATH dependency. Auth is picked up from ``~/.codex/auth.json`` (set by
+``codex login``) unless ``CODEX_API_KEY`` is exported.
+
+This SDK is **not yet on PyPI** as of 2026-05; install from git, pinned
+to a verified commit (see examples/codex_loc_agent.py docstring).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from openai_codex import ApprovalMode, AsyncCodex
+from openai_codex.types import SandboxMode
+
+from ..log_utils import get_logger
+from .claude_agent import (
+    LOC_OUTPUT_SCHEMA,
+    LOC_SYMBOL_NAMING_RULES,
+    CodeSymbol,
+    LocResult,
+)
+
+_DEFAULT_SYSTEM_PROMPT = (
+    "You are an expert at code analysis and issue localization. "
+    "Your task is to identify the exact code locations in a repository "
+    "that are relevant to a given issue or query.\n\n"
+    "CRITICAL RULES:\n"
+    "- You are a READ-ONLY agent. DO NOT modify, create, or delete any files.\n"
+    "- Thoroughly explore the codebase using your available read and shell "
+    "tools.\n"
+    "- Trace through call chains, imports, and dependencies to find ALL "
+    "relevant locations.\n"
+    "- For each relevant symbol (function, class, method, field, etc.), "
+    "identify its location and classify the action to be done on it as "
+    '"modify", "add", or "delete" based on what would be needed to '
+    "resolve the issue.\n"
+    "- " + LOC_SYMBOL_NAMING_RULES + "- Order symbols by relevance (most "
+    "relevant first).\n"
+    "\nBUDGET CONSTRAINT:\n"
+    "- You have a LIMITED number of tool calls. Be efficient and focused.\n"
+    "- Start with targeted searches (grep for keywords from the issue), "
+    "NOT broad directory listings.\n"
+    "- Once you have identified the relevant files, read only the "
+    "necessary sections.\n"
+    "- Do NOT exhaustively explore every file. Focus on the most likely "
+    "locations first.\n"
+    "- Return the final answer as a JSON object matching the provided "
+    "output_schema (a `locations` array of symbol objects).\n"
+)
+
+
+class CodexLocAgent:
+    """
+    Read-only code localization agent powered by the official OpenAI Codex SDK.
+
+    Sandbox is pinned to ``SandboxMode.read_only`` and approvals to
+    ``ApprovalMode.deny_all`` so the agent cannot write to disk or escalate.
+    The system prompt is passed via ``base_instructions`` (the SDK's
+    canonical place) rather than folded into the user message.
+    """
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        approval_mode: ApprovalMode = ApprovalMode.deny_all,
+        sandbox: SandboxMode = SandboxMode.read_only,
+        reasoning_effort: str = "medium",
+    ):
+        self.logger = get_logger(__name__)
+        self.model = model
+        self.system_prompt = system_prompt or _DEFAULT_SYSTEM_PROMPT
+        self.approval_mode = approval_mode
+        self.sandbox = sandbox
+        self.reasoning_effort = reasoning_effort
+
+    async def locate_code(
+        self,
+        query_text: str,
+        repo_path: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> LocResult:
+        """
+        Locate relevant code positions for a given query in a repository.
+
+        Args:
+            query_text: The issue description or query to localize.
+            repo_path: Path to the repository root.
+            context: Additional context with keys like
+                     'issue_title', 'issue_body', 'diff', 'hints'.
+
+        Returns:
+            LocResult with identified code locations and symbol details.
+        """
+        if not os.path.isdir(repo_path):
+            return LocResult(
+                success=False,
+                repo_path=repo_path,
+                error_message=f"Repository path does not exist: {repo_path}",
+            )
+
+        user_prompt = self._prepare_user_prompt(query_text, context)
+
+        try:
+            async with AsyncCodex() as codex:
+                thread = await codex.thread_start(
+                    model=self.model,
+                    base_instructions=self.system_prompt,
+                    cwd=str(repo_path),
+                    sandbox=self.sandbox,
+                    approval_mode=self.approval_mode,
+                    config={"model_reasoning_effort": self.reasoning_effort},
+                )
+
+                self.logger.info(f"Starting code localization in: {repo_path}")
+                self.logger.debug(f"Query: {query_text[:200]}...")
+
+                result = await thread.run(
+                    user_prompt,
+                    output_schema=LOC_OUTPUT_SCHEMA,
+                )
+
+            usage_info = self._extract_usage(result)
+            self._log_usage(usage_info)
+
+            locations = self._parse_locations(result.final_response)
+            execution_log = [str(item) for item in result.items]
+
+            return LocResult(
+                success=True,
+                repo_path=repo_path,
+                locations=locations,
+                execution_log=execution_log,
+                usage=usage_info or None,
+            )
+
+        except Exception as e:
+            error_msg = f"Error during code localization: {str(e)}"
+            self.logger.error(error_msg)
+            return LocResult(
+                success=False,
+                repo_path=repo_path,
+                error_message=error_msg,
+            )
+
+    def _prepare_user_prompt(
+        self, query_text: str, context: Optional[Dict[str, Any]]
+    ) -> str:
+        """Build the user-facing prompt; system rules are sent via base_instructions."""
+        parts: List[str] = []
+
+        if context:
+            if "issue_title" in context:
+                parts.append(f"## Issue Title\n{context['issue_title']}\n")
+            if "issue_body" in context:
+                parts.append(f"## Issue Body\n{context['issue_body']}\n")
+            if "diff" in context:
+                parts.append(f"## Related Diff\n```diff\n{context['diff']}\n```\n")
+            if "hints" in context:
+                parts.append(f"## Hints\n{context['hints']}\n")
+
+        parts.append(f"## Query\n{query_text}")
+
+        parts.append(
+            "\n## Instructions\n"
+            "1. Explore the repository to understand its structure.\n"
+            "2. Identify ALL code symbols relevant to the query above.\n"
+            "3. For each relevant symbol, note the name (in the canonical "
+            "format described in your base instructions), type, file path "
+            "(relative to repo root), line range, and what action is needed.\n"
+            "4. Return the final answer as a JSON object matching the "
+            "provided output_schema.\n"
+            "5. DO NOT modify any files. This is a read-only analysis task.\n"
+        )
+
+        return "\n".join(parts)
+
+    def _extract_usage(self, result: Any) -> Dict[str, Any]:
+        """Normalize the official SDK's TurnResult.usage into a flat dict."""
+        info: Dict[str, Any] = {
+            "duration_ms": getattr(result, "duration_ms", None),
+            "status": (
+                result.status.value if getattr(result, "status", None) else None
+            ),
+            "num_items": len(getattr(result, "items", []) or []),
+        }
+        usage = getattr(result, "usage", None)
+        if usage is not None and getattr(usage, "total", None) is not None:
+            total = usage.total
+            info.update(
+                {
+                    "input_tokens": total.input_tokens,
+                    "cached_input_tokens": total.cached_input_tokens,
+                    "output_tokens": total.output_tokens,
+                    "reasoning_output_tokens": total.reasoning_output_tokens,
+                    "total_tokens": total.total_tokens,
+                }
+            )
+        return info
+
+    def _log_usage(self, usage_info: Dict[str, Any]) -> None:
+        if not usage_info:
+            return
+        self.logger.info(
+            "Usage: status=%s, input=%s, cached=%s, output=%s, "
+            "reasoning=%s, total=%s, duration_ms=%s, items=%s",
+            usage_info.get("status"),
+            usage_info.get("input_tokens"),
+            usage_info.get("cached_input_tokens"),
+            usage_info.get("output_tokens"),
+            usage_info.get("reasoning_output_tokens"),
+            usage_info.get("total_tokens"),
+            usage_info.get("duration_ms"),
+            usage_info.get("num_items"),
+        )
+
+    def _parse_locations(self, final_response: Optional[str]) -> List[CodeSymbol]:
+        """
+        Parse CodeSymbol objects from Codex's schema-validated JSON response.
+
+        With ``output_schema`` set, ``final_response`` is a JSON string
+        matching LOC_OUTPUT_SCHEMA -- a direct ``json.loads`` of
+        ``{"locations": [...]}``.
+        """
+        if not final_response:
+            self.logger.warning("Codex returned empty final_response.")
+            return []
+        try:
+            data = json.loads(final_response)
+        except json.JSONDecodeError:
+            self.logger.warning(
+                "Codex final_response is not valid JSON: %r",
+                final_response[:200],
+            )
+            return []
+
+        if isinstance(data, dict) and isinstance(data.get("locations"), list):
+            items = data["locations"]
+        elif isinstance(data, list):
+            items = data
+        else:
+            self.logger.warning("Unexpected output structure: %s", type(data))
+            return []
+
+        symbols = []
+        for item in items:
+            if not isinstance(item, dict) or "name" not in item:
+                continue
+            symbols.append(
+                CodeSymbol(
+                    name=item.get("name", ""),
+                    type=item.get("type", ""),
+                    file_path=item.get("file_path", ""),
+                    line_start=int(item.get("line_start", 0)),
+                    line_end=int(item.get("line_end", 0)),
+                    action=item.get("action", ""),
+                    description=item.get("description", ""),
+                )
+            )
+        return symbols
+
+
+class SyncCodexLocAgent:
+    """Synchronous wrapper for CodexLocAgent."""
+
+    def __init__(self, **kwargs):
+        self.agent = CodexLocAgent(**kwargs)
+        self.logger = get_logger(__name__)
+
+    def locate_code(
+        self,
+        query_text: str,
+        repo_path: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> LocResult:
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                return loop.run_until_complete(
+                    self.agent.locate_code(
+                        query_text=query_text,
+                        repo_path=repo_path,
+                        context=context,
+                    )
+                )
+            finally:
+                loop.close()
+        except Exception as e:
+            error_msg = f"Error in synchronous code localization: {str(e)}"
+            self.logger.error(error_msg)
+            return LocResult(
+                success=False,
+                repo_path=repo_path,
+                error_message=error_msg,
+            )

--- a/codeminer/eval/loc_agent_runner.py
+++ b/codeminer/eval/loc_agent_runner.py
@@ -1,0 +1,449 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared loop + I/O for agentic localization baseline runners (#150).
+
+Used by ``examples/claude_loc_agent.py`` and ``examples/codex_loc_agent.py``.
+Holds:
+
+- ``BUILTIN_DATASET_CHOICES`` and ``build_dataset(args)`` — same shape as
+  the existing retrieval-baseline scripts (e.g. embedding_retrieve_baseline.py)
+- ``already_done_ids(path)`` — skim a JSONL result file for completed IDs
+- ``build_result_entry(...)`` — per-instance record with ``metric_k_files`` /
+  ``metric_k_node_ids`` and per-scope/per-k ``metrics``, so it joins cleanly
+  against the internal harness (see retrieve_rerank.py)
+- ``run_agent_baseline(args, agent_factory, agent_name)`` — async driver
+  that iterates the dataset, calls the agent, scores against GT, and
+  appends JSONL incrementally; logs aggregate file/symbol@k at the end
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set
+
+from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
+from codeminer.dataset.locbench import LocbenchDataset
+from codeminer.dataset.swebench import SwebenchDataset
+from codeminer.eval.retrieval_eval import (
+    aggregate_metrics,
+    average_metrics,
+    collect_targets,
+    compute_metrics,
+    normalize_file_path,
+)
+from codeminer.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+BUILTIN_DATASET_CHOICES = ["codeminer_base", "swebench_lite", "locbench_v1"]
+DEFAULT_METRICS_K = [1, 3, 5, 10]
+
+
+def build_dataset(args):
+    """Mirror of embedding_retrieve_baseline._build_dataset()."""
+    if args.dataset == "codeminer_base":
+        return CodeMinerBaseDataset(
+            dataset="fishmingyu/codeminer-base-dataset",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=os.path.expanduser(args.repo_cache_dir),
+        )
+    if args.dataset == "swebench_lite":
+        return SwebenchDataset(
+            dataset="princeton-nlp/SWE-bench_Lite",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=os.path.expanduser(args.repo_cache_dir),
+        )
+    if args.dataset == "locbench_v1":
+        return LocbenchDataset(
+            dataset="czlll/Loc-Bench_V1",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=os.path.expanduser(args.repo_cache_dir),
+        )
+    raise ValueError(f"Unsupported dataset: {args.dataset}")
+
+
+def already_done_ids(result_path: Path) -> Set[str]:
+    """Return instance_ids already present in an existing JSONL result file."""
+    if not result_path.exists():
+        return set()
+    done: Set[str] = set()
+    with result_path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            iid = obj.get("instance_id")
+            if iid:
+                done.add(iid)
+    return done
+
+
+def _unique_files(locations) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for sym in locations:
+        if sym.file_path and sym.file_path not in seen:
+            out.append(sym.file_path)
+            seen.add(sym.file_path)
+    return out
+
+
+def _agent_symbol_id(file_path: str, name: str) -> Optional[str]:
+    """Compose an agent ``(file_path, name)`` into the GT ``file:symbol`` form.
+
+    GT (from ``codeminer/code_chunking/``) is exactly one of:
+        ``<file>:bare_function()``
+        ``<file>:Class.method()``
+        ``<file>:ClassName``
+
+    The agents' ``name`` field is constrained to this same canonical shape by
+    the JSON-Schema ``pattern`` on ``LOC_OUTPUT_SCHEMA`` (at most one ``.``,
+    no ``::``, no signatures) plus the system-prompt format rules. So scoring
+    is just exact string match against GT — no candidate generation, no FP
+    risk from over-permissive normalization.
+    """
+    if not name or not file_path:
+        return None
+    file_norm = normalize_file_path(file_path)
+    if not file_norm:
+        return None
+    return f"{file_norm}:{name}"
+
+
+def _agent_symbol_ids(locations) -> List[str]:
+    """Build the predicted symbol id list in agent-output order."""
+    out: List[str] = []
+    for sym in locations:
+        sid = _agent_symbol_id(sym.file_path, sym.name)
+        if sid is not None:
+            out.append(sid)
+    return out
+
+
+def _score_predictions(
+    predicted_files: Sequence[str],
+    predicted_symbols: Sequence[str],
+    target_files: Sequence[str],
+    target_symbols: Sequence[str],
+    ks: Sequence[int],
+) -> Dict[str, Dict[int, Dict[str, float]]]:
+    """``{files, symbols}`` × k metric dict via retrieval_eval.compute_metrics."""
+    metrics: Dict[str, Dict[int, Dict[str, float]]] = {"files": {}, "symbols": {}}
+    for k in ks:
+        metrics["files"][k] = compute_metrics(list(predicted_files[:k]), target_files)
+        metrics["symbols"][k] = compute_metrics(
+            list(predicted_symbols[:k]), target_symbols
+        )
+    return metrics
+
+
+def build_result_entry(
+    *,
+    instance_id: str,
+    agent_name: str,
+    model: Optional[str],
+    result,
+    target_files: Sequence[str],
+    target_symbols: Sequence[str],
+    metrics_k: Sequence[int],
+    error: Optional[str] = None,
+) -> Dict[str, Any]:
+    """One JSONL record: predictions + GT + per-scope/per-k metrics."""
+    base = {
+        "instance_id": instance_id,
+        "agent": agent_name,
+        "model": model,
+        "target_files": list(target_files),
+        "target_symbols": list(target_symbols),
+    }
+    if error or result is None or not result.success:
+        base.update(
+            {
+                "success": False,
+                "error": error or (result.error_message if result else "no result"),
+                "metric_k_files": [],
+                "metric_k_node_ids": [],
+                "locations": [],
+                "usage": None,
+                "metrics": None,
+            }
+        )
+        return base
+
+    locations_payload = [
+        {
+            "name": sym.name,
+            "type": sym.type,
+            "file_path": sym.file_path,
+            "line_start": sym.line_start,
+            "line_end": sym.line_end,
+            "action": sym.action,
+            "description": sym.description,
+        }
+        for sym in result.locations
+    ]
+    predicted_files = _unique_files(result.locations)
+    predicted_symbols = _agent_symbol_ids(result.locations)
+    metrics = _score_predictions(
+        predicted_files,
+        predicted_symbols,
+        target_files,
+        target_symbols,
+        metrics_k,
+    )
+
+    base.update(
+        {
+            "success": True,
+            "metric_k_files": predicted_files,
+            "metric_k_node_ids": predicted_symbols,
+            "locations": locations_payload,
+            "usage": result.usage,
+            "metrics": metrics,
+            "error": None,
+        }
+    )
+    return base
+
+
+def _empty_aggregate(ks: Sequence[int]) -> Dict[str, Dict[int, Dict[str, float]]]:
+    """Pre-seed the running aggregate so `aggregate_metrics` accumulates in place."""
+    return {
+        scope: {
+            k: {"accuracy": 0.0, "precision": 0.0, "recall": 0.0, "hits": 0.0}
+            for k in ks
+        }
+        for scope in ("files", "symbols")
+    }
+
+
+def _log_aggregate_table(
+    averaged: Mapping[str, Mapping[int, Mapping[str, float]]],
+    eval_count: int,
+) -> None:
+    """Pretty-print the aggregated files@k / symbols@k table to the logger."""
+    if eval_count == 0:
+        logger.info("No instances were scored (eval_count=0).")
+        return
+    logger.info("Aggregate metrics over %d scored instance(s):", eval_count)
+    for scope in ("files", "symbols"):
+        per_k = averaged.get(scope, {})
+        if not per_k:
+            continue
+        for k in sorted(per_k):
+            stats = per_k[k]
+            logger.info(
+                "  [%s] k=%-2d  accuracy=%.3f  precision=%.3f  recall=%.3f  "
+                "avg_hits=%.2f",
+                scope,
+                k,
+                stats["accuracy"],
+                stats["precision"],
+                stats["recall"],
+                stats["avg_hits"],
+            )
+
+
+async def run_agent_baseline(
+    args,
+    *,
+    agent_factory: Callable[[], Any],
+    agent_name: str,
+    model_label: Optional[str] = None,
+) -> int:
+    """Iterate dataset, call agent.locate_code on each instance, append JSONL.
+
+    Per-instance: score against GT (``target_files`` + ``target_symbols``)
+    via ``codeminer.eval.retrieval_eval.compute_metrics`` for the configured
+    ``--metrics-k`` cutoffs and embed the result in the JSONL row. At the
+    end, aggregate + log the dataset-level table.
+    """
+    dataset_obj = build_dataset(args)
+    instances = dataset_obj.load()
+    if len(instances) == 0:
+        raise ValueError(
+            f"No instances matched filter {args.filter_instance!r} "
+            f"on dataset {args.dataset!r}"
+        )
+    if getattr(args, "limit", None):
+        instances = instances.select(range(min(args.limit, len(instances))))
+    logger.info("Loaded %d instance(s) from %s", len(instances), args.dataset)
+
+    eval_metadata = dataset_obj.load_eval_metadata(args.eval_instances or "")
+    simplified_symbols = getattr(dataset_obj, "simplified_symbols", True)
+    metrics_k = list(args.metrics_k)
+
+    result_path = Path(args.result_path).expanduser().resolve()
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+
+    done = already_done_ids(result_path) if args.resume else set()
+    if done:
+        logger.info(
+            "Resuming — %d instance(s) already in %s, will skip",
+            len(done),
+            result_path,
+        )
+
+    agent = agent_factory()
+
+    aggregate = _empty_aggregate(metrics_k)
+    scored_count = 0
+    n_success = 0
+    n_failed = 0
+    n_skipped = 0
+
+    with result_path.open("a", encoding="utf-8") as out:
+        for i, inst in enumerate(instances):
+            instance_id = inst["instance_id"]
+            if instance_id in done:
+                n_skipped += 1
+                logger.info(
+                    "[%d/%d] %s — skipped (resume)",
+                    i + 1,
+                    len(instances),
+                    instance_id,
+                )
+                continue
+
+            metadata = eval_metadata.get(instance_id)
+            if metadata is None:
+                target_files: List[str] = []
+                target_symbols: List[str] = []
+            else:
+                target_files, target_symbols = collect_targets(
+                    metadata, simplified_symbols=simplified_symbols
+                )
+
+            logger.info("[%d/%d] %s", i + 1, len(instances), instance_id)
+            try:
+                dataset_obj.process_instance(inst)
+                repo = dataset_obj.get_repo_path(inst)
+                context = {
+                    "issue_title": f"[{instance_id}] {inst['repo']}",
+                    "issue_body": inst["problem_statement"],
+                }
+                if inst.get("hints_text"):
+                    context["hints"] = inst["hints_text"]
+                result = await agent.locate_code(
+                    inst["problem_statement"], repo, context=context
+                )
+                entry = build_result_entry(
+                    instance_id=instance_id,
+                    agent_name=agent_name,
+                    model=model_label,
+                    result=result,
+                    target_files=target_files,
+                    target_symbols=target_symbols,
+                    metrics_k=metrics_k,
+                )
+                if entry["success"]:
+                    n_success += 1
+                else:
+                    n_failed += 1
+            except Exception as e:  # noqa: BLE001 — record + continue
+                logger.exception("[%s] failed", instance_id)
+                entry = build_result_entry(
+                    instance_id=instance_id,
+                    agent_name=agent_name,
+                    model=model_label,
+                    result=None,
+                    target_files=target_files,
+                    target_symbols=target_symbols,
+                    metrics_k=metrics_k,
+                    error=str(e),
+                )
+                n_failed += 1
+
+            if entry["success"] and entry["metrics"] is not None:
+                aggregate_metrics(aggregate, entry["metrics"])
+                scored_count += 1
+                fk = entry["metrics"]["files"][metrics_k[0]]
+                sk = entry["metrics"]["symbols"][metrics_k[0]]
+                logger.info(
+                    "  files@%d acc=%.2f rec=%.2f | symbols@%d acc=%.2f rec=%.2f",
+                    metrics_k[0],
+                    fk["accuracy"],
+                    fk["recall"],
+                    metrics_k[0],
+                    sk["accuracy"],
+                    sk["recall"],
+                )
+
+            out.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            out.flush()
+
+    averaged = average_metrics(aggregate, scored_count)
+    _log_aggregate_table(averaged, scored_count)
+
+    logger.info(
+        "Done. success=%d failed=%d skipped=%d scored=%d total=%d result=%s",
+        n_success,
+        n_failed,
+        n_skipped,
+        scored_count,
+        len(instances),
+        result_path,
+    )
+    return 0 if n_failed == 0 else 1
+
+
+def add_common_args(parser) -> None:
+    """Attach the shared dataset / output / resume / scoring flags."""
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        choices=BUILTIN_DATASET_CHOICES,
+    )
+    parser.add_argument("--split", type=str, default="test")
+    parser.add_argument("--filter-instance", type=str, default=".*")
+    parser.add_argument(
+        "--repo-cache-dir",
+        type=str,
+        default="~/.codeminer/",
+    )
+    parser.add_argument(
+        "--result-path",
+        type=str,
+        required=True,
+        help="Path to JSONL result file (one instance per line, appended).",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip instance_ids already present in --result-path.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap number of instances to process (post-filter).",
+    )
+    parser.add_argument(
+        "--eval-instances",
+        type=str,
+        default="",
+        help=(
+            "Path to JSON file with eval annotations (target_files, symbols_*). "
+            "Leave empty for codeminer_base — GT is projected from dataset columns."
+        ),
+    )
+    parser.add_argument(
+        "--metrics-k",
+        type=int,
+        nargs="+",
+        default=DEFAULT_METRICS_K,
+        help="Cutoffs for files@k / symbols@k reporting.",
+    )

--- a/examples/claude_loc_agent.py
+++ b/examples/claude_loc_agent.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the ClaudeLocAgent baseline (Sub-issue #150) over a benchmark dataset.
+
+Setup:
+    pip install claude-agent-sdk>=0.2.82
+    export ANTHROPIC_API_KEY=...   # or use a logged-in `claude` CLI
+
+Usage:
+    # Full codeminer-base corpus (100 instances), append-only JSONL
+    python examples/claude_loc_agent.py \\
+        --dataset codeminer_base \\
+        --result-path .ttmp/baselines/claude_codeminer_base.jsonl
+
+    # Filter to a single instance (smoke):
+    python examples/claude_loc_agent.py \\
+        --dataset codeminer_base \\
+        --filter-instance "^fmtlib__fmt-2317$" \\
+        --result-path .ttmp/baselines/claude_smoke.jsonl
+
+    # Resume after a crash -- skip instance_ids already in the result file:
+    python examples/claude_loc_agent.py \\
+        --dataset codeminer_base \\
+        --result-path .ttmp/baselines/claude_codeminer_base.jsonl \\
+        --resume
+
+Output: JSONL, one record per instance with retrieve_rerank-compatible
+``metric_k_files`` / ``metric_k_node_ids`` plus the full agent ``locations``
+and ``usage``.
+"""
+
+import argparse
+import asyncio
+
+from codeminer.agent.claude_agent import ClaudeLocAgent
+from codeminer.eval.loc_agent_runner import add_common_args, run_agent_baseline
+from codeminer.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run ClaudeLocAgent baseline on a benchmark dataset",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    add_common_args(parser)
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="sonnet",
+        help="Claude model alias passed to claude_agent_sdk (e.g. sonnet, opus).",
+    )
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=100,
+        help="Hard cap on agent turns (claude_agent_sdk max_turns).",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    logger.info(
+        "ClaudeLocAgent baseline | dataset=%s model=%s max_turns=%d",
+        args.dataset,
+        args.model,
+        args.max_turns,
+    )
+
+    def factory():
+        return ClaudeLocAgent(model=args.model, max_turns=args.max_turns)
+
+    rc = asyncio.run(
+        run_agent_baseline(
+            args,
+            agent_factory=factory,
+            agent_name="claude",
+            model_label=args.model,
+        )
+    )
+    raise SystemExit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/codex_loc_agent.py
+++ b/examples/codex_loc_agent.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the CodexLocAgent baseline (Sub-issue #150) over a benchmark dataset.
+
+Setup:
+    # OpenAI's official Codex SDK ships from github.com/openai/codex
+    # (not yet on PyPI as of 2026-05). Install from git, pinned to a
+    # verified commit. --no-deps + manual cli-bin pin is required because
+    # the SDK's pyproject pins to a cli-bin version that isn't published
+    # yet (pre-release version skew); same-minor cli-bin is compatible.
+    pip install --pre --no-deps \\
+        "openai-codex @ git+https://github.com/openai/codex.git@\\
+e389e01f8347a4861ed139b01956fe64aa0c0fda#subdirectory=sdk/python"
+    pip install --pre "openai-codex-cli-bin==0.131.0a8"
+    codex login   # writes ~/.codex/auth.json
+    # or: export CODEX_API_KEY=...
+
+Usage:
+    # Full codeminer-base corpus (100 instances), append-only JSONL
+    python examples/codex_loc_agent.py \\
+        --dataset codeminer_base \\
+        --result-path .ttmp/baselines/codex_codeminer_base.jsonl
+
+    # Filter to a single instance (smoke):
+    python examples/codex_loc_agent.py \\
+        --dataset codeminer_base \\
+        --filter-instance "^fmtlib__fmt-2317$" \\
+        --result-path .ttmp/baselines/codex_smoke.jsonl
+
+    # Resume after a crash -- skip instance_ids already in the result file:
+    python examples/codex_loc_agent.py \\
+        --dataset codeminer_base \\
+        --result-path .ttmp/baselines/codex_codeminer_base.jsonl \\
+        --resume
+
+Output: JSONL, one record per instance with retrieve_rerank-compatible
+``metric_k_files`` / ``metric_k_node_ids`` plus the full agent ``locations``
+and ``usage``.
+"""
+
+import argparse
+import asyncio
+
+from codeminer.agent.codex_agent import CodexLocAgent
+from codeminer.eval.loc_agent_runner import add_common_args, run_agent_baseline
+from codeminer.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run CodexLocAgent baseline on a benchmark dataset",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    add_common_args(parser)
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help="Codex model name; defaults to the codex CLI's configured model.",
+    )
+    parser.add_argument(
+        "--reasoning-effort",
+        type=str,
+        default="medium",
+        choices=["minimal", "low", "medium", "high"],
+        help="model_reasoning_effort passed to openai_codex thread config.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    logger.info(
+        "CodexLocAgent baseline | dataset=%s model=%s reasoning_effort=%s",
+        args.dataset,
+        args.model or "(cli-default)",
+        args.reasoning_effort,
+    )
+
+    def factory():
+        return CodexLocAgent(
+            model=args.model,
+            reasoning_effort=args.reasoning_effort,
+        )
+
+    rc = asyncio.run(
+        run_agent_baseline(
+            args,
+            agent_factory=factory,
+            agent_name="codex",
+            model_label=args.model,
+        )
+    )
+    raise SystemExit(rc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #150. Lands the programmatic harness for the two third-party
agentic baselines: `ClaudeLocAgent` over `claude_agent_sdk` and
`CodexLocAgent` over OpenAI's official `openai_codex` SDK, plus
dataset-iterating runners that score `files@k` and `symbols@k`
against `codeminer_base` GT.

## Summary

Both agents are read-only (sandbox + approval lock down writes) and
emit names matching the chunker's canonical shape via a JSON-Schema
`pattern` on the shared `LOC_OUTPUT_SCHEMA` — so per-instance scoring
is exact `file:name` string match through the same
`retrieval_eval.compute_metrics` the retrieval baselines use.
Per-row JSONL carries `metric_k_files` / `metric_k_node_ids` /
`metrics.{files,symbols}.{k}` (joinable against `retrieve_rerank.py`),
written incrementally with `--resume` to survive crashes on long runs
(~80 min for 100 instances).

## Architecture

- **`codeminer/agent/{claude,codex}_agent.py`** — sibling agent classes
  sharing `LOC_OUTPUT_SCHEMA` / `LOC_SYMBOL_NAMING_RULES` / `CodeSymbol`
  / `LocResult`. The schema's `name` regex
  (`^[A-Za-z_]\w*(\.\w+)?(\(\))?$`) is the load-bearing constraint —
  agents emit GT-form names directly, no post-hoc normalization. Probe
  confirmed `openai_codex` honors `pattern` (rewrote `fmt::detail::foo()`
  to `fmt.detail.foo()`).
- **`codeminer/eval/loc_agent_runner.py`** — sibling of
  `retrieval_eval.py`: dataset iteration, GT scoring via
  `compute_metrics`, per-instance JSONL row with embedded `metrics`,
  aggregate table at end, `--resume`.
- **`examples/{claude,codex}_loc_agent.py`** — thin argparse entries
  (~80 LOC each); Setup blocks in docstrings carry SDK install commands.
  SDKs are **not** in `pyproject.toml` — they're for paid experiments,
  not library deps.

## SDK install

```bash
# Claude side — PyPI
pip install claude-agent-sdk>=0.2.82
export ANTHROPIC_API_KEY=...

# Codex side — official openai_codex (github-only as of 2026-05);
# --no-deps + manual cli-bin pin because the SDK's pyproject pins to a
# pre-release cli-bin version not yet on PyPI.
pip install --pre --no-deps \
    "openai-codex @ git+https://github.com/openai/codex.git@e389e01f8347a4861ed139b01956fe64aa0c0fda#subdirectory=sdk/python"
pip install --pre "openai-codex-cli-bin==0.131.0a8"
codex login
```

Per #150 v2 Table 3, `$` / `wall_time` / `tokens` aren't promoted to
scoring axes (third-party infra overhead makes them non-comparable);
captured per row for billing sanity, not aggregated.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Verified locally:
- Cross-lang scoring sanity on 4 instances (`fmt-2317`, `astropy-13579`,
  `ruff-15356`, `caddy-4943`) — all agents emit GT-form names directly
- `--resume` correctly skips already-completed instance_ids
- Pre-commit suite (black / isort / flake8 / reuse / etc.) clean
- 100-instance run left for the API-budget owner

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
