### PR TITLE
test(agent-compile): everything-available arm — graph used 1/24 when grep present (#133)

### DIFF
--- a/configs/agent_compile/cost_everything.yaml
+++ b/configs/agent_compile/cost_everything.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+# EVERYTHING-AVAILABLE arm (#133, task #16): the agent has the FULL toolset at
+# once — grep + file_read (defaults) AND compact search (bm25_names) AND the
+# call-graph verbs (find_callers/callees/trace/impact_analysis) AND read by
+# symbol (read_code_block). The prompt is NEUTRAL: it lists every tool without
+# steering toward the graph. This isolates the one question the prior LocAgent
+# arms couldn't (they forced graph use only by REMOVING grep, which hurt
+# accuracy): when the agent has grep AND the graph, does it VOLUNTARILY use the
+# graph, and does that help tokens/accuracy vs the grep/read baseline (cost_grep)?
+sweep_id: cost_everything
+model: vertex_ai/claude-haiku-4-5
+vertex_location: us-east5
+vertex_project: null
+reps: 3
+max_turns: 16
+temperature: 0.0
+max_tokens: 4096
+topk: 50
+num_retries: 8
+dataset: fishmingyu/codeminer-base-dataset
+split: test
+prebuilt_dir: /mnt/data/codeminer
+embedding_model: Qwen/Qwen3-Embedding-0.6B
+embedding_dimension: 1024
+metrics_k: [1, 3, 5, 10]
+gt_simplified_symbols: true
+include_default_tools: true
+system_prompt: |
+  You are a code localization agent. Find the code locations (files and symbols)
+  relevant to the request, then give a concise answer naming them.
+
+  Available tools (use whichever you judge best — no prescribed order):
+  - file_search(mode="content", pattern=...) — grep file contents.
+  - file_search(mode="files", pattern=...) — list files by glob.
+  - file_read(path, start_line, end_line) — read a file / line range.
+  - bm25_names(query) — candidate symbol NAMES (name + file:line, no bodies).
+  - find_callers(symbol) / find_callees(symbol) — who calls X / what X calls.
+  - trace(from_symbol, to_symbol) — the call path between two symbols.
+  - impact_analysis(symbol, direction) — transitive callers/callees.
+  - read_code_block(symbol) — read a symbol's source by its graph node.
+
+  Localize the relevant code, confirm by reading it, then answer. End with two
+  lines, repo-relative:
+    Files: path/one.ext, path/two.ext
+    Symbols: path/one.ext:symbol_name, ...
+
+  You have a limited tool budget — converge once a location looks right.
+instances:
+  - redis__redis-10095
+  - tokio-rs__tokio-4898
+  - facebook__docusaurus-10130
+  - axios__axios-4731
+  - hashicorp__terraform-34814
+  - caddyserver__caddy-5870
+  - pydata__xarray-2905
+  - sympy__sympy-13031
+subsets:
+  EVERYTHING:
+    - bm25_names
+    - find_callers
+    - find_callees
+    - trace
+    - impact_analysis
+    - read_code_block

--- a/docs/experiments/agent_compile.md
+++ b/docs/experiments/agent_compile.md
@@ -754,7 +754,7 @@ actions (~1.6/cell vs ~17 search+read) — the agent reads the *named* candidate
 directly rather than traversing to it, since for localization search already
 names the target.
 
-**Five harness designs** (vs the grep/read agent). The **"graph used"** column is
+**Six harness designs** (vs the grep/read agent). The **"graph used"** column is
 critical: several arms *offered* the graph tools but the agent barely touched
 them, so they are NOT tests of the graph — read them as "search+read without
 grep."
@@ -766,6 +766,16 @@ grep."
 | LocAgent (content-bm25, no grep) | **0/24, 0 calls** | +113 % | parity | **NO — graph unused** |
 | strict (no fs, read_code_block) | 5/24, 6 calls | +77 % | −1 regression | barely |
 | faithful (names-bm25, no fs) | **18/24, 39 calls** | +43 % | −3 regressions | **yes (agent-chosen)** |
+| **everything (grep+read+search+graph all available)** | **1/24, 1 call** | +9 % [CI −19,+36] | −1 regression | **NO — graph unused despite being offered** |
+
+The **everything-available** arm (task #16) is the decisive one for *voluntary*
+adoption: give the agent grep + file_read + bm25_names + the graph verbs +
+read_code_block all at once, with a neutral prompt that pushes nothing. Result:
+the agent localizes with file_read (5.8/cell) + grep (5.4) + bm25_names (2.2) +
+read_code_block (1.9) and calls the call-graph **once in 24 cells**. So the
+faithful arm's 18/24 graph use was purely an artifact of *removing grep*; restore
+grep and voluntary graph use collapses to ~0. Tokens are neutral (+9 %, CI spans
+0) because grep is back — far cheaper than the no-grep arms.
 
 So only **two** rows actually exercise the call-graph:
 
@@ -777,12 +787,15 @@ So only **two** rows actually exercise the call-graph:
 
 The `content-bm25 LocAgent` (+113 %) and `strict` (+77 %) rows are **not** graph
 results — the agent used ~0 graph calls; they only show that removing grep and
-leaning on bm25+read is expensive. The honest conclusion stands on the two rows
-that *do* test the graph: whether forced (deterministic, +18 %/no gain) or
-chosen (faithful, +43 %/−3 acc), **the call-graph does not help in the agent
-loop on localization.** The only config that beats grep/read is **search seeds
-*added to* grep/read** (−19 %). The graph's value is offline — the
-dependency-analysis plugin.
+leaning on bm25+read is expensive. The honest conclusion stands on the rows that
+*do* test the graph: whether forced (deterministic, +18 %/no gain) or chosen
+(faithful, +43 %/−3 acc), **the call-graph does not help in the agent loop on
+localization.** And the **everything-available** arm settles the adoption
+question outright: when the agent has grep *and* the graph, it picks the graph
+**1 time in 24 cells** — so the graph is not its tool of choice for localization,
+period. The only config that beats grep/read is **search seeds *added to*
+grep/read** (−19 %). The graph's value is offline — the dependency-analysis
+plugin.
 
 **The LocAgent token-savings thesis does not replicate here.** Likely because
 LocAgent uses a graph-*native* agent (trained/forced to navigate the graph) vs


### PR DESCRIPTION
## Summary

Closes the LocAgent-vs-grep investigation with the one missing arm (task #16): give the agent the **full toolset at once** — grep + file_read + bm25_names + call-graph verbs + read_code_block — under a **neutral prompt**, and measure whether it *voluntarily* uses the call-graph when grep is also available.

**Result: the agent calls the graph 1 time across 24 cells (1/24).** The faithful LocAgent arm's 18/24 graph use was purely an artifact of *removing* grep; restore grep and voluntary graph use collapses to ~0. This settles the adoption question: the call-graph is not the agent's tool of choice for localization — its value is offline (the dependency-analysis plugin from #173).

## Changes

- `configs/agent_compile/cost_everything.yaml` — everything-available arm (neutral prompt, reps=3, N=8).
- `docs/experiments/agent_compile.md` — sixth harness row + the voluntary-adoption conclusion.

## Result (vs grep/read baseline, reps=3, N=8)

| metric | value |
|---|---|
| graph-tool use | **1 call / 24 cells** (file_read 5.8, grep 5.4, bm25_names 2.2, read_code_block 1.9 per cell) |
| tokens | +9 % [95% CI −19 %, +36 %] — neutral (grep is available) |
| accuracy | files@5 parity, 1 regression (terraform 1.0→0.67); sympy recovered 0→1.0 via search |

## Type of Change
- [x] Documentation update
- [x] Tests (experiment config/harness)

## Testing
- [x] Tests pass locally — config validated; analysis via `compare_harnesses.py`. (No code changes; experiment scaffolding only.)

## Checklist
- [x] My code follows the project's style guidelines (REUSE/YAML checks pass)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published — builds on #173 (`bm25_names`, `read_code_block`, graph verbs)
