### PR TITLE
feat(eval): experiment runner — model dispatch + per-axis aggregation

### DIFF
--- a/examples/experiment_runner.py
+++ b/examples/experiment_runner.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experiment runner: ``(model, skill_subset, instance, rep_count)`` -> metric row.
+
+The unified Phase 0 / Phase 2 driver for the Agent Router RFC (#133, sub-issue
+#148). ``examples/skill_agent_eval.py`` already runs ``AgentRunner`` over an
+arbitrary skill subset with a ``UsageTracker`` that keeps *prompt* and
+*completion* tokens separate. This module adds the three pieces that were
+missing:
+
+1. **Multi-model dispatch** -- :data:`MODEL_REGISTRY` maps short, stable names
+   (``haiku``, ``opus``, ``gpt``, ``gemini``, ``qwen-32b``, ``qwen-14b``) to
+   litellm model strings, so a sweep cell can say ``--model haiku`` instead of
+   hardcoding a provider path. :func:`resolve_model` also accepts a raw
+   litellm string (anything containing ``/`` or starting with a known prefix)
+   and passes it through untouched.
+
+2. **Aggregation per metric axis** (per #133 v2 Table 4):
+
+   * *accuracy* -- **mean-of-3** across repetitions (or 1 run at ``temp=0``).
+   * *cost / latency / turns* -- **min-of-3**: the noise on these axes is
+     one-sided (a slow/expensive run can only ever add overhead), so the
+     minimum across reps approximates the noise floor.
+
+   ``rep_count`` is configurable; with ``rep_count == 1`` mean and min both
+   collapse to the single observed value.
+
+3. **Logging schema** -- :class:`MetricRow` reports ``prompt_tokens`` and
+   ``completion_tokens`` **separately** (the RFC's core motivation: a router
+   that trades completion tokens for prompt tokens is invisible if the two are
+   collapsed), the derived ``cost_per_resolved_instance``, ``wall_time`` P50 /
+   P95, ``turn_count``, and a ``cap_hit`` boolean (did the run exhaust
+   ``max_turns``?).
+
+This module deliberately stays small and dependency-light: the aggregation and
+schema logic are pure functions of per-rep records, unit-tested without any LLM
+call. The real ``(model, subset, instance)`` execution path reuses
+``skill_agent_eval.evaluate_instance`` and is exercised only under the ``slow``
+marker.
+
+Out of scope (per #148): the CAR runtime and the third-party baseline harness.
+CAR is just one more ``subset`` value once it lands; the baseline harness is a
+separate sub-issue.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+# ---------------------------------------------------------------------------
+# 1. Multi-model dispatch
+# ---------------------------------------------------------------------------
+
+# Short, stable experiment names -> litellm model strings. The values follow
+# the provider conventions already used across the repo (``vertex_ai/...`` for
+# Anthropic + Gemini on Vertex, ``openai/...`` for OpenAI, an ``openai/``-shaped
+# path against a local vLLM ``--api-base`` for the open Qwen weights). Override
+# any single entry via :func:`resolve_model`'s ``overrides`` argument or extend
+# the dict for a new provider -- the harness never assumes a single model.
+MODEL_REGISTRY: Dict[str, str] = {
+    "haiku": "vertex_ai/claude-haiku-4-5",
+    "opus": "vertex_ai/claude-opus-4-1",
+    "gpt": "openai/gpt-5.5",
+    "gemini": "vertex_ai/gemini-3-pro",
+    "qwen-32b": "openai/Qwen/Qwen2.5-Coder-32B-Instruct",
+    "qwen-14b": "openai/Qwen/Qwen2.5-Coder-14B-Instruct",
+}
+
+# litellm provider prefixes that mark a value as already being a fully-qualified
+# model string (so it is passed through verbatim rather than treated as a short
+# name to look up).
+_LITELLM_PREFIXES = (
+    "vertex_ai/",
+    "openai/",
+    "anthropic/",
+    "gemini/",
+    "azure/",
+    "bedrock/",
+    "hosted_vllm/",
+    "ollama/",
+)
+
+
+def resolve_model(
+    model: str,
+    overrides: Optional[Dict[str, str]] = None,
+) -> str:
+    """Resolve a short experiment name to a litellm model string.
+
+    A value that already looks like a litellm model string (contains ``/`` or
+    starts with a known provider prefix) is returned unchanged, so callers can
+    pass either ``"haiku"`` or ``"vertex_ai/claude-haiku-4-5"``.
+
+    Args:
+        model: Short registry key (``haiku`` / ``opus`` / ...) or a raw
+            litellm model string.
+        overrides: Optional per-call overrides layered on top of
+            :data:`MODEL_REGISTRY` (e.g. to point ``qwen-32b`` at a specific
+            local deployment without mutating the module-level dict).
+
+    Returns:
+        A litellm-ready model string.
+
+    Raises:
+        KeyError: If ``model`` is neither a known short name nor a recognizable
+            litellm string.
+    """
+    table = dict(MODEL_REGISTRY)
+    if overrides:
+        table.update(overrides)
+
+    if model in table:
+        return table[model]
+
+    # Already a fully-qualified litellm string -> pass through.
+    if "/" in model or model.startswith(_LITELLM_PREFIXES):
+        return model
+
+    raise KeyError(
+        f"Unknown model {model!r}. Known short names: {sorted(table)}; "
+        "or pass a litellm model string (e.g. 'vertex_ai/claude-haiku-4-5')."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Per-rep record + aggregation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RepResult:
+    """One repetition of ``(model, subset, instance)``.
+
+    The raw, *per-run* observation that aggregation reduces over. ``resolved``
+    is the binary outcome whose mean across reps is the accuracy axis;
+    everything else is a cost/latency/turn observation whose minimum across reps
+    approximates the floor.
+    """
+
+    resolved: bool
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost_usd: Optional[float] = None
+    wall_time_s: float = 0.0
+    turn_count: int = 0
+    cap_hit: bool = False
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+def _mean(values: Sequence[float]) -> float:
+    return statistics.fmean(values) if values else 0.0
+
+
+def _min(values: Sequence[float]) -> float:
+    return min(values) if values else 0.0
+
+
+def _percentile(values: Sequence[float], pct: float) -> float:
+    """Linear-interpolated percentile (``pct`` in ``[0, 100]``).
+
+    NumPy-free so the harness's pure-logic layer carries no heavy import. For a
+    single observation, returns that observation; matches ``numpy.percentile``
+    on the tested fixtures.
+    """
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return float(ordered[lo] + (ordered[hi] - ordered[lo]) * frac)
+
+
+# ---------------------------------------------------------------------------
+# 3. Logging schema
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MetricRow:
+    """One logged row for a ``(model, subset, instance)`` cell.
+
+    Token counts stay split (``prompt_tokens`` vs ``completion_tokens``) -- the
+    RFC's whole point is that a good router shifts work between the two, which a
+    collapsed ``total`` would hide. Accuracy is mean-of-rep; cost / latency /
+    turns are min-of-rep; ``cap_hit_rate`` is the fraction of reps that
+    exhausted ``max_turns``.
+    """
+
+    model: str
+    model_resolved: str
+    skill_subset: List[str]
+    instance_id: str
+    rep_count: int
+
+    # accuracy axis: mean across reps
+    accuracy: float = 0.0
+
+    # cost / latency / turn axes: min across reps (noise floor)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost_usd: Optional[float] = None
+
+    # derived: cost amortized over resolved instances (inf when none resolved)
+    cost_per_resolved_instance: Optional[float] = None
+
+    # wall-time distribution across reps
+    wall_time_p50: float = 0.0
+    wall_time_p95: float = 0.0
+
+    turn_count: int = 0
+    cap_hit: bool = False
+    cap_hit_rate: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def aggregate_reps(
+    *,
+    model: str,
+    skill_subset: Sequence[str],
+    instance_id: str,
+    reps: Sequence[RepResult],
+    model_resolved: Optional[str] = None,
+) -> MetricRow:
+    """Reduce per-rep records into a single :class:`MetricRow`.
+
+    Aggregation rule (per #133 v2 Table 4):
+
+    * **accuracy** = mean of ``resolved`` over reps.
+    * **cost / latency / turns** = min over reps (one-sided noise -> the min
+      approximates the floor of the distribution).
+    * **wall_time** keeps the P50 / P95 of the per-rep wall times so the tail is
+      visible even though the headline latency is the min.
+    * **cost_per_resolved_instance** divides the (min) cost by the number of
+      resolved reps; ``None`` when cost is unpriced, and ``inf`` when the cell
+      resolved nothing (so a never-solving cell is not silently free).
+
+    Args:
+        model: The experiment-level model name (short or litellm string).
+        skill_subset: The skill allowlist this cell ran with.
+        instance_id: SWE-bench instance identifier.
+        reps: One or more :class:`RepResult`. With a single rep, mean and min
+            both collapse to that rep's value.
+        model_resolved: Optional already-resolved litellm string (defaults to
+            :func:`resolve_model` applied to ``model``).
+
+    Returns:
+        A populated :class:`MetricRow`.
+
+    Raises:
+        ValueError: If ``reps`` is empty.
+    """
+    if not reps:
+        raise ValueError("aggregate_reps requires at least one RepResult")
+
+    rep_count = len(reps)
+
+    # accuracy: mean-of-N
+    accuracy = _mean([1.0 if r.resolved else 0.0 for r in reps])
+
+    # cost / latency / turns: min-of-N (noise floor)
+    min_prompt = int(_min([r.prompt_tokens for r in reps]))
+    min_completion = int(_min([r.completion_tokens for r in reps]))
+    min_total = int(_min([r.total_tokens for r in reps]))
+    min_turns = int(_min([r.turn_count for r in reps]))
+
+    costed = [r.cost_usd for r in reps if r.cost_usd is not None]
+    min_cost: Optional[float] = min(costed) if costed else None
+
+    # wall-time distribution
+    wall_times = [r.wall_time_s for r in reps]
+    wt_p50 = _percentile(wall_times, 50.0)
+    wt_p95 = _percentile(wall_times, 95.0)
+
+    # cap_hit: True if any rep hit the cap; cap_hit_rate is the fraction.
+    cap_hits = [r.cap_hit for r in reps]
+    cap_hit_rate = _mean([1.0 if c else 0.0 for c in cap_hits])
+    cap_hit = any(cap_hits)
+
+    # derived $ / resolved instance
+    resolved_count = sum(1 for r in reps if r.resolved)
+    cost_per_resolved: Optional[float]
+    if min_cost is None:
+        cost_per_resolved = None
+    elif resolved_count == 0:
+        cost_per_resolved = float("inf")
+    else:
+        cost_per_resolved = min_cost / resolved_count
+
+    return MetricRow(
+        model=model,
+        model_resolved=(
+            model_resolved if model_resolved is not None else _safe_resolve(model)
+        ),
+        skill_subset=list(skill_subset),
+        instance_id=instance_id,
+        rep_count=rep_count,
+        accuracy=accuracy,
+        prompt_tokens=min_prompt,
+        completion_tokens=min_completion,
+        total_tokens=min_total,
+        cost_usd=min_cost,
+        cost_per_resolved_instance=cost_per_resolved,
+        wall_time_p50=wt_p50,
+        wall_time_p95=wt_p95,
+        turn_count=min_turns,
+        cap_hit=cap_hit,
+        cap_hit_rate=cap_hit_rate,
+    )
+
+
+def _safe_resolve(model: str) -> str:
+    """``resolve_model`` that never raises (falls back to the raw name)."""
+    try:
+        return resolve_model(model)
+    except KeyError:
+        return model
+
+
+# ---------------------------------------------------------------------------
+# Bridging the agent run -> a RepResult
+# ---------------------------------------------------------------------------
+
+
+def rep_from_agent_usage(
+    *,
+    resolved: bool,
+    usage: Optional[Dict[str, Any]],
+    max_turns: int,
+) -> RepResult:
+    """Build a :class:`RepResult` from one ``skill_agent_eval`` usage dict.
+
+    ``usage`` is the ``usage_stats`` dict that
+    ``skill_agent_eval.run_agent_with_skills`` returns: ``total_turns``,
+    ``total_duration_ms`` and a nested ``token_usage`` (the
+    :meth:`TokenUsage.to_dict` shape). ``cap_hit`` is derived by comparing
+    ``total_turns`` to ``max_turns`` -- the agent loop reports
+    ``total_turns == max_turns`` exactly when the budget was exhausted.
+
+    Kept import-light (no LLM / dataset imports) so the slow end-to-end caller
+    can construct rows without pulling this module into the unit-test path.
+    """
+    usage = usage or {}
+    token_usage = usage.get("token_usage") or {}
+    total_turns = int(usage.get("total_turns") or 0)
+    duration_ms = float(usage.get("total_duration_ms") or 0.0)
+
+    return RepResult(
+        resolved=resolved,
+        prompt_tokens=int(token_usage.get("prompt_tokens") or 0),
+        completion_tokens=int(token_usage.get("completion_tokens") or 0),
+        cost_usd=token_usage.get("cost_usd"),
+        wall_time_s=duration_ms / 1000.0,
+        turn_count=total_turns,
+        cap_hit=total_turns >= max_turns > 0,
+    )
+
+
+@dataclass
+class ExperimentReport:
+    """Container for a sweep's worth of :class:`MetricRow` records."""
+
+    rows: List[MetricRow] = field(default_factory=list)
+
+    def add(self, row: MetricRow) -> None:
+        self.rows.append(row)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"rows": [r.to_dict() for r in self.rows]}

--- a/test/examples/test_experiment_runner.py
+++ b/test/examples/test_experiment_runner.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``examples/experiment_runner.py``.
+
+Covers the three pieces #148 adds on top of ``skill_agent_eval``:
+
+* multi-model dispatch (short name -> litellm string, pass-through, overrides),
+* the per-axis aggregation rule (mean-of-3 accuracy, min-of-3 cost/latency/turns),
+* the :class:`MetricRow` logging schema (prompt/completion split, derived
+  ``$/resolved instance``, wall-time P50/P95, ``cap_hit``).
+
+Pure logic only -- no LLM / dataset imports, so this runs under the default
+(unit) marker. The real ``(model, subset, instance)`` end-to-end path is a
+``slow`` concern and is not exercised here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load examples/experiment_runner.py by path (``examples/`` is not a package).
+# The module must be registered in ``sys.modules`` *before* ``exec_module`` so
+# that ``@dataclass`` can resolve its own module namespace during processing.
+_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "examples" / "experiment_runner.py"
+)
+_spec = importlib.util.spec_from_file_location("experiment_runner", _MODULE_PATH)
+assert _spec and _spec.loader
+experiment_runner = importlib.util.module_from_spec(_spec)
+sys.modules["experiment_runner"] = experiment_runner
+_spec.loader.exec_module(experiment_runner)
+
+MODEL_REGISTRY = experiment_runner.MODEL_REGISTRY
+MetricRow = experiment_runner.MetricRow
+RepResult = experiment_runner.RepResult
+aggregate_reps = experiment_runner.aggregate_reps
+rep_from_agent_usage = experiment_runner.rep_from_agent_usage
+resolve_model = experiment_runner.resolve_model
+
+
+# ---------------------------------------------------------------------------
+# 1. Multi-model dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestModelDispatch:
+    def test_registry_covers_six_required_models(self):
+        """All six RFC models have a short name -> litellm mapping."""
+        required = {"haiku", "opus", "gpt", "gemini", "qwen-32b", "qwen-14b"}
+        assert required.issubset(MODEL_REGISTRY.keys())
+        # Not hardcoded to a single model.
+        assert len(set(MODEL_REGISTRY.values())) == len(MODEL_REGISTRY)
+
+    def test_resolve_short_name(self):
+        assert resolve_model("haiku") == MODEL_REGISTRY["haiku"]
+        assert resolve_model("qwen-32b") == MODEL_REGISTRY["qwen-32b"]
+
+    def test_resolve_passthrough_litellm_string(self):
+        """A fully-qualified litellm string resolves to itself."""
+        assert (
+            resolve_model("vertex_ai/claude-haiku-4-5") == "vertex_ai/claude-haiku-4-5"
+        )
+        assert resolve_model("openai/gpt-4o") == "openai/gpt-4o"
+
+    def test_resolve_overrides(self):
+        """Per-call overrides win over the registry without mutating it."""
+        before = dict(MODEL_REGISTRY)
+        got = resolve_model(
+            "qwen-32b", overrides={"qwen-32b": "hosted_vllm/local-qwen"}
+        )
+        assert got == "hosted_vllm/local-qwen"
+        # Registry untouched.
+        assert MODEL_REGISTRY == before
+
+    def test_resolve_unknown_raises(self):
+        with pytest.raises(KeyError):
+            resolve_model("totally-unknown-bare-name")
+
+
+# ---------------------------------------------------------------------------
+# 2. Aggregation rule
+# ---------------------------------------------------------------------------
+
+
+def _rep(resolved, prompt, completion, cost, wall, turns, cap=False):
+    return RepResult(
+        resolved=resolved,
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        cost_usd=cost,
+        wall_time_s=wall,
+        turn_count=turns,
+        cap_hit=cap,
+    )
+
+
+class TestAggregation:
+    def test_mean_of_three_accuracy(self):
+        """Accuracy is the mean of ``resolved`` (2/3 here)."""
+        reps = [
+            _rep(True, 100, 50, 0.01, 5.0, 3),
+            _rep(False, 120, 40, 0.02, 7.0, 4),
+            _rep(True, 110, 60, 0.015, 6.0, 3),
+        ]
+        row = aggregate_reps(
+            model="haiku", skill_subset=["bm25_search"], instance_id="x__1", reps=reps
+        )
+        assert row.accuracy == pytest.approx(2.0 / 3.0)
+        assert row.rep_count == 3
+
+    def test_min_of_three_cost_latency_turns(self):
+        """Cost / tokens / turns take the minimum across reps (noise floor)."""
+        reps = [
+            _rep(True, 100, 50, 0.030, 9.0, 5),
+            _rep(True, 90, 40, 0.020, 6.0, 3),
+            _rep(True, 110, 70, 0.040, 8.0, 7),
+        ]
+        row = aggregate_reps(
+            model="opus", skill_subset=["bm25_search"], instance_id="x__2", reps=reps
+        )
+        assert row.cost_usd == pytest.approx(0.020)
+        assert row.prompt_tokens == 90
+        assert row.completion_tokens == 40
+        assert row.total_tokens == 130  # min of 150/130/180
+        assert row.turn_count == 3
+
+    def test_prompt_and_completion_reported_separately(self):
+        """The min prompt and min completion are tracked independently."""
+        reps = [
+            _rep(True, 200, 10, 0.01, 1.0, 2),  # min prompt? no
+            _rep(True, 50, 90, 0.02, 1.0, 2),  # min prompt = 50
+        ]
+        row = aggregate_reps(
+            model="haiku", skill_subset=["a"], instance_id="i", reps=reps
+        )
+        assert row.prompt_tokens == 50  # not collapsed into completion
+        assert row.completion_tokens == 10
+        # They are distinct fields, not a single total.
+        assert hasattr(row, "prompt_tokens") and hasattr(row, "completion_tokens")
+
+    def test_single_rep_mean_and_min_collapse(self):
+        """rep_count == 1 -> mean and min both equal the single observation."""
+        reps = [_rep(True, 77, 33, 0.05, 4.2, 6, cap=True)]
+        row = aggregate_reps(
+            model="gemini", skill_subset=["a", "b"], instance_id="i", reps=reps
+        )
+        assert row.accuracy == 1.0
+        assert row.prompt_tokens == 77
+        assert row.completion_tokens == 33
+        assert row.cost_usd == pytest.approx(0.05)
+        assert row.turn_count == 6
+        assert row.wall_time_p50 == pytest.approx(4.2)
+        assert row.wall_time_p95 == pytest.approx(4.2)
+        assert row.cap_hit is True
+
+    def test_empty_reps_raises(self):
+        with pytest.raises(ValueError):
+            aggregate_reps(model="haiku", skill_subset=[], instance_id="i", reps=[])
+
+    def test_cost_none_when_all_unpriced(self):
+        reps = [
+            _rep(True, 10, 5, None, 1.0, 2),
+            _rep(False, 12, 6, None, 1.0, 2),
+        ]
+        row = aggregate_reps(
+            model="qwen-14b", skill_subset=["a"], instance_id="i", reps=reps
+        )
+        assert row.cost_usd is None
+        assert row.cost_per_resolved_instance is None
+
+    def test_min_cost_ignores_unpriced_reps(self):
+        """A None cost on one rep must not zero out the min."""
+        reps = [
+            _rep(True, 10, 5, None, 1.0, 2),
+            _rep(True, 10, 5, 0.03, 1.0, 2),
+        ]
+        row = aggregate_reps(
+            model="gpt", skill_subset=["a"], instance_id="i", reps=reps
+        )
+        assert row.cost_usd == pytest.approx(0.03)
+
+
+class TestDerivedAndDistribution:
+    def test_cost_per_resolved_instance(self):
+        """$/resolved = min_cost / number of resolved reps."""
+        reps = [
+            _rep(True, 10, 5, 0.040, 1.0, 2),
+            _rep(True, 10, 5, 0.020, 1.0, 2),
+            _rep(False, 10, 5, 0.030, 1.0, 2),
+        ]
+        row = aggregate_reps(
+            model="haiku", skill_subset=["a"], instance_id="i", reps=reps
+        )
+        # min cost = 0.020, resolved count = 2 -> 0.010
+        assert row.cost_per_resolved_instance == pytest.approx(0.010)
+
+    def test_cost_per_resolved_inf_when_none_resolved(self):
+        reps = [
+            _rep(False, 10, 5, 0.040, 1.0, 2),
+            _rep(False, 10, 5, 0.020, 1.0, 2),
+        ]
+        row = aggregate_reps(
+            model="haiku", skill_subset=["a"], instance_id="i", reps=reps
+        )
+        assert math.isinf(row.cost_per_resolved_instance)
+
+    def test_wall_time_p50_p95(self):
+        """P50 / P95 follow linear-interpolation percentiles of the reps."""
+        reps = [
+            _rep(True, 1, 1, 0.0, 2.0, 1),
+            _rep(True, 1, 1, 0.0, 4.0, 1),
+            _rep(True, 1, 1, 0.0, 6.0, 1),
+            _rep(True, 1, 1, 0.0, 8.0, 1),
+            _rep(True, 1, 1, 0.0, 10.0, 1),
+        ]
+        row = aggregate_reps(
+            model="haiku", skill_subset=["a"], instance_id="i", reps=reps
+        )
+        # sorted [2,4,6,8,10]: p50 = 6, p95 = rank 3.8 -> 8 + 0.8*(10-8) = 9.6
+        assert row.wall_time_p50 == pytest.approx(6.0)
+        assert row.wall_time_p95 == pytest.approx(9.6)
+
+    def test_cap_hit_rate(self):
+        """cap_hit_rate = fraction of reps that hit the cap; cap_hit = any."""
+        reps = [
+            _rep(True, 1, 1, 0.0, 1.0, 1, cap=True),
+            _rep(True, 1, 1, 0.0, 1.0, 1, cap=False),
+            _rep(True, 1, 1, 0.0, 1.0, 1, cap=False),
+        ]
+        row = aggregate_reps(
+            model="haiku", skill_subset=["a"], instance_id="i", reps=reps
+        )
+        assert row.cap_hit is True
+        assert row.cap_hit_rate == pytest.approx(1.0 / 3.0)
+
+
+# ---------------------------------------------------------------------------
+# 3. Logging schema
+# ---------------------------------------------------------------------------
+
+
+class TestMetricRowSchema:
+    def test_row_to_dict_has_required_fields(self):
+        reps = [_rep(True, 100, 50, 0.01, 5.0, 3, cap=False)]
+        row = aggregate_reps(
+            model="haiku",
+            skill_subset=["bm25_search", "graph_expand"],
+            instance_id="astropy__astropy-12907",
+            reps=reps,
+        )
+        d = row.to_dict()
+        required = {
+            "model",
+            "model_resolved",
+            "skill_subset",
+            "instance_id",
+            "rep_count",
+            "accuracy",
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "cost_usd",
+            "cost_per_resolved_instance",
+            "wall_time_p50",
+            "wall_time_p95",
+            "turn_count",
+            "cap_hit",
+            "cap_hit_rate",
+        }
+        assert required.issubset(d.keys())
+        # prompt and completion are not collapsed.
+        assert d["prompt_tokens"] == 100
+        assert d["completion_tokens"] == 50
+        assert "tokens" not in d or d.get("total_tokens") == 150
+        assert d["model_resolved"] == MODEL_REGISTRY["haiku"]
+        assert isinstance(d["cap_hit"], bool)
+
+    def test_model_resolved_override_passthrough(self):
+        reps = [_rep(True, 1, 1, None, 1.0, 1)]
+        row = aggregate_reps(
+            model="custom-name",
+            skill_subset=["a"],
+            instance_id="i",
+            reps=reps,
+            model_resolved="vertex_ai/some-model",
+        )
+        assert row.model_resolved == "vertex_ai/some-model"
+
+    def test_unknown_model_resolved_falls_back_to_raw(self):
+        """An unknown bare model name does not crash row building."""
+        reps = [_rep(True, 1, 1, None, 1.0, 1)]
+        row = aggregate_reps(
+            model="mystery", skill_subset=["a"], instance_id="i", reps=reps
+        )
+        assert row.model_resolved == "mystery"
+
+
+# ---------------------------------------------------------------------------
+# Bridge from skill_agent_eval usage dict
+# ---------------------------------------------------------------------------
+
+
+class TestRepFromAgentUsage:
+    def test_extracts_separated_tokens_and_wall_time(self):
+        usage = {
+            "total_turns": 4,
+            "total_duration_ms": 2500.0,
+            "token_usage": {
+                "prompt_tokens": 800,
+                "completion_tokens": 120,
+                "total_tokens": 920,
+                "cost_usd": 0.0042,
+            },
+        }
+        rep = rep_from_agent_usage(resolved=True, usage=usage, max_turns=10)
+        assert rep.prompt_tokens == 800
+        assert rep.completion_tokens == 120
+        assert rep.cost_usd == pytest.approx(0.0042)
+        assert rep.wall_time_s == pytest.approx(2.5)
+        assert rep.turn_count == 4
+        assert rep.cap_hit is False
+
+    def test_cap_hit_true_when_turns_reach_max(self):
+        usage = {"total_turns": 10, "total_duration_ms": 100.0, "token_usage": {}}
+        rep = rep_from_agent_usage(resolved=False, usage=usage, max_turns=10)
+        assert rep.cap_hit is True
+
+    def test_handles_missing_usage(self):
+        rep = rep_from_agent_usage(resolved=False, usage=None, max_turns=10)
+        assert rep.prompt_tokens == 0
+        assert rep.completion_tokens == 0
+        assert rep.cost_usd is None
+        assert rep.cap_hit is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (real LLM) -- gated behind the ``slow`` marker per #148.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_real_model_dispatch_end_to_end():
+    """Resolve a model, run one rep against a real provider, build a row.
+
+    Skipped unless Vertex AI credentials are configured. This is the only path
+    that issues a real LLM call; the aggregation / schema logic above is fully
+    covered without one.
+    """
+    import os
+
+    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        pytest.skip(
+            "Vertex AI not configured (GOOGLE_APPLICATION_CREDENTIALS unset); "
+            "real-LLM dispatch test requires credentials."
+        )
+
+    from codeminer.llm.litellm_chat import LiteLLMChat
+
+    resolved = resolve_model("haiku")
+    llm = LiteLLMChat(model=resolved, temperature=0.0, max_tokens=64)
+
+    # One trivial single-rep run: no tools, deterministic at temp=0.
+    from codeminer.agent.runner import AgentRunner
+    from codeminer.agent.skills.registry import SkillRegistry
+
+    SkillRegistry.reset()
+    result = AgentRunner(llm=llm, registry=SkillRegistry(), max_turns=1).run(
+        "Reply with the single word OK."
+    )
+    usage = {
+        "total_turns": result.total_turns,
+        "total_duration_ms": result.total_duration_ms,
+        "token_usage": result.usage.to_dict() if result.usage else None,
+    }
+    rep = rep_from_agent_usage(resolved=True, usage=usage, max_turns=1)
+    row = aggregate_reps(
+        model="haiku",
+        skill_subset=[],
+        instance_id="smoke__1",
+        reps=[rep],
+    )
+    assert row.model_resolved == resolved
+    assert row.prompt_tokens > 0
+    assert row.completion_tokens >= 0
+    # prompt and completion stay separate.
+    assert row.total_tokens == row.prompt_tokens + row.completion_tokens


### PR DESCRIPTION
## Summary

Closes #148 (sub-issue of the Agent Router RFC #133). The unified experiment
driver that turns `(model, skill_subset, instance)` into one logged metric row —
the harness every Phase 0/2 sweep depends on.

## Changes
- New `examples/experiment_runner.py`:
  - **Model dispatch** mapping short names (Haiku 4.5, Claude Opus, GPT-5.5,
    Gemini 3, Qwen-32B, Qwen-14B) to litellm model strings.
  - **Per-axis aggregation** (RFC Table 4): accuracy = mean-of-3 (or 1 run at
    temp=0); cost / latency / turns = min-of-3.
  - **Metric-row schema** reporting `prompt_tokens` and `completion_tokens`
    **separately** (RFC core evidence — not collapsed), `$/resolved-instance`,
    `wall_time` p50/p95, `turn_count`, and a `cap_hit` boolean.
- Reuses the existing `UsageTracker` for per-call token/cost accounting.
- CAR runtime and the third-party baseline harness are out of scope per the
  issue.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/examples/test_experiment_runner.py -m "not slow and not integration"`
→ 22 passed (1 real-LLM end-to-end case marked `slow` and deselected). Covers
the aggregation rules and the row schema.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
