### PR TITLE
feat(agent): centralize 0↔1 line numbering at the agent boundary (closes #153)

### DIFF
--- a/codeminer/agent/boundary.py
+++ b/codeminer/agent/boundary.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent-boundary line-numbering conversion (issue #153).
+
+Internal representations are uniformly **0-based**: BM25 docs, FAISS
+metadata, symbol-graph anchors, and the tree-sitter ``CodeChunk`` all count
+lines from 0. The *agent boundary* is **1-based outward** — line numbers
+shown to, and accepted back from, the LLM are 1-based, mirroring the
+``CodeLocation`` convention already used at the dataset/HuggingFace
+boundary (see ``_chunk_to_code_block`` in ``dataset/gt_locate.py``, which
+does the same ``+1`` once).
+
+Without a single conversion site there is a silent 0/1 split *inside one
+result*: a ``bm25_search`` hit renders its ``content`` gutter 1-based while
+its structured ``start_line`` stays 0-based, so an LLM that reads "line 42"
+from the snippet and feeds it back as a 0-based seed hits an off-by-one
+that never raises.
+
+Two helpers, one conversion each:
+
+- :func:`to_agent_repr` — serialize a result node for the LLM (``+1``).
+- :func:`from_agent_repr` — parse a line number coming back (``-1``).
+
+Internals stay 0-based; only these two functions touch the offset.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# The LLM sees 1-based lines; every internal index is 0-based.
+AGENT_LINE_OFFSET = 1
+
+# Structured fields carrying a line number on a result node.
+_LINE_FIELDS = ("start_line", "end_line")
+
+
+def is_line_bearing(obj: Any) -> bool:
+    """Whether *obj* is a result node that carries line-number fields.
+
+    Used to decide whether :func:`to_agent_repr` should be applied during
+    serialization; non-node results (bare strings, scores, dicts without
+    line fields) are left untouched.
+    """
+    if isinstance(obj, dict):
+        return "start_line" in obj or "end_line" in obj
+    return hasattr(obj, "start_line") or hasattr(obj, "end_line")
+
+
+def to_agent_repr(node: Any) -> Dict[str, Any]:
+    """Serialize a result node to a 1-based dict for the LLM.
+
+    Accepts a pydantic ``NodeInfo`` / ``QueriedNode``, a plain object with
+    ``__dict__``, or a mapping. Returns a plain dict with ``start_line`` /
+    ``end_line`` shifted ``+1`` (0-based → 1-based). ``None`` line values
+    are preserved as ``None``; all other fields pass through unchanged.
+    """
+    data = _as_dict(node)
+    for fld in _LINE_FIELDS:
+        val = data.get(fld)
+        # bool is an int subclass — exclude it defensively.
+        if isinstance(val, int) and not isinstance(val, bool):
+            data[fld] = val + AGENT_LINE_OFFSET
+    return data
+
+
+def from_agent_repr(line: Optional[int]) -> Optional[int]:
+    """Convert a single 1-based line number from the LLM to 0-based.
+
+    ``None`` passes through. A malformed seed (the LLM emitting ``0`` or a
+    negative, which is not a valid 1-based line) is clamped at ``0`` so it
+    can never produce a negative internal index.
+    """
+    if line is None:
+        return None
+    converted = int(line) - AGENT_LINE_OFFSET
+    return converted if converted >= 0 else 0
+
+
+def from_agent_repr_arg(value: Any) -> Any:
+    """Apply :func:`from_agent_repr` across a whole tool argument.
+
+    Handles the shapes a line-bearing skill argument can take:
+
+    - a scalar line number,
+    - a list/tuple of line numbers,
+    - a list of ``[start, end]`` pairs, or
+    - ``{"start_line": ..., "end_line": ...}`` range dicts.
+
+    Any other shape passes through unchanged. This is the input-side
+    counterpart wired into :class:`AgentRunner` for skill inputs marked
+    ``is_line_number`` (e.g. ``graph_expand.ranges``, ``file_read``).
+    """
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return from_agent_repr(value)
+    if isinstance(value, (list, tuple)):
+        return type(value)(from_agent_repr_arg(v) for v in value)
+    if isinstance(value, dict):
+        out = dict(value)
+        for fld in _LINE_FIELDS:
+            if isinstance(out.get(fld), int) and not isinstance(out.get(fld), bool):
+                out[fld] = from_agent_repr(out[fld])
+        return out
+    return value
+
+
+def _as_dict(node: Any) -> Dict[str, Any]:
+    """Best-effort conversion of a result node to a mutable dict."""
+    if isinstance(node, dict):
+        return dict(node)
+    if hasattr(node, "model_dump"):
+        return node.model_dump(exclude_none=True)
+    if hasattr(node, "__dict__"):
+        return dict(node.__dict__)
+    return {"value": node}

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -19,6 +19,7 @@ from ..llm.litellm_chat import LiteLLMChat
 from ..llm.usage import UsageTracker
 from ..log_utils import get_logger
 from .agent_types import AgentResult, ToolCallRecord
+from .boundary import from_agent_repr_arg, is_line_bearing, to_agent_repr
 from .skills.registry import SkillRegistry
 from .tool_schema import registry_to_tools
 
@@ -212,6 +213,9 @@ class AgentRunner:
 
         # Apply parameter scaling if session context is available
         resolved_args = self._resolve_params(meta, arguments)
+        # Agent boundary (#153): inputs declared ``is_line_number`` arrive
+        # 1-based from the LLM; convert to 0-based before the executor.
+        resolved_args = self._apply_input_boundary(meta, resolved_args)
 
         start = time.monotonic()
         try:
@@ -254,6 +258,25 @@ class AgentRunner:
         )
         return resolved.params
 
+    def _apply_input_boundary(self, meta: Any, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert ``is_line_number`` inputs from 1-based (LLM) to 0-based.
+
+        No-op for skills that declare no line-number inputs, so the common
+        path is untouched. See ``codeminer/agent/boundary.py`` (#153).
+        """
+        line_params = {
+            i.name
+            for i in getattr(meta, "inputs", [])
+            if getattr(i, "is_line_number", False)
+        }
+        if not line_params:
+            return args
+        converted = dict(args)
+        for name in line_params:
+            if name in converted:
+                converted[name] = from_agent_repr_arg(converted[name])
+        return converted
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -287,13 +310,18 @@ def _serialize_result(result: Any) -> str:
     elif isinstance(result, (list, tuple)):
         items = []
         for item in result:
-            if hasattr(item, "model_dump"):
+            # Agent boundary (#153): emit line numbers 1-based to the LLM.
+            if is_line_bearing(item):
+                items.append(to_agent_repr(item))
+            elif hasattr(item, "model_dump"):
                 items.append(item.model_dump(exclude_none=True))
             elif hasattr(item, "__dict__"):
                 items.append(item.__dict__)
             else:
                 items.append(item)
         text = json.dumps(items, default=str, ensure_ascii=False)
+    elif is_line_bearing(result):
+        text = json.dumps(to_agent_repr(result), default=str, ensure_ascii=False)
     elif hasattr(result, "model_dump"):
         text = json.dumps(result.model_dump(exclude_none=True), default=str)
     else:

--- a/codeminer/agent/skills/core.py
+++ b/codeminer/agent/skills/core.py
@@ -55,6 +55,10 @@ class SkillInputSpec:
     required: bool = True
     default: Any = None
     description: str = ""
+    # Marks an input carrying 1-based line numbers from the LLM; the runner
+    # applies ``from_agent_repr`` (1-based → 0-based) before the executor
+    # sees it. See ``codeminer/agent/boundary.py`` (#153).
+    is_line_number: bool = False
 
 
 @dataclass(slots=True)
@@ -119,6 +123,7 @@ class SkillMetadata:
                     "required": i.required,
                     "default": i.default,
                     "description": i.description,
+                    "is_line_number": i.is_line_number,
                 }
                 for i in self.inputs
             ],

--- a/codeminer/agent/skills/loader.py
+++ b/codeminer/agent/skills/loader.py
@@ -170,6 +170,7 @@ def _parse_inputs(raw: List[Dict[str, Any]]) -> List[SkillInputSpec]:
                 required=item.get("required", True),
                 default=item.get("default"),
                 description=item.get("description", ""),
+                is_line_number=item.get("is_line_number", False),
             )
         )
     return result

--- a/docs/agent_skills.md
+++ b/docs/agent_skills.md
@@ -75,3 +75,36 @@ result = runner.run("How does authentication work in this repo?")
 | `llm_rerank` | rerank | High-precision LLM-judged reranking to refine top results. |
 | `query_transform` | transform | Expands/reformulates a query via keyword extraction to improve recall. |
 | `code_to_query` | transform | Turns a code snippet into a search query for finding similar code. |
+
+## Line-numbering at the agent boundary
+
+Internally, every line number is **0-based** — BM25 docs, FAISS metadata,
+symbol-graph anchors, and the tree-sitter `CodeChunk` all count from 0. The
+*agent boundary* is **1-based outward**: line numbers shown to, and accepted
+back from, the LLM are 1-based. This mirrors the `CodeLocation` convention at
+the dataset/HuggingFace boundary.
+
+All conversion happens in one module, `codeminer/agent/boundary.py`, with one
+site per direction:
+
+- **Output** — `AgentRunner._serialize_result` runs every line-bearing result
+  through `to_agent_repr` (`+1`) before it reaches the LLM, so a result's
+  structured `start_line`/`end_line` agree with its rendered `content` gutter.
+- **Input** — a skill input declared `is_line_number: true` in its
+  `config.yaml` is passed through `from_agent_repr` (`-1`) by the runner before
+  the executor sees it, so executors keep working in 0-based internals.
+
+### Authoring a skill that accepts line numbers
+
+Mark the input in `config.yaml`; the runner handles the conversion:
+
+```yaml
+inputs:
+  - name: ranges
+    type: List[List[int]]
+    is_line_number: true
+    description: 1-based [start, end] line ranges (converted to 0-based for you)
+```
+
+Do **not** add ad-hoc `+1`/`-1` in executors or rendering paths — route
+through the boundary helpers so the offset lives in exactly one place.

--- a/test/agent/test_boundary.py
+++ b/test/agent/test_boundary.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the agent-boundary line-numbering helpers (issue #153).
+
+Internals are 0-based; the LLM sees 1-based. These tests pin the single
+conversion site each direction, the round-trip identity, and the wiring
+into ``AgentRunner`` (output via ``_serialize_result``, input via
+``is_line_number`` skill inputs).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.agent.boundary import (
+    AGENT_LINE_OFFSET,
+    from_agent_repr,
+    from_agent_repr_arg,
+    is_line_bearing,
+    to_agent_repr,
+)
+from codeminer.agent.runner import AgentRunner, _serialize_result
+from codeminer.agent.skills.core import (
+    SkillInputSpec,
+    SkillMetadata,
+    SkillOutputSpec,
+    SkillType,
+)
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.llm.litellm_chat import LiteLLMChat
+from codeminer.types import QueriedNode
+
+# ---------------------------------------------------------------------------
+# to_agent_repr — outward (+1)
+# ---------------------------------------------------------------------------
+
+
+class TestToAgentRepr:
+    def test_queried_node_shifts_to_one_based(self):
+        node = QueriedNode(node_name="foo", file="a.py", start_line=41, end_line=50)
+        out = to_agent_repr(node)
+        assert out["start_line"] == 42
+        assert out["end_line"] == 51
+        assert out["node_name"] == "foo"
+        assert out["file"] == "a.py"
+
+    def test_zero_based_first_line_becomes_one(self):
+        node = QueriedNode(node_name="top", start_line=0, end_line=0)
+        out = to_agent_repr(node)
+        assert out["start_line"] == 1
+        assert out["end_line"] == 1
+
+    def test_none_lines_preserved(self):
+        out = to_agent_repr(QueriedNode(node_name="x"))
+        # exclude_none drops them entirely; absence is fine, never shifted.
+        assert "start_line" not in out or out["start_line"] is None
+
+    def test_dict_input(self):
+        out = to_agent_repr({"start_line": 0, "end_line": 9, "score": 0.5})
+        assert out["start_line"] == 1
+        assert out["end_line"] == 10
+        assert out["score"] == 0.5
+
+    def test_bool_not_treated_as_int(self):
+        # Defensive: a bool must never be incremented as a line number.
+        out = to_agent_repr({"start_line": True, "end_line": 2})
+        assert out["start_line"] is True
+        assert out["end_line"] == 3
+
+
+# ---------------------------------------------------------------------------
+# from_agent_repr — inward (-1)
+# ---------------------------------------------------------------------------
+
+
+class TestFromAgentRepr:
+    def test_one_based_to_zero_based(self):
+        assert from_agent_repr(42) == 41
+        assert from_agent_repr(1) == 0
+
+    def test_none_passthrough(self):
+        assert from_agent_repr(None) is None
+
+    def test_malformed_zero_or_negative_clamped(self):
+        # 0 and negatives are not valid 1-based lines; clamp at 0.
+        assert from_agent_repr(0) == 0
+        assert from_agent_repr(-5) == 0
+
+
+class TestFromAgentReprArg:
+    def test_scalar(self):
+        assert from_agent_repr_arg(10) == 9
+
+    def test_list_of_scalars(self):
+        assert from_agent_repr_arg([1, 2, 3]) == [0, 1, 2]
+
+    def test_list_of_range_pairs(self):
+        assert from_agent_repr_arg([[10, 20], [5, 5]]) == [[9, 19], [4, 4]]
+
+    def test_range_dicts(self):
+        out = from_agent_repr_arg([{"start_line": 10, "end_line": 20}])
+        assert out == [{"start_line": 9, "end_line": 19}]
+
+    def test_non_line_shapes_passthrough(self):
+        assert from_agent_repr_arg("a.py") == "a.py"
+        assert from_agent_repr_arg(None) is None
+        assert from_agent_repr_arg(True) is True
+
+
+# ---------------------------------------------------------------------------
+# Round-trip identity (the #153 acceptance test)
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize("internal", [0, 1, 41, 999])
+    def test_seed_round_trips_to_identity(self, internal):
+        node = QueriedNode(node_name="n", start_line=internal, end_line=internal)
+        agent_view = to_agent_repr(node)
+        back = from_agent_repr(agent_view["start_line"])
+        assert back == internal
+
+    def test_offset_is_one(self):
+        assert AGENT_LINE_OFFSET == 1
+
+
+# ---------------------------------------------------------------------------
+# is_line_bearing
+# ---------------------------------------------------------------------------
+
+
+class TestIsLineBearing:
+    def test_queried_node(self):
+        assert is_line_bearing(QueriedNode(node_name="x", start_line=0))
+
+    def test_dict_with_line(self):
+        assert is_line_bearing({"start_line": 3})
+        assert is_line_bearing({"end_line": 3})
+
+    def test_non_line(self):
+        assert not is_line_bearing({"score": 1.0})
+        assert not is_line_bearing("just a string")
+        assert not is_line_bearing(42)
+
+
+# ---------------------------------------------------------------------------
+# _serialize_result — output boundary integration
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeResultBoundary:
+    def test_list_of_nodes_is_one_based(self):
+        results = [
+            QueriedNode(node_name="a", file="a.py", start_line=0, end_line=4),
+            QueriedNode(node_name="b", file="b.py", start_line=10, end_line=12),
+        ]
+        payload = json.loads(_serialize_result(results))
+        assert payload[0]["start_line"] == 1
+        assert payload[0]["end_line"] == 5
+        assert payload[1]["start_line"] == 11
+        assert payload[1]["end_line"] == 13
+
+    def test_single_node_is_one_based(self):
+        payload = json.loads(
+            _serialize_result(QueriedNode(node_name="a", start_line=7, end_line=9))
+        )
+        assert payload["start_line"] == 8
+        assert payload["end_line"] == 10
+
+    def test_string_result_untouched(self):
+        assert _serialize_result("plain text") == "plain text"
+
+    def test_non_line_dicts_untouched(self):
+        payload = json.loads(_serialize_result([{"score": 0.9, "name": "x"}]))
+        assert payload == [{"score": 0.9, "name": "x"}]
+
+
+# ---------------------------------------------------------------------------
+# _apply_input_boundary — input boundary integration
+# ---------------------------------------------------------------------------
+
+
+def _runner() -> AgentRunner:
+    return AgentRunner(llm=MagicMock(spec=LiteLLMChat), registry=SkillRegistry())
+
+
+def _meta_with_line_input(name: str = "ranges") -> SkillMetadata:
+    return SkillMetadata(
+        skill_id="line_skill",
+        skill_type=SkillType.EXPAND,
+        inputs=[
+            SkillInputSpec(name=name, type_hint="Any", is_line_number=True),
+            SkillInputSpec(name="top_k", type_hint="int", required=False),
+        ],
+        outputs=SkillOutputSpec(type_hint="Any"),
+    )
+
+
+class TestInputBoundary:
+    def test_marked_input_converted_to_zero_based(self):
+        runner = _runner()
+        meta = _meta_with_line_input("ranges")
+        out = runner._apply_input_boundary(meta, {"ranges": [[10, 20]], "top_k": 5})
+        assert out["ranges"] == [[9, 19]]
+        # Non-line args untouched.
+        assert out["top_k"] == 5
+
+    def test_no_line_inputs_is_noop_same_object_contents(self):
+        runner = _runner()
+        meta = SkillMetadata(
+            skill_id="plain",
+            skill_type=SkillType.RETRIEVAL,
+            inputs=[SkillInputSpec(name="query", type_hint="str")],
+            outputs=SkillOutputSpec(type_hint="Any"),
+        )
+        args = {"query": "find foo", "top_k": 20}
+        assert runner._apply_input_boundary(meta, args) == args
+
+    def test_scalar_line_input(self):
+        runner = _runner()
+        meta = _meta_with_line_input("line")
+        out = runner._apply_input_boundary(meta, {"line": 42})
+        assert out["line"] == 41
+
+
+# ---------------------------------------------------------------------------
+# SkillInputSpec.is_line_number contract
+# ---------------------------------------------------------------------------
+
+
+class TestSkillInputSpecField:
+    def test_defaults_false(self):
+        assert SkillInputSpec(name="q", type_hint="str").is_line_number is False
+
+    def test_serialized_in_to_dict(self):
+        meta = SkillMetadata(
+            skill_id="s",
+            skill_type=SkillType.EXPAND,
+            inputs=[
+                SkillInputSpec(name="ranges", type_hint="Any", is_line_number=True)
+            ],
+            outputs=SkillOutputSpec(type_hint="Any"),
+        )
+        d = meta.to_dict()
+        assert d["inputs"][0]["is_line_number"] is True


### PR DESCRIPTION
## Summary

Closes #153. Internals are uniformly **0-based** (BM25 docs, FAISS metadata, symbol-graph anchors, tree-sitter `CodeChunk`). The **agent boundary is now 1-based outward**, with one conversion site per direction — mirroring the `CodeLocation` convention already used at the dataset/HuggingFace boundary (`_chunk_to_code_block` in `dataset/gt_locate.py`).

### The bug this fixes
There was a silent 0/1 split *inside a single result*: a `bm25_search` hit renders its `content` gutter 1-based while its structured `start_line` stays 0-based. An LLM that reads "line 42" from the snippet and feeds it back as a seed hits an off-by-one that never raises. Per #153, this would silently **under-report `graph_expand` (A3/A4) in #133 Phase 0** — we couldn't distinguish "graph_expand is weak" from "graph_expand was fed off-by-one seeds."

## Changes

- **`codeminer/agent/boundary.py`** (new) — the single conversion module:
  - `to_agent_repr(node) -> dict` — `+1` on `start_line`/`end_line` once (0→1-based); `None` preserved; bool guarded.
  - `from_agent_repr(line)` — `-1` once (1→0-based); `None` passthrough; clamps malformed `0`/negative at `0`.
  - `from_agent_repr_arg(value)` — applies the above across scalars, lists, `[start, end]` pairs, and `{start_line, end_line}` dicts.
  - `is_line_bearing(obj)`, `AGENT_LINE_OFFSET`.
- **`runner.py`**:
  - **Output boundary** — `_serialize_result` routes every line-bearing result through `to_agent_repr`, so all five retrieval executors emit 1-based lines to the LLM with no per-executor edits.
  - **Input boundary** — `_apply_input_boundary` converts inputs declared `is_line_number` from 1-based to 0-based before the executor runs (no-op for skills without such inputs).
- **`SkillInputSpec.is_line_number`** flag, threaded through the loader (`config.yaml`) and `to_dict`, so `graph_expand.ranges` (#155) and `file_read` (#145) opt in declaratively — no ad-hoc `±1` in executors.
- **Docs** — new "Line-numbering at the agent boundary" section in `docs/agent_skills.md` with an authoring example.

## Coordination with #155

#155 keeps `graph_expand` 0-based pending exactly this helper pair (per its "open cross-cutting question"). Once both land, `graph_expand`'s `ranges` input should set `is_line_number: true` in its config and drop any internal conversion — no executor logic changes needed.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactoring
- [x] Tests
- [x] Documentation update

## Testing
- `pytest test/agent/test_boundary.py` → **30 passed**, including the round-trip identity acceptance test (`internal → to_agent_repr → from_agent_repr == internal`) over `[0, 1, 41, 999]`.
- `pytest test/agent/ -m "not slow and not integration"` → **98 passed, 7 skipped**, no regressions.
- `test/compiler/test_skill_loader.py` green (the `to_dict`/loader change).
- Pre-commit (black, isort, flake8, REUSE) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)