### PR TITLE
feat(agent): GraphRAG retriever — graph +5@10, identifier seeding 2x@1 (#133)

### DIFF
--- a/codeminer/agent/skills/codeminer_context/executor.py
+++ b/codeminer/agent/skills/codeminer_context/executor.py
@@ -19,6 +19,7 @@ Skill type is ``custom`` so the loader hands it the full ``contexts`` dict
 from __future__ import annotations
 
 import os
+import re
 from itertools import zip_longest
 from typing import Any, Callable, Dict, List
 
@@ -26,6 +27,39 @@ from typing import Any, Callable, Dict, List
 # search seeds (no call-graph expansion). Used to isolate how much the graph/LSP
 # expansion contributes on top of plain bm25+embedding search.
 _NO_GRAPH = os.environ.get("CODEMINER_COMPOSER_NO_GRAPH") == "1"
+
+# A token is "code-ish" (a likely symbol/identifier the user named) if it has an
+# underscore, an internal camelCase hump, or is an ALL_CAPS word (>=3). This
+# excludes plain English Titlecase ("Null", "Array") that misleads bm25.
+_CODEISH = re.compile(r"_|[a-z][A-Z]")
+_BACKTICK = re.compile(r"`([^`\n]{2,60})`")
+_TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+# Common bug-report ALL_CAPS noise that is never a code symbol.
+_IDENT_STOP = {"BUG", "TODO", "FIXME", "NOTE", "XXX", "HACK", "WARNING", "ERROR"}
+
+
+def _query_identifiers(query: str, limit: int = 4) -> List[str]:
+    """Extract code-like identifiers the user explicitly named in the query.
+
+    Bug reports usually mention the API/command/symbol involved (``LPOP``,
+    ``popGenericCommand``, ``foo_bar``). bm25 over the full NL text latches onto
+    literal English tokens; searching these identifiers directly seeds the graph
+    from the right place even when the prose misleads plain search.
+    """
+    out: List[str] = []
+    for m in _BACKTICK.findall(query or ""):
+        out.append(m.strip())
+    for tok in _TOKEN.findall(query or ""):
+        if _CODEISH.search(tok) or (tok.isupper() and len(tok) >= 3):
+            out.append(tok)
+    seen: set = set()
+    res: List[str] = []
+    for t in out:
+        t = t.strip("`.,():;").strip()
+        if t and t.upper() not in _IDENT_STOP and t.lower() not in seen:
+            seen.add(t.lower())
+            res.append(t)
+    return res[:limit]
 
 
 def _interleave(*seqs: List[Any]) -> List[Any]:
@@ -89,7 +123,9 @@ def create_executor(contexts: Dict[str, Any]) -> Callable[..., List[Any]]:
         #    site (the command handler); round-robin guarantees both are seeded.
         bm: List[Any] = []
         ve: List[Any] = []
-        if retrieve is not None and getattr(retrieve, "bm25", None) is not None:
+        ident: List[Any] = []
+        has_bm25 = retrieve is not None and getattr(retrieve, "bm25", None) is not None
+        if has_bm25:
             bm = to_queried_nodes(
                 retrieve.bm25.search(
                     query=query,
@@ -99,12 +135,26 @@ def create_executor(contexts: Dict[str, Any]) -> Callable[..., List[Any]]:
                     filter_test=True,
                 )
             )
+            # Identifier seeding: bm25 each code-token the user named directly,
+            # so the graph expands from the right symbol even when the NL prose
+            # misleads the full-text query (the redis "null array" -> wrong-seed
+            # miss). These lead the interleave — they are the most precise.
+            for tok in _query_identifiers(query):
+                ident += to_queried_nodes(
+                    retrieve.bm25.search(
+                        query=tok,
+                        top_k=2,
+                        return_code_content=False,
+                        wrap_with_ln=False,
+                        filter_test=True,
+                    )
+                )
         if retrieve is not None and getattr(retrieve, "vector_store", None) is not None:
             level = getattr(retrieve, "default_level", "l2")
             ve = to_queried_nodes(
                 retrieve.vector_store.search(query=query, top_k=seeds * 2, level=level)
             )
-        entry = _dedup_by_id(_interleave(bm, ve))[:seeds]
+        entry = _dedup_by_id(_interleave(ident, ve, bm))[:seeds]
 
         # 2) GRAPH-EXPAND each seed deterministically (callers + callees).
         #    Expand on the canonical (hash) name FIRST — it resolves exactly —

--- a/docs/experiments/agent_compile.md
+++ b/docs/experiments/agent_compile.md
@@ -926,3 +926,42 @@ loop. This is the graph's real home — a recall-boosting retrieval pipeline, ru
 from scripts, not an in-loop agent tool. (Caveat: identifier seeding would also
 lift a search-only baseline — it's a seeding gain, not a graph gain; the graph's
 own contribution is the strictly-additive +5 @10.)
+
+---
+
+# Fair index comparison: flat vs IVF vs graph-scoped (#25)
+
+Our vector store is `IndexFlatIP` (exhaustive). To judge the graph's retrieval
+value fairly you must control for the index — an IVF/ANN index speeds up flat
+search with NO graph. `index_compare.py`, recall@k + query latency over 100
+codeminer-base instances (no LLM):
+
+| method | median ms | p90 ms | files@1 | files@5 | files@10 |
+|---|---|---|---|---|---|
+| flat (exact) | 1.22 | 3.82 | 34 | 49 | 56 |
+| IVF (approx) | **0.29** | **0.65** | 33 | 49 | 55 |
+| graph-scoped (PPR) | 7.20 | 29.48 | **26** | **33** | **36** |
+
+1. **IVF: ~4× faster than flat at identical recall** (33/49/55 ≈ 34/49/56). The
+   speed comes from the ANN index, not the graph — so "the graph makes retrieval
+   faster" is unsupported; a plain IVF index gets it with zero graph.
+2. **Graph-scoping is strictly worse on both axes**: 6× slower than flat (PPR
+   compute) AND much lower recall (26/33/36). Restricting candidates to the
+   call-graph subgraph *excludes relevant files* — refutes "scope the query to a
+   subgraph helps" for this variant. (Seeds resolved on 77/100; the other 23 had
+   no graph-resolvable seed → empty scoped result, part of the recall drop.)
+
+**Caveat — what was tested:** the scoped arm RANKS the PPR subgraph (graph-only
+ranking from flat-top-5 seeds), it does NOT do embedding search *restricted to*
+the subgraph's vectors (the literal "limit the query in a subgraph" idea). That
+faithful variant is untested — it needs a subgraph-node → vector-row map
+(fragile under C/C++ hash-vs-readable naming). But since PPR-scoping already
+loses recall by excluding relevant files, embedding-within-subgraph faces the
+same risk: the target file must be inside the chosen subgraph.
+
+**Verdict on GraphRAG's retrieval value:** the only positive is the *additive*
+expansion (+5 files@10, zero regressions; earlier section). Graph does NOT win
+speed (IVF does) and does NOT win via scoping (hurts). For retrieval at this
+scale, **IVF is the win** (4× faster, same recall); the call-graph's real value
+remains offline structural/impact analysis (the dependency_subgraph tool), not
+faster or more-accurate flat retrieval.

--- a/docs/experiments/agent_compile.md
+++ b/docs/experiments/agent_compile.md
@@ -886,3 +886,43 @@ context is not more localized truth; distractors cost both tokens and accuracy.
    fan-out rather than adding to it — the additive setup measured here shows the
    agent double-dips (1 composer call but still 5 greps + 7 reads/cell), so graph
    context is read-once overhead, not a replacement.
+
+---
+
+# GraphRAG as a *retriever* (recall@k, not the agent loop) — #24
+
+The graph fails in the agent loop but the composer (search seeds → call-graph
+expansion) is a legitimate **retrieval pipeline**. Evaluated as a retriever
+(`scripts/agent_compile/graphrag_retrieve.py`, files@k recall vs ground truth,
+no LLM) over all **100 codeminer-base** instances:
+
+| recall@k | search-only | GraphRAG (search+graph) | GraphRAG + identifier seeding |
+|---|---|---|---|
+| files@1 | 10 % | 10 % | **23 %** |
+| files@5 | 47 % | 48 % | 49 % |
+| files@10 | 47 % | **52 %** | 52 % |
+
+Two distinct, honest wins:
+
+1. **Graph expansion is a strictly-additive recall booster: files@10 47 %→52 %
+   (+5 instances, ZERO regressions).** It appends caller/callee neighbors to the
+   search seeds, so it can only add the right file, never drop it — the opposite
+   of its net-negative behavior as an agent tool. The lift sits at @10 (not @5)
+   because neighbors land in ranks 6–30; the budget squeezes them out of top-5.
+
+2. **Identifier seeding doubles top-1 precision: files@1 10 %→23 %.** This is a
+   *seeding-stage* improvement (independent of graph expansion): extract the
+   code symbols the user named in the query (backtick-quoted, camelCase,
+   ALL_CAPS commands like `LPOP`, snake_case; minus bug-report noise) and
+   bm25-search each as a leading interleaved seed source. Fixes the redis-class
+   miss where NL prose ("null array") misleads full-text bm25 but the named
+   command (`LPOP`→`lpopCommand`) seeds from the right place. Its gain is
+   concentrated at @1; @5/@10 show minor churn (+4/−3, +5/−5) as identifier hits
+   reshuffle the budget — net @5 +1, @10 ±0.
+
+**Takeaway:** the call-graph and query-identifier signals both help *retrieval*
+(graph: +5 @10 additive; identifiers: 2× @1) even though neither helps the agent
+loop. This is the graph's real home — a recall-boosting retrieval pipeline, run
+from scripts, not an in-loop agent tool. (Caveat: identifier seeding would also
+lift a search-only baseline — it's a seeding gain, not a graph gain; the graph's
+own contribution is the strictly-additive +5 @10.)

--- a/scripts/agent_compile/index_compare.py
+++ b/scripts/agent_compile/index_compare.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fair retrieval comparison: flat vs IVF vs graph-scoped (#133, #25).
+
+Our vector store is ``IndexFlatIP`` — exhaustive, exact, O(N). To judge whether
+the call-graph adds value to *retrieval* fairly, you must control for the index:
+an IVF (ANN) index speeds up flat search with NO graph at all, so any "graph is
+faster" claim is confounded unless compared against IVF. And both IVF (approx)
+and graph-scoping (candidate restriction) change *which* chunks are retrieved,
+so both affect accuracy. This harness measures recall@k AND query latency for:
+
+  - flat        : exhaustive IndexFlatIP over all N L2 vectors (exact, current).
+  - ivf         : IndexIVFFlat (nlist/nprobe) over the SAME vectors (approx, fast).
+  - graph-scoped: flat top-`seeds` -> resolve to graph -> expand_ppr k-hop region
+                  -> rank that subgraph (graph restricts the candidate set).
+
+No LLM. Per instance: stage prebuilt indexes, reconstruct vectors from the flat
+index (same data for flat+ivf), embed the problem statement once, run all three.
+
+Usage:
+    python -m scripts.agent_compile.index_compare \
+        --instances-json /tmp/have.json --out results/agent_compile/index_compare.json \
+        --k 1 5 10 --nlist 64 --nprobe 8 --seeds 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import faiss
+import numpy as np
+
+
+def _norm(p: str) -> str:
+    return (p or "").strip().strip("`'\"").replace("\\", "/")
+
+
+def _covers(cands: List[str], target: str) -> bool:
+    t = _norm(target)
+    return any(c == t or c.endswith("/" + t) or t.endswith("/" + c) for c in cands)
+
+
+def _recall(ranked: List[str], targets: List[str], ks: List[int]) -> Dict[str, bool]:
+    out = {}
+    for k in ks:
+        top = [c for c in ranked[:k] if c]
+        out[f"files@{k}"] = bool(targets) and all(_covers(top, t) for t in targets)
+    return out
+
+
+def _files(docs: List[Any], idxs: List[int]) -> List[str]:
+    out = []
+    for i in idxs:
+        if 0 <= i < len(docs):
+            out.append(_norm(docs[i].metadata.get("file", "")))
+    return out
+
+
+def _analyze(inst, cfg, prebuilt_dir, cache_root, ks, nlist, nprobe, seeds):
+    from codeminer.eval.retrieval_eval import collect_targets
+    from codeminer.graph.roi_subgraph import ROISubgraph
+    from scripts.agent_compile.prebuilt import stage_prebuilt_indexes
+    from scripts.agent_compile.run_agent_sweep import (
+        _load_dataset_rows,
+        _load_full_contexts,
+    )
+
+    rows_by_id, eval_lookup = _load_dataset_rows(cfg)
+    row = rows_by_id[inst]
+    query = row["problem_statement"]
+    targets = [
+        _norm(t) for t in collect_targets(eval_lookup.get(inst, row), True)[0] if t
+    ]
+    cache_dir = os.path.join(cache_root, inst)
+    repo = stage_prebuilt_indexes(prebuilt_dir, inst, cache_dir)
+    ctx = _load_full_contexts(cfg, repo, cache_dir)
+    vs = ctx["retrieve"].vector_store
+    graph = ctx["expand"].code_graph
+    index, docs = vs._get_index_and_docs("l2")
+    n, dim = index.ntotal, index.d
+    topn = max(ks)
+    qv = np.asarray(vs.embedding.embed_query(query), dtype="float32").reshape(1, -1)
+
+    # FLAT (exact)
+    t = time.perf_counter()
+    _, fi = index.search(qv, topn)
+    flat_ms = (time.perf_counter() - t) * 1000
+    flat_files = _files(docs, list(fi[0]))
+    flat_names = [docs[i].metadata.get("name", "") for i in fi[0] if 0 <= i < len(docs)]
+
+    # IVF (approx) over the same reconstructed vectors
+    xb = index.reconstruct_n(0, n)
+    nl = max(1, min(nlist, n // 39))
+    ivf = faiss.IndexIVFFlat(
+        faiss.IndexFlatIP(dim), dim, nl, faiss.METRIC_INNER_PRODUCT
+    )
+    ivf.train(xb)
+    ivf.add(xb)
+    ivf.nprobe = min(nprobe, nl)
+    t = time.perf_counter()
+    _, ii = ivf.search(qv, topn)
+    ivf_ms = (time.perf_counter() - t) * 1000
+    ivf_files = _files(docs, list(ii[0]))
+
+    # GRAPH-SCOPED: resolve flat-top-`seeds` names -> PPR subgraph region
+    roi = ROISubgraph(graph)
+    seed_canon = []
+    for nm in flat_names[:seeds]:
+        c, _ = graph.resolve_symbol(nm)
+        if c:
+            seed_canon.append(c)
+    t = time.perf_counter()
+    nodes = roi.expand_ppr(seed_canon, top_k=topn) if seed_canon else []
+    scoped_ms = (time.perf_counter() - t) * 1000
+    scoped_files = [_norm(getattr(nd, "file", "") or "") for nd in nodes]
+
+    return {
+        "instance_id": inst,
+        "language": row.get("language_group"),
+        "n_vectors": int(n),
+        "n_targets": len(targets),
+        "latency_ms": {
+            "flat": round(flat_ms, 2),
+            "ivf": round(ivf_ms, 2),
+            "scoped": round(scoped_ms, 2),
+        },
+        "recall": {
+            "flat": _recall(flat_files, targets, ks),
+            "ivf": _recall(ivf_files, targets, ks),
+            "scoped": _recall(scoped_files, targets, ks),
+        },
+        "scoped_resolved_seeds": len(seed_canon),
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    from scripts.agent_compile.run_agent_sweep import SampleConfig
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--instances-json", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--k", type=int, nargs="+", default=[1, 5, 10])
+    ap.add_argument("--nlist", type=int, default=64)
+    ap.add_argument("--nprobe", type=int, default=8)
+    ap.add_argument("--seeds", type=int, default=5)
+    ap.add_argument("--prebuilt-dir", default="/mnt/data/codeminer")
+    args = ap.parse_args(argv)
+
+    instances = json.loads(args.instances_json.read_text())
+    cache_root = os.path.join(os.environ.get("CLAUDE_JOB_DIR", "/tmp"), "idxcmp_cache")
+    cfg = SampleConfig(
+        sweep_id="idxcmp",
+        subsets={"CTX": ["codeminer_context"]},
+        instances=instances,
+        embedding_model="Qwen/Qwen3-Embedding-0.6B",
+        embedding_dimension=1024,
+    )
+
+    results: List[Dict[str, Any]] = []
+    for i, inst in enumerate(instances, 1):
+        t0 = time.time()
+        try:
+            r = _analyze(
+                inst,
+                cfg,
+                args.prebuilt_dir,
+                cache_root,
+                args.k,
+                args.nlist,
+                args.nprobe,
+                args.seeds,
+            )
+        except Exception as e:  # noqa: BLE001 — keep scanning
+            r = {"instance_id": inst, "error": repr(e)}
+            traceback.print_exc()
+        results.append(r)
+        print(
+            f"[{i}/{len(instances)}] {inst} {r.get('latency_ms', r.get('error'))} "
+            f"({time.time() - t0:.1f}s)",
+            flush=True,
+        )
+        args.out.write_text(json.dumps(results, indent=2))
+
+    ok = [r for r in results if "recall" in r and r.get("n_targets")]
+    print(f"\n=== {len(ok)} scored instances ===")
+    for method in ("flat", "ivf", "scoped"):
+        lat = [r["latency_ms"][method] for r in ok]
+        med_lat = sorted(lat)[len(lat) // 2] if lat else 0.0
+        line = f"{method:7}: median query {med_lat:.2f} ms"
+        for k in args.k:
+            hits = sum(r["recall"][method][f"files@{k}"] for r in ok)
+            line += f" | files@{k} {hits}/{len(ok)} ({100 * hits / len(ok):.0f}%)"
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/agent/test_codeminer_context.py
+++ b/test/agent/test_codeminer_context.py
@@ -143,3 +143,19 @@ def test_context_handles_missing_graph_gracefully():
     ex = create_executor({"retrieve": retrieve, "expand": None})
     res = ex(query="x")
     assert any(n.node_name == "pkg.a.doWatch" for n in res)  # seed still returned
+
+
+def test_query_identifiers_extracts_codeish_tokens():
+    """Identifier seeding (#24): pull symbol/command names the user named,
+    skip plain English Titlecase + bug-report noise words."""
+    from codeminer.agent.skills.codeminer_context.executor import _query_identifiers
+
+    ids = _query_identifiers(
+        "[BUG] LPOP with count returns Null Bulk instead of Null array; "
+        "see popGenericCommand and `addReplyNull` in t_list.c"
+    )
+    assert "LPOP" in ids  # ALL_CAPS command
+    assert "popGenericCommand" in ids  # camelCase symbol
+    assert "addReplyNull" in ids  # backtick-quoted
+    assert "BUG" not in ids  # stoplisted report-noise
+    assert "Null" not in ids and "Bulk" not in ids  # plain Titlecase English


### PR DESCRIPTION
## Summary

The call-graph fails in the agent loop (PRs #172/#173) but the composer (search seeds → call-graph expansion) is a legitimate **retrieval pipeline**. This PR quantifies its retrieval value at full scale and improves its seeding. The graph's real home: a recall-boosting retriever run from scripts, not an in-loop agent tool.

## Changes
- `codeminer/agent/skills/codeminer_context/executor.py` — **identifier seeding**: extract code symbols the user named in the query (backtick-quoted, camelCase, `ALL_CAPS` commands, snake_case; minus bug-report noise) and bm25-search each as a leading interleaved seed source.
- `test/agent/test_codeminer_context.py` — unit test for `_query_identifiers`.
- `docs/experiments/agent_compile.md` — GraphRAG-as-retriever recall@k section.

## Result (recall@k over 100 codeminer-base instances, `graphrag_retrieve.py`, no LLM)

| recall@k | search-only | GraphRAG | GraphRAG + identifier seeding |
|---|---|---|---|
| files@1 | 10% | 10% | **23%** |
| files@5 | 47% | 48% | 49% |
| files@10 | 47% | **52%** | 52% |

- **Graph expansion: +5 @10 (47→52%), zero regressions** — strictly additive as a retriever.
- **Identifier seeding: 2× @1 (10→23%)** — surfaces the user-named symbol (`LPOP`→`lpopCommand`) as the top result. Seeding-stage gain (would also lift search-only); minor @5/@10 churn.

## Type of Change
- [x] New feature
- [x] Performance improvement
- [x] Documentation update
- [x] Tests

## Testing
- [x] Tests pass locally — `test_codeminer_context.py` (4) green; benchmark via `graphrag_retrieve.py`.
- [x] Added new tests for the changes

## Checklist
- [x] Style guidelines (black/isort/flake8/REUSE pass)
- [x] Self-review done
- [x] No new warnings
- [ ] Dependent changes merged — builds on #172/#173 (composer, `_graphnav`)
