### PR TITLE
ci: stop integration-serial timeout + gate serial chain behind path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ on:
       - "docs/**"
       - "LICENSE"
       - ".gitignore"
+  schedule:
+    # 07:00 UTC daily — forces a full serial-chain run so the graph.pkl cache
+    # and C++ parity never silently rot on light-only weeks.
+    - cron: "0 7 * * *"
   workflow_dispatch:
     inputs:
       skip_tests:
@@ -45,7 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
+      run-serial: ${{ steps.serial.outputs.run-serial }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Evaluate skip condition
         id: check
         run: |
@@ -69,6 +77,43 @@ jobs:
           else
             echo "should-run=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # Detect whether any changed file lies OUTSIDE the "light" set (docs,
+      # scripts, examples). Expressed as a catch-all '**' plus '!light'
+      # negations under predicate-quantifier 'every': a file matches `heavy`
+      # only if it matches '**' AND none of the negations exclude it — i.e. it
+      # is outside the light set. Output `heavy` is true iff >=1 heavy file.
+      - name: Detect heavy (serial-chain) source changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          base: ${{ github.event_name == 'push' && github.ref || '' }}
+          predicate-quantifier: "every"
+          filters: |
+            heavy:
+              - "**"
+              - "!scripts/**"
+              - "!examples/**"
+              - "!docs/**"
+              - "!**/*.md"
+              - "!LICENSE"
+              - "!.gitignore"
+
+      - name: Compute run-serial
+        id: serial
+        run: |
+          # Fail closed: run the serial chain unless we are sure it isn't needed.
+          RUN_SERIAL=true
+          case "${{ github.event_name }}" in
+            schedule|workflow_dispatch)
+              RUN_SERIAL=true ;;          # forced full run
+            push|pull_request)
+              # Only skip when the filter ran cleanly and found no heavy files.
+              if [[ "${{ steps.filter.outputs.heavy }}" == "false" ]]; then
+                RUN_SERIAL=false
+              fi ;;
+          esac
+          echo "run-serial=$RUN_SERIAL" >> "$GITHUB_OUTPUT"
 
   # =============================================================
   # Job 1 — Unit tests  (pure logic, mocks only, ~1 min)
@@ -143,7 +188,7 @@ jobs:
   # =============================================================
   integration-serial:
     needs: [preflight, integration]
-    if: needs.preflight.outputs.should-run == 'true'
+    if: needs.preflight.outputs.should-run == 'true' && needs.preflight.outputs.run-serial == 'true'
     runs-on: self-hosted
     timeout-minutes: 45
     env:
@@ -201,7 +246,7 @@ jobs:
   # =============================================================
   scip-core:
     needs: [preflight, integration-serial]
-    if: needs.preflight.outputs.should-run == 'true'
+    if: needs.preflight.outputs.should-run == 'true' && needs.preflight.outputs.run-serial == 'true'
     runs-on: self-hosted
     timeout-minutes: 30
     env:
@@ -308,7 +353,7 @@ jobs:
   # =============================================================
   graph-consumer:
     needs: [preflight, integration-serial]
-    if: needs.preflight.outputs.should-run == 'true'
+    if: needs.preflight.outputs.should-run == 'true' && needs.preflight.outputs.run-serial == 'true'
     runs-on: self-hosted
     timeout-minutes: 15
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
   # =============================================================
   preflight:
     runs-on: ubuntu-latest
+    # paths-filter fetches the PR's changed-file list via the GitHub API
+    # (base is empty for pull_request events), which needs pull-requests:read.
+    # Job-level permissions replace the top-level block, so contents:read is
+    # repeated here for actions/checkout.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       run-serial: ${{ steps.serial.outputs.run-serial }}

--- a/codeminer/scip_interface/scip_indexer_python.py
+++ b/codeminer/scip_interface/scip_indexer_python.py
@@ -17,6 +17,13 @@ from .scip_indexer_base import SCIPIndexerBase
 
 logger = get_logger("scip_python_indexer")
 
+# Upper bounds (seconds) that turn a hung child process into a fast, clear
+# failure instead of letting it run until the CI job's wall-clock timeout.
+# These are generous relative to normal runtime (scip-python indexes sympy in
+# a few minutes) and only fire on a genuine stall.
+_SCIP_PYTHON_INDEX_TIMEOUT_S = 1200  # scip-python (Node) index run
+_CONDA_ENV_CREATE_TIMEOUT_S = 600  # fallback `conda env create`
+
 
 class SCIPPythonIndexer(SCIPIndexerBase):
     """
@@ -247,6 +254,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                     subprocess.run(
                         ["conda", "env", "create", "--file", str(self.env_file)],
                         check=True,
+                        timeout=_CONDA_ENV_CREATE_TIMEOUT_S,
                     )
 
                 logger.info(
@@ -257,6 +265,12 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                 logger.error(f"Environment file not found at {self.env_file}")
                 return False
 
+        except subprocess.TimeoutExpired as e:
+            logger.error(
+                f"Conda environment creation timed out after {e.timeout}s "
+                f"(cmd: {e.cmd}). Aborting instead of hanging the job."
+            )
+            return False
         except subprocess.CalledProcessError as e:
             logger.error(f"Error setting up conda environment: {e}")
             if hasattr(e, "output") and e.output:
@@ -335,6 +349,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                     check=True,
                     cwd=work_dir,
                     env=env,
+                    timeout=_SCIP_PYTHON_INDEX_TIMEOUT_S,
                 )
             else:
                 # Fallback: use conda run (may have PATH issues)
@@ -344,8 +359,15 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                     conda_cmd,
                     check=True,
                     cwd=work_dir,
+                    timeout=_SCIP_PYTHON_INDEX_TIMEOUT_S,
                 )
             return True
+        except subprocess.TimeoutExpired as e:
+            logger.error(
+                f"scip-python timed out after {e.timeout}s (cmd: {e.cmd}). "
+                "Aborting instead of hanging the job."
+            )
+            return False
         except subprocess.CalledProcessError as e:
             logger.error(f"Error running command in conda environment: {e}")
             return False


### PR DESCRIPTION
## Summary

The `integration-serial` CI job has been running to ~100% then getting **cancelled at its 45-minute `timeout-minutes` cap**, which cascades into `scip-core` and `graph-consumer` (both `needs: integration-serial`) showing up as **skipped**. This is what made checks on PRs like #144 go red even though the PR itself (a scripts-only change) had nothing to do with the failure.

Two complementary fixes:

1. **Stop the hang.** The final `integration_serial` test (the sympy Python pipeline) reaches two unbounded `subprocess.run` calls — the `scip-python` (Node) index run and the fallback `conda env create`. A stall in either hung the whole job until the wall-clock kill. Both are now bounded with timeouts that turn a stalled child into a fast, clear test failure instead of a 45-min cancellation.

2. **Don't run the heavy chain when it isn't needed.** The `integration-serial → scip-core/graph-consumer` chain (~25–45 min) now only runs when a change actually touches code it exercises. A path filter in `preflight` computes a `run-serial` flag; the three serial-chain jobs are gated on it as a single unit (they share a persistent `graph.pkl` cache, so they must run-all/skip-all together). `unit`/`integration`/`slow` stay always-on for smoke coverage, and a nightly cron forces a full run so nothing rots.

## Changes

- `codeminer/scip_interface/scip_indexer_python.py`: add `timeout=` to the `scip-python` run in `_run_in_conda_env` (both PATH and `conda run` branches) and to the fallback `conda env create`; translate `subprocess.TimeoutExpired` into a clean `False`/abort with an actionable log message.
- `.github/workflows/ci.yml`:
  - `preflight` now checks out the repo and runs `dorny/paths-filter@v3`, exposing a new `run-serial` output. It is `false` only when *every* changed file is in the light set (`scripts/`, `examples/`, `docs/`, `*.md`, `LICENSE`, `.gitignore`); `schedule`/`workflow_dispatch` force `true`, and any uncertain filter result fails closed to `true`.
  - `integration-serial`, `scip-core`, `graph-consumer` now require `should-run == 'true' && run-serial == 'true'`.
  - Added a daily `schedule: cron "0 7 * * *"` trigger that forces the full serial chain.
  - `unit`/`integration`/`slow` and all job names, the `needs:` DAG, and `concurrency:` are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [ ] Tests pass locally
- [ ] Added new tests for the changes

Verification notes (the path-filter behavior needs a real PR diff to exercise `dorny/paths-filter`; YAML and per-job `if:`/outputs were validated with a parser locally — `actionlint` was not available in the dev environment):

- **Light-only (should skip serial chain):** a scripts-only PR (replicates #144) → `preflight` logs `heavy=false`, `run-serial=false`; `integration-serial`/`scip-core`/`graph-consumer` show `skipped`; `unit`/`integration`/`slow` run green.
- **Heavy (should run):** a PR touching `codeminer/scip_interface/**` → `heavy=true`, full serial chain executes.
- **Mixed:** touches both a `scripts/` and a `codeminer/scip_interface/` file → `heavy=true`.
- **Fail-closed:** brand-new branch / missing base ref → `run-serial=true`.
- **Forced full run:** `workflow_dispatch` on a docs-only HEAD → `run-serial=true`.

> Note for reviewers: if `integration-serial`/`scip-core`/`graph-consumer` are configured as **required** status checks, a `run-serial=false` skip reports conclusion `skipped`, which branch protection treats as passing — the same mechanism the existing `skip-tests` label already relies on. No required-check config change is needed; please don't rename these jobs or convert them to a matrix.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published