### PR TITLE
chore(agent): codify PR-template + no-attribution rules for code agents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__
 my_project/
 *.json
+!.claude/settings.json
 graph.png
 graph.pkl
 build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,23 @@ pytest -m slow                                 # slow only
   `interface`, `object`, `enum`, `trait`, `impl`, `var`, `const`, `static`,
   `declaration`, `macro`, `variable`.
 
+## Git & PR conventions
+
+Rules for any AI/code agent (Claude Code, etc.) committing or opening PRs here.
+
+- **No agent attribution.** Do **not** add `Co-Authored-By: Claude ...`,
+  `🤖 Generated with Claude Code`, session links, or any "made by an AI"
+  footer to commit messages, PR bodies, or review comments. This is also
+  enforced by `includeCoAuthoredBy: false` in `.claude/settings.json`.
+- **Commit messages**: Conventional Commits — `type(scope): summary`, where
+  `type` is `feat`/`fix`/`docs`/`refactor`/`perf`/`test`/`chore`/`ci`.
+  Imperative mood, ≤72-char subject; body explains *why* + how it was verified.
+- **PRs must follow `.github/PULL_REQUEST_TEMPLATE.md` verbatim** — keep every
+  section heading (`Summary`, `Changes`, `Type of Change`, `Testing`,
+  `Checklist`) in order. Fill the bullets, tick the relevant `- [x]` boxes;
+  do not substitute ad-hoc sections. Add extra context *below* the template,
+  never in place of it.
+
 ## CI
 
 Three parallel jobs on a self-hosted runner (see `.github/workflows/ci.yml`):

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -25,6 +25,12 @@ SPDX-FileCopyrightText = "CodeMiner Contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
+path = ".claude/settings.json"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "CodeMiner Contributors"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
 path = "codeminer/model/prompts/*.txt"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "CodeMiner Contributors"


### PR DESCRIPTION
## Summary
Two recurring annoyances when code agents (Claude Code, etc.) commit and open PRs in this repo — fixed at the harness level and documented as project rules so every contributor's agent follows them.

- Agents append `Co-Authored-By: Claude` / `🤖 Generated with Claude Code` footers to commits, PRs, and review comments.
- Agents ignore `.github/PULL_REQUEST_TEMPLATE.md` and substitute ad-hoc sections (e.g. #160).

## Changes
- **`.claude/settings.json`** (new, committed): `includeCoAuthoredBy: false` — the authoritative switch that drops the co-author commit trailer **and** the "Generated with Claude Code" PR footer.
- **`.gitignore`**: add `!.claude/settings.json` exception after the broad `*.json` rule, so the shared setting is tracked while `settings.local.json` stays per-developer.
- **`CLAUDE.md`**: new "Git & PR conventions" section — no agent attribution anywhere, Conventional Commits, and PRs must follow the template verbatim.
- **`REUSE.toml`**: declare Apache-2.0 for `.claude/settings.json` (JSON can't carry an inline SPDX header).

This PR dogfoods both rules: the commit has no attribution trailer, and this body follows the template.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally — `pre-commit run --files ...` passes on all four files, including the REUSE/SPDX compliance hook and JSON/TOML syntax checks.
- [ ] Added new tests for the changes — N/A (config/docs only)

Note: config/docs-only change; CI auto-skips Python tiers where applicable.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published