### PR TITLE
feat(agent): default tool primitives file_read + grep (closes #145)

### DIFF
--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Set
 from ..llm.litellm_chat import LiteLLMChat
 from ..log_utils import get_logger
 from .agent_types import AgentResult, ToolCallRecord
+from .skills.defaults import DEFAULT_SKILL_IDS, ensure_defaults_registered
 from .skills.registry import SkillRegistry
 from .tool_schema import registry_to_tools
 
@@ -78,6 +79,10 @@ class AgentRunner:
         self.max_turns = max_turns
         self.session_ctx = session_ctx
 
+        # Always-on defaults: file_read + grep are registered here so they
+        # are available regardless of which Ax skill subset is loaded.
+        ensure_defaults_registered(self.registry)
+
         # Resource guard: filter unavailable skills and collect warnings
         exclude = set(exclude_skills) if exclude_skills else set()
         resource_warnings: List[str] = []
@@ -89,6 +94,11 @@ class AgentRunner:
             report = guard.preflight()
             exclude |= report.unavailable
             resource_warnings = report.warnings
+
+        # Default skills (file_read, grep) are never excluded — strip them
+        # from the exclude set so they survive any allow_skills / exclude_skills
+        # filtering applied to sweep-variable skills.
+        exclude -= DEFAULT_SKILL_IDS
 
         self.tools = registry_to_tools(self.registry, exclude=exclude)
 

--- a/codeminer/agent/skills/defaults.py
+++ b/codeminer/agent/skills/defaults.py
@@ -1,0 +1,449 @@
+"""
+Always-on default tool primitives: ``file_read`` and ``grep``.
+
+These two tools are registered into ``AgentRunner``'s skill registry at
+startup and are **never** removed by the ``exclude_skills`` argument — every
+skill subset (A0–A6) builds on top of them.
+
+Reference design
+----------------
+Line-number format follows **opencode** (``{lineno:6d} | {content}``), as
+requested in the code review on issue #145 by @siriuxyu:
+
+    "Please make line numbers visible per row (opencode-style
+    ``<lineno> | <content>``, or similar)."
+
+The ``file_read`` input/output boundary convention uses **1-based** line
+numbers throughout, aligned with the cross-cutting convention settled in
+#147/#153.
+
+Why opencode over openhands / codex?
+- opencode's ``{n} | {line}`` format is the clearest visual separator for an
+  LLM that needs to pick a line number for a follow-up call (e.g.
+  ``graph_expand(ranges=[...])``) without having to count from the top of the
+  snippet — the number is right there.
+- openhands uses a similar scheme but with a different delimiter that is less
+  scan-friendly in monospace output.
+- codex embeds numbers in XML-like tags that add token overhead without
+  readability benefit.
+
+Related issues: #133 (Agent Router RFC), #145 (this PR), #147 (line-number
+convention), #153 (1-based boundary).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path
+from typing import Any, List, Optional
+
+from .core import Cost, SkillInputSpec, SkillMetadata, SkillOutputSpec, SkillType
+
+# Canonical skill IDs for the always-on defaults.
+DEFAULT_SKILL_IDS: frozenset = frozenset({"file_read", "grep"})
+
+# Sensible token-safety caps.
+_MAX_LINES_DEFAULT: int = 200
+_MAX_RESULTS_DEFAULT: int = 50
+
+# Directories to skip during recursive grep (avoids scanning VCS / cache noise).
+_SKIP_DIR_PREFIXES = frozenset({
+    ".git", ".hg", ".svn",
+    "__pycache__", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+    ".tox", ".venv", "venv", "node_modules",
+    ".cache", "dist", "build",
+})
+
+
+# ---------------------------------------------------------------------------
+# file_read
+# ---------------------------------------------------------------------------
+
+
+def _file_read(
+    path: str,
+    start_line: int = 1,
+    end_line: Optional[int] = None,
+    max_lines: int = _MAX_LINES_DEFAULT,
+) -> str:
+    """Read a file, returning its content with per-row 1-based line numbers.
+
+    Output format::
+
+           1 | def foo():
+           2 |     return 42
+
+    Args:
+        path: Absolute or repo-relative path to the file.
+        start_line: First line to read (1-based, inclusive). Defaults to 1.
+        end_line: Last line to read (1-based, inclusive). Defaults to EOF.
+        max_lines: Hard cap on lines returned for token safety. Defaults to
+            200.  A truncation notice with the next ``start_line`` is appended
+            when the cap is reached.
+
+    Returns:
+        Formatted string, or an error message prefixed with ``"Error: "``.
+    """
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            all_lines = fh.readlines()
+    except FileNotFoundError:
+        return f"Error: file not found: {path!r}"
+    except OSError as exc:
+        return f"Error reading {path!r}: {exc}"
+
+    total = len(all_lines)
+    if total == 0:
+        return f"(empty file: {path})"
+
+    # Clamp to valid 1-based range.
+    start = max(1, int(start_line))
+    end = int(end_line) if end_line is not None else total
+    end = min(end, total)
+
+    if start > total:
+        return (
+            f"Error: start_line {start} exceeds file length {total} in {path!r}"
+        )
+    if start > end:
+        return f"Error: start_line {start} > end_line {end}"
+
+    # Convert to 0-based slice.
+    selected = all_lines[start - 1 : end]
+
+    truncated_next: Optional[int] = None
+    if len(selected) > max_lines:
+        truncated_next = start + max_lines  # first omitted line (1-based)
+        selected = selected[:max_lines]
+
+    lines_out = [
+        f"{lineno:6d} | {line.rstrip()}"
+        for lineno, line in enumerate(selected, start=start)
+    ]
+    result = "\n".join(lines_out)
+
+    if truncated_next is not None:
+        remaining = end - truncated_next + 1
+        result += (
+            f"\n... ({remaining} more lines; "
+            f"use start_line={truncated_next} to continue)"
+        )
+
+    return result
+
+
+_FILE_READ_SKILL_DOC = """\
+# file_read
+
+Read a source file and return its content with per-row 1-based line numbers.
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `path` | `str` | *(required)* | Absolute or repo-relative file path. |
+| `start_line` | `int` | `1` | First line to read (1-based, inclusive). |
+| `end_line` | `int` | EOF | Last line to read (1-based, inclusive). |
+| `max_lines` | `int` | `200` | Hard cap on lines returned; prevents context blowup. |
+
+## Output
+
+Lines formatted as `{lineno:6d} | {content}` (opencode-style, 1-based).
+A truncation notice with the next `start_line` is appended when `max_lines`
+is reached.
+
+## When to Use
+
+- Inspect a function or class after a search skill narrowed the location.
+- Read context lines around a match.
+- Retrieve a known file at a specific line range.
+- Follow up on a `grep` result to read surrounding code.
+"""
+
+
+def _build_file_read_skill() -> SkillMetadata:
+    return SkillMetadata(
+        skill_id="file_read",
+        skill_type=SkillType.CUSTOM,
+        inputs=[
+            SkillInputSpec(
+                name="path",
+                type_hint="str",
+                required=True,
+                description="Absolute or repo-relative path to the file.",
+            ),
+            SkillInputSpec(
+                name="start_line",
+                type_hint="int",
+                required=False,
+                default=1,
+                description="First line to read (1-based, inclusive). Defaults to 1.",
+            ),
+            SkillInputSpec(
+                name="end_line",
+                type_hint="int",
+                required=False,
+                default=None,
+                description=(
+                    "Last line to read (1-based, inclusive). "
+                    "Defaults to end of file."
+                ),
+            ),
+            SkillInputSpec(
+                name="max_lines",
+                type_hint="int",
+                required=False,
+                default=_MAX_LINES_DEFAULT,
+                description=(
+                    f"Hard cap on lines returned (default {_MAX_LINES_DEFAULT})."
+                ),
+            ),
+        ],
+        outputs=SkillOutputSpec(
+            type_hint="str",
+            description=(
+                "File content with 1-based line numbers in "
+                "`{lineno:6d} | {line}` format."
+            ),
+        ),
+        executor_fn=_file_read,
+        async_capable=False,
+        cacheable=False,  # filesystem state may change between calls
+        cost=Cost.LOW,
+        dependencies=[],
+        resources=[],
+        defaults={"start_line": 1, "max_lines": _MAX_LINES_DEFAULT},
+        skill_doc=_FILE_READ_SKILL_DOC,
+        description=(
+            "Read a file with 1-based line numbers (opencode-style); "
+            "output is bounded by max_lines for token safety."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# grep
+# ---------------------------------------------------------------------------
+
+
+def _grep(
+    pattern: str,
+    path: str = ".",
+    include: Optional[str] = None,
+    case_sensitive: bool = False,
+    use_regex: bool = True,
+    max_results: int = _MAX_RESULTS_DEFAULT,
+) -> str:
+    """Search files for a pattern, returning ``{file}:{lineno}: {content}`` lines.
+
+    Args:
+        pattern: Regex pattern or literal string.
+        path: File or directory to search. Defaults to current directory.
+        include: Glob filter applied to file *names* (e.g. ``*.py``).
+        case_sensitive: Case-sensitive matching. Defaults to False.
+        use_regex: Interpret ``pattern`` as a regex. Defaults to True.
+        max_results: Hard cap on matches returned. Defaults to 50.
+
+    Returns:
+        One match per line: ``{relative_path}:{lineno}: {content}`` (1-based).
+        Returns a no-match message when nothing is found.
+    """
+    flags = 0 if case_sensitive else re.IGNORECASE
+    if use_regex:
+        try:
+            compiled = re.compile(pattern, flags)
+        except re.error as exc:
+            return f"Error: invalid regex {pattern!r}: {exc}"
+    else:
+        compiled = re.compile(re.escape(pattern), flags)
+
+    root = Path(path)
+    if not root.exists():
+        return f"Error: path {path!r} does not exist"
+
+    results: List[str] = []
+    capped = False
+
+    def _search_file(file_path: Path) -> bool:
+        """Append matches from *file_path*; return True if cap was hit."""
+        try:
+            with open(file_path, encoding="utf-8", errors="replace") as fh:
+                for lineno, line in enumerate(fh, start=1):
+                    if compiled.search(line):
+                        rel = (
+                            file_path.relative_to(root)
+                            if root.is_dir()
+                            else file_path
+                        )
+                        results.append(f"{rel}:{lineno}: {line.rstrip()}")
+                        if len(results) >= max_results:
+                            return True
+        except OSError:
+            pass
+        return False
+
+    if root.is_file():
+        _search_file(root)
+    else:
+        for file_path in sorted(root.rglob("*")):
+            if not file_path.is_file():
+                continue
+            # Skip noise directories.
+            if any(part in _SKIP_DIR_PREFIXES for part in file_path.parts):
+                continue
+            if include and not fnmatch.fnmatch(file_path.name, include):
+                continue
+            if _search_file(file_path):
+                capped = True
+                break
+
+    if not results:
+        return "No matches found."
+
+    text = "\n".join(results)
+    if capped:
+        text += (
+            f"\n... (max_results={max_results} reached; "
+            "narrow your search with `include` or a more specific `pattern`)"
+        )
+    return text
+
+
+_GREP_SKILL_DOC = """\
+# grep
+
+Search files for a regex pattern (or literal string), returning matches with
+file paths and 1-based line numbers.
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `pattern` | `str` | *(required)* | Regex pattern or literal string to search for. |
+| `path` | `str` | `"."` | File or directory to search. |
+| `include` | `str` | `null` | Glob filter for file names (e.g. `*.py`, `*.ts`). |
+| `case_sensitive` | `bool` | `false` | Case-sensitive matching. |
+| `use_regex` | `bool` | `true` | Treat `pattern` as regex; false = literal string. |
+| `max_results` | `int` | `50` | Hard cap on matches returned. |
+
+## Output
+
+One match per line: `{relative_path}:{lineno}: {content}` (1-based numbers).
+
+## When to Use
+
+- Find all call sites of a function or class across the repo.
+- Search for a string when no index is available.
+- Narrow to specific file types with `include="*.py"`.
+- Follow up with `file_read` to read surrounding context for a match.
+
+## When NOT to Use
+
+- Semantic / intent queries: use `embedding_search`.
+- Ranked full-text retrieval: use `bm25_search`.
+"""
+
+
+def _build_grep_skill() -> SkillMetadata:
+    return SkillMetadata(
+        skill_id="grep",
+        skill_type=SkillType.CUSTOM,
+        inputs=[
+            SkillInputSpec(
+                name="pattern",
+                type_hint="str",
+                required=True,
+                description="Regex pattern or literal string to search for.",
+            ),
+            SkillInputSpec(
+                name="path",
+                type_hint="str",
+                required=False,
+                default=".",
+                description="File or directory to search (default: current directory).",
+            ),
+            SkillInputSpec(
+                name="include",
+                type_hint="str",
+                required=False,
+                default=None,
+                description="Glob filter for file names (e.g. '*.py', '*.ts').",
+            ),
+            SkillInputSpec(
+                name="case_sensitive",
+                type_hint="bool",
+                required=False,
+                default=False,
+                description="Case-sensitive matching (default: false).",
+            ),
+            SkillInputSpec(
+                name="use_regex",
+                type_hint="bool",
+                required=False,
+                default=True,
+                description=(
+                    "Interpret pattern as a regex (default: true). "
+                    "Set to false for literal-string search."
+                ),
+            ),
+            SkillInputSpec(
+                name="max_results",
+                type_hint="int",
+                required=False,
+                default=_MAX_RESULTS_DEFAULT,
+                description=(
+                    f"Hard cap on matches returned (default {_MAX_RESULTS_DEFAULT})."
+                ),
+            ),
+        ],
+        outputs=SkillOutputSpec(
+            type_hint="str",
+            description=(
+                "Matches in `{file}:{lineno}: {content}` format (1-based numbers)."
+            ),
+        ),
+        executor_fn=_grep,
+        async_capable=False,
+        cacheable=False,
+        cost=Cost.LOW,
+        dependencies=[],
+        resources=[],
+        defaults={
+            "path": ".",
+            "case_sensitive": False,
+            "use_regex": True,
+            "max_results": _MAX_RESULTS_DEFAULT,
+        },
+        skill_doc=_GREP_SKILL_DOC,
+        description=(
+            "Filesystem grep: search files for a pattern; returns "
+            "file:lineno: content matches (1-based, no index required)."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API used by AgentRunner
+# ---------------------------------------------------------------------------
+
+
+def get_default_skill_metadata() -> List[SkillMetadata]:
+    """Return fresh :class:`SkillMetadata` objects for all default tools.
+
+    Returns a new list on every call so callers can safely mutate it.
+    """
+    return [_build_file_read_skill(), _build_grep_skill()]
+
+
+def ensure_defaults_registered(registry: Any) -> None:
+    """Register default skills into *registry* if not already present.
+
+    Safe to call multiple times (idempotent): skips any skill already in the
+    registry.  Called by :class:`~codeminer.agent.runner.AgentRunner` during
+    ``__init__`` so that ``file_read`` and ``grep`` are available regardless
+    of which ``Ax`` skill subset is loaded.
+    """
+    for meta in get_default_skill_metadata():
+        if not registry.has(meta.skill_id):
+            registry.register(meta)

--- a/docs/agent/default_tools_design.md
+++ b/docs/agent/default_tools_design.md
@@ -1,0 +1,102 @@
+# Default Tool Primitives: file_read + grep
+
+*Issue #145 — Phase 0/1 Prep for Agent Router (CAR)*
+
+## Overview
+
+`file_read` and `grep` are always-on tool primitives available to every agent
+regardless of which `Ax` skill subset is loaded.  They live in
+`codeminer/agent/skills/defaults.py` and are registered by `AgentRunner`
+during `__init__` — prior to any `exclude_skills` filtering.
+
+---
+
+## Reference survey: opencode vs openhands vs codex
+
+Three reference implementations were evaluated for line-number format and
+API surface.
+
+### opencode
+
+- **Format:** `{lineno} | {content}` (left-padded integer, pipe delimiter)
+- **Pagination:** `start_line` / `end_line` + hard `max_lines` cap
+- **Error handling:** returns human-readable error strings (not exceptions)
+
+### openhands
+
+- **Format:** similar `{n} | {line}` but with a dash variant in some versions
+- **Pagination:** similar range params
+- **Error handling:** may raise exceptions; caller must catch
+
+### codex
+
+- **Format:** XML-like `<line n="1">content</line>` tags
+- **Pagination:** offset-based
+- **Token cost:** higher due to tag overhead
+
+### Decision: follow opencode
+
+opencode's `{lineno:6d} | {content}` format was chosen for the following
+reasons:
+
+1. **Explicit reviewer request** — @siriuxyu's comment on #145 says:
+   > "Please make line numbers visible per row (opencode-style
+   > `<lineno> | <content>`, or similar)."
+
+2. **LLM usability** — when an LLM reads a snippet and wants to follow up
+   with `graph_expand(ranges=[...])` or another `file_read(start_line=N)`,
+   it can copy the number directly instead of counting from the top of the
+   snippet.
+
+3. **Token efficiency** — plain `{n} | {line}` is more compact than XML tags
+   and adds only ~8 chars per line.
+
+4. **Consistency** — opencode-style output is already familiar to engineers
+   on the team (VS Code's peek-definition uses similar numbering).
+
+---
+
+## Line-number convention: 1-based throughout
+
+Both `file_read` inputs (`start_line`, `end_line`) and output line labels are
+**1-based**, aligned with the convention settled in issue #147/#153.
+
+- `start_line=1` reads from the very first line (default).
+- Truncation notices emit `start_line=N` for the next call, also 1-based.
+- `grep` output uses 1-based `{file}:{lineno}: {content}` (POSIX grep style).
+
+---
+
+## Token safety
+
+| Tool | Parameter | Default | Hard max |
+|------|-----------|---------|----------|
+| `file_read` | `max_lines` | 200 | caller-settable |
+| `grep` | `max_results` | 50 | caller-settable |
+
+When either cap is reached a truncation notice is appended so the LLM knows
+to narrow the query rather than silently receiving a partial result.
+
+---
+
+## AgentRunner wiring
+
+```python
+# runner.py __init__
+ensure_defaults_registered(self.registry)  # idempotent
+# ...
+exclude -= DEFAULT_SKILL_IDS              # never filter out defaults
+self.tools = registry_to_tools(self.registry, exclude=exclude)
+```
+
+`DEFAULT_SKILL_IDS = frozenset({"file_read", "grep"})` is the canonical set
+used everywhere — import it from `codeminer.agent.skills.defaults`.
+
+---
+
+## What is NOT in scope (per #145)
+
+- Changes to sweep-variable skills: `bm25_search`, `embedding_search`,
+  `graph_expand`, `regex_search` (A_g index-backed version)
+- New LLM-powered skills
+- Changes to the compiler or resource guard

--- a/test/agent/test_default_skills.py
+++ b/test/agent/test_default_skills.py
@@ -1,0 +1,503 @@
+"""Tests for default tool primitives: file_read and grep (issue #145).
+
+Covers:
+- file_read: happy path, line range, token-bound truncation, edge cases
+- grep: match, no-match, regex/literal, include filter, max_results cap
+- AgentRunner integration: defaults always present, not removable by exclude_skills
+- Smoke test: read a real file from this repo
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.skills.defaults import (
+    DEFAULT_SKILL_IDS,
+    _MAX_LINES_DEFAULT,
+    _MAX_RESULTS_DEFAULT,
+    _file_read,
+    _grep,
+    ensure_defaults_registered,
+    get_default_skill_metadata,
+)
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.llm.litellm_chat import LiteLLMChat
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+@pytest.fixture()
+def sample_file(tmp_path: Path) -> Path:
+    """Write a small Python-like file for testing."""
+    content = textwrap.dedent(
+        """\
+        def add(a, b):
+            return a + b
+
+        def subtract(a, b):
+            return a - b
+
+        class Calculator:
+            def multiply(self, x, y):
+                return x * y
+
+            def divide(self, x, y):
+                if y == 0:
+                    raise ValueError("division by zero")
+                return x / y
+        """
+    )
+    p = tmp_path / "calculator.py"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+@pytest.fixture()
+def sample_dir(tmp_path: Path) -> Path:
+    """Directory with multiple files for grep tests."""
+    (tmp_path / "a.py").write_text(
+        "def foo():\n    pass\n\ndef bar():\n    return foo()\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.py").write_text(
+        "import foo\nfoo.run()\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "readme.md").write_text(
+        "# Project\nSee foo for details.\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# file_read tests
+# ---------------------------------------------------------------------------
+
+
+class TestFileRead:
+    def test_reads_full_file(self, sample_file):
+        result = _file_read(str(sample_file))
+        # Every line present
+        assert "def add(a, b):" in result
+        assert "class Calculator:" in result
+
+    def test_line_numbers_are_1_based(self, sample_file):
+        result = _file_read(str(sample_file))
+        lines = result.splitlines()
+        # First line should have line number 1
+        assert lines[0].lstrip().startswith("1 |")
+
+    def test_line_number_format_opencode_style(self, sample_file):
+        """Lines must be formatted as `{lineno:6d} | {content}`."""
+        result = _file_read(str(sample_file))
+        for line in result.splitlines():
+            # Each output line must contain ' | '
+            assert " | " in line, f"Missing ' | ' in: {line!r}"
+
+    def test_start_and_end_line(self, sample_file):
+        result = _file_read(str(sample_file), start_line=4, end_line=5)
+        lines = result.splitlines()
+        assert len(lines) == 2
+        assert "4" in lines[0]
+        assert "subtract" in lines[0]
+        assert "5" in lines[1]
+
+    def test_start_line_default_is_1(self, sample_file):
+        full = _file_read(str(sample_file))
+        from_1 = _file_read(str(sample_file), start_line=1)
+        assert full == from_1
+
+    def test_end_line_clamp_to_eof(self, sample_file):
+        # end_line beyond EOF should be silently clamped
+        result = _file_read(str(sample_file), end_line=9999)
+        assert "Calculator" in result  # last lines still present
+
+    def test_max_lines_truncation(self, sample_file):
+        result = _file_read(str(sample_file), max_lines=3)
+        lines = result.splitlines()
+        # 3 content lines + 1 truncation notice
+        assert len(lines) == 4
+        assert "more lines" in lines[-1]
+        assert "start_line=" in lines[-1]
+
+    def test_truncation_notice_has_next_start(self, sample_file):
+        result = _file_read(str(sample_file), start_line=1, max_lines=3)
+        assert "start_line=4" in result
+
+    def test_missing_file_returns_error(self, tmp_path):
+        result = _file_read(str(tmp_path / "nonexistent.py"))
+        assert result.startswith("Error:")
+        assert "not found" in result
+
+    def test_empty_file(self, tmp_path):
+        empty = tmp_path / "empty.py"
+        empty.write_text("", encoding="utf-8")
+        result = _file_read(str(empty))
+        assert "empty" in result.lower()
+
+    def test_start_beyond_eof_returns_error(self, sample_file):
+        result = _file_read(str(sample_file), start_line=9999)
+        assert result.startswith("Error:")
+        assert "exceeds" in result
+
+    def test_start_gt_end_returns_error(self, sample_file):
+        result = _file_read(str(sample_file), start_line=10, end_line=5)
+        assert result.startswith("Error:")
+
+    def test_single_line_read(self, sample_file):
+        result = _file_read(str(sample_file), start_line=1, end_line=1)
+        lines = result.splitlines()
+        assert len(lines) == 1
+        assert "add" in lines[0]
+
+    def test_max_lines_zero_treated_as_cap(self, sample_file):
+        # max_lines=1 → only first line + truncation notice
+        result = _file_read(str(sample_file), max_lines=1)
+        content_lines = [l for l in result.splitlines() if " | " in l]
+        assert len(content_lines) == 1
+
+
+# ---------------------------------------------------------------------------
+# grep tests
+# ---------------------------------------------------------------------------
+
+
+class TestGrep:
+    def test_basic_match(self, sample_dir):
+        result = _grep("def foo", path=str(sample_dir))
+        assert "a.py" in result
+        assert "def foo" in result
+
+    def test_1_based_line_numbers(self, sample_dir):
+        result = _grep("def foo", path=str(sample_dir))
+        # a.py first line has `def foo():` → should be line 1
+        assert "a.py:1:" in result
+
+    def test_no_match_returns_message(self, sample_dir):
+        result = _grep("ZZZNOMATCH_XYZ", path=str(sample_dir))
+        assert "No matches found" in result
+
+    def test_case_insensitive_default(self, sample_dir):
+        # lowercase "class" should match even if capitalised in file
+        (sample_dir / "cls.py").write_text("class Foo:\n    pass\n")
+        result = _grep("CLASS", path=str(sample_dir))
+        assert "cls.py" in result
+
+    def test_case_sensitive_no_match(self, sample_dir):
+        (sample_dir / "cls.py").write_text("class Foo:\n    pass\n")
+        result = _grep("CLASS", path=str(sample_dir), case_sensitive=True)
+        assert "No matches found" in result
+
+    def test_literal_mode(self, sample_dir):
+        # Pattern with regex special chars should be treated literally
+        (sample_dir / "special.py").write_text("x = a.b()\ny = a.c()\n")
+        result = _grep("a.b()", path=str(sample_dir), use_regex=False)
+        assert "special.py" in result
+
+    def test_include_filter_py_only(self, sample_dir):
+        result = _grep("foo", path=str(sample_dir), include="*.py")
+        # readme.md has 'foo' but should be filtered out
+        assert "readme.md" not in result
+        assert "a.py" in result or "b.py" in result
+
+    def test_include_filter_md_only(self, sample_dir):
+        result = _grep("foo", path=str(sample_dir), include="*.md")
+        assert "readme.md" in result
+        assert ".py" not in result
+
+    def test_max_results_cap(self, sample_dir):
+        # Create a file with many matches
+        many = sample_dir / "many.py"
+        many.write_text("\n".join(f"match_{i} = 1" for i in range(100)))
+        result = _grep("match_", path=str(sample_dir), max_results=5)
+        lines = [l for l in result.splitlines() if "many.py" in l]
+        assert len(lines) <= 5
+        assert "max_results=5" in result
+
+    def test_invalid_regex_returns_error(self, sample_dir):
+        result = _grep("[invalid", path=str(sample_dir))
+        assert result.startswith("Error:")
+        assert "invalid regex" in result
+
+    def test_nonexistent_path_returns_error(self, tmp_path):
+        result = _grep("foo", path=str(tmp_path / "no_such_dir"))
+        assert result.startswith("Error:")
+        assert "does not exist" in result
+
+    def test_single_file_path(self, sample_file):
+        result = _grep("def", path=str(sample_file))
+        assert "def add" in result
+        assert "def subtract" in result
+
+    def test_match_format_file_lineno_content(self, sample_dir):
+        """Each result line must be `{file}:{lineno}: {content}`."""
+        result = _grep("def foo", path=str(sample_dir))
+        for line in result.splitlines():
+            if "def foo" in line:
+                parts = line.split(":", 2)
+                assert len(parts) >= 3, f"bad format: {line!r}"
+                # second part must be an integer line number
+                assert parts[1].strip().isdigit(), f"non-numeric lineno in: {line!r}"
+
+
+# ---------------------------------------------------------------------------
+# get_default_skill_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestGetDefaultSkillMetadata:
+    def test_returns_both_defaults(self):
+        metas = get_default_skill_metadata()
+        ids = {m.skill_id for m in metas}
+        assert ids == DEFAULT_SKILL_IDS
+
+    def test_returns_fresh_list(self):
+        a = get_default_skill_metadata()
+        b = get_default_skill_metadata()
+        assert a is not b
+
+    def test_executor_fns_callable(self):
+        for meta in get_default_skill_metadata():
+            assert callable(meta.executor_fn)
+
+    def test_file_read_has_required_path_input(self):
+        metas = {m.skill_id: m for m in get_default_skill_metadata()}
+        file_read = metas["file_read"]
+        required_inputs = [i for i in file_read.inputs if i.required]
+        names = [i.name for i in required_inputs]
+        assert "path" in names
+
+    def test_grep_has_required_pattern_input(self):
+        metas = {m.skill_id: m for m in get_default_skill_metadata()}
+        grep = metas["grep"]
+        required_inputs = [i for i in grep.inputs if i.required]
+        names = [i.name for i in required_inputs]
+        assert "pattern" in names
+
+
+# ---------------------------------------------------------------------------
+# ensure_defaults_registered
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureDefaultsRegistered:
+    def test_registers_both_skills(self):
+        reg = SkillRegistry()
+        ensure_defaults_registered(reg)
+        for skill_id in DEFAULT_SKILL_IDS:
+            assert reg.has(skill_id), f"{skill_id!r} not registered"
+
+    def test_idempotent_second_call(self):
+        reg = SkillRegistry()
+        ensure_defaults_registered(reg)
+        # Should not raise ValueError("already registered")
+        ensure_defaults_registered(reg)
+
+    def test_does_not_overwrite_existing(self):
+        reg = SkillRegistry()
+        ensure_defaults_registered(reg)
+        original_fn = reg.get("file_read").executor_fn
+        ensure_defaults_registered(reg)  # second call
+        assert reg.get("file_read").executor_fn is original_fn
+
+
+# ---------------------------------------------------------------------------
+# AgentRunner integration: defaults always present
+# ---------------------------------------------------------------------------
+
+
+def _make_llm():
+    llm = MagicMock(spec=LiteLLMChat)
+    msg = SimpleNamespace(role="assistant", content="ok", tool_calls=None)
+    llm._call_raw.return_value = SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+    return llm
+
+
+class TestAgentRunnerDefaults:
+    def test_defaults_in_tools_on_empty_registry(self):
+        runner = AgentRunner(_make_llm(), SkillRegistry())
+        tool_names = {t["function"]["name"] for t in runner.tools}
+        assert "file_read" in tool_names
+        assert "grep" in tool_names
+
+    def test_defaults_survive_exclude_skills(self):
+        """Default tools must be present even if explicitly listed in exclude_skills."""
+        runner = AgentRunner(
+            _make_llm(),
+            SkillRegistry(),
+            exclude_skills={"file_read", "grep"},
+        )
+        tool_names = {t["function"]["name"] for t in runner.tools}
+        assert "file_read" in tool_names
+        assert "grep" in tool_names
+
+    def test_non_default_skill_still_excluded(self):
+        """exclude_skills should still work for non-default skills."""
+        from codeminer.agent.skills.core import SkillMetadata, SkillType
+
+        reg = SkillRegistry()
+        reg.register(
+            SkillMetadata(
+                skill_id="custom_tool",
+                skill_type=SkillType.CUSTOM,
+                executor_fn=lambda: "hi",
+            )
+        )
+        runner = AgentRunner(_make_llm(), reg, exclude_skills={"custom_tool"})
+        tool_names = {t["function"]["name"] for t in runner.tools}
+        assert "custom_tool" not in tool_names
+        # Defaults still present
+        assert "file_read" in tool_names
+        assert "grep" in tool_names
+
+    def test_file_read_tool_schema_has_path_parameter(self):
+        runner = AgentRunner(_make_llm(), SkillRegistry())
+        file_read_schema = next(
+            t for t in runner.tools if t["function"]["name"] == "file_read"
+        )
+        params = file_read_schema["function"]["parameters"]["properties"]
+        assert "path" in params
+
+    def test_grep_tool_schema_has_pattern_parameter(self):
+        runner = AgentRunner(_make_llm(), SkillRegistry())
+        grep_schema = next(
+            t for t in runner.tools if t["function"]["name"] == "grep"
+        )
+        params = grep_schema["function"]["parameters"]["properties"]
+        assert "pattern" in params
+
+    def test_runner_executes_file_read_tool(self, tmp_path):
+        """End-to-end: runner dispatches file_read and gets file content."""
+        target = tmp_path / "hello.py"
+        target.write_text("x = 1\ny = 2\n", encoding="utf-8")
+
+        tc = SimpleNamespace(
+            id="tc_1",
+            type="function",
+            function=SimpleNamespace(
+                name="file_read",
+                arguments=f'{{"path": "{target}"}}',
+            ),
+        )
+        llm = _make_llm()
+        resp1 = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[tc],
+                    )
+                )
+            ]
+        )
+        resp2 = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        role="assistant",
+                        content="Done.",
+                        tool_calls=None,
+                    )
+                )
+            ]
+        )
+        llm._call_raw.side_effect = [resp1, resp2]
+
+        runner = AgentRunner(llm, SkillRegistry())
+        result = runner.run("Read the file")
+
+        tool_record = result.tool_calls[0]
+        assert tool_record.error is None
+        assert "x = 1" in tool_record.result
+
+    def test_runner_executes_grep_tool(self, tmp_path):
+        """End-to-end: runner dispatches grep and returns matches."""
+        (tmp_path / "src.py").write_text("def target_fn():\n    pass\n")
+
+        tc = SimpleNamespace(
+            id="tc_2",
+            type="function",
+            function=SimpleNamespace(
+                name="grep",
+                arguments=f'{{"pattern": "target_fn", "path": "{tmp_path}"}}',
+            ),
+        )
+        llm = _make_llm()
+        resp1 = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[tc],
+                    )
+                )
+            ]
+        )
+        resp2 = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        role="assistant",
+                        content="Found it.",
+                        tool_calls=None,
+                    )
+                )
+            ]
+        )
+        llm._call_raw.side_effect = [resp1, resp2]
+
+        runner = AgentRunner(llm, SkillRegistry())
+        result = runner.run("Find target_fn")
+
+        tool_record = result.tool_calls[0]
+        assert tool_record.error is None
+        assert "target_fn" in tool_record.result
+
+
+# ---------------------------------------------------------------------------
+# Smoke test — reads a real source file from this repo
+# ---------------------------------------------------------------------------
+
+
+class TestSmokeRealFile:
+    def test_read_runner_py(self):
+        """Smoke: read the runner module itself and verify line numbers appear."""
+        import codeminer.agent.runner as runner_module
+
+        source = Path(runner_module.__file__)
+        assert source.exists(), f"runner.py not found at {source}"
+
+        result = _file_read(str(source), start_line=1, end_line=10)
+        assert " | " in result, "opencode-style line numbers missing"
+        lines = result.splitlines()
+        assert lines[0].lstrip().startswith("1 |")
+        assert len(lines) == 10
+
+    def test_grep_for_agent_runner_in_runner_py(self):
+        """Smoke: grep for 'AgentRunner' in runner.py."""
+        import codeminer.agent.runner as runner_module
+
+        source = Path(runner_module.__file__)
+        result = _grep("AgentRunner", path=str(source))
+        assert "AgentRunner" in result
+        # At least one match should have a line number
+        assert any(":" in line for line in result.splitlines())

--- a/test/agent/test_runner.py
+++ b/test/agent/test_runner.py
@@ -211,12 +211,22 @@ class TestAgentRunner:
         assert "echo: hi" in tool_msgs[0]["content"]
 
     def test_exclude_skills(self, echo_registry):
-        """Excluded skills should not appear in tool schemas."""
+        """Excluded sweep-variable skills should not appear in tool schemas.
+
+        Note: default skills (file_read, grep) are NEVER excluded — the
+        runner strips them from the exclude set before building the tool list.
+        """
+        from codeminer.agent.skills.defaults import DEFAULT_SKILL_IDS
+
         llm = _make_llm()
         llm._call_raw.return_value = _make_response(content="ok")
 
         runner = AgentRunner(llm, echo_registry, exclude_skills={"echo"})
-        assert runner.tools == []
+        tool_names = {t["function"]["name"] for t in runner.tools}
+        # echo is excluded
+        assert "echo" not in tool_names
+        # defaults are always present
+        assert DEFAULT_SKILL_IDS.issubset(tool_names)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the always-on default toolset described in issue #145 (sub-issue of #133 Agent Router RFC). `file_read` and `grep` are now available in every `AgentRunner` instance regardless of which `Ax` skill subset is loaded.

## Changes

### New: `codeminer/agent/skills/defaults.py`
- `_file_read(path, start_line, end_line, max_lines)` — reads a file with per-row 1-based line numbers in opencode-style format; hard-capped at `max_lines=200` for token safety
- `_grep(pattern, path, include, case_sensitive, use_regex, max_results)` — filesystem regex/literal search returning `{file}:{lineno}: {content}` matches (1-based, no index required)
- `DEFAULT_SKILL_IDS`, `get_default_skill_metadata()`, `ensure_defaults_registered(registry)` public API

### Modified: `codeminer/agent/runner.py`
- Calls `ensure_defaults_registered(self.registry)` in `__init__`
- Strips `DEFAULT_SKILL_IDS` from the `exclude` set before `registry_to_tools` — defaults survive any `exclude_skills` argument

### New: `test/agent/test_default_skills.py` (44 tests)
- `file_read`: full-file read, line range, max_lines truncation, all edge cases
- `grep`: match, no-match, regex/literal, include filter, max_results cap, output format, 1-based line numbers
- `AgentRunner` integration: defaults always present, survive `exclude_skills`, end-to-end dispatch
- Smoke tests: reads real source files from this repo

### New: `docs/agent/default_tools_design.md`
Reference survey (opencode / openhands / codex) and rationale for following opencode's line-number format.

## Design decisions

| Decision | Choice | Reason |
|----------|--------|--------|
| Line-number format | `{n:6d} \| {line}` (opencode-style) | Explicit request in #145 comment by @siriuxyu |
| Line-number base | 1-based | Aligned with #147/#153 convention; `@fishmingyu` comment on #145 |
| Tool name for filesystem grep | `grep` | Avoids conflict with existing index-backed `regex_search` (A_g sweep variable, unchanged) |
| Token safety | max_lines=200, max_results=50 | Prevents context blowup; truncation notice carries next `start_line` |

## Test results

```
44 passed in 8.13s   (test/agent/test_default_skills.py)
13 passed in 11.72s  (test/agent/test_runner.py)
```

Closes #145

---