### PR TITLE
refactor(agent): move third-party agent wrappers into agent/external/

### DIFF
--- a/codeminer/agent/external/__init__.py
+++ b/codeminer/agent/external/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wrappers around third-party agent SDKs used as localization baselines.
+
+These agents are external to CodeMiner's own agent stack (``rerank_agent``,
+``runner``, ``tools``...): each is a thin, read-only wrapper over a vendor SDK
+(``claude_agent_sdk``, ``openai_codex``) that emits chunker-canonical symbol
+names through a shared ``LOC_OUTPUT_SCHEMA``. The vendor SDKs are intentionally
+not declared in ``pyproject.toml`` — they are only needed for the paid baseline
+experiments, not as library dependencies.
+"""

--- a/codeminer/agent/external/claude_agent.py
+++ b/codeminer/agent/external/claude_agent.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional
 
 from claude_agent_sdk import ClaudeAgentOptions, query
 
-from ..log_utils import get_logger
+from ...log_utils import get_logger
 
 # Canonical chunker-format rules for the `name` field. Shared with
 # codex_agent so both system prompts derive from a single source of truth.

--- a/codeminer/agent/external/codex_agent.py
+++ b/codeminer/agent/external/codex_agent.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, Optional
 from openai_codex import ApprovalMode, AsyncCodex
 from openai_codex.types import SandboxMode
 
-from ..log_utils import get_logger
+from ...log_utils import get_logger
 from .claude_agent import (
     LOC_OUTPUT_SCHEMA,
     LOC_SYMBOL_NAMING_RULES,

--- a/examples/claude_loc_agent.py
+++ b/examples/claude_loc_agent.py
@@ -36,7 +36,7 @@ and ``usage``.
 import argparse
 import asyncio
 
-from codeminer.agent.claude_agent import ClaudeLocAgent
+from codeminer.agent.external.claude_agent import ClaudeLocAgent
 from codeminer.eval.loc_agent_runner import add_common_args, run_agent_baseline
 from codeminer.log_utils import get_logger
 

--- a/examples/codex_loc_agent.py
+++ b/examples/codex_loc_agent.py
@@ -45,7 +45,7 @@ and ``usage``.
 import argparse
 import asyncio
 
-from codeminer.agent.codex_agent import CodexLocAgent
+from codeminer.agent.external.codex_agent import CodexLocAgent
 from codeminer.eval.loc_agent_runner import add_common_args, run_agent_baseline
 from codeminer.log_utils import get_logger
 


### PR DESCRIPTION
Stacked on top of #156 (base = `eval/agentic-baselines-150`). Merging this folds the reorganization into the #156 branch.

## Summary

Separates the third-party vendor-SDK localization agents from CodeMiner's own agent stack by relocating them under a dedicated `codeminer/agent/external/` package.

- `codeminer/agent/claude_agent.py` → `codeminer/agent/external/claude_agent.py`
- `codeminer/agent/codex_agent.py` → `codeminer/agent/external/codex_agent.py`
- New `codeminer/agent/external/__init__.py` documenting the ours-vs-theirs boundary.

## Why

`codeminer/agent/` is CodeMiner's own agent stack (`rerank_agent`, `runner`, `tools`, `extract_agent`, `skills/`), re-exported through `agent/__init__.py`. The new files are thin read-only wrappers over external SDKs (`claude_agent_sdk`, `openai_codex`) used purely as evaluation baselines — a different category. A sub-package keeps `agent/` meaning "our agents" and avoids saddling its `__init__` with heavy optional SDK imports.

## Changes beyond the move

- Fixed the now-deeper relative import in both files: `..log_utils` → `...log_utils`.
- Updated the two example entrypoints to `codeminer.agent.external.{claude,codex}_agent`.
- `codex_agent`'s `from .claude_agent import ...` (shared `LOC_OUTPUT_SCHEMA`) stays valid since both moved together.

## Notes

- `loc_agent_runner.py` is unchanged — it takes the agent class as an argument and doesn't import these modules.
- Verified with `py_compile`; full runtime import wasn't exercised in the dev container (missing unrelated `litellm` dep), but the change is a mechanical move + import-path fix.
