### PR TITLE
docs: refresh for MCP server, agent skills, graph range query, and C++ backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,25 +8,29 @@ SPDX-License-Identifier: Apache-2.0
 
 CodeMiner is a code analysis agent with graph-enhanced search. It parses
 multi-language codebases with tree-sitter, builds semantic graphs (igraph),
-and provides hybrid retrieval (BM25 + FAISS/Milvus embeddings + LLM re-ranking)
-via litellm. Python 3.10+.
+and provides hybrid retrieval (BM25 + FAISS/Milvus embeddings + regex/trigram +
+LLM re-ranking) via litellm. Retrieval is exposed both as composable agent
+skills and over the Model Context Protocol (MCP). Python 3.10+.
 
 ## Package structure
 
 ```
 codeminer/
   code_chunking/   # Tree-sitter chunkers: Python, Go, Rust, C++, JS/TS
-  graph/           # CodeGraph (igraph), ROI subgraph, incremental patchers
+  graph/           # CodeGraph (igraph), ROI subgraph, range queries; graph/incremental/ LSP patchers
   dataset/         # SWE-bench loading, ground-truth extraction, query synthesis
-  index/           # BM25 sparse index, FAISS embedding search, regex node index
-  agent/           # Keyword extraction, re-ranking, resource guards, tool runners
+  index/           # BM25 sparse, FAISS/embedding, regex node, trigram (Zoekt) indexes
+  incremental/     # Incremental embedding pipeline (git-diff driven chunk/index updates)
+  agent/           # Keyword extraction, re-ranking, resource guards, skills + runner
+  compiler/        # Two-phase index compilation: IndexCompiler -> RepoManifest
+  mcp/             # Model Context Protocol server (semantic/BM25/regex/Zoekt search)
+  model/           # Retrieval pipelines (bm25/embedding/graph/rerank) + agentless prompts
   llm/             # litellm-based chat interface
   scip_interface/  # SCIP indexing bindings (proto, shell scripts)
   ls_index/        # Language server index (clangd, rust-analyzer, scip-typescript)
   ops/             # Graph operations (expand, traverse)
   eval/            # Evaluation utilities
-  compiler/        # Build / compilation integration
-  plans/           # Plan generation and management
+core/              # C++ decoder backend (libigraph) mirroring CodeGraph/SCIPGraphDecoder
 test/              # Mirrors package structure; uses pytest markers
 scripts/           # CLI entry points: dataset collection, embedding, evaluation
 third_party/       # Git submodules (scip-python)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ make scip
 
 - **LSP-oriented symbol graphs** -- structural code intelligence via SCIP protocol and language servers (scip-python, rust-analyzer, clangd, gopls, scip-typescript)
 - **Incremental graph patching** -- update CodeGraph in-place via LSP without full re-indexing, enabling fast iteration on evolving codebases
-- **Lightweight hybrid retrieval** -- BM25 sparse, regex, and FAISS/Milvus dense indexes with LLM re-ranking
+- **Lightweight hybrid retrieval** -- BM25 sparse, regex, Zoekt trigram, and FAISS/Milvus dense indexes with LLM re-ranking
 - **Tree-sitter chunking** at file, symbol, and method granularity
+- **MCP server** -- expose semantic, BM25, regex, and Zoekt search to LLM agents over the Model Context Protocol (`codeminer-mcp`)
+- **Composable agent skills** -- retrieval/rerank/expand skills selected via a registry with `allow_skills` gating and index-aware resource guards
 - **SWE-bench integration** -- ground-truth extraction, multi-language dataset collection, and evaluation
 
 ## Development

--- a/codeminer/mcp/README.md
+++ b/codeminer/mcp/README.md
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 # CodeMiner MCP Server
 
-Model Context Protocol (MCP) server for CodeMiner's semantic search capabilities.
+A [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes
+CodeMiner's search over a **pre-built index** to LLM agents. It serves four search
+tools — vector (semantic), BM25, regex, and Zoekt trigram — plus a manifest tool, a
+usage-guidance prompt, and a status helper. Transport is stdio.
 
 ## Installation
 
@@ -15,84 +18,137 @@ pip install -e ".[dev]"
 pip install 'mcp[server]'
 ```
 
+Zoekt search additionally requires the Go-based Zoekt binaries on `PATH`:
+
+```bash
+go install github.com/sourcegraph/zoekt/cmd/...@latest
+```
+
 ## Usage
 
-### 1. Build Index First
+The server is **query-only**: it loads a `repo_manifest.json` produced by the index
+compiler and serves search over those indexes. Build the manifest first, then start
+the server against it.
 
-Before running the MCP server, you need to build indexes for your repository:
+### 1. Build the index (writes the manifest)
 
-```bash
-# Index your repository with vector embeddings
-python scripts/index_repo.py --repo /path/to/repo --embedding-model text-embedding-3-small
-```
+There is no standalone CLI for this step — drive `IndexCompiler` from Python
+(`codeminer.compiler`). It runs the registered index builders and writes
+`<repo>/.codeminer_cache/repo_manifest.json`:
 
-This creates `.codeminer_cache/repo_manifest.json` in your repository.
-
-### 2. Start MCP Server
-
-```bash
-codeminer-mcp --manifest /path/to/repo/.codeminer_cache/repo_manifest.json
-```
-
-Or using Python module:
-
-```bash
-python -m codeminer.mcp.server --manifest /path/to/repo/.codeminer_cache/repo_manifest.json
-```
-
-### 3. Check Server Status
-
-The server exposes a status resource at `info://status` that shows:
-- Repository path and commit
-- Supported languages
-- Loaded indexes (vector, BM25, graph)
-- Index statistics (document counts, model info)
-
-## Available Tools
-
-### `semantic_search`
-
-Search codebase using vector embeddings.
-
-**Parameters:**
-- `query` (str): Natural language or code search query
-- `top_k` (int): Maximum results to return (default: 10)
-- `level` (str): Hierarchy level - "l0" (files), "l1" (top symbols), "l2" (functions/methods). Default: "l2"
-- `score_threshold` (float): Minimum similarity score (0.0-1.0)
-
-**Returns:**
-- List of code nodes with:
-  - `node_id`: Unique identifier
-  - `file_path`: Source file path
-  - `node_type`: Symbol type (function, class, method, etc.)
-  - `content`: Source code
-  - `score`: Similarity score (higher = more relevant)
-  - `start_line`, `end_line`: Line numbers (1-based)
-
-**Example:**
 ```python
-results = await semantic_search(
-    query="function that validates email addresses",
-    top_k=5,
-    level="l2",
-    score_threshold=0.7
+from codeminer.compiler import IndexCompiler, IndexCompilerConfig
+from codeminer.compiler.index_builders import (
+    IndexBuilderRegistry,
+    register_default_builders,
 )
+
+registry = IndexBuilderRegistry()
+register_default_builders(registry, languages=["python"])
+
+compiler = IndexCompiler(
+    registry,
+    IndexCompilerConfig(
+        # bm25/vector/symbol_graph are the defaults; add "zoekt" to enable
+        # trigram search (requires the zoekt-git-index binary on PATH).
+        index_types=["bm25", "vector", "symbol_graph", "zoekt"],
+        languages=["python"],
+    ),
+)
+manifest = compiler.compile_repo("/path/to/repo")
+# -> writes /path/to/repo/.codeminer_cache/repo_manifest.json
 ```
+
+`search_semantic` needs the `vector` index, `search_bm25` needs `bm25`,
+`search_regex` needs `symbol_graph` (the regex index is derived from it), and
+`search_zoekt` needs `zoekt`. Builds that fail (e.g. Zoekt binary missing) are marked
+`failed` in the manifest and the corresponding tool returns a clear error rather than
+aborting the others.
+
+### 2. Start the MCP server
+
+```bash
+codeminer-mcp /path/to/repo/.codeminer_cache/repo_manifest.json
+# or, equivalently:
+codeminer-mcp --manifest /path/to/repo/.codeminer_cache/repo_manifest.json
+python -m codeminer.mcp /path/to/repo/.codeminer_cache/repo_manifest.json
+```
+
+Optional `--log-level {DEBUG,INFO,WARNING,ERROR}` (default `INFO`); logs go to stderr.
+
+## Tools
+
+| Tool | Backing index | Result granularity | Use for |
+|------|---------------|--------------------|---------|
+| `search_semantic` | `vector` | symbol (l0/l1/l2) | natural-language / conceptual queries |
+| `search_bm25` | `bm25` | symbol | exact-name / keyword lookups |
+| `search_regex` | `symbol_graph` | symbol | structural pattern matching |
+| `search_zoekt` | `zoekt` | file | fast substring/regex across raw repo contents |
+| `get_manifest` | — | — | repo metadata: path, commit, languages, capabilities |
+
+### `search_semantic`
+Vector-embedding similarity search.
+
+- `query` (str): natural-language or code query.
+- `top_k` (int, default 10): max results.
+- `level` (str, default `"l2"`): hierarchy level — `"l0"` (files), `"l1"` (top-level
+  symbols), `"l2"` (functions/methods).
+- `score_threshold` (float, default 0.0): minimum similarity; `0` disables the filter.
+
+Returns a list of node dicts (`node_id`, `file_path`, `node_type`, `content`, `score`,
+`start_line`/`end_line` 1-based). If no vector index is loaded it returns
+`{"error": ...}` so callers can recover gracefully.
+
+### `search_bm25`
+BM25 keyword retrieval over indexed symbols.
+
+- `query` (str), `top_k` (int, default 20), `filter_test` (bool, default `False`) —
+  when `True`, excludes results from test files.
+
+### `search_regex`
+Grep-like regex over CodeGraph nodes.
+
+- `pattern` (str): Python `re` pattern.
+- `top_k` (int, default 20).
+- `file_glob` (str, default `""`): restrict by file path (e.g. `*.py`).
+- `node_type` (str, default `""`): filter by type (`function`, `class`, `method`,
+  `file`, …).
+- `case_sensitive` (bool, default `False`).
+
+### `search_zoekt`
+Trigram search over **raw repository contents** (not the CodeGraph), so results are
+file-level (`type="file"`).
+
+- `query` (str): plain substring, regex (`r:foo`), or atoms like `case:yes` /
+  `lang:python`.
+- `top_k` (int, default 20).
+- `file_filter` (str, default `""`): glob/regex appended as `file:<expr>`.
+
+### `get_manifest`
+Returns the repo manifest as a dict: path, commit, languages, available indexes, and
+derived capabilities.
+
+## Prompt & status
+
+- **Prompt `codeminer-guide`** — returns guidance on choosing between the search tools.
+- **`server_status()`** — a non-tool helper (used by tests/debugging) that reports the
+  repo, commit, languages, and which indexes (vector / bm25 / symbol_graph / zoekt) are
+  loaded.
 
 ## Architecture
 
-- **ServerContext**: Loads and manages indexes from manifest
-- **Phase 1 (Indexing)**: `IndexCompiler` builds indexes and writes manifest
-- **Phase 2 (Query)**: MCP server loads manifest and serves search tools
-- **Model validation**: Ensures embedding model consistency between indexing and serving
+- **`ServerContext`** (`context.py`): loads the manifest and hydrates available indexes.
+- **Phase 1 (indexing)**: `IndexCompiler` builds indexes and writes the manifest.
+- **Phase 2 (query)**: this server loads the manifest and serves the search tools.
+- **Tool implementations** live in `tools/search.py`; the `@mcp.tool` wrappers and CLI
+  live in `server.py`.
 
 ## Development
 
-Run tests:
 ```bash
 # Unit tests (no MCP dependency required)
 pytest test/mcp/test_mcp_server.py -v
 
-# Integration tests (requires built indexes)
-pytest test/mcp/test_search_semantic_integration.py -v -m integration
+# Integration tests (require built indexes)
+pytest test/mcp -v -m integration
 ```

--- a/docs/agent_skills.md
+++ b/docs/agent_skills.md
@@ -1,0 +1,77 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Agent Skills
+
+CodeMiner's retrieval, reranking, and graph-expansion capabilities are packaged as
+**skills** — self-contained units of metadata + execution logic that an LLM agent can
+select and invoke. Skills live under `codeminer/agent/skills/`.
+
+## How skills are defined
+
+A skill is a package directory containing:
+
+- `config.yaml` — metadata (`skill_id`, `skill_type`, inputs/outputs, `cost`,
+  `index_requirements`, default params)
+- `skill.md` — agent-readable description of when to use the skill
+- `executor.py` — a `create_executor(context) -> Callable` factory returning the
+  execution function
+
+`SkillLoader.load_all(skills_dir, contexts)` scans the directory, parses each
+`config.yaml`, reads `skill.md`, imports the executor, and registers a `SkillMetadata`
+in the registry. Skills can also be declared in code with the `@skill` decorator
+(`codeminer/agent/skills/registry.py`), which captures the same metadata and registers
+the decorated function.
+
+## Registry API
+
+`SkillRegistry` is a singleton catalogue of `SkillMetadata`:
+
+```python
+from codeminer.agent.skills.registry import SkillRegistry
+
+registry = SkillRegistry()
+registry.list_skills()       # -> {skill_id: SkillMetadata}
+registry.get("bm25_search")  # -> SkillMetadata | None
+registry.has("llm_rerank")   # -> bool
+```
+
+## Exposing skills to an agent
+
+`registry_to_tools(registry, allow=..., exclude=...)`
+(`codeminer/agent/tool_schema.py`) converts registered skills into LLM tool schemas,
+applying an optional `allow` set first, then an `exclude` set.
+
+`AgentRunner` (`codeminer/agent/runner.py`) wraps this. It accepts `allow_skills` and
+`exclude_skills`, and — when given a `manifest` — runs a `ResourceGuard` preflight that
+automatically excludes skills whose required indexes are unavailable and surfaces
+warnings in the system prompt:
+
+```python
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.skills.registry import SkillRegistry
+
+runner = AgentRunner(
+    model="gpt-4o",
+    registry=SkillRegistry(),
+    allow_skills={"bm25_search", "graph_expand", "llm_rerank"},
+)
+result = runner.run("How does authentication work in this repo?")
+```
+
+## Available skills
+
+| Skill | Type | Description |
+|-------|------|-------------|
+| `bm25_search` | retrieval | Fast keyword retrieval (TF-IDF/BM25); best for exact identifiers and tokens. |
+| `embedding_search` | retrieval | Semantic vector retrieval that matches code by meaning, not literal tokens. |
+| `regex_search` | retrieval | Pattern-based retrieval over the node index for structural queries. |
+| `hybrid_search` | aggregate | Fuses multiple retrievers (e.g. BM25 + embedding) via weighted score normalization. |
+| `graph_expand` | expand | Expands seed code blocks along the symbol graph to surface structurally related symbols. |
+| `embedding_rerank` | rerank | Fast embedding-based reranking for large candidate sets. |
+| `llm_rerank` | rerank | High-precision LLM-judged reranking to refine top results. |
+| `query_transform` | transform | Expands/reformulates a query via keyword extraction to improve recall. |
+| `code_to_query` | transform | Turns a code snippet into a search query for finding similar code. |

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -1,0 +1,49 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Core C++ Backend
+
+The `core/` directory contains a C++ implementation of the high-traffic pieces of the
+Python graph pipeline. It mirrors the behaviour of
+`codeminer.graph.code_graph.CodeGraph` and
+`codeminer.scip_interface.scip_decode.SCIPGraphDecoder` while using the libigraph C API
+for higher throughput on large `.decoded` SCIP index files.
+
+## Components
+
+- `code_graph.h` / `code_graph.cpp` — graph container (vertices, edges, metadata)
+  compatible with the Python implementation.
+- `scip_decode.h` / `scip_decode.cpp` — translates a `.decoded` SCIP index into the C++
+  `CodeGraph`.
+- `CMakeLists.txt` — builds the static library `codeminer_core`, suitable for wrapping
+  with pybind11 or another binding layer.
+
+## Building
+
+Requirements: CMake ≥ 3.15, a C++17 compiler, and libigraph + pkg-config installed.
+
+```bash
+cmake -S core -B build/core
+cmake --build build/core
+```
+
+The resulting library (`libcodeminer_core.a`) is placed in `build/core`.
+
+## Using the decoder
+
+```cpp
+#include "scip_decode.h"
+
+int main() {
+    codeminer::core::SCIPGraphDecoder decoder("index.decoded", ".");
+    auto graph = decoder.decode();
+    graph.save_graph("graph.json");  // JSON snapshot for inspection / downstream load
+    return 0;
+}
+```
+
+See [`core/README.md`](https://github.com/sysevol-ai/CodeMiner/blob/main/core/README.md)
+for the latest details.

--- a/docs/graph_query.md
+++ b/docs/graph_query.md
@@ -1,0 +1,76 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Graph Range Query
+
+`CodeGraph` supports LSP-aligned queries that resolve a **source-file line range** (or a
+symbol) into the symbols defined there and the reference edges crossing that range.
+These return typed records (`NodeRef`/`EdgeRef`/`RangeQueryResult`) so consumers never
+poke `graph.vs[...]` directly. The API lives in `codeminer/graph/code_graph.py`.
+
+## Building the indexes
+
+Range queries are served from per-file indexes that must be built once after the graph
+is fully constructed (and again after any incremental patcher batch):
+
+```python
+graph.build_range_indexes()   # O(V + E); pickled with the graph by save_graph()
+```
+
+Because the indexes are saved with the graph, a subsequent `load_graph()` does not need
+to rebuild them.
+
+## Querying
+
+```python
+result = graph.query_range(
+    file="src/auth.py",
+    start_line=10,      # inclusive, 0-based
+    end_line=42,        # inclusive, 0-based
+    kinds=None,         # defaults to {EDGE_TYPE_REFERENCE}
+    depth=1,            # only depth=1 is supported in v1
+)
+
+result.defined    # List[NodeRef]  — symbols defined within the range
+result.outgoing   # List[EdgeRef]  — references anchored inside the range
+result.incoming   # List[EdgeRef]  — references targeting symbols defined in the range
+```
+
+`query_range_by_symbol(name, kinds=None, depth=1)` resolves a symbol by its identity
+`name` (the globally-unique, semi-raw SCIP symbol — not the display `unified_name`) to
+its file/line span and forwards to `query_range`. It returns an empty result if the
+symbol is unknown or has no associated range.
+
+By default only `EDGE_TYPE_REFERENCE` edges are returned; `CONTAIN` edges have no
+meaningful anchor and are excluded. Pass an explicit `kinds` set to opt in.
+
+## Typed results
+
+`NodeRef`: `vid`, `name` (identity), `unified_name` (display, may collide), `file`,
+`start_line`, `end_line`, `kind`.
+
+`EdgeRef`: `eid`, `source_vid`, `target_vid`, `edge_kind`, and `anchor_file` /
+`anchor_line` (the call/reference site).
+
+## Anchor invariants & the multi-edge schema
+
+Reference edges carry an **anchor** — the location of the call/reference site:
+
+- `anchor_file` equals the *source* vertex's file (the anchor lives at the call site,
+  never the target).
+- `anchor_file`/`anchor_line` are populated only for `REFERENCE` edges; `CONTAIN` edges
+  leave both `None`.
+- `outgoing` and `incoming` are disjoint: self-edges (recursion) are emitted once, in
+  `outgoing`.
+
+Edges are deduplicated on the 5-tuple
+`(source_id, target_id, type, anchor_file, anchor_line)`, so the same symbol pair can be
+connected by multiple anchored reference edges — one per occurrence.
+
+!!! note "Line-number convention"
+    `CodeGraph` line ranges are **0-based** (matching tree-sitter / the graph's internal
+    representation). This differs from the **1-based** `CodeLocation` lines used in
+    output and HuggingFace datasets.

--- a/docs/incremental_graph/index.md
+++ b/docs/incremental_graph/index.md
@@ -46,7 +46,7 @@ The patcher queries three LSP methods to rebuild the graph:
 
 ## Prerequisites
 
-- An existing `CodeGraph` (built via `LSIndexer.run_pipeline()`, see [scip_index](scip_index.md))
+- An existing `CodeGraph` (built via `LSIndexer.run_pipeline()`, see [scip_index](../scip_index.md))
 - The corresponding language server installed (see table above)
 - The project must be a git repository with both the base and target commits reachable
 
@@ -87,4 +87,4 @@ graph.save_graph("/cache/project/graph.pkl")
 
 ## Interactive Demo
 
-See the [Interactive Demo](incremental_interactive.md) for a step-by-step visual walkthrough of the symbol classification and graph rebuild process.
+See the [Interactive Demo](interactive.md) for a step-by-step visual walkthrough of the symbol classification and graph rebuild process.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,16 +16,22 @@ CodeMiner provides tools for structural code analysis, symbol-level change detec
 
 | Component | Description |
 |-----------|-------------|
+| [MCP Server](mcp.md) | Serve semantic/BM25/regex/Zoekt search to LLM agents over MCP |
+| [Agent Skills](agent_skills.md) | Composable retrieval/rerank/expand skills with index-aware gating |
 | [GT Locator](gt_locator.md) | Extract symbol-level ground truth from SWE-bench patches |
-| [Incremental Graph](incremental_graph.md) | Update CodeGraph in-place without full re-indexing |
+| [Incremental Graph](incremental_graph/index.md) | Update CodeGraph in-place without full re-indexing |
+| [Graph Range Query](graph_query.md) | LSP-aligned line-range / symbol queries with typed results |
 | [Regex Index](regex_index.md) | Fast regex search across CodeGraph nodes |
 | [SCIP Index](scip_index.md) | Code intelligence via the SCIP protocol |
 | [Graph Cache](graph_cache_usage.md) | Caching system for SCIP indexing |
+| [Core C++ Backend](core_cpp.md) | libigraph-based decoder mirroring the Python pipeline |
 
 ### Guides
 
 - [Collecting SWE-bench Instances](collect_swebench.md) — sample representative instances across languages
 - [Uploading to HuggingFace](upload_dataset_to_huggingface.md) — build and publish the dataset
+- [CI/CD](ci_cd.md) — pipeline setup and test tiers
+- [Diagnose Query Leak](diagnose_query_leak.md) — detect lexical/semantic leakage in synthesized queries
 
 ## Quick Start
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# MCP Server
+
+CodeMiner ships a [Model Context Protocol](https://modelcontextprotocol.io/) server
+(`codeminer-mcp`) that exposes its search over a **pre-built index** to LLM agents.
+It is query-only: build a repository index once, then point the server at the
+resulting manifest.
+
+## Build the index
+
+Indexes are compiled with `IndexCompiler` (`codeminer.compiler`), which writes
+`<repo>/.codeminer_cache/repo_manifest.json`:
+
+```python
+from codeminer.compiler import IndexCompiler, IndexCompilerConfig
+from codeminer.compiler.index_builders import (
+    IndexBuilderRegistry,
+    register_default_builders,
+)
+
+registry = IndexBuilderRegistry()
+register_default_builders(registry, languages=["python"])
+
+compiler = IndexCompiler(
+    registry,
+    IndexCompilerConfig(index_types=["bm25", "vector", "symbol_graph", "zoekt"]),
+)
+compiler.compile_repo("/path/to/repo")
+```
+
+Each tool depends on a specific index (see the table below). A build that fails — for
+example Zoekt when its binary is missing — is recorded as `failed` in the manifest and
+only that tool returns an error; the others still work.
+
+## Run the server
+
+```bash
+codeminer-mcp /path/to/repo/.codeminer_cache/repo_manifest.json
+```
+
+Transport is stdio; logs go to stderr (`--log-level` to adjust).
+
+## Tools
+
+| Tool | Backing index | Granularity | Use for |
+|------|---------------|-------------|---------|
+| `search_semantic` | `vector` | symbol (l0/l1/l2) | natural-language / conceptual queries |
+| `search_bm25` | `bm25` | symbol | exact-name / keyword lookups |
+| `search_regex` | `symbol_graph` | symbol | structural pattern matching |
+| `search_zoekt` | `zoekt` | file | fast substring/regex across raw file contents |
+| `get_manifest` | — | — | repo metadata: path, commit, languages, capabilities |
+
+A `codeminer-guide` prompt returns guidance on choosing between these tools.
+
+See [`codeminer/mcp/README.md`](https://github.com/sysevol-ai/CodeMiner/blob/main/codeminer/mcp/README.md)
+for full parameter and return-shape details.

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -93,7 +93,7 @@ The `LSIndexer` class provides a Python interface for working with SCIP indices.
 
 The indexer automatically:
 1. Checks if conda is installed
-2. Creates a dedicated `scip-env` environment (if not exists) using [scip-environment.yml](scip-environment.yml)
+2. Creates a dedicated `scip-env` environment (if not exists) using [scip-environment.yml](https://github.com/sysevol-ai/CodeMiner/blob/main/codeminer/scip_interface/scip-environment.yml)
 3. Runs all `scip-python` commands within this isolated environment
 
 **Manual conda environment setup** (optional - the indexer does this automatically):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,11 +62,16 @@ nav:
       - SWE-bench Collection: collect_swebench.md
       - Upload to HuggingFace: upload_dataset_to_huggingface.md
       - CI/CD: ci_cd.md
+      - Diagnose Query Leak: diagnose_query_leak.md
   - Components:
+      - MCP Server: mcp.md
+      - Agent Skills: agent_skills.md
       - GT Locator: gt_locator.md
       - Incremental Graph:
           - incremental_graph/index.md
           - Interactive Demo: incremental_graph/interactive.md
+      - Graph Range Query: graph_query.md
       - Regex Index: regex_index.md
       - SCIP Index: scip_index.md
       - Graph Cache: graph_cache_usage.md
+      - Core C++ Backend: core_cpp.md


### PR DESCRIPTION
## Summary
The docs had drifted from the code after several months of merged PRs. This refresh documents the major feature areas that landed but were missing from the docs site, fixes structural drift, and repairs broken links so `mkdocs build --strict` passes.

## Changes
- **MCP server**: rewrote `codeminer/mcp/README.md` to cover all five tools (`search_semantic`, `search_bm25`, `search_regex`, `search_zoekt`, `get_manifest`) plus the `codeminer-guide` prompt and status helper, and replaced the non-existent `scripts/index_repo.py` build step with the real `IndexCompiler.compile_repo()` path (PRs #123, #126, #136).
- **New docs pages** wired into the MkDocs nav + homepage: `docs/mcp.md`, `docs/agent_skills.md` (registry/loader + `AgentRunner` `allow_skills` gating), `docs/graph_query.md` (`query_range`/`query_range_by_symbol` typed API + multi-edge anchor schema, PR #127), `docs/core_cpp.md` (libigraph C++ decoder backend, PR #120).
- **`CLAUDE.md`**: corrected the package tree (added `mcp/`, `incremental/`, `model/`, `core/`; removed the stale `plans/` entry) and broadened the retrieval summary.
- **`README.md`**: added MCP-server and agent-skills capability bullets.
- **Broken links**: fixed three stale links in `docs/incremental_graph/index.md` and `docs/scip_index.md`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally — `mkdocs build --strict` succeeds with zero warnings (previously aborted on 3 broken links); cross-checked documented MCP tool names against the `@mcp.tool` defs in `codeminer/mcp/server.py` and the `query_range` signatures against `codeminer/graph/code_graph.py`.
- [ ] Added new tests for the changes — N/A (docs-only)

Note: docs-only change, so CI tests auto-skip via `paths-ignore` (`**.md`, `docs/**`).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
