### PR TITLE
perf(graph): batch edge insertion in decoders (O(E^2) → O(E))

### DIFF
--- a/codeminer/graph/code_graph.py
+++ b/codeminer/graph/code_graph.py
@@ -5,6 +5,7 @@
 import bisect
 import pickle
 from collections import defaultdict
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
@@ -123,6 +124,14 @@ class CodeGraph:
         # eids would point at wrong edges). Lookup via _ensure_edge_index().
         # Not pickled — rebuilt on demand after load.
         self._edge_index: Optional[Dict[Tuple, int]] = None
+
+        # Edge insertion buffer, active only inside a `batch_edges()` block.
+        # igraph rebuilds its adjacency index on every `add_edges` call, so
+        # inserting one edge at a time is O(E^2). Decoders wrap their build
+        # loop in `batch_edges()` to defer insertion into a single add_edges
+        # flush (O(E)). When None, `_add_edge` inserts immediately as before.
+        self._edge_buffer: Optional[List[Tuple[int, int]]] = None
+        self._edge_attr_buffer: Optional[List[Tuple]] = None
 
     def add_file_node(self, file_path):
         """
@@ -373,6 +382,18 @@ class CodeGraph:
         if existing is not None:
             return existing
 
+        # Inside a batch_edges() block: buffer the insertion instead of calling
+        # igraph per edge (which is O(E^2)). The provisional eid is the position
+        # the edge will occupy after flush — current ecount is unchanged while
+        # buffering, so it equals ecount + buffer length. Decoders don't use the
+        # returned eid, and dedup stays correct because the index is updated now.
+        if self._edge_buffer is not None:
+            edge_id = self.graph.ecount() + len(self._edge_buffer)
+            self._edge_buffer.append((source_id, target_id))
+            self._edge_attr_buffer.append((edge_type, anchor_file, anchor_line))
+            self._edge_index[key] = edge_id
+            return edge_id
+
         self.graph.add_edges([(source_id, target_id)])
         edge_id = self.graph.ecount() - 1
 
@@ -385,6 +406,60 @@ class CodeGraph:
 
         self._edge_index[key] = edge_id
         return edge_id
+
+    @contextmanager
+    def batch_edges(self):
+        """Defer igraph edge insertion until the block exits, flushing all
+        buffered edges in a single ``add_edges`` call.
+
+        igraph rebuilds its internal adjacency index on every ``add_edges``
+        call, so inserting one edge at a time (as bare ``_add_edge`` does) is
+        O(E^2) in the number of edges — the dominant cost when decoding a large
+        repo. Wrapping a build loop in this context collapses that to O(E):
+
+            with graph.batch_edges():
+                # ... many add_symbol_reference / _add_edge calls ...
+
+        Edge dedup is unaffected (the dedup index is updated as edges are
+        buffered). Edge *ids* returned by ``_add_edge`` while buffering are
+        provisional and only become real after flush; no caller relies on them
+        mid-build. Outside this block ``_add_edge`` inserts immediately, so the
+        incremental patcher and all other callers are unchanged. Nesting is a
+        no-op (the outermost block owns the flush)."""
+        if self._edge_buffer is not None:
+            # Already batching — let the outer block own the buffer/flush.
+            yield
+            return
+        if self._edge_index is None:
+            self._rebuild_edge_index()
+        self._edge_buffer = []
+        self._edge_attr_buffer = []
+        try:
+            yield
+        finally:
+            self._flush_edge_buffer()
+
+    def _flush_edge_buffer(self) -> None:
+        """Insert all buffered edges in one ``add_edges`` call, then assign
+        per-edge attributes. Attribute assignment mirrors the immediate path
+        exactly (anchor_* set only when not None), and does not trigger the
+        adjacency rebuild that makes per-edge ``add_edges`` quadratic."""
+        pairs = self._edge_buffer
+        attrs = self._edge_attr_buffer
+        self._edge_buffer = None
+        self._edge_attr_buffer = None
+        if not pairs:
+            return
+        base = self.graph.ecount()
+        self.graph.add_edges(pairs)
+        es = self.graph.es
+        for offset, (edge_type, anchor_file, anchor_line) in enumerate(attrs):
+            eid = base + offset
+            es[eid]["type"] = edge_type
+            if anchor_file is not None:
+                es[eid]["anchor_file"] = anchor_file
+            if anchor_line is not None:
+                es[eid]["anchor_line"] = anchor_line
 
     def _rebuild_edge_index(self) -> None:
         """Rebuild the edge dedup index by walking all current edges. O(E).

--- a/codeminer/scip_interface/scip_decode_go.py
+++ b/codeminer/scip_interface/scip_decode_go.py
@@ -75,9 +75,11 @@ class SCIPGoGraphDecoder:
         # Add the root node to the graph
         self.code_graph.add_root_node(ROOT_NODE)
 
-        # Process all documents
-        for document in document_blocks:
-            self._process_document(document)
+        # Process all documents. Batch edge insertion: per-edge add_edges is
+        # O(E^2) (igraph reindexes each call); buffering flushes once as O(E).
+        with self.code_graph.batch_edges():
+            for document in document_blocks:
+                self._process_document(document)
 
         return self.code_graph
 

--- a/codeminer/scip_interface/scip_decode_python.py
+++ b/codeminer/scip_interface/scip_decode_python.py
@@ -79,9 +79,11 @@ class SCIPPythonGraphDecoder:
         # Add the root node to the graph
         self.code_graph.add_root_node(ROOT_NODE)
 
-        # Process all documents
-        for document in document_blocks:
-            self._process_document(document)
+        # Process all documents. Batch edge insertion: per-edge add_edges is
+        # O(E^2) (igraph reindexes each call); buffering flushes once as O(E).
+        with self.code_graph.batch_edges():
+            for document in document_blocks:
+                self._process_document(document)
 
         self._fix_unified_names()
         return self.code_graph

--- a/codeminer/scip_interface/scip_decode_rust.py
+++ b/codeminer/scip_interface/scip_decode_rust.py
@@ -88,9 +88,11 @@ class SCIPRustGraphDecoder:
         # Add the root node to the graph
         self.code_graph.add_root_node(ROOT_NODE)
 
-        # Process all documents
-        for document in document_blocks:
-            self._process_document(document)
+        # Process all documents. Batch edge insertion: per-edge add_edges is
+        # O(E^2) (igraph reindexes each call); buffering flushes once as O(E).
+        with self.code_graph.batch_edges():
+            for document in document_blocks:
+                self._process_document(document)
 
         return self.code_graph
 

--- a/codeminer/scip_interface/scip_decode_ts.py
+++ b/codeminer/scip_interface/scip_decode_ts.py
@@ -60,9 +60,11 @@ class SCIPTypeScriptGraphDecoder:
         # out for lack of a populated ``_project_packages``.
         self._prescan_project_packages(document_blocks)
 
-        # Process all documents
-        for document in document_blocks:
-            self._process_document(document)
+        # Process all documents. Batch edge insertion: per-edge add_edges is
+        # O(E^2) (igraph reindexes each call); buffering flushes once as O(E).
+        with self.code_graph.batch_edges():
+            for document in document_blocks:
+                self._process_document(document)
 
         self.logger.info(
             f"Decoded {len(document_blocks)} documents, "


### PR DESCRIPTION
## What

`CodeGraph._add_edge` inserted edges into igraph one at a time via `add_edges([(s,t)])`. igraph rebuilds its internal adjacency index on **every** `add_edges` call, so building a graph during decode is **O(E²)** in edge count.

This is the **root cause of the `integration-serial` CI hang**: `test_scip_exclude` (scip-python indexing of `sympy__sympy-21847`) ran 27+ min and never completed, blowing past the 45-min job cap and hogging the single self-hosted runner. With a warm cache (`skip_level="decode"`) the scip-python subprocess — and its 600 s timeout — is skipped, so the pure-Python graph build had no bound at all.

## Fix

Add an opt-in `CodeGraph.batch_edges()` context manager. Inside it, `_add_edge` buffers `(src, tgt)` + attributes (the dedup index is updated immediately, so dedup is preserved) and flushes once via a single `add_edges` call, then assigns per-edge attributes (which do **not** trigger the adjacency rebuild). Outside the block, `_add_edge` inserts immediately exactly as before — the incremental patcher and all other callers are unchanged. Each SCIP decoder (`python`/`go`/`rust`/`ts`) wraps its document loop in `batch_edges()`.

## Validation (local)

Measured on the real `CodeGraph` API:

| edges | immediate | batched |
|------:|----------:|--------:|
| 10000 | 1.11 s | 0.059 s |
| 20000 | 3.18 s | 0.085 s |
| 40000 | 12.93 s | 0.170 s |
| 80000 | 46.80 s | 0.320 s (~146×) |

At the ~370k-edge regime that produced the 27-min hang: **~15 min → ~1.5 s**. This also speeds up the *healthy* `integration-serial` run materially (helps the CI duration target).

- Immediate vs batched produce **byte-identical edge sets** (incl. dedup of duplicate references and anchorless containment edges).
- Dedup index survives the flush; `batched + immediate == all-immediate`.
- **38/38 graph unit tests pass** (incl. `test_subgraph` incremental patcher, on the unchanged immediate path).
- C++ decoder parity preserved (the C++ side already batches; resulting graphs are identical).
