### PR TITLE
[scripts] harden profile_incremental_graph.py (review fixes for #144)

### DIFF
--- a/scripts/profile_incremental_graph.py
+++ b/scripts/profile_incremental_graph.py
@@ -38,6 +38,7 @@ Usage:
     # Or from a JSON file:
     python scripts/profile_incremental_graph.py --config instances.json --steps 20
 """
+
 from __future__ import annotations
 
 import argparse
@@ -199,8 +200,6 @@ def is_test_path(path: str) -> bool:
             return True
         if part.startswith("test_"):
             return True
-    if base.startswith("test_"):
-        return True
     if base.endswith("_test.go") or base.endswith("_test.py"):
         return True
     if base.endswith((".test.ts", ".test.tsx", ".test.js", ".test.jsx")):
@@ -376,9 +375,19 @@ def compute_delta_symbols(
     added = removed = modified = 0
     with tempfile.TemporaryDirectory(prefix="chainbench_") as tmpdir:
         tmp = Path(tmpdir)
+        tmp_resolved = tmp.resolve()
         for rel_path in changed_files:
             base_file = tmp / "base" / rel_path
             tgt_file = tmp / "target" / rel_path
+            # Defensive: git diff output shouldn't contain ``..`` segments
+            # for tracked paths, but a malformed entry would let
+            # ``tmp / rel_path`` escape the temporary directory. Drop
+            # anything that doesn't resolve under tmp.
+            try:
+                base_file.resolve().relative_to(tmp_resolved)
+                tgt_file.resolve().relative_to(tmp_resolved)
+            except ValueError:
+                continue
             has_base = git_show_to_file(repo, base, rel_path, base_file)
             has_target = git_show_to_file(repo, target, rel_path, tgt_file)
             base_map = (
@@ -580,6 +589,26 @@ def run_rebuild_step(
 # ---------------------------------------------------------------------------
 
 
+def _first_symbol_position(symbols) -> Optional[Tuple[int, int]]:
+    """First (line, char) found by DFS into LSP documentSymbol output."""
+    for s in symbols or []:
+        sel = s.get("selectionRange", s.get("range", {}))
+        line = sel.get("start", {}).get("line")
+        char = sel.get("start", {}).get("character", 0)
+        if line is not None:
+            return (line, char)
+        nested = _first_symbol_position(s.get("children", []))
+        if nested is not None:
+            return nested
+    return None
+
+
+def _get_lsp_client(patcher):
+    return getattr(patcher, "lsp_client", None) or getattr(
+        getattr(patcher, "_impl", None), "lsp_client", None
+    )
+
+
 def _warmup_lsp(
     patcher, repo: Path, base_sha: str, target_sha: str, language: str
 ) -> float:
@@ -587,20 +616,11 @@ def _warmup_lsp(
     falls outside the timed region. Excluded from t_s.
     """
     t0 = time.monotonic()
-    try:
-        names = subprocess.check_output(
-            ["git", "diff", "--name-only", base_sha, target_sha],
-            cwd=str(repo),
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).split()
-    except subprocess.CalledProcessError:
-        names = []
+    r = run_git(["diff", "--name-only", base_sha, target_sha], cwd=repo, timeout=60)
+    names = r.stdout.split() if r.returncode == 0 else []
     exts = LANG_EXTS.get(language, set())
     abs_paths = [repo / n for n in names if Path(n).suffix in exts]
-    lsp = getattr(patcher, "lsp_client", None) or getattr(
-        getattr(patcher, "_impl", None), "lsp_client", None
-    )
+    lsp = _get_lsp_client(patcher)
     if lsp is None:
         return 0.0
     for p in abs_paths:
@@ -617,22 +637,7 @@ def _warmup_lsp(
             continue
         try:
             syms = lsp.document_symbol(str(p)) or []
-            real_pos = None
-
-            def _walk(items):
-                nonlocal real_pos
-                for s in items or []:
-                    if real_pos:
-                        return
-                    sel = s.get("selectionRange", s.get("range", {}))
-                    line = sel.get("start", {}).get("line")
-                    char = sel.get("start", {}).get("character", 0)
-                    if line is not None:
-                        real_pos = (line, char)
-                        return
-                    _walk(s.get("children", []))
-
-            _walk(syms)
+            real_pos = _first_symbol_position(syms)
             if real_pos:
                 lsp.definition(str(p), real_pos[0], real_pos[1])
         except Exception:
@@ -706,27 +711,16 @@ def run_patcher_phase(
             exts = LANG_EXTS.get(lang, set())
             seen_files: set = set()
             for t in chain:
-                try:
-                    names = subprocess.check_output(
-                        [
-                            "git",
-                            "diff",
-                            "--name-only",
-                            t["from_commit"],
-                            t["to_commit"],
-                        ],
-                        cwd=str(repo),
-                        text=True,
-                        stderr=subprocess.DEVNULL,
-                    ).split()
-                except subprocess.CalledProcessError:
-                    names = []
+                r = run_git(
+                    ["diff", "--name-only", t["from_commit"], t["to_commit"]],
+                    cwd=repo,
+                    timeout=60,
+                )
+                names = r.stdout.split() if r.returncode == 0 else []
                 for n in names:
                     if Path(n).suffix in exts:
                         seen_files.add(n)
-            lsp = getattr(patcher, "lsp_client", None) or getattr(
-                getattr(patcher, "_impl", None), "lsp_client", None
-            )
+            lsp = _get_lsp_client(patcher)
             if lsp is not None:
                 for rel in sorted(seen_files):
                     abs_p = repo / rel
@@ -749,12 +743,28 @@ def run_patcher_phase(
         f"phase-warmup {phase_warmup_s:.1f}s, running {len(chain)} steps"
     )
 
+    # ``poisoned`` flips to True after any timeout/exception inside
+    # ``patch_files``. The in-memory graph mutates in place and the LSP
+    # JSON-RPC socket can be left in an undefined state after a SIGALRM
+    # interrupt, so measurements past that point are unreliable. Remaining
+    # steps are recorded as ``aborted_prior_step_poisoned`` instead of
+    # silently producing bad t_s / v / e numbers.
+    poisoned = False
+    poisoned_at: Optional[int] = None
+
     try:
         for i, t in enumerate(chain):
             step = t["step"]
             step_dir = out_root / iid / f"step{step}"
             step_dir.mkdir(parents=True, exist_ok=True)
             out_pkl = step_dir / out_filename
+
+            if poisoned:
+                sub_records[step] = {
+                    "status": "aborted_prior_step_poisoned",
+                    "poisoned_at_step": poisoned_at,
+                }
+                continue
 
             # Per-step LSP profile capture.
             profile_path: Optional[Path] = None
@@ -824,6 +834,15 @@ def run_patcher_phase(
                     "profile": stats.get("profile") or {},
                 }
             except StrategyTimeout:
+                # Graph + LSP state are now suspect — poison the rest of
+                # the phase so we don't report numbers off a half-mutated
+                # graph or a broken JSON-RPC pipe.
+                poisoned = True
+                poisoned_at = step
+                log(
+                    f"  {strategy} step{step}: timeout — "
+                    f"poisoning remaining {len(chain) - i - 1} step(s)"
+                )
                 sub = {
                     "status": "timeout",
                     "t_s": timeout_s,
@@ -831,6 +850,12 @@ def run_patcher_phase(
                     "warmup_s": warmup_s,
                 }
             except Exception as e:
+                poisoned = True
+                poisoned_at = step
+                log(
+                    f"  {strategy} step{step}: {type(e).__name__}: {e} — "
+                    f"poisoning remaining {len(chain) - i - 1} step(s)"
+                )
                 sub = {
                     "status": "error",
                     "error": f"{type(e).__name__}: {e}",
@@ -964,10 +989,15 @@ def process_instance(
     base_graph_pkl = cache_root / iid / "graph.pkl"
     if not base_graph_pkl.exists():
         log(f"[{iid}] missing base graph: {base_graph_pkl}")
+        # ``step=0`` so the row is keyed and --resume skips it next time;
+        # without a step the resume index drops the row (key (iid, None)
+        # is filtered out at load) and the same error is re-appended on
+        # every retry.
         return [
             {
                 "instance_id": iid,
                 "language": language,
+                "step": 0,
                 "error": f"no base graph at {base_graph_pkl}",
             }
         ]
@@ -1106,16 +1136,29 @@ def parse_instances_config(path: Path) -> List[Tuple[str, str, str]]:
 
 
 def _infer_language(repo: Path) -> Optional[str]:
+    """Sample up to 200 tracked files to guess the dominant language.
+
+    Uses ``os.walk`` with in-place dir pruning to skip dot-dirs
+    (``.git``, ``.cache``) and known build/dependency trees so the scan
+    doesn't traverse millions of objects on large repos.
+    """
     if not repo.is_dir():
         return None
     counts: Dict[str, int] = {lang: 0 for lang in LANG_EXTS}
-    for f in repo.rglob("*"):
-        if f.is_file():
+    prune = {"node_modules", "target", "build", "dist", "vendor", "__pycache__"}
+    sampled = 0
+    for dirpath, dirnames, filenames in os.walk(repo):
+        dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in prune]
+        for name in filenames:
+            suffix = Path(name).suffix
             for lang, exts in LANG_EXTS.items():
-                if f.suffix in exts:
+                if suffix in exts:
                     counts[lang] += 1
                     break
-        if sum(counts.values()) > 200:
+            sampled += 1
+            if sampled > 200:
+                break
+        if sampled > 200:
             break
     if not any(counts.values()):
         return None
@@ -1218,8 +1261,11 @@ def main():
     if args.out_root is None:
         args.out_root = args.output.parent / "chain_work"
 
-    # Load already-done keys for --resume.
+    # Load already-done keys for --resume. ``done_steps[iid]`` is the set
+    # of step ids written for that instance, including ``0`` for the
+    # missing-base-graph sentinel from process_instance.
     done: set = set()
+    done_steps: Dict[str, set] = {}
     if args.resume and args.output.exists():
         for line in args.output.open():
             try:
@@ -1230,6 +1276,7 @@ def main():
             step = r.get("step")
             if iid and step is not None:
                 done.add((iid, step))
+                done_steps.setdefault(iid, set()).add(step)
 
     def log(msg: str) -> None:
         print(msg, flush=True)
@@ -1242,12 +1289,21 @@ def main():
     fh = args.output.open("a")
     try:
         for iid, language, base_sha in instances:
-            # Whole-instance short-circuit: if every step is already in the
-            # output file, skip the entire chain so we don't re-walk it just
-            # to throw away the rows at write-time.
-            if args.resume and all((iid, s) in done for s in range(1, args.steps + 1)):
-                log(f"[{iid}] all {args.steps} steps already in output, skipping")
-                continue
+            # Whole-instance short-circuit. Two reasons to skip walking
+            # the chain at all:
+            #   1. every step 1..N already written, OR
+            #   2. step ``0`` (missing-base-graph sentinel) written.
+            # Repos whose first-parent walk produces fewer than --steps
+            # rows can't be detected without re-walking, so they fall
+            # through and rely on the per-row resume-skip below.
+            if args.resume:
+                steps_done = done_steps.get(iid, set())
+                if 0 in steps_done:
+                    log(f"[{iid}] resume-skip (missing-base-graph sentinel)")
+                    continue
+                if all(s in steps_done for s in range(1, args.steps + 1)):
+                    log(f"[{iid}] resume-skip (all {args.steps} steps in output)")
+                    continue
             rows = process_instance(
                 iid,
                 language,

--- a/scripts/profile_incremental_graph.py
+++ b/scripts/profile_incremental_graph.py
@@ -1147,7 +1147,7 @@ def _infer_language(repo: Path) -> Optional[str]:
     counts: Dict[str, int] = {lang: 0 for lang in LANG_EXTS}
     prune = {"node_modules", "target", "build", "dist", "vendor", "__pycache__"}
     sampled = 0
-    for dirpath, dirnames, filenames in os.walk(repo):
+    for _dirpath, dirnames, filenames in os.walk(repo):
         dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in prune]
         for name in filenames:
             suffix = Path(name).suffix

--- a/test/scripts/test_profile_incremental_graph.py
+++ b/test/scripts/test_profile_incremental_graph.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the pure helpers in scripts/profile_incremental_graph.py.
+
+The script transitively imports the full ``codeminer`` package (which pulls
+litellm and other heavy deps at import time). Tests here stub those imports
+via ``sys.modules`` so the pure helpers can be loaded without a full dev
+environment.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "profile_incremental_graph.py"
+)
+
+
+def _load_script_module():
+    """Load the benchmark script with codeminer.* deps stubbed."""
+    cached = sys.modules.get("profile_incremental_graph")
+    if cached is not None:
+        return cached
+
+    stubs = {
+        "codeminer": types.ModuleType("codeminer"),
+        "codeminer.code_chunker": types.ModuleType("codeminer.code_chunker"),
+        "codeminer.graph": types.ModuleType("codeminer.graph"),
+        "codeminer.graph.code_graph": types.ModuleType("codeminer.graph.code_graph"),
+        "codeminer.graph.incremental": types.ModuleType("codeminer.graph.incremental"),
+        "codeminer.graph.incremental.graph_patcher": types.ModuleType(
+            "codeminer.graph.incremental.graph_patcher"
+        ),
+        "codeminer.ls_router": types.ModuleType("codeminer.ls_router"),
+    }
+    stubs["codeminer.code_chunker"].CodeChunker = type("CodeChunker", (), {})
+    stubs["codeminer.graph.code_graph"].CodeGraph = type("CodeGraph", (), {})
+    stubs["codeminer.graph.incremental.graph_patcher"].GraphPatcher = type(
+        "GraphPatcher", (), {}
+    )
+    stubs["codeminer.ls_router"].LSIndexer = type("LSIndexer", (), {})
+
+    saved = {name: sys.modules.get(name) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "profile_incremental_graph", _SCRIPT_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["profile_incremental_graph"] = module
+        spec.loader.exec_module(module)
+    finally:
+        for name, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_script_module()
+
+
+class TestIsTestPath:
+    """Files/dirs the test-exclusion filter should catch vs. let through."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "test/foo.py",
+            "tests/bar.go",
+            "src/__tests__/baz.ts",
+            "pkg/testing/x.go",
+            "fixtures/data.json",
+            "testdata/sample.txt",
+            "src/test_helper.py",
+            "src/handler_test.go",
+            "src/handler_test.py",
+            "src/component.test.ts",
+            "src/component.test.tsx",
+            "src/component.spec.js",
+            "src/SPEC.spec.ts",
+            "deeply/nested/specs/x.py",
+        ],
+    )
+    def test_excludes(self, script, path):
+        assert script.is_test_path(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/foo.py",
+            "lib/handler.go",
+            "pkg/server/main.go",
+            "src/component.ts",
+            "src/myspec.py",
+            "src/contestant.py",
+        ],
+    )
+    def test_includes(self, script, path):
+        assert script.is_test_path(path) is False
+
+
+class TestParseInstancesInline:
+    """Comma-separated instance spec parsing."""
+
+    def test_three_field_form(self, script, tmp_path):
+        out = script.parse_instances_inline("foo:python:abc123,bar:go:def456", tmp_path)
+        assert out == [("foo", "python", "abc123"), ("bar", "go", "def456")]
+
+    def test_whitespace_tolerance(self, script, tmp_path):
+        out = script.parse_instances_inline(" foo:python:abc , bar:go:def ", tmp_path)
+        assert out == [("foo", "python", "abc"), ("bar", "go", "def")]
+
+    def test_skip_malformed(self, script, tmp_path, capsys):
+        out = script.parse_instances_inline("only_one_field,foo:python:abc", tmp_path)
+        assert out == [("foo", "python", "abc")]
+        assert "cannot parse" in capsys.readouterr().err
+
+    def test_two_field_with_inference_failure(self, script, tmp_path, capsys):
+        # No repo on disk → inference returns None → entry dropped with warning.
+        out = script.parse_instances_inline("ghost:abc123", tmp_path)
+        assert out == []
+        assert "language inference failed" in capsys.readouterr().err
+
+    def test_two_field_with_inference_success(self, script, tmp_path):
+        # Create a repo dir with .py files to force python inference.
+        repo = tmp_path / "real" / "repo"
+        repo.mkdir(parents=True)
+        for i in range(3):
+            (repo / f"f{i}.py").write_text("x = 1\n")
+        out = script.parse_instances_inline("real:abc123", tmp_path)
+        assert out == [("real", "python", "abc123")]
+
+
+class TestSummarizeLspProfile:
+    """LSP profile JSONL → aggregate summary."""
+
+    def test_missing_file(self, script, tmp_path):
+        out = script._summarize_lsp_profile(tmp_path / "nope.jsonl")
+        assert out == {"calls_total": 0, "calls_by_method": {}, "ms_by_method": {}}
+
+    def test_aggregates_by_method(self, script, tmp_path):
+        p = tmp_path / "calls.jsonl"
+        p.write_text(
+            "\n".join(
+                [
+                    '{"m": "definition", "ms": 10.5, "n": 2}',
+                    '{"m": "definition", "ms": 4.5, "n": 0}',
+                    '{"m": "references", "ms": 100, "n": 5}',
+                    "",
+                    "garbage line — must not crash the parser",
+                ]
+            )
+        )
+        out = script._summarize_lsp_profile(p)
+        assert out["calls_total"] == 3
+        assert out["calls_by_method"] == {"definition": 2, "references": 1}
+        assert out["ms_by_method"]["definition"] == 15.0
+        assert out["ms_by_method"]["references"] == 100.0
+        assert out["empty_by_method"]["definition"] == 1
+        assert out["empty_by_method"]["references"] == 0
+
+
+class TestFirstSymbolPosition:
+    """DFS into LSP documentSymbol output."""
+
+    def test_empty(self, script):
+        assert script._first_symbol_position([]) is None
+        assert script._first_symbol_position(None) is None
+
+    def test_top_level(self, script):
+        syms = [{"selectionRange": {"start": {"line": 7, "character": 4}}}]
+        assert script._first_symbol_position(syms) == (7, 4)
+
+    def test_falls_back_to_range(self, script):
+        syms = [{"range": {"start": {"line": 12, "character": 0}}}]
+        assert script._first_symbol_position(syms) == (12, 0)
+
+    def test_descends_into_children(self, script):
+        syms = [
+            {"children": []},  # no positional info
+            {"children": [{"selectionRange": {"start": {"line": 99}}}]},
+        ]
+        assert script._first_symbol_position(syms) == (99, 0)
+
+    def test_skips_missing_line(self, script):
+        syms = [
+            {"range": {"start": {}}},  # missing line
+            {"range": {"start": {"line": 3}}},
+        ]
+        assert script._first_symbol_position(syms) == (3, 0)


### PR DESCRIPTION
Stacks onto #144 (targets `profile-incremental-graph`, not `main`). Merging this brings the review fixes into PR #144's branch.

## Correctness
- **Timeout corrupts the in-memory graph.** `run_with_timeout` wraps `patcher.patch_files`, which mutates the `CodeGraph` in place; a SIGALRM mid-mutation also leaves the LSP JSON-RPC socket undefined. The next step in the phase reused that half-mutated graph and reported `t_s`/`v`/`e` off it. A timeout/exception now flips a `poisoned` flag and remaining steps are recorded as `aborted_prior_step_poisoned` (with `poisoned_at_step`) rather than silently emitting bad numbers.
- **`--resume` error-row leak.** The missing-base-graph row had no `step` key, so the resume loader (which filters `step is None`) dropped it and re-appended the same error every retry. It now carries `step=0`, and the whole-instance short-circuit recognises that sentinel.
- **`--resume` short-circuit** keys off a per-instance `done_steps` set; dropped the `all((iid, s) in done ...)` form that could mis-skip when `--steps` was raised between runs.

## Cleanups
- Lifted the documentSymbol DFS into `_first_symbol_position`; extracted `_get_lsp_client`.
- Replaced ad-hoc `subprocess.check_output` git calls with the existing `run_git` helper.
- `_infer_language` uses `os.walk` with dir-pruning (skips `.git`, `target`, `node_modules`, `build`, `dist`, `vendor`) instead of `rglob('*')`.
- Removed the redundant `base.startswith("test_")` branch in `is_test_path`; added a path-traversal guard in `compute_delta_symbols`.

## Tests
New `test/scripts/test_profile_incremental_graph.py` — 32 cases over `is_test_path`, `parse_instances_inline`, `_summarize_lsp_profile`, `_first_symbol_position`. Stubs `codeminer.*` via `sys.modules` so they run in the unit tier with no SCIP/LSP deps.

## Verification
Local `flake8` (+bugbear), `black --check`, `isort --check`, `reuse lint`, and the 32 unit tests all pass. Only the unit tier was verifiable here — the poison-on-timeout path isn't exercised without a real patcher (integration/slow).
