### PR TITLE
feat(web): improve code graph expand and node source peeks

### DIFF
--- a/web/components/CodeGraph.tsx
+++ b/web/components/CodeGraph.tsx
@@ -23,6 +23,7 @@ export interface GraphNodeInfo {
   short: string;
   file: string | null;
   line: number | null;
+  endLine: number | null; // 1-based end of the definition, so the peek shows just this symbol
   kind: string;
   external: boolean; // defined outside this repo — no source to open
 }
@@ -169,16 +170,54 @@ function buildElements(data: CodemapResponse, expanded: Set<string>): ElementDef
   return els;
 }
 
+// The subsystem "spine": the few highest-importance files that actually take part
+// in a cross-file edge. We auto-expand these on load so the default view shows real
+// symbol-level calls through the core, while the long tail of singletons stays as
+// pills — a level-of-detail middle ground between Files and Symbols.
+function spineFiles(data: CodemapResponse, maxFiles = 4, maxSymbols = 16): Set<string> {
+  const fileOf = new Map<string, string>();
+  const score = new Map<string, number>();
+  const size = new Map<string, number>();
+  for (const n of data.nodes) {
+    const f = fileKey(n);
+    if (f === "· external") continue;
+    fileOf.set(n.id, f);
+    score.set(f, Math.max(score.get(f) ?? 0, n.is_root ? 1 : n.importance ?? 0));
+    size.set(f, (size.get(f) ?? 0) + 1);
+  }
+  // Only files with a cross-file edge — expanding an isolated singleton reveals nothing.
+  const connected = new Set<string>();
+  for (const e of data.edges) {
+    const sf = fileOf.get(e.source);
+    const tf = fileOf.get(e.target);
+    if (sf && tf && sf !== tf) {
+      connected.add(sf);
+      connected.add(tf);
+    }
+  }
+  const ranked = [...connected].sort((a, b) => (score.get(b) ?? 0) - (score.get(a) ?? 0));
+  const out = new Set<string>();
+  let symbols = 0;
+  for (const f of ranked) {
+    if (out.size >= maxFiles || symbols >= maxSymbols) break;
+    out.add(f);
+    symbols += size.get(f) ?? 0;
+  }
+  return out;
+}
+
 // Lay out the current elements with fcose (compound-aware spring embedder), then
 // fit. packComponents keeps disconnected pieces from sprawling across the canvas.
-function runLayout(cy: Core): void {
+// `stable` warm-starts from current positions and skips the refit so expand/
+// collapse stays anchored.
+function runLayout(cy: Core, opts: { stable?: boolean } = {}): void {
   if (cy.nodes().length === 0) return;
   cy.layout({
     name: "fcose",
     quality: "proof",
-    randomize: true,
+    randomize: !opts.stable,
     animate: false,
-    fit: true,
+    fit: !opts.stable,
     padding: 28,
     packComponents: true,
     nodeSeparation: 78,
@@ -189,7 +228,7 @@ function runLayout(cy: Core): void {
     gravityCompound: 1.2,
     tile: true,
   } as any).run();
-  if (cy.zoom() > 1.2) {
+  if (!opts.stable && cy.zoom() > 1.2) {
     cy.zoom(1.2);
     cy.center();
   }
@@ -250,9 +289,11 @@ export default function CodeGraph({
 
     const dark = document.documentElement.dataset.theme === "dark";
 
-    // "files" opens as the collapsed overview; "symbols" expands every file.
+    // "files" opens as the hybrid spine (key files expanded, tail as pills);
+    // "symbols" expands every file.
     const initExpanded = new Set<string>();
     if (mode === "symbols") for (const n of data.nodes) initExpanded.add(fileKey(n));
+    else for (const f of spineFiles(data)) initExpanded.add(f);
     expandedRef.current = initExpanded;
 
     const nodeText = dark ? "#e6e6e6" : "#1f2937";
@@ -442,15 +483,47 @@ export default function CodeGraph({
     // it out. Cheap (<=120 nodes) and keeps meta-edge aggregation correct.
     const toggleFile = (file: string) => {
       const s = expandedRef.current;
-      if (s.has(file)) s.delete(file);
-      else s.add(file);
+      const willExpand = !s.has(file);
+
+      // Anchor on the clicked node (pill when expanding, box when collapsing).
+      const anchor = cy.getElementById(willExpand ? META + file : BOX + file);
+      const anchorScreen = anchor.nonempty() ? { ...anchor.renderedPosition() } : null;
+      const anchorModel = anchor.nonempty() ? { ...anchor.position() } : null;
+
+      if (willExpand) s.add(file);
+      else s.delete(file);
       focusedRef.current = null;
       setHover(null);
+
+      // Keep surviving nodes where they are; seed the new box + symbols at the
+      // clicked file so they grow out from there instead of the origin.
+      const prev = new Map<string, { x: number; y: number }>();
+      cy.nodes().forEach((n) => {
+        prev.set(n.id(), { ...n.position() });
+      });
       cy.batch(() => {
         cy.elements().remove();
         cy.add(buildElements(data, s));
+        cy.nodes().forEach((n) => {
+          const p = prev.get(n.id());
+          if (p) n.position(p);
+          else if (anchorModel)
+            n.position({
+              x: anchorModel.x + (Math.random() - 0.5) * 40,
+              y: anchorModel.y + (Math.random() - 0.5) * 40,
+            });
+        });
       });
-      runLayout(cy);
+      runLayout(cy, { stable: true });
+
+      // Pin the clicked file back where it was clicked so it expands in place.
+      if (anchorScreen) {
+        const after = cy.getElementById(willExpand ? BOX + file : META + file);
+        if (after.nonempty()) {
+          const now = after.renderedPosition();
+          cy.panBy({ x: anchorScreen.x - now.x, y: anchorScreen.y - now.y });
+        }
+      }
     };
 
     // Hover: a transient preview of the node + its neighbours. Suppressed while a
@@ -493,6 +566,7 @@ export default function CodeGraph({
         short: d.short,
         file: d.file ?? null,
         line: d.line ?? null,
+        endLine: d.endLine ?? null,
         kind: d.kind,
         external: d.external === 1,
       });
@@ -583,24 +657,24 @@ export default function CodeGraph({
             type="button"
             className={mode === "files" ? "on" : ""}
             onClick={() => setMode("files")}
-            title="Files: one box per file, click to expand its symbols"
+            title="Overview: key files expanded to symbols, the rest as pills you can expand"
           >
-            Files
+            Overview
           </button>
           <button
             type="button"
             className={mode === "symbols" ? "on" : ""}
             onClick={() => setMode("symbols")}
-            title="Symbols: every symbol shown at once"
+            title="All symbols: every file expanded at once"
           >
-            Symbols
+            All symbols
           </button>
         </div>
         <span
           className="codegraph-depnote"
           title="Solid edges are exact SCIP/LSP references; dashed edges are file-level aggregates you expand to reach."
         >
-          {mode === "files" ? "▸ click a file to expand" : "click a file box to collapse"}
+          click a file to expand · its box to collapse
         </span>
         <button type="button" className="codegraph-fit" onClick={() => cyRef.current?.fit(undefined, 24)}>
           Fit

--- a/web/components/GraphView.tsx
+++ b/web/components/GraphView.tsx
@@ -39,6 +39,7 @@ function SourcePeek({
   onFocus?: (label: string) => void;
 }) {
   const isNode = source.kind === "node";
+  const nodeEnd = source.kind === "node" ? source.node.endLine : null;
   const sites: CallSite[] = isNode
     ? [{ file: source.node.file || "", line: source.node.line }]
     : source.anchors;
@@ -57,10 +58,13 @@ function SourcePeek({
     if (isExternal) return; // external dep — no in-repo source to fetch
     let cancelled = false;
     setState("loading");
-    // Nodes show their definition from its first line; call sites get context above.
+    // A node renders its exact definition span [line, endLine]; a call site (a
+    // point, not a span) gets ±6 lines of context. Long spans scroll inside the
+    // pane (CSS max-height), so there's no arbitrary line cap. Fall back to a
+    // small window only when a node has no recorded end line.
     const before = isNode ? 0 : 6;
-    const after = isNode ? 16 : 6;
-    fetchSource(repoId, rel, Math.max(1, line - before), line + after)
+    const end = isNode ? (nodeEnd && nodeEnd >= line ? nodeEnd : line + 12) : line + 6;
+    fetchSource(repoId, rel, Math.max(1, line - before), end)
       .then((s) => {
         if (cancelled) return;
         setCode(s.content || "");
@@ -71,7 +75,7 @@ function SourcePeek({
     return () => {
       cancelled = true;
     };
-  }, [repoId, rel, line, isNode, isExternal]);
+  }, [repoId, rel, line, isNode, nodeEnd, isExternal]);
 
   return (
     <div className="callsite-peek">

--- a/web/components/GraphView.tsx
+++ b/web/components/GraphView.tsx
@@ -58,12 +58,14 @@ function SourcePeek({
     if (isExternal) return; // external dep — no in-repo source to fetch
     let cancelled = false;
     setState("loading");
-    // A node renders its exact definition span [line, endLine]; a call site (a
-    // point, not a span) gets ±6 lines of context. Long spans scroll inside the
-    // pane (CSS max-height), so there's no arbitrary line cap. Fall back to a
-    // small window only when a node has no recorded end line.
-    const before = isNode ? 0 : 6;
-    const end = isNode ? (nodeEnd && nodeEnd >= line ? nodeEnd : line + 12) : line + 6;
+    // A node shows its definition span [line, endLine] plus a few lines of
+    // context on each side, so even a one-line field isn't shown bare (its
+    // own lines are highlighted). A call site (a point, not a span) gets ±6
+    // lines of context. Long spans scroll in the pane (CSS max-height).
+    const PAD = 3;
+    const symEnd = nodeEnd && nodeEnd >= line ? nodeEnd : line;
+    const before = isNode ? PAD : 6;
+    const end = isNode ? symEnd + PAD : line + 6;
     fetchSource(repoId, rel, Math.max(1, line - before), end)
       .then((s) => {
         if (cancelled) return;
@@ -130,7 +132,13 @@ function SourcePeek({
       ) : state === "err" ? (
         <p className="muted callsite-msg">Source not available.</p>
       ) : (
-        <HighlightedCode code={code} file={rel} startLine={start} highlightLine={line} />
+        <HighlightedCode
+          code={code}
+          file={rel}
+          startLine={start}
+          highlightLine={line}
+          highlightEnd={isNode ? nodeEnd ?? line : undefined}
+        />
       )}
     </div>
   );

--- a/web/components/HighlightedCode.tsx
+++ b/web/components/HighlightedCode.tsx
@@ -34,12 +34,15 @@ export default function HighlightedCode({
   file,
   startLine = 1,
   highlightLine,
+  highlightEnd,
 }: {
   code: string;
   file?: string | null;
   startLine?: number;
-  /** 1-based absolute line to spotlight (e.g. an exact call site). */
+  /** 1-based absolute line to spotlight (e.g. an exact call site, or a span start). */
   highlightLine?: number | null;
+  /** 1-based end of the spotlight; defaults to highlightLine (a single line). */
+  highlightEnd?: number | null;
 }) {
   const ext = (file || "").split(".").pop()?.toLowerCase() || "";
   const lang = EXT_LANG[ext];
@@ -52,24 +55,29 @@ export default function HighlightedCode({
     html = code.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]!);
   }
   const lineCount = code ? code.split("\n").length : 0;
-  const hlIdx =
-    highlightLine != null && highlightLine >= startLine && highlightLine < startLine + lineCount
-      ? highlightLine - startLine
-      : -1;
+  // Spotlight band over [highlightLine, highlightEnd], clamped to what's shown.
+  const hlA = highlightLine ?? null;
+  const hlB = highlightEnd ?? highlightLine ?? null;
+  const bandFrom = hlA != null ? Math.max(0, hlA - startLine) : -1;
+  const bandTo = hlB != null ? Math.min(lineCount - 1, hlB - startLine) : -1;
+  const hasBand = hlA != null && bandTo >= 0 && bandFrom <= bandTo;
   const LINE_H = 19.375; // 12.5px × 1.55 — matches the gutter & code line-height
 
   return (
     <div className="hl-code">
-      {hlIdx >= 0 && (
+      {hasBand && (
         <div
           className="hl-band"
-          style={{ top: `${10 + hlIdx * LINE_H}px`, height: `${LINE_H}px` }}
+          style={{
+            top: `${10 + bandFrom * LINE_H}px`,
+            height: `${(bandTo - bandFrom + 1) * LINE_H}px`,
+          }}
           aria-hidden
         />
       )}
       <div className="hl-gutter" aria-hidden>
         {Array.from({ length: lineCount }, (_, i) => (
-          <div key={i} className={i === hlIdx ? "hl-gutter-on" : undefined}>
+          <div key={i} className={hasBand && i >= bandFrom && i <= bandTo ? "hl-gutter-on" : undefined}>
             {startLine + i}
           </div>
         ))}


### PR DESCRIPTION
## Summary
Three UX fixes to the wiki code graph: file expand/collapse no longer jumps the
whole layout, the default view shows the important files instead of a flat pill
scatter, and node source peeks show the symbol's exact definition span.

## Changes
- Expand/collapse now warm-starts the layout and pins the clicked file in place,
  instead of re-randomizing every node and refitting the camera.
- Default ("Overview") auto-expands the high-importance "spine" files to their
  symbols and keeps the long tail as pills; the toggle is relabeled
  Overview / All symbols and the hint reworded to fit either state.
- Node peeks render the symbol's real range (`line..end_line`) and scroll if
  long, replacing a fixed 16-line window that bled into the next symbol.
  
preview:
<img width="2980" height="1678" alt="image" src="https://github.com/user-attachments/assets/f61ff250-50fa-4056-86aa-fb26a8799cdc" />
<img width="2950" height="1640" alt="image" src="https://github.com/user-attachments/assets/b62706c0-1314-4b05-820b-65713c81f3cf" />

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

`tsc` passes. Verified live against the indexed vLLM snapshot that every
non-external node carries `line`/`end_line`, so peeks are span-accurate
(field → 1 line, property → 3 lines, class → full body), and that expanding a
file keeps it anchored.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
