### PR TITLE
feat(web): multi-turn ask conversations

### DIFF
--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -336,8 +336,15 @@ class AgentRunner:
         query: str,
         *,
         max_turns: Optional[int] = None,
+        chat_history: Optional[List[Dict[str, str]]] = None,
     ) -> AgentResult:
-        """Execute the agent loop and return the result."""
+        """Execute the agent loop and return the result.
+
+        ``chat_history`` seeds prior conversation turns (text-only
+        ``{"role": "user"|"assistant", "content": ...}`` dicts, no tool
+        messages) between the system prompt and *query*, so follow-up
+        questions can reference earlier answers.
+        """
         max_turns = max_turns or self.max_turns
 
         # CAR / agent_compile: when a compile_table is set, classify the
@@ -373,6 +380,8 @@ class AgentRunner:
 
         history = self._new_history()
         history.add_message({"role": "system", "content": self.system_prompt})
+        for msg in chat_history or []:
+            history.add_message({"role": msg["role"], "content": msg["content"]})
         history.add_message({"role": "user", "content": query})
         all_tool_calls: List[ToolCallRecord] = []
         usage_tracker = UsageTracker()

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -194,7 +194,11 @@ async def codemap(
 
 @app.post("/api/chat", response_model=ChatResponse)
 async def chat(req: ChatRequest) -> ChatResponse:
-    query = req.query.strip()
+    if not req.messages or req.messages[-1].role != "user":
+        raise HTTPException(
+            status_code=400, detail="last message must be from the user"
+        )
+    query = req.messages[-1].content.strip()
     if not query:
         raise HTTPException(status_code=400, detail="query must not be empty")
 
@@ -202,8 +206,14 @@ async def chat(req: ChatRequest) -> ChatResponse:
     if bundle is None:
         raise HTTPException(status_code=404, detail=f"Unknown repo: {req.repo_id!r}")
 
+    # Earlier messages give the agent context so it can resolve follow-ups
+    # like "what calls it?".
+    chat_history = [{"role": m.role, "content": m.content} for m in req.messages[:-1]]
+
     try:
-        result = await asyncio.to_thread(bundle.runner.run, query)
+        result = await asyncio.to_thread(
+            bundle.runner.run, query, chat_history=chat_history
+        )
     except Exception as exc:  # noqa: BLE001 - surface a clean 500 to the client
         logger.error("agent run failed for %r: %s", req.repo_id, exc, exc_info=True)
         raise HTTPException(status_code=500, detail="agent run failed") from exc

--- a/codeminer/web/schemas.py
+++ b/codeminer/web/schemas.py
@@ -11,7 +11,7 @@ flat, UI-friendly ``ChatResponse`` the Next.js frontend renders.
 from __future__ import annotations
 
 import os
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -38,9 +38,19 @@ class RepoInfo(BaseModel):
     capabilities: dict[str, bool] = Field(default_factory=dict)
 
 
+class ChatMessage(BaseModel):
+    """One conversation message (text only — citations stay client-side)."""
+
+    role: Literal["user", "assistant"]
+    content: str
+
+
 class ChatRequest(BaseModel):
     repo_id: str
-    query: str
+    # Full conversation, oldest first; the last message is the current question
+    # and must be from the user (OpenAI/DeepWiki-style). Earlier messages give
+    # the agent context for follow-ups.
+    messages: List[ChatMessage]
 
 
 class Citation(BaseModel):

--- a/web/app/[repoId]/ask/page.tsx
+++ b/web/app/[repoId]/ask/page.tsx
@@ -1,17 +1,30 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Header from "@/components/Header";
 import Markdown from "@/components/Markdown";
 import AskBar from "@/components/AskBar";
 import CodePanel from "@/components/CodePanel";
-import { askQuestion, fetchRepos, type ChatResponse, type RepoInfo } from "@/lib/api";
+import {
+  askQuestion,
+  fetchRepos,
+  type ChatMessage,
+  type ChatResponse,
+  type RepoInfo,
+} from "@/lib/api";
 import { codeRefs } from "@/lib/citations";
 
 // DeepWiki clamps the question to ~200 chars before "Show full text".
 const Q_TRUNCATE = 200;
+
+// One question + its (eventual) answer in the conversation thread.
+interface Turn {
+  q: string;
+  resp: ChatResponse | null;
+  err: string | null;
+}
 
 function AskAnswer() {
   const params = useParams<{ repoId: string }>();
@@ -19,9 +32,11 @@ function AskAnswer() {
   const q = (useSearchParams().get("q") ?? "").trim();
 
   const [repo, setRepo] = useState<RepoInfo | null>(null);
-  const [resp, setResp] = useState<ChatResponse | null>(null);
+  const [turns, setTurns] = useState<Turn[]>([]);
   const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
+  // Bumped whenever the thread resets so in-flight answers from a previous
+  // conversation can't land in the new one.
+  const genRef = useRef(0);
 
   useEffect(() => {
     fetchRepos()
@@ -29,42 +44,103 @@ function AskAnswer() {
       .catch(() => {});
   }, [repoId]);
 
-  // Re-fetch whenever the question changes — every submit is its own answer.
+  // Append a turn and fetch its answer. The request carries the prior turns
+  // plus this question as the final user message (DeepWiki-style) so the agent
+  // can resolve follow-ups ("what calls it?", "show me where").
+  const runAsk = useCallback(
+    (query: string, history: ChatMessage[]) => {
+      const gen = genRef.current;
+      setTurns((ts) => [...ts, { q: query, resp: null, err: null }]);
+      setLoading(true);
+      askQuestion(repoId, [...history, { role: "user", content: query }])
+        .then((r) => {
+          if (gen !== genRef.current) return;
+          setTurns((ts) => {
+            const next = [...ts];
+            next[next.length - 1] = { ...next[next.length - 1], resp: r };
+            return next;
+          });
+        })
+        .catch((e) => {
+          if (gen !== genRef.current) return;
+          setTurns((ts) => {
+            const next = [...ts];
+            next[next.length - 1] = { ...next[next.length - 1], err: String(e) };
+            return next;
+          });
+        })
+        .finally(() => {
+          if (gen === genRef.current) setLoading(false);
+        });
+    },
+    [repoId]
+  );
+
+  // A new URL question (arriving from a wiki page's ask bar) starts a fresh
+  // conversation; follow-ups submitted on this page append in place instead.
   useEffect(() => {
-    if (!q) {
-      setResp(null);
-      return;
+    genRef.current += 1;
+    setTurns([]);
+    setLoading(false);
+    setQExpanded(new Set());
+    if (q) runAsk(q, []);
+  }, [repoId, q, runAsk]);
+
+  function followUp(query: string) {
+    if (loading) return;
+    const history: ChatMessage[] = [];
+    for (const t of turns) {
+      if (!t.resp) continue; // skip errored / unanswered turns
+      history.push({ role: "user", content: t.q });
+      history.push({ role: "assistant", content: t.resp.answer });
     }
-    let cancelled = false;
-    setLoading(true);
-    setResp(null);
-    setErr(null);
-    askQuestion(repoId, q)
-      .then((r) => !cancelled && setResp(r))
-      .catch((e) => !cancelled && setErr(String(e)))
-      .finally(() => !cancelled && setLoading(false));
-    return () => {
-      cancelled = true;
-    };
-  }, [repoId, q]);
+    runAsk(query, history);
+  }
 
   const repoName = repo ? repo.repo : repoId;
-  // Shared list so a chip's index lines up with the code pane's fragments.
-  const refs = useMemo(() => codeRefs(resp?.citations ?? []), [resp]);
+  // Per-turn citation lists so a chip's index lines up with the code pane.
+  const turnRefs = useMemo(
+    () => turns.map((t) => codeRefs(t.resp?.citations ?? [])),
+    [turns]
+  );
+  // Which turn's citations the code pane shows + the highlighted one.
+  const [activeTurn, setActiveTurn] = useState(0);
   const [active, setActive] = useState(0);
   const [scrollSignal, setScrollSignal] = useState(0);
-  useEffect(() => setActive(0), [resp]);
+  // Focus the newest answered turn's citations whenever the thread changes.
+  useEffect(() => {
+    for (let i = turns.length - 1; i >= 0; i--) {
+      if (turns[i].resp) {
+        setActiveTurn(i);
+        setActive(0);
+        return;
+      }
+    }
+    setActiveTurn(0);
+    setActive(0);
+  }, [turns]);
   // Select a citation: highlight it and (re-)scroll the code pane to it.
-  const selectCitation = (i: number) => {
+  const selectCitation = (turn: number, i: number) => {
+    setActiveTurn(turn);
     setActive(i);
     setScrollSignal((s) => s + 1);
   };
 
-  // Truncate a long question to a fixed length with a "Show full text" toggle.
-  const [qExpanded, setQExpanded] = useState(false);
-  useEffect(() => setQExpanded(false), [q]);
-  const qLong = q.length > Q_TRUNCATE;
-  const qShown = !qLong || qExpanded ? q : q.slice(0, Q_TRUNCATE).trimEnd() + "…";
+  // Scroll the latest question into view as the thread grows.
+  const endRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (turns.length > 1) endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [turns.length]);
+
+  // Truncate long questions with a per-turn "Show full text" toggle.
+  const [qExpanded, setQExpanded] = useState<Set<number>>(new Set());
+  const toggleQ = (i: number) =>
+    setQExpanded((s) => {
+      const next = new Set(s);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
 
   return (
     <div className="wiki ask-page">
@@ -86,50 +162,76 @@ function AskAnswer() {
           <Link className="ask-back" href={`/${encodeURIComponent(repoId)}`}>
             ← Back to wiki
           </Link>
-          <h1 className="ask-q">{qShown || "Ask a question"}</h1>
-          {qLong && (
-            <button className="ask-q-toggle" onClick={() => setQExpanded((e) => !e)}>
-              {qExpanded ? "Show less" : "Show full text"}
-            </button>
-          )}
 
-          {!q && <p className="muted">Type a question in the bar below.</p>}
-          {loading && <p className="muted ask-thinking">Searching {repoName}…</p>}
-          {err && (
-            <p className="muted">
-              Couldn&apos;t reach the retrieval backend. Is the API running?
-            </p>
-          )}
-
-          {resp && (
+          {turns.length === 0 && (
             <>
-              <article className="ask-a">
-                <Markdown citations={refs} onCite={selectCitation}>
-                  {resp.answer || "(no answer)"}
-                </Markdown>
-              </article>
-              <div className="ask-tools muted small">
-                {resp.tool_calls.length} tool calls · {resp.total_turns} turns ·{" "}
-                {Math.round(resp.total_duration_ms)} ms · {refs.length} references
-              </div>
+              <h1 className="ask-q">Ask a question</h1>
+              <p className="muted">Type a question in the bar below.</p>
             </>
           )}
+
+          {turns.map((t, i) => {
+            const long = t.q.length > Q_TRUNCATE;
+            const shown =
+              !long || qExpanded.has(i) ? t.q : t.q.slice(0, Q_TRUNCATE).trimEnd() + "…";
+            return (
+              <div className={`ask-turn ${i > 0 ? "followup" : ""}`} key={i}>
+                {i === 0 ? (
+                  <h1 className="ask-q">{shown}</h1>
+                ) : (
+                  <h2 className="ask-q">{shown}</h2>
+                )}
+                {long && (
+                  <button className="ask-q-toggle" onClick={() => toggleQ(i)}>
+                    {qExpanded.has(i) ? "Show less" : "Show full text"}
+                  </button>
+                )}
+
+                {!t.resp && !t.err && (
+                  <p className="muted ask-thinking">Searching {repoName}…</p>
+                )}
+                {t.err && (
+                  <p className="muted">
+                    Couldn&apos;t reach the retrieval backend. Is the API running?
+                  </p>
+                )}
+                {t.resp && (
+                  <>
+                    <article className="ask-a">
+                      <Markdown
+                        citations={turnRefs[i]}
+                        onCite={(j) => selectCitation(i, j)}
+                      >
+                        {t.resp.answer || "(no answer)"}
+                      </Markdown>
+                    </article>
+                    <div className="ask-tools muted small">
+                      {t.resp.tool_calls.length} tool calls · {t.resp.total_turns}{" "}
+                      turns · {Math.round(t.resp.total_duration_ms)} ms ·{" "}
+                      {turnRefs[i].length} references
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+          <div ref={endRef} />
         </section>
 
         <aside className="ask-code">
           <CodePanel
             repoId={repoId}
-            citations={refs}
+            citations={turnRefs[activeTurn] ?? []}
             repo={repo?.repo}
             commit={repo?.base_commit}
             active={active}
-            onSelect={selectCitation}
+            onSelect={(i) => selectCitation(activeTurn, i)}
             scrollSignal={scrollSignal}
           />
         </aside>
       </div>
 
-      <AskBar repoId={repoId} repo={repoName} defaultValue={q} />
+      <AskBar repoId={repoId} repo={repoName} onSubmit={followUp} disabled={loading} />
     </div>
   );
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1108,6 +1108,15 @@ pre {
 .ask-q-toggle:hover {
   color: var(--accent);
 }
+/* Follow-up turns in the ask conversation thread. */
+.ask-turn.followup {
+  margin-top: 30px;
+  border-top: 1px solid var(--border);
+  padding-top: 22px;
+}
+.ask-turn.followup .ask-q {
+  font-size: 18px;
+}
 .ask-thinking {
   animation: ask-pulse 1.4s ease-in-out infinite;
 }

--- a/web/components/AskBar.tsx
+++ b/web/components/AskBar.tsx
@@ -4,18 +4,23 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 /**
- * DeepWiki-style ask bar pinned to the bottom of the page. Submitting routes
- * to the dedicated answer page (`/[repoId]/ask?q=...`) — every question opens
- * its own page rather than appending to an in-place chat.
+ * DeepWiki-style ask bar pinned to the bottom of the page. By default,
+ * submitting routes to the dedicated answer page (`/[repoId]/ask?q=...`).
+ * When `onSubmit` is given (the ask page's conversation thread), the question
+ * is handed to it in place instead and the input clears for the next one.
  */
 export default function AskBar({
   repoId,
   repo,
   defaultValue = "",
+  onSubmit,
+  disabled = false,
 }: {
   repoId: string;
   repo: string;
   defaultValue?: string;
+  onSubmit?: (query: string) => void;
+  disabled?: boolean;
 }) {
   const router = useRouter();
   const [q, setQ] = useState(defaultValue);
@@ -23,7 +28,12 @@ export default function AskBar({
   function submit(e: React.FormEvent) {
     e.preventDefault();
     const query = q.trim();
-    if (!query) return;
+    if (!query || disabled) return;
+    if (onSubmit) {
+      onSubmit(query);
+      setQ("");
+      return;
+    }
     router.push(`/${encodeURIComponent(repoId)}/ask?q=${encodeURIComponent(query)}`);
   }
 
@@ -37,10 +47,12 @@ export default function AskBar({
           className="askbar-input"
           value={q}
           onChange={(e) => setQ(e.target.value)}
-          placeholder={`Ask anything about ${repo}…`}
+          placeholder={
+            onSubmit ? `Ask a follow-up about ${repo}…` : `Ask anything about ${repo}…`
+          }
           aria-label={`Ask a question about ${repo}`}
         />
-        <button className="askbar-send" type="submit" disabled={!q.trim()}>
+        <button className="askbar-send" type="submit" disabled={disabled || !q.trim()}>
           Ask <span className="askbar-kbd">↵</span>
         </button>
       </div>

--- a/web/components/AskPanel.tsx
+++ b/web/components/AskPanel.tsx
@@ -47,7 +47,7 @@ export default function AskPanel({ repoId, repo }: { repoId: string; repo: strin
     setMessages((m) => [...m, { role: "user", text: query }]);
     setLoading(true);
     try {
-      const resp = await askQuestion(repoId, query);
+      const resp = await askQuestion(repoId, [{ role: "user", content: query }]);
       setMessages((m) => [
         ...m,
         { role: "assistant", text: resp.answer || "(no answer)", citations: resp.citations },

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -113,14 +113,20 @@ export async function fetchSource(
   return res.json();
 }
 
+/** One conversation message. The last one sent is the current question. */
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
 export async function askQuestion(
   repoId: string,
-  query: string
+  messages: ChatMessage[]
 ): Promise<ChatResponse> {
   const res = await fetch(`${API_BASE}/api/chat`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ repo_id: repoId, query }),
+    body: JSON.stringify({ repo_id: repoId, messages }),
   });
   if (!res.ok) {
     const detail = await res.text();


### PR DESCRIPTION
## Summary
Makes the ask page a real conversation instead of one question per page load. Adopts the DeepWiki/OpenAI-style chat contract: the request carries a `messages` list and the agent gets prior turns as context, so follow-ups resolve against earlier answers.

## Changes
- `/api/chat` now takes `messages: [{role, content}]` (was a single `query`); the last message must be from the user, earlier ones are the conversation so far
- `AgentRunner.run()` accepts optional `chat_history`, seeded between the system prompt and the new question
- Ask page keeps a conversation thread: first question from the URL, follow-ups append in place; the code pane tracks whichever turn's citations you click
- Ask bar submits follow-ups in place on the ask page; on wiki pages it still opens a new conversation

## Type of Change
- [x] New feature

## Testing
- [x] Tests pass locally

`tsc --noEmit` clean, `pytest test/web` passes. Drove a live two-turn conversation on astropy ("Where is the separability_matrix function defined?" then "What does that function return?") — the follow-up resolved "that function" from the prior turn. Empty / non-user-last `messages` return 400.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
