### PR TITLE
feat(web): clickable citation chips on ask page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ web/*.tsbuildinfo
 !web/package-lock.json
 # Keep committed experiment-run evidence (relocated out of results/).
 !docs/experiments/agent_compile_runs/**/*.json
+.env.local
+web_before
+qa_config.local.yaml

--- a/codeminer/web/schemas.py
+++ b/codeminer/web/schemas.py
@@ -15,6 +15,8 @@ from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
 
+from codeminer.agent.boundary import to_agent_repr
+
 
 class RepoInfo(BaseModel):
     """A repository the demo can answer questions about.
@@ -42,7 +44,11 @@ class ChatRequest(BaseModel):
 
 
 class Citation(BaseModel):
-    """A code reference backing the answer, rendered as a card in the UI."""
+    """A code reference backing the answer, rendered as a card in the UI.
+
+    Line numbers are 1-based at this API boundary, matching the agent-facing
+    representation and the ``/source`` endpoint.
+    """
 
     file: Optional[str] = None
     start_line: Optional[int] = None
@@ -99,12 +105,16 @@ def _repo_relative(path: Optional[str], repo_path: str = "") -> Optional[str]:
 
 def _node_to_citation(node: Any, repo_path: str = "") -> Optional[Citation]:
     """Coerce a single retrieval result (QueriedNode / dict) into a Citation."""
-    if hasattr(node, "model_dump"):
-        data = node.model_dump()
-    elif isinstance(node, dict):
-        data = node
-    else:
+    if not (
+        hasattr(node, "model_dump")
+        or isinstance(node, dict)
+        or hasattr(node, "__dict__")
+    ):
         return None
+
+    # Retrieval/tool results keep internal 0-based lines; API responses are an
+    # agent-facing boundary and expose 1-based locations.
+    data = to_agent_repr(node)
     if not (data.get("file") or data.get("node_name")):
         return None
     content = data.get("content")

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -29,7 +29,7 @@ def test_maps_tool_calls_and_citations():
                 tool_call_id="1",
                 skill_id="bm25_search",
                 arguments={"query": "auth", "top_k": 5},
-                result=[_node("a.py", 1, 10), _node("b.py", 20, 30)],
+                result=[_node("a.py", 0, 9), _node("b.py", 19, 29)],
                 duration_ms=12.5,
             )
         ],
@@ -47,15 +47,16 @@ def test_maps_tool_calls_and_citations():
     assert len(resp.citations) == 2
     assert resp.citations[0].file == "a.py"
     assert resp.citations[0].start_line == 1
+    assert resp.citations[0].end_line == 10
 
 
 def test_citations_are_deduplicated_across_tool_calls():
-    same = _node("a.py", 1, 10)
+    same = _node("a.py", 0, 9)
     result = AgentResult(
         answer="ans",
         tool_calls=[
             ToolCallRecord("1", "bm25_search", {}, result=[same]),
-            ToolCallRecord("2", "embedding_search", {}, result=[_node("a.py", 1, 10)]),
+            ToolCallRecord("2", "embedding_search", {}, result=[_node("a.py", 0, 9)]),
         ],
     )
     resp = agent_result_to_response(result)
@@ -90,3 +91,5 @@ def test_handles_dict_results():
     assert len(resp.citations) == 1
     assert resp.citations[0].file == "c.py"
     assert resp.citations[0].node_name == "g"
+    assert resp.citations[0].start_line == 6
+    assert resp.citations[0].end_line == 10

--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Header from "@/components/Header";
@@ -8,6 +8,7 @@ import Markdown from "@/components/Markdown";
 import AskBar from "@/components/AskBar";
 import CodePanel from "@/components/CodePanel";
 import { askQuestion, fetchRepos, type ChatResponse, type RepoInfo } from "@/lib/api";
+import { codeRefs } from "@/lib/citations";
 
 function AskAnswer() {
   const params = useParams<{ repoId: string }>();
@@ -45,7 +46,10 @@ function AskAnswer() {
   }, [repoId, q]);
 
   const repoName = repo ? repo.repo : repoId;
-  const citations = resp?.citations ?? [];
+  // Shared list so a chip's index lines up with the code pane's fragments.
+  const refs = useMemo(() => codeRefs(resp?.citations ?? []), [resp]);
+  const [active, setActive] = useState(0);
+  useEffect(() => setActive(0), [resp]);
 
   return (
     <div className="wiki ask-page">
@@ -80,11 +84,13 @@ function AskAnswer() {
           {resp && (
             <>
               <article className="ask-a">
-                <Markdown>{resp.answer || "(no answer)"}</Markdown>
+                <Markdown citations={refs} onCite={setActive}>
+                  {resp.answer || "(no answer)"}
+                </Markdown>
               </article>
               <div className="ask-tools muted small">
                 {resp.tool_calls.length} tool calls · {resp.total_turns} turns ·{" "}
-                {Math.round(resp.total_duration_ms)} ms · {citations.length} references
+                {Math.round(resp.total_duration_ms)} ms · {refs.length} references
               </div>
             </>
           )}
@@ -93,9 +99,11 @@ function AskAnswer() {
         <aside className="ask-code">
           <CodePanel
             repoId={repoId}
-            citations={citations}
+            citations={refs}
             repo={repo?.repo}
             commit={repo?.base_commit}
+            active={active}
+            onActiveChange={setActive}
           />
         </aside>
       </div>

--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -10,6 +10,9 @@ import CodePanel from "@/components/CodePanel";
 import { askQuestion, fetchRepos, type ChatResponse, type RepoInfo } from "@/lib/api";
 import { codeRefs } from "@/lib/citations";
 
+// DeepWiki clamps the question to ~200 chars before "Show full text".
+const Q_TRUNCATE = 200;
+
 function AskAnswer() {
   const params = useParams<{ repoId: string }>();
   const repoId = decodeURIComponent(params.repoId);
@@ -57,6 +60,12 @@ function AskAnswer() {
     setScrollSignal((s) => s + 1);
   };
 
+  // Truncate a long question to a fixed length with a "Show full text" toggle.
+  const [qExpanded, setQExpanded] = useState(false);
+  useEffect(() => setQExpanded(false), [q]);
+  const qLong = q.length > Q_TRUNCATE;
+  const qShown = !qLong || qExpanded ? q : q.slice(0, Q_TRUNCATE).trimEnd() + "…";
+
   return (
     <div className="wiki ask-page">
       <Header
@@ -77,7 +86,12 @@ function AskAnswer() {
           <Link className="ask-back" href={`/${encodeURIComponent(repoId)}`}>
             ← Back to wiki
           </Link>
-          <h1 className="ask-q">{q || "Ask a question"}</h1>
+          <h1 className="ask-q">{qShown || "Ask a question"}</h1>
+          {qLong && (
+            <button className="ask-q-toggle" onClick={() => setQExpanded((e) => !e)}>
+              {qExpanded ? "Show less" : "Show full text"}
+            </button>
+          )}
 
           {!q && <p className="muted">Type a question in the bar below.</p>}
           {loading && <p className="muted ask-thinking">Searching {repoName}…</p>}

--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -49,7 +49,13 @@ function AskAnswer() {
   // Shared list so a chip's index lines up with the code pane's fragments.
   const refs = useMemo(() => codeRefs(resp?.citations ?? []), [resp]);
   const [active, setActive] = useState(0);
+  const [scrollSignal, setScrollSignal] = useState(0);
   useEffect(() => setActive(0), [resp]);
+  // Select a citation: highlight it and (re-)scroll the code pane to it.
+  const selectCitation = (i: number) => {
+    setActive(i);
+    setScrollSignal((s) => s + 1);
+  };
 
   return (
     <div className="wiki ask-page">
@@ -84,7 +90,7 @@ function AskAnswer() {
           {resp && (
             <>
               <article className="ask-a">
-                <Markdown citations={refs} onCite={setActive}>
+                <Markdown citations={refs} onCite={selectCitation}>
                   {resp.answer || "(no answer)"}
                 </Markdown>
               </article>
@@ -103,7 +109,8 @@ function AskAnswer() {
             repo={repo?.repo}
             commit={repo?.base_commit}
             active={active}
-            onActiveChange={setActive}
+            onSelect={selectCitation}
+            scrollSignal={scrollSignal}
           />
         </aside>
       </div>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1840,8 +1840,16 @@ a.codepanel-name:hover {
 .frag {
   border-bottom: 1px solid var(--border);
 }
+/* Selected fragment: a blue band across the whole cited range (DeepWiki-style).
+   The code's own backgrounds are made transparent so the tint shows through. */
 .frag.active {
-  background: #f6f8fa;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  box-shadow: inset 3px 0 var(--accent);
+}
+.frag.active .hl-code,
+.frag.active .hl-pre,
+.frag.active .hl-gutter {
+  background: transparent;
 }
 .frag-head {
   position: sticky;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1092,6 +1092,22 @@ pre {
   line-height: 1.35;
   margin: 0 0 20px;
 }
+/* "Show full text" toggle under a truncated question. */
+.ask-q-toggle {
+  display: inline-block;
+  margin: -12px 0 18px;
+  padding: 0;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 13px;
+  color: var(--muted);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.ask-q-toggle:hover {
+  color: var(--accent);
+}
 .ask-thinking {
   animation: ask-pulse 1.4s ease-in-out infinite;
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -663,6 +663,35 @@ pre {
   font-size: 0.85em;
   color: var(--text);
 }
+/* Inline citation chip: a cited symbol/file in prose; click scrolls the code pane. */
+.cite-chip {
+  display: inline;
+  border: 1px solid color-mix(in srgb, var(--accent) 32%, transparent);
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+  border-radius: 5px;
+  padding: 1px 4px;
+  margin: 0 1px;
+  cursor: pointer;
+  font: inherit;
+  line-height: inherit;
+  vertical-align: baseline;
+}
+.cite-chip:hover {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border-color: var(--accent);
+}
+.cite-chip > code {
+  background: none;
+  padding: 0;
+  font-size: 0.85em;
+  color: var(--accent);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+}
+.cite-chip-loc {
+  font-size: 0.72em;
+  color: var(--muted);
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+}
 .markdown table {
   border-collapse: collapse;
   margin: 12px 0;

--- a/web/components/CodePanel.tsx
+++ b/web/components/CodePanel.tsx
@@ -34,39 +34,50 @@ function Fragment({
     let cancelled = false;
     setLoading(true);
     setErr(false);
-    if (c.content) {
+    // Prefer clean /source; the citation `content` is line-number-wrapped for the
+    // LLM and would double the gutter. Fall back to it only if the fetch fails.
+    if (rel && c.start_line != null) {
+      fetchSource(repoId, rel, c.start_line, c.end_line ?? undefined)
+        .then((s) => {
+          if (cancelled) return;
+          setCode(s.content || "");
+          setStart(s.start_line || c.start_line || 1);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          if (c.content) {
+            setCode(c.content);
+            setStart(c.start_line ?? 1);
+          } else setErr(true);
+        })
+        .finally(() => !cancelled && setLoading(false));
+    } else if (c.content) {
       setCode(c.content);
       setStart(c.start_line ?? 1);
       setLoading(false);
-      return;
+    } else {
+      setErr(true);
+      setLoading(false);
     }
-    fetchSource(repoId, rel, c.start_line ?? undefined, c.end_line ?? undefined)
-      .then((s) => {
-        if (cancelled) return;
-        setCode(s.content || "");
-        setStart(s.start_line || c.start_line || 1);
-      })
-      .catch(() => !cancelled && setErr(true))
-      .finally(() => !cancelled && setLoading(false));
     return () => {
       cancelled = true;
     };
   }, [repoId, rel, c.start_line, c.end_line, c.content]);
 
   const gh = ghUrl(repo, commit, c, rel);
+  // node_name is the qualified "file:symbol()" form; show just the symbol.
+  const symbol = (c.node_name || "").split(":").pop() || rel.split("/").pop() || rel;
+  const loc = `${rel}${c.start_line != null ? `:${c.start_line}-${c.end_line}` : ""}`;
   return (
     <div className={`frag ${active ? "active" : ""}`}>
       <div className="frag-head mono">
+        <span className="frag-name">{symbol}</span>
         {gh ? (
-          <a href={gh} target="_blank" rel="noreferrer" title="Open on GitHub">
-            <span className="frag-name">{c.node_name || rel}</span>
-            <span className="frag-loc">
-              {rel}
-              {c.start_line != null ? `:${c.start_line}-${c.end_line}` : ""} ↗
-            </span>
+          <a href={gh} target="_blank" rel="noreferrer" className="frag-loc" title="Open on GitHub">
+            {loc} ↗
           </a>
         ) : (
-          <span className="frag-name">{c.node_name || rel}</span>
+          <span className="frag-loc">{loc}</span>
         )}
       </div>
       {loading ? (
@@ -91,24 +102,39 @@ export default function CodePanel({
   citations,
   repo,
   commit,
+  active: activeProp,
+  onActiveChange,
 }: {
   repoId: string;
   citations: Citation[];
   repo?: string;
   commit?: string;
+  /** Controlled active fragment, so prose chips can drive the pane. */
+  active?: number;
+  onActiveChange?: (i: number) => void;
 }) {
   const refs = citations.filter((c) => repoRelative(c.file)).slice(0, 12);
-  const [active, setActive] = useState(0);
+  const [internal, setInternal] = useState(0);
+  const active = activeProp ?? internal;
+  const setActive = onActiveChange ?? setInternal;
   const fragEls = useRef<(HTMLDivElement | null)[]>([]);
+  const didMount = useRef(false);
 
   useEffect(() => {
-    setActive(0);
     fragEls.current = [];
   }, [citations]);
 
+  // Scroll the active fragment into view on change (skip the first render).
+  useEffect(() => {
+    if (!didMount.current) {
+      didMount.current = true;
+      return;
+    }
+    fragEls.current[active]?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [active]);
+
   function jump(i: number) {
     setActive(i);
-    fragEls.current[i]?.scrollIntoView({ behavior: "smooth", block: "start" });
   }
 
   if (refs.length === 0) {

--- a/web/components/CodePanel.tsx
+++ b/web/components/CodePanel.tsx
@@ -103,7 +103,8 @@ export default function CodePanel({
   repo,
   commit,
   active: activeProp,
-  onActiveChange,
+  onSelect,
+  scrollSignal,
 }: {
   repoId: string;
   citations: Citation[];
@@ -111,30 +112,39 @@ export default function CodePanel({
   commit?: string;
   /** Controlled active fragment, so prose chips can drive the pane. */
   active?: number;
-  onActiveChange?: (i: number) => void;
+  onSelect?: (i: number) => void;
+  /** Bumped by the parent on every selection; each bump re-scrolls to active. */
+  scrollSignal?: number;
 }) {
   const refs = citations.filter((c) => repoRelative(c.file)).slice(0, 12);
   const [internal, setInternal] = useState(0);
   const active = activeProp ?? internal;
-  const setActive = onActiveChange ?? setInternal;
   const fragEls = useRef<(HTMLDivElement | null)[]>([]);
-  const didMount = useRef(false);
+  const firstScroll = useRef(true);
 
   useEffect(() => {
     fragEls.current = [];
   }, [citations]);
 
-  // Scroll the active fragment into view on change (skip the first render).
+  const scrollToFrag = (i: number) =>
+    fragEls.current[i]?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+  // Scroll on every selection, even re-selecting the same fragment after the
+  // user scrolled away. Keyed on scrollSignal (not active) so it always fires.
   useEffect(() => {
-    if (!didMount.current) {
-      didMount.current = true;
+    if (firstScroll.current) {
+      firstScroll.current = false;
       return;
     }
-    fragEls.current[active]?.scrollIntoView({ behavior: "smooth", block: "start" });
-  }, [active]);
+    scrollToFrag(active);
+  }, [scrollSignal]);
 
-  function jump(i: number) {
-    setActive(i);
+  function select(i: number) {
+    if (onSelect) onSelect(i);
+    else {
+      setInternal(i);
+      scrollToFrag(i);
+    }
   }
 
   if (refs.length === 0) {
@@ -155,7 +165,7 @@ export default function CodePanel({
             aria-selected={i === active}
             className={`codepane-tab ${i === active ? "active" : ""}`}
             title={`${c.node_name || ""} ${repoRelative(c.file)}`}
-            onClick={() => jump(i)}
+            onClick={() => select(i)}
           >
             {(c.node_name || repoRelative(c.file).split("/").pop() || "").split(":").pop()}
           </button>
@@ -168,7 +178,6 @@ export default function CodePanel({
             ref={(el) => {
               fragEls.current[i] = el;
             }}
-            onMouseEnter={() => setActive(i)}
           >
             <Fragment repoId={repoId} c={c} repo={repo} commit={commit} active={i === active} />
           </div>

--- a/web/components/Markdown.tsx
+++ b/web/components/Markdown.tsx
@@ -7,6 +7,8 @@ import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
 import rehypeHighlight from "rehype-highlight";
 import "highlight.js/styles/github.css";
+import { matchCitation, lineLabel } from "@/lib/citations";
+import type { Citation } from "@/lib/api";
 
 // Mermaid (~1MB) is only needed when a diagram actually appears; load it on
 // demand so it never weighs down pages that have none (wiki strips diagrams).
@@ -47,7 +49,47 @@ function CodeBlock({ text, lang, children }: { text: string; lang: string; child
   );
 }
 
-export default function Markdown({ children }: { children: string }) {
+/** Inline `code` span that names a cited symbol/file: click to jump the code pane. */
+function CiteChip({
+  text,
+  c,
+  showLoc,
+  onClick,
+}: {
+  text: string;
+  c: Citation;
+  /** Only symbol matches carry a meaningful range; a file has many symbols. */
+  showLoc: boolean;
+  onClick: () => void;
+}) {
+  const loc = showLoc ? lineLabel(c) : "";
+  return (
+    <button
+      type="button"
+      className="cite-chip"
+      onClick={onClick}
+      title={
+        loc
+          ? `Jump to ${c.node_name || text} (lines ${loc})`
+          : `Jump to ${text} in the code panel`
+      }
+    >
+      <code>{text}</code>
+      {loc && <span className="cite-chip-loc">:{loc}</span>}
+    </button>
+  );
+}
+
+export default function Markdown({
+  children,
+  citations,
+  onCite,
+}: {
+  children: string;
+  /** When provided (with onCite), inline code naming a citation becomes a clickable chip. */
+  citations?: Citation[];
+  onCite?: (index: number) => void;
+}) {
   return (
     <div className="markdown">
       <ReactMarkdown
@@ -65,6 +107,25 @@ export default function Markdown({ children }: { children: string }) {
             }
             const lang = (className.match(/language-(\w+)/) || [])[1] || "";
             return <CodeBlock text={text} lang={lang}>{children}</CodeBlock>;
+          },
+          code({ className, children }) {
+            // Inline code only; block code has a language-* class or newlines.
+            const text = nodeText(children);
+            const inline = !/language-/.test(className || "") && !text.includes("\n");
+            if (inline && citations && onCite) {
+              const m = matchCitation(text, citations);
+              if (m != null) {
+                return (
+                  <CiteChip
+                    text={text}
+                    c={citations[m.index]}
+                    showLoc={m.kind === "symbol"}
+                    onClick={() => onCite(m.index)}
+                  />
+                );
+              }
+            }
+            return <code className={className}>{children}</code>;
           },
         }}
       >

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -26,6 +26,7 @@ export interface RepoInfo {
 
 export interface Citation {
   file: string | null;
+  /** 1-based inclusive source range, matching the /source endpoint. */
   start_line: number | null;
   end_line: number | null;
   node_name: string;

--- a/web/lib/citations.test.ts
+++ b/web/lib/citations.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { Citation } from "./api";
+import { codeRefs, lineLabel, matchCitation } from "./citations";
+
+function citation(overrides: Partial<Citation> = {}): Citation {
+  return {
+    file: "src/auth.py",
+    start_line: 11,
+    end_line: 20,
+    node_name: "src/auth.py:authenticate()",
+    type: "function",
+    score: 0.9,
+    content: null,
+    ...overrides,
+  };
+}
+
+describe("codeRefs", () => {
+  it("keeps API line numbers unchanged because citations are already 1-based", () => {
+    const refs = codeRefs([citation({ start_line: 11, end_line: 20 })]);
+
+    expect(refs[0].start_line).toBe(11);
+    expect(refs[0].end_line).toBe(20);
+  });
+
+  it("filters non-source citations and caps the shared list at twelve", () => {
+    const citations = [
+      citation({ file: null }),
+      ...Array.from({ length: 13 }, (_, i) =>
+        citation({
+          file: `src/file${i}.py`,
+          node_name: `src/file${i}.py:fn${i}()`,
+        })
+      ),
+    ];
+
+    const refs = codeRefs(citations);
+
+    expect(refs).toHaveLength(12);
+    expect(refs[0].file).toBe("src/file0.py");
+    expect(refs[11].file).toBe("src/file11.py");
+  });
+});
+
+describe("matchCitation", () => {
+  const refs = [
+    citation(),
+    citation({
+      file: "src/config.py",
+      start_line: 4,
+      end_line: 4,
+      node_name: "src/config.py:load_settings()",
+    }),
+  ];
+
+  it("matches inline code naming a cited symbol", () => {
+    expect(matchCitation("authenticate", refs)).toEqual({ index: 0, kind: "symbol" });
+    expect(matchCitation("load_settings()", refs)).toEqual({ index: 1, kind: "symbol" });
+  });
+
+  it("matches inline code naming a cited file", () => {
+    expect(matchCitation("config.py", refs)).toEqual({ index: 1, kind: "file" });
+    expect(matchCitation("src/auth.py:11", refs)).toEqual({ index: 0, kind: "file" });
+  });
+});
+
+describe("lineLabel", () => {
+  it("renders the 1-based API range without shifting it", () => {
+    expect(lineLabel(citation({ start_line: 11, end_line: 20 }))).toBe("11-20");
+    expect(lineLabel(citation({ start_line: 11, end_line: 11 }))).toBe("11");
+    expect(lineLabel(citation({ start_line: null, end_line: null }))).toBe("");
+  });
+});

--- a/web/lib/citations.ts
+++ b/web/lib/citations.ts
@@ -1,0 +1,93 @@
+import { repoRelative, type Citation } from "./api";
+
+/** Filtered, index-stable citation list both panes share. Backend line numbers
+ *  are 0-based; convert to 1-based here for display + the /source endpoint. */
+export function codeRefs(citations: Citation[]): Citation[] {
+  return citations
+    .filter((c) => repoRelative(c.file))
+    .slice(0, 12)
+    .map((c) => ({
+      ...c,
+      start_line: c.start_line != null ? c.start_line + 1 : null,
+      end_line: c.end_line != null ? c.end_line + 1 : null,
+    }));
+}
+
+function norm(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+function basename(p: string): string {
+  return p.split("/").pop() || p;
+}
+
+/** A match: its index in {@link codeRefs}, and whether the span named a symbol
+ *  (has a real line range) or a file (ambiguous — no range shown). */
+export interface CiteMatch {
+  index: number;
+  kind: "symbol" | "file";
+}
+
+/**
+ * Map an inline `code` span to the citation it names, or null. Conservative so
+ * ordinary inline code (`Wald`, `[0, 1]`) stays plain; only a clear symbol or
+ * file matches. Symbol matches carry a line range; file matches don't.
+ */
+export function matchCitation(raw: string, refs: Citation[]): CiteMatch | null {
+  const text = raw.trim().replace(/\(\)$/, "");
+  if (text.length < 2) return null;
+  const t = norm(text);
+
+  const rels = refs.map((c) => repoRelative(c.file));
+
+  // exact symbol
+  for (let i = 0; i < refs.length; i++) {
+    const n = refs[i].node_name;
+    if (n && norm(n.replace(/\(\)$/, "")) === t) return { index: i, kind: "symbol" };
+  }
+  // exact repo-relative path
+  for (let i = 0; i < refs.length; i++) {
+    if (rels[i] && norm(rels[i]) === t) return { index: i, kind: "file" };
+  }
+  // file basename
+  if (/\.[a-z0-9]+$/i.test(text)) {
+    for (let i = 0; i < refs.length; i++) {
+      if (rels[i] && norm(basename(rels[i])) === t) return { index: i, kind: "file" };
+    }
+  }
+  // last segment of a qualified symbol ("file.py:sym()"); >=3 chars avoids "py"
+  if (t.length >= 3) {
+    for (let i = 0; i < refs.length; i++) {
+      const n = refs[i].node_name;
+      if (n) {
+        const seg = n.replace(/\(\)$/, "").split(/[/.:#]/).pop();
+        if (seg && norm(seg) === t) return { index: i, kind: "symbol" };
+      }
+    }
+  }
+  // partial path suffix (needs a slash)
+  if (text.includes("/")) {
+    for (let i = 0; i < refs.length; i++) {
+      const r = rels[i] ? norm(rels[i]) : "";
+      if (r && (r.endsWith(t) || t.endsWith(r))) return { index: i, kind: "file" };
+    }
+  }
+  // path:line form
+  const m = text.match(/^(.+?):(\d+)/);
+  if (m) {
+    const file = norm(m[1]);
+    for (let i = 0; i < refs.length; i++) {
+      const r = rels[i] ? norm(rels[i]) : "";
+      if (r && (r === file || norm(basename(r)) === norm(basename(m[1]))))
+        return { index: i, kind: "file" };
+    }
+  }
+  return null;
+}
+
+/** "843-851" / "843" / "" — the line-range badge shown on a chip. */
+export function lineLabel(c: Citation): string {
+  if (c.start_line == null) return "";
+  if (c.end_line == null || c.end_line === c.start_line) return String(c.start_line);
+  return `${c.start_line}-${c.end_line}`;
+}

--- a/web/lib/citations.ts
+++ b/web/lib/citations.ts
@@ -1,16 +1,9 @@
 import { repoRelative, type Citation } from "./api";
 
-/** Filtered, index-stable citation list both panes share. Backend line numbers
- *  are 0-based; convert to 1-based here for display + the /source endpoint. */
+/** Filtered, index-stable citation list both panes share.
+ *  Backend API citations are already 1-based for display + /source lookup. */
 export function codeRefs(citations: Citation[]): Citation[] {
-  return citations
-    .filter((c) => repoRelative(c.file))
-    .slice(0, 12)
-    .map((c) => ({
-      ...c,
-      start_line: c.start_line != null ? c.start_line + 1 : null,
-      end_line: c.end_line != null ? c.end_line + 1 : null,
-    }));
+  return citations.filter((c) => repoRelative(c.file)).slice(0, 12);
 }
 
 function norm(s: string): string {


### PR DESCRIPTION
## Summary
Adds DeepWiki-style clickable citation chips to the ask page. Inline code in an answer that names a cited symbol or file becomes a chip linking to the right-hand code panel, so readers can jump from a claim to its source.

## Changes
- `web/lib/citations.ts`: matcher from an inline `code` span to a citation (symbol vs file), and `codeRefs` — the index-stable list shared by the chips and the code panel, converting backend 0-based line numbers to 1-based for display.
- `web/components/Markdown.tsx`: render a matched inline `code` span as a `.cite-chip`; symbol chips show the line range, file chips don't (a file has many symbols).
- `web/components/CodePanel.tsx`: controllable active fragment so a chip click drives the panel; render clean source from `/source` instead of the agent's line-number-wrapped content (fixes a doubled gutter); tidy the fragment header.
- `web/app/[repoId]/ask/page.tsx`: wire the chips and code panel to one shared citation list.
- `web/app/globals.css`: `.cite-chip` styles.
- `.gitignore`: ignore `.env.local`.

Web Preview:
<img width="3024" height="1570" alt="image" src="https://github.com/user-attachments/assets/b3980ae8-6318-43fa-a473-f0f1d18180f5" />

Deepwiki reference:
<img width="3016" height="1646" alt="image" src="https://github.com/user-attachments/assets/097b2e78-ed91-483c-a813-c235b5c7e3d5" />


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Type-checked with `tsc --noEmit`. Manually verified on a local hybrid index: chips render with correct line ranges, clicking a chip scrolls and highlights the matching fragment, and symbol/file classification behaves (file mentions carry no misleading range).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published