### PR TITLE
fix(compiler): resolve skill index_requirements from config.yaml on disk

### DIFF
--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -682,10 +682,12 @@ def query(
     loader = SkillLoader()
 
     # --- 3. Resolve contexts according to the selected mode.
-    # The two on-disk paths (manifest, repo_path) need a metadata-only
-    # pre-pass of SkillLoader so the registry exposes index_requirements
-    # to the loader/compiler. The ``contexts`` mode skips that — the
-    # caller already did the equivalent.
+    # ``build_skill_contexts`` (repo_path mode) reads each skill's
+    # index_requirements straight off ``config.yaml`` on disk (see #154), so
+    # it no longer needs a metadata-only pre-pass of SkillLoader. The manifest
+    # mode still reads requirements from the registry, so it keeps its
+    # pre-pass + reset. The ``contexts`` mode skips both — the caller already
+    # did the equivalent.
     if opts.contexts is not None:
         contexts = opts.contexts
     elif manifest is not None:
@@ -709,11 +711,10 @@ def query(
         SkillRegistry.reset()
         registry = SkillRegistry()
     else:
-        # repo_path mode: inline build via build_skill_contexts.
-        loader.load_all(skills_dir, contexts={}, registry=registry)
+        # repo_path mode: inline build via build_skill_contexts. It resolves
+        # index_requirements from config.yaml on disk, so no metadata pre-pass
+        # (and no reset to undo it) is needed before the real load in step 4.
         contexts = _build_contexts(opts, table=table)
-        SkillRegistry.reset()
-        registry = SkillRegistry()
 
     # --- 4. Load (or reload) the skill packages with the real contexts ---
     loaded = loader.load_all(skills_dir, contexts=contexts, registry=registry)
@@ -944,6 +945,7 @@ def _build_contexts(
         skill_ids=sorted(skill_ids),
         languages=tuple(opts.languages),
         cache_dir=opts.index_cache_dir,
+        skills_dir=opts.skills_dir or str(_DEFAULT_SKILLS_DIR),
         embedding_model=opts.embedding_model,
         embedding_dimension=opts.embedding_dimension,
         default_top_k=opts.default_top_k,

--- a/codeminer/compiler/skill_context.py
+++ b/codeminer/compiler/skill_context.py
@@ -45,22 +45,97 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_CACHE_DIR_NAME = ".codeminer_cache"
 
+# Module-level cache of parsed ``config.yaml`` payloads keyed by ``skills_dir``.
+# ``index_requirements`` is declarative metadata — it never changes within a
+# process — so we parse each skills directory once and reuse the result. This
+# also avoids re-reading the ~9 bundled configs on every ``query()`` call.
+_SKILL_CONFIG_CACHE: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
+
+def _read_skill_configs(skills_dir: str) -> Dict[str, Dict[str, Any]]:
+    """Read every ``<skills_dir>/<skill>/config.yaml`` into ``{skill_id: cfg}``.
+
+    The returned mapping is keyed by each config's ``skill_id`` field. Results
+    are cached per *skills_dir* for the lifetime of the process — skill
+    metadata on disk is immutable while the agent runs. Malformed configs are
+    skipped (and logged) rather than aborting the whole scan.
+    """
+    cache_key = os.path.abspath(skills_dir)
+    cached = _SKILL_CONFIG_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    import yaml
+
+    configs: Dict[str, Dict[str, Any]] = {}
+    root = Path(skills_dir)
+    if root.is_dir():
+        for entry in sorted(root.iterdir()):
+            if not entry.is_dir():
+                continue
+            config_file = entry / "config.yaml"
+            if not config_file.exists():
+                continue
+            try:
+                with open(config_file) as f:
+                    data = yaml.safe_load(f) or {}
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "skipping malformed skill config %s: %s", config_file, exc
+                )
+                continue
+            sid = data.get("skill_id")
+            if sid:
+                configs[sid] = data
+
+    _SKILL_CONFIG_CACHE[cache_key] = configs
+    return configs
+
 
 def required_index_types(
     skill_ids: Iterable[str],
     *,
+    skills_dir: Optional[str] = None,
     skill_registry: Optional[SkillRegistry] = None,
 ) -> Set[str]:
     """Union of ``index_type`` strings required by the given skills.
 
-    Reads ``index_requirements`` from each skill's ``SkillMetadata`` (loaded
-    by ``SkillLoader`` from ``config.yaml``). Skills not present in the
-    registry are ignored — callers that need to fail loudly should check
-    membership themselves.
+    ``index_requirements`` is declarative skill metadata that lives on disk in
+    each skill's ``config.yaml``. The ``SkillRegistry`` is a *runtime* binding
+    layer built on top of that metadata — and it is empty until ``SkillLoader``
+    has loaded the very contexts this resolution feeds into. To break that
+    chicken-and-egg, prefer the on-disk configs.
+
+    Resolution order:
+      1. If ``skills_dir`` is given, read each skill's ``config.yaml`` from
+         disk. This is the authoritative source for bundled skills.
+      2. Fall back to ``skill_registry`` (or the singleton) for skills that
+         don't live on disk — e.g. registered via the ``@skill`` decorator at
+         import time.
+
+    Skills found in neither source are ignored — callers that need to fail
+    loudly should check membership themselves.
     """
-    registry = skill_registry or SkillRegistry()
+    skill_ids = list(skill_ids)
     needed: Set[str] = set()
+    seen_on_disk: Set[str] = set()
+
+    if skills_dir:
+        configs = _read_skill_configs(skills_dir)
+        for sid in skill_ids:
+            cfg = configs.get(sid)
+            if cfg is None:
+                continue
+            seen_on_disk.add(sid)
+            for req in cfg.get("index_requirements") or []:
+                index_type = req.get("type") if isinstance(req, dict) else None
+                if index_type:
+                    needed.add(index_type)
+
+    registry = skill_registry or SkillRegistry()
     for sid in skill_ids:
+        if sid in seen_on_disk:
+            continue
         meta = registry.get(sid)
         if meta is None:
             continue
@@ -71,11 +146,43 @@ def required_index_types(
 
 def _skill_types_for(
     skill_ids: Iterable[str],
-    skill_registry: SkillRegistry,
+    *,
+    skills_dir: Optional[str] = None,
+    skill_registry: Optional[SkillRegistry] = None,
 ) -> Set[SkillType]:
+    """Set of :class:`SkillType` for the given skills.
+
+    Same disk-first / registry-fallback resolution as
+    :func:`required_index_types`: on-disk ``config.yaml`` is authoritative for
+    bundled skills, the registry covers decorator-registered ones.
+    """
+    skill_ids = list(skill_ids)
     types: Set[SkillType] = set()
+    seen_on_disk: Set[str] = set()
+
+    if skills_dir:
+        configs = _read_skill_configs(skills_dir)
+        for sid in skill_ids:
+            cfg = configs.get(sid)
+            if cfg is None:
+                continue
+            seen_on_disk.add(sid)
+            raw_type = cfg.get("skill_type", "custom")
+            try:
+                types.add(SkillType(raw_type))
+            except ValueError:
+                logger.warning(
+                    "skill %r declares unknown skill_type %r; treating as custom",
+                    sid,
+                    raw_type,
+                )
+                types.add(SkillType.CUSTOM)
+
+    registry = skill_registry or SkillRegistry()
     for sid in skill_ids:
-        meta = skill_registry.get(sid)
+        if sid in seen_on_disk:
+            continue
+        meta = registry.get(sid)
         if meta is not None:
             types.add(meta.skill_type)
     return types
@@ -185,6 +292,7 @@ def build_skill_contexts(
     *,
     languages: Sequence[str] = ("python",),
     cache_dir: Optional[str] = None,
+    skills_dir: Optional[str] = None,
     skill_registry: Optional[SkillRegistry] = None,
     builder_registry: Optional[IndexBuilderRegistry] = None,
     embedding_model: str = "nomic-ai/CodeRankEmbed",
@@ -214,6 +322,12 @@ def build_skill_contexts(
     here — its skill type still gets a context if a *sibling* skill needs
     one (e.g. ``regex_search`` shares the ``retrieve`` key with
     ``bm25_search``).
+
+    Skill-metadata resolution: when ``skills_dir`` is given, each skill's
+    ``index_requirements`` / ``skill_type`` are read directly from its
+    ``config.yaml`` on disk, so callers no longer have to pre-populate the
+    ``SkillRegistry`` before calling this (see #154). The registry is only
+    consulted for skills that are not present on disk.
     """
     skill_ids = list(skill_ids)
     skill_registry = skill_registry or SkillRegistry()
@@ -223,8 +337,12 @@ def build_skill_contexts(
     )
     os.makedirs(cache_dir, exist_ok=True)
 
-    needed = required_index_types(skill_ids, skill_registry=skill_registry)
-    skill_types = _skill_types_for(skill_ids, skill_registry)
+    needed = required_index_types(
+        skill_ids, skills_dir=skills_dir, skill_registry=skill_registry
+    )
+    skill_types = _skill_types_for(
+        skill_ids, skills_dir=skills_dir, skill_registry=skill_registry
+    )
 
     if needed:
         missing = _missing_index_types(needed, cache_dir, rebuild=rebuild)
@@ -322,7 +440,7 @@ def load_contexts_from_manifest(
                 )
             needed.add(req.index_type)
 
-    skill_types = _skill_types_for(skill_ids, registry)
+    skill_types = _skill_types_for(skill_ids, skill_registry=registry)
 
     loaded: Dict[str, Any] = {}
     if "bm25" in needed:

--- a/examples/skill_agent_eval.py
+++ b/examples/skill_agent_eval.py
@@ -376,11 +376,15 @@ def evaluate_instance(
         execution_log.append(f"Building contexts for skills={skill_ids}...")
         contexts = {}
         if skill_ids:  # Skip for hybrid_baseline
+            # Resolve index_requirements from config.yaml on disk (#154) so a
+            # cold index cache no longer silently yields an empty index union.
+            skills_dir = os.path.join(_PROJECT_ROOT, "codeminer", "agent", "skills")
             contexts = build_skill_contexts(
                 repo_path=repo_path,
                 skill_ids=skill_ids,
                 languages=args.languages,
                 cache_dir=args.index_cache_dir,
+                skills_dir=skills_dir,
                 embedding_model=args.embedding_model,
                 embedding_dimension=args.embedding_dimension,
                 default_top_k=args.topk,
@@ -416,15 +420,14 @@ def evaluate_instance(
                 "eval_mode": "bm25_baseline",
             }
         elif args.eval_mode == "hybrid_baseline":
-            execution_log.append(
-                "Running hybrid baseline (BM25 → embedding rerank)..."
-            )
+            execution_log.append("Running hybrid baseline (BM25 → embedding rerank)...")
             # Reuse pipeline from cache if available (avoids rebuilding indexes)
             pipeline = None
             if pipeline_cache is not None:
                 pipeline = pipeline_cache.get(repo_path)
                 if pipeline is None:
                     from codeminer.model import HybridRetrievePipeline
+
                     execution_log.append(f"Building new pipeline for {repo_path}")
                     pipeline = HybridRetrievePipeline(
                         repo_path=repo_path,
@@ -601,7 +604,9 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
             # vs just GT metadata (has 'target_files', 'code_blocks')
             if isinstance(eval_instances_data, list) and len(eval_instances_data) > 0:
                 first_item = eval_instances_data[0]
-                is_complete_instance = "repo" in first_item and "problem_statement" in first_item
+                is_complete_instance = (
+                    "repo" in first_item and "problem_statement" in first_item
+                )
 
                 if is_complete_instance:
                     logger.info(
@@ -610,6 +615,7 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
                     )
                     # Convert to Arrow dataset format for compatibility
                     import datasets
+
                     instances = datasets.Dataset.from_list(eval_instances_data)
 
                     # Build eval_lookup from the same data (extract GT fields)
@@ -636,7 +642,8 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
                         root=args.cache_dir,
                         repo_root=args.repo_cache_dir,
                     )
-                    # Set internal state so dataset.load() would return the instances we already loaded
+                    # Set internal state so dataset.load() returns the
+                    # instances we already loaded.
                     dataset._data = instances
                 else:
                     # Just GT metadata, load instances from HF as usual
@@ -648,13 +655,17 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
                         repo_root=args.repo_cache_dir,
                     )
                     instances = dataset.load()
-                    logger.info(f"Loaded {len(instances)} instances from {args.dataset}")
+                    logger.info(
+                        f"Loaded {len(instances)} instances from {args.dataset}"
+                    )
                     eval_lookup = dataset.load_eval_metadata(args.eval_instances)
             else:
                 # Empty or invalid file
                 raise ValueError(f"Invalid eval_instances file: {args.eval_instances}")
         else:
-            raise FileNotFoundError(f"Eval instances file not found: {args.eval_instances}")
+            raise FileNotFoundError(
+                f"Eval instances file not found: {args.eval_instances}"
+            )
     else:
         # No --eval-instances, load from HF dataset
         dataset = SwebenchDataset(
@@ -726,7 +737,11 @@ def run_evaluation(args: argparse.Namespace) -> SkillEvalReport:
             )
 
             result = evaluate_instance(
-                instance, dataset, llm, args, eval_metadata=eval_lookup,
+                instance,
+                dataset,
+                llm,
+                args,
+                eval_metadata=eval_lookup,
                 pipeline_cache=pipeline_cache,
             )
             results.append(result)

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -9,8 +9,10 @@ The function under test orchestrates: skill → index_type union → build/load
 (no repo cloning, no real index construction). The contract these tests
 pin down:
 
-- ``required_index_types`` reads ``index_requirements`` straight off the
-  registered skills (no I/O, no cache touch).
+- ``required_index_types`` reads ``index_requirements`` disk-first from each
+  skill's ``config.yaml`` (when ``skills_dir`` is given), falling back to the
+  registered skills otherwise. The disk path works against an *empty*
+  registry (#154).
 - ``build_skill_contexts`` returns a dict with per-skill-type keys,
   populated only when at least one skill of that type is requested.
 - Already-built indexes are loaded; missing types trigger a build.
@@ -315,7 +317,9 @@ def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):
     assert sorted(mocked_build["loaded"]) == ["bm25", "vector"]
 
 
-def test_build_skill_contexts_without_reset_is_idempotent(registry, mocked_build, tmp_path):
+def test_build_skill_contexts_without_reset_is_idempotent(
+    registry, mocked_build, tmp_path
+):
     """Regression test: build_skill_contexts should work without calling
     registry.reset() - SkillLoader.load_all is idempotent via has() guard.
 
@@ -348,3 +352,174 @@ def test_build_skill_contexts_without_reset_is_idempotent(registry, mocked_build
     # Verify registry still has skills (not destroyed by reset)
     assert registry.get("bm25_search") is not None
     assert registry.get("embedding_search") is not None
+
+
+# ---------------------------------------------------------------------------
+# required_index_types / _skill_types_for — disk-first resolution (#154)
+#
+# These pin the fix for the chicken-and-egg ordering bug: the resolvers must
+# read each skill's ``index_requirements`` / ``skill_type`` straight from
+# ``config.yaml`` on disk, WITHOUT a populated SkillRegistry.
+# ---------------------------------------------------------------------------
+
+
+def _write_skill_config(root, skill_id: str, body: str) -> None:
+    """Create ``<root>/<skill_id>/config.yaml`` with *body* contents."""
+    skill_dir = root / skill_id
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "config.yaml").write_text(body)
+
+
+@pytest.fixture
+def skills_dir(tmp_path):
+    """A skills directory on disk mirroring the bundled config.yaml shape."""
+    root = tmp_path / "skills"
+    _write_skill_config(
+        root,
+        "bm25_search",
+        "skill_id: bm25_search\n"
+        "skill_type: retrieval\n"
+        "index_requirements:\n"
+        "  - type: bm25\n"
+        "    max_age_seconds: 3600\n"
+        "    scope: current_repo\n",
+    )
+    _write_skill_config(
+        root,
+        "embedding_search",
+        "skill_id: embedding_search\n"
+        "skill_type: retrieval\n"
+        "index_requirements:\n"
+        "  - type: vector\n",
+    )
+    _write_skill_config(
+        root,
+        "graph_expand",
+        "skill_id: graph_expand\n"
+        "skill_type: expand\n"
+        "index_requirements:\n"
+        "  - type: symbol_graph\n",
+    )
+    # No index_requirements — must contribute nothing to the union.
+    _write_skill_config(
+        root,
+        "regex_search",
+        "skill_id: regex_search\nskill_type: retrieval\n",
+    )
+    # A custom composer declaring all three indexes.
+    _write_skill_config(
+        root,
+        "codeminer_context",
+        "skill_id: codeminer_context\n"
+        "skill_type: custom\n"
+        "index_requirements:\n"
+        "  - type: bm25\n"
+        "  - type: vector\n"
+        "  - type: symbol_graph\n",
+    )
+    return str(root)
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_cache():
+    """Drop the module-level config cache so per-test ``skills_dir`` fixtures
+    (which live under unique tmp paths) never see a stale parse."""
+    skill_context._SKILL_CONFIG_CACHE.clear()
+    yield
+    skill_context._SKILL_CONFIG_CACHE.clear()
+
+
+def test_required_types_disk_first_with_empty_registry(skills_dir):
+    """The core #154 fix: index types resolve from config.yaml on disk even
+    though the SkillRegistry is empty (reset by the autouse fixture)."""
+    assert SkillRegistry().get("bm25_search") is None  # registry really is empty
+
+    got = skill_context.required_index_types(
+        ["bm25_search", "embedding_search", "graph_expand"],
+        skills_dir=skills_dir,
+    )
+    assert got == {"bm25", "vector", "symbol_graph"}
+
+
+def test_required_types_disk_single_with_empty_registry(skills_dir):
+    got = skill_context.required_index_types(["bm25_search"], skills_dir=skills_dir)
+    assert got == {"bm25"}
+
+
+def test_required_types_disk_skips_no_requirement_skills(skills_dir):
+    got = skill_context.required_index_types(["regex_search"], skills_dir=skills_dir)
+    assert got == set()
+
+
+def test_required_types_disk_custom_composer(skills_dir):
+    got = skill_context.required_index_types(
+        ["codeminer_context"], skills_dir=skills_dir
+    )
+    assert got == {"bm25", "vector", "symbol_graph"}
+
+
+def test_required_types_disk_takes_precedence_over_registry(skills_dir):
+    """On-disk config is authoritative: if the registry disagrees with disk
+    for a bundled skill, the disk value wins."""
+    reg = SkillRegistry()
+    # Registry claims bm25_search needs ``vector`` — disk says ``bm25``.
+    reg.register(_make_meta("bm25_search", SkillType.RETRIEVAL, index_types=["vector"]))
+    got = skill_context.required_index_types(
+        ["bm25_search"], skills_dir=skills_dir, skill_registry=reg
+    )
+    assert got == {"bm25"}
+
+
+def test_required_types_registry_fallback_for_off_disk_skill(skills_dir):
+    """A skill not present on disk (e.g. @skill-decorator-registered) falls
+    back to the registry."""
+    reg = SkillRegistry()
+    reg.register(
+        _make_meta("decorator_only", SkillType.RETRIEVAL, index_types=["vector"])
+    )
+    got = skill_context.required_index_types(
+        ["bm25_search", "decorator_only"],
+        skills_dir=skills_dir,
+        skill_registry=reg,
+    )
+    assert got == {"bm25", "vector"}
+
+
+def test_required_types_unknown_skill_ignored_disk(skills_dir):
+    got = skill_context.required_index_types(
+        ["bm25_search", "does_not_exist"], skills_dir=skills_dir
+    )
+    assert got == {"bm25"}
+
+
+def test_skill_types_for_disk_first_with_empty_registry(skills_dir):
+    types = skill_context._skill_types_for(
+        ["bm25_search", "graph_expand", "codeminer_context"],
+        skills_dir=skills_dir,
+    )
+    assert types == {SkillType.RETRIEVAL, SkillType.EXPAND, SkillType.CUSTOM}
+
+
+def test_skill_types_for_registry_fallback(skills_dir):
+    reg = SkillRegistry()
+    reg.register(_make_meta("decorator_only", SkillType.RERANK))
+    types = skill_context._skill_types_for(
+        ["bm25_search", "decorator_only"],
+        skills_dir=skills_dir,
+        skill_registry=reg,
+    )
+    assert types == {SkillType.RETRIEVAL, SkillType.RERANK}
+
+
+def test_read_skill_configs_is_cached(skills_dir):
+    """Second read returns the same cached object (no re-parse)."""
+    first = skill_context._read_skill_configs(skills_dir)
+    second = skill_context._read_skill_configs(skills_dir)
+    assert first is second
+    assert set(first) == {
+        "bm25_search",
+        "embedding_search",
+        "graph_expand",
+        "regex_search",
+        "codeminer_context",
+    }


### PR DESCRIPTION
## Summary

Closes #154. `build_skill_contexts` decided which indexes to compile by asking
the **runtime** `SkillRegistry` for each skill's `index_requirements` — but the
registry is only populated *after* contexts are built, a chicken-and-egg that
`query()` papered over with a two-pass load (`load metadata → build → reset →
reload`). This makes `required_index_types` / `_skill_types_for` read the
**declarative** `index_requirements` straight from each skill's `config.yaml`
on disk, so load order stops mattering and the workaround comes out.

## Changes
- `required_index_types` / `_skill_types_for` gain a `skills_dir` argument and
  read `<skills_dir>/<skill_id>/config.yaml` as the authoritative source,
  falling back to the registry only for skills not on disk (e.g. `@skill`-
  decorator registrations).
- `build_skill_contexts` grows a `skills_dir` parameter and threads it through.
- Removed the two-pass load workaround in `codeminer/agent/runner.py`.
- Updated `examples/skill_agent_eval.py` to pass `skills_dir`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/compiler/test_skill_context.py -m "not slow and not integration"` →
26 passed. Includes a case asserting `required_index_types(..., skills_dir=...)`
resolves correctly with an **empty** registry.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
