### PR TITLE
feat(examples): complete graph-RAG profiling harness + codeminer_base wiring (#131, #119)

### DIFF
--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -30,12 +30,25 @@ Usage:
     # Adjust stage parameters
     python examples/graph_retrieve_baseline.py --dataset swebench_lite \\
         --stage1-topk 5 --stage2-topk 50 --k-hop 2
+
+    # codeminer_base (multi-language; GT read from the dataset)
+    python examples/graph_retrieve_baseline.py --dataset codeminer_base \\
+        --metrics-k 1 3 5 10
+
+    # Profiling sweep over a fixed corpus CSV (see
+    # scripts/profiling/profile_graph_rag.sh)
+    python examples/graph_retrieve_baseline.py --dataset swebench_lite \\
+        --filter-csv examples/selected_instance.csv \\
+        --enable-profiler --record-samples --record-memory
 """
 import argparse
+import csv
 import json
 import logging
+import re
 import time
 from pathlib import Path
+from typing import List, Optional
 
 from codeminer.dataset.locbench import LocbenchDataset
 from codeminer.dataset.swebench import SwebenchDataset
@@ -51,6 +64,173 @@ from codeminer.model import GraphRetrievePipeline
 from codeminer.profiler import Profiler, percentile_from_sorted
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Language helpers (mirrors embedding_retrieve_baseline / build_embeddings)
+# ---------------------------------------------------------------------------
+
+
+def _map_language_group(label: Optional[str], fallback: str = "python") -> List[str]:
+    """Map a dataset ``language_group`` value to chunker language string(s)."""
+    if not label:
+        return [fallback]
+    text = label.lower()
+    if "rust" in text:
+        return ["rust"]
+    if "javascript" in text and "typescript" in text:
+        return ["ts", "js"]
+    if "typescript" in text or text == "ts":
+        return ["ts"]
+    if "javascript" in text or text == "js":
+        return ["js"]
+    if "c++" in text or text in ("cpp", "c"):
+        return ["cpp"]
+    if "go" in text or text == "golang":
+        return ["go"]
+    if "python" in text:
+        return ["python"]
+    return [fallback]
+
+
+def _resolve_instance_languages(instance: dict, cli_languages: List[str]) -> List[str]:
+    """Return chunker languages for this instance.
+
+    CodeMiner-base instances carry a ``language_group`` column; fall back to
+    the CLI ``--languages`` for datasets that don't have it (SWE-bench /
+    Loc-Bench). Only Stage 3 embedding rerank consumes this — graph build and
+    BM25 are language-agnostic — so SWE-bench runs are unchanged (default
+    ``["python"]``).
+    """
+    lang_group = instance.get("language_group")
+    if lang_group:
+        return _map_language_group(lang_group, fallback=cli_languages[0])
+    return list(cli_languages)
+
+
+# ---------------------------------------------------------------------------
+# Corpus / query helpers
+# ---------------------------------------------------------------------------
+
+# Token-count bins for per-query latency attribution (issue #131 Phase 2).
+_QUERY_LENGTH_BUCKETS = ("<128", "128-512", "512-2k", ">2k")
+_TIKTOKEN_ENCODING = None
+
+
+def _load_instance_ids_from_csv(path: str) -> List[str]:
+    """Read the ``instance_id`` column from a CSV (header required).
+
+    Mirrors the sampled-CSV reader in ``scripts/swebench_graph_index.py``.
+    Returns instance ids in file order with duplicates removed.
+    """
+    resolved = Path(path).expanduser()
+    ids: List[str] = []
+    seen = set()
+    with open(resolved, newline="", encoding="utf-8") as fp:
+        reader = csv.DictReader(fp)
+        if reader.fieldnames is None or "instance_id" not in reader.fieldnames:
+            raise ValueError(
+                f"CSV {resolved} must have an 'instance_id' column; "
+                f"got header {reader.fieldnames!r}"
+            )
+        for row in reader:
+            iid = (row.get("instance_id") or "").strip()
+            if iid and iid not in seen:
+                seen.add(iid)
+                ids.append(iid)
+    if not ids:
+        raise ValueError(f"No instance_id values found in {resolved}")
+    return ids
+
+
+def _filter_regex_from_ids(ids: List[str]) -> str:
+    """Build an anchored regex matching exactly the given instance ids.
+
+    The dataset loaders filter via ``re.match(filter_instance, instance_id)``,
+    so we anchor with ``^...$`` and escape each id (instance ids carry no regex
+    metacharacters today, but escaping keeps this robust to future ids).
+    """
+    return "^(" + "|".join(re.escape(i) for i in ids) + ")$"
+
+
+def _count_query_tokens(text: str) -> int:
+    """Token count of a query string.
+
+    Prefers ``tiktoken`` (cl100k_base) for a model-relevant count and caches
+    the encoder; falls back to whitespace splitting so the harness never hard
+    depends on tiktoken being installed.
+    """
+    if not text:
+        return 0
+    global _TIKTOKEN_ENCODING
+    if _TIKTOKEN_ENCODING is None:
+        try:
+            import tiktoken
+
+            _TIKTOKEN_ENCODING = tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            _TIKTOKEN_ENCODING = False  # sentinel: tiktoken unavailable
+    if _TIKTOKEN_ENCODING:
+        try:
+            return len(_TIKTOKEN_ENCODING.encode(text))
+        except Exception:
+            pass
+    return len(text.split())
+
+
+def _query_length_bucket(text: str) -> str:
+    """Bin a query's token count into ``<128 / 128-512 / 512-2k / >2k``."""
+    n = _count_query_tokens(text)
+    if n < 128:
+        return "<128"
+    if n < 512:
+        return "128-512"
+    if n < 2048:
+        return "512-2k"
+    return ">2k"
+
+
+def _aggregate_query_length_buckets(instance_query_profiles) -> dict:
+    """Histogram of per-instance ``query_length_bucket`` labels."""
+    counts = {bucket: 0 for bucket in _QUERY_LENGTH_BUCKETS}
+    for profile in instance_query_profiles:
+        bucket = profile.get("query_length_bucket")
+        if bucket in counts:
+            counts[bucket] += 1
+    return counts
+
+
+def _build_dataset(args):
+    """Dataset factory — mirrors ``embedding_retrieve_baseline._build_dataset``.
+
+    ``codeminer_base`` is loaded lazily so SWE-bench / Loc-Bench runs don't
+    import the HuggingFace-backed wrapper (and its ``datasets`` dependency
+    chain) unless they need it.
+    """
+    if args.dataset == "swebench_lite":
+        return SwebenchDataset(
+            dataset="princeton-nlp/SWE-bench_Lite",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=args.repo_cache_dir,
+        )
+    if args.dataset == "locbench_v1":
+        return LocbenchDataset(
+            dataset="czlll/Loc-Bench_V1",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=args.repo_cache_dir,
+        )
+    if args.dataset == "codeminer_base":
+        from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
+
+        return CodeMinerBaseDataset(
+            dataset="fishmingyu/codeminer-base-dataset",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=args.repo_cache_dir,
+        )
+    raise ValueError(f"Unsupported dataset: {args.dataset}")
 
 
 # ---------------------------------------------------------------------------
@@ -245,10 +425,33 @@ def parse_args():
         "--dataset",
         type=str,
         required=True,
-        choices=["swebench_lite", "locbench_v1"],
+        choices=["swebench_lite", "locbench_v1", "codeminer_base"],
     )
     parser.add_argument("--split", type=str, default="test")
     parser.add_argument("--filter-instance", type=str, default=".*")
+    parser.add_argument(
+        "--filter-csv",
+        type=str,
+        default=None,
+        help=(
+            "Path to a CSV with an 'instance_id' column (e.g. "
+            "examples/selected_instance.csv). Restricts the run to exactly "
+            "those instances. Takes precedence over --filter-instance."
+        ),
+    )
+    # Chunker languages for Stage 3 embedding rerank when rebuilding an index.
+    # codeminer_base auto-detects per instance from its language_group column;
+    # SWE-bench / Loc-Bench fall back to this value (default python).
+    parser.add_argument(
+        "--languages",
+        type=str,
+        nargs="+",
+        default=["python"],
+        help=(
+            "Chunker languages for Stage 3 embedding rerank. Ignored for "
+            "codeminer_base instances (read from the language_group column)."
+        ),
+    )
 
     # Stage 1: BM25 seed selection
     parser.add_argument(
@@ -429,6 +632,20 @@ def run_graph_pipeline(args):
     rerank_strategy = _resolve_rerank_strategy(args)
     use_embedding_rerank = rerank_strategy == "embedding"
 
+    # --filter-csv restricts the run to an explicit instance allowlist; build
+    # an anchored regex and let it override --filter-instance (warn if both).
+    if args.filter_csv:
+        ids = _load_instance_ids_from_csv(args.filter_csv)
+        csv_regex = _filter_regex_from_ids(ids)
+        if args.filter_instance not in (".*", csv_regex):
+            logger.warning(
+                "Both --filter-instance and --filter-csv given; "
+                "--filter-csv (%d ids) takes precedence.",
+                len(ids),
+            )
+        args.filter_instance = csv_regex
+        logger.info("Restricting to %d instance(s) from %s", len(ids), args.filter_csv)
+
     # Profiler setup ---------------------------------------------------------
     profiling_enabled = args.enable_profiler or args.profile_dir is not None
 
@@ -452,22 +669,7 @@ def run_graph_pipeline(args):
     instance_seed_recalls = []
 
     # Load dataset
-    if args.dataset == "swebench_lite":
-        dataset_obj = SwebenchDataset(
-            dataset="princeton-nlp/SWE-bench_Lite",
-            split=args.split,
-            filter_instance=args.filter_instance,
-            repo_root=args.repo_cache_dir,
-        )
-    elif args.dataset == "locbench_v1":
-        dataset_obj = LocbenchDataset(
-            dataset="czlll/Loc-Bench_V1",
-            split=args.split,
-            filter_instance=args.filter_instance,
-            repo_root=args.repo_cache_dir,
-        )
-    else:
-        raise ValueError(f"Unsupported dataset: {args.dataset}")
+    dataset_obj = _build_dataset(args)
 
     dataset_instances = dataset_obj.load()
     if not dataset_instances:
@@ -477,9 +679,14 @@ def run_graph_pipeline(args):
 
     # GT files are dataset-specific; derive the default from --dataset so a
     # Loc-Bench run can't silently align against the SWE-bench ground truth.
-    eval_path = args.eval_instances or str(
-        Path.home() / ".codeminer" / f"{args.dataset}_{args.split}_gt.json"
-    )
+    # codeminer_base carries GT in-dataset, so an empty path makes
+    # load_eval_metadata project the gt_* columns directly (no on-disk file).
+    if args.dataset == "codeminer_base":
+        eval_path = args.eval_instances or ""
+    else:
+        eval_path = args.eval_instances or str(
+            Path.home() / ".codeminer" / f"{args.dataset}_{args.split}_gt.json"
+        )
     eval_metadata = dataset_obj.load_eval_metadata(eval_path)
     metrics_k = sorted(set(args.metrics_k))
     metric_max_k = max(metrics_k)
@@ -526,6 +733,9 @@ def run_graph_pipeline(args):
             index_path = str(
                 Path(args.index_cache_dir) / instance_id.replace("/", "__")
             )
+            # Per-instance chunker language for Stage 3 rerank (codeminer_base
+            # is multi-language; SWE-bench / Loc-Bench fall back to --languages).
+            instance_languages = _resolve_instance_languages(instance, args.languages)
 
             pipeline = GraphRetrievePipeline(
                 repo_path=repo_path,
@@ -539,6 +749,7 @@ def run_graph_pipeline(args):
                 embedding_model=args.embedding_model,
                 embedding_provider=args.embedding_provider,
                 embedding_dimension=args.embedding_dimension,
+                languages=instance_languages,
                 project_name=instance_id.replace("/", "__"),
                 profiler=index_profiler,
             )
@@ -581,7 +792,13 @@ def run_graph_pipeline(args):
                     {"instance_id": instance_id, "sections": index_only}
                 )
                 instance_query_profiles.append(
-                    {"instance_id": instance_id, "sections": query_only}
+                    {
+                        "instance_id": instance_id,
+                        "sections": query_only,
+                        "query_length_bucket": _query_length_bucket(
+                            instance["problem_statement"]
+                        ),
+                    }
                 )
 
             metrics = evaluate_predictions(
@@ -672,6 +889,8 @@ def run_graph_pipeline(args):
             "dataset": args.dataset,
             "split": args.split,
             "filter_instance": args.filter_instance,
+            "filter_csv": args.filter_csv,
+            "languages": args.languages,
             "expansion": "ppr" if args.ppr else "bfs",
             "stage1_topk": args.stage1_topk,
             "stage2_topk": args.stage2_topk,
@@ -707,6 +926,9 @@ def run_graph_pipeline(args):
             "query_time": {
                 "per_instance": instance_query_profiles,
                 "aggregate_sections": _aggregate_section_stats(instance_query_profiles),
+                "query_length_buckets": _aggregate_query_length_buckets(
+                    instance_query_profiles
+                ),
             },
             "bm25_seed_recall": {
                 "per_instance": instance_seed_recalls,

--- a/scripts/profiling/profile_graph_rag.sh
+++ b/scripts/profiling/profile_graph_rag.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Profiling sweep for the graph-RAG retrieval pipeline (issue #131, Phase 3).
+#
+# Runs examples/graph_retrieve_baseline.py with profiling enabled across the
+# three headline configurations, each over the same fixed corpus
+# (examples/selected_instance.csv — 12 SWE-bench Lite instances) so per-stage
+# wall-clock / memory / per-query-bucket breakdowns are attributable to the
+# pipeline rather than to instance churn:
+#
+#   1. BFS expansion,  no rerank
+#   2. PPR expansion,  no rerank
+#   3. BFS expansion + embedding rerank (Qwen3-Embedding-0.6B, dim 1024)
+#
+# Each run writes one JSON to $PROFILE_DIR:
+#   graph_rag_<dataset>_<expansion>_<rerank>__<tag>.json
+#
+# Usage:
+#   scripts/profiling/profile_graph_rag.sh
+#   PROFILE_DIR=/tmp/graphrag CSV=examples/selected_instance.csv \
+#       scripts/profiling/profile_graph_rag.sh
+#
+# Optional Phase 4 (LLM rerank) is intentionally NOT run here: LLM listwise
+# rerank lives in examples/retrieve_rerank.py and needs a running vLLM server,
+# so it is a separate, opt-in measurement rather than part of this sweep.
+set -euo pipefail
+
+# Resolve repo root from this script's location so the sweep runs from anywhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# ---- Config (override via environment) ------------------------------------
+DATASET="${DATASET:-swebench_lite}"
+SPLIT="${SPLIT:-test}"
+CSV="${CSV:-examples/selected_instance.csv}"
+PROFILE_DIR="${PROFILE_DIR:-${REPO_ROOT}/profile_log/graph_rag}"
+PROFILE_TAG="${PROFILE_TAG:-sweep}"
+
+# Stage parameters (issue #131: stage1 top-K=5, 2-hop, up to 50 nodes).
+STAGE1_TOPK="${STAGE1_TOPK:-5}"
+STAGE2_TOPK="${STAGE2_TOPK:-50}"
+K_HOP="${K_HOP:-2}"
+
+# Stage 3 embedding rerank model (config #3).
+EMBED_MODEL="${EMBED_MODEL:-Qwen/Qwen3-Embedding-0.6B}"
+EMBED_PROVIDER="${EMBED_PROVIDER:-huggingface}"
+EMBED_DIM="${EMBED_DIM:-1024}"
+
+PY="${PYTHON:-python}"
+RUNNER="examples/graph_retrieve_baseline.py"
+
+mkdir -p "${PROFILE_DIR}"
+
+# Common args shared by every config. --record-samples / --record-memory turn
+# on the p50/p95/p99 and RSS/GPU rollups; --filter-csv pins the corpus.
+COMMON_ARGS=(
+  --dataset "${DATASET}"
+  --split "${SPLIT}"
+  --filter-csv "${CSV}"
+  --stage1-topk "${STAGE1_TOPK}"
+  --stage2-topk "${STAGE2_TOPK}"
+  --k-hop "${K_HOP}"
+  --enable-profiler
+  --record-samples
+  --record-memory
+  --profile-dir "${PROFILE_DIR}"
+  --profile-tag "${PROFILE_TAG}"
+)
+
+echo "=================================================================="
+echo "graph-RAG profiling sweep"
+echo "  dataset    : ${DATASET} (${SPLIT})"
+echo "  corpus     : ${CSV}"
+echo "  profile dir: ${PROFILE_DIR}"
+echo "  tag        : ${PROFILE_TAG}"
+echo "=================================================================="
+
+echo
+echo "[1/3] BFS expansion, no rerank"
+"${PY}" "${RUNNER}" "${COMMON_ARGS[@]}"
+
+echo
+echo "[2/3] PPR expansion, no rerank"
+"${PY}" "${RUNNER}" "${COMMON_ARGS[@]}" --ppr
+
+echo
+echo "[3/3] BFS expansion + embedding rerank (${EMBED_MODEL}, dim ${EMBED_DIM})"
+"${PY}" "${RUNNER}" "${COMMON_ARGS[@]}" \
+  --embedding \
+  --embedding-model "${EMBED_MODEL}" \
+  --embedding-provider "${EMBED_PROVIDER}" \
+  --embedding-dimension "${EMBED_DIM}"
+
+echo
+echo "=================================================================="
+echo "Done. Profiler JSONs written to ${PROFILE_DIR}:"
+ls -1 "${PROFILE_DIR}"/graph_rag_*"${PROFILE_TAG}".json 2>/dev/null || true
+echo "=================================================================="

--- a/test/examples/test_graph_retrieve_baseline.py
+++ b/test/examples/test_graph_retrieve_baseline.py
@@ -26,6 +26,7 @@ The runner script is not part of the ``codeminer`` package (see
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -457,3 +458,231 @@ def test_seed_recall_dedupes_seeds_before_k_slice(runner):
     # k=2 covers the two unique files {dup.py, target.py}, hitting target.py
     out = runner._compute_bm25_seed_recall(seeds, ["target.py"], [1, 2])
     assert out == {1: 0.0, 2: 1.0}
+
+
+# ---------------------------------------------------------------------------
+# _load_instance_ids_from_csv / _filter_regex_from_ids  (#131 corpus filter)
+# ---------------------------------------------------------------------------
+
+
+def test_load_instance_ids_reads_column_in_order(runner, tmp_path):
+    csv_path = tmp_path / "ids.csv"
+    csv_path.write_text("instance_id\nrepo__a-1\nrepo__b-2\nrepo__c-3\n")
+    assert runner._load_instance_ids_from_csv(str(csv_path)) == [
+        "repo__a-1",
+        "repo__b-2",
+        "repo__c-3",
+    ]
+
+
+def test_load_instance_ids_dedupes_and_strips(runner, tmp_path):
+    """Duplicate / blank / whitespace-padded rows collapse to ordered uniques."""
+    csv_path = tmp_path / "ids.csv"
+    csv_path.write_text("instance_id\nrepo__a-1\n  repo__a-1  \n\nrepo__b-2\n")
+    assert runner._load_instance_ids_from_csv(str(csv_path)) == [
+        "repo__a-1",
+        "repo__b-2",
+    ]
+
+
+def test_load_instance_ids_extra_columns_ok(runner, tmp_path):
+    """A CSV with extra columns still works as long as instance_id is present."""
+    csv_path = tmp_path / "ids.csv"
+    csv_path.write_text("instance_id,language_group\nrepo__a-1,python\nrepo__b-2,go\n")
+    assert runner._load_instance_ids_from_csv(str(csv_path)) == [
+        "repo__a-1",
+        "repo__b-2",
+    ]
+
+
+def test_load_instance_ids_missing_column_raises(runner, tmp_path):
+    csv_path = tmp_path / "bad.csv"
+    csv_path.write_text("id,foo\nrepo__a-1,x\n")
+    with pytest.raises(ValueError, match="instance_id"):
+        runner._load_instance_ids_from_csv(str(csv_path))
+
+
+def test_load_instance_ids_empty_raises(runner, tmp_path):
+    csv_path = tmp_path / "empty.csv"
+    csv_path.write_text("instance_id\n")
+    with pytest.raises(ValueError, match="No instance_id"):
+        runner._load_instance_ids_from_csv(str(csv_path))
+
+
+def test_filter_regex_matches_exactly_listed_ids(runner):
+    """The regex anchors with ^...$, so it matches the listed ids and nothing
+    that merely shares a prefix/suffix — the dataset loaders apply it via
+    re.match, which only anchors the start."""
+    rx = runner._filter_regex_from_ids(["astropy__astropy-14096", "django__django-1"])
+    assert re.match(rx, "astropy__astropy-14096")
+    assert re.match(rx, "django__django-1")
+    # Prefix of a listed id must NOT match (the $ anchor guards the tail).
+    assert not re.match(rx, "astropy__astropy-140960")
+    assert not re.match(rx, "astropy__astropy-1409")
+    assert not re.match(rx, "unrelated__repo-9")
+
+
+def test_filter_regex_escapes_metacharacters(runner):
+    """Instance ids are treated as literals — any regex metacharacter in an id
+    must be escaped so it can't widen the match."""
+    rx = runner._filter_regex_from_ids(["a.b+c"])
+    assert re.match(rx, "a.b+c")
+    assert not re.match(rx, "axbxc")  # '.' and '+' must be literal
+
+
+# ---------------------------------------------------------------------------
+# _count_query_tokens / _query_length_bucket / _aggregate_query_length_buckets
+# ---------------------------------------------------------------------------
+
+
+def test_count_query_tokens_whitespace_fallback(runner, monkeypatch):
+    """When tiktoken is unavailable (sentinel False), fall back to a
+    whitespace token count rather than crashing."""
+    monkeypatch.setattr(runner, "_TIKTOKEN_ENCODING", False)
+    assert runner._count_query_tokens("") == 0
+    assert runner._count_query_tokens("one two three") == 3
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (0, "<128"),
+        (127, "<128"),
+        (128, "128-512"),
+        (511, "128-512"),
+        (512, "512-2k"),
+        (2047, "512-2k"),
+        (2048, ">2k"),
+        (10000, ">2k"),
+    ],
+)
+def test_query_length_bucket_boundaries(runner, monkeypatch, n, expected):
+    """Bucket edges are half-open [lo, hi): 128 lands in 128-512, 512 in
+    512-2k, 2048 in >2k. Drive the count directly so the test is independent
+    of whichever tokenizer is installed."""
+    monkeypatch.setattr(runner, "_count_query_tokens", lambda _text: n)
+    assert runner._query_length_bucket("ignored") == expected
+
+
+def test_aggregate_query_length_buckets_histograms(runner):
+    profiles = [
+        {"query_length_bucket": "<128"},
+        {"query_length_bucket": "512-2k"},
+        {"query_length_bucket": "<128"},
+        {"query_length_bucket": ">2k"},
+    ]
+    assert runner._aggregate_query_length_buckets(profiles) == {
+        "<128": 2,
+        "128-512": 0,
+        "512-2k": 1,
+        ">2k": 1,
+    }
+
+
+def test_aggregate_query_length_buckets_ignores_unknown_and_missing(runner):
+    """All canonical buckets are present even when no instance hit them, and a
+    stray/missing label is not counted (defends against silent schema drift)."""
+    profiles = [
+        {"query_length_bucket": "<128"},
+        {"query_length_bucket": "nonsense"},
+        {"no_bucket_key": True},
+    ]
+    out = runner._aggregate_query_length_buckets(profiles)
+    assert out == {"<128": 1, "128-512": 0, "512-2k": 0, ">2k": 0}
+
+
+# ---------------------------------------------------------------------------
+# _map_language_group / _resolve_instance_languages  (#119 multi-language)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        ("python", ["python"]),
+        ("Python", ["python"]),
+        ("rust", ["rust"]),
+        ("go", ["go"]),
+        ("golang", ["go"]),
+        ("cpp", ["cpp"]),
+        ("C++", ["cpp"]),
+        ("typescript", ["ts"]),
+        ("javascript", ["js"]),
+        ("JavaScript/TypeScript", ["ts", "js"]),
+    ],
+)
+def test_map_language_group_known(runner, label, expected):
+    assert runner._map_language_group(label) == expected
+
+
+def test_map_language_group_unknown_uses_fallback(runner):
+    assert runner._map_language_group("klingon", fallback="go") == ["go"]
+    assert runner._map_language_group(None) == ["python"]
+    assert runner._map_language_group("") == ["python"]
+
+
+def test_resolve_instance_languages_prefers_language_group(runner):
+    """codeminer_base instances carry language_group; it wins over the CLI."""
+    inst = {"language_group": "rust"}
+    assert runner._resolve_instance_languages(inst, ["python"]) == ["rust"]
+
+
+def test_resolve_instance_languages_falls_back_to_cli(runner):
+    """SWE-bench instances have no language_group → use --languages verbatim."""
+    assert runner._resolve_instance_languages({}, ["go", "rust"]) == ["go", "rust"]
+
+
+# ---------------------------------------------------------------------------
+# _build_dataset  (#119 dataset factory dispatch)
+# ---------------------------------------------------------------------------
+
+
+def _ds_args(dataset):
+    return SimpleNamespace(
+        dataset=dataset,
+        split="test",
+        filter_instance="^(x)$",
+        repo_cache_dir="/tmp/codeminer-repos",
+    )
+
+
+def test_build_dataset_swebench_lite(runner, monkeypatch):
+    captured = {}
+
+    def _stub(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(runner, "SwebenchDataset", _stub)
+    out = runner._build_dataset(_ds_args("swebench_lite"))
+    assert captured["dataset"] == "princeton-nlp/SWE-bench_Lite"
+    assert captured["filter_instance"] == "^(x)$"
+    assert captured["repo_root"] == "/tmp/codeminer-repos"
+    assert out.split == "test"
+
+
+def test_build_dataset_locbench(runner, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        runner, "LocbenchDataset", lambda **kw: captured.update(kw) or SimpleNamespace()
+    )
+    runner._build_dataset(_ds_args("locbench_v1"))
+    assert captured["dataset"] == "czlll/Loc-Bench_V1"
+
+
+def test_build_dataset_codeminer_base(runner, monkeypatch):
+    """codeminer_base is imported lazily inside the factory; patch the source
+    module so dispatch is verified without importing/loading the HF dataset."""
+    captured = {}
+    monkeypatch.setattr(
+        "codeminer.dataset.codeminer_base.CodeMinerBaseDataset",
+        lambda **kw: captured.update(kw) or SimpleNamespace(),
+    )
+    runner._build_dataset(_ds_args("codeminer_base"))
+    assert captured["dataset"] == "fishmingyu/codeminer-base-dataset"
+    assert captured["filter_instance"] == "^(x)$"
+
+
+def test_build_dataset_unsupported_raises(runner):
+    with pytest.raises(ValueError, match="Unsupported dataset"):
+        runner._build_dataset(_ds_args("nope"))


### PR DESCRIPTION
## Summary

Completes the graph-RAG profiling harness (#131) and wires `codeminer_base`
into the graph retrieval baseline (#119). Both extend the profiler already
embedded in `examples/graph_retrieve_baseline.py` (landed in #134), matching
the `embedding_retrieve_baseline.py` convention — there is intentionally no
separate `graph_retrieve_profile.py`, since the issue's "separate entry point"
wording predates that inline profiler.

## Changes

**#131 — profiling harness (Phases 1–3; Phase 4 LLM rerank left optional):**
- `--filter-csv` pins a fixed corpus (`examples/selected_instance.csv`, the 12
  SWE-bench Lite IDs) via an anchored allowlist regex.
- Per-instance `query_length_bucket` + aggregate `query_length_buckets`
  histogram in the profiler JSON (tiktoken `cl100k_base`, whitespace fallback).
- `scripts/profiling/profile_graph_rag.sh` — 3-config sweep (BFS / PPR /
  BFS + embedding rerank Qwen3-Embedding-0.6B dim 1024), one JSON per config.

**#119 — `codeminer_base` wiring (multi-language at scale still gated on #118):**
- `_build_dataset` factory adds `codeminer_base` (mirrors the embedding
  baseline); ground truth is projected directly from the dataset.
- Per-instance chunker language resolved from `language_group` and passed to
  Stage 3 embedding rerank; SWE-bench / Loc-Bench runs are unchanged.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/examples/test_graph_retrieve_baseline.py` → **58 passed** (30 new
pure-helper tests: CSV filter, query-length buckets, language mapping, dataset
factory dispatch). `black --check` and `flake8 --extend-select=B` clean on the
changed Python; `bash -n` clean on the sweep script.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

Closes #131. Refs #119 (this resolves the `codeminer_base` dataset-wiring
blocker; the RFC's full multi-language E1–E3 runs remain gated on #118).
Phase 4 (LLM rerank on top of graph RAG) is intentionally deferred — it needs
a separate vLLM server and is marked optional in the issue.
