### PR TITLE
feat(agent-compile): span-overlap localization eval + pre-load architecture + synthesis per-category sweep

### DIFF
--- a/.claude/design/preload-vs-skill-architecture.md
+++ b/.claude/design/preload-vs-skill-architecture.md
@@ -1,0 +1,113 @@
+# Pre-load vs Skill — confirmed architecture for agent-compile
+
+Status: **confirmed** (2026-06-05). Supersedes the "offer-a-skill" framing of the
+agent-compile sweep. See also `line-span-eval-harness` memory + the span-eval
+work in `codeminer/eval/retrieval_eval.py`.
+
+## Problem (evidence-backed)
+
+The agent-compile arms are defined by which **skills** the agent is *offered*.
+But the agent *chooses* whether to use them, and under the neutral prompt it
+almost never does:
+
+| skill | adoption (E0 100×3 / subset 15) |
+|------|------|
+| `embedding_search` | 4% / **0%** |
+| `hybrid_search` | 0% / 0% |
+| `codeminer_context` (composer) | ~21% |
+| `find_callers/callees/trace` | offered-but-ignored |
+
+It localizes with `read`/`bash`/`grep` instead (a strong pretrain prior —
+Claude is post-trained on exactly this agentic-coding loop). Consequence: the
+`embedding`/`hybrid`/`composer` arms largely measured **"agent + default tools"**,
+not their headline skill. The arms collapse together and skill value is
+unmeasurable. This is NOT a wiring bug — the tools are offered; the agent
+declines.
+
+Yet the retrieval is genuinely useful on the **hard tail**: E0 hard-subset
+files@5 went 0.133 (baseline) → 0.283 (bm25_embedding). The tragedy: adoption is
+lowest exactly where value is highest.
+
+## Decision
+
+Split by **division of labor**:
+
+- **Retrieval = recall, done UP FRONT as context assembly (pre-load).** It solves
+  cold-start / semantic-gap / "where to even look" — the part the agent won't
+  reliably invoke and that is most valuable at the start. Don't make it an
+  optional tool; **pre-compute candidates and inject them into the opening
+  context.**
+- **Agent + grep/read = precision, in the loop.** Confirm the candidate, follow
+  references, read the exact lines. This is the agent's pretrain strength — keep
+  it.
+
+**agent-compile becomes a ROUTER over the pre-load recipe** (per scenario:
+language / stacktrace / repo size → which retrievers, top-k, graph expansion on,
+rerank on), not a chooser of which tools to offer.
+
+### Classification
+
+| capability | home | note |
+|-----------|------|------|
+| `embedding_search` | **pre-load** | semantic candidates (primary) |
+| `codeminer_context` / graph expansion | **pre-load** | orientation map (was an under-adopted tool) |
+| `hybrid`/fusion | **pre-load stage** | fuse embedding+bm25; drop as a standalone tool |
+| `bm25` | **pre-load stage** (compile may disable) | most redundant with grep |
+| `llm_rerank` | **NOT in the agent** | the LLM reranks candidates itself via reasoning over context; rerank is a RAG-pipeline concern (used only for the `retrieval_rec` RAG baseline, never in the agent pre-load). Double-reranking is pointless. |
+| `grep`/`read`/`glob`/`bash` | **skill (always-on)** | the confirm/precision loop |
+| `find_callers`/`callees`/`trace` | **skill + auto-trigger** | needs a mid-loop symbol binding; auto-expand when the agent reads a symbol, else it is ignored too |
+| `code_to_query` | **drop** | marginal |
+
+> **No rerank in the agent pre-load** (decided 2026-06-05): the agent LLM already
+> understands the injected candidates and reasons/confirms over them with grep —
+> a separate `llm_rerank` stage just re-sorts what the model will re-judge anyway.
+> Pre-load = pure *retrieve* (embedding [+bm25] [+graph expand]). Rerank stays in
+> the RAG-pipeline lane for the `retrieval_rec` comparison only.
+
+## Metrics (how to report — see `retrieval_eval.py`)
+
+Single ruler = **span overlap recall@k** (line-range overlap vs `gt_code_blocks`).
+- **Headline: `answer_rec@k` / `answer_acc@k`** — the agent's committed final
+  answer. This is the deliverable; it is the point of having an agent.
+- **`retrieval_rec@k`** — the retriever's ranked spans (nodes only). The
+  cross-system ALIGNMENT axis: identical to a plain RAG pipeline's recall@k
+  (node_id match == span overlap, verified per-instance |diff|=0). Diagnostic.
+- Legacy string `symbols@k*` kept with `*` (≈0 on agent prose; back-reference).
+
+## Test validity — avoid "looks used but fell back to grep"
+
+A measurement where the capability-under-test silently fell back to grep == no
+measurement. Two confirmed gates:
+
+1. **Adoption gate.** Every cell logs whether the capability-under-test was
+   actually exercised. A skill arm whose adoption < threshold (e.g. 50%) is
+   reported as **`N/A — not exercised`**, never a misleading number.
+2. **Pre-load contribution attribution.** For pre-loaded context, measure the
+   fraction of the committed answer's spans that overlap a pre-injected candidate
+   (came from pre-load) vs found independently by grep. Distinguishes "pre-load
+   helped" from "pre-load ignored, grep did it anyway."
+
+(Considered but NOT adopted: a no-grep counterfactual arm.)
+
+### Decisive comparison (one `answer_rec@k` ruler)
+
+1. `grep_only` — defaults only (the fallback itself; baseline).
+2. `preinjected` — retrieval candidates (file:span) in the opening prompt + grep.
+   Report `answer_rec@k` AND pre-load contribution rate.
+
+If (2) ≫ (1): the pre-load architecture is validated and the skills' value lives
+in **pre-injection, not tool-offering**. If they tie: grep/read is the real
+ceiling on this dataset → prune unused skills.
+
+## Implementation roadmap (incremental)
+
+1. Pre-load assembler: a function that runs the compiled retrieval recipe
+   (embedding [+bm25] [+graph expand]; NO rerank) → top-k `(file, span, snippet)`
+   → render into the opening user/system context. Reuse `nodes_to_spans`.
+2. Runner: accept pre-injected context; keep grep/read loop unchanged.
+3. Harness: `preinjected` arm + adoption gate + contribution attribution in the
+   persisted cell; aggregate renders `N/A` for un-exercised skill arms.
+4. design_space: replace skill-offer arms with pre-load-recipe arms; drop
+   `hybrid`/`code_to_query`; add `grep_only` and `preinjected`.
+5. Validate on the 15-instance subset (answer_rec + contribution rate), then full
+   100×3.

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -55,9 +55,24 @@ LOCALIZATION_SCHEMA = (
     "Locations: path/one.ext:START-END, path/two.ext:START-END"
 )
 
-# Detects whether an answer already carries the contract (markdown-tolerant, to
-# match the eval parser): ``Files:``, ``**Files:**``, ``- files =`` all count.
-_HAS_FILES_CONTRACT = re.compile(r"(?im)^[\s>#*_`\-]*files?[\s*_`]*[:=]")
+# Detect whether an answer already carries the full contract (markdown-tolerant,
+# to match the eval parser): ``Files:``, ``**Files:**``, ``- files =`` all count.
+_LABEL_PREFIX = r"(?im)^[\s>#*_`\-]*"
+_HAS_FILES_CONTRACT = re.compile(rf"{_LABEL_PREFIX}files?[\s*_`]*[:=]")
+_HAS_SYMBOLS_CONTRACT = re.compile(rf"{_LABEL_PREFIX}symbols?[\s*_`]*[:=]")
+_HAS_LOCATIONS_CONTRACT = re.compile(rf"{_LABEL_PREFIX}locations?[\s*_`]*[:=]")
+
+
+def _has_localization_contract(answer: str) -> bool:
+    return all(
+        pattern.search(answer or "")
+        for pattern in (
+            _HAS_FILES_CONTRACT,
+            _HAS_SYMBOLS_CONTRACT,
+            _HAS_LOCATIONS_CONTRACT,
+        )
+    )
+
 
 _DEFAULT_SYSTEM_PROMPT = f"""\
 You are a code localization agent. Find the code locations (files and \
@@ -388,7 +403,7 @@ class AgentRunner:
                 # without the contract (it explored but didn't format), force one
                 # schema turn so a genuine localization isn't lost to formatting.
                 answer = getattr(assistant_msg, "content", None) or ""
-                if all_tool_calls and not _HAS_FILES_CONTRACT.search(answer):
+                if all_tool_calls and not _has_localization_contract(answer):
                     answer = (
                         self._force_schema_answer(history, usage_tracker, turn + 2)
                         or answer
@@ -430,7 +445,7 @@ class AgentRunner:
         # Budget exhausted. A capped agent usually left mid-exploration chatter
         # ("Let me check…"), so force a schema-conforming final answer unless it
         # already emitted the contract.
-        if all_tool_calls and not _HAS_FILES_CONTRACT.search(last_content):
+        if all_tool_calls and not _has_localization_contract(last_content):
             last_content = (
                 self._force_schema_answer(history, usage_tracker, max_turns + 1)
                 or last_content

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -12,6 +12,7 @@ produces a final answer.
 from __future__ import annotations
 
 import json
+import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -45,7 +46,20 @@ _DEFAULT_SKILLS_DIR: Path = Path(__file__).parent / "skills"
 
 CompileTableInput = Union[str, Path, Mapping[str, Any]]
 
-_DEFAULT_SYSTEM_PROMPT = """\
+# Single source of truth for the answer contract. The system prompt below and
+# the forced final-answer turn (on budget exhaustion) both reference this, and
+# the eval harness parses exactly these lines — so prompt and parser never drift.
+LOCALIZATION_SCHEMA = (
+    "Files: path/one.ext, path/two.ext\n"
+    "Symbols: path/one.ext:symbol_name, ...\n"
+    "Locations: path/one.ext:START-END, path/two.ext:START-END"
+)
+
+# Detects whether an answer already carries the contract (markdown-tolerant, to
+# match the eval parser): ``Files:``, ``**Files:**``, ``- files =`` all count.
+_HAS_FILES_CONTRACT = re.compile(r"(?im)^[\s>#*_`\-]*files?[\s*_`]*[:=]")
+
+_DEFAULT_SYSTEM_PROMPT = f"""\
 You are a code localization agent. Find the code locations (files and \
 symbols) relevant to the request, then give a concise answer naming them.
 
@@ -80,9 +94,9 @@ the symbol across the repo (grep pattern=...). A base-class method \
 often has the real change in a SUBCLASS OVERRIDE — grep the method name to find \
 all definitions, then read them. Loop back to READ.
 4. ANSWER — only once you have READ a file and confirmed it contains the code \
-to change. End with two lines, repo-relative:
-   Files: path/one.ext, path/two.ext
-   Symbols: path/one.ext:symbol_name, ...
+to change. End with these three lines, repo-relative. The line numbers come \
+straight from what `read` showed you — cite the exact range of the code to change:
+{LOCALIZATION_SCHEMA}
 
 Guidelines:
 - The graph map is a hint, not the answer — always confirm by reading.
@@ -370,8 +384,15 @@ class AgentRunner:
             # Check for tool calls
             tool_calls = getattr(assistant_msg, "tool_calls", None)
             if not tool_calls:
-                # Terminal: LLM produced a final answer
+                # Terminal: LLM stopped calling tools. If it answered in prose
+                # without the contract (it explored but didn't format), force one
+                # schema turn so a genuine localization isn't lost to formatting.
                 answer = getattr(assistant_msg, "content", None) or ""
+                if all_tool_calls and not _HAS_FILES_CONTRACT.search(answer):
+                    answer = (
+                        self._force_schema_answer(history, usage_tracker, turn + 2)
+                        or answer
+                    )
                 elapsed = (time.monotonic() - start) * 1000
                 return AgentResult(
                     answer=answer,
@@ -406,33 +427,14 @@ class AgentRunner:
                 last_content = msg["content"]
                 break
 
-        # If the model spent every turn calling tools and never wrote prose,
-        # force one final tool-free turn so the agent still returns its best
-        # answer instead of an empty string — a budget-bound run that did real
-        # work should not report nothing. Best-effort: never crash on the
-        # summary call.
-        if not last_content and all_tool_calls:
-            history.add_message(
-                {
-                    "role": "user",
-                    "content": (
-                        "You have reached the tool-call budget. Do not call any "
-                        "more tools. Based on what you have found so far, give "
-                        "your final answer now."
-                    ),
-                }
+        # Budget exhausted. A capped agent usually left mid-exploration chatter
+        # ("Let me check…"), so force a schema-conforming final answer unless it
+        # already emitted the contract.
+        if all_tool_calls and not _HAS_FILES_CONTRACT.search(last_content):
+            last_content = (
+                self._force_schema_answer(history, usage_tracker, max_turns + 1)
+                or last_content
             )
-            try:
-                final = self.llm._call_raw(
-                    history.get_messages(),
-                    usage_tracker=usage_tracker,
-                    usage_turn=max_turns + 1,
-                )
-                forced_msg = final.choices[0].message
-                history.add_message(_message_to_dict(forced_msg))
-                last_content = getattr(forced_msg, "content", None) or ""
-            except Exception as exc:  # best-effort summary; keep the partial run
-                logger.warning("forced final-answer turn failed: %s", exc)
 
         elapsed = (time.monotonic() - start) * 1000
         return AgentResult(
@@ -448,6 +450,43 @@ class AgentRunner:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    def _force_schema_answer(self, history, usage_tracker, usage_turn: int) -> str:
+        """One tool-free turn that extracts a contract-conforming final answer.
+
+        Used when the agent stopped (budget hit, or terminated in prose) without
+        emitting the ``Files:/Symbols:/Locations:`` contract — so a genuine
+        localization is not lost to formatting / an unfinished answer. This is an
+        extra turn; it does NOT consume the exploration budget. Anthropic rejects
+        a tool-history conversation unless ``tools=`` is passed, so we pass it
+        with ``tool_choice="none"`` to forbid further calls. Best-effort.
+        """
+        history.add_message(
+            {
+                "role": "user",
+                "content": (
+                    "Stop. Do not call any more tools. Based on everything you "
+                    "have found, give your final answer NOW in exactly this "
+                    "format (repo-relative paths; line numbers as shown by "
+                    f"`read`):\n{LOCALIZATION_SCHEMA}"
+                ),
+            }
+        )
+        try:
+            overrides: Dict[str, Any] = {
+                "usage_tracker": usage_tracker,
+                "usage_turn": usage_turn,
+            }
+            if self.tools:
+                overrides["tools"] = self.tools
+                overrides["tool_choice"] = "none"
+            final = self.llm._call_raw(history.get_messages(), **overrides)
+            forced_msg = final.choices[0].message
+            history.add_message(_message_to_dict(forced_msg))
+            return getattr(forced_msg, "content", None) or ""
+        except Exception as exc:  # best-effort; keep the partial run
+            logger.warning("forced final-answer turn failed: %s", exc)
+            return ""
 
     def _new_history(self):
         """Build the chat-history container for one ``run()``.

--- a/codeminer/dataset/synthesize/__init__.py
+++ b/codeminer/dataset/synthesize/__init__.py
@@ -2,7 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Query synthesis tools for SWE-bench multiplexed indexing."""
+"""Query synthesis tools for SWE-bench multiplexed indexing.
+
+Heavy synthesis components depend on the optional Claude Agent SDK. Keep package
+import lightweight so tests and utility modules can import ``_types`` /
+``vocab_guard`` without installing that optional runtime.
+"""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
 
 from codeminer.dataset.utils import (
     CodeLocation,
@@ -14,16 +22,35 @@ from codeminer.dataset.utils import (
 )
 
 from ._types import QuerySynthesisResult
-from .context_loader import ContextLoader
-from .query_curator import QueryCurator
-from .query_synthesizer import ClaudeQuerySynthesizer
-from .verifier import Verifier
 from .vocab_guard import (
     DEFAULT_OVERLAP_THRESHOLD,
     VocabOverlapResult,
     VocabularyOverlapGuard,
     gt_identifier_tokens,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
+    from .context_loader import ContextLoader
+    from .query_curator import QueryCurator
+    from .query_synthesizer import ClaudeQuerySynthesizer
+    from .verifier import Verifier
+
+_LAZY_EXPORTS = {
+    "ClaudeQuerySynthesizer": ".query_synthesizer",
+    "ContextLoader": ".context_loader",
+    "QueryCurator": ".query_curator",
+    "Verifier": ".verifier",
+}
+
+
+def __getattr__(name: str):
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(_LAZY_EXPORTS[name], __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "ClaudeQuerySynthesizer",

--- a/codeminer/dataset/synthesize/_types.py
+++ b/codeminer/dataset/synthesize/_types.py
@@ -6,9 +6,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
@@ -118,6 +118,11 @@ class BehavioralContext:
     core_block: SampledCodeBlock
     candidate_blocks: List[SampledCodeBlock]
     neighborhood_blocks: List[SampledCodeBlock]
+    # {(file_path, leaf_symbol): (start_line, end_line)} over ALL graph symbol
+    # nodes (0-based, graph attrs) — used to resolve real line spans for the
+    # hint/reasoning path, whose ground truth carries only file:symbol strings.
+    # NOT candidate_blocks: those are randomly downsampled to max_candidate_blocks.
+    symbol_spans: Dict[Tuple[str, str], Tuple[int, int]] = field(default_factory=dict)
 
 
 def format_prompt_block(

--- a/codeminer/dataset/synthesize/context_loader.py
+++ b/codeminer/dataset/synthesize/context_loader.py
@@ -11,7 +11,7 @@ import math
 import random
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from pydantic import ValidationError
 
@@ -28,7 +28,6 @@ from codeminer.types import (
 )
 from codeminer.utils import is_test_file
 
-from ._agent import AgentRunner
 from ._types import (
     BehavioralContext,
     RepoSnapshot,
@@ -36,7 +35,27 @@ from ._types import (
     TargetDiscoveryResult,
 )
 
+if TYPE_CHECKING:
+    from ._agent import AgentRunner
+
 logger = get_logger(__name__)
+
+
+def _leaf_symbol(name: Any) -> str:
+    """Return the answer/GT leaf symbol from graph or display names.
+
+    Graph vertex names vary by language (``file.py:foo()``,
+    ``pkg/Type#method``, ``Class.method``), while answer/GT matching uses the
+    final human-readable leaf. Normalize both sides through one helper.
+    """
+    s = str(name or "").strip()
+    if not s:
+        return ""
+    if ":" in s:
+        s = s.rsplit(":", 1)[1]
+    s = s.replace("#", ".")
+    s = s.split("(", 1)[0]
+    return s.split("/")[-1].split(".")[-1].strip()
 
 
 class ContextLoader:
@@ -219,15 +238,18 @@ class ContextLoader:
             start_line = attrs.get("start_line")
             end_line = attrs.get("end_line")
             name = attrs.get("name")
+            unified_name = attrs.get("unified_name")
             if (
                 not file_path
-                or not name
                 or not isinstance(start_line, int)
                 or not isinstance(end_line, int)
+                or not (name or unified_name)
             ):
                 continue
-            leaf = str(name).split(":")[-1].split("/")[-1].split(".")[-1].rstrip("()")
-            index.setdefault((file_path, leaf), (start_line, end_line))
+            for label in (name, unified_name):
+                leaf = _leaf_symbol(label)
+                if leaf:
+                    index.setdefault((file_path, leaf), (start_line, end_line))
         return index
 
     def load_code_graph(

--- a/codeminer/dataset/synthesize/context_loader.py
+++ b/codeminer/dataset/synthesize/context_loader.py
@@ -197,7 +197,38 @@ class ContextLoader:
             core_block=core_block,
             candidate_blocks=candidates,
             neighborhood_blocks=neighborhood,
+            symbol_spans=self.build_symbol_span_index(graph),
         )
+
+    @staticmethod
+    def build_symbol_span_index(code_graph) -> Dict[Tuple[str, str], Tuple[int, int]]:
+        """``{(file, leaf_symbol): (start_line, end_line)}`` over ALL graph symbol
+        nodes (0-based graph attrs, uncapped).
+
+        ``candidate_blocks`` is randomly downsampled to ``max_candidate_blocks``,
+        so it cannot resolve an arbitrary ground-truth symbol; this scans every
+        symbol vertex so the hint/reasoning path can recover real line spans.
+        """
+        index: Dict[Tuple[str, str], Tuple[int, int]] = {}
+        graph = code_graph.get_graph()
+        for node in graph.vs:
+            attrs = node.attributes()
+            if not is_symbol_node(attrs.get("type", "")):
+                continue
+            file_path = attrs.get("file")
+            start_line = attrs.get("start_line")
+            end_line = attrs.get("end_line")
+            name = attrs.get("name")
+            if (
+                not file_path
+                or not name
+                or not isinstance(start_line, int)
+                or not isinstance(end_line, int)
+            ):
+                continue
+            leaf = str(name).split(":")[-1].split("/")[-1].split(".")[-1].rstrip("()")
+            index.setdefault((file_path, leaf), (start_line, end_line))
+        return index
 
     def load_code_graph(
         self,

--- a/codeminer/dataset/synthesize/query_curator.py
+++ b/codeminer/dataset/synthesize/query_curator.py
@@ -10,14 +10,13 @@ import hashlib
 import math
 import random
 import re
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from pydantic import ValidationError
 
 from codeminer.dataset.utils import QueryType, get_prompt_for_query_type
 from codeminer.log_utils import get_logger
 
-from ._agent import AgentRunner
 from ._types import (
     BehavioralContext,
     BehavioralSelectionResult,
@@ -26,6 +25,9 @@ from ._types import (
     TargetDiscoveryResult,
     format_prompt_block,
 )
+
+if TYPE_CHECKING:
+    from ._agent import AgentRunner
 
 logger = get_logger(__name__)
 

--- a/codeminer/dataset/synthesize/query_synthesizer.py
+++ b/codeminer/dataset/synthesize/query_synthesizer.py
@@ -26,14 +26,13 @@ from codeminer.dataset.utils import CodeLocation, GroundTruth, QueryType
 from codeminer.log_utils import get_logger
 from codeminer.types import NodeInfo
 
-from ._agent import AgentRunner
 from ._types import (
     BehavioralContext,
     RepoSnapshot,
     SampledCodeBlock,
     TargetDiscoveryResult,
 )
-from .context_loader import ContextLoader
+from .context_loader import ContextLoader, _leaf_symbol
 from .query_curator import QueryCurator
 from .verifier import Verifier
 from .vocab_guard import DEFAULT_OVERLAP_THRESHOLD
@@ -85,6 +84,8 @@ class ClaudeQuerySynthesizer:
         self.num_queries = max(1, num_queries)
 
         # --- Agent runners with per-stage tool configs ---
+        from ._agent import AgentRunner
+
         context_agent = AgentRunner(
             model=model,
             max_turns=max_turns,
@@ -453,19 +454,14 @@ class ClaudeQuerySynthesizer:
         if gt is None:
             return []
 
-        def _leaf(name: Any) -> str:
-            # Robust to "file.py:Class.method()", "pkg/path/leaf", "Class.method".
-            s = str(name or "")
-            if ":" in s:
-                s = s.split(":")[-1]
-            return s.split("/")[-1].split(".")[-1].rstrip("()")
-
         # Resolve real spans from the FULL graph index (candidate_blocks is
         # downsampled and can't be relied on to contain the GT symbol).
         span_index = behavioral_context.symbol_spans if behavioral_context else {}
         nodes: List[NodeInfo] = []
         for loc in gt.primary_locations:
-            span = span_index.get((loc.file_path, _leaf(loc.symbol or loc.node_id)))
+            span = span_index.get(
+                (loc.file_path, _leaf_symbol(loc.symbol or loc.node_id))
+            )
             start, end = span if span else (loc.start_line, loc.end_line)
             nodes.append(
                 NodeInfo(

--- a/codeminer/dataset/synthesize/query_synthesizer.py
+++ b/codeminer/dataset/synthesize/query_synthesizer.py
@@ -27,7 +27,12 @@ from codeminer.log_utils import get_logger
 from codeminer.types import NodeInfo
 
 from ._agent import AgentRunner
-from ._types import RepoSnapshot, SampledCodeBlock, TargetDiscoveryResult
+from ._types import (
+    BehavioralContext,
+    RepoSnapshot,
+    SampledCodeBlock,
+    TargetDiscoveryResult,
+)
 from .context_loader import ContextLoader
 from .query_curator import QueryCurator
 from .verifier import Verifier
@@ -177,7 +182,9 @@ class ClaudeQuerySynthesizer:
                 ground_truth,
                 discovered_targets=discovered,
             )
-            target_symbol_nodes = self._build_symbol_nodes_from_ground_truth(gt)
+            target_symbol_nodes = self._build_symbol_nodes_from_ground_truth(
+                gt, behavioral_context
+            )
 
         return self._build_output(
             instance=instance,
@@ -237,7 +244,9 @@ class ClaudeQuerySynthesizer:
                 ground_truth,
                 discovered_targets=discovered,
             )
-            target_symbol_nodes = self._build_symbol_nodes_from_ground_truth(gt)
+            target_symbol_nodes = self._build_symbol_nodes_from_ground_truth(
+                gt, behavioral_context
+            )
 
         return self._build_output(
             instance=instance,
@@ -428,18 +437,43 @@ class ClaudeQuerySynthesizer:
     @staticmethod
     def _build_symbol_nodes_from_ground_truth(
         gt: Optional[GroundTruth],
+        behavioral_context: Optional["BehavioralContext"] = None,
     ) -> List[NodeInfo]:
+        """Build target symbol nodes for the non-behavioral (hint) path.
+
+        ``_build_ground_truth`` derives primary_locations from ``file:symbol``
+        strings only, so they carry NO line ranges (start/end_line default to 0).
+        That produced the (0,0) ``gt_symbol_nodes`` for the file_hint /
+        module_hint / symbol_hint / reasoning categories on HuggingFace, which
+        makes span-overlap eval impossible for them. Resolve each symbol's real
+        span from the sampled graph blocks (``behavioral_context.candidate_blocks``
+        is built for every query, behavioral or not, and carries true graph
+        spans); fall back to the location's own (possibly 0) span when unmatched.
+        """
         if gt is None:
             return []
+
+        def _leaf(name: Any) -> str:
+            # Robust to "file.py:Class.method()", "pkg/path/leaf", "Class.method".
+            s = str(name or "")
+            if ":" in s:
+                s = s.split(":")[-1]
+            return s.split("/")[-1].split(".")[-1].rstrip("()")
+
+        # Resolve real spans from the FULL graph index (candidate_blocks is
+        # downsampled and can't be relied on to contain the GT symbol).
+        span_index = behavioral_context.symbol_spans if behavioral_context else {}
         nodes: List[NodeInfo] = []
         for loc in gt.primary_locations:
+            span = span_index.get((loc.file_path, _leaf(loc.symbol or loc.node_id)))
+            start, end = span if span else (loc.start_line, loc.end_line)
             nodes.append(
                 NodeInfo(
                     node_name=loc.node_id,
                     type=loc.symbol_type or "",
                     file=loc.file_path,
-                    start_line=loc.start_line,
-                    end_line=loc.end_line,
+                    start_line=start,
+                    end_line=end,
                 )
             )
         return nodes

--- a/codeminer/dataset/synthesize/verifier.py
+++ b/codeminer/dataset/synthesize/verifier.py
@@ -8,17 +8,19 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from codeminer.log_utils import get_logger
 
-from ._agent import AgentRunner
 from ._types import BehavioralContext, SampledCodeBlock, format_prompt_block
 from .vocab_guard import (
     DEFAULT_OVERLAP_THRESHOLD,
     VocabOverlapResult,
     VocabularyOverlapGuard,
 )
+
+if TYPE_CHECKING:
+    from ._agent import AgentRunner
 
 logger = get_logger(__name__)
 

--- a/codeminer/eval/retrieval_eval.py
+++ b/codeminer/eval/retrieval_eval.py
@@ -360,25 +360,34 @@ def _make_span(
 
 
 def collect_target_blocks(instance: Mapping[str, Any]) -> List[Dict[str, Any]]:
-    """Normalized 1-based ground-truth code blocks from ``gt_code_blocks``.
+    """Normalized 1-based ground-truth code blocks.
 
-    Accepts either the ``gt_code_blocks`` (raw dataset row) or ``code_blocks``
-    key. Each block keeps ``symbol``/``change_type`` for downstream inspection.
+    Two sources, with DIFFERENT line origins (the project's line-origin gotcha):
+      * ``gt_code_blocks`` / ``code_blocks`` (SWE-bench patch hunks) are 1-based.
+      * ``gt_symbol_nodes`` (codeminer-synthesis) are copied straight from the
+        0-based tree-sitter graph attrs by the synthesis context_loader, so they
+        are 0-based and must be shifted +1.
+    Each block keeps ``symbol``/``change_type`` for downstream inspection.
     """
     raw = instance.get("gt_code_blocks")
     if raw is None:
-        raw = instance.get("code_blocks") or []
+        raw = instance.get("code_blocks")
+    if raw is not None:
+        base, symbol_key = 1, "symbol"
+    else:  # synthesis rows expose 0-based symbol nodes instead
+        raw = instance.get("gt_symbol_nodes") or []
+        base, symbol_key = 0, "node_name"
     blocks: List[Dict[str, Any]] = []
     for blk in raw:
         sp = _make_span(
             blk.get("file_path") or blk.get("file"),
             blk.get("start_line"),
             blk.get("end_line"),
-            base=1,
+            base=base,
             source="gt",
         )
         if sp:
-            sp["symbol"] = blk.get("symbol")
+            sp["symbol"] = blk.get("symbol") or blk.get(symbol_key)
             sp["change_type"] = blk.get("change_type")
             blocks.append(sp)
     return blocks

--- a/codeminer/eval/retrieval_eval.py
+++ b/codeminer/eval/retrieval_eval.py
@@ -205,8 +205,13 @@ def summarize_predictions(
 # ablations so files@k is defined once.
 # ---------------------------------------------------------------------------
 
-_FILES_LINE = re.compile(r"(?im)^\s*files?\s*[:=]\s*(.+)$")
-_SYMBOLS_LINE = re.compile(r"(?im)^\s*symbols?\s*[:=]\s*(.+)$")
+# Agents routinely decorate the answer contract with markdown — ``**Files:**``,
+# ``- Symbols:``, ``### Locations``. A strict ``^\s*files?`` anchor silently
+# missed all of those (a major cause of the symbols@k≈0 artifact), so tolerate
+# leading/surrounding markdown emphasis (* _ ` # > -) around the label.
+_MD = r"[\s>#*_`\-]*"
+_FILES_LINE = re.compile(rf"(?im)^{_MD}files?{_MD}[:=]{_MD}\s*(.+)$")
+_SYMBOLS_LINE = re.compile(rf"(?im)^{_MD}symbols?{_MD}[:=]{_MD}\s*(.+)$")
 _PATH_TOKEN = re.compile(r"[\w./\\-]+\.[A-Za-z0-9_]+")
 
 
@@ -286,3 +291,254 @@ def score_agent_localization(
         metrics["files"][k] = compute_metrics(pred_files[:k], target_files)
         metrics["symbols"][k] = compute_metrics(pred_symbols[:k], target_symbols)
     return metrics
+
+
+# ---------------------------------------------------------------------------
+# Line-span localization scoring
+#
+# Symbol-name string matching is brittle: the GT carries ``file:Class.foo()``
+# while the agent writes a bare ``foo`` in prose, so genuinely-located code can
+# score zero (see the "named-but-missed" failure mode). Line spans sidestep this
+# entirely — a prediction ``(file, start, end)`` HITS a ground-truth code block
+# when the files match and the line ranges OVERLAP. Overlap (not exact equality)
+# is what makes this robust to two real skews:
+#   * origin: tree-sitter graph nodes are 0-based, ``gt_code_blocks`` are 1-based
+#     (the project-wide line-origin gotcha) — callers pass ``base=0`` for nodes;
+#   * boundary: a graph node spans the whole *definition* while a GT block is the
+#     edited *hunk*, so their starts differ by a line or two but still overlap.
+#
+# Two scopes are scored from DIFFERENT prediction sources — neither bounds the
+# other (an agent can name in its answer a region grep/reasoning found that the
+# retriever never returned, so ``answer`` can exceed ``retrieval``; see the
+# "answer > retrieval" unit test):
+#   retrieval — the ranked spans the retrieval skills returned (nodes only).
+#               This is the cross-system ALIGNMENT axis: it is defined
+#               identically to a plain RAG pipeline's recall@k (node_id match ==
+#               span overlap, verified), so RAG / pure-embedding / agent are
+#               directly comparable on it. Measures RETRIEVAL quality.
+#   answer    — the spans the agent committed to in its final answer
+#               (``Locations:`` ranges + ``Symbols:`` resolved via the graph).
+#               This is the agent's end-to-end DELIVERABLE (the headline);
+#               precision-honest, so dumping context cannot inflate it.
+# ("surfaced"/"ceiling" framing was dropped: it conflated nodes+reads and was not
+# a true upper bound.)
+# ---------------------------------------------------------------------------
+
+# ``path:start-end`` / ``path:start`` / ``path#L12-L45`` location tokens.
+# Markdown-tolerant label (see ``_FILES_LINE``): ``**Locations:**`` is common.
+_LOCATIONS_LINE = re.compile(rf"(?im)^{_MD}locations?{_MD}[:=]{_MD}\s*(.+)$")
+_LOC_TOKEN = re.compile(r"([\w./\\-]+\.[A-Za-z0-9_]+)[:#]L?(\d+)(?:\s*[-–]\s*L?(\d+))?")
+
+
+def _make_span(
+    file: Optional[str],
+    start: Any,
+    end: Any,
+    *,
+    base: int = 1,
+    score: float = 0.0,
+    source: str = "",
+    repo_path: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Normalize a raw ``(file, start, end)`` into a 1-based inclusive span dict.
+
+    ``base=0`` shifts 0-based inputs (tree-sitter graph nodes) up to 1-based so
+    they line up with ``gt_code_blocks``. Returns ``None`` for unusable input.
+    """
+    nf = _rel_norm(file, repo_path) if repo_path else normalize_file_path(file)
+    if not nf or start is None or end is None:
+        return None
+    try:
+        s, e = int(start), int(end)
+    except (TypeError, ValueError):
+        return None
+    shift = 1 - base  # base=0 -> +1 ; base=1 -> +0
+    s, e = s + shift, e + shift
+    if e < s:
+        s, e = e, s
+    return {"file": nf, "start": s, "end": e, "score": float(score), "source": source}
+
+
+def collect_target_blocks(instance: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    """Normalized 1-based ground-truth code blocks from ``gt_code_blocks``.
+
+    Accepts either the ``gt_code_blocks`` (raw dataset row) or ``code_blocks``
+    key. Each block keeps ``symbol``/``change_type`` for downstream inspection.
+    """
+    raw = instance.get("gt_code_blocks")
+    if raw is None:
+        raw = instance.get("code_blocks") or []
+    blocks: List[Dict[str, Any]] = []
+    for blk in raw:
+        sp = _make_span(
+            blk.get("file_path") or blk.get("file"),
+            blk.get("start_line"),
+            blk.get("end_line"),
+            base=1,
+            source="gt",
+        )
+        if sp:
+            sp["symbol"] = blk.get("symbol")
+            sp["change_type"] = blk.get("change_type")
+            blocks.append(sp)
+    return blocks
+
+
+def spans_overlap(a: Mapping[str, Any], b: Mapping[str, Any]) -> bool:
+    """True when two spans are in the same file and their line ranges overlap."""
+    return a["file"] == b["file"] and a["start"] <= b["end"] and b["start"] <= a["end"]
+
+
+def dedup_spans(spans: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop spans that overlap an already-kept span (first-wins, rank-order).
+
+    Reading a function twice, or a retrieval node plus an answer line that point
+    at the same region, should occupy ONE slot in the top-k, not several — else a
+    single hit could be padded to fill the cutoff.
+    """
+    kept: List[Dict[str, Any]] = []
+    for sp in spans:
+        if any(spans_overlap(sp, k) for k in kept):
+            continue
+        kept.append(sp)
+    return kept
+
+
+def nodes_to_spans(nodes: Sequence[QueriedNode]) -> List[Dict[str, Any]]:
+    """Spans from retrieval nodes, ranked by score desc.
+
+    Two empirically-verified quirks of retrieval ``QueriedNode``s drive this:
+      * ``node.file`` is the absolute *build-time* path baked into the index
+        (``/.../.codeminer/...``), which matches neither the GT nor the current
+        repo. The ``node_id`` file part IS repo-relative, so prefer it.
+      * lines are already ~1-based (start = graph-0-based + 1), so ``base=1`` —
+        NO further shift (unlike the 0-based graph in ``build_symbol_span_index``).
+    """
+    out: List[Dict[str, Any]] = []
+    for node in nodes:
+        node_id = getattr(node, "node_id", None)
+        file = node_id.split(":")[0] if node_id and ":" in node_id else None
+        if not file:
+            file = getattr(node, "file", None)
+        sp = _make_span(
+            file,
+            getattr(node, "start_line", None),
+            getattr(node, "end_line", None),
+            base=1,
+            score=getattr(node, "score", 0.0) or 0.0,
+            source="node",
+        )
+        if sp:
+            out.append(sp)
+    out.sort(key=lambda s: s["score"], reverse=True)
+    return out
+
+
+def parse_answer_spans(answer: str, repo_path: str = "") -> List[Dict[str, Any]]:
+    """Spans the agent *committed to* via a ``Locations:`` line.
+
+    Only the structured line is trusted — scraping arbitrary prose line mentions
+    is too noisy and would reward verbosity. Line numbers there are 1-based (the
+    agent reads them straight from the 1-based ``read`` output).
+    """
+    payload = " ".join(m.group(1) for m in _LOCATIONS_LINE.finditer(answer or ""))
+    if not payload:
+        return []
+    spans: List[Dict[str, Any]] = []
+    for m in _LOC_TOKEN.finditer(payload):
+        sp = _make_span(
+            m.group(1),
+            m.group(2),
+            m.group(3) or m.group(2),
+            base=1,
+            source="answer",
+            repo_path=repo_path,
+        )
+        if sp:
+            spans.append(sp)
+    return spans
+
+
+def resolve_symbol_spans(
+    answer: str,
+    span_index: Mapping[Tuple[str, str], Tuple[int, int]],
+    repo_path: str = "",
+) -> List[Dict[str, Any]]:
+    """Spans for symbols named in the agent's ``Symbols:`` line, resolved via a
+    ``{(norm_file, leaf_name): (start, end)}`` 1-based index.
+
+    Bridges the exact gap the span metric exists to close: the agent commits to a
+    symbol name (``fixes.rs:remove_unused...``) but not an explicit line range —
+    string matching scores it zero, but resolving the name to its span credits
+    the genuine hit.
+    """
+    spans: List[Dict[str, Any]] = []
+    for raw in _answer_symbols(answer):
+        norm = normalize_symbol_identifier(raw)
+        if not norm or ":" not in norm:
+            continue
+        file_part, sym = norm.split(":", 1)
+        file = normalize_file_path(file_part)
+        leaf = sym.strip().split("(")[0].split(".")[-1].split("/")[-1]
+        rng = span_index.get((file, leaf)) if file else None
+        if rng:
+            sp = _make_span(file, rng[0], rng[1], base=1, source="answer_symbol")
+            if sp:
+                spans.append(sp)
+    return spans
+
+
+def compute_block_metrics(
+    pred_spans: Sequence[Mapping[str, Any]],
+    gt_blocks: Sequence[Mapping[str, Any]],
+) -> Dict[str, float]:
+    """Overlap-based accuracy / precision / recall for one top-k prediction set.
+
+    ``pred_spans`` must already be ranked and truncated to k. A GT block is
+    recalled if any prediction overlaps it; a prediction is a hit if it overlaps
+    any GT block (precision = on-target fraction of the top-k).
+    """
+    if not gt_blocks:
+        return {"accuracy": 0.0, "precision": 0.0, "recall": 0.0, "hits": 0}
+    recalled = sum(1 for g in gt_blocks if any(spans_overlap(p, g) for p in pred_spans))
+    on_target = sum(
+        1 for p in pred_spans if any(spans_overlap(p, g) for g in gt_blocks)
+    )
+    accuracy = 1.0 if recalled == len(gt_blocks) else 0.0
+    precision = on_target / max(len(pred_spans), 1)
+    recall = recalled / len(gt_blocks)
+    return {
+        "accuracy": accuracy,
+        "precision": precision,
+        "recall": recall,
+        "hits": recalled,
+    }
+
+
+def score_localization_spans(
+    *,
+    answer_spans: Sequence[Dict[str, Any]],
+    retrieval_spans: Sequence[Dict[str, Any]],
+    gt_blocks: Sequence[Mapping[str, Any]],
+    ks: Sequence[int],
+) -> Dict[str, Dict[int, Dict[str, float]]]:
+    """blocks@k for the ``answer`` and ``retrieval`` scopes (overlap-based).
+
+    ``answer`` = what the agent committed to (its DELIVERABLE; the headline).
+    ``retrieval`` = the retriever's ranked spans (the cross-system ALIGNMENT
+    axis, == a RAG pipeline's recall@k). Neither bounds the other: the agent can
+    commit to a region grep/reasoning found that retrieval never returned. Both
+    lists are deduped by overlap before truncation so a region predicted several
+    times cannot pad the top-k. Each scope reports accuracy / precision / recall;
+    ``recall`` is the metric used for cross-system alignment.
+    """
+    answer = dedup_spans(list(answer_spans))
+    retrieval = dedup_spans(list(retrieval_spans))
+    out: Dict[str, Dict[int, Dict[str, float]]] = {
+        "answer_blocks": {},
+        "retrieval_blocks": {},
+    }
+    for k in ks:
+        out["answer_blocks"][k] = compute_block_metrics(answer[:k], gt_blocks)
+        out["retrieval_blocks"][k] = compute_block_metrics(retrieval[:k], gt_blocks)
+    return out

--- a/codeminer/eval/retrieval_eval.py
+++ b/codeminer/eval/retrieval_eval.py
@@ -420,8 +420,9 @@ def nodes_to_spans(nodes: Sequence[QueriedNode]) -> List[Dict[str, Any]]:
       * ``node.file`` is the absolute *build-time* path baked into the index
         (``/.../.codeminer/...``), which matches neither the GT nor the current
         repo. The ``node_id`` file part IS repo-relative, so prefer it.
-      * lines are already ~1-based (start = graph-0-based + 1), so ``base=1`` —
-        NO further shift (unlike the 0-based graph in ``build_symbol_span_index``).
+      * raw ``NodeInfo`` / ``QueriedNode`` line spans are internal 0-based
+        (the agent boundary shifts only the JSON shown to the LLM), so shift
+        them +1 here to score against 1-based GT / answer spans.
     """
     out: List[Dict[str, Any]] = []
     for node in nodes:
@@ -433,7 +434,7 @@ def nodes_to_spans(nodes: Sequence[QueriedNode]) -> List[Dict[str, Any]]:
             file,
             getattr(node, "start_line", None),
             getattr(node, "end_line", None),
-            base=1,
+            base=0,
             score=getattr(node, "score", 0.0) or 0.0,
             source="node",
         )

--- a/scripts/agent_compile/aggregate.py
+++ b/scripts/agent_compile/aggregate.py
@@ -82,6 +82,15 @@ def _at_k(cell: Dict[str, Any], scope: str, k: int) -> Optional[float]:
     return stats
 
 
+def _field_at_k(
+    cell: Dict[str, Any], scope: str, k: int, field: str
+) -> Optional[float]:
+    """Read an arbitrary metric field (precision/recall/...) at cutoff k."""
+    bucket = (cell.get("metrics") or {}).get(scope) or {}
+    stats = bucket.get(k, bucket.get(str(k)))
+    return stats.get(field) if isinstance(stats, dict) else None
+
+
 def _safe_mean(xs: Sequence[Optional[float]]) -> Optional[float]:
     vals = [x for x in xs if x is not None]
     return statistics.fmean(vals) if vals else None
@@ -158,6 +167,17 @@ def aggregate(
 
         files_k = {k: [] for k in ks}
         symbols_k = {k: [] for k in ks}
+        # Line-span localization (overlap-based, replaces the brittle string
+        # symbols@k). ``answer`` = the agent's committed final answer (its
+        # deliverable); ``retrieval`` = the retriever's ranked spans (the
+        # RAG-comparable alignment axis). Both scopes report BOTH acc (hit@k,
+        # all GT blocks covered) and recall (fraction covered) — mirroring the
+        # original RAG/rerank baselines, which logged acc+recall symmetrically;
+        # acc==recall for single-block instances (the majority).
+        answer_acc_k = {k: [] for k in ks}
+        answer_recall_k = {k: [] for k in ks}
+        retrieval_acc_k = {k: [] for k in ks}
+        retrieval_recall_k = {k: [] for k in ks}
         tokens, turns, cost, cap_hit, durations = [], [], [], [], []
         f5_easy, f5_hard = [], []
 
@@ -175,6 +195,22 @@ def aggregate(
                     files_k[k].append(fv)
                 if sv is not None:
                     symbols_k[k].append(sv)
+                aa = _safe_mean([_at_k(r, "answer_blocks", k) for r in reps])
+                ar = _safe_mean(
+                    [_field_at_k(r, "answer_blocks", k, "recall") for r in reps]
+                )
+                ra = _safe_mean([_at_k(r, "retrieval_blocks", k) for r in reps])
+                rr = _safe_mean(
+                    [_field_at_k(r, "retrieval_blocks", k, "recall") for r in reps]
+                )
+                if aa is not None:
+                    answer_acc_k[k].append(aa)
+                if ar is not None:
+                    answer_recall_k[k].append(ar)
+                if ra is not None:
+                    retrieval_acc_k[k].append(ra)
+                if rr is not None:
+                    retrieval_recall_k[k].append(rr)
             tokens.append(_safe_min([r.get("total_tokens") for r in reps]))
             turns.append(_safe_min([r.get("total_turns") for r in reps]))
             durations.append(_safe_min([r.get("total_duration_ms") for r in reps]))
@@ -226,6 +262,10 @@ def aggregate(
             "instance_count": n_inst,
             "files_at_k": {k: _safe_mean(files_k[k]) for k in ks},
             "symbols_at_k": {k: _safe_mean(symbols_k[k]) for k in ks},
+            "answer_acc_at_k": {k: _safe_mean(answer_acc_k[k]) for k in ks},
+            "answer_recall_at_k": {k: _safe_mean(answer_recall_k[k]) for k in ks},
+            "retrieval_acc_at_k": {k: _safe_mean(retrieval_acc_k[k]) for k in ks},
+            "retrieval_recall_at_k": {k: _safe_mean(retrieval_recall_k[k]) for k in ks},
             "mean_total_tokens": _safe_mean(tokens),
             "mean_total_turns": _safe_mean(turns),
             "mean_total_duration_ms": _safe_mean(durations),
@@ -346,6 +386,44 @@ def render_markdown(agg, front, ks) -> str:
         L.append("| " + " | ".join(row) + " |")
     L.append("")
     L.append(f"**Pareto front (files@5 ↑ / tokens ↓):** {', '.join(front) or '(none)'}")
+    L.append("")
+
+    L.append("## Symbol-level localization (span recall@k — replaces symbols@k*)")
+    L.append("")
+    L.append(
+        "Overlap-based, so it is robust to the symbol-name string-match artifact "
+        "(`symbols@k*` in the per-arm table above scores agent prose ≈0 and is "
+        "kept only for back-reference). Two scopes, scored from different sources "
+        "— neither bounds the other:\n\n"
+        "- **`answer_rec@k`** — recall over the agent's committed final answer "
+        "(`Locations:` + graph-resolved `Symbols:`). The agent's deliverable / "
+        "headline. `answer_acc@k` is the strict variant (ALL gt blocks hit).\n"
+        "- **`retr_rec@k`** — recall over the retriever's ranked spans (nodes "
+        "only). The cross-system ALIGNMENT axis: identical to a plain RAG "
+        "pipeline's recall@k (node_id match == span overlap), so RAG / "
+        "pure-retrieval / agent are directly comparable on it.\n\n"
+        "`answer_rec > retr_rec` means the agent localized via grep/reasoning "
+        "beyond what retrieval returned; `answer_rec < retr_rec` means it failed "
+        "to use what retrieval surfaced."
+    )
+    L.append("")
+    head2 = (
+        ["arm"]
+        + [f"answer_acc@{k}" for k in ks]
+        + [f"answer_rec@{k}" for k in ks]
+        + [f"retr_acc@{k}" for k in ks]
+        + [f"retr_rec@{k}" for k in ks]
+    )
+    L.append("| " + " | ".join(head2) + " |")
+    L.append("| " + " | ".join("---" for _ in head2) + " |")
+    for sid in sorted(agg["arms"]):
+        m = agg["arms"][sid]
+        row2 = [sid]
+        row2 += [_fmt((m.get("answer_acc_at_k") or {}).get(k), 3) for k in ks]
+        row2 += [_fmt((m.get("answer_recall_at_k") or {}).get(k), 3) for k in ks]
+        row2 += [_fmt((m.get("retrieval_acc_at_k") or {}).get(k), 3) for k in ks]
+        row2 += [_fmt((m.get("retrieval_recall_at_k") or {}).get(k), 3) for k in ks]
+        L.append("| " + " | ".join(row2) + " |")
     L.append("")
 
     L.append("## Skill-invocation histogram")

--- a/scripts/agent_compile/aggregate_synthesis.py
+++ b/scripts/agent_compile/aggregate_synthesis.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Aggregate a codeminer-synthesis per-query sweep, broken down by CATEGORY.
+
+The synthesis ``category`` is the axis that discriminates grep vs retrieval:
+``behavioral`` queries name no identifiers (grep must explore the repo blind),
+``symbol_hint`` names the symbol (grep wins), ``traversal`` needs call-graph
+navigation. So we report span-overlap localization PER (category x arm):
+
+  answer_rec@k  — the agent's committed-answer recall (headline / deliverable)
+  answer_acc@k  — strict variant (all GT blocks hit)
+  retr_rec@k    — retriever recall (RAG-comparable ceiling)
+  contrib       — fraction of answer spans that came from a pre-injected
+                  candidate (pre-load arms only)
+  turns/tokens/cost — the Pareto cost axis
+
+Rep folding mirrors aggregate.py: accuracy/recall mean across reps, cost-like
+min across reps.
+
+Usage::
+
+    python scripts/agent_compile/aggregate_synthesis.py \
+        --cells-dir results/agent_compile/synth_python/cells \
+        --output-dir results/agent_compile/synth_python
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+KS = [1, 3, 5, 10]
+
+
+def _load(cells_dir: Path) -> List[Dict[str, Any]]:
+    out = []
+    for p in sorted(cells_dir.glob("*.json")):
+        try:
+            out.append(json.loads(p.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError):
+            pass
+    return out
+
+
+def _field(cell: Dict[str, Any], scope: str, k: int, field: str) -> Optional[float]:
+    b = (cell.get("metrics") or {}).get(scope) or {}
+    s = b.get(k, b.get(str(k)))
+    return s.get(field) if isinstance(s, dict) else None
+
+
+def _mean(xs: Sequence[Optional[float]]) -> Optional[float]:
+    v = [x for x in xs if x is not None]
+    return statistics.fmean(v) if v else None
+
+
+def _min(xs: Sequence[Optional[float]]) -> Optional[float]:
+    v = [x for x in xs if x is not None]
+    return min(v) if v else None
+
+
+def _fmt(v: Optional[float], nd: int = 3) -> str:
+    return "n/a" if v is None else f"{v:.{nd}f}"
+
+
+def aggregate(cells: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    # Fold reps: group by (category, arm, query_id) -> reps.
+    by_q: Dict[tuple, List[Dict[str, Any]]] = defaultdict(list)
+    for c in cells:
+        if not c.get("success"):
+            continue
+        by_q[(c.get("category"), c.get("subset_id"), c.get("query_id"))].append(c)
+
+    # Per (category, arm): accumulate query-level folded values.
+    cat_arm: Dict[tuple, Dict[str, List]] = defaultdict(lambda: defaultdict(list))
+    for (cat, arm, _qid), reps in by_q.items():
+        acc = cat_arm[(cat, arm)]
+        for k in KS:
+            acc[f"answer_acc@{k}"].append(
+                _mean([_field(r, "answer_blocks", k, "accuracy") for r in reps])
+            )
+            acc[f"answer_rec@{k}"].append(
+                _mean([_field(r, "answer_blocks", k, "recall") for r in reps])
+            )
+            acc[f"retr_rec@{k}"].append(
+                _mean([_field(r, "retrieval_blocks", k, "recall") for r in reps])
+            )
+        acc["contrib"].append(_mean([r.get("preload_contribution") for r in reps]))
+        acc["turns"].append(_min([r.get("total_turns") for r in reps]))
+        acc["tokens"].append(_min([r.get("total_tokens") for r in reps]))
+        acc["cost"].append(_min([r.get("cost_usd") for r in reps]))
+
+    rows = {}
+    for (cat, arm), acc in cat_arm.items():
+        rows[(cat, arm)] = {
+            "n_queries": len(acc["turns"]),
+            **{key: _mean(vals) for key, vals in acc.items()},
+        }
+    return {"by_cat_arm": rows}
+
+
+def render(agg: Dict[str, Any]) -> str:
+    rows = agg["by_cat_arm"]
+    cats = sorted({c for (c, _a) in rows})
+    arms = sorted({a for (_c, a) in rows})
+    L = ["# CodeMiner-synthesis per-category localization", ""]
+    L.append(
+        "Headline = `answer_rec@5` (the agent's committed-answer span recall). "
+        "`retr_rec@10` is the retriever ceiling. `contrib` = fraction of answer "
+        "spans from a pre-injected candidate. Categories ordered easy→hard for "
+        "grep (symbol_hint names the target; behavioral/traversal hide it)."
+    )
+    L.append("")
+    head = [
+        "category",
+        "arm",
+        "n",
+        "answer_rec@5",
+        "answer_acc@5",
+        "retr_rec@10",
+        "contrib",
+        "turns",
+        "tokens",
+        "cost$",
+    ]
+    L.append("| " + " | ".join(head) + " |")
+    L.append("| " + " | ".join("---" for _ in head) + " |")
+    for cat in cats:
+        for arm in arms:
+            m = rows.get((cat, arm))
+            if not m:
+                continue
+            L.append(
+                "| "
+                + " | ".join(
+                    [
+                        str(cat),
+                        arm,
+                        str(m["n_queries"]),
+                        _fmt(m.get("answer_rec@5")),
+                        _fmt(m.get("answer_acc@5")),
+                        _fmt(m.get("retr_rec@10")),
+                        _fmt(m.get("contrib")),
+                        _fmt(m.get("turns"), 1),
+                        _fmt(m.get("tokens"), 0),
+                        _fmt(m.get("cost"), 4),
+                    ]
+                )
+                + " |"
+            )
+    L.append("")
+    # grep vs preinj delta on answer_rec@5 per category
+    L.append("## answer_rec@5: preinj − grep, per category")
+    L.append("")
+    L.append("| category | grep_only | preinj_embed | Δ |")
+    L.append("| --- | --- | --- | --- |")
+    for cat in cats:
+        g = rows.get((cat, "grep_only"), {}).get("answer_rec@5")
+        p = rows.get((cat, "preinj_embed"), {}).get("answer_rec@5")
+        d = (p - g) if (g is not None and p is not None) else None
+        L.append(f"| {cat} | {_fmt(g)} | {_fmt(p)} | {_fmt(d)} |")
+    L.append("")
+    return "\n".join(L)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--cells-dir", required=True, type=Path)
+    p.add_argument("--output-dir", required=True, type=Path)
+    args = p.parse_args(argv)
+    cells = _load(args.cells_dir)
+    agg = aggregate(cells)
+    report = render(agg)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "report_by_category.md").write_text(report, encoding="utf-8")
+    # JSON with string keys
+    js = {f"{c}/{a}": v for (c, a), v in agg["by_cat_arm"].items()}
+    (args.output_dir / "metrics_by_category.json").write_text(
+        json.dumps(js, indent=2), encoding="utf-8"
+    )
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_compile/configs/preload_graph_probe.yaml
+++ b/scripts/agent_compile/configs/preload_graph_probe.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ===========================================================================
+# Graph pre-load probe — does call-graph pre-injection beat embedding (and grep)
+# on the traversal category?
+# ===========================================================================
+# The Python per-category run showed embedding pre-injection REGRESSES on
+# `traversal` (multi-hop: file-level files@5 1.0 -> 0.8) because semantic
+# candidates anchor on the wrong hop. Traversal needs STRUCTURE, so this probe
+# adds a graph recipe (codeminer_context composer: search seeds + call-graph
+# expansion) and compares on the traversal queries (which carry real GT spans,
+# so symbol-level answer_rec is valid — no dataset regen needed).
+#
+#   grep_only     — defaults only (baseline)
+#   preinj_embed  — embedding candidates pre-injected
+#   preinj_graph  — call-graph-expanded candidates pre-injected
+base: design_space.yaml
+
+sweep_id: preload_graph_probe
+reps: 1
+
+subsets:
+  grep_only:
+    - read
+    - grep
+    - glob
+    - bash
+  preinj_embed:
+    - read
+    - grep
+    - glob
+    - bash
+  preinj_graph:
+    - read
+    - grep
+    - glob
+    - bash
+
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+  preinj_graph:
+    retrievers: [graph]
+    top_k: 10
+    level: l2

--- a/scripts/agent_compile/configs/preload_graph_probe.yaml
+++ b/scripts/agent_compile/configs/preload_graph_probe.yaml
@@ -37,6 +37,11 @@ subsets:
     - grep
     - glob
     - bash
+  preinj_graph2:
+    - read
+    - grep
+    - glob
+    - bash
 
 preload:
   preinj_embed:
@@ -47,3 +52,11 @@ preload:
     retrievers: [graph]
     top_k: 10
     level: l2
+  # 2-hop + more seeds: give the graph its best shot at multi-hop chains before
+  # concluding it has no agent-level value.
+  preinj_graph2:
+    retrievers: [graph]
+    top_k: 20
+    level: l2
+    seeds: 8
+    hops: 2

--- a/scripts/agent_compile/configs/preload_graph_probe.yaml
+++ b/scripts/agent_compile/configs/preload_graph_probe.yaml
@@ -42,6 +42,14 @@ subsets:
     - grep
     - glob
     - bash
+  # Clean hops ablation: SAME top_k/seeds as preinj_graph, only hops differs,
+  # so preinj_graph(1-hop) vs preinj_graph_h2(2-hop) isolates the pure hop
+  # effect from the candidate-count confound that preinj_graph2 also changes.
+  preinj_graph_h2:
+    - read
+    - grep
+    - glob
+    - bash
 
 preload:
   preinj_embed:
@@ -59,4 +67,11 @@ preload:
     top_k: 20
     level: l2
     seeds: 8
+    hops: 2
+  # identical to preinj_graph except hops=2 (top_k=10, seeds=5) -> isolates hops
+  preinj_graph_h2:
+    retrievers: [graph]
+    top_k: 10
+    level: l2
+    seeds: 5
     hops: 2

--- a/scripts/agent_compile/configs/preload_probe.yaml
+++ b/scripts/agent_compile/configs/preload_probe.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ===========================================================================
+# Pre-load probe — does pre-injecting retrieval beat plain grep/read?
+# ===========================================================================
+# The decisive test from .claude/design/preload-vs-skill-architecture.md.
+# Same model / dataset / scorer as the canonical sweep (inherited via base:),
+# only the harness differs:
+#
+#   grep_only     — defaults only (read/grep/glob/bash). The fallback itself /
+#                   baseline: what the agent achieves with no retrieval.
+#   preinj_embed  — same default tools, BUT embedding retrieval candidates are
+#                   computed up front and injected into the opening prompt
+#                   (retrieve-only, NO rerank). The agent reads/greps to confirm.
+#
+# Judge on answer_rec@k (the agent's committed-answer span recall). If
+# preinj_embed >> grep_only, the pre-load architecture is validated AND the
+# `preload_contribution` field shows how much of the win came from the injected
+# candidates vs grep finding it anyway.
+base: design_space.yaml
+
+sweep_id: preload_probe
+reps: 1
+
+# Small, language-diverse slice for fast iteration on answer_rec.
+instances:
+  - astral-sh__ruff-15309      # rust
+  - axios__axios-4738          # js/ts
+  - caddyserver__caddy-5761    # go
+  - astropy__astropy-13236     # python
+  - redis__redis-10095         # c
+
+subsets:
+  grep_only:
+    - read
+    - grep
+    - glob
+    - bash
+  preinj_embed:
+    - read
+    - grep
+    - glob
+    - bash
+
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2

--- a/scripts/agent_compile/lib/config.py
+++ b/scripts/agent_compile/lib/config.py
@@ -61,6 +61,14 @@ class SweepConfig:
     # LocAgent-style harness: restrict the always-on defaults to this subset
     # (e.g. ["file_read"] → no grep). None = all of read + grep + glob + bash.
     default_tool_ids: Optional[List[str]] = None
+    # Pre-load (context-assembly) recipes, keyed by arm label. An arm listed here
+    # gets retrieval candidates computed UP FRONT and injected into its opening
+    # prompt (retrieve-only — NO rerank; the agent reasons over them itself), so
+    # retrieval value no longer depends on the agent choosing to call a tool.
+    # Recipe: {retrievers: [embedding|bm25], top_k: int, level: l0|l2}. Arms NOT
+    # listed run plain (no pre-injection). See
+    # .claude/design/preload-vs-skill-architecture.md.
+    preload: Dict[str, Any] = field(default_factory=dict)
     # Override the agent system prompt (e.g. a graph-primary prompt with no grep
     # guidance). None = runner's default localization prompt.
     system_prompt: Optional[str] = None

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -88,6 +88,9 @@ def scenario_for(query: str, language_key: str) -> str:
 _PRELOAD_RETRIEVER_SKILL = {
     "embedding": "embedding_search",
     "bm25": "bm25_search",
+    # graph = the codeminer_context composer (search seeds + call-graph expand);
+    # pulling it into the union builds the "expand" (symbol_graph) context.
+    "graph": "codeminer_context",
 }
 
 

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -21,7 +21,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from .config import SweepConfig
 
@@ -82,13 +82,31 @@ def scenario_for(query: str, language_key: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+# Pre-load recipes name retrievers ("embedding"/"bm25"), not skills; map them to
+# the skill that backs each index so the contexts get built even when no ARM
+# offers that retriever as a tool (pre-load arms only carry default tools).
+_PRELOAD_RETRIEVER_SKILL = {
+    "embedding": "embedding_search",
+    "bm25": "bm25_search",
+}
+
+
 def all_index_skill_ids(cfg: SweepConfig) -> List[str]:
-    """Union of skills across all subsets — used to load the full context once."""
+    """Union of skills across all subsets — used to load the full context once.
+
+    Also includes the skills implied by any ``preload`` recipe, so a pre-load
+    arm whose subset is just default tools still gets its retrieval index built.
+    """
     seen: List[str] = []
     for skills in cfg.subsets.values():
         for s in skills:
             if s not in seen:
                 seen.append(s)
+    for recipe in (cfg.preload or {}).values():
+        for retriever in recipe.get("retrievers") or []:
+            sk = _PRELOAD_RETRIEVER_SKILL.get(retriever)
+            if sk and sk not in seen:
+                seen.append(sk)
     return seen
 
 
@@ -123,6 +141,47 @@ def load_full_contexts(cfg: SweepConfig, repo_path: str, cache_dir: str):
     return contexts
 
 
+def build_symbol_span_index(prebuilt_dir: str, instance_id: str) -> Dict[Any, Any]:
+    """``{(norm_file, leaf_name): (start_1based, end_1based)}`` from the prebuilt
+    graph, so committed scoring can resolve a named symbol to its line span.
+
+    Graph vertices are 0-based (tree-sitter); shifted +1 here to match the
+    1-based ground-truth blocks. Returns an empty dict when no graph is present.
+    """
+    import pickle
+
+    from codeminer.eval.retrieval_eval import normalize_file_path
+
+    path = os.path.join(prebuilt_dir, instance_id, "graph.pkl")
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "rb") as f:
+            graph = pickle.load(f)
+    except Exception:  # noqa: BLE001 — a missing/corrupt graph just disables this
+        return {}
+    g = graph.get("graph") if isinstance(graph, dict) else None
+    if g is None:
+        return {}
+    index: Dict[Any, Any] = {}
+    for v in g.vs:
+        attrs = v.attributes()
+        file, start, end = (
+            attrs.get("file"),
+            attrs.get("start_line"),
+            attrs.get("end_line"),
+        )
+        name = attrs.get("name")
+        if file is None or start is None or end is None or not name:
+            continue
+        nf = normalize_file_path(file)
+        leaf = str(name).split("/")[-1].split(".")[-1]
+        key = (nf, leaf)
+        if key not in index:  # first definition wins
+            index[key] = (int(start) + 1, int(end) + 1)
+    return index
+
+
 def run_cell(
     cfg: SweepConfig,
     *,
@@ -133,11 +192,28 @@ def run_cell(
     query: str,
     subset_id: str,
     skills: Sequence[str],
+    preload_spec: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    """Run one (subset) agent cell against already-loaded contexts."""
+    """Run one (subset) agent cell against already-loaded contexts.
+
+    When ``preload_spec`` is given, retrieval candidates are computed up front
+    and injected into the agent's opening prompt (the pre-load architecture);
+    the returned ``preload_candidates`` lists the injected ``(file, span)``s for
+    contribution attribution.
+    """
     from codeminer.agent.runner import AgentRunner
     from codeminer.agent.skills.registry import SkillRegistry
     from codeminer.compiler.params import SessionContext
+    from scripts.agent_compile.lib.preload import assemble_preload
+
+    preload_candidates: List[Dict[str, Any]] = []
+    effective_query = query
+    if preload_spec:
+        preamble, preload_candidates = assemble_preload(
+            contexts, query, recipe=preload_spec
+        )
+        if preamble:
+            effective_query = f"{query}\n\n{preamble}"
 
     sctx = SessionContext(
         repo_path=repo_path, repo_size=1000, primary_language=language_key
@@ -160,13 +236,14 @@ def run_cell(
     prev_cwd = os.getcwd()
     try:
         os.chdir(repo_path)
-        result = runner.run(query)
+        result = runner.run(effective_query)
     finally:
         os.chdir(prev_cwd)
 
     nodes: List[Any] = []
     tool_calls: List[Dict[str, Any]] = []
     file_read_paths: List[str] = []
+    file_reads: List[Dict[str, Any]] = []
     for tc in result.tool_calls:
         n = len(tc.result) if isinstance(tc.result, list) else 0
         tool_calls.append(
@@ -179,9 +256,19 @@ def run_cell(
         if isinstance(tc.result, list):
             nodes.extend(tc.result)
         if tc.skill_id == "read" and not tc.error:
-            p = (tc.arguments or {}).get("file_path")
+            args = tc.arguments or {}
+            p = args.get("file_path")
             if p:
                 file_read_paths.append(str(p))
+                # Capture the read window (1-based offset/limit) for audit (which
+                # line range the agent inspected); not scored.
+                file_reads.append(
+                    {
+                        "file_path": str(p),
+                        "offset": args.get("offset"),
+                        "limit": args.get("limit"),
+                    }
+                )
 
     usage = result.usage.to_dict() if result.usage else {}
     token_usage = usage.get("token_usage") or usage or {}
@@ -189,6 +276,8 @@ def run_cell(
         "nodes": nodes,
         "tool_calls": tool_calls,
         "file_read_paths": file_read_paths,
+        "file_reads": file_reads,
+        "preload_candidates": preload_candidates,
         "answer": result.answer or "",
         "total_turns": result.total_turns,
         "total_duration_ms": result.total_duration_ms,

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -144,6 +144,18 @@ def load_full_contexts(cfg: SweepConfig, repo_path: str, cache_dir: str):
     return contexts
 
 
+def _leaf_symbol(name: Any) -> str:
+    """Return the final answer/GT leaf from graph or display symbol names."""
+    s = str(name or "").strip()
+    if not s:
+        return ""
+    if ":" in s:
+        s = s.rsplit(":", 1)[1]
+    s = s.replace("#", ".")
+    s = s.split("(", 1)[0]
+    return s.split("/")[-1].split(".")[-1].strip()
+
+
 def build_symbol_span_index(prebuilt_dir: str, instance_id: str) -> Dict[Any, Any]:
     """``{(norm_file, leaf_name): (start_1based, end_1based)}`` from the prebuilt
     graph, so committed scoring can resolve a named symbol to its line span.
@@ -175,13 +187,17 @@ def build_symbol_span_index(prebuilt_dir: str, instance_id: str) -> Dict[Any, An
             attrs.get("end_line"),
         )
         name = attrs.get("name")
-        if file is None or start is None or end is None or not name:
+        unified_name = attrs.get("unified_name")
+        if file is None or start is None or end is None or not (name or unified_name):
             continue
         nf = normalize_file_path(file)
-        leaf = str(name).split("/")[-1].split(".")[-1]
-        key = (nf, leaf)
-        if key not in index:  # first definition wins
-            index[key] = (int(start) + 1, int(end) + 1)
+        for label in (name, unified_name):
+            leaf = _leaf_symbol(label)
+            if not leaf:
+                continue
+            key = (nf, leaf)
+            if key not in index:  # first definition wins
+                index[key] = (int(start) + 1, int(end) + 1)
     return index
 
 

--- a/scripts/agent_compile/lib/preload.py
+++ b/scripts/agent_compile/lib/preload.py
@@ -31,10 +31,17 @@ _DEFAULT_TOP_K = 10
 _DEFAULT_LEVEL = "l2"
 
 
-def _graph_compose(contexts: Dict[str, Any], query: str, top_k: int) -> List[Any]:
+def _graph_compose(
+    contexts: Dict[str, Any], query: str, top_k: int, *, seeds: int = 5, hops: int = 1
+) -> List[Any]:
     """Graph-aware candidates via the codeminer_context composer (search seeds
-    then call-graph expansion). Needs both the retrieve and expand contexts."""
+    then call-graph expansion). Needs both the retrieve and expand contexts.
+
+    ``hops=2`` adds a second expansion pass over the 1-hop neighbors, so a 2-hop
+    chain (anchor -> A -> B) can surface B — the composer alone is 1-hop.
+    """
     try:
+        from codeminer.agent.skills._graphnav import neighbors
         from codeminer.agent.skills.codeminer_context.executor import create_executor
         from codeminer.agent.skills.context import ComposerContexts
 
@@ -43,17 +50,39 @@ def _graph_compose(contexts: Dict[str, Any], query: str, top_k: int) -> List[Any
         )
         if cc.retrieve is None or cc.expand is None:
             return []
-        return list(create_executor(cc)(query, max_results=top_k, seeds=5))
+        base = list(create_executor(cc)(query, max_results=top_k, seeds=seeds))
+        if hops <= 1:
+            return base
+        graph = getattr(cc.expand, "code_graph", None)
+        if graph is None:
+            return base
+        extra: List[Any] = []
+        for node in base:
+            name = getattr(node, "node_name", None)
+            if not name:
+                continue
+            try:
+                extra += neighbors(graph, name, "both", top_k=4)
+            except Exception:  # noqa: BLE001 — unresolved node, skip
+                continue
+        return base + extra
     except Exception:  # noqa: BLE001 — a failing retriever just contributes nothing
         return []
 
 
 def _retrieve(
-    contexts: Dict[str, Any], retriever: str, query: str, top_k: int, level: str
+    contexts: Dict[str, Any],
+    retriever: str,
+    query: str,
+    top_k: int,
+    level: str,
+    *,
+    seeds: int = 5,
+    hops: int = 1,
 ) -> List[Any]:
     """Run a single retriever, returning its ranked nodes (best-effort)."""
     if retriever == "graph":
-        return _graph_compose(contexts, query, top_k)
+        return _graph_compose(contexts, query, top_k, seeds=seeds, hops=hops)
     rc = contexts.get("retrieve")
     try:
         if retriever == "embedding" and getattr(rc, "vector_store", None) is not None:
@@ -104,7 +133,12 @@ def assemble_preload(
     if contexts.get("retrieve") is None:
         return "", []
 
-    per_retriever = [_retrieve(contexts, r, query, top_k, level) for r in retrievers]
+    seeds = int(recipe.get("seeds", 5))
+    hops = int(recipe.get("hops", 1))
+    per_retriever = [
+        _retrieve(contexts, r, query, top_k, level, seeds=seeds, hops=hops)
+        for r in retrievers
+    ]
     nodes = _interleave(per_retriever)
     # Map nodes -> spans (1-based, repo-relative via node_id), dedup overlapping
     # regions, cap to top_k. nodes_to_spans re-sorts by score, so derive spans

--- a/scripts/agent_compile/lib/preload.py
+++ b/scripts/agent_compile/lib/preload.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pre-load context assembly for the agent.
+
+Retrieval value was being lost because the agent (a strong grep/read pretrain
+prior) almost never *calls* the retrieval skills. So instead of offering
+retrieval as an optional tool, we compute candidates UP FRONT and inject them
+into the agent's opening prompt. The agent then reasons over them and confirms
+with grep/read.
+
+Retrieve-ONLY by design: no rerank (the LLM re-judges the candidates itself; a
+rerank stage would just re-sort what the model re-sorts anyway — see
+``.claude/design/preload-vs-skill-architecture.md``).
+
+Multi-retriever recipes INTERLEAVE (round-robin) rather than concatenate-and-
+sort-by-score, because BM25 (unbounded) and embedding (cosine) scores are not
+comparable — the exact normalization trap that sank the ``hybrid_search`` skill.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Tuple
+
+from codeminer.eval.retrieval_eval import dedup_spans, nodes_to_spans
+
+# Keep snippets short so a candidate list of ~10 does not blow up the context.
+_SNIPPET_LINES = 4
+_DEFAULT_TOP_K = 10
+_DEFAULT_LEVEL = "l2"
+
+
+def _retrieve(rc: Any, retriever: str, query: str, top_k: int, level: str) -> List[Any]:
+    """Run a single retriever, returning its ranked nodes (best-effort)."""
+    try:
+        if retriever == "embedding" and getattr(rc, "vector_store", None) is not None:
+            return list(
+                rc.vector_store.search_with_content(
+                    query=query, top_k=top_k, level=level
+                )
+            )
+        if retriever == "bm25" and getattr(rc, "bm25", None) is not None:
+            return list(rc.bm25.search(query, top_k))
+    except Exception:  # noqa: BLE001 — a failing retriever just contributes nothing
+        return []
+    return []
+
+
+def _interleave(lists: Sequence[List[Any]]) -> List[Any]:
+    """Round-robin merge: rank-1 of each retriever, then rank-2, ... (avoids
+    cross-retriever score-scale bias)."""
+    out: List[Any] = []
+    for i in range(max((len(x) for x in lists), default=0)):
+        for lst in lists:
+            if i < len(lst):
+                out.append(lst[i])
+    return out
+
+
+def _snippet(node: Any) -> str:
+    content = getattr(node, "content", None) or ""
+    lines = [ln for ln in content.splitlines() if ln.strip()][:_SNIPPET_LINES]
+    return "\n".join("    " + ln for ln in lines)
+
+
+def assemble_preload(
+    contexts: Dict[str, Any],
+    query: str,
+    *,
+    recipe: Dict[str, Any],
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Run a retrieve-only recipe -> (preamble_text, candidate_spans).
+
+    ``recipe``: ``{retrievers: ["embedding"(,"bm25")], top_k: int, level: str}``.
+    ``candidate_spans`` are 1-based ``{file,start,end,...}`` (for the prompt AND
+    for pre-load contribution attribution in the scorer).
+    """
+    retrievers = recipe.get("retrievers") or ["embedding"]
+    top_k = int(recipe.get("top_k", _DEFAULT_TOP_K))
+    level = recipe.get("level", _DEFAULT_LEVEL)
+    rc = contexts.get("retrieve")
+    if rc is None:
+        return "", []
+
+    per_retriever = [_retrieve(rc, r, query, top_k, level) for r in retrievers]
+    nodes = _interleave(per_retriever)
+    # Map nodes -> spans (1-based, repo-relative via node_id), dedup overlapping
+    # regions, cap to top_k. nodes_to_spans re-sorts by score, so derive spans
+    # per node to PRESERVE the interleave order; keep a parallel node map for
+    # snippet rendering.
+    span_by_key: Dict[Tuple[str, int, int], Any] = {}
+    ordered: List[Dict[str, Any]] = []
+    for node in nodes:
+        sp = nodes_to_spans([node])
+        if sp:
+            ordered.append(sp[0])
+            span_by_key[(sp[0]["file"], sp[0]["start"], sp[0]["end"])] = node
+    ordered = dedup_spans(ordered)[:top_k]
+    if not ordered:
+        return "", []
+
+    lines = [
+        "# Candidate locations (UNVERIFIED retrieval hints — often wrong/incomplete)",
+        "A retriever guessed these; the code you must change may be in NONE of "
+        "them (it could be a caller, a subclass override, or elsewhere entirely). "
+        "They are unordered starting points, not answers. RULES:",
+        "- Do NOT anchor on the first candidate. Check each against the actual "
+        "problem.",
+        "- Never put a location in your final answer unless you have READ it and "
+        "confirmed it contains the behavior to change.",
+        "- If, after reading, none of these is the real edit site, IGNORE this "
+        "list entirely and locate the code with grep / your own search.",
+        "",
+    ]
+    for i, sp in enumerate(ordered, 1):
+        lines.append(f"{i}. {sp['file']}:{sp['start']}-{sp['end']}")
+        node = span_by_key.get((sp["file"], sp["start"], sp["end"]))
+        snip = _snippet(node) if node is not None else ""
+        if snip:
+            lines.append(snip)
+    preamble = "\n".join(lines)
+    # Strip provenance keys the scorer doesn't need in the persisted candidate.
+    candidate_spans = [
+        {"file": s["file"], "start": s["start"], "end": s["end"]} for s in ordered
+    ]
+    return preamble, candidate_spans

--- a/scripts/agent_compile/lib/preload.py
+++ b/scripts/agent_compile/lib/preload.py
@@ -31,8 +31,30 @@ _DEFAULT_TOP_K = 10
 _DEFAULT_LEVEL = "l2"
 
 
-def _retrieve(rc: Any, retriever: str, query: str, top_k: int, level: str) -> List[Any]:
+def _graph_compose(contexts: Dict[str, Any], query: str, top_k: int) -> List[Any]:
+    """Graph-aware candidates via the codeminer_context composer (search seeds
+    then call-graph expansion). Needs both the retrieve and expand contexts."""
+    try:
+        from codeminer.agent.skills.codeminer_context.executor import create_executor
+        from codeminer.agent.skills.context import ComposerContexts
+
+        cc = ComposerContexts(
+            retrieve=contexts.get("retrieve"), expand=contexts.get("expand")
+        )
+        if cc.retrieve is None or cc.expand is None:
+            return []
+        return list(create_executor(cc)(query, max_results=top_k, seeds=5))
+    except Exception:  # noqa: BLE001 — a failing retriever just contributes nothing
+        return []
+
+
+def _retrieve(
+    contexts: Dict[str, Any], retriever: str, query: str, top_k: int, level: str
+) -> List[Any]:
     """Run a single retriever, returning its ranked nodes (best-effort)."""
+    if retriever == "graph":
+        return _graph_compose(contexts, query, top_k)
+    rc = contexts.get("retrieve")
     try:
         if retriever == "embedding" and getattr(rc, "vector_store", None) is not None:
             return list(
@@ -79,11 +101,10 @@ def assemble_preload(
     retrievers = recipe.get("retrievers") or ["embedding"]
     top_k = int(recipe.get("top_k", _DEFAULT_TOP_K))
     level = recipe.get("level", _DEFAULT_LEVEL)
-    rc = contexts.get("retrieve")
-    if rc is None:
+    if contexts.get("retrieve") is None:
         return "", []
 
-    per_retriever = [_retrieve(rc, r, query, top_k, level) for r in retrievers]
+    per_retriever = [_retrieve(contexts, r, query, top_k, level) for r in retrievers]
     nodes = _interleave(per_retriever)
     # Map nodes -> spans (1-based, repo-relative via node_id), dedup overlapping
     # regions, cap to top_k. nodes_to_spans re-sorts by score, so derive spans

--- a/scripts/agent_compile/run_sweep.py
+++ b/scripts/agent_compile/run_sweep.py
@@ -45,6 +45,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 from scripts.agent_compile.lib.config import SweepConfig  # noqa: E402
 from scripts.agent_compile.lib.harness import (  # noqa: E402
     LANG_GROUP_TO_KEY,
+    build_symbol_span_index,
     load_dataset_rows,
     load_full_contexts,
     run_cell,
@@ -93,7 +94,17 @@ def _validate_harness(cfg: SweepConfig) -> None:
 
 
 def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dict:
-    from codeminer.eval.retrieval_eval import collect_targets, score_agent_localization
+    from codeminer.eval.retrieval_eval import (
+        collect_target_blocks,
+        collect_targets,
+        dedup_spans,
+        nodes_to_spans,
+        parse_answer_spans,
+        resolve_symbol_spans,
+        score_agent_localization,
+        score_localization_spans,
+        spans_overlap,
+    )
     from codeminer.llm.litellm_chat import LiteLLMChat
 
     _validate_harness(cfg)
@@ -151,6 +162,12 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
         target_files, target_symbols = collect_targets(
             meta, simplified_symbols=cfg.gt_simplified_symbols
         )
+        # 1-based ground-truth line spans for overlap-based localization scoring
+        # (read from the raw row, which carries ``gt_code_blocks``).
+        gt_blocks = collect_target_blocks(row)
+        # {(file, leaf): (start, end)} so committed scoring can resolve a named
+        # symbol to its span when the agent didn't emit an explicit range.
+        symbol_span_index = build_symbol_span_index(cfg.prebuilt_dir, instance_id)
         gt_meaningful = bool(target_files or target_symbols)
 
         cache_dir = os.path.join(
@@ -204,6 +221,7 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                     query=query,
                     subset_id=subset_id,
                     skills=skills,
+                    preload_spec=(cfg.preload or {}).get(subset_id),
                 )
                 metrics = score_agent_localization(
                     answer=out["answer"],
@@ -213,6 +231,38 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                     target_symbols=target_symbols,
                     ks=cfg.metrics_k,
                     repo_path=repo_path,
+                )
+                # Line-span localization (overlap-based) — robust to the
+                # symbol-name string-match artifact. ``answer`` = the agent's
+                # deliverable (its ``Locations:`` ranges + ``Symbols:`` resolved
+                # via the graph); ``retrieval`` = the retriever's ranked spans
+                # (the RAG-comparable alignment axis). Neither bounds the other.
+                answer_spans = parse_answer_spans(
+                    out["answer"], repo_path
+                ) + resolve_symbol_spans(out["answer"], symbol_span_index, repo_path)
+                retrieval_spans = nodes_to_spans(out["nodes"])
+                metrics.update(
+                    score_localization_spans(
+                        answer_spans=answer_spans,
+                        retrieval_spans=retrieval_spans,
+                        gt_blocks=gt_blocks,
+                        ks=cfg.metrics_k,
+                    )
+                )
+                # Pre-load contribution: fraction of the agent's committed answer
+                # spans that overlap an injected candidate (vs found by grep).
+                # Distinguishes "pre-load helped" from "ignored, grep did it".
+                preload_candidates = out.get("preload_candidates") or []
+                ans_dedup = dedup_spans(answer_spans)
+                preload_contribution = (
+                    sum(
+                        1
+                        for a in ans_dedup
+                        if any(spans_overlap(a, c) for c in preload_candidates)
+                    )
+                    / len(ans_dedup)
+                    if (ans_dedup and preload_candidates)
+                    else None
                 )
                 record = {
                     "cell_id": cell_id,
@@ -228,8 +278,14 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                     "metrics_meaningful": gt_meaningful,
                     "target_files": target_files,
                     "target_symbols": target_symbols,
+                    "gt_code_blocks": gt_blocks,
+                    "answer_spans": answer_spans,
+                    "retrieval_spans": retrieval_spans,
+                    "preload_candidates": preload_candidates,
+                    "preload_contribution": preload_contribution,
                     "tool_calls": out["tool_calls"],
                     "file_read_paths": out["file_read_paths"],
+                    "file_reads": out.get("file_reads", []),
                     "answer": out["answer"],
                     "total_turns": out["total_turns"],
                     "total_duration_ms": out["total_duration_ms"],

--- a/scripts/agent_compile/run_synthesis_sweep.py
+++ b/scripts/agent_compile/run_synthesis_sweep.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-query sweep over the ``sysevol-ai/codeminer-synthesis`` dataset.
+
+Unlike ``run_sweep.py`` (one query per SWE-bench instance), synthesis has many
+queries (50-80) per repo, varying by ``category`` (behavioral / symbol_hint /
+traversal / ...). That is exactly the setting where retrieval should pay off:
+
+* category DISCRIMINATES grep vs retrieval — ``behavioral`` queries name no
+  identifiers (grep must explore the whole repo), ``symbol_hint`` names the
+  symbol (grep wins), ``traversal`` needs call-graph navigation.
+* index REUSE — the repo index is built ONCE and amortized across all its
+  queries (this loop loads contexts once per instance, then runs every query),
+  whereas grep re-searches per query.
+
+Scoring is the same span-overlap harness as ``run_sweep.py`` (answer + retrieval
+scopes); each cell additionally records ``category`` and ``query_id`` so the
+aggregator can break ``answer_rec@k`` down per category.
+
+Usage::
+
+    python scripts/agent_compile/run_synthesis_sweep.py \
+        --config scripts/agent_compile/configs/preload_probe.yaml \
+        --output-dir results/agent_compile/synthesis \
+        --synthesis-configs Python,Go,Rust,TypeScript_JavaScript
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.agent_compile.lib.config import SweepConfig  # noqa: E402
+from scripts.agent_compile.lib.harness import (  # noqa: E402
+    build_symbol_span_index,
+    load_full_contexts,
+    run_cell,
+    slug,
+)
+from scripts.agent_compile.lib.prebuilt import (  # noqa: E402
+    has_full_indexes,
+    repo_path_for,
+    stage_prebuilt_indexes,
+)
+
+# language_group / config -> SessionContext primary_language key.
+_LANG_KEY = {
+    "Python": "python",
+    "Go": "go",
+    "Rust": "rust",
+    "TypeScript_JavaScript": "typescript",
+    "C++_C": "cpp",
+}
+_ALL_CONFIGS = list(_LANG_KEY)
+
+
+def _load_normalized(config_name: str) -> List[Dict[str, Any]]:
+    """Load + normalize one synthesis config into common CodeMiner rows."""
+    from datasets import load_dataset
+
+    from codeminer.dataset.codeminer_synthesis import normalize_synthesis_record
+
+    ds = load_dataset("sysevol-ai/codeminer-synthesis", config_name, split="test")
+    return [normalize_synthesis_record(r, config_name) for r in ds]
+
+
+def _targets(row: Dict[str, Any], simplified: bool):
+    """target_files / target_symbols from the synthesis gt_files / gt_symbols."""
+    from codeminer.eval.retrieval_eval import (
+        normalize_file_path,
+        normalize_symbol_identifier,
+    )
+
+    files = [normalize_file_path(f) for f in (row.get("gt_files") or [])]
+    syms_raw = row.get("gt_symbols") or []
+    if simplified:  # function-like only (mirrors collect_targets)
+        syms_raw = [s for s in syms_raw if "(" in s]
+    syms = [normalize_symbol_identifier(s) for s in syms_raw]
+    return [f for f in files if f], [s for s in syms if s]
+
+
+def run(
+    cfg: SweepConfig,
+    output_dir: Path,
+    configs: Sequence[str],
+    *,
+    categories: Optional[set],
+    max_queries: Optional[int],
+    resume: bool,
+) -> Dict:
+    from codeminer.eval.retrieval_eval import (
+        collect_target_blocks,
+        dedup_spans,
+        nodes_to_spans,
+        parse_answer_spans,
+        resolve_symbol_spans,
+        score_agent_localization,
+        score_localization_spans,
+        spans_overlap,
+    )
+    from codeminer.llm.litellm_chat import LiteLLMChat
+
+    cells_dir = output_dir / "cells"
+    cells_dir.mkdir(parents=True, exist_ok=True)
+    vertex_extra: Dict[str, Any] = {}
+    if cfg.vertex_project:
+        vertex_extra["vertex_project"] = cfg.vertex_project
+    if cfg.vertex_location:
+        vertex_extra["vertex_location"] = cfg.vertex_location
+    vertex_extra["num_retries"] = cfg.num_retries
+    llm = LiteLLMChat(
+        model=cfg.model,
+        temperature=cfg.temperature,
+        max_tokens=cfg.max_tokens,
+        extra_kwargs=vertex_extra,
+    )
+    summary: Dict[str, Any] = {"completed": [], "skipped": [], "failed": []}
+
+    for config_name in configs:
+        rows = _load_normalized(config_name)
+        if categories:
+            rows = [r for r in rows if r.get("category") in categories]
+        # Group by instance_id so the repo index loads ONCE per instance.
+        by_instance: Dict[str, List[Dict[str, Any]]] = {}
+        for r in rows:
+            by_instance.setdefault(r["instance_id"], []).append(r)
+
+        for instance_id, inst_rows in by_instance.items():
+            if max_queries:
+                inst_rows = inst_rows[:max_queries]
+            if not has_full_indexes(cfg.prebuilt_dir, instance_id, cfg.embedding_model):
+                print(f"synth: WARN {instance_id} missing prebuilt; skipping")
+                summary["skipped"].append(
+                    {"instance_id": instance_id, "reason": "no-prebuilt"}
+                )
+                continue
+            # Decide which cells still need running before paying the load cost.
+            plan = []
+            for row in inst_rows:
+                for subset_id, skills in cfg.subsets.items():
+                    for rep in range(1, cfg.reps + 1):
+                        cid = f"{row['query_id']}__{subset_id}__rep{rep}"
+                        cpath = cells_dir / f"{slug(cid)}.json"
+                        if resume and cpath.exists():
+                            continue
+                        plan.append((row, subset_id, list(skills), rep, cid, cpath))
+            if not plan:
+                print(f"synth: {instance_id} ({config_name}) fully cached; skipping")
+                continue
+
+            repo_path = repo_path_for(cfg.prebuilt_dir, instance_id)
+            cache_dir = repo_path  # prebuilt staged in place
+            t0 = time.time()
+            print(
+                f"synth: {instance_id} ({config_name}) staging + loading contexts "
+                f"({len(plan)} cells over {len(inst_rows)} queries)"
+            )
+            try:
+                stage_prebuilt_indexes(cfg.prebuilt_dir, instance_id, cache_dir)
+                contexts = load_full_contexts(cfg, repo_path, cache_dir)
+            except Exception as exc:  # noqa: BLE001
+                print(f"synth: FAIL load {instance_id}: {exc}", file=sys.stderr)
+                summary["failed"].append(
+                    {"instance_id": instance_id, "reason": f"load:{exc}"}
+                )
+                continue
+            symbol_span_index = build_symbol_span_index(cfg.prebuilt_dir, instance_id)
+            print(f"synth:   contexts ready in {time.time() - t0:.1f}s")
+
+            for row, subset_id, skills, rep, cid, cpath in plan:
+                t = time.time()
+                gt_blocks = collect_target_blocks(row)
+                target_files, target_symbols = _targets(row, cfg.gt_simplified_symbols)
+                try:
+                    out = run_cell(
+                        cfg,
+                        contexts=contexts,
+                        llm=llm,
+                        repo_path=repo_path,
+                        language_key=_LANG_KEY.get(config_name, "python"),
+                        query=row["query"],
+                        subset_id=subset_id,
+                        skills=skills,
+                        preload_spec=(cfg.preload or {}).get(subset_id),
+                    )
+                    metrics = score_agent_localization(
+                        answer=out["answer"],
+                        file_read_paths=out["file_read_paths"],
+                        nodes=out["nodes"],
+                        target_files=target_files,
+                        target_symbols=target_symbols,
+                        ks=cfg.metrics_k,
+                        repo_path=repo_path,
+                    )
+                    answer_spans = parse_answer_spans(
+                        out["answer"], repo_path
+                    ) + resolve_symbol_spans(
+                        out["answer"], symbol_span_index, repo_path
+                    )
+                    retrieval_spans = nodes_to_spans(out["nodes"])
+                    metrics.update(
+                        score_localization_spans(
+                            answer_spans=answer_spans,
+                            retrieval_spans=retrieval_spans,
+                            gt_blocks=gt_blocks,
+                            ks=cfg.metrics_k,
+                        )
+                    )
+                    preload_candidates = out.get("preload_candidates") or []
+                    ans_dedup = dedup_spans(answer_spans)
+                    preload_contribution = (
+                        sum(
+                            1
+                            for a in ans_dedup
+                            if any(spans_overlap(a, c) for c in preload_candidates)
+                        )
+                        / len(ans_dedup)
+                        if (ans_dedup and preload_candidates)
+                        else None
+                    )
+                    record = {
+                        "cell_id": cid,
+                        "instance_id": instance_id,
+                        "query_id": row["query_id"],
+                        "category": row.get("category"),
+                        "length_variant": row.get("length_variant"),
+                        "source_config": config_name,
+                        "subset_id": subset_id,
+                        "skills": skills,
+                        "model": cfg.model,
+                        "rep": rep,
+                        "language": _LANG_KEY.get(config_name, "python"),
+                        "success": True,
+                        "metrics": metrics,
+                        "metrics_meaningful": bool(target_files or gt_blocks),
+                        "query": row["query"],
+                        "target_files": target_files,
+                        "target_symbols": target_symbols,
+                        "gt_code_blocks": gt_blocks,
+                        "answer_spans": answer_spans,
+                        "retrieval_spans": retrieval_spans,
+                        "preload_candidates": preload_candidates,
+                        "preload_contribution": preload_contribution,
+                        "tool_calls": out["tool_calls"],
+                        "file_read_paths": out["file_read_paths"],
+                        "answer": out["answer"],
+                        "total_turns": out["total_turns"],
+                        "total_tokens": out["total_tokens"],
+                        "cost_usd": out["cost_usd"],
+                        "cache_read_input_tokens": out["cache_read_input_tokens"],
+                        "elapsed_seconds": time.time() - t,
+                        "error": None,
+                    }
+                    summary["completed"].append(cid)
+                    ar = metrics.get("answer_blocks", {}).get(5, {}).get("recall")
+                    print(
+                        f"synth:   done {cid} [{row.get('category')}] "
+                        f"in {time.time() - t:.1f}s turns={out['total_turns']} "
+                        f"answer_rec@5={ar}"
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    traceback.print_exc()
+                    summary["failed"].append({"cell_id": cid, "reason": str(exc)})
+                    print(f"synth:   FAIL {cid}: {exc}", file=sys.stderr)
+                    if any(
+                        s in str(exc).lower()
+                        for s in (
+                            "ratelimit",
+                            "rate limit",
+                            "429",
+                            "quota",
+                            "resourceexhausted",
+                        )
+                    ):
+                        print(f"synth:   (transient; not persisting {cid})")
+                        continue
+                    record = {
+                        "cell_id": cid,
+                        "instance_id": instance_id,
+                        "query_id": row["query_id"],
+                        "category": row.get("category"),
+                        "subset_id": subset_id,
+                        "success": False,
+                        "metrics": {},
+                        "error": str(exc),
+                        "elapsed_seconds": time.time() - t,
+                    }
+                with cpath.open("w", encoding="utf-8") as f:
+                    json.dump(record, f, indent=2, ensure_ascii=False)
+
+    with (output_dir / "synthesis_summary.json").open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False)
+    print(
+        f"synth done: completed={len(summary['completed'])} "
+        f"skipped={len(summary['skipped'])} failed={len(summary['failed'])}"
+    )
+    return summary
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--config", required=True, type=Path)
+    p.add_argument("--output-dir", required=True, type=Path)
+    p.add_argument(
+        "--synthesis-configs",
+        default=",".join(_ALL_CONFIGS),
+        help="comma list of HF configs (Python,Go,Rust,TypeScript_JavaScript,C++_C)",
+    )
+    p.add_argument(
+        "--categories",
+        default=None,
+        help="comma list to filter (e.g. behavioral,symbol_hint)",
+    )
+    p.add_argument(
+        "--max-queries", type=int, default=None, help="cap queries per instance (smoke)"
+    )
+    p.add_argument("--reps", type=int, default=None)
+    p.add_argument("--no-resume", action="store_true")
+    args = p.parse_args(argv)
+
+    cfg = SweepConfig.from_yaml(args.config)
+    if args.reps is not None:
+        cfg.reps = args.reps
+    configs = [c.strip() for c in args.synthesis_configs.split(",") if c.strip()]
+    categories = (
+        {c.strip() for c in args.categories.split(",")} if args.categories else None
+    )
+    run(
+        cfg,
+        args.output_dir,
+        configs,
+        categories=categories,
+        max_queries=args.max_queries,
+        resume=not args.no_resume,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/agent/test_runner.py
+++ b/test/agent/test_runner.py
@@ -125,6 +125,30 @@ class TestAgentRunner:
         assert record.result == "echo: hello"
         assert record.error is None
 
+    def test_partial_contract_answer_forces_schema_turn(self, echo_registry):
+        """A Files-only answer is not enough for span scoring; force schema."""
+        llm = _make_llm()
+        tc = _make_tool_call("call_1", "echo", '{"text": "hello"}')
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(content="Files: src/a.py"),
+            _make_response(
+                content=(
+                    "Files: src/a.py\n"
+                    "Symbols: src/a.py:foo\n"
+                    "Locations: src/a.py:10-20"
+                )
+            ),
+        ]
+
+        runner = AgentRunner(llm, echo_registry)
+        result = runner.run("Echo hello")
+
+        assert result.total_turns == 2
+        assert result.answer.endswith("Locations: src/a.py:10-20")
+        assert llm._call_raw.call_count == 3
+        assert llm._call_raw.call_args.kwargs.get("tool_choice") == "none"
+
     def test_multiple_tool_calls_in_one_response(self, echo_registry):
         """LLM returns multiple tool calls in a single response."""
         llm = _make_llm()

--- a/test/dataset/test_synthesis_span_resolution.py
+++ b/test/dataset/test_synthesis_span_resolution.py
@@ -13,6 +13,7 @@ re-generated dataset has usable spans for span-overlap eval.
 """
 
 from codeminer.dataset.synthesize._types import BehavioralContext, SampledCodeBlock
+from codeminer.dataset.synthesize.context_loader import _leaf_symbol
 from codeminer.dataset.synthesize.query_synthesizer import ClaudeQuerySynthesizer
 from codeminer.dataset.utils import CodeLocation, GroundTruth
 
@@ -33,10 +34,7 @@ def _block(file: str, node_name: str, start: int, end: int) -> SampledCodeBlock:
 
 
 def _leaf(name: str) -> str:
-    s = str(name)
-    if ":" in s:
-        s = s.split(":")[-1]
-    return s.split("/")[-1].split(".")[-1].rstrip("()")
+    return _leaf_symbol(name)
 
 
 def _ctx(*blocks: SampledCodeBlock) -> BehavioralContext:
@@ -88,6 +86,13 @@ def test_resolves_span_from_graph_style_nodename():
     blk = _block("src/m.rs", "crate/m/do_it", 10, 40)
     nodes = ClaudeQuerySynthesizer._build_symbol_nodes_from_ground_truth(gt, _ctx(blk))
     assert (nodes[0].start_line, nodes[0].end_line) == (10, 40)
+
+
+def test_resolves_span_from_hash_member_nodename():
+    gt = _gt("pkg/calc.go", "Add")
+    blk = _block("pkg/calc.go", "pkg/Calculator#Add", 3, 8)
+    nodes = ClaudeQuerySynthesizer._build_symbol_nodes_from_ground_truth(gt, _ctx(blk))
+    assert (nodes[0].start_line, nodes[0].end_line) == (3, 8)
 
 
 def test_falls_back_to_zero_when_unmatched_or_no_context():

--- a/test/dataset/test_synthesis_span_resolution.py
+++ b/test/dataset/test_synthesis_span_resolution.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test: hint-category synthesis must carry real line spans.
+
+The HuggingFace ``codeminer-synthesis`` build had (0,0) ``gt_symbol_nodes`` for
+the file_hint / module_hint / symbol_hint / reasoning categories, because their
+ground truth is derived from ``file:symbol`` strings (no line ranges). The fix
+resolves each symbol's real span from the graph-sampled ``candidate_blocks``
+(built for every query). This locks that behavior at the unit level so a
+re-generated dataset has usable spans for span-overlap eval.
+"""
+
+from codeminer.dataset.synthesize._types import BehavioralContext, SampledCodeBlock
+from codeminer.dataset.synthesize.query_synthesizer import ClaudeQuerySynthesizer
+from codeminer.dataset.utils import CodeLocation, GroundTruth
+
+
+def _block(file: str, node_name: str, start: int, end: int) -> SampledCodeBlock:
+    return SampledCodeBlock(
+        block_id="blk_001",
+        node_id=1,
+        node_name=node_name,
+        file_path=file,
+        node_type="function",
+        start_line=start,
+        end_line=end,
+        content="...",
+        char_count=3,
+        line_count=1,
+    )
+
+
+def _leaf(name: str) -> str:
+    s = str(name)
+    if ":" in s:
+        s = s.split(":")[-1]
+    return s.split("/")[-1].split(".")[-1].rstrip("()")
+
+
+def _ctx(*blocks: SampledCodeBlock) -> BehavioralContext:
+    # symbol_spans is built from the FULL graph by context_loader; here we build
+    # it from the given blocks to mirror that (resolution reads symbol_spans, not
+    # candidate_blocks, which is downsampled).
+    spans = {
+        (b.file_path, _leaf(b.node_name)): (b.start_line, b.end_line) for b in blocks
+    }
+    return BehavioralContext(
+        core_block=blocks[0],
+        candidate_blocks=list(blocks),
+        neighborhood_blocks=[],
+        symbol_spans=spans,
+    )
+
+
+def _gt(file: str, symbol: str) -> GroundTruth:
+    # start/end_line 0 reproduces the spanless _build_ground_truth output.
+    return GroundTruth(
+        primary_locations=[
+            CodeLocation(
+                file_path=file,
+                symbol=symbol,
+                start_line=0,
+                end_line=0,
+                symbol_type="function",
+            )
+        ]
+    )
+
+
+def test_resolves_span_from_blocks_file_symbol_nodename():
+    gt = _gt("astropy/stats/funcs.py", "binom_conf_interval")
+    blk = _block(
+        "astropy/stats/funcs.py",
+        "astropy/stats/funcs.py:binom_conf_interval()",  # file:symbol() form
+        89,
+        313,
+    )
+    nodes = ClaudeQuerySynthesizer._build_symbol_nodes_from_ground_truth(gt, _ctx(blk))
+    assert len(nodes) == 1
+    assert (nodes[0].start_line, nodes[0].end_line) == (89, 313)
+
+
+def test_resolves_span_from_graph_style_nodename():
+    # graph node["name"] is path-like (no file: prefix, no extension)
+    gt = _gt("src/m.rs", "do_it")
+    blk = _block("src/m.rs", "crate/m/do_it", 10, 40)
+    nodes = ClaudeQuerySynthesizer._build_symbol_nodes_from_ground_truth(gt, _ctx(blk))
+    assert (nodes[0].start_line, nodes[0].end_line) == (10, 40)
+
+
+def test_falls_back_to_zero_when_unmatched_or_no_context():
+    gt = _gt("a.py", "foo")
+    # no behavioral_context -> unchanged (0,0) fallback (no regression / no crash)
+    nodes = ClaudeQuerySynthesizer._build_symbol_nodes_from_ground_truth(gt, None)
+    assert (nodes[0].start_line, nodes[0].end_line) == (0, 0)
+    # context present but no matching block -> still falls back
+    blk = _block("other.py", "other.py:bar()", 5, 9)
+    nodes = ClaudeQuerySynthesizer._build_symbol_nodes_from_ground_truth(gt, _ctx(blk))
+    assert (nodes[0].start_line, nodes[0].end_line) == (0, 0)

--- a/test/eval/test_span_localization.py
+++ b/test/eval/test_span_localization.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for overlap-based line-span localization scoring.
+
+These cover the failure mode that motivated the metric: the agent genuinely
+locates the code but the symbol-name string match scores it zero. Span overlap
+must credit it, must survive the 0-based-node vs 1-based-GT origin skew, and must
+not let a verbose agent inflate its score by dumping context.
+"""
+
+from types import SimpleNamespace
+
+from codeminer.eval.retrieval_eval import (
+    collect_target_blocks,
+    compute_block_metrics,
+    dedup_spans,
+    nodes_to_spans,
+    parse_answer_spans,
+    resolve_symbol_spans,
+    score_localization_spans,
+    spans_overlap,
+)
+
+
+def _node(file, start, end, score=0.0, node_id=None):
+    """Duck-typed QueriedNode. Retrieval nodes are ~1-based and carry a
+    repo-relative ``node_id`` (``node.file`` is an absolute build-time path)."""
+    return SimpleNamespace(
+        file=file,
+        start_line=start,
+        end_line=end,
+        score=score,
+        node_id=node_id if node_id is not None else f"{file}:sym()",
+    )
+
+
+def _span(file, start, end, **kw):
+    return {"file": file, "start": start, "end": end, "score": kw.get("score", 0.0)}
+
+
+# --- ground-truth blocks ----------------------------------------------------
+
+
+def test_collect_target_blocks_from_gt_code_blocks():
+    inst = {
+        "gt_code_blocks": [
+            {
+                "change_type": "modified",
+                "start_line": 67,
+                "end_line": 105,
+                "file_path": "src/a.rs",
+                "symbol": "foo()",
+                "symbol_type": "function",
+            }
+        ]
+    }
+    blocks = collect_target_blocks(inst)
+    assert blocks == [
+        {
+            "file": "src/a.rs",
+            "start": 67,
+            "end": 105,
+            "score": 0.0,
+            "source": "gt",
+            "symbol": "foo()",
+            "change_type": "modified",
+        }
+    ]
+
+
+def test_collect_target_blocks_empty():
+    assert collect_target_blocks({}) == []
+
+
+# --- overlap + origin skew --------------------------------------------------
+
+
+def test_spans_overlap_same_file():
+    assert spans_overlap(_span("a.py", 10, 20), _span("a.py", 20, 30))  # touch
+    assert spans_overlap(_span("a.py", 10, 20), _span("a.py", 5, 12))
+    assert not spans_overlap(_span("a.py", 10, 20), _span("a.py", 21, 30))
+    assert not spans_overlap(_span("a.py", 10, 20), _span("b.py", 10, 20))
+
+
+def test_retrieval_node_1based_no_shift_and_overlap():
+    """Retrieval nodes are ~1-based already: no shift, and they overlap GT."""
+    gt = collect_target_blocks(
+        {
+            "gt_code_blocks": [
+                {"start_line": 67, "end_line": 105, "file_path": "src/fixes.rs"}
+            ]
+        }
+    )
+    spans = nodes_to_spans([_node("src/fixes.rs", 80, 100)])
+    assert spans[0]["start"] == 80 and spans[0]["end"] == 100  # unshifted
+    m = compute_block_metrics(spans, gt)
+    assert m["accuracy"] == 1.0 and m["recall"] == 1.0
+
+
+def test_nodes_to_spans_uses_relative_node_id_not_absolute_file():
+    """node.file is the absolute build-time path; node_id is repo-relative."""
+    n = _node("/abs/build/x.go", 10, 20, node_id="pkg/x.go:foo()")
+    spans = nodes_to_spans([n])
+    assert spans[0]["file"] == "pkg/x.go"
+
+
+def test_named_but_missed_now_hits_by_span():
+    """Symbol string match would score 0; span overlap credits the real hit."""
+    gt = collect_target_blocks(
+        {"gt_code_blocks": [{"start_line": 40, "end_line": 60, "file_path": "x.go"}]}
+    )
+    # retrieval returned the right region even with no exact symbol string match
+    retrieval = nodes_to_spans([_node("x.go", 41, 59, score=0.9)])
+    m = score_localization_spans(
+        answer_spans=[], retrieval_spans=retrieval, gt_blocks=gt, ks=[1, 5]
+    )
+    assert m["retrieval_blocks"][5]["accuracy"] == 1.0
+    assert m["answer_blocks"][5]["accuracy"] == 0.0  # never committed
+
+
+def test_answer_can_exceed_retrieval_no_superset():
+    """answer is NOT a subset of retrieval: the agent can commit to a region
+    grep/reasoning found that the retriever never returned (the real axios case).
+    Locks the "neither scope bounds the other" semantics."""
+    gt = collect_target_blocks(
+        {"gt_code_blocks": [{"start_line": 13, "end_line": 19, "file_path": "h.js"}]}
+    )
+    answer = parse_answer_spans("Locations: h.js:13-19")  # found via grep
+    retrieval = nodes_to_spans([_node("h.js", 82, 85, score=0.9)])  # wrong region
+    m = score_localization_spans(
+        answer_spans=answer, retrieval_spans=retrieval, gt_blocks=gt, ks=[10]
+    )
+    assert m["answer_blocks"][10]["recall"] == 1.0
+    assert m["retrieval_blocks"][10]["recall"] == 0.0  # answer > retrieval
+
+
+# --- answer Locations parsing -----------------------------------------------
+
+
+def test_parse_answer_spans_formats():
+    answer = (
+        "blah blah\n"
+        "Files: src/a.py\n"
+        "Locations: src/a.py:10-25, pkg/b.go:7, src/c.ts#L3-L9\n"
+    )
+    spans = parse_answer_spans(answer)
+    got = {(s["file"], s["start"], s["end"]) for s in spans}
+    assert got == {("src/a.py", 10, 25), ("pkg/b.go", 7, 7), ("src/c.ts", 3, 9)}
+
+
+def test_parse_answer_spans_none_without_locations_line():
+    # Prose line mentions must NOT be scraped (would reward verbosity).
+    assert parse_answer_spans("The bug is on line 76 of src/a.py somewhere") == []
+
+
+def test_parse_answer_spans_tolerates_markdown_bold():
+    """Agents routinely bold the contract: ``**Locations:** ...`` must parse."""
+    answer = "analysis...\n**Locations:** src/a.py:66-105\n"
+    spans = parse_answer_spans(answer)
+    assert spans and (spans[0]["start"], spans[0]["end"]) == (66, 105)
+
+
+def test_parse_answer_spans_markdown_list_and_heading():
+    for line in ("- Locations: a.py:10-20", "### Locations: a.py:10-20"):
+        spans = parse_answer_spans(line)
+        assert spans and (spans[0]["start"], spans[0]["end"]) == (10, 20)
+
+
+# --- symbol -> span resolution (named-symbol committed credit) ---------------
+
+
+def test_resolve_symbol_spans_bridges_named_symbol():
+    """Agent names a symbol but gives no line range — resolved via the index."""
+    index = {("src/fixes.rs", "remove_unused"): (66, 105)}
+    answer = "Symbols: src/fixes.rs:remove_unused\n"
+    spans = resolve_symbol_spans(answer, index)
+    assert spans == [
+        {
+            "file": "src/fixes.rs",
+            "start": 66,
+            "end": 105,
+            "score": 0.0,
+            "source": "answer_symbol",
+        }
+    ]
+
+
+def test_resolve_symbol_spans_strips_parens_and_qualifier():
+    index = {("a.go", "method"): (10, 20)}
+    # GT-style qualified + parenthesized name resolves on the bare leaf.
+    spans = resolve_symbol_spans("Symbols: a.go:Receiver.method()", index)
+    assert spans and (spans[0]["start"], spans[0]["end"]) == (10, 20)
+
+
+def test_resolve_symbol_spans_unknown_symbol_is_dropped():
+    assert resolve_symbol_spans("Symbols: a.py:does_not_exist", {}) == []
+
+
+# --- ranking, dedup, anti-flooding ------------------------------------------
+
+
+def test_nodes_to_spans_ranked_by_score_desc():
+    spans = nodes_to_spans(
+        [_node("a.py", 1, 2, score=0.1), _node("b.py", 3, 4, score=0.9)]
+    )
+    assert [s["file"] for s in spans] == ["b.py", "a.py"]
+
+
+def test_dedup_collapses_overlapping_region():
+    spans = [_span("a.py", 10, 20), _span("a.py", 12, 18), _span("b.py", 1, 2)]
+    kept = dedup_spans(spans)
+    assert len(kept) == 2  # the 12-18 duplicate of 10-20 is dropped
+
+
+def test_flooding_does_not_inflate_answer_precision():
+    """Dumping many wrong locations tanks precision; one right hit, padded."""
+    gt = collect_target_blocks(
+        {"gt_code_blocks": [{"start_line": 100, "end_line": 120, "file_path": "a.py"}]}
+    )
+    answer = [
+        _span("a.py", 100, 120),  # the real hit
+        _span("z.py", 1, 5),
+        _span("z.py", 10, 15),
+        _span("z.py", 20, 25),
+        _span("z.py", 30, 35),
+    ]
+    m = score_localization_spans(
+        answer_spans=answer, retrieval_spans=[], gt_blocks=gt, ks=[1, 5]
+    )
+    # recall/accuracy still 1.0 (found it), but precision punishes the padding.
+    assert m["answer_blocks"][5]["accuracy"] == 1.0
+    assert m["answer_blocks"][5]["precision"] == 1 / 5
+    assert m["answer_blocks"][1]["precision"] == 1.0  # top-1 is the hit
+
+
+def test_compute_block_metrics_no_gt_is_zero():
+    m = compute_block_metrics([_span("a.py", 1, 2)], [])
+    assert m == {"accuracy": 0.0, "precision": 0.0, "recall": 0.0, "hits": 0}
+
+
+def test_partial_recall_multiple_gt_blocks():
+    gt = collect_target_blocks(
+        {
+            "gt_code_blocks": [
+                {"start_line": 10, "end_line": 20, "file_path": "a.py"},
+                {"start_line": 50, "end_line": 60, "file_path": "b.py"},
+            ]
+        }
+    )
+    preds = [_span("a.py", 11, 19)]  # hits only the first
+    m = compute_block_metrics(preds, gt)
+    assert m["recall"] == 0.5 and m["accuracy"] == 0.0 and m["hits"] == 1

--- a/test/eval/test_span_localization.py
+++ b/test/eval/test_span_localization.py
@@ -10,7 +10,10 @@ must credit it, must survive the 0-based-node vs 1-based-GT origin skew, and mus
 not let a verbose agent inflate its score by dumping context.
 """
 
+import pickle
 from types import SimpleNamespace
+
+import igraph as ig
 
 from codeminer.eval.retrieval_eval import (
     collect_target_blocks,
@@ -22,6 +25,7 @@ from codeminer.eval.retrieval_eval import (
     score_localization_spans,
     spans_overlap,
 )
+from scripts.agent_compile.lib.harness import build_symbol_span_index
 
 
 def _node(file, start, end, score=0.0, node_id=None):
@@ -114,8 +118,8 @@ def test_spans_overlap_same_file():
     assert not spans_overlap(_span("a.py", 10, 20), _span("b.py", 10, 20))
 
 
-def test_retrieval_node_1based_no_shift_and_overlap():
-    """Retrieval nodes are ~1-based already: no shift, and they overlap GT."""
+def test_retrieval_node_0based_shift_and_overlap():
+    """Raw retrieval nodes are internal 0-based; scoring shifts them +1."""
     gt = collect_target_blocks(
         {
             "gt_code_blocks": [
@@ -123,10 +127,20 @@ def test_retrieval_node_1based_no_shift_and_overlap():
             ]
         }
     )
-    spans = nodes_to_spans([_node("src/fixes.rs", 80, 100)])
-    assert spans[0]["start"] == 80 and spans[0]["end"] == 100  # unshifted
+    spans = nodes_to_spans([_node("src/fixes.rs", 66, 104)])
+    assert spans[0]["start"] == 67 and spans[0]["end"] == 105
     m = compute_block_metrics(spans, gt)
     assert m["accuracy"] == 1.0 and m["recall"] == 1.0
+
+
+def test_retrieval_node_single_line_off_by_one_hits():
+    """A one-line node at internal line 9 must hit 1-based GT line 10."""
+    gt = collect_target_blocks(
+        {"gt_code_blocks": [{"start_line": 10, "end_line": 10, "file_path": "a.py"}]}
+    )
+    spans = nodes_to_spans([_node("a.py", 9, 9)])
+    assert (spans[0]["start"], spans[0]["end"]) == (10, 10)
+    assert compute_block_metrics(spans, gt)["recall"] == 1.0
 
 
 def test_nodes_to_spans_uses_relative_node_id_not_absolute_file():
@@ -226,6 +240,28 @@ def test_resolve_symbol_spans_strips_parens_and_qualifier():
 
 def test_resolve_symbol_spans_unknown_symbol_is_dropped():
     assert resolve_symbol_spans("Symbols: a.py:does_not_exist", {}) == []
+
+
+def test_prebuilt_symbol_span_index_normalizes_graph_names(tmp_path):
+    inst = tmp_path / "iid"
+    inst.mkdir()
+    graph = ig.Graph()
+    graph.add_vertices(2)
+    graph.vs[0]["file"] = "src/foo.py"
+    graph.vs[0]["start_line"] = 9
+    graph.vs[0]["end_line"] = 19
+    graph.vs[0]["name"] = "src/foo.py:bar()"
+    graph.vs[0]["unified_name"] = "src/foo.py:Foo.bar()"
+    graph.vs[1]["file"] = "pkg/calc.go"
+    graph.vs[1]["start_line"] = 3
+    graph.vs[1]["end_line"] = 7
+    graph.vs[1]["name"] = "pkg/Calculator#Add"
+    with (inst / "graph.pkl").open("wb") as f:
+        pickle.dump({"graph": graph}, f)
+
+    index = build_symbol_span_index(str(tmp_path), "iid")
+    assert index[("src/foo.py", "bar")] == (10, 20)
+    assert index[("pkg/calc.go", "Add")] == (4, 8)
 
 
 # --- ranking, dedup, anti-flooding ------------------------------------------

--- a/test/eval/test_span_localization.py
+++ b/test/eval/test_span_localization.py
@@ -74,6 +74,36 @@ def test_collect_target_blocks_empty():
     assert collect_target_blocks({}) == []
 
 
+def test_collect_target_blocks_from_synthesis_symbol_nodes():
+    """codeminer-synthesis exposes 0-based gt_symbol_nodes (graph attrs) -> +1."""
+    inst = {
+        "gt_symbol_nodes": [
+            {
+                "file": "astropy/stats/funcs.py",
+                "start_line": 89,  # 0-based (graph) -> 90 expected
+                "end_line": 313,
+                "node_name": "astropy/stats/funcs.py:binom_conf_interval()",
+                "type": "function",
+            }
+        ]
+    }
+    blocks = collect_target_blocks(inst)
+    assert len(blocks) == 1
+    assert (blocks[0]["start"], blocks[0]["end"]) == (90, 314)
+    assert blocks[0]["symbol"] == "astropy/stats/funcs.py:binom_conf_interval()"
+
+
+def test_gt_code_blocks_take_priority_over_symbol_nodes():
+    inst = {
+        "gt_code_blocks": [
+            {"file_path": "a.py", "start_line": 10, "end_line": 20}  # 1-based
+        ],
+        "gt_symbol_nodes": [{"file": "b.py", "start_line": 1, "end_line": 5}],
+    }
+    blocks = collect_target_blocks(inst)
+    assert [(b["file"], b["start"], b["end"]) for b in blocks] == [("a.py", 10, 20)]
+
+
 # --- overlap + origin skew --------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Replaces the brittle symbol-name `symbols@k` (which scored agent prose ≈0 even
when the agent had located the code) with **line-span overlap localization
eval**, and uses it to investigate how retrieval should reach a grep/read agent.
Headline findings (codeminer-base + codeminer-synthesis, Claude Haiku 4.5):

- The agent ignores retrieval skills offered as tools (embedding 0–4%, graph
  nav ~0% adoption) and localizes with its pretrained grep/read loop, so the
  "offer-a-skill" arms measured grep, not the skill.
- **Pre-loading** retrieval candidates into the opening prompt (instead of
  offering them as tools) is a Pareto win: ≥ grep accuracy at −10..26% tokens on
  5/6 synthesis categories, and beats grep on traversal in 5/5 languages.
- **Graph pre-load is useful**: the 2-hop graph composer is the top single arm
  on multi-hop traversal (answer_rec@5 0.637 vs grep 0.557) and is the best
  pre-load in 4/5 languages (Go 0.817), surfacing call-graph neighbours that
  grep/embedding can't reach by name.

Design + decisions: `.claude/design/preload-vs-skill-architecture.md`.

## Changes

- **Span-overlap eval** (`codeminer/eval/retrieval_eval.py`): `answer` (the
  agent's committed `Locations:`/graph-resolved `Symbols:`) and `retrieval`
  (ranked nodes) blocks@k by line-range overlap; markdown-tolerant Files/Symbols/
  Locations parsing; reads SWE-bench `gt_code_blocks` (1-based) AND synthesis
  `gt_symbol_nodes` (0-based) with correct origin handling. Verified RAG node_id
  match == span overlap per-instance, so RAG and agent share one recall@k ruler.
- **Runner** (`codeminer/agent/runner.py`): single `LOCALIZATION_SCHEMA` shared
  by the system prompt and parser; forced schema final-answer on budget/prose
  exit (fixes `tools=` `UnsupportedParamsError`) → answer-contract rate 32%→100%.
- **Pre-load** (`scripts/agent_compile/lib/preload.py` + `config.preload`):
  assemble retrieval candidates up front (embedding / bm25 / graph composer,
  optional 2-hop), inject them, attribute pre-load contribution. `run_sweep.py`
  + `aggregate.py` wired for span scopes.
- **Synthesis benchmark** (builds on #209): `run_synthesis_sweep.py` (per-query,
  groups by instance so the index loads once and amortizes across its 50–80
  queries) + `aggregate_synthesis.py` (per-category answer_rec/retr_rec/cost).
- **Fix**: synthesis hint/reasoning rows had `gt_symbol_nodes` with
  `start_line=end_line=0`; `ContextLoader.prepare_behavioral_context` now resolves
  spans from a full-graph symbol index (takes effect on dataset regeneration).

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`test/eval/test_span_localization.py` (span overlap, 0/1-based origin, markdown
labels, anti-flooding, answer⊄retrieval) and
`test/dataset/test_synthesis_span_resolution.py` (hint-path span resolution)
added. `pytest test/eval test/dataset test/agent -m "not slow and not
integration"` → 370 passed, 2 skipped. Full unit suite: 1035 passed, 1 failed —
the lone failure is the pre-existing `test_scip_multilingual[cpp]` fmt
templated-header chunker issue, unrelated to this PR. Orchestration scripts under
`scripts/agent_compile/` are experiment tooling (runtime-validated via probes),
consistent with the existing sweep scripts.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
