### PR TITLE
test(graph): skip [cpp] range-query test — no TU-bearing C++ fixture in Multilingual (#133)

### DIFF
--- a/test/graph/test_range_queries_swebench.py
+++ b/test/graph/test_range_queries_swebench.py
@@ -60,7 +60,8 @@ def _tools_ready(language: str) -> bool:
 
 
 _REPO_KEYWORDS = {
-    "cpp": ["fmtlib/", "google/", "gabime/", "nlohmann/", "catchorg/"],
+    # NB: "google/" was dropped — it matched google/gson, a JAVA library, not C++.
+    "cpp": ["fmtlib/", "gabime/", "nlohmann/", "catchorg/"],
     "rust": ["BurntSushi/", "tokio-rs/", "clap-rs/", "rust-lang/", "image-rs/"],
     "ts": ["axios/", "expressjs/", "facebook/", "lodash/", "vuejs/"],
     "go": ["caddyserver/", "gin-gonic/", "gohugoio/", "hashicorp/", "prometheus/"],
@@ -133,6 +134,19 @@ def indexed_repo(language) -> CodeGraph:
     """
     if not _tools_ready(language):
         pytest.skip(f"SCIP tool {_tool_for(language)!r} not installed")
+
+    if language == "cpp":
+        # The only SWE-bench_Multilingual C++ repos that match here are
+        # fmtlib/fmt and nlohmann/json — both header-only, heavily-templated
+        # libraries. clangd/scip-clang produces no flat symbol graph for them
+        # (no CONTAIN edges, empty unified_to_names → StopIteration), so the
+        # range-query assertions cannot run meaningfully. No translation-unit-
+        # bearing C++ repo exists in the dataset; revisit by repointing to one
+        # (e.g. a redis-style .c codebase) if C++ coverage is needed here.
+        pytest.skip(
+            "no translation-unit-bearing C++ fixture in SWE-bench_Multilingual "
+            "(fmtlib/fmt, nlohmann/json are header-only templates → empty graph)"
+        )
 
     if language == "python":
         dataset_obj, instance = _pick_python_instance()


### PR DESCRIPTION
## Summary
The `[cpp]` params of `test_range_queries_swebench` fail (`StopIteration`, "no CONTAIN edges", "_unified_to_names empty") — root-caused: the fixture indexes **fmtlib/fmt**, a header-only heavily-templated lib that clangd/scip-clang produces no flat symbol graph for. The only other Multilingual C++ match is `nlohmann/json` (also header-only), and `"google/"` wrongly matched **google/gson (a Java lib)**.

## Changes
- Drop the bogus `"google/"` keyword from `_REPO_KEYWORDS["cpp"]`.
- Skip the `[cpp]` param at fixture setup with a clear reason (no TU-bearing C++ repo in the dataset). py/rust/ts/go unaffected.

## Type of Change
- [x] Bug fix
- [x] Tests

## Testing
- [x] `[cpp]` now SKIPS in ~3s (fixture-level) instead of failing; collection intact; flake8 clean. (Full integration build not run — other-language params unchanged.)

## Checklist
- [x] Style guidelines (flake8 clean)
- [x] Self-review done
- [x] No new warnings

Alternative if C++ coverage is wanted: repoint the cpp fixture to a translation-unit-bearing C/C++ repo (redis-style). Flagged in the skip reason.