### PR TITLE
feat(dataset): synthesis pipeline for categorized eval queries

### DIFF
--- a/scripts/_post_fix.py
+++ b/scripts/_post_fix.py
@@ -1,0 +1,501 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Post-fix loop for queries flagged by the LLM judge.
+
+Triages each flagged row (valid / fix / regenerate) and applies the matching
+repair via Claude, up to ``max_retries`` times. Modifies rows in-place.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from codeminer.dataset.synthesize._agent import AgentRunner
+from codeminer.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+JUDGE_SYSTEM_PROMPT = (
+    "You evaluate synthesized code-search queries for a retrieval benchmark. "
+    "For each item you receive a query text, its declared query_type, and the "
+    "target code it is supposed to resolve to. Decide whether the query is a "
+    "reasonable search query of its declared type AND whether the target code "
+    "is a plausible answer.\n\n"
+    "Query type expectations:\n"
+    "  - behavioral: plain English, no file paths or code identifiers.\n"
+    "  - module_hint: may name a module/package, no file paths or symbols.\n"
+    "  - file_hint: may name file paths, no specific symbols.\n"
+    "  - symbol_hint: may name specific functions/classes/methods.\n"
+    "  - reasoning: requires reasoning over call chains, inheritance, control "
+    "flow.\n\n"
+    "Pick exactly one verdict per item:\n"
+    "  - 'valid': query is correct as written.\n"
+    "  - 'fix': query has a SMALL, EDITABLE issue (e.g. category violation "
+    "such as a behavioral query that mentions a function name, length out of "
+    "range, mildly too generic) but the topic / target / framing is right. "
+    "A small rewrite of the same query would resolve it.\n"
+    "  - 'regenerate': query is FUNDAMENTALLY broken — wrong target, inverts "
+    "the code's actual behavior, describes unrelated functionality, vacuous, "
+    "malformed, or empty. The original phrasing should NOT be reused; a "
+    "fresh generation from the anchor is the right repair.\n\n"
+    "Give a one-sentence reason per item."
+)
+
+
+FIX_SYSTEM_PROMPT = (
+    "You are repairing a code-search query that has a SMALL editable issue. "
+    "You are shown the original query AND the judge's specific complaint. "
+    "Produce a NEW query that addresses the complaint while preserving the "
+    "topic/framing of the original, still describes the same code anchor, "
+    "and respects the category + length constraints.\n\n"
+    'Output STRICT JSON with one key: {"query": "..."}. No prose, no '
+    "markdown, no commentary."
+)
+
+
+REGENERATE_SYSTEM_PROMPT = (
+    "You are generating a code-search query from scratch because a previous "
+    "attempt was judged fundamentally broken. You will NOT see the prior "
+    "query (it would bias you). Produce a fresh query that accurately "
+    "describes the supplied code anchor and respects the category + length "
+    "constraints.\n\n"
+    'Output STRICT JSON with one key: {"query": "..."}. No prose, no '
+    "markdown, no commentary."
+)
+
+
+def _derive_dotted_module(anchor_file: str) -> str:
+    """``astropy/stats/funcs.py`` -> ``astropy.stats``."""
+    if not anchor_file:
+        return ""
+    parts = anchor_file.replace("\\", "/").split("/")
+    if len(parts) < 2:
+        return ""
+    return ".".join(p for p in parts[:-1] if p)
+
+
+def _category_rule(category: str, anchor_file: str) -> str:
+    dotted = _derive_dotted_module(anchor_file)
+    if category == "behavioral":
+        return (
+            "Avoid ALL code identifiers, file paths, and technical names. "
+            "Focus purely on observable behavior."
+        )
+    if category == "module_hint":
+        if dotted:
+            return (
+                f"Your question MUST explicitly name the module in dotted "
+                f"form `{dotted}` (or a clearly-recognizable sub-module of "
+                "it). It MUST NOT mention the file path or any specific "
+                "function/class names."
+            )
+        return (
+            "Your question MUST explicitly name the module in dotted form "
+            "(e.g. `astropy.stats`, `numpy.linalg`). It MUST NOT mention the "
+            "file path or any specific function/class names."
+        )
+    if category == "file_hint":
+        return (
+            "Your question SHOULD mention the file path shown above, but "
+            "MUST NOT mention specific function or class names."
+        )
+    if category == "symbol_hint":
+        return (
+            "Your question SHOULD mention the specific function/class/method "
+            "name shown above and describe its behavior."
+        )
+    if category == "reasoning":
+        return (
+            "Your question SHOULD mention the symbol shown above and frame "
+            "the problem in terms of call chains, inheritance, or control "
+            "flow that involve it."
+        )
+    return "Describe the behavior of the anchor code."
+
+
+def _length_rule(length_variant: str) -> str:
+    if length_variant == "simple":
+        return "5 to 30 words. One sentence only, symptom-style."
+    if length_variant == "detailed":
+        return (
+            "80 to 150 words. Multiple observed symptoms, inputs and outputs, "
+            "and at least one edge case. Read like a detailed GitHub issue."
+        )
+    return "Match the original query's register."
+
+
+def _symbol_basename(symbol_id: str) -> str:
+    # The trailing identifier is stable across Go/Rust file-prefix mangling
+    # (e.g. ``terminal.py:foo()`` vs ``src/terminal.rs:foo()``); the prefix
+    # is not. We use the trailing form as the cross-row matching key.
+    if not symbol_id:
+        return ""
+    return re.split(r"[:/]", symbol_id)[-1]
+
+
+def _build_anchor_content_lookups(
+    rows: List[Dict[str, Any]],
+) -> Tuple[Dict[str, str], Dict[Tuple[str, str], str]]:
+    # Behavioral rows have content in ``gt_symbol_nodes[*].content``;
+    # non-behavioral rows often have ``content=null``. The file+basename
+    # lookup recovers content for non-behavioral when its prefix doesn't
+    # match the behavioral row's prefix but the file and trailing
+    # identifier do.
+    by_node_name: Dict[str, str] = {}
+    by_file_basename: Dict[Tuple[str, str], str] = {}
+    for r in rows:
+        gt_file = (r.get("gt_files") or [""])[0]
+        for n in r.get("gt_symbol_nodes") or []:
+            sym = n.get("node_name") or ""
+            content = n.get("content")
+            file = n.get("file") or gt_file
+            if not (sym and content):
+                continue
+            by_node_name.setdefault(sym, content)
+            base = _symbol_basename(sym)
+            if file and base:
+                by_file_basename.setdefault((file, base), content)
+    return by_node_name, by_file_basename
+
+
+def _get_anchor(
+    row: Dict[str, Any],
+    by_node_name: Dict[str, str],
+    by_file_basename: Dict[Tuple[str, str], str],
+) -> Tuple[str, str, str]:
+    nodes = row.get("gt_symbol_nodes") or []
+    file = (row.get("gt_files") or [""])[0]
+    symbol = (row.get("gt_symbols") or [""])[0]
+    content = ""
+    if nodes:
+        n0 = nodes[0]
+        file = n0.get("file") or file
+        symbol = n0.get("node_name") or symbol
+        content = n0.get("content") or ""
+    if not content:
+        content = by_node_name.get(symbol, "")
+    if not content:
+        base = _symbol_basename(symbol)
+        if file and base:
+            content = by_file_basename.get((file, base), "")
+    return file, symbol, content
+
+
+def _extract_query_from_payload(raw: str) -> Optional[str]:
+    fenced = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", raw)
+    if fenced:
+        candidate = fenced.group(1)
+    else:
+        m = re.search(r'\{[\s\S]*?"query"[\s\S]*?\}', raw)
+        if not m:
+            return None
+        candidate = m.group(0)
+    try:
+        obj = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    q = obj.get("query")
+    return q.strip() if isinstance(q, str) and q.strip() else None
+
+
+async def _fix_one(
+    row: Dict[str, Any],
+    *,
+    anchor_file: str,
+    anchor_symbol: str,
+    anchor_content: str,
+    model: str,
+) -> Optional[str]:
+    category = row.get("category") or "behavioral"
+    length_variant = row.get("length_variant") or "detailed"
+    original_query = row.get("query") or ""
+    judge_reason = row.get("judge_reason") or ""
+
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=FIX_SYSTEM_PROMPT,
+    )
+    snippet = (
+        anchor_content if len(anchor_content) <= 1800 else anchor_content[:1800] + "..."
+    )
+    prompt = (
+        f"Category: {category}\n"
+        f"Category rule: {_category_rule(category, anchor_file)}\n"
+        f"Length: {length_variant}\n"
+        f"Length rule: {_length_rule(length_variant)}\n\n"
+        f"Anchor file: {anchor_file}\n"
+        f"Anchor symbol: {anchor_symbol}\n"
+        f"Anchor code:\n```\n{snippet}\n```\n\n"
+        f"Original query (FLAGGED):\n{original_query}\n\n"
+        f"Judge complaint:\n{judge_reason}\n\n"
+        'Produce a fixed query as JSON: {"query": "..."}'
+    )
+    raw = await agent.run_async(prompt)
+    return _extract_query_from_payload(raw)
+
+
+async def _regenerate_one(
+    row: Dict[str, Any],
+    *,
+    anchor_file: str,
+    anchor_symbol: str,
+    anchor_content: str,
+    model: str,
+) -> Optional[str]:
+    # Showing the prior (broken) query would bias the new generation toward
+    # the same mistake; the LLM only sees the anchor + constraints.
+    category = row.get("category") or "behavioral"
+    length_variant = row.get("length_variant") or "detailed"
+
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=REGENERATE_SYSTEM_PROMPT,
+    )
+    snippet = (
+        anchor_content if len(anchor_content) <= 1800 else anchor_content[:1800] + "..."
+    )
+    prompt = (
+        f"Category: {category}\n"
+        f"Category rule: {_category_rule(category, anchor_file)}\n"
+        f"Length: {length_variant}\n"
+        f"Length rule: {_length_rule(length_variant)}\n\n"
+        f"Anchor file: {anchor_file}\n"
+        f"Anchor symbol: {anchor_symbol}\n"
+        f"Anchor code:\n```\n{snippet}\n```\n\n"
+        'Produce a fresh query as JSON: {"query": "..."}'
+    )
+    raw = await agent.run_async(prompt)
+    return _extract_query_from_payload(raw)
+
+
+async def _judge_one(
+    row: Dict[str, Any],
+    *,
+    by_node_name: Dict[str, str],
+    by_file_basename: Dict[Tuple[str, str], str],
+    model: str,
+) -> Tuple[str, str]:
+    _, _, anchor_content = _get_anchor(row, by_node_name, by_file_basename)
+    payload = [
+        {
+            "query_id": row.get("query_id"),
+            "query_type": row.get("category"),
+            "query": row.get("query"),
+            "target_files": row.get("gt_files", []),
+            "target_symbols": row.get("gt_symbols", []),
+            "target_code_excerpt": (anchor_content or "")[:2000],
+        }
+    ]
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=JUDGE_SYSTEM_PROMPT,
+    )
+    prompt = (
+        "Evaluate the following synthesized query. Reply with a JSON array of "
+        "one object: "
+        '[{"query_id": "...", "verdict": "valid|regenerate", "reason": "..."}]. '
+        "Do not include any prose outside the JSON.\n\n"
+        f"QUERIES:\n{json.dumps(payload, ensure_ascii=False, indent=2)}"
+    )
+    raw = await agent.run_async(prompt)
+    fenced = re.search(r"```(?:json)?\s*(\[[\s\S]*?\])\s*```", raw)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        m = re.search(r"\[[\s\S]*\]", raw)
+        text = m.group(0) if m else None
+    if not text:
+        return "unknown", "judge did not return JSON"
+    try:
+        arr = json.loads(text)
+    except json.JSONDecodeError:
+        return "unknown", "judge JSON parse failed"
+    if not arr or not isinstance(arr[0], dict):
+        return "unknown", "judge returned empty / invalid"
+    v = arr[0]
+    return v.get("verdict", "unknown"), v.get("reason", "")
+
+
+async def post_fix_flagged(
+    rows: List[Dict[str, Any]],
+    *,
+    model: str,
+    judge_model: str,
+    max_retries: int = 3,
+) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
+    """Triage flagged rows, then loop fix/regenerate up to ``max_retries`` times.
+
+    Returns the mutated rows plus a stats dict
+    (``flagged`` / ``promoted_at_triage`` / ``fixed_via_fix`` /
+    ``fixed_via_regenerate`` / ``still_flagged``).
+    """
+    by_node_name, by_file_basename = _build_anchor_content_lookups(rows)
+
+    def is_flagged(r: Dict[str, Any]) -> bool:
+        # 'unknown' is included because a truncated judge-batch JSON leaves
+        # rows without a real verdict; triage them too.
+        return r.get("judge_verdict") in ("regenerate", "fix", "unknown")
+
+    n_flagged = sum(1 for r in rows if is_flagged(r))
+    stats = {
+        "flagged": n_flagged,
+        "promoted_at_triage": 0,
+        "fixed_via_fix": 0,
+        "fixed_via_regenerate": 0,
+        "still_flagged": 0,
+    }
+    if n_flagged == 0:
+        logger.info("post_fix: 0 rows flagged; nothing to do.")
+        return rows, stats
+
+    logger.info("post_fix: %d rows flagged for follow-up.", n_flagged)
+
+    for row in rows:
+        if not is_flagged(row):
+            continue
+        anchor_file, anchor_symbol, anchor_content = _get_anchor(
+            row, by_node_name, by_file_basename
+        )
+        if not anchor_content:
+            logger.warning(
+                "post_fix [%s]: no anchor content available; skipping.",
+                row.get("query_id"),
+            )
+            stats["still_flagged"] += 1
+            continue
+
+        attempts: List[Dict[str, Any]] = []
+
+        triage_verdict, triage_reason = await _judge_one(
+            row,
+            by_node_name=by_node_name,
+            by_file_basename=by_file_basename,
+            model=judge_model,
+        )
+        attempts.append(
+            {
+                "attempt": 0,
+                "mode": "triage",
+                "verdict": triage_verdict,
+                "reason": triage_reason,
+            }
+        )
+        row["judge_verdict"] = triage_verdict
+        row["judge_reason"] = triage_reason
+        if triage_verdict == "valid":
+            logger.info(
+                "post_fix [%s] triage promoted to valid (no repair needed).",
+                row.get("query_id"),
+            )
+            row["post_fix_attempts"] = attempts
+            stats["promoted_at_triage"] += 1
+            continue
+        if triage_verdict not in ("fix", "regenerate"):
+            logger.warning(
+                "post_fix [%s] triage returned unknown verdict %r; skipping.",
+                row.get("query_id"),
+                triage_verdict,
+            )
+            row["post_fix_attempts"] = attempts
+            stats["still_flagged"] += 1
+            continue
+
+        current_mode = triage_verdict  # 'fix' or 'regenerate'
+        fixed_via: Optional[str] = None
+        for attempt in range(1, max_retries + 1):
+            logger.info(
+                "post_fix [%s] attempt %d/%d mode=%s",
+                row.get("query_id"),
+                attempt,
+                max_retries,
+                current_mode,
+            )
+            if current_mode == "fix":
+                new_query = await _fix_one(
+                    row,
+                    anchor_file=anchor_file,
+                    anchor_symbol=anchor_symbol,
+                    anchor_content=anchor_content,
+                    model=model,
+                )
+            else:
+                new_query = await _regenerate_one(
+                    row,
+                    anchor_file=anchor_file,
+                    anchor_symbol=anchor_symbol,
+                    anchor_content=anchor_content,
+                    model=model,
+                )
+            if not new_query:
+                logger.warning(
+                    "post_fix [%s] attempt %d (%s): repair returned no query.",
+                    row.get("query_id"),
+                    attempt,
+                    current_mode,
+                )
+                attempts.append(
+                    {
+                        "attempt": attempt,
+                        "mode": current_mode,
+                        "query": None,
+                        "verdict": "no_query",
+                    }
+                )
+                continue
+            row["query"] = new_query
+            verdict, reason = await _judge_one(
+                row,
+                by_node_name=by_node_name,
+                by_file_basename=by_file_basename,
+                model=judge_model,
+            )
+            attempts.append(
+                {
+                    "attempt": attempt,
+                    "mode": current_mode,
+                    "query": new_query,
+                    "verdict": verdict,
+                    "reason": reason,
+                }
+            )
+            if verdict == "valid":
+                row["judge_verdict"] = "valid"
+                row["judge_reason"] = reason
+                row["post_fix_attempts"] = attempts
+                fixed_via = current_mode
+                logger.info(
+                    "post_fix [%s] FIXED via %s on attempt %d.",
+                    row.get("query_id"),
+                    current_mode,
+                    attempt,
+                )
+                break
+            row["judge_reason"] = reason
+            if verdict in ("fix", "regenerate"):
+                current_mode = verdict
+
+        if fixed_via is None:
+            row["post_fix_attempts"] = attempts
+            stats["still_flagged"] += 1
+            logger.info(
+                "post_fix [%s] still flagged after %d attempts.",
+                row.get("query_id"),
+                max_retries,
+            )
+        elif fixed_via == "fix":
+            stats["fixed_via_fix"] += 1
+        else:
+            stats["fixed_via_regenerate"] += 1
+
+    return rows, stats

--- a/scripts/multiply_behavior_queries.py
+++ b/scripts/multiply_behavior_queries.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Synthesize N behavioral queries for one SWE-bench instance.
+
+Cycles ``query_index`` so each query gets a distinct anchor block; mixes
+simple (5-30 word) and detailed (80-150 word) variants via length-biased
+system prompts; runs a 3-way judge + post-fix loop.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from codeminer.dataset.synthesize import ClaudeQuerySynthesizer
+from codeminer.dataset.synthesize._agent import AgentRunner
+from codeminer.dataset.utils import QueryType, get_prompt_for_query_type
+from codeminer.log_utils import get_logger
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _post_fix import post_fix_flagged  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+_BASE_PROMPT = (
+    "You are a codebase assistant helping create code search evaluation queries. "
+)
+_LEVEL_PROMPT = get_prompt_for_query_type(QueryType.BEHAVIORAL)
+
+_LENGTH_DETAILED = (
+    "\n\nLENGTH CONSTRAINT: 80 to 150 words. Include multiple observed symptoms, "
+    "inputs and outputs, and at least one edge case. Read like a detailed GitHub "
+    "issue. Close with an explicit question."
+)
+_LENGTH_SIMPLE = (
+    "\n\nLENGTH CONSTRAINT: 5 to 30 words. One sentence only, symptom-style — "
+    "the kind of one-liner a developer pastes in chat or files as a terse issue."
+)
+
+DETAILED_SYSTEM_PROMPT = _BASE_PROMPT + _LEVEL_PROMPT + _LENGTH_DETAILED
+SIMPLE_SYSTEM_PROMPT = _BASE_PROMPT + _LEVEL_PROMPT + _LENGTH_SIMPLE
+
+
+JUDGE_SYSTEM_PROMPT = (
+    "You evaluate synthesized code-search queries for a retrieval benchmark. "
+    "For each item you receive a query text plus the target code it is supposed "
+    "to resolve to. Decide whether the query is a reasonable behavioral search "
+    "query AND whether the target code is a plausible answer.\n\n"
+    "Pick exactly one verdict per item:\n"
+    "  - 'valid': query is correct as written.\n"
+    "  - 'fix': query has a SMALL, EDITABLE issue (mentions a code identifier "
+    "in a behavioral context, length out of range, mildly too generic) but "
+    "the topic / target / framing is right. A small rewrite would resolve it.\n"
+    "  - 'regenerate': query is FUNDAMENTALLY broken — wrong target, inverts "
+    "the code's actual behavior, describes unrelated functionality, vacuous, "
+    "malformed, or empty. A fresh generation from the anchor is the right "
+    "repair.\n\n"
+    "Give a one-sentence reason per item."
+)
+
+
+def _load_seed_instance(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    seed = data[0] if isinstance(data, list) and data else data
+    required = ("repo", "instance_id", "base_commit")
+    missing = [k for k in required if not seed.get(k)]
+    if missing:
+        raise ValueError(f"Seed file {path} missing fields: {missing}")
+    return {k: seed[k] for k in required}
+
+
+def _build_synth(
+    *,
+    system_prompt: str,
+    model: str,
+    max_turns: int,
+    sampling_seed: int,
+    max_candidate_blocks: int,
+    behavioral_consensus_runs: int,
+) -> ClaudeQuerySynthesizer:
+    return ClaudeQuerySynthesizer(
+        model=model,
+        max_turns=max_turns,
+        allowed_tools=["Read", "Glob", "Grep", "Bash"],
+        permission_mode="bypassPermissions",
+        system_prompt=system_prompt,
+        query_type=QueryType.BEHAVIORAL,
+        sampling_seed=sampling_seed,
+        max_candidate_blocks=max_candidate_blocks,
+        behavioral_consensus_runs=behavioral_consensus_runs,
+        num_queries=1,
+        verification_mode="lenient",
+    )
+
+
+def _assign_length_variants(
+    n: int, simple_ratio: float, rng: random.Random
+) -> List[str]:
+    n_simple = round(n * simple_ratio)
+    variants = ["simple"] * n_simple + ["detailed"] * (n - n_simple)
+    rng.shuffle(variants)
+    return variants
+
+
+# Strip a `"question": "...` prefix that occasionally leaks when the
+# curator's structured parser falls back to text-coerce mode.
+_QUERY_LEAK_PREFIX = re.compile(r'^\s*["\']?question["\']?\s*:\s*["\']?', re.IGNORECASE)
+
+
+def _clean_query_text(text: Optional[str]) -> str:
+    if not text:
+        return text or ""
+    cleaned = _QUERY_LEAK_PREFIX.sub("", text).strip()
+    return cleaned
+
+
+def _to_compact_record(item: Dict[str, Any]) -> Dict[str, Any]:
+    record: Dict[str, Any] = {
+        "repo": item.get("repo"),
+        "instance_id": item.get("instance_id"),
+        "base_commit": item.get("base_commit"),
+        "query": _clean_query_text(item.get("query")),
+        "category": item.get("query_type") or item.get("difficulty"),
+        "gt_symbols": item.get("target_symbols") or [],
+        "gt_symbol_nodes": item.get("target_symbol_nodes") or [],
+        "gt_files": item.get("target_files") or [],
+        "query_id": item.get("query_id"),
+    }
+    if item.get("language_group"):
+        record["language_group"] = item["language_group"]
+    if "verification_passed" in item:
+        record["verification_passed"] = item["verification_passed"]
+    if "length_variant" in item:
+        record["length_variant"] = item["length_variant"]
+    if "judge_verdict" in item:
+        record["judge_verdict"] = item["judge_verdict"]
+    if "judge_reason" in item:
+        record["judge_reason"] = item["judge_reason"]
+    if item.get("error"):
+        record["error"] = item["error"]
+    return record
+
+
+def _write_compact(results: List[Dict[str, Any]], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(
+            [_to_compact_record(r) for r in results], fh, indent=2, ensure_ascii=False
+        )
+
+
+def _judge_payload(results: List[Dict[str, Any]]) -> str:
+    items: List[Dict[str, Any]] = []
+    for r in results:
+        if r.get("error") or not r.get("query"):
+            continue
+        nodes = r.get("target_symbol_nodes") or []
+        target_code = (nodes[0].get("content", "") if nodes else "") or ""
+        items.append(
+            {
+                "query_id": r.get("query_id"),
+                "query": r.get("query"),
+                "target_files": r.get("target_files", []),
+                "target_symbols": r.get("target_symbols", []),
+                "target_code_excerpt": target_code[:2000],
+            }
+        )
+    return json.dumps(items, ensure_ascii=False, indent=2)
+
+
+async def _run_judge(
+    *, results: List[Dict[str, Any]], model: str
+) -> Dict[str, Dict[str, str]]:
+    payload = _judge_payload(results)
+    if not payload or payload == "[]":
+        return {}
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=JUDGE_SYSTEM_PROMPT,
+    )
+    prompt = (
+        "Evaluate each of the following synthesized queries. Reply with a JSON "
+        "array, one object per query: "
+        '[{"query_id": "...", "verdict": "valid|regenerate", "reason": "..."}]. '
+        "Do not include any prose outside the JSON.\n\n"
+        f"QUERIES:\n{payload}"
+    )
+    raw = await agent.run_async(prompt)
+    fenced = re.search(r"```(?:json)?\s*(\[[\s\S]*?\])\s*```", raw)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        m = re.search(r"\[[\s\S]*\]", raw)
+        text = m.group(0) if m else raw
+    try:
+        verdicts = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.error("Judge returned non-JSON response: %s\nRaw: %s", exc, raw[:500])
+        return {}
+    return {
+        v["query_id"]: v for v in verdicts if isinstance(v, dict) and "query_id" in v
+    }
+
+
+async def _generate_one(
+    *,
+    synth: ClaudeQuerySynthesizer,
+    instance: Dict[str, Any],
+    query_index: int,
+    repo_root: Optional[str],
+    cache_dir: str,
+) -> Dict[str, Any]:
+    inst = dict(instance)
+    inst["synthesis_run_id"] = 1  # one shared candidate pool; query_index varies pick
+    return await synth.synthesize_query_async(
+        inst,
+        repo_root=repo_root,
+        cache_dir=cache_dir,
+        query_index=query_index,
+    )
+
+
+async def _run_pipeline(args: argparse.Namespace) -> None:
+    seed_path = Path(args.seed_file).expanduser()
+    instance = _load_seed_instance(seed_path)
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = (
+        Path(args.cache_dir).expanduser()
+        if args.cache_dir
+        else Path.home() / ".codeminer"
+    )
+
+    rng = random.Random(args.assignment_seed)
+    variants = _assign_length_variants(args.n_queries, args.simple_ratio, rng)
+
+    pool_size = max(args.n_queries * 2, 40)
+    detailed_synth = _build_synth(
+        system_prompt=DETAILED_SYSTEM_PROMPT,
+        model=args.model,
+        max_turns=args.max_turns,
+        sampling_seed=args.sampling_seed,
+        max_candidate_blocks=pool_size,
+        behavioral_consensus_runs=args.behavioral_consensus_runs,
+    )
+    simple_synth = _build_synth(
+        system_prompt=SIMPLE_SYSTEM_PROMPT,
+        model=args.model,
+        max_turns=args.max_turns,
+        sampling_seed=args.sampling_seed,
+        max_candidate_blocks=pool_size,
+        behavioral_consensus_runs=args.behavioral_consensus_runs,
+    )
+
+    output_path = output_dir / f"synthesized_queries_{instance['instance_id']}.json"
+    results: List[Dict[str, Any]] = []
+    for i, variant in enumerate(variants):
+        logger.info(
+            "[%d/%d] Generating %s query (query_index=%d)...",
+            i + 1,
+            args.n_queries,
+            variant,
+            i,
+        )
+        synth = simple_synth if variant == "simple" else detailed_synth
+        try:
+            result = await _generate_one(
+                synth=synth,
+                instance=instance,
+                query_index=i,
+                repo_root=args.repo_cache_dir,
+                cache_dir=str(cache_dir),
+            )
+        except Exception as exc:
+            logger.error(
+                "[%d/%d] FAILED: %s", i + 1, args.n_queries, exc, exc_info=True
+            )
+            result = {
+                "instance_id": instance["instance_id"],
+                "repo": instance["repo"],
+                "base_commit": instance["base_commit"],
+                "query_id": (f"{instance['instance_id']}_behavioral_q{i + 1}"),
+                "error": str(exc),
+            }
+        result["length_variant"] = variant
+        results.append(result)
+        _write_compact(results, output_path)
+        logger.info(
+            "Saved %d/%d results to %s", len(results), args.n_queries, output_path
+        )
+
+    logger.info("Running judge over %d generated queries...", len(results))
+    verdicts = await _run_judge(results=results, model=args.judge_model)
+    for r in results:
+        v = verdicts.get(r.get("query_id"), {})
+        r["judge_verdict"] = v.get("verdict", "unknown")
+        r["judge_reason"] = v.get("reason", "")
+
+    _write_compact(results, output_path)
+
+    # Operate on the compact projection so the saved file matches what we judged.
+    compact = [_to_compact_record(r) for r in results]
+    compact, postfix_stats = await post_fix_flagged(
+        compact,
+        model=args.model,
+        judge_model=args.judge_model,
+        max_retries=args.post_fix_max_retries,
+    )
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(compact, fh, indent=2, ensure_ascii=False)
+
+    n_valid = sum(1 for r in compact if r.get("judge_verdict") == "valid")
+    n_regen = sum(1 for r in compact if r.get("judge_verdict") == "regenerate")
+    n_unknown = sum(1 for r in compact if r.get("judge_verdict") == "unknown")
+    n_err = sum(1 for r in compact if r.get("error"))
+
+    print("\n--- Summary ---")
+    print(f"Total queries generated: {len(compact)}")
+    print(f"  Errored during generation: {n_err}")
+    print(f"  Judge valid:               {n_valid}")
+    print(f"  Judge needs regeneration:  {n_regen}")
+    print(f"  Judge unknown / no verdict:{n_unknown}")
+    print(f"  Post-fix: {postfix_stats}")
+    print(f"Output: {output_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--seed-file",
+        required=True,
+        type=str,
+        help="Per-instance q1 JSON; reads repo / instance_id / base_commit from it.",
+    )
+    p.add_argument("--output-dir", default="synthesis_output_behavior_x20", type=str)
+    p.add_argument("--n-queries", type=int, default=20)
+    p.add_argument(
+        "--simple-ratio",
+        type=float,
+        default=0.5,
+        help="Fraction of queries that should be short symptom-style (0..1).",
+    )
+    p.add_argument("--model", default="opus", help="Claude model for the synthesizer.")
+    p.add_argument(
+        "--judge-model", default="opus", help="Claude model for the final judge."
+    )
+    p.add_argument("--max-turns", type=int, default=10)
+    p.add_argument(
+        "--sampling-seed",
+        type=int,
+        default=42,
+        help="Seed for the candidate-block pool.",
+    )
+    p.add_argument(
+        "--assignment-seed",
+        type=int,
+        default=0,
+        help="Seed for shuffling simple/detailed assignment.",
+    )
+    p.add_argument("--cache-dir", type=str, default=None)
+    p.add_argument("--repo-cache-dir", type=str, default=None)
+    p.add_argument(
+        "--behavioral-consensus-runs",
+        type=int,
+        default=3,
+        help=(
+            "How many LLM passes to run per behavioral query. Blocks selected "
+            "by majority (>= ceil(N/2)) become the ground truth. N=3 matches "
+            "synthesize_swebench.py and yields organic multi-hop gt when the "
+            "LLM consistently picks the core block + related neighbors. N=1 "
+            "is faster but suppresses multi-hop."
+        ),
+    )
+    p.add_argument(
+        "--post-fix-max-retries",
+        type=int,
+        default=3,
+        help=(
+            "After the batch judge, for each row flagged 'regenerate', call "
+            "Claude with the judge's complaint and ask for a fix, then "
+            "re-judge. Repeat up to N times before giving up. Set 0 to skip."
+        ),
+    )
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if not 0.0 <= args.simple_ratio <= 1.0:
+        raise ValueError("--simple-ratio must be in [0, 1]")
+    if args.n_queries < 1:
+        raise ValueError("--n-queries must be >= 1")
+    asyncio.run(_run_pipeline(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/multiply_queries.py
+++ b/scripts/multiply_queries.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Synthesize a mix of query types (module_hint / file_hint / symbol_hint /
+reasoning, and optionally behavioral) for one SWE-bench instance, with each
+non-behavioral row grounded on an anchor pulled from a populated behavioral
+JSON (so gt_files / gt_symbols / gt_symbol_nodes are real, not LLM-invented).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from codeminer.dataset.synthesize import ClaudeQuerySynthesizer
+from codeminer.dataset.synthesize._agent import AgentRunner
+from codeminer.dataset.utils import QueryType, get_prompt_for_query_type
+from codeminer.log_utils import get_logger
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _post_fix import post_fix_flagged  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+_BASE_PROMPT = (
+    "You are a codebase assistant helping create code search evaluation queries. "
+)
+
+_LENGTH_DETAILED = (
+    "\n\nLENGTH CONSTRAINT: 80 to 150 words. Include multiple observed symptoms, "
+    "inputs and outputs, and at least one edge case. Read like a detailed GitHub "
+    "issue. Close with an explicit question."
+)
+_LENGTH_SIMPLE = (
+    "\n\nLENGTH CONSTRAINT: 5 to 30 words. One sentence only, symptom-style — "
+    "the kind of one-liner a developer pastes in chat or files as a terse issue."
+)
+
+
+JUDGE_SYSTEM_PROMPT = (
+    "You evaluate synthesized code-search queries for a retrieval benchmark. "
+    "For each item you receive a query text, its declared query_type, and the "
+    "target code it is supposed to resolve to. Decide whether the query is a "
+    "reasonable search query of its declared type AND whether the target code "
+    "is a plausible answer.\n\n"
+    "Query type expectations:\n"
+    "  - behavioral: plain English, no file paths or code identifiers.\n"
+    "  - module_hint: may name a module/package, no file paths or symbols.\n"
+    "  - file_hint: may name file paths, no specific symbols.\n"
+    "  - symbol_hint: may name specific functions/classes/methods.\n"
+    "  - reasoning: requires reasoning over call chains, inheritance, control "
+    "flow.\n\n"
+    "Pick exactly one verdict per item:\n"
+    "  - 'valid': query is correct as written.\n"
+    "  - 'fix': query has a SMALL, EDITABLE issue (e.g. category violation "
+    "such as a behavioral query that mentions a function name, length out of "
+    "range, mildly too generic) but the topic / target / framing is right. "
+    "A small rewrite of the same query would resolve it.\n"
+    "  - 'regenerate': query is FUNDAMENTALLY broken — wrong target, inverts "
+    "the code's actual behavior, describes unrelated functionality, vacuous, "
+    "malformed, or empty. The original phrasing should NOT be reused; a "
+    "fresh generation from the anchor is the right repair.\n\n"
+    "Give a one-sentence reason per item."
+)
+
+
+def _system_prompt_for(query_type: QueryType, length_variant: str) -> str:
+    level = get_prompt_for_query_type(query_type)
+    length = _LENGTH_SIMPLE if length_variant == "simple" else _LENGTH_DETAILED
+    return _BASE_PROMPT + level + length
+
+
+def _parse_type_counts(raw: str) -> Dict[QueryType, int]:
+    """Parse "module_hint=10,file_hint=10,symbol_hint=5,reasoning=5"."""
+    out: Dict[QueryType, int] = {}
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            raise ValueError(f"Bad --type-counts entry {chunk!r}; want name=N.")
+        name, value = chunk.split("=", 1)
+        try:
+            qt = QueryType(name.strip())
+        except ValueError as exc:
+            valid = ", ".join(t.value for t in QueryType)
+            raise ValueError(f"Unknown query type {name!r}. Valid: {valid}") from exc
+        n = int(value.strip())
+        if n < 0:
+            raise ValueError(f"Count for {name!r} must be >= 0.")
+        if n > 0:
+            out[qt] = n
+    if not out:
+        raise ValueError("--type-counts produced no types with count > 0.")
+    return out
+
+
+def _load_seed_instance(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    seed = data[0] if isinstance(data, list) and data else data
+    required = ("repo", "instance_id", "base_commit")
+    missing = [k for k in required if not seed.get(k)]
+    if missing:
+        raise ValueError(f"Seed file {path} missing fields: {missing}")
+    return {k: seed[k] for k in required}
+
+
+def _load_anchors(path: Path) -> List[Dict[str, Any]]:
+    """Load anchors (file + symbol + actual code content) from a populated
+    synthesized-queries JSON (e.g. the behavioral x20 output).
+
+    Each entry becomes one anchor dict in the shape expected by
+    ``QueryCurator._build_anchor_block`` — including ``anchor_content`` (the
+    real code) so the curator binds the LLM to it rather than letting it
+    hallucinate other repo areas.
+    """
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    entries = data if isinstance(data, list) else [data]
+    anchors: List[Dict[str, Any]] = []
+    for e in entries:
+        files = e.get("gt_files") or e.get("target_files") or []
+        symbols = e.get("gt_symbols") or e.get("target_symbols") or []
+        nodes = e.get("gt_symbol_nodes") or e.get("target_symbol_nodes") or []
+        anchor_content = ""
+        anchor_file = files[0] if files else ""
+        anchor_symbol = symbols[0] if symbols else ""
+        for node in nodes:
+            if node.get("content"):
+                anchor_content = node["content"]
+                anchor_file = node.get("file") or anchor_file
+                anchor_symbol = node.get("node_name") or anchor_symbol
+                break
+        if not files and not symbols:
+            continue
+        anchors.append(
+            {
+                "target_files": list(files),
+                "symbols_modified": list(symbols),
+                "anchor_content": anchor_content,
+                "anchor_file": anchor_file,
+                "anchor_symbol": anchor_symbol,
+            }
+        )
+    if not anchors:
+        raise ValueError(
+            f"No usable anchors (gt_files/gt_symbols) found in {path}. "
+            "Point --anchor-file at a populated synthesized-queries JSON."
+        )
+    n_with_content = sum(1 for a in anchors if a["anchor_content"])
+    logger.info(
+        "Loaded %d anchors (%d with code content) from %s",
+        len(anchors),
+        n_with_content,
+        path,
+    )
+    return anchors
+
+
+def _build_synth(
+    *,
+    query_type: QueryType,
+    system_prompt: str,
+    model: str,
+    max_turns: int,
+    sampling_seed: int,
+    max_candidate_blocks: int,
+    behavioral_consensus_runs: int,
+) -> ClaudeQuerySynthesizer:
+    return ClaudeQuerySynthesizer(
+        model=model,
+        max_turns=max_turns,
+        allowed_tools=["Read", "Glob", "Grep", "Bash"],
+        permission_mode="bypassPermissions",
+        system_prompt=system_prompt,
+        query_type=query_type,
+        sampling_seed=sampling_seed,
+        max_candidate_blocks=max_candidate_blocks,
+        behavioral_consensus_runs=behavioral_consensus_runs,
+        num_queries=1,
+        verification_mode="lenient",
+    )
+
+
+def _assign_length_variants(
+    n: int, simple_ratio: float, rng: random.Random
+) -> List[str]:
+    n_simple = round(n * simple_ratio)
+    variants = ["simple"] * n_simple + ["detailed"] * (n - n_simple)
+    rng.shuffle(variants)
+    return variants
+
+
+# Strip a `"question": "...` prefix that occasionally leaks from the
+# curator's text-coerce fallback.
+_QUERY_LEAK_PREFIX = re.compile(r'^\s*["\']?question["\']?\s*:\s*["\']?', re.IGNORECASE)
+
+
+def _clean_query_text(text: Optional[str]) -> str:
+    if not text:
+        return text or ""
+    return _QUERY_LEAK_PREFIX.sub("", text).strip()
+
+
+def _to_compact_record(item: Dict[str, Any]) -> Dict[str, Any]:
+    record: Dict[str, Any] = {
+        "repo": item.get("repo"),
+        "instance_id": item.get("instance_id"),
+        "base_commit": item.get("base_commit"),
+        "query": _clean_query_text(item.get("query")),
+        "category": item.get("query_type") or item.get("difficulty"),
+        "gt_symbols": item.get("target_symbols") or [],
+        "gt_symbol_nodes": item.get("target_symbol_nodes") or [],
+        "gt_files": item.get("target_files") or [],
+        "query_id": item.get("query_id"),
+    }
+    if item.get("language_group"):
+        record["language_group"] = item["language_group"]
+    if "verification_passed" in item:
+        record["verification_passed"] = item["verification_passed"]
+    if "length_variant" in item:
+        record["length_variant"] = item["length_variant"]
+    if "judge_verdict" in item:
+        record["judge_verdict"] = item["judge_verdict"]
+    if "judge_reason" in item:
+        record["judge_reason"] = item["judge_reason"]
+    if item.get("error"):
+        record["error"] = item["error"]
+    return record
+
+
+def _write_compact(results: List[Dict[str, Any]], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(
+            [_to_compact_record(r) for r in results], fh, indent=2, ensure_ascii=False
+        )
+
+
+def _judge_payload(results: List[Dict[str, Any]]) -> str:
+    items: List[Dict[str, Any]] = []
+    for r in results:
+        if r.get("error") or not r.get("query"):
+            continue
+        nodes = r.get("target_symbol_nodes") or []
+        target_code = (nodes[0].get("content", "") if nodes else "") or ""
+        items.append(
+            {
+                "query_id": r.get("query_id"),
+                "query_type": r.get("query_type") or r.get("difficulty"),
+                "query": r.get("query"),
+                "target_files": r.get("target_files", []),
+                "target_symbols": r.get("target_symbols", []),
+                "target_code_excerpt": target_code[:2000],
+            }
+        )
+    return json.dumps(items, ensure_ascii=False, indent=2)
+
+
+async def _run_judge(
+    *, results: List[Dict[str, Any]], model: str
+) -> Dict[str, Dict[str, str]]:
+    payload = _judge_payload(results)
+    if not payload or payload == "[]":
+        return {}
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=JUDGE_SYSTEM_PROMPT,
+    )
+    prompt = (
+        "Evaluate each of the following synthesized queries. Reply with a JSON "
+        "array, one object per query: "
+        '[{"query_id": "...", "verdict": "valid|regenerate", "reason": "..."}]. '
+        "Do not include any prose outside the JSON.\n\n"
+        f"QUERIES:\n{payload}"
+    )
+    raw = await agent.run_async(prompt)
+    fenced = re.search(r"```(?:json)?\s*(\[[\s\S]*?\])\s*```", raw)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        m = re.search(r"\[[\s\S]*\]", raw)
+        text = m.group(0) if m else raw
+    try:
+        verdicts = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.error("Judge returned non-JSON response: %s\nRaw: %s", exc, raw[:500])
+        return {}
+    return {
+        v["query_id"]: v for v in verdicts if isinstance(v, dict) and "query_id" in v
+    }
+
+
+def _build_plan(
+    type_counts: Dict[QueryType, int], simple_ratio: float, rng: random.Random
+) -> List[Tuple[QueryType, str, int]]:
+    """Return a list of (query_type, length_variant, per_type_index) tuples,
+    sized to sum(type_counts.values()). per_type_index is 0-based within its
+    type — for BEHAVIORAL this is fed to query_index for anchor diversity.
+    """
+    plan: List[Tuple[QueryType, str, int]] = []
+    for qt, n in type_counts.items():
+        variants = _assign_length_variants(n, simple_ratio, rng)
+        for i, variant in enumerate(variants):
+            plan.append((qt, variant, i))
+    return plan
+
+
+async def _generate_one(
+    *,
+    synth: ClaudeQuerySynthesizer,
+    instance: Dict[str, Any],
+    query_type: QueryType,
+    per_type_index: int,
+    repo_root: Optional[str],
+    cache_dir: str,
+    anchor: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    inst = dict(instance)
+    if query_type == QueryType.BEHAVIORAL:
+        # Shared candidate pool; vary the anchor via query_index.
+        inst["synthesis_run_id"] = 1
+        query_index = per_type_index
+        ground_truth = None
+    else:
+        # Re-seed per query + pass a real anchor; without ground_truth the
+        # curator's target discovery hallucinates plausible-wrong symbols.
+        inst["synthesis_run_id"] = per_type_index + 1
+        query_index = per_type_index
+        ground_truth = anchor
+    return await synth.synthesize_query_async(
+        inst,
+        repo_root=repo_root,
+        cache_dir=cache_dir,
+        ground_truth=ground_truth,
+        query_index=query_index,
+    )
+
+
+async def _run_pipeline(args: argparse.Namespace) -> None:
+    type_counts = _parse_type_counts(args.type_counts)
+    total = sum(type_counts.values())
+    logger.info(
+        "Generating %d queries across %d types: %s",
+        total,
+        len(type_counts),
+        {qt.value: n for qt, n in type_counts.items()},
+    )
+
+    seed_path = Path(args.seed_file).expanduser()
+    instance = _load_seed_instance(seed_path)
+
+    anchor_path = Path(args.anchor_file).expanduser() if args.anchor_file else seed_path
+    anchors: List[Dict[str, Any]] = []
+    needs_anchors = any(qt != QueryType.BEHAVIORAL for qt in type_counts)
+    if needs_anchors:
+        anchors = _load_anchors(anchor_path)
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = (
+        Path(args.cache_dir).expanduser()
+        if args.cache_dir
+        else Path.home() / ".codeminer"
+    )
+
+    rng = random.Random(args.assignment_seed)
+    plan = _build_plan(type_counts, args.simple_ratio, rng)
+
+    pool_size = max(total * 2, 40)
+    synth_cache: Dict[Tuple[QueryType, str], ClaudeQuerySynthesizer] = {}
+    for qt in type_counts:
+        for variant in ("simple", "detailed"):
+            synth_cache[(qt, variant)] = _build_synth(
+                query_type=qt,
+                system_prompt=_system_prompt_for(qt, variant),
+                model=args.model,
+                max_turns=args.max_turns,
+                sampling_seed=args.sampling_seed,
+                max_candidate_blocks=pool_size,
+                behavioral_consensus_runs=args.behavioral_consensus_runs,
+            )
+
+    output_path = output_dir / f"synthesized_queries_{instance['instance_id']}.json"
+    results: List[Dict[str, Any]] = []
+    for i, (qt, variant, per_type_idx) in enumerate(plan):
+        logger.info(
+            "[%d/%d] type=%s variant=%s per_type_idx=%d",
+            i + 1,
+            total,
+            qt.value,
+            variant,
+            per_type_idx,
+        )
+        synth = synth_cache[(qt, variant)]
+        anchor = (
+            anchors[per_type_idx % len(anchors)]
+            if anchors and qt != QueryType.BEHAVIORAL
+            else None
+        )
+        try:
+            result = await _generate_one(
+                synth=synth,
+                instance=instance,
+                query_type=qt,
+                per_type_index=per_type_idx,
+                repo_root=args.repo_cache_dir,
+                cache_dir=str(cache_dir),
+                anchor=anchor,
+            )
+        except Exception as exc:
+            logger.error("[%d/%d] FAILED: %s", i + 1, total, exc, exc_info=True)
+            result = {
+                "instance_id": instance["instance_id"],
+                "repo": instance["repo"],
+                "base_commit": instance["base_commit"],
+                "query_id": (
+                    f"{instance['instance_id']}_{qt.value}_q{per_type_idx + 1}"
+                ),
+                "query_type": qt.value,
+                "error": str(exc),
+            }
+        result["length_variant"] = variant
+        results.append(result)
+        _write_compact(results, output_path)
+        logger.info("Saved %d/%d results to %s", len(results), total, output_path)
+
+    logger.info("Running judge over %d generated queries...", len(results))
+    verdicts = await _run_judge(results=results, model=args.judge_model)
+    for r in results:
+        v = verdicts.get(r.get("query_id"), {})
+        r["judge_verdict"] = v.get("verdict", "unknown")
+        r["judge_reason"] = v.get("reason", "")
+
+    _write_compact(results, output_path)
+
+    # Operate on the compact projection so the saved file matches what we judged.
+    compact = [_to_compact_record(r) for r in results]
+    compact, postfix_stats = await post_fix_flagged(
+        compact,
+        model=args.model,
+        judge_model=args.judge_model,
+        max_retries=args.post_fix_max_retries,
+    )
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(compact, fh, indent=2, ensure_ascii=False)
+
+    n_valid = sum(1 for r in compact if r.get("judge_verdict") == "valid")
+    n_regen = sum(1 for r in compact if r.get("judge_verdict") == "regenerate")
+    n_unknown = sum(1 for r in compact if r.get("judge_verdict") == "unknown")
+    n_err = sum(1 for r in compact if r.get("error"))
+
+    print("\n--- Summary ---")
+    print(f"Total queries generated: {len(compact)}")
+    by_type: Dict[str, int] = {}
+    for r in compact:
+        t = r.get("category") or "unknown"
+        by_type[t] = by_type.get(t, 0) + 1
+    print(f"  By type: {by_type}")
+    print(f"  Errored during generation: {n_err}")
+    print(f"  Judge valid:               {n_valid}")
+    print(f"  Judge needs regeneration:  {n_regen}")
+    print(f"  Judge unknown / no verdict:{n_unknown}")
+    print(f"  Post-fix: {postfix_stats}")
+    print(f"Output: {output_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--seed-file",
+        required=True,
+        type=str,
+        help="Per-instance q1 JSON; reads repo / instance_id / base_commit from it.",
+    )
+    p.add_argument(
+        "--anchor-file",
+        default=None,
+        type=str,
+        help=(
+            "JSON with populated gt_files/gt_symbols (e.g. the x20 behavioral "
+            "output) used to ground non-behavioral queries. Defaults to "
+            "--seed-file. Anchors are cycled per type."
+        ),
+    )
+    p.add_argument("--output-dir", default="synthesis_output_mixed_x30", type=str)
+    p.add_argument(
+        "--type-counts",
+        required=True,
+        type=str,
+        help=(
+            "Comma-separated <type>=<count>, e.g. "
+            '"module_hint=10,file_hint=10,symbol_hint=5,reasoning=5". '
+            "Valid types: behavioral, module_hint, file_hint, symbol_hint, reasoning."
+        ),
+    )
+    p.add_argument(
+        "--simple-ratio",
+        type=float,
+        default=0.5,
+        help="Fraction of queries that should be short symptom-style (0..1).",
+    )
+    p.add_argument("--model", default="opus", help="Claude model for the synthesizer.")
+    p.add_argument(
+        "--judge-model", default="opus", help="Claude model for the final judge."
+    )
+    p.add_argument("--max-turns", type=int, default=10)
+    p.add_argument(
+        "--sampling-seed",
+        type=int,
+        default=42,
+        help="Seed for the candidate-block pool.",
+    )
+    p.add_argument(
+        "--assignment-seed",
+        type=int,
+        default=0,
+        help="Seed for shuffling simple/detailed assignment within each type.",
+    )
+    p.add_argument("--cache-dir", type=str, default=None)
+    p.add_argument("--repo-cache-dir", type=str, default=None)
+    p.add_argument(
+        "--behavioral-consensus-runs",
+        type=int,
+        default=3,
+        help=(
+            "How many LLM passes to run per behavioral query for consensus "
+            "voting on selected_blocks. N=3 matches synthesize_swebench.py "
+            "and yields organic multi-hop gt; N=1 is faster but suppresses "
+            "multi-hop. Only affects behavioral queries."
+        ),
+    )
+    p.add_argument(
+        "--post-fix-max-retries",
+        type=int,
+        default=3,
+        help=(
+            "After the batch judge, for each row flagged 'regenerate', call "
+            "Claude with the judge's complaint and ask for a fix, then "
+            "re-judge. Repeat up to N times before giving up. Set 0 to skip."
+        ),
+    )
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if not 0.0 <= args.simple_ratio <= 1.0:
+        raise ValueError("--simple-ratio must be in [0, 1]")
+    asyncio.run(_run_pipeline(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/postfix_flagged_file.py
+++ b/scripts/postfix_flagged_file.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Apply post-fix to flagged rows in an existing synthesized-queries JSON.
+
+Reads ``--input`` JSON, finds rows with ``judge_verdict='regenerate'``, asks
+Claude to fix each one with the judge's complaint as feedback, re-judges, and
+writes the modified rows back to ``--input`` in place (or to ``--output``).
+
+Example
+-------
+    python scripts/postfix_flagged_file.py \\
+        --input synthesis_output_per_language/Go.json \\
+        --model opus --judge-model opus
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _post_fix import post_fix_flagged  # noqa: E402
+
+
+async def _main(args: argparse.Namespace) -> None:
+    input_path = Path(args.input).expanduser()
+    output_path = Path(args.output).expanduser() if args.output else input_path
+    rows = json.loads(input_path.read_text(encoding="utf-8"))
+    print(f"Loaded {len(rows)} rows from {input_path}")
+
+    rows, stats = await post_fix_flagged(
+        rows,
+        model=args.model,
+        judge_model=args.judge_model,
+        max_retries=args.max_retries,
+    )
+
+    output_path.write_text(
+        json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"\n--- Post-fix summary ---")
+    print(f"Flagged at start:            {stats['flagged']}")
+    print(f"Promoted at triage re-judge: {stats['promoted_at_triage']}")
+    print(f"Fixed via 'fix' mode:        {stats['fixed_via_fix']}")
+    print(f"Fixed via 'regenerate' mode: {stats['fixed_via_regenerate']}")
+    print(f"Still flagged:               {stats['still_flagged']}")
+    print(f"Wrote: {output_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--input", required=True, type=str)
+    p.add_argument(
+        "--output",
+        default=None,
+        type=str,
+        help="Where to write fixed rows. Defaults to overwriting --input.",
+    )
+    p.add_argument("--model", default="opus", help="Model for the fixer.")
+    p.add_argument("--judge-model", default="opus", help="Model for re-judging.")
+    p.add_argument("--max-retries", type=int, default=3)
+    return p
+
+
+if __name__ == "__main__":
+    asyncio.run(_main(build_parser().parse_args()))


### PR DESCRIPTION
## Summary

Slimmed per @fishmingyu's review-limit ask. This PR is now the **core scripts** slice (1550 LOC, 4 files). The original 2773-LOC PR is split into three:

| PR | Scope | LOC |
|---|---|---|
| #207 | `QueryCurator` library change | +93 |
| **#203 (this)** | core synthesis scripts (`_post_fix`, `multiply_behavior_queries`, `multiply_queries`, `postfix_flagged_file`) | +1550 |
| #208 | traversal-stance script | +566 |
| dropped | `push_synthesis_to_hf.py` (dataset already published; helper not load-bearing) | — |

Base = `synthesis-query-curator` (#207's branch); will retarget to `main` automatically once #207 lands.

## What's in this PR

Scripts that produced the **non-traversal** categories of `sysevol-ai/codeminer-synthesis` — `behavioral` / `module_hint` / `file_hint` / `symbol_hint` / `reasoning` — plus the shared 3-way triage / repair library they all run through.

- `scripts/multiply_behavior_queries.py` — N behavioral queries per instance, cycling `query_index` to vary the anchor; consensus voting yields organic multi-hop GT.
- `scripts/multiply_queries.py` — non-behavioral mix (module / file / symbol / reasoning) per instance. Cycles through anchors from a populated behavioral JSON so every row is grounded on real code (`gt_files` / `gt_symbols` / `gt_symbol_nodes` carry over).
- `scripts/_post_fix.py` — shared 3-way triage + repair loop (`valid` / `fix` / `regenerate`), with a `(file, basename)` lookup for cross-row anchor matching when symbol IDs have prefix mismatches.
- `scripts/postfix_flagged_file.py` — standalone CLI wrapping `post_fix_flagged()` for an already-generated JSON.

## Reviewer findings being tracked

From the first review pass (will be addressed in this PR or in #208, whichever owns the file):

1. *(belongs to #208)* `multiply_traversal_queries.py` flagged rows pass through `post_fix_flagged()` which doesn't know the `traversal` category. Either traversal-aware post-fix or skip generic post-fix for traversal rows.
2. *(dropped from #203; would belong to a follow-up if `push_synthesis_to_hf.py` is reintroduced)* `Dataset.from_list(rows)` on heterogeneous rows can silently drop optional columns like `chain_metadata`. Normalize to the union of keys or define explicit `Features`.
3. *(belongs to #208)* `_generate_one_with_anti_grep()` still returns leaky queries after max retries; judge is then trusted. Force regenerate / skip on non-empty leaks.
4. *(belongs to #208)* Seed loop exits at `next_seed_idx == len(seed_members)` even when `overall_done < total` → silent under-fill. Resample / fail non-zero when stance counts can't be met.
5. *(belongs to this PR)* Judge user-prompt schema example shows `"valid|regenerate"` but downstream handles three (`valid`/`fix`/`regenerate`). Update the schema example wherever `fix` is handled.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

End-to-end pipeline runs over five SWE-bench instances (one per language group) produced the published HF dataset; per-subset counts, judge-verdict distribution, and multi-hop GT coverage are documented in the dataset README. The multipliers are wall-clock + LLM-API heavy, so no unit tests are added — verification is the dataset itself.

Pre-commit hooks (`black`, `isort`, `flake8 + bugbear`) pass on all touched files.

- [ ] Tests pass locally
- [ ] Added new tests for the changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published