### PR TITLE
ci: iter-2 add pytest-timeout guardrail to integration-serial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,13 @@ jobs:
         # SCIP outputs land at ~/.codeminer/<instance_id>/ (conftest fixture
         # hard-codes this path; self-hosted runner's symlink makes it persist
         # so the downstream `scip-core` job sees it).
-        run: pytest -m "integration_serial" -v --tb=short
+        #
+        # --timeout=900: per-test hang guardrail. The slowest healthy serial test
+        # is ~7.5 min, so a 15-min cap leaves 2x headroom yet fails a hung test
+        # (e.g. scip-python indexing of sympy, observed hanging ~27 min) fast
+        # instead of letting it run out the 45-min job cap and hog the single
+        # self-hosted runner. Default (signal) method fails just the hung test.
+        run: pytest -m "integration_serial" -v --tb=short --timeout=900
 
   # =============================================================
   # Job 3b — SCIP core  (builds core/ pybind + parity-checks the C++

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
     "flake8-bugbear>=24.4.0",
     "mkdocs-material>=9.5.0",
 ]
-test = ["pytest>=6.0.0", "pytest-cov>=3.0.0", "pytest-xdist>=3.0.0", "filelock>=3.0.0"]
+test = ["pytest>=6.0.0", "pytest-cov>=3.0.0", "pytest-xdist>=3.0.0", "pytest-timeout>=2.1.0", "filelock>=3.0.0"]
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Hypothesis (CI-optimization loop, iteration 2)

> **Current bottleneck:** Post-iter-1 (concurrency fixed), the dominant remaining cancellation is `integration-serial` hitting its 45-min `timeout-minutes` cap. Root-caused to a **hang**: `test_scip_exclude` (scip-python indexing of `sympy__sympy-21847`) runs ~27 min and never completes (healthy ~7.5 min), so it hogs the single self-hosted runner for 45 min, times out (counts as a cancellation), and starves every other queued run.
>
> **Root cause hypothesis:** the existing inner guard `_SCIP_PYTHON_INDEX_TIMEOUT_S = 600` (`scip_indexer_python.py:29`) does **not** fire on this path (the test ran 27 min, not ~10), so the hang escapes the subprocess-level timeout. A test-level cap bounds it regardless of where the hang lives.
>
> **Proposed change:** add `pytest-timeout` to the `test` extra and pass `--timeout=900` to the `integration-serial` pytest invocation. Slowest healthy serial test is ~7.5 min, so a 15-min per-test cap gives 2× headroom while killing the ~27-min hang at 15 min.
>
> **Expected delta on target metric:** integration-serial wall time on a hang 45m → ~15m+setup; the run becomes a fast `failure` instead of a 45-min `cancelled`; runner freed ~30 min sooner per hang, cutting downstream queue/cancellation. Cancel-rate (timeout bucket) should drop.
>
> **Risk if wrong:** if the hang is in a C call that ignores SIGALRM, the default (signal) method may not interrupt it; pivot to `--timeout-method=thread`. Healthy tests near 7.5 min could false-trip under heavy load; if so, raise to 1200s.

## Scope
This is a **CI hang-guardrail only** — it does not weaken or skip any test (a hung test is already broken; this just fails it fast and frees the runner).

## Tracked for the team to fix (separate from CI config — these are code bugs)
1. `_SCIP_PYTHON_INDEX_TIMEOUT_S = 600` not bounding `test_scip_exclude` (sympy scip-python index path).
2. `[rust]` multilingual index leaks `rust-analyzer` / `rust-analyzer-proc-macro-srv` orphan processes.
3. `slow`: `test_agent_explores_httpie_graph` regressed — agent returns empty answer after `graph_expand` fails to resolve seed `httpie.core.main`.
