### PR TITLE
fix(ci): stop self-hosted runner wedging on subprocess timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
+    timeout-minutes: 20
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
       npm_config_cache: ${{ github.workspace }}/../.cache/npm
@@ -167,6 +168,7 @@ jobs:
     needs: [preflight, unit]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
+    timeout-minutes: 30
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
       npm_config_cache: ${{ github.workspace }}/../.cache/npm
@@ -400,6 +402,7 @@ jobs:
     needs: [preflight, unit]
     if: needs.preflight.outputs.should-run == 'true'
     runs-on: self-hosted
+    timeout-minutes: 60
     env:
       PIP_CACHE_DIR: ${{ github.workspace }}/../.cache/pip
       npm_config_cache: ${{ github.workspace }}/../.cache/npm

--- a/codeminer/scip_interface/scip_indexer_python.py
+++ b/codeminer/scip_interface/scip_indexer_python.py
@@ -7,6 +7,8 @@
 """
 SCIP indexer for Python projects using scip-python (via conda environment).
 """
+import os
+import signal
 import subprocess
 from pathlib import Path
 from typing import List, Optional, Union
@@ -23,6 +25,34 @@ logger = get_logger("scip_python_indexer")
 # a few minutes) and only fire on a genuine stall.
 _SCIP_PYTHON_INDEX_TIMEOUT_S = 1200  # scip-python (Node) index run
 _CONDA_ENV_CREATE_TIMEOUT_S = 600  # fallback `conda env create`
+
+
+def _run_checked_with_timeout(cmd, *, timeout, **popen_kwargs):
+    """Like ``subprocess.run(cmd, check=True, timeout=...)`` but kills the whole
+    process group on timeout.
+
+    ``subprocess.run``'s own timeout only SIGKILLs the immediate child. conda
+    (libmamba solver) and scip-python (Node) spawn grandchildren that survive
+    as orphans, keep holding the conda env/pkg lock, and wedge a self-hosted
+    runner so later steps block forever. Running in a new session and killing
+    the group ensures no descendant leaks past the timeout.
+    """
+    with subprocess.Popen(cmd, start_new_session=True, **popen_kwargs) as proc:
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            proc.communicate()
+            raise
+        retcode = proc.poll()
+        if retcode:
+            raise subprocess.CalledProcessError(
+                retcode, cmd, output=stdout, stderr=stderr
+            )
+    return subprocess.CompletedProcess(proc.args, retcode, stdout, stderr)
 
 
 class SCIPPythonIndexer(SCIPIndexerBase):
@@ -245,15 +275,14 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                 ]
 
                 try:
-                    subprocess.run(create_cmd, check=True, timeout=300)
+                    _run_checked_with_timeout(create_cmd, timeout=300)
                 except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                     logger.warning(
                         f"Fast environment creation failed: {e}. "
                         "Falling back to standard method..."
                     )
-                    subprocess.run(
+                    _run_checked_with_timeout(
                         ["conda", "env", "create", "--file", str(self.env_file)],
-                        check=True,
                         timeout=_CONDA_ENV_CREATE_TIMEOUT_S,
                     )
 
@@ -322,8 +351,6 @@ class SCIPPythonIndexer(SCIPIndexerBase):
             bool: True if command succeeded, False otherwise
         """
         try:
-            import os
-
             scip_bin = self._get_conda_env_bin()
             # Resolve symlinks so subprocess cwd matches real paths
             work_dir = Path(cwd if cwd else self.project_root).resolve()
@@ -344,9 +371,8 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                         node_opts + " --max-old-space-size=8192"
                     ).strip()
                 logger.info(f"Running with scip-env PATH ({scip_bin}): {cmd}")
-                subprocess.run(
+                _run_checked_with_timeout(
                     cmd,
-                    check=True,
                     cwd=work_dir,
                     env=env,
                     timeout=_SCIP_PYTHON_INDEX_TIMEOUT_S,
@@ -355,9 +381,8 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                 # Fallback: use conda run (may have PATH issues)
                 conda_cmd = ["conda", "run", "-n", self.conda_env_name] + cmd
                 logger.info(f"Running via conda run (fallback): {cmd}")
-                subprocess.run(
+                _run_checked_with_timeout(
                     conda_cmd,
-                    check=True,
                     cwd=work_dir,
                     timeout=_SCIP_PYTHON_INDEX_TIMEOUT_S,
                 )

--- a/codeminer/scip_interface/scip_indexer_python.py
+++ b/codeminer/scip_interface/scip_indexer_python.py
@@ -44,7 +44,9 @@ def _run_checked_with_timeout(cmd, *, timeout, **popen_kwargs):
             try:
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except ProcessLookupError:
-                pass
+                # The process group may already have exited between timeout and kill.
+                # In that race, there is nothing left to terminate.
+                logger.debug("Process group %s already exited before SIGKILL", proc.pid)
             proc.communicate()
             raise
         retcode = proc.poll()


### PR DESCRIPTION
## Summary

The subprocess timeouts added in #158 to *prevent* CI hangs were actually
wedging the self-hosted runner.

`subprocess.run(cmd, check=True, timeout=...)` only SIGKILLs the **immediate**
child on timeout. But `conda env create` (libmamba solver) and `scip-python`
(Node) spawn grandchildren — on timeout those orphan to init, keep running,
and hold the conda env/pkg lock. The next step or CI run that touches conda
then blocks on that lock indefinitely, so the runner looks stuck and never
finishes tasks.

## Changes

- **`codeminer/scip_interface/scip_indexer_python.py`**: route the three
  timeout-guarded calls through a new `_run_checked_with_timeout` helper that
  launches in a new session (`start_new_session=True`) and, on
  `TimeoutExpired`, kills the **entire process group** (`os.killpg(...,
  SIGKILL)`) before reaping. Preserves the prior `check=True` semantics.
- **`.github/workflows/ci.yml`**: add `timeout-minutes` to the always-on
  `unit` (20), `integration` (30), and `slow` (60) jobs, which previously had
  no wall-clock bound, so a stall there can't occupy the single runner forever.

## Recovering the currently-wedged runner

This prevents recurrence; the running runner likely still holds leaked
processes/locks. On the runner box:

```bash
pkill -f scip-python; pkill -f 'conda env create'; pkill -f libmamba
conda clean --locks -y
```

## Test plan

- [x] Verified the helper kills a spawned grandchild on timeout (orphan
      survives with plain `subprocess.run`, is killed with the helper)
- [x] Verified `check=True` semantics: rc 0 passes, non-zero raises
      `CalledProcessError`
- [ ] Confirm a real `integration-serial` run on the self-hosted runner
      completes without leaving orphaned conda/node processes