### PR TITLE
ci: iter-1 scope cancel-in-progress to PR refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Group by PR head ref so only a *new commit on the same PR* preempts the
+  # in-flight run. On main/master pushes and scheduled runs (no head_ref) we
+  # fall back to a per-run-unique group, so those runs never cancel each other.
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # cancel-in-progress only for pull_request events; never on main/release or
+  # schedule (those must always run to completion).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # =============================================================


### PR DESCRIPTION
## Hypothesis (CI-optimization loop, iteration 1)

> **Current bottleneck:** 96% cancel rate (46/48 of last 50 runs), dominated by `concurrency-preempt` (25+/46) and **100% main cancellation** (push 7/7, schedule 6/6).
>
> **Root cause hypothesis:** `cancel-in-progress: true` on `group: ci-${{ github.ref }}` applies to *every* ref. Main pushes and scheduled runs share `group: ci-refs/heads/main`, so each push/schedule tick preempts the previous main run; PR runs are killed even when not superseded by a newer commit on the same PR.
>
> **Proposed change:** group by `${{ github.workflow }}-${{ github.head_ref || github.run_id }}` (PRs group by head ref; main/schedule get a unique-per-run group so they never cancel each other) and set `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
>
> **Expected delta on target metric:** main cancel rate 100%→~0%; overall cancel rate 96%→<40% (residual = legitimate new-commit preempts on active PRs + the separate 24h runner-hang `timeout` bucket, addressed in a later iteration).
>
> **Risk if wrong:** if cross-branch single-runner contention (not concurrency) is the real driver, cancel rate barely moves; pivot to per-job `timeout-minutes` on unit/integration/slow next.

## Change
`.github/workflows/ci.yml` concurrency block only (7-line diff). No test, job, or timeout changes. Honors the constraint *never set cancel-in-progress on main/release/schedule*.

Targets for this optimization loop: **p50 ≤ 30 min, cancel rate ≤ 10%**, ITER_MAX = 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)