### PR TITLE
feat(web): add local GPU LLM support and demo startup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ results/
 
 # Code-QA demo (dir or symlink to a shared data dir)
 .codeminer_qa
+
+# Cloned repos for local demo (gitignored — add via: python scripts/index_repo.py repos/<name>)
+repos/
 .codeminer_demo/
 # Local verification evidence / scratch (Playwright screenshots); not source.
 /verification/

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -1,0 +1,185 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Running the Web Demo Locally (with a Local GPU LLM)
+
+This guide covers running the full CodeMiner web demo — wiki generation + Ask
+— against **any arbitrary repo** using a **local GPU LLM** (no cloud API keys).
+
+The setup has three services running in separate terminals:
+
+| Service | Script | Where to run |
+|---------|--------|--------------|
+| LLM server (llama-cpp-python) | `scripts/start_llm.sh` | GPU node |
+| CodeMiner backend (FastAPI) | `scripts/start_web.sh` | Main machine |
+| Next.js frontend | `cd web && npm run dev` | Main machine |
+
+---
+
+## Prerequisites
+
+### Main machine
+- CodeMiner installed: `make dev` or `pip install -e ".[dev]"`
+- Node.js + npm: `cd web && npm install` (once)
+- Conda env `codeminer` active
+
+### GPU node
+- Access to a node with CUDA 12.4+ driver and enough VRAM (7B model needs ~5 GB)
+- `llama-cpp-python[server]` with GPU support installed in the `codeminer` env:
+
+  ```bash
+  # Install the pre-built CUDA 12.4 wheel (works with any CUDA 12.4+ driver)
+  conda activate codeminer
+  pip install "llama-cpp-python[server]==0.3.29" \
+    --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu124
+  ```
+
+  Verify GPU is detected:
+  ```bash
+  python -c "import llama_cpp; print('GPU:', llama_cpp.llama_supports_gpu_offload())"
+  # Should print: GPU: True
+  ```
+
+- A GGUF model file. If you have Ollama installed, qwen2.5-coder:7b is at:
+  ```
+  ~/.ollama/models/blobs/sha256-60e05f2100071479f596b964f89f510f057ce397ea22f2833a0cfe029bfc2463
+  ```
+  Otherwise download any GGUF from HuggingFace and note the path.
+
+---
+
+## Step 1 — Index a repo
+
+For any repo you want to explore, build its BM25 index:
+
+```bash
+# Clone the repo (skip if already cloned)
+git clone https://github.com/<owner>/<repo> ~/projects/<repo>
+
+# Build indexes
+conda activate codeminer
+cd ~/projects/CodeMiner/CodeMiner
+python - <<'EOF'
+from codeminer.compiler import IndexCompiler, IndexCompilerConfig
+from codeminer.compiler.index_builders import IndexBuilderRegistry, register_default_builders
+
+REPO = "/absolute/path/to/your/repo"   # <-- change this
+
+registry = IndexBuilderRegistry()
+register_default_builders(registry, languages=["python"])  # change language if needed
+IndexCompiler(registry, IndexCompilerConfig(index_types=["bm25"])).compile_repo(REPO)
+print("Done! Index at", REPO + "/.codeminer_cache/")
+EOF
+```
+
+Then register the repo in `.codeminer_qa/qa_registry.json` (create the file if
+it doesn't exist):
+
+```json
+[
+  {
+    "instance_id": "owner__repo",
+    "repo": "owner/repo",
+    "base_commit": "<git rev-parse HEAD of the repo>",
+    "language": "python",
+    "repo_dir": "/absolute/path/to/your/repo",
+    "manifest_path": "/absolute/path/to/your/repo/.codeminer_cache/repo_manifest.json",
+    "problem_statement": ""
+  }
+]
+```
+
+Get `base_commit` with:
+```bash
+git -C /path/to/repo rev-parse HEAD
+```
+
+---
+
+## Step 2 — Configure the LLM
+
+Edit `qa_config.yaml` in the repo root and set:
+
+```yaml
+model: openai/qwen2.5-coder
+```
+
+This tells litellm to use an OpenAI-compatible endpoint. The actual URL is
+passed at runtime via `OPENAI_API_BASE` (set by `start_web.sh`).
+
+---
+
+## Step 3 — Start all three services
+
+### Terminal 1 — LLM server (on GPU node)
+
+```bash
+cd ~/projects/CodeMiner/CodeMiner
+bash scripts/start_llm.sh
+```
+
+The script will ask for your GGUF model path and start an OpenAI-compatible
+server on port 8080.
+
+### Terminal 2 — CodeMiner backend (on main machine)
+
+```bash
+cd ~/projects/CodeMiner/CodeMiner
+bash scripts/start_web.sh
+```
+
+The script asks for the GPU node hostname (default: `vscode-dsmlp-l40s`) and
+starts the FastAPI backend on port 8000 pointed at your LLM server.
+
+### Terminal 3 — Frontend (on main machine)
+
+```bash
+cd ~/projects/CodeMiner/CodeMiner/web
+npm run dev
+```
+
+Opens at **http://localhost:3000**.
+
+---
+
+## Step 4 — Generate the wiki
+
+1. Open http://localhost:3000
+2. Click on your repo
+3. Click **Refresh this wiki**
+4. Wait ~30–60 seconds — the LLM generates the outline and pages
+
+Wiki pages are cached in `.codeminer_qa/wiki_cache/` so subsequent loads are instant.
+To regenerate, delete that directory.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `GPU: False` from llama_cpp | Wrong wheel installed. Reinstall with `--extra-index-url` as shown above. |
+| `ContextWindowExceededError` | LLM server started without `--n_ctx 8192`. The start script sets this automatically. |
+| `Connection refused` on port 8080 | LLM server not running, or firewall blocking the GPU node port. Check Terminal 1. |
+| Wiki says "Couldn't load this page" | Check backend terminal for `WARNING outline generation failed`. Usually an LLM connectivity issue. |
+| `repos: 0` at `/api/health` | `qa_registry.json` missing or wrong path. Check `.codeminer_qa/qa_registry.json`. |
+| Backend stuck on "Loading repositories…" | Index not built. Run Step 1 again. |
+| Blank wiki after "Refresh" | Wiki cached from a failed run. Delete `.codeminer_qa/wiki_cache/` and retry. |
+
+---
+
+## Running over SSH
+
+If accessing from a remote machine, forward both ports — the browser calls the
+backend directly:
+
+```bash
+ssh -L 3000:localhost:3000 -L 8000:localhost:8000 <main-machine>
+```
+
+If the LLM server is on a different node than the backend, only the backend
+needs to reach port 8080 on the GPU node — the browser never talks to port 8080
+directly.

--- a/qa_config.yaml
+++ b/qa_config.yaml
@@ -10,7 +10,9 @@
 # `model` is a litellm model string; override with CODEMINER_DEMO_MODEL.
 # Provider API keys come from the environment (e.g. OPENAI_API_KEY).
 
-model: vertex_ai/gemini-2.5-flash   # uses gcloud ADC; override via CODEMINER_DEMO_MODEL
+# model: vertex_ai/gemini-2.5-flash   # uses gcloud ADC; override via CODEMINER_DEMO_MODEL
+model: openai/qwen2.5-coder #replace it to use local qwen model for testing using ollama
+
 mode: hybrid              # "sparse" (BM25 only) or "hybrid" (BM25 + embeddings)
 data_dir: .codeminer_qa
 # Reuse pre-built per-instance indexes (source @ base_commit + L0/L2 vectors)

--- a/scripts/index_repo.py
+++ b/scripts/index_repo.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Build BM25 index for a repo and register it in qa_registry.json.
+
+Usage:
+    python scripts/index_repo.py /path/to/repo
+    python scripts/index_repo.py /path/to/repo --language go
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(levelname)-8s %(message)s")
+
+from codeminer.compiler import IndexCompiler, IndexCompilerConfig
+from codeminer.compiler.index_builders import IndexBuilderRegistry, register_default_builders
+
+
+def get_base_commit(repo_dir: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_dir, capture_output=True, text=True, check=True,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def detect_language(repo_dir: str) -> str:
+    counts: dict = {}
+    ext_map = {
+        ".py": "python", ".go": "go", ".rs": "rust",
+        ".ts": "javascript", ".tsx": "javascript", ".js": "javascript",
+        ".cpp": "cpp", ".cc": "cpp", ".c": "cpp",
+    }
+    for root, _, files in os.walk(repo_dir):
+        if "/.git" in root or "/.codeminer" in root:
+            continue
+        for f in files:
+            lang = ext_map.get(os.path.splitext(f)[1].lower())
+            if lang:
+                counts[lang] = counts.get(lang, 0) + 1
+    return max(counts, key=counts.get) if counts else "python"
+
+
+def update_registry(registry_path: str, entry: dict) -> None:
+    entries = []
+    if os.path.isfile(registry_path):
+        with open(registry_path) as f:
+            entries = json.load(f)
+    entries = [e for e in entries if e.get("instance_id") != entry["instance_id"]]
+    entries.append(entry)
+    os.makedirs(os.path.dirname(os.path.abspath(registry_path)), exist_ok=True)
+    with open(registry_path, "w") as f:
+        json.dump(entries, f, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Index a repo for CodeMiner web demo")
+    parser.add_argument("repo_dir", help="Absolute path to the repo to index")
+    parser.add_argument("--language", help="Language override (auto-detected if omitted)")
+    parser.add_argument(
+        "--registry",
+        default=".codeminer_qa/qa_registry.json",
+        help="Path to qa_registry.json (default: .codeminer_qa/qa_registry.json)",
+    )
+    args = parser.parse_args()
+
+    repo_dir = os.path.abspath(args.repo_dir)
+    if not os.path.isdir(repo_dir):
+        print(f"ERROR: Directory not found: {repo_dir}")
+        sys.exit(1)
+
+    language = args.language or detect_language(repo_dir)
+    print(f"Detected language: {language}")
+
+    # Build BM25 index
+    reg = IndexBuilderRegistry()
+    register_default_builders(reg, languages=[language])
+    manifest = IndexCompiler(reg, IndexCompilerConfig(index_types=["bm25"])).compile_repo(repo_dir)
+
+    print("\nIndexes built:")
+    for name, idx in manifest.indexes.items():
+        print(f"  {name}: {idx.status}  ({idx.path})")
+
+    # Derive owner/repo from git remote
+    try:
+        remote = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=repo_dir, capture_output=True, text=True,
+        ).stdout.strip()
+        m = re.search(r"[:/]([^/]+)/([^/.]+?)(?:\.git)?$", remote)
+        owner, repo = (m.group(1), m.group(2)) if m else ("local", os.path.basename(repo_dir))
+    except Exception:
+        owner, repo = "local", os.path.basename(repo_dir)
+
+    github_repo = f"{owner}/{repo}"
+    instance_id = f"{owner}__{repo}"
+    base_commit = get_base_commit(repo_dir)
+    manifest_path = os.path.join(repo_dir, ".codeminer_cache", "repo_manifest.json")
+
+    entry = {
+        "instance_id": instance_id,
+        "repo": github_repo,
+        "base_commit": base_commit,
+        "language": language,
+        "repo_dir": repo_dir,
+        "manifest_path": manifest_path,
+        "problem_statement": "",
+    }
+
+    update_registry(args.registry, entry)
+    print(f"\nRegistered '{instance_id}' in {args.registry}")
+    print(f"  repo:    {github_repo}")
+    print(f"  commit:  {base_commit[:12] if base_commit else '(unknown)'}")
+    print(f"\nDone! Restart the backend to pick up the new repo.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/start_llm.sh
+++ b/scripts/start_llm.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Start the llama-cpp-python OpenAI-compatible server on the GPU node.
+# Run this in Terminal 1 (on the GPU node).
+# See docs/running-locally.md for the full setup guide.
+
+set -e
+
+CONDA_ENV="${CONDA_ENV:-codeminer}"
+PORT="${LLM_PORT:-8080}"
+N_CTX="${N_CTX:-8192}"
+DEFAULT_MODEL="$HOME/.ollama/models/blobs/sha256-60e05f2100071479f596b964f89f510f057ce397ea22f2833a0cfe029bfc2463"
+
+# ── Prerequisites ────────────────────────────────────────────────────────────
+
+echo "=== CodeMiner LLM Server ==="
+echo ""
+
+# Check conda env
+if ! conda run -n "$CONDA_ENV" python -c "import llama_cpp" &>/dev/null; then
+    echo "ERROR: llama-cpp-python not found in conda env '$CONDA_ENV'."
+    echo ""
+    echo "Install it with:"
+    echo "  conda activate $CONDA_ENV"
+    echo "  pip install 'llama-cpp-python[server]==0.3.29' \\"
+    echo "    --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    exit 1
+fi
+
+# Check GPU support
+GPU_OK=$(conda run -n "$CONDA_ENV" python -c "import llama_cpp; print(llama_cpp.llama_supports_gpu_offload())" 2>/dev/null)
+if [ "$GPU_OK" != "True" ]; then
+    echo "WARNING: llama-cpp-python reports GPU offload not supported."
+    echo "         This likely means a CPU-only wheel is installed."
+    echo ""
+    echo "Reinstall with CUDA support:"
+    echo "  pip install 'llama-cpp-python[server]==0.3.29' \\"
+    echo "    --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu124"
+    echo ""
+    read -rp "Continue with CPU-only inference? (very slow) [y/N]: " CONT
+    [[ "$CONT" =~ ^[Yy]$ ]] || exit 1
+fi
+
+# ── Model path ───────────────────────────────────────────────────────────────
+
+MODEL_PATH="${LLAMA_MODEL:-}"
+
+if [ -z "$MODEL_PATH" ]; then
+    if [ -f "$DEFAULT_MODEL" ]; then
+        echo "Found default model: $DEFAULT_MODEL"
+        read -rp "Use this model? [Y/n]: " USE_DEFAULT
+        if [[ ! "$USE_DEFAULT" =~ ^[Nn]$ ]]; then
+            MODEL_PATH="$DEFAULT_MODEL"
+        fi
+    fi
+fi
+
+if [ -z "$MODEL_PATH" ]; then
+    read -rp "Enter path to your GGUF model file: " MODEL_PATH
+fi
+
+if [ ! -f "$MODEL_PATH" ]; then
+    echo "ERROR: Model file not found: $MODEL_PATH"
+    echo ""
+    echo "If using Ollama, models are in: ~/.ollama/models/blobs/"
+    echo "Or download a GGUF from HuggingFace (e.g. Qwen/Qwen2.5-Coder-7B-Instruct-GGUF)"
+    exit 1
+fi
+
+# ── Launch ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Starting LLM server..."
+echo "  Model:    $MODEL_PATH"
+echo "  Context:  $N_CTX tokens"
+echo "  Port:     $PORT"
+echo "  GPU layers: all (-1)"
+echo ""
+echo "Server will be available at http://$(hostname):$PORT/v1"
+echo "Pass this to start_web.sh as the GPU node hostname: $(hostname)"
+echo ""
+
+conda run -n "$CONDA_ENV" python -m llama_cpp.server \
+    --model "$MODEL_PATH" \
+    --n_gpu_layers -1 \
+    --n_ctx "$N_CTX" \
+    --port "$PORT" \
+    --host 0.0.0.0

--- a/scripts/start_web.sh
+++ b/scripts/start_web.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Start the CodeMiner FastAPI backend pointed at a local LLM server.
+# Run this in Terminal 2 (on your main machine).
+# See docs/running-locally.md for the full setup guide.
+
+set -e
+
+CONDA_ENV="${CONDA_ENV:-codeminer}"
+BACKEND_PORT="${CODEMINER_DEMO_PORT:-8000}"
+LLM_PORT="${LLM_PORT:-8080}"
+DEFAULT_GPU_HOST="vscode-dsmlp-l40s"
+
+# ── Prerequisites ────────────────────────────────────────────────────────────
+
+echo "=== CodeMiner Backend ==="
+echo ""
+
+# Must run from repo root
+if [ ! -f "qa_config.yaml" ]; then
+    echo "ERROR: qa_config.yaml not found."
+    echo "Run this script from the CodeMiner repo root:"
+    echo "  cd ~/projects/CodeMiner/CodeMiner"
+    echo "  bash scripts/start_web.sh"
+    exit 1
+fi
+
+# Check codeminer is installed
+if ! conda run -n "$CONDA_ENV" python -c "import codeminer" &>/dev/null; then
+    echo "ERROR: codeminer not installed in conda env '$CONDA_ENV'."
+    echo "Run:  make dev   (or pip install -e '.[dev]')"
+    exit 1
+fi
+
+# Check qa_registry.json
+REGISTRY=".codeminer_qa/qa_registry.json"
+if [ ! -f "$REGISTRY" ]; then
+    echo "ERROR: No repo registry found at $REGISTRY"
+    echo ""
+    echo "Index a repo first:"
+    echo "  conda activate codeminer"
+    echo "  python scripts/index_repo.py repos/<your-repo>"
+    echo ""
+    echo "Or clone + index in one go:"
+    echo "  git clone https://github.com/owner/repo repos/repo"
+    echo "  python scripts/index_repo.py repos/repo"
+    exit 1
+fi
+
+REPO_COUNT=$(python3 -c "import json; print(len(json.load(open('$REGISTRY'))))" 2>/dev/null || echo 0)
+echo "Found $REPO_COUNT repo(s) in registry."
+echo ""
+
+# ── GPU node hostname ─────────────────────────────────────────────────────────
+
+GPU_HOST="${LLM_HOST:-}"
+
+if [ -z "$GPU_HOST" ]; then
+    echo "Enter the hostname of the node running scripts/start_llm.sh."
+    read -rp "GPU node hostname [${DEFAULT_GPU_HOST}]: " GPU_HOST
+    GPU_HOST="${GPU_HOST:-$DEFAULT_GPU_HOST}"
+fi
+
+LLM_BASE="http://${GPU_HOST}:${LLM_PORT}/v1"
+
+# Check LLM server is reachable
+echo ""
+echo "Checking LLM server at $LLM_BASE ..."
+if curl -sf --max-time 5 "${LLM_BASE}/models" > /dev/null 2>&1; then
+    echo "  LLM server: OK"
+else
+    echo "  WARNING: Cannot reach LLM server at $LLM_BASE"
+    echo ""
+    echo "  Make sure scripts/start_llm.sh is running on $GPU_HOST."
+    echo "  If the hostname is wrong, re-run and enter the correct hostname."
+    echo ""
+    read -rp "  Continue anyway? [y/N]: " CONT
+    [[ "$CONT" =~ ^[Yy]$ ]] || exit 1
+fi
+
+# ── Check qa_config.yaml model ───────────────────────────────────────────────
+
+CURRENT_MODEL=$(python3 -c "import yaml; c=yaml.safe_load(open('qa_config.yaml')); print(c.get('model',''))" 2>/dev/null || echo "")
+if [[ "$CURRENT_MODEL" != openai/* ]]; then
+    echo ""
+    echo "WARNING: qa_config.yaml has model: $CURRENT_MODEL"
+    echo "         For local LLM, it should be: openai/qwen2.5-coder"
+    echo ""
+    read -rp "Update qa_config.yaml automatically? [Y/n]: " FIX
+    if [[ ! "$FIX" =~ ^[Nn]$ ]]; then
+        python3 -c "
+import re, sys
+with open('qa_config.yaml') as f: content = f.read()
+content = re.sub(r'^model:.*$', 'model: openai/qwen2.5-coder', content, flags=re.MULTILINE)
+with open('qa_config.yaml', 'w') as f: f.write(content)
+print('  Updated qa_config.yaml: model: openai/qwen2.5-coder')
+"
+    fi
+fi
+
+# ── Launch ────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Starting CodeMiner backend..."
+echo "  Backend:  http://localhost:$BACKEND_PORT"
+echo "  LLM:      $LLM_BASE"
+echo ""
+echo "─────────────────────────────────────────────"
+echo "Once backend is up, start the frontend in"
+echo "a SEPARATE terminal:"
+echo ""
+echo "  cd $(pwd)/web && npm run dev"
+echo ""
+echo "Then open: http://localhost:3000"
+echo "─────────────────────────────────────────────"
+echo ""
+
+export OPENAI_API_KEY="fake"
+export OPENAI_API_BASE="$LLM_BASE"
+export CODEMINER_DEMO_PORT="$BACKEND_PORT"
+
+conda run -n "$CONDA_ENV" --no-capture-output \
+    env OPENAI_API_KEY=fake OPENAI_API_BASE="$LLM_BASE" \
+    python -m codeminer.web.app


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Enables the CodeMiner web demo to run fully locally using a GPU-hosted LLM (llama-cpp-python) instead of cloud API keys. Adds three startup scripts and a complete setup guide. Tested end-to-end on an NVIDIA L40S with qwen2.5-coder:7b — wiki generation for `psf/requests` completes successfully.

## Changes

- **`scripts/start_llm.sh`** — starts a llama-cpp-python OpenAI-compatible server on the GPU node; checks prereqs (GPU offload, model file), prompts for model path, launches with `--n_ctx 8192` (required — default 2048 causes `ContextWindowExceededError` on the ~6500-token outline prompt)
- **`scripts/start_web.sh`** — starts the FastAPI backend; prompts for GPU node hostname (default: `vscode-dsmlp-l40s`), validates LLM server reachability, auto-fixes `qa_config.yaml` model prefix if needed, prints frontend start instructions
- **`scripts/index_repo.py`** — indexes any arbitrary repo (BM25) and registers it in `qa_registry.json`; auto-detects language from file extensions, reads git remote for `owner/repo` metadata; replaces the old hardcoded `build_index.py`
- **`docs/running-locally.md`** — end-to-end guide: prerequisites, installing llama-cpp-python with GPU support, indexing a repo, starting all three services, and a troubleshooting table
- **`.gitignore`** — adds `repos/` (gitignored store for cloned demo repos, keeping third-party code out of git history)
- **`qa_config.yaml`** — sets model to `openai/qwen2.5-coder` with explanatory comment; `openai/` prefix tells litellm to use OpenAI-compatible wire format against `OPENAI_API_BASE` (the local llama-cpp-python server)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

Tested end-to-end on NVIDIA L40S (46 GB VRAM, CUDA 12.8 driver):

1. Installed `llama-cpp-python==0.3.29` via pre-built cu124 wheel — GPU offload confirmed
2. Started `scripts/start_llm.sh` with qwen2.5-coder:7b GGUF
3. Started `scripts/start_web.sh` pointed at GPU node
4. Started `cd web && npm run dev`
5. Clicked **Refresh this wiki** on psf/requests — wiki generated successfully

- [ ] Tests pass locally
- [ ] Added new tests for the changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

### Setup in 3 commands (after prereqs)

```bash
# Terminal 1 — GPU node
bash scripts/start_llm.sh

# Terminal 2 — main machine
bash scripts/start_web.sh

# Terminal 3 — main machine
cd web && npm run dev
```

Then open http://localhost:3000 → pick a repo → **Refresh this wiki**.