### PR TITLE
fix(test): drop test/scripts/__init__.py shadowing top-level scripts

### DIFF
--- a/test/scripts/__init__.py
+++ b/test/scripts/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
-#
-# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
## Summary

main's CI is red on the **unit** job (which aborts everything downstream): `test/agent/test_build_codeminer_base_partition.py` fails to collect with `ModuleNotFoundError: No module named 'scripts.agent_compile'`. Root cause is a cross-PR interaction between #190 and #193 that neither PR's CI could catch alone.

`test/scripts/__init__.py` (added in #193) makes `test/scripts` a regular package named `scripts`. Under pytest's prepend import mode `test/` lands on `sys.path`, so `import scripts` resolves to `test/scripts/` and **shadows the real top-level `scripts/` package** (its `__path__` has no `agent_compile`). #190's test driver falls back to `from scripts.agent_compile.partition import ...`, which then fails — and with the unit job's `-x`, that single collection error turns all of main red.

`test/scripts/test_profile_incremental_graph.py` loads its target via `importlib.util` and uses no relative imports, so it does not need the package (matching `test/agent/`, which has no `__init__.py`).

## Changes
- Remove `test/scripts/__init__.py` so `test/scripts` no longer shadows the top-level `scripts/` package under pytest.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Ran the exact unit-job command on this branch:
`pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x` → **948 passed, 9 skipped**, 0 collection errors (previously aborted at the `test_build_codeminer_base_partition.py` collection error). Both `test/scripts/test_profile_incremental_graph.py` and `test/agent/test_build_codeminer_base_partition.py` collect and pass together under xdist.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published