### PR TITLE
feat(retrieval): pure-retrieval BM25+embedding baseline for RFC #133 (#146)

### DIFF
--- a/codeminer/compiler/skill_context.py
+++ b/codeminer/compiler/skill_context.py
@@ -122,6 +122,7 @@ def _load_vector(cache_dir: str, *, embedding_model: str, embedding_dimension: i
         embedding_model=embedding_model,
         embedding_provider="huggingface",
         dimension=embedding_dimension,
+        trust_remote_code=True,  # Required for models like nomic-ai/CodeRankEmbed
     )
     store.load(_index_dir(cache_dir, "vector"))
     return store

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -183,6 +183,8 @@ class _HuggingFaceEmbeddingWrapper:
         kwargs = self._build_encode_kwargs(
             self._document_prompt, self._document_prompt_name
         )
+        # Use smaller batch size to avoid CUDA OOM on large repos
+        kwargs.setdefault("batch_size", 8)
         vecs = self._model.encode(texts, **kwargs)
         return vecs.tolist()
 

--- a/codeminer/model/__init__.py
+++ b/codeminer/model/__init__.py
@@ -8,6 +8,7 @@ from .agentless_pipeline import AgentlessPipeline
 from .bm25_retrieve_pipeline import BM25RetrievePipeline
 from .embedding_retrieve_pipeline import EmbeddingRetrievePipeline
 from .graph_retrieve_pipeline import GraphRetrievePipeline
+from .hybrid_retrieve_pipeline import HybridRetrievePipeline
 from .retrieve_rerank_pipeline import (
     RetrieveRerankPipeline,
     RetrieveStageConfig,
@@ -19,6 +20,7 @@ __all__ = [
     "BM25RetrievePipeline",
     "EmbeddingRetrievePipeline",
     "GraphRetrievePipeline",
+    "HybridRetrievePipeline",
     "RetrieveRerankPipeline",
     "RetrieveStageConfig",
     "build_retrieve_plan",

--- a/codeminer/model/hybrid_retrieve_pipeline.py
+++ b/codeminer/model/hybrid_retrieve_pipeline.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cascade-style hybrid retrieval: BM25 → embedding rerank (no agent loop).
+
+This pipeline is the pure-retrieval baseline for RFC #133's agent evaluation.
+It uses the same index artifacts as the agent path (via ``build_skill_contexts``)
+but applies a deterministic heuristic instead of LLM-driven tool selection.
+
+Architecture
+------------
+    Stage 1: BM25 sparse search over code chunks (recall-oriented filter)
+    Stage 2: Embedding similarity rerank within BM25 results (precision-oriented)
+
+Fusion Strategy
+---------------
+This pipeline implements a **cascade** (also called "rerank" or "filter-then-rank")
+strategy, distinct from common hybrid retrieval variants in IR literature:
+
+1. **Cascade (this pipeline)**:
+   - BM25 retrieves top-K₁ candidates (K₁ >> K₂, e.g., 128)
+   - Embedding reranker scores ONLY those K₁ candidates, returns top-K₂ (e.g., 50)
+   - Final ranking: purely embedding similarity (BM25 scores discarded after stage 1)
+   - Advantage: embedding model only scores promising candidates (faster)
+   - Used by: ColBERT late interaction [Khattab+ SIGIR'20], SPLADE+rerank
+
+2. **Reciprocal Rank Fusion (RRF)**:
+   - BM25 and embedding run in parallel, each returns ranked list
+   - Merge via: score(doc) = 1/(k + rank_BM25) + 1/(k + rank_embedding)
+   - Final ranking: RRF combined scores
+   - Advantage: simple, no weight tuning, robust across domains
+   - Used by: Elasticsearch hybrid search, BEIR benchmark default
+
+3. **Linear Combination**:
+   - BM25 and embedding run in parallel
+   - Merge via: score(doc) = α·norm(BM25) + β·norm(embedding), α+β=1
+   - Final ranking: weighted sum (requires score normalization)
+   - Advantage: interpretable weights, can tune α/β per domain
+   - Used by: dense-sparse fusion in DPR+BM25, Pyserini hybrid
+
+Our cascade choice is motivated by RFC #133's requirement to **match the agent's
+tool-calling behavior**: the agent typically calls ``bm25_search`` first (cheap,
+high recall), then decides whether to call ``embedding_search`` on a subset. The
+cascade pipeline mirrors this sequential dependency.
+
+Score Normalization
+-------------------
+- **Stage 1 (BM25)**: raw BM25 scores from ``BM25Retriever`` (Okapi BM25 formula).
+  Scores are **not normalized** — only used for stage-1 ranking, then discarded.
+- **Stage 2 (Embedding)**: cosine similarity ∈ [-1, 1] via inner-product metric.
+  No further normalization needed (already bounded).
+- **Final output**: embedding similarity scores (stage-2 output), sorted descending.
+
+The lack of cross-stage score fusion simplifies the pipeline and avoids the
+normalization pitfalls documented in BEIR [Thakur+ NeurIPS'21]: min-max / z-score
+normalization can distort score distributions when candidate sets have different
+characteristics (e.g., BM25's long tail vs embedding's tight cluster).
+
+Contrast with Other Pipelines
+------------------------------
+- ``GraphRetrievePipeline``: BM25 → **graph expansion** → embedding rerank
+  (adds a graph-walk middle stage; used for graph-RAG experiments)
+- Agent A2 (``bm25_search`` + ``embedding_search``): **LLM decides** when/how to
+  call each tool (adaptive, but token-expensive and non-deterministic)
+- ``RetrieveRerankPipeline``: parallel **hybrid fusion** with configurable weights
+  (RRF or linear combination; more flexible but higher latency)
+
+References
+----------
+- Khattab & Zaharia (2020): "ColBERT: Efficient and Effective Passage Search via
+  Contextualized Late Interaction over BERT." SIGIR.
+- Thakur et al. (2021): "BEIR: A Heterogeneous Benchmark for Zero-shot Evaluation
+  of Information Retrieval Models." NeurIPS Datasets & Benchmarks.
+- Karpukhin et al. (2020): "Dense Passage Retrieval for Open-Domain Question
+  Answering." EMNLP. (DPR+BM25 hybrid baseline)
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from ..compiler import build_skill_contexts
+from ..log_utils import get_logger
+from ..types import QueriedNode
+
+logger = get_logger(__name__)
+
+
+class HybridRetrievePipeline:
+    """Two-stage cascade retrieval: BM25 → embedding rerank.
+
+    Args:
+        repo_path: Repository root to index.
+        index_cache_dir: Directory for cached indexes (default: <repo>/.codeminer_cache).
+        stage1_topk: Number of BM25 candidates to retrieve (default: 128).
+        stage2_topk: Final number of results after embedding rerank (default: 50).
+        embedding_model: Embedding model name (default: nomic-ai/CodeRankEmbed).
+        embedding_dimension: Embedding vector dimension (default: 768).
+        languages: Languages to index (default: ["python"]).
+        max_lines_per_chunk: Maximum lines per chunk (default: 300).
+
+    Example:
+        >>> pipeline = HybridRetrievePipeline(
+        ...     repo_path="/path/to/repo",
+        ...     index_cache_dir="~/.codeminer/cache",
+        ... )
+        >>> results = pipeline.query("how to parse CSV files", top_k=10)
+        >>> for node in results[:5]:
+        ...     print(f"{node.file}:{node.node_name} (score={node.score:.3f})")
+    """
+
+    def __init__(
+        self,
+        repo_path: str,
+        *,
+        index_cache_dir: Optional[str] = None,
+        stage1_topk: int = 128,
+        stage2_topk: int = 50,
+        embedding_model: str = "nomic-ai/CodeRankEmbed",
+        embedding_dimension: int = 768,
+        languages: Sequence[str] = ("python",),
+        max_lines_per_chunk: int = 300,
+    ):
+        self.repo_path = repo_path
+        self.stage1_topk = stage1_topk
+        self.stage2_topk = stage2_topk
+
+        # Load skill registry (required before build_skill_contexts)
+        from ..agent.skills.loader import SkillLoader
+        from ..agent.skills.registry import SkillRegistry
+        import os as _os
+
+        skills_dir = _os.path.join(
+            _os.path.dirname(_os.path.dirname(__file__)), "agent", "skills"
+        )
+        registry = SkillRegistry()
+        registry.reset()  # Clear any stale state
+        loader = SkillLoader()
+        loaded_skills = loader.load_all(skills_dir, contexts={}, registry=registry)
+        logger.debug("Loaded %d skills into registry", len(loaded_skills))
+
+        # Build indexes via compiler (ADR-0001: always-chunks path)
+        logger.info(
+            "Building indexes for BM25 + embedding (cascade mode) at %s",
+            index_cache_dir or "<repo>/.codeminer_cache",
+        )
+        contexts = build_skill_contexts(
+            repo_path=repo_path,
+            skill_ids=["bm25_search", "embedding_search"],
+            languages=list(languages),
+            cache_dir=index_cache_dir,
+            skill_registry=registry,  # Pass loaded registry
+            embedding_model=embedding_model,
+            embedding_dimension=embedding_dimension,
+            default_top_k=stage1_topk,  # BM25 max_k
+            default_level="l2",  # embedding level
+        )
+
+        retrieve_ctx = contexts.get("retrieve")
+        if retrieve_ctx is None:
+            raise RuntimeError(
+                "build_skill_contexts did not return a 'retrieve' context. "
+                "Check skill registry and index_requirements."
+            )
+
+        self.bm25 = retrieve_ctx.bm25
+        self.vector_store = retrieve_ctx.vector_store
+
+        if self.bm25 is None:
+            raise RuntimeError("BM25 index not built (bm25_search skill failed).")
+        if self.vector_store is None:
+            raise RuntimeError(
+                "Embedding index not built (embedding_search skill failed)."
+            )
+
+        logger.info(
+            "HybridRetrievePipeline ready: BM25 (top-%d) → embedding rerank (top-%d)",
+            stage1_topk,
+            stage2_topk,
+        )
+
+    def query(self, query: str, top_k: Optional[int] = None) -> List[QueriedNode]:
+        """Run cascade retrieval: BM25 → embedding rerank.
+
+        Args:
+            query: Search query (e.g., problem statement).
+            top_k: Number of final results (overrides stage2_topk if provided).
+
+        Returns:
+            List of QueriedNode sorted by embedding similarity (descending).
+        """
+        final_k = top_k if top_k is not None else self.stage2_topk
+
+        # Stage 1: BM25 sparse search (recall-oriented filter)
+        logger.debug("Stage 1: BM25 search (top_k=%d)", self.stage1_topk)
+        bm25_results = self.bm25.search(
+            query=query,
+            top_k=self.stage1_topk,
+            return_code_content=False,  # embedding rerank will fetch content
+            wrap_with_ln=False,
+            filter_test=False,
+        )
+
+        if not bm25_results:
+            logger.warning("BM25 returned no results for query: %r", query)
+            return []
+
+        # Extract node_ids for embedding rerank mask
+        candidate_ids = {r.node_id for r in bm25_results if r.node_id}
+        logger.debug(
+            "Stage 1 complete: %d candidates (unique node_ids: %d)",
+            len(bm25_results),
+            len(candidate_ids),
+        )
+
+        # Stage 2: Embedding rerank within BM25 candidates
+        logger.debug("Stage 2: embedding rerank within %d candidates", len(candidate_ids))
+        reranked = self.vector_store.search_within_ids(
+            query=query,
+            mask_node_ids=candidate_ids,
+            top_k=final_k,
+        )
+
+        logger.info(
+            "Pipeline complete: %d results (BM25=%d → embedding=%d)",
+            len(reranked),
+            len(bm25_results),
+            len(reranked),
+        )
+
+        # Convert to QueriedNode format (search_within_ids returns NodeInfo)
+        return [
+            QueriedNode(
+                node_name=n.node_name,
+                type=n.type,
+                file=n.file,
+                node_id=n.node_id or n.node_name,
+                start_line=n.start_line,
+                end_line=n.end_line,
+                score=n.score,
+                content=n.content,
+            )
+            for n in reranked
+        ]
+
+    def close(self) -> None:
+        """Release pipeline resources."""
+        if self.vector_store is not None:
+            self.vector_store.close()
+            self.vector_store = None
+        self.bm25 = None

--- a/examples/skill_agent_eval.py
+++ b/examples/skill_agent_eval.py
@@ -206,6 +206,26 @@ def run_bm25_baseline_retrieval(
     return to_queried_nodes(raw)
 
 
+def run_hybrid_baseline_retrieval(
+    problem_statement: str,
+    repo_path: str,
+    args: argparse.Namespace,
+) -> List[QueriedNode]:
+    """Pure-retrieval baseline: BM25 → embedding rerank (RFC #133 baseline)."""
+    from codeminer.model import HybridRetrievePipeline
+
+    pipeline = HybridRetrievePipeline(
+        repo_path=repo_path,
+        index_cache_dir=args.index_cache_dir,
+        stage1_topk=128,  # BM25 candidate pool
+        stage2_topk=args.topk,  # Final results (align with agent default_top_k)
+        embedding_model=args.embedding_model,
+        embedding_dimension=args.embedding_dimension,
+        languages=args.languages,
+    )
+    return pipeline.query(problem_statement)
+
+
 def run_agent_with_skills(
     query: str,
     contexts: Dict[str, Any],
@@ -323,23 +343,33 @@ def evaluate_instance(
         # In bm25_baseline mode we still go through the compiler so the
         # build path stays single-source; we just read the BM25 index back
         # out for the direct-query call.
-        skill_ids = list(args.skills) if args.eval_mode == "agent" else ["bm25_search"]
+        # In hybrid_baseline mode, the pipeline builds indexes internally.
+        if args.eval_mode == "agent":
+            skill_ids = list(args.skills)
+        elif args.eval_mode == "bm25_baseline":
+            skill_ids = ["bm25_search"]
+        else:
+            # hybrid_baseline: skip build_skill_contexts (HybridRetrievePipeline does it)
+            skill_ids = []
+
         execution_log.append(f"Building contexts for skills={skill_ids}...")
-        contexts = build_skill_contexts(
-            repo_path=repo_path,
-            skill_ids=skill_ids,
-            languages=args.languages,
-            cache_dir=args.index_cache_dir,
-            embedding_model=args.embedding_model,
-            embedding_dimension=args.embedding_dimension,
-            default_top_k=args.topk,
-            default_level="l2",
-        )
-        execution_log.append(f"Built contexts for {sorted(contexts.keys())}")
+        contexts = {}
+        if skill_ids:  # Skip for hybrid_baseline
+            contexts = build_skill_contexts(
+                repo_path=repo_path,
+                skill_ids=skill_ids,
+                languages=args.languages,
+                cache_dir=args.index_cache_dir,
+                embedding_model=args.embedding_model,
+                embedding_dimension=args.embedding_dimension,
+                default_top_k=args.topk,
+                default_level="l2",
+            )
+            execution_log.append(f"Built contexts for {sorted(contexts.keys())}")
 
         simplified_gt = args.gt_symbols != "full"
 
-        # Step 3: Retrieve (agent tool-calling vs single-query BM25 baseline)
+        # Step 3: Retrieve (agent tool-calling vs single-query BM25 baseline vs hybrid cascade)
         if args.eval_mode == "bm25_baseline":
             retrieve_ctx = contexts.get("retrieve")
             if retrieve_ctx is None or retrieve_ctx.bm25 is None:
@@ -363,6 +393,23 @@ def evaluate_instance(
                 "total_duration_ms": 0.0,
                 "tool_call_count": 0,
                 "eval_mode": "bm25_baseline",
+            }
+        elif args.eval_mode == "hybrid_baseline":
+            execution_log.append(
+                "Running hybrid baseline (BM25 → embedding rerank)..."
+            )
+            results = run_hybrid_baseline_retrieval(
+                problem_statement, repo_path, args
+            )
+            search_log = [
+                f"Hybrid baseline retrieved {len(results)} nodes (cascade mode)"
+            ]
+            execution_log.extend(search_log)
+            usage = {
+                "total_turns": 0,
+                "total_duration_ms": 0.0,
+                "tool_call_count": 0,
+                "eval_mode": "hybrid_baseline",
             }
         else:
             if llm is None:
@@ -477,19 +524,82 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
         )
 
     # Load dataset
-    dataset = SwebenchDataset(
-        dataset=args.dataset,
-        split=args.split,
-        filter_instance=args.filter_instance,
-        root=args.cache_dir,
-        repo_root=args.repo_cache_dir,
-    )
-    instances = dataset.load()
-    logger.info(f"Loaded {len(instances)} instances")
-
+    # If --eval-instances points to a complete instance JSON (not just GT),
+    # load instances directly from it instead of from HF dataset
     eval_lookup: Optional[Dict[str, Any]] = None
     if args.eval_instances:
-        eval_lookup = dataset.load_eval_metadata(args.eval_instances)
+        eval_instances_path = Path(os.path.expanduser(args.eval_instances))
+        if eval_instances_path.exists():
+            with open(eval_instances_path, encoding="utf-8") as f:
+                eval_instances_data = json.load(f)
+
+            # Check if this is a complete instance file (has 'repo', 'problem_statement')
+            # vs just GT metadata (has 'target_files', 'code_blocks')
+            if isinstance(eval_instances_data, list) and len(eval_instances_data) > 0:
+                first_item = eval_instances_data[0]
+                is_complete_instance = "repo" in first_item and "problem_statement" in first_item
+
+                if is_complete_instance:
+                    logger.info(
+                        f"Loading instances directly from {args.eval_instances} "
+                        f"({len(eval_instances_data)} instances)"
+                    )
+                    # Convert to Arrow dataset format for compatibility
+                    import datasets
+                    instances = datasets.Dataset.from_list(eval_instances_data)
+
+                    # Build eval_lookup from the same data (extract GT fields)
+                    eval_lookup = {}
+                    for inst in eval_instances_data:
+                        iid = inst["instance_id"]
+                        eval_lookup[iid] = {
+                            "instance_id": iid,
+                            "repo": inst.get("repo"),
+                            "base_commit": inst.get("base_commit"),
+                            "target_files": inst.get("gt_target_files", []),
+                            "code_blocks": inst.get("gt_code_blocks", []),
+                            "symbols_modified": inst.get("gt_symbols_modified", []),
+                            "symbols_added": inst.get("gt_symbols_added", []),
+                            "symbols_deleted": inst.get("gt_symbols_deleted", []),
+                        }
+
+                    # Still need dataset object for process_instance/get_repo_path
+                    # Create a dataset object but don't load from HF (instances already loaded)
+                    dataset = SwebenchDataset(
+                        dataset=args.dataset,
+                        split=args.split,
+                        filter_instance=args.filter_instance,
+                        root=args.cache_dir,
+                        repo_root=args.repo_cache_dir,
+                    )
+                else:
+                    # Just GT metadata, load instances from HF as usual
+                    dataset = SwebenchDataset(
+                        dataset=args.dataset,
+                        split=args.split,
+                        filter_instance=args.filter_instance,
+                        root=args.cache_dir,
+                        repo_root=args.repo_cache_dir,
+                    )
+                    instances = dataset.load()
+                    logger.info(f"Loaded {len(instances)} instances from {args.dataset}")
+                    eval_lookup = dataset.load_eval_metadata(args.eval_instances)
+            else:
+                # Empty or invalid file
+                raise ValueError(f"Invalid eval_instances file: {args.eval_instances}")
+        else:
+            raise FileNotFoundError(f"Eval instances file not found: {args.eval_instances}")
+    else:
+        # No --eval-instances, load from HF dataset
+        dataset = SwebenchDataset(
+            dataset=args.dataset,
+            split=args.split,
+            filter_instance=args.filter_instance,
+            root=args.cache_dir,
+            repo_root=args.repo_cache_dir,
+        )
+        instances = dataset.load()
+        logger.info(f"Loaded {len(instances)} instances")
 
     if args.locagent_lite_subset:
         if not eval_lookup:
@@ -511,7 +621,7 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
             before,
         )
 
-    # Initialize LLM (agent mode only)
+    # Initialize LLM (agent mode only; baselines don't need LLM)
     llm: Optional[LiteLLMChat] = None
     if args.eval_mode == "agent":
         llm_kwargs = {}
@@ -558,8 +668,15 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
     avg_metrics = average_metrics(aggregate, metric_count) if metric_count else {}
 
     # Build report
-    skill_ids = list(args.skills) if args.eval_mode == "agent" else ["bm25_baseline"]
-    report_model = args.model if args.eval_mode == "agent" else "bm25_baseline"
+    if args.eval_mode == "agent":
+        skill_ids = list(args.skills)
+        report_model = args.model
+    elif args.eval_mode == "bm25_baseline":
+        skill_ids = ["bm25_baseline"]
+        report_model = "bm25_baseline"
+    else:  # hybrid_baseline
+        skill_ids = ["hybrid_baseline"]
+        report_model = "hybrid_baseline"
 
     # Aggregate token usage across all instances (agent mode only).
     total_usage: Optional[Dict[str, Any]] = None
@@ -646,12 +763,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--eval-mode",
         type=str,
-        choices=["agent", "bm25_baseline"],
+        choices=["agent", "bm25_baseline", "hybrid_baseline"],
         default="agent",
         help=(
             "agent: AgentRunner + bm25_search tool-calling. "
             "bm25_baseline: one BM25 query per instance using problem_statement "
-            "(LocAgent Table 4 sparse baseline style; no LLM calls)."
+            "(LocAgent Table 4 sparse baseline style; no LLM calls). "
+            "hybrid_baseline: cascade BM25 → embedding rerank (pure-retrieval baseline "
+            "for RFC #133; no agent loop)."
         ),
     )
     parser.add_argument(

--- a/scripts/compare_retrieval_modes.py
+++ b/scripts/compare_retrieval_modes.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare hybrid_baseline vs agent A2 retrieval modes.
+
+Loads JSON reports from skill_agent_eval.py and generates comparison tables
+for RFC #133 Phase 0/2 analysis.
+
+Usage:
+    python scripts/compare_retrieval_modes.py \\
+        --baseline results/car_phase0_hybrid_baseline.json \\
+        --agent results/car_phase0_agent_a2.json \\
+        --output results/comparison.md
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def load_report(path: str) -> Dict[str, Any]:
+    """Load skill_agent_eval.py JSON report."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def extract_metrics(report: Dict[str, Any], mode_name: str) -> Dict[str, Any]:
+    """Extract key metrics from a report."""
+    agg = report.get("aggregate_metrics", {})
+    row = {"mode": mode_name}
+
+    # Accuracy @ K for files and symbols
+    for scope in ["files", "symbols"]:
+        scope_metrics = agg.get(scope, {})
+        for k in ["1", "3", "5", "10"]:
+            stats = scope_metrics.get(k, {})
+            row[f"{scope}@{k}_acc"] = stats.get("accuracy", 0.0)
+            row[f"{scope}@{k}_recall"] = stats.get("recall", 0.0)
+            row[f"{scope}@{k}_prec"] = stats.get("precision", 0.0)
+
+    # Usage stats (agent only)
+    total_usage = report.get("total_usage")
+    if total_usage:
+        row["total_tokens"] = total_usage.get("total_tokens", 0)
+        row["cost_usd"] = total_usage.get("cost_usd", 0.0)
+    else:
+        row["total_tokens"] = 0
+        row["cost_usd"] = 0.0
+
+    # Average wall time per instance
+    results = report.get("results", [])
+    if results:
+        total_time = sum(
+            r.get("elapsed_seconds", 0) for r in results if r.get("success")
+        )
+        row["avg_time_sec"] = total_time / len(results)
+        row["success_rate"] = sum(1 for r in results if r.get("success")) / len(results)
+    else:
+        row["avg_time_sec"] = 0.0
+        row["success_rate"] = 0.0
+
+    # Instance count
+    row["instance_count"] = report.get("instance_count", len(results))
+
+    return row
+
+
+def format_markdown_table(rows: List[Dict[str, Any]]) -> str:
+    """Format comparison as markdown table."""
+    if not rows:
+        return ""
+
+    # Key metrics to display
+    headers = [
+        "Mode",
+        "files@5",
+        "symbols@5",
+        "Avg Time (s)",
+        "Tokens",
+        "Cost (USD)",
+        "Success Rate",
+    ]
+
+    lines = ["| " + " | ".join(headers) + " |"]
+    lines.append("|" + "|".join(["---"] * len(headers)) + "|")
+
+    for row in rows:
+        cells = [
+            row["mode"],
+            f"{row.get('files@5_acc', 0.0):.3f}",
+            f"{row.get('symbols@5_acc', 0.0):.3f}",
+            f"{row.get('avg_time_sec', 0.0):.1f}",
+            f"{row.get('total_tokens', 0):,}",
+            f"${row.get('cost_usd', 0.0):.2f}",
+            f"{row.get('success_rate', 0.0):.1%}",
+        ]
+        lines.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join(lines)
+
+
+def format_detailed_table(rows: List[Dict[str, Any]]) -> str:
+    """Detailed accuracy breakdown by k."""
+    if not rows:
+        return ""
+
+    lines = []
+    for row in rows:
+        lines.append(f"\n## {row['mode']}\n")
+        lines.append("### Files")
+        lines.append("| K | Accuracy | Recall | Precision |")
+        lines.append("|---|----------|--------|-----------|")
+        for k in ["1", "3", "5", "10"]:
+            lines.append(
+                f"| {k} | {row.get(f'files@{k}_acc', 0.0):.3f} | "
+                f"{row.get(f'files@{k}_recall', 0.0):.3f} | "
+                f"{row.get(f'files@{k}_prec', 0.0):.3f} |"
+            )
+
+        lines.append("\n### Symbols")
+        lines.append("| K | Accuracy | Recall | Precision |")
+        lines.append("|---|----------|--------|-----------|")
+        for k in ["1", "3", "5", "10"]:
+            lines.append(
+                f"| {k} | {row.get(f'symbols@{k}_acc', 0.0):.3f} | "
+                f"{row.get(f'symbols@{k}_recall', 0.0):.3f} | "
+                f"{row.get(f'symbols@{k}_prec', 0.0):.3f} |"
+            )
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare hybrid_baseline vs agent A2 retrieval modes"
+    )
+    parser.add_argument(
+        "--baseline",
+        type=str,
+        required=True,
+        help="Path to hybrid_baseline JSON report",
+    )
+    parser.add_argument(
+        "--agent", type=str, required=True, help="Path to agent A2 JSON report"
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output markdown file (default: print to stdout)",
+    )
+    args = parser.parse_args()
+
+    # Load reports
+    baseline_report = load_report(args.baseline)
+    agent_report = load_report(args.agent)
+
+    # Extract metrics
+    baseline_metrics = extract_metrics(baseline_report, "hybrid_baseline")
+    agent_metrics = extract_metrics(agent_report, "agent_a2")
+
+    # Generate comparison
+    output = []
+    output.append("# Retrieval Mode Comparison\n")
+    output.append(f"Baseline: `{args.baseline}`")
+    output.append(f"Agent: `{args.agent}`\n")
+
+    output.append("## Summary\n")
+    output.append(format_markdown_table([baseline_metrics, agent_metrics]))
+
+    output.append("\n## Detailed Metrics\n")
+    output.append(format_detailed_table([baseline_metrics, agent_metrics]))
+
+    # Analysis
+    output.append("\n## Analysis\n")
+    files_delta = agent_metrics["files@5_acc"] - baseline_metrics["files@5_acc"]
+    symbols_delta = agent_metrics["symbols@5_acc"] - baseline_metrics["symbols@5_acc"]
+    time_ratio = (
+        agent_metrics["avg_time_sec"] / baseline_metrics["avg_time_sec"]
+        if baseline_metrics["avg_time_sec"] > 0
+        else 0
+    )
+
+    output.append(f"- **Accuracy gain (files@5)**: {files_delta:+.3f}")
+    output.append(f"- **Accuracy gain (symbols@5)**: {symbols_delta:+.3f}")
+    output.append(f"- **Time overhead**: {time_ratio:.1f}x")
+    output.append(
+        f"- **Token cost**: {agent_metrics['total_tokens']:,} "
+        f"(${agent_metrics['cost_usd']:.2f})"
+    )
+
+    if files_delta > 0.03:
+        output.append(
+            "\n**Conclusion**: Agent A2 shows meaningful accuracy improvement "
+            "over heuristic baseline."
+        )
+    elif files_delta > 0:
+        output.append(
+            "\n**Conclusion**: Agent A2 shows marginal accuracy improvement. "
+            "Cost/benefit trade-off unclear."
+        )
+    else:
+        output.append(
+            "\n**Conclusion**: Agent A2 does NOT improve over heuristic baseline. "
+            "LLM tool-calling adds cost without accuracy gain."
+        )
+
+    result = "\n".join(output)
+
+    # Write or print
+    if args.output:
+        Path(args.output).write_text(result)
+        print(f"Comparison written to {args.output}")
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_skill_loading_only.py
+++ b/scripts/test_skill_loading_only.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test that HybridRetrievePipeline can load skills correctly.
+
+This test does NOT build indexes (avoids GPU/embedding issues),
+just validates the skill loading fix.
+"""
+
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+def test_skill_loading():
+    """Test that build_skill_contexts returns contexts when skills are loaded."""
+    print("Test: build_skill_contexts with skill registry loading\n")
+
+    from codeminer.agent.skills.loader import SkillLoader
+    from codeminer.agent.skills.registry import SkillRegistry
+    from codeminer.compiler import required_index_types
+    import os
+
+    # Step 1: Load skills into registry
+    print("Step 1: Loading skills...")
+    skills_dir = os.path.join("codeminer", "agent", "skills")
+    registry = SkillRegistry()
+    registry.reset()
+    loader = SkillLoader()
+    loaded_skills = loader.load_all(skills_dir, contexts={}, registry=registry)
+
+    print(f"✓ Loaded {len(loaded_skills)} skills")
+    print(f"  Skill IDs: {[s.skill_id for s in loaded_skills]}")
+
+    # Step 2: Check required_index_types
+    print("\nStep 2: Checking required_index_types...")
+    needed = required_index_types(
+        ["bm25_search", "embedding_search"],
+        skill_registry=registry
+    )
+    print(f"✓ Required index types: {needed}")
+
+    if "bm25" not in needed or "vector" not in needed:
+        print(f"✗ FAIL: Expected {{'bm25', 'vector'}}, got {needed}")
+        return False
+
+    # Step 3: Verify _skill_types_for
+    print("\nStep 3: Checking skill_types_for...")
+    from codeminer.compiler.skill_context import _skill_types_for
+    skill_types = _skill_types_for(
+        ["bm25_search", "embedding_search"],
+        registry
+    )
+    print(f"✓ Skill types: {skill_types}")
+
+    from codeminer.agent.skills.core import SkillType
+    if SkillType.RETRIEVAL not in skill_types:
+        print(f"✗ FAIL: Expected RETRIEVAL in skill_types, got {skill_types}")
+        return False
+
+    print("\n✓ All skill loading tests passed!")
+    return True
+
+
+if __name__ == "__main__":
+    try:
+        success = test_skill_loading()
+        sys.exit(0 if success else 1)
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Implements Issue #146: establishes a non-agent retrieval baseline to compare against the agent path on the same corpus.

## Core Implementation

- ✅ **HybridRetrievePipeline**: BM25 → embedding cascade (no agent loop)
  - Stage 1: BM25 retrieves top-128 candidates
  - Stage 2: Embedding reranks within BM25 results, returns top-50
  - Cascade strategy (vs RRF/linear combination) documented with literature references
- ✅ **Agent A2 mode**: bm25_search + embedding_search skills via AgentRunner
- ✅ **Direct JSON loading**: supports fishmingyu/codeminer-base-dataset
- ✅ **Comparison tool**: `compare_retrieval_modes.py` generates markdown tables

## Bug Fixes

- **Skill loading**: SkillRegistry must be populated before build_skill_contexts
- **trust_remote_code=True**: required for nomic-ai/CodeRankEmbed
- **batch_size=8**: prevents CUDA OOM on large repos

## Files Changed

**New (3 files, 553 lines)**:
- `codeminer/model/hybrid_retrieve_pipeline.py` (252 lines)
- `scripts/compare_retrieval_modes.py` (223 lines)
- `scripts/test_skill_loading_only.py` (78 lines)

**Modified (4 files, +153 lines)**:
- `examples/skill_agent_eval.py`
- `codeminer/compiler/skill_context.py`
- `codeminer/index/embedding/vector_store.py`
- `codeminer/model/__init__.py`

## Testing

- ✅ `scripts/test_skill_loading_only.py` passes
- ✅ End-to-end validation passed (3 instances from fishmingyu/codeminer-base-dataset)
- ✅ Both baseline and agent modes verified runnable

## Related

- Closes #146
- Related: RFC #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)