### PR TITLE
fix(dataset): avoid optional Claude SDK imports in unit tests

### DIFF
--- a/codeminer/dataset/synthesize/__init__.py
+++ b/codeminer/dataset/synthesize/__init__.py
@@ -14,10 +14,6 @@ from codeminer.dataset.utils import (
 )
 
 from ._types import QuerySynthesisResult
-from .context_loader import ContextLoader
-from .query_curator import QueryCurator
-from .query_synthesizer import ClaudeQuerySynthesizer
-from .verifier import Verifier
 from .vocab_guard import (
     DEFAULT_OVERLAP_THRESHOLD,
     VocabOverlapResult,
@@ -42,3 +38,24 @@ __all__ = [
     "QueryType",
     "get_prompt_for_query_type",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy-load synthesis helpers that require optional Claude SDK deps."""
+    if name == "ClaudeQuerySynthesizer":
+        from .query_synthesizer import ClaudeQuerySynthesizer
+
+        return ClaudeQuerySynthesizer
+    if name == "ContextLoader":
+        from .context_loader import ContextLoader
+
+        return ContextLoader
+    if name == "QueryCurator":
+        from .query_curator import QueryCurator
+
+        return QueryCurator
+    if name == "Verifier":
+        from .verifier import Verifier
+
+        return Verifier
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/codeminer/dataset/synthesize/verifier.py
+++ b/codeminer/dataset/synthesize/verifier.py
@@ -8,17 +8,19 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from codeminer.log_utils import get_logger
 
-from ._agent import AgentRunner
 from ._types import BehavioralContext, SampledCodeBlock, format_prompt_block
 from .vocab_guard import (
     DEFAULT_OVERLAP_THRESHOLD,
     VocabOverlapResult,
     VocabularyOverlapGuard,
 )
+
+if TYPE_CHECKING:
+    from ._agent import AgentRunner
 
 logger = get_logger(__name__)
 
@@ -52,7 +54,7 @@ class Verifier:
     def __init__(
         self,
         *,
-        agent: AgentRunner,
+        agent: "AgentRunner",
         verification_mode: str = "lenient",
         max_block_chars_in_prompt: int = 1800,
         vocab_overlap_threshold: float = DEFAULT_OVERLAP_THRESHOLD,

--- a/codeminer/dataset/synthesize/verifier.py
+++ b/codeminer/dataset/synthesize/verifier.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from codeminer.log_utils import get_logger
 
@@ -18,9 +18,6 @@ from .vocab_guard import (
     VocabOverlapResult,
     VocabularyOverlapGuard,
 )
-
-if TYPE_CHECKING:
-    from ._agent import AgentRunner
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- Lazy-load heavy synthesis helpers from `codeminer.dataset.synthesize` so importing lightweight modules does not require `claude_agent_sdk`.
- Make `Verifier` reference `AgentRunner` only for type checking, since vocab guard tests use `verification_mode=none` and do not need the SDK.

## Root Cause
CI unit failed during collection of `test/dataset/test_synthesize_vocab_guard.py`: importing `codeminer.dataset.synthesize._types` executed package `__init__`, which eagerly imported `ContextLoader`, then `_agent`, then `claude_agent_sdk`. The CI unit environment does not install that optional synthesis dependency.

## Validation
- Simulated missing `claude_agent_sdk` with an import blocker and successfully imported `_types`, `Verifier`, and `VocabularyOverlapGuard`.
- `PYTHONPATH=. /home/zhongming/anaconda3/envs/codeminer/bin/pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` -> 927 passed, 10 skipped.
- pre-commit hooks passed.