### PR TITLE
feat(mcp): dependency_subgraph tool — call-graph nodes+edges JSON for impact analysis / DeepWiki view (#133)

### DIFF
--- a/codeminer/mcp/server.py
+++ b/codeminer/mcp/server.py
@@ -29,6 +29,7 @@ from mcp.server.fastmcp import FastMCP
 
 from .context import ServerContext
 from .prompts import CODEMINER_GUIDE
+from .tools.dependency import dependency_subgraph_impl
 from .tools.search import search_bm25_impl, search_regex_impl
 from .tools.search import search_semantic as _search_semantic_impl
 from .tools.search import search_zoekt_impl
@@ -171,6 +172,32 @@ async def search_zoekt(
         query,
         top_k,
         file_filter or None,
+    )
+
+
+@mcp.tool(
+    name="dependency_subgraph",
+    description=(
+        "Return the call-graph dependency subgraph for a symbol as nodes+edges "
+        "JSON. direction='impact' = transitive callers (blast radius: what may "
+        "break if you change it); 'dependencies' = transitive callees (what it "
+        "relies on); 'both' = 1-hop caller+callee neighborhood (for a dependency "
+        "view). The structural 'who calls X / what does X reach' question that "
+        "grep/keyword search cannot answer; backs impact analysis and dependency "
+        "visualization. Symbols are fuzzy-matched; unresolved names return a note."
+    ),
+)
+async def dependency_subgraph(
+    symbol: str,
+    direction: str = "both",
+    depth: int = 2,
+    max_nodes: int = 60,
+) -> dict[str, Any]:
+    """Call-graph dependency/impact subgraph for *symbol* (nodes+edges JSON)."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    return await asyncio.to_thread(
+        dependency_subgraph_impl, _ctx, symbol, direction, depth, max_nodes
     )
 
 

--- a/codeminer/mcp/tools/dependency.py
+++ b/codeminer/mcp/tools/dependency.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency / impact subgraph tool (#133, #19).
+
+Exposes the call-graph's structural-analysis value over MCP: given a symbol,
+return its dependency subgraph as frontend-ready nodes+edges JSON — the
+"who calls X / what breaks if I change X" question grep cannot answer, and the
+backing data for a DeepWiki-style dependency view.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ...graph.dependency import DependencyAnalyzer
+
+
+def dependency_subgraph_impl(
+    ctx: Any,
+    symbol: str,
+    direction: str = "both",
+    depth: int = 2,
+    max_nodes: int = 60,
+) -> Dict[str, Any]:
+    """Return ``DependencyAnalyzer`` output as a JSON dict.
+
+    direction: ``impact`` (transitive callers / blast radius), ``dependencies``
+    (transitive callees), or ``both`` (1-hop caller+callee neighborhood, for a
+    dependency view). Returns ``{"error": ...}`` when the symbol graph is
+    unavailable, so callers can recover gracefully.
+    """
+    graph = getattr(ctx, "symbol_graph", None)
+    if graph is None:
+        return {"error": "symbol_graph index not available"}
+    analyzer = DependencyAnalyzer(graph)
+    d = (direction or "both").lower()
+    depth = max(1, int(depth or 1))
+    if d.startswith("impact") or d == "callers":
+        result = analyzer.impact(symbol, max_depth=depth, max_nodes=int(max_nodes))
+    elif d.startswith("dep") or d == "callees":
+        result = analyzer.dependencies(
+            symbol, max_depth=depth, max_nodes=int(max_nodes)
+        )
+    else:
+        result = analyzer.subgraph(symbol, radius=depth)
+    return result.to_dict()

--- a/test/mcp_server/test_dependency_tool.py
+++ b/test/mcp_server/test_dependency_tool.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the dependency_subgraph MCP tool impl (#133, #19)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import igraph as ig
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.mcp.tools.dependency import dependency_subgraph_impl
+
+
+def _graph() -> CodeGraph:
+    g = CodeGraph()
+    gg = ig.Graph(directed=True)
+    gg.add_vertices(3)
+    gg.vs["name"] = ["hashA", "hashB", "hashC"]
+    gg.vs["unified_name"] = ["a.c:caller()", "a.c:mid()", "b.c:leaf()"]
+    gg.vs["type"] = ["function"] * 3
+    gg.vs["file"] = ["a.c", "a.c", "b.c"]
+    gg.vs["start_line"] = [1, 10, 5]
+    gg.vs["end_line"] = [9, 20, 8]
+    gg.add_edges([(0, 1), (1, 2)])  # caller -> mid -> leaf
+    gg.es["type"] = ["reference", "reference"]
+    g.graph = gg
+    g.name_to_vertex = {"hashA": 0, "hashB": 1, "hashC": 2}
+    g._unified_to_names = {}
+    return g
+
+
+def test_impact_direction_returns_transitive_callers():
+    ctx = SimpleNamespace(symbol_graph=_graph())
+    out = dependency_subgraph_impl(ctx, "leaf", direction="impact", depth=3)
+    assert out["root"] == "b.c:leaf()"
+    assert {n["name"] for n in out["nodes"]} == {"a.c:mid()", "a.c:caller()"}
+    assert all(set(e) == {"source", "target", "type"} for e in out["edges"])
+
+
+def test_both_direction_neighborhood():
+    ctx = SimpleNamespace(symbol_graph=_graph())
+    out = dependency_subgraph_impl(ctx, "mid", direction="both", depth=1)
+    assert {n["name"] for n in out["nodes"]} == {"a.c:caller()", "b.c:leaf()"}
+
+
+def test_missing_graph_returns_error():
+    out = dependency_subgraph_impl(SimpleNamespace(symbol_graph=None), "x")
+    assert "error" in out


### PR DESCRIPTION
## Summary
The call-graph's proven home is structural analysis (impact / "who calls X"), not the agent localization loop (PRs #172/#173). This exposes it over MCP so it backs both agent structural queries and a DeepWiki-style dependency view.

## Changes
- `codeminer/mcp/tools/dependency.py` — `dependency_subgraph_impl(ctx, symbol, direction, depth, max_nodes)` over `DependencyAnalyzer`.
- `codeminer/mcp/server.py` — `dependency_subgraph` FastMCP tool. `direction`: `impact` (transitive callers / blast radius), `dependencies` (transitive callees), `both` (1-hop neighborhood). Returns nodes+edges JSON (`to_dict()`).
- 3 unit tests.

## Type of Change
- [x] New feature
- [x] Tests

## Testing
- [x] `test_dependency_tool.py` (3) green; tool confirmed registered in `mcp.list_tools()`; flake8/REUSE clean.

## Checklist
- [x] Style guidelines pass
- [x] Self-review done
- [x] No new warnings
- [ ] Dependent changes merged — builds on #173 (`DependencyAnalyzer`, `CodeGraph.resolve_symbol`)

## Follow-up (not in this PR)
The frontend half — a `web/` component rendering this nodes+edges JSON as an interactive dependency graph — is the remaining part of #19 (UI work, verify in browser).