### PR TITLE
feat(web): interactive code graph (LSP click-to-source) + wiki-as-graph UI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -59,6 +59,18 @@ rules, but keep these in mind everywhere:
   and [`codeminer/code_chunking/CLAUDE.md`](../codeminer/code_chunking/CLAUDE.md).
 - **`.c` files** use the `cpp` chunker (not a separate C chunker).
 
+## Frontend / web demo
+
+The DeepWiki-style web demo (FastAPI backend `codeminer/web/` + Next.js frontend
+`web/` + `codeminer/wiki/`) is on `main` (merged via PR #166/#167). To run,
+screenshot, or iterate the UI:
+
+- **How to run, screenshot (Playwright), and self-critique** the demo:
+  [`.claude/guides/frontend-loop.md`](guides/frontend-loop.md).
+- **Where the graph UI is headed** (Cytoscape overhaul, the compiler-precise
+  edge-provenance differentiator, wiki reframe):
+  [`.claude/design/graph-frontend-direction.md`](design/graph-frontend-direction.md).
+
 ## Git & PR conventions
 
 Rules for any AI/code agent (Claude Code, etc.) committing or opening PRs here.

--- a/.claude/design/graph-frontend-direction.md
+++ b/.claude/design/graph-frontend-direction.md
@@ -1,0 +1,192 @@
+# Graph-frontend direction & differentiation
+
+Design memo for the web demo's graph. Records the thesis and the concrete path.
+Operational run/loop instructions live in
+[`../guides/frontend-loop.md`](../guides/frontend-loop.md).
+
+## Status — P1+P2 implemented (2026-06-01)
+
+The graph overhaul and the click-to-source differentiator are **live** on branch
+`worktree-frontend-loop-guide` (screenshots in `web/`'s sibling `verification/`):
+
+- **Mermaid → Cytoscape** (`web/components/CodeGraph.tsx`): dagre LR layout,
+  per-file colour borders, zoom/pan, hover spotlight, node-click refocus, a
+  readable-zoom clamp, light + dark themes. `Codemap.tsx` renders it instead of
+  `<Mermaid>` (Mermaid is still used by the wiki diagrams).
+- **Click an edge → exact call site** (the differentiator): anchors flow
+  `traverse_graph.get_neighbors` (adds `anchor_file`/`anchor_line` to edge meta,
+  additive) → `codeminer/web/codemap.py` (aggregates call sites per `(src,tgt)`
+  edge, 1-based) → `CodemapEdge.anchors` (`web/lib/api.ts`) → `CodeGraph` edge tap
+  → `CallSitePeek` in `Codemap.tsx` (source window + spotlighted line via
+  `HighlightedCode`'s new `highlightLine`). Multi-site edges get a call-site pager.
+- **Node click → its definition source** (`SourcePeek` handles both node-def and
+  edge-call-site); a "Focus here" button re-roots from a node peek; chips still
+  refocus. So *everything on the graph is clickable to real code*: node → def,
+  edge → call site.
+- **Graph is now the repo's default view** (`page.tsx` default mode `codemap`, tab
+  order `Graph | Wiki`); the wiki is one click away (tab, the TOC sidebar, or a
+  `?p=<page>` deep-link which forces wiki). The right rail shows "About this graph"
+  stating the LSP/SCIP-precision differentiator. This is the **P3 "weaken wiki"**
+  step (graph as spine) — short of the deeper "wiki pages *are* graph views".
+- **Deeper P3 — wiki pages ARE graph views**: each wiki page leads with a
+  "Subsystem map" — `build_page_subgraph` (`codemap.py`) resolves the page's
+  citations to graph nodes, adds a 1-hop neighbourhood, and returns an anchored
+  induced subgraph (seeds highlighted, self-loops dropped); served at
+  `/api/repos/{id}/wiki/{page_id}/graph`. A shared `GraphView` component (Cytoscape
+  + source peek) renders it; "Focus here" on a node cross-links into full Graph
+  mode (`Codemap` gained an `initialSymbol` prop). Verified: node→def, edge→call
+  site, and the wiki→graph jump all work on the wiki page.
+- Verified across Go/Python/Rust/TS; backend graph+web unit tests pass (195/10).
+- **Honest caveat (matches the thesis):** anchor *precision* is indexer-bound.
+  Go (caddy:220) and Python (astropy:1381) landed on the exact call line; one
+  Rust (ruff) edge's first occurrence sat ~2 lines off the visible use — SCIP
+  occurrence placement, not a numbering bug (the +1 0→1-based conversion is
+  correct, since Go/Python are exact). Gaps show as missing/slightly-shifted
+  anchors, never fabricated edges.
+
+Still open: **P4** (fine edge types: CALLS/IMPORTS/EXTENDS/IMPLEMENTS from SCIP
+roles — colour/label edges by relation). Original design rationale below.
+
+## The problem
+
+Two things to fix at once:
+
+1. **The graph looks crude.** Root cause: the codemap renders through **Mermaid**
+   (`web/components/Codemap.tsx` + `codeminer/web/codemap.py`), and Mermaid is a
+   *static-diagram* tool. Its auto-layout on a dense call graph is unavoidably
+   messy — no zoom/pan, no clustering, no filtering, only click-a-chip-to-refocus.
+   No amount of CSS fixes this; it's the wrong rendering layer.
+2. **Product looks like a clone.** "Wiki + graph + ask" reads as DeepWiki ∪ GitNexus
+   → "就这 / 抄袭". We need a differentiator a layperson can *see* in one interaction.
+
+## Thesis: lead with edge **provenance**
+
+The one capability neither competitor offers — and that we already have the data
+for — is **compiler-derived reference edges anchored to exact occurrence sites.**
+
+| | How edges are built | Per-call-site location | Can "click edge → jump to exact line"? |
+|---|---|---|---|
+| **GitNexus** | tree-sitter AST + heuristic resolution (12-phase DAG, MRO/import inference), every edge carries a **confidence tier** (0.5–0.95) | node-to-node; docs describe no per-invocation file+line | not advertised |
+| **DeepWiki** | LLM/RAG; emits prose + diagrams + an Ask interface | line-level **citations** (RAG-selected evidence opening the file on GitHub) | citations, not traversable graph edges |
+| **CodeMiner** | **SCIP / clangd** semantic indexes | `anchor_file` + `anchor_line` **on every reference edge** | **yes — once threaded to the UI** |
+
+**Hero interaction:** click an edge → the code pane opens at the *exact call site*,
+highlighted. "Verifiable code intelligence, not vibes." That is hard to copy
+because GitNexus surfaces node-level relations with confidence tiers but does not
+advertise per-call-site occurrence anchors you can traverse, and DeepWiki's
+evidence is LLM/RAG-selected, not graph-derived.
+
+### Be honest, don't strawman (these framings are load-bearing)
+
+- **Not "zero hallucinated edges."** SCIP/clangd coverage is bounded — dynamic
+  dispatch, reflection, macros/templates, conditional compilation, unindexed deps,
+  and partial builds all leave **gaps**. Frame it as: *edges are compiler-derived,
+  not heuristically guessed, so they don't fabricate references; coverage is
+  bounded by what the indexer resolves — gaps appear as **missing** edges, not
+  **wrong** ones.* Scope claims to "anchored to indexer-reported occurrence ranges."
+- **DeepWiki is more than prose.** It has clickable line-level citations and warns
+  users to verify load-bearing claims. The real difference: its citations are
+  RAG/LLM-selected evidence links, **not** a compiler-resolved graph you can
+  traverse edge by edge.
+- **GitNexus is a strong product.** Real blast-radius/impact, multi-file rename,
+  Cypher over a property graph (KuzuDB, now LadybugDB), Leiden clustering, process
+  tracing, 16 MCP tools, Sigma.js + Graphology WebGL viz, 14 languages, zero-server
+  WASM. Its confidence tiers
+  are *honest engineering*, not a flaw. Frame our edge over it as **precision of
+  edge provenance / click-to-exact-line**, never "they don't have a graph."
+
+## Direction
+
+### 1. Replace Mermaid with **Cytoscape.js**
+
+Cytoscape is the right fit at demo scale (tens–hundreds of nodes): clean layouts,
+rich built-in interactivity, edge-click handlers, easy theming. Target UX:
+
+- **dagre** (directional, for call flow) or **fcose** (clustered) layout.
+- **Compound nodes** grouping symbols by file/module.
+- **Progressive expand-on-click** — start at one symbol, expand neighbors on demand;
+  not a BFS dump.
+- **Hover → code preview**; **edge click → open the exact `anchor_line`** (the bet).
+- **Filter** by node kind; **search/focus**; zoom/pan/minimap.
+
+*Graduation path:* if we ever render whole-repo-scale graphs, move to **Sigma.js +
+Graphology** (WebGL, what GitNexus uses). Not needed for the demo.
+
+### 2. Weaken the wiki — make pages **views over the graph**
+
+The wiki is the most copyable surface. Don't delete it (it's real onboarding
+value), but stop shipping it as standalone prose. Reframe: a subsystem page **is** a
+saved graph neighborhood + narration, where **every claim carries a clickable
+anchor**. Graph is the spine; prose is connective tissue. This sheds "just another
+wiki" while keeping the narration layer (`codeminer/wiki/`).
+
+## What to build (the two backend gaps)
+
+**The anchor data already flows end-to-end at the storage/query layer — the drop is
+purely in the graph-*consumption* layer.** Providers thread `anchor_file`/`anchor_line`
+into `CodeGraph._add_edge` (`codeminer/graph/code_graph.py:329-405`, stored on igraph
+edge attrs ~:401-405) from SCIP 5-tuples (`scip_interface/scip_decode_core.py:99-123`
++ per-language decoders) and clangd `.idx` locations (`ls_index/clangd_decode.py:847-889`).
+`CodeGraph.query_range` already exposes them via `EdgeRef.anchor_file/anchor_line`
+(`code_graph.py:57-69`, `:619-629`). **Do not claim the storage layer lacks anchors.**
+
+**Gap A — thread anchors to the UI (the click-to-source feature).** Each consumer
+re-builds edges without the anchor:
+
+1. `traverse_graph.RepoDependencySearcher.get_neighbors` forwards only `{"type": etype}`
+   (`codeminer/graph/traverse_graph.py:81-88`) — it has `edge.attributes()` but drops
+   the anchors. **This is the upstream origin of the drop**; `DependencyAnalyzer`
+   never even receives them.
+2. `DependencyAnalyzer._bfs`/`call_path` build `DepEdge(source,target,type)` and
+   `DepEdge` has no anchor fields (`codeminer/graph/dependency.py:59-66`, `:154-160`,
+   `:193-201`).
+3. MCP `dependency_subgraph` serializes that anchor-less edge
+   (`codeminer/mcp/tools/dependency.py:48`, `codeminer/mcp/server.py:178-201`).
+4. Web codemap edges are `{source,target}` node-ids only — no type, no anchor, and
+   the node `line` is the symbol's *own definition* line, not the call site
+   (`codeminer/web/codemap.py:203-207`; `web/lib/api.ts` `CodemapEdge`:143-146).
+
+   *Plan:* add `anchor_file`/`anchor_line` to `DepEdge` + `to_dict`; have
+   `get_neighbors` carry the edge's anchor attrs into the tuple; thread through
+   `DependencyResult.to_dict` → MCP JSON → `codemap.py` edge dicts → `CodemapEdge`;
+   handle edge-click in the new Cytoscape component to open the code pane at the anchor.
+   *(Alternative: read `CodeGraph.query_range`/`EdgeRef` directly, which already carry anchors.)*
+
+   ⚠️ **Per-call-site dedup nuance:** `codemap.py` dedups edges by `(src,tgt)` (its
+   `edge_seen` set, `codemap.py:153-170`), collapsing multiple call sites between the
+   same pair; `get_neighbors` doesn't dedup but already drops the anchors upstream. To
+   keep **one clickable edge per call site**, carry anchors through `get_neighbors`
+   **and** drop `codemap.py`'s `(src,tgt)` dedup.
+
+**Gap B — coarse edge types (stretch, scope later).** Only `EDGE_TYPE_CONTAIN="contain"`
+and `EDGE_TYPE_REFERENCE="reference"` exist (`codeminer/types.py:16-17`). There is no
+CALLS/IMPORTS/EXTENDS/IMPLEMENTS distinction — even clangd inheritance/override fold
+into reference-class edges (`ls_index/clangd_decode.py:891+`). GitNexus distinguishes
+these. SCIP symbol roles can recover some; bigger backend change — defer.
+
+## Reuse, don't reinvent (graph ops that already exist)
+
+- `DependencyAnalyzer` (`codeminer/graph/dependency.py`): `impact()` (blast radius,
+  `:108-115`), `dependencies()` (callees, `:117-121`), `subgraph()` (1-hop, `:123-125`),
+  `call_path()` (shortest A→B, `:127-161`).
+- MCP `dependency_subgraph` (`codeminer/mcp/tools/dependency.py:20-48`) →
+  `{root,direction,nodes,edges,truncated,note}`.
+- Agent skills `find_callees`/`find_callers`/`trace` (`codeminer/agent/skills/_graphnav.py`).
+  ⚠️ `find_callees` executor docstring says "incoming" but returns callees (stale
+  docstring; behavior is correct). ⚠️ `impact_analysis` skill dir has no source
+  `executor.py` in the checkout (only `__pycache__`) — verify before relying on it.
+
+## Rough roadmap (next round, not this one)
+
+- **P1** — Gap A: thread anchors (`DepEdge` → MCP → web), add a Cytoscape component behind a flag.
+- **P2** — Cytoscape UX: compound nodes, expand-on-click, filter, **edge click → exact source**.
+- **P3** — Wiki-as-graph-views reframe.
+- **P4 (stretch)** — Gap B: fine-grained edge types from SCIP roles.
+
+## Verify the bet end-to-end
+
+After P1–P2: open the codemap on a C/C++ repo (clangd-indexed, e.g. `redis/redis`)
+and a Python repo (SCIP-indexed), click an edge, and confirm the code pane lands on
+the **exact call-site line** (cross-check against `CodeGraph.query_range` anchors).
+Confirm distinct call sites between the same two symbols render as **separate**
+clickable edges (dedup nuance above).

--- a/.claude/guides/frontend-loop.md
+++ b/.claude/guides/frontend-loop.md
@@ -51,6 +51,32 @@ npm run dev            # = `next dev`; binds :3000 (no port flag anywhere)
 - **Over SSH, forward both ports** — API calls run *in the browser*, not server-side:
   `ssh -L 3000:localhost:3000 -L 8000:localhost:8000 <host>`.
 
+## Performance & caching (why a page can feel slow)
+
+- **Wiki prose is LLM-generated and disk-cached** under `<data_dir>/wiki_cache/`
+  (i.e. `.codeminer_qa/wiki_cache/agentwiki_<sha1(instance@commit/suffix)[:16]>.json`)
+  — NOT under `/mnt/data/codeminer` (that holds the prebuilt graph + vectors).
+  The **first** visit to an un-narrated page runs the model (~8–20s); after that
+  it's ~2ms. The codemap / wiki-page subgraph is computed **dynamically** per
+  request but is fast (~50–115ms), so it isn't cached.
+- **Pre-warm the cache** so navigation is instant (run once per data_dir; ~minutes):
+  ```bash
+  B=http://127.0.0.1:8000; PY=<codeminer-conda-python>
+  ids(){ curl -s "$B/api/repos/$1/wiki" | $PY -c "import sys,json
+  def w(ps):
+   for p in ps:
+    print(p['id']); w(p.get('children',[]))
+  w(json.load(sys.stdin).get('pages',[]))"; }
+  for r in $(curl -s "$B/api/repos" | $PY -c "import sys,json;[print(x['id']) for x in json.load(sys.stdin)]"); do
+    for p in $(ids "$r"); do curl -s -o /dev/null --max-time 120 "$B/api/repos/$r/wiki/$p"; done
+  done
+  ```
+  To force re-narration after a prompt change, delete the matching
+  `agentwiki_*.json` (outline key = `sha1("<instance>@<commit_short>/outline")[:16]`).
+- **Frontend weight**: Mermaid (~1MB) and the Cytoscape graph are `next/dynamic`
+  lazy-loaded, so the narrative paints first. Remember `next dev` is unminified —
+  a production `next build && next start` is markedly faster than the dev server.
+
 ## Screenshot / visual verification (Playwright)
 
 Playwright (chromium) is a `web/` devDep. Two ready scripts; **run them from inside

--- a/.claude/guides/frontend-loop.md
+++ b/.claude/guides/frontend-loop.md
@@ -1,0 +1,109 @@
+# Frontend loop — running & iterating the web demo
+
+How to run, screenshot, and self-critique CodeMiner's web demo (the
+DeepWiki-style repo browser: **wiki / codemap / ask**). This is the playbook for
+any agent doing a UI iteration loop. For where the product is *headed* (graph
+overhaul, differentiation), see [`graph-frontend-direction.md`](../design/graph-frontend-direction.md).
+
+> **The demo is on `main`** — FastAPI backend `codeminer/web/`, Next.js frontend
+> `web/`, and the wiki layer `codeminer/wiki/` were merged via PR #166/#167. No
+> branch switch is needed; work from the repo checkout. (The original iteration
+> branch `claude/deepwiki-loop` is now effectively merged — only a 1-line diff in
+> `codeminer/web/repo_registry.py` remains, so don't `git switch` to it.)
+
+## Run it
+
+Two processes: a FastAPI backend on **:8000** and a Next.js dev server on **:3000**.
+Run the backend **from the repo root** (its `data_dir` is relative).
+
+```bash
+# --- backend (FastAPI / uvicorn) ---
+export CODEMINER_DEMO_MODEL=openai/gpt-4o-mini   # REQUIRED: on-branch qa_config.yaml
+                                                 # defaults to vertex_ai/gemini-2.5-flash,
+                                                 # which needs gcloud ADC (not set here).
+                                                 # OPENAI_API_KEY is set, so override to it.
+PY=/home/zhongming/anaconda3/envs/codeminer/bin/python   # has litellm; `which python` in the
+                                                         # codeminer conda env resolves here.
+                                                         # System /usr/bin/python3 has NO litellm.
+setsid bash -c "exec $PY -m uvicorn codeminer.web.app:app --host 127.0.0.1 --port 8000" \
+  >/tmp/cm-web.log 2>&1 </dev/null &                # setsid + </dev/null so it survives the
+                                                    # background-job wrapper exiting.
+# The port stays CLOSED until indices finish loading (~20s) — the lifespan loads
+# repos before uvicorn accepts connections, so an early curl gets connection-refused.
+# Retry until healthy:
+until curl -sf http://127.0.0.1:8000/api/health; do sleep 2; done   # -> {"status":"ok","repos":N}
+```
+
+```bash
+# --- frontend (Next.js) ---
+cd web
+npm install            # first time only
+npm run dev            # = `next dev`; binds :3000 (no port flag anywhere)
+```
+
+- The ASGI app is `app = FastAPI(...)` in `codeminer/web/app.py` (target `codeminer.web.app:app`).
+  There is also a `codeminer-web` console script (honors `CODEMINER_DEMO_HOST`/`PORT`).
+- **Repo pool**: 4 repos served from prebuilt vector stores under `/mnt/data/codeminer`
+  (~840 per-instance dirs; `qa_config.yaml` sets `prebuilt_dir`, overridable via
+  `CODEMINER_DEMO_PREBUILT_DIR`). Layout: `<dir>/<instance_id>/{repo,l0,l2}/index_<suffix>.faiss`.
+- **Frontend → backend** is wired by `NEXT_PUBLIC_API_BASE` (default `http://127.0.0.1:8000`).
+  Don't confuse it with `CODEMINER_DEMO_MODEL`, which only sets the backend's LLM.
+- **Over SSH, forward both ports** — API calls run *in the browser*, not server-side:
+  `ssh -L 3000:localhost:3000 -L 8000:localhost:8000 <host>`.
+
+## Screenshot / visual verification (Playwright)
+
+Playwright (chromium) is a `web/` devDep. Two ready scripts; **run them from inside
+`web/`** (they `import { chromium } from "playwright"`, resolved from
+`web/node_modules` — a script in `/tmp` or `$CLAUDE_JOB_DIR` fails with
+`ERR_MODULE_NOT_FOUND`). Screenshots write to
+`../verification/` (a sibling of `web/`, **not** in the repo — `mkdir` it first).
+
+```bash
+cd web && mkdir -p ../verification
+# (1) live smoke test against the REAL running stack:
+node verify.mjs http://127.0.0.1:3000/ home 1280 900
+#     -> ../verification/home.png + JSON {httpStatus, horizontalScroll, consoleErrors, pageErrors}
+# (2) offline flow test with a fully MOCKED backend (no server/LLM, but next dev must be up):
+node qa_verify.mjs answer        # modes: loaded | answer | mobile | down
+#     -> ../verification/<name>.png : qa-loaded / qa-answer / qa-mobile / qa-backend-down
+#        (note: `down` writes qa-backend-down.png, NOT qa-down.png) + JSON {counts, consoleErrors}
+```
+
+Then `Read` the PNG to eyeball it. Both scripts launch headless chromium, `goto`
+with `waitUntil:'networkidle'`, wait ~1.5s for mermaid/fetches to settle, screenshot
+full-page, and print a JSON report (console/pageerror capture + a horizontal-overflow
+check). New screenshot scripts should follow that shape.
+
+> **No pixel-diff yet.** `pixelmatch` + `pngjs` are devDeps but **unused** — no
+> baseline-diff step is implemented. If you add regression diffing, that's the hook.
+
+## Operational gotchas
+
+- **Kill by port, never `pkill -f uvicorn`** (mandatory here): the launching shell's
+  command line matches the pattern, so `pkill` SIGTERMs *itself* (exit 144) and the
+  server with it — **and** a foreign user's uvicorn already runs on this host, which
+  `pkill` would also kill. Use:
+  ```bash
+  PID=$(ss -tlnp | awk '$4 ~ /:8000$/' | grep -oE 'pid=[0-9]+' | cut -d= -f2); [ -n "$PID" ] && kill $PID
+  ```
+- **Confirm litellm with `import litellm`**, not `litellm.__version__` (no such attr →
+  false negative). For the version: `python -c "from importlib.metadata import version; print(version('litellm'))"`.
+
+## Self-critique loop discipline (G5)
+
+When iterating the UI against criteria:
+
+- **Never declare "exit criteria met" on a *blessing* critique** ("no actionable
+  findings"). Re-run an *adversarial* critique against the **live app** (screenshot
+  it, attack it) before claiming convergence.
+- **Don't loosen a criterion to make a new one pass.** If a probe's assumption breaks
+  (e.g. an LLM rewrite moved the text a probe keyed on), fix the *probe location* and
+  document it as a probe update — not a relaxation of the bar.
+
+## What "good" looks like
+
+Legible labels, real interactivity, and — the product's whole bet — **every claim
+and every graph edge is clickable to the exact source line**. The current graph
+(Mermaid auto-layout) does not meet this bar; the planned replacement does. See
+[`graph-frontend-direction.md`](../design/graph-frontend-direction.md).

--- a/codeminer/graph/traverse_graph.py
+++ b/codeminer/graph/traverse_graph.py
@@ -82,10 +82,19 @@ class RepoDependencySearcher:
             if etype_filter and etype not in etype_filter:
                 continue
 
+            # Carry the LSP/SCIP reference-site anchor (caller file + line) in the
+            # edge meta so consumers can link an edge back to the exact call site.
+            # Additive: callers reading meta["type"] are unaffected.
+            attrs = edge.attributes()
+            meta = {
+                "type": etype,
+                "anchor_file": attrs.get("anchor_file"),
+                "anchor_line": attrs.get("anchor_line"),
+            }
             if edge_dir == "forward":
-                edges.append((nid, neighbor_nid, 0, {"type": etype}))
+                edges.append((nid, neighbor_nid, 0, meta))
             else:
-                edges.append((neighbor_nid, nid, 0, {"type": etype}))
+                edges.append((neighbor_nid, nid, 0, meta))
             nodes.append(neighbor_nid)
 
         return nodes, edges

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -27,7 +27,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from ..log_utils import get_logger
 from ..wiki import WikiBuilder
 from ..wiki.narrator import Narrator
-from .codemap import build_codemap
+from .codemap import build_codemap, build_page_subgraph
 from .config import load_config
 from .repo_registry import RepoRegistry
 from .schemas import ChatRequest, ChatResponse, RepoInfo, agent_result_to_response
@@ -126,6 +126,24 @@ async def wiki_page(repo_id: str, page_id: str) -> dict:
     if page is None:
         raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
     return page
+
+
+@app.get("/api/repos/{repo_id}/wiki/{page_id}/graph")
+async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
+    """Induced dependency subgraph over a wiki page's cited symbols.
+
+    Lets a wiki page render as a *view over the graph* (subsystem symbols + how
+    they connect), using the same ``{nodes, edges}`` payload as ``/codemap``.
+    """
+    page = _wiki(repo_id).page(page_id)
+    if page is None:
+        raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
+    bundle = _bundle(repo_id)
+    graph = await asyncio.to_thread(bundle.code_graph)
+    if graph is None:
+        return {"available": False, "nodes": [], "edges": [], "mermaid": ""}
+    citations = page.get("citations", []) if isinstance(page, dict) else []
+    return await asyncio.to_thread(build_page_subgraph, graph, citations)
 
 
 @app.get("/api/repos/{repo_id}/source")

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -143,7 +143,9 @@ async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
     if graph is None:
         return {"available": False, "nodes": [], "edges": [], "mermaid": ""}
     citations = page.get("citations", []) if isinstance(page, dict) else []
-    return await asyncio.to_thread(build_page_subgraph, graph, citations)
+    return await asyncio.to_thread(
+        build_page_subgraph, graph, citations, repo_dir=bundle.entry.repo_dir
+    )
 
 
 @app.get("/api/repos/{repo_id}/source")
@@ -180,7 +182,13 @@ async def codemap(
             "note": "This repo has no symbol graph.",
         }
     return await asyncio.to_thread(
-        build_codemap, graph, symbol, direction, depth, max_nodes
+        build_codemap,
+        graph,
+        symbol,
+        direction,
+        depth,
+        max_nodes,
+        repo_dir=bundle.entry.repo_dir,
     )
 
 

--- a/codeminer/web/codemap.py
+++ b/codeminer/web/codemap.py
@@ -17,6 +17,7 @@ plugin, which postdates this branch) — it walks the graph through the
 
 from __future__ import annotations
 
+import os
 from collections import deque
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -25,6 +26,37 @@ from ..graph.traverse_graph import RepoDependencySearcher
 
 # Node types eligible as a focus / default seed (skip file/dir/import nodes).
 _SYMBOL_TYPES = frozenset({"function", "method", "class"})
+# Recognized source-file extensions (fallback when the repo root isn't known).
+_SOURCE_EXTS = frozenset(
+    {
+        ".py",
+        ".pyx",
+        ".pyi",
+        ".go",
+        ".rs",
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx",
+        ".mjs",
+        ".cjs",
+        ".c",
+        ".h",
+        ".cc",
+        ".cpp",
+        ".hpp",
+        ".cxx",
+        ".java",
+        ".rb",
+        ".php",
+        ".cs",
+        ".kt",
+        ".swift",
+        ".scala",
+        ".m",
+        ".mm",
+    }
+)
 _MERMAID_MAX_LABEL = 42
 _DIR_TO_MODE = {"both": "all", "callees": "forward", "callers": "backward"}
 
@@ -106,17 +138,24 @@ def _default_seed(graph: CodeGraph) -> Optional[str]:
     return best
 
 
-def _is_external(a: Dict[str, Any]) -> bool:
+def _is_external(a: Dict[str, Any], repo_dir: Optional[str] = None) -> bool:
     """True if a node has no openable in-repo source.
 
-    External library symbols carry a dotted module path as their ``file``
-    (e.g. ``setuptools.extension``) with no line; pure file/dir nodes carry no
-    line either. A real repo source location is a path (contains ``/``) plus a
-    line — anything else can't be opened in the source pane.
+    External library symbols carry a dotted module path (e.g.
+    ``setuptools.extension``) and no line; file/dir nodes carry no line either.
+    When the repo root is known, "openable" means the file actually exists under
+    it — mirroring the ``/source`` endpoint — so repo-root files like
+    ``setup.py`` / ``main.go`` are NOT misflagged. Without a root, fall back to:
+    needs a line, and the file is a path or has a known source extension.
     """
     f = a.get("file")
     s = a.get("start_line")
-    return not (isinstance(s, int) and isinstance(f, str) and "/" in f)
+    if not isinstance(s, int) or not isinstance(f, str) or not f:
+        return True
+    if repo_dir:
+        safe = os.path.normpath(f).lstrip(os.sep).lstrip("/")
+        return not os.path.isfile(os.path.join(repo_dir, safe))
+    return ("/" not in f) and (os.path.splitext(f)[1].lower() not in _SOURCE_EXTS)
 
 
 def build_codemap(
@@ -125,6 +164,7 @@ def build_codemap(
     direction: str = "both",
     depth: int = 2,
     max_nodes: int = 40,
+    repo_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Return a dependency subgraph + Mermaid rendering around *symbol*.
 
@@ -224,7 +264,7 @@ def build_codemap(
                 "kind": a.get("type") or "symbol",
                 "depth": depth_of.get(name, 0),
                 "is_root": name == root,
-                "external": _is_external(a),
+                "external": _is_external(a, repo_dir),
             }
         )
 
@@ -306,6 +346,7 @@ def build_page_subgraph(
     graph: CodeGraph,
     citations: List[Dict[str, Any]],
     max_nodes: int = 40,
+    repo_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Induced reference subgraph over a wiki page's cited symbols.
 
@@ -414,7 +455,7 @@ def build_page_subgraph(
                 "kind": a.get("type") or "symbol",
                 "depth": 0 if name in seeds else 1,
                 "is_root": name in seeds,  # highlight the page's own symbols
-                "external": _is_external(a),
+                "external": _is_external(a, repo_dir),
             }
         )
 

--- a/codeminer/web/codemap.py
+++ b/codeminer/web/codemap.py
@@ -106,6 +106,19 @@ def _default_seed(graph: CodeGraph) -> Optional[str]:
     return best
 
 
+def _is_external(a: Dict[str, Any]) -> bool:
+    """True if a node has no openable in-repo source.
+
+    External library symbols carry a dotted module path as their ``file``
+    (e.g. ``setuptools.extension``) with no line; pure file/dir nodes carry no
+    line either. A real repo source location is a path (contains ``/``) plus a
+    line — anything else can't be opened in the source pane.
+    """
+    f = a.get("file")
+    s = a.get("start_line")
+    return not (isinstance(s, int) and isinstance(f, str) and "/" in f)
+
+
 def build_codemap(
     graph: CodeGraph,
     symbol: Optional[str] = None,
@@ -152,6 +165,10 @@ def build_codemap(
     depth_of: Dict[str, int] = {root: 0}
     raw_edges: List[Tuple[str, str]] = []
     edge_seen: Set[Tuple[str, str]] = set()
+    # Aggregate the exact reference (call) site(s) per edge so the UI can jump
+    # to source. One displayed edge collects several call sites (a list) rather
+    # than multiplying edges, which keeps the graph readable.
+    edge_anchors: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
     queue: deque[str] = deque([root])
     truncated = False
 
@@ -163,11 +180,21 @@ def build_codemap(
         neighbors, n_edges = searcher.get_neighbors(
             cur, direction=mode, etype_filter={"reference"}, ignore_test_file=True
         )
-        for src, tgt, _w, _meta in n_edges:
+        for src, tgt, _w, meta in n_edges:
+            if src == tgt:
+                continue  # drop self-loops (recursion) — visual noise
             key = (src, tgt)
             if key not in edge_seen:
                 edge_seen.add(key)
                 raw_edges.append(key)
+            af = meta.get("anchor_file") if isinstance(meta, dict) else None
+            al = meta.get("anchor_line") if isinstance(meta, dict) else None
+            if af:
+                anchors = edge_anchors.setdefault(key, [])
+                # anchor_line is 0-based (tree-sitter/LSP); expose 1-based.
+                entry = {"file": af, "line": (al + 1) if isinstance(al, int) else None}
+                if entry not in anchors:
+                    anchors.append(entry)
         for nb in neighbors:
             if nb in seen:
                 continue
@@ -197,14 +224,19 @@ def build_codemap(
                 "kind": a.get("type") or "symbol",
                 "depth": depth_of.get(name, 0),
                 "is_root": name == root,
+                "external": _is_external(a),
             }
         )
 
-    edges = [
-        {"source": id_of[s], "target": id_of[t]}
-        for s, t in raw_edges
-        if s in id_of and t in id_of
-    ]
+    edges: List[Dict[str, Any]] = []
+    for s, t in raw_edges:
+        if s not in id_of or t not in id_of:
+            continue
+        edge: Dict[str, Any] = {"source": id_of[s], "target": id_of[t]}
+        anchors = edge_anchors.get((s, t))
+        if anchors:
+            edge["anchors"] = anchors[:8]
+        edges.append(edge)
 
     return {
         "available": True,
@@ -240,3 +272,171 @@ def _to_mermaid(
     lines.append("  classDef root fill:#2d7ff9,stroke:#1b5fd0,color:#ffffff;")
     lines.append(f"  class {root_id} root;")
     return "\n".join(lines)
+
+
+def _resolve_citation(
+    graph: CodeGraph,
+    cit: Dict[str, Any],
+    by_loc: Dict[Tuple[str, int], str],
+    by_file: Dict[str, List[Tuple[int, str]]],
+) -> Optional[str]:
+    """Map a wiki citation (file + 1-based line, or node_name) to a graph identity.
+
+    Prefers an exact ``(file, 0-based start)`` hit, then the nearest symbol start
+    in that file (small tolerance), then a readable-name match.
+    """
+    f = cit.get("file")
+    sl = cit.get("start_line")
+    if f and isinstance(sl, int):
+        s0 = sl - 1  # citations are 1-based (CodeLocation); the graph is 0-based
+        if (f, s0) in by_loc:
+            return by_loc[(f, s0)]
+        best, best_d = None, 3
+        for s, name in by_file.get(f, []):
+            d = abs(s - s0)
+            if d < best_d:
+                best, best_d = name, d
+        if best:
+            return best
+    nm = cit.get("node_name")
+    return _resolve(graph, nm) if nm else None
+
+
+def build_page_subgraph(
+    graph: CodeGraph,
+    citations: List[Dict[str, Any]],
+    max_nodes: int = 40,
+) -> Dict[str, Any]:
+    """Induced reference subgraph over a wiki page's cited symbols.
+
+    Resolves each citation to a graph node, then returns those nodes plus the
+    reference (call) edges *between* them — anchored to their exact call sites —
+    in the same ``{nodes, edges}`` shape as :func:`build_codemap`. This makes a
+    wiki page a *view over the graph*: the subsystem's symbols and how they wire
+    together, every node/edge clickable to real source.
+    """
+    g = graph.get_graph()
+
+    # Location + name index for resolving citations precisely (built once).
+    by_loc: Dict[Tuple[str, int], str] = {}
+    by_file: Dict[str, List[Tuple[int, str]]] = {}
+    for v in g.vs:
+        a = v.attributes()
+        f = a.get("file")
+        s = a.get("start_line")
+        if not f or not isinstance(s, int) or not a.get("unified_name"):
+            continue
+        by_loc.setdefault((f, s), a["name"])
+        by_file.setdefault(f, []).append((s, a["name"]))
+
+    names: List[str] = []
+    chosen: Set[str] = set()
+    for cit in citations:
+        nm = _resolve_citation(graph, cit, by_loc, by_file)
+        if nm and nm not in chosen:
+            chosen.add(nm)
+            names.append(nm)
+        if len(names) >= max_nodes:
+            break
+
+    if not names:
+        return {
+            "available": False,
+            "root": "",
+            "root_label": "",
+            "direction": "both",
+            "nodes": [],
+            "edges": [],
+            "mermaid": "",
+            "note": "No graph symbols for this page.",
+        }
+
+    seeds = set(names)  # the page's own cited symbols (highlighted)
+    searcher = RepoDependencySearcher(graph)
+
+    # The page's symbols rarely call each other directly, so a pure induced
+    # subgraph is mostly disconnected dots. Expand one hop: pull in each seed's
+    # immediate neighbours so the subsystem's wiring is visible.
+    for nm in list(names):
+        if len(names) >= max_nodes:
+            break
+        nbrs, _ = searcher.get_neighbors(
+            nm, direction="all", etype_filter={"reference"}, ignore_test_file=True
+        )
+        for nb in nbrs:
+            if nb not in chosen:
+                chosen.add(nb)
+                names.append(nb)
+            if len(names) >= max_nodes:
+                break
+    nameset = set(names)
+
+    edge_order: List[Tuple[str, str]] = []
+    edge_seen: Set[Tuple[str, str]] = set()
+    edge_anchors: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for nm in names:
+        _, n_edges = searcher.get_neighbors(
+            nm, direction="all", etype_filter={"reference"}, ignore_test_file=True
+        )
+        for src, tgt, _w, meta in n_edges:
+            if src == tgt or src not in nameset or tgt not in nameset:
+                continue  # induced subgraph; drop self-loops
+            key = (src, tgt)
+            if key not in edge_seen:
+                edge_seen.add(key)
+                edge_order.append(key)
+            af = meta.get("anchor_file") if isinstance(meta, dict) else None
+            al = meta.get("anchor_line") if isinstance(meta, dict) else None
+            if af:
+                anchors = edge_anchors.setdefault(key, [])
+                entry = {"file": af, "line": (al + 1) if isinstance(al, int) else None}
+                if entry not in anchors:
+                    anchors.append(entry)
+
+    # Order seeds first (they're the page's subject); neighbours follow.
+    ordered = [n for n in names if n in seeds] + [n for n in names if n not in seeds]
+    id_of: Dict[str, str] = {}
+    nodes: List[Dict[str, Any]] = []
+    for i, name in enumerate(ordered):
+        a = _attrs(graph, name)
+        label = _label(a, name)
+        start = a.get("start_line")
+        nid = f"n{i}"
+        id_of[name] = nid
+        nodes.append(
+            {
+                "id": nid,
+                "name": name,
+                "label": label,
+                "short": _short(label),
+                "file": a.get("file"),
+                "line": (start + 1) if isinstance(start, int) else None,
+                "kind": a.get("type") or "symbol",
+                "depth": 0 if name in seeds else 1,
+                "is_root": name in seeds,  # highlight the page's own symbols
+                "external": _is_external(a),
+            }
+        )
+
+    edges: List[Dict[str, Any]] = []
+    for s, t in edge_order:
+        if s not in id_of or t not in id_of:
+            continue
+        edge: Dict[str, Any] = {"source": id_of[s], "target": id_of[t]}
+        anchors = edge_anchors.get((s, t))
+        if anchors:
+            edge["anchors"] = anchors[:8]
+        edges.append(edge)
+
+    return {
+        "available": True,
+        "root": "",
+        "root_label": "",
+        "direction": "both",
+        "depth": 1,
+        "truncated": len(names) >= max_nodes,
+        "nodes": nodes,
+        "edges": edges,
+        "mermaid": "",
+        "note": "",
+    }

--- a/codeminer/wiki/outline.py
+++ b/codeminer/wiki/outline.py
@@ -67,16 +67,25 @@ Salient files:
 Top symbols (name — file — kind):
 {symbols}
 
-Return ONLY JSON, no prose, of exactly this shape (6-9 top-level pages; each \
-may have 0-3 children). Start with an "Overview" page.
+Return ONLY JSON, no prose, of exactly this shape. Aim for 8-14 top-level pages \
+that together cover the WHOLE system, and give the major subsystems 1-3 children \
+so the tree is genuinely TWO LEVELS deep — not a flat list. Start with "Overview".
 {{"pages":[{{"id":"kebab-case-id","title":"Concept Title","summary":"1-2 \
 sentences on what this page explains","keywords":["specific","symbol or \
-feature","search","terms"],"files":["likely/relevant/path.ext"],"children":[]}}]}}
+feature","search","terms"],"files":["likely/relevant/path.ext"],"children":[\
+{{"id":"child-id","title":"Sub-topic","summary":"...","keywords":["..."],\
+"files":["..."],"children":[]}}]}}]}}
 
 Rules:
+- Structure it like a senior engineer's onboarding docs: top-level = major areas; \
+children = specific capabilities or flows inside them (e.g. an "I/O" page with \
+"FITS", "ASCII", "Registry" children; a "Table System" page with "Operations").
+- Cover not only domain subsystems but the cross-cutting pages a new contributor \
+needs, WHEN APPLICABLE: Getting Started / Installation, Project Structure, \
+Configuration, Testing, Extensibility / Plugins.
 - Titles are CONCEPTS, not paths (no "lib/core", no file names as titles).
 - keywords drive a code search, so make them specific symbol/feature terms.
-- Together the pages should cover the whole system, not just a few files.
+- Cover the whole system, not just a few files; prefer depth over a flat list.
 """
 
 
@@ -84,7 +93,7 @@ def _format_symbols(symbols: List[Symbol]) -> str:
     return "\n".join(f"- {s.name} — {s.file} — {s.type}" for s in symbols)
 
 
-def generate_outline(bundle: Any, model: str, max_tokens: int = 3200) -> Dict[str, Any]:
+def generate_outline(bundle: Any, model: str, max_tokens: int = 4096) -> Dict[str, Any]:
     """Produce a conceptual wiki page tree for *bundle* using *model*.
 
     Returns ``{"pages": [...]}``. On a model/parse failure returns

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -6,12 +6,14 @@ import Header from "@/components/Header";
 import Markdown from "@/components/Markdown";
 import AskBar from "@/components/AskBar";
 import Codemap from "@/components/Codemap";
-import CitationItem from "@/components/CitationItem";
+import GraphView from "@/components/GraphView";
 import {
   fetchRepos,
+  fetchWikiGraph,
   fetchWikiPage,
   fetchWikiTree,
   repoRelative,
+  type CodemapResponse,
   type RepoInfo,
   type WikiPage,
   type WikiPageRef,
@@ -22,6 +24,22 @@ interface Heading {
   id: string;
   text: string;
   level: number;
+}
+
+// The wiki page now leads with an interactive subsystem graph, so the narrator's
+// generated mermaid diagrams (and any heading left empty once removed) are
+// redundant — strip them before rendering.
+function stripGeneratedDiagrams(md: string): string {
+  return md
+    .replace(/\n#{1,6}[^\n]*\n+```mermaid[\s\S]*?```/g, "") // a heading + its diagram
+    .replace(/```mermaid[\s\S]*?```/g, "") // any stray diagram
+    .trimEnd();
+}
+
+// Link a repo-relative source path to the exact blob on GitHub at the indexed commit.
+function ghFileUrl(repo: string | undefined, commit: string | undefined, file: string): string | null {
+  if (!repo) return null;
+  return `https://github.com/${repo}/blob/${commit || "HEAD"}/${file}`;
 }
 
 function TocTree({
@@ -61,6 +79,11 @@ export default function WikiPageView() {
   const [pages, setPages] = useState<WikiPageRef[]>([]);
   const [activeId, setActiveId] = useState<string>("overview");
   const [page, setPage] = useState<WikiPage | null>(null);
+  const [pageGraph, setPageGraph] = useState<CodemapResponse | null>(null);
+  // Seed passed to the codemap when "explore in graph" is used from a wiki page.
+  const [graphSeed, setGraphSeed] = useState<string | undefined>(undefined);
+  // Wiki-first: a repo opens on its narrative — which now leads with a subsystem
+  // graph — and the full Graph explorer is one tab away.
   const [mode, setMode] = useState<Mode>("wiki");
   const [headings, setHeadings] = useState<Heading[]>([]);
   const [activeHeading, setActiveHeading] = useState<string>("");
@@ -70,11 +93,19 @@ export default function WikiPageView() {
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    // Deep-link support: ?p=<pageId> selects a page directly.
+    // Deep-link support: ?p=<pageId> opens that wiki page directly.
     const p = new URLSearchParams(window.location.search).get("p");
-    if (p) setActiveId(p);
+    if (p) {
+      setActiveId(p);
+      setMode("wiki"); // a page deep-link wants the narrative, not the graph
+    }
     fetchRepos()
-      .then((rs) => setRepo(rs.find((r) => r.id === repoId) ?? null))
+      .then((rs) => {
+        const r = rs.find((x) => x.id === repoId) ?? null;
+        setRepo(r);
+        // Fall back to wiki if this repo has no symbol graph.
+        if (r && !r.capabilities?.codemap && !p) setMode("wiki");
+      })
       .catch(() => {});
     fetchWikiTree(repoId)
       .then((t) => setPages(t.pages))
@@ -85,9 +116,14 @@ export default function WikiPageView() {
     let cancelled = false;
     setPage(null);
     setPageError(null);
+    setPageGraph(null);
     fetchWikiPage(repoId, activeId)
       .then((p) => !cancelled && setPage(p))
       .catch((e) => !cancelled && setPageError(String(e)));
+    // The page's symbols as a view over the graph (rendered atop the narrative).
+    fetchWikiGraph(repoId, activeId)
+      .then((g) => !cancelled && setPageGraph(g))
+      .catch(() => !cancelled && setPageGraph(null));
     return () => {
       cancelled = true;
     };
@@ -164,6 +200,9 @@ export default function WikiPageView() {
         {tocOpen && <div className="toc-scrim" onClick={() => setTocOpen(false)} aria-hidden />}
         <aside className={`wiki-toc ${tocOpen ? "open" : ""}`} data-rail="left">
           <div className="rail-title">{repo ? repo.repo : repoId}</div>
+          {repo?.commit_short && (
+            <div className="rail-sub mono">Last indexed {repo.commit_short}</div>
+          )}
           {error && <div className="muted">Failed to load wiki.</div>}
           <TocTree pages={pages} activeId={activeId} onPick={pick} />
         </aside>
@@ -185,9 +224,22 @@ export default function WikiPageView() {
 
           {mode === "wiki" && (
             <div className="wiki-content" ref={contentRef}>
-              <div className="wiki-meta mono">
-                {repo ? `Last indexed ${repo.commit_short}` : ""}
-              </div>
+              {pageGraph && pageGraph.available && pageGraph.nodes.length > 0 && (
+                <details className="subsystem-map" open>
+                  <summary>
+                    Subsystem map · {pageGraph.nodes.length} symbols
+                    <span className="subsystem-hint"> — this page as a view over the graph</span>
+                  </summary>
+                  <GraphView
+                    repoId={repoId}
+                    data={pageGraph}
+                    onFocus={(label) => {
+                      setGraphSeed(label);
+                      setMode("codemap");
+                    }}
+                  />
+                </details>
+              )}
               {page && page.citations.length > 0 && (
                 <details className="relevant-files-wiki">
                   {(() => {
@@ -200,11 +252,25 @@ export default function WikiPageView() {
                       <>
                         <summary>Relevant source files ({wikiFiles.length})</summary>
                         <div className="relevant-files-list">
-                          {wikiFiles.map((f) => (
-                            <span key={f} className="relevant-file mono">
-                              {f}
-                            </span>
-                          ))}
+                          {wikiFiles.map((f) => {
+                            const url = ghFileUrl(repo?.repo, repo?.base_commit, f);
+                            return url ? (
+                              <a
+                                key={f}
+                                className="relevant-file mono"
+                                href={url}
+                                target="_blank"
+                                rel="noreferrer"
+                                title={`Open ${f} on GitHub`}
+                              >
+                                {f} ↗
+                              </a>
+                            ) : (
+                              <span key={f} className="relevant-file mono">
+                                {f}
+                              </span>
+                            );
+                          })}
                         </div>
                       </>
                     );
@@ -212,28 +278,20 @@ export default function WikiPageView() {
                 </details>
               )}
               {page ? (
-                <Markdown>{page.markdown}</Markdown>
+                <Markdown>{stripGeneratedDiagrams(page.markdown)}</Markdown>
               ) : pageError ? (
                 <p className="muted">Couldn't load this page. It may not exist — pick a section from the sidebar.</p>
               ) : (
                 <p className="muted">Loading…</p>
               )}
-              {page && page.citations.length > 0 && (
-                <details className="citations" open>
-                  <summary>{page.citations.length} code references</summary>
-                  {page.citations.map((c, i) => (
-                    <CitationItem repoId={repoId} c={c} key={i} />
-                  ))}
-                </details>
-              )}
             </div>
           )}
 
-          {mode === "codemap" && <Codemap repoId={repoId} />}
+          {mode === "codemap" && <Codemap repoId={repoId} initialSymbol={graphSeed} />}
         </main>
 
         <aside className="wiki-onthispage" data-rail="right">
-          <div className="rail-title">On this page</div>
+          <div className="rail-title">{mode === "codemap" ? "About this graph" : "On this page"}</div>
           {mode === "wiki" && headings.length > 0 ? (
             <ul className="onthispage-list">
               {headings.map((h) => (
@@ -244,12 +302,25 @@ export default function WikiPageView() {
                 </li>
               ))}
             </ul>
-          ) : (
-            <div className="muted small">
-              {mode === "wiki" ? "—" : `${mode} view`}
+          ) : mode === "codemap" ? (
+            <div className="rail-graphnote small">
+              <p>
+                Every edge is a <b>real reference</b> from the LSP/SCIP index — not a guess.
+              </p>
+              <ul>
+                <li>
+                  Click an <b>edge</b> → the exact call site
+                </li>
+                <li>
+                  Click a <b>node</b> → refocus the map
+                </li>
+                <li>Colour = file · scroll to zoom · drag to pan</li>
+              </ul>
             </div>
+          ) : (
+            <div className="muted small">—</div>
           )}
-          {repo && (
+          {repo && mode === "wiki" && (
             <button
               className="refresh-wiki"
               title="Re-fetch this wiki page"

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -16,8 +16,8 @@
   --accent: #2d7ff9;      /* links / primary */
   --accent-contrast: #ffffff;
   --top-h: 56px;
-  --rail-left: 288px;
-  --rail-right: 256px;
+  --rail-left: 320px;
+  --rail-right: 248px;
   --content-w: 768px;
 }
 
@@ -408,8 +408,8 @@ pre {
   max-height: calc(100vh - var(--top-h));
   overflow-y: auto;
   width: var(--rail-left);
-  padding: 20px 16px;
-  border-right: 1px dashed var(--border);
+  padding: 22px 20px;
+  border-right: 1px solid var(--border);
 }
 .wiki-onthispage {
   position: sticky;
@@ -422,7 +422,7 @@ pre {
   border-left: 1px solid var(--border);
 }
 .rail-title {
-  font-size: 13.5px;
+  font-size: 15px;
   font-weight: 650;
   color: var(--text);
   margin-bottom: 2px;
@@ -452,8 +452,9 @@ pre {
   background: transparent;
   border: none;
   border-radius: 6px;
-  padding: 5px 8px;
-  font-size: 13px;
+  padding: 6px 10px;
+  font-size: 14px;
+  line-height: 1.45;
   color: var(--muted);
   cursor: pointer;
   word-break: break-word;
@@ -471,12 +472,12 @@ pre {
 
 .wiki-main {
   min-width: 0;
-  padding: 16px 32px 80px;
+  padding: 18px 28px 80px;
 }
 .wiki-content,
 .wiki-diagram,
 .ask-panel {
-  max-width: 720px;
+  max-width: 1100px;
   margin: 0 auto;
 }
 .wiki-meta {

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1160,6 +1160,12 @@ pre {
   width: 100%;
   height: 540px;
 }
+.codegraph-loading {
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  font-size: 13px;
+}
 .codegraph-bar {
   display: flex;
   align-items: center;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -19,7 +19,6 @@
   --rail-left: 320px;
   --rail-right: 248px;
   --content-w: 768px;
-  --page-max: 1400px;
 }
 
 [data-theme="dark"] {
@@ -73,8 +72,8 @@ pre {
   display: flex;
   align-items: center;
   gap: 16px;
-  /* Align header content with the centred page container below. */
-  padding: 0 max(24px, calc((100% - var(--page-max)) / 2));
+  /* Match the page gutter below so the brand aligns with the left rail. */
+  padding: 0 clamp(24px, 4vw, 80px);
   border-bottom: 1px solid var(--border);
   background: var(--bg);
 }
@@ -117,6 +116,45 @@ pre {
 .btn-primary:hover {
   filter: brightness(0.96);
   text-decoration: none;
+}
+
+/* ---- modern interaction polish: smooth transitions, focus rings, hover glow ---- */
+.btn-primary,
+.repo-card,
+.toc-link,
+.mode-tab,
+.relevant-file,
+.codemap-chip,
+.codemap-controls button,
+.codegraph-fit,
+.callsite-focus,
+.askbar-send,
+.askbar-inner,
+.onthispage-list a {
+  transition:
+    background-color 0.13s ease,
+    border-color 0.13s ease,
+    box-shadow 0.13s ease,
+    color 0.13s ease,
+    filter 0.13s ease;
+}
+.btn-primary:hover,
+.codemap-controls button:hover,
+.askbar-send:not(:disabled):hover {
+  box-shadow: 0 2px 12px -3px color-mix(in srgb, var(--accent) 55%, transparent);
+}
+/* Accent focus ring on the text inputs / the ask bar. */
+.codemap-symbol:focus,
+.repo-search:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+.askbar-inner:focus-within {
+  border-color: var(--accent);
+  box-shadow:
+    0 8px 28px -8px rgba(0, 0, 0, 0.18),
+    0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 .icon-btn {
   display: inline-flex;
@@ -292,10 +330,10 @@ pre {
   gap: 4px;
 }
 
-/* language pill */
+/* language tag */
 .lang {
-  border-radius: 999px;
-  padding: 1px 9px;
+  border-radius: 6px;
+  padding: 2px 8px;
   font-size: 11px;
   border: 1px solid var(--border-2);
   color: var(--muted);
@@ -333,10 +371,9 @@ pre {
   grid-template-columns: var(--rail-left) minmax(0, 1fr) var(--rail-right);
   align-items: start;
   gap: 0;
-  /* Inset the whole layout on wide screens so the rails aren't flush to the
-     viewport edges — a centred document reads as cohesive, not spread out. */
-  max-width: var(--page-max);
-  margin: 0 auto;
+  /* A consistent, modest gutter at every width: never flush to the edges, but
+     not the cavernous margins a fixed centred cap leaves on wide screens. */
+  padding-inline: clamp(24px, 4vw, 80px);
 }
 @media (max-width: 1180px) {
   .wiki-grid {
@@ -710,7 +747,7 @@ pre {
   background: var(--surface);
   border: 1px solid var(--border);
   color: var(--text);
-  border-radius: 999px;
+  border-radius: 8px;
   padding: 7px 14px;
   font-size: 13px;
   cursor: pointer;
@@ -952,11 +989,11 @@ pre {
   align-items: center;
   gap: 10px;
   width: min(720px, 100%);
-  padding: 7px 7px 7px 16px;
+  padding: 8px 8px 8px 16px;
   background: var(--surface-2);
   border: 1px solid var(--border);
-  border-radius: 999px;
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+  border-radius: 16px;
+  box-shadow: 0 8px 28px -8px rgba(0, 0, 0, 0.18), 0 2px 6px -2px rgba(0, 0, 0, 0.08);
 }
 .askbar-icon {
   color: var(--accent);
@@ -974,7 +1011,7 @@ pre {
   border: none;
   background: var(--accent);
   color: #fff;
-  border-radius: 999px;
+  border-radius: 9px;
   padding: 9px 18px;
   font-size: 14px;
   cursor: pointer;
@@ -1095,7 +1132,7 @@ pre {
 .codemap-chip {
   padding: 4px 10px;
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: 7px;
   background: var(--surface);
   color: var(--text);
   font-size: 12px;
@@ -1146,7 +1183,7 @@ pre {
 .codegraph-kind {
   margin-left: 8px;
   padding: 1px 7px;
-  border-radius: 999px;
+  border-radius: 6px;
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--muted);
@@ -1218,7 +1255,7 @@ pre {
 }
 .callsite-kindtag {
   padding: 1px 7px;
-  border-radius: 999px;
+  border-radius: 6px;
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--muted);

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -15,7 +15,7 @@
   --muted: #666666;       /* secondary text */
   --accent: #2d7ff9;      /* links / primary */
   --accent-contrast: #ffffff;
-  --top-h: 56px;
+  --top-h: 64px;
   --rail-left: 320px;
   --rail-right: 248px;
   --content-w: 768px;
@@ -68,6 +68,9 @@ pre {
 
 /* ----------------------------- site header ----------------------------- */
 .site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
   height: var(--top-h);
   display: flex;
   align-items: center;
@@ -80,13 +83,15 @@ pre {
 .site-header .brand {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-weight: 600;
-  font-size: 16px;
+  gap: 9px;
+  font-weight: 650;
+  font-size: 18px;
+  letter-spacing: -0.01em;
   color: var(--text);
 }
 .site-header .brand .brand-mark {
   color: var(--accent);
+  font-size: 17px;
 }
 .site-header .header-right {
   margin-left: auto;
@@ -608,6 +613,12 @@ pre {
   font-size: 15px;
   line-height: 1.65;
   color: var(--text);
+}
+/* Anchor jumps (the "On this page" rail) must clear the sticky header. */
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+  scroll-margin-top: calc(var(--top-h) + 16px);
 }
 .markdown h1 {
   font-size: 22px;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -19,6 +19,7 @@
   --rail-left: 320px;
   --rail-right: 248px;
   --content-w: 768px;
+  --page-max: 1400px;
 }
 
 [data-theme="dark"] {
@@ -72,7 +73,8 @@ pre {
   display: flex;
   align-items: center;
   gap: 16px;
-  padding: 0 24px;
+  /* Align header content with the centred page container below. */
+  padding: 0 max(24px, calc((100% - var(--page-max)) / 2));
   border-bottom: 1px solid var(--border);
   background: var(--bg);
 }
@@ -331,6 +333,10 @@ pre {
   grid-template-columns: var(--rail-left) minmax(0, 1fr) var(--rail-right);
   align-items: start;
   gap: 0;
+  /* Inset the whole layout on wide screens so the rails aren't flush to the
+     viewport edges — a centred document reads as cohesive, not spread out. */
+  max-width: var(--page-max);
+  margin: 0 auto;
 }
 @media (max-width: 1180px) {
   .wiki-grid {
@@ -516,23 +522,30 @@ pre {
   list-style: none;
   margin: 0;
   padding: 0;
-  font-size: 12px;
+  font-size: 13px;
 }
 .onthispage-list li {
-  margin: 4px 0;
+  margin: 1px 0;
 }
-.onthispage-list li.lvl-3 {
-  padding-left: 12px;
+.onthispage-list li.lvl-3 a {
+  padding-left: 20px;
 }
 .onthispage-list a {
+  display: block;
+  padding: 4px 8px;
+  border-radius: 6px;
   color: var(--muted);
+  line-height: 1.4;
+  text-decoration: none;
 }
 .onthispage-list a:hover {
-  color: var(--accent);
+  color: var(--text);
+  background: var(--surface);
 }
 .onthispage-list a.active {
   color: var(--accent);
-  font-weight: 500;
+  font-weight: 600;
+  box-shadow: inset 2px 0 var(--accent);
 }
 .refresh-wiki {
   margin-top: 18px;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -422,11 +422,17 @@ pre {
   border-left: 1px solid var(--border);
 }
 .rail-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--muted);
-  margin-bottom: 12px;
+  font-size: 13.5px;
+  font-weight: 650;
+  color: var(--text);
+  margin-bottom: 2px;
+  letter-spacing: -0.01em;
   word-break: break-word;
+}
+.rail-sub {
+  font-size: 11px;
+  color: var(--muted);
+  margin-bottom: 18px;
 }
 
 .toc-tree {
@@ -459,7 +465,8 @@ pre {
 .toc-link.active {
   background: var(--surface);
   color: var(--accent);
-  font-weight: 500;
+  font-weight: 600;
+  box-shadow: inset 2px 0 var(--accent);
 }
 
 .wiki-main {
@@ -845,6 +852,57 @@ pre {
   color: #7ee787;
 }
 
+/* Dark theme for the standalone code component (.hl-code) — used by the Ask
+   citations pane and the codemap call-site peek. Mirrors the .markdown palette
+   above; additive, so the light defaults and wiki rules are untouched. */
+[data-theme="dark"] .hl-code,
+[data-theme="dark"] .hl-pre {
+  background: #0d1117;
+}
+[data-theme="dark"] .hl-gutter {
+  background: #0b0f15;
+  color: #6e7681;
+}
+[data-theme="dark"] .hl-code .hljs {
+  color: #c9d1d9;
+}
+[data-theme="dark"] .hl-code .hljs-doctag,
+[data-theme="dark"] .hl-code .hljs-keyword,
+[data-theme="dark"] .hl-code .hljs-meta .hljs-keyword,
+[data-theme="dark"] .hl-code .hljs-template-tag,
+[data-theme="dark"] .hl-code .hljs-template-variable,
+[data-theme="dark"] .hl-code .hljs-type,
+[data-theme="dark"] .hl-code .hljs-built_in {
+  color: #ff7b72;
+}
+[data-theme="dark"] .hl-code .hljs-title,
+[data-theme="dark"] .hl-code .hljs-title.class_,
+[data-theme="dark"] .hl-code .hljs-title.function_,
+[data-theme="dark"] .hl-code .hljs-section {
+  color: #d2a8ff;
+}
+[data-theme="dark"] .hl-code .hljs-string,
+[data-theme="dark"] .hl-code .hljs-meta .hljs-string,
+[data-theme="dark"] .hl-code .hljs-regexp {
+  color: #a5d6ff;
+}
+[data-theme="dark"] .hl-code .hljs-number,
+[data-theme="dark"] .hl-code .hljs-literal,
+[data-theme="dark"] .hl-code .hljs-variable,
+[data-theme="dark"] .hl-code .hljs-attr,
+[data-theme="dark"] .hl-code .hljs-attribute {
+  color: #79c0ff;
+}
+[data-theme="dark"] .hl-code .hljs-comment,
+[data-theme="dark"] .hl-code .hljs-quote {
+  color: #8b949e;
+}
+[data-theme="dark"] .hl-code .hljs-name,
+[data-theme="dark"] .hl-code .hljs-symbol,
+[data-theme="dark"] .hl-code .hljs-bullet {
+  color: #7ee787;
+}
+
 /* Mobile TOC positioning — declared last so it wins over the base
    `.wiki-toc { position: sticky }` rule (media queries add no specificity). */
 @media (max-width: 820px) {
@@ -956,7 +1014,25 @@ pre {
 
 /* ===== Codemap mode (dependency / call graph) ===== */
 .codemap {
-  padding: 4px 0 8px;
+  /* bottom room so the last chips clear the fixed Ask bar */
+  padding: 4px 0 96px;
+}
+.rail-graphnote p {
+  margin: 0 0 8px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.rail-graphnote ul {
+  margin: 0;
+  padding-left: 16px;
+  color: var(--muted);
+}
+.rail-graphnote li {
+  margin: 3px 0;
+  line-height: 1.45;
+}
+.rail-graphnote b {
+  color: var(--text);
 }
 .codemap-controls {
   display: flex;
@@ -1021,15 +1097,180 @@ pre {
   color: #fff;
   border-color: var(--accent);
 }
-/* Render the dependency graph at natural size (legible labels) inside a
-   scrollable box rather than letting Mermaid shrink it to the column width. */
-.codemap .mermaid-diagram {
-  max-height: 72vh;
-  overflow: auto;
+/* Interactive dependency graph (Cytoscape + dagre). */
+.codegraph {
+  margin: 4px 0 2px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--surface-2);
 }
-.codemap .mermaid-diagram svg {
-  max-width: none !important;
-  height: auto;
+.codegraph-canvas {
+  width: 100%;
+  height: 540px;
+}
+.codegraph-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  font-size: 12px;
+  color: var(--text);
+}
+.codegraph-bar > span:first-child {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.codegraph-bar b {
+  font-weight: 600;
+}
+.codegraph-kind {
+  margin-left: 8px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+}
+.codegraph-fit {
+  padding: 3px 13px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.codegraph-fit:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Call-site peek: the exact reference line behind a clicked edge. */
+.callsite-peek {
+  margin: 10px 0 2px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--surface-2);
+}
+.callsite-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  font-size: 12px;
+}
+.callsite-title {
+  color: var(--text);
+}
+.callsite-arrow {
+  color: var(--muted);
+}
+.callsite-loc {
+  color: var(--accent);
+  font-weight: 600;
+}
+.callsite-pager {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+}
+.callsite-pager button {
+  padding: 1px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+.callsite-pager button.on {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.callsite-kindtag {
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 11px;
+}
+.callsite-focus {
+  padding: 2px 10px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+.callsite-focus:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* Wiki page rendered as a view over the graph: its symbols' subsystem map. */
+.subsystem-map {
+  margin: 6px 0 22px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+  padding: 6px 10px 10px;
+}
+.subsystem-map > summary {
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  padding: 5px 2px;
+  list-style: none;
+}
+.subsystem-map > summary::-webkit-details-marker {
+  display: none;
+}
+.subsystem-map > summary::before {
+  content: "▸ ";
+  color: var(--muted);
+}
+.subsystem-map[open] > summary::before {
+  content: "▾ ";
+}
+.subsystem-hint {
+  font-weight: 400;
+  color: var(--muted);
+}
+.callsite-close {
+  margin-left: auto;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.callsite-close:hover {
+  color: var(--text);
+}
+.callsite-msg {
+  padding: 14px;
+  margin: 0;
 }
 
 /* ===== Ask "codemap": hierarchical explanation (left) + code pane (right) ===== */
@@ -1206,6 +1447,7 @@ pre {
   color: var(--text);
   font-size: 12px;
   cursor: pointer;
+  text-decoration: none;
 }
 .relevant-file:hover {
   border-color: var(--accent);
@@ -1380,6 +1622,20 @@ a.codepanel-name:hover {
   display: flex;
   overflow-x: auto;
   background: #fff;
+  position: relative;
+}
+.hl-band {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: rgba(45, 127, 249, 0.14);
+  border-left: 3px solid var(--accent);
+  pointer-events: none;
+  z-index: 2;
+}
+.hl-gutter-on {
+  color: var(--accent);
+  font-weight: 700;
 }
 .hl-gutter {
   flex: 0 0 auto;

--- a/web/components/CodeGraph.tsx
+++ b/web/components/CodeGraph.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import cytoscape, { type Core, type ElementDefinition } from "cytoscape";
+import dagre from "cytoscape-dagre";
+import type { CallSite, CodemapResponse } from "@/lib/api";
+
+export interface EdgeClickInfo {
+  anchors: CallSite[];
+  srcLabel: string;
+  tgtLabel: string;
+}
+
+export interface GraphNodeInfo {
+  label: string; // full unified_name (for refocus)
+  short: string;
+  file: string | null;
+  line: number | null;
+  kind: string;
+  external: boolean; // defined outside this repo — no source to open
+}
+
+// Register the dagre layout once (module scope; guard for HMR / double-import).
+let dagreRegistered = false;
+function ensureDagre() {
+  if (!dagreRegistered) {
+    cytoscape.use(dagre);
+    dagreRegistered = true;
+  }
+}
+
+// Stable, pleasant per-file accent palette. Files map to a border color so the
+// graph reads as "grouped by file" without heavy compound boxes.
+const FILE_COLORS = [
+  "#2d7ff9", "#e8590c", "#0ca678", "#ae3ec9", "#f08c00",
+  "#1098ad", "#e64980", "#5c7cfa", "#37b24d", "#f76707",
+];
+function colorFor(file: string | null, cache: Map<string, string>): string {
+  const key = file || "·";
+  let c = cache.get(key);
+  if (!c) {
+    let h = 0;
+    for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) | 0;
+    c = FILE_COLORS[Math.abs(h) % FILE_COLORS.length];
+    cache.set(key, c);
+  }
+  return c;
+}
+
+interface HoverInfo {
+  short: string;
+  file: string | null;
+  line: number | null;
+  kind: string;
+}
+
+/**
+ * Interactive dependency graph rendered with Cytoscape + dagre.
+ * Replaces the old Mermaid auto-layout: directional (left→right) call flow,
+ * per-file colour accents, zoom/pan, click-a-node-to-refocus, hover for file:line.
+ */
+export default function CodeGraph({
+  data,
+  onNodeClick,
+  onEdgeClick,
+}: {
+  data: CodemapResponse;
+  onNodeClick?: (node: GraphNodeInfo) => void;
+  onEdgeClick?: (info: EdgeClickInfo) => void;
+}) {
+  const boxRef = useRef<HTMLDivElement>(null);
+  const cyRef = useRef<Core | null>(null);
+  const [hover, setHover] = useState<HoverInfo | null>(null);
+  const [edgeHover, setEdgeHover] = useState<{ count: number } | null>(null);
+
+  useEffect(() => {
+    ensureDagre();
+    const box = boxRef.current;
+    if (!box) return;
+
+    const dark = document.documentElement.dataset.theme === "dark";
+    const colorCache = new Map<string, string>();
+
+    const shortById = new Map(data.nodes.map((n) => [n.id, n.short]));
+    const elements: ElementDefinition[] = [
+      ...data.nodes.map((n) => ({
+        data: {
+          id: n.id,
+          short: n.short,
+          flabel: n.label, // full unified_name, used to refocus
+          file: n.file,
+          line: n.line,
+          kind: n.kind,
+          accent: colorFor(n.file, colorCache),
+          root: n.is_root ? 1 : 0,
+          external: n.external ? 1 : 0,
+        },
+      })),
+      ...data.edges
+        .filter((e) => e.source && e.target)
+        .map((e, i) => {
+          const anchors = e.anchors || [];
+          return {
+            data: {
+              id: `e${i}`,
+              source: e.source,
+              target: e.target,
+              anchors,
+              hasAnchor: anchors.length ? 1 : 0,
+              srcShort: shortById.get(e.source) || "",
+              tgtShort: shortById.get(e.target) || "",
+            },
+          };
+        }),
+    ];
+
+    const nodeText = dark ? "#e6e6e6" : "#1f2937";
+    const nodeBg = dark ? "#1b1d21" : "#ffffff";
+    const edgeColor = dark ? "#4b5159" : "#c9ccd1";
+
+    const cy = cytoscape({
+      container: box,
+      elements,
+      wheelSensitivity: 0.2,
+      minZoom: 0.2,
+      maxZoom: 2.5,
+      style: [
+        {
+          selector: "node",
+          style: {
+            shape: "round-rectangle",
+            "background-color": nodeBg,
+            "border-width": 2,
+            "border-color": "data(accent)",
+            label: "data(short)",
+            color: nodeText,
+            "font-size": 12,
+            "font-family": "var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif",
+            "text-valign": "center",
+            "text-halign": "center",
+            "text-wrap": "wrap",
+            "text-max-width": "180px",
+            width: "label",
+            height: "label",
+            padding: "8px",
+            "transition-property": "border-width, background-color",
+            "transition-duration": 120,
+          },
+        },
+        {
+          selector: "node[root = 1]",
+          style: {
+            "background-color": "#2d7ff9",
+            "border-color": "#1b5fd0",
+            color: "#ffffff",
+            "font-weight": 600,
+          },
+        },
+        {
+          selector: "node[external = 1]",
+          style: {
+            "border-style": "dashed",
+            "border-color": dark ? "#4b5159" : "#b3b8c0",
+            color: dark ? "#8b9099" : "#9099a3",
+            "font-style": "italic",
+          },
+        },
+        {
+          selector: "node.hl",
+          style: { "border-width": 4 },
+        },
+        {
+          selector: "node.faded",
+          style: { opacity: 0.25 },
+        },
+        {
+          selector: "edge",
+          style: {
+            width: 1.5,
+            "line-color": edgeColor,
+            "target-arrow-color": edgeColor,
+            "target-arrow-shape": "triangle",
+            "arrow-scale": 0.9,
+            "curve-style": "bezier",
+            opacity: 0.8,
+          },
+        },
+        {
+          selector: "edge.hl",
+          style: { "line-color": "#2d7ff9", "target-arrow-color": "#2d7ff9", width: 2.5, opacity: 1 },
+        },
+        {
+          selector: "edge.faded",
+          style: { opacity: 0.12 },
+        },
+      ],
+    });
+    cyRef.current = cy;
+    // Test/e2e seam (dev only): expose the instance on the container so
+    // screenshot scripts can drive interactions.
+    if (process.env.NODE_ENV !== "production") {
+      (box as unknown as { __cy?: Core }).__cy = cy;
+    }
+
+    cy.layout({
+      name: "dagre",
+      rankDir: "LR",
+      nodeSep: 24,
+      rankSep: 58,
+      edgeSep: 10,
+      fit: true,
+      padding: 26,
+      stop: () => {
+        // A wide left→right call graph fitted to the box shrinks nodes to
+        // illegibility. Clamp the zoom to a readable band and re-centre; the
+        // user pans/zooms from there.
+        const z = cy.zoom();
+        if (z < 0.62) cy.zoom(0.62);
+        else if (z > 1.3) cy.zoom(1.3);
+        cy.center();
+      },
+    } as any).run();
+
+    // Hover: highlight the node + its incident edges/neighbours, show file:line.
+    cy.on("mouseover", "node", (evt) => {
+      const n = evt.target;
+      box.style.cursor = "pointer";
+      const nbr = n.closedNeighborhood();
+      cy.elements().not(nbr).addClass("faded");
+      nbr.removeClass("faded");
+      n.addClass("hl");
+      n.connectedEdges().addClass("hl");
+      setHover({ short: n.data("short"), file: n.data("file"), line: n.data("line"), kind: n.data("kind") });
+    });
+    cy.on("mouseout", "node", () => {
+      box.style.cursor = "";
+      cy.elements().removeClass("faded hl");
+      setHover(null);
+    });
+    // Click a node → inspect its definition source (parent opens the peek,
+    // which also offers "Focus here" to re-root the map).
+    cy.on("tap", "node", (evt) => {
+      const d = evt.target.data();
+      onNodeClick?.({
+        label: d.flabel,
+        short: d.short,
+        file: d.file ?? null,
+        line: d.line ?? null,
+        kind: d.kind,
+        external: d.external === 1,
+      });
+    });
+
+    // Edge hover: spotlight the call relationship + show its call-site count.
+    cy.on("mouseover", "edge", (evt) => {
+      const e = evt.target;
+      box.style.cursor = e.data("hasAnchor") ? "pointer" : "default";
+      const nbr = e.connectedNodes().union(e);
+      cy.elements().not(nbr).addClass("faded");
+      nbr.removeClass("faded");
+      e.addClass("hl");
+      setEdgeHover({ count: (e.data("anchors") || []).length });
+    });
+    cy.on("mouseout", "edge", () => {
+      box.style.cursor = "";
+      cy.elements().removeClass("faded hl");
+      setEdgeHover(null);
+    });
+    // Click an edge → open its exact LSP/SCIP call site(s) in source.
+    cy.on("tap", "edge", (evt) => {
+      const d = evt.target.data();
+      if (d.anchors?.length && onEdgeClick) {
+        onEdgeClick({ anchors: d.anchors, srcLabel: d.srcShort, tgtLabel: d.tgtShort });
+      }
+    });
+
+    return () => {
+      cy.destroy();
+      cyRef.current = null;
+    };
+  }, [data, onNodeClick, onEdgeClick]);
+
+  return (
+    <div className="codegraph">
+      <div className="codegraph-canvas" ref={boxRef} aria-label="dependency graph" />
+      <div className="codegraph-bar mono">
+        {edgeHover ? (
+          <span>
+            <b>
+              {edgeHover.count} call site{edgeHover.count === 1 ? "" : "s"}
+            </b>
+            <span className="muted"> — click the edge to open the exact reference line</span>
+          </span>
+        ) : hover ? (
+          <span>
+            <b>{hover.short}</b>
+            {hover.file ? ` — ${hover.file}${hover.line ? `:${hover.line}` : ""}` : ""}
+            <span className="codegraph-kind">{hover.kind}</span>
+          </span>
+        ) : (
+          <span className="muted">
+            Click an edge → its call site · click a node → its definition · scroll to zoom · drag to pan
+          </span>
+        )}
+        <button type="button" className="codegraph-fit" onClick={() => cyRef.current?.fit(undefined, 24)}>
+          Fit
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/components/CodeGraph.tsx
+++ b/web/components/CodeGraph.tsx
@@ -73,6 +73,16 @@ export default function CodeGraph({
   const [hover, setHover] = useState<HoverInfo | null>(null);
   const [edgeHover, setEdgeHover] = useState<{ count: number } | null>(null);
 
+  // Keep the click callbacks in refs so the cytoscape instance is built once
+  // per `data` and is NOT torn down/rebuilt when a parent re-render hands us new
+  // handler identities (e.g. opening the source peek) — that would reset zoom/pan.
+  const onNodeClickRef = useRef(onNodeClick);
+  const onEdgeClickRef = useRef(onEdgeClick);
+  useEffect(() => {
+    onNodeClickRef.current = onNodeClick;
+    onEdgeClickRef.current = onEdgeClick;
+  });
+
   useEffect(() => {
     ensureDagre();
     const box = boxRef.current;
@@ -241,7 +251,7 @@ export default function CodeGraph({
     // which also offers "Focus here" to re-root the map).
     cy.on("tap", "node", (evt) => {
       const d = evt.target.data();
-      onNodeClick?.({
+      onNodeClickRef.current?.({
         label: d.flabel,
         short: d.short,
         file: d.file ?? null,
@@ -269,8 +279,8 @@ export default function CodeGraph({
     // Click an edge → open its exact LSP/SCIP call site(s) in source.
     cy.on("tap", "edge", (evt) => {
       const d = evt.target.data();
-      if (d.anchors?.length && onEdgeClick) {
-        onEdgeClick({ anchors: d.anchors, srcLabel: d.srcShort, tgtLabel: d.tgtShort });
+      if (d.anchors?.length) {
+        onEdgeClickRef.current?.({ anchors: d.anchors, srcLabel: d.srcShort, tgtLabel: d.tgtShort });
       }
     });
 
@@ -278,7 +288,7 @@ export default function CodeGraph({
       cy.destroy();
       cyRef.current = null;
     };
-  }, [data, onNodeClick, onEdgeClick]);
+  }, [data]); // build once per graph; callbacks come through refs (see above)
 
   return (
     <div className="codegraph">

--- a/web/components/Codemap.tsx
+++ b/web/components/Codemap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Mermaid from "@/components/Mermaid";
+import GraphView from "@/components/GraphView";
 import { fetchCodemap, type CodemapResponse } from "@/lib/api";
 
 type Direction = "both" | "callees" | "callers";
@@ -9,16 +9,30 @@ type Direction = "both" | "callees" | "callers";
 /**
  * Codemap mode: an interactive dependency (call-graph) map for the repo.
  * Walks reference edges out from a focus symbol (or the repo's busiest symbol
- * by default) and renders them with the shared Mermaid component. Clicking a
- * symbol chip refocuses the map on it.
+ * by default) and renders them via the shared GraphView (Cytoscape graph +
+ * source peek). A chip — or "Focus here" in a node's peek — re-roots the map.
  */
-export default function Codemap({ repoId }: { repoId: string }) {
-  const [symbol, setSymbol] = useState("");
-  const [query, setQuery] = useState(""); // last submitted focus symbol
+export default function Codemap({
+  repoId,
+  initialSymbol,
+}: {
+  repoId: string;
+  initialSymbol?: string;
+}) {
+  const [symbol, setSymbol] = useState(initialSymbol ?? "");
+  const [query, setQuery] = useState(initialSymbol ?? ""); // last submitted focus symbol
   const [direction, setDirection] = useState<Direction>("both");
   const [data, setData] = useState<CodemapResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  // Re-seed when an external focus arrives (e.g. "explore in graph" from a wiki page).
+  useEffect(() => {
+    if (initialSymbol) {
+      setSymbol(initialSymbol);
+      setQuery(initialSymbol);
+    }
+  }, [initialSymbol]);
 
   useEffect(() => {
     let cancelled = false;
@@ -81,10 +95,7 @@ export default function Codemap({ repoId }: { repoId: string }) {
             {data.truncated ? " · truncated" : ""}
           </div>
           {data.note && <p className="muted small">{data.note}</p>}
-          <Mermaid chart={data.mermaid} />
-          <p className="muted small">
-            Reference (call) edges. Click a symbol to refocus the map.
-          </p>
+          <GraphView repoId={repoId} data={data} onFocus={focus} />
           <div className="codemap-nodes">
             {data.nodes.map((n) => (
               <button

--- a/web/components/GraphView.tsx
+++ b/web/components/GraphView.tsx
@@ -1,9 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import CodeGraph, { type EdgeClickInfo, type GraphNodeInfo } from "@/components/CodeGraph";
+import dynamic from "next/dynamic";
+import type { EdgeClickInfo, GraphNodeInfo } from "@/components/CodeGraph";
 import HighlightedCode from "@/components/HighlightedCode";
 import { fetchSource, repoRelative, type CallSite, type CodemapResponse } from "@/lib/api";
+
+// Cytoscape + dagre (~3MB) load only when a graph is shown, so the wiki
+// narrative paints first and the graph fills in a beat later.
+const CodeGraph = dynamic(() => import("@/components/CodeGraph"), {
+  ssr: false,
+  loading: () => (
+    <div className="codegraph">
+      <div className="codegraph-canvas codegraph-loading">Loading graph…</div>
+    </div>
+  ),
+});
 
 // What a source peek is showing: an edge's exact call site(s), or a node's
 // definition. Both resolve to a (file, line) the /source endpoint can open.

--- a/web/components/GraphView.tsx
+++ b/web/components/GraphView.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import CodeGraph, { type EdgeClickInfo, type GraphNodeInfo } from "@/components/CodeGraph";
+import HighlightedCode from "@/components/HighlightedCode";
+import { fetchSource, repoRelative, type CallSite, type CodemapResponse } from "@/lib/api";
+
+// What a source peek is showing: an edge's exact call site(s), or a node's
+// definition. Both resolve to a (file, line) the /source endpoint can open.
+type PeekSource = ({ kind: "edge" } & EdgeClickInfo) | { kind: "node"; node: GraphNodeInfo };
+
+/**
+ * Source peek grounded in the LSP/SCIP index — the payoff of the graph:
+ *  - edge → the exact line(s) where the call happens (pager for multiple sites);
+ *  - node → the symbol's definition, with an optional "Focus here" shortcut.
+ * Either way the precise line is spotlighted; nothing here is a guess.
+ */
+function SourcePeek({
+  repoId,
+  source,
+  onClose,
+  onFocus,
+}: {
+  repoId: string;
+  source: PeekSource;
+  onClose: () => void;
+  onFocus?: (label: string) => void;
+}) {
+  const isNode = source.kind === "node";
+  const sites: CallSite[] = isNode
+    ? [{ file: source.node.file || "", line: source.node.line }]
+    : source.anchors;
+
+  const [idx, setIdx] = useState(0);
+  const [code, setCode] = useState("");
+  const [start, setStart] = useState(1);
+  const [state, setState] = useState<"loading" | "ok" | "err">("loading");
+
+  const site = sites[Math.min(idx, sites.length - 1)] || sites[0];
+  const rel = repoRelative(site.file);
+  const line = site.line ?? 1;
+  const isExternal = source.kind === "node" && !!source.node.external;
+
+  useEffect(() => {
+    if (isExternal) return; // external dep — no in-repo source to fetch
+    let cancelled = false;
+    setState("loading");
+    // Nodes show their definition from its first line; call sites get context above.
+    const before = isNode ? 0 : 6;
+    const after = isNode ? 16 : 6;
+    fetchSource(repoId, rel, Math.max(1, line - before), line + after)
+      .then((s) => {
+        if (cancelled) return;
+        setCode(s.content || "");
+        setStart(s.start_line || Math.max(1, line - before));
+        setState("ok");
+      })
+      .catch(() => !cancelled && setState("err"));
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId, rel, line, isNode, isExternal]);
+
+  return (
+    <div className="callsite-peek">
+      <div className="callsite-head mono">
+        {source.kind === "edge" ? (
+          <span className="callsite-title">
+            <b>{source.srcLabel}</b> <span className="callsite-arrow">→</span> <b>{source.tgtLabel}</b>
+          </span>
+        ) : (
+          <span className="callsite-title">
+            <span className="callsite-kindtag">{source.node.kind}</span> <b>{source.node.short}</b>
+          </span>
+        )}
+        <span className="callsite-loc">{isExternal ? "external dependency" : `${rel}:${line}`}</span>
+        {source.kind === "edge" && sites.length > 1 && (
+          <span className="callsite-pager">
+            {sites.length} call sites:
+            {sites.map((a, i) => (
+              <button
+                key={i}
+                type="button"
+                className={i === idx ? "on" : ""}
+                onClick={() => setIdx(i)}
+                title={`${repoRelative(a.file)}:${a.line}`}
+              >
+                {a.line}
+              </button>
+            ))}
+          </span>
+        )}
+        {source.kind === "node" && onFocus && (
+          <button
+            type="button"
+            className="callsite-focus"
+            onClick={() => onFocus(source.node.label)}
+            title="Re-root the graph on this symbol"
+          >
+            ⟳ Focus here
+          </button>
+        )}
+        <button type="button" className="callsite-close" onClick={onClose} aria-label="Close">
+          ×
+        </button>
+      </div>
+      {isExternal ? (
+        <p className="muted callsite-msg">
+          External symbol — its definition lives outside this repository, so there&apos;s no source to show.
+          Use “Focus here” to see where this repo references it.
+        </p>
+      ) : state === "loading" ? (
+        <p className="muted callsite-msg">Loading source…</p>
+      ) : state === "err" ? (
+        <p className="muted callsite-msg">Source not available.</p>
+      ) : (
+        <HighlightedCode code={code} file={rel} startLine={start} highlightLine={line} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Reusable interactive graph + source peek. Used both by the codemap mode and
+ * by wiki pages (rendered as a view over the graph). `onFocus` (optional) wires
+ * the node peek's "Focus here" — omit it on surfaces that can't re-root.
+ */
+export default function GraphView({
+  repoId,
+  data,
+  onFocus,
+}: {
+  repoId: string;
+  data: CodemapResponse;
+  onFocus?: (label: string) => void;
+}) {
+  const [peek, setPeek] = useState<PeekSource | null>(null);
+  useEffect(() => setPeek(null), [data]); // a fresh graph invalidates the open peek
+
+  return (
+    <>
+      <CodeGraph
+        data={data}
+        onNodeClick={(node) => setPeek({ kind: "node", node })}
+        onEdgeClick={(info) => setPeek({ kind: "edge", ...info })}
+      />
+      {peek && (
+        <SourcePeek
+          key={peek.kind === "node" ? `node:${peek.node.label}` : `${peek.srcLabel}->${peek.tgtLabel}`}
+          repoId={repoId}
+          source={peek}
+          onClose={() => setPeek(null)}
+          onFocus={onFocus}
+        />
+      )}
+    </>
+  );
+}

--- a/web/components/HighlightedCode.tsx
+++ b/web/components/HighlightedCode.tsx
@@ -33,10 +33,13 @@ export default function HighlightedCode({
   code,
   file,
   startLine = 1,
+  highlightLine,
 }: {
   code: string;
   file?: string | null;
   startLine?: number;
+  /** 1-based absolute line to spotlight (e.g. an exact call site). */
+  highlightLine?: number | null;
 }) {
   const ext = (file || "").split(".").pop()?.toLowerCase() || "";
   const lang = EXT_LANG[ext];
@@ -49,12 +52,26 @@ export default function HighlightedCode({
     html = code.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]!);
   }
   const lineCount = code ? code.split("\n").length : 0;
+  const hlIdx =
+    highlightLine != null && highlightLine >= startLine && highlightLine < startLine + lineCount
+      ? highlightLine - startLine
+      : -1;
+  const LINE_H = 19.375; // 12.5px × 1.55 — matches the gutter & code line-height
 
   return (
     <div className="hl-code">
+      {hlIdx >= 0 && (
+        <div
+          className="hl-band"
+          style={{ top: `${10 + hlIdx * LINE_H}px`, height: `${LINE_H}px` }}
+          aria-hidden
+        />
+      )}
       <div className="hl-gutter" aria-hidden>
         {Array.from({ length: lineCount }, (_, i) => (
-          <div key={i}>{startLine + i}</div>
+          <div key={i} className={i === hlIdx ? "hl-gutter-on" : undefined}>
+            {startLine + i}
+          </div>
         ))}
       </div>
       <pre className="hl-pre">

--- a/web/components/Markdown.tsx
+++ b/web/components/Markdown.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
+import dynamic from "next/dynamic";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import rehypeHighlight from "rehype-highlight";
 import "highlight.js/styles/github.css";
-import Mermaid from "./Mermaid";
+
+// Mermaid (~1MB) is only needed when a diagram actually appears; load it on
+// demand so it never weighs down pages that have none (wiki strips diagrams).
+const Mermaid = dynamic(() => import("./Mermaid"), { ssr: false });
 
 // Recursively collect plain text from React children (to recover raw code).
 function nodeText(n: ReactNode): string {

--- a/web/components/Markdown.tsx
+++ b/web/components/Markdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useState, type ReactElement, type ReactNode } from "react";
 import dynamic from "next/dynamic";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -55,10 +55,10 @@ export default function Markdown({ children }: { children: string }) {
         rehypePlugins={[rehypeSlug, [rehypeHighlight, { ignoreMissing: true }]]}
         components={{
           pre({ children }) {
-            const codeEl = Array.isArray(children) ? children[0] : children;
-            // @ts-expect-error - element prop access
-            const className: string = codeEl?.props?.className || "";
-            // @ts-expect-error - element prop access
+            const codeEl = (Array.isArray(children) ? children[0] : children) as
+              | ReactElement<{ className?: string; children?: ReactNode }>
+              | undefined;
+            const className = codeEl?.props?.className || "";
             const text = nodeText(codeEl?.props?.children);
             if (/language-mermaid/.test(className)) {
               return <Mermaid chart={text} />;

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -138,11 +138,20 @@ export interface CodemapNode {
   kind: string;
   depth: number;
   is_root: boolean;
+  external?: boolean; // no openable in-repo source (external dep / file node)
+}
+
+export interface CallSite {
+  file: string;
+  line: number | null;
 }
 
 export interface CodemapEdge {
   source: string;
   target: string;
+  // Exact LSP/SCIP reference (call) site(s) for this edge — the caller file +
+  // line where the call happens. Lets the UI jump an edge to its source.
+  anchors?: CallSite[];
 }
 
 export interface CodemapResponse {
@@ -172,5 +181,15 @@ export async function fetchCodemap(
     `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/codemap${qs ? `?${qs}` : ""}`
   );
   if (!res.ok) throw new Error(`Failed to load codemap (${res.status})`);
+  return res.json();
+}
+
+// Induced dependency subgraph over a wiki page's cited symbols — lets a wiki
+// page render as a view over the graph.
+export async function fetchWikiGraph(repoId: string, pageId: string): Promise<CodemapResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}/graph`
+  );
+  if (!res.ok) throw new Error(`Failed to load page graph (${res.status})`);
   return res.json();
 }

--- a/web/loopshot.mjs
+++ b/web/loopshot.mjs
@@ -1,0 +1,117 @@
+// Loop screenshot helper — capture a repo page in a given mode (wiki|codemap).
+// Usage: node loopshot.mjs <repoId> <mode> <outName> [width=1440] [height=1000]
+// Writes ../verification/<outName>.png and prints a JSON report.
+// Run from inside web/ (resolves playwright from web/node_modules).
+import { chromium } from "playwright";
+
+const [, , repoId, mode = "wiki", outName = "shot", w = "1440", h = "1000"] = process.argv;
+const base = process.env.WEB_BASE || "http://127.0.0.1:3000";
+const url = `${base}/${encodeURIComponent(repoId)}`;
+const out = `../verification/${outName}.png`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: +w, height: +h } });
+if (process.env.THEME === "dark") {
+  await page.addInitScript(() => localStorage.setItem("cm-theme", "dark"));
+}
+const consoleErrors = [];
+const pageErrors = [];
+page.on("console", (m) => m.type() === "error" && consoleErrors.push(m.text()));
+page.on("pageerror", (e) => pageErrors.push(String(e)));
+
+const report = { url, mode, outPath: out, repoId };
+try {
+  const resp = await page.goto(url, { waitUntil: "networkidle", timeout: 30000 });
+  report.httpStatus = resp ? resp.status() : null;
+
+  if (mode === "codemap") {
+    // Click the graph/codemap mode tab (labeled "Graph"; role=tab in .wiki-modeswitch).
+    const tab = page.locator('.mode-tab', { hasText: /graph|codemap/i });
+    if (await tab.count()) {
+      await tab.first().click();
+      // Wait for the dependency graph (mermaid svg) or the "no codemap" message.
+      await page
+        .waitForSelector(".codemap .mermaid-diagram svg, .codemap .muted", { timeout: 20000 })
+        .catch(() => {});
+      report.hasGraphSvg = (await page.locator(".codemap .mermaid-diagram svg").count()) > 0;
+      report.codemapMeta = (await page.locator(".codemap-meta").first().textContent().catch(() => null)) || null;
+      report.chipCount = await page.locator(".codemap-chip").count();
+    } else {
+      report.codemapTab = "absent (capabilities.codemap false)";
+    }
+  } else {
+    await page.waitForSelector(".wiki-content, .markdown, article", { timeout: 15000 }).catch(() => {});
+  }
+
+  await page.waitForTimeout(1500); // let layout settle
+
+  if (process.env.CLICK_EDGE && mode === "codemap") {
+    // Drive a real cytoscape edge tap via the test seam, then peek the call site.
+    const clicked = await page.evaluate(() => {
+      const el = document.querySelector(".codegraph-canvas");
+      const cy = el && el.__cy;
+      if (!cy) return "no-cy";
+      const anchored = cy.edges().filter((e) => e.data("hasAnchor") === 1);
+      // Prefer the edge with the most call sites so the multi-site pager shows.
+      let edge = anchored[0] || cy.edges()[0];
+      anchored.forEach((e) => {
+        if ((e.data("anchors") || []).length > (edge.data("anchors") || []).length) edge = e;
+      });
+      if (!edge) return "no-edge";
+      edge.emit("tap");
+      return `${edge.data("srcShort")} -> ${edge.data("tgtShort")} (${(edge.data("anchors") || []).length} sites)`;
+    });
+    report.clickedEdge = clicked;
+    await page.waitForSelector(".callsite-peek .hl-code, .callsite-peek .callsite-msg", { timeout: 12000 }).catch(() => {});
+    await page.waitForTimeout(700);
+    report.peekLoc = (await page.locator(".callsite-loc").first().textContent().catch(() => null)) || null;
+    report.hasBand = (await page.locator(".callsite-peek .hl-band").count()) > 0;
+  }
+
+  if (process.env.CLICK_NODE && mode === "codemap") {
+    // Tap a node → its definition source peek.
+    const clicked = await page.evaluate(() => {
+      const el = document.querySelector(".codegraph-canvas");
+      const cy = el && el.__cy;
+      if (!cy) return "no-cy";
+      const node = cy.nodes().filter((n) => n.data("root") !== 1)[0] || cy.nodes()[0];
+      if (!node) return "no-node";
+      node.emit("tap");
+      return node.data("short");
+    });
+    report.clickedNode = clicked;
+    await page.waitForSelector(".callsite-peek .hl-code, .callsite-peek .callsite-msg", { timeout: 12000 }).catch(() => {});
+    await page.waitForTimeout(700);
+    report.peekLoc = (await page.locator(".callsite-loc").first().textContent().catch(() => null)) || null;
+    report.hasFocusBtn = (await page.locator(".callsite-focus").count()) > 0;
+  }
+
+  if (process.env.CLICK && mode === "codemap") {
+    // Click the Nth symbol chip to verify the refocus path (shared with node clicks).
+    const chips = page.locator(".codemap-chip");
+    const idx = Math.min(+process.env.CLICK, (await chips.count()) - 1);
+    report.clickedChip = await chips.nth(idx).textContent().catch(() => null);
+    await chips.nth(idx).click();
+    await page.waitForSelector(".codegraph-canvas", { timeout: 15000 }).catch(() => {});
+    await page.waitForTimeout(2000);
+    report.metaAfterClick = (await page.locator(".codemap-meta").first().textContent().catch(() => null)) || null;
+  }
+  report.horizontalScroll = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth
+  );
+  if (process.env.CLIP) {
+    const el = page.locator(process.env.CLIP).first();
+    await el.screenshot({ path: out }).catch(async () => {
+      await page.screenshot({ path: out, fullPage: true });
+    });
+  } else {
+    await page.screenshot({ path: out, fullPage: true });
+  }
+} catch (e) {
+  report.error = String(e);
+} finally {
+  report.consoleErrors = consoleErrors.slice(0, 10);
+  report.pageErrors = pageErrors.slice(0, 10);
+  await browser.close();
+}
+console.log(JSON.stringify(report, null, 2));

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "codeminer-qa-demo",
       "version": "0.1.0",
       "dependencies": {
+        "cytoscape": "^3.33.4",
+        "cytoscape-dagre": "^2.5.0",
+        "dagre": "^0.8.5",
         "geist": "^1.7.1",
         "highlight.js": "^11.11.1",
         "mermaid": "^11.15.0",
@@ -770,6 +773,18 @@
         "cytoscape": "^3.2.0"
       }
     },
+    "node_modules/cytoscape-dagre": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.5.0.tgz",
+      "integrity": "sha512-VG2Knemmshop4kh5fpLO27rYcyUaaDkRw+6PiX4bstpB+QFt0p2oauMrsjVbUamGWQ6YNavh7x2em2uZlzV44g==",
+      "license": "MIT",
+      "dependencies": {
+        "dagre": "^0.8.5"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.22"
+      }
+    },
     "node_modules/cytoscape-fcose": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
@@ -1238,6 +1253,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/dagre-d3-es": {
       "version": "7.0.14",
       "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
@@ -1397,6 +1422,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/hachure-fill": {
       "version": "0.5.2",
@@ -1651,6 +1685,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "cytoscape": "^3.33.4",
+    "cytoscape-dagre": "^2.5.0",
+    "dagre": "^0.8.5",
     "geist": "^1.7.1",
     "highlight.js": "^11.11.1",
     "mermaid": "^11.15.0",

--- a/web/types/cytoscape-dagre.d.ts
+++ b/web/types/cytoscape-dagre.d.ts
@@ -1,0 +1,7 @@
+// cytoscape-dagre ships no type declarations; it's a cytoscape layout plugin
+// registered via cytoscape.use(). A module shim is enough for our usage.
+declare module "cytoscape-dagre" {
+  import type { Ext } from "cytoscape";
+  const ext: Ext;
+  export default ext;
+}


### PR DESCRIPTION
## Summary

Overhaul the web demo's graph into an interactive, LSP/SCIP-grounded code map and make it the product's spine: every node and edge is clickable to real source. Wiki pages are reframed as views over that graph, the UI is modernized, and page-load latency is fixed. The differentiator versus DeepWiki (prose) and GitNexus (tree-sitter heuristics) is **compiler-precise edge provenance** — click an edge to jump to the exact call site.

## Changes

- **Interactive graph**: replace the Mermaid auto-layout codemap with Cytoscape + dagre (per-file colour, zoom/pan, hover spotlight, light/dark). `web/components/CodeGraph.tsx`, `GraphView.tsx`.
- **Click-to-source (the differentiator)**: thread the reference-site anchor end-to-end (`graph/traverse_graph.py:get_neighbors` → `web/codemap.py`, additive) so clicking an edge opens the exact call line(s) with a multi-site pager, and a node opens its definition. External / locationless symbols are marked instead of showing a misleading "source not available".
- **Wiki = graph view**: `build_page_subgraph` + `GET /api/repos/{id}/wiki/{page_id}/graph` induce an anchored subsystem subgraph rendered atop each wiki page; "Focus here" cross-links into the full graph (`Codemap` gained an `initialSymbol`).
- **Wiki generation**: hierarchical, DeepWiki-style outline (8–14 pages, subsystems get children) in `wiki/outline.py`; "Relevant source files" link to GitHub at the indexed commit.
- **UI / layout**: wiki-first tab order, drop the redundant generated Architecture diagram + block code-references, move "Last indexed" into the sidebar, modern radius scale (de-pill the controls), centred-with-gutter layout, larger and cohesive nav rails.
- **Performance**: lazy-load Mermaid (~1MB of dead weight) and Cytoscape via `next/dynamic`; document the wiki disk cache location and a pre-warm step.
- **Docs**: `.claude/guides/frontend-loop.md` (run / screenshot / cache playbook) and `.claude/design/graph-frontend-direction.md` (differentiation thesis + roadmap).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

Backend graph/web/wiki unit tests pass locally — 196 passed, 32 skipped — via `pytest test/graph test/web test/wiki -m "not slow and not integration"`. The backend graph change is additive (extra keys on the edge meta), so existing graph consumers are unaffected. Frontend verified with Playwright across Go/Python/Rust/TS: edge → exact call line (e.g. caddy `Handler.UnmarshalCaddyfile` at `caddyfile.go:220`), node → definition, the wiki subsystem map and the wiki→graph jump; `tsc --noEmit` is clean for the changed files. The web demo already lives on `main` (merged via #166/#167), so no extra setup is needed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
