### PR TITLE
feat(synthesis): v2 multi-repo benchmark — 25 repos, 500 queries, 99% valid

### DIFF
--- a/codeminer/code_chunking/base.py
+++ b/codeminer/code_chunking/base.py
@@ -11,10 +11,11 @@ Base code chunker class with common functionality.
 import json
 import os
 import sys
+import threading
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import ClassVar, List, Optional, Tuple
 
 from tree_sitter import Parser
 from tree_sitter_language_pack import get_language
@@ -32,6 +33,9 @@ CodeChunk = namedtuple(
 
 class BaseCodeChunker(ABC):
     """Base class for language-specific code chunkers."""
+
+    _language_cache: ClassVar[dict[str, object]] = {}
+    _language_cache_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(
         self,
@@ -81,7 +85,7 @@ class BaseCodeChunker(ABC):
         self.skeleton_mode = skeleton_mode
         self.include_l2_in_file_skeleton = include_l2_in_file_skeleton
         try:
-            self.tree_sitter_language = get_language(language)
+            self.tree_sitter_language = self._get_tree_sitter_language(language)
             self.parser = self._create_parser(self.tree_sitter_language)
             logger.info(
                 "Successfully loaded %s language parser from tree-sitter-language-pack",
@@ -90,6 +94,14 @@ class BaseCodeChunker(ABC):
         except Exception as e:
             logger.error("Error loading %s parser: %s", language, e)
             sys.exit(1)
+
+    @classmethod
+    def _get_tree_sitter_language(cls, language: str):
+        """Load each tree-sitter language once per process."""
+        with cls._language_cache_lock:
+            if language not in cls._language_cache:
+                cls._language_cache[language] = get_language(language)
+            return cls._language_cache[language]
 
     @staticmethod
     def _create_parser(language):

--- a/codeminer/dataset/synthesize/context_loader.py
+++ b/codeminer/dataset/synthesize/context_loader.py
@@ -26,7 +26,7 @@ from codeminer.types import (
     NODE_TYPE_METHOD,
     is_symbol_node,
 )
-from codeminer.utils import is_test_file
+from codeminer.utils import is_non_source_file, is_test_file
 
 from ._types import (
     BehavioralContext,
@@ -317,6 +317,11 @@ class ContextLoader:
 
             file_path = attrs.get("file")
             if not file_path or is_test_file(file_path):
+                continue
+            # Build artifacts / type-def stubs (dist/, .d.ts) are generated
+            # copies — never anchor a behavioral query (and its mixed children)
+            # on them, or the GT points at the wrong file.
+            if is_non_source_file(file_path):
                 continue
 
             start_line = attrs.get("start_line")

--- a/codeminer/dataset/synthesize/query_curator.py
+++ b/codeminer/dataset/synthesize/query_curator.py
@@ -393,10 +393,13 @@ class QueryCurator:
             QueryType.REASONING,
         ):
             gt_info = []
-            if ground_truth.get("target_files"):
-                gt_info.append(
-                    f"Target files: {', '.join(ground_truth['target_files'])}"
-                )
+            src_files = [
+                f
+                for f in (ground_truth.get("target_files") or [])
+                if self._is_source_path(str(f))
+            ]
+            if src_files:
+                gt_info.append(f"Target files: {', '.join(src_files)}")
             if ground_truth.get("symbols_modified"):
                 gt_info.append(
                     f"Modified symbols: {', '.join(ground_truth['symbols_modified'][:5])}"
@@ -426,7 +429,29 @@ class QueryCurator:
                     "Repository exploration targets:\n" + "\n".join(discovered_info)
                 )
 
+        # Ground the curator to the REAL anchor code. Without this the model only
+        # sees the repo summary + a one-line constraint and free-associates a
+        # plausible-but-wrong topic (module_hint drifted off-target 100% of the
+        # time). Showing the actual target code forces the query to be about it.
+        anchor_code = (ground_truth or {}).get("anchor_content")
+        if anchor_code:
+            snippet = str(anchor_code)[: self.max_block_chars_in_prompt]
+            context_parts.append(
+                "Target code — the query MUST be about the behavior in THIS exact "
+                "code (it is the ground-truth answer a searcher has to land on). Do "
+                "NOT write a query about some other part of the repo:\n"
+                f"```\n{snippet}\n```"
+            )
+
         context_parts.append(f"Constraints:\n{constraint_clause}")
+        context_parts.append(
+            "Phrasing: write `question` as ONE concise, realistic search query — "
+            "what a developer would actually type to find this code (a single "
+            "sentence, aim for under 30 words). Do NOT narrate your reasoning (no "
+            "'Now I…', 'Let me…', 'Looking at…'), and do NOT pack in step-by-step "
+            "analysis, speculative implementation details, or a multi-sentence "
+            "problem report — the judge rejects verbose, narrated queries."
+        )
         context_parts.append(
             "Output JSON with keys: question (string), focus (string or null), "
             "hints (array of strings or null). Return only JSON."
@@ -453,11 +478,19 @@ class QueryCurator:
 
         if self.query_type == QueryType.BEHAVIORAL:
             question = self._sanitize_question(question)
+        elif question:
+            # Agent-thinking the model prepends to the query ("Now let me look at
+            # X. <query>") leaks through the JSON path too, not just prose
+            # fallback — strip it here so it is caught regardless of source.
+            question = self._strip_leading_narration(question)
 
         if not question:
             question = self._fallback_question(discovered_targets)
-        if not question.endswith("?"):
-            question = question.rstrip(".") + "?"
+        # Normalize trailing punctuation to exactly one '?' so salvaged prose
+        # ending in ':' never becomes the malformed ':?' the judge flags.
+        question = question.rstrip().rstrip("?").rstrip(" .:;,-—")
+        if question:
+            question = question + "?"
 
         return {"question": question, "focus": focus, "hints": hints}
 
@@ -485,9 +518,23 @@ class QueryCurator:
             )
 
         elif level == QueryType.MODULE_HINT:
+            modules = self._modules_from_ground_truth(ground_truth)
+            if modules:
+                # Bind to the ACTUAL target module (like file_hint/symbol_hint do)
+                # — the old generic prompt gave the curator no anchor, so it drifted
+                # off-target (query about X, target an unrelated module) and leaked
+                # file paths. That collapsed module_hint to ~9% judge-valid.
+                return (
+                    "Name ONLY the module/package, in dotted form, drawn from: "
+                    f"{', '.join(modules)}. Describe the behavior implemented THERE so "
+                    "the query is bound to that module. You MUST NOT mention any file "
+                    "path (no '/', no '.py'/'.go'/'.ts'/'.rs'/'.c'/'.h' suffix) and MUST "
+                    "NOT mention any function, class, or method name."
+                )
             return (
-                "You MAY mention module or package names (e.g., 'the caching module') "
-                "but AVOID specific file paths or function/class names."
+                "Name the relevant module/package in dotted form (e.g. 'the "
+                "pkg.subpkg module'). You MUST NOT mention file paths (no '/', no file "
+                "extension) or any function/class/method name."
             )
 
         elif level == QueryType.FILE_HINT:
@@ -535,6 +582,59 @@ class QueryCurator:
     # Private: text helpers
     # ------------------------------------------------------------------
 
+    # Non-source targets that poison MODULE_HINT/anchor binding: in-tree build
+    # output, bundles, type-definition stubs, sourcemaps, lockfiles. Binding a
+    # query to ``dist.esm.axios`` or ``index.d`` produces a target the judge
+    # correctly rejects as "not the source implementation".
+    _NON_SOURCE_DIR_RE = re.compile(
+        r"(^|/)(dist|build|out|node_modules|vendor|third_party|\.git|__pycache__)/",
+        re.I,
+    )
+    _NON_SOURCE_FILE_RE = re.compile(
+        r"(\.min\.js|\.d\.[cm]?ts|\.map|\.lock|\.snap)$", re.I
+    )
+
+    @classmethod
+    def _is_source_path(cls, path: str) -> bool:
+        return not (
+            cls._NON_SOURCE_DIR_RE.search(path) or cls._NON_SOURCE_FILE_RE.search(path)
+        )
+
+    @classmethod
+    def _modules_from_ground_truth(
+        cls, ground_truth: Optional[Dict[str, Any]]
+    ) -> List[str]:
+        """Dotted module paths derived from the target files (for MODULE_HINT).
+
+        ``astropy/units/core.py`` -> ``astropy.units.core``. Gives the curator the
+        real module to name (and to bind the described behavior to), instead of an
+        unanchored "the X module". Skips non-source targets (bundles, type-def
+        stubs) so we never bind to ``dist.esm.axios`` / ``index.d``.
+        """
+        files = (ground_truth or {}).get("target_files") or []
+        mods: List[str] = []
+        for f in files:
+            f = str(f)
+            if not cls._is_source_path(f):
+                continue
+            base = re.sub(r"\.[A-Za-z0-9]+$", "", f)  # drop extension
+            dotted = base.replace("/", ".").strip(".")
+            if dotted:
+                mods.append(dotted)
+        return list(dict.fromkeys(mods))[:3]
+
+    @classmethod
+    def _strip_leading_narration(cls, q: str) -> str:
+        """Drop leading agent-thinking sentences the model prepends to a query
+        ("Now let me look at X. <real query>"). Returns "" when the whole string
+        is narration so the caller falls back to a clean question."""
+        if not q:
+            return q
+        parts = re.split(r"(?<=[.:])\s+", q.strip())
+        while parts and cls._NARRATION_RE.match(parts[0].strip()):
+            parts.pop(0)
+        return " ".join(parts).strip()
+
     @staticmethod
     def _extract_avoid_terms(text: str) -> List[str]:
         if not text:
@@ -558,6 +658,16 @@ class QueryCurator:
         text = re.sub(r"\s{2,}", " ", text).strip()
         return text
 
+    # Agent chain-of-thought preambles that leak into the query field when the
+    # model returns prose instead of JSON ("Now I understand the code...",
+    # "Let me look at..."). Skip these lines so we fall back to a clean question
+    # rather than salvaging reasoning narration as the query.
+    _NARRATION_RE = re.compile(
+        r"^(now\b|let me\b|let's\b|i'?ll\b|i now\b|i understand\b|i can see\b|"
+        r"i need to\b|i'?ve\b|looking at\b|first,|okay\b|ok\b|so,|here'?s what)",
+        re.I,
+    )
+
     @staticmethod
     def _coerce_question_text(text: str) -> str:
         if not text:
@@ -570,6 +680,8 @@ class QueryCurator:
             if not candidate:
                 continue
             candidate = re.sub(r"^(question|query)\s*:\s*", "", candidate, flags=re.I)
+            if QueryCurator._NARRATION_RE.match(candidate):
+                continue
             if len(candidate) >= 12:
                 if "?" in candidate:
                     return candidate.split("?", 1)[0].strip() + "?"

--- a/codeminer/utils.py
+++ b/codeminer/utils.py
@@ -36,6 +36,41 @@ def is_test_file(nid):
     return False
 
 
+_NON_SOURCE_DIR_PARTS = {"dist", "build", "out", "node_modules", "vendor"}
+_NON_SOURCE_SUFFIXES = (
+    ".min.js",
+    ".d.ts",
+    ".d.cts",
+    ".d.mts",
+    ".map",
+    ".snap",
+)
+
+
+def is_non_source_file(nid):
+    """Check whether a node ID / path is a build artifact or type-def stub.
+
+    Bundles (``dist/``), minified output, sourcemaps, and TypeScript declaration
+    stubs (``.d.ts`` / ``.d.cts``) are generated copies of the real source — they
+    make poor localization ground truth, so synthesis should not anchor queries
+    on them. Mirrors the assembly-time guard in
+    ``rebuild_codeminer_synthesis_dataset.py``.
+    """
+    if ":" in nid:
+        file_path = nid.split(":")[0]
+    else:
+        file_path = nid
+
+    normalized = file_path.replace("\\", "/").lower()
+    path_parts = [part for part in normalized.split("/") if part]
+    if not path_parts:
+        return False
+
+    if any(part in _NON_SOURCE_DIR_PARTS for part in path_parts[:-1]):
+        return True
+    return path_parts[-1].endswith(_NON_SOURCE_SUFFIXES)
+
+
 def wrap_code_snippet(code_snippet, start_line, end_line):
     """Wrap code snippet with line numbers"""
     lines = code_snippet.split("\n")

--- a/scripts/_post_fix.py
+++ b/scripts/_post_fix.py
@@ -11,10 +11,24 @@ import json
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from codeminer.dataset.synthesize._agent import AgentRunner
 from codeminer.log_utils import get_logger
 
 logger = get_logger(__name__)
+
+
+def _make_agent(*, model: str, system_prompt: str):
+    # ``claude_agent_sdk`` is an optional synthesis-time dependency. Import the
+    # runner only when the post-fix loop actually needs an LLM call so tests can
+    # import the pure helpers in this module without that SDK installed.
+    from codeminer.dataset.synthesize._agent import AgentRunner
+
+    return AgentRunner(
+        model=model,
+        max_turns=1,
+        allowed_tools=[],
+        permission_mode="bypassPermissions",
+        system_prompt=system_prompt,
+    )
 
 
 JUDGE_SYSTEM_PROMPT = (
@@ -231,13 +245,7 @@ async def _fix_one(
     original_query = row.get("query") or ""
     judge_reason = row.get("judge_reason") or ""
 
-    agent = AgentRunner(
-        model=model,
-        max_turns=1,
-        allowed_tools=[],
-        permission_mode="bypassPermissions",
-        system_prompt=FIX_SYSTEM_PROMPT,
-    )
+    agent = _make_agent(model=model, system_prompt=FIX_SYSTEM_PROMPT)
     snippet = (
         anchor_content if len(anchor_content) <= 1800 else anchor_content[:1800] + "..."
     )
@@ -270,13 +278,7 @@ async def _regenerate_one(
     category = row.get("category") or "behavioral"
     length_variant = row.get("length_variant") or "detailed"
 
-    agent = AgentRunner(
-        model=model,
-        max_turns=1,
-        allowed_tools=[],
-        permission_mode="bypassPermissions",
-        system_prompt=REGENERATE_SYSTEM_PROMPT,
-    )
+    agent = _make_agent(model=model, system_prompt=REGENERATE_SYSTEM_PROMPT)
     snippet = (
         anchor_content if len(anchor_content) <= 1800 else anchor_content[:1800] + "..."
     )
@@ -312,13 +314,7 @@ async def _judge_one(
             "target_code_excerpt": (anchor_content or "")[:2000],
         }
     ]
-    agent = AgentRunner(
-        model=model,
-        max_turns=1,
-        allowed_tools=[],
-        permission_mode="bypassPermissions",
-        system_prompt=JUDGE_SYSTEM_PROMPT,
-    )
+    agent = _make_agent(model=model, system_prompt=JUDGE_SYSTEM_PROMPT)
     prompt = (
         "Evaluate the following synthesized query. Reply with a JSON array of "
         "one object: "

--- a/scripts/_post_fix.py
+++ b/scripts/_post_fix.py
@@ -138,6 +138,7 @@ def _symbol_basename(symbol_id: str) -> str:
 
 def _build_anchor_content_lookups(
     rows: List[Dict[str, Any]],
+    anchors: Optional[List[Dict[str, Any]]] = None,
 ) -> Tuple[Dict[str, str], Dict[Tuple[str, str], str]]:
     # Behavioral rows have content in ``gt_symbol_nodes[*].content``;
     # non-behavioral rows often have ``content=null``. The file+basename
@@ -154,6 +155,22 @@ def _build_anchor_content_lookups(
             file = n.get("file") or gt_file
             if not (sym and content):
                 continue
+            by_node_name.setdefault(sym, content)
+            base = _symbol_basename(sym)
+            if file and base:
+                by_file_basename.setdefault((file, base), content)
+    # Mixed rows (module/file/symbol/reasoning) store target_symbol_nodes with
+    # content=null, so the loop above recovers nothing for them — every flagged
+    # mixed row then hits "no anchor content" and is skipped instead of
+    # regenerated. The anchors (behavioral output) DO carry the real code, so
+    # index them too: this is what unblocks regeneration for the mixed types.
+    for a in anchors or []:
+        content = a.get("anchor_content")
+        if not content:
+            continue
+        sym = a.get("anchor_symbol") or ""
+        file = a.get("anchor_file") or (a.get("target_files") or [""])[0]
+        if sym:
             by_node_name.setdefault(sym, content)
             base = _symbol_basename(sym)
             if file and base:
@@ -334,14 +351,20 @@ async def post_fix_flagged(
     model: str,
     judge_model: str,
     max_retries: int = 3,
+    anchors: Optional[List[Dict[str, Any]]] = None,
 ) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
     """Triage flagged rows, then loop fix/regenerate up to ``max_retries`` times.
+
+    ``anchors`` (the behavioral-output anchor dicts, each with ``anchor_content``)
+    let the mixed callers recover code that their own rows store as
+    ``content=null`` — without it every flagged mixed row is skipped instead of
+    regenerated.
 
     Returns the mutated rows plus a stats dict
     (``flagged`` / ``promoted_at_triage`` / ``fixed_via_fix`` /
     ``fixed_via_regenerate`` / ``still_flagged``).
     """
-    by_node_name, by_file_basename = _build_anchor_content_lookups(rows)
+    by_node_name, by_file_basename = _build_anchor_content_lookups(rows, anchors)
 
     def is_flagged(r: Dict[str, Any]) -> bool:
         # 'unknown' is included because a truncated judge-batch JSON leaves

--- a/scripts/build_synthesis_v2_plan.py
+++ b/scripts/build_synthesis_v2_plan.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the codeminer-synthesis v2 (multi-repo) generation plan.
+
+v1 used ONE repo per language (5 repos total) → "Go graph wins" could be "this
+one Go repo's graph is clean", not a language property. v2 spans ALL 5 repos per
+language available in codeminer-base (25 repos, prebuilt indexes already on
+disk), keeping per-repo DEPTH (a query floor) while adding multi-repo BREADTH.
+
+This planner is deterministic + read-only (reads the base dataset + each
+instance's prebuilt graph). It:
+  1. groups codeminer-base by (language, repo),
+  2. picks ONE instance per repo — the one whose prebuilt graph has the most
+     symbol nodes (richest graph → most reliable GT spans + graph expansion),
+  3. attaches a fixed per-category query budget (the v1 60-split scaled to ~20),
+and emits a plan JSON consumed by the generation driver
+(generate_codeminer_synthesis_config.py per instance, then
+rebuild_codeminer_synthesis_dataset.py to assemble).
+
+Importance sampling note: at Tier-1 every language has exactly 5 base repos and
+we take all of them, so repo SELECTION is moot and per-repo counts are EQUAL
+(unbiased per-repo comparison). Importance weighting re-enters at Tier-2 (when a
+larger pool, e.g. SWE-bench Multilingual's 41 repos, must be down-selected).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pickle
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# base language_group -> synthesis HF config name
+_LANG_TO_CONFIG = {
+    "Python": "Python",
+    "Go": "Go",
+    "Rust": "Rust",
+    "C++/C": "C++_C",
+    "TypeScript/JavaScript": "TypeScript_JavaScript",
+}
+
+# v1 per-instance split (=60) scaled by 1/3 to ~20/repo; keeps all 6 categories.
+_COUNTS = {
+    "behavioral": 7,
+    "file_hint": 3,
+    "module_hint": 3,
+    "traversal": 3,
+    "reasoning": 2,
+    "symbol_hint": 2,
+}
+
+
+def _graph_symbol_count(prebuilt_dir: str, instance_id: str) -> int:
+    """#symbol-bearing vertices in the prebuilt graph (0 if missing)."""
+    path = os.path.join(prebuilt_dir, instance_id, "graph.pkl")
+    if not os.path.exists(path):
+        return 0
+    try:
+        with open(path, "rb") as f:
+            g = pickle.load(f)
+        G = g.get("graph")
+        return G.vcount() if G is not None else 0
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def build_plan(prebuilt_dir: str, repos_per_lang: int) -> List[Dict[str, Any]]:
+    from scripts.agent_compile.lib.config import SweepConfig
+    from scripts.agent_compile.lib.harness import load_dataset_rows
+
+    cfg = SweepConfig.from_yaml(
+        str(_PROJECT_ROOT / "scripts/agent_compile/configs/design_space.yaml")
+    )
+    rows, _ = load_dataset_rows(cfg)
+
+    # (lang, repo) -> [(instance_id, graph_symbol_count)]
+    by_repo: Dict[tuple, List] = defaultdict(list)
+    for iid, r in rows.items():
+        lang = r.get("language_group")
+        repo = r.get("repo")
+        if lang not in _LANG_TO_CONFIG or not repo:
+            continue
+        by_repo[(lang, repo)].append((iid, _graph_symbol_count(prebuilt_dir, iid)))
+
+    # group repos per language, pick richest instance per repo
+    by_lang: Dict[str, List] = defaultdict(list)
+    for (lang, repo), insts in by_repo.items():
+        best_iid, best_n = max(insts, key=lambda t: t[1])
+        by_lang[lang].append((repo, best_iid, best_n))
+
+    plan: List[Dict[str, Any]] = []
+    for lang in sorted(by_lang):
+        # richest repos first; take up to repos_per_lang
+        repos = sorted(by_lang[lang], key=lambda t: t[2], reverse=True)[:repos_per_lang]
+        for repo, iid, n in repos:
+            plan.append(
+                {
+                    "config": _LANG_TO_CONFIG[lang],
+                    "language_group": lang,
+                    "repo": repo,
+                    "instance_id": iid,
+                    "graph_symbols": n,
+                    "counts": dict(_COUNTS),
+                    "total_queries": sum(_COUNTS.values()),
+                }
+            )
+    return plan
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--prebuilt-dir", default="/mnt/data/codeminer")
+    p.add_argument("--repos-per-lang", type=int, default=5)
+    p.add_argument("--out", type=Path, default=Path("synthesis_v2_plan.json"))
+    args = p.parse_args(argv)
+
+    plan = build_plan(args.prebuilt_dir, args.repos_per_lang)
+    args.out.write_text(json.dumps(plan, indent=2), encoding="utf-8")
+
+    total_q = sum(e["total_queries"] for e in plan)
+    print(f"plan: {len(plan)} repos, {total_q} queries -> {args.out}")
+    print(f"{'config':22}{'repo':28}{'instance_id':28}{'graph':>7}{'q':>4}")
+    for e in plan:
+        print(
+            f"{e['config']:22}{e['repo']:28}{e['instance_id']:28}"
+            f"{e['graph_symbols']:>7}{e['total_queries']:>4}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_codeminer_synthesis_config.py
+++ b/scripts/generate_codeminer_synthesis_config.py
@@ -114,8 +114,6 @@ def _common_multiplier_args(args: argparse.Namespace) -> List[str]:
         str(args.behavioral_consensus_runs),
         "--post-fix-max-retries",
         str(args.post_fix_max_retries),
-        "--judge-retries",
-        str(args.traversal_judge_retries),
     ]
     if args.cache_dir:
         cmd.extend(["--cache-dir", args.cache_dir])

--- a/scripts/generate_codeminer_synthesis_config.py
+++ b/scripts/generate_codeminer_synthesis_config.py
@@ -136,6 +136,10 @@ def _common_traversal_args(args: argparse.Namespace) -> List[str]:
         str(args.traversal_judge_retries),
         "--post-fix-max-retries",
         str(args.post_fix_max_retries),
+        # Tolerate a short traversal yield (repos whose graph can't build a 2-hop
+        # bridge chain) instead of RuntimeError-ing the WHOLE instance — that
+        # lost behavioral+hint for scikit-learn / coreutils / axios in v2.
+        "--allow-partial",
     ]
     if args.cache_dir:
         cmd.extend(["--cache-dir", args.cache_dir])

--- a/scripts/generate_synthesis_v2.py
+++ b/scripts/generate_synthesis_v2.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -80,6 +81,17 @@ def main(argv: Optional[List[str]] = None) -> int:
     p.add_argument("--cache-dir", default="")
     p.add_argument("--repo-cache-dir", default="")
     p.add_argument("--dry-run", action="store_true", help="print commands, run nothing")
+    p.add_argument(
+        "--regen-mixed",
+        action="store_true",
+        help=(
+            "Re-generate ONLY the mixed categories (file/module/symbol/reasoning) "
+            "in place: delete each repo's mixed_x30 + combined files and re-run "
+            "with --skip-existing so the already-good behavioral_x20 and "
+            "traversal_x10 are reused. Use after a curator/post-fix quality fix to "
+            "refresh the weak categories without paying for behavioral again."
+        ),
+    )
     args = p.parse_args(argv)
 
     plan = build_plan(args.prebuilt_dir, args.repos_per_lang)
@@ -94,7 +106,16 @@ def main(argv: Optional[List[str]] = None) -> int:
         iid = e["instance_id"]
         gen_dir = args.output_dir / config / iid
         seed_marker = gen_dir / "behavioral_x20" / f"synthesized_queries_{iid}.json"
-        if seed_marker.exists():
+        if args.regen_mixed:
+            # Drop the weak categories so they regenerate; keep behavioral +
+            # traversal (already good) for --skip-existing to reuse.
+            mixed_dir = gen_dir / "mixed_x30"
+            if mixed_dir.exists() and not args.dry_run:
+                shutil.rmtree(mixed_dir)
+            for stale in gen_dir.glob(f"{config}_combined*.json"):
+                if not args.dry_run:
+                    stale.unlink()
+        elif seed_marker.exists():
             print(f"skip {config}/{iid} (already generated)")
             continue
         cmd = [
@@ -113,6 +134,8 @@ def main(argv: Optional[List[str]] = None) -> int:
             "--judge-model",
             args.judge_model,
         ]
+        if args.regen_mixed:
+            cmd.append("--skip-existing")
         if args.cache_dir:
             cmd += ["--cache-dir", args.cache_dir]
         if args.repo_cache_dir:

--- a/scripts/generate_synthesis_v2.py
+++ b/scripts/generate_synthesis_v2.py
@@ -30,6 +30,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -40,6 +41,29 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 from scripts.build_synthesis_v2_plan import build_plan  # noqa: E402
+
+
+def _gen_env() -> dict:
+    """Env with the SCIP indexer dirs on PATH.
+
+    The graph build shells out to per-language SCIP indexers (scip-go,
+    scip-clang, scip-typescript, scip-python, rust-analyzer). ``scip-go`` lives
+    in ``~/go/bin``, which is NOT on the default conda PATH — without it the Go
+    graph build fails ("scip-go not found") and every span comes out (0,0).
+    Prepend the common toolchain dirs so all 5 languages resolve.
+    """
+    env = dict(os.environ)
+    extra = [
+        os.path.expanduser("~/go/bin"),
+        os.path.expanduser("~/.local/bin"),
+        os.path.expanduser("~/.cargo/bin"),
+        "/usr/local/bin",
+    ]
+    have = env.get("PATH", "").split(os.pathsep)
+    env["PATH"] = os.pathsep.join(
+        [d for d in extra if os.path.isdir(d) and d not in have] + have
+    )
+    return env
 
 
 def _counts_arg(counts: dict) -> str:
@@ -98,7 +122,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         if args.dry_run:
             continue
         try:
-            subprocess.run(cmd, cwd=str(_PROJECT_ROOT), check=True)
+            subprocess.run(cmd, cwd=str(_PROJECT_ROOT), check=True, env=_gen_env())
         except subprocess.CalledProcessError as exc:
             print(f"  FAIL {iid}: {exc}", file=sys.stderr)
             failures.append(iid)

--- a/scripts/generate_synthesis_v2.py
+++ b/scripts/generate_synthesis_v2.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drive codeminer-synthesis v2 (multi-repo) generation from the v2 plan.
+
+Consumes the plan from ``build_synthesis_v2_plan`` (25 repos, 5/language, one
+graph-richest instance each, 20 queries/repo) and, per instance, invokes
+``generate_codeminer_synthesis_config.py`` with that repo's per-category counts.
+Resumable (skips an instance whose per-config seed/output already exists). Then
+prints the ``rebuild_codeminer_synthesis_dataset.py`` assembly command.
+
+Generation is heavy (repo clone + LSIndexer graph build + Opus curator/judge per
+query via the Claude Agent SDK), so run it where that toolchain + auth live.
+``--dry-run`` prints the exact commands without spending anything — use it to
+review the plan before committing to the full run.
+
+Usage::
+
+    # review the commands (no cost):
+    python scripts/generate_synthesis_v2.py --output-dir gen/v2 --dry-run
+    # generate (heavy):
+    python scripts/generate_synthesis_v2.py --output-dir gen/v2 \
+        --cache-dir .cache/synth --repo-cache-dir .cache/repos
+    # then assemble (command is printed at the end)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from scripts.build_synthesis_v2_plan import build_plan  # noqa: E402
+
+
+def _counts_arg(counts: dict) -> str:
+    return ",".join(f"{k}={v}" for k, v in counts.items() if v)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--output-dir", required=True, type=Path, help="generation root")
+    p.add_argument("--prebuilt-dir", default="/mnt/data/codeminer")
+    p.add_argument("--repos-per-lang", type=int, default=5)
+    p.add_argument("--model-name", default="opus")
+    p.add_argument("--judge-model", default="opus")
+    p.add_argument("--cache-dir", default="")
+    p.add_argument("--repo-cache-dir", default="")
+    p.add_argument("--dry-run", action="store_true", help="print commands, run nothing")
+    args = p.parse_args(argv)
+
+    plan = build_plan(args.prebuilt_dir, args.repos_per_lang)
+    print(
+        f"v2 generation: {len(plan)} repos, "
+        f"{sum(e['total_queries'] for e in plan)} queries"
+    )
+
+    failures: List[str] = []
+    for e in plan:
+        config = e["config"]
+        iid = e["instance_id"]
+        gen_dir = args.output_dir / config / iid
+        seed_marker = gen_dir / "behavioral_x20" / f"synthesized_queries_{iid}.json"
+        if seed_marker.exists():
+            print(f"skip {config}/{iid} (already generated)")
+            continue
+        cmd = [
+            sys.executable,
+            "scripts/generate_codeminer_synthesis_config.py",
+            "--config",
+            config,
+            "--instance-id",
+            iid,
+            "--counts",
+            _counts_arg(e["counts"]),
+            "--output-dir",
+            str(gen_dir),
+            "--model-name",
+            args.model_name,
+            "--judge-model",
+            args.judge_model,
+        ]
+        if args.cache_dir:
+            cmd += ["--cache-dir", args.cache_dir]
+        if args.repo_cache_dir:
+            cmd += ["--repo-cache-dir", args.repo_cache_dir]
+        print(f"\n# {config}/{iid} ({e['repo']}, graph={e['graph_symbols']})")
+        print("  " + " ".join(cmd))
+        if args.dry_run:
+            continue
+        try:
+            subprocess.run(cmd, cwd=str(_PROJECT_ROOT), check=True)
+        except subprocess.CalledProcessError as exc:
+            print(f"  FAIL {iid}: {exc}", file=sys.stderr)
+            failures.append(iid)
+
+    # assembly command (per-config replacements -> parquet)
+    print("\n# assemble (after generation):")
+    reps = " ".join(
+        f"--replacement {c}={args.output_dir}/{c}"
+        for c in sorted({e["config"] for e in plan})
+    )
+    print(
+        f"  {sys.executable} scripts/rebuild_codeminer_synthesis_dataset.py "
+        f"{reps} --output-dir {args.output_dir}/dataset"
+    )
+    if failures:
+        print(f"\n{len(failures)} instance(s) FAILED: {failures}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/multiply_queries.py
+++ b/scripts/multiply_queries.py
@@ -454,6 +454,10 @@ async def _run_pipeline(args: argparse.Namespace) -> None:
         model=args.model,
         judge_model=args.judge_model,
         max_retries=args.post_fix_max_retries,
+        # The mixed rows carry content=null; pass the anchors (which hold the
+        # real code) so flagged module/file/symbol/reasoning rows can actually
+        # be regenerated instead of skipped for "no anchor content".
+        anchors=anchors,
     )
     with output_path.open("w", encoding="utf-8") as fh:
         json.dump(compact, fh, indent=2, ensure_ascii=False)

--- a/scripts/multiply_traversal_queries.py
+++ b/scripts/multiply_traversal_queries.py
@@ -31,6 +31,7 @@ from codeminer.dataset.synthesize._agent import AgentRunner
 from codeminer.dataset.synthesize.context_loader import ContextLoader
 from codeminer.log_utils import get_logger
 from codeminer.types import NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+from codeminer.utils import is_non_source_file
 
 sys.path.insert(0, str(Path(__file__).parent))
 from _post_fix import post_fix_flagged  # noqa: E402
@@ -214,6 +215,10 @@ def _vertex_to_member(code_graph: Any, vid: int) -> Optional[ChainMember]:
     end = attrs.get("end_line")
     name = attrs.get("name")
     if not (file and name and isinstance(start, int) and isinstance(end, int)):
+        return None
+    # Skip build artifacts / type-def stubs (dist/, .d.ts) — generated copies
+    # make poor traversal-chain ground truth.
+    if is_non_source_file(file):
         return None
     line_count = max(0, end - start + 1)
     if line_count < _MIN_CHAIN_MEMBER_LINES or line_count > _MAX_CHAIN_MEMBER_LINES:

--- a/scripts/rebuild_codeminer_synthesis_dataset.py
+++ b/scripts/rebuild_codeminer_synthesis_dataset.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -67,9 +68,19 @@ def _read_json_records(path: Path) -> List[Mapping[str, Any]]:
 def _load_replacement(path: Path, config_name: str) -> List[Dict[str, Any]]:
     paths: List[Path]
     if path.is_dir():
-        paths = sorted(
-            p for p in path.rglob("*") if p.suffix.lower() in {".json", ".jsonl"}
-        )
+        # The per-instance generation tree holds the canonical, complete record
+        # set in ``<iid>/<config>_combined.json`` PLUS its per-category sources
+        # (behavioral_x20/, mixed_x30/, traversal_x10/) and seed/quality files.
+        # Reading everything double-counts every query (duplicate_query_id) and
+        # mixes in non-record files — so prefer the combined files, which each
+        # already union behavioral + mixed + traversal for one repo.
+        combined = sorted(path.rglob("*_combined.json"))
+        if combined:
+            paths = combined
+        else:
+            paths = sorted(
+                p for p in path.rglob("*") if p.suffix.lower() in {".json", ".jsonl"}
+            )
     else:
         paths = [path]
     if not paths:
@@ -110,6 +121,27 @@ def _parse_replacements(values: Iterable[str]) -> Dict[str, Path]:
             raise ValueError(f"Only one --replacement is allowed for {config_name}.")
         replacements[config_name] = paths[0]
     return replacements
+
+
+# Build artifacts / type stubs are not valid localization targets: the real
+# logic lives in the source copy (lib/), not the bundle (dist/) or the .d.ts
+# declaration. Rows whose ground truth is ENTIRELY such files are dropped so the
+# benchmark never asks a retriever to land on generated code.
+_NON_SOURCE_GT_RE = re.compile(
+    r"(^|/)(dist|build|out|node_modules|vendor)/|(\.min\.js|\.d\.[cm]?ts|\.map)$",
+    re.I,
+)
+
+
+def _has_source_gt(row: Dict[str, Any]) -> bool:
+    files = row.get("gt_files") or row.get("target_files") or []
+    if not files:
+        return True  # no file constraint to judge; keep (handled elsewhere)
+    return any(not _NON_SOURCE_GT_RE.search(str(f)) for f in files)
+
+
+def _drop_non_source_gt(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [row for row in records if _has_source_gt(row)]
 
 
 def _filter_base_distribution(
@@ -239,6 +271,11 @@ def build_dataset(args: argparse.Namespace) -> Dict[str, Any]:
             records,
             keep_extra_categories=args.keep_extra_categories,
         )
+        before = len(records)
+        records = _drop_non_source_gt(records)
+        dropped = before - len(records)
+        if dropped:
+            print(f"  {config_name}: dropped {dropped} row(s) with non-source GT")
         for append_path in appends.get(config_name, []):
             appended = _load_replacement(append_path, config_name)
             records.extend(appended)

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shared code chunker behavior."""
+
+from typing import List, Optional, Tuple
+
+import pytest
+
+from codeminer.code_chunking.base import BaseCodeChunker
+
+
+class StubCodeChunker(BaseCodeChunker):
+    """Minimal concrete chunker for base-class tests."""
+
+    def _build_file_skeleton(
+        self,
+        definitions: List[Tuple],
+        code_content: str,
+        include_l2: Optional[bool] = None,
+    ) -> str:
+        return ""
+
+    def _find_top_level_definitions(
+        self, root_node, include_l2_in_file_skeleton: bool = False
+    ) -> List[Tuple]:
+        return []
+
+    def _extract_signature_text(self, node, def_type: str, code_content: str) -> str:
+        return ""
+
+    def _extract_function_name(self, node) -> Optional[str]:
+        return None
+
+    def _extract_class_name(self, node) -> Optional[str]:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def clear_language_cache():
+    BaseCodeChunker._language_cache.clear()
+    yield
+    BaseCodeChunker._language_cache.clear()
+
+
+def test_tree_sitter_language_load_is_cached_per_language(monkeypatch):
+    calls = []
+    languages = {"python": object(), "go": object()}
+
+    def fake_get_language(language: str):
+        calls.append(language)
+        return languages[language]
+
+    monkeypatch.setattr("codeminer.code_chunking.base.get_language", fake_get_language)
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_create_parser",
+        staticmethod(lambda language: object()),
+    )
+
+    first = StubCodeChunker("python")
+    second = StubCodeChunker("python")
+    third = StubCodeChunker("go")
+
+    assert calls == ["python", "go"]
+    assert first.tree_sitter_language is second.tree_sitter_language
+    assert third.tree_sitter_language is languages["go"]

--- a/test/dataset/test_synthesis_query_cleanup.py
+++ b/test/dataset/test_synthesis_query_cleanup.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the synthesis query-quality cleanup fixes.
+
+These lock in the pure-function behaviours behind the v2 dataset quality pass:
+
+* ``_strip_leading_narration`` / ``_coerce_question_text`` — strip agent
+  chain-of-thought ("Now let me look at…") that leaked into the query field and
+  produced the malformed ``:?`` the judge rejected.
+* ``_modules_from_ground_truth`` / ``_is_source_path`` — derive the dotted
+  module for MODULE_HINT and drop non-source anchors (bundles, ``.d.cts``).
+* ``post_fix`` anchor-content recovery — the mixed rows store ``content=null``,
+  so the post-fix regenerate path must recover code from the behavioral
+  anchors; without it every flagged mixed row was skipped, not regenerated.
+"""
+
+from codeminer.dataset.synthesize.query_curator import QueryCurator
+from scripts._post_fix import _build_anchor_content_lookups, _get_anchor
+
+# ---------------------------------------------------------------------------
+# Narration stripping (B)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_leading_narration_drops_pure_thinking():
+    q = "Now let me look at how `TimeBase.insert` interacts with callers:"
+    assert QueryCurator._strip_leading_narration(q) == ""
+
+
+def test_strip_leading_narration_keeps_real_query_after_narration():
+    q = "Let me look at this. How does the fast C reader validate delimiters?"
+    assert (
+        QueryCurator._strip_leading_narration(q)
+        == "How does the fast C reader validate delimiters?"
+    )
+
+
+def test_strip_leading_narration_leaves_clean_query_untouched():
+    q = "Why does comoving distance fail near zero redshift?"
+    assert QueryCurator._strip_leading_narration(q) == q
+
+
+def test_coerce_question_text_skips_narration_only_blob():
+    blob = "Now I understand the code.\nLet me check the callers next:"
+    assert QueryCurator._coerce_question_text(blob) == ""
+
+
+def test_coerce_question_text_recovers_real_question_line():
+    blob = "Let me explore.\nHow does the loader resolve nested imports?"
+    assert (
+        QueryCurator._coerce_question_text(blob)
+        == "How does the loader resolve nested imports?"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module derivation + non-source filtering (C, #4)
+# ---------------------------------------------------------------------------
+
+
+def test_modules_from_ground_truth_derives_dotted_module():
+    gt = {"target_files": ["astropy/units/core.py"]}
+    assert QueryCurator._modules_from_ground_truth(gt) == ["astropy.units.core"]
+
+
+def test_modules_from_ground_truth_drops_non_source():
+    gt = {
+        "target_files": [
+            "src/core/dispatchRequest.js",
+            "dist/esm/axios.js",
+            "index.d.cts",
+            "lib/foo.min.js",
+        ]
+    }
+    # Only the real source file survives; bundle / type-def / minified drop out.
+    assert QueryCurator._modules_from_ground_truth(gt) == ["src.core.dispatchRequest"]
+
+
+def test_is_source_path_rejects_build_artifacts():
+    assert not QueryCurator._is_source_path("dist/esm/axios.js")
+    assert not QueryCurator._is_source_path("index.d.cts")
+    assert not QueryCurator._is_source_path("build/out/x.js")
+    assert not QueryCurator._is_source_path("node_modules/dep/index.js")
+    assert QueryCurator._is_source_path("src/core/dispatchRequest.js")
+    assert QueryCurator._is_source_path("astropy/units/core.py")
+
+
+# ---------------------------------------------------------------------------
+# post_fix anchor-content recovery (F)
+# ---------------------------------------------------------------------------
+
+
+def test_post_fix_recovers_anchor_content_from_anchors():
+    # Mixed row as produced by multiply_queries: gt_symbol_nodes carry the
+    # target identity but content=null.
+    row = {
+        "gt_files": ["astropy/time/core.py"],
+        "gt_symbols": ["astropy/time/core.py:TimeBase.insert()"],
+        "gt_symbol_nodes": [
+            {
+                "node_name": "astropy/time/core.py:TimeBase.insert()",
+                "content": None,
+                "file": "astropy/time/core.py",
+            }
+        ],
+    }
+    anchors = [
+        {
+            "anchor_symbol": "astropy/time/core.py:TimeBase.insert()",
+            "anchor_file": "astropy/time/core.py",
+            "anchor_content": "class TimeBase:\n    def insert(self, idx): ...",
+            "target_files": ["astropy/time/core.py"],
+        }
+    ]
+    by_node, by_file = _build_anchor_content_lookups([row], anchors)
+    _, _, content = _get_anchor(row, by_node, by_file)
+    assert content  # non-empty -> regenerate runs instead of being skipped
+    assert "def insert" in content
+
+
+def test_post_fix_without_anchors_finds_no_content_for_null_rows():
+    # Regression guard: the bug was that mixed rows alone yield no content.
+    row = {
+        "gt_files": ["astropy/time/core.py"],
+        "gt_symbols": ["astropy/time/core.py:TimeBase.insert()"],
+        "gt_symbol_nodes": [
+            {
+                "node_name": "astropy/time/core.py:TimeBase.insert()",
+                "content": None,
+                "file": "astropy/time/core.py",
+            }
+        ],
+    }
+    by_node, by_file = _build_anchor_content_lookups([row])
+    _, _, content = _get_anchor(row, by_node, by_file)
+    assert content == ""

--- a/test/dataset/test_synthesis_query_cleanup.py
+++ b/test/dataset/test_synthesis_query_cleanup.py
@@ -17,6 +17,7 @@ These lock in the pure-function behaviours behind the v2 dataset quality pass:
 """
 
 from codeminer.dataset.synthesize.query_curator import QueryCurator
+from codeminer.utils import is_non_source_file
 from scripts._post_fix import _build_anchor_content_lookups, _get_anchor
 
 # ---------------------------------------------------------------------------
@@ -85,6 +86,19 @@ def test_is_source_path_rejects_build_artifacts():
     assert not QueryCurator._is_source_path("node_modules/dep/index.js")
     assert QueryCurator._is_source_path("src/core/dispatchRequest.js")
     assert QueryCurator._is_source_path("astropy/units/core.py")
+
+
+def test_is_non_source_file_blocks_synthesis_anchors():
+    # Used by behavioral candidate sampling + traversal seed selection so
+    # bundles / type-def stubs never become ground truth.
+    assert is_non_source_file("dist/esm/axios.js")
+    assert is_non_source_file("index.d.cts")
+    assert is_non_source_file("src/jsx.d.ts")
+    assert is_non_source_file("a/b.min.js")
+    assert is_non_source_file("dist/bundle.js:Foo")  # node-id form (file:symbol)
+    assert not is_non_source_file("lib/core/AxiosHeaders.js")
+    assert not is_non_source_file("src/cat/main.rs")
+    assert not is_non_source_file("astropy/time/core.py:TimeBase.insert()")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Generates and ships **v2 of the `codeminer-synthesis` benchmark**: a multi-repo
locator dataset of **500 queries across 25 repos (5/language)**, replacing the
v1 single-repo-per-language version whose narrow repo coverage biased
evaluation. The branch adds the generation pipeline (planner + driver),
root-causes and fixes the query-quality issues that capped v1 at ~69%
judge-valid, and backfills to exactly 500 rows. The assembled dataset is **99%
judge-valid (495/500), 0 assembly errors**, all 5 languages ≥98%, and has been
pushed to `sysevol-ai/codeminer-synthesis` (split `test`) and verified live.

## Changes

- **v2 generation pipeline**: `build_synthesis_v2_plan.py` (picks the
  graph-richest instance per repo, 25 repos × ~20 queries) and
  `generate_synthesis_v2.py` (per-instance driver; `--regen-mixed` reuses the
  already-good behavioral/traversal and only re-generates the mixed categories).
- **Query-quality fixes** (lifted module_hint 9%→99%, reasoning 41%→96%,
  file_hint 55%→100%, symbol_hint 54%→96%):
  - `_post_fix.py` (keystone): thread behavioral anchors into `post_fix_flagged`
    so flagged mixed rows (which store `content=null`) can actually be
    regenerated instead of skipped for "no anchor content".
  - `query_curator.py`: inject the real anchor code into the question prompt;
    bind module_hint to the dotted ground-truth module; strip agent
    chain-of-thought that leaked into the query (incl. the JSON path) and
    normalize trailing punctuation; conciseness directive.
- **Non-source guard** (`is_non_source_file` in `codeminer/utils.py`): behavioral
  candidate sampling and traversal seed selection now skip build artifacts /
  type-def stubs (dist/, .d.ts, .min.js, …), so ground truth lands on the real
  source copy (e.g. axios `lib/` instead of its in-tree bundle); the assembler
  also drops any row whose GT is entirely non-source.
- **Assembly fixes** (`rebuild_codeminer_synthesis_dataset.py`): read only the
  canonical `*_combined.json` per repo (was double-counting every query via a
  broad rglob); document that `--keep-extra-categories --include-traversal` are
  required to retain the traversal category.
- **traversal `--allow-partial`**: a short 2-hop bridge yield no longer
  RuntimeErrors the whole instance (had failed scikit-learn / coreutils / axios).

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/dataset/test_synthesis_query_cleanup.py` (11 new unit tests
covering narration stripping, dotted-module derivation, the non-source filter,
and post_fix anchor-content recovery) plus the existing synthesis suite
(`test_codeminer_synthesis.py`, `test_synthesize_vocab_guard.py`,
`test_synthesis_span_resolution.py`) — all green. End-to-end: regenerated all 25
repos, assembled to 500 rows with 0 quality-gate errors, pushed to HF and
re-loaded to confirm 500 rows / 99% valid. Per-language smokes (Python, JS, C++)
each at 100% before the full run.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
