### PR TITLE
fix(agent): make the forced localization schema turn optional

### DIFF
--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -158,6 +158,7 @@ class AgentRunner:
         include_default_tools: bool = True,
         default_tool_ids: Optional[Set[str]] = None,
         retry: Optional[RetryConfig] = None,
+        force_localization_contract: bool = True,
     ) -> None:
         if llm is not None:
             self.llm = llm
@@ -214,6 +215,10 @@ class AgentRunner:
             )
         self.max_turns = max_turns
         self.session_ctx = session_ctx
+        # The localization eval needs answers to end in the Files:/Symbols:/
+        # Locations: contract; QA callers (web demo) keep prose, so they turn
+        # this off and skip the schema-forcing final turn entirely.
+        self._force_contract = force_localization_contract
 
         # Resource guard: filter unavailable skills and collect warnings.
         # The "base" allow / exclude are stored so we can recompute the
@@ -403,7 +408,11 @@ class AgentRunner:
                 # without the contract (it explored but didn't format), force one
                 # schema turn so a genuine localization isn't lost to formatting.
                 answer = getattr(assistant_msg, "content", None) or ""
-                if all_tool_calls and not _has_localization_contract(answer):
+                if (
+                    self._force_contract
+                    and all_tool_calls
+                    and not _has_localization_contract(answer)
+                ):
                     answer = (
                         self._force_schema_answer(history, usage_tracker, turn + 2)
                         or answer
@@ -445,7 +454,11 @@ class AgentRunner:
         # Budget exhausted. A capped agent usually left mid-exploration chatter
         # ("Let me check…"), so force a schema-conforming final answer unless it
         # already emitted the contract.
-        if all_tool_calls and not _has_localization_contract(last_content):
+        if (
+            self._force_contract
+            and all_tool_calls
+            and not _has_localization_contract(last_content)
+        ):
             last_content = (
                 self._force_schema_answer(history, usage_tracker, max_turns + 1)
                 or last_content

--- a/codeminer/web/repo_registry.py
+++ b/codeminer/web/repo_registry.py
@@ -305,6 +305,9 @@ class RepoRegistry:
             # default read/grep/glob/bash tools return plain text (no
             # citations) and let the model grep-and-give-up, so withhold them.
             include_default_tools=False,
+            # Keep prose answers: the Files:/Symbols:/Locations: schema turn is
+            # for the localization eval and would replace the explanation.
+            force_localization_contract=False,
         )
         return RepoBundle(
             entry=entry,


### PR DESCRIPTION
## Summary
Web demo chat answers turned into bare `Files:/Symbols:/Locations:` lines after #214: the runner now replaces any final answer missing that contract with a forced schema turn. The contract is for the localization eval — the demo's QA prose was being thrown away.

## Changes
- Add `force_localization_contract` flag to `AgentRunner` (default `True`, eval behavior unchanged)
- When off, skip the schema-forcing turn so prose answers are returned verbatim
- Demo runner (`repo_registry.py`) opts out so chat answers stay full explanations

Before change:
<img width="3008" height="1536" alt="image" src="https://github.com/user-attachments/assets/ab73419b-72ec-4285-9098-aba98307cd4e" />


After change:
<img width="3010" height="1534" alt="image" src="https://github.com/user-attachments/assets/1d850ee1-6c6d-477e-a2de-746c09025b43" />


## Type of Change
- [x] Bug fix

## Testing
- [x] Tests pass locally

`pytest test/agent/test_runner.py test/web` passes. Reproduced the terse answers on main with a live `/api/chat` query, re-ran with the fix and got the detailed explanation back.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
