### PR TITLE
refactor(agent): split default tools into read/grep/glob/bash

### DIFF
--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -46,10 +46,10 @@ You are a code localization agent. Find the code locations (files and \
 symbols) relevant to the request, then give a concise answer naming them.
 
 You always have a filesystem toolset for navigating the repository:
-- file_search(mode="files", pattern=...) — list files by glob (explore layout)
-- file_search(mode="content", pattern=...) — grep file contents (regex/literal)
-- file_search(mode="shell", command=...) — run a shell command (ls, find, git)
-- file_read(path, start_line, end_line) — read a file or a line range
+- glob(pattern, path) — list files by glob (explore layout)
+- grep(pattern, path, glob, type, output_mode) — search file contents (regex)
+- bash(command) — run a shell command (ls, find, git)
+- read(file_path, offset, limit) — read a file or a line range
 
 Depending on the request you may also have retrieval skills:
 - bm25_search(query) — fast lexical search for exact names / identifiers
@@ -58,21 +58,21 @@ Depending on the request you may also have retrieval skills:
 - find_callers(symbol) / find_callees(symbol) / trace(from_symbol, to_symbol) — \
 call-graph navigation (who calls X, what X calls, the path from X to Y). Use \
 for impact and to follow a bug across functions — the structural questions \
-grep cannot answer. Compact results; file_read the ones you care about.
+grep cannot answer. Compact results; read the ones you care about.
 
 Accuracy comes first: you MUST end up having read the file that actually \
 implements the behavior to change. Use codeminer_context / the graph as a \
-*heuristic* to point you there fast — but grep and file_read are how you \
+*heuristic* to point you there fast — but grep and read are how you \
 confirm you reached it.
 
 Workflow — iterate EXPAND → READ → EXPAND until you've confirmed the file:
 1. ORIENT — call codeminer_context(query) first: one call returns candidate \
 entry-point symbols plus their callers/callees as a starting map.
-2. READ — file_read the most promising candidate(s) to check whether the code \
+2. READ — read the most promising candidate(s) to check whether the code \
 to change is really there.
 3. EXPAND — if it's not (e.g. you landed on a base class, a caller, or a near \
 miss): follow the graph (find_callers / find_callees / trace) AND/OR grep for \
-the symbol across the repo (file_search mode="content"). A base-class method \
+the symbol across the repo (grep pattern=...). A base-class method \
 often has the real change in a SUBCLASS OVERRIDE — grep the method name to find \
 all definitions, then read them. Loop back to READ.
 4. ANSWER — only once you have READ a file and confirmed it contains the code \
@@ -135,7 +135,7 @@ class AgentRunner:
         else:
             raise ValueError("Either 'llm' or 'model' must be provided")
         self.registry = registry or SkillRegistry()
-        # Always-on default tool layer (file_read + file_search): registered
+        # Always-on default tool layer (read + grep + glob + bash): registered
         # unconditionally so every query — and every agent-compile subset —
         # has the filesystem primitives (read / grep / glob / shell) the model
         # is pretrained on. These sit *outside* the allow/compile_table funnel.
@@ -146,8 +146,8 @@ class AgentRunner:
         if include_default_tools:
             ensure_defaults_registered(self.registry)
             # Which of the registered defaults to actually expose. Defaults to
-            # ALL (file_read + file_search). Restricting to a subset — e.g.
-            # ``{"file_read"}`` — yields a graph-primary / LocAgent-style harness
+            # ALL (read + grep + glob + bash). Restricting to a subset — e.g.
+            # ``{"read"}`` — yields a graph-primary / LocAgent-style harness
             # that can read code but has NO grep escape hatch, so the structured
             # (bm25 + call-graph) tools must carry navigation.
             allowed = set(DEFAULT_SKILL_IDS)
@@ -237,8 +237,8 @@ class AgentRunner:
 
         The always-on default layer (``self._default_ids``) is added *after*
         any allow/compile_table narrowing, so the funnel's "table narrows,
-        never broadens" rule still governs the swept skills while file_read /
-        file_search remain available in every subset. ``allow=None`` exposes
+        never broadens" rule still governs the swept skills while the default
+        primitives remain available in every subset. ``allow=None`` exposes
         the full registry (defaults already registered there).
         """
         resolved = self._resolve_allow_set(allow)

--- a/codeminer/agent/skills/_graphnav.py
+++ b/codeminer/agent/skills/_graphnav.py
@@ -192,7 +192,7 @@ def neighbors(graph: Any, symbol: str, relation: str, top_k: int = 40) -> List[A
             )
         raise ValueError(
             f"symbol {symbol!r} not found in the code graph. Use a name from a "
-            "search result, or grep with file_search to find it."
+            "search result, or grep to find it."
         )
     label = display_name(graph, name)
     results: List[Any] = []

--- a/codeminer/agent/skills/core.py
+++ b/codeminer/agent/skills/core.py
@@ -55,6 +55,11 @@ class SkillInputSpec:
     required: bool = True
     default: Any = None
     description: str = ""
+    # Optional closed set of allowed values. When set, emitted as a JSON-Schema
+    # ``enum`` constraint in the OpenAI tool schema so the model sees the valid
+    # choices in-band (e.g. ``output_mode`` on the ``grep`` default tool) rather
+    # than only in prose. Not part of the Python↔Rust ``to_dict`` contract.
+    enum: Optional[List[str]] = None
 
 
 @dataclass(slots=True)

--- a/codeminer/agent/skills/graph_expand/executor.py
+++ b/codeminer/agent/skills/graph_expand/executor.py
@@ -107,7 +107,7 @@ def create_executor(context: Any) -> Callable[..., List[Any]]:
                     "graph_expand: none of the seed_symbols resolve to graph "
                     f"nodes: {unresolved}. Copy the exact node_name from a "
                     "search result, or grep for the symbol with "
-                    "file_search(mode='content')."
+                    "grep(pattern=...)."
                 )
 
         roi = ROISubgraph(context.code_graph)

--- a/codeminer/agent/skills/regex_search/executor.py
+++ b/codeminer/agent/skills/regex_search/executor.py
@@ -26,7 +26,7 @@ def create_executor(context: Any) -> Callable[..., List[Any]]:
             # default tool instead.
             raise RuntimeError(
                 "regex_search is unavailable (no regex node index is built). "
-                "Use file_search(mode='content', pattern=...) for grep-style "
+                "Use grep(pattern=...) for grep-style "
                 "regex over file contents — it is always available."
             )
 

--- a/codeminer/agent/tool_schema.py
+++ b/codeminer/agent/tool_schema.py
@@ -52,6 +52,8 @@ def skill_to_tool_schema(meta: SkillMetadata) -> Dict[str, Any]:
         prop: Dict[str, Any] = _schema_for_type(inp.type_hint)
         if inp.description:
             prop["description"] = inp.description
+        if getattr(inp, "enum", None):
+            prop["enum"] = list(inp.enum)
         if inp.default is not None:
             prop["default"] = inp.default
         properties[inp.name] = prop

--- a/codeminer/agent/tools/__init__.py
+++ b/codeminer/agent/tools/__init__.py
@@ -7,10 +7,11 @@
 This package is deliberately separate from ``codeminer/agent/skills/``:
 
 - **``tools/`` (here)** — always-on primitives that scan the *raw
-  filesystem* (``file_read``, ``file_search``). They carry no
-  ``index_requirements``, are never loaded from ``config.yaml``/``executor.py``
-  packages, and are never dropped by the ``allow_skills`` / ``exclude_skills``
-  filters. Every ``Ax`` subset builds on top of them.
+  filesystem* (``read``, ``grep``, ``glob``, ``bash`` — the mainstream Claude
+  Code tool shapes). They carry no ``index_requirements``, are never loaded
+  from ``config.yaml``/``executor.py`` packages, and are never dropped by the
+  ``allow_skills`` / ``exclude_skills`` filters. Every ``Ax`` subset builds on
+  top of them.
 - **``skills/``** — index-backed retrieval skills (``bm25_search``,
   ``embedding_search``, ``graph_expand``, ...) declared as
   ``config.yaml`` + ``executor.py`` packages and gated by their declared

--- a/codeminer/agent/tools/defaults.py
+++ b/codeminer/agent/tools/defaults.py
@@ -2,58 +2,54 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Always-on default tool primitives: ``file_read`` and ``file_search``.
+"""Always-on default tool primitives: ``read`` / ``grep`` / ``glob`` / ``bash``.
 
-These two tools are registered into ``AgentRunner``'s skill registry at
-startup and are **never** removed by the ``exclude_skills`` or
-``allow_skills`` arguments — every skill subset (A0–A6) builds on top of
-them.
+These four tools are registered into ``AgentRunner``'s skill registry at
+startup and are **never** removed by the ``exclude_skills`` or ``allow_skills``
+arguments — every skill subset (A0–A6) builds on top of them.
 
-Per #145, the search default is "grep / glob / bash-style primitives
-(single tool or split — your call)". This module takes the **single
-tool** route: ``file_search`` is one skill that dispatches via a
-``mode`` argument:
+Why four tools (and not the older single ``file_search`` multiplexer)?
+----------------------------------------------------------------------
+The shape mirrors the mainstream Claude Code tool reference
+(https://code.claude.com/docs/en/tools-reference): one focused tool per
+concern — ``Read`` / ``Grep`` / ``Glob`` / ``Bash`` — instead of one
+``file_search`` skill with a ``mode`` discriminator and a flat schema whose
+parameters are silently ignored depending on the mode. Splitting them gives
+each tool a clean, self-describing schema: the model never sees ``timeout`` on
+a content search or ``case_insensitive`` on a shell command.
 
-- ``mode="content"`` *(default)* — grep-style regex over file contents.
-- ``mode="files"`` — glob-style filename enumeration (``Path.rglob``).
-- ``mode="shell"`` — bash-style shell command execution.
+Deviations from the upstream reference (and why)
+------------------------------------------------
+The registry dispatches tool calls as ``executor_fn(**json_args)`` (see
+``AgentRunner._execute_tool_call``), so every schema parameter must be a valid
+Python identifier. That rules out the reference's literal flag names
+(``-i`` / ``-n`` / ``-A`` / ``-B`` / ``-C``). We therefore:
 
-The tool is named ``file_search`` (not ``regex_search``) so it does not
-collide with the existing index-backed ``regex_search`` retrieval skill
-in ``skills/regex_search/`` — that one searches the in-memory node index
-(``regex.retrieve``), this one scans the raw filesystem with no index.
+- name the skills in lowercase snake_case (``read`` / ``grep`` / ``glob`` /
+  ``bash``) to match the existing registry convention (``bm25_search``,
+  ``graph_expand``, ...), not the reference's TitleCase display names;
+- expose ``-i`` as ``case_insensitive`` (defaulting to ``True`` to preserve the
+  prior always-on behaviour, where upstream grep defaults to case-sensitive);
+  line numbers are always emitted (the reference ``-n``) and context lines
+  (``-A`` / ``-B`` / ``-C``) are not implemented;
+- default ``grep.output_mode`` to ``content`` (upstream defaults to
+  ``files_with_matches``) — content is the more useful default for a
+  localization agent;
+- express ``bash.timeout`` in **milliseconds** to match the reference units,
+  drop ``run_in_background`` (no background-task infrastructure here), and add
+  ``cwd`` (the reference relies on session ``cd`` persistence, which this
+  subprocess-per-call executor lacks);
+- cap ``glob`` at 100 results internally (matching the reference's documented
+  cap) rather than exposing a ``max_results`` knob.
 
-The internal helpers ``_file_search_content`` / ``_file_search_files``
-/ ``_file_search_shell`` implement each back-end; the public
-``_file_search`` is the dispatcher referenced by
-``_build_file_search_skill``. Shell mode has a loose safety policy
-(``shell=True``, no allow/deny list); see the shell skill_doc for the
-trust-boundary contract.
+Line numbers follow **opencode** style (``{lineno:6d} | {content}``) and the
+read/grep boundary is **1-based** throughout, aligned with #147/#153.
 
-Reference design
-----------------
-Line-number format follows **opencode** (``{lineno:6d} | {content}``), as
-requested in the code review on issue #145 by @siriuxyu:
+The ``grep`` tool scans the raw filesystem with no index; for index-backed
+regex retrieval over parsed nodes use the separate ``regex_search`` skill in
+``skills/regex_search/``.
 
-    "Please make line numbers visible per row (opencode-style
-    ``<lineno> | <content>``, or similar)."
-
-The ``file_read`` input/output boundary convention uses **1-based** line
-numbers throughout, aligned with the cross-cutting convention settled in
-#147/#153.
-
-Why opencode over openhands / codex?
-- opencode's ``{n} | {line}`` format is the clearest visual separator for an
-  LLM that needs to pick a line number for a follow-up call (e.g.
-  ``graph_expand(ranges=[...])``) without having to count from the top of the
-  snippet — the number is right there.
-- openhands uses a similar scheme but with a different delimiter that is less
-  scan-friendly in monospace output.
-- codex embeds numbers in XML-like tags that add token overhead without
-  readability benefit.
-
-Related issues: #133 (Agent Router RFC), #145 (this PR), #147 (line-number
+Related issues: #133 (Agent Router RFC), #145 (defaults), #147 (line-number
 convention), #153 (1-based boundary).
 """
 
@@ -64,7 +60,7 @@ import re
 import signal
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from ..skills.core import (
     Cost,
@@ -76,12 +72,13 @@ from ..skills.core import (
 from ..skills.registry import SkillRegistry
 
 # Canonical skill IDs for the always-on defaults.
-DEFAULT_SKILL_IDS: frozenset[str] = frozenset({"file_read", "file_search"})
+DEFAULT_SKILL_IDS: frozenset[str] = frozenset({"read", "grep", "glob", "bash"})
 
 # Sensible token-safety caps.
 _MAX_LINES_DEFAULT: int = 200
 _MAX_RESULTS_DEFAULT: int = 50
-_BASH_TIMEOUT_DEFAULT: int = 30  # seconds
+_GLOB_MAX_RESULTS: int = 100  # mirrors the reference Glob's documented cap
+_BASH_TIMEOUT_MS_DEFAULT: int = 30_000  # 30s, expressed in ms (reference units)
 _BASH_MAX_OUTPUT_CHARS: int = 16_000  # matches runner._MAX_RESULT_CHARS
 
 # Directories to skip during recursive search (avoids scanning VCS / cache noise).
@@ -104,17 +101,37 @@ _SKIP_DIR_PREFIXES = frozenset(
     }
 )
 
+# `grep` file-type filter: maps a language token to the extensions it covers.
+# Mirrors the reference Grep's ``type`` parameter (ripgrep types) for the
+# languages CodeMiner indexes, plus a few common siblings.
+_TYPE_EXTENSIONS: Dict[str, Tuple[str, ...]] = {
+    "py": (".py", ".pyi"),
+    "python": (".py", ".pyi"),
+    "js": (".js", ".jsx", ".mjs", ".cjs"),
+    "ts": (".ts", ".tsx"),
+    "go": (".go",),
+    "rust": (".rs",),
+    "rs": (".rs",),
+    "c": (".c", ".h"),
+    "cpp": (".cpp", ".cc", ".cxx", ".hpp", ".hh", ".h"),
+    "java": (".java",),
+    "rb": (".rb",),
+    "ruby": (".rb",),
+    "md": (".md", ".markdown"),
+}
+
+_GREP_OUTPUT_MODES = ("content", "files_with_matches", "count")
+
 
 # ---------------------------------------------------------------------------
-# file_read
+# read
 # ---------------------------------------------------------------------------
 
 
-def _file_read(
-    path: str,
-    start_line: int = 1,
-    end_line: Optional[int] = None,
-    max_lines: int = _MAX_LINES_DEFAULT,
+def _read(
+    file_path: str,
+    offset: int = 1,
+    limit: int = _MAX_LINES_DEFAULT,
 ) -> str:
     """Read a file, returning its content with per-row 1-based line numbers.
 
@@ -124,56 +141,53 @@ def _file_read(
            2 |     return 42
 
     Args:
-        path: Absolute or repo-relative path to the file.
-        start_line: First line to read (1-based, inclusive). Defaults to 1.
-        end_line: Last line to read (1-based, inclusive). Defaults to EOF.
-        max_lines: Hard cap on lines returned for token safety. Defaults to
-            200.  A truncation notice with the next ``start_line`` is appended
-            when the cap is reached.
+        file_path: Absolute or repo-relative path to the file.
+        offset: First line to read (1-based, inclusive). Defaults to 1. Mirrors
+            the reference ``Read.offset``.
+        limit: Hard cap on lines returned for token safety. Defaults to 200. A
+            truncation notice with the next ``offset`` is appended when the cap
+            is reached. Mirrors the reference ``Read.limit``.
 
     Returns:
         Formatted string, or an error message prefixed with ``"Error: "``.
     """
     # Coerce inputs up front: a non-integer arg returns an Error string (the
-    # module contract) instead of raising into the caller. `max_lines` is
-    # floored at 1 so `max_lines=0` cannot emit a "0 lines; continue at the
-    # same start_line" notice that loops forever.
+    # module contract) instead of raising into the caller. `limit` is floored at
+    # 1 so `limit=0` cannot emit a "0 lines; continue at the same offset" notice
+    # that loops forever.
     try:
-        start = max(1, int(start_line))
-        max_lines = max(1, int(max_lines))
-        end = int(end_line) if end_line is not None else None
+        start = max(1, int(offset))
+        limit = max(1, int(limit))
     except (TypeError, ValueError):
-        return "Error: start_line, end_line, and max_lines must be integers"
-    if end is not None and start > end:
-        return f"Error: start_line {start} > end_line {end}"
+        return "Error: offset and limit must be integers"
 
-    # Stream the file: keep at most `max_lines` lines in memory and merely
-    # *count* any further requested lines (for the truncation notice) without
-    # storing them, so a huge file is never fully materialised.
+    # Stream the file: keep at most `limit` lines in memory and merely *count*
+    # any further lines (for the truncation notice) without storing them, so a
+    # huge file is never fully materialised.
     selected: List[str] = []
-    extra = 0  # requested lines present beyond the kept window
+    extra = 0  # lines present beyond the kept window
     total = 0
     try:
-        with open(path, encoding="utf-8", errors="replace") as fh:
+        with open(file_path, encoding="utf-8", errors="replace") as fh:
             for idx, line in enumerate(fh, start=1):
                 total = idx
                 if idx < start:
                     continue
-                if end is not None and idx > end:
-                    break
-                if len(selected) < max_lines:
+                if len(selected) < limit:
                     selected.append(line)
                 else:
                     extra += 1
     except FileNotFoundError:
-        return f"Error: file not found: {path!r}"
+        return f"Error: file not found: {file_path!r}"
+    except IsADirectoryError:
+        return f"Error: {file_path!r} is a directory, not a file"
     except OSError as exc:
-        return f"Error reading {path!r}: {exc}"
+        return f"Error reading {file_path!r}: {exc}"
 
     if total == 0:
-        return f"(empty file: {path})"
+        return f"(empty file: {file_path})"
     if start > total:
-        return f"Error: start_line {start} exceeds file length {total} in {path!r}"
+        return f"Error: offset {start} exceeds file length {total} in {file_path!r}"
 
     lines_out = [
         f"{lineno:6d} | {line.rstrip()}"
@@ -182,89 +196,71 @@ def _file_read(
     result = "\n".join(lines_out)
 
     if extra > 0:
-        next_start = start + max_lines  # first omitted line (1-based)
-        result += (
-            f"\n... ({extra} more lines; " f"use start_line={next_start} to continue)"
-        )
+        next_start = start + limit  # first omitted line (1-based)
+        result += f"\n... ({extra} more lines; " f"use offset={next_start} to continue)"
 
     return result
 
 
-_FILE_READ_SKILL_DOC = """\
-# file_read
+_READ_SKILL_DOC = """\
+# read
 
 Read a source file and return its content with per-row 1-based line numbers.
+Shape mirrors the mainstream Claude Code `Read` tool.
 
 ## Parameters
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `path` | `str` | *(required)* | Absolute or repo-relative file path. |
-| `start_line` | `int` | `1` | First line to read (1-based, inclusive). |
-| `end_line` | `int` | EOF | Last line to read (1-based, inclusive). |
-| `max_lines` | `int` | `200` | Hard cap on lines returned; prevents context blowup. |
+| `file_path` | `str` | *(required)* | Absolute or repo-relative file path. |
+| `offset` | `int` | `1` | First line to read (1-based, inclusive). |
+| `limit` | `int` | `200` | Max lines returned; prevents context blowup. |
 
 ## Output
 
 Lines formatted as `{lineno:6d} | {content}` (opencode-style, 1-based).
-A truncation notice with the next `start_line` is appended when `max_lines`
-is reached.
+A truncation notice with the next `offset` is appended when `limit` is reached.
 
 ## When to Use
 
-- Inspect a function or class after a search skill narrowed the location.
-- Read context lines around a match.
-- Retrieve a known file at a specific line range.
-- Follow up on a `grep` result to read surrounding code.
+- Inspect a function or class after a search tool narrowed the location.
+- Read context lines around a `grep` match.
+- Retrieve a known file at a specific line range (pass `offset`/`limit`).
 
 ## Safety
 
-`file_read` opens the `path` as given — there is **no path jail**. The
-`path` description says "repo-relative", but this is not enforced: an
-absolute path reads any file the process can (`/etc/shadow`,
-`~/.ssh/id_rsa`, ...). As an always-on tool every agent turn can call,
-this means untrusted query input or prompt injection could exfiltrate any
-readable file. Callers running the agent on untrusted input MUST sandbox
-at the container / VM / process level.
+`read` opens `file_path` as given — there is **no path jail**. An absolute
+path reads any file the process can (`/etc/shadow`, `~/.ssh/id_rsa`, ...). As
+an always-on tool every agent turn can call, untrusted query input or prompt
+injection could exfiltrate any readable file. Callers running the agent on
+untrusted input MUST sandbox at the container / VM / process level.
 """
 
 
-def _build_file_read_skill() -> SkillMetadata:
+def _build_read_skill() -> SkillMetadata:
     return SkillMetadata(
-        skill_id="file_read",
+        skill_id="read",
         skill_type=SkillType.CUSTOM,
         inputs=[
             SkillInputSpec(
-                name="path",
+                name="file_path",
                 type_hint="str",
                 required=True,
                 description="Absolute or repo-relative path to the file.",
             ),
             SkillInputSpec(
-                name="start_line",
+                name="offset",
                 type_hint="int",
                 required=False,
                 default=1,
                 description="First line to read (1-based, inclusive). Defaults to 1.",
             ),
             SkillInputSpec(
-                name="end_line",
-                type_hint="int",
-                required=False,
-                default=None,
-                description=(
-                    "Last line to read (1-based, inclusive). "
-                    "Defaults to end of file."
-                ),
-            ),
-            SkillInputSpec(
-                name="max_lines",
+                name="limit",
                 type_hint="int",
                 required=False,
                 default=_MAX_LINES_DEFAULT,
-                description=(
-                    f"Hard cap on lines returned (default {_MAX_LINES_DEFAULT})."
-                ),
+                description=(f"Max lines returned (default {_MAX_LINES_DEFAULT})."),
             ),
         ],
         outputs=SkillOutputSpec(
@@ -274,148 +270,336 @@ def _build_file_read_skill() -> SkillMetadata:
                 "`{lineno:6d} | {line}` format."
             ),
         ),
-        executor_fn=_file_read,
+        executor_fn=_read,
         async_capable=False,
         cacheable=False,  # filesystem state may change between calls
         cost=Cost.LOW,
         dependencies=[],
         resources=[],
-        defaults={"start_line": 1, "max_lines": _MAX_LINES_DEFAULT},
-        skill_doc=_FILE_READ_SKILL_DOC,
+        defaults={"offset": 1, "limit": _MAX_LINES_DEFAULT},
+        skill_doc=_READ_SKILL_DOC,
         description=(
             "Read a file with 1-based line numbers (opencode-style); "
-            "output is bounded by max_lines for token safety."
+            "output is bounded by `limit` for token safety."
         ),
     )
 
 
 # ---------------------------------------------------------------------------
-# file_search — multi-mode primitive (content / files / shell)
-#
-# Per #145, the ``file_search`` slot is "grep / glob / bash-style primitives
-# (single tool or split — your call)". This module takes the **single tool**
-# route: one skill, three internal modes, dispatched by the ``mode`` argument.
+# grep — content search over the raw filesystem
 # ---------------------------------------------------------------------------
 
 
-def _file_search_content(
+def _grep_candidate_files(
+    root: Path,
+    glob: Optional[str],
+    type_: Optional[str],
+):
+    """Yield candidate files under *root* honouring ``glob`` / ``type`` filters.
+
+    ``glob`` filters file *names* (passed to ``rglob``); ``type`` further
+    restricts by extension via ``_TYPE_EXTENSIONS``. Noise directories
+    (``_SKIP_DIR_PREFIXES``) are skipped.
+    """
+    exts = _TYPE_EXTENSIONS.get((type_ or "").lower()) if type_ else None
+    for file_path in root.rglob(glob or "*"):
+        if not file_path.is_file():
+            continue
+        if any(part in _SKIP_DIR_PREFIXES for part in file_path.parts):
+            continue
+        if exts is not None and file_path.suffix.lower() not in exts:
+            continue
+        yield file_path
+
+
+def _grep(
     pattern: str,
     path: str = ".",
-    include: Optional[str] = None,
-    case_sensitive: bool = False,
-    use_regex: bool = True,
-    max_results: int = _MAX_RESULTS_DEFAULT,
+    glob: Optional[str] = None,
+    type: Optional[str] = None,  # noqa: A002 — matches the reference param name
+    output_mode: str = "content",
+    case_insensitive: bool = True,
+    multiline: bool = False,
+    head_limit: int = _MAX_RESULTS_DEFAULT,
 ) -> str:
-    """Grep-style content search.
+    """Regex content search over file contents (the reference ``Grep`` shape).
 
-    Returns one match per line: ``{relative_path}:{lineno}: {content}``
-    (1-based). Returns a no-match message when nothing is found.
+    Returns text shaped by ``output_mode``:
+
+    - ``content`` *(default)* — ``{file}:{lineno}: {line}`` per match (1-based).
+    - ``files_with_matches`` — unique file paths that contain a match.
+    - ``count`` — ``{file}:{count}`` per matching file.
+
+    ``head_limit`` caps the number of emitted rows (matches in content mode,
+    files in the other two). A no-match message is returned when nothing hits.
     """
-    flags = 0 if case_sensitive else re.IGNORECASE
-    if use_regex:
-        try:
-            compiled = re.compile(pattern, flags)
-        except re.error as exc:
-            return f"Error: invalid regex {pattern!r}: {exc}"
-    else:
-        compiled = re.compile(re.escape(pattern), flags)
+    if output_mode not in _GREP_OUTPUT_MODES:
+        return (
+            f"Error: invalid output_mode {output_mode!r}; "
+            f"expected one of {list(_GREP_OUTPUT_MODES)}"
+        )
+    try:
+        head_limit = max(1, int(head_limit))
+    except (TypeError, ValueError):
+        return "Error: head_limit must be an integer"
+
+    flags = 0 if case_insensitive is False else re.IGNORECASE
+    if multiline:
+        flags |= re.MULTILINE | re.DOTALL
+    try:
+        compiled = re.compile(pattern, flags)
+    except re.error as exc:
+        return f"Error: invalid regex {pattern!r}: {exc}"
 
     root = Path(path)
     if not root.exists():
         return f"Error: path {path!r} does not exist"
 
-    results: List[str] = []
+    content_rows: List[str] = []  # "{rel}:{lineno}: {line}"
+    file_match_count: "Dict[str, int]" = {}  # rel -> match count, insertion order
     capped = False
 
-    def _search_file(file_path: Path) -> bool:
-        """Append matches from *file_path*; return True if cap was hit."""
+    def _rel(file_path: Path) -> str:
+        if root.is_dir():
+            try:
+                return str(file_path.relative_to(root))
+            except ValueError:
+                return str(file_path)
+        return str(file_path)
+
+    def _scan(file_path: Path) -> bool:
+        """Record matches for *file_path*; return True if the head cap was hit."""
+        rel = _rel(file_path)
         try:
-            with open(file_path, encoding="utf-8", errors="replace") as fh:
-                for lineno, line in enumerate(fh, start=1):
-                    if compiled.search(line):
-                        rel = (
-                            file_path.relative_to(root) if root.is_dir() else file_path
-                        )
-                        results.append(f"{rel}:{lineno}: {line.rstrip()}")
-                        if len(results) >= max_results:
+            if multiline:
+                text = file_path.read_text(encoding="utf-8", errors="replace")
+                for m in compiled.finditer(text):
+                    lineno = text.count("\n", 0, m.start()) + 1
+                    snippet = text[m.start() : m.end()].splitlines()[0]
+                    file_match_count[rel] = file_match_count.get(rel, 0) + 1
+                    if output_mode == "content":
+                        content_rows.append(f"{rel}:{lineno}: {snippet}")
+                        if len(content_rows) >= head_limit:
                             return True
+            else:
+                with open(file_path, encoding="utf-8", errors="replace") as fh:
+                    for lineno, line in enumerate(fh, start=1):
+                        if compiled.search(line):
+                            file_match_count[rel] = file_match_count.get(rel, 0) + 1
+                            if output_mode == "content":
+                                content_rows.append(f"{rel}:{lineno}: {line.rstrip()}")
+                                if len(content_rows) >= head_limit:
+                                    return True
         except OSError:
-            # Best-effort search: a single unreadable file (permission denied,
-            # broken symlink, encoding issue past errors="replace", etc.) must
-            # not abort the overall scan. Silently skip and move on so the LLM
-            # still sees the matches from other files.
+            # Best-effort: a single unreadable file must not abort the scan.
             pass
+        # In file-granular modes, cap on the number of distinct matching files.
+        if output_mode != "content" and len(file_match_count) >= head_limit:
+            return True
         return False
 
     if root.is_file():
-        _search_file(root)
+        _scan(root)
     else:
-        # Pass `include` straight to rglob so the OS filters file *names*
-        # during traversal — avoids materialising the whole tree (a `sorted()`
-        # over `rglob("*")` would allocate one Path per file before any match
-        # check, and the max_results cap gives no protection against that).
-        # Traversal order is filesystem-dependent, but content matches are
-        # identified by `{file}:{lineno}`, so cross-file ordering is not
-        # load-bearing. rglob is a generator, so a bad `include` glob raises
-        # during iteration (ValueError/OSError/NotImplementedError) — wrap it.
         try:
-            for file_path in root.rglob(include or "*"):
-                if not file_path.is_file():
-                    continue
-                # Skip noise directories.
-                if any(part in _SKIP_DIR_PREFIXES for part in file_path.parts):
-                    continue
-                if _search_file(file_path):
+            for file_path in _grep_candidate_files(root, glob, type):
+                if _scan(file_path):
                     capped = True
                     break
         except (ValueError, OSError, NotImplementedError) as exc:
-            return f"Error: invalid include glob {include!r}: {exc}"
+            return f"Error: invalid glob {glob!r}: {exc}"
 
-    if not results:
+    if not file_match_count:
         return "No matches found."
 
-    text = "\n".join(results)
+    if output_mode == "content":
+        rows = content_rows
+        cap_unit = "matches"
+    elif output_mode == "files_with_matches":
+        rows = sorted(file_match_count)[:head_limit]
+        cap_unit = "files"
+    else:  # count
+        rows = [f"{rel}:{n}" for rel, n in list(file_match_count.items())[:head_limit]]
+        cap_unit = "files"
+
+    text = "\n".join(rows)
     if capped:
         text += (
-            f"\n... (max_results={max_results} reached; "
-            "narrow your search with `include` or a more specific `pattern`)"
+            f"\n... (head_limit={head_limit} {cap_unit} reached; "
+            "narrow with `glob`/`type` or a more specific `pattern`)"
         )
     return text
 
 
-def _file_search_files(
-    pattern: str,
-    path: str = ".",
-    max_results: int = _MAX_RESULTS_DEFAULT,
-) -> str:
-    """Glob-style filename enumeration under *path*.
+_GREP_SKILL_DOC = """\
+# grep
+
+Regex content search over the raw filesystem (no index). Shape mirrors the
+mainstream Claude Code `Grep` tool. For index-backed regex over parsed nodes,
+use the separate `regex_search` skill.
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `pattern` | str | *required* | Regular expression (Python `re` syntax). |
+| `path` | str | `.` | Directory (or single file) to search. |
+| `glob` | str | null | Filter file *names* (e.g. `*.py`, `**/test_*.py`). |
+| `type` | str | null | Filter by language (`py`, `ts`, `go`, `rust`, `cpp`, ...). |
+| `output_mode` | str | `content` | `content` / `files_with_matches` / `count`. |
+| `case_insensitive` | bool | true | Case-insensitive matching (reference `-i`). |
+| `multiline` | bool | false | Let `.`/`^`/`$` span lines (reference `multiline`). |
+| `head_limit` | int | 50 | Cap on rows (matches, or files in the other modes). |
+
+## Output
+
+- `content` — `{file}:{lineno}: {line}` per match (1-based).
+- `files_with_matches` — sorted unique file paths that contain a match.
+- `count` — `{file}:{count}` per matching file.
+
+## When to Use
+
+- Find call sites, error strings, or identifier usage anywhere in the repo.
+- A base-class method often has the real change in a SUBCLASS OVERRIDE — grep
+  the method name to find all definitions, then `read` them.
+- Use `output_mode="files_with_matches"` to locate *which* files first, then
+  `read` them; `count` to gauge how widespread a symbol is.
+
+## Note vs the reference
+
+Parameter names differ from upstream where they must be Python identifiers:
+`-i` → `case_insensitive` (defaulting to true here), line numbers are always
+on, and context lines (`-A`/`-B`/`-C`) are not implemented.
+"""
+
+
+def _build_grep_skill() -> SkillMetadata:
+    return SkillMetadata(
+        skill_id="grep",
+        skill_type=SkillType.CUSTOM,
+        inputs=[
+            SkillInputSpec(
+                name="pattern",
+                type_hint="str",
+                required=True,
+                description="Regular expression to search for (Python re syntax).",
+            ),
+            SkillInputSpec(
+                name="path",
+                type_hint="str",
+                required=False,
+                default=".",
+                description="Directory (or single file) to search. Defaults to '.'.",
+            ),
+            SkillInputSpec(
+                name="glob",
+                type_hint="str",
+                required=False,
+                default=None,
+                description="Filter file names by glob (e.g. '*.py', '**/test_*.py').",
+            ),
+            SkillInputSpec(
+                name="type",
+                type_hint="str",
+                required=False,
+                default=None,
+                description=(
+                    "Filter by language: py, js, ts, go, rust, c, cpp, " "java, rb, md."
+                ),
+            ),
+            SkillInputSpec(
+                name="output_mode",
+                type_hint="str",
+                required=False,
+                default="content",
+                enum=list(_GREP_OUTPUT_MODES),
+                description=(
+                    "'content' (matching lines), 'files_with_matches' (paths "
+                    "only), or 'count' (matches per file). Defaults to 'content'."
+                ),
+            ),
+            SkillInputSpec(
+                name="case_insensitive",
+                type_hint="bool",
+                required=False,
+                default=True,
+                description="Case-insensitive matching (reference '-i'). Default true.",
+            ),
+            SkillInputSpec(
+                name="multiline",
+                type_hint="bool",
+                required=False,
+                default=False,
+                description="Let '.'/'^'/'$' span line boundaries. Default false.",
+            ),
+            SkillInputSpec(
+                name="head_limit",
+                type_hint="int",
+                required=False,
+                default=_MAX_RESULTS_DEFAULT,
+                description=(
+                    "Cap on rows returned (matches in content mode, files "
+                    f"otherwise; default {_MAX_RESULTS_DEFAULT})."
+                ),
+            ),
+        ],
+        outputs=SkillOutputSpec(
+            type_hint="str",
+            description=(
+                "Matching lines, file paths, or per-file counts depending on "
+                "output_mode."
+            ),
+        ),
+        executor_fn=_grep,
+        async_capable=False,
+        cacheable=False,
+        cost=Cost.LOW,
+        dependencies=[],
+        resources=[],
+        defaults={
+            "path": ".",
+            "output_mode": "content",
+            "case_insensitive": True,
+            "multiline": False,
+            "head_limit": _MAX_RESULTS_DEFAULT,
+        },
+        skill_doc=_GREP_SKILL_DOC,
+        description=(
+            "Regex content search over the raw filesystem; output shaped by "
+            "output_mode (content / files_with_matches / count)."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# glob — filename enumeration
+# ---------------------------------------------------------------------------
+
+
+def _glob(pattern: str, path: str = ".") -> str:
+    """Glob-style filename enumeration under *path* (the reference ``Glob``).
 
     ``pattern`` follows ``Path.rglob`` syntax (e.g. ``"*.py"``,
     ``"**/test_*.py"``). Returns a sorted newline-separated list of relative
-    paths, or a no-match message when empty.
-
-    Ordering contract: the ``max_results`` cap is applied during traversal
-    (filesystem order) and only the *returned* subset is sorted — so which
-    files survive the cap is filesystem-dependent on large match sets. The
-    output is sorted among returned results, not globally sorted.
+    paths, or a no-match message when empty. Capped at ``_GLOB_MAX_RESULTS``
+    (mirrors the reference cap); the cap is applied during traversal
+    (filesystem order) and only the returned subset is sorted.
     """
     root_path = Path(path)
     if not root_path.exists():
         return f"Error: path {path!r} does not exist"
     if not root_path.is_dir():
-        return f"Error: files-mode root {path!r} is not a directory"
+        return f"Error: glob root {path!r} is not a directory"
 
     matches: List[str] = []
     capped = False
     # rglob is a generator: a bad pattern (empty, absolute, unsupported glob)
-    # raises during *iteration*, not at creation, and may raise
-    # NotImplementedError as well as ValueError — so wrap the whole loop, not
-    # just the rglob() call.
+    # raises during *iteration*, and may raise NotImplementedError as well as
+    # ValueError — so wrap the whole loop, not just the rglob() call.
     try:
         for found in root_path.rglob(pattern):
             if not found.is_file():
                 continue
-            # Skip noise directories.
             if any(part in _SKIP_DIR_PREFIXES for part in found.parts):
                 continue
             try:
@@ -423,7 +607,7 @@ def _file_search_files(
             except ValueError:
                 rel = found
             matches.append(str(rel))
-            if len(matches) >= max_results:
+            if len(matches) >= _GLOB_MAX_RESULTS:
                 capped = True
                 break
     except (ValueError, OSError, NotImplementedError) as exc:
@@ -434,30 +618,104 @@ def _file_search_files(
 
     text = "\n".join(sorted(matches))
     if capped:
-        text += (
-            f"\n... (max_results={max_results} reached; "
-            "narrow the pattern or raise max_results)"
-        )
+        text += f"\n... ({_GLOB_MAX_RESULTS}-result cap reached; " "narrow the pattern)"
     return text
 
 
-def _file_search_shell(
+_GLOB_SKILL_DOC = """\
+# glob
+
+Enumerate files by name pattern (the mainstream Claude Code `Glob` shape).
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `pattern` | str | *required* | `Path.rglob` glob (e.g. `*.py`, `**/*.proto`). |
+| `path` | str | `.` | Root directory to search. |
+
+## Output
+
+Sorted newline-separated relative paths. Capped at 100 results (narrow the
+pattern if you hit it).
+
+## When to Use
+
+- Enumerate files matching a structure (`**/__init__.py`, `**/*.proto`).
+- Confirm a file exists before `read`.
+- Map the layout of an unfamiliar subtree.
+"""
+
+
+def _build_glob_skill() -> SkillMetadata:
+    return SkillMetadata(
+        skill_id="glob",
+        skill_type=SkillType.CUSTOM,
+        inputs=[
+            SkillInputSpec(
+                name="pattern",
+                type_hint="str",
+                required=True,
+                description="Glob pattern (Path.rglob syntax, e.g. '**/*.py').",
+            ),
+            SkillInputSpec(
+                name="path",
+                type_hint="str",
+                required=False,
+                default=".",
+                description="Root directory to search. Defaults to '.'.",
+            ),
+        ],
+        outputs=SkillOutputSpec(
+            type_hint="str",
+            description="Sorted newline-separated list of matching relative paths.",
+        ),
+        executor_fn=_glob,
+        async_capable=False,
+        cacheable=False,
+        cost=Cost.LOW,
+        dependencies=[],
+        resources=[],
+        defaults={"path": "."},
+        skill_doc=_GLOB_SKILL_DOC,
+        description=(
+            "Enumerate files by glob pattern; returns sorted relative paths "
+            "(capped at 100)."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# bash — shell command execution
+# ---------------------------------------------------------------------------
+
+
+def _bash(
     command: str,
+    timeout: int = _BASH_TIMEOUT_MS_DEFAULT,
+    description: Optional[str] = None,  # noqa: ARG001 — reference metadata field
     cwd: Optional[str] = None,
-    timeout: int = _BASH_TIMEOUT_DEFAULT,
 ) -> str:
-    """Bash-style shell execution.
+    """Execute a shell command (the reference ``Bash`` shape).
 
     ``command`` runs in its own session (``start_new_session=True``) so that on
     timeout the entire process *group* is killed — otherwise ``subprocess``
-    kills only the spawned ``/bin/sh`` and leaves its children (the actual
-    ``pytest`` / ``find`` / ...) orphaned and still running. Returns a
-    multi-section string with the command, exit code, stdout, stderr; capped at
-    ``_BASH_MAX_OUTPUT_CHARS``. On timeout / spawn failure returns
-    ``"Error: ..."``.
+    kills only the spawned ``/bin/sh`` and leaves its children orphaned. Returns
+    a multi-section string (command, exit code, stdout, stderr) capped at
+    ``_BASH_MAX_OUTPUT_CHARS``. On timeout / spawn failure returns ``"Error: "``.
 
-    Loose safety policy — see the "Safety" section of the skill_doc.
+    ``timeout`` is in **milliseconds** (reference units); ``description`` is
+    accepted for parity with the reference and is otherwise unused. Loose safety
+    policy — see the "Safety" section of the skill_doc.
     """
+    try:
+        timeout_ms = int(timeout)
+    except (TypeError, ValueError):
+        return "Error: timeout must be an integer (milliseconds)"
+    # Convert ms -> whole seconds for subprocess, flooring at 1s so a small
+    # sub-second value never becomes a 0s (i.e. immediate) timeout.
+    timeout_s = max(1, timeout_ms // 1000)
+
     try:
         proc = subprocess.Popen(  # noqa: S602 — loose shell policy by design
             command,
@@ -472,7 +730,7 @@ def _file_search_shell(
         return f"Error executing command {command!r}: {exc}"
 
     try:
-        stdout, stderr = proc.communicate(timeout=timeout)
+        stdout, stderr = proc.communicate(timeout=timeout_s)
     except subprocess.TimeoutExpired:
         # Kill the whole process group, not just the shell, then reap.
         try:
@@ -480,7 +738,7 @@ def _file_search_shell(
         except OSError:  # incl. ProcessLookupError / PermissionError
             proc.kill()
         proc.communicate()
-        return f"Error: command timed out after {timeout}s: {command!r}"
+        return f"Error: command timed out after {timeout_s}s: {command!r}"
     except (OSError, ValueError) as exc:
         proc.kill()
         proc.communicate()
@@ -498,241 +756,96 @@ def _file_search_shell(
     return text
 
 
-# ---------------------------------------------------------------------------
-# Public dispatcher
-# ---------------------------------------------------------------------------
+_BASH_SKILL_DOC = """\
+# bash
 
-
-_FILE_SEARCH_MODES = frozenset({"content", "files", "shell"})
-
-
-def _file_search(
-    pattern: str,
-    mode: str = "content",
-    path: str = ".",
-    max_results: int = _MAX_RESULTS_DEFAULT,
-    # content mode:
-    include: Optional[str] = None,
-    case_sensitive: bool = False,
-    use_regex: bool = True,
-    # shell mode:
-    cwd: Optional[str] = None,
-    timeout: int = _BASH_TIMEOUT_DEFAULT,
-) -> str:
-    """Multi-mode search primitive (the ``file_search`` slot in #145).
-
-    The ``mode`` argument dispatches between three back-ends:
-
-    - ``"content"`` (default) — grep-style regex over file *contents*. Uses
-      ``path``, ``include``, ``case_sensitive``, ``use_regex``, ``max_results``.
-    - ``"files"`` — glob-style enumeration of file *names*. Uses ``pattern``
-      as a ``Path.rglob`` glob, plus ``path`` (root) and ``max_results``.
-    - ``"shell"`` — execute ``pattern`` as a shell command line. Uses
-      ``cwd`` and ``timeout``. Loose safety policy.
-
-    Mode-irrelevant parameters are accepted (the SkillMetadata is one flat
-    schema) but silently ignored.
-    """
-    if mode not in _FILE_SEARCH_MODES:
-        return (
-            f"Error: invalid mode {mode!r}; "
-            f"expected one of {sorted(_FILE_SEARCH_MODES)}"
-        )
-    # Coerce numeric args: a non-integer (e.g. an LLM emitting "5") returns an
-    # Error string rather than raising a TypeError into the caller.
-    try:
-        max_results = max(1, int(max_results))
-        timeout = max(1, int(timeout))
-    except (TypeError, ValueError):
-        return "Error: max_results and timeout must be integers"
-    if mode == "content":
-        return _file_search_content(
-            pattern=pattern,
-            path=path,
-            include=include,
-            case_sensitive=case_sensitive,
-            use_regex=use_regex,
-            max_results=max_results,
-        )
-    if mode == "files":
-        return _file_search_files(pattern=pattern, path=path, max_results=max_results)
-    # mode == "shell"
-    return _file_search_shell(command=pattern, cwd=cwd, timeout=timeout)
-
-
-_FILE_SEARCH_SKILL_DOC = """\
-# file_search
-
-Multi-mode search primitive — pick a `mode` to choose the back-end. This
-is the always-on search default from #145 / #133, bundling
-grep / glob / bash-style search into one tool per #145's "single tool"
-option. It scans the raw filesystem (no index); for index-backed regex
-retrieval over parsed nodes, use the separate `regex_search` skill.
-
-## Modes
-
-- `"content"` *(default)* — grep-style regex over file contents.
-  Returns `{file}:{lineno}: {content}` lines (1-based).
-- `"files"` — glob-style filename enumeration (`Path.rglob`).
-  Returns a sorted newline-separated list of paths.
-- `"shell"` — execute the pattern as a shell command line.
-  Returns `$ <cmd>` / exit code / stdout / stderr.
+Execute a shell command (the mainstream Claude Code `Bash` shape). Anything
+that doesn't fit `read` / `grep` / `glob`: `git log`, `find -newer`, `wc -l`,
+test runners.
 
 ## Parameters
 
-| Name | Type | Default | Used by | Description |
-|------|------|---------|---------|-------------|
-| `pattern` | str | *required* | all | Regex / glob / shell command. |
-| `mode` | str | `content` | all | `content` / `files` / `shell`. |
-| `path` | str | `.` | content, files | Directory (or file) to search. |
-| `max_results` | int | 50 | content, files | Cap on matches / paths. |
-| `include` | str | null | content | Glob filter for file *names*. |
-| `case_sensitive` | bool | false | content | Case-sensitive matching. |
-| `use_regex` | bool | true | content | Regex (true) vs literal (false). |
-| `cwd` | str | null | shell | Working dir for the command. |
-| `timeout` | int | 30 | shell | Wall-clock seconds before kill. |
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `command` | str | *required* | Shell command line to run. |
+| `timeout` | int | 30000 | Wall-clock **milliseconds** before kill. |
+| `description` | str | null | Short human label (accepted for parity; unused). |
+| `cwd` | str | null | Working directory for the command. |
 
-## When to Use which mode
+## Output
 
-- **`content`** — find call sites, error strings, identifier usage anywhere
-  in the repo without an index. Narrow by `include="*.py"`.
-- **`files`** — enumerate files matching a structure (`**/__init__.py`,
-  `**/*.proto`); confirm a file exists before `file_read`.
-- **`shell`** — anything that doesn't fit the above (`pytest`, `git log`,
-  `find . -newer ...`, `wc -l`). See Safety below.
+`$ <cmd>` / `(exit code: N)` / stdout / stderr sections, capped at 16k chars.
+On timeout or spawn failure, an `Error: ...` string.
 
-## Safety (shell mode)
+## Safety
 
-Shell mode runs `subprocess.run(command, shell=True)` with **no command
-filtering, no allow/deny list, and no path jail** — loose by design. An
-in-process filter is either too restrictive (blocks legitimate `pytest` /
-`git`) or trivially bypassed (`bash -c '...'`, `eval`), so the trust
-boundary is the *environment*: callers running the agent on untrusted
-input MUST sandbox at the container / VM / process level. `timeout`
-(default 30s) guards against hangs; a 16k-char output cap guards against
-runaway producers (`yes`, `seq`).
+Runs `subprocess(command, shell=True)` with **no command filtering, no
+allow/deny list, and no path jail** — loose by design. An in-process filter is
+either too restrictive (blocks legitimate `pytest`/`git`) or trivially bypassed
+(`bash -c '...'`), so the trust boundary is the *environment*: callers running
+the agent on untrusted input MUST sandbox at the container / VM / process level.
+`timeout` guards against hangs; a 16k-char output cap guards against runaway
+producers (`yes`, `seq`).
 
-## When NOT to Use
+## Note vs the reference
 
-- Single file content — prefer `file_read` (predictable, line-numbered).
-- Index-backed regex over parsed nodes — use the `regex_search` skill.
-- Semantic / intent queries — use `embedding_search`.
-- Ranked full-text retrieval — use `bm25_search`.
+`timeout` is in milliseconds (matching the reference units); `run_in_background`
+is not supported (no background-task infrastructure), and `cwd` is added here
+because this executor has no session `cd` persistence to rely on.
 """
 
 
-def _build_file_search_skill() -> SkillMetadata:
+def _build_bash_skill() -> SkillMetadata:
     return SkillMetadata(
-        skill_id="file_search",
+        skill_id="bash",
         skill_type=SkillType.CUSTOM,
         inputs=[
             SkillInputSpec(
-                name="pattern",
+                name="command",
                 type_hint="str",
                 required=True,
-                description=(
-                    "Mode-dependent: regex (content) / glob (files) / "
-                    "shell command (shell)."
-                ),
+                description="Shell command line to execute.",
             ),
             SkillInputSpec(
-                name="mode",
-                type_hint="str",
-                required=False,
-                default="content",
-                description=(
-                    "Back-end to dispatch to: 'content' (grep), 'files' "
-                    "(glob), 'shell' (bash). Defaults to 'content'."
-                ),
-            ),
-            SkillInputSpec(
-                name="path",
-                type_hint="str",
-                required=False,
-                default=".",
-                description=(
-                    "Directory (or file, content mode) to search. "
-                    "Ignored in shell mode (use cwd)."
-                ),
-            ),
-            SkillInputSpec(
-                name="max_results",
+                name="timeout",
                 type_hint="int",
                 required=False,
-                default=_MAX_RESULTS_DEFAULT,
+                default=_BASH_TIMEOUT_MS_DEFAULT,
                 description=(
-                    "Hard cap on matches/paths returned "
-                    f"(content / files modes; default {_MAX_RESULTS_DEFAULT})."
+                    "Wall-clock milliseconds before kill "
+                    f"(default {_BASH_TIMEOUT_MS_DEFAULT})."
                 ),
             ),
             SkillInputSpec(
-                name="include",
+                name="description",
                 type_hint="str",
                 required=False,
                 default=None,
-                description=("Content mode: glob filter for file names (e.g. '*.py')."),
-            ),
-            SkillInputSpec(
-                name="case_sensitive",
-                type_hint="bool",
-                required=False,
-                default=False,
-                description="Content mode: case-sensitive matching.",
-            ),
-            SkillInputSpec(
-                name="use_regex",
-                type_hint="bool",
-                required=False,
-                default=True,
-                description=(
-                    "Content mode: treat pattern as regex (true) or "
-                    "literal string (false)."
-                ),
+                description="Short human-readable label for the command (optional).",
             ),
             SkillInputSpec(
                 name="cwd",
                 type_hint="str",
                 required=False,
                 default=None,
-                description="Shell mode: working directory for the command.",
-            ),
-            SkillInputSpec(
-                name="timeout",
-                type_hint="int",
-                required=False,
-                default=_BASH_TIMEOUT_DEFAULT,
-                description=(
-                    f"Shell mode: wall-clock seconds before kill "
-                    f"(default {_BASH_TIMEOUT_DEFAULT})."
-                ),
+                description="Working directory for the command (optional).",
             ),
         ],
         outputs=SkillOutputSpec(
             type_hint="str",
-            description=(
-                "Mode-dependent text: grep-style matches, sorted paths, "
-                "or shell stdout/stderr/exit code."
-            ),
+            description="Command, exit code, stdout, and stderr sections.",
         ),
-        executor_fn=_file_search,
+        executor_fn=_bash,
         async_capable=False,
         cacheable=False,
         cost=Cost.LOW,
         dependencies=[],
         resources=[],
-        defaults={
-            "mode": "content",
-            "path": ".",
-            "case_sensitive": False,
-            "use_regex": True,
-            "max_results": _MAX_RESULTS_DEFAULT,
-            "timeout": _BASH_TIMEOUT_DEFAULT,
-        },
-        skill_doc=_FILE_SEARCH_SKILL_DOC,
+        defaults={"timeout": _BASH_TIMEOUT_MS_DEFAULT},
+        skill_doc=_BASH_SKILL_DOC,
         description=(
-            "Multi-mode search: grep-style content (default), glob-style "
-            "filename enumeration, or shell command execution. One tool, "
-            "three modes via `mode` argument."
+            "Execute a shell command; returns exit code plus stdout/stderr. "
+            "Loose safety policy — sandbox untrusted input at the OS level."
         ),
     )
 
@@ -747,7 +860,12 @@ def get_default_skill_metadata() -> List[SkillMetadata]:
 
     Returns a new list on every call so callers can safely mutate it.
     """
-    return [_build_file_read_skill(), _build_file_search_skill()]
+    return [
+        _build_read_skill(),
+        _build_grep_skill(),
+        _build_glob_skill(),
+        _build_bash_skill(),
+    ]
 
 
 def ensure_defaults_registered(registry: SkillRegistry) -> None:
@@ -755,8 +873,8 @@ def ensure_defaults_registered(registry: SkillRegistry) -> None:
 
     Safe to call multiple times (idempotent): skips any skill already in the
     registry.  Called by :class:`~codeminer.agent.runner.AgentRunner` during
-    ``__init__`` so that the default tools (``file_read``, ``file_search``)
-    are available regardless of which ``Ax`` skill subset is loaded.
+    ``__init__`` so that the default tools (``read``, ``grep``, ``glob``,
+    ``bash``) are available regardless of which ``Ax`` skill subset is loaded.
     """
     for meta in get_default_skill_metadata():
         if not registry.has(meta.skill_id):

--- a/scripts/agent_compile/aggregate_phase2.py
+++ b/scripts/agent_compile/aggregate_phase2.py
@@ -43,12 +43,12 @@ A0_SUBSET = "A0"
 FULL_SUBSET = "A6"
 EASY_FILES_AT_5 = 0.5  # A0 mean-rep files@5 >= this => "easy" instance
 
-# Always-on default tool layer (file_read / file_search). These are unioned
+# Always-on default tool layer (read / grep / glob / bash). These are unioned
 # into every subset by AgentRunner, so they are NOT sweep variables: they must
 # never appear in a derived compile_table. They DO show in the invocation
 # histogram (tagged "always-on") so we can see how the agent uses them.
 # Kept as a literal to keep this script free of heavy agent imports.
-ALWAYS_ON_SKILLS = frozenset({"file_read", "file_search"})
+ALWAYS_ON_SKILLS = frozenset({"read", "grep", "glob", "bash"})
 
 
 # ---------------------------------------------------------------------------
@@ -430,7 +430,7 @@ def render_markdown(agg, table, rationale, front, ks) -> str:
     L.append("## Skill-invocation histogram")
     L.append("")
     L.append(
-        "`file_read` / `file_search` are the always-on default tool layer "
+        "`read` / `grep` / `glob` / `bash` are the always-on default tool layer "
         "(present in every subset, not swept)."
     )
     L.append("")

--- a/scripts/agent_compile/run_agent_sweep.py
+++ b/scripts/agent_compile/run_agent_sweep.py
@@ -49,11 +49,8 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from scripts.agent_compile.prebuilt import (  # noqa: E402
-    has_full_indexes,
-    repo_path_for,
-    stage_prebuilt_indexes,
-)
+from scripts.agent_compile.prebuilt import has_full_indexes  # noqa: E402
+from scripts.agent_compile.prebuilt import repo_path_for, stage_prebuilt_indexes
 
 # language_group (HF column) -> classify() language key
 _LANG_GROUP_TO_KEY = {
@@ -88,7 +85,7 @@ class SampleConfig:
     gt_simplified_symbols: bool = True
     include_default_tools: bool = True
     # LocAgent-style harness: restrict the always-on defaults to this subset
-    # (e.g. ["file_read"] → no grep). None = both file_read + file_search.
+    # (e.g. ["read"] → no grep). None = all of read + grep + glob + bash.
     default_tool_ids: Optional[List[str]] = None
     # Override the agent system prompt (e.g. a graph-primary prompt with no grep
     # guidance). None = runner's default localization prompt.
@@ -236,8 +233,8 @@ def _run_cell(
         )
         if isinstance(tc.result, list):
             nodes.extend(tc.result)
-        if tc.skill_id == "file_read" and not tc.error:
-            p = (tc.arguments or {}).get("path")
+        if tc.skill_id == "read" and not tc.error:
+            p = (tc.arguments or {}).get("file_path")
             if p:
                 file_read_paths.append(str(p))
 

--- a/test/agent/test_default_skills.py
+++ b/test/agent/test_default_skills.py
@@ -2,22 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for default tool primitives: file_read + file_search (issue #145).
+"""Tests for default tool primitives: read / grep / glob / bash.
 
-Two skills, both always-on:
+Four always-on tools, shaped after the mainstream Claude Code tool reference
+(one focused tool per concern instead of the old ``file_search`` multiplexer):
 
-- ``file_read`` — bounded reader with opencode-style line numbers.
-- ``file_search`` — multi-mode primitive dispatching to grep / glob /
-  bash back-ends via the ``mode`` argument (``content`` / ``files`` /
-  ``shell``).
+- ``read``  — bounded reader with opencode-style 1-based line numbers.
+- ``grep``  — regex content search (content / files_with_matches / count).
+- ``glob``  — filename enumeration.
+- ``bash``  — shell command execution.
 
 Test layout:
-- ``TestFileRead``                 — file_read happy path + token-bound edges.
-- ``TestRegexSearchContent``       — grep-style content search back-end.
-- ``TestRegexSearchFiles``         — glob-style filename enumeration back-end.
-- ``TestRegexSearchShell``         — shell-execution back-end.
-- ``TestRegexSearchDispatch``      — the public ``_file_search`` dispatcher.
-- ``TestGetDefaultSkillMetadata``  — registry-facing metadata.
+- ``TestRead``                     — read happy path + token-bound edges.
+- ``TestGrep``                     — content / files / count modes + filters.
+- ``TestGlob``                     — filename enumeration.
+- ``TestBash``                     — shell execution.
+- ``TestGetDefaultSkillMetadata``  — registry-facing metadata + enum schema.
 - ``TestEnsureDefaultsRegistered`` — idempotent registration.
 - ``TestAgentRunnerDefaults``      — defaults survive allow/exclude filters
                                      and dispatch end-to-end through the runner.
@@ -37,14 +37,14 @@ import pytest
 
 from codeminer.agent.runner import AgentRunner
 from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.agent.tool_schema import skill_to_tool_schema
 from codeminer.agent.tools.defaults import (
     _BASH_MAX_OUTPUT_CHARS,
     DEFAULT_SKILL_IDS,
-    _file_read,
-    _file_search,
-    _file_search_content,
-    _file_search_files,
-    _file_search_shell,
+    _bash,
+    _glob,
+    _grep,
+    _read,
     ensure_defaults_registered,
     get_default_skill_metadata,
 )
@@ -95,121 +95,137 @@ def sample_dir(tmp_path: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# file_read tests
+# read
 # ---------------------------------------------------------------------------
 
 
-class TestFileRead:
+class TestRead:
     def test_reads_full_file_with_opencode_line_format(self, sample_file):
         """All lines present, formatted as `{lineno:6d} | {content}`, 1-based."""
-        result = _file_read(str(sample_file))
+        result = _read(str(sample_file))
         assert "def add(a, b):" in result
         assert "class Calculator:" in result
         lines = result.splitlines()
-        # First line is line-1, formatted with the ' | ' delimiter.
         assert lines[0].lstrip().startswith("1 |")
         for line in lines:
             assert " | " in line, f"missing ' | ' in: {line!r}"
 
-    def test_start_and_end_line(self, sample_file):
-        result = _file_read(str(sample_file), start_line=4, end_line=5)
+    def test_offset_and_limit_window(self, sample_file):
+        result = _read(str(sample_file), offset=4, limit=2)
         lines = result.splitlines()
-        assert len(lines) == 2
+        # 2 content lines (limit=2); line 6 is blank so no truncation notice for
+        # this tiny file is asserted here — just the window contents.
         assert "subtract" in lines[0] and "4" in lines[0]
         assert "5" in lines[1]
 
-    def test_end_line_clamp_to_eof(self, sample_file):
-        result = _file_read(str(sample_file), end_line=9999)
-        assert "Calculator" in result
-
-    def test_max_lines_truncation_emits_next_start(self, sample_file):
-        result = _file_read(str(sample_file), start_line=1, max_lines=3)
+    def test_limit_truncation_emits_next_offset(self, sample_file):
+        result = _read(str(sample_file), offset=1, limit=3)
         lines = result.splitlines()
         # 3 content lines + 1 truncation notice
         assert len(lines) == 4
         assert "more lines" in lines[-1]
-        assert "start_line=4" in result
+        assert "offset=4" in result
 
     def test_missing_file_returns_error(self, tmp_path):
-        result = _file_read(str(tmp_path / "nonexistent.py"))
+        result = _read(str(tmp_path / "nonexistent.py"))
         assert result.startswith("Error:") and "not found" in result
+
+    def test_directory_returns_error(self, tmp_path):
+        result = _read(str(tmp_path))
+        assert result.startswith("Error:") and "directory" in result
 
     def test_empty_file(self, tmp_path):
         empty = tmp_path / "empty.py"
         empty.write_text("", encoding="utf-8")
-        assert "empty" in _file_read(str(empty)).lower()
+        assert "empty" in _read(str(empty)).lower()
 
-    def test_invalid_range_returns_error(self, sample_file):
-        """Both start>EOF and start>end report a clear error."""
-        assert _file_read(str(sample_file), start_line=9999).startswith("Error:")
-        assert _file_read(str(sample_file), start_line=10, end_line=5).startswith(
-            "Error:"
-        )
+    def test_offset_beyond_eof_returns_error(self, sample_file):
+        assert _read(str(sample_file), offset=9999).startswith("Error:")
 
 
 # ---------------------------------------------------------------------------
-# file_search — content mode (grep-style)
+# grep
 # ---------------------------------------------------------------------------
 
 
-class TestRegexSearchContent:
+class TestGrep:
     def test_basic_match_1_based(self, sample_dir):
-        result = _file_search_content("def foo", path=str(sample_dir))
+        result = _grep("def foo", path=str(sample_dir))
         assert "a.py:1:" in result and "def foo" in result
 
     def test_no_match_returns_message(self, sample_dir):
-        assert "No matches found" in _file_search_content(
-            "ZZZNOMATCH_XYZ", path=str(sample_dir)
-        )
+        assert "No matches found" in _grep("ZZZNOMATCH_XYZ", path=str(sample_dir))
 
-    def test_case_sensitive_flag(self, sample_dir):
-        """Default is case-insensitive; case_sensitive=True flips it."""
+    def test_case_insensitive_default_then_disabled(self, sample_dir):
+        """Default is case-insensitive; case_insensitive=False flips it."""
         (sample_dir / "cls.py").write_text("class Foo:\n    pass\n", encoding="utf-8")
-        assert "cls.py" in _file_search_content("CLASS", path=str(sample_dir))
-        assert "No matches found" in _file_search_content(
-            "CLASS", path=str(sample_dir), case_sensitive=True
+        assert "cls.py" in _grep("CLASS", path=str(sample_dir))
+        assert "No matches found" in _grep(
+            "CLASS", path=str(sample_dir), case_insensitive=False
         )
 
-    def test_literal_mode_escapes_regex_chars(self, sample_dir):
-        (sample_dir / "special.py").write_text(
-            "x = a.b()\ny = a.c()\n", encoding="utf-8"
-        )
-        result = _file_search_content("a.b()", path=str(sample_dir), use_regex=False)
-        assert "special.py" in result
-
-    def test_include_filter(self, sample_dir):
-        """include='*.py' filters out the .md file."""
-        result = _file_search_content("foo", path=str(sample_dir), include="*.py")
+    def test_glob_filter(self, sample_dir):
+        """glob='*.py' filters out the .md file."""
+        result = _grep("foo", path=str(sample_dir), glob="*.py")
         assert "readme.md" not in result
         assert "a.py" in result or "b.py" in result
 
-    def test_max_results_cap(self, sample_dir):
+    def test_type_filter(self, sample_dir):
+        """type='py' restricts to Python files by extension."""
+        result = _grep("foo", path=str(sample_dir), type="py")
+        assert "readme.md" not in result
+        assert "a.py" in result or "b.py" in result
+
+    def test_output_mode_files_with_matches(self, sample_dir):
+        result = _grep("foo", path=str(sample_dir), output_mode="files_with_matches")
+        lines = set(result.splitlines())
+        # File paths only — no "lineno:" content rows.
+        assert "a.py" in lines and "b.py" in lines
+        assert not any(line.count(":") >= 2 for line in lines)
+
+    def test_output_mode_count(self, sample_dir):
+        result = _grep("foo", path=str(sample_dir), output_mode="count")
+        # "{rel}:{count}" rows; a.py has one "foo" occurrence.
+        assert any(line.startswith("a.py:") for line in result.splitlines())
+
+    def test_multiline_spans_lines(self, tmp_path):
+        (tmp_path / "m.py").write_text("start\nmiddle\nend\n", encoding="utf-8")
+        result = _grep("start.*end", path=str(tmp_path), multiline=True)
+        assert "m.py:1:" in result
+        # Without multiline, the dot does not cross newlines → no match.
+        assert "No matches found" in _grep("start.*end", path=str(tmp_path))
+
+    def test_head_limit_cap(self, sample_dir):
         many = sample_dir / "many.py"
         many.write_text(
             "\n".join(f"match_{i} = 1" for i in range(100)), encoding="utf-8"
         )
-        result = _file_search_content("match_", path=str(sample_dir), max_results=5)
-        assert "max_results=5" in result
+        result = _grep("match_", path=str(sample_dir), head_limit=5)
+        assert "head_limit=5" in result
         hits = [line for line in result.splitlines() if "many.py" in line]
         assert len(hits) <= 5
 
     def test_invalid_regex_returns_error(self, sample_dir):
-        result = _file_search_content("[invalid", path=str(sample_dir))
+        result = _grep("[invalid", path=str(sample_dir))
         assert result.startswith("Error:") and "invalid regex" in result
 
+    def test_invalid_output_mode_returns_error(self, sample_dir):
+        result = _grep("x", path=str(sample_dir), output_mode="bogus")
+        assert result.startswith("Error:") and "output_mode" in result
+
     def test_nonexistent_path_returns_error(self, tmp_path):
-        result = _file_search_content("x", path=str(tmp_path / "missing"))
+        result = _grep("x", path=str(tmp_path / "missing"))
         assert result.startswith("Error:") and "does not exist" in result
 
 
 # ---------------------------------------------------------------------------
-# file_search — files mode (glob-style)
+# glob
 # ---------------------------------------------------------------------------
 
 
-class TestRegexSearchFiles:
+class TestGlob:
     def test_basic_glob_lists_matching_names(self, sample_dir):
-        result = _file_search_files("*.py", path=str(sample_dir))
+        result = _glob("*.py", path=str(sample_dir))
         names = set(result.splitlines())
         assert {"a.py", "b.py"}.issubset(names)
         assert "readme.md" not in names
@@ -219,85 +235,67 @@ class TestRegexSearchFiles:
         (tmp_path / "src" / "x.py").write_text("# x", encoding="utf-8")
         (tmp_path / "src" / "nested").mkdir()
         (tmp_path / "src" / "nested" / "y.py").write_text("# y", encoding="utf-8")
-        result = _file_search_files("**/*.py", path=str(tmp_path))
+        result = _glob("**/*.py", path=str(tmp_path))
         lines = set(result.splitlines())
         assert "src/x.py" in lines and "src/nested/y.py" in lines
 
     def test_no_match_returns_message(self, sample_dir):
-        result = _file_search_files("*.rs", path=str(sample_dir))
+        result = _glob("*.rs", path=str(sample_dir))
         assert result.startswith("No files match")
 
-    def test_max_results_cap(self, tmp_path):
-        for i in range(10):
+    def test_result_cap(self, tmp_path):
+        for i in range(120):
             (tmp_path / f"f{i}.py").write_text("x = 1\n", encoding="utf-8")
-        result = _file_search_files("*.py", path=str(tmp_path), max_results=3)
-        assert "max_results=3" in result
+        result = _glob("*.py", path=str(tmp_path))
+        assert "cap reached" in result
         names = [line for line in result.splitlines() if line.endswith(".py")]
-        assert len(names) <= 3
+        assert len(names) <= 100
 
     def test_nonexistent_root_returns_error(self, tmp_path):
-        result = _file_search_files("*.py", path=str(tmp_path / "missing"))
+        result = _glob("*.py", path=str(tmp_path / "missing"))
         assert result.startswith("Error:") and "does not exist" in result
 
 
 # ---------------------------------------------------------------------------
-# file_search — shell mode (bash-style)
+# bash
 # ---------------------------------------------------------------------------
 
 
-class TestRegexSearchShell:
+class TestBash:
     def test_basic_echo(self):
-        result = _file_search_shell("echo hello")
+        result = _bash("echo hello")
         assert "hello" in result and "exit code: 0" in result
 
     def test_stdout_and_stderr_sections(self):
-        result = _file_search_shell("echo out; echo err 1>&2")
+        result = _bash("echo out; echo err 1>&2")
         assert "--- stdout ---" in result and "out" in result
         assert "--- stderr ---" in result and "err" in result
 
     def test_non_zero_exit_and_command_not_found(self):
         """`false` → exit 1; unknown command → exit 127."""
-        assert "exit code: 1" in _file_search_shell("false")
-        not_found = _file_search_shell("nonexistent_cmd_xyz_zzz")
+        assert "exit code: 1" in _bash("false")
+        not_found = _bash("nonexistent_cmd_xyz_zzz")
         assert "exit code:" in not_found and "127" in not_found
 
-    def test_timeout_returns_error(self):
-        result = _file_search_shell("sleep 2", timeout=1)
+    def test_timeout_returns_error_ms(self):
+        """timeout is in milliseconds: 1000ms = 1s kills a 2s sleep."""
+        result = _bash("sleep 2", timeout=1000)
         assert result.startswith("Error:") and "timed out" in result
 
+    def test_description_accepted(self):
+        """The reference `description` metadata field is accepted and ignored."""
+        result = _bash("echo labelled", description="say hello")
+        assert "labelled" in result and "exit code: 0" in result
+
     def test_cwd_argument(self, tmp_path):
-        result = _file_search_shell("pwd", cwd=str(tmp_path))
+        result = _bash("pwd", cwd=str(tmp_path))
         # macOS may symlink /var → /private/var; check tail.
         assert str(tmp_path) in result or tmp_path.name in result
 
     def test_output_truncation(self):
-        result = _file_search_shell("yes hello | head -n 20000")
+        result = _bash("yes hello | head -n 20000")
         assert "(output truncated)" in result
         assert len(result) <= _BASH_MAX_OUTPUT_CHARS + 200
-
-
-# ---------------------------------------------------------------------------
-# file_search — dispatcher
-# ---------------------------------------------------------------------------
-
-
-class TestRegexSearchDispatch:
-    def test_mode_default_is_content(self, sample_dir):
-        """Calling without `mode` should grep file contents."""
-        result = _file_search("def foo", path=str(sample_dir))
-        assert "a.py:1:" in result
-
-    def test_files_mode_routes_to_glob(self, sample_dir):
-        result = _file_search("*.py", mode="files", path=str(sample_dir))
-        assert "a.py" in result.splitlines()
-
-    def test_shell_mode_runs_command(self):
-        result = _file_search("echo dispatched", mode="shell")
-        assert "dispatched" in result and "exit code: 0" in result
-
-    def test_invalid_mode_returns_error(self):
-        result = _file_search("x", mode="bogus")
-        assert result.startswith("Error:") and "invalid mode" in result
 
 
 # ---------------------------------------------------------------------------
@@ -306,22 +304,38 @@ class TestRegexSearchDispatch:
 
 
 class TestGetDefaultSkillMetadata:
-    def test_returns_exactly_two_defaults(self):
+    def test_returns_exactly_four_defaults(self):
         ids = {m.skill_id for m in get_default_skill_metadata()}
-        assert ids == DEFAULT_SKILL_IDS == {"file_read", "file_search"}
+        assert ids == set(DEFAULT_SKILL_IDS) == {"read", "grep", "glob", "bash"}
 
-    def test_file_read_requires_path(self):
-        meta = {m.skill_id: m for m in get_default_skill_metadata()}["file_read"]
+    def test_read_requires_file_path(self):
+        meta = {m.skill_id: m for m in get_default_skill_metadata()}["read"]
         required = {i.name for i in meta.inputs if i.required}
-        assert "path" in required
+        assert "file_path" in required
 
-    def test_file_search_requires_pattern_exposes_mode(self):
-        meta = {m.skill_id: m for m in get_default_skill_metadata()}["file_search"]
+    def test_grep_requires_pattern_exposes_output_mode_enum(self):
+        meta = {m.skill_id: m for m in get_default_skill_metadata()}["grep"]
         required = {i.name for i in meta.inputs if i.required}
-        all_inputs = {i.name for i in meta.inputs}
         assert "pattern" in required
-        # mode is optional but must appear in the schema for the LLM to use.
-        assert "mode" in all_inputs and "mode" not in required
+        # output_mode is optional and must carry an enum constraint in-schema.
+        schema = skill_to_tool_schema(meta)
+        props = schema["function"]["parameters"]["properties"]
+        assert "output_mode" in props
+        assert props["output_mode"].get("enum") == [
+            "content",
+            "files_with_matches",
+            "count",
+        ]
+
+    def test_glob_requires_pattern(self):
+        meta = {m.skill_id: m for m in get_default_skill_metadata()}["glob"]
+        required = {i.name for i in meta.inputs if i.required}
+        assert "pattern" in required
+
+    def test_bash_requires_command(self):
+        meta = {m.skill_id: m for m in get_default_skill_metadata()}["bash"]
+        required = {i.name for i in meta.inputs if i.required}
+        assert "command" in required
 
 
 # ---------------------------------------------------------------------------
@@ -340,9 +354,9 @@ class TestEnsureDefaultsRegistered:
         """Second call is a no-op and preserves the original executor_fn."""
         reg = SkillRegistry()
         ensure_defaults_registered(reg)
-        original_fn = reg.get("file_read").executor_fn
+        original_fn = reg.get("read").executor_fn
         ensure_defaults_registered(reg)  # would ValueError if not idempotent
-        assert reg.get("file_read").executor_fn is original_fn
+        assert reg.get("read").executor_fn is original_fn
 
 
 # ---------------------------------------------------------------------------
@@ -383,14 +397,14 @@ class TestAgentRunnerDefaults:
     def test_defaults_in_tools_on_empty_registry(self):
         runner = AgentRunner(_make_llm(), SkillRegistry())
         names = {t["function"]["name"] for t in runner.tools}
-        assert DEFAULT_SKILL_IDS.issubset(names)
+        assert set(DEFAULT_SKILL_IDS).issubset(names)
 
     def test_defaults_survive_exclude_skills(self):
         runner = AgentRunner(
             _make_llm(), SkillRegistry(), exclude_skills=set(DEFAULT_SKILL_IDS)
         )
         names = {t["function"]["name"] for t in runner.tools}
-        assert DEFAULT_SKILL_IDS.issubset(names)
+        assert set(DEFAULT_SKILL_IDS).issubset(names)
 
     def test_defaults_survive_allow_skills(self):
         """allow_skills with a disjoint set still surfaces the defaults."""
@@ -398,7 +412,7 @@ class TestAgentRunnerDefaults:
             _make_llm(), SkillRegistry(), allow_skills={"some_other_skill"}
         )
         names = {t["function"]["name"] for t in runner.tools}
-        assert DEFAULT_SKILL_IDS.issubset(names)
+        assert set(DEFAULT_SKILL_IDS).issubset(names)
 
     def test_non_default_skill_still_excluded(self):
         from codeminer.agent.skills.core import SkillMetadata, SkillType
@@ -414,19 +428,19 @@ class TestAgentRunnerDefaults:
         runner = AgentRunner(_make_llm(), reg, exclude_skills={"custom_tool"})
         names = {t["function"]["name"] for t in runner.tools}
         assert "custom_tool" not in names
-        assert DEFAULT_SKILL_IDS.issubset(names)
+        assert set(DEFAULT_SKILL_IDS).issubset(names)
 
-    def test_runner_executes_file_read(self, tmp_path):
-        """End-to-end: runner dispatches a file_read tool call."""
+    def test_runner_executes_read(self, tmp_path):
+        """End-to-end: runner dispatches a read tool call."""
         target = tmp_path / "hello.py"
         target.write_text("x = 1\ny = 2\n", encoding="utf-8")
 
         tc = SimpleNamespace(
-            id="tc_fr",
+            id="tc_read",
             type="function",
             function=SimpleNamespace(
-                name="file_read",
-                arguments=json.dumps({"path": str(target)}),
+                name="read",
+                arguments=json.dumps({"file_path": str(target)}),
             ),
         )
         llm = _make_llm()
@@ -438,16 +452,14 @@ class TestAgentRunnerDefaults:
         record = AgentRunner(llm, SkillRegistry()).run("Read it").tool_calls[0]
         assert record.error is None and "x = 1" in record.result
 
-    def test_runner_executes_file_search_shell_mode(self):
-        """End-to-end with the dispatcher: shell mode via mode argument."""
+    def test_runner_executes_bash(self):
+        """End-to-end: runner dispatches a bash tool call."""
         tc = SimpleNamespace(
-            id="tc_rs",
+            id="tc_bash",
             type="function",
             function=SimpleNamespace(
-                name="file_search",
-                arguments=json.dumps(
-                    {"pattern": "echo runner_dispatch", "mode": "shell"}
-                ),
+                name="bash",
+                arguments=json.dumps({"command": "echo runner_dispatch"}),
             ),
         )
         llm = _make_llm()
@@ -478,18 +490,18 @@ class TestSmokeRealFile:
         """
         return Path(sys.modules[AgentRunner.__module__].__file__)
 
-    def test_file_read_runner_py(self):
+    def test_read_runner_py(self):
         """Read the runner module itself, verify per-row line numbers appear."""
         source = self._runner_source_path()
         assert source.exists(), f"runner.py not found at {source}"
 
-        result = _file_read(str(source), start_line=1, end_line=10)
+        result = _read(str(source), offset=1, limit=10)
         lines = result.splitlines()
-        assert lines[0].lstrip().startswith("1 |") and len(lines) == 10
+        assert lines[0].lstrip().startswith("1 |") and len(lines) == 11
 
-    def test_file_search_for_agent_runner_in_runner_py(self):
-        """Default (content) mode regex-search for 'AgentRunner' in runner.py."""
+    def test_grep_for_agent_runner_in_runner_py(self):
+        """Content-mode regex-search for 'AgentRunner' in runner.py."""
         source = self._runner_source_path()
-        result = _file_search("AgentRunner", path=str(source))
+        result = _grep("AgentRunner", path=str(source))
         assert "AgentRunner" in result
         assert any(":" in line for line in result.splitlines())

--- a/test/agent/test_runner_allow_skills.py
+++ b/test/agent/test_runner_allow_skills.py
@@ -192,19 +192,20 @@ class TestAgentRunnerAllowSkills:
         assert not (set(DEFAULT_SKILL_IDS) & names)
 
     def test_default_tool_ids_subset_graph_primary(self, three_skill_registry):
-        """LocAgent-style harness: expose file_read but withhold file_search
-        (grep), so the structured tools carry navigation."""
+        """LocAgent-style harness: expose read but withhold grep/glob/bash,
+        so the structured tools carry navigation."""
         llm = MagicMock(spec=LiteLLMChat)
         runner = AgentRunner(
             llm,
             three_skill_registry,
             allow_skills={"a"},
             include_default_tools=True,
-            default_tool_ids={"file_read"},
+            default_tool_ids={"read"},
         )
         names = {t["function"]["name"] for t in runner.tools}
-        assert "file_read" in names
-        assert "file_search" not in names  # no grep escape hatch
+        assert "read" in names
+        assert "grep" not in names  # no grep escape hatch
+        assert "glob" not in names and "bash" not in names
         assert "a" in names  # swept skill still present
 
 

--- a/test/agent/test_runner_env_prompt.py
+++ b/test/agent/test_runner_env_prompt.py
@@ -61,5 +61,5 @@ def test_workflow_prompt_teaches_graph_and_files():
     runner = AgentRunner(llm, SkillRegistry())
     p = runner.system_prompt
     assert "find_callers" in p and "find_callees" in p  # graph navigation verbs
-    assert "file_search" in p and "file_read" in p
-    assert "file_search" in p and "file_read" in p
+    assert "grep" in p and "read" in p
+    assert "glob" in p and "bash" in p


### PR DESCRIPTION
## Summary

The always-on default tool layer bundled file reading and a multi-mode `file_search` (content/files/shell behind a `mode` argument) into two skills. The flat `file_search` schema exposed parameters that were silently ignored depending on the mode, giving the model no in-schema signal which apply when. This diverged from the mainstream [Claude Code tool reference](https://code.claude.com/docs/en/tools-reference), which splits the same surface into focused single-purpose tools.

This PR splits the defaults into four reference-shaped tools — `read` / `grep` / `glob` / `bash` — one concern each, each with a clean self-describing schema.

## Changes

- Rewrite `agent/tools/defaults.py` from `file_read` + multi-mode `file_search` into four tools:
  - `read(file_path, offset, limit)`
  - `grep(pattern, path, glob, type, output_mode, case_insensitive, multiline, head_limit)`
  - `glob(pattern, path)`
  - `bash(command, timeout, description, cwd)`
- Add an optional `enum` field to `SkillInputSpec` (`agent/skills/core.py`) and emit it as a JSON-Schema `enum` in `agent/tool_schema.py`, so `grep`'s `output_mode` advertises its valid values in-band rather than only in prose.
- Update the runner system prompt and the LLM-facing hint strings in `graph_expand` / `regex_search` / `_graphnav` to the new tool ids.
- Update the agent-compile sweep scripts (`ALWAYS_ON_SKILLS`, read-path extraction) to the new ids.
- Rewrite `test/agent/test_default_skills.py` and patch the allow-skills / env-prompt tests.

Names are lowercase to match the existing registry convention (`bm25_search`, `graph_expand`, …). Deviations from the upstream reference are forced by the `executor_fn(**json_args)` dispatch (flag names like `-i`/`-n` are not valid Python identifiers) and the lack of session infrastructure; all are documented in the module docstring (`-i` → `case_insensitive`, `run_in_background` dropped, `cwd` added, `bash` `timeout` in ms).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Full agent unit suite: **266 passed**. Full unit tier: **780 passed** (the 5 failures are pre-existing/environmental — git-clone/network for SWE-bench fixtures and the known fmtlib templated-header C++ chunker issue — and are unrelated to this change). black / isort / flake8 / REUSE pre-commit hooks all pass.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

Note: `read`/`grep`/`glob`/`bash` are lowercase to fit the registry convention. If TitleCase (`Read`/`Grep`/`Glob`/`Bash`) matching the docs verbatim is preferred, it's a one-line change to `DEFAULT_SKILL_IDS` plus the builders.
