### PR TITLE
feat(agent): LLM retry policy + token-budgeted chat history

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -10,6 +10,7 @@ from .extract_agent import (
     KeywordExtractor,
     extract_keywords_from_statement,
 )
+from .history import PlainChatHistory, TokenBudgetedChatHistory, count_message_tokens
 from .rerank_agent import RerankAgent, RerankResult, rerank_nodes_with_query
 from .runner import AgentRunner, CodeMinerAgentOptions, compile_repo, query
 from .tool_schema import registry_to_tools, skill_to_tool_schema
@@ -20,10 +21,13 @@ __all__ = [
     "CodeMinerAgentOptions",
     "KeywordExtraction",
     "KeywordExtractor",
+    "PlainChatHistory",
     "RerankAgent",
     "RerankResult",
+    "TokenBudgetedChatHistory",
     "ToolCallRecord",
     "compile_repo",
+    "count_message_tokens",
     "extract_keywords_from_statement",
     "query",
     "rerank_nodes_with_query",

--- a/codeminer/agent/history.py
+++ b/codeminer/agent/history.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Token-budgeted chat history for the agent loop (issue #109, phase 4).
+
+The agent loop in :mod:`codeminer.agent.runner` appends every assistant
+turn and every tool result to a flat ``messages`` list. On long runs that
+list grows without bound and eventually overflows the model's context
+window.
+
+:class:`TokenBudgetedChatHistory` is a drop-in container that caps the
+*total* context tokens. When adding a message would exceed the budget it
+evicts the **oldest non-system messages first**, always preserving:
+
+* every ``system`` message (the system prompt — pinned, never evicted), and
+* the most recent messages (the live working set the model needs to act).
+
+It is deliberately a plain container (``add_message`` / ``get_messages`` /
+``clear``) so the runner can swap a bare ``list`` for it with no other
+change. Token counting uses ``litellm.token_counter`` when available and
+falls back to a cheap character-based heuristic so the class stays usable
+in unit tests and offline environments.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from ..log_utils import get_logger
+
+logger = get_logger(__name__)
+
+# Rough chars-per-token used by the offline heuristic. ~4 chars/token is the
+# conventional English-text approximation; intentionally conservative so the
+# fallback over-counts slightly rather than under-counts (eviction is safer
+# than overflow).
+_CHARS_PER_TOKEN = 4
+
+
+def _message_text(message: Dict[str, Any]) -> str:
+    """Flatten a chat message dict into the text we count tokens for.
+
+    Covers the three shapes the runner produces: a plain ``content`` string,
+    ``content=None`` with ``tool_calls`` (assistant tool requests), and tool
+    result messages. Best-effort — anything unrecognized is ``str()``-ified.
+    """
+    parts: List[str] = []
+    content = message.get("content")
+    if isinstance(content, str):
+        parts.append(content)
+    elif content is not None:
+        parts.append(str(content))
+
+    for tc in message.get("tool_calls") or []:
+        fn = (tc or {}).get("function") if isinstance(tc, dict) else None
+        if isinstance(fn, dict):
+            parts.append(str(fn.get("name", "")))
+            parts.append(str(fn.get("arguments", "")))
+    return "\n".join(p for p in parts if p)
+
+
+def count_message_tokens(
+    messages: List[Dict[str, Any]],
+    *,
+    model: Optional[str] = None,
+) -> int:
+    """Best-effort token count for a list of chat messages.
+
+    Uses ``litellm.token_counter`` (which understands the model's real
+    tokenizer and per-message role overhead) when a ``model`` is supplied
+    and litellm is importable. Falls back to a ``chars / 4`` heuristic
+    otherwise, so this never raises and stays usable in offline tests.
+    """
+    if not messages:
+        return 0
+    if model:
+        try:
+            import litellm
+
+            return int(litellm.token_counter(model=model, messages=messages))
+        except Exception as exc:  # offline / unknown model / litellm bug
+            logger.debug("token_counter unavailable (%s); using char heuristic", exc)
+
+    chars = sum(len(_message_text(m)) for m in messages)
+    # +4 per message approximates the role / formatting overhead litellm adds.
+    return chars // _CHARS_PER_TOKEN + 4 * len(messages)
+
+
+class TokenBudgetedChatHistory:
+    """Chat-history container that caps total context tokens.
+
+    Pinned ``system`` messages are always retained. When appending a message
+    would push the estimated token total above ``max_tokens``, the oldest
+    *non-system* messages are evicted one at a time (oldest first) until the
+    history fits again, so the system prompt plus the most recent turns are
+    preserved.
+
+    ``keep_last`` guards the tail: the most recent ``keep_last`` non-system
+    messages are never evicted even under budget pressure, so the model
+    always sees the immediate context it needs to act. A single message that
+    on its own exceeds the budget is kept (we never drop the message just
+    added) and a warning is logged.
+
+    The container is intentionally minimal — ``add_message`` /
+    ``get_messages`` / ``clear`` / ``__len__`` / ``__iter__`` — so the runner
+    can use it in place of a bare ``list``.
+    """
+
+    def __init__(
+        self,
+        max_tokens: int,
+        *,
+        model: Optional[str] = None,
+        keep_last: int = 2,
+    ) -> None:
+        if max_tokens <= 0:
+            raise ValueError(f"max_tokens must be positive, got {max_tokens}")
+        self.max_tokens = max_tokens
+        self.model = model
+        self.keep_last = max(0, keep_last)
+        self._messages: List[Dict[str, Any]] = []
+
+    # -- container protocol -------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._messages)
+
+    def __iter__(self):
+        return iter(self._messages)
+
+    def get_messages(self) -> List[Dict[str, Any]]:
+        """Return the live message list (the object the LLM is called with)."""
+        return self._messages
+
+    def clear(self) -> None:
+        """Drop all messages."""
+        self._messages.clear()
+
+    # -- mutation -----------------------------------------------------------
+
+    def add_message(self, message: Dict[str, Any]) -> None:
+        """Append *message*, then evict oldest non-system messages if over budget."""
+        self._messages.append(message)
+        self._enforce_budget()
+
+    def extend(self, messages: List[Dict[str, Any]]) -> None:
+        """Append several messages, enforcing the budget after each one."""
+        for message in messages:
+            self.add_message(message)
+
+    def total_tokens(self) -> int:
+        """Estimated token total of the current history."""
+        return count_message_tokens(self._messages, model=self.model)
+
+    # -- internals ----------------------------------------------------------
+
+    def _enforce_budget(self) -> None:
+        """Evict oldest non-system messages until within ``max_tokens``.
+
+        Walks from the front, skipping pinned ``system`` messages and the
+        protected ``keep_last`` tail, dropping the oldest eligible message
+        each pass until the total fits or nothing more is evictable.
+        """
+        while self.total_tokens() > self.max_tokens:
+            idx = self._oldest_evictable_index()
+            if idx is None:
+                # Only system + protected tail remain (or the single message
+                # is itself over budget). Keep what we have; the budget is a
+                # best-effort cap, not a hard guarantee against a giant turn.
+                logger.warning(
+                    "TokenBudgetedChatHistory: %d tokens still over budget %d "
+                    "with only system + last %d message(s) left; not evicting "
+                    "further",
+                    self.total_tokens(),
+                    self.max_tokens,
+                    self.keep_last,
+                )
+                return
+            evicted = self._messages.pop(idx)
+            logger.debug(
+                "TokenBudgetedChatHistory: evicted oldest %s message to stay "
+                "within %d-token budget",
+                evicted.get("role", "?"),
+                self.max_tokens,
+            )
+
+    def _oldest_evictable_index(self) -> Optional[int]:
+        """Index of the oldest message that may be evicted, or ``None``.
+
+        A message is evictable when it is non-system and not inside the
+        protected ``keep_last`` tail of non-system messages.
+        """
+        n = len(self._messages)
+        # The last ``keep_last`` *non-system* messages are pinned (the live
+        # working set the model needs to act). Everything older than that and
+        # non-system is evictable, oldest first.
+        non_system_positions = [
+            i for i, m in enumerate(self._messages) if m.get("role") != "system"
+        ]
+        if self.keep_last:
+            protected = set(non_system_positions[-self.keep_last :])
+        else:
+            protected = set()
+        for i in range(n):
+            m = self._messages[i]
+            if m.get("role") == "system":
+                continue
+            if i in protected:
+                continue
+            return i
+        return None
+
+
+class PlainChatHistory:
+    """Unbounded chat history with the same interface as the budgeted one.
+
+    Lets :class:`~codeminer.agent.runner.AgentRunner` use a single code path
+    whether or not a token budget is configured. Behaviour is identical to a
+    bare ``list`` of message dicts — nothing is ever evicted.
+    """
+
+    def __init__(self, messages: Optional[List[Dict[str, Any]]] = None) -> None:
+        self._messages: List[Dict[str, Any]] = list(messages or [])
+
+    def __len__(self) -> int:
+        return len(self._messages)
+
+    def __iter__(self):
+        return iter(self._messages)
+
+    def get_messages(self) -> List[Dict[str, Any]]:
+        return self._messages
+
+    def add_message(self, message: Dict[str, Any]) -> None:
+        self._messages.append(message)
+
+    def extend(self, messages: List[Dict[str, Any]]) -> None:
+        self._messages.extend(messages)
+
+    def clear(self) -> None:
+        self._messages.clear()

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -18,11 +18,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union
 
 from ..compiler.manifest import RepoManifest
-from ..llm.litellm_chat import LiteLLMChat
+from ..llm.litellm_chat import LiteLLMChat, RetryConfig
 from ..llm.usage import UsageTracker
 from ..log_utils import get_logger
 from .agent_types import AgentResult, ToolCallRecord
 from .boundary import from_agent_repr_arg, is_line_bearing, to_agent_repr
+from .history import PlainChatHistory, TokenBudgetedChatHistory
 from .skills.loader import SkillLoader
 from .skills.registry import SkillRegistry
 from .tool_schema import registry_to_tools
@@ -117,6 +118,7 @@ class AgentRunner:
         max_tokens: int = 512,
         system_prompt: Optional[str] = None,
         max_turns: int = 10,
+        max_context_tokens: Optional[int] = None,
         allow_skills: Optional[Set[str]] = None,
         exclude_skills: Optional[Set[str]] = None,
         manifest: Optional[Any] = None,
@@ -124,6 +126,7 @@ class AgentRunner:
         compile_table: Optional[Any] = None,
         include_default_tools: bool = True,
         default_tool_ids: Optional[Set[str]] = None,
+        retry: Optional[RetryConfig] = None,
     ) -> None:
         if llm is not None:
             self.llm = llm
@@ -132,9 +135,15 @@ class AgentRunner:
                 model=model,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                retry=retry or RetryConfig(),
             )
         else:
             raise ValueError("Either 'llm' or 'model' must be provided")
+        # Optional per-run context-window cap. When set, ``run()`` keeps the
+        # conversation in a :class:`TokenBudgetedChatHistory` that evicts the
+        # oldest non-system messages once the budget would be exceeded, so a
+        # long tool-calling loop can't overflow the model context.
+        self.max_context_tokens = max_context_tokens
         self.registry = registry or SkillRegistry()
         # Always-on default tool layer (read + grep + glob + bash): registered
         # unconditionally so every query — and every agent-compile subset —
@@ -310,10 +319,9 @@ class AgentRunner:
                         effective = set(self._base_allow)
                 tools = self._tools_for(effective)
 
-        messages: List[Dict[str, Any]] = [
-            {"role": "system", "content": self.system_prompt},
-            {"role": "user", "content": query},
-        ]
+        history = self._new_history()
+        history.add_message({"role": "system", "content": self.system_prompt})
+        history.add_message({"role": "user", "content": query})
         all_tool_calls: List[ToolCallRecord] = []
         usage_tracker = UsageTracker()
         start = time.monotonic()
@@ -328,12 +336,13 @@ class AgentRunner:
             if tools:
                 call_kwargs["tools"] = tools
 
-            response = self.llm._call_raw(messages, **call_kwargs)
+            response = self.llm._call_raw(history.get_messages(), **call_kwargs)
             choice = response.choices[0]
             assistant_msg = choice.message
 
-            # Append assistant message to conversation
-            messages.append(_message_to_dict(assistant_msg))
+            # Append assistant message to conversation (may evict oldest
+            # non-system messages when a context-token budget is set).
+            history.add_message(_message_to_dict(assistant_msg))
 
             # Check for tool calls
             tool_calls = getattr(assistant_msg, "tool_calls", None)
@@ -344,7 +353,7 @@ class AgentRunner:
                 return AgentResult(
                     answer=answer,
                     tool_calls=all_tool_calls,
-                    messages=messages,
+                    messages=history.get_messages(),
                     total_turns=turn + 1,
                     total_duration_ms=elapsed,
                     usage=usage_tracker.totals(),
@@ -357,7 +366,7 @@ class AgentRunner:
                 all_tool_calls.append(record)
 
                 # Append tool response message
-                messages.append(
+                history.add_message(
                     {
                         "role": "tool",
                         "tool_call_id": tc.id,
@@ -369,7 +378,7 @@ class AgentRunner:
 
         # Max turns exhausted. Prefer the last textual assistant message.
         last_content = ""
-        for msg in reversed(messages):
+        for msg in reversed(history.get_messages()):
             if msg.get("role") == "assistant" and msg.get("content"):
                 last_content = msg["content"]
                 break
@@ -380,7 +389,7 @@ class AgentRunner:
         # work should not report nothing. Best-effort: never crash on the
         # summary call.
         if not last_content and all_tool_calls:
-            messages.append(
+            history.add_message(
                 {
                     "role": "user",
                     "content": (
@@ -392,12 +401,12 @@ class AgentRunner:
             )
             try:
                 final = self.llm._call_raw(
-                    messages,
+                    history.get_messages(),
                     usage_tracker=usage_tracker,
                     usage_turn=max_turns + 1,
                 )
                 forced_msg = final.choices[0].message
-                messages.append(_message_to_dict(forced_msg))
+                history.add_message(_message_to_dict(forced_msg))
                 last_content = getattr(forced_msg, "content", None) or ""
             except Exception as exc:  # best-effort summary; keep the partial run
                 logger.warning("forced final-answer turn failed: %s", exc)
@@ -406,7 +415,7 @@ class AgentRunner:
         return AgentResult(
             answer=last_content,
             tool_calls=all_tool_calls,
-            messages=messages,
+            messages=history.get_messages(),
             total_turns=max_turns,
             total_duration_ms=elapsed,
             usage=usage_tracker.totals(),
@@ -416,6 +425,20 @@ class AgentRunner:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    def _new_history(self):
+        """Build the chat-history container for one ``run()``.
+
+        Returns a :class:`~codeminer.agent.history.TokenBudgetedChatHistory`
+        when ``max_context_tokens`` is set (so a long loop can't overflow the
+        model context), otherwise an unbounded
+        :class:`~codeminer.agent.history.PlainChatHistory` that behaves like
+        the original bare message list.
+        """
+        if self.max_context_tokens:
+            model = getattr(self.llm, "model", None)
+            return TokenBudgetedChatHistory(self.max_context_tokens, model=model)
+        return PlainChatHistory()
 
     def _execute_tool_call(self, tc: Any) -> ToolCallRecord:
         """Execute a single tool call from the LLM response."""
@@ -654,6 +677,8 @@ class CodeMinerAgentOptions:
     max_tokens: int = 512
     system_prompt: Optional[str] = None
     max_turns: int = 10
+    max_context_tokens: Optional[int] = None
+    retry: Optional[RetryConfig] = None
 
     # --- extras for SessionContext.extras ---
     session_extras: Dict[str, Any] = field(default_factory=dict)
@@ -788,6 +813,8 @@ def query(
         max_tokens=opts.max_tokens,
         system_prompt=opts.system_prompt,
         max_turns=opts.max_turns,
+        max_context_tokens=opts.max_context_tokens,
+        retry=opts.retry,
         allow_skills=set(opts.allowed_skills) if opts.allowed_skills else None,
         exclude_skills=set(opts.excluded_skills) if opts.excluded_skills else None,
         manifest=manifest,

--- a/codeminer/llm/__init__.py
+++ b/codeminer/llm/__init__.py
@@ -4,11 +4,20 @@
 
 """LLM module for CodeMiner."""
 
-from .litellm_chat import ChatMessage, LiteLLMChat, human_message, system_message
+from .litellm_chat import (
+    ChatMessage,
+    LiteLLMChat,
+    RetryConfig,
+    human_message,
+    is_transient_error,
+    system_message,
+)
 
 __all__ = [
     "ChatMessage",
     "LiteLLMChat",
+    "RetryConfig",
     "human_message",
+    "is_transient_error",
     "system_message",
 ]

--- a/codeminer/llm/litellm_chat.py
+++ b/codeminer/llm/litellm_chat.py
@@ -15,9 +15,11 @@ with a single thin wrapper that provides the same two-method interface:
 
 from __future__ import annotations
 
+import random
 import re
+import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import litellm
 from pydantic import BaseModel
@@ -25,6 +27,89 @@ from pydantic import BaseModel
 from ..log_utils import get_logger
 
 logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Retry policy (issue #109)
+# ---------------------------------------------------------------------------
+#
+# litellm normalizes every provider error to an OpenAI-style exception class.
+# Only a subset are *transient* -- worth retrying because a later attempt may
+# succeed without any change to the request (rate limits, timeouts, upstream
+# 5xx / connection blips). Everything else (auth, bad request, content policy,
+# context-window-exceeded, ...) is a deterministic failure of *this* request
+# and retrying just wastes the budget, so we re-raise immediately.
+
+
+def _transient_exception_types() -> Tuple[type, ...]:
+    """litellm exception classes that warrant a retry.
+
+    Resolved at call time (not import time) so the tuple reflects whatever
+    litellm version is installed; unknown names degrade to ``()`` gracefully.
+    """
+    names = (
+        "RateLimitError",
+        "Timeout",
+        "APIConnectionError",
+        "ServiceUnavailableError",
+        "InternalServerError",
+        "BadGatewayError",
+        "APIError",  # generic upstream error; kept last (broadest)
+    )
+    types: List[type] = []
+    for name in names:
+        exc = getattr(litellm, name, None)
+        if isinstance(exc, type) and issubclass(exc, BaseException):
+            types.append(exc)
+    # Network-level timeouts can surface as the stdlib TimeoutError too.
+    types.append(TimeoutError)
+    return tuple(types)
+
+
+def is_transient_error(exc: BaseException) -> bool:
+    """True if *exc* is a transient LLM error worth retrying.
+
+    Non-transient errors (authentication, bad request, content policy,
+    context-window-exceeded, ...) return ``False`` so the caller fails fast.
+    """
+    transient = _transient_exception_types()
+    if not isinstance(exc, transient):
+        return False
+    # ``ContextWindowExceededError`` subclasses ``BadRequestError`` in some
+    # litellm versions but ``APIError`` in others; it is never transient
+    # (the request is too big and will be on every retry), so exclude it.
+    permanent = tuple(
+        t
+        for name in ("ContextWindowExceededError", "BadRequestError")
+        if isinstance((t := getattr(litellm, name, None)), type)
+    )
+    if permanent and isinstance(exc, permanent):
+        return False
+    return True
+
+
+@dataclass(slots=True)
+class RetryConfig:
+    """Exponential-backoff retry policy for transient LLM errors.
+
+    ``max_retries`` is the number of *additional* attempts after the first,
+    so the call is made at most ``max_retries + 1`` times. ``base_delay`` is
+    the first backoff in seconds; each subsequent wait is ``base_delay *
+    2**attempt`` capped at ``max_delay``. A small random jitter spreads
+    retries out so concurrent callers don't synchronize.
+    """
+
+    max_retries: int = 2
+    base_delay: float = 0.5
+    max_delay: float = 8.0
+    jitter: float = 0.1
+
+    def backoff(self, attempt: int) -> float:
+        """Seconds to sleep before retry ``attempt`` (0-based)."""
+        delay = min(self.base_delay * (2**attempt), self.max_delay)
+        if self.jitter:
+            delay += random.uniform(0, self.jitter * delay)
+        return delay
 
 
 def _no_thinking_kwargs(model: str) -> Dict[str, Any]:
@@ -83,6 +168,7 @@ class LiteLLMChat:
     api_key: Optional[str] = None
     api_base: Optional[str] = None
     extra_kwargs: Dict[str, Any] = field(default_factory=dict)
+    retry: RetryConfig = field(default_factory=RetryConfig)
 
     def invoke(self, messages: List[ChatMessage]) -> str:
         """Send messages and return the assistant content string."""
@@ -111,8 +197,6 @@ class LiteLLMChat:
           provided, the response's token usage and cost are recorded.
         - ``usage_turn``: turn index attached to the recorded usage entry.
         """
-        import time as _time
-
         usage_tracker = overrides.pop("usage_tracker", None)
         usage_turn = overrides.pop("usage_turn", None)
 
@@ -133,9 +217,9 @@ class LiteLLMChat:
         # Drop None values so litellm uses its defaults
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
-        start = _time.monotonic()
-        response = litellm.completion(**kwargs)
-        duration_ms = (_time.monotonic() - start) * 1000
+        start = time.monotonic()
+        response = self._completion_with_retry(kwargs)
+        duration_ms = (time.monotonic() - start) * 1000
 
         if usage_tracker is not None:
             usage_tracker.record_response(
@@ -146,6 +230,38 @@ class LiteLLMChat:
             )
 
         return response
+
+    def _completion_with_retry(self, kwargs: Dict[str, Any]) -> Any:
+        """Call ``litellm.completion`` with exponential-backoff retries.
+
+        Transient errors (rate limit, timeout, upstream 5xx / connection
+        blips -- see :func:`is_transient_error`) are retried up to
+        ``self.retry.max_retries`` times with backoff. Non-transient errors
+        (auth, bad request, content policy, context-window-exceeded) are
+        re-raised on the first failure so the caller fails fast.
+        """
+        max_retries = max(0, self.retry.max_retries)
+        last_exc: Optional[BaseException] = None
+        for attempt in range(max_retries + 1):
+            try:
+                return litellm.completion(**kwargs)
+            except Exception as exc:  # noqa: BLE001 -- classified below
+                last_exc = exc
+                if attempt >= max_retries or not is_transient_error(exc):
+                    raise
+                delay = self.retry.backoff(attempt)
+                logger.warning(
+                    "litellm.completion transient error (attempt %d/%d), "
+                    "retrying in %.2fs: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    delay,
+                    exc,
+                )
+                time.sleep(delay)
+        # Unreachable: the loop either returns or raises. Re-raise defensively.
+        assert last_exc is not None
+        raise last_exc
 
 
 # ---------------------------------------------------------------------------

--- a/test/agent/test_history.py
+++ b/test/agent/test_history.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TokenBudgetedChatHistory (issue #109, phase 4).
+
+A token-budgeted history caps total context tokens and evicts the OLDEST
+non-system messages first when the budget would be exceeded, always
+preserving the system prompt and the most recent turns.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.agent.history import (
+    PlainChatHistory,
+    TokenBudgetedChatHistory,
+    count_message_tokens,
+)
+
+
+def _msg(role, content):
+    return {"role": role, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# count_message_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestCountMessageTokens:
+    def test_empty_is_zero(self):
+        assert count_message_tokens([]) == 0
+
+    def test_char_heuristic_grows_with_content(self):
+        small = count_message_tokens([_msg("user", "hi")])
+        big = count_message_tokens([_msg("user", "x" * 400)])
+        assert big > small
+
+    def test_counts_tool_call_arguments(self):
+        plain = count_message_tokens([{"role": "assistant", "content": "hi"}])
+        with_tc = count_message_tokens(
+            [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "function": {
+                                "name": "bm25_search",
+                                "arguments": '{"query": "' + "x" * 200 + '"}',
+                            },
+                        }
+                    ],
+                }
+            ]
+        )
+        assert with_tc > plain
+
+    def test_uses_litellm_token_counter_when_model_given(self):
+        # When a model is supplied and litellm.token_counter succeeds, its
+        # result is used verbatim (not the char heuristic).
+        import sys
+
+        fake_litellm = MagicMock()
+        fake_litellm.token_counter.return_value = 1234
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setitem(sys.modules, "litellm", fake_litellm)
+            n = count_message_tokens([_msg("user", "hi")], model="gpt-4o")
+        assert n == 1234
+        fake_litellm.token_counter.assert_called_once()
+
+    def test_falls_back_when_token_counter_raises(self):
+        import sys
+
+        fake_litellm = MagicMock()
+        fake_litellm.token_counter.side_effect = RuntimeError("no tokenizer")
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setitem(sys.modules, "litellm", fake_litellm)
+            n = count_message_tokens([_msg("user", "x" * 400)], model="weird-model")
+        # Fell back to the char heuristic → positive count, no crash.
+        assert n > 0
+
+
+# ---------------------------------------------------------------------------
+# TokenBudgetedChatHistory
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBudgetedChatHistory:
+    def test_rejects_nonpositive_budget(self):
+        with pytest.raises(ValueError):
+            TokenBudgetedChatHistory(0)
+        with pytest.raises(ValueError):
+            TokenBudgetedChatHistory(-5)
+
+    def test_under_budget_keeps_everything(self):
+        h = TokenBudgetedChatHistory(max_tokens=10_000, keep_last=2)
+        h.add_message(_msg("system", "system prompt"))
+        h.add_message(_msg("user", "question"))
+        h.add_message(_msg("assistant", "answer"))
+        assert len(h) == 3
+
+    def test_evicts_oldest_nonsystem_when_over_budget(self):
+        """Adding beyond the budget evicts oldest non-system; keeps system + recent."""
+        # Each message ~= 40 chars → ~14 tokens via the heuristic. Budget of 40
+        # tokens fits the system message plus only the most recent couple.
+        h = TokenBudgetedChatHistory(max_tokens=40, keep_last=1)
+        h.add_message(_msg("system", "SYSTEM-PROMPT-PINNED-" + "s" * 20))
+        for i in range(6):
+            h.add_message(_msg("user", f"turn-{i}-" + "x" * 32))
+
+        roles = [m["role"] for m in h.get_messages()]
+        # System prompt is always first and preserved.
+        assert roles[0] == "system"
+        assert sum(1 for r in roles if r == "system") == 1
+        # The most recent message (the live tail) is preserved.
+        assert h.get_messages()[-1]["content"].startswith("turn-5-")
+        # Older non-system messages were evicted: fewer messages than added.
+        assert len(h) < 7
+        # turn-0 (the oldest non-system message) must be gone.
+        contents = [m["content"] for m in h.get_messages()]
+        assert not any(c.startswith("turn-0-") for c in contents)
+
+    def test_system_message_never_evicted(self):
+        h = TokenBudgetedChatHistory(max_tokens=20, keep_last=1)
+        h.add_message(_msg("system", "S" * 200))  # alone over budget
+        for _ in range(5):
+            h.add_message(_msg("user", "u" * 80))
+        roles = [m["role"] for m in h.get_messages()]
+        assert "system" in roles
+        assert roles[0] == "system"
+
+    def test_keep_last_protects_recent_tail(self):
+        """The last keep_last non-system messages survive even under pressure."""
+        h = TokenBudgetedChatHistory(max_tokens=60, keep_last=3)
+        h.add_message(_msg("system", "sys"))
+        for i in range(10):
+            h.add_message(_msg("user", f"m{i}-" + "z" * 40))
+        contents = [m["content"] for m in h.get_messages() if m["role"] != "system"]
+        # The three most-recent messages are always retained.
+        assert contents[-3:] == [
+            "m7-" + "z" * 40,
+            "m8-" + "z" * 40,
+            "m9-" + "z" * 40,
+        ]
+
+    def test_single_oversized_message_is_kept(self):
+        """A lone message over budget is not dropped (we never drop what we just
+        added when nothing else is evictable)."""
+        h = TokenBudgetedChatHistory(max_tokens=10, keep_last=1)
+        h.add_message(_msg("system", "sys"))
+        h.add_message(_msg("user", "u" * 1000))
+        # Both remain: system is pinned, the user message is the protected tail.
+        assert len(h) == 2
+        assert h.total_tokens() > h.max_tokens  # best-effort cap, not a guarantee
+
+    def test_keep_last_zero_can_evict_all_nonsystem(self):
+        h = TokenBudgetedChatHistory(max_tokens=15, keep_last=0)
+        h.add_message(_msg("system", "sys"))
+        for _ in range(4):
+            h.add_message(_msg("user", "u" * 80))
+        # With keep_last=0 the tail isn't protected, so eviction can remove
+        # everything non-system if the last message itself fits the budget.
+        roles = [m["role"] for m in h.get_messages()]
+        assert roles[0] == "system"
+
+    def test_clear(self):
+        h = TokenBudgetedChatHistory(max_tokens=1000)
+        h.add_message(_msg("system", "s"))
+        h.add_message(_msg("user", "u"))
+        h.clear()
+        assert len(h) == 0
+        assert h.get_messages() == []
+
+    def test_iter_and_get_messages_are_live(self):
+        h = TokenBudgetedChatHistory(max_tokens=1000)
+        h.add_message(_msg("user", "a"))
+        assert list(h) == h.get_messages()
+
+
+# ---------------------------------------------------------------------------
+# PlainChatHistory (unbounded shim)
+# ---------------------------------------------------------------------------
+
+
+class TestPlainChatHistory:
+    def test_never_evicts(self):
+        h = PlainChatHistory()
+        for _ in range(50):
+            h.add_message(_msg("user", "x" * 1000))
+        assert len(h) == 50
+
+    def test_extend_and_clear(self):
+        h = PlainChatHistory()
+        h.extend([_msg("user", "a"), _msg("user", "b")])
+        assert len(h) == 2
+        h.clear()
+        assert len(h) == 0

--- a/test/agent/test_runner_history_retry.py
+++ b/test/agent/test_runner_history_retry.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""AgentRunner wiring for the #109 retry + context-budget knobs.
+
+Verifies the runner threads ``retry`` into the LiteLLMChat it builds and
+selects a TokenBudgetedChatHistory when ``max_context_tokens`` is set.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.agent.history import PlainChatHistory, TokenBudgetedChatHistory
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.llm.litellm_chat import LiteLLMChat, RetryConfig
+
+
+def _make_response(content=None, tool_calls=None):
+    msg = SimpleNamespace(role="assistant", content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+def test_retry_threaded_into_built_llm():
+    """When constructed via model=, the runner passes retry into LiteLLMChat."""
+    retry = RetryConfig(max_retries=5, base_delay=0.25)
+    runner = AgentRunner(model="gpt-4o", registry=SkillRegistry(), retry=retry)
+    assert isinstance(runner.llm, LiteLLMChat)
+    assert runner.llm.retry is retry
+
+
+def test_default_retry_present_when_built_from_model():
+    runner = AgentRunner(model="gpt-4o", registry=SkillRegistry())
+    assert isinstance(runner.llm.retry, RetryConfig)
+
+
+def test_new_history_plain_by_default():
+    llm = MagicMock(spec=LiteLLMChat)
+    runner = AgentRunner(llm, SkillRegistry())
+    assert isinstance(runner._new_history(), PlainChatHistory)
+
+
+def test_new_history_budgeted_when_max_context_tokens_set():
+    llm = MagicMock(spec=LiteLLMChat)
+    llm.model = "gpt-4o"
+    runner = AgentRunner(llm, SkillRegistry(), max_context_tokens=5000)
+    hist = runner._new_history()
+    assert isinstance(hist, TokenBudgetedChatHistory)
+    assert hist.max_tokens == 5000
+    assert hist.model == "gpt-4o"
+
+
+def test_run_uses_budgeted_history_and_still_answers():
+    """A budgeted run still returns the final answer (smoke through run())."""
+    llm = MagicMock(spec=LiteLLMChat)
+    llm.model = "gpt-4o"
+    llm._call_raw.return_value = _make_response(content="final answer")
+
+    runner = AgentRunner(llm, SkillRegistry(), max_context_tokens=10_000)
+    result = runner.run("hello")
+
+    assert result.answer == "final answer"
+    # system + user + assistant present (budget high enough to keep all).
+    roles = [m["role"] for m in result.messages]
+    assert roles[0] == "system"
+    assert "user" in roles

--- a/test/llm/test_litellm_retry.py
+++ b/test/llm/test_litellm_retry.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the LLM-call retry policy (issue #109).
+
+Transient errors (rate-limit / timeout / upstream 5xx / connection blips)
+must be retried with exponential backoff up to a configurable max; a single
+transient blip followed by success returns the success. Non-transient errors
+(auth, bad request, content policy, context-window-exceeded) must NOT be
+retried.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import litellm
+import pytest
+
+from codeminer.llm.litellm_chat import LiteLLMChat, RetryConfig, is_transient_error
+
+
+def _make_response(content="ok"):
+    msg = SimpleNamespace(role="assistant", content=content, tool_calls=None)
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)], usage=None)
+
+
+def _no_sleep():
+    """Patch out the backoff sleep so tests don't actually wait."""
+    return patch("codeminer.llm.litellm_chat.time.sleep", return_value=None)
+
+
+# ---------------------------------------------------------------------------
+# RetryConfig.backoff
+# ---------------------------------------------------------------------------
+
+
+class TestRetryConfig:
+    def test_backoff_is_exponential_and_capped(self):
+        rc = RetryConfig(base_delay=0.5, max_delay=8.0, jitter=0.0)
+        delays = [rc.backoff(i) for i in range(6)]
+        assert delays == [0.5, 1.0, 2.0, 4.0, 8.0, 8.0]
+
+    def test_jitter_stays_within_bounds(self):
+        rc = RetryConfig(base_delay=1.0, max_delay=100.0, jitter=0.1)
+        # base for attempt 0 is 1.0, jitter adds up to 10% → [1.0, 1.1)
+        for _ in range(50):
+            d = rc.backoff(0)
+            assert 1.0 <= d < 1.1
+
+
+# ---------------------------------------------------------------------------
+# Transient classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsTransientError:
+    def test_rate_limit_is_transient(self):
+        exc = litellm.RateLimitError("rate limited", "gpt-4o", "openai")
+        assert is_transient_error(exc) is True
+
+    def test_timeout_is_transient(self):
+        exc = litellm.Timeout("timed out", "gpt-4o", "openai")
+        assert is_transient_error(exc) is True
+
+    def test_stdlib_timeout_is_transient(self):
+        assert is_transient_error(TimeoutError("slow")) is True
+
+    def test_authentication_is_not_transient(self):
+        exc = litellm.AuthenticationError("bad key", "gpt-4o", "openai")
+        assert is_transient_error(exc) is False
+
+    def test_bad_request_is_not_transient(self):
+        exc = litellm.BadRequestError("nope", "gpt-4o", "openai")
+        assert is_transient_error(exc) is False
+
+    def test_context_window_exceeded_is_not_transient(self):
+        exc = litellm.ContextWindowExceededError("too big", "gpt-4o", "openai")
+        assert is_transient_error(exc) is False
+
+    def test_plain_value_error_is_not_transient(self):
+        assert is_transient_error(ValueError("boom")) is False
+
+
+# ---------------------------------------------------------------------------
+# _completion_with_retry / _call_raw integration
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionWithRetry:
+    def test_transient_then_success_is_retried(self):
+        """A transient error once, then success → retried and returns success."""
+        chat = LiteLLMChat(
+            model="gpt-4o", retry=RetryConfig(max_retries=2, base_delay=0.01)
+        )
+        good = _make_response("recovered")
+        side_effects = [
+            litellm.RateLimitError("rate limited", "gpt-4o", "openai"),
+            good,
+        ]
+        with (
+            patch(
+                "codeminer.llm.litellm_chat.litellm.completion",
+                side_effect=side_effects,
+            ) as mock_completion,
+            _no_sleep(),
+        ):
+            resp = chat._call_raw([{"role": "user", "content": "hi"}])
+
+        assert resp is good
+        assert mock_completion.call_count == 2  # one failure + one success
+
+    def test_non_transient_error_is_not_retried(self):
+        """A non-transient error is raised immediately — never retried."""
+        chat = LiteLLMChat(
+            model="gpt-4o", retry=RetryConfig(max_retries=5, base_delay=0.01)
+        )
+        with (
+            patch(
+                "codeminer.llm.litellm_chat.litellm.completion",
+                side_effect=litellm.AuthenticationError("bad key", "gpt-4o", "openai"),
+            ) as mock_completion,
+            _no_sleep(),
+        ):
+            with pytest.raises(litellm.AuthenticationError):
+                chat._call_raw([{"role": "user", "content": "hi"}])
+
+        assert mock_completion.call_count == 1  # no retry on permanent error
+
+    def test_exhausts_retries_then_raises(self):
+        """Persistent transient errors raise after max_retries + 1 attempts."""
+        chat = LiteLLMChat(
+            model="gpt-4o", retry=RetryConfig(max_retries=2, base_delay=0.01)
+        )
+        with (
+            patch(
+                "codeminer.llm.litellm_chat.litellm.completion",
+                side_effect=litellm.Timeout("slow", "gpt-4o", "openai"),
+            ) as mock_completion,
+            _no_sleep(),
+        ):
+            with pytest.raises(litellm.Timeout):
+                chat._call_raw([{"role": "user", "content": "hi"}])
+
+        # 1 initial attempt + 2 retries
+        assert mock_completion.call_count == 3
+
+    def test_max_retries_zero_disables_retry(self):
+        """max_retries=0 → a single attempt, transient error propagates."""
+        chat = LiteLLMChat(model="gpt-4o", retry=RetryConfig(max_retries=0))
+        with (
+            patch(
+                "codeminer.llm.litellm_chat.litellm.completion",
+                side_effect=litellm.RateLimitError("rl", "gpt-4o", "openai"),
+            ) as mock_completion,
+            _no_sleep(),
+        ):
+            with pytest.raises(litellm.RateLimitError):
+                chat._call_raw([{"role": "user", "content": "hi"}])
+
+        assert mock_completion.call_count == 1
+
+    def test_backoff_sleep_called_between_retries(self):
+        """Backoff sleep is invoked once per retry, with the configured delay."""
+        chat = LiteLLMChat(
+            model="gpt-4o",
+            retry=RetryConfig(max_retries=2, base_delay=0.5, jitter=0.0),
+        )
+        good = _make_response("ok")
+        side_effects = [
+            litellm.Timeout("t", "gpt-4o", "openai"),
+            litellm.Timeout("t", "gpt-4o", "openai"),
+            good,
+        ]
+        with (
+            patch(
+                "codeminer.llm.litellm_chat.litellm.completion",
+                side_effect=side_effects,
+            ),
+            patch("codeminer.llm.litellm_chat.time.sleep") as mock_sleep,
+        ):
+            resp = chat._call_raw([{"role": "user", "content": "hi"}])
+
+        assert resp is good
+        # Two retries → two sleeps with exponential delays 0.5, 1.0.
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [0.5, 1.0]
+
+    def test_default_retry_config_present(self):
+        """A LiteLLMChat constructed without retry= has a default RetryConfig."""
+        chat = LiteLLMChat(model="gpt-4o")
+        assert isinstance(chat.retry, RetryConfig)
+        assert chat.retry.max_retries == 2


### PR DESCRIPTION
## Summary

Implements the two remaining pieces of #109 (token tracking and the
`allow_skills` allowlist already shipped): an LLM **retry policy** and a
**token-budgeted chat history**. Both unblock reliable Phase 2 sweeps in #148.

## Changes
- **Retry policy**: transient LLM errors / timeouts / rate-limits retry with
  exponential backoff up to a configurable max; non-transient errors are not
  retried. Wired into the litellm call path and `AgentRunner`.
- **`TokenBudgetedChatHistory`** (`codeminer/agent/history.py`): caps total
  context tokens and evicts the oldest non-system messages when the budget would
  be exceeded, preserving the system prompt and most-recent turns. `AgentRunner`
  opts in via a max-context-tokens setting.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/agent/test_history.py test/agent/test_runner_history_retry.py test/llm/test_litellm_retry.py -m "not slow and not integration"`
→ 36 passed. Covers retry-then-succeed, no-retry on non-transient errors, and
eviction of oldest non-system messages when over budget.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

<!-- Note: #109 is an umbrella refactor; this PR delivers the retry-policy and
token-budgeted-history items. Other items (token tracking, allow_skills) already
shipped. -->
