### PR TITLE
perf(profiling): incremental-graph commit-chain benchmark

### DIFF
--- a/scripts/profiling/profile_incremental_graph.py
+++ b/scripts/profiling/profile_incremental_graph.py
@@ -1,0 +1,1266 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark three graph-update strategies along a real commit chain (#129).
+
+For each instance repo, walk its first-parent commit chain ``N`` steps and, at
+every step, run all three strategies independently and record per-step timing:
+
+  1. ``fully-rebuild`` — wipe the indexer's own cache and re-run the full
+     SCIP/clangd pipeline from a cold start.
+  2. ``file-level-patch`` — the patcher in naive (file-granularity) mode:
+     delete + rebuild every vertex/edge of each modified file, no symbol diff.
+  3. ``symbol-level-patch`` — the production incremental patcher
+     (``codeminer.graph.incremental.patcher_base``): rewire edges by changed
+     lines + affected symbols.
+
+Strategies run as phases so the long-lived LSP cold-start cost is amortised
+across the chain for the two patcher strategies:
+
+  Phase 1 — symbol-level-patch, one LSP, N steps
+  Phase 2 — fully-rebuild, cold-start each step (skip when only docs changed)
+  Phase 3 — file-level-patch, one LSP, N steps
+
+Output: one JSONL row per ``(instance, step)`` carrying each strategy's
+``t_s``/``v``/``e``/``status``, the patcher stats, an LSP call summary, and the
+derived ``speedup_vs_fully_rebuild`` / ``speedup_vs_file_level_patch`` ratios.
+``notes`` flags commits with no source diff (``"no-source-change"``) or
+super-large diffs (``"too_large"``); both are kept (not skipped) because they
+reflect real-world commit traffic.
+
+The heavy ``codeminer.*`` imports (chunker, graph, patcher, indexer) are loaded
+lazily inside the functions that need them so the pure string/parse helpers can
+be imported and unit-tested without a full dev environment.
+
+Usage::
+
+    # Use the hardcoded DEFAULT_INSTANCES list (5 steps each):
+    python scripts/profiling/profile_incremental_graph.py --steps 5
+
+    # Pass instances inline ("iid:base_sha" or "iid:lang:base_sha"):
+    python scripts/profiling/profile_incremental_graph.py \\
+        --instances "gin-gonic__gin-1805:go:70a0aba,pydata__xarray-3151:python:118f4d9" \\
+        --steps 5
+
+    # Or from a JSON file:
+    python scripts/profiling/profile_incremental_graph.py --config instances.json --steps 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+HERE = Path(__file__).resolve().parent
+_PROJECT_ROOT = HERE.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+# Allow the C++ pybind decoder to load when present (faster SCIP decode).
+_CORE = _PROJECT_ROOT / "build" / "core"
+if _CORE.exists() and str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+
+# ---------------------------------------------------------------------------
+# Lazy importers — keep module import light so the pure helpers (and their
+# unit tests) don't drag in litellm / faiss / torch / tree-sitter.
+# ---------------------------------------------------------------------------
+
+
+def _CodeChunker():
+    from codeminer.code_chunker import CodeChunker
+
+    return CodeChunker
+
+
+def _CodeGraph():
+    from codeminer.graph.code_graph import CodeGraph
+
+    return CodeGraph
+
+
+def _GraphPatcher():
+    from codeminer.graph.incremental.graph_patcher import GraphPatcher
+
+    return GraphPatcher
+
+
+def _LSIndexer():
+    from codeminer.ls_router import LSIndexer
+
+    return LSIndexer
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_CACHE_ROOT = Path("/mnt/data/codeminer")
+DEFAULT_STEPS = 5
+DEFAULT_TIMEOUT_S = 600
+DEFAULT_MAX_DELTA_LINES = 5000
+DEFAULT_MAX_WALK = 200
+DEFAULT_OUTPUT = Path("profile_incremental.jsonl")
+
+# Hardcoded fallback instance list. Override with --instances or --config.
+# Each tuple is (instance_id, language, base_commit). Start at 5 steps; the
+# issue expands to 10 once the first results are in.
+DEFAULT_INSTANCES: List[Tuple[str, str, str]] = [
+    # C/C++
+    ("redis__redis-10068", "cpp", "e88f6acb94c77c9a5b81f0b2a8bd132b2a5c3d3c"),
+    ("jqlang__jq-2235", "cpp", "b8816caf0a7f58c6483f4344e222a6fea47732e8"),
+    # Go
+    ("caddyserver__caddy-4943", "go", "7f6a328b4744bbdd5ee07c5eccb3f897390ff982"),
+    ("gin-gonic__gin-1805", "go", "70a0aba3e423246be37462cfdaedd510c26c566e"),
+    # Python
+    ("pydata__xarray-3151", "python", "118f4d996e7711c9aced916e6049af9f28d5ec66"),
+    (
+        "scikit-learn__scikit-learn-10297",
+        "python",
+        "b90661d6a46aa3619d3eec94d5281f5888add501",
+    ),
+    # Rust
+    ("tokio-rs__tokio-4898", "rust", "9d9488db67136651f85d839efcb5f61aba8531c9"),
+    ("astral-sh__ruff-15309", "rust", "75a24bbc67aa31b825b6326cfb6e6afdf3ca90d5"),
+    # TS/JS
+    ("preactjs__preact-2757", "ts", "b17a932342bfdeeaf1dc0fbe4f436c83e258d6c8"),
+    ("axios__axios-4731", "ts", "c30252f685e8f4326722de84923fcbc8cf557f06"),
+]
+
+LANG_EXTS: Dict[str, set] = {
+    "cpp": {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"},
+    "go": {".go"},
+    "python": {".py"},
+    "rust": {".rs"},
+    "ts": {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"},
+}
+
+LANG_PATHSPEC: Dict[str, List[str]] = {
+    "cpp": ["*.c", "*.cc", "*.cpp", "*.cxx", "*.h", "*.hh", "*.hpp", "*.hxx"],
+    "go": ["*.go"],
+    "python": ["*.py"],
+    "rust": ["*.rs"],
+    "ts": ["*.ts", "*.tsx", "*.js", "*.jsx", "*.mjs", "*.cjs"],
+}
+
+_TEST_TOKENS = (
+    "test",
+    "tests",
+    "testing",
+    "spec",
+    "specs",
+    "__tests__",
+    "testdata",
+    "fixtures",
+)
+
+
+def is_test_path(path: str) -> bool:
+    """True when ``path`` looks like a test/fixture file the symbol-diff
+    should exclude (test churn isn't representative of source-graph load)."""
+    p = path.lower()
+    parts = p.split("/")
+    base = parts[-1] if parts else ""
+    for part in parts:
+        if part in _TEST_TOKENS:
+            return True
+        if part.startswith("test_"):
+            return True
+    if base.endswith("_test.go") or base.endswith("_test.py"):
+        return True
+    if base.endswith((".test.ts", ".test.tsx", ".test.js", ".test.jsx")):
+        return True
+    if base.endswith((".spec.ts", ".spec.js")):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# git helpers
+# ---------------------------------------------------------------------------
+
+
+def run_git(args: Sequence[str], cwd: Path, timeout: int = 120):
+    return subprocess.run(
+        ["git"] + list(args),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def checkout(repo: Path, sha: str) -> None:
+    r = run_git(["checkout", "-f", sha], cwd=repo, timeout=120)
+    if r.returncode != 0:
+        raise RuntimeError(f"checkout {sha[:12]} failed: {r.stderr[-400:]}")
+    # Preserve LSP/indexer caches AND compile-database artifacts across steps.
+    # Without these excludes ``git clean -fd`` wipes .cache/clangd/index,
+    # target/rust-analyzer, node_modules, compile_commands.json / build.
+    run_git(
+        [
+            "clean",
+            "-fd",
+            "-e",
+            ".cache",
+            "-e",
+            "target",
+            "-e",
+            "node_modules",
+            "-e",
+            "compile_commands.json",
+            "-e",
+            "build",
+        ],
+        cwd=repo,
+        timeout=60,
+    )
+
+
+def resolve_default_branch(repo: Path) -> Optional[str]:
+    r = run_git(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd=repo, timeout=15)
+    if r.returncode == 0:
+        ref = r.stdout.strip()
+        if ref:
+            return ref
+    for cand in ("origin/main", "origin/master", "origin/develop", "origin/trunk"):
+        r = run_git(["rev-parse", "--verify", cand], cwd=repo, timeout=15)
+        if r.returncode == 0:
+            return cand
+    return None
+
+
+def first_parent_commits(repo: Path, base: str, limit: int) -> List[str]:
+    """SHAs strictly after ``base`` on the first-parent path, oldest-first."""
+    upper = resolve_default_branch(repo)
+    if upper is None:
+        return []
+    r = run_git(
+        ["log", "--first-parent", "--reverse", "--format=%H", f"{base}..{upper}"],
+        cwd=repo,
+        timeout=120,
+    )
+    if r.returncode != 0:
+        return []
+    out = [s for s in r.stdout.splitlines() if s.strip()]
+    return out[:limit]
+
+
+def diff_shortstat(
+    repo: Path, base: str, target: str, pathspec: Optional[List[str]] = None
+) -> Tuple[int, int]:
+    """Return (lines_changed, files_changed). lines = insertions + deletions."""
+    args = ["diff", "--shortstat", f"{base}..{target}"]
+    if pathspec:
+        args.append("--")
+        args.extend(pathspec)
+    r = run_git(args, cwd=repo, timeout=120)
+    if r.returncode != 0:
+        return (0, 0)
+    line = r.stdout.strip()
+    files = ins = dels = 0
+    for tok in line.split(","):
+        tok = tok.strip()
+        try:
+            if "file" in tok:
+                files = int(tok.split()[0])
+            elif "insertion" in tok:
+                ins = int(tok.split()[0])
+            elif "deletion" in tok:
+                dels = int(tok.split()[0])
+        except (ValueError, IndexError):
+            # Best-effort shortstat parse: skip a malformed field rather than
+            # failing the whole diff.
+            pass
+    return (ins + dels, files)
+
+
+def diff_file_list(
+    repo: Path,
+    base: str,
+    target: str,
+    pathspec: Optional[List[str]] = None,
+    exclude_test: bool = True,
+) -> List[str]:
+    args = ["diff", "--name-only", f"{base}..{target}"]
+    if pathspec:
+        args.append("--")
+        args.extend(pathspec)
+    r = run_git(args, cwd=repo, timeout=120)
+    if r.returncode != 0:
+        return []
+    out = []
+    for f in r.stdout.splitlines():
+        f = f.strip()
+        if not f:
+            continue
+        if exclude_test and is_test_path(f):
+            continue
+        out.append(f)
+    return out
+
+
+def git_show_to_file(repo: Path, sha: str, path: str, dest: Path) -> bool:
+    r = subprocess.run(
+        ["git", "show", f"{sha}:{path}"],
+        cwd=str(repo),
+        capture_output=True,
+        timeout=30,
+    )
+    if r.returncode != 0:
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(r.stdout)
+    return True
+
+
+def _chunk_to_symbol_map(
+    chunker, file_path: Path, relative_path: str
+) -> Dict[Tuple[str, str], str]:
+    try:
+        chunks = chunker.chunk_file(str(file_path), relative_path=relative_path)
+    except Exception:
+        return {}
+    out: Dict[Tuple[str, str], str] = {}
+    for c in chunks:
+        if c.chunk_type in ("file", "header"):
+            continue
+        h = hashlib.sha1(c.content.encode("utf-8", errors="replace")).hexdigest()
+        out[(c.node_id, c.chunk_type)] = h
+    return out
+
+
+def compute_delta_symbols(
+    repo: Path, base: str, target: str, changed_files: List[str], language: str
+) -> Tuple[int, int, int]:
+    """Return (added, removed, modified) symbol counts via tree-sitter."""
+    if not changed_files:
+        return (0, 0, 0)
+    chunker = _CodeChunker()(language=language, chunk_depth=2)
+    added = removed = modified = 0
+    with tempfile.TemporaryDirectory(prefix="chainbench_") as tmpdir:
+        tmp = Path(tmpdir)
+        tmp_resolved = tmp.resolve()
+        for rel_path in changed_files:
+            base_file = tmp / "base" / rel_path
+            tgt_file = tmp / "target" / rel_path
+            # Defensive: a malformed diff entry with ``..`` segments could let
+            # ``tmp / rel_path`` escape the temp dir. Drop anything that
+            # doesn't resolve under tmp.
+            try:
+                base_file.resolve().relative_to(tmp_resolved)
+                tgt_file.resolve().relative_to(tmp_resolved)
+            except ValueError:
+                continue
+            has_base = git_show_to_file(repo, base, rel_path, base_file)
+            has_target = git_show_to_file(repo, target, rel_path, tgt_file)
+            base_map = (
+                _chunk_to_symbol_map(chunker, base_file, rel_path) if has_base else {}
+            )
+            tgt_map = (
+                _chunk_to_symbol_map(chunker, tgt_file, rel_path) if has_target else {}
+            )
+            base_keys = set(base_map.keys())
+            tgt_keys = set(tgt_map.keys())
+            added += len(tgt_keys - base_keys)
+            removed += len(base_keys - tgt_keys)
+            for k in base_keys & tgt_keys:
+                if base_map[k] != tgt_map[k]:
+                    modified += 1
+    return (added, removed, modified)
+
+
+# ---------------------------------------------------------------------------
+# Cold-start helpers
+# ---------------------------------------------------------------------------
+
+
+def clear_indexer_cache(repo: Path, language: str) -> None:
+    """Wipe per-language indexer caches so the next rebuild is cold."""
+    paths: List[Path] = []
+    if language in ("cpp", "c"):
+        paths.append(repo / ".cache" / "clangd")
+    elif language in ("ts", "typescript"):
+        paths.append(repo / "node_modules" / ".cache" / "scip-typescript")
+    elif language == "rust":
+        paths.append(repo / "target" / "rust-analyzer")
+    for p in paths:
+        if p.exists():
+            try:
+                shutil.rmtree(p)
+            except Exception:
+                # Cache wipe is best-effort: a permission/in-use error just
+                # warm-starts the rebuild (inflates t_rebuild), not a
+                # correctness issue.
+                pass
+
+
+# ---------------------------------------------------------------------------
+# SIGALRM per-strategy timeout
+# ---------------------------------------------------------------------------
+
+
+class StrategyTimeout(Exception):
+    pass
+
+
+def _alarm_handler(signum, frame):
+    raise StrategyTimeout()
+
+
+def run_with_timeout(seconds: int, fn, *args, **kwargs):
+    if seconds <= 0:
+        return fn(*args, **kwargs)
+    prev = signal.signal(signal.SIGALRM, _alarm_handler)
+    signal.alarm(seconds)
+    try:
+        return fn(*args, **kwargs)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, prev)
+
+
+# ---------------------------------------------------------------------------
+# LSP profile aggregation
+# ---------------------------------------------------------------------------
+
+
+def _summarize_lsp_profile(path: Optional[Path]) -> Dict[str, Any]:
+    if not path or not path.exists():
+        return {"calls_total": 0, "calls_by_method": {}, "ms_by_method": {}}
+    by_method: Dict[str, Dict[str, float]] = {}
+    total = 0
+    for line in path.open():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        m = r.get("m", "?")
+        d = by_method.setdefault(m, {"count": 0, "ms": 0.0, "empty": 0})
+        d["count"] += 1
+        d["ms"] += r.get("ms", 0)
+        if (r.get("n", 0) or 0) == 0:
+            d["empty"] += 1
+        total += 1
+    return {
+        "calls_total": total,
+        "calls_by_method": {m: int(v["count"]) for m, v in by_method.items()},
+        "ms_by_method": {m: round(v["ms"], 1) for m, v in by_method.items()},
+        "empty_by_method": {m: int(v["empty"]) for m, v in by_method.items()},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strategy 1: full rebuild at one commit
+# ---------------------------------------------------------------------------
+
+
+def _do_rebuild(
+    language: str, repo: Path, target_sha: str, out_dir: Path
+) -> Dict[str, Any]:
+    """Cold-start full SCIP/clangd rebuild at ``target_sha``."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for f in ("index.scip", "index.decoded", "graph.pkl"):
+        (out_dir / f).unlink(missing_ok=True)
+
+    checkout(repo, target_sha)
+    indexer = _LSIndexer()(
+        project_root=repo,
+        output_dir=out_dir,
+        language=language,
+    )
+    t0 = time.monotonic()
+    g = indexer.run_pipeline(
+        output_file=str(out_dir / "graph.pkl"),
+        skip_level=None,
+        reset_profiler=True,
+        report_profile=False,
+    )
+    elapsed = time.monotonic() - t0
+    if g is None:
+        raise RuntimeError("rebuild returned no graph")
+    return {
+        "t_s": elapsed,
+        "v": g.graph.vcount(),
+        "e": g.graph.ecount(),
+        "status": "ok",
+    }
+
+
+def run_rebuild_step(
+    target: Dict[str, Any],
+    cache_root: Path,
+    step_out_dir: Path,
+    prev_rebuild_pkl: Optional[Path],
+    timeout_s: int,
+    log,
+) -> Dict[str, Any]:
+    """Run a rebuild for one step. When the commit touched 0 source files,
+    skip the cold rebuild and reuse the previous step's rebuild graph."""
+    iid = target["instance_id"]
+    lang = target["language"]
+    repo = cache_root / iid / "repo"
+    rebuild_pkl = step_out_dir / "rebuild.pkl"
+
+    is_no_source = target.get("delta_files_test_excluded", 0) == 0
+    if is_no_source and prev_rebuild_pkl is not None and prev_rebuild_pkl.exists():
+        log(f"  rebuild step{target['step']} SKIPPED (no source diff)")
+        try:
+            shutil.copyfile(str(prev_rebuild_pkl), str(rebuild_pkl))
+            g = _CodeGraph().load_graph(str(rebuild_pkl))
+            return {
+                "t_s": 0.0,
+                "v": g.graph.vcount(),
+                "e": g.graph.ecount(),
+                "status": "ok",
+                "skipped_no_source": True,
+            }
+        except Exception as e:
+            return {
+                "status": "error",
+                "error": f"reuse-prev failed: {type(e).__name__}: {e}",
+            }
+
+    log(f"  rebuild step{target['step']} {target['to_commit'][:8]} (cold start)")
+    try:
+        clear_indexer_cache(repo, lang)
+        info = run_with_timeout(
+            timeout_s,
+            _do_rebuild,
+            lang,
+            repo,
+            target["to_commit"],
+            step_out_dir,
+        )
+        # _do_rebuild writes graph.pkl; rename to rebuild.pkl.
+        src = step_out_dir / "graph.pkl"
+        if src.exists() and src != rebuild_pkl:
+            shutil.move(str(src), str(rebuild_pkl))
+        return info
+    except StrategyTimeout:
+        return {"status": "timeout", "t_s": timeout_s}
+    except Exception as e:
+        return {"status": "error", "error": f"{type(e).__name__}: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Strategies 2/3: patcher phase (one long-lived LSP, walk the whole chain)
+# ---------------------------------------------------------------------------
+
+
+def _first_symbol_position(symbols) -> Optional[Tuple[int, int]]:
+    """First (line, char) found by DFS into LSP documentSymbol output."""
+    for s in symbols or []:
+        sel = s.get("selectionRange", s.get("range", {}))
+        line = sel.get("start", {}).get("line")
+        char = sel.get("start", {}).get("character", 0)
+        if line is not None:
+            return (line, char)
+        nested = _first_symbol_position(s.get("children", []))
+        if nested is not None:
+            return nested
+    return None
+
+
+def _get_lsp_client(patcher):
+    return getattr(patcher, "lsp_client", None) or getattr(
+        getattr(patcher, "_impl", None), "lsp_client", None
+    )
+
+
+def _warmup_lsp(
+    patcher, repo: Path, base_sha: str, target_sha: str, language: str
+) -> float:
+    """Open changed files + a dummy ``definition`` so LSP first-call cost
+    falls outside the timed region. Excluded from t_s."""
+    t0 = time.monotonic()
+    r = run_git(["diff", "--name-only", base_sha, target_sha], cwd=repo, timeout=60)
+    names = r.stdout.split() if r.returncode == 0 else []
+    exts = LANG_EXTS.get(language, set())
+    abs_paths = [repo / n for n in names if Path(n).suffix in exts]
+    lsp = _get_lsp_client(patcher)
+    if lsp is None:
+        return 0.0
+    for p in abs_paths:
+        if p.is_file():
+            try:
+                lsp.open_document(str(p))
+            except Exception:
+                # Best-effort: a single file failing to open just means its
+                # first real query inside the timed region pays the lazy-init
+                # cost. Don't abort the run.
+                pass
+    for p in abs_paths:
+        if not p.is_file():
+            continue
+        try:
+            syms = lsp.document_symbol(str(p)) or []
+            real_pos = _first_symbol_position(syms)
+            if real_pos:
+                lsp.definition(str(p), real_pos[0], real_pos[1])
+        except Exception:
+            # Best-effort: documentSymbol/definition failure here just shifts
+            # the first-call cost into the timed region — measurement noise.
+            pass
+    return time.monotonic() - t0
+
+
+def run_patcher_phase(
+    strategy: str,
+    mode: str,
+    chain: List[Dict[str, Any]],
+    base_graph_pkl: Path,
+    cache_root: Path,
+    out_root: Path,
+    timeout_s: int,
+    lsp_profile_dir: Optional[Path],
+    log,
+    out_filename: str,
+) -> Dict[int, Dict[str, Any]]:
+    """Run the ``mode`` patcher across the chain with a single long-lived LSP.
+
+    The graph mutates in memory across steps, so each step inherits the prior
+    step's output without pickle round-trips. Returns ``{step -> sub-record}``.
+    """
+    iid = chain[0]["instance_id"]
+    lang = chain[0]["language"]
+    repo = cache_root / iid / "repo"
+    sub_records: Dict[int, Dict[str, Any]] = {}
+
+    try:
+        g = _CodeGraph().load_graph(str(base_graph_pkl))
+    except Exception as e:
+        for t in chain:
+            sub_records[t["step"]] = {"status": "error", "error": f"load_base: {e}"}
+        return sub_records
+
+    patcher = _GraphPatcher()(
+        project_root=str(repo),
+        code_graph=g,
+        language=lang,
+        mode=mode,
+    )
+
+    t0 = time.monotonic()
+    try:
+        patcher.start_lsp()
+    except Exception as e:
+        for t in chain:
+            sub_records[t["step"]] = {"status": "error", "error": f"start_lsp: {e}"}
+        return sub_records
+    cold_start_total = time.monotonic() - t0
+
+    log(
+        f"  {strategy}: LSP cold-start {cold_start_total:.1f}s, "
+        f"running {len(chain)} steps"
+    )
+
+    # ``poisoned`` flips True after any timeout/exception inside
+    # ``patch_files``. The in-memory graph mutates in place and the LSP
+    # JSON-RPC socket can be left in an undefined state after a SIGALRM
+    # interrupt, so measurements past that point are unreliable. Remaining
+    # steps are recorded as ``aborted_prior_step_poisoned`` instead of
+    # silently producing bad t_s / v / e numbers.
+    poisoned = False
+    poisoned_at: Optional[int] = None
+
+    try:
+        for i, t in enumerate(chain):
+            step = t["step"]
+            step_dir = out_root / iid / f"step{step}"
+            step_dir.mkdir(parents=True, exist_ok=True)
+            out_pkl = step_dir / out_filename
+
+            if poisoned:
+                sub_records[step] = {
+                    "status": "aborted_prior_step_poisoned",
+                    "poisoned_at_step": poisoned_at,
+                }
+                continue
+
+            # Per-step LSP profile capture.
+            profile_path: Optional[Path] = None
+            if lsp_profile_dir is not None:
+                lsp_profile_dir.mkdir(parents=True, exist_ok=True)
+                profile_path = lsp_profile_dir / f"{iid}_step{step}_{strategy}.jsonl"
+                profile_path.unlink(missing_ok=True)
+                os.environ["LSP_PROFILE_PATH"] = str(profile_path)
+            else:
+                os.environ.pop("LSP_PROFILE_PATH", None)
+
+            try:
+                checkout(repo, t["to_commit"])
+            except Exception as e:
+                sub_records[step] = {
+                    "status": "error",
+                    "error": f"checkout: {type(e).__name__}: {e}",
+                }
+                os.environ.pop("LSP_PROFILE_PATH", None)
+                continue
+
+            # Per-step warmup (cpp skipped: patcher_cpp doesn't query LSP).
+            warmup_t0 = time.monotonic()
+            if lang != "cpp":
+                try:
+                    _warmup_lsp(patcher, repo, t["from_commit"], t["to_commit"], lang)
+                except Exception:
+                    # Best-effort: any failure just shifts the first-call cost
+                    # into the timed region.
+                    pass
+            warmup_s = time.monotonic() - warmup_t0
+
+            log(
+                f"  {strategy} step{step} {t['to_commit'][:8]} "
+                f"L{t['delta_lines']} F{t['delta_files_test_excluded']} "
+                f"S{t['delta_symbols']}"
+            )
+            try:
+                changed = patcher.detect_changed_files(
+                    str(repo),
+                    t["from_commit"],
+                    t["to_commit"],
+                    extensions=LANG_EXTS.get(lang),
+                )
+                pt0 = time.monotonic()
+                stats = run_with_timeout(
+                    timeout_s,
+                    patcher.patch_files,
+                    changed,
+                    earlier_commit=t["from_commit"],
+                    later_commit=t["to_commit"],
+                )
+                elapsed = time.monotonic() - pt0
+                g.save_graph(str(out_pkl))
+                sub: Dict[str, Any] = {
+                    "t_s": elapsed,
+                    "cold_start_s": cold_start_total if i == 0 else 0.0,
+                    "warmup_s": warmup_s,
+                    "v": g.graph.vcount(),
+                    "e": g.graph.ecount(),
+                    "status": "ok",
+                    "stats": {
+                        k: v
+                        for k, v in stats.items()
+                        if isinstance(v, (int, float, str, bool))
+                    },
+                    "profile": stats.get("profile") or {},
+                }
+            except StrategyTimeout:
+                # Graph + LSP state are now suspect — poison the rest of the
+                # phase so we don't report numbers off a half-mutated graph or
+                # a broken JSON-RPC pipe.
+                poisoned = True
+                poisoned_at = step
+                log(
+                    f"  {strategy} step{step}: timeout — "
+                    f"poisoning remaining {len(chain) - i - 1} step(s)"
+                )
+                sub = {
+                    "status": "timeout",
+                    "t_s": timeout_s,
+                    "cold_start_s": cold_start_total if i == 0 else 0.0,
+                    "warmup_s": warmup_s,
+                }
+            except Exception as e:
+                poisoned = True
+                poisoned_at = step
+                log(
+                    f"  {strategy} step{step}: {type(e).__name__}: {e} — "
+                    f"poisoning remaining {len(chain) - i - 1} step(s)"
+                )
+                sub = {
+                    "status": "error",
+                    "error": f"{type(e).__name__}: {e}",
+                    "cold_start_s": cold_start_total if i == 0 else 0.0,
+                    "warmup_s": warmup_s,
+                }
+            sub["lsp"] = (
+                _summarize_lsp_profile(profile_path)
+                if profile_path
+                else {"calls_total": 0, "calls_by_method": {}, "ms_by_method": {}}
+            )
+            os.environ.pop("LSP_PROFILE_PATH", None)
+            sub_records[step] = sub
+    finally:
+        try:
+            patcher.stop_lsp()
+        except Exception:
+            # Teardown is best-effort: a hung/dead LSP child should not
+            # propagate out of ``finally`` and mask the real result we already
+            # wrote to sub_records.
+            pass
+
+    return sub_records
+
+
+# ---------------------------------------------------------------------------
+# Commit chain construction
+# ---------------------------------------------------------------------------
+
+
+def build_chain(
+    iid: str,
+    language: str,
+    base_commit: str,
+    cache_root: Path,
+    n_steps: int,
+    max_walk: int,
+    max_delta_lines: int,
+    log,
+) -> List[Dict[str, Any]]:
+    """Walk first-parent commits and emit ``n_steps`` rows. ``notes`` flags
+    no-source / too-large commits but the chain still advances past them so
+    real-world commit traffic is faithfully represented."""
+    repo = cache_root / iid / "repo"
+    if not repo.exists():
+        log(f"[{iid}] repo missing: {repo}")
+        return []
+
+    pathspec = LANG_PATHSPEC.get(language, [])
+    candidates = first_parent_commits(repo, base_commit, max_walk)
+    out: List[Dict[str, Any]] = []
+    prev = base_commit
+    step = 0
+    for sha in candidates:
+        files_all = diff_file_list(repo, prev, sha, pathspec, exclude_test=False)
+        files_excl = diff_file_list(repo, prev, sha, pathspec, exclude_test=True)
+        if not files_excl:
+            delta_lines = 0
+        else:
+            delta_lines, _ = diff_shortstat(repo, prev, sha, files_excl)
+        added, removed, modified = compute_delta_symbols(
+            repo,
+            prev,
+            sha,
+            files_excl,
+            language,
+        )
+
+        if delta_lines > max_delta_lines:
+            notes = "too_large"
+        elif len(files_excl) == 0:
+            notes = "no-source-change"
+        else:
+            notes = None
+
+        step += 1
+        out.append(
+            {
+                "instance_id": iid,
+                "language": language,
+                "step": step,
+                "from_commit": prev,
+                "to_commit": sha,
+                "delta_lines": delta_lines,
+                "delta_files": len(files_all),
+                "delta_files_test_excluded": len(files_excl),
+                "delta_symbols": added + removed + modified,
+                "delta_symbols_added": added,
+                "delta_symbols_removed": removed,
+                "delta_symbols_modified": modified,
+                "notes": notes,
+            }
+        )
+        prev = sha
+        if step >= n_steps:
+            break
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-instance orchestration
+# ---------------------------------------------------------------------------
+
+
+def process_instance(
+    iid: str,
+    language: str,
+    base_commit: str,
+    cache_root: Path,
+    n_steps: int,
+    max_walk: int,
+    max_delta_lines: int,
+    timeout_s: int,
+    out_root: Path,
+    lsp_profile_dir: Optional[Path],
+    log,
+) -> List[Dict[str, Any]]:
+    """Build chain, then run three strategies as phases. Returns one result
+    row per step (each row contains rebuild/naive/symbol sub-records)."""
+    chain = build_chain(
+        iid, language, base_commit, cache_root, n_steps, max_walk, max_delta_lines, log
+    )
+    if not chain:
+        return []
+    repo = cache_root / iid / "repo"
+
+    # The base graph for the patcher is loaded from the instance's pre-existing
+    # rebuild at ``base_commit`` (``<cache_root>/<iid>/graph.pkl``).
+    base_graph_pkl = cache_root / iid / "graph.pkl"
+    if not base_graph_pkl.exists():
+        log(f"[{iid}] missing base graph: {base_graph_pkl}")
+        # ``step=0`` keys the row so --resume skips it next time; without a
+        # step the resume index drops the row and the error re-appends on
+        # every retry.
+        return [
+            {
+                "instance_id": iid,
+                "language": language,
+                "step": 0,
+                "error": f"no base graph at {base_graph_pkl}",
+            }
+        ]
+
+    # Initial per-step record (merged with strategy sub-records below).
+    step_recs: Dict[int, Dict[str, Any]] = {}
+    for t in chain:
+        step_recs[t["step"]] = {
+            "instance_id": t["instance_id"],
+            "language": t["language"],
+            "step": t["step"],
+            "from_commit": t["from_commit"],
+            "to_commit": t["to_commit"],
+            "delta_lines": t["delta_lines"],
+            "delta_files": t["delta_files"],
+            "delta_files_test_excluded": t["delta_files_test_excluded"],
+            "delta_symbols": t["delta_symbols"],
+            "delta_symbols_added": t["delta_symbols_added"],
+            "delta_symbols_removed": t["delta_symbols_removed"],
+            "delta_symbols_modified": t["delta_symbols_modified"],
+            "notes": t["notes"],
+            "started": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        }
+
+    log(f"=== {iid} ({language}) — {len(chain)} steps ===")
+
+    # Phase 1: symbol-level patcher.
+    log(f"=== {iid} phase 1/3: symbol-level-patch ===")
+    symbol_subs = run_patcher_phase(
+        "symbol-level-patch",
+        "symbol",
+        chain,
+        base_graph_pkl,
+        cache_root,
+        out_root,
+        timeout_s,
+        lsp_profile_dir,
+        log,
+        "symbol-level-patch.pkl",
+    )
+    for step, sub in symbol_subs.items():
+        step_recs[step]["symbol-level-patch"] = sub
+
+    # Phase 2: cold-start rebuild per step (skip when no source diff).
+    log(f"=== {iid} phase 2/3: fully-rebuild ===")
+    prev_rb_pkl: Optional[Path] = None
+    for t in chain:
+        step_dir = out_root / iid / f"step{t['step']}"
+        step_dir.mkdir(parents=True, exist_ok=True)
+        sub = run_rebuild_step(t, cache_root, step_dir, prev_rb_pkl, timeout_s, log)
+        step_recs[t["step"]]["fully-rebuild"] = sub
+        rb_pkl = step_dir / "rebuild.pkl"
+        if rb_pkl.exists():
+            prev_rb_pkl = rb_pkl
+
+    # Phase 3: file-level (naive-mode) patcher, with clangd cache cleared.
+    log(f"=== {iid} phase 3/3: file-level-patch ===")
+    clear_indexer_cache(repo, language)
+    file_subs = run_patcher_phase(
+        "file-level-patch",
+        "naive",
+        chain,
+        base_graph_pkl,
+        cache_root,
+        out_root,
+        timeout_s,
+        lsp_profile_dir,
+        log,
+        "file-level-patch.pkl",
+    )
+    for step, sub in file_subs.items():
+        step_recs[step]["file-level-patch"] = sub
+
+    # Speedups + finished timestamp.
+    out: List[Dict[str, Any]] = []
+    for t in chain:
+        rec = step_recs[t["step"]]
+        out.append(finalize_step_record(rec))
+    return out
+
+
+def finalize_step_record(rec: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute derived speedups + finished timestamp for one step record.
+
+    Pure helper (no I/O) so the per-step comparison can be unit-tested with
+    mocked sub-records.
+    """
+    rb = rec.get("fully-rebuild", {})
+    fl = rec.get("file-level-patch", {})
+    sl = rec.get("symbol-level-patch", {})
+    tr = rb.get("t_s") if rb.get("status") == "ok" else None
+    tf = fl.get("t_s") if fl.get("status") == "ok" else None
+    ts = sl.get("t_s") if sl.get("status") == "ok" else None
+    rec["speedup_vs_fully_rebuild"] = (tr / ts) if (tr and ts) else None
+    rec["speedup_vs_file_level_patch"] = (tf / ts) if (tf and ts) else None
+    rec["finished"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# Input parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_instances_inline(spec: str, cache_root: Path) -> List[Tuple[str, str, str]]:
+    """Parse ``"iid:sha"`` or ``"iid:lang:sha"`` (comma-separated).
+
+    Two-field form ``iid:sha``: language inferred from the cloned repo's file
+    extensions. Three-field form ``iid:lang:sha`` skips inference. Drops
+    entries with unknown language (with a warning).
+    """
+    out = []
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        tokens = part.split(":")
+        if len(tokens) == 3:
+            iid, lang, sha = tokens[0].strip(), tokens[1].strip(), tokens[2].strip()
+        elif len(tokens) == 2:
+            iid, sha = tokens[0].strip(), tokens[1].strip()
+            lang = _infer_language(cache_root / iid / "repo")
+            if not lang:
+                print(
+                    f"warning: language inference failed for {iid!r}; "
+                    f"skipping. Pass iid:lang:sha to disambiguate.",
+                    file=sys.stderr,
+                )
+                continue
+        else:
+            print(
+                f"warning: cannot parse instance spec {part!r}; "
+                f'expected "iid:sha" or "iid:lang:sha"',
+                file=sys.stderr,
+            )
+            continue
+        out.append((iid, lang, sha))
+    return out
+
+
+def parse_instances_config(path: Path) -> List[Tuple[str, str, str]]:
+    """Parse JSON: ``[{"instance_id":.., "language":.., "base_commit":..}, ...]``"""
+    rows = json.loads(path.read_text())
+    return [(r["instance_id"], r["language"], r["base_commit"]) for r in rows]
+
+
+def _infer_language(repo: Path) -> Optional[str]:
+    """Sample up to 200 tracked files to guess the dominant language.
+
+    Uses ``os.walk`` with in-place dir pruning to skip dot-dirs (``.git``,
+    ``.cache``) and known build/dependency trees so the scan doesn't traverse
+    millions of objects on large repos.
+    """
+    if not repo.is_dir():
+        return None
+    counts: Dict[str, int] = {lang: 0 for lang in LANG_EXTS}
+    prune = {"node_modules", "target", "build", "dist", "vendor", "__pycache__"}
+    sampled = 0
+    for _dirpath, dirnames, filenames in os.walk(repo):
+        dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in prune]
+        for name in filenames:
+            suffix = Path(name).suffix
+            for lang, exts in LANG_EXTS.items():
+                if suffix in exts:
+                    counts[lang] += 1
+                    break
+            sampled += 1
+            if sampled > 200:
+                break
+        if sampled > 200:
+            break
+    if not any(counts.values()):
+        return None
+    return max(counts, key=counts.get)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--instances",
+        default=None,
+        help='Comma-separated "iid:base_sha" or "iid:lang:base_sha" entries. '
+        "Overrides DEFAULT_INSTANCES and --config.",
+    )
+    ap.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="JSON file with [{instance_id, language, base_commit}, ...]. "
+        "Overrides DEFAULT_INSTANCES.",
+    )
+    ap.add_argument(
+        "--steps",
+        type=int,
+        default=DEFAULT_STEPS,
+        help=f"steps per instance (default {DEFAULT_STEPS})",
+    )
+    ap.add_argument(
+        "--max-walk",
+        type=int,
+        default=DEFAULT_MAX_WALK,
+        help="max first-parent commits to consider per instance "
+        f"(default {DEFAULT_MAX_WALK})",
+    )
+    ap.add_argument(
+        "--max-delta-lines",
+        type=int,
+        default=DEFAULT_MAX_DELTA_LINES,
+        help='delta_lines above this gets notes="too_large" '
+        f"(default {DEFAULT_MAX_DELTA_LINES}); NOT skipped",
+    )
+    ap.add_argument(
+        "--timeout-s",
+        type=int,
+        default=DEFAULT_TIMEOUT_S,
+        help=f"per-strategy wall-clock cap, seconds (default {DEFAULT_TIMEOUT_S})",
+    )
+    ap.add_argument(
+        "--cache-root",
+        type=Path,
+        default=DEFAULT_CACHE_ROOT,
+        help=f"where instance repos live (default {DEFAULT_CACHE_ROOT})",
+    )
+    ap.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"jsonl output path (default {DEFAULT_OUTPUT})",
+    )
+    ap.add_argument(
+        "--lsp-profile-dir",
+        type=Path,
+        default=None,
+        help="if set, capture per-call LSP profile jsonl per "
+        "(iid, step, strategy) into this dir",
+    )
+    ap.add_argument(
+        "--out-root",
+        type=Path,
+        default=None,
+        help="dir for per-(iid, step) graph pkls (default: alongside output)",
+    )
+    ap.add_argument(
+        "--resume",
+        action="store_true",
+        help="skip (iid, step) rows that already exist in --output",
+    )
+    args = ap.parse_args()
+
+    # Resolve the instance list.
+    if args.instances:
+        instances = parse_instances_inline(args.instances, args.cache_root)
+    elif args.config:
+        instances = parse_instances_config(args.config)
+    else:
+        instances = list(DEFAULT_INSTANCES)
+    if not instances:
+        print("error: no instances to run", file=sys.stderr)
+        sys.exit(2)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    if args.out_root is None:
+        args.out_root = args.output.parent / "chain_work"
+
+    # Load already-done keys for --resume. ``done_steps[iid]`` is the set of
+    # step ids written for that instance, including ``0`` for the
+    # missing-base-graph sentinel from process_instance.
+    done: set = set()
+    done_steps: Dict[str, set] = {}
+    if args.resume and args.output.exists():
+        for line in args.output.open():
+            try:
+                r = json.loads(line)
+            except Exception:
+                continue
+            iid = r.get("instance_id")
+            step = r.get("step")
+            if iid and step is not None:
+                done.add((iid, step))
+                done_steps.setdefault(iid, set()).add(step)
+
+    def log(msg: str) -> None:
+        print(msg, flush=True)
+
+    log(
+        f"instances={len(instances)} steps={args.steps} "
+        f"timeout_s={args.timeout_s} output={args.output}"
+    )
+
+    fh = args.output.open("a")
+    try:
+        for iid, language, base_sha in instances:
+            # Whole-instance short-circuit. Skip walking the chain when either
+            # every step 1..N is already written, or the step-0
+            # (missing-base-graph) sentinel was written. Repos whose walk
+            # produces fewer than --steps rows can't be detected without
+            # re-walking, so they fall through to the per-row resume-skip.
+            if args.resume:
+                steps_done = done_steps.get(iid, set())
+                if 0 in steps_done:
+                    log(f"[{iid}] resume-skip (missing-base-graph sentinel)")
+                    continue
+                if all(s in steps_done for s in range(1, args.steps + 1)):
+                    log(f"[{iid}] resume-skip (all {args.steps} steps in output)")
+                    continue
+            rows = process_instance(
+                iid,
+                language,
+                base_sha,
+                args.cache_root,
+                args.steps,
+                args.max_walk,
+                args.max_delta_lines,
+                args.timeout_s,
+                args.out_root,
+                args.lsp_profile_dir,
+                log,
+            )
+            for r in rows:
+                key = (r.get("instance_id"), r.get("step"))
+                if key in done:
+                    log(f"[{iid}] step{r.get('step')} resume-skip (already in output)")
+                    continue
+                fh.write(json.dumps(r) + "\n")
+                fh.flush()
+    finally:
+        fh.close()
+    log(f"done. wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/scripts/__init__.py
+++ b/test/scripts/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/test/scripts/test_profile_incremental_graph.py
+++ b/test/scripts/test_profile_incremental_graph.py
@@ -1,0 +1,261 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``scripts/profiling/profile_incremental_graph.py``.
+
+The benchmark itself needs real SCIP/clangd + cloned repos (that side is an
+integration concern, exercised manually). These tests cover the pure helpers
+and the per-step comparison harness with mocked strategy sub-records — no LSP,
+no git, no ``codeminer.*`` heavy deps (those imports are lazy in the script).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "profiling" / "profile_incremental_graph.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "_profile_incremental_graph_for_tests", _SCRIPT_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+prof = importlib.util.module_from_spec(_SPEC)
+sys.modules["_profile_incremental_graph_for_tests"] = prof
+_SPEC.loader.exec_module(prof)
+
+
+class TestIsTestPath:
+    """Files/dirs the test-exclusion filter should catch vs. let through."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "test/foo.py",
+            "tests/bar.go",
+            "src/__tests__/baz.ts",
+            "pkg/testing/x.go",
+            "fixtures/data.json",
+            "testdata/sample.txt",
+            "src/test_helper.py",
+            "src/handler_test.go",
+            "src/handler_test.py",
+            "src/component.test.ts",
+            "src/component.test.tsx",
+            "src/component.spec.js",
+            "src/SPEC.spec.ts",
+            "deeply/nested/specs/x.py",
+        ],
+    )
+    def test_excludes(self, path):
+        assert prof.is_test_path(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/foo.py",
+            "lib/handler.go",
+            "pkg/server/main.go",
+            "src/component.ts",
+            "src/myspec.py",
+            "src/contestant.py",
+        ],
+    )
+    def test_includes(self, path):
+        assert prof.is_test_path(path) is False
+
+
+class TestParseInstancesInline:
+    """Comma-separated instance spec parsing."""
+
+    def test_three_field_form(self, tmp_path):
+        out = prof.parse_instances_inline("foo:python:abc123,bar:go:def456", tmp_path)
+        assert out == [("foo", "python", "abc123"), ("bar", "go", "def456")]
+
+    def test_whitespace_tolerance(self, tmp_path):
+        out = prof.parse_instances_inline(" foo:python:abc , bar:go:def ", tmp_path)
+        assert out == [("foo", "python", "abc"), ("bar", "go", "def")]
+
+    def test_skip_malformed(self, tmp_path, capsys):
+        out = prof.parse_instances_inline("only_one_field,foo:python:abc", tmp_path)
+        assert out == [("foo", "python", "abc")]
+        assert "cannot parse" in capsys.readouterr().err
+
+    def test_two_field_with_inference_failure(self, tmp_path, capsys):
+        # No repo on disk -> inference returns None -> entry dropped + warning.
+        out = prof.parse_instances_inline("ghost:abc123", tmp_path)
+        assert out == []
+        assert "language inference failed" in capsys.readouterr().err
+
+    def test_two_field_with_inference_success(self, tmp_path):
+        # Create a repo dir with .py files to force python inference.
+        repo = tmp_path / "real" / "repo"
+        repo.mkdir(parents=True)
+        for i in range(3):
+            (repo / f"f{i}.py").write_text("x = 1\n")
+        out = prof.parse_instances_inline("real:abc123", tmp_path)
+        assert out == [("real", "python", "abc123")]
+
+
+class TestParseInstancesConfig:
+    """JSON config file parsing."""
+
+    def test_roundtrip(self, tmp_path):
+        cfg = tmp_path / "instances.json"
+        cfg.write_text(
+            '[{"instance_id": "foo", "language": "rust", "base_commit": "aa"}]'
+        )
+        assert prof.parse_instances_config(cfg) == [("foo", "rust", "aa")]
+
+
+class TestInferLanguage:
+    """Dominant-language detection from a repo's file extensions."""
+
+    def test_picks_dominant(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        for i in range(5):
+            (repo / f"a{i}.rs").write_text("fn main() {}\n")
+        (repo / "one.py").write_text("x = 1\n")
+        assert prof._infer_language(repo) == "rust"
+
+    def test_none_when_no_source(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "README.md").write_text("# hi\n")
+        assert prof._infer_language(repo) is None
+
+    def test_missing_dir(self, tmp_path):
+        assert prof._infer_language(tmp_path / "nope") is None
+
+
+class TestSummarizeLspProfile:
+    """LSP profile JSONL -> aggregate summary."""
+
+    def test_missing_file(self, tmp_path):
+        out = prof._summarize_lsp_profile(tmp_path / "nope.jsonl")
+        assert out == {"calls_total": 0, "calls_by_method": {}, "ms_by_method": {}}
+
+    def test_none_path(self):
+        out = prof._summarize_lsp_profile(None)
+        assert out == {"calls_total": 0, "calls_by_method": {}, "ms_by_method": {}}
+
+    def test_aggregates_by_method(self, tmp_path):
+        p = tmp_path / "calls.jsonl"
+        p.write_text(
+            "\n".join(
+                [
+                    '{"m": "definition", "ms": 10.5, "n": 2}',
+                    '{"m": "definition", "ms": 4.5, "n": 0}',
+                    '{"m": "references", "ms": 100, "n": 5}',
+                    "",
+                    "garbage line - must not crash the parser",
+                ]
+            )
+        )
+        out = prof._summarize_lsp_profile(p)
+        assert out["calls_total"] == 3
+        assert out["calls_by_method"] == {"definition": 2, "references": 1}
+        assert out["ms_by_method"]["definition"] == 15.0
+        assert out["ms_by_method"]["references"] == 100.0
+        assert out["empty_by_method"]["definition"] == 1
+        assert out["empty_by_method"]["references"] == 0
+
+
+class TestFirstSymbolPosition:
+    """DFS into LSP documentSymbol output."""
+
+    def test_empty(self):
+        assert prof._first_symbol_position([]) is None
+        assert prof._first_symbol_position(None) is None
+
+    def test_top_level(self):
+        syms = [{"selectionRange": {"start": {"line": 7, "character": 4}}}]
+        assert prof._first_symbol_position(syms) == (7, 4)
+
+    def test_falls_back_to_range(self):
+        syms = [{"range": {"start": {"line": 12, "character": 0}}}]
+        assert prof._first_symbol_position(syms) == (12, 0)
+
+    def test_descends_into_children(self):
+        syms = [
+            {"children": []},  # no positional info
+            {"children": [{"selectionRange": {"start": {"line": 99}}}]},
+        ]
+        assert prof._first_symbol_position(syms) == (99, 0)
+
+    def test_skips_missing_line(self):
+        syms = [
+            {"range": {"start": {}}},  # missing line
+            {"range": {"start": {"line": 3}}},
+        ]
+        assert prof._first_symbol_position(syms) == (3, 0)
+
+
+class TestFinalizeStepRecord:
+    """Per-step comparison harness: derive speedups from mocked strategy
+    sub-records (no LSP / git / indexer)."""
+
+    def _rec(self, rebuild=None, file_level=None, symbol=None):
+        rec = {"instance_id": "x", "step": 1}
+        if rebuild is not None:
+            rec["fully-rebuild"] = rebuild
+        if file_level is not None:
+            rec["file-level-patch"] = file_level
+        if symbol is not None:
+            rec["symbol-level-patch"] = symbol
+        return rec
+
+    def test_speedups_computed(self):
+        rec = self._rec(
+            rebuild={"status": "ok", "t_s": 100.0},
+            file_level={"status": "ok", "t_s": 40.0},
+            symbol={"status": "ok", "t_s": 10.0},
+        )
+        out = prof.finalize_step_record(rec)
+        assert out["speedup_vs_fully_rebuild"] == pytest.approx(10.0)
+        assert out["speedup_vs_file_level_patch"] == pytest.approx(4.0)
+        assert "finished" in out
+
+    def test_none_when_symbol_failed(self):
+        # Symbol strategy errored -> no t_s denominator -> ratios are None.
+        rec = self._rec(
+            rebuild={"status": "ok", "t_s": 100.0},
+            file_level={"status": "ok", "t_s": 40.0},
+            symbol={"status": "error", "error": "boom"},
+        )
+        out = prof.finalize_step_record(rec)
+        assert out["speedup_vs_fully_rebuild"] is None
+        assert out["speedup_vs_file_level_patch"] is None
+
+    def test_none_when_rebuild_failed(self):
+        # Rebuild timed out -> rebuild ratio None, but file-level ratio holds.
+        rec = self._rec(
+            rebuild={"status": "timeout", "t_s": 600.0},
+            file_level={"status": "ok", "t_s": 40.0},
+            symbol={"status": "ok", "t_s": 10.0},
+        )
+        out = prof.finalize_step_record(rec)
+        assert out["speedup_vs_fully_rebuild"] is None
+        assert out["speedup_vs_file_level_patch"] == pytest.approx(4.0)
+
+    def test_missing_strategies_are_safe(self):
+        # No strategy sub-records at all -> both ratios None, no crash.
+        out = prof.finalize_step_record(self._rec())
+        assert out["speedup_vs_fully_rebuild"] is None
+        assert out["speedup_vs_file_level_patch"] is None
+
+
+class TestStrategyNames:
+    """Guard the three strategy labels the issue specifies stay wired up."""
+
+    def test_default_instances_cover_five_languages(self):
+        langs = {lang for (_iid, lang, _sha) in prof.DEFAULT_INSTANCES}
+        assert langs == {"cpp", "go", "python", "rust", "ts"}
+
+    def test_lang_exts_and_pathspec_cover_same_languages(self):
+        assert set(prof.LANG_EXTS) == set(prof.LANG_PATHSPEC)


### PR DESCRIPTION
## Summary

Closes #129. A single-file benchmark that walks each repo's first-parent commit
chain N steps and, per step, compares three graph-update strategies so we can
quantify the incremental patcher's payoff.

## Changes
- New `scripts/profiling/profile_incremental_graph.py` comparing, per commit
  step:
  - `fully-rebuild` — wipe the indexer cache, re-run SCIP / clangd from scratch
  - `file-level-patch` — the patcher in naive per-file mode
  - `incremental` — the incremental patcher
  recording timing per strategy per step.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/scripts/test_profile_incremental_graph.py -m "not slow and not integration"`
→ 43 passed (per-step comparison harness with mocked indexers; the
real-SCIP/clone path is gated behind the `integration` marker).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
