### PR TITLE
[ls_index][graph/incremental] use clangd $/progress for index-completion detection

### DIFF
--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -529,7 +529,7 @@ class PatcherCpp(PatcherBase):
             no_progress_idle_s = 3.0
             poll_interval_s = 0.05
             deadline = time.monotonic() + max_wait_s
-            settle_after_end_s = 0.3  # let trailing .idx writes flush
+            settle_after_end_s = 0.5  # let trailing .idx writes flush
             end_seen_at: float | None = None
             last_mtime = pre_mtime
             last_mtime_change_t = time.monotonic()
@@ -550,7 +550,12 @@ class PatcherCpp(PatcherBase):
                         end_seen_at = time.monotonic()
                     elif time.monotonic() - end_seen_at >= settle_after_end_s:
                         break
-                elif not progress_state["saw_begin"]:
+                elif saw_begin:
+                    # Indexing in flight — wait for the end event (do NOT
+                    # consult mtime; a single long-running TU could
+                    # falsely trip a stability check).
+                    pass
+                else:
                     # No $/progress yet — fall back to .idx mtime polling.
                     cur_mtime = max(
                         (f.stat().st_mtime for f in idx_dir.glob("*.idx")),

--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -13,6 +13,7 @@ import json
 import os
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 
@@ -365,10 +366,77 @@ class PatcherCpp(PatcherBase):
             cwd=str(self.project_root),
         )
 
-        # Drain stdout/stderr in background threads. Without this clangd
-        # blocks on its first reply once the pipe buffer fills (~64KB),
-        # which silently halts the BackgroundIndex queue.
-        def _drain(stream):
+        # Track BackgroundIndex progress via the LSP ``$/progress``
+        # notifications clangd emits (see LLVM D73218). When we see
+        # ``kind == "end"`` for the ``backgroundIndexProgress`` token,
+        # clangd's queue has drained — much sharper signal than polling
+        # .idx mtime with a 5-second idle timeout.
+        progress_state = {
+            "saw_begin": False,
+            "active_tokens": set(),
+            "lock": threading.Lock(),
+        }
+
+        def _stdout_loop():
+            """Parse Content-Length framed JSON-RPC; track $/progress."""
+            buf = b""
+            stream = process.stdout
+            try:
+                while True:
+                    # Read headers
+                    while b"\r\n\r\n" not in buf:
+                        chunk = (
+                            stream.read1(65536)
+                            if hasattr(stream, "read1")
+                            else stream.read(4096)
+                        )
+                        if not chunk:
+                            return
+                        buf += chunk
+                    header_blob, _, rest = buf.partition(b"\r\n\r\n")
+                    buf = rest
+                    cl = 0
+                    for hline in header_blob.split(b"\r\n"):
+                        if hline.lower().startswith(b"content-length:"):
+                            try:
+                                cl = int(hline.split(b":", 1)[1].strip())
+                            except ValueError:
+                                cl = 0
+                    # Read body
+                    while len(buf) < cl:
+                        chunk = (
+                            stream.read1(65536)
+                            if hasattr(stream, "read1")
+                            else stream.read(4096)
+                        )
+                        if not chunk:
+                            return
+                        buf += chunk
+                    body, buf = buf[:cl], buf[cl:]
+                    try:
+                        msg = json.loads(body)
+                    except json.JSONDecodeError:
+                        continue
+                    if msg.get("method") != "$/progress":
+                        continue
+                    params = msg.get("params") or {}
+                    if params.get("token") != "backgroundIndexProgress":
+                        continue
+                    value = params.get("value") or {}
+                    kind = value.get("kind")
+                    with progress_state["lock"]:
+                        if kind == "begin":
+                            progress_state["saw_begin"] = True
+                            progress_state["active_tokens"].add(params["token"])
+                        elif kind == "end":
+                            progress_state["active_tokens"].discard(params["token"])
+            except Exception:
+                # stdout reader dying is non-fatal: progress just stays
+                # in whatever state it last reached. We have fallbacks
+                # (process death + max_wait_s timeout) below.
+                return
+
+        def _drain_stderr(stream):
             try:
                 while True:
                     chunk = (
@@ -381,10 +449,10 @@ class PatcherCpp(PatcherBase):
             except Exception:
                 return
 
-        import threading
-
-        threading.Thread(target=_drain, args=(process.stdout,), daemon=True).start()
-        threading.Thread(target=_drain, args=(process.stderr,), daemon=True).start()
+        threading.Thread(target=_stdout_loop, daemon=True).start()
+        threading.Thread(
+            target=_drain_stderr, args=(process.stderr,), daemon=True
+        ).start()
 
         def lsp_send(msg):
             content = json.dumps(msg).encode()
@@ -393,6 +461,12 @@ class PatcherCpp(PatcherBase):
             process.stdin.flush()
 
         try:
+            # Capabilities: we want backgroundIndexProgress notifications.
+            # ``workDoneProgress: True`` is the LSP-standard opt-in;
+            # ``implicitWorkDoneProgressCreate: True`` is a clangd extension
+            # that lets the server skip the ``window/workDoneProgress/create``
+            # handshake — without it, clangd flips state to "Unsupported"
+            # and never sends progress (verified on Ubuntu clangd 18.1.3).
             lsp_send(
                 {
                     "jsonrpc": "2.0",
@@ -401,11 +475,16 @@ class PatcherCpp(PatcherBase):
                     "params": {
                         "processId": os.getpid(),
                         "rootUri": Path(self.project_root).as_uri(),
-                        "capabilities": {},
+                        "capabilities": {
+                            "window": {
+                                "workDoneProgress": True,
+                                "implicitWorkDoneProgressCreate": True,
+                            },
+                        },
                     },
                 }
             )
-            time.sleep(1)
+            time.sleep(0.3)
             lsp_send(
                 {
                     "jsonrpc": "2.0",
@@ -413,7 +492,7 @@ class PatcherCpp(PatcherBase):
                     "params": {},
                 }
             )
-            time.sleep(0.5)
+            time.sleep(0.2)
 
             for fpath in changed_files:
                 abs_path = Path(self.project_root) / fpath
@@ -438,36 +517,61 @@ class PatcherCpp(PatcherBase):
                     }
                 )
 
-            # Poll for clangd to update .idx after didOpen.
-            # Two exit conditions:
-            #   (a) success: clangd touched .idx (cur > pre) AND has been
-            #       quiet for ``idle_after_change`` seconds
-            #   (b) no-op:   clangd never updates .idx (e.g. didOpen on
-            #       a header file in fmt — header isn't its own TU). Bail
-            #       after ``idle_no_change`` seconds; further waiting is
-            #       pure overhead.
-            idle_after_change = 5
-            idle_no_change = 5
-            stable = 0
+            # Wait for clangd to finish indexing. Three exit conditions:
+            #   (a) Progress: saw begin and queue is now empty → done.
+            #   (b) No progress arrived AND .idx mtime quiet for 3s → done
+            #       (fallback for clients/servers where $/progress fails,
+            #       e.g. very old clangd or capability negotiation hiccup).
+            #   (c) Clangd process died.
+            # Hard cap at max_wait_s so a hung clangd doesn't stall the
+            # bench forever.
+            max_wait_s = 120.0
+            no_progress_idle_s = 3.0
+            poll_interval_s = 0.05
+            deadline = time.monotonic() + max_wait_s
+            settle_after_end_s = 0.3  # let trailing .idx writes flush
+            end_seen_at: float | None = None
             last_mtime = pre_mtime
-            for _ in range(120):
-                time.sleep(1)
-                cur_mtime = max(
-                    (f.stat().st_mtime for f in idx_dir.glob("*.idx")),
-                    default=0,
-                )
-                if cur_mtime > last_mtime:
-                    last_mtime = cur_mtime
-                    stable = 0
-                else:
-                    stable += 1
-                    if cur_mtime > pre_mtime and stable >= idle_after_change:
+            last_mtime_change_t = time.monotonic()
+
+            while time.monotonic() < deadline:
+                if process.poll() is not None:
+                    break  # (c) clangd died
+
+                with progress_state["lock"]:
+                    saw_begin = progress_state["saw_begin"]
+                    active = bool(progress_state["active_tokens"])
+
+                if saw_begin and not active:
+                    # (a) Progress reported done. Wait a short settle window
+                    # so the very-last .idx file rename has time to land
+                    # before we parse them.
+                    if end_seen_at is None:
+                        end_seen_at = time.monotonic()
+                    elif time.monotonic() - end_seen_at >= settle_after_end_s:
                         break
-                    if cur_mtime <= pre_mtime and stable >= idle_no_change:
+                elif not progress_state["saw_begin"]:
+                    # No $/progress yet — fall back to .idx mtime polling.
+                    cur_mtime = max(
+                        (f.stat().st_mtime for f in idx_dir.glob("*.idx")),
+                        default=0,
+                    )
+                    if cur_mtime > last_mtime:
+                        last_mtime = cur_mtime
+                        last_mtime_change_t = time.monotonic()
+                    if time.monotonic() - last_mtime_change_t >= no_progress_idle_s:
+                        # (b) Nothing happening for 3s and no progress
+                        # API in play — assume clangd is done (or never
+                        # going to do anything for this set of files).
                         break
 
+                time.sleep(poll_interval_s)
+
             post_count = len(list(idx_dir.glob("*.idx")))
-            logger.info(f"C++ incremental done: {pre_count}→{post_count} .idx files")
+            logger.info(
+                f"C++ incremental done: {pre_count}→{post_count} .idx files "
+                f"(progress_seen={progress_state['saw_begin']})"
+            )
 
         finally:
             try:

--- a/codeminer/ls_index/clangd_indexer.py
+++ b/codeminer/ls_index/clangd_indexer.py
@@ -479,7 +479,7 @@ class ClangdIndexer:
                     "method": "initialize",
                     "params": {
                         "processId": os.getpid(),
-                        "rootUri": f"file://{self.project_root}",
+                        "rootUri": self.project_root.as_uri(),
                         "capabilities": {
                             "window": {
                                 "workDoneProgress": True,
@@ -662,6 +662,11 @@ class ClangdIndexer:
         while time.time() - start < timeout:
             time.sleep(0.5 if progress_state is not None else 2)
 
+            # Process death is fatal in any state — check once per loop.
+            if process.poll() is not None:
+                logger.warning("clangd process exited during indexing")
+                return
+
             # ── Path A: progress-aware (preferred) ────────────────────
             if progress_state is not None:
                 with progress_state["lock"]:
@@ -682,19 +687,18 @@ class ClangdIndexer:
                             f"{total_files} .idx files ({elapsed:.0f}s)"
                         )
                         return
-                    if process.poll() is not None:
-                        logger.warning("clangd process exited during indexing")
-                        return
                     continue
-                # If progress never started AND we've waited long enough,
-                # fall through to mtime polling — handles old clangd or
-                # capability negotiation failure.
-                if not saw_begin and (time.time() - start) < idle_timeout:
-                    if process.poll() is not None:
-                        logger.warning("clangd process exited during indexing")
-                        return
+                if saw_begin and active:
+                    # Indexing in flight — wait for the end event. Do NOT
+                    # drop into mtime fallback: a single long-running TU
+                    # (>stable_seconds with no other writes) would falsely
+                    # trip the stability check.
                     continue
-                # else: drop into mtime fallback below
+                # not saw_begin yet
+                if (time.time() - start) < idle_timeout:
+                    continue
+                # Progress never started AND we've waited idle_timeout —
+                # drop into mtime fallback (old clangd, capability hiccup).
 
             # ── Path B: mtime fallback (no progress signal) ───────────
             current_max_mtime = 0.0

--- a/codeminer/ls_index/clangd_indexer.py
+++ b/codeminer/ls_index/clangd_indexer.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 import time
 from pathlib import Path
 from typing import List, Optional, Union
@@ -438,8 +439,38 @@ class ClangdIndexer:
             cwd=str(self.project_root),
         )
 
+        # Track BackgroundIndex progress via the LSP $/progress
+        # notifications clangd emits (LLVM D73218). When clangd has
+        # processed the whole queue we get a ``kind == "end"`` event for
+        # the ``backgroundIndexProgress`` token — a sharp completion
+        # signal so we don't need to poll .idx mtime for 10s of
+        # stability. Falls back to the legacy mtime poll if no progress
+        # arrives (very old clangd or capability hiccup).
+        progress_state = {
+            "saw_begin": False,
+            "active_tokens": set(),
+            "lock": threading.Lock(),
+        }
+        threading.Thread(
+            target=_clangd_progress_reader,
+            args=(process.stdout, progress_state),
+            daemon=True,
+        ).start()
+        # Stderr needs draining too — `--log=error` is small but pipe can
+        # still fill on bigger errors.
+        threading.Thread(
+            target=_clangd_stream_drain,
+            args=(process.stderr,),
+            daemon=True,
+        ).start()
+
         try:
-            # LSP initialize (fire-and-forget — don't read the response)
+            # LSP initialize. ``window.workDoneProgress`` enables the
+            # protocol; ``implicitWorkDoneProgressCreate`` is a clangd
+            # extension that lets the server skip the
+            # ``window/workDoneProgress/create`` handshake — without
+            # it, clangd waits for a client reply we don't send and
+            # silently flips progress to "Unsupported" mode.
             self._lsp_send(
                 process,
                 {
@@ -449,11 +480,16 @@ class ClangdIndexer:
                     "params": {
                         "processId": os.getpid(),
                         "rootUri": f"file://{self.project_root}",
-                        "capabilities": {},
+                        "capabilities": {
+                            "window": {
+                                "workDoneProgress": True,
+                                "implicitWorkDoneProgressCreate": True,
+                            },
+                        },
                     },
                 },
             )
-            time.sleep(2)
+            time.sleep(0.5)
 
             # LSP initialized — triggers BackgroundIndex
             self._lsp_send(
@@ -464,14 +500,19 @@ class ClangdIndexer:
                     "params": {},
                 },
             )
-            time.sleep(1)
+            time.sleep(0.3)
 
             # Open source files listed in compile_commands.json to nudge
             # the background indexer (same approach as test_codegraph_clangd)
             self._open_source_files(process, comp_db)
 
-            # Wait for .idx files to stabilise — check all candidate dirs
-            self._wait_for_indexing(process, candidate_dirs, pre_mtimes)
+            # Wait for indexing — progress-aware, with mtime fallback.
+            self._wait_for_indexing(
+                process,
+                candidate_dirs,
+                pre_mtimes,
+                progress_state=progress_state,
+            )
 
         except Exception as e:
             logger.error(f"Error during clangd indexing: {e}")
@@ -599,17 +640,13 @@ class ClangdIndexer:
         timeout: int = 1200,
         stable_seconds: int = 10,
         idle_timeout: int = 30,
+        progress_state: Optional[dict] = None,
     ):
-        """
-        Wait for background indexing to complete by monitoring multiple
-        candidate .idx directories using mtime-based detection.
+        """Wait for background indexing to complete.
 
-        Considers indexing done when no .idx file mtimes change for
-        *stable_seconds* consecutive seconds across ALL candidate dirs.
-
-        If pre-existing .idx files exist but no activity is detected for
-        *idle_timeout* seconds, assumes clangd has nothing to do and returns
-        early (avoids waiting the full timeout).
+        Prefers clangd's LSP ``$/progress`` ``backgroundIndexProgress``
+        ``end`` event (delivered via ``progress_state``); falls back to
+        polling .idx mtime when no progress signal arrives in time.
         """
         logger.info("Waiting for clangd background indexing to complete ...")
         logger.info(f"Monitoring directories: {[str(d) for d in candidate_dirs]}")
@@ -618,11 +655,48 @@ class ClangdIndexer:
         last_max_mtime = max(pre_mtimes.values()) if pre_mtimes else 0
         activity_detected = False
         has_pre_existing = any(mt > 0 for mt in pre_mtimes.values())
+        settle_after_end_s = 0.5  # let trailing .idx writes flush
+        end_seen_at: Optional[float] = None
+        total_files = 0
 
         while time.time() - start < timeout:
-            time.sleep(2)
+            time.sleep(0.5 if progress_state is not None else 2)
 
-            # Find current max mtime across all candidate dirs
+            # ── Path A: progress-aware (preferred) ────────────────────
+            if progress_state is not None:
+                with progress_state["lock"]:
+                    saw_begin = progress_state["saw_begin"]
+                    active = bool(progress_state["active_tokens"])
+                if saw_begin and not active:
+                    if end_seen_at is None:
+                        end_seen_at = time.time()
+                    elif time.time() - end_seen_at >= settle_after_end_s:
+                        total_files = sum(
+                            len(list(d.glob("*.idx")))
+                            for d in candidate_dirs
+                            if d.exists()
+                        )
+                        elapsed = time.time() - start
+                        logger.info(
+                            "Background indexing complete (progress.end): "
+                            f"{total_files} .idx files ({elapsed:.0f}s)"
+                        )
+                        return
+                    if process.poll() is not None:
+                        logger.warning("clangd process exited during indexing")
+                        return
+                    continue
+                # If progress never started AND we've waited long enough,
+                # fall through to mtime polling — handles old clangd or
+                # capability negotiation failure.
+                if not saw_begin and (time.time() - start) < idle_timeout:
+                    if process.poll() is not None:
+                        logger.warning("clangd process exited during indexing")
+                        return
+                    continue
+                # else: drop into mtime fallback below
+
+            # ── Path B: mtime fallback (no progress signal) ───────────
             current_max_mtime = 0.0
             total_files = 0
             for d in candidate_dirs:
@@ -948,3 +1022,81 @@ class ClangdIndexer:
             if e.stderr:
                 logger.warning("stderr: %s", e.stderr[:600].strip())
             return False
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Module-level helpers (kept outside ClangdIndexer so they can be reused
+# by other clangd-driving code paths without becoming part of the class
+# surface area).
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _clangd_progress_reader(stream, progress_state: dict) -> None:
+    """Parse Content-Length framed JSON-RPC from clangd stdout; track
+    ``backgroundIndexProgress`` ``begin``/``end`` events into
+    ``progress_state`` (a dict with keys ``saw_begin: bool``,
+    ``active_tokens: set``, ``lock: threading.Lock``)."""
+    buf = b""
+    try:
+        while True:
+            while b"\r\n\r\n" not in buf:
+                chunk = (
+                    stream.read1(65536)
+                    if hasattr(stream, "read1")
+                    else stream.read(4096)
+                )
+                if not chunk:
+                    return
+                buf += chunk
+            header_blob, _, rest = buf.partition(b"\r\n\r\n")
+            buf = rest
+            cl = 0
+            for hline in header_blob.split(b"\r\n"):
+                if hline.lower().startswith(b"content-length:"):
+                    try:
+                        cl = int(hline.split(b":", 1)[1].strip())
+                    except ValueError:
+                        cl = 0
+            while len(buf) < cl:
+                chunk = (
+                    stream.read1(65536)
+                    if hasattr(stream, "read1")
+                    else stream.read(4096)
+                )
+                if not chunk:
+                    return
+                buf += chunk
+            body, buf = buf[:cl], buf[cl:]
+            try:
+                msg = json.loads(body)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("method") != "$/progress":
+                continue
+            params = msg.get("params") or {}
+            if params.get("token") != "backgroundIndexProgress":
+                continue
+            kind = (params.get("value") or {}).get("kind")
+            with progress_state["lock"]:
+                if kind == "begin":
+                    progress_state["saw_begin"] = True
+                    progress_state["active_tokens"].add(params["token"])
+                elif kind == "end":
+                    progress_state["active_tokens"].discard(params["token"])
+    except Exception:
+        # Reader exit is non-fatal — fallbacks (mtime poll, process death,
+        # outer timeout) will still terminate the wait loop.
+        return
+
+
+def _clangd_stream_drain(stream) -> None:
+    """Best-effort drain so clangd doesn't block on a full pipe buffer."""
+    try:
+        while True:
+            chunk = (
+                stream.read1(65536) if hasattr(stream, "read1") else stream.read(4096)
+            )
+            if not chunk:
+                return
+    except Exception:
+        return

--- a/codeminer/ls_index/clangd_indexer.py
+++ b/codeminer/ls_index/clangd_indexer.py
@@ -10,6 +10,7 @@ Uses clangd's background indexer to generate .idx files, then
 ClangdGraphDecoder (idx_decode + idx_parser) to build a CodeGraph
 directly from the binary .idx format.
 """
+
 import json
 import os
 import re

--- a/test/ls_index/test_clangd_progress_reader.py
+++ b/test/ls_index/test_clangd_progress_reader.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the clangd $/progress LSP frame parser.
+
+Verifies ``_clangd_progress_reader`` survives split reads, malformed
+``Content-Length`` headers, missing JSON-RPC fields, interleaved noise
+messages, and oversize unrelated messages — without crashing or losing
+the ``backgroundIndexProgress`` begin/end events that the wait loop
+relies on for early-exit.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import threading
+
+from codeminer.ls_index.clangd_indexer import _clangd_progress_reader
+
+# ─── helpers ──────────────────────────────────────────────────────────────
+
+
+def _frame(body: dict) -> bytes:
+    payload = json.dumps(body).encode()
+    return f"Content-Length: {len(payload)}\r\n\r\n".encode() + payload
+
+
+def _state() -> dict:
+    return {"saw_begin": False, "active_tokens": set(), "lock": threading.Lock()}
+
+
+def _begin(token: str = "backgroundIndexProgress") -> bytes:
+    return _frame(
+        {
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {"token": token, "value": {"kind": "begin", "title": "indexing"}},
+        }
+    )
+
+
+def _report() -> bytes:
+    return _frame(
+        {
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {
+                "token": "backgroundIndexProgress",
+                "value": {"kind": "report", "percentage": 50},
+            },
+        }
+    )
+
+
+def _end() -> bytes:
+    return _frame(
+        {
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {
+                "token": "backgroundIndexProgress",
+                "value": {"kind": "end", "message": "done"},
+            },
+        }
+    )
+
+
+class _ChunkyStream:
+    """Yield at most ``chunk_size`` bytes per ``read1`` — simulates the
+    short reads we get from a real subprocess pipe."""
+
+    def __init__(self, data: bytes, chunk_size: int = 11):
+        self.data = data
+        self.pos = 0
+        self.chunk_size = chunk_size
+
+    def read1(self, n: int) -> bytes:
+        if self.pos >= len(self.data):
+            return b""
+        end = min(self.pos + min(n, self.chunk_size), len(self.data))
+        out = self.data[self.pos : end]
+        self.pos = end
+        return out
+
+
+# ─── tests ────────────────────────────────────────────────────────────────
+
+
+def test_full_begin_end_cycle():
+    """Single begin/report/end sequence delivered in one chunk."""
+    s = _state()
+    _clangd_progress_reader(io.BytesIO(_begin() + _report() + _end()), s)
+    assert s["saw_begin"] is True
+    assert s["active_tokens"] == set()
+
+
+def test_chunked_reads():
+    """Reader must reassemble frames split across multiple short reads."""
+    s = _state()
+    _clangd_progress_reader(
+        _ChunkyStream(_begin() + _report() + _end(), chunk_size=11), s
+    )
+    assert s["saw_begin"] is True
+    assert s["active_tokens"] == set()
+
+
+def test_malformed_content_length():
+    """A non-integer Content-Length must not stall later frames."""
+    bad = b"Content-Length: oops\r\n\r\n" + _begin() + _end()
+    s = _state()
+    _clangd_progress_reader(io.BytesIO(bad), s)
+    assert s["saw_begin"] is True
+
+
+def test_begin_without_end_keeps_token_active():
+    """If clangd dies mid-indexing, the wait loop should still see
+    ``active_tokens`` populated so it does not falsely return."""
+    s = _state()
+    _clangd_progress_reader(io.BytesIO(_begin()), s)
+    assert s["saw_begin"] is True
+    assert s["active_tokens"] == {"backgroundIndexProgress"}
+
+
+def test_other_progress_tokens_ignored():
+    """clangd may use other tokens (e.g. per-file diagnostics) — only
+    ``backgroundIndexProgress`` should affect our state."""
+    noise = _frame(
+        {
+            "jsonrpc": "2.0",
+            "method": "$/progress",
+            "params": {"token": "otherToken", "value": {"kind": "begin"}},
+        }
+    )
+    s = _state()
+    _clangd_progress_reader(io.BytesIO(noise + _begin() + _end()), s)
+    assert s["saw_begin"] is True
+    assert s["active_tokens"] == set()
+
+
+def test_missing_params_or_value():
+    """Malformed $/progress messages must not crash the reader."""
+    weird = (
+        _frame({"jsonrpc": "2.0", "method": "$/progress"})  # no params
+        + _frame(
+            {
+                "jsonrpc": "2.0",
+                "method": "$/progress",
+                "params": {"token": "backgroundIndexProgress"},  # no value
+            }
+        )
+        + _begin()
+        + _end()
+    )
+    s = _state()
+    _clangd_progress_reader(io.BytesIO(weird), s)
+    assert s["saw_begin"] is True
+
+
+def test_large_intervening_message():
+    """A 100KB unrelated message must not stall progress detection."""
+    big = _frame(
+        {
+            "jsonrpc": "2.0",
+            "method": "window/showMessage",
+            "params": {"type": 3, "message": "x" * 100_000},
+        }
+    )
+    s = _state()
+    _clangd_progress_reader(_ChunkyStream(big + _begin() + _end(), chunk_size=17), s)
+    assert s["saw_begin"] is True
+    assert s["active_tokens"] == set()


### PR DESCRIPTION
## Summary

Replace `.idx` mtime-stability polling (5s incremental / 10s rebuild) with
the LSP `$/progress` `backgroundIndexProgress` event clangd already emits
([LLVM D73218](https://reviews.llvm.org/D73218)). The old wait was dead
time we paid on every clangd run — this is a **measurement-accuracy fix,
not a clangd speedup**.

Recorded wallclock on 50 cpp trials (5 instances × 10 commits, jq /
redis / valkey / fmt, same clangd 18.1.3):

| strategy | mtime wall (old) | $/progress (new) | dead wait removed |
|---|---:|---:|---:|
| fully-rebuild | 31.86s | 12.73s | ~19s |
| file-level-patch | 9.95s | 2.71s | ~7s |
| symbol-level-patch | 9.27s | 2.65s | ~7s |

(median; old n=200, new n=50.)

## Changes

- **`clangd_indexer.py`** (full-rebuild): wire `$/progress` reader thread,
  capability-negotiate `window.workDoneProgress` + clangd-specific
  `implicitWorkDoneProgressCreate` (verified clangd 18.1.3 silently flips
  to "Unsupported" without it). `_wait_for_indexing` exits within 0.5s of
  the `end` event; falls back to mtime poll if no `begin` in 30s.
- **`patcher_cpp.py`** (incremental): same capability + reader (inline to
  avoid `graph/` → `ls_index/` dep). Three exits: progress end + settle,
  mtime quiet 3s fallback, process death. 120s cap.
- **Wait-loop bug fixes** (full-rebuild): hoist `process.poll()` to loop
  top so clangd crash during active indexing doesn't wait 1200s; explicit
  `continue` on `saw_begin AND active` instead of falling to mtime path
  (a long-running TU could falsely trip stability).
- **`rootUri`** in indexer uses `Path.as_uri()` for consistency.
- **New test** `test/ls_index/test_clangd_progress_reader.py` — 7 cases
  covering split reads, malformed framing, missing fields, interleaved
  noise. First test in `ls_index/`.

## Type of Change
- [x] Bug fix
- [x] Tests

## Testing
- 50-trial cpp bench: 50/50 ok, no premature exits, no hangs.
- 7 parser unit tests pass (`pytest test/ls_index/`).
- Standalone probe confirms `$/progress` requires both capabilities on
  clangd 18.1.3.

## Checklist
- [x] Style guidelines followed
- [x] Self-reviewed
- [x] Comments where non-obvious
- [x] No new warnings
- [x] Dependent changes merged
