### PR TITLE
feat(skills): rewrite graph_expand as a 1-hop range/symbol primitive

### DIFF
--- a/codeminer/agent/skills/graph_expand/config.yaml
+++ b/codeminer/agent/skills/graph_expand/config.yaml
@@ -4,72 +4,72 @@
 
 skill_id: graph_expand
 skill_type: expand
-operator: graph.walk
-cost: medium
+operator: graph.range_query
+cost: low
 
 defaults:
-  method: bfs
+  mode: all
   top_k: 50
-  hops: 2
-  direction: both
-  damping: 0.85
   filter_tests: true
+  hops: 1
 
 inputs:
-  - name: seed_files
+  - name: ranges
+    type: List[Dict]
+    required: false
+    description: >-
+      Source ranges to expand from, as
+      [{"file": str, "start_line": int, "end_line": int}, ...].
+      Either `ranges` or `symbols` (or both) must be provided.
+      Lines are 1-based inclusive (agent-facing, same as BM25/embedding
+      results). Inverted (start > end) ranges are silently swapped;
+      malformed entries are skipped.
+  - name: symbols
     type: List[str]
     required: false
     description: >-
-      Files you already read (repo-relative paths). Expands from every symbol
-      defined in them — the easiest way to seed: after reading a file, pass it
-      here to pull in callers / callees / related code via the call graph.
-  - name: seed_symbols
-    type: List[str]
-    required: false
-    description: >-
-      Qualified symbol names to expand from, e.g. "module.ClassName.method"
-      (exact node_name strings from prior search results). Provide either
-      seed_files or seed_symbols (at least one).
-  - name: method
+      Symbol identifiers to expand from, as a list of identity names
+      ("module/foo.py:Cls.method") or display unified_names. Resolution
+      tries identity first then unified_name; unknown symbols are dropped.
+  - name: mode
     type: str
     required: false
-    default: bfs
-    description: Expansion method - "bfs" for k-hop BFS or "ppr" for Personalized PageRank
+    default: all
+    description: >-
+      Which graph relationships to fetch for each seed:
+      "defined" (symbols whose definition spans the range),
+      "callees" (symbols this range calls/references),
+      "callers" (symbols that call into this range), or
+      "all" (all three concatenated; default; ~3x tokens).
   - name: top_k
     type: int
     required: false
     default: 50
-  - name: hops
-    type: int
-    required: false
-    default: 2
-    description: Number of hops for BFS expansion
-  - name: direction
-    type: str
-    required: false
-    default: both
-    description: Edge traversal direction - "forward", "backward", or "both"
-  - name: damping
-    type: float
-    required: false
-    default: 0.85
-    description: PPR damping factor (only used with method=ppr)
+    description: >-
+      Maximum number of results to return. When truncated, a sentinel
+      record is appended.
   - name: filter_tests
     type: bool
     required: false
     default: true
-  - name: edge_types
-    type: List[str]
+    description: Exclude test files from results.
+  - name: hops
+    type: int
     required: false
-    description: Edge types to traverse (null for all)
-  - name: node_types
-    type: List[str]
-    required: false
-    description: Node types to include in results (null for all)
+    default: 1
+    description: >-
+      Number of expansion hops. v1 supports only hops=1; other values are
+      silently treated as 1, reserved for future multi-hop queries when
+      CodeGraph.query_range gains depth>1. The LLM should iterate via
+      repeated 1-hop calls (LSP-style) rather than requesting multi-hop here.
 
 outputs:
   type: List[QueriedNode]
-  description: Expanded related symbols with content
+  description: >-
+    Symbols related to the seeds, each tagged with `role`
+    (defined/callees/callers), `edge_kind`, and `anchor_file`/`anchor_line`
+    (call-site location, 1-based, for callees/callers). No code body is
+    included — use a file-reading tool to fetch any body of interest.
 
 index_requirements:
   - type: symbol_graph

--- a/codeminer/agent/skills/graph_expand/executor.py
+++ b/codeminer/agent/skills/graph_expand/executor.py
@@ -2,139 +2,295 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Executor factory for the ``graph_expand`` skill.
+
+LSP-aligned 1-hop range / symbol query. Given one or more source ranges
+(file + line span) or named symbols, returns the symbols adjacent to each
+seed, tagged by ``role`` (defined / callees / callers), built directly on
+``CodeGraph.query_range`` / ``CodeGraph.query_range_by_symbol``.
+
+Line-numbering convention (CLAUDE.md): the ``ranges`` input is **1-based,
+inclusive** (agent-facing), matching ``CodeLocation`` and BM25/embedding
+result line numbers. ``CodeGraph.query_range`` expects **0-based** spans, so
+each range is converted ``-1`` locally before the call. Symmetrically, the
+``anchor_line`` carried by ``query_range`` edges is 0-based; it is converted
+``+1`` back to 1-based for output. The dedicated agent-boundary helper from
+#153 lands on a separate branch, so the conversion is done inline here.
+
+Each result carries ``role``, ``edge_kind``, and the call-site ``anchor_*``
+so the LLM can reason about graph relationships without reading code. Use a
+file-reading tool to fetch any body the LLM decides is worth inspecting.
+"""
+
 from __future__ import annotations
 
-import os
-from typing import Any, Callable, List, Optional
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 
-def _symbols_in_files(code_graph: Any, files: List[str]) -> List[str]:
-    """Resolve file paths to the qualified names of symbols defined in them.
-
-    Uses ``CodeGraph._file_nodes`` (file -> [(start, end, vid)]). Matches a
-    requested path against graph file keys by exact / suffix / basename so the
-    agent can pass whatever path form it read (repo-relative or absolute).
-    """
-    file_nodes = getattr(code_graph, "_file_nodes", None) or {}
-    if not file_nodes:
-        return []
-    graph = code_graph.graph
-    names: List[str] = []
-    for raw in files:
-        want = (raw or "").strip().strip("`'\"").lstrip("./")
-        if not want:
-            continue
-        keys = [
-            k
-            for k in file_nodes
-            if k == want or k.endswith("/" + want) or want.endswith(k)
-        ]
-        if not keys:  # last resort: basename match
-            base = os.path.basename(want)
-            keys = [k for k in file_nodes if os.path.basename(k) == base]
-        for k in keys:
-            for _s, _e, vid in file_nodes[k]:
-                try:
-                    nm = graph.vs[vid]["name"]
-                except (KeyError, IndexError):
-                    nm = None
-                if nm:
-                    names.append(nm)
-    return names
+def _normalize_path(p: Optional[str]) -> Optional[str]:
+    """Match ``retrieval_eval.normalize_file_path`` so file keys agree."""
+    if not p:
+        return None
+    return str(Path(p).as_posix()).lstrip("./")
 
 
 def create_executor(context: Any) -> Callable[..., List[Any]]:
-    """Factory: returns a callable that expands seed nodes via the symbol graph.
+    """Factory: return a callable that runs ``graph_expand`` against ``context``.
 
     Parameters
     ----------
     context:
-        An ``ExpandContext`` instance (from ``codeminer.ops.expand``)
-        that carries the loaded ``CodeGraph``.
+        An ``ExpandContext`` (from ``codeminer.ops.expand``) carrying the
+        loaded ``CodeGraph``.
     """
-    from ....graph.roi_subgraph import ROISubgraph
-    from ....ops.expand import nodeinfo_to_queried
+    from ....graph.code_graph import CodeGraph
+    from ....types import EDGE_TYPE_REFERENCE, QueriedNode
+    from ....utils import is_test_file
+
+    _VALID_MODES = {"defined", "callees", "callers", "all"}
+    _ROLE_ORDER: Dict[str, int] = {"defined": 0, "callees": 1, "callers": 2}
+
+    def _build_node_id(file: Optional[str], display: str) -> str:
+        f = file or ""
+        return f"{f}:{display}" if f else display
+
+    def _to_one_based_line(line: Optional[int]) -> Optional[int]:
+        """0-based graph line -> 1-based agent-facing line."""
+        return None if line is None else line + 1
+
+    # graph_expand has no relevance signal — `score` is left at 0.0 (matches
+    # bm25_search's convention when scores aren't available). Result ordering
+    # is driven by `role` via `_ROLE_ORDER` below, not by score.
+
+    def _node_ref_to_queried(ref: Any, role: str) -> QueriedNode:
+        display = ref.unified_name or ref.name
+        return QueriedNode(
+            node_name=display,
+            type=ref.kind,
+            file=ref.file,
+            node_id=_build_node_id(ref.file, display),
+            start_line=_to_one_based_line(ref.start_line),
+            end_line=_to_one_based_line(ref.end_line),
+            score=0.0,
+            role=role,
+            # `defined` carries no edge — anchor_* and edge_kind stay None.
+        )
+
+    def _vid_to_queried_with_edge(
+        graph: CodeGraph, vid: int, edge: Any, role: str
+    ) -> Optional[QueriedNode]:
+        attrs = graph.graph.vs[vid].attributes()
+        name = graph.graph.vs[vid]["name"]
+        file = attrs.get("file")
+        if file is None:
+            return None
+        display = attrs.get("unified_name") or name
+        return QueriedNode(
+            node_name=display,
+            type=attrs.get("type", ""),
+            file=file,
+            node_id=_build_node_id(file, display),
+            start_line=_to_one_based_line(attrs.get("start_line")),
+            end_line=_to_one_based_line(attrs.get("end_line")),
+            score=0.0,
+            role=role,
+            edge_kind=edge.edge_kind,
+            anchor_file=edge.anchor_file,
+            anchor_line=_to_one_based_line(edge.anchor_line),
+        )
+
+    def _flatten_result(graph: CodeGraph, result: Any, mode: str) -> List[QueriedNode]:
+        """Convert a ``RangeQueryResult`` into role-tagged ``QueriedNode``s."""
+        out: List[QueriedNode] = []
+
+        if mode in ("defined", "all"):
+            for n in result.defined:
+                out.append(_node_ref_to_queried(n, role="defined"))
+
+        if mode in ("callees", "all"):
+            seen_targets: Set[int] = set()
+            for e in result.outgoing:
+                if e.edge_kind != EDGE_TYPE_REFERENCE:
+                    continue
+                if e.target_vid in seen_targets:
+                    continue
+                seen_targets.add(e.target_vid)
+                node = _vid_to_queried_with_edge(graph, e.target_vid, e, role="callees")
+                if node is not None:
+                    out.append(node)
+
+        if mode in ("callers", "all"):
+            seen_sources: Set[int] = set()
+            for e in result.incoming:
+                if e.edge_kind != EDGE_TYPE_REFERENCE:
+                    continue
+                if e.source_vid in seen_sources:
+                    continue
+                seen_sources.add(e.source_vid)
+                node = _vid_to_queried_with_edge(graph, e.source_vid, e, role="callers")
+                if node is not None:
+                    out.append(node)
+
+        return out
+
+    def _resolve_symbol_to_identities(graph: CodeGraph, symbol: str) -> List[str]:
+        """Resolve an LLM-supplied symbol name to identity names.
+
+        Tries identity exact match first; falls back to ``_unified_to_names``
+        reverse lookup (display ``unified_name`` -> [identities]). Returns the
+        list of identity names (possibly empty for unknown symbols).
+        """
+        if symbol in graph.name_to_vertex:
+            return [symbol]
+        return list(graph._unified_to_names.get(symbol, []))
+
+    @lru_cache(maxsize=1024)
+    def _resolve_cached(graph_key: int, symbol: str) -> Tuple[str, ...]:
+        return tuple(_resolve_symbol_to_identities(context.code_graph, symbol))
+
+    def _truncate_with_hint(
+        results: List[QueriedNode], top_k: int
+    ) -> List[QueriedNode]:
+        """Apply top_k cap and append a sentinel record describing truncation."""
+        if len(results) <= top_k:
+            return results
+        kept = results[:top_k]
+        sentinel = QueriedNode(
+            node_name="__truncated__",
+            type="meta",
+            file=None,
+            node_id=None,
+            start_line=None,
+            end_line=None,
+            score=0.0,
+            content=(
+                f"truncated: returned top_k={top_k} of {len(results)} total; "
+                f"narrow the ranges or set mode= to a single role to see more"
+            ),
+        )
+        kept.append(sentinel)
+        return kept
+
+    def _parse_ranges(raw: Any) -> List[Tuple[str, int, int]]:
+        """Normalize the ``ranges`` input into (file, start0, end0) tuples.
+
+        Input lines are 1-based inclusive (agent-facing); they are converted to
+        0-based here before being handed to ``query_range``. Malformed entries
+        are skipped silently (matches LSP tolerance for partial client state).
+        """
+        if not raw:
+            return []
+        out: List[Tuple[str, int, int]] = []
+        for r in raw:
+            if not isinstance(r, dict):
+                continue
+            file = _normalize_path(r.get("file"))
+            s = r.get("start_line")
+            e = r.get("end_line")
+            if file is None or s is None or e is None:
+                continue
+            try:
+                si, ei = int(s), int(e)
+            except (TypeError, ValueError):
+                # LLM-generated tool-call JSON may carry non-numeric strings
+                # in numeric fields ("abc", "12.5", lists). Drop, don't crash.
+                continue
+            if isinstance(s, bool) or isinstance(e, bool):
+                # bool is an int subclass; a JSON `true` is never a line number.
+                continue
+            if si > ei:
+                si, ei = ei, si
+            # 1-based inclusive -> 0-based inclusive. Clamp at 0 so a stray
+            # 0/negative agent line never underflows into a bogus query.
+            si0 = max(si - 1, 0)
+            ei0 = max(ei - 1, 0)
+            out.append((file, si0, ei0))
+        return out
 
     def execute(
-        seed_symbols: Optional[List[str]] = None,
-        seed_files: Optional[List[str]] = None,
-        seed_nodes: Optional[List[Any]] = None,
-        method: str = "bfs",
+        ranges: Optional[List[Dict[str, Any]]] = None,
+        symbols: Optional[List[str]] = None,
+        mode: str = "all",
         top_k: int = 50,
+        filter_tests: bool = True,
+        hops: int = 1,
         **kwargs: Any,
-    ) -> List[Any]:
-        if context.code_graph is None:
+    ) -> List[QueriedNode]:
+        graph = context.code_graph
+        if graph is None:
             raise RuntimeError("Symbol graph not available")
 
-        hops: int = kwargs.get("hops", 2)
-        direction: str = kwargs.get("direction", "both")
-        damping: float = kwargs.get("damping", 0.85)
-        filter_tests: bool = kwargs.get("filter_tests", True)
-        edge_types: Optional[List[str]] = kwargs.get("edge_types")
-        node_types: Optional[List[str]] = kwargs.get("node_types")
-
-        # Two ergonomic ways to seed (the agent rarely has exact node_names):
-        #   - seed_files: a file the agent already read → expand from every
-        #     symbol defined in it (the LSP "what references this file" move).
-        #   - seed_symbols: exact node_name strings from prior search results.
-        # ``seed_nodes`` is a back-compat shim (QueriedNode objects / strings).
-        raw_seeds: List[Any] = list(seed_symbols or []) + list(seed_nodes or [])
-        seed_names: List[str] = []
-        for node in raw_seeds:
-            name = getattr(node, "node_name", None) or (
-                node if isinstance(node, str) else None
-            )
-            if name:
-                seed_names.append(name)
-        if seed_files:
-            seed_names.extend(_symbols_in_files(context.code_graph, seed_files))
-
-        if not seed_names:
+        if mode not in _VALID_MODES:
             raise ValueError(
-                "graph_expand needs seeds. Easiest: pass seed_files=[path] for "
-                "a file you already read, to expand from its symbols. Or pass "
-                "seed_symbols as exact node_name strings from prior search "
-                "results."
+                f"mode must be one of {sorted(_VALID_MODES)}, got {mode!r}"
             )
 
-        # Surface seeds that don't exist in the graph so the model can re-seed
-        # instead of getting a silent empty result.
-        name_to_vertex = getattr(context.code_graph, "name_to_vertex", {}) or {}
-        if name_to_vertex:
-            unresolved = [n for n in seed_names if n not in name_to_vertex]
-            if len(unresolved) == len(seed_names):
-                raise ValueError(
-                    "graph_expand: none of the seed_symbols resolve to graph "
-                    f"nodes: {unresolved}. Copy the exact node_name from a "
-                    "search result, or grep for the symbol with "
-                    "grep(pattern=...)."
-                )
+        # `hops` is reserved in the API for forward compatibility (see module
+        # docstring) but only depth=1 is implemented today, because
+        # CodeGraph.query_range itself only supports depth=1. Any other value
+        # is silently treated as 1 — no clamp/assignment needed since `hops`
+        # is not read again below.
+        del hops
 
-        roi = ROISubgraph(context.code_graph)
-
-        if method == "ppr":
-            node_infos = roi.expand_ppr(
-                node_names=seed_names,
-                top_k=top_k,
-                damping=damping,
-                filter_tests=filter_tests,
-            )
-            seed_set = set(seed_names)
-            node_infos = [n for n in node_infos if n.node_name not in seed_set]
-        else:
-            subgraph = roi.extract_subgraph(
-                node_names=seed_names,
-                k_hop=hops,
-                edge_types=edge_types,
-                direction=direction,
-            )
-            node_infos = roi.get_filtered_subgraph_nodes(
-                subgraph,
-                exclude_nodes=seed_names,
-                filter_tests=filter_tests,
-                node_types=node_types,
+        if not graph._file_nodes and not graph._unified_to_names:
+            raise RuntimeError(
+                "Range indexes empty — call CodeGraph.build_range_indexes() "
+                "before querying. Likely a partially-built or pre-v3 graph."
             )
 
-        return nodeinfo_to_queried(node_infos)[:top_k]
+        # Distinguish "no input shape was provided at all" (a usage error worth
+        # raising on) from "an input list was given but every entry normalized
+        # away" (degenerate but valid — return []). Empty-string / whitespace /
+        # non-string symbols and malformed ranges fall into the latter bucket.
+        if not ranges and not symbols:
+            raise ValueError(
+                "graph_expand needs either `ranges` "
+                "([{file, start_line, end_line}, ...], 1-based lines) or "
+                "`symbols` ([identity_or_unified_name, ...])"
+            )
+
+        norm_ranges = _parse_ranges(ranges)
+        norm_symbols = [s for s in (symbols or []) if isinstance(s, str) and s.strip()]
+
+        results: List[QueriedNode] = []
+
+        for file, s, e in norm_ranges:
+            r = graph.query_range(file, s, e)
+            results.extend(_flatten_result(graph, r, mode))
+
+        for sym in norm_symbols:
+            identities = _resolve_cached(id(graph), sym)
+            for identity in identities:
+                r = graph.query_range_by_symbol(identity)
+                results.extend(_flatten_result(graph, r, mode))
+
+        if filter_tests:
+            results = [
+                n for n in results if not (n.node_id and is_test_file(n.node_id))
+            ]
+
+        # Dedup across multiple seeds + multiple overloads sharing the same
+        # unified_name in the same file: keep only the first (node_id, role)
+        # hit. Consequence — if vertex X is reached from two different seed
+        # ranges, only the FIRST seed's anchor_line is recorded on the
+        # surviving QueriedNode; the second call site is invisible to the
+        # caller. Acceptable for retrieval (each candidate once), surprising
+        # for "every call-site" analysis (which graph_expand doesn't claim to
+        # support — use raw `query_range` for that).
+        seen: Set[Tuple[Optional[str], Optional[str]]] = set()
+        deduped: List[QueriedNode] = []
+        for n in results:
+            key = (n.node_id, n.role)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(n)
+
+        # Stable sort by role: defined first, then callees, then callers.
+        deduped.sort(key=lambda n: _ROLE_ORDER.get(n.role or "", 99))
+
+        return _truncate_with_hint(deduped, top_k)
 
     return execute

--- a/codeminer/agent/skills/graph_expand/skill.md
+++ b/codeminer/agent/skills/graph_expand/skill.md
@@ -6,39 +6,93 @@ SPDX-License-Identifier: Apache-2.0
 
 # graph_expand
 
-Expand seed code blocks along the symbol graph to discover structurally related symbols in bulk.
+LSP-aligned 1-hop graph query. Given one or more **source ranges** (file +
+line span) or **symbol names**, returns the symbols related to each seed
+tagged by role:
+
+- `defined`  — symbols whose definition spans the seed range
+- `callees`  — symbols the seed range calls/references
+- `callers`  — symbols that call into the seed range/symbol
+
+Each result carries the call-site `anchor_line` (where the relationship was
+observed), so you can reason about graph structure without reading any code.
+To inspect a candidate's body, follow up with a file-reading tool.
 
 ## When to use
 
-- After an initial search (BM25, embedding, or regex) has identified seed code locations
-- When you need to find callers, callees, class members, imported dependencies, or other structurally related code
-- When you want to enlarge the context around known functions/classes at the code-chunk level
+- Just got a BM25 / embedding hit — expand it to see what it calls, what
+  calls it, and what other symbols share its range
+- Following a call chain across turns: range → callees → pick one → its
+  callers → ...
+- Resolving an ambiguous symbol name to all definition sites that match it
 
 ## When NOT to use
 
-- As a first retrieval step (requires seed nodes from an upstream search)
-- For semantic similarity search (use `embedding_search` instead)
-- When the symbol graph has not been built
+- As a first retrieval step (use `bm25_search` / `embedding_search` /
+  `regex_search` to get seed locations first)
+- For semantic similarity (use `embedding_search`)
+- For reading code bodies — use a file-reading tool once you've picked
+  candidates
 
-## Parameters
+## Upstream seeding contract
 
-| Parameter     | Type       | Default | Description                                              |
-|---------------|------------|---------|----------------------------------------------------------|
-| seed_symbols  | List[str]  | required | Exact `node_name` strings copied from prior search results (e.g. `module.ClassName.method`). If a name doesn't resolve, grep for it with `file_search(mode="content")` first. |
-| method        | str        | bfs     | `"bfs"` for k-hop BFS or `"ppr"` for Personalized PageRank |
-| top_k         | int        | 50      | Maximum number of expanded nodes to return               |
-| hops          | int        | 2       | Number of hops for BFS expansion                         |
-| direction     | str        | both    | `"forward"`, `"backward"`, or `"both"`                   |
-| damping       | float      | 0.85    | PPR damping factor (only for method=ppr)                 |
-| filter_tests  | bool       | true    | Exclude test files from results                          |
-| edge_types    | List[str]  | null    | Edge types to traverse (null = all)                      |
-| node_types    | List[str]  | null    | Node types to include (null = all)                       |
+When `graph_expand` is reached from another tool, the caller **should** pass
+`ranges`, not `symbols` — because:
+
+- BM25 / embedding hits naturally carry `file + start_line + end_line` on
+  every result; passing those directly avoids a string-based symbol name
+  round-trip that can fail on non-Python languages (rust / ts / go raw SCIP
+  names, clangd USRs).
+- LSP-aligned: ranges are the universal addressing primitive across
+  languages. Symbol resolution via `unified_name` is best-effort and
+  language-specific.
+
+`symbols` is intended for LLM-driven follow-up calls only: the agent saw a
+callee name in a previous `graph_expand` result and wants to drill into it
+without re-querying its range. In that case `symbols=[...]` is the shortest
+path.
+
+## Input shapes
+
+Provide at least one of `ranges` or `symbols` (or both).
+
+| Parameter      | Type         | Default | Description                                                                                                |
+|----------------|--------------|---------|------------------------------------------------------------------------------------------------------------|
+| `ranges`       | `List[Dict]` | none    | `[{"file": str, "start_line": int, "end_line": int}, ...]`. **1-based inclusive.** Inverted ranges auto-swap.|
+| `symbols`      | `List[str]`  | none    | Identity names (`"foo.py:Cls.method"`) or display unified_names. Unknown symbols silently dropped.          |
+| `mode`         | `str`        | `all`   | `"defined"` / `"callees"` / `"callers"` / `"all"`                                                           |
+| `top_k`        | `int`        | `50`    | Cap on result count. When truncated, a sentinel record is appended.                                         |
+| `filter_tests` | `bool`       | `true`  | Exclude test files from results.                                                                            |
+| `hops`         | `int`        | `1`     | Multi-hop reserved for future. v1 treats any value as 1 — iterate via repeated calls for deeper traversal.  |
+
+Line numbers in `ranges` are **1-based**, matching the line numbers reported
+by `bm25_search` / `embedding_search` / `regex_search`. They are converted to
+the graph's internal 0-based form before querying; the returned
+`start_line` / `end_line` / `anchor_line` are also 1-based.
 
 ## Output
 
-`List[QueriedNode]` — expanded related symbols with file path, line range, score, and source content.
+`List[QueriedNode]`. Each result carries:
 
-## Methods
+- `node_name`, `type` (function / class / method / ...), `file`, `start_line`, `end_line`
+- `role` — `"defined"` / `"callees"` / `"callers"`
+- `edge_kind` — graph edge type for callees/callers; `None` for defined
+- `anchor_file`, `anchor_line` — call-site location, 1-based (for callees: in
+  source range; for callers: in the calling symbol)
 
-- **BFS** (`method: bfs`): Local k-hop neighborhood expansion. Good for finding directly related code within a bounded radius.
-- **PPR** (`method: ppr`): Personalized PageRank over the full graph seeded from the input nodes. Good for finding globally relevant code weighted by structural importance.
+**No code body is returned.** Use a file-reading tool to fetch any body you
+decide is worth inspecting.
+
+**Dedup behaviour.** When the same target/caller vertex is reached from
+multiple seeds (or appears as several overloads with the same display name in
+one file), graph_expand returns it **once** — keeping the first anchor. If you
+need every call site, use the lower-level `query_range` API directly (not
+exposed as a skill).
+
+## Why iterate instead of multi-hop
+
+Each call is cheap. Asking for `hops=2` upfront forces the tool to make
+relevance decisions that the LLM is better at: "is callee X interesting enough
+to walk into" depends on the current task, which only the LLM knows. A
+repeated `hops=1` chain is both more controllable and almost always shorter
+than the equivalent batch expansion.

--- a/codeminer/agent/tool_schema.py
+++ b/codeminer/agent/tool_schema.py
@@ -29,7 +29,7 @@ def _schema_for_type(type_hint: str) -> Dict[str, Any]:
     """JSON Schema for a SkillInputSpec ``type_hint`` string.
 
     Handles ``List[X]`` / ``list[X]`` → ``{"type":"array","items":<X>}`` so
-    list-valued params (e.g. ``graph_expand.seed_symbols: List[str]``,
+    list-valued params (e.g. ``graph_expand.symbols: List[str]``,
     ``edge_types: List[str]``) get a real schema instead of an empty ``{}``
     that gives the model no hint how to populate them. Unknown inner or
     scalar hints fall back to ``string`` (the safest LLM-producible type),

--- a/codeminer/ops/expand.py
+++ b/codeminer/ops/expand.py
@@ -16,14 +16,17 @@ logger = get_logger(__name__)
 
 @dataclass
 class ExpandContext:
-    """Shared resources for graph expansion operators."""
+    """Shared resources for graph expansion skills.
+
+    Post-#155 ``graph_expand`` is a 1-hop LSP-aligned primitive that does
+    not consume BFS/PPR tunables; those used to live here as
+    ``default_hops`` / ``default_method`` / ``default_direction`` /
+    ``default_damping`` but were removed as dead state. The remaining fields
+    are read by the skill executor at call time.
+    """
 
     code_graph: Optional[CodeGraph] = None
     default_top_k: int = 50
-    default_hops: int = 2
-    default_direction: str = "both"
-    default_method: str = "bfs"
-    default_damping: float = 0.85
     filter_tests: bool = True
 
 

--- a/codeminer/types.py
+++ b/codeminer/types.py
@@ -46,6 +46,15 @@ class NodeInfo(BaseModel):
 
 
 class QueriedNode(NodeInfo):
-    """Node attributes representing ranked nodes that keep optional content."""
+    """Ranked node optionally carrying graph relationship metadata.
 
-    pass
+    Skills like ``graph_expand`` populate ``edge_kind`` / ``role`` /
+    ``anchor_file`` / ``anchor_line`` so the LLM sees how each result relates
+    to the query (range or symbol). Retrieval-only skills (bm25, embedding)
+    leave them ``None``.
+    """
+
+    edge_kind: Optional[str] = None
+    role: Optional[str] = None
+    anchor_file: Optional[str] = None
+    anchor_line: Optional[int] = None

--- a/test/agent/test_agent_graph_vertex.py
+++ b/test/agent/test_agent_graph_vertex.py
@@ -76,7 +76,14 @@ def httpie_graph(httpie_cli_repo) -> CodeGraph:
 
 
 def _register_graph_expand(registry: SkillRegistry, graph: CodeGraph) -> None:
-    """Register graph_expand skill backed by a real CodeGraph."""
+    """Register graph_expand skill backed by a real CodeGraph.
+
+    Mirrors the post-#155 graph_expand API: 1-hop LSP-aligned range/symbol
+    query returning defined/callees/callers tagged by role. This test
+    exercises the symbol-input path; a comma-separated ``str`` keeps the
+    Vertex AI tool schema simple (``type_hint="str"``) — the wrapper splits
+    it into the ``List[str]`` the executor expects.
+    """
     ctx = ExpandContext(code_graph=graph)
     raw_executor = create_executor(ctx)
 
@@ -86,19 +93,22 @@ def _register_graph_expand(registry: SkillRegistry, graph: CodeGraph) -> None:
             skill_type=SkillType.EXPAND,
             inputs=[
                 SkillInputSpec(
-                    name="seed_nodes",
+                    name="symbols",
                     type_hint="str",
                     required=True,
-                    description="Comma-separated qualified symbol names to expand from",
+                    description=(
+                        "Comma-separated qualified symbol names to expand "
+                        "from (e.g. 'httpie.core.main, httpie.cli.argparser')."
+                    ),
                 ),
                 SkillInputSpec(
-                    name="method",
+                    name="mode",
                     type_hint="str",
                     required=False,
-                    default="bfs",
+                    default="all",
                     description=(
-                        'Expansion method: "bfs" for k-hop BFS or "ppr" for '
-                        "Personalized PageRank"
+                        'Which relationships to return: "defined" / "callees" '
+                        '/ "callers" / "all" (default).'
                     ),
                 ),
                 SkillInputSpec(
@@ -107,20 +117,13 @@ def _register_graph_expand(registry: SkillRegistry, graph: CodeGraph) -> None:
                     required=False,
                     default=20,
                 ),
-                SkillInputSpec(
-                    name="hops",
-                    type_hint="int",
-                    required=False,
-                    default=2,
-                    description="Number of hops for BFS expansion",
-                ),
             ],
             executor_fn=_wrap_executor_for_agent(raw_executor),
             description=(
-                "Expand from seed code symbols to find structurally related "
-                "symbols (callers, callees, class members, references) in the "
-                "code graph. seed_nodes is a comma-separated list of qualified "
-                "symbol names (e.g. 'httpie.cli.definition.HTTPieArgumentParser')."
+                "1-hop graph query: given one or more symbol names, return "
+                "the symbols defined at each, the symbols they call, and "
+                "the symbols that call them. Each result carries the "
+                "call-site anchor_line."
             ),
         )
     )
@@ -161,8 +164,9 @@ class TestAgentGraphVertexAI:
 
         system_prompt = (
             "You are a code exploration agent for the httpie/cli Python project. "
-            "You have a graph_expand tool that finds structurally related code "
-            "symbols (callers, callees, references) given seed symbol names.\n\n"
+            "You have a graph_expand tool that, given one or more symbol names, "
+            "returns the symbols defined at each (`defined`), the symbols they "
+            "call (`callees`), and the symbols that call them (`callers`).\n\n"
             f"Here are some symbols in the codebase:\n{symbol_list}\n\n"
             "Use graph_expand to explore relationships, then summarize findings."
         )
@@ -178,7 +182,7 @@ class TestAgentGraphVertexAI:
         seed = sample_symbols[0] if sample_symbols else "httpie.core.main"
         result = runner.run(
             f"What symbols are related to {seed!r}? "
-            f"Use graph_expand with seed_nodes={seed!r} to find out."
+            f"Use graph_expand with symbols={seed!r} to find out."
         )
 
         assert isinstance(result, AgentResult)
@@ -209,20 +213,20 @@ class TestAgentGraphVertexAI:
 
 
 def _wrap_executor_for_agent(executor_fn):
-    """Wrap the graph_expand executor so it accepts string-based args from LLM.
+    """Wrap the graph_expand executor so it accepts a comma-separated string.
 
-    The raw executor expects ``seed_nodes: List[Any]``, but the LLM will
-    pass a comma-separated string. This wrapper handles the conversion.
+    Vertex's tool schema has no clean way to express ``List[str]``, so the
+    LLM passes a comma-separated string. This wrapper splits it into
+    ``symbols=[...]`` and forwards remaining kwargs untouched.
     """
 
-    def wrapped(seed_nodes, method="bfs", top_k=20, hops=2, **kwargs):
-        if isinstance(seed_nodes, str):
-            seed_nodes = [s.strip() for s in seed_nodes.split(",") if s.strip()]
+    def wrapped(symbols, mode="all", top_k=20, **kwargs):
+        if isinstance(symbols, str):
+            symbols = [s.strip() for s in symbols.split(",") if s.strip()]
         return executor_fn(
-            seed_nodes=seed_nodes,
-            method=method,
+            symbols=symbols,
+            mode=mode,
             top_k=int(top_k),
-            hops=int(hops),
             **kwargs,
         )
 

--- a/test/agent/test_graph_expand.py
+++ b/test/agent/test_graph_expand.py
@@ -1,0 +1,601 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the ``graph_expand`` skill executor and loader.
+
+graph_expand is a 1-hop LSP-aligned range/symbol query built on
+``CodeGraph.query_range`` / ``query_range_by_symbol``. The ``ranges`` input is
+**1-based inclusive** (agent-facing); the executor converts to the graph's
+0-based form internally, and converts ``start_line`` / ``end_line`` /
+``anchor_line`` back to 1-based on output.
+
+The internal builder helpers (``add_symbol_node`` / ``add_symbol_reference``)
+operate on 0-based lines, so the fixtures below use 0-based spans while the
+range *queries* use 1-based (0-based + 1).
+
+- TestGraphExpandRangeInput: range-keyed queries (defined / callees / callers).
+- TestGraphExpandSymbolInput: symbol-keyed queries with identity + unified fallback.
+- TestGraphExpandCombinedInput: ranges + symbols union + dedup.
+- TestGraphExpandFiltersAndCaps: filter_tests + top_k truncation.
+- TestGraphExpandLineNumbering: explicit 1-based <-> 0-based boundary checks.
+- TestGraphExpandForwardCompat: hops>1 clamp behaviour.
+- TestGraphExpandLoader: smoke test that the real skill package loads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codeminer.agent.skills.loader import SkillLoader
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.ops.expand import ExpandContext
+
+
+def _skill_dir() -> str:
+    """Return the absolute path to the graph_expand skill package."""
+    import codeminer.agent.skills as pkg
+
+    return str(Path(pkg.__file__).parent / "graph_expand")
+
+
+def _load_executor(context: Any):
+    spec = importlib.util.spec_from_file_location(
+        "codeminer.agent.skills.graph_expand.executor",
+        os.path.join(_skill_dir(), "executor.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.create_executor(context)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders (lines are 0-based — that's what the builder API expects)
+# ---------------------------------------------------------------------------
+
+
+def _build_simple_graph() -> CodeGraph:
+    """Two functions in foo.py with cross-references in both directions.
+
+    foo.py:bar  defined 0-based lines 5-20, references baz at line 12
+    foo.py:baz  defined 0-based lines 25-40, references bar at line 28
+    """
+    g = CodeGraph()
+    g.add_file_node("foo.py")
+    g.add_symbol_node("foo.py:bar", 10, 5, 20, "function")
+    g.add_symbol_node("foo.py:baz", 30, 25, 40, "function")
+
+    g.update_current_scope("foo.py:bar", 5, 20)
+    g.add_symbol_reference("foo.py:baz", anchor_line=12)
+
+    g.update_current_scope("foo.py:baz", 25, 40)
+    g.add_symbol_reference("foo.py:bar", anchor_line=28)
+
+    g.build_range_indexes()
+    return g
+
+
+def _build_graph_with_unified_collision() -> CodeGraph:
+    """Two distinct identity names sharing the same unified_name (cross-file)."""
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("a.py")
+    g._add_vertex(
+        "ident_a",
+        {
+            "type": "function",
+            "file": "a.py",
+            "start_line": 0,
+            "end_line": 4,
+            "unified_name": "shared_name",
+        },
+    )
+    g.add_file_node("b.py")
+    g._add_vertex(
+        "ident_b",
+        {
+            "type": "function",
+            "file": "b.py",
+            "start_line": 9,
+            "end_line": 13,
+            "unified_name": "shared_name",
+        },
+    )
+    g.build_range_indexes()
+    return g
+
+
+def _build_graph_with_test_caller() -> CodeGraph:
+    """target.py:fn has one prod caller (caller.py) and one test caller (test_x.py)."""
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("target.py")
+    g.add_symbol_node("target.py:fn", 5, 5, 10, "function")
+
+    g.add_file_node("caller.py")
+    g.add_symbol_node("caller.py:c", 1, 1, 20, "function")
+    g.update_current_scope("caller.py:c", 1, 20)
+    g.add_symbol_reference("target.py:fn", anchor_line=8)
+
+    g.add_file_node("test_x.py")
+    g.add_symbol_node("test_x.py:tc", 1, 1, 20, "function")
+    g.update_current_scope("test_x.py:tc", 1, 20)
+    g.add_symbol_reference("target.py:fn", anchor_line=15)
+
+    g.build_range_indexes()
+    return g
+
+
+def _build_recursive_graph() -> CodeGraph:
+    """foo.py:rec calls itself (self-edge); foo.py:boot also calls rec.
+
+    Used to verify that under mode='all' the recursive vertex appears with
+    BOTH defined and callees roles — dedup is keyed by (node_id, role), not
+    by node_id alone. query_range excludes self-edges from `incoming`
+    (invariant iii) so the caller-side surface comes from boot -> rec.
+    """
+    g = CodeGraph()
+    g.add_file_node("foo.py")
+    g.add_symbol_node("foo.py:rec", 10, 5, 20, "function")
+    g.add_symbol_node("foo.py:boot", 30, 25, 30, "function")
+
+    g.update_current_scope("foo.py:rec", 5, 20)
+    g.add_symbol_reference("foo.py:rec", anchor_line=12)
+
+    g.update_current_scope("foo.py:boot", 25, 30)
+    g.add_symbol_reference("foo.py:rec", anchor_line=28)
+
+    g.build_range_indexes()
+    return g
+
+
+def _build_hot_target_graph(n_callers: int) -> CodeGraph:
+    """target.py:hot has many callers; used for top_k truncation tests."""
+    g = CodeGraph(project_root="/tmp/x")
+    g.add_file_node("target.py")
+    g.add_symbol_node("target.py:hot", 1, 1, 5, "function")
+    for i in range(n_callers):
+        f = f"caller_{i}.py"
+        g.add_file_node(f)
+        sym = f"{f}:c"
+        g.add_symbol_node(sym, 1, 1, 5, "function")
+        g.update_current_scope(sym, 1, 5)
+        g.add_symbol_reference("target.py:hot", anchor_line=3)
+    g.build_range_indexes()
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Test classes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+class TestGraphExpandRangeInput:
+    """Range-keyed query path: `ranges=[{file, start_line, end_line}, ...]` (1-based)."""
+
+    def _execute(self, graph: CodeGraph):
+        return _load_executor(ExpandContext(code_graph=graph))
+
+    # --- error paths ---
+
+    def test_raises_when_graph_is_none(self):
+        execute = _load_executor(ExpandContext(code_graph=None))
+        with pytest.raises(RuntimeError, match="Symbol graph not available"):
+            execute(ranges=[{"file": "foo.py", "start_line": 1, "end_line": 10}])
+
+    def test_raises_when_neither_ranges_nor_symbols(self):
+        execute = self._execute(_build_simple_graph())
+        with pytest.raises(ValueError, match="needs either"):
+            execute()
+
+    def test_raises_on_invalid_mode(self):
+        execute = self._execute(_build_simple_graph())
+        with pytest.raises(ValueError, match="mode must be one of"):
+            execute(
+                ranges=[{"file": "foo.py", "start_line": 1, "end_line": 6}],
+                mode="bogus",
+            )
+
+    def test_raises_on_unbuilt_range_indexes(self):
+        g = CodeGraph()
+        g.add_file_node("foo.py")
+        execute = self._execute(g)
+        with pytest.raises(RuntimeError, match="Range indexes empty"):
+            execute(ranges=[{"file": "foo.py", "start_line": 1, "end_line": 6}])
+
+    # --- mode coverage ---
+
+    def test_defined_returns_overlapping_symbol(self):
+        execute = self._execute(_build_simple_graph())
+        # 1-based query 9-16 overlaps bar's 0-based span 5-20.
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 9, "end_line": 16}],
+            mode="defined",
+        )
+        names = {r.node_name for r in results}
+        assert "foo.py:bar" in names
+        assert all(r.role == "defined" for r in results)
+        # defined results carry no edge metadata
+        assert all(r.edge_kind is None and r.anchor_line is None for r in results)
+
+    def test_callees_returns_target_of_outgoing_edge(self):
+        execute = self._execute(_build_simple_graph())
+        # 1-based 6-21 == bar's 0-based span 5-20.
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 21}],
+            mode="callees",
+        )
+        names = {r.node_name for r in results}
+        assert "foo.py:baz" in names
+        assert all(r.role == "callees" for r in results)
+        baz = next(r for r in results if r.node_name == "foo.py:baz")
+        # anchor 0-based 12 -> 1-based 13 on output.
+        assert baz.anchor_line == 13
+        assert baz.edge_kind is not None
+
+    def test_callers_returns_source_of_incoming_edge(self):
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 21}],
+            mode="callers",
+        )
+        names = {r.node_name for r in results}
+        assert "foo.py:baz" in names
+        assert all(r.role == "callers" for r in results)
+        baz = next(r for r in results if r.node_name == "foo.py:baz")
+        # baz calls bar at 0-based 28 -> 1-based 29.
+        assert baz.anchor_line == 29
+
+    def test_mode_all_concatenates_three_roles_ordered(self):
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 21}],
+            mode="all",
+        )
+        roles = [r.role for r in results]
+        assert roles.count("defined") >= 1
+        assert roles.count("callees") >= 1
+        assert roles.count("callers") >= 1
+        # role ordering invariant: defined < callees < callers
+        first_callees = roles.index("callees")
+        first_callers = roles.index("callers")
+        last_defined = len(roles) - 1 - roles[::-1].index("defined")
+        assert last_defined < first_callees
+        assert first_callees <= first_callers
+
+    # --- input normalization ---
+
+    def test_normalizes_dotslash_path_prefix(self):
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[{"file": "./foo.py", "start_line": 9, "end_line": 16}],
+            mode="defined",
+        )
+        assert any(r.node_name == "foo.py:bar" for r in results)
+
+    def test_swaps_inverted_line_range(self):
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 16, "end_line": 9}],
+            mode="defined",
+        )
+        assert any(r.node_name == "foo.py:bar" for r in results)
+
+    def test_unknown_file_returns_empty(self):
+        execute = self._execute(_build_simple_graph())
+        assert (
+            execute(ranges=[{"file": "missing.py", "start_line": 1, "end_line": 99}])
+            == []
+        )
+
+    def test_skips_malformed_range_entries(self):
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[
+                {"file": "foo.py"},
+                {"start_line": 1, "end_line": 6},
+                {"file": "foo.py", "start_line": 9, "end_line": 16},
+            ],
+            mode="defined",
+        )
+        assert any(r.node_name == "foo.py:bar" for r in results)
+
+    def test_skips_non_integer_line_numbers(self):
+        # LLM-generated JSON occasionally puts strings/floats/lists into
+        # numeric fields. Drop those entries, don't crash, but keep valid ones.
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[
+                {"file": "foo.py", "start_line": "abc", "end_line": 16},
+                {"file": "foo.py", "start_line": 9, "end_line": [16]},
+                {"file": "foo.py", "start_line": 9, "end_line": 16},  # valid
+            ],
+            mode="defined",
+        )
+        assert any(r.node_name == "foo.py:bar" for r in results)
+
+    # --- multi-range path ---
+
+    def test_multiple_ranges_union_results(self):
+        execute = self._execute(_build_simple_graph())
+        # Two non-overlapping ranges, each defines a distinct symbol.
+        results = execute(
+            ranges=[
+                {"file": "foo.py", "start_line": 6, "end_line": 11},
+                {"file": "foo.py", "start_line": 26, "end_line": 31},
+            ],
+            mode="defined",
+        )
+        names = {r.node_name for r in results}
+        assert names == {"foo.py:bar", "foo.py:baz"}
+
+
+class TestGraphExpandSymbolInput:
+    """Symbol-keyed query path: `symbols=[name, ...]` via query_range_by_symbol."""
+
+    def _execute(self, graph: CodeGraph):
+        return _load_executor(ExpandContext(code_graph=graph))
+
+    def test_resolves_identity_directly(self):
+        execute = self._execute(_build_simple_graph())
+        results = execute(symbols=["foo.py:bar"], mode="defined")
+        assert any(r.node_name == "foo.py:bar" for r in results)
+
+    def test_merges_unified_name_collision_candidates(self):
+        execute = self._execute(_build_graph_with_unified_collision())
+        # `shared_name` maps to two identities (a.py and b.py); both must be
+        # returned even though they share a display name.
+        results = execute(symbols=["shared_name"], mode="defined")
+        files = {r.file for r in results}
+        assert files == {"a.py", "b.py"}, f"expected both files, got {files}"
+        assert len(results) == 2
+
+    def test_unknown_symbol_returns_empty(self):
+        execute = self._execute(_build_simple_graph())
+        assert execute(symbols=["not_a_real_symbol"]) == []
+
+    def test_empty_string_symbol_silently_dropped(self):
+        execute = self._execute(_build_simple_graph())
+        assert execute(symbols=["", "   ", None]) == []
+
+    def test_non_string_symbols_silently_filtered(self):
+        # Defensive: LLM might pass mixed types via tool-call JSON. The
+        # isinstance(s, str) gate must drop anything non-string without raising.
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            symbols=[123, None, {}, ["nested"], "foo.py:bar"], mode="defined"
+        )
+        names = {r.node_name for r in results}
+        assert names == {"foo.py:bar"}
+
+
+class TestGraphExpandCombinedInput:
+    """Both `ranges` and `symbols` provided — union, dedup by (node_id, role)."""
+
+    def _execute(self, graph: CodeGraph):
+        return _load_executor(ExpandContext(code_graph=graph))
+
+    def test_ranges_and_symbols_union(self):
+        execute = self._execute(_build_simple_graph())
+        # Range hits bar; symbol hits baz directly.
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 11}],
+            symbols=["foo.py:baz"],
+            mode="defined",
+        )
+        names = {r.node_name for r in results}
+        assert "foo.py:bar" in names
+        assert "foo.py:baz" in names
+
+    def test_dedups_when_range_and_symbol_overlap(self):
+        execute = self._execute(_build_simple_graph())
+        # Both inputs resolve to bar; should appear once.
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 21}],
+            symbols=["foo.py:bar"],
+            mode="defined",
+        )
+        bar_count = sum(1 for r in results if r.node_name == "foo.py:bar")
+        assert bar_count == 1
+
+    def test_ranges_and_symbols_across_different_files(self):
+        # ranges hit a symbol in file A; symbols pick one in file B. The union
+        # must contain both; dedup shouldn't collapse symbols across files.
+        execute = self._execute(_build_graph_with_test_caller())
+        results = execute(
+            ranges=[{"file": "target.py", "start_line": 6, "end_line": 11}],
+            symbols=["caller.py:c"],
+            mode="defined",
+            filter_tests=False,
+        )
+        names = {r.node_name for r in results}
+        assert "target.py:fn" in names
+        assert "caller.py:c" in names
+
+    def test_recursive_vertex_appears_in_both_roles(self):
+        # Dedup key is (node_id, role), NOT node_id alone — a recursive
+        # function (rec calls itself) must surface as BOTH defined and callee.
+        execute = self._execute(_build_recursive_graph())
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 21}],
+            mode="all",
+            filter_tests=False,
+        )
+        rec_entries = [r for r in results if r.node_name == "foo.py:rec"]
+        roles_for_rec = {r.role for r in rec_entries}
+        assert {"defined", "callees"}.issubset(
+            roles_for_rec
+        ), f"recursive rec missing expected roles: {roles_for_rec}"
+        # boot shows up as a caller (incoming edge into rec from outside).
+        assert any(
+            r.node_name == "foo.py:boot" and r.role == "callers" for r in results
+        )
+
+    def test_dedup_preserves_first_seed_anchor(self):
+        # When two seed ranges both surface the same callee, dedup keeps the
+        # FIRST occurrence — the second seed's anchor is invisible (documented
+        # in skill.md).
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[
+                {"file": "foo.py", "start_line": 6, "end_line": 16},
+                {"file": "foo.py", "start_line": 11, "end_line": 21},
+            ],
+            mode="callees",
+            filter_tests=False,
+        )
+        baz_entries = [r for r in results if r.node_name == "foo.py:baz"]
+        assert len(baz_entries) == 1
+        # Anchor is the call-site line (0-based 12 -> 1-based 13).
+        assert baz_entries[0].anchor_line == 13
+
+
+class TestGraphExpandFiltersAndCaps:
+    """`filter_tests` exclusion and `top_k` truncation."""
+
+    def _execute(self, graph: CodeGraph):
+        return _load_executor(ExpandContext(code_graph=graph))
+
+    def test_filter_tests_excludes_test_callers_by_default(self):
+        execute = self._execute(_build_graph_with_test_caller())
+        results = execute(
+            ranges=[{"file": "target.py", "start_line": 6, "end_line": 11}],
+            mode="callers",
+        )
+        names = {r.node_name for r in results}
+        assert "caller.py:c" in names
+        assert "test_x.py:tc" not in names
+
+    def test_filter_tests_false_keeps_test_callers(self):
+        execute = self._execute(_build_graph_with_test_caller())
+        results = execute(
+            ranges=[{"file": "target.py", "start_line": 6, "end_line": 11}],
+            mode="callers",
+            filter_tests=False,
+        )
+        names = {r.node_name for r in results}
+        assert "caller.py:c" in names
+        assert "test_x.py:tc" in names
+
+    def test_top_k_truncation_appends_sentinel(self):
+        execute = self._execute(_build_hot_target_graph(n_callers=20))
+        results = execute(
+            ranges=[{"file": "target.py", "start_line": 2, "end_line": 6}],
+            mode="callers",
+            top_k=5,
+            filter_tests=False,
+        )
+        assert len(results) == 6  # 5 real + 1 sentinel
+        sentinel = results[-1]
+        assert sentinel.node_name == "__truncated__"
+        assert sentinel.type == "meta"
+        assert "truncated" in (sentinel.content or "")
+
+    def test_top_k_no_truncation_when_within_cap(self):
+        execute = self._execute(_build_hot_target_graph(n_callers=3))
+        results = execute(
+            ranges=[{"file": "target.py", "start_line": 2, "end_line": 6}],
+            mode="callers",
+            top_k=10,
+            filter_tests=False,
+        )
+        assert all(r.node_name != "__truncated__" for r in results)
+        assert len(results) == 3
+
+
+class TestGraphExpandLineNumbering:
+    """Explicit checks for the 1-based (agent) <-> 0-based (graph) boundary."""
+
+    def _execute(self, graph: CodeGraph):
+        return _load_executor(ExpandContext(code_graph=graph))
+
+    def test_defined_span_returned_one_based(self):
+        # bar's 0-based span is 5-20 -> output start/end must be 6/21.
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 9, "end_line": 9}],
+            mode="defined",
+        )
+        bar = next(r for r in results if r.node_name == "foo.py:bar")
+        assert bar.start_line == 6
+        assert bar.end_line == 21
+
+    def test_one_based_query_excludes_off_by_one_neighbor(self):
+        # bar occupies 0-based 5-20 (1-based 6-21). A 1-based query of just
+        # line 5 (0-based 4) must NOT overlap bar.
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 5, "end_line": 5}],
+            mode="defined",
+        )
+        assert all(r.node_name != "foo.py:bar" for r in results)
+        # But the boundary line 6 (0-based 5) does overlap.
+        results2 = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 6}],
+            mode="defined",
+        )
+        assert any(r.node_name == "foo.py:bar" for r in results2)
+
+    def test_zero_or_negative_line_clamped_not_underflowed(self):
+        # A stray 0 / negative agent line must clamp to the start, not produce
+        # a negative 0-based query that silently misses everything.
+        execute = self._execute(_build_simple_graph())
+        results = execute(
+            ranges=[{"file": "foo.py", "start_line": 0, "end_line": 11}],
+            mode="defined",
+        )
+        # 0 -> clamp to 0-based 0; range 0..10 overlaps bar (5-20).
+        assert any(r.node_name == "foo.py:bar" for r in results)
+
+
+class TestGraphExpandForwardCompat:
+    """`hops` is reserved for future multi-hop; v1 always behaves as 1."""
+
+    @pytest.mark.parametrize("hops_value", [0, -1, 2, 5, 100])
+    def test_hops_non_one_behaves_like_one(self, hops_value):
+        execute = _load_executor(ExpandContext(code_graph=_build_simple_graph()))
+        baseline = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 21}],
+            mode="defined",
+            hops=1,
+        )
+        actual = execute(
+            ranges=[{"file": "foo.py", "start_line": 6, "end_line": 21}],
+            mode="defined",
+            hops=hops_value,
+        )
+        assert [r.node_name for r in actual] == [r.node_name for r in baseline]
+
+
+class TestGraphExpandLoader:
+    """Smoke test: SkillLoader registers the real skill package."""
+
+    def test_skill_package_loads(self):
+        ctx = ExpandContext(code_graph=_build_simple_graph())
+        skills_dir = str(Path(_skill_dir()).parent)
+        loader = SkillLoader()
+        loaded = loader.load_all(skills_dir, contexts={"expand": ctx})
+
+        loaded_ids = {m.skill_id for m in loaded}
+        assert "graph_expand" in loaded_ids
+        assert "graph_locate" not in loaded_ids  # never landed / folded in
+
+        meta = SkillRegistry().get("graph_expand")
+        assert meta is not None
+        assert meta.executor_fn is not None
+        results = meta.executor_fn(
+            ranges=[{"file": "foo.py", "start_line": 9, "end_line": 16}],
+            mode="defined",
+        )
+        assert any(r.node_name == "foo.py:bar" for r in results)

--- a/test/agent/test_graph_expand_seed.py
+++ b/test/agent/test_graph_expand_seed.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for model-seedable graph_expand + List[...] tool schemas (#133)."""
+"""Tests for List[...] tool schemas used by graph_expand (#133).
+
+The executor's behaviour (range / symbol input, dedup, modes) is covered in
+``test/agent/test_graph_expand.py``; this module keeps the focused tool-schema
+checks that guard the ``List[str]`` -> ``array`` lowering the agent relies on.
+"""
 
 from __future__ import annotations
-
-from types import SimpleNamespace
-
-import pytest
 
 from codeminer.agent.skills.core import (
     SkillInputSpec,
@@ -48,7 +49,7 @@ def test_skill_to_tool_schema_emits_array_items():
         skill_type=SkillType.EXPAND,
         inputs=[
             SkillInputSpec(
-                name="seed_symbols",
+                name="symbols",
                 type_hint="List[str]",
                 required=True,
                 description="qualified names",
@@ -58,80 +59,7 @@ def test_skill_to_tool_schema_emits_array_items():
         executor_fn=lambda **k: [],
     )
     schema = skill_to_tool_schema(meta)
-    prop = schema["function"]["parameters"]["properties"]["seed_symbols"]
+    prop = schema["function"]["parameters"]["properties"]["symbols"]
     assert prop["type"] == "array"
     assert prop["items"] == {"type": "string"}
-    assert schema["function"]["parameters"]["required"] == ["seed_symbols"]
-
-
-# ---------------------------------------------------------------------------
-# graph_expand executor: informative errors instead of silent []
-# ---------------------------------------------------------------------------
-
-
-def _load_executor():
-    # Import via the package path so the executor's relative imports resolve.
-    from codeminer.agent.skills.graph_expand.executor import create_executor
-
-    return create_executor
-
-
-def test_graph_expand_raises_on_no_seeds():
-    create_executor = _load_executor()
-    ctx = SimpleNamespace(code_graph=SimpleNamespace(name_to_vertex={"a": 0}))
-    execute = create_executor(ctx)
-    with pytest.raises(ValueError, match="seed_symbols"):
-        execute(seed_symbols=[])
-
-
-def test_graph_expand_raises_when_all_seeds_unresolved():
-    create_executor = _load_executor()
-    ctx = SimpleNamespace(code_graph=SimpleNamespace(name_to_vertex={"real.sym": 0}))
-    execute = create_executor(ctx)
-    with pytest.raises(ValueError, match="resolve"):
-        execute(seed_symbols=["nonexistent.symbol"])
-
-
-def test_symbols_in_files_resolves_via_file_nodes():
-    from codeminer.agent.skills.graph_expand.executor import _symbols_in_files
-
-    class _VS:
-        def __init__(self, names):
-            self._n = names
-
-        def __getitem__(self, vid):
-            return {"name": self._n[vid]}
-
-    class _Graph:
-        def __init__(self, names):
-            self.vs = _VS(names)
-
-    class _CG:
-        def __init__(self):
-            self.graph = _Graph({0: "pkg.adminHandler", 1: "pkg.deleteConfig"})
-            self._file_nodes = {"admin.go": [(1, 10, 0), (12, 20, 1)]}
-
-    cg = _CG()
-    # exact key
-    assert _symbols_in_files(cg, ["admin.go"]) == [
-        "pkg.adminHandler",
-        "pkg.deleteConfig",
-    ]
-    # suffix / absolute-ish path still matches
-    assert _symbols_in_files(cg, ["/repo/admin.go"]) == [
-        "pkg.adminHandler",
-        "pkg.deleteConfig",
-    ]
-    # unknown file → nothing
-    assert _symbols_in_files(cg, ["nope.go"]) == []
-
-
-def test_graph_expand_accepts_legacy_seed_nodes_shim():
-    """Back-compat: objects with .node_name still work via seed_nodes."""
-    create_executor = _load_executor()
-    ctx = SimpleNamespace(code_graph=SimpleNamespace(name_to_vertex={"x.y": 0}))
-    execute = create_executor(ctx)
-    # All unresolved (node_name not in graph) → informative raise, proving the
-    # shim extracted the name from the object rather than silently dropping it.
-    with pytest.raises(ValueError, match="resolve"):
-        execute(seed_nodes=[SimpleNamespace(node_name="ghost.sym")])
+    assert schema["function"]["parameters"]["required"] == ["symbols"]

--- a/test/agent/test_tool_schema.py
+++ b/test/agent/test_tool_schema.py
@@ -106,7 +106,7 @@ class TestSkillToToolSchema:
 
         Previously complex types produced an empty ``{}`` schema, giving the
         model no hint how to populate list params (e.g.
-        ``graph_expand.seed_symbols``). Now they get ``array`` + ``items``.
+        ``graph_expand.symbols``). Now they get ``array`` + ``items``.
         """
         meta = SkillMetadata(
             skill_id="test_complex",

--- a/test/ops/test_expand.py
+++ b/test/ops/test_expand.py
@@ -58,8 +58,16 @@ class TestExpandContext:
         ctx = ExpandContext()
         assert ctx.code_graph is None
         assert ctx.default_top_k == 50
-        assert ctx.default_hops == 2
-        assert ctx.default_direction == "both"
-        assert ctx.default_method == "bfs"
-        assert ctx.default_damping == 0.85
         assert ctx.filter_tests is True
+
+    def test_bfs_ppr_tunables_removed(self):
+        # Post-#155 graph_expand is a 1-hop range/symbol primitive — the old
+        # BFS/PPR tunables were dropped as dead state.
+        ctx = ExpandContext()
+        for attr in (
+            "default_hops",
+            "default_direction",
+            "default_method",
+            "default_damping",
+        ):
+            assert not hasattr(ctx, attr), f"{attr} should have been removed"


### PR DESCRIPTION
## Summary

Closes #155 (refs #147). Rewrites `graph_expand` as a single LSP-aligned 1-hop
primitive with dual input — `ranges` (file + 1-based line range) **or**
`symbols` — built directly on `CodeGraph.query_range` /
`query_range_by_symbol`. Folds the WIP `graph_locate` functionality into this
one primitive.

## Changes
- `codeminer/agent/skills/graph_expand/{executor.py,config.yaml,skill.md}`
  rewritten around `query_range` / `query_range_by_symbol`; `ranges` are
  1-based agent-facing and converted to 0-based internally.
- `codeminer/ops/expand.py` and `codeminer/types.py` updated for the new
  range/symbol seeding; `codeminer/agent/tool_schema.py` reflects the new
  signature.
- Tests updated/added: `test/agent/test_graph_expand.py`,
  `test/agent/test_graph_expand_seed.py`, `test/agent/test_tool_schema.py`,
  `test/ops/test_expand.py`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/agent/test_graph_expand.py test/agent/test_graph_expand_seed.py test/agent/test_tool_schema.py test/ops/test_expand.py -m "not slow and not integration"`
→ 61 passed.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
