### PR TITLE
feat(web): clamp long ask question with a show full text toggle

### DIFF
--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Header from "@/components/Header";
@@ -47,6 +47,17 @@ function AskAnswer() {
   const repoName = repo ? repo.repo : repoId;
   const citations = resp?.citations ?? [];
 
+  // Long questions are clamped to a few lines with a "Show full text" toggle
+  // (matches DeepWiki). Measure while clamped to decide whether to show it.
+  const [qExpanded, setQExpanded] = useState(false);
+  const [qOverflows, setQOverflows] = useState(false);
+  const qRef = useRef<HTMLHeadingElement>(null);
+  useEffect(() => {
+    setQExpanded(false);
+    const el = qRef.current;
+    if (el) setQOverflows(el.scrollHeight > el.clientHeight + 2);
+  }, [q]);
+
   return (
     <div className="wiki ask-page">
       <Header
@@ -67,7 +78,14 @@ function AskAnswer() {
           <Link className="ask-back" href={`/${encodeURIComponent(repoId)}`}>
             ← Back to wiki
           </Link>
-          <h1 className="ask-q">{q || "Ask a question"}</h1>
+          <h1 ref={qRef} className={`ask-q ${qExpanded ? "" : "clamped"}`}>
+            {q || "Ask a question"}
+          </h1>
+          {q && qOverflows && (
+            <button className="ask-q-toggle" onClick={() => setQExpanded((e) => !e)}>
+              {qExpanded ? "Show less" : "Show full text"}
+            </button>
+          )}
 
           {!q && <p className="muted">Type a question in the bar below.</p>}
           {loading && <p className="muted ask-thinking">Searching {repoName}…</p>}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1063,6 +1063,28 @@ pre {
   line-height: 1.35;
   margin: 0 0 20px;
 }
+/* Clamp a long question to a fixed height; a "Show full text" toggle expands it. */
+.ask-q.clamped {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.ask-q-toggle {
+  display: inline-block;
+  margin: -12px 0 18px;
+  padding: 0;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 13px;
+  color: var(--muted);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.ask-q-toggle:hover {
+  color: var(--accent);
+}
 .ask-thinking {
   animation: ask-pulse 1.4s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary
On the ask page, a long question heading currently renders in full and pushes the answer down. This clamps it to a fixed height with a "Show full text" toggle, matching DeepWiki.

## Changes
- `web/app/[repoId]/ask/page.tsx`: clamp the `ask-q` heading to 4 lines; when it overflows, show a "Show full text" / "Show less" toggle (overflow measured while clamped, so the toggle only appears for long questions). Selection resets to collapsed on a new question.
- `web/app/globals.css`: `.ask-q.clamped` (line-clamp) + `.ask-q-toggle` styles.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Type-checked with `tsc --noEmit`. Verified locally: a long question clamps to 4 lines with `…` and a "Show full text" link (collapsed height ~119px → expanded ~178px); the toggle flips to "Show less"; short questions show no toggle.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published