### PR TITLE
feat(dataset): add CodeMiner synthesis traversal pipeline

### DIFF
--- a/codeminer/dataset/__init__.py
+++ b/codeminer/dataset/__init__.py
@@ -4,6 +4,7 @@
 
 from .base import DatasetBase
 from .codeminer_base import CodeMinerBaseDataset
+from .codeminer_synthesis import CodeMinerSynthesisDataset
 from .local_json import LocalJsonDataset
 from .locbench import LocbenchDataset
 from .swebench import SwebenchDataset
@@ -11,6 +12,7 @@ from .swebench_multilingual import SwebenchMultilingualDataset
 
 __all__ = [
     "CodeMinerBaseDataset",
+    "CodeMinerSynthesisDataset",
     "DatasetBase",
     "LocalJsonDataset",
     "LocbenchDataset",

--- a/codeminer/dataset/codeminer_synthesis.py
+++ b/codeminer/dataset/codeminer_synthesis.py
@@ -1,0 +1,540 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dataset wrapper and quality checks for ``sysevol-ai/codeminer-synthesis``."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Union
+
+import datasets
+from datasets import Features, Value
+
+from ..log_utils import get_logger
+from .base import DatasetBase
+
+logger = get_logger(__name__)
+
+
+DEFAULT_DATASET = "sysevol-ai/codeminer-synthesis"
+DEFAULT_SPLIT = "test"
+ALL_CONFIGS = ("C++_C", "Go", "Python", "Rust", "TypeScript_JavaScript")
+
+CONFIG_LANGUAGE_GROUP = {
+    "C++_C": "C++/C",
+    "Go": "Go",
+    "Python": "Python",
+    "Rust": "Rust",
+    "TypeScript_JavaScript": "TypeScript/JavaScript",
+}
+
+LANGUAGE_EXTENSIONS = {
+    "C++/C": {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"},
+    "Go": {".go"},
+    "Python": {".py", ".pyi", ".pyx"},
+    "Rust": {".rs"},
+    "TypeScript/JavaScript": {".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"},
+}
+
+EXPECTED_BASE_CATEGORY_COUNTS = {
+    "behavioral": 20,
+    "module_hint": 10,
+    "file_hint": 10,
+    "symbol_hint": 5,
+    "reasoning": 5,
+}
+
+EXPECTED_TRAVERSAL_COUNT = 10
+EXPECTED_CATEGORY_COUNTS_WITH_TRAVERSAL = {
+    **EXPECTED_BASE_CATEGORY_COUNTS,
+    "traversal": EXPECTED_TRAVERSAL_COUNT,
+}
+
+
+_SYMBOL_NODE_FEATURE = [
+    {
+        "content": Value("string"),
+        "end_line": Value("int64"),
+        "file": Value("string"),
+        "node_name": Value("string"),
+        "start_line": Value("int64"),
+        "type": Value("string"),
+    }
+]
+
+_CHAIN_METADATA_FEATURE = {
+    "anchor_indices": [Value("int64")],
+    "anchor_symbols": [Value("string")],
+    "anti_grep_leaks_at_last_gen": [Value("string")],
+    "chain_length": Value("int64"),
+    "direction": Value("string"),
+    "hidden_indices": [Value("int64")],
+    "hidden_symbols": [Value("string")],
+    "hop_count": Value("int64"),
+    "spans_files": [Value("string")],
+    "spans_n_files": Value("int64"),
+    "stance": Value("string"),
+}
+
+SYNTHESIS_FEATURES = Features(
+    {
+        "repo": Value("string"),
+        "instance_id": Value("string"),
+        "base_commit": Value("string"),
+        "query": Value("string"),
+        "problem_statement": Value("string"),
+        "category": Value("string"),
+        "gt_symbols": [Value("string")],
+        "gt_symbol_nodes": _SYMBOL_NODE_FEATURE,
+        "gt_files": [Value("string")],
+        "query_id": Value("string"),
+        "length_variant": Value("string"),
+        "judge_verdict": Value("string"),
+        "judge_reason": Value("string"),
+        "chain_metadata": _CHAIN_METADATA_FEATURE,
+        "language_group": Value("string"),
+        "source_config": Value("string"),
+        "gt_code_blocks_count": Value("int64"),
+    }
+)
+
+
+def parse_config_list(configs: Optional[Union[str, Sequence[str]]]) -> List[str]:
+    """Normalize a config selector into concrete HF config names."""
+
+    if configs is None:
+        return list(ALL_CONFIGS)
+    if isinstance(configs, str):
+        raw = [part.strip() for part in configs.split(",") if part.strip()]
+    else:
+        raw = [str(part).strip() for part in configs if str(part).strip()]
+    if not raw or any(part.lower() == "all" for part in raw):
+        return list(ALL_CONFIGS)
+    unknown = [name for name in raw if name not in ALL_CONFIGS]
+    if unknown:
+        raise ValueError(
+            f"Unknown CodeMiner synthesis config(s): {unknown}. "
+            f"Valid configs: {', '.join(ALL_CONFIGS)}"
+        )
+    return raw
+
+
+def language_group_for_config(config_name: str) -> str:
+    """Return the canonical ``language_group`` label for a HF config."""
+
+    return CONFIG_LANGUAGE_GROUP.get(config_name, config_name.replace("_", "/"))
+
+
+def expected_extensions_for_language(language_group: str) -> set[str]:
+    """Return accepted source extensions for a ``language_group`` label."""
+
+    if language_group in LANGUAGE_EXTENSIONS:
+        return set(LANGUAGE_EXTENSIONS[language_group])
+    text = (language_group or "").lower()
+    for label, extensions in LANGUAGE_EXTENSIONS.items():
+        label_text = label.lower()
+        if label_text == text or any(part in text for part in label_text.split("/")):
+            return set(extensions)
+    return set()
+
+
+def normalize_synthesis_record(
+    row: Mapping[str, Any], config_name: str
+) -> Dict[str, Any]:
+    """Project a HF synthesis row into the common CodeMiner dataset shape."""
+
+    gt_symbol_nodes = []
+    for node in row.get("gt_symbol_nodes") or []:
+        gt_symbol_nodes.append(
+            {
+                "content": node.get("content") or "",
+                "end_line": int(node.get("end_line") or 0),
+                "file": node.get("file") or "",
+                "node_name": node.get("node_name") or "",
+                "start_line": int(node.get("start_line") or 0),
+                "type": node.get("type") or "",
+            }
+        )
+
+    chain_metadata = row.get("chain_metadata")
+    if chain_metadata is not None:
+        chain_metadata = _normalize_chain_metadata(chain_metadata)
+
+    query = row.get("query") or row.get("question") or ""
+    return {
+        "repo": row.get("repo") or "",
+        "instance_id": row.get("instance_id") or "",
+        "base_commit": row.get("base_commit") or "",
+        "query": query,
+        "problem_statement": row.get("problem_statement") or query,
+        "category": row.get("category")
+        or row.get("query_type")
+        or row.get("difficulty")
+        or "",
+        "gt_symbols": list(row.get("gt_symbols") or row.get("target_symbols") or []),
+        "gt_symbol_nodes": gt_symbol_nodes,
+        "gt_files": list(row.get("gt_files") or row.get("target_files") or []),
+        "query_id": row.get("query_id") or row.get("instance_id") or "",
+        "length_variant": row.get("length_variant") or "",
+        "judge_verdict": row.get("judge_verdict") or "",
+        "judge_reason": row.get("judge_reason") or "",
+        "chain_metadata": chain_metadata,
+        "language_group": row.get("language_group")
+        or language_group_for_config(config_name),
+        "source_config": config_name,
+        "gt_code_blocks_count": len(gt_symbol_nodes),
+    }
+
+
+def _normalize_chain_metadata(raw: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "anchor_indices": [int(v) for v in raw.get("anchor_indices") or []],
+        "anchor_symbols": list(raw.get("anchor_symbols") or []),
+        "anti_grep_leaks_at_last_gen": list(
+            raw.get("anti_grep_leaks_at_last_gen") or []
+        ),
+        "chain_length": int(raw.get("chain_length") or 0),
+        "direction": raw.get("direction") or "",
+        "hidden_indices": [int(v) for v in raw.get("hidden_indices") or []],
+        "hidden_symbols": list(raw.get("hidden_symbols") or []),
+        "hop_count": int(raw.get("hop_count") or 0),
+        "spans_files": list(raw.get("spans_files") or []),
+        "spans_n_files": int(raw.get("spans_n_files") or 0),
+        "stance": raw.get("stance") or "",
+    }
+
+
+def gt_file_language_mismatches(row: Mapping[str, Any]) -> List[str]:
+    """Return GT files whose extensions do not match the row language group."""
+
+    expected = expected_extensions_for_language(str(row.get("language_group") or ""))
+    if not expected:
+        return []
+    files = set(row.get("gt_files") or [])
+    for node in row.get("gt_symbol_nodes") or []:
+        file_path = node.get("file") if isinstance(node, Mapping) else None
+        if file_path:
+            files.add(str(file_path))
+    bad = []
+    for file_path in sorted(files):
+        suffix = Path(file_path).suffix.lower()
+        if suffix and suffix not in expected:
+            bad.append(file_path)
+    return bad
+
+
+def validate_synthesis_records(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    expected_category_counts: Optional[Mapping[str, int]] = None,
+    compare_category_distribution: bool = True,
+) -> Dict[str, Any]:
+    """Validate normalized synthesis records and return a structured report."""
+
+    records = list(rows)
+    issues: List[Dict[str, Any]] = []
+    by_config_category: Dict[str, Counter[str]] = {}
+    by_config: Counter[str] = Counter()
+    by_category: Counter[str] = Counter()
+    seen_query_ids: set[str] = set()
+
+    for row in records:
+        source_config = str(row.get("source_config") or "")
+        query_id = str(row.get("query_id") or "")
+        category = str(row.get("category") or "")
+        by_config[source_config] += 1
+        by_category[category] += 1
+        by_config_category.setdefault(source_config, Counter())[category] += 1
+
+        if not query_id:
+            issues.append(_issue("error", "missing_query_id", row))
+        elif query_id in seen_query_ids:
+            issues.append(_issue("error", "duplicate_query_id", row))
+        seen_query_ids.add(query_id)
+
+        for key in ("repo", "instance_id", "base_commit", "query", "category"):
+            if not row.get(key):
+                issues.append(_issue("error", f"missing_{key}", row))
+
+        if not row.get("gt_files") and not row.get("gt_symbols"):
+            issues.append(_issue("error", "empty_ground_truth", row))
+
+        if row.get("judge_verdict") and row.get("judge_verdict") != "valid":
+            issues.append(_issue("warning", "non_valid_judge_verdict", row))
+
+        bad_files = gt_file_language_mismatches(row)
+        if bad_files:
+            item = _issue("error", "gt_file_language_mismatch", row)
+            item["files"] = bad_files
+            item["language_group"] = row.get("language_group")
+            issues.append(item)
+
+    expected_counts = dict(expected_category_counts or {})
+    if expected_counts:
+        for config_name, counter in by_config_category.items():
+            actual = {k: int(counter.get(k, 0)) for k in expected_counts}
+            extras = {k: int(v) for k, v in counter.items() if k not in expected_counts}
+            if actual != expected_counts or extras:
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "code": "category_counts_differ_from_expected",
+                        "source_config": config_name,
+                        "expected": expected_counts,
+                        "actual": dict(sorted(counter.items())),
+                    }
+                )
+
+    if compare_category_distribution and len(by_config_category) > 1:
+        reference_config, reference_counts = sorted(by_config_category.items())[0]
+        for config_name, counter in sorted(by_config_category.items())[1:]:
+            if dict(counter) != dict(reference_counts):
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "code": "category_distribution_mismatch",
+                        "source_config": config_name,
+                        "reference_config": reference_config,
+                        "reference": dict(sorted(reference_counts.items())),
+                        "actual": dict(sorted(counter.items())),
+                    }
+                )
+
+    return {
+        "row_count": len(records),
+        "by_config": dict(sorted(by_config.items())),
+        "by_category": dict(sorted(by_category.items())),
+        "by_config_category": {
+            cfg: dict(sorted(counter.items()))
+            for cfg, counter in sorted(by_config_category.items())
+        },
+        "issues": issues,
+        "error_count": sum(1 for issue in issues if issue["severity"] == "error"),
+        "warning_count": sum(1 for issue in issues if issue["severity"] == "warning"),
+    }
+
+
+def _issue(severity: str, code: str, row: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "severity": severity,
+        "code": code,
+        "query_id": row.get("query_id"),
+        "instance_id": row.get("instance_id"),
+        "source_config": row.get("source_config"),
+        "category": row.get("category"),
+    }
+
+
+class CodeMinerSynthesisDataset(DatasetBase):
+    """Dataset wrapper for synthesized CodeMiner query benchmark rows.
+
+    The public HF dataset is organized by language config. CodeMiner consumers
+    expect each row to carry its own ``language_group`` and
+    ``problem_statement`` fields, so this loader injects them while preserving
+    the source config and synthesized GT columns.
+    """
+
+    simplified_symbols: bool = False
+
+    def __init__(
+        self,
+        dataset: str = DEFAULT_DATASET,
+        split: str = DEFAULT_SPLIT,
+        configs: Optional[Union[str, Sequence[str]]] = None,
+        filter_instance: str = ".*",
+        root: str | None = None,
+        repo_root: str | None = None,
+        log: bool = True,
+        force_reload: bool = False,
+    ) -> None:
+        super().__init__(root=root, log=log, force_reload=force_reload)
+        self.dataset = dataset
+        self.split = split
+        self.configs = parse_config_list(configs)
+        self.filter_instance = filter_instance
+        self.repo_root = (
+            self._resolve_root(repo_root) if repo_root else self.processed_dir
+        )
+        self._data: Optional[datasets.arrow_dataset.Dataset] = None
+
+    def load(
+        self,
+        idx_list: Optional[Sequence[int]] = None,
+        idx_range: Optional[Sequence[int]] = None,
+    ) -> datasets.arrow_dataset.Dataset:
+        data = self._load_dataset()
+        if idx_list is not None and idx_range is not None:
+            raise ValueError("Cannot have both idx_list and idx_range")
+        if idx_list is not None:
+            return data.select(list(idx_list))
+        if idx_range is not None:
+            start_idx, end_idx = idx_range[0], idx_range[1]
+            if start_idx >= end_idx:
+                raise ValueError("start_idx should be smaller than end_idx")
+            return data.select(range(start_idx, end_idx))
+        return data
+
+    def _load_dataset(self) -> datasets.arrow_dataset.Dataset:
+        if self._data is not None and not self.force_reload:
+            return self._data
+
+        records: List[Dict[str, Any]] = []
+        for config_name in self.configs:
+            try:
+                ds = datasets.load_dataset(
+                    self.dataset,
+                    config_name,
+                    split=self.split,
+                    cache_dir=os.path.abspath(os.path.expanduser(self.processed_dir)),
+                )
+            except ValueError as exc:
+                raise ValueError(
+                    f"Failed to load {self.dataset!r} config {config_name!r} "
+                    f"split {self.split!r}. CodeMiner synthesis is expected to "
+                    f"publish benchmark data under split {DEFAULT_SPLIT!r}."
+                ) from exc
+            logger.info(
+                "Loaded %d rows from %s/%s split %s",
+                len(ds),
+                self.dataset,
+                config_name,
+                self.split,
+            )
+            records.extend(normalize_synthesis_record(row, config_name) for row in ds)
+
+        data = datasets.Dataset.from_list(records, features=SYNTHESIS_FEATURES)
+        data = data.filter(
+            input_columns=["query_id", "instance_id"],
+            function=lambda query_id, instance_id: bool(
+                re.match(self.filter_instance, query_id)
+                or re.match(self.filter_instance, instance_id)
+            ),
+        )
+        self._data = data
+        return data
+
+    def get_repo_path(
+        self, dataset_row: Dict[str, Any], repo_root: Union[Path, str, None] = None
+    ) -> str:
+        repo_name = dataset_row["repo"]
+        root = self.repo_root
+        if repo_root is not None:
+            root = os.path.abspath(os.path.expanduser(str(repo_root)))
+        repo_dir_name = repo_name.replace("/", "_")
+        return os.path.join(root, repo_dir_name)
+
+    def process_instance(
+        self, dataset_row: Dict[str, Any], repo_root: Union[Path, str, None] = None
+    ) -> None:
+        """Clone the repository if needed and check out the row's base commit."""
+
+        repo_name = dataset_row["repo"]
+        base_commit = dataset_row["base_commit"]
+        repo_path = self.get_repo_path(dataset_row, repo_root=repo_root)
+        os.makedirs(os.path.dirname(repo_path), exist_ok=True)
+
+        if not os.path.exists(repo_path):
+            logger.info("Cloning repository %s to %s", repo_name, repo_path)
+            subprocess.run(
+                ["git", "clone", f"https://github.com/{repo_name}.git", repo_path],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        else:
+            logger.info("Repository %s already exists at %s", repo_name, repo_path)
+
+        original_dir = os.getcwd()
+        os.chdir(repo_path)
+        try:
+            subprocess.run(
+                [
+                    "git",
+                    "config",
+                    "remote.origin.fetch",
+                    "+refs/heads/*:refs/remotes/origin/*",
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            subprocess.run(
+                ["git", "fetch", "--all", "--tags"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            subprocess.run(
+                ["git", "reset", "--hard"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            subprocess.run(
+                ["git", "clean", "-fd"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            subprocess.run(
+                ["git", "checkout", "-f", base_commit],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        finally:
+            os.chdir(original_dir)
+
+    def process(self) -> Any:
+        self._data = self._load_dataset()
+        return self._data
+
+    def get_summary(self) -> Dict[str, Any]:
+        data = self._data or self._load_dataset()
+        return {
+            "dataset": self.dataset,
+            "split": self.split,
+            "configs": list(self.configs),
+            "instances": len(data),
+            "by_language": dict(Counter(data["language_group"])),
+            "by_category": dict(Counter(data["category"])),
+            "by_source_config": dict(Counter(data["source_config"])),
+        }
+
+    def load_eval_metadata(self, path: str = "") -> Dict[str, Any]:
+        if path:
+            resolved = Path(os.path.expanduser(path)).resolve()
+            if resolved.exists():
+                return super().load_eval_metadata(str(resolved))
+            logger.info(
+                "No eval metadata file at %s; projecting GT columns from %s",
+                resolved,
+                self.dataset,
+            )
+
+        data = self._data or self._load_dataset()
+        metadata: Dict[str, Any] = {}
+        instance_counts = Counter(row["instance_id"] for row in data)
+        for row in data:
+            key = row.get("query_id") or row["instance_id"]
+            entry = {
+                "instance_id": row["instance_id"],
+                "query_id": row.get("query_id"),
+                "repo": row.get("repo"),
+                "base_commit": row.get("base_commit"),
+                "target_files": list(row.get("gt_files") or []),
+                "symbols_modified": list(row.get("gt_symbols") or []),
+                "symbols_deleted": [],
+                "symbols_added": [],
+                "code_blocks": list(row.get("gt_symbol_nodes") or []),
+            }
+            metadata[key] = entry
+            if instance_counts[row["instance_id"]] == 1:
+                metadata[row["instance_id"]] = entry
+        return metadata

--- a/codeminer/dataset/synthesize/_agent.py
+++ b/codeminer/dataset/synthesize/_agent.py
@@ -62,7 +62,9 @@ class AgentRunner:
             cwd=cwd,
         )
         text_chunks: List[str] = []
+        final_text: Optional[str] = None
         query_gen = query(prompt=prompt, options=options)
+        completed = False
 
         try:
             async for message in query_gen:
@@ -71,9 +73,12 @@ class AgentRunner:
 
                 if msg_type == "ResultMessage":
                     result = getattr(message, "result", None)
+                    completed = True
                     if result and isinstance(result, str):
-                        return result.strip()
-                    return "\n".join(text_chunks).strip()
+                        final_text = result.strip()
+                    else:
+                        final_text = "\n".join(text_chunks).strip()
+                    continue
 
                 if msg_type == "ErrorMessage":
                     error_msg = getattr(message, "error", "Unknown error")
@@ -92,9 +97,10 @@ class AgentRunner:
                     if block_texts:
                         text_chunks.append("\n".join(block_texts))
         finally:
-            await query_gen.aclose()
+            if not completed:
+                await query_gen.aclose()
 
-        return "\n".join(text_chunks).strip()
+        return final_text if final_text is not None else "\n".join(text_chunks).strip()
 
     @staticmethod
     def extract_json(text: str) -> str:

--- a/codeminer/dataset/synthesize/context_loader.py
+++ b/codeminer/dataset/synthesize/context_loader.py
@@ -241,6 +241,8 @@ class ContextLoader:
             return "rust"
         if "javascript" in language_group or "typescript" in language_group:
             return "ts"
+        if "go" in language_group:
+            return "go"
         if "c++" in language_group or language_group == "c":
             return "cpp"
         return "python"

--- a/scripts/_post_fix.py
+++ b/scripts/_post_fix.py
@@ -1,0 +1,502 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Post-fix loop for queries flagged by the LLM judge.
+
+Triages each flagged row (valid / fix / regenerate) and applies the matching
+repair via Claude, up to ``max_retries`` times. Modifies rows in-place.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from codeminer.dataset.synthesize._agent import AgentRunner
+from codeminer.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+JUDGE_SYSTEM_PROMPT = (
+    "You evaluate synthesized code-search queries for a retrieval benchmark. "
+    "For each item you receive a query text, its declared query_type, and the "
+    "target code it is supposed to resolve to. Decide whether the query is a "
+    "reasonable search query of its declared type AND whether the target code "
+    "is a plausible answer.\n\n"
+    "Query type expectations:\n"
+    "  - behavioral: plain English, no file paths or code identifiers.\n"
+    "  - module_hint: may name a module/package, no file paths or symbols.\n"
+    "  - file_hint: may name file paths, no specific symbols.\n"
+    "  - symbol_hint: may name specific functions/classes/methods.\n"
+    "  - reasoning: requires reasoning over call chains, inheritance, control "
+    "flow.\n\n"
+    "Pick exactly one verdict per item:\n"
+    "  - 'valid': query is correct as written.\n"
+    "  - 'fix': query has a SMALL, EDITABLE issue (e.g. category violation "
+    "such as a behavioral query that mentions a function name, length out of "
+    "range, mildly too generic) but the topic / target / framing is right. "
+    "A small rewrite of the same query would resolve it.\n"
+    "  - 'regenerate': query is FUNDAMENTALLY broken — wrong target, inverts "
+    "the code's actual behavior, describes unrelated functionality, vacuous, "
+    "malformed, or empty. The original phrasing should NOT be reused; a "
+    "fresh generation from the anchor is the right repair.\n\n"
+    "Give a one-sentence reason per item."
+)
+
+
+FIX_SYSTEM_PROMPT = (
+    "You are repairing a code-search query that has a SMALL editable issue. "
+    "You are shown the original query AND the judge's specific complaint. "
+    "Produce a NEW query that addresses the complaint while preserving the "
+    "topic/framing of the original, still describes the same code anchor, "
+    "and respects the category + length constraints.\n\n"
+    'Output STRICT JSON with one key: {"query": "..."}. No prose, no '
+    "markdown, no commentary."
+)
+
+
+REGENERATE_SYSTEM_PROMPT = (
+    "You are generating a code-search query from scratch because a previous "
+    "attempt was judged fundamentally broken. You will NOT see the prior "
+    "query (it would bias you). Produce a fresh query that accurately "
+    "describes the supplied code anchor and respects the category + length "
+    "constraints.\n\n"
+    'Output STRICT JSON with one key: {"query": "..."}. No prose, no '
+    "markdown, no commentary."
+)
+
+
+def _derive_dotted_module(anchor_file: str) -> str:
+    """``astropy/stats/funcs.py`` -> ``astropy.stats``."""
+    if not anchor_file:
+        return ""
+    parts = anchor_file.replace("\\", "/").split("/")
+    if len(parts) < 2:
+        return ""
+    return ".".join(p for p in parts[:-1] if p)
+
+
+def _category_rule(category: str, anchor_file: str) -> str:
+    dotted = _derive_dotted_module(anchor_file)
+    if category == "behavioral":
+        return (
+            "Avoid ALL code identifiers, file paths, and technical names. "
+            "Focus purely on observable behavior."
+        )
+    if category == "module_hint":
+        if dotted:
+            return (
+                f"Your question MUST explicitly name the module in dotted "
+                f"form `{dotted}` (or a clearly-recognizable sub-module of "
+                "it). It MUST NOT mention the file path or any specific "
+                "function/class names."
+            )
+        return (
+            "Your question MUST explicitly name the module in dotted form "
+            "(e.g. `astropy.stats`, `numpy.linalg`). It MUST NOT mention the "
+            "file path or any specific function/class names."
+        )
+    if category == "file_hint":
+        return (
+            "Your question SHOULD mention the file path shown above, but "
+            "MUST NOT mention specific function or class names."
+        )
+    if category == "symbol_hint":
+        return (
+            "Your question SHOULD mention the specific function/class/method "
+            "name shown above and describe its behavior."
+        )
+    if category == "reasoning":
+        return (
+            "Your question SHOULD mention the symbol shown above and frame "
+            "the problem in terms of call chains, inheritance, or control "
+            "flow that involve it."
+        )
+    return "Describe the behavior of the anchor code."
+
+
+def _length_rule(length_variant: str) -> str:
+    if length_variant == "simple":
+        return "5 to 30 words. One sentence only, symptom-style."
+    if length_variant == "detailed":
+        return (
+            "80 to 150 words. Multiple observed symptoms, inputs and outputs, "
+            "and at least one edge case. Read like a detailed GitHub issue."
+        )
+    return "Match the original query's register."
+
+
+def _symbol_basename(symbol_id: str) -> str:
+    # The trailing identifier is stable across Go/Rust file-prefix mangling
+    # (e.g. ``terminal.py:foo()`` vs ``src/terminal.rs:foo()``); the prefix
+    # is not. We use the trailing form as the cross-row matching key.
+    if not symbol_id:
+        return ""
+    base = re.split(r"[:/]", symbol_id)[-1]
+    return re.sub(r"\([^)]*\)$", "", base)
+
+
+def _build_anchor_content_lookups(
+    rows: List[Dict[str, Any]],
+) -> Tuple[Dict[str, str], Dict[Tuple[str, str], str]]:
+    # Behavioral rows have content in ``gt_symbol_nodes[*].content``;
+    # non-behavioral rows often have ``content=null``. The file+basename
+    # lookup recovers content for non-behavioral when its prefix doesn't
+    # match the behavioral row's prefix but the file and trailing
+    # identifier do.
+    by_node_name: Dict[str, str] = {}
+    by_file_basename: Dict[Tuple[str, str], str] = {}
+    for r in rows:
+        gt_file = (r.get("gt_files") or [""])[0]
+        for n in r.get("gt_symbol_nodes") or []:
+            sym = n.get("node_name") or ""
+            content = n.get("content")
+            file = n.get("file") or gt_file
+            if not (sym and content):
+                continue
+            by_node_name.setdefault(sym, content)
+            base = _symbol_basename(sym)
+            if file and base:
+                by_file_basename.setdefault((file, base), content)
+    return by_node_name, by_file_basename
+
+
+def _get_anchor(
+    row: Dict[str, Any],
+    by_node_name: Dict[str, str],
+    by_file_basename: Dict[Tuple[str, str], str],
+) -> Tuple[str, str, str]:
+    nodes = row.get("gt_symbol_nodes") or []
+    file = (row.get("gt_files") or [""])[0]
+    symbol = (row.get("gt_symbols") or [""])[0]
+    content = ""
+    if nodes:
+        n0 = nodes[0]
+        file = n0.get("file") or file
+        symbol = n0.get("node_name") or symbol
+        content = n0.get("content") or ""
+    if not content:
+        content = by_node_name.get(symbol, "")
+    if not content:
+        base = _symbol_basename(symbol)
+        if file and base:
+            content = by_file_basename.get((file, base), "")
+    return file, symbol, content
+
+
+def _extract_query_from_payload(raw: str) -> Optional[str]:
+    fenced = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", raw)
+    if fenced:
+        candidate = fenced.group(1)
+    else:
+        m = re.search(r'\{[\s\S]*?"query"[\s\S]*?\}', raw)
+        if not m:
+            return None
+        candidate = m.group(0)
+    try:
+        obj = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    q = obj.get("query")
+    return q.strip() if isinstance(q, str) and q.strip() else None
+
+
+async def _fix_one(
+    row: Dict[str, Any],
+    *,
+    anchor_file: str,
+    anchor_symbol: str,
+    anchor_content: str,
+    model: str,
+) -> Optional[str]:
+    category = row.get("category") or "behavioral"
+    length_variant = row.get("length_variant") or "detailed"
+    original_query = row.get("query") or ""
+    judge_reason = row.get("judge_reason") or ""
+
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=FIX_SYSTEM_PROMPT,
+    )
+    snippet = (
+        anchor_content if len(anchor_content) <= 1800 else anchor_content[:1800] + "..."
+    )
+    prompt = (
+        f"Category: {category}\n"
+        f"Category rule: {_category_rule(category, anchor_file)}\n"
+        f"Length: {length_variant}\n"
+        f"Length rule: {_length_rule(length_variant)}\n\n"
+        f"Anchor file: {anchor_file}\n"
+        f"Anchor symbol: {anchor_symbol}\n"
+        f"Anchor code:\n```\n{snippet}\n```\n\n"
+        f"Original query (FLAGGED):\n{original_query}\n\n"
+        f"Judge complaint:\n{judge_reason}\n\n"
+        'Produce a fixed query as JSON: {"query": "..."}'
+    )
+    raw = await agent.run_async(prompt)
+    return _extract_query_from_payload(raw)
+
+
+async def _regenerate_one(
+    row: Dict[str, Any],
+    *,
+    anchor_file: str,
+    anchor_symbol: str,
+    anchor_content: str,
+    model: str,
+) -> Optional[str]:
+    # Showing the prior (broken) query would bias the new generation toward
+    # the same mistake; the LLM only sees the anchor + constraints.
+    category = row.get("category") or "behavioral"
+    length_variant = row.get("length_variant") or "detailed"
+
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=REGENERATE_SYSTEM_PROMPT,
+    )
+    snippet = (
+        anchor_content if len(anchor_content) <= 1800 else anchor_content[:1800] + "..."
+    )
+    prompt = (
+        f"Category: {category}\n"
+        f"Category rule: {_category_rule(category, anchor_file)}\n"
+        f"Length: {length_variant}\n"
+        f"Length rule: {_length_rule(length_variant)}\n\n"
+        f"Anchor file: {anchor_file}\n"
+        f"Anchor symbol: {anchor_symbol}\n"
+        f"Anchor code:\n```\n{snippet}\n```\n\n"
+        'Produce a fresh query as JSON: {"query": "..."}'
+    )
+    raw = await agent.run_async(prompt)
+    return _extract_query_from_payload(raw)
+
+
+async def _judge_one(
+    row: Dict[str, Any],
+    *,
+    by_node_name: Dict[str, str],
+    by_file_basename: Dict[Tuple[str, str], str],
+    model: str,
+) -> Tuple[str, str]:
+    _, _, anchor_content = _get_anchor(row, by_node_name, by_file_basename)
+    payload = [
+        {
+            "query_id": row.get("query_id"),
+            "query_type": row.get("category"),
+            "query": row.get("query"),
+            "target_files": row.get("gt_files", []),
+            "target_symbols": row.get("gt_symbols", []),
+            "target_code_excerpt": (anchor_content or "")[:2000],
+        }
+    ]
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=JUDGE_SYSTEM_PROMPT,
+    )
+    prompt = (
+        "Evaluate the following synthesized query. Reply with a JSON array of "
+        "one object: "
+        '[{"query_id": "...", "verdict": "valid|regenerate", "reason": "..."}]. '
+        "Do not include any prose outside the JSON.\n\n"
+        f"QUERIES:\n{json.dumps(payload, ensure_ascii=False, indent=2)}"
+    )
+    raw = await agent.run_async(prompt)
+    fenced = re.search(r"```(?:json)?\s*(\[[\s\S]*?\])\s*```", raw)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        m = re.search(r"\[[\s\S]*\]", raw)
+        text = m.group(0) if m else None
+    if not text:
+        return "unknown", "judge did not return JSON"
+    try:
+        arr = json.loads(text)
+    except json.JSONDecodeError:
+        return "unknown", "judge JSON parse failed"
+    if not arr or not isinstance(arr[0], dict):
+        return "unknown", "judge returned empty / invalid"
+    v = arr[0]
+    return v.get("verdict", "unknown"), v.get("reason", "")
+
+
+async def post_fix_flagged(
+    rows: List[Dict[str, Any]],
+    *,
+    model: str,
+    judge_model: str,
+    max_retries: int = 3,
+) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
+    """Triage flagged rows, then loop fix/regenerate up to ``max_retries`` times.
+
+    Returns the mutated rows plus a stats dict
+    (``flagged`` / ``promoted_at_triage`` / ``fixed_via_fix`` /
+    ``fixed_via_regenerate`` / ``still_flagged``).
+    """
+    by_node_name, by_file_basename = _build_anchor_content_lookups(rows)
+
+    def is_flagged(r: Dict[str, Any]) -> bool:
+        # 'unknown' is included because a truncated judge-batch JSON leaves
+        # rows without a real verdict; triage them too.
+        return r.get("judge_verdict") in ("regenerate", "fix", "unknown")
+
+    n_flagged = sum(1 for r in rows if is_flagged(r))
+    stats = {
+        "flagged": n_flagged,
+        "promoted_at_triage": 0,
+        "fixed_via_fix": 0,
+        "fixed_via_regenerate": 0,
+        "still_flagged": 0,
+    }
+    if n_flagged == 0:
+        logger.info("post_fix: 0 rows flagged; nothing to do.")
+        return rows, stats
+
+    logger.info("post_fix: %d rows flagged for follow-up.", n_flagged)
+
+    for row in rows:
+        if not is_flagged(row):
+            continue
+        anchor_file, anchor_symbol, anchor_content = _get_anchor(
+            row, by_node_name, by_file_basename
+        )
+        if not anchor_content:
+            logger.warning(
+                "post_fix [%s]: no anchor content available; skipping.",
+                row.get("query_id"),
+            )
+            stats["still_flagged"] += 1
+            continue
+
+        attempts: List[Dict[str, Any]] = []
+
+        triage_verdict, triage_reason = await _judge_one(
+            row,
+            by_node_name=by_node_name,
+            by_file_basename=by_file_basename,
+            model=judge_model,
+        )
+        attempts.append(
+            {
+                "attempt": 0,
+                "mode": "triage",
+                "verdict": triage_verdict,
+                "reason": triage_reason,
+            }
+        )
+        row["judge_verdict"] = triage_verdict
+        row["judge_reason"] = triage_reason
+        if triage_verdict == "valid":
+            logger.info(
+                "post_fix [%s] triage promoted to valid (no repair needed).",
+                row.get("query_id"),
+            )
+            row["post_fix_attempts"] = attempts
+            stats["promoted_at_triage"] += 1
+            continue
+        if triage_verdict not in ("fix", "regenerate"):
+            logger.warning(
+                "post_fix [%s] triage returned unknown verdict %r; skipping.",
+                row.get("query_id"),
+                triage_verdict,
+            )
+            row["post_fix_attempts"] = attempts
+            stats["still_flagged"] += 1
+            continue
+
+        current_mode = triage_verdict  # 'fix' or 'regenerate'
+        fixed_via: Optional[str] = None
+        for attempt in range(1, max_retries + 1):
+            logger.info(
+                "post_fix [%s] attempt %d/%d mode=%s",
+                row.get("query_id"),
+                attempt,
+                max_retries,
+                current_mode,
+            )
+            if current_mode == "fix":
+                new_query = await _fix_one(
+                    row,
+                    anchor_file=anchor_file,
+                    anchor_symbol=anchor_symbol,
+                    anchor_content=anchor_content,
+                    model=model,
+                )
+            else:
+                new_query = await _regenerate_one(
+                    row,
+                    anchor_file=anchor_file,
+                    anchor_symbol=anchor_symbol,
+                    anchor_content=anchor_content,
+                    model=model,
+                )
+            if not new_query:
+                logger.warning(
+                    "post_fix [%s] attempt %d (%s): repair returned no query.",
+                    row.get("query_id"),
+                    attempt,
+                    current_mode,
+                )
+                attempts.append(
+                    {
+                        "attempt": attempt,
+                        "mode": current_mode,
+                        "query": None,
+                        "verdict": "no_query",
+                    }
+                )
+                continue
+            row["query"] = new_query
+            verdict, reason = await _judge_one(
+                row,
+                by_node_name=by_node_name,
+                by_file_basename=by_file_basename,
+                model=judge_model,
+            )
+            attempts.append(
+                {
+                    "attempt": attempt,
+                    "mode": current_mode,
+                    "query": new_query,
+                    "verdict": verdict,
+                    "reason": reason,
+                }
+            )
+            if verdict == "valid":
+                row["judge_verdict"] = "valid"
+                row["judge_reason"] = reason
+                row["post_fix_attempts"] = attempts
+                fixed_via = current_mode
+                logger.info(
+                    "post_fix [%s] FIXED via %s on attempt %d.",
+                    row.get("query_id"),
+                    current_mode,
+                    attempt,
+                )
+                break
+            row["judge_reason"] = reason
+            if verdict in ("fix", "regenerate"):
+                current_mode = verdict
+
+        if fixed_via is None:
+            row["post_fix_attempts"] = attempts
+            stats["still_flagged"] += 1
+            logger.info(
+                "post_fix [%s] still flagged after %d attempts.",
+                row.get("query_id"),
+                max_retries,
+            )
+        elif fixed_via == "fix":
+            stats["fixed_via_fix"] += 1
+        else:
+            stats["fixed_via_regenerate"] += 1
+
+    return rows, stats

--- a/scripts/generate_codeminer_synthesis_config.py
+++ b/scripts/generate_codeminer_synthesis_config.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate one CodeMiner synthesis config replacement with per-category counts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
+from codeminer.dataset.codeminer_synthesis import (
+    ALL_CONFIGS,
+    EXPECTED_BASE_CATEGORY_COUNTS,
+    EXPECTED_CATEGORY_COUNTS_WITH_TRAVERSAL,
+    normalize_synthesis_record,
+    validate_synthesis_records,
+)
+
+
+def _parse_counts(raw: str) -> Dict[str, int]:
+    if not raw:
+        return dict(EXPECTED_BASE_CATEGORY_COUNTS)
+    counts: Dict[str, int] = {}
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            raise ValueError(f"Bad --counts entry {chunk!r}; expected category=N")
+        name, value = chunk.split("=", 1)
+        counts[name.strip()] = int(value.strip())
+    return counts
+
+
+def _stance_counts_for_total(total: int) -> str:
+    stances = ("trace_back", "trace_down", "bridge")
+    base, extra = divmod(total, len(stances))
+    counts = {
+        stance: base + (1 if idx < extra else 0) for idx, stance in enumerate(stances)
+    }
+    return ",".join(f"{stance}={count}" for stance, count in counts.items() if count)
+
+
+def _parse_total(raw: str) -> int:
+    total = 0
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            raise ValueError(f"Bad stance count entry {chunk!r}; expected stance=N")
+        _, value = chunk.split("=", 1)
+        total += int(value.strip())
+    return total
+
+
+def _read_json_list(path: Path) -> List[Dict[str, Any]]:
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        raise ValueError(f"Expected list in {path}, got {type(data).__name__}")
+    return data
+
+
+def _write_seed_file(args: argparse.Namespace) -> Path:
+    ds = CodeMinerBaseDataset(
+        dataset=args.source_dataset,
+        split=args.split,
+        filter_instance=f"^({re.escape(args.instance_id)})$",
+        root=args.cache_dir or None,
+        repo_root=args.repo_cache_dir or None,
+        log=True,
+    )
+    rows = [dict(row) for row in ds.load()]
+    if len(rows) != 1:
+        raise ValueError(
+            f"Expected exactly one codeminer-base row for {args.instance_id!r}, "
+            f"got {len(rows)}."
+        )
+    row = rows[0]
+    seed = {
+        "repo": row["repo"],
+        "instance_id": row["instance_id"],
+        "base_commit": row["base_commit"],
+        "language_group": row.get("language_group"),
+    }
+    path = args.output_dir / f"{args.config}_{args.instance_id}_seed.json"
+    path.write_text(json.dumps([seed], indent=2, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def _common_multiplier_args(args: argparse.Namespace) -> List[str]:
+    cmd = [
+        "--model",
+        args.model_name,
+        "--judge-model",
+        args.judge_model,
+        "--max-turns",
+        str(args.max_turns),
+        "--sampling-seed",
+        str(args.sampling_seed),
+        "--assignment-seed",
+        str(args.assignment_seed),
+        "--simple-ratio",
+        str(args.simple_ratio),
+        "--behavioral-consensus-runs",
+        str(args.behavioral_consensus_runs),
+        "--post-fix-max-retries",
+        str(args.post_fix_max_retries),
+        "--judge-retries",
+        str(args.traversal_judge_retries),
+    ]
+    if args.cache_dir:
+        cmd.extend(["--cache-dir", args.cache_dir])
+    if args.repo_cache_dir:
+        cmd.extend(["--repo-cache-dir", args.repo_cache_dir])
+    return cmd
+
+
+def _common_traversal_args(args: argparse.Namespace) -> List[str]:
+    cmd = [
+        "--model",
+        args.model_name,
+        "--judge-model",
+        args.judge_model,
+        "--max-turns",
+        str(args.max_turns),
+        "--sampling-seed",
+        str(args.sampling_seed),
+        "--judge-retries",
+        str(args.traversal_judge_retries),
+        "--post-fix-max-retries",
+        str(args.post_fix_max_retries),
+    ]
+    if args.cache_dir:
+        cmd.extend(["--cache-dir", args.cache_dir])
+    if args.repo_cache_dir:
+        cmd.extend(["--repo-cache-dir", args.repo_cache_dir])
+    return cmd
+
+
+def _run_behavioral(args: argparse.Namespace, seed_file: Path, count: int) -> Path:
+    out_dir = args.output_dir / "behavioral_x20"
+    out_path = out_dir / f"synthesized_queries_{args.instance_id}.json"
+    if args.skip_existing and out_path.exists():
+        return out_path
+    cmd = [
+        sys.executable,
+        "scripts/multiply_behavior_queries.py",
+        "--seed-file",
+        str(seed_file),
+        "--output-dir",
+        str(out_dir),
+        "--n-queries",
+        str(count),
+        *_common_multiplier_args(args),
+    ]
+    print("running:", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+    return out_path
+
+
+def _run_mixed(
+    args: argparse.Namespace,
+    seed_file: Path,
+    anchor_file: Path,
+    counts: Dict[str, int],
+) -> Path:
+    out_dir = args.output_dir / "mixed_x30"
+    out_path = out_dir / f"synthesized_queries_{args.instance_id}.json"
+    if args.skip_existing and out_path.exists():
+        return out_path
+    type_counts = ",".join(f"{name}={count}" for name, count in counts.items() if count)
+    cmd = [
+        sys.executable,
+        "scripts/multiply_queries.py",
+        "--seed-file",
+        str(seed_file),
+        "--anchor-file",
+        str(anchor_file),
+        "--output-dir",
+        str(out_dir),
+        "--type-counts",
+        type_counts,
+        *_common_multiplier_args(args),
+    ]
+    print("running:", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+    return out_path
+
+
+def _run_traversal(args: argparse.Namespace, seed_file: Path, count: int) -> Path:
+    out_dir = args.output_dir / "traversal_x10"
+    out_path = out_dir / f"synthesized_queries_{args.instance_id}.json"
+    if args.skip_existing and out_path.exists():
+        return out_path
+    stance_counts = args.traversal_stance_counts or _stance_counts_for_total(count)
+    stance_total = _parse_total(stance_counts)
+    if stance_total != count:
+        raise ValueError(
+            f"--traversal-stance-counts sums to {stance_total}, "
+            f"but traversal count is {count}."
+        )
+    cmd = [
+        sys.executable,
+        "scripts/multiply_traversal_queries.py",
+        "--seed-file",
+        str(seed_file),
+        "--output-dir",
+        str(out_dir),
+        "--stance-counts",
+        stance_counts,
+        *_common_traversal_args(args),
+    ]
+    print("running:", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+    return out_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--config", required=True, choices=ALL_CONFIGS)
+    p.add_argument("--instance-id", required=True)
+    p.add_argument("--split", default="test")
+    p.add_argument("--source-dataset", default="fishmingyu/codeminer-base-dataset")
+    p.add_argument(
+        "--counts",
+        default="",
+        help=(
+            "Comma-separated category=N counts. Defaults to the base 50-row mix."
+            " Include traversal=10 to generate traversal rows."
+        ),
+    )
+    p.add_argument(
+        "--include-traversal",
+        action="store_true",
+        help="Shortcut for the base 50-row mix plus traversal=10.",
+    )
+    p.add_argument(
+        "--traversal-stance-counts",
+        default="",
+        help=(
+            "Optional traversal stance counts. Defaults to an even split, "
+            "so traversal=10 becomes trace_back=4,trace_down=3,bridge=3."
+        ),
+    )
+    p.add_argument("--traversal-judge-retries", type=int, default=2)
+    p.add_argument("--output-dir", required=True, type=Path)
+    p.add_argument("--combined-file", default="")
+    p.add_argument("--model-name", default="opus")
+    p.add_argument("--judge-model", default="opus")
+    p.add_argument("--max-turns", type=int, default=10)
+    p.add_argument("--behavioral-consensus-runs", type=int, default=3)
+    p.add_argument("--post-fix-max-retries", type=int, default=3)
+    p.add_argument("--sampling-seed", type=int, default=42)
+    p.add_argument("--assignment-seed", type=int, default=0)
+    p.add_argument("--simple-ratio", type=float, default=0.5)
+    p.add_argument("--cache-dir", default="")
+    p.add_argument("--repo-cache-dir", default="")
+    p.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Reuse existing per-category JSON files in --output-dir.",
+    )
+    p.add_argument(
+        "--allow-quality-errors",
+        action="store_true",
+        help="Write combined output even if validation finds errors.",
+    )
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    args.output_dir = args.output_dir.expanduser()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    counts = (
+        dict(EXPECTED_CATEGORY_COUNTS_WITH_TRAVERSAL)
+        if args.include_traversal and not args.counts
+        else _parse_counts(args.counts)
+    )
+    seed_file = _write_seed_file(args)
+
+    combined: List[Dict[str, Any]] = []
+    behavioral_count = counts.get("behavioral", 0)
+    traversal_count = counts.get("traversal", 0)
+    if behavioral_count <= 0 and traversal_count <= 0:
+        raise ValueError("The standard synthesis pipeline requires behavioral > 0.")
+    behavioral_path: Path | None = None
+    if behavioral_count > 0:
+        behavioral_path = _run_behavioral(args, seed_file, behavioral_count)
+        combined.extend(
+            normalize_synthesis_record(row, args.config)
+            for row in _read_json_list(behavioral_path)
+        )
+
+    mixed_counts = {
+        k: v
+        for k, v in counts.items()
+        if k not in {"behavioral", "traversal"} and v > 0
+    }
+    if mixed_counts:
+        if behavioral_path is None:
+            raise ValueError("Mixed categories require behavioral anchors.")
+        mixed_path = _run_mixed(args, seed_file, behavioral_path, mixed_counts)
+        combined.extend(
+            normalize_synthesis_record(row, args.config)
+            for row in _read_json_list(mixed_path)
+        )
+
+    if traversal_count > 0:
+        traversal_path = _run_traversal(args, seed_file, traversal_count)
+        combined.extend(
+            normalize_synthesis_record(row, args.config)
+            for row in _read_json_list(traversal_path)
+        )
+
+    combined_path = (
+        Path(args.combined_file).expanduser()
+        if args.combined_file
+        else args.output_dir / f"{args.config}_combined.json"
+    )
+    combined_path.write_text(
+        json.dumps(combined, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    report = validate_synthesis_records(
+        combined,
+        expected_category_counts=counts,
+        compare_category_distribution=False,
+    )
+    report_path = combined_path.with_suffix(".quality.json")
+    report_path.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"combined -> {combined_path}")
+    print(
+        f"quality -> {report_path} "
+        f"({report['error_count']} error(s), {report['warning_count']} warning(s))"
+    )
+    if report["error_count"] and not args.allow_quality_errors:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/multiply_behavior_queries.py
+++ b/scripts/multiply_behavior_queries.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Synthesize N behavioral queries for one SWE-bench instance.
+
+Cycles ``query_index`` so each query gets a distinct anchor block; mixes
+simple (5-30 word) and detailed (80-150 word) variants via length-biased
+system prompts; runs a 3-way judge + post-fix loop.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from codeminer.dataset.synthesize import ClaudeQuerySynthesizer
+from codeminer.dataset.synthesize._agent import AgentRunner
+from codeminer.dataset.utils import QueryType, get_prompt_for_query_type
+from codeminer.log_utils import get_logger
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _post_fix import post_fix_flagged  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+_BASE_PROMPT = (
+    "You are a codebase assistant helping create code search evaluation queries. "
+)
+_LEVEL_PROMPT = get_prompt_for_query_type(QueryType.BEHAVIORAL)
+
+_LENGTH_DETAILED = (
+    "\n\nLENGTH CONSTRAINT: 80 to 150 words. Include multiple observed symptoms, "
+    "inputs and outputs, and at least one edge case. Read like a detailed GitHub "
+    "issue. Close with an explicit question."
+)
+_LENGTH_SIMPLE = (
+    "\n\nLENGTH CONSTRAINT: 5 to 30 words. One sentence only, symptom-style — "
+    "the kind of one-liner a developer pastes in chat or files as a terse issue."
+)
+
+DETAILED_SYSTEM_PROMPT = _BASE_PROMPT + _LEVEL_PROMPT + _LENGTH_DETAILED
+SIMPLE_SYSTEM_PROMPT = _BASE_PROMPT + _LEVEL_PROMPT + _LENGTH_SIMPLE
+
+
+JUDGE_SYSTEM_PROMPT = (
+    "You evaluate synthesized code-search queries for a retrieval benchmark. "
+    "For each item you receive a query text plus the target code it is supposed "
+    "to resolve to. Decide whether the query is a reasonable behavioral search "
+    "query AND whether the target code is a plausible answer.\n\n"
+    "Pick exactly one verdict per item:\n"
+    "  - 'valid': query is correct as written.\n"
+    "  - 'fix': query has a SMALL, EDITABLE issue (mentions a code identifier "
+    "in a behavioral context, length out of range, mildly too generic) but "
+    "the topic / target / framing is right. A small rewrite would resolve it.\n"
+    "  - 'regenerate': query is FUNDAMENTALLY broken — wrong target, inverts "
+    "the code's actual behavior, describes unrelated functionality, vacuous, "
+    "malformed, or empty. A fresh generation from the anchor is the right "
+    "repair.\n\n"
+    "Give a one-sentence reason per item."
+)
+
+
+def _load_seed_instance(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    seed = data[0] if isinstance(data, list) and data else data
+    required = ("repo", "instance_id", "base_commit")
+    missing = [k for k in required if not seed.get(k)]
+    if missing:
+        raise ValueError(f"Seed file {path} missing fields: {missing}")
+    instance = {k: seed[k] for k in required}
+    if seed.get("language_group"):
+        instance["language_group"] = seed["language_group"]
+    return instance
+
+
+def _build_synth(
+    *,
+    system_prompt: str,
+    model: str,
+    max_turns: int,
+    sampling_seed: int,
+    max_candidate_blocks: int,
+    behavioral_consensus_runs: int,
+) -> ClaudeQuerySynthesizer:
+    return ClaudeQuerySynthesizer(
+        model=model,
+        max_turns=max_turns,
+        allowed_tools=["Read", "Glob", "Grep", "Bash"],
+        permission_mode="bypassPermissions",
+        system_prompt=system_prompt,
+        query_type=QueryType.BEHAVIORAL,
+        sampling_seed=sampling_seed,
+        max_candidate_blocks=max_candidate_blocks,
+        behavioral_consensus_runs=behavioral_consensus_runs,
+        num_queries=1,
+        verification_mode="lenient",
+    )
+
+
+def _assign_length_variants(
+    n: int, simple_ratio: float, rng: random.Random
+) -> List[str]:
+    n_simple = round(n * simple_ratio)
+    variants = ["simple"] * n_simple + ["detailed"] * (n - n_simple)
+    rng.shuffle(variants)
+    return variants
+
+
+# Strip a `"question": "...` prefix that occasionally leaks when the
+# curator's structured parser falls back to text-coerce mode.
+_QUERY_LEAK_PREFIX = re.compile(r'^\s*["\']?question["\']?\s*:\s*["\']?', re.IGNORECASE)
+
+
+def _clean_query_text(text: Optional[str]) -> str:
+    if not text:
+        return text or ""
+    cleaned = _QUERY_LEAK_PREFIX.sub("", text).strip()
+    return cleaned
+
+
+def _to_compact_record(item: Dict[str, Any]) -> Dict[str, Any]:
+    record: Dict[str, Any] = {
+        "repo": item.get("repo"),
+        "instance_id": item.get("instance_id"),
+        "base_commit": item.get("base_commit"),
+        "query": _clean_query_text(item.get("query")),
+        "category": item.get("query_type") or item.get("difficulty"),
+        "gt_symbols": item.get("target_symbols") or [],
+        "gt_symbol_nodes": item.get("target_symbol_nodes") or [],
+        "gt_files": item.get("target_files") or [],
+        "query_id": item.get("query_id"),
+    }
+    if item.get("language_group"):
+        record["language_group"] = item["language_group"]
+    if "verification_passed" in item:
+        record["verification_passed"] = item["verification_passed"]
+    if "length_variant" in item:
+        record["length_variant"] = item["length_variant"]
+    if "judge_verdict" in item:
+        record["judge_verdict"] = item["judge_verdict"]
+    if "judge_reason" in item:
+        record["judge_reason"] = item["judge_reason"]
+    if item.get("error"):
+        record["error"] = item["error"]
+    return record
+
+
+def _write_compact(results: List[Dict[str, Any]], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(
+            [_to_compact_record(r) for r in results], fh, indent=2, ensure_ascii=False
+        )
+
+
+def _judge_payload(results: List[Dict[str, Any]]) -> str:
+    items: List[Dict[str, Any]] = []
+    for r in results:
+        if r.get("error") or not r.get("query"):
+            continue
+        nodes = r.get("target_symbol_nodes") or []
+        target_code = (nodes[0].get("content", "") if nodes else "") or ""
+        items.append(
+            {
+                "query_id": r.get("query_id"),
+                "query": r.get("query"),
+                "target_files": r.get("target_files", []),
+                "target_symbols": r.get("target_symbols", []),
+                "target_code_excerpt": target_code[:2000],
+            }
+        )
+    return json.dumps(items, ensure_ascii=False, indent=2)
+
+
+async def _run_judge(
+    *, results: List[Dict[str, Any]], model: str
+) -> Dict[str, Dict[str, str]]:
+    payload = _judge_payload(results)
+    if not payload or payload == "[]":
+        return {}
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=JUDGE_SYSTEM_PROMPT,
+    )
+    prompt = (
+        "Evaluate each of the following synthesized queries. Reply with a JSON "
+        "array, one object per query: "
+        '[{"query_id": "...", "verdict": "valid|regenerate", "reason": "..."}]. '
+        "Do not include any prose outside the JSON.\n\n"
+        f"QUERIES:\n{payload}"
+    )
+    raw = await agent.run_async(prompt)
+    fenced = re.search(r"```(?:json)?\s*(\[[\s\S]*?\])\s*```", raw)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        m = re.search(r"\[[\s\S]*\]", raw)
+        text = m.group(0) if m else raw
+    try:
+        verdicts = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.error("Judge returned non-JSON response: %s\nRaw: %s", exc, raw[:500])
+        return {}
+    return {
+        v["query_id"]: v for v in verdicts if isinstance(v, dict) and "query_id" in v
+    }
+
+
+async def _generate_one(
+    *,
+    synth: ClaudeQuerySynthesizer,
+    instance: Dict[str, Any],
+    query_index: int,
+    repo_root: Optional[str],
+    cache_dir: str,
+) -> Dict[str, Any]:
+    inst = dict(instance)
+    inst["synthesis_run_id"] = 1  # one shared candidate pool; query_index varies pick
+    return await synth.synthesize_query_async(
+        inst,
+        repo_root=repo_root,
+        cache_dir=cache_dir,
+        query_index=query_index,
+    )
+
+
+async def _run_pipeline(args: argparse.Namespace) -> None:
+    seed_path = Path(args.seed_file).expanduser()
+    instance = _load_seed_instance(seed_path)
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = (
+        Path(args.cache_dir).expanduser()
+        if args.cache_dir
+        else Path.home() / ".codeminer"
+    )
+
+    rng = random.Random(args.assignment_seed)
+    variants = _assign_length_variants(args.n_queries, args.simple_ratio, rng)
+
+    pool_size = max(args.n_queries * 2, 40)
+    detailed_synth = _build_synth(
+        system_prompt=DETAILED_SYSTEM_PROMPT,
+        model=args.model,
+        max_turns=args.max_turns,
+        sampling_seed=args.sampling_seed,
+        max_candidate_blocks=pool_size,
+        behavioral_consensus_runs=args.behavioral_consensus_runs,
+    )
+    simple_synth = _build_synth(
+        system_prompt=SIMPLE_SYSTEM_PROMPT,
+        model=args.model,
+        max_turns=args.max_turns,
+        sampling_seed=args.sampling_seed,
+        max_candidate_blocks=pool_size,
+        behavioral_consensus_runs=args.behavioral_consensus_runs,
+    )
+
+    output_path = output_dir / f"synthesized_queries_{instance['instance_id']}.json"
+    results: List[Dict[str, Any]] = []
+    for i, variant in enumerate(variants):
+        logger.info(
+            "[%d/%d] Generating %s query (query_index=%d)...",
+            i + 1,
+            args.n_queries,
+            variant,
+            i,
+        )
+        synth = simple_synth if variant == "simple" else detailed_synth
+        try:
+            result = await _generate_one(
+                synth=synth,
+                instance=instance,
+                query_index=i,
+                repo_root=args.repo_cache_dir,
+                cache_dir=str(cache_dir),
+            )
+        except Exception as exc:
+            logger.error(
+                "[%d/%d] FAILED: %s", i + 1, args.n_queries, exc, exc_info=True
+            )
+            result = {
+                "instance_id": instance["instance_id"],
+                "repo": instance["repo"],
+                "base_commit": instance["base_commit"],
+                "query_id": (f"{instance['instance_id']}_behavioral_q{i + 1}"),
+                "error": str(exc),
+            }
+        result["language_group"] = instance.get("language_group")
+        result["length_variant"] = variant
+        results.append(result)
+        _write_compact(results, output_path)
+        logger.info(
+            "Saved %d/%d results to %s", len(results), args.n_queries, output_path
+        )
+
+    logger.info("Running judge over %d generated queries...", len(results))
+    verdicts = await _run_judge(results=results, model=args.judge_model)
+    for r in results:
+        v = verdicts.get(r.get("query_id"), {})
+        r["judge_verdict"] = v.get("verdict", "unknown")
+        r["judge_reason"] = v.get("reason", "")
+
+    _write_compact(results, output_path)
+
+    # Operate on the compact projection so the saved file matches what we judged.
+    compact = [_to_compact_record(r) for r in results]
+    compact, postfix_stats = await post_fix_flagged(
+        compact,
+        model=args.model,
+        judge_model=args.judge_model,
+        max_retries=args.post_fix_max_retries,
+    )
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(compact, fh, indent=2, ensure_ascii=False)
+
+    n_valid = sum(1 for r in compact if r.get("judge_verdict") == "valid")
+    n_regen = sum(1 for r in compact if r.get("judge_verdict") == "regenerate")
+    n_unknown = sum(1 for r in compact if r.get("judge_verdict") == "unknown")
+    n_err = sum(1 for r in compact if r.get("error"))
+
+    print("\n--- Summary ---")
+    print(f"Total queries generated: {len(compact)}")
+    print(f"  Errored during generation: {n_err}")
+    print(f"  Judge valid:               {n_valid}")
+    print(f"  Judge needs regeneration:  {n_regen}")
+    print(f"  Judge unknown / no verdict:{n_unknown}")
+    print(f"  Post-fix: {postfix_stats}")
+    print(f"Output: {output_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--seed-file",
+        required=True,
+        type=str,
+        help="Per-instance q1 JSON; reads repo / instance_id / base_commit from it.",
+    )
+    p.add_argument("--output-dir", default="synthesis_output_behavior_x20", type=str)
+    p.add_argument("--n-queries", type=int, default=20)
+    p.add_argument(
+        "--simple-ratio",
+        type=float,
+        default=0.5,
+        help="Fraction of queries that should be short symptom-style (0..1).",
+    )
+    p.add_argument("--model", default="opus", help="Claude model for the synthesizer.")
+    p.add_argument(
+        "--judge-model", default="opus", help="Claude model for the final judge."
+    )
+    p.add_argument("--max-turns", type=int, default=10)
+    p.add_argument(
+        "--sampling-seed",
+        type=int,
+        default=42,
+        help="Seed for the candidate-block pool.",
+    )
+    p.add_argument(
+        "--assignment-seed",
+        type=int,
+        default=0,
+        help="Seed for shuffling simple/detailed assignment.",
+    )
+    p.add_argument("--cache-dir", type=str, default=None)
+    p.add_argument("--repo-cache-dir", type=str, default=None)
+    p.add_argument(
+        "--behavioral-consensus-runs",
+        type=int,
+        default=3,
+        help=(
+            "How many LLM passes to run per behavioral query. Blocks selected "
+            "by majority (>= ceil(N/2)) become the ground truth. N=3 matches "
+            "synthesize_swebench.py and yields organic multi-hop gt when the "
+            "LLM consistently picks the core block + related neighbors. N=1 "
+            "is faster but suppresses multi-hop."
+        ),
+    )
+    p.add_argument(
+        "--post-fix-max-retries",
+        type=int,
+        default=3,
+        help=(
+            "After the batch judge, for each row flagged 'regenerate', call "
+            "Claude with the judge's complaint and ask for a fix, then "
+            "re-judge. Repeat up to N times before giving up. Set 0 to skip."
+        ),
+    )
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if not 0.0 <= args.simple_ratio <= 1.0:
+        raise ValueError("--simple-ratio must be in [0, 1]")
+    if args.n_queries < 1:
+        raise ValueError("--n-queries must be >= 1")
+    asyncio.run(_run_pipeline(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/multiply_queries.py
+++ b/scripts/multiply_queries.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Synthesize a mix of query types (module_hint / file_hint / symbol_hint /
+reasoning, and optionally behavioral) for one SWE-bench instance, with each
+non-behavioral row grounded on an anchor pulled from a populated behavioral
+JSON (so gt_files / gt_symbols / gt_symbol_nodes are real, not LLM-invented).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from codeminer.dataset.synthesize import ClaudeQuerySynthesizer
+from codeminer.dataset.synthesize._agent import AgentRunner
+from codeminer.dataset.utils import QueryType, get_prompt_for_query_type
+from codeminer.log_utils import get_logger
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _post_fix import post_fix_flagged  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+_BASE_PROMPT = (
+    "You are a codebase assistant helping create code search evaluation queries. "
+)
+
+_LENGTH_DETAILED = (
+    "\n\nLENGTH CONSTRAINT: 80 to 150 words. Include multiple observed symptoms, "
+    "inputs and outputs, and at least one edge case. Read like a detailed GitHub "
+    "issue. Close with an explicit question."
+)
+_LENGTH_SIMPLE = (
+    "\n\nLENGTH CONSTRAINT: 5 to 30 words. One sentence only, symptom-style — "
+    "the kind of one-liner a developer pastes in chat or files as a terse issue."
+)
+
+
+JUDGE_SYSTEM_PROMPT = (
+    "You evaluate synthesized code-search queries for a retrieval benchmark. "
+    "For each item you receive a query text, its declared query_type, and the "
+    "target code it is supposed to resolve to. Decide whether the query is a "
+    "reasonable search query of its declared type AND whether the target code "
+    "is a plausible answer.\n\n"
+    "Query type expectations:\n"
+    "  - behavioral: plain English, no file paths or code identifiers.\n"
+    "  - module_hint: may name a module/package, no file paths or symbols.\n"
+    "  - file_hint: may name file paths, no specific symbols.\n"
+    "  - symbol_hint: may name specific functions/classes/methods.\n"
+    "  - reasoning: requires reasoning over call chains, inheritance, control "
+    "flow.\n\n"
+    "Pick exactly one verdict per item:\n"
+    "  - 'valid': query is correct as written.\n"
+    "  - 'fix': query has a SMALL, EDITABLE issue (e.g. category violation "
+    "such as a behavioral query that mentions a function name, length out of "
+    "range, mildly too generic) but the topic / target / framing is right. "
+    "A small rewrite of the same query would resolve it.\n"
+    "  - 'regenerate': query is FUNDAMENTALLY broken — wrong target, inverts "
+    "the code's actual behavior, describes unrelated functionality, vacuous, "
+    "malformed, or empty. The original phrasing should NOT be reused; a "
+    "fresh generation from the anchor is the right repair.\n\n"
+    "Give a one-sentence reason per item."
+)
+
+
+def _system_prompt_for(query_type: QueryType, length_variant: str) -> str:
+    level = get_prompt_for_query_type(query_type)
+    length = _LENGTH_SIMPLE if length_variant == "simple" else _LENGTH_DETAILED
+    return _BASE_PROMPT + level + length
+
+
+def _parse_type_counts(raw: str) -> Dict[QueryType, int]:
+    """Parse "module_hint=10,file_hint=10,symbol_hint=5,reasoning=5"."""
+    out: Dict[QueryType, int] = {}
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            raise ValueError(f"Bad --type-counts entry {chunk!r}; want name=N.")
+        name, value = chunk.split("=", 1)
+        try:
+            qt = QueryType(name.strip())
+        except ValueError as exc:
+            valid = ", ".join(t.value for t in QueryType)
+            raise ValueError(f"Unknown query type {name!r}. Valid: {valid}") from exc
+        n = int(value.strip())
+        if n < 0:
+            raise ValueError(f"Count for {name!r} must be >= 0.")
+        if n > 0:
+            out[qt] = n
+    if not out:
+        raise ValueError("--type-counts produced no types with count > 0.")
+    return out
+
+
+def _load_seed_instance(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    seed = data[0] if isinstance(data, list) and data else data
+    required = ("repo", "instance_id", "base_commit")
+    missing = [k for k in required if not seed.get(k)]
+    if missing:
+        raise ValueError(f"Seed file {path} missing fields: {missing}")
+    instance = {k: seed[k] for k in required}
+    if seed.get("language_group"):
+        instance["language_group"] = seed["language_group"]
+    return instance
+
+
+def _load_anchors(path: Path) -> List[Dict[str, Any]]:
+    """Load anchors (file + symbol + actual code content) from a populated
+    synthesized-queries JSON (e.g. the behavioral x20 output).
+
+    Each entry becomes one anchor dict in the shape expected by
+    ``QueryCurator._build_anchor_block`` — including ``anchor_content`` (the
+    real code) so the curator binds the LLM to it rather than letting it
+    hallucinate other repo areas.
+    """
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    entries = data if isinstance(data, list) else [data]
+    anchors: List[Dict[str, Any]] = []
+    for e in entries:
+        files = e.get("gt_files") or e.get("target_files") or []
+        symbols = e.get("gt_symbols") or e.get("target_symbols") or []
+        nodes = e.get("gt_symbol_nodes") or e.get("target_symbol_nodes") or []
+        anchor_content = ""
+        anchor_file = files[0] if files else ""
+        anchor_symbol = symbols[0] if symbols else ""
+        for node in nodes:
+            if node.get("content"):
+                anchor_content = node["content"]
+                anchor_file = node.get("file") or anchor_file
+                anchor_symbol = node.get("node_name") or anchor_symbol
+                break
+        if not files and not symbols:
+            continue
+        anchors.append(
+            {
+                "target_files": list(files),
+                "symbols_modified": list(symbols),
+                "anchor_content": anchor_content,
+                "anchor_file": anchor_file,
+                "anchor_symbol": anchor_symbol,
+            }
+        )
+    if not anchors:
+        raise ValueError(
+            f"No usable anchors (gt_files/gt_symbols) found in {path}. "
+            "Point --anchor-file at a populated synthesized-queries JSON."
+        )
+    n_with_content = sum(1 for a in anchors if a["anchor_content"])
+    logger.info(
+        "Loaded %d anchors (%d with code content) from %s",
+        len(anchors),
+        n_with_content,
+        path,
+    )
+    return anchors
+
+
+def _build_synth(
+    *,
+    query_type: QueryType,
+    system_prompt: str,
+    model: str,
+    max_turns: int,
+    sampling_seed: int,
+    max_candidate_blocks: int,
+    behavioral_consensus_runs: int,
+) -> ClaudeQuerySynthesizer:
+    return ClaudeQuerySynthesizer(
+        model=model,
+        max_turns=max_turns,
+        allowed_tools=["Read", "Glob", "Grep", "Bash"],
+        permission_mode="bypassPermissions",
+        system_prompt=system_prompt,
+        query_type=query_type,
+        sampling_seed=sampling_seed,
+        max_candidate_blocks=max_candidate_blocks,
+        behavioral_consensus_runs=behavioral_consensus_runs,
+        num_queries=1,
+        verification_mode="lenient",
+    )
+
+
+def _assign_length_variants(
+    n: int, simple_ratio: float, rng: random.Random
+) -> List[str]:
+    n_simple = round(n * simple_ratio)
+    variants = ["simple"] * n_simple + ["detailed"] * (n - n_simple)
+    rng.shuffle(variants)
+    return variants
+
+
+# Strip a `"question": "...` prefix that occasionally leaks from the
+# curator's text-coerce fallback.
+_QUERY_LEAK_PREFIX = re.compile(r'^\s*["\']?question["\']?\s*:\s*["\']?', re.IGNORECASE)
+
+
+def _clean_query_text(text: Optional[str]) -> str:
+    if not text:
+        return text or ""
+    return _QUERY_LEAK_PREFIX.sub("", text).strip()
+
+
+def _to_compact_record(item: Dict[str, Any]) -> Dict[str, Any]:
+    record: Dict[str, Any] = {
+        "repo": item.get("repo"),
+        "instance_id": item.get("instance_id"),
+        "base_commit": item.get("base_commit"),
+        "query": _clean_query_text(item.get("query")),
+        "category": item.get("query_type") or item.get("difficulty"),
+        "gt_symbols": item.get("target_symbols") or [],
+        "gt_symbol_nodes": item.get("target_symbol_nodes") or [],
+        "gt_files": item.get("target_files") or [],
+        "query_id": item.get("query_id"),
+    }
+    if item.get("language_group"):
+        record["language_group"] = item["language_group"]
+    if "verification_passed" in item:
+        record["verification_passed"] = item["verification_passed"]
+    if "length_variant" in item:
+        record["length_variant"] = item["length_variant"]
+    if "judge_verdict" in item:
+        record["judge_verdict"] = item["judge_verdict"]
+    if "judge_reason" in item:
+        record["judge_reason"] = item["judge_reason"]
+    if item.get("error"):
+        record["error"] = item["error"]
+    return record
+
+
+def _write_compact(results: List[Dict[str, Any]], path: Path) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(
+            [_to_compact_record(r) for r in results], fh, indent=2, ensure_ascii=False
+        )
+
+
+def _judge_payload(results: List[Dict[str, Any]]) -> str:
+    items: List[Dict[str, Any]] = []
+    for r in results:
+        if r.get("error") or not r.get("query"):
+            continue
+        nodes = r.get("target_symbol_nodes") or []
+        target_code = (nodes[0].get("content", "") if nodes else "") or ""
+        items.append(
+            {
+                "query_id": r.get("query_id"),
+                "query_type": r.get("query_type") or r.get("difficulty"),
+                "query": r.get("query"),
+                "target_files": r.get("target_files", []),
+                "target_symbols": r.get("target_symbols", []),
+                "target_code_excerpt": target_code[:2000],
+            }
+        )
+    return json.dumps(items, ensure_ascii=False, indent=2)
+
+
+async def _run_judge(
+    *, results: List[Dict[str, Any]], model: str
+) -> Dict[str, Dict[str, str]]:
+    payload = _judge_payload(results)
+    if not payload or payload == "[]":
+        return {}
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=JUDGE_SYSTEM_PROMPT,
+    )
+    prompt = (
+        "Evaluate each of the following synthesized queries. Reply with a JSON "
+        "array, one object per query: "
+        '[{"query_id": "...", "verdict": "valid|regenerate", "reason": "..."}]. '
+        "Do not include any prose outside the JSON.\n\n"
+        f"QUERIES:\n{payload}"
+    )
+    raw = await agent.run_async(prompt)
+    fenced = re.search(r"```(?:json)?\s*(\[[\s\S]*?\])\s*```", raw)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        m = re.search(r"\[[\s\S]*\]", raw)
+        text = m.group(0) if m else raw
+    try:
+        verdicts = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.error("Judge returned non-JSON response: %s\nRaw: %s", exc, raw[:500])
+        return {}
+    return {
+        v["query_id"]: v for v in verdicts if isinstance(v, dict) and "query_id" in v
+    }
+
+
+def _build_plan(
+    type_counts: Dict[QueryType, int], simple_ratio: float, rng: random.Random
+) -> List[Tuple[QueryType, str, int]]:
+    """Return a list of (query_type, length_variant, per_type_index) tuples,
+    sized to sum(type_counts.values()). per_type_index is 0-based within its
+    type — for BEHAVIORAL this is fed to query_index for anchor diversity.
+    """
+    plan: List[Tuple[QueryType, str, int]] = []
+    for qt, n in type_counts.items():
+        variants = _assign_length_variants(n, simple_ratio, rng)
+        for i, variant in enumerate(variants):
+            plan.append((qt, variant, i))
+    return plan
+
+
+async def _generate_one(
+    *,
+    synth: ClaudeQuerySynthesizer,
+    instance: Dict[str, Any],
+    query_type: QueryType,
+    per_type_index: int,
+    repo_root: Optional[str],
+    cache_dir: str,
+    anchor: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    inst = dict(instance)
+    if query_type == QueryType.BEHAVIORAL:
+        # Shared candidate pool; vary the anchor via query_index.
+        inst["synthesis_run_id"] = 1
+        query_index = per_type_index
+        ground_truth = None
+    else:
+        # Re-seed per query + pass a real anchor; without ground_truth the
+        # curator's target discovery hallucinates plausible-wrong symbols.
+        inst["synthesis_run_id"] = per_type_index + 1
+        query_index = per_type_index
+        ground_truth = anchor
+    return await synth.synthesize_query_async(
+        inst,
+        repo_root=repo_root,
+        cache_dir=cache_dir,
+        ground_truth=ground_truth,
+        query_index=query_index,
+    )
+
+
+async def _run_pipeline(args: argparse.Namespace) -> None:
+    type_counts = _parse_type_counts(args.type_counts)
+    total = sum(type_counts.values())
+    logger.info(
+        "Generating %d queries across %d types: %s",
+        total,
+        len(type_counts),
+        {qt.value: n for qt, n in type_counts.items()},
+    )
+
+    seed_path = Path(args.seed_file).expanduser()
+    instance = _load_seed_instance(seed_path)
+
+    anchor_path = Path(args.anchor_file).expanduser() if args.anchor_file else seed_path
+    anchors: List[Dict[str, Any]] = []
+    needs_anchors = any(qt != QueryType.BEHAVIORAL for qt in type_counts)
+    if needs_anchors:
+        anchors = _load_anchors(anchor_path)
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = (
+        Path(args.cache_dir).expanduser()
+        if args.cache_dir
+        else Path.home() / ".codeminer"
+    )
+
+    rng = random.Random(args.assignment_seed)
+    plan = _build_plan(type_counts, args.simple_ratio, rng)
+
+    pool_size = max(total * 2, 40)
+    synth_cache: Dict[Tuple[QueryType, str], ClaudeQuerySynthesizer] = {}
+    for qt in type_counts:
+        for variant in ("simple", "detailed"):
+            synth_cache[(qt, variant)] = _build_synth(
+                query_type=qt,
+                system_prompt=_system_prompt_for(qt, variant),
+                model=args.model,
+                max_turns=args.max_turns,
+                sampling_seed=args.sampling_seed,
+                max_candidate_blocks=pool_size,
+                behavioral_consensus_runs=args.behavioral_consensus_runs,
+            )
+
+    output_path = output_dir / f"synthesized_queries_{instance['instance_id']}.json"
+    results: List[Dict[str, Any]] = []
+    for i, (qt, variant, per_type_idx) in enumerate(plan):
+        logger.info(
+            "[%d/%d] type=%s variant=%s per_type_idx=%d",
+            i + 1,
+            total,
+            qt.value,
+            variant,
+            per_type_idx,
+        )
+        synth = synth_cache[(qt, variant)]
+        anchor = (
+            anchors[per_type_idx % len(anchors)]
+            if anchors and qt != QueryType.BEHAVIORAL
+            else None
+        )
+        try:
+            result = await _generate_one(
+                synth=synth,
+                instance=instance,
+                query_type=qt,
+                per_type_index=per_type_idx,
+                repo_root=args.repo_cache_dir,
+                cache_dir=str(cache_dir),
+                anchor=anchor,
+            )
+        except Exception as exc:
+            logger.error("[%d/%d] FAILED: %s", i + 1, total, exc, exc_info=True)
+            result = {
+                "instance_id": instance["instance_id"],
+                "repo": instance["repo"],
+                "base_commit": instance["base_commit"],
+                "query_id": (
+                    f"{instance['instance_id']}_{qt.value}_q{per_type_idx + 1}"
+                ),
+                "query_type": qt.value,
+                "error": str(exc),
+            }
+        result["language_group"] = instance.get("language_group")
+        result["length_variant"] = variant
+        results.append(result)
+        _write_compact(results, output_path)
+        logger.info("Saved %d/%d results to %s", len(results), total, output_path)
+
+    logger.info("Running judge over %d generated queries...", len(results))
+    verdicts = await _run_judge(results=results, model=args.judge_model)
+    for r in results:
+        v = verdicts.get(r.get("query_id"), {})
+        r["judge_verdict"] = v.get("verdict", "unknown")
+        r["judge_reason"] = v.get("reason", "")
+
+    _write_compact(results, output_path)
+
+    # Operate on the compact projection so the saved file matches what we judged.
+    compact = [_to_compact_record(r) for r in results]
+    compact, postfix_stats = await post_fix_flagged(
+        compact,
+        model=args.model,
+        judge_model=args.judge_model,
+        max_retries=args.post_fix_max_retries,
+    )
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(compact, fh, indent=2, ensure_ascii=False)
+
+    n_valid = sum(1 for r in compact if r.get("judge_verdict") == "valid")
+    n_regen = sum(1 for r in compact if r.get("judge_verdict") == "regenerate")
+    n_unknown = sum(1 for r in compact if r.get("judge_verdict") == "unknown")
+    n_err = sum(1 for r in compact if r.get("error"))
+
+    print("\n--- Summary ---")
+    print(f"Total queries generated: {len(compact)}")
+    by_type: Dict[str, int] = {}
+    for r in compact:
+        t = r.get("category") or "unknown"
+        by_type[t] = by_type.get(t, 0) + 1
+    print(f"  By type: {by_type}")
+    print(f"  Errored during generation: {n_err}")
+    print(f"  Judge valid:               {n_valid}")
+    print(f"  Judge needs regeneration:  {n_regen}")
+    print(f"  Judge unknown / no verdict:{n_unknown}")
+    print(f"  Post-fix: {postfix_stats}")
+    print(f"Output: {output_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--seed-file",
+        required=True,
+        type=str,
+        help="Per-instance q1 JSON; reads repo / instance_id / base_commit from it.",
+    )
+    p.add_argument(
+        "--anchor-file",
+        default=None,
+        type=str,
+        help=(
+            "JSON with populated gt_files/gt_symbols (e.g. the x20 behavioral "
+            "output) used to ground non-behavioral queries. Defaults to "
+            "--seed-file. Anchors are cycled per type."
+        ),
+    )
+    p.add_argument("--output-dir", default="synthesis_output_mixed_x30", type=str)
+    p.add_argument(
+        "--type-counts",
+        required=True,
+        type=str,
+        help=(
+            "Comma-separated <type>=<count>, e.g. "
+            '"module_hint=10,file_hint=10,symbol_hint=5,reasoning=5". '
+            "Valid types: behavioral, module_hint, file_hint, symbol_hint, reasoning."
+        ),
+    )
+    p.add_argument(
+        "--simple-ratio",
+        type=float,
+        default=0.5,
+        help="Fraction of queries that should be short symptom-style (0..1).",
+    )
+    p.add_argument("--model", default="opus", help="Claude model for the synthesizer.")
+    p.add_argument(
+        "--judge-model", default="opus", help="Claude model for the final judge."
+    )
+    p.add_argument("--max-turns", type=int, default=10)
+    p.add_argument(
+        "--sampling-seed",
+        type=int,
+        default=42,
+        help="Seed for the candidate-block pool.",
+    )
+    p.add_argument(
+        "--assignment-seed",
+        type=int,
+        default=0,
+        help="Seed for shuffling simple/detailed assignment within each type.",
+    )
+    p.add_argument("--cache-dir", type=str, default=None)
+    p.add_argument("--repo-cache-dir", type=str, default=None)
+    p.add_argument(
+        "--behavioral-consensus-runs",
+        type=int,
+        default=3,
+        help=(
+            "How many LLM passes to run per behavioral query for consensus "
+            "voting on selected_blocks. N=3 matches synthesize_swebench.py "
+            "and yields organic multi-hop gt; N=1 is faster but suppresses "
+            "multi-hop. Only affects behavioral queries."
+        ),
+    )
+    p.add_argument(
+        "--post-fix-max-retries",
+        type=int,
+        default=3,
+        help=(
+            "After the batch judge, for each row flagged 'regenerate', call "
+            "Claude with the judge's complaint and ask for a fix, then "
+            "re-judge. Repeat up to N times before giving up. Set 0 to skip."
+        ),
+    )
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if not 0.0 <= args.simple_ratio <= 1.0:
+        raise ValueError("--simple-ratio must be in [0, 1]")
+    asyncio.run(_run_pipeline(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/multiply_traversal_queries.py
+++ b/scripts/multiply_traversal_queries.py
@@ -1,0 +1,1078 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Synthesize "traversal" queries — code-search queries whose answer requires
+walking 2-3 call/reference edges in the code graph and whose text contains no
+direct lexical hook to the chain symbols (so a grep agent loses, a graph
+agent wins). GT carries the full chain.
+
+Example
+-------
+    SEED=synthesis_output_behavior/synthesized_queries_<instance>.json
+    python scripts/multiply_traversal_queries.py \\
+        --seed-file "$SEED" \\
+        --output-dir synthesis_output_traversal_x10/ \\
+        --stance-counts "trace_back=10,trace_down=10,bridge=10" \\
+        --model opus --judge-model opus \\
+        --cache-dir ~/.codeminer --repo-cache-dir ~/.codeminer
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from codeminer.dataset.synthesize._agent import AgentRunner
+from codeminer.dataset.synthesize.context_loader import ContextLoader
+from codeminer.log_utils import get_logger
+from codeminer.types import NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _post_fix import post_fix_flagged  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+# A stance picks the graph walk direction, which chain members the query may
+# paraphrase (anchors), and which are hidden (targets). Symbol names are
+# always forbidden — stance only governs whose behavior can be described.
+STANCES = {
+    "trace_back": {
+        # chain = [symptom_loc, caller1, (caller2)], walked via predecessor edges
+        "direction": "predecessor",
+        "narrative": (
+            "Write the question from the perspective of someone DEBUGGING. "
+            "They see a wrong observable behavior at the SYMPTOM symbol "
+            "(SYMBOL 1) — e.g. unexpected output, confusing exception, "
+            "missing side-effect — and want to know WHERE UPSTREAM the cause "
+            "originates. The remaining symbols are upstream callers; "
+            "describing them would defeat the question, so describe ONLY the "
+            "symptom's observable misbehavior."
+        ),
+        "anchor_indices": [0],  # describe the leaf (symptom)
+    },
+    "trace_down": {
+        # chain = [entry, callee1, (callee2)], walked via successor edges
+        "direction": "successor",
+        "narrative": (
+            "Write the question from the perspective of someone USING the "
+            "ENTRY symbol's API (SYMBOL 1). They describe the interface — "
+            "what they call with, what comes back, an observable surprise — "
+            "and ask WHAT HAPPENS INTERNALLY that explains it. The remaining "
+            "symbols are downstream helpers/callees that the entry dispatches "
+            "into; describing them would defeat the question, so describe "
+            "ONLY the entry's interface and the surprising output."
+        ),
+        "anchor_indices": [0],  # describe the entry (top)
+    },
+    "bridge": {
+        # chain = [start, middle, end], 3 symbols, callee direction
+        "direction": "successor",
+        "narrative": (
+            "Write the question from the perspective of someone who can "
+            "OBSERVE BOTH ENDS of a data/control flow but does not know the "
+            "middle. They describe the START symbol's responsibility (SYMBOL "
+            "1, an entry/setup) AND the END symbol's observable state "
+            "(SYMBOL N, a final effect), and ask HOW DATA TRAVELS between "
+            "them. The middle symbol(s) are the answer to be discovered; "
+            "describe ONLY the two ends."
+        ),
+        "anchor_indices": "ends",  # special: chain[0] + chain[-1]
+    },
+}
+
+
+def _resolve_anchor_indices(stance: str, chain_len: int) -> List[int]:
+    cfg = STANCES[stance]
+    raw = cfg["anchor_indices"]
+    if raw == "ends":
+        return [0, chain_len - 1]
+    return list(raw)
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+_TRAVERSAL_BASE_RULES = (
+    "  (a) Frames a real debugging / understanding question that requires "
+    "      reading ALL chain symbols together to answer — not just one of "
+    "      them in isolation.\n"
+    "  (b) Reads like a user encountering an observable issue at runtime.\n"
+    "  (c) ABSOLUTELY DOES NOT mention any symbol name, function name, "
+    "      class name, method name, file path, file extension, variable "
+    "      name, or any other lexical token taken verbatim from ANY chain "
+    "      member (including the anchor symbols whose BEHAVIOR you DO "
+    "      describe). Names of the language, library, or domain (e.g. "
+    '      "astropy", "numpy") are also forbidden.\n'
+    "  (d) Frames the question so a keyword/grep agent has NO lexical hook "
+    "      to land on the right symbols, but a graph agent can follow edges "
+    "      from one anchor to the next.\n"
+    "  (e) Length: 60–130 words, ends with a question mark.\n"
+)
+
+
+def _system_prompt_for(stance: str) -> str:
+    cfg = STANCES[stance]
+    return (
+        "You are creating a code-search benchmark query for testing graph-"
+        "based retrieval. You will be given an ORDERED CHAIN of source-code "
+        f"symbols connected by call/reference edges.\n\n"
+        f"STANCE = {stance!r}\n{cfg['narrative']}\n\n"
+        "Your job: write ONE natural-language question that satisfies ALL of:\n"
+        + _TRAVERSAL_BASE_RULES
+        + '\nOutput STRICT JSON with one key: {"query": "..."}. No prose, no '
+        "markdown, no commentary outside the JSON."
+    )
+
+
+def _judge_prompt_for(stance: str) -> str:
+    cfg = STANCES[stance]
+    return (
+        "You evaluate synthesized 'traversal' code-search queries for a "
+        "retrieval benchmark. The query has a declared STANCE that controls "
+        "which symbols' behavior should be paraphrased vs. hidden.\n\n"
+        f"STANCE = {stance!r}\n{cfg['narrative']}\n\n"
+        "Grade against THREE bars at once:\n"
+        "  - Topic correctness: the question accurately describes the "
+        "    STANCE's intended anchor(s) and the answer plausibly requires "
+        "    traversing the remaining (hidden) chain members.\n"
+        "  - Graph-only solvability: the question contains NO verbatim "
+        "    symbol/file/class/method/variable names from ANY chain member.\n"
+        "  - Stance compliance: behaviors of HIDDEN chain members must not "
+        "    be paraphrased; only the anchor positions for this stance may "
+        "    be described.\n\n"
+        "Pick exactly one verdict:\n"
+        "  - 'valid': all three bars met.\n"
+        "  - 'fix': topic + stance right but minor lexical leak; small edit "
+        "    would fix it.\n"
+        "  - 'regenerate': topic mismatch, multiple leaks, hidden member "
+        "    behavior described, or vacuous/malformed.\n\n"
+        "Give a one-sentence reason."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chain extraction
+# ---------------------------------------------------------------------------
+
+
+# Classes are weaker chain members (mostly contain edges) but kept as fallback.
+_CHAIN_NODE_KINDS = {NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_CLASS}
+
+_MIN_CHAIN_MEMBER_LINES = 8
+_MAX_CHAIN_MEMBER_LINES = 400
+
+
+class ChainMember:
+    __slots__ = ("vid", "name", "type", "file", "start_line", "end_line", "content")
+
+    def __init__(
+        self,
+        vid: int,
+        name: str,
+        type_: str,
+        file: str,
+        start_line: int,
+        end_line: int,
+        content: str,
+    ) -> None:
+        self.vid = vid
+        self.name = name
+        self.type = type_
+        self.file = file
+        self.start_line = start_line
+        self.end_line = end_line
+        self.content = content
+
+    @property
+    def basename(self) -> str:
+        return re.split(r"[:/]", self.name)[-1].rstrip("()")
+
+    @property
+    def line_count(self) -> int:
+        return max(0, (self.end_line or 0) - (self.start_line or 0) + 1)
+
+
+def _vertex_to_member(code_graph: Any, vid: int) -> Optional[ChainMember]:
+    try:
+        attrs = code_graph.get_node_info_by_id(vid)
+    except Exception:
+        return None
+    if not attrs:
+        return None
+    node_type = attrs.get("type")
+    if node_type not in _CHAIN_NODE_KINDS:
+        return None
+    file = attrs.get("file")
+    start = attrs.get("start_line")
+    end = attrs.get("end_line")
+    name = attrs.get("name")
+    if not (file and name and isinstance(start, int) and isinstance(end, int)):
+        return None
+    line_count = max(0, end - start + 1)
+    if line_count < _MIN_CHAIN_MEMBER_LINES or line_count > _MAX_CHAIN_MEMBER_LINES:
+        return None
+    content = code_graph.get_node_content(vid) or ""
+    content = content.strip()
+    if len(content) < 60:
+        return None
+    return ChainMember(vid, name, node_type, file, start, end, content)
+
+
+def _pick_neighbor(
+    code_graph: Any,
+    member: ChainMember,
+    *,
+    direction: str,
+    visited_vids: set,
+    visited_basenames: set,
+    rng: random.Random,
+) -> Optional[ChainMember]:
+    # Weighted by graph degree (more central node → richer chain story) and
+    # by cross-file bias (same-file neighbors are weaker because file_hint
+    # would already pin them).
+    if direction == "successor":
+        cand_vids = code_graph.get_successors(member.name)
+    elif direction == "predecessor":
+        cand_vids = code_graph.get_predecessors(member.name)
+    else:
+        raise ValueError(direction)
+    cand_vids = [v for v in cand_vids if v not in visited_vids]
+    if not cand_vids:
+        return None
+
+    candidates: List[Tuple[ChainMember, int]] = []
+    g = code_graph.get_graph()
+    for vid in cand_vids:
+        m = _vertex_to_member(code_graph, vid)
+        if m is None:
+            continue
+        if m.basename.lower() in visited_basenames:
+            continue
+        if m.file == member.file:
+            weight = 1  # same-file: down-weighted, since file_hint would already pin it
+        else:
+            weight = 5
+        deg = g.degree(vid) if isinstance(vid, int) else 1
+        candidates.append((m, weight * (1 + min(deg, 20))))
+
+    if not candidates:
+        return None
+    members, weights = zip(*candidates, strict=False)
+    pick = rng.choices(members, weights=weights, k=1)[0]
+    return pick
+
+
+def build_chain(
+    code_graph: Any,
+    seed: ChainMember,
+    *,
+    hops: int,
+    direction: str,
+    rng: random.Random,
+) -> Optional[List[ChainMember]]:
+    chain = [seed]
+    visited_vids = {seed.vid}
+    visited_basenames = {seed.basename.lower()}
+
+    for _ in range(hops):
+        prev = chain[-1]
+        nxt = _pick_neighbor(
+            code_graph,
+            prev,
+            direction=direction,
+            visited_vids=visited_vids,
+            visited_basenames=visited_basenames,
+            rng=rng,
+        )
+        if nxt is None:
+            return None
+        chain.append(nxt)
+        visited_vids.add(nxt.vid)
+        visited_basenames.add(nxt.basename.lower())
+
+    return chain
+
+
+def _chain_is_good(chain: List[ChainMember]) -> Tuple[bool, str]:
+    if len(chain) < 2:
+        return False, "chain too short"
+    normalized_contents = {
+        re.sub(r"\s+", " ", (m.content or "").strip()) for m in chain
+    }
+    if len(normalized_contents) < len(chain):
+        return False, "chain contains duplicate code excerpts"
+    return True, "ok"
+
+
+def _chain_key(chain: List[ChainMember]) -> Tuple[str, ...]:
+    return tuple(m.name for m in chain)
+
+
+def _read_json_payload(path: Path) -> Any:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _load_excluded_chain_keys(paths: List[str]) -> set[Tuple[str, ...]]:
+    excluded: set[Tuple[str, ...]] = set()
+    for raw_path in paths:
+        path = Path(raw_path).expanduser()
+        if path.is_dir():
+            candidates = sorted(
+                p
+                for p in path.rglob("*.json")
+                if p.name.startswith("synthesized_queries_")
+            )
+        else:
+            candidates = [path]
+        for candidate in candidates:
+            if not candidate.exists():
+                raise FileNotFoundError(candidate)
+            payload = _read_json_payload(candidate)
+            rows = payload if isinstance(payload, list) else [payload]
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                symbols = row.get("gt_symbols") or row.get("target_symbols") or []
+                if symbols:
+                    excluded.add(tuple(str(s) for s in symbols))
+    return excluded
+
+
+# ---------------------------------------------------------------------------
+# Query generation
+# ---------------------------------------------------------------------------
+
+_MAX_BLOCK_CHARS_IN_PROMPT = 1500
+
+
+def _format_chain_for_prompt(chain: List[ChainMember], stance: str) -> str:
+    anchor_idxs = set(_resolve_anchor_indices(stance, len(chain)))
+    parts = []
+    for i, m in enumerate(chain, 1):
+        is_anchor = (i - 1) in anchor_idxs
+        role = (
+            "ANCHOR (paraphrase this symbol's BEHAVIOR; never its name)"
+            if is_anchor
+            else "HIDDEN (do NOT describe this symbol's behavior; it is the answer to discover)"
+        )
+        if is_anchor:
+            snippet = (
+                m.content
+                if len(m.content) <= _MAX_BLOCK_CHARS_IN_PROMPT
+                else m.content[:_MAX_BLOCK_CHARS_IN_PROMPT] + "..."
+            )
+        else:
+            snippet = (
+                "[hidden from generation: this chain member is part of the "
+                "answer and must not be paraphrased or named in the query]"
+            )
+        if is_anchor:
+            location = (
+                f"file: {m.file}\n"
+                f"name: {m.name}\n"
+                f"kind: {m.type}\n"
+                f"lines: {m.start_line}-{m.end_line}"
+            )
+        else:
+            location = "file: [hidden]\nname: [hidden]\nkind: [hidden]\nlines: [hidden]"
+        parts.append(
+            f"--- SYMBOL {i} of {len(chain)} — ROLE: {role} ---\n"
+            f"{location}\n"
+            f"```\n{snippet}\n```"
+        )
+    return "\n\n".join(parts)
+
+
+def _forbidden_lexical_hooks(chain: List[ChainMember]) -> List[str]:
+    hooks: set = set()
+    for m in chain:
+        if m.file:
+            hooks.add(m.file)
+            hooks.add(Path(m.file).name)
+            hooks.add(Path(m.file).stem)
+        parts = re.split(r"[:/.]", m.name)
+        for p in parts:
+            p = p.strip("()")
+            if p and not p.isdigit():
+                hooks.add(p)
+        if m.basename:
+            hooks.add(m.basename)
+    # Skip short / generic tokens to avoid false positives on words like "name", "data".
+    return [h for h in hooks if len(h) >= 4 and h.lower() not in _COMMON_TOKENS]
+
+
+_COMMON_TOKENS = {
+    "self",
+    "init",
+    "main",
+    "test",
+    "data",
+    "type",
+    "info",
+    "value",
+    "name",
+    "path",
+    "file",
+    "line",
+    "true",
+    "false",
+    "none",
+    "null",
+    "args",
+    "kwargs",
+    "func",
+    "list",
+    "dict",
+    "node",
+    "root",
+    "size",
+}
+
+
+def _query_violates_anti_grep(query: str, hooks: List[str]) -> List[str]:
+    q = query.lower()
+    leaked = []
+    for h in hooks:
+        # Substring (not word-boundary) so compound matches like
+        # "binom_conf_interval" inside "binom_conf_intervalled" still leak.
+        if h.lower() in q:
+            leaked.append(h)
+    return leaked
+
+
+async def _generate_query(
+    chain: List[ChainMember],
+    *,
+    stance: str,
+    model: str,
+    extra_instruction: str = "",
+    max_turns: int = 1,
+) -> Optional[str]:
+    agent = AgentRunner(
+        model=model,
+        max_turns=max_turns,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=_system_prompt_for(stance),
+    )
+    prompt = _format_chain_for_prompt(chain, stance)
+    if extra_instruction:
+        prompt = f"{prompt}\n\nADDITIONAL CONSTRAINT: {extra_instruction}"
+    prompt += "\n\nOutput JSON only."
+    raw = await agent.run_async(prompt)
+    return _extract_query(raw)
+
+
+def _extract_query(raw: str) -> Optional[str]:
+    fenced = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", raw)
+    candidate = fenced.group(1) if fenced else None
+    if not candidate:
+        m = re.search(r'\{[\s\S]*?"query"[\s\S]*?\}', raw)
+        if not m:
+            return None
+        candidate = m.group(0)
+    try:
+        obj = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    q = obj.get("query")
+    if isinstance(q, str) and q.strip():
+        return q.strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Judge
+# ---------------------------------------------------------------------------
+
+
+async def _judge_one(
+    *, query: str, chain: List[ChainMember], stance: str, model: str
+) -> Tuple[str, str]:
+    anchor_idxs = set(_resolve_anchor_indices(stance, len(chain)))
+    payload = {
+        "query": query,
+        "stance": stance,
+        "chain": [
+            {
+                "position": i + 1,
+                "role": "anchor" if i in anchor_idxs else "hidden",
+                "name": m.name,
+                "file": m.file,
+                "code_excerpt": (m.content or "")[:1200],
+            }
+            for i, m in enumerate(chain)
+        ],
+    }
+    agent = AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=_judge_prompt_for(stance),
+    )
+    prompt = (
+        "Evaluate the following traversal query against the supplied chain. "
+        'Reply with a single JSON object: {"verdict": "valid|fix|regenerate", '
+        '"reason": "..."}. Do not include any prose outside the JSON.\n\n'
+        f"INPUT:\n{json.dumps(payload, ensure_ascii=False, indent=2)}"
+    )
+    raw = await agent.run_async(prompt)
+    fenced = re.search(r"```(?:json)?\s*(\{[\s\S]*?\})\s*```", raw)
+    text = fenced.group(1) if fenced else None
+    if not text:
+        m = re.search(r"\{[\s\S]*?\"verdict\"[\s\S]*?\}", raw)
+        text = m.group(0) if m else None
+    if not text:
+        return "unknown", "judge did not return JSON"
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        return "unknown", "judge JSON parse failed"
+    return obj.get("verdict", "unknown"), obj.get("reason", "")
+
+
+# ---------------------------------------------------------------------------
+# Record assembly
+# ---------------------------------------------------------------------------
+
+
+def _to_record(
+    *,
+    instance: Dict[str, Any],
+    query_id: str,
+    query: str,
+    chain: List[ChainMember],
+    hops: int,
+    stance: str,
+    judge_verdict: str,
+    judge_reason: str,
+    anti_grep_leaks: List[str],
+) -> Dict[str, Any]:
+    anchor_idxs = _resolve_anchor_indices(stance, len(chain))
+    hidden_idxs = [i for i in range(len(chain)) if i not in anchor_idxs]
+    return {
+        "repo": instance.get("repo"),
+        "instance_id": instance.get("instance_id"),
+        "base_commit": instance.get("base_commit"),
+        "language_group": instance.get("language_group"),
+        "query": query,
+        "category": "traversal",
+        "gt_files": sorted({m.file for m in chain}),
+        "gt_symbols": [m.name for m in chain],
+        "gt_symbol_nodes": [
+            {
+                "node_name": m.name,
+                "file": m.file,
+                "type": m.type,
+                "start_line": m.start_line,
+                "end_line": m.end_line,
+                "content": m.content,
+            }
+            for m in chain
+        ],
+        "query_id": query_id,
+        "length_variant": "detailed",
+        "judge_verdict": judge_verdict,
+        "judge_reason": judge_reason,
+        "chain_metadata": {
+            "hop_count": hops,
+            "chain_length": len(chain),
+            "stance": stance,
+            "direction": STANCES[stance]["direction"],
+            "anchor_indices": anchor_idxs,
+            "hidden_indices": hidden_idxs,
+            "anchor_symbols": [chain[i].name for i in anchor_idxs],
+            "hidden_symbols": [chain[i].name for i in hidden_idxs],
+            "spans_files": sorted({m.file for m in chain}),
+            "spans_n_files": len({m.file for m in chain}),
+            "anti_grep_leaks_at_last_gen": anti_grep_leaks,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main pipeline
+# ---------------------------------------------------------------------------
+
+
+def _parse_stance_counts(raw: str) -> Dict[str, int]:
+    """Parse ``"trace_back=10,trace_down=10,bridge=10"`` into a dict.
+
+    Validates stance names against the STANCES registry; raises on unknown
+    or non-positive counts.
+    """
+    out: Dict[str, int] = {}
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            raise ValueError(f"Bad --stance-counts entry {chunk!r}; want name=N.")
+        name, value = chunk.split("=", 1)
+        name = name.strip()
+        if name not in STANCES:
+            valid = ", ".join(STANCES.keys())
+            raise ValueError(f"Unknown stance {name!r}. Valid: {valid}")
+        n = int(value.strip())
+        if n < 0:
+            raise ValueError(f"Count for {name!r} must be >= 0.")
+        if n > 0:
+            out[name] = n
+    if not out:
+        raise ValueError("--stance-counts produced no stances with count > 0.")
+    return out
+
+
+def _load_seed_instance(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    seed = data[0] if isinstance(data, list) and data else data
+    required = ("repo", "instance_id", "base_commit")
+    missing = [k for k in required if not seed.get(k)]
+    if missing:
+        raise ValueError(f"Seed file {path} missing fields: {missing}")
+    instance = {k: seed[k] for k in required}
+    if seed.get("language_group"):
+        instance["language_group"] = seed["language_group"]
+    return instance
+
+
+async def _generate_one_with_anti_grep(
+    chain: List[ChainMember],
+    *,
+    stance: str,
+    model: str,
+    max_turns: int,
+    extra_instruction: str = "",
+    max_anti_grep_retries: int = 2,
+) -> Tuple[Optional[str], List[str]]:
+    hooks = _forbidden_lexical_hooks(chain)
+    leaks: List[str] = []
+    extra = extra_instruction
+    query: Optional[str] = None
+    for attempt in range(1, max_anti_grep_retries + 1 + 1):
+        query = await _generate_query(
+            chain,
+            stance=stance,
+            model=model,
+            extra_instruction=extra,
+            max_turns=max_turns,
+        )
+        if not query:
+            logger.warning("generator returned no query (attempt %d)", attempt)
+            continue
+        leaks = _query_violates_anti_grep(query, hooks)
+        if not leaks:
+            return query, []
+        logger.info(
+            "anti-grep leak on attempt %d: %s — retrying with stronger nudge",
+            attempt,
+            leaks[:3],
+        )
+        leak_instruction = (
+            "Your previous attempt leaked these forbidden tokens: "
+            + ", ".join(f"`{t}`" for t in leaks[:5])
+            + ". Rewrite the query so NONE of these tokens appear anywhere in "
+            "it, even as a substring of another word. Use pure behavioral "
+            "English."
+        )
+        extra = (
+            f"{extra_instruction}\n\n{leak_instruction}"
+            if extra_instruction
+            else leak_instruction
+        )
+    return query, leaks
+
+
+async def _run_pipeline(args: argparse.Namespace) -> None:
+    instance = _load_seed_instance(Path(args.seed_file).expanduser())
+
+    stance_counts = _parse_stance_counts(args.stance_counts)
+    total = sum(stance_counts.values())
+
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = (
+        Path(args.cache_dir).expanduser()
+        if args.cache_dir
+        else Path.home() / ".codeminer"
+    )
+
+    # ---- Phase 1: load repo + build CodeGraph ----
+    logger.info("Building CodeGraph for %s ...", instance["instance_id"])
+    context_agent = AgentRunner(
+        model=args.model,
+        max_turns=4,
+        allowed_tools=["Read", "Glob", "Grep", "Bash"],
+        permission_mode="bypassPermissions",
+    )
+    loader = ContextLoader(
+        agent=context_agent,
+        max_candidate_blocks=max(total * 10, 100),
+        sampling_seed=args.sampling_seed,
+    )
+    repo_path, snapshot = loader.checkout_and_snapshot(
+        instance,
+        repo_root=args.repo_cache_dir,
+        cache_dir=str(cache_dir),
+    )
+    code_graph = loader.load_code_graph(
+        instance=instance, repo_path=repo_path, cache_dir=str(cache_dir)
+    )
+    if code_graph is None:
+        raise RuntimeError("Failed to build SCIP code graph.")
+    candidate_blocks = loader.sample_candidate_blocks(code_graph, instance)
+    if not candidate_blocks:
+        raise RuntimeError("No usable candidate blocks sampled from graph.")
+    logger.info("Graph + %d candidate blocks ready.", len(candidate_blocks))
+
+    # ---- Phase 2: pick seeds ----
+    rng = random.Random(args.sampling_seed)
+    seed_members: List[ChainMember] = []
+    for blk in candidate_blocks:
+        m = _vertex_to_member(code_graph, blk.node_id)
+        if m is not None:
+            seed_members.append(m)
+        if len(seed_members) >= total * 10:
+            break
+    if len(seed_members) < total:
+        logger.warning(
+            "Only %d hydratable seeds available for %d queries; will retry "
+            "until we hit the target.",
+            len(seed_members),
+            total,
+        )
+
+    # ---- Phase 3: generate queries ----
+    logger.info(
+        "Stance plan: %s (total=%d)",
+        {k: v for k, v in stance_counts.items()},
+        total,
+    )
+    excluded_chain_keys = _load_excluded_chain_keys(args.exclude_chain_file)
+    if excluded_chain_keys:
+        logger.info("Loaded %d excluded traversal chain(s).", len(excluded_chain_keys))
+
+    # Shuffle so failures in one stance don't starve others.
+    stance_plan: List[str] = []
+    for stance, n in stance_counts.items():
+        stance_plan.extend([stance] * n)
+    rng.shuffle(stance_plan)
+
+    output_path = output_dir / f"synthesized_queries_{instance['instance_id']}.json"
+    records: List[Dict[str, Any]] = []
+    seen_chain_keys: set[Tuple[str, ...]] = set(excluded_chain_keys)
+
+    next_seed_idx = 0
+    per_stance_q_counter: Dict[str, int] = {s: 0 for s in stance_counts}
+    overall_done = 0
+    plan_idx = 0
+    while overall_done < total and next_seed_idx < len(seed_members):
+        if plan_idx >= len(stance_plan):
+            # Refill with whatever's left of each stance's quota.
+            stance_plan = [
+                s
+                for s, target in stance_counts.items()
+                for _ in range(target - per_stance_q_counter[s])
+            ]
+            rng.shuffle(stance_plan)
+            plan_idx = 0
+            if not stance_plan:
+                break
+
+        stance = stance_plan[plan_idx]
+        plan_idx += 1
+        seed = seed_members[next_seed_idx]
+        next_seed_idx += 1
+
+        # bridge needs 3-symbol chains (2 hops); trace_back/down need 2-symbol (1 hop)
+        hops = 2 if stance == "bridge" else 1
+        direction = STANCES[stance]["direction"]
+        chain = build_chain(
+            code_graph,
+            seed,
+            hops=hops,
+            direction=direction,
+            rng=rng,
+        )
+        if chain is None:
+            logger.info(
+                "[seed=%s][stance=%s] chain build failed (no %s neighbor)",
+                seed.basename,
+                stance,
+                direction,
+            )
+            continue
+        chain_key = _chain_key(chain)
+        if chain_key in seen_chain_keys:
+            logger.info(
+                "[seed=%s][stance=%s] chain skipped: already generated/excluded",
+                seed.basename,
+                stance,
+            )
+            continue
+        ok, why = _chain_is_good(chain)
+        if not ok:
+            logger.info(
+                "[seed=%s][stance=%s] chain rejected: %s (members=%s)",
+                seed.basename,
+                stance,
+                why,
+                [m.basename for m in chain],
+            )
+            continue
+
+        query_id = (
+            f"{instance['instance_id']}_traversal_{stance}_q"
+            f"{per_stance_q_counter[stance] + 1}"
+        )
+        logger.info(
+            "[%d/%d] %s — chain (%d hops, %s): %s",
+            overall_done + 1,
+            total,
+            query_id,
+            len(chain) - 1,
+            direction,
+            " -> ".join(m.basename for m in chain),
+        )
+
+        query: Optional[str] = None
+        leaks: List[str] = []
+        verdict = "regenerate"
+        reason = "empty query from generator"
+        extra_instruction = ""
+        for judge_attempt in range(args.judge_retries + 1):
+            query, leaks = await _generate_one_with_anti_grep(
+                chain,
+                stance=stance,
+                model=args.model,
+                max_turns=args.max_turns,
+                extra_instruction=extra_instruction,
+                max_anti_grep_retries=args.anti_grep_retries,
+            )
+            if not query:
+                logger.warning("[%s] empty query after retries", query_id)
+                reason = "empty query from generator"
+                continue
+
+            verdict, reason = await _judge_one(
+                query=query, chain=chain, stance=stance, model=args.judge_model
+            )
+            logger.info(
+                "[%s] judge=%s | leaks=%s | first 120ch=%s",
+                query_id,
+                verdict,
+                leaks[:3] if leaks else "none",
+                query[:120],
+            )
+            if verdict == "valid":
+                break
+            if judge_attempt < args.judge_retries:
+                extra_instruction = (
+                    "A traversal-query judge rejected the previous attempt: "
+                    f"{reason} Regenerate a substantially different query that "
+                    "keeps only the allowed anchor behavior, hides every answer "
+                    "symbol's behavior, and avoids verbatim code tokens."
+                )
+
+        if not query:
+            if args.keep_invalid:
+                records.append(
+                    _to_record(
+                        instance=instance,
+                        query_id=query_id,
+                        query="",
+                        chain=chain,
+                        hops=len(chain) - 1,
+                        stance=stance,
+                        judge_verdict=verdict,
+                        judge_reason=reason,
+                        anti_grep_leaks=leaks,
+                    )
+                )
+                per_stance_q_counter[stance] += 1
+                overall_done += 1
+            continue
+
+        record = _to_record(
+            instance=instance,
+            query_id=query_id,
+            query=query,
+            chain=chain,
+            hops=len(chain) - 1,
+            stance=stance,
+            judge_verdict=verdict,
+            judge_reason=reason,
+            anti_grep_leaks=leaks,
+        )
+        if verdict == "valid" or args.keep_invalid:
+            records.append(record)
+            seen_chain_keys.add(chain_key)
+            per_stance_q_counter[stance] += 1
+            overall_done += 1
+            # Incremental save
+            output_path.write_text(
+                json.dumps(records, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+        else:
+            logger.info("[%s] skipped non-valid traversal query.", query_id)
+
+    # ---- Phase 4: post-fix flagged rows ----
+    if args.keep_invalid and args.post_fix_max_retries > 0:
+        logger.info(
+            "Initial pass complete (%d/%d generated). Running post-fix on any "
+            "flagged rows...",
+            len(records),
+            total,
+        )
+        records, postfix_stats = await post_fix_flagged(
+            records,
+            model=args.model,
+            judge_model=args.judge_model,
+            max_retries=args.post_fix_max_retries,
+        )
+    else:
+        postfix_stats = {
+            "flagged": 0,
+            "promoted_at_triage": 0,
+            "fixed_via_fix": 0,
+            "fixed_via_regenerate": 0,
+            "still_flagged": 0,
+        }
+    output_path.write_text(
+        json.dumps(records, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    # ---- Phase 5: summary ----
+    n_valid = sum(1 for r in records if r.get("judge_verdict") == "valid")
+    n_multihop = sum(1 for r in records if len(r.get("gt_symbol_nodes") or []) > 1)
+    by_stance: Dict[str, Dict[str, int]] = {
+        s: {"total": 0, "valid": 0} for s in stance_counts
+    }
+    for r in records:
+        s = (r.get("chain_metadata") or {}).get("stance") or "unknown"
+        if s not in by_stance:
+            by_stance[s] = {"total": 0, "valid": 0}
+        by_stance[s]["total"] += 1
+        if r.get("judge_verdict") == "valid":
+            by_stance[s]["valid"] += 1
+
+    print()
+    print("=" * 60)
+    print(f"traversal synthesis  →  {output_path}")
+    print("=" * 60)
+    print(f"  total queries:           {len(records)}/{total}")
+    print(f"  judge valid:             {n_valid}")
+    print(f"  with multi-hop GT (>=2): {n_multihop}")
+    print(f"  post-fix stats:          {postfix_stats}")
+    print(f"  per-stance:")
+    for s, d in by_stance.items():
+        print(f"      {s:<12}  {d['valid']:>2}/{d['total']:<2} valid")
+    if len(records) < total and not args.allow_partial:
+        raise RuntimeError(
+            f"Generated {len(records)} traversal rows, expected {total}. "
+            "Rerun with a different --sampling-seed or --allow-partial for diagnostics."
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--seed-file",
+        required=True,
+        type=str,
+        help="JSON whose first row gives repo / instance_id / base_commit.",
+    )
+    p.add_argument(
+        "--output-dir", default="synthesis_output_traversal_v2_x30", type=str
+    )
+    p.add_argument(
+        "--stance-counts",
+        default="trace_back=10,trace_down=10,bridge=10",
+        type=str,
+        help=(
+            "Comma-separated <stance>=<count>, e.g. "
+            '"trace_back=10,trace_down=10,bridge=10". '
+            "Valid stances: trace_back, trace_down, bridge."
+        ),
+    )
+    p.add_argument(
+        "--n-queries",
+        type=int,
+        default=None,
+        help="Deprecated. Use --stance-counts instead.",
+    )
+    p.add_argument("--model", default="opus", help="Model for the generator.")
+    p.add_argument("--judge-model", default="opus", help="Model for the judge.")
+    p.add_argument(
+        "--sampling-seed",
+        type=int,
+        default=42,
+        help="Seed for chain extraction RNG.",
+    )
+    p.add_argument(
+        "--anti-grep-retries",
+        type=int,
+        default=2,
+        help="Extra generator attempts when the first attempt leaks chain "
+        "symbol names into the query.",
+    )
+    p.add_argument(
+        "--judge-retries",
+        type=int,
+        default=2,
+        help="Regenerate a candidate this many times after traversal judge rejection.",
+    )
+    p.add_argument("--max-turns", type=int, default=10)
+    p.add_argument(
+        "--post-fix-max-retries",
+        type=int,
+        default=3,
+        help="Standard post-fix loop max retries (same flag as other multipliers).",
+    )
+    p.add_argument(
+        "--keep-invalid",
+        action="store_true",
+        help=(
+            "Keep traversal rows judged non-valid instead of skipping them. "
+            "Useful for diagnostics; release generation should leave this off."
+        ),
+    )
+    p.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Exit successfully even if fewer than the requested rows are generated.",
+    )
+    p.add_argument(
+        "--exclude-chain-file",
+        action="append",
+        default=[],
+        help=(
+            "Existing traversal JSON file or directory whose gt_symbols chains "
+            "should be skipped while generating new rows. May be repeated."
+        ),
+    )
+    p.add_argument("--cache-dir", type=str, default=None)
+    p.add_argument("--repo-cache-dir", type=str, default=None)
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    asyncio.run(_run_pipeline(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/postfix_flagged_file.py
+++ b/scripts/postfix_flagged_file.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Apply post-fix to flagged rows in an existing synthesized-queries JSON.
+
+Reads ``--input`` JSON, finds rows with ``judge_verdict='regenerate'``, asks
+Claude to fix each one with the judge's complaint as feedback, re-judges, and
+writes the modified rows back to ``--input`` in place (or to ``--output``).
+
+Example
+-------
+    python scripts/postfix_flagged_file.py \\
+        --input synthesis_output_per_language/Go.json \\
+        --model opus --judge-model opus
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _post_fix import post_fix_flagged  # noqa: E402
+
+
+async def _main(args: argparse.Namespace) -> None:
+    input_path = Path(args.input).expanduser()
+    output_path = Path(args.output).expanduser() if args.output else input_path
+    rows = json.loads(input_path.read_text(encoding="utf-8"))
+    print(f"Loaded {len(rows)} rows from {input_path}")
+
+    rows, stats = await post_fix_flagged(
+        rows,
+        model=args.model,
+        judge_model=args.judge_model,
+        max_retries=args.max_retries,
+    )
+
+    output_path.write_text(
+        json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"\n--- Post-fix summary ---")
+    print(f"Flagged at start:            {stats['flagged']}")
+    print(f"Promoted at triage re-judge: {stats['promoted_at_triage']}")
+    print(f"Fixed via 'fix' mode:        {stats['fixed_via_fix']}")
+    print(f"Fixed via 'regenerate' mode: {stats['fixed_via_regenerate']}")
+    print(f"Still flagged:               {stats['still_flagged']}")
+    print(f"Wrote: {output_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--input", required=True, type=str)
+    p.add_argument(
+        "--output",
+        default=None,
+        type=str,
+        help="Where to write fixed rows. Defaults to overwriting --input.",
+    )
+    p.add_argument("--model", default="opus", help="Model for the fixer.")
+    p.add_argument("--judge-model", default="opus", help="Model for re-judging.")
+    p.add_argument("--max-retries", type=int, default=3)
+    return p
+
+
+if __name__ == "__main__":
+    asyncio.run(_main(build_parser().parse_args()))

--- a/scripts/push_synthesis_to_hf.py
+++ b/scripts/push_synthesis_to_hf.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Push a directory of synthesized-query JSONs to HuggingFace as one config
+of a multi-config dataset.
+
+Each row of the resulting dataset is one query entry (the schema produced by
+``scripts/multiply_behavior_queries.py:_to_compact_record``). All ``*.json``
+files in ``--input-dir`` are flattened into rows.
+
+First push creates the repo. Subsequent pushes with a different
+``--config-name`` add new configurations under the same dataset and downstream
+users load them as ``load_dataset(repo_id, config_name)``.
+
+Auth: ``hf auth login`` (or ``huggingface-cli login``) before running.
+
+Example
+-------
+    python scripts/push_synthesis_to_hf.py \\
+        --input-dir synthesis_output_behavior_x20/ \\
+        --repo-id sysevol-ai/codeminer-synthesis \\
+        --config-name behavioral_x20
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from datasets import Dataset
+from huggingface_hub import DatasetCard, DatasetCardData
+
+
+def _load_rows(input_dir: Path) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    files = sorted(input_dir.glob("*.json"))
+    if not files:
+        raise FileNotFoundError(f"No JSON files in {input_dir}")
+    for f in files:
+        with f.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        entries = data if isinstance(data, list) else [data]
+        rows.extend(entries)
+    return rows
+
+
+def _ensure_license(repo_id: str, license_id: str) -> None:
+    """Set the dataset card license without disturbing the configs block."""
+    try:
+        card = DatasetCard.load(repo_id, repo_type="dataset")
+    except Exception:
+        card = DatasetCard(content="", data=DatasetCardData())
+    card.data.license = license_id
+    card.push_to_hub(repo_id, repo_type="dataset")
+    print(f"License set to {license_id}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--input-dir", required=True, type=Path)
+    p.add_argument("--repo-id", default="sysevol-ai/codeminer-synthesis")
+    p.add_argument(
+        "--config-name",
+        required=True,
+        help="HuggingFace config name (e.g. behavioral_x20, symbol_hint_v1).",
+    )
+    p.add_argument("--split", default="test")
+    p.add_argument(
+        "--private",
+        action="store_true",
+        help="Make the repo private (default: public).",
+    )
+    p.add_argument("--license", default="apache-2.0")
+    p.add_argument(
+        "--commit-message",
+        default=None,
+        help="Override the auto-generated commit message.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the Dataset locally but don't push.",
+    )
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    rows = _load_rows(args.input_dir.expanduser())
+    print(f"Loaded {len(rows)} rows from {args.input_dir}")
+    if not rows:
+        raise ValueError("No rows to upload.")
+
+    n_instances = len({r.get("instance_id") for r in rows if r.get("instance_id")})
+    print(f"  spans {n_instances} instance(s)")
+
+    ds = Dataset.from_list(rows)
+    print(f"  first row keys: {list(rows[0].keys())}")
+
+    if args.dry_run:
+        print("--dry-run set; not pushing.")
+        return
+
+    commit_msg = args.commit_message or f"Add {args.config_name} ({len(rows)} rows)"
+    print(
+        f"Pushing to {args.repo_id} "
+        f"(config={args.config_name}, split={args.split}, private={args.private})..."
+    )
+    ds.push_to_hub(
+        args.repo_id,
+        config_name=args.config_name,
+        split=args.split,
+        private=args.private,
+        commit_message=commit_msg,
+    )
+    _ensure_license(args.repo_id, args.license)
+    print(f"Done. https://huggingface.co/datasets/{args.repo_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rebuild_codeminer_synthesis_dataset.py
+++ b/scripts/rebuild_codeminer_synthesis_dataset.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rebuild the CodeMiner synthesis dataset into a Hugging Face-ready folder.
+
+This script assembles one parquet file per language config, writes dataset-card
+metadata with the benchmark split set to ``test``, and runs the local quality
+gate before an optional upload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+import datasets
+from huggingface_hub import HfApi
+
+from codeminer.dataset.codeminer_synthesis import (
+    ALL_CONFIGS,
+    DEFAULT_DATASET,
+    DEFAULT_SPLIT,
+    EXPECTED_BASE_CATEGORY_COUNTS,
+    EXPECTED_CATEGORY_COUNTS_WITH_TRAVERSAL,
+    SYNTHESIS_FEATURES,
+    normalize_synthesis_record,
+    parse_config_list,
+    validate_synthesis_records,
+)
+
+
+def _load_hf_config(
+    dataset_name: str, config_name: str, split: str
+) -> List[Dict[str, Any]]:
+    ds = datasets.load_dataset(dataset_name, config_name, split=split)
+    return [normalize_synthesis_record(row, config_name) for row in ds]
+
+
+def _read_json_records(path: Path) -> List[Mapping[str, Any]]:
+    if path.suffix.lower() == ".jsonl":
+        rows: List[Mapping[str, Any]] = []
+        with path.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    rows.append(json.loads(line))
+        return rows
+
+    with path.open(encoding="utf-8") as fh:
+        payload = json.load(fh)
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        for key in ("rows", "data", "instances", "queries"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+        return [payload]
+    raise ValueError(f"Unsupported JSON payload in {path}: {type(payload).__name__}")
+
+
+def _load_replacement(path: Path, config_name: str) -> List[Dict[str, Any]]:
+    paths: List[Path]
+    if path.is_dir():
+        paths = sorted(
+            p for p in path.rglob("*") if p.suffix.lower() in {".json", ".jsonl"}
+        )
+    else:
+        paths = [path]
+    if not paths:
+        raise ValueError(f"No JSON/JSONL replacement files found under {path}")
+
+    records: List[Dict[str, Any]] = []
+    for file_path in paths:
+        records.extend(
+            normalize_synthesis_record(row, config_name)
+            for row in _read_json_records(file_path)
+        )
+    return records
+
+
+def _parse_config_paths(values: Iterable[str]) -> Dict[str, List[Path]]:
+    paths_by_config: Dict[str, List[Path]] = {}
+    for value in values:
+        if "=" not in value:
+            raise ValueError(
+                f"Bad config path {value!r}; expected CONFIG=/path/to/json"
+            )
+        config_name, path = value.split("=", 1)
+        config_name = config_name.strip()
+        if config_name not in ALL_CONFIGS:
+            raise ValueError(
+                f"Unknown config {config_name!r}; "
+                f"valid configs: {', '.join(ALL_CONFIGS)}"
+            )
+        paths_by_config.setdefault(config_name, []).append(Path(path).expanduser())
+    return paths_by_config
+
+
+def _parse_replacements(values: Iterable[str]) -> Dict[str, Path]:
+    parsed = _parse_config_paths(values)
+    replacements: Dict[str, Path] = {}
+    for config_name, paths in parsed.items():
+        if len(paths) > 1:
+            raise ValueError(f"Only one --replacement is allowed for {config_name}.")
+        replacements[config_name] = paths[0]
+    return replacements
+
+
+def _filter_base_distribution(
+    records: List[Dict[str, Any]],
+    *,
+    keep_extra_categories: bool,
+) -> List[Dict[str, Any]]:
+    if keep_extra_categories:
+        return records
+    expected = set(EXPECTED_BASE_CATEGORY_COUNTS)
+    return [row for row in records if row.get("category") in expected]
+
+
+def _sort_records(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return sorted(
+        records,
+        key=lambda row: (
+            str(row.get("source_config") or ""),
+            str(row.get("category") or ""),
+            str(row.get("query_id") or ""),
+        ),
+    )
+
+
+def _write_config_parquet(
+    records: List[Dict[str, Any]],
+    *,
+    output_dir: Path,
+    config_name: str,
+    split: str,
+) -> Path:
+    config_dir = output_dir / config_name
+    config_dir.mkdir(parents=True, exist_ok=True)
+    out_path = config_dir / f"{split}-00000-of-00001.parquet"
+    ds = datasets.Dataset.from_list(_sort_records(records), features=SYNTHESIS_FEATURES)
+    ds.to_parquet(str(out_path))
+    return out_path
+
+
+def _read_existing_card(dataset_name: str) -> str:
+    try:
+        from huggingface_hub import hf_hub_download
+
+        path = hf_hub_download(dataset_name, "README.md", repo_type="dataset")
+        text = Path(path).read_text(encoding="utf-8")
+    except Exception:
+        return ""
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) == 3:
+            return parts[2].lstrip()
+    return text
+
+
+def _write_readme(
+    *,
+    output_dir: Path,
+    dataset_name: str,
+    configs: List[str],
+    split: str,
+    existing_body: str,
+) -> Path:
+    lines = [
+        "---",
+        "license: apache-2.0",
+        "configs:",
+    ]
+    for config_name in configs:
+        lines.extend(
+            [
+                f"- config_name: {config_name}",
+                "  data_files:",
+                f"  - split: {split}",
+                f"    path: {config_name}/{split}-*",
+            ]
+        )
+    lines.append("---")
+    if existing_body.strip():
+        lines.append(existing_body.rstrip())
+    else:
+        lines.extend(
+            [
+                "",
+                "# CodeMiner Synthesis",
+                "",
+                "Synthetic code-search benchmark queries for CodeMiner.",
+            ]
+        )
+    path = output_dir / "README.md"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _write_gitattributes(output_dir: Path) -> None:
+    (output_dir / ".gitattributes").write_text(
+        "*.parquet filter=lfs diff=lfs merge=lfs -text\n", encoding="utf-8"
+    )
+
+
+def _summarize(records_by_config: Mapping[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+    return {
+        config_name: {
+            "rows": len(records),
+            "categories": dict(Counter(row.get("category") or "" for row in records)),
+            "repos": sorted({row.get("repo") for row in records if row.get("repo")}),
+        }
+        for config_name, records in records_by_config.items()
+    }
+
+
+def build_dataset(args: argparse.Namespace) -> Dict[str, Any]:
+    configs = parse_config_list(args.configs)
+    replacements = _parse_replacements(args.replacement)
+    appends = _parse_config_paths(args.append)
+    output_dir = Path(args.output_dir).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    records_by_config: Dict[str, List[Dict[str, Any]]] = {}
+    for config_name in configs:
+        if config_name in replacements:
+            records = _load_replacement(replacements[config_name], config_name)
+            source = str(replacements[config_name])
+        else:
+            records = _load_hf_config(args.dataset, config_name, args.source_split)
+            source = f"{args.dataset}/{config_name}:{args.source_split}"
+        records = _filter_base_distribution(
+            records,
+            keep_extra_categories=args.keep_extra_categories,
+        )
+        for append_path in appends.get(config_name, []):
+            appended = _load_replacement(append_path, config_name)
+            records.extend(appended)
+            source += f" + {append_path}"
+        records_by_config[config_name] = records
+        print(f"{config_name}: {len(records)} row(s) from {source}")
+
+    all_records = [row for records in records_by_config.values() for row in records]
+    expected_counts = (
+        EXPECTED_CATEGORY_COUNTS_WITH_TRAVERSAL
+        if args.include_traversal
+        else EXPECTED_BASE_CATEGORY_COUNTS
+    )
+    quality = validate_synthesis_records(
+        all_records,
+        expected_category_counts=expected_counts if args.enforce_base_counts else None,
+        compare_category_distribution=not args.allow_category_drift,
+    )
+
+    for config_name, records in records_by_config.items():
+        _write_config_parquet(
+            records,
+            output_dir=output_dir,
+            config_name=config_name,
+            split=args.output_split,
+        )
+    _write_readme(
+        output_dir=output_dir,
+        dataset_name=args.dataset,
+        configs=configs,
+        split=args.output_split,
+        existing_body=(
+            "" if args.no_reuse_card_body else _read_existing_card(args.dataset)
+        ),
+    )
+    _write_gitattributes(output_dir)
+
+    report = {
+        "dataset": args.dataset,
+        "source_split": args.source_split,
+        "output_split": args.output_split,
+        "configs": configs,
+        "replacements": {k: str(v) for k, v in replacements.items()},
+        "appends": {
+            k: [str(path) for path in paths] for k, paths in sorted(appends.items())
+        },
+        "summary": _summarize(records_by_config),
+        "quality": quality,
+    }
+    report_path = output_dir / "quality_report.json"
+    report_path.write_text(
+        json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"Wrote {output_dir}")
+    print(
+        "Quality: "
+        f"{quality['error_count']} error(s), {quality['warning_count']} warning(s) "
+        f"-> {report_path}"
+    )
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dataset", default=DEFAULT_DATASET)
+    p.add_argument(
+        "--source-split",
+        default=DEFAULT_SPLIT,
+        help="Split to read from the current/source HF dataset.",
+    )
+    p.add_argument(
+        "--output-split",
+        default=DEFAULT_SPLIT,
+        help="Split to write into the rebuilt dataset folder.",
+    )
+    p.add_argument("--configs", default="all")
+    p.add_argument(
+        "--replacement",
+        action="append",
+        default=[],
+        help="Replace one config with local rows: CONFIG=/path/to/file-or-dir.",
+    )
+    p.add_argument(
+        "--append",
+        action="append",
+        default=[],
+        help="Append local rows to one config: CONFIG=/path/to/file-or-dir.",
+    )
+    p.add_argument(
+        "--keep-extra-categories",
+        action="store_true",
+        help="Keep categories outside the base synthesis mix, such as traversal.",
+    )
+    p.add_argument(
+        "--include-traversal",
+        action="store_true",
+        help="Expect the base 50-row mix plus 10 traversal rows per config.",
+    )
+    p.add_argument(
+        "--no-enforce-base-counts",
+        dest="enforce_base_counts",
+        action="store_false",
+        help="Do not warn when each config differs from the 50-row base mix.",
+    )
+    p.set_defaults(enforce_base_counts=True)
+    p.add_argument(
+        "--allow-category-drift",
+        action="store_true",
+        help="Do not warn when configs have different category distributions.",
+    )
+    p.add_argument(
+        "--allow-quality-errors",
+        action="store_true",
+        help="Write output even when the quality gate finds errors.",
+    )
+    p.add_argument("--output-dir", required=True)
+    p.add_argument(
+        "--push-to-hub",
+        default="",
+        help="Optional dataset repo id to update after the quality gate passes.",
+    )
+    p.add_argument(
+        "--private",
+        action="store_true",
+        help="Create/update the target HF dataset repo as private.",
+    )
+    p.add_argument(
+        "--no-reuse-card-body",
+        action="store_true",
+        help="Do not copy the existing README body from the source dataset.",
+    )
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    report = build_dataset(args)
+    quality = report["quality"]
+    if quality["error_count"] and not args.allow_quality_errors:
+        print(
+            "Quality gate failed; inspect quality_report.json or rerun with "
+            "--allow-quality-errors for a draft-only build.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.push_to_hub:
+        api = HfApi()
+        api.create_repo(
+            repo_id=args.push_to_hub,
+            repo_type="dataset",
+            private=args.private,
+            exist_ok=True,
+        )
+        api.upload_folder(
+            repo_id=args.push_to_hub,
+            repo_type="dataset",
+            folder_path=str(Path(args.output_dir).expanduser()),
+            delete_patterns=["*/train-*", "train-*"],
+            commit_message=(
+                "Rebuild CodeMiner synthesis dataset with test split and QA gate"
+            ),
+        )
+        print(f"Pushed dataset to https://huggingface.co/datasets/{args.push_to_hub}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/report_codeminer_synthesis.py
+++ b/scripts/report_codeminer_synthesis.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Report and gate quality for the CodeMiner synthesis Hugging Face dataset."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+import datasets
+
+from codeminer.dataset.codeminer_synthesis import (
+    DEFAULT_DATASET,
+    DEFAULT_SPLIT,
+    EXPECTED_BASE_CATEGORY_COUNTS,
+    normalize_synthesis_record,
+    parse_config_list,
+    validate_synthesis_records,
+)
+
+
+def _parse_expected_counts(raw: str) -> Dict[str, int]:
+    if not raw:
+        return dict(EXPECTED_BASE_CATEGORY_COUNTS)
+    out: Dict[str, int] = {}
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            raise ValueError(f"Bad expected count {chunk!r}; expected category=N")
+        name, value = chunk.split("=", 1)
+        out[name.strip()] = int(value.strip())
+    return out
+
+
+def _split_info(dataset_name: str, configs: List[str]) -> Dict[str, Dict[str, Any]]:
+    info: Dict[str, Dict[str, Any]] = {}
+    for config_name in configs:
+        try:
+            splits = datasets.get_dataset_split_names(dataset_name, config_name)
+        except Exception as exc:
+            info[config_name] = {"available": [], "error": str(exc)}
+            continue
+        info[config_name] = {"available": splits}
+    return info
+
+
+def _load_rows(
+    *,
+    dataset_name: str,
+    configs: List[str],
+    expected_split: str,
+    inspect_fallback_split: bool,
+) -> tuple[List[Dict[str, Any]], Dict[str, Dict[str, Any]], List[Dict[str, Any]]]:
+    split_report = _split_info(dataset_name, configs)
+    rows: List[Dict[str, Any]] = []
+    issues: List[Dict[str, Any]] = []
+
+    for config_name in configs:
+        entry = split_report[config_name]
+        available = list(entry.get("available") or [])
+        if entry.get("error"):
+            issues.append(
+                {
+                    "severity": "error",
+                    "code": "split_lookup_failed",
+                    "source_config": config_name,
+                    "reason": entry["error"],
+                }
+            )
+            continue
+
+        if expected_split in available:
+            load_split = expected_split
+        else:
+            issues.append(
+                {
+                    "severity": "error",
+                    "code": "missing_expected_split",
+                    "source_config": config_name,
+                    "expected_split": expected_split,
+                    "available_splits": available,
+                }
+            )
+            if inspect_fallback_split and available:
+                load_split = available[0]
+            else:
+                continue
+
+        entry["loaded_split"] = load_split
+        ds = datasets.load_dataset(dataset_name, config_name, split=load_split)
+        rows.extend(normalize_synthesis_record(row, config_name) for row in ds)
+    return rows, split_report, issues
+
+
+def build_report(args: argparse.Namespace) -> Dict[str, Any]:
+    configs = parse_config_list(args.configs)
+    expected_counts = _parse_expected_counts(args.expected_category_counts)
+    rows, split_report, split_issues = _load_rows(
+        dataset_name=args.dataset,
+        configs=configs,
+        expected_split=args.split,
+        inspect_fallback_split=args.inspect_fallback_split,
+    )
+    quality = validate_synthesis_records(
+        rows,
+        expected_category_counts=expected_counts,
+        compare_category_distribution=not args.allow_category_drift,
+    )
+    issues = split_issues + quality["issues"]
+    language_counts = Counter(row.get("language_group") or "" for row in rows)
+    return {
+        "dataset": args.dataset,
+        "expected_split": args.split,
+        "configs": configs,
+        "split_report": split_report,
+        "row_count": len(rows),
+        "by_language": dict(sorted(language_counts.items())),
+        "by_config": quality["by_config"],
+        "by_category": quality["by_category"],
+        "by_config_category": quality["by_config_category"],
+        "issues": issues,
+        "error_count": sum(1 for issue in issues if issue["severity"] == "error"),
+        "warning_count": sum(1 for issue in issues if issue["severity"] == "warning"),
+    }
+
+
+def _table(headers: List[str], rows: List[List[Any]]) -> str:
+    values = [[str(cell) for cell in row] for row in rows]
+    widths = [
+        (
+            max(len(headers[i]), *(len(row[i]) for row in values))
+            if values
+            else len(headers[i])
+        )
+        for i in range(len(headers))
+    ]
+    lines = [
+        "  ".join(headers[i].ljust(widths[i]) for i in range(len(headers))),
+        "  ".join("-" * widths[i] for i in range(len(headers))),
+    ]
+    for row in values:
+        lines.append("  ".join(row[i].ljust(widths[i]) for i in range(len(headers))))
+    return "\n".join(lines)
+
+
+def format_text_report(report: Mapping[str, Any], *, max_issues: int) -> str:
+    lines = [
+        f"Dataset: {report['dataset']}",
+        f"Expected split: {report['expected_split']}",
+        f"Rows inspected: {report['row_count']}",
+        f"Errors: {report['error_count']}  Warnings: {report['warning_count']}",
+        "",
+        "Splits:",
+    ]
+    split_rows = []
+    for config_name, info in report["split_report"].items():
+        split_rows.append(
+            [
+                config_name,
+                ",".join(info.get("available") or []),
+                info.get("loaded_split") or "",
+            ]
+        )
+    lines.append(_table(["config", "available", "loaded"], split_rows))
+
+    lines.extend(["", "Category Counts:"])
+    categories = sorted(report["by_category"])
+    cat_rows = []
+    for config_name, counts in report["by_config_category"].items():
+        cat_rows.append([config_name] + [counts.get(cat, 0) for cat in categories])
+    lines.append(_table(["config"] + categories, cat_rows))
+
+    lines.extend(["", "Language Counts:"])
+    lines.append(
+        _table(
+            ["language_group", "rows"],
+            [[name, count] for name, count in report["by_language"].items()],
+        )
+    )
+
+    issues = list(report["issues"])
+    if issues:
+        lines.extend(["", f"Issues (first {min(max_issues, len(issues))}):"])
+        issue_rows = []
+        for issue in issues[:max_issues]:
+            issue_rows.append(
+                [
+                    issue.get("severity", ""),
+                    issue.get("code", ""),
+                    issue.get("source_config", ""),
+                    issue.get("query_id", ""),
+                    ",".join(issue.get("files") or []),
+                ]
+            )
+        lines.append(
+            _table(["severity", "code", "config", "query_id", "files"], issue_rows)
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dataset", default=DEFAULT_DATASET)
+    p.add_argument("--split", default=DEFAULT_SPLIT)
+    p.add_argument("--configs", default="all")
+    p.add_argument(
+        "--inspect-fallback-split",
+        action="store_true",
+        help=(
+            "If --split is absent on HF, inspect the first available split while "
+            "still reporting the missing expected split as an error."
+        ),
+    )
+    p.add_argument(
+        "--expected-category-counts",
+        default="",
+        help=(
+            "Comma-separated category=N expectations per config. Defaults to the "
+            "base 50-row synthesis mix."
+        ),
+    )
+    p.add_argument(
+        "--allow-category-drift",
+        action="store_true",
+        help="Do not warn when configs have different category distributions.",
+    )
+    p.add_argument("--json-output", default="")
+    p.add_argument("--max-issues", type=int, default=40)
+    p.add_argument("--no-fail", action="store_true", help="Always exit zero.")
+    p.add_argument(
+        "--fail-on-warnings",
+        action="store_true",
+        help="Exit nonzero on warnings as well as errors.",
+    )
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    report = build_report(args)
+    print(format_text_report(report, max_issues=args.max_issues))
+    if args.json_output:
+        path = Path(args.json_output).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+
+    should_fail = report["error_count"] > 0 or (
+        args.fail_on_warnings and report["warning_count"] > 0
+    )
+    return 0 if args.no_fail or not should_fail else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/synthesize_swebench.py
+++ b/scripts/synthesize_swebench.py
@@ -276,18 +276,29 @@ def main() -> None:
             filter_pattern,
         )
 
-        dataset_cls = (
-            SwebenchMultilingualDataset
-            if args.dataset in ("swebench_multilingual", "codeminer_base")
-            else SwebenchDataset
-        )
-        dataset_obj = dataset_cls(
-            dataset=dataset_name,
-            split=args.split,
-            filter_instance=filter_pattern,
-            root=str(cache_dir),
-            repo_root=args.repo_cache_dir or str(cache_dir),
-        )
+        if args.dataset == "codeminer_base":
+            from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
+
+            dataset_obj = CodeMinerBaseDataset(
+                dataset=dataset_name,
+                split=args.split,
+                filter_instance=filter_pattern,
+                root=str(cache_dir),
+                repo_root=args.repo_cache_dir or str(cache_dir),
+            )
+        else:
+            dataset_cls = (
+                SwebenchMultilingualDataset
+                if args.dataset == "swebench_multilingual"
+                else SwebenchDataset
+            )
+            dataset_obj = dataset_cls(
+                dataset=dataset_name,
+                split=args.split,
+                filter_instance=filter_pattern,
+                root=str(cache_dir),
+                repo_root=args.repo_cache_dir or str(cache_dir),
+            )
         dataset_instances = dataset_obj.load()
 
         # Convert to list of dicts

--- a/test/dataset/test_codeminer_synthesis.py
+++ b/test/dataset/test_codeminer_synthesis.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codeminer.dataset.codeminer_synthesis import (
+    EXPECTED_CATEGORY_COUNTS_WITH_TRAVERSAL,
+    CodeMinerSynthesisDataset,
+    normalize_synthesis_record,
+    validate_synthesis_records,
+)
+from scripts.rebuild_codeminer_synthesis_dataset import build_parser
+
+
+def _row(**overrides):
+    row = {
+        "repo": "example/repo",
+        "instance_id": "example__repo-1",
+        "base_commit": "abc123",
+        "query": "Where is the relevant behavior implemented?",
+        "category": "behavioral",
+        "gt_symbols": ["src/main.py:run()"],
+        "gt_symbol_nodes": [
+            {
+                "content": "def run():\n    pass",
+                "end_line": 2,
+                "file": "src/main.py",
+                "node_name": "src/main.py:run()",
+                "start_line": 1,
+                "type": "function",
+            }
+        ],
+        "gt_files": ["src/main.py"],
+        "query_id": "example__repo-1_behavioral_q1",
+        "length_variant": "detailed",
+        "judge_verdict": "valid",
+        "judge_reason": "ok",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_normalize_record_injects_language_and_problem_statement():
+    raw = _row(gt_files=["src/main.cpp"], gt_symbols=["src/main.cpp:run()"])
+
+    record = normalize_synthesis_record(raw, "C++_C")
+
+    assert record["language_group"] == "C++/C"
+    assert record["source_config"] == "C++_C"
+    assert record["problem_statement"] == raw["query"]
+    assert record["gt_code_blocks_count"] == 1
+
+
+def test_validate_records_catches_cpp_python_ground_truth_and_category_drift():
+    cpp_bad = normalize_synthesis_record(
+        _row(
+            gt_files=["support/docopt.py"],
+            gt_symbols=["support/docopt.py:docopt()"],
+            gt_symbol_nodes=[
+                {
+                    "content": "def docopt():\n    pass",
+                    "end_line": 2,
+                    "file": "support/docopt.py",
+                    "node_name": "support/docopt.py:docopt()",
+                    "start_line": 1,
+                    "type": "function",
+                }
+            ],
+            query_id="cpp_bad",
+        ),
+        "C++_C",
+    )
+    go_ok = normalize_synthesis_record(
+        _row(
+            gt_files=["cmd/main.go"],
+            gt_symbols=["cmd/main.go:main()"],
+            gt_symbol_nodes=[],
+            query_id="go_ok",
+        ),
+        "Go",
+    )
+    python_extra = normalize_synthesis_record(
+        _row(category="traversal", query_id="python_extra"),
+        "Python",
+    )
+
+    report = validate_synthesis_records([cpp_bad, go_ok, python_extra])
+
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "gt_file_language_mismatch" in codes
+    assert "category_distribution_mismatch" in codes
+    assert report["error_count"] == 1
+
+
+def test_validate_records_accepts_expected_traversal_distribution():
+    rows = []
+    for category, count in EXPECTED_CATEGORY_COUNTS_WITH_TRAVERSAL.items():
+        for idx in range(count):
+            rows.append(
+                normalize_synthesis_record(
+                    _row(
+                        category=category,
+                        query_id=f"python_{category}_{idx}",
+                    ),
+                    "Python",
+                )
+            )
+
+    report = validate_synthesis_records(
+        rows,
+        expected_category_counts=EXPECTED_CATEGORY_COUNTS_WITH_TRAVERSAL,
+        compare_category_distribution=False,
+    )
+
+    assert report["error_count"] == 0
+    assert report["warning_count"] == 0
+
+
+def test_rebuild_parser_defaults_to_test_source_split():
+    args = build_parser().parse_args(["--output-dir", "/tmp/out"])
+
+    assert args.source_split == "test"
+
+
+def test_dataset_loader_defaults_to_test_split(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_load_dataset(dataset, config_name, *, split, cache_dir):
+        calls.append((dataset, config_name, split, cache_dir))
+        return [_row(gt_files=["src/main.py"], query_id="python_q1")]
+
+    monkeypatch.setattr(
+        "codeminer.dataset.codeminer_synthesis.datasets.load_dataset",
+        fake_load_dataset,
+    )
+
+    ds = CodeMinerSynthesisDataset(
+        configs="Python",
+        root=str(tmp_path),
+        log=False,
+    )
+    data = ds.load()
+
+    assert calls[0][1] == "Python"
+    assert calls[0][2] == "test"
+    assert len(data) == 1
+    assert data[0]["language_group"] == "Python"
+    assert data[0]["problem_statement"] == _row()["query"]


### PR DESCRIPTION
## Summary
- Add a CodeMiner synthesis dataset loader with normalization, split/config handling, and quality reporting.
- Add scripts for behavior/mixed/traversal query multiplication, post-fix, per-config generation, HF rebuild/push, and reports.
- Add traversal QA support including valid-only output, judge retries, duplicate-chain exclusion, Go graph inference, and test-only dataset rebuild defaults.
- Export the synthesis dataset loader and fix the Codex agent runner close path used by synthesis generation.

## Dataset Update
- Updated `sysevol-ai/codeminer-synthesis` with test-only configs at HF commit `45e1cf03bff9cf0a6081688ebb37d05b5e5f4361`.
- Each config now has 60 rows: behavioral=20, file_hint=10, module_hint=10, reasoning=5, symbol_hint=5, traversal=10.

## Validation
- `PYTHONPATH=. /home/zhongming/anaconda3/envs/codeminer/bin/python -m py_compile codeminer/dataset/codeminer_synthesis.py codeminer/dataset/synthesize/context_loader.py scripts/rebuild_codeminer_synthesis_dataset.py scripts/generate_codeminer_synthesis_config.py scripts/multiply_traversal_queries.py`
- `PYTHONPATH=. /home/zhongming/anaconda3/envs/codeminer/bin/pytest -q test/dataset/test_codeminer_synthesis.py test/dataset/test_synthesize_vocab_guard.py` (18 passed)
- `git diff --cached --check`
- Remote HF smoke-load: all five configs expose only `test` split with 60 rows and aligned category distribution.