### PR TITLE
[codex] Productize wiki system maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: install scip dev test
+.PHONY: install scip dev test web-start web-stop web-restart web-reclaim web-status web-logs web-follow
 
 install:
 	pip install -e .
@@ -16,3 +16,24 @@ dev:
 
 test:
 	pytest
+
+web-start:
+	./scripts/dev_web.sh start
+
+web-stop:
+	./scripts/dev_web.sh stop
+
+web-restart:
+	./scripts/dev_web.sh restart
+
+web-reclaim:
+	CODEMINER_WEB_RECLAIM_PORTS=1 ./scripts/dev_web.sh restart
+
+web-status:
+	./scripts/dev_web.sh status
+
+web-logs:
+	./scripts/dev_web.sh logs
+
+web-follow:
+	./scripts/dev_web.sh follow

--- a/codeminer/graph/hierarchy.py
+++ b/codeminer/graph/hierarchy.py
@@ -1,0 +1,828 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Repo-level compound graph model for code visualization.
+
+The raw :class:`CodeGraph` already contains both structural ``contain`` edges
+and reference/call edges, but most UI consumers want those relations separated:
+
+``containment`` is a tree-like backbone (repo -> directory -> file -> symbol),
+while ``dependencies`` are a graph overlay routed through that backbone.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from ..types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE, is_symbol_node
+from .code_graph import CodeGraph
+
+HIERARCHY_ROOT = "hier::root"
+EXTERNAL_FILE = "· external"
+_CONTAINER_SYMBOL_TYPES = frozenset(
+    {"class", "interface", "trait", "struct", "enum", "type", "module", "namespace"}
+)
+
+
+@dataclass
+class ContainmentNode:
+    id: str
+    parent: Optional[str]
+    kind: str
+    label: str
+    path: str = ""
+    depth: int = 0
+    child_count: int = 0
+    symbol_count: int = 0
+    doi: float = 0.0
+    open_by_default: bool = False
+    file: Optional[str] = None
+    node_id: Optional[str] = None
+    line: Optional[int] = None
+    end_line: Optional[int] = None
+    importance: float = 0.0
+    external: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        return {k: v for k, v in data.items() if v is not None}
+
+
+@dataclass
+class DependencyEdge:
+    source: str
+    target: str
+    kind: str = EDGE_TYPE_REFERENCE
+    weight: int = 1
+    anchors: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        if not self.anchors:
+            data.pop("anchors", None)
+        return data
+
+
+@dataclass
+class HierarchicalCodeGraph:
+    """A compound graph: containment tree plus dependency overlay."""
+
+    root: str
+    containment: List[ContainmentNode]
+    dependencies: List[DependencyEdge]
+    source_root: str = ""
+
+    def __post_init__(self) -> None:
+        self._nodes_by_id = {node.id: node for node in self.containment}
+        self._parent_by_id = {node.id: node.parent for node in self.containment}
+        self._symbol_hierarchy_by_name = {
+            node.node_id: node.id
+            for node in self.containment
+            if node.kind == "symbol" and node.node_id
+        }
+
+    @property
+    def nodes_by_id(self) -> Dict[str, ContainmentNode]:
+        return self._nodes_by_id
+
+    def symbol_hierarchy_id(self, graph_name: str) -> Optional[str]:
+        return self._symbol_hierarchy_by_name.get(graph_name)
+
+    def route(self, source_hid: str, target_hid: str) -> Tuple[List[str], str]:
+        """Route a dependency edge through the containment tree."""
+
+        def chain(node_id: str) -> List[str]:
+            out: List[str] = []
+            cur: Optional[str] = node_id
+            while cur:
+                out.append(cur)
+                cur = self._parent_by_id.get(cur)
+            return out
+
+        src_chain = chain(source_hid)
+        tgt_chain = chain(target_hid)
+        tgt_index = {node_id: i for i, node_id in enumerate(tgt_chain)}
+        for i, node_id in enumerate(src_chain):
+            if node_id in tgt_index:
+                route = src_chain[: i + 1] + list(
+                    reversed(tgt_chain[: tgt_index[node_id]])
+                )
+                return route, node_id
+        return [source_hid, target_hid], ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "root": self.root,
+            "nodes": [node.to_dict() for node in self.containment],
+            "dependencies": [edge.to_dict() for edge in self.dependencies],
+            "source_root": self.source_root,
+        }
+
+
+def empty_hierarchy() -> Dict[str, Any]:
+    return {"root": HIERARCHY_ROOT, "nodes": [], "open_files": []}
+
+
+def _file_parts(file: str) -> List[str]:
+    if file.startswith("·"):
+        return [file]
+    return [p for p in file.replace("\\", "/").split("/") if p]
+
+
+def _common_source_root(files: Sequence[str]) -> Optional[str]:
+    concrete = [
+        _file_parts(f)
+        for f in files
+        if f and not f.startswith("·") and len(_file_parts(f)) > 1
+    ]
+    if not concrete:
+        return None
+    first = concrete[0][0]
+    if all(p[0] == first for p in concrete):
+        return first
+
+    counts: Dict[str, int] = {}
+    for parts in concrete:
+        counts[parts[0]] = counts.get(parts[0], 0) + 1
+    root, count = max(counts.items(), key=lambda item: item[1])
+    # Repo roots often have setup.py/pyproject/docs next to one dominant package
+    # directory. Keep that package out of labels when it clearly dominates.
+    return root if count >= 2 and count / len(concrete) >= 0.6 else None
+
+
+def _hierarchy_path(file: str, source_root: Optional[str]) -> List[str]:
+    parts = _file_parts(file)
+    if source_root and parts and parts[0] == source_root:
+        return parts[1:]
+    return parts
+
+
+def _is_external_symbol(attrs: Dict[str, Any], repo_dir: Optional[str]) -> bool:
+    file = attrs.get("file")
+    start = attrs.get("start_line")
+    if not isinstance(file, str) or not file or not isinstance(start, int):
+        return True
+    if repo_dir:
+        safe = os.path.normpath(file).lstrip(os.sep).lstrip("/")
+        return not os.path.isfile(os.path.join(repo_dir, safe))
+    return False
+
+
+def _file_key(attrs: Dict[str, Any], repo_dir: Optional[str]) -> str:
+    file = attrs.get("file")
+    if _is_external_symbol(attrs, repo_dir) or not isinstance(file, str) or not file:
+        return EXTERNAL_FILE
+    return file.replace("\\", "/")
+
+
+def _symbol_label(attrs: Dict[str, Any], name: str) -> str:
+    label = (attrs.get("unified_name") or "").strip() or name
+    return label.split(":", 1)[-1] if ":" in label else label.rsplit("/", 1)[-1]
+
+
+def _contains_line(parent: Dict[str, Any], child: Dict[str, Any]) -> bool:
+    parent_start = parent.get("start_line")
+    parent_end = parent.get("end_line")
+    child_start = child.get("start_line")
+    if not isinstance(parent_start, int) or not isinstance(child_start, int):
+        return True
+    if child_start < parent_start:
+        return False
+    return not isinstance(parent_end, int) or child_start <= parent_end
+
+
+def _infer_symbol_parent(
+    name: str,
+    attrs: Dict[str, Any],
+    names_in_file: Sequence[str],
+    attrs_by_name: Dict[str, Dict[str, Any]],
+) -> Optional[str]:
+    """Infer scope from readable symbol names when explicit contain edges lack."""
+
+    label = _symbol_label(attrs, name)
+    if not label:
+        return None
+
+    best: Optional[str] = None
+    best_len = -1
+    for candidate in names_in_file:
+        if candidate == name:
+            continue
+        c_attrs = attrs_by_name[candidate]
+        if c_attrs.get("type") not in _CONTAINER_SYMBOL_TYPES:
+            continue
+        c_label = _symbol_label(c_attrs, candidate)
+        if not c_label or len(c_label) <= best_len:
+            continue
+        if not (label.startswith(f"{c_label}.") or label.startswith(f"{c_label}::")):
+            continue
+        if not _contains_line(c_attrs, attrs):
+            continue
+        best = candidate
+        best_len = len(c_label)
+    return best
+
+
+def _hier_dir_id(path: str) -> str:
+    return f"hier::dir::{path}"
+
+
+def _hier_file_id(file: str) -> str:
+    return f"hier::file::{file}"
+
+
+def _hier_symbol_id(name: str) -> str:
+    return f"hier::symbol::{name}"
+
+
+def _reference_importance(
+    graph: CodeGraph, symbol_names: Iterable[str]
+) -> Dict[str, float]:
+    names = set(symbol_names)
+    degree: Dict[str, int] = {name: 0 for name in names}
+    g = graph.get_graph()
+    for edge in g.es:
+        if edge.attributes().get("type") != EDGE_TYPE_REFERENCE:
+            continue
+        src = g.vs[edge.source]["name"]
+        tgt = g.vs[edge.target]["name"]
+        if src in names:
+            degree[src] += 1
+        if tgt in names:
+            degree[tgt] += 1
+    max_degree = max(degree.values(), default=0)
+    if max_degree <= 0:
+        return {name: 0.0 for name in names}
+    denom = math.log1p(max_degree)
+    return {name: round(math.log1p(count) / denom, 4) for name, count in degree.items()}
+
+
+def _recompute_counts(nodes: List[ContainmentNode]) -> None:
+    by_id = {node.id: node for node in nodes}
+    for node in nodes:
+        node.child_count = 0
+        node.symbol_count = 1 if node.kind == "symbol" else 0
+    for node in nodes:
+        if node.parent in by_id:
+            by_id[node.parent].child_count += 1
+    for node in sorted(nodes, key=lambda n: n.depth, reverse=True):
+        if node.parent in by_id:
+            parent = by_id[node.parent]
+            parent.symbol_count += node.symbol_count
+            parent.doi = round(max(parent.doi, node.doi), 4)
+
+
+def _assign_depths(nodes: List[ContainmentNode]) -> None:
+    by_id = {node.id: node for node in nodes}
+
+    def depth(node: ContainmentNode, seen: Optional[set[str]] = None) -> int:
+        if node.parent is None or node.parent not in by_id:
+            return 0
+        if seen is None:
+            seen = set()
+        if node.id in seen:
+            node.parent = None
+            return 0
+        seen.add(node.id)
+        return depth(by_id[node.parent], seen) + 1
+
+    for node in nodes:
+        node.depth = depth(node)
+
+
+def build_hierarchical_code_graph(
+    graph: CodeGraph, repo_dir: Optional[str] = None
+) -> HierarchicalCodeGraph:
+    """Build a reusable repo-level compound graph from a :class:`CodeGraph`."""
+
+    g = graph.get_graph()
+    symbol_vids: Dict[int, str] = {}
+    attrs_by_name: Dict[str, Dict[str, Any]] = {}
+    file_by_name: Dict[str, str] = {}
+    for vertex in g.vs:
+        attrs = vertex.attributes()
+        if not is_symbol_node(attrs.get("type")):
+            continue
+        name = attrs.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        symbol_vids[vertex.index] = name
+        attrs_by_name[name] = attrs
+        file_by_name[name] = _file_key(attrs, repo_dir)
+
+    source_root = _common_source_root(list(file_by_name.values()))
+    importance = _reference_importance(graph, attrs_by_name.keys())
+
+    nodes: List[ContainmentNode] = [
+        ContainmentNode(
+            id=HIERARCHY_ROOT,
+            parent=None,
+            kind="root",
+            label="root",
+            open_by_default=True,
+        )
+    ]
+    by_id: Dict[str, ContainmentNode] = {HIERARCHY_ROOT: nodes[0]}
+
+    def add(node: ContainmentNode) -> ContainmentNode:
+        existing = by_id.get(node.id)
+        if existing is not None:
+            return existing
+        by_id[node.id] = node
+        nodes.append(node)
+        return node
+
+    def ensure_dirs(file: str) -> str:
+        if file == EXTERNAL_FILE:
+            add(
+                ContainmentNode(
+                    id=_hier_dir_id(EXTERNAL_FILE),
+                    parent=HIERARCHY_ROOT,
+                    kind="directory",
+                    label="external",
+                    path=EXTERNAL_FILE,
+                    external=True,
+                )
+            )
+            return _hier_dir_id(EXTERNAL_FILE)
+
+        parent = HIERARCHY_ROOT
+        accum: List[str] = []
+        parts = _hierarchy_path(file, source_root)
+        for part in parts[:-1]:
+            accum.append(part)
+            path = "/".join(accum)
+            parent = add(
+                ContainmentNode(
+                    id=_hier_dir_id(path),
+                    parent=parent,
+                    kind="directory",
+                    label=f"{path}/",
+                    path=path,
+                )
+            ).id
+        return parent
+
+    for file in sorted(set(file_by_name.values())):
+        parent = ensure_dirs(file)
+        parts = _hierarchy_path(file, source_root)
+        label = "external" if file == EXTERNAL_FILE else (parts[-1] if parts else file)
+        add(
+            ContainmentNode(
+                id=_hier_file_id(file),
+                parent=parent,
+                kind="file",
+                label=label,
+                path=file,
+                file=file,
+                external=file == EXTERNAL_FILE,
+            )
+        )
+
+    symbol_parent: Dict[str, str] = {}
+    for edge in g.es:
+        if edge.attributes().get("type") != EDGE_TYPE_CONTAIN:
+            continue
+        src = symbol_vids.get(edge.source)
+        tgt = symbol_vids.get(edge.target)
+        if not src or not tgt or src == tgt:
+            continue
+        if file_by_name.get(src) != file_by_name.get(tgt):
+            continue
+        symbol_parent.setdefault(tgt, _hier_symbol_id(src))
+
+    names_by_file: Dict[str, List[str]] = {}
+    for name, file in file_by_name.items():
+        names_by_file.setdefault(file, []).append(name)
+    for names in names_by_file.values():
+        names.sort(
+            key=lambda n: (
+                (
+                    attrs_by_name[n].get("start_line")
+                    if isinstance(attrs_by_name[n].get("start_line"), int)
+                    else 10**9
+                ),
+                n,
+            )
+        )
+    for name, attrs in attrs_by_name.items():
+        if name in symbol_parent:
+            continue
+        parent_name = _infer_symbol_parent(
+            name,
+            attrs,
+            names_by_file.get(file_by_name.get(name, ""), []),
+            attrs_by_name,
+        )
+        if parent_name:
+            symbol_parent[name] = _hier_symbol_id(parent_name)
+
+    for name in sorted(
+        attrs_by_name,
+        key=lambda n: (
+            file_by_name.get(n, ""),
+            (
+                attrs_by_name[n].get("start_line")
+                if isinstance(attrs_by_name[n].get("start_line"), int)
+                else 10**9
+            ),
+            n,
+        ),
+    ):
+        attrs = attrs_by_name[name]
+        file = file_by_name[name]
+        parent = symbol_parent.get(name) or _hier_file_id(file)
+        if parent not in by_id:
+            parent = _hier_file_id(file)
+        start = attrs.get("start_line")
+        end = attrs.get("end_line")
+        imp = importance.get(name, 0.0)
+        add(
+            ContainmentNode(
+                id=_hier_symbol_id(name),
+                parent=parent,
+                kind="symbol",
+                label=_symbol_label(attrs, name),
+                path=name,
+                file=file,
+                node_id=name,
+                line=(start + 1) if isinstance(start, int) else None,
+                end_line=(end + 1) if isinstance(end, int) else None,
+                importance=imp,
+                doi=imp,
+                external=file == EXTERNAL_FILE,
+            )
+        )
+
+    dependencies_by_key: Dict[Tuple[str, str, str], DependencyEdge] = {}
+    for edge in g.es:
+        attrs = edge.attributes()
+        kind = attrs.get("type")
+        if kind != EDGE_TYPE_REFERENCE:
+            continue
+        src = symbol_vids.get(edge.source)
+        tgt = symbol_vids.get(edge.target)
+        if not src or not tgt or src == tgt:
+            continue
+        key = (src, tgt, kind)
+        dep = dependencies_by_key.setdefault(
+            key, DependencyEdge(source=src, target=tgt, kind=kind, weight=0)
+        )
+        dep.weight += 1
+        anchor_file = attrs.get("anchor_file")
+        anchor_line = attrs.get("anchor_line")
+        if anchor_file:
+            anchor = {
+                "file": anchor_file,
+                "line": (anchor_line + 1) if isinstance(anchor_line, int) else None,
+            }
+            if anchor not in dep.anchors:
+                dep.anchors.append(anchor)
+
+    _assign_depths(nodes)
+    _recompute_counts(nodes)
+
+    return HierarchicalCodeGraph(
+        root=HIERARCHY_ROOT,
+        containment=nodes,
+        dependencies=list(dependencies_by_key.values()),
+        source_root=source_root or "",
+    )
+
+
+def _node_doi(node: Dict[str, Any]) -> float:
+    if node.get("is_root"):
+        return 1.0
+    importance = float(node.get("importance") or 0.0)
+    distance = int(node.get("depth") or 0)
+    return round(max(0.0, importance - 0.18 * distance), 4)
+
+
+def hierarchy_for_view(
+    hgraph: HierarchicalCodeGraph,
+    view_nodes: Sequence[Dict[str, Any]],
+    *,
+    max_open_files: int = 4,
+    max_open_symbols: int = 16,
+) -> Dict[str, Any]:
+    """Project the repo-level hierarchy onto a codemap/page subgraph view.
+
+    ``view_nodes`` use short frontend ids (``n0``/``n1``). The projection remaps
+    visible symbol hierarchy ids to those ids so existing CodeGraph clients can
+    route edges without knowing the graph's canonical symbol names.
+    """
+
+    view_by_graph_name = {
+        node["name"]: node
+        for node in view_nodes
+        if isinstance(node.get("name"), str) and isinstance(node.get("id"), str)
+    }
+    graph_to_view = {node["name"]: node["id"] for node in view_by_graph_name.values()}
+    focus_hids = [
+        hid
+        for name, node in view_by_graph_name.items()
+        if node.get("is_root")
+        for hid in [hgraph.symbol_hierarchy_id(name)]
+        if hid
+    ]
+
+    def tree_distance(hid: Optional[str]) -> int:
+        if not hid or not focus_hids:
+            return 0
+        distances: List[int] = []
+        for focus_hid in focus_hids:
+            route, _ = hgraph.route(hid, focus_hid)
+            distances.append(max(0, len(route) - 1))
+        return min(distances) if distances else 0
+
+    def projected_doi(graph_name: Optional[str], node: ContainmentNode) -> float:
+        if not graph_name:
+            return float(node.doi or 0.0)
+        view_node = view_by_graph_name.get(graph_name)
+        if not view_node:
+            return float(node.doi or 0.0)
+        if view_node.get("is_root"):
+            return 1.0
+        importance = float(view_node.get("importance") or node.importance or 0.0)
+        ref_distance = int(view_node.get("depth") or 0)
+        containment_distance = tree_distance(hgraph.symbol_hierarchy_id(graph_name))
+        return round(
+            max(0.0, importance - 0.12 * ref_distance - 0.04 * containment_distance),
+            4,
+        )
+
+    focus_files = {
+        node.get("file")
+        for node in view_nodes
+        if node.get("is_root") and isinstance(node.get("file"), str)
+    }
+    visible_graph_names = set(graph_to_view)
+
+    def remap_id(hid: str) -> str:
+        if hid.startswith("hier::symbol::"):
+            graph_name = hid[len("hier::symbol::") :]
+            return f"hier::symbol::{graph_to_view.get(graph_name, graph_name)}"
+        return hid
+
+    needed: set[str] = {hgraph.root}
+    for graph_name in visible_graph_names:
+        hid = hgraph.symbol_hierarchy_id(graph_name)
+        while hid:
+            needed.add(hid)
+            hid = (
+                hgraph.nodes_by_id.get(hid).parent
+                if hid in hgraph.nodes_by_id
+                else None
+            )
+
+    projected: List[ContainmentNode] = []
+    for node in hgraph.containment:
+        if node.id not in needed:
+            continue
+        graph_name = node.node_id
+        projected.append(
+            ContainmentNode(
+                id=remap_id(node.id),
+                parent=remap_id(node.parent) if node.parent else None,
+                kind=node.kind,
+                label=node.label,
+                path=node.path,
+                depth=node.depth,
+                file=node.file,
+                node_id=(
+                    graph_to_view.get(graph_name, graph_name) if graph_name else None
+                ),
+                line=node.line,
+                end_line=node.end_line,
+                importance=node.importance,
+                doi=projected_doi(graph_name, node),
+                external=node.external,
+                open_by_default=node.open_by_default,
+            )
+        )
+
+    _assign_depths(projected)
+    _recompute_counts(projected)
+
+    by_id = {node.id: node for node in projected}
+    file_nodes = [
+        node for node in projected if node.kind == "file" and not node.external
+    ]
+    file_nodes.sort(
+        key=lambda n: (
+            1 if n.file in focus_files else 0,
+            float(n.doi or 0.0),
+            -int(n.symbol_count or 0),
+            n.path,
+        ),
+        reverse=True,
+    )
+    open_files: List[str] = []
+    open_symbols = 0
+    for node in file_nodes:
+        if len(open_files) >= max_open_files or open_symbols >= max_open_symbols:
+            break
+        if not open_files or float(node.doi or 0.0) >= 0.25:
+            node.open_by_default = True
+            if node.file:
+                open_files.append(node.file)
+            open_symbols += int(node.symbol_count or 0)
+            parent = node.parent
+            while parent and parent in by_id:
+                by_id[parent].open_by_default = True
+                parent = by_id[parent].parent
+
+    return {
+        "root": hgraph.root,
+        "nodes": [node.to_dict() for node in projected],
+        "open_files": open_files,
+        "source_root": hgraph.source_root,
+    }
+
+
+def hierarchy_from_view_nodes(nodes: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Compatibility fallback when a repo-level hierarchy is unavailable."""
+
+    by_file: Dict[str, List[Dict[str, Any]]] = {}
+    for node in nodes:
+        file = node.get("file")
+        key = (
+            EXTERNAL_FILE
+            if node.get("external") or not isinstance(file, str) or not file
+            else file.replace("\\", "/")
+        )
+        by_file.setdefault(key, []).append(node)
+
+    source_root = _common_source_root(list(by_file.keys()))
+    hnodes: List[ContainmentNode] = [
+        ContainmentNode(
+            id=HIERARCHY_ROOT,
+            parent=None,
+            kind="root",
+            label="root",
+            open_by_default=True,
+        )
+    ]
+    by_id = {HIERARCHY_ROOT: hnodes[0]}
+
+    def add(node: ContainmentNode) -> ContainmentNode:
+        existing = by_id.get(node.id)
+        if existing is not None:
+            return existing
+        by_id[node.id] = node
+        hnodes.append(node)
+        return node
+
+    for file in sorted(by_file):
+        if file == EXTERNAL_FILE:
+            parent = add(
+                ContainmentNode(
+                    id=_hier_dir_id(EXTERNAL_FILE),
+                    parent=HIERARCHY_ROOT,
+                    kind="directory",
+                    label="external",
+                    path=EXTERNAL_FILE,
+                    external=True,
+                )
+            ).id
+            rel_parts = [file]
+        else:
+            rel_parts = _hierarchy_path(file, source_root)
+            parent = HIERARCHY_ROOT
+            accum: List[str] = []
+            for part in rel_parts[:-1]:
+                accum.append(part)
+                path = "/".join(accum)
+                parent = add(
+                    ContainmentNode(
+                        id=_hier_dir_id(path),
+                        parent=parent,
+                        kind="directory",
+                        label=f"{path}/",
+                        path=path,
+                    )
+                ).id
+
+        file_id = _hier_file_id(file)
+        add(
+            ContainmentNode(
+                id=file_id,
+                parent=parent,
+                kind="file",
+                label=rel_parts[-1] if rel_parts else file.rsplit("/", 1)[-1],
+                path=file,
+                file=file,
+                doi=max((_node_doi(node) for node in by_file[file]), default=0.0),
+                external=file == EXTERNAL_FILE,
+            )
+        )
+        for node in sorted(
+            by_file[file],
+            key=lambda n: (0 if n.get("is_root") else 1, n.get("line") or 0, n["id"]),
+        ):
+            add(
+                ContainmentNode(
+                    id=f"hier::symbol::{node['id']}",
+                    parent=file_id,
+                    kind="symbol",
+                    label=node.get("short") or node.get("label") or node["id"],
+                    node_id=node["id"],
+                    path=node.get("name") or node["id"],
+                    file=file,
+                    doi=_node_doi(node),
+                    external=bool(node.get("external")),
+                )
+            )
+
+    _assign_depths(hnodes)
+    _recompute_counts(hnodes)
+
+    focus_files = {
+        node.get("file")
+        for node in nodes
+        if node.get("is_root") and isinstance(node.get("file"), str)
+    }
+    file_nodes = [node for node in hnodes if node.kind == "file" and not node.external]
+    file_nodes.sort(
+        key=lambda n: (
+            1 if n.file in focus_files else 0,
+            float(n.doi or 0.0),
+            -int(n.symbol_count or 0),
+            n.path,
+        ),
+        reverse=True,
+    )
+    open_files: List[str] = []
+    open_symbols = 0
+    for node in file_nodes:
+        if len(open_files) >= 4 or open_symbols >= 16:
+            break
+        if not open_files or float(node.doi or 0.0) >= 0.25:
+            node.open_by_default = True
+            if node.file:
+                open_files.append(node.file)
+            open_symbols += int(node.symbol_count or 0)
+            parent = node.parent
+            while parent and parent in by_id:
+                by_id[parent].open_by_default = True
+                parent = by_id[parent].parent
+
+    return {
+        "root": HIERARCHY_ROOT,
+        "nodes": [node.to_dict() for node in hnodes],
+        "open_files": open_files,
+        "source_root": source_root or "",
+    }
+
+
+def attach_edge_routes(
+    edges: List[Dict[str, Any]], hierarchy: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    parent_by_id = {
+        node["id"]: node.get("parent") for node in hierarchy.get("nodes", [])
+    }
+    kind_by_id = {node["id"]: node.get("kind") for node in hierarchy.get("nodes", [])}
+    file_by_symbol = {
+        node["node_id"]: node.get("file")
+        for node in hierarchy.get("nodes", [])
+        if node.get("kind") == "symbol" and node.get("node_id")
+    }
+
+    def chain(node_id: str) -> List[str]:
+        out: List[str] = []
+        cur: Optional[str] = node_id
+        while cur:
+            out.append(cur)
+            cur = parent_by_id.get(cur)
+        return out
+
+    def route(source_id: str, target_id: str) -> Tuple[List[str], str]:
+        src_chain = chain(source_id)
+        tgt_chain = chain(target_id)
+        tgt_index = {node_id: i for i, node_id in enumerate(tgt_chain)}
+        for i, node_id in enumerate(src_chain):
+            if node_id in tgt_index:
+                return (
+                    src_chain[: i + 1]
+                    + list(reversed(tgt_chain[: tgt_index[node_id]])),
+                    node_id,
+                )
+        return [source_id, target_id], ""
+
+    for edge in edges:
+        source_hid = f"hier::symbol::{edge['source']}"
+        target_hid = f"hier::symbol::{edge['target']}"
+        bundle_path, lca = route(source_hid, target_hid)
+        edge["source_hierarchy"] = source_hid
+        edge["target_hierarchy"] = target_hid
+        edge["bundle_path"] = bundle_path
+        edge["bundle_lca"] = lca
+        edge["bundle_lca_kind"] = kind_by_id.get(lca) or ""
+        edge["cross_file"] = file_by_symbol.get(edge["source"]) != file_by_symbol.get(
+            edge["target"]
+        )
+    return edges

--- a/codeminer/llm/litellm_chat.py
+++ b/codeminer/llm/litellm_chat.py
@@ -118,12 +118,13 @@ def _no_thinking_kwargs(model: str) -> Dict[str, Any]:
 
     Gemini 2.5 models spend the ``max_tokens`` budget on hidden reasoning
     tokens before emitting any answer; a tight budget leaves ``content`` empty
-    (``finish_reason="length"``). ``reasoning_effort="disable"`` turns thinking
-    off so the budget goes to the answer. No-op for non-thinking providers.
+    (``finish_reason="length"``). LiteLLM maps Anthropic-style ``thinking`` to
+    Gemini's ``thinkingConfig``; a zero budget turns thinking off so the budget
+    goes to the answer. No-op for non-thinking providers.
     """
     m = (model or "").lower()
     if "gemini-2.5" in m or "gemini-2-5" in m:
-        return {"reasoning_effort": "disable"}
+        return {"thinking": {"type": "disabled", "budget_tokens": 0}}
     return {}
 
 

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -142,9 +142,14 @@ async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
     graph = await asyncio.to_thread(bundle.code_graph)
     if graph is None:
         return {"available": False, "nodes": [], "edges": [], "mermaid": ""}
+    hierarchy_graph = await asyncio.to_thread(bundle.hierarchical_graph)
     citations = page.get("citations", []) if isinstance(page, dict) else []
     return await asyncio.to_thread(
-        build_page_subgraph, graph, citations, repo_dir=bundle.entry.repo_dir
+        build_page_subgraph,
+        graph,
+        citations,
+        repo_dir=bundle.entry.repo_dir,
+        hierarchy_graph=hierarchy_graph,
     )
 
 
@@ -178,6 +183,7 @@ async def codemap(
             "available": False,
             "nodes": [],
             "edges": [],
+            "hierarchy": {"root": "hier::root", "nodes": [], "open_files": []},
             "mermaid": "",
             "note": "This repo has no symbol graph.",
         }
@@ -189,6 +195,7 @@ async def codemap(
         depth,
         max_nodes,
         repo_dir=bundle.entry.repo_dir,
+        hierarchy_graph=await asyncio.to_thread(bundle.hierarchical_graph),
     )
 
 
@@ -205,6 +212,9 @@ async def chat(req: ChatRequest) -> ChatResponse:
     bundle = _registry().get(req.repo_id)
     if bundle is None:
         raise HTTPException(status_code=404, detail=f"Unknown repo: {req.repo_id!r}")
+    await asyncio.to_thread(bundle.ensure_runtime)
+    if bundle.runner is None:
+        raise HTTPException(status_code=503, detail="repo runtime is unavailable")
 
     # Earlier messages give the agent context so it can resolve follow-ups
     # like "what calls it?".

--- a/codeminer/web/codemap.py
+++ b/codeminer/web/codemap.py
@@ -22,6 +22,13 @@ from collections import deque
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ..graph.code_graph import CodeGraph
+from ..graph.hierarchy import (
+    HierarchicalCodeGraph,
+    attach_edge_routes,
+    empty_hierarchy,
+    hierarchy_for_view,
+    hierarchy_from_view_nodes,
+)
 from ..graph.traverse_graph import RepoDependencySearcher
 
 # Node types eligible as a focus / default seed (skip file/dir/import nodes).
@@ -273,6 +280,7 @@ def build_codemap(
     depth: int = 2,
     max_nodes: int = 40,
     repo_dir: Optional[str] = None,
+    hierarchy_graph: Optional[HierarchicalCodeGraph] = None,
 ) -> Dict[str, Any]:
     """Return a dependency subgraph + Mermaid rendering around *symbol*.
 
@@ -302,6 +310,7 @@ def build_codemap(
             "direction": direction,
             "nodes": [],
             "edges": [],
+            "hierarchy": empty_hierarchy(),
             "mermaid": "",
             "note": "This repo has no symbol graph.",
         }
@@ -392,6 +401,12 @@ def build_codemap(
         edges.append(edge)
 
     nodes, edges = _enrich(graph, nodes, edges)
+    hierarchy = (
+        hierarchy_for_view(hierarchy_graph, nodes)
+        if hierarchy_graph is not None
+        else hierarchy_from_view_nodes(nodes)
+    )
+    edges = attach_edge_routes(edges, hierarchy)
     return {
         "available": True,
         "root": root,
@@ -401,6 +416,7 @@ def build_codemap(
         "truncated": truncated,
         "nodes": nodes,
         "edges": edges,
+        "hierarchy": hierarchy,
         "mermaid": _to_mermaid(nodes, edges, id_of[root]),
         "note": note,
     }
@@ -459,17 +475,20 @@ def _resolve_citation(
 def build_page_subgraph(
     graph: CodeGraph,
     citations: List[Dict[str, Any]],
-    max_nodes: int = 40,
+    max_nodes: int = 18,
     repo_dir: Optional[str] = None,
+    hierarchy_graph: Optional[HierarchicalCodeGraph] = None,
 ) -> Dict[str, Any]:
-    """Induced reference subgraph over a wiki page's cited symbols.
+    """Page-evidence-first reference subgraph over a wiki page's cited symbols.
 
-    Resolves each citation to a graph node, then returns those nodes plus the
-    reference (call) edges *between* them — anchored to their exact call sites —
-    in the same ``{nodes, edges}`` shape as :func:`build_codemap`. This makes a
-    wiki page a *view over the graph*: the subsystem's symbols and how they wire
-    together, every node/edge clickable to real source.
+    Resolves each citation to a graph node, then returns the cited nodes plus
+    direct reference edges between them. It admits only a tiny number of
+    non-cited bridge symbols, and only when a bridge touches multiple cited
+    symbols. That keeps the wiki map grounded in the page's evidence instead of
+    dragging in a one-hop neighbourhood that may be true code but not relevant
+    to the page.
     """
+    max_nodes = max(2, min(int(max_nodes), 40))
     g = graph.get_graph()
 
     # Location + name index for resolving citations precisely (built once).
@@ -502,6 +521,7 @@ def build_page_subgraph(
             "direction": "both",
             "nodes": [],
             "edges": [],
+            "hierarchy": empty_hierarchy(),
             "mermaid": "",
             "note": "No graph symbols for this page.",
         }
@@ -509,44 +529,103 @@ def build_page_subgraph(
     seeds = set(names)  # the page's own cited symbols (highlighted)
     searcher = RepoDependencySearcher(graph)
 
-    # The page's symbols rarely call each other directly, so a pure induced
-    # subgraph is mostly disconnected dots. Expand one hop: pull in each seed's
-    # immediate neighbours so the subsystem's wiring is visible.
-    for nm in list(names):
-        if len(names) >= max_nodes:
-            break
-        nbrs, _ = searcher.get_neighbors(
-            nm, direction="all", etype_filter={"reference"}, ignore_test_file=True
+    direct_edges: List[Tuple[str, str]] = []
+    direct_seen: Set[Tuple[str, str]] = set()
+    bridge_edges: Dict[str, Set[Tuple[str, str]]] = {}
+    bridge_touches: Dict[str, Set[str]] = {}
+    bridge_weight: Dict[str, int] = {}
+    candidate_order: Dict[str, int] = {}
+    edge_anchors: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+
+    def add_anchor(key: Tuple[str, str], meta: Any) -> None:
+        af = meta.get("anchor_file") if isinstance(meta, dict) else None
+        al = meta.get("anchor_line") if isinstance(meta, dict) else None
+        if not af:
+            return
+        anchors = edge_anchors.setdefault(key, [])
+        entry = {"file": af, "line": (al + 1) if isinstance(al, int) else None}
+        if entry not in anchors:
+            anchors.append(entry)
+
+    for seed in names:
+        _, n_edges = searcher.get_neighbors(
+            seed, direction="all", etype_filter={"reference"}, ignore_test_file=True
         )
-        for nb in nbrs:
-            if nb not in chosen:
-                chosen.add(nb)
-                names.append(nb)
-            if len(names) >= max_nodes:
-                break
+        for src, tgt, _w, meta in n_edges:
+            if src == tgt:
+                continue
+            key = (src, tgt)
+            add_anchor(key, meta)
+            if src in seeds and tgt in seeds:
+                if key not in direct_seen:
+                    direct_seen.add(key)
+                    direct_edges.append(key)
+                continue
+
+            other = tgt if src == seed else src if tgt == seed else None
+            if other is None or other in seeds:
+                continue
+            other_attrs = _attrs(graph, other)
+            if _is_external(other_attrs, repo_dir):
+                continue
+            candidate_order.setdefault(other, len(candidate_order))
+            bridge_edges.setdefault(other, set()).add(key)
+            bridge_touches.setdefault(other, set()).add(seed)
+            bridge_weight[other] = bridge_weight.get(other, 0) + max(
+                1, len(edge_anchors.get(key) or [])
+            )
+
+    # A bridge has to explain relationships among page evidence, not merely be a
+    # random one-hop neighbour of one citation. Rank by exact call-site evidence
+    # first so broad generic types like Context do not crowd out stronger domain
+    # connectors.
+    bridge_candidates = [
+        name for name, touches in bridge_touches.items() if len(touches) >= 2
+    ]
+    bridge_candidates.sort(
+        key=lambda name: (
+            -bridge_weight.get(name, 0),
+            -len(bridge_touches.get(name, set())),
+            candidate_order.get(name, 0),
+            name,
+        )
+    )
+    bridge_budget = min(2, max(0, max_nodes - len(names)))
+    bridges = bridge_candidates[:bridge_budget]
+    names = names[:max_nodes] + [b for b in bridges if b not in chosen]
+    names = names[:max_nodes]
     nameset = set(names)
 
     edge_order: List[Tuple[str, str]] = []
     edge_seen: Set[Tuple[str, str]] = set()
-    edge_anchors: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
-    for nm in names:
+    for key in direct_edges:
+        if key[0] in nameset and key[1] in nameset and key not in edge_seen:
+            edge_seen.add(key)
+            edge_order.append(key)
+    for bridge in bridges:
+        for key in sorted(bridge_edges.get(bridge, set())):
+            if key[0] in nameset and key[1] in nameset and key not in edge_seen:
+                edge_seen.add(key)
+                edge_order.append(key)
+
+    # Collect anchors for any direct seed-seed edges that were not observed from
+    # the first seed's neighbour walk due traversal direction/order.
+    for nm in nameset:
         _, n_edges = searcher.get_neighbors(
             nm, direction="all", etype_filter={"reference"}, ignore_test_file=True
         )
         for src, tgt, _w, meta in n_edges:
             if src == tgt or src not in nameset or tgt not in nameset:
-                continue  # induced subgraph; drop self-loops
+                continue
             key = (src, tgt)
-            if key not in edge_seen:
+            touches_seed = src in seeds or tgt in seeds
+            if not touches_seed:
+                continue
+            if key not in edge_seen and src in seeds and tgt in seeds:
                 edge_seen.add(key)
                 edge_order.append(key)
-            af = meta.get("anchor_file") if isinstance(meta, dict) else None
-            al = meta.get("anchor_line") if isinstance(meta, dict) else None
-            if af:
-                anchors = edge_anchors.setdefault(key, [])
-                entry = {"file": af, "line": (al + 1) if isinstance(al, int) else None}
-                if entry not in anchors:
-                    anchors.append(entry)
+            if key in edge_seen:
+                add_anchor(key, meta)
 
     # Order seeds first (they're the page's subject); neighbours follow.
     ordered = [n for n in names if n in seeds] + [n for n in names if n not in seeds]
@@ -589,6 +668,12 @@ def build_page_subgraph(
         edges.append(edge)
 
     nodes, edges = _enrich(graph, nodes, edges)
+    hierarchy = (
+        hierarchy_for_view(hierarchy_graph, nodes)
+        if hierarchy_graph is not None
+        else hierarchy_from_view_nodes(nodes)
+    )
+    edges = attach_edge_routes(edges, hierarchy)
     return {
         "available": True,
         "root": "",
@@ -598,6 +683,7 @@ def build_page_subgraph(
         "truncated": len(names) >= max_nodes,
         "nodes": nodes,
         "edges": edges,
+        "hierarchy": hierarchy,
         "mermaid": "",
         "note": "",
     }

--- a/codeminer/web/repo_registry.py
+++ b/codeminer/web/repo_registry.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from threading import Lock
+from typing import Callable, Dict, List, Optional
 
 from ..agent.runner import AgentRunner
 from ..agent.skills.loader import SkillLoader
@@ -100,10 +101,27 @@ class RepoBundle:
 
     entry: RepoEntry
     manifest: RepoManifest
-    runner: AgentRunner
+    runner: Optional[AgentRunner] = None
     # Read-only handles reused by the wiki builder (index-derived docs).
     vector_store: Optional[CodeVectorStore] = None
     bm25: Optional[BM25CodeIndexer] = None
+    runtime_loader: Optional[Callable[["RepoBundle"], None]] = None
+
+    def __post_init__(self) -> None:
+        self._runtime_lock = Lock()
+        self._runtime_loaded = self.runner is not None
+
+    def ensure_runtime(self) -> None:
+        """Load heavy retrieval indexes and the QA runner on first real use."""
+        if self._runtime_loaded:
+            return
+        with self._runtime_lock:
+            if self._runtime_loaded:
+                return
+            if self.runtime_loader is None:
+                raise RuntimeError("repo runtime loader is not configured")
+            self.runtime_loader(self)
+            self._runtime_loaded = True
 
     def info(self) -> RepoInfo:
         capabilities = dict(self.manifest.capabilities)
@@ -168,6 +186,38 @@ class RepoBundle:
             self._code_graph = None
         return self._code_graph
 
+    def hierarchical_graph(self):
+        """Lazily build + cache the repo-level compound graph for CodeGraph UI."""
+        if getattr(self, "_hierarchical_graph_loaded", False):
+            return self._hierarchical_graph
+        self._hierarchical_graph_loaded = True
+        self._hierarchical_graph = None
+        graph = self.code_graph()
+        if graph is None:
+            return None
+        try:
+            from ..graph.hierarchy import build_hierarchical_code_graph
+
+            self._hierarchical_graph = build_hierarchical_code_graph(
+                graph, repo_dir=self.entry.repo_dir
+            )
+            logger.info(
+                "codemap: built hierarchical graph for %r "
+                "(%d containment nodes, %d dependencies)",
+                self.entry.instance_id,
+                len(self._hierarchical_graph.containment),
+                len(self._hierarchical_graph.dependencies),
+            )
+        except Exception as exc:  # noqa: BLE001 - hierarchy is a UI enhancement
+            logger.warning(
+                "codemap: failed to build hierarchy for %r: %s",
+                self.entry.instance_id,
+                exc,
+                exc_info=True,
+            )
+            self._hierarchical_graph = None
+        return self._hierarchical_graph
+
     def _file_count(self) -> int:
         cached = getattr(self, "_file_count_cache", None)
         if cached is not None:
@@ -229,15 +279,24 @@ class RepoRegistry:
                 )
                 continue
             try:
-                self._bundles[entry.instance_id] = self._load_repo(entry)
-                logger.info("Loaded %r (%s)", entry.instance_id, entry.repo)
+                self._bundles[entry.instance_id] = self._load_repo_metadata(entry)
+                logger.info("Registered %r (%s)", entry.instance_id, entry.repo)
             except Exception as exc:  # noqa: BLE001 - keep other repos alive
                 logger.error(
                     "Failed to load %r: %s", entry.instance_id, exc, exc_info=True
                 )
 
-    def _load_repo(self, entry: RepoEntry) -> RepoBundle:
+    def _load_repo_metadata(self, entry: RepoEntry) -> RepoBundle:
         manifest = RepoManifest.load(entry.manifest_path)
+        return RepoBundle(
+            entry=entry,
+            manifest=manifest,
+            runtime_loader=self._load_repo_runtime,
+        )
+
+    def _load_repo_runtime(self, bundle: RepoBundle) -> None:
+        entry = bundle.entry
+        manifest = bundle.manifest
 
         bm25_index: Optional[BM25CodeIndexer] = None
         vector_store: Optional[CodeVectorStore] = None
@@ -309,13 +368,9 @@ class RepoRegistry:
             # for the localization eval and would replace the explanation.
             force_localization_contract=False,
         )
-        return RepoBundle(
-            entry=entry,
-            manifest=manifest,
-            runner=runner,
-            vector_store=vector_store,
-            bm25=bm25_index,
-        )
+        bundle.runner = runner
+        bundle.vector_store = vector_store
+        bundle.bm25 = bm25_index
 
     # -- queries --
 

--- a/codeminer/wiki/agent_wiki.py
+++ b/codeminer/wiki/agent_wiki.py
@@ -197,25 +197,124 @@ class AgentWiki:
         return page
 
     def _retrieve(self, meta: Dict[str, Any], top_k: int = 8) -> List[Any]:
+        ensure_runtime = getattr(self._bundle, "ensure_runtime", None)
+        if callable(ensure_runtime):
+            ensure_runtime()
+        files = [f for f in meta.get("files") or [] if isinstance(f, str)]
         query = " ".join(
             [meta.get("title", ""), meta.get("summary", "")]
             + (meta.get("keywords") or [])
+            + files
         ).strip()
+        pool_k = max(top_k, top_k * 4)
         store = self._bundle.vector_store
+        nodes: List[Any] = []
         try:
             if store is not None and hasattr(store, "search_with_content"):
-                return store.search_with_content(query, top_k=top_k)
+                nodes = store.search_with_content(query, top_k=pool_k)
+                return self._rerank_for_page(meta, nodes)[:top_k]
             if store is not None:
-                return store.search(query, top_k=top_k)
+                nodes = store.search(query, top_k=pool_k)
+                return self._rerank_for_page(meta, nodes)[:top_k]
         except Exception as exc:  # noqa: BLE001 - fall back to BM25 below
             logger.warning("wiki retrieve (vector) failed: %s", exc)
         bm25 = self._bundle.bm25
         if bm25 is not None:
             try:
-                return bm25.search(query, top_k)
+                nodes = bm25.search(query, pool_k)
+                return self._rerank_for_page(meta, nodes)[:top_k]
             except Exception:  # noqa: BLE001
                 return []
         return []
+
+    @staticmethod
+    def _norm_hint_path(path: str) -> str:
+        return path.replace("\\", "/").strip().strip("/")
+
+    @staticmethod
+    def _path_matches_hint(file: str, hint: str) -> bool:
+        if not file or not hint:
+            return False
+        hint = hint.rstrip("/")
+        return (
+            file == hint
+            or file.endswith("/" + hint)
+            or file.startswith(hint + "/")
+            or ("/" + hint + "/") in ("/" + file)
+        )
+
+    @staticmethod
+    def _keyword_terms(keywords: List[str]) -> List[str]:
+        terms: List[str] = []
+        seen = set()
+        for keyword in keywords:
+            for term in re.findall(r"[a-zA-Z0-9_]{3,}", keyword.lower()):
+                if term not in seen:
+                    seen.add(term)
+                    terms.append(term)
+        return terms
+
+    def _candidate_hint_score(
+        self, meta: Dict[str, Any], node: Any, file_hints: List[str], terms: List[str]
+    ) -> float:
+        file = self._norm_hint_path(self._rel(self._node_attr(node, "file")) or "")
+        name = self._node_attr(node, "node_name") or self._node_attr(node, "name") or ""
+        content = (self._node_attr(node, "content") or "")[:1200]
+        haystack = f"{file} {name} {content}".lower()
+        score = 0.0
+
+        for hint in file_hints:
+            if self._path_matches_hint(file, hint):
+                score += 5.0
+            else:
+                base = hint.rsplit("/", 1)[-1]
+                if base and base in file:
+                    score += 1.0
+
+        phrase_hits = 0
+        for keyword in meta.get("keywords") or []:
+            phrase = str(keyword).strip().lower()
+            if len(phrase) >= 3 and phrase in haystack:
+                phrase_hits += 1
+        score += min(4.0, phrase_hits * 2.0)
+
+        term_hits = sum(1 for term in terms if term in haystack)
+        score += min(3.0, term_hits * 0.5)
+        return score
+
+    def _rerank_for_page(self, meta: Dict[str, Any], nodes: List[Any]) -> List[Any]:
+        file_hints = [
+            self._norm_hint_path(f)
+            for f in meta.get("files") or []
+            if isinstance(f, str) and f.strip()
+        ]
+        terms = self._keyword_terms(
+            [str(k) for k in meta.get("keywords") or [] if str(k).strip()]
+        )
+        if not file_hints and not terms:
+            return nodes
+
+        scored: List[tuple[float, int, Any]] = []
+        seen = set()
+        for i, node in enumerate(nodes):
+            file = self._norm_hint_path(self._rel(self._node_attr(node, "file")) or "")
+            key = (
+                file,
+                self._node_attr(node, "start_line"),
+                self._node_attr(node, "end_line"),
+                self._node_attr(node, "node_name")
+                or self._node_attr(node, "name")
+                or "",
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            scored.append(
+                (self._candidate_hint_score(meta, node, file_hints, terms), i, node)
+            )
+        if any(score > 0 for score, _, _ in scored):
+            scored.sort(key=lambda item: (-item[0], item[1]))
+        return [node for _, _, node in scored]
 
     def _node_attr(self, node: Any, key: str, default: Any = None) -> Any:
         if isinstance(node, dict):

--- a/codeminer/wiki/narrator.py
+++ b/codeminer/wiki/narrator.py
@@ -39,12 +39,13 @@ def _no_thinking_kwargs(model: str) -> dict:
 
     Gemini 2.5 models spend the ``max_tokens`` budget on hidden reasoning
     tokens first; with the small prose budgets here that leaves ``content``
-    empty (``finish_reason="length"``). ``reasoning_effort="disable"`` turns
-    thinking off so the budget goes to the answer. No-op for other providers.
+    empty (``finish_reason="length"``). LiteLLM maps Anthropic-style
+    ``thinking`` to Gemini's ``thinkingConfig``; a zero budget turns thinking off
+    so the budget goes to the answer. No-op for other providers.
     """
     m = model.lower()
     if "gemini-2.5" in m or "gemini-2-5" in m:
-        return {"reasoning_effort": "disable"}
+        return {"thinking": {"type": "disabled", "budget_tokens": 0}}
     return {}
 
 

--- a/docs/codegraph_hierarchy_model.md
+++ b/docs/codegraph_hierarchy_model.md
@@ -1,0 +1,207 @@
+# CodeGraph Hierarchy Model
+
+The CodeGraph UI should not render the raw LSP/SCIP reference graph as the
+primary structure. Reference graphs are dense, cyclic, and quickly become a
+hairball. The model we want is a compound graph:
+
+```text
+G = (V, containment_edges, dependency_edges)
+```
+
+- `containment_edges` form a tree: directory -> file -> symbol.
+- `dependency_edges` are the call/reference/import overlay.
+
+This lets the UI use the containment tree as the visual backbone and draw only a
+small number of important cross-edges on top.
+
+## Current API shape
+
+`codeminer.graph.hierarchy` builds a reusable repo-level
+`HierarchicalCodeGraph` from the indexed `CodeGraph`. The web codemap response
+projects that repo-level structure onto the current focus window, so existing
+clients still receive compact `nodes`/`edges` plus the relevant containment
+ancestors:
+
+```ts
+interface CodemapResponse {
+  nodes: CodemapNode[];       // symbol nodes in the current focus window
+  edges: CodemapEdge[];       // reference/call overlay
+  hierarchy: CodemapHierarchy;
+}
+
+interface CodemapEdge {
+  source: string;              // CodemapNode id
+  target: string;
+  anchors?: CallSite[];
+  weight?: number;
+  source_hierarchy?: string;   // hier::symbol::<source>
+  target_hierarchy?: string;   // hier::symbol::<target>
+  bundle_path?: string[];      // source -> LCA -> target through containment
+  bundle_lca?: string;
+  cross_file?: boolean;
+}
+
+interface CodemapHierarchyNode {
+  id: string;
+  parent: string | null;
+  kind: "root" | "directory" | "file" | "symbol";
+  label: string;
+  path?: string;
+  file?: string;
+  node_id?: string;           // present for symbol hierarchy leaves
+  line?: number;
+  end_line?: number;
+  depth: number;
+  child_count: number;
+  symbol_count: number;
+  doi: number;                // importance - distance from focus
+  open_by_default?: boolean;
+}
+```
+
+`hierarchy.open_files` is a backend Degree-of-Interest expansion hint. The UI
+can cap it further for viewport constraints, but the ranking belongs to the data
+model rather than to ad hoc frontend path parsing. `edges[].bundle_path` connects
+the call/reference overlay back to the containment tree, which is the data needed
+for true hierarchical edge bundling.
+
+## Current frontend pass
+
+`web/components/CodeGraph.tsx` now prefers the backend hierarchy and falls back
+to deriving it from `node.file` only for older payloads. It renders:
+
+- directory compound boxes from `hierarchy.nodes`,
+- file pills/boxes under those directories,
+- symbol scope boxes (class/container symbols) under expanded files,
+- concrete symbol nodes inside those scopes,
+- reference edges between the currently visible endpoints,
+- SVG bundled paths for cross-file aggregate edges, routed through
+  `edges[].bundle_path`,
+- scope-aware SVG routes for exact same-file references, so class/member calls
+  visually follow the containment path while the original Cytoscape edge remains
+  clickable for exact source peeks.
+
+The hierarchy is intentionally mode-sensitive:
+
+- `Files`: shows the full directory/file backbone.
+- `Symbols`: expands only the DOI-like core spine and keeps the long tail as
+  file pills.
+- wiki embedded maps start in `Symbols` so the narrative page shows the cited
+  subsystem's active symbols immediately; the standalone explorer still starts
+  in `Files` as an overview.
+- manual file expansion in `Files`: preserves the same directory/file
+  projection, then semantically zooms into the clicked file's internal scope
+  tree. The global `Fit` action remains available to restore the whole graph.
+
+The dependency overlay also has lightweight layers:
+
+- `Map`: default compound view; containment stays primary, routed dependency
+  overlays are visible, raw exact edges are subdued;
+- `Routes`: emphasizes hierarchical routes/bundles and further quiets raw edges;
+- `Raw`: hides SVG routes and shows the original Cytoscape reference edges for
+  debugging exact graph structure.
+
+The wiki embedded map keeps the reader-facing controls minimal: mode switch,
+compact status, and fit. The explorer modal keeps the full edge-layer controls
+for debugging and deeper navigation.
+
+The standalone graph explorer defaults to a one-hop focus window. This follows
+Sourcetrail's focus+context pattern: start with the current symbol and immediate
+callers/callees, then let the user explicitly expand to two hops when they need
+broader context.
+
+The Cytoscape layer also applies semantic zoom classes:
+
+- low zoom: concrete symbol nodes become small landmarks and hide labels, while
+  directory/file/scope labels remain visible;
+- mid zoom: concrete symbol labels return in a compact style;
+- high zoom / hover / focus: exact symbol labels are fully readable and still
+  open source peeks without rebuilding the graph instance.
+
+## Current backend model
+
+The backend model now separates containment and dependency edges before any
+view-specific filtering:
+
+```ts
+interface ContainmentNode {
+  id: string;
+  parent: string | null;
+  kind: "root" | "directory" | "file" | "symbol";
+  label: string;
+  file?: string;
+  node_id?: string;            // canonical CodeGraph symbol identity
+  line?: number;               // 1-based display line
+  end_line?: number;
+  importance?: number;
+}
+
+interface DependencyEdge {
+  source: string;
+  target: string;
+  kind: "reference" | "import" | "type-use";
+  weight: number;
+  anchors: CallSite[];
+}
+
+interface HierarchicalCodeGraph {
+  root: string;
+  containment: ContainmentNode[];
+  dependencies: DependencyEdge[];
+  source_root: string;
+}
+```
+
+The repo bundle builds this object lazily and caches it in memory. The codemap
+projection remaps visible symbol ids to frontend ids (`n0`, `n1`, ...), keeps
+invisible ancestor symbols in the route when the index has `contain` edges, and
+uses a dominant source-root heuristic so root files such as `setup.py` do not
+make package labels noisy.
+
+When explicit `contain` edges are missing, the backend now has a conservative
+fallback: within a file, container-like symbols such as classes can parent
+members whose readable names share the same scope prefix (`Widget` ->
+`Widget.run()`) and whose source ranges fit inside the container. This keeps the
+compound graph from collapsing to a flat file whenever an index lacks explicit
+scope edges but still exposes SCIP/LSP-style symbol names.
+
+## DOI and semantic zoom
+
+The current implementation uses DOI-style ranking in two places:
+
+- the backend computes `doi`/`open_by_default` hints for the current focus
+  window, combining reference distance and containment-tree distance from the
+  focus symbol;
+- the frontend `Symbols` mode expands only the highest-value file spine and
+  keeps the long tail folded as file pills.
+
+The ranking follows the fisheye shape:
+
+```text
+doi(node) = importance(node) - distance(node, focus)
+```
+
+Nodes above threshold are expanded; the rest stay folded at directory/file level.
+The UI also applies semantic zoom:
+
+- low zoom keeps concrete symbols as landmarks and hides most labels;
+- hover/focus temporarily reveals exact labels without rebuilding Cytoscape;
+- mid/high zoom reveals symbol labels and supports source peeks.
+
+## Remaining model upgrades
+
+- Promote the current in-memory expansion overrides into a route-level graph
+  session state if we need them to survive modal close/reopen or page navigation.
+- Add per-edge-kind filters if we start indexing imports/type-use/read-write in
+  addition to SCIP/LSP references.
+
+## References
+
+- Compound digraphs: Kozo Sugiyama and Kazuo Misue, "Visualization of structural
+  information: automatic drawing of compound digraphs."
+- Degree-of-interest / fisheye views: George W. Furnas, "Generalized Fisheye
+  Views."
+- Hierarchical edge bundling: Danny Holten, "Hierarchical Edge Bundles:
+  Visualization of Adjacency Relations in Hierarchical Data."
+- Interaction reference: Sourcetrail, especially its focus-and-context graph
+  navigation model.

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -85,6 +85,30 @@ Config lives in `qa_config.yaml` (override path with `CODEMINER_DEMO_CONFIG`).
 Key env overrides: `CODEMINER_DEMO_MODEL`, `CODEMINER_DEMO_DATA_DIR`,
 `CODEMINER_DEMO_PREBUILT_DIR`.
 
+### Managed local dev servers
+
+For day-to-day development, prefer the repo-local manager instead of launching
+long-lived `uvicorn` and `next dev` processes by hand:
+
+```bash
+make web-start      # start backend :8000 and frontend :3000
+make web-status     # show PIDs, cwd, port owners, health, and log paths
+make web-logs       # print recent backend/frontend logs
+make web-stop       # stop managed processes
+make web-restart    # restart managed processes
+make web-reclaim    # reclaim current-user listeners on :3000/:8000, then restart
+```
+
+PID files and logs live under `.codeminer_demo/server/`:
+
+- `.codeminer_demo/server/backend.log`
+- `.codeminer_demo/server/frontend.log`
+
+If `localhost:3000` returns `Internal Server Error` after switching branches or
+deleting a worktree, run `make web-status`. A stale Next.js process from an old
+cwd is usually visible there. Use `make web-reclaim` to stop current-user
+listeners on the demo ports and restart both services from the current checkout.
+
 The backend exposes (all under `/api`):
 
 | Endpoint | Purpose |

--- a/scripts/dev_web.sh
+++ b/scripts/dev_web.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WEB_DIR="$ROOT/web"
+STATE_DIR="${CODEMINER_WEB_STATE_DIR:-$ROOT/.codeminer_demo/server}"
+
+BACKEND_HOST="${CODEMINER_DEMO_HOST:-127.0.0.1}"
+BACKEND_PORT="${CODEMINER_DEMO_PORT:-8000}"
+FRONTEND_HOST="${CODEMINER_WEB_FRONTEND_HOST:-0.0.0.0}"
+FRONTEND_PORT="${CODEMINER_WEB_FRONTEND_PORT:-3000}"
+PUBLIC_FRONTEND_HOST="${CODEMINER_WEB_PUBLIC_FRONTEND_HOST:-localhost}"
+# Backend URL used by Next.js rewrites. Browser code should normally use the
+# same-origin /api path so remote/forwarded browsers don't try to reach their
+# own 127.0.0.1:8000.
+API_BASE="${CODEMINER_API_BASE:-http://${BACKEND_HOST}:${BACKEND_PORT}}"
+PUBLIC_API_BASE="${NEXT_PUBLIC_API_BASE:-}"
+
+PYTHON_BIN="${CODEMINER_WEB_PYTHON:-python}"
+NODE_BIN="${CODEMINER_WEB_NODE:-node}"
+RECLAIM_PORTS="${CODEMINER_WEB_RECLAIM_PORTS:-0}"
+
+BACKEND_PID="$STATE_DIR/backend.pid"
+FRONTEND_PID="$STATE_DIR/frontend.pid"
+BACKEND_LOG="$STATE_DIR/backend.log"
+FRONTEND_LOG="$STATE_DIR/frontend.log"
+
+usage() {
+  cat <<EOF
+Usage: $0 <command>
+
+Commands:
+  start      Start the FastAPI backend and Next.js frontend.
+  stop       Stop managed backend/frontend processes.
+  restart    Stop managed processes, then start both services.
+  reclaim    Stop current-user listeners on the managed ports.
+  status     Show PID, cwd, port, health, and log locations.
+  logs       Print recent backend and frontend logs.
+  follow     Follow backend and frontend logs.
+
+Environment:
+  CODEMINER_WEB_PYTHON         Python executable for uvicorn (default: python)
+  CODEMINER_WEB_NODE           node executable for Next.js (default: node)
+  CODEMINER_DEMO_HOST          Backend host (default: 127.0.0.1)
+  CODEMINER_DEMO_PORT          Backend port (default: 8000)
+  CODEMINER_WEB_FRONTEND_HOST  Next.js bind host (default: 0.0.0.0)
+  CODEMINER_WEB_FRONTEND_PORT  Next.js port (default: 3000)
+  CODEMINER_API_BASE           Backend URL for Next.js /api rewrites (default: http://127.0.0.1:8000)
+  NEXT_PUBLIC_API_BASE         Optional direct browser API base; leave unset for same-origin /api proxy.
+  CODEMINER_WEB_RECLAIM_PORTS  If 1, start/restart may stop current-user port owners.
+EOF
+}
+
+ensure_state_dir() {
+  mkdir -p "$STATE_DIR"
+}
+
+is_alive() {
+  local pid="${1:-}"
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+pid_from_file() {
+  local file="$1"
+  [[ -f "$file" ]] && sed -n '1p' "$file" || true
+}
+
+pid_user() {
+  ps -o user= -p "$1" 2>/dev/null | awk '{print $1}'
+}
+
+pid_cwd() {
+  readlink "/proc/$1/cwd" 2>/dev/null || printf '?'
+}
+
+pid_cmd() {
+  ps -o args= -p "$1" 2>/dev/null | sed 's/^ *//'
+}
+
+port_pids() {
+  local port="$1"
+  if command -v ss >/dev/null 2>&1; then
+    ss -ltnp "( sport = :$port )" 2>/dev/null \
+      | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' \
+      | sort -u
+  elif command -v lsof >/dev/null 2>&1; then
+    lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | sort -u
+  fi
+}
+
+print_pid_details() {
+  local pid="$1"
+  printf '    pid=%s user=%s cwd=%s\n' "$pid" "$(pid_user "$pid")" "$(pid_cwd "$pid")"
+  printf '    cmd=%s\n' "$(pid_cmd "$pid")"
+}
+
+terminate_pid_group() {
+  local pid="$1"
+  local pgid
+  if ! is_alive "$pid"; then
+    return 0
+  fi
+
+  pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | awk '{print $1}')"
+  if [[ -n "$pgid" ]]; then
+    kill -TERM "-$pgid" 2>/dev/null || true
+  fi
+  kill -TERM "$pid" 2>/dev/null || true
+  for _ in 1 2 3 4 5; do
+    if ! is_alive "$pid"; then
+      return 0
+    fi
+    sleep 1
+  done
+  if [[ -n "$pgid" ]]; then
+    kill -KILL "-$pgid" 2>/dev/null || true
+  fi
+  kill -KILL "$pid" 2>/dev/null || true
+}
+
+wait_for_pid_file() {
+  local pid_file="$1"
+  local label="$2"
+  local pid
+
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    pid="$(pid_from_file "$pid_file")"
+    if is_alive "$pid"; then
+      printf '%s' "$pid"
+      return 0
+    fi
+    sleep 0.2
+  done
+
+  printf '%s pid file was not written or process exited early: %s\n' "$label" "$pid_file" >&2
+  return 1
+}
+
+stop_service() {
+  local name="$1"
+  local pid_file="$2"
+  local pid
+
+  pid="$(pid_from_file "$pid_file")"
+  if is_alive "$pid"; then
+    printf 'Stopping %s pid=%s\n' "$name" "$pid"
+    terminate_pid_group "$pid"
+  elif [[ -n "$pid" ]]; then
+    printf '%s pid file was stale: %s\n' "$name" "$pid"
+  fi
+  rm -f "$pid_file"
+}
+
+stop_all() {
+  stop_service frontend "$FRONTEND_PID"
+  stop_service backend "$BACKEND_PID"
+}
+
+reclaim_port() {
+  local port="$1"
+  local label="$2"
+  local current_user
+  local pids
+
+  current_user="$(id -un)"
+  mapfile -t pids < <(port_pids "$port")
+  if ((${#pids[@]} == 0)); then
+    return 0
+  fi
+
+  for pid in "${pids[@]}"; do
+    if [[ "$(pid_user "$pid")" != "$current_user" ]]; then
+      printf 'Refusing to stop %s port %s owned by another user:\n' "$label" "$port" >&2
+      print_pid_details "$pid" >&2
+      continue
+    fi
+    printf 'Reclaiming %s port %s from pid=%s\n' "$label" "$port" "$pid"
+    print_pid_details "$pid"
+    terminate_pid_group "$pid"
+  done
+}
+
+reclaim_ports() {
+  reclaim_port "$FRONTEND_PORT" frontend
+  reclaim_port "$BACKEND_PORT" backend
+}
+
+require_port_available() {
+  local port="$1"
+  local label="$2"
+  local pids
+
+  mapfile -t pids < <(port_pids "$port")
+  if ((${#pids[@]} == 0)); then
+    return 0
+  fi
+
+  if [[ "$RECLAIM_PORTS" == "1" ]]; then
+    reclaim_port "$port" "$label"
+    mapfile -t pids < <(port_pids "$port")
+    if ((${#pids[@]} == 0)); then
+      return 0
+    fi
+  fi
+
+  printf '%s port %s is already in use. Run status to inspect it, or set CODEMINER_WEB_RECLAIM_PORTS=1.\n' "$label" "$port" >&2
+  for pid in "${pids[@]}"; do
+    print_pid_details "$pid" >&2
+  done
+  return 1
+}
+
+wait_for_http() {
+  local label="$1"
+  local url="$2"
+  local attempts="${3:-60}"
+
+  if ! command -v curl >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for _ in $(seq 1 "$attempts"); do
+    if curl -fsS --max-time 2 "$url" >/dev/null 2>&1; then
+      printf '%s is ready: %s\n' "$label" "$url"
+      return 0
+    fi
+    sleep 1
+  done
+
+  printf '%s did not become ready: %s\n' "$label" "$url" >&2
+  return 1
+}
+
+start_backend() {
+  local pid
+  pid="$(pid_from_file "$BACKEND_PID")"
+  if is_alive "$pid"; then
+    printf 'Backend already running pid=%s\n' "$pid"
+    return 0
+  fi
+
+  command -v "$PYTHON_BIN" >/dev/null 2>&1 || {
+    printf 'Python executable not found: %s\n' "$PYTHON_BIN" >&2
+    return 1
+  }
+  require_port_available "$BACKEND_PORT" backend
+
+  : > "$BACKEND_LOG"
+  BACKEND_PID_FILE="$BACKEND_PID" \
+  ROOT="$ROOT" \
+  PYTHON_BIN="$PYTHON_BIN" \
+  BACKEND_HOST="$BACKEND_HOST" \
+  BACKEND_PORT="$BACKEND_PORT" \
+  setsid -f bash -c '
+    echo $$ > "$BACKEND_PID_FILE"
+    cd "$ROOT"
+    exec "$PYTHON_BIN" -m uvicorn codeminer.web.app:app --host "$BACKEND_HOST" --port "$BACKEND_PORT"
+  ' >>"$BACKEND_LOG" 2>&1 </dev/null
+
+  printf 'Started backend pid=%s log=%s\n' "$(wait_for_pid_file "$BACKEND_PID" backend)" "$BACKEND_LOG"
+  wait_for_http backend "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" 60 || {
+    tail -n 80 "$BACKEND_LOG" >&2 || true
+    return 1
+  }
+}
+
+start_frontend() {
+  local pid
+  pid="$(pid_from_file "$FRONTEND_PID")"
+  if is_alive "$pid"; then
+    printf 'Frontend already running pid=%s\n' "$pid"
+    return 0
+  fi
+
+  command -v "$NODE_BIN" >/dev/null 2>&1 || {
+    printf 'node executable not found: %s\n' "$NODE_BIN" >&2
+    return 1
+  }
+  [[ -f "$WEB_DIR/node_modules/next/dist/bin/next" ]] || {
+    printf 'Missing Next.js CLI. Run: cd web && npm install\n' >&2
+    return 1
+  }
+  [[ -d "$WEB_DIR/node_modules" ]] || {
+    printf 'Missing %s. Run: cd web && npm install\n' "$WEB_DIR/node_modules" >&2
+    return 1
+  }
+  require_port_available "$FRONTEND_PORT" frontend
+
+  : > "$FRONTEND_LOG"
+  FRONTEND_PID_FILE="$FRONTEND_PID" \
+  WEB_DIR="$WEB_DIR" \
+  NODE_BIN="$NODE_BIN" \
+  FRONTEND_HOST="$FRONTEND_HOST" \
+  FRONTEND_PORT="$FRONTEND_PORT" \
+  CODEMINER_API_BASE="$API_BASE" \
+  NEXT_PUBLIC_API_BASE="$PUBLIC_API_BASE" \
+  setsid -f bash -c '
+    echo $$ > "$FRONTEND_PID_FILE"
+    cd "$WEB_DIR"
+    export CODEMINER_API_BASE NEXT_PUBLIC_API_BASE
+    exec "$NODE_BIN" "$WEB_DIR/node_modules/next/dist/bin/next" dev --hostname "$FRONTEND_HOST" --port "$FRONTEND_PORT"
+  ' >>"$FRONTEND_LOG" 2>&1 </dev/null
+
+  printf 'Started frontend pid=%s log=%s\n' "$(wait_for_pid_file "$FRONTEND_PID" frontend)" "$FRONTEND_LOG"
+  wait_for_http frontend "http://${PUBLIC_FRONTEND_HOST}:${FRONTEND_PORT}/" 60 || {
+    tail -n 80 "$FRONTEND_LOG" >&2 || true
+    return 1
+  }
+}
+
+start_all() {
+  ensure_state_dir
+  start_backend
+  start_frontend
+  printf '\nOpen http://%s:%s\n' "$PUBLIC_FRONTEND_HOST" "$FRONTEND_PORT"
+}
+
+show_service() {
+  local label="$1"
+  local pid_file="$2"
+  local port="$3"
+  local log_file="$4"
+  local pid
+  local port_owners
+
+  pid="$(pid_from_file "$pid_file")"
+  if is_alive "$pid"; then
+    printf '%s: managed, running\n' "$label"
+    print_pid_details "$pid"
+  elif [[ -n "$pid" ]]; then
+    printf '%s: managed pid stale (%s)\n' "$label" "$pid"
+  else
+    printf '%s: no managed pid\n' "$label"
+  fi
+  printf '    port=%s log=%s\n' "$port" "$log_file"
+
+  mapfile -t port_owners < <(port_pids "$port")
+  if ((${#port_owners[@]} > 0)); then
+    printf '    listeners:\n'
+    for owner in "${port_owners[@]}"; do
+      print_pid_details "$owner"
+    done
+  else
+    printf '    listeners: none\n'
+  fi
+}
+
+status_all() {
+  show_service backend "$BACKEND_PID" "$BACKEND_PORT" "$BACKEND_LOG"
+  show_service frontend "$FRONTEND_PID" "$FRONTEND_PORT" "$FRONTEND_LOG"
+  if command -v curl >/dev/null 2>&1; then
+    printf 'backend health: '
+    curl -fsS --max-time 3 "http://${BACKEND_HOST}:${BACKEND_PORT}/api/health" 2>/dev/null || printf 'unavailable'
+    printf '\n'
+    printf 'frontend: '
+    if curl -fsS --max-time 3 "http://${PUBLIC_FRONTEND_HOST}:${FRONTEND_PORT}/" >/dev/null 2>&1; then
+      printf 'ok\n'
+    else
+      printf 'unavailable\n'
+    fi
+  fi
+}
+
+logs_all() {
+  printf '== backend: %s ==\n' "$BACKEND_LOG"
+  tail -n 80 "$BACKEND_LOG" 2>/dev/null || true
+  printf '\n== frontend: %s ==\n' "$FRONTEND_LOG"
+  tail -n 80 "$FRONTEND_LOG" 2>/dev/null || true
+}
+
+follow_logs() {
+  touch "$BACKEND_LOG" "$FRONTEND_LOG"
+  tail -n 80 -f "$BACKEND_LOG" "$FRONTEND_LOG"
+}
+
+cmd="${1:-status}"
+case "$cmd" in
+  start)
+    start_all
+    ;;
+  stop)
+    ensure_state_dir
+    stop_all
+    ;;
+  restart)
+    ensure_state_dir
+    stop_all
+    [[ "$RECLAIM_PORTS" == "1" ]] && reclaim_ports
+    start_all
+    ;;
+  reclaim)
+    reclaim_ports
+    ;;
+  status)
+    ensure_state_dir
+    status_all
+    ;;
+  logs)
+    logs_all
+    ;;
+  follow)
+    ensure_state_dir
+    follow_logs
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/test/graph/test_hierarchy.py
+++ b/test/graph/test_hierarchy.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the repo-level hierarchical code graph model."""
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.graph.hierarchy import (
+    attach_edge_routes,
+    build_hierarchical_code_graph,
+    hierarchy_for_view,
+)
+
+
+def _compound_graph() -> CodeGraph:
+    graph = CodeGraph()
+    graph._add_vertex(
+        "src/pkg/model.py:Widget",
+        {
+            "type": "class",
+            "file": "src/pkg/model.py",
+            "start_line": 0,
+            "end_line": 20,
+            "unified_name": "src/pkg/model.py:Widget",
+        },
+    )
+    graph._add_vertex(
+        "src/pkg/model.py:Widget.run()",
+        {
+            "type": "method",
+            "file": "src/pkg/model.py",
+            "start_line": 4,
+            "end_line": 10,
+            "unified_name": "src/pkg/model.py:Widget.run()",
+        },
+    )
+    graph._add_vertex(
+        "src/pkg/helper.py:load()",
+        {
+            "type": "function",
+            "file": "src/pkg/helper.py",
+            "start_line": 30,
+            "end_line": 36,
+            "unified_name": "src/pkg/helper.py:load()",
+        },
+    )
+    graph._add_vertex(
+        "setup.py:main()",
+        {
+            "type": "function",
+            "file": "setup.py",
+            "start_line": 0,
+            "end_line": 2,
+            "unified_name": "setup.py:main()",
+        },
+    )
+    graph._add_vertex(
+        "docs/conf.py:configure()",
+        {
+            "type": "function",
+            "file": "docs/conf.py",
+            "start_line": 0,
+            "end_line": 3,
+            "unified_name": "docs/conf.py:configure()",
+        },
+    )
+    graph._add_edge(
+        "src/pkg/model.py:Widget",
+        "src/pkg/model.py:Widget.run()",
+        "contain",
+    )
+    for line in (5, 8):
+        graph._add_edge(
+            "src/pkg/model.py:Widget.run()",
+            "src/pkg/helper.py:load()",
+            "reference",
+            anchor_file="src/pkg/model.py",
+            anchor_line=line,
+        )
+    return graph
+
+
+def test_hierarchical_code_graph_keeps_containment_and_dependency_layers():
+    hgraph = build_hierarchical_code_graph(_compound_graph())
+    nodes = {node.id: node for node in hgraph.containment}
+
+    assert hgraph.source_root == "src"
+    assert nodes["hier::dir::pkg"].parent == "hier::root"
+    assert nodes["hier::file::src/pkg/model.py"].parent == "hier::dir::pkg"
+    assert (
+        nodes["hier::symbol::src/pkg/model.py:Widget.run()"].parent
+        == "hier::symbol::src/pkg/model.py:Widget"
+    )
+    assert nodes["hier::symbol::src/pkg/model.py:Widget"].symbol_count == 2
+
+    assert len(hgraph.dependencies) == 1
+    dep = hgraph.dependencies[0]
+    assert dep.source == "src/pkg/model.py:Widget.run()"
+    assert dep.target == "src/pkg/helper.py:load()"
+    assert dep.weight == 2
+    assert dep.anchors == [
+        {"file": "src/pkg/model.py", "line": 6},
+        {"file": "src/pkg/model.py", "line": 9},
+    ]
+
+
+def test_hierarchical_code_graph_infers_scope_when_containment_edges_are_absent():
+    graph = CodeGraph()
+    graph._add_vertex(
+        "src/pkg/model.py:Widget",
+        {
+            "type": "class",
+            "file": "src/pkg/model.py",
+            "start_line": 0,
+            "end_line": 20,
+            "unified_name": "src/pkg/model.py:Widget",
+        },
+    )
+    graph._add_vertex(
+        "src/pkg/model.py:Widget.run()",
+        {
+            "type": "method",
+            "file": "src/pkg/model.py",
+            "start_line": 4,
+            "end_line": 10,
+            "unified_name": "src/pkg/model.py:Widget.run()",
+        },
+    )
+    graph._add_vertex(
+        "src/pkg/model.py:WidgetHelper.run()",
+        {
+            "type": "function",
+            "file": "src/pkg/model.py",
+            "start_line": 25,
+            "end_line": 28,
+            "unified_name": "src/pkg/model.py:WidgetHelper.run()",
+        },
+    )
+
+    hgraph = build_hierarchical_code_graph(graph)
+    nodes = {node.id: node for node in hgraph.containment}
+
+    assert (
+        nodes["hier::symbol::src/pkg/model.py:Widget.run()"].parent
+        == "hier::symbol::src/pkg/model.py:Widget"
+    )
+    assert (
+        nodes["hier::symbol::src/pkg/model.py:WidgetHelper.run()"].parent
+        == "hier::file::src/pkg/model.py"
+    )
+
+
+def test_hierarchy_projection_remaps_visible_symbols_for_frontend_routes():
+    hgraph = build_hierarchical_code_graph(_compound_graph())
+    view_nodes = [
+        {
+            "id": "n0",
+            "name": "src/pkg/model.py:Widget.run()",
+            "file": "src/pkg/model.py",
+            "depth": 0,
+            "importance": 0.9,
+            "is_root": True,
+        },
+        {
+            "id": "n1",
+            "name": "src/pkg/helper.py:load()",
+            "file": "src/pkg/helper.py",
+            "depth": 1,
+            "importance": 0.4,
+        },
+    ]
+
+    hierarchy = hierarchy_for_view(hgraph, view_nodes)
+    nodes = {node["id"]: node for node in hierarchy["nodes"]}
+
+    assert "hier::symbol::n0" in nodes
+    assert "hier::symbol::n1" in nodes
+    assert (
+        nodes["hier::symbol::n0"]["parent"] == "hier::symbol::src/pkg/model.py:Widget"
+    )
+    assert (
+        nodes["hier::symbol::src/pkg/model.py:Widget"]["parent"]
+        == "hier::file::src/pkg/model.py"
+    )
+    assert hierarchy["open_files"][0] == "src/pkg/model.py"
+
+    edge = {"source": "n0", "target": "n1"}
+    attach_edge_routes([edge], hierarchy)
+    assert edge["source_hierarchy"] == "hier::symbol::n0"
+    assert edge["target_hierarchy"] == "hier::symbol::n1"
+    assert edge["bundle_path"][0] == "hier::symbol::n0"
+    assert edge["bundle_path"][-1] == "hier::symbol::n1"
+    assert "hier::symbol::src/pkg/model.py:Widget" in edge["bundle_path"]
+    assert edge["bundle_lca"] == "hier::dir::pkg"
+    assert edge["bundle_lca_kind"] == "directory"
+    assert edge["cross_file"] is True
+
+
+def test_hierarchy_projection_doi_prefers_nearby_containment_context():
+    graph = _compound_graph()
+    graph._add_vertex(
+        "src/pkg/model.py:Widget.close()",
+        {
+            "type": "method",
+            "file": "src/pkg/model.py",
+            "start_line": 12,
+            "end_line": 18,
+            "unified_name": "src/pkg/model.py:Widget.close()",
+        },
+    )
+    graph._add_edge(
+        "src/pkg/model.py:Widget",
+        "src/pkg/model.py:Widget.close()",
+        "contain",
+    )
+    hgraph = build_hierarchical_code_graph(graph)
+    view_nodes = [
+        {
+            "id": "n0",
+            "name": "src/pkg/model.py:Widget.run()",
+            "file": "src/pkg/model.py",
+            "depth": 0,
+            "importance": 0.8,
+            "is_root": True,
+        },
+        {
+            "id": "n1",
+            "name": "src/pkg/model.py:Widget.close()",
+            "file": "src/pkg/model.py",
+            "depth": 1,
+            "importance": 0.6,
+        },
+        {
+            "id": "n2",
+            "name": "src/pkg/helper.py:load()",
+            "file": "src/pkg/helper.py",
+            "depth": 1,
+            "importance": 0.6,
+        },
+    ]
+
+    hierarchy = hierarchy_for_view(hgraph, view_nodes)
+    nodes = {node["id"]: node for node in hierarchy["nodes"]}
+
+    assert nodes["hier::symbol::n1"]["doi"] > nodes["hier::symbol::n2"]["doi"]

--- a/test/llm/test_litellm_retry.py
+++ b/test/llm/test_litellm_retry.py
@@ -19,7 +19,12 @@ from unittest.mock import patch
 import litellm
 import pytest
 
-from codeminer.llm.litellm_chat import LiteLLMChat, RetryConfig, is_transient_error
+from codeminer.llm.litellm_chat import (
+    LiteLLMChat,
+    RetryConfig,
+    _no_thinking_kwargs,
+    is_transient_error,
+)
 
 
 def _make_response(content="ok"):
@@ -30,6 +35,21 @@ def _make_response(content="ok"):
 def _no_sleep():
     """Patch out the backoff sleep so tests don't actually wait."""
     return patch("codeminer.llm.litellm_chat.time.sleep", return_value=None)
+
+
+# ---------------------------------------------------------------------------
+# Gemini thinking parameter normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNoThinkingKwargs:
+    def test_gemini_25_uses_litellm_thinking_zero_budget(self):
+        assert _no_thinking_kwargs("vertex_ai/gemini-2.5-pro") == {
+            "thinking": {"type": "disabled", "budget_tokens": 0}
+        }
+
+    def test_non_thinking_model_has_no_extra_kwargs(self):
+        assert _no_thinking_kwargs("openai/gpt-4o-mini") == {}
 
 
 # ---------------------------------------------------------------------------

--- a/test/web/test_codemap.py
+++ b/test/web/test_codemap.py
@@ -5,7 +5,7 @@
 """Unit tests for the web codemap payload builder."""
 
 from codeminer.graph.code_graph import CodeGraph
-from codeminer.web.codemap import build_codemap
+from codeminer.web.codemap import build_codemap, build_page_subgraph
 
 
 def _symbol_graph_with_many_call_sites() -> CodeGraph:
@@ -55,3 +55,155 @@ def test_codemap_preserves_all_call_site_anchors():
     assert len(edge["anchors"]) == 12
     assert {anchor["file"] for anchor in edge["anchors"]} == {"src/main.py"}
     assert sorted(anchor["line"] for anchor in edge["anchors"]) == list(range(1, 13))
+    assert edge["bundle_path"][0] == f"hier::symbol::{edge['source']}"
+    assert edge["bundle_path"][-1] == f"hier::symbol::{edge['target']}"
+    assert edge["bundle_lca"] == "hier::root"
+    assert edge["cross_file"] is True
+
+
+def test_codemap_returns_explicit_containment_hierarchy():
+    graph = CodeGraph()
+    graph._add_vertex(
+        "src/main.py:caller()",
+        {
+            "type": "function",
+            "file": "src/main.py",
+            "start_line": 0,
+            "end_line": 4,
+            "unified_name": "src/main.py:caller()",
+        },
+    )
+    graph._add_vertex(
+        "src/pkg/a.py:alpha()",
+        {
+            "type": "function",
+            "file": "src/pkg/a.py",
+            "start_line": 10,
+            "end_line": 14,
+            "unified_name": "src/pkg/a.py:alpha()",
+        },
+    )
+    graph._add_vertex(
+        "src/pkg/b.py:beta()",
+        {
+            "type": "function",
+            "file": "src/pkg/b.py",
+            "start_line": 20,
+            "end_line": 24,
+            "unified_name": "src/pkg/b.py:beta()",
+        },
+    )
+    graph._add_edge(
+        "src/main.py:caller()",
+        "src/pkg/a.py:alpha()",
+        "reference",
+        anchor_file="src/main.py",
+        anchor_line=1,
+    )
+    graph._add_edge(
+        "src/main.py:caller()",
+        "src/pkg/b.py:beta()",
+        "reference",
+        anchor_file="src/main.py",
+        anchor_line=2,
+    )
+
+    result = build_codemap(
+        graph, symbol="caller", direction="callees", depth=1, max_nodes=5
+    )
+
+    assert "hierarchy" in result, result
+    hierarchy = result["hierarchy"]
+    assert hierarchy["root"] == "hier::root"
+    assert hierarchy["source_root"] == "src"
+    assert hierarchy["open_files"][0] == "src/main.py"
+
+    nodes_by_id = {node["id"]: node for node in hierarchy["nodes"]}
+    assert nodes_by_id["hier::root"]["kind"] == "root"
+    assert nodes_by_id["hier::dir::pkg"]["parent"] == "hier::root"
+    assert nodes_by_id["hier::dir::pkg"]["symbol_count"] == 2
+
+    file_a = nodes_by_id["hier::file::src/pkg/a.py"]
+    assert file_a["parent"] == "hier::dir::pkg"
+    assert file_a["kind"] == "file"
+    assert file_a["symbol_count"] == 1
+
+    symbol_nodes = [node for node in hierarchy["nodes"] if node["kind"] == "symbol"]
+    assert {node["parent"] for node in symbol_nodes} >= {
+        "hier::file::src/main.py",
+        "hier::file::src/pkg/a.py",
+        "hier::file::src/pkg/b.py",
+    }
+    assert all(isinstance(node["doi"], float) for node in symbol_nodes)
+
+    for edge in result["edges"]:
+        assert edge["source_hierarchy"] == f"hier::symbol::{edge['source']}"
+        assert edge["target_hierarchy"] == f"hier::symbol::{edge['target']}"
+        assert edge["bundle_path"][0] == edge["source_hierarchy"]
+        assert edge["bundle_path"][-1] == edge["target_hierarchy"]
+        assert edge["bundle_lca"] in edge["bundle_path"]
+        assert edge["bundle_lca_kind"] == "root"
+        assert edge["cross_file"] is True
+
+
+def test_page_subgraph_keeps_only_cited_symbols_and_multi_seed_bridges():
+    graph = CodeGraph()
+    for name, file, line in [
+        ("src/a.py:seed_a()", "src/a.py", 0),
+        ("src/b.py:seed_b()", "src/b.py", 10),
+        ("src/bridge.py:bridge()", "src/bridge.py", 20),
+        ("src/noise.py:noise()", "src/noise.py", 30),
+    ]:
+        graph._add_vertex(
+            name,
+            {
+                "type": "function",
+                "file": file,
+                "start_line": line,
+                "end_line": line + 2,
+                "unified_name": name,
+            },
+        )
+    graph._add_edge(
+        "src/a.py:seed_a()",
+        "src/bridge.py:bridge()",
+        "reference",
+        anchor_file="src/a.py",
+        anchor_line=1,
+    )
+    graph._add_edge(
+        "src/bridge.py:bridge()",
+        "src/b.py:seed_b()",
+        "reference",
+        anchor_file="src/bridge.py",
+        anchor_line=20,
+    )
+    graph._add_edge(
+        "src/a.py:seed_a()",
+        "src/noise.py:noise()",
+        "reference",
+        anchor_file="src/a.py",
+        anchor_line=2,
+    )
+
+    result = build_page_subgraph(
+        graph,
+        [
+            {"file": "src/a.py", "start_line": 1, "node_name": "seed_a"},
+            {"file": "src/b.py", "start_line": 11, "node_name": "seed_b"},
+        ],
+        max_nodes=10,
+    )
+
+    assert result["available"] is True
+    labels = {node["label"]: node for node in result["nodes"]}
+    assert set(labels) == {
+        "src/a.py:seed_a()",
+        "src/b.py:seed_b()",
+        "src/bridge.py:bridge()",
+    }
+    assert labels["src/a.py:seed_a()"]["is_root"] is True
+    assert labels["src/b.py:seed_b()"]["is_root"] is True
+    assert labels["src/bridge.py:bridge()"]["is_root"] is False
+    assert len(result["edges"]) == 2
+    assert {edge["weight"] for edge in result["edges"]} == {1}

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast unit tests for the agent wiki retrieval guardrails."""
+
+from types import SimpleNamespace
+
+from codeminer.wiki.agent_wiki import AgentWiki
+
+
+class _FakeVectorStore:
+    def __init__(self, nodes):
+        self.nodes = nodes
+        self.calls = []
+
+    def search_with_content(self, query, top_k):
+        self.calls.append((query, top_k))
+        return self.nodes[:top_k]
+
+
+def test_agent_wiki_retrieval_reranks_by_page_files_and_keywords(tmp_path):
+    nodes = [
+        {
+            "file": "src/unrelated.py",
+            "node_name": "unrelated",
+            "start_line": 0,
+            "end_line": 5,
+            "content": "generic helper",
+        },
+        {
+            "file": "src/core/http.py",
+            "node_name": "dispatch_request",
+            "start_line": 10,
+            "end_line": 30,
+            "content": "request pipeline dispatch handling",
+        },
+        {
+            "file": "src/core/http.py",
+            "node_name": "dispatch_request",
+            "start_line": 10,
+            "end_line": 30,
+            "content": "duplicate copy should collapse",
+        },
+        {
+            "file": "src/core/interceptors.py",
+            "node_name": "InterceptorChain",
+            "start_line": 40,
+            "end_line": 70,
+            "content": "request response modification",
+        },
+    ]
+    store = _FakeVectorStore(nodes)
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=store,
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"]),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    result = wiki._retrieve(
+        {
+            "id": "request-pipeline",
+            "title": "Request Pipeline",
+            "summary": "How requests are dispatched",
+            "files": ["src/core/http.py"],
+            "keywords": ["request pipeline", "dispatch"],
+        },
+        top_k=2,
+    )
+
+    assert store.calls
+    query, top_k = store.calls[0]
+    assert "src/core/http.py" in query
+    assert top_k == 8
+    assert [node["node_name"] for node in result] == [
+        "dispatch_request",
+        "InterceptorChain",
+    ]

--- a/test/wiki/test_builder.py
+++ b/test/wiki/test_builder.py
@@ -149,7 +149,13 @@ def test_overview_links_modules(repo_dir):
 
 # -- Critique #8: LLM-authored content layer ---------------------------------
 
-from codeminer.wiki.narrator import Narrator  # noqa: E402
+from codeminer.wiki.narrator import Narrator, _no_thinking_kwargs  # noqa: E402
+
+
+def test_narrator_gemini_25_uses_litellm_thinking_zero_budget():
+    assert _no_thinking_kwargs("vertex_ai/gemini-2.5-flash") == {
+        "thinking": {"type": "disabled", "budget_tokens": 0}
+    }
 
 
 def test_narrator_disabled_returns_none():

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -193,7 +193,8 @@ export default function WikiPageView() {
             >
               ☰
             </button>
-            <span className="mono">{repo ? repo.repo : repoId}</span>
+            <span className="crumb-sep">/</span>
+            <span className="crumb-repo mono">{repo ? repo.repo : repoId}</span>
             {hasGraph && (
               <button
                 className="codegraph-launch"
@@ -224,15 +225,20 @@ export default function WikiPageView() {
           <div className="wiki-content" ref={contentRef}>
               {pageGraph && pageGraph.available && pageGraph.nodes.length > 0 && (
                 <details className="subsystem-map" open>
-                  <summary>
-                    Subsystem map · {pageGraph.nodes.length} symbols
-                    <span className="subsystem-hint"> — this page as a view over the graph</span>
+                  <summary className="subsystem-summary">
+                    <span className="subsystem-title">Subsystem map</span>
+                    <span className="subsystem-count">{pageGraph.nodes.length} symbols</span>
+                    {repo?.commit_short && (
+                      <span className="subsystem-index mono">Last indexed {repo.commit_short}</span>
+                    )}
                   </summary>
                   <GraphView
                     repoId={repoId}
                     data={pageGraph}
                     variant="wiki"
                     onFocus={(label) => openGraph(label)}
+                    repoFullName={repo?.repo}
+                    commit={repo?.base_commit}
                   />
                 </details>
               )}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,19 +1,36 @@
 /* ---------------------------------------------------------------------------
-   CodeMiner Wiki — DeepWiki-style theme.
-   Tokens mirror observed deepwiki.com values (see web/loop/OBSERVATIONS.md):
-   light is default; dark is opt-in via [data-theme="dark"].
+   CodeMiner Wiki — technical workspace theme.
+   Mostly-neutral surfaces with blue reserved for focus/selection semantics.
 --------------------------------------------------------------------------- */
 :root,
 [data-theme="light"] {
-  --bg: #f8f7f6;          /* page background  (#F8F7F6) */
-  --surface: #f2f1f0;     /* inputs / cards   (#F2F1F0) */
-  --surface-2: #ffffff;
-  --code-bg: #e5e5e5;     /* inline + block code bg */
-  --border: #e0e0e0;      /* hairlines */
-  --border-2: #d8d8d8;
-  --text: #333333;        /* primary text */
-  --muted: #666666;       /* secondary text */
-  --accent: #2d7ff9;      /* links / primary */
+  --bg-page: #f8fafc;
+  --bg-surface: #ffffff;
+  --bg-subtle: #f1f5f9;
+  --bg-muted: #f8fafc;
+  --border-subtle: #e2e8f0;
+  --border-strong: #cbd5e1;
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --accent: #2563eb;
+  --accent-soft: #eff6ff;
+  --accent-border: #bfdbfe;
+  --indigo-soft: #eef2ff;
+  --indigo-border: #a5b4fc;
+  --indigo-text: #3730a3;
+  --purple-soft: #f5f3ff;
+  --purple-border: #c4b5fd;
+  --purple-text: #5b21b6;
+  --code-bg: #f8fafc;
+  --code-line-active: #e0eaff;
+  --bg: var(--bg-page);
+  --surface: var(--bg-subtle);
+  --surface-2: var(--bg-surface);
+  --border: var(--border-subtle);
+  --border-2: var(--border-strong);
+  --text: var(--text-primary);
+  --muted: var(--text-secondary);
   --accent-contrast: #ffffff;
   --top-h: 64px;
   --rail-left: 320px;
@@ -22,16 +39,34 @@
 }
 
 [data-theme="dark"] {
-  --bg: #0d1117;
-  --surface: #161b22;
-  --surface-2: #1c2230;
-  --code-bg: #0b0f14;
-  --border: #2a3038;
-  --border-2: #30363d;
-  --text: #e6edf3;
-  --muted: #9198a1;
-  --accent: #4493f8;
-  --accent-contrast: #ffffff;
+  --bg-page: #0f172a;
+  --bg-surface: #111827;
+  --bg-subtle: #1e293b;
+  --bg-muted: #0b1220;
+  --border-subtle: #263244;
+  --border-strong: #334155;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --accent: #60a5fa;
+  --accent-soft: #10233f;
+  --accent-border: #1d4ed8;
+  --indigo-soft: #1e1b4b;
+  --indigo-border: #6366f1;
+  --indigo-text: #c7d2fe;
+  --purple-soft: #2e1065;
+  --purple-border: #7c3aed;
+  --purple-text: #ddd6fe;
+  --code-bg: #0b1220;
+  --code-line-active: #172554;
+  --bg: var(--bg-page);
+  --surface: var(--bg-subtle);
+  --surface-2: var(--bg-surface);
+  --border: var(--border-subtle);
+  --border-2: var(--border-strong);
+  --text: var(--text-primary);
+  --muted: var(--text-secondary);
+  --accent-contrast: #0f172a;
 }
 
 * {
@@ -78,7 +113,8 @@ pre {
   /* Match the page gutter below so the brand aligns with the left rail. */
   padding: 0 clamp(24px, 4vw, 80px);
   border-bottom: 1px solid var(--border);
-  background: var(--bg);
+  background: color-mix(in srgb, var(--bg-surface) 92%, transparent);
+  backdrop-filter: blur(12px);
 }
 .site-header .brand {
   display: flex;
@@ -86,11 +122,11 @@ pre {
   gap: 9px;
   font-weight: 650;
   font-size: 18px;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   color: var(--text);
 }
 .site-header .brand .brand-mark {
-  color: var(--accent);
+  color: var(--text-secondary);
   font-size: 17px;
 }
 .site-header .header-right {
@@ -109,17 +145,19 @@ pre {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: var(--accent);
-  color: var(--accent-contrast);
-  border: none;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 7px 14px;
+  padding: 7px 12px;
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
 }
 .btn-primary:hover {
-  filter: brightness(0.96);
+  color: var(--text);
+  border-color: var(--border-2);
+  background: var(--bg-muted);
   text-decoration: none;
 }
 
@@ -146,7 +184,7 @@ pre {
 .btn-primary:hover,
 .codemap-controls button:hover,
 .askbar-send:not(:disabled):hover {
-  box-shadow: 0 2px 12px -3px color-mix(in srgb, var(--accent) 55%, transparent);
+  box-shadow: 0 1px 8px -4px rgba(15, 23, 42, 0.28);
 }
 /* Accent focus ring on the text inputs / the ask bar. */
 .codemap-symbol:focus,
@@ -360,15 +398,24 @@ pre {
 .breadcrumb {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   font-size: 13px;
   color: var(--muted);
+  min-width: 0;
 }
 .breadcrumb .crumb-sep {
-  opacity: 0.5;
+  color: var(--text-muted);
 }
 .breadcrumb .crumb-page {
   color: var(--text);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.breadcrumb .crumb-repo {
+  color: var(--text);
+  font-weight: 600;
 }
 
 .wiki-grid {
@@ -456,7 +503,7 @@ pre {
   max-height: calc(100vh - var(--top-h));
   overflow-y: auto;
   width: var(--rail-left);
-  padding: 22px 20px;
+  padding: 22px 18px 22px 0;
 }
 .wiki-onthispage {
   position: sticky;
@@ -465,7 +512,7 @@ pre {
   max-height: calc(100vh - var(--top-h));
   overflow-y: auto;
   width: var(--rail-right);
-  padding: 20px 16px;
+  padding: 20px 0 20px 18px;
   border-left: 1px solid var(--border);
 }
 .rail-title {
@@ -473,7 +520,7 @@ pre {
   font-weight: 650;
   color: var(--text);
   margin-bottom: 2px;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
   word-break: break-word;
 }
 .rail-sub {
@@ -504,7 +551,7 @@ pre {
   text-align: left;
   background: transparent;
   border: none;
-  border-radius: 6px;
+  border-radius: 8px;
   padding: 6px 10px;
   font-size: 14px;
   line-height: 1.45;
@@ -513,14 +560,14 @@ pre {
   word-break: break-word;
 }
 .toc-link:hover {
-  background: var(--surface);
+  background: var(--bg-subtle);
   color: var(--text);
 }
 .toc-link.active {
-  background: color-mix(in srgb, var(--accent) 11%, transparent);
-  color: var(--accent);
+  background: color-mix(in srgb, var(--bg-subtle) 76%, var(--bg-surface));
+  color: var(--text);
   font-weight: 600;
-  box-shadow: inset 2px 0 var(--accent);
+  box-shadow: inset 2px 0 #64748b;
 }
 
 .wiki-main {
@@ -532,6 +579,49 @@ pre {
 .ask-panel {
   max-width: 1100px;
   margin: 0 auto;
+}
+@media (max-width: 820px) {
+  .wiki-grid {
+    padding-inline: 12px;
+  }
+  .wiki-main {
+    padding: 12px 0 72px;
+  }
+  .wiki-content,
+  .wiki-diagram,
+  .ask-panel {
+    width: 100%;
+    max-width: none;
+  }
+  .wiki-toc {
+    width: 280px;
+    padding: 22px 18px;
+  }
+  .site-header {
+    gap: 8px;
+    padding-inline: 12px;
+  }
+  .site-header .brand {
+    white-space: nowrap;
+    font-size: 16px;
+  }
+  .breadcrumb {
+    flex: 1;
+    max-width: none;
+    overflow: hidden;
+  }
+  .breadcrumb .crumb-sep,
+  .breadcrumb .crumb-page,
+  .breadcrumb .codegraph-launch {
+    display: none;
+  }
+  .breadcrumb .crumb-repo {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 .wiki-meta {
   font-size: 12px;
@@ -581,28 +671,28 @@ pre {
   display: block;
   padding: 4px 8px;
   border-radius: 6px;
-  color: var(--muted);
+  color: var(--text-secondary);
   line-height: 1.4;
   text-decoration: none;
 }
 .onthispage-list a:hover {
   color: var(--text);
-  background: var(--surface);
+  background: var(--bg-subtle);
 }
 .onthispage-list a.active {
-  color: var(--accent);
+  color: var(--text);
   font-weight: 600;
-  box-shadow: inset 2px 0 var(--accent);
+  box-shadow: inset 2px 0 #94a3b8;
 }
 .refresh-wiki {
   margin-top: 18px;
   width: 100%;
-  background: var(--surface);
+  background: transparent;
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 7px;
   font-size: 12px;
-  color: var(--muted);
+  color: var(--text-secondary);
   cursor: pointer;
 }
 .refresh-wiki:hover {
@@ -1025,10 +1115,21 @@ pre {
   display: flex;
   justify-content: center;
   padding: 16px;
+  background: transparent;
+  pointer-events: none;
+}
+.askbar::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  left: 50%;
+  width: min(760px, calc(100% - 32px));
+  transform: translateX(-50%);
   background: linear-gradient(to top, var(--bg) 72%, transparent);
   pointer-events: none;
 }
 .askbar-inner {
+  position: relative;
   pointer-events: auto;
   display: flex;
   align-items: center;
@@ -1053,14 +1154,20 @@ pre {
   color: var(--text);
 }
 .askbar-send {
-  border: none;
-  background: var(--accent);
-  color: #fff;
+  border: 1px solid var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent);
   border-radius: 9px;
   padding: 9px 18px;
   font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
+}
+.askbar-send:not(:disabled):hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
 }
 .askbar-send:disabled {
   opacity: 0.5;
@@ -1218,17 +1325,549 @@ pre {
   color: #fff;
   border-color: var(--accent);
 }
-/* Interactive dependency graph (Cytoscape + dagre). */
-.codegraph {
-  margin: 4px 0 2px;
+
+/* High-level wiki system map: component cards first, code snippets on demand. */
+.system-map {
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+  padding: 16px;
+}
+.system-map-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+.system-map-kicker {
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.system-map-title {
+  margin-top: 2px;
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+.system-map-stats {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.system-map-stats span {
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 999px;
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 550;
+  padding: 4px 8px;
+  white-space: nowrap;
+}
+.system-flow-strip {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-muted);
+  margin-bottom: 12px;
+}
+.system-flow-step {
+  position: relative;
+  display: grid;
+  align-content: center;
+  gap: 2px;
+  min-width: 150px;
+  flex: 1 0 150px;
+  padding: 10px 28px 10px 12px;
+  border-right: 1px solid var(--border);
+}
+.system-flow-step:last-child {
+  border-right: 0;
+}
+.system-flow-step span {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+.system-flow-step b {
+  min-width: 0;
   overflow: hidden;
-  background: var(--surface-2);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.25;
+}
+.system-flow-step i {
+  position: absolute;
+  right: 9px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  font-style: normal;
+  font-weight: 700;
+}
+.system-stage-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 14px;
+  align-items: start;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-muted);
+}
+.system-stage {
+  position: relative;
+  min-width: 0;
+}
+.system-stage:not(:last-child)::after {
+  content: "->";
+  position: absolute;
+  top: 9px;
+  right: -13px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+.system-stage-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.system-stage-head b {
+  display: inline-grid;
+  min-width: 20px;
+  height: 20px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+.system-stage-body {
+  display: grid;
+  gap: 9px;
+}
+.system-node-card {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  padding: 10px;
+  box-shadow: 0 1px 1px rgba(15, 23, 42, 0.03);
+}
+.system-node-card.root {
+  border-color: var(--accent-border);
+}
+.system-node-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 8px;
+}
+.system-node-card h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.25;
+}
+.system-node-card p {
+  margin: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+.system-node-flow {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 3px 6px;
+  white-space: nowrap;
+}
+.system-source-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+.system-source-row span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+  font-size: 10px;
+  padding: 3px 6px;
+}
+.system-symbols {
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+}
+.system-symbol {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "kind name"
+    "loc loc";
+  gap: 3px 7px;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-surface);
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+  padding: 7px 8px;
+  text-align: left;
+}
+.system-symbol:hover {
+  border-color: var(--border-2);
+  background: var(--bg-muted);
+}
+.system-symbol.root {
+  border-color: var(--accent-border);
+  background: color-mix(in srgb, var(--accent-soft) 72%, var(--bg));
+}
+.system-symbol span {
+  grid-area: kind;
+  align-self: center;
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+.system-symbol b {
+  grid-area: name;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  line-height: 1.2;
+}
+.system-symbol em {
+  grid-area: loc;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-style: normal;
+}
+.system-more {
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding-left: 2px;
+}
+.system-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 8px;
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.system-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  max-width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 11px;
+  padding: 7px 9px;
+  text-align: left;
+}
+.system-link:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+.system-link:not(:disabled):hover {
+  border-color: var(--border-2);
+  background: var(--bg-muted);
+}
+.system-link-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+.system-link-main span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.system-link b {
+  color: var(--accent);
+  font-weight: 700;
+}
+.system-link em {
+  color: var(--text-muted);
+  font-style: normal;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .system-map-head {
+    display: grid;
+  }
+  .system-map-stats {
+    justify-content: flex-start;
+  }
+  .system-stage-board {
+    grid-template-columns: 1fr;
+  }
+  .system-stage:not(:last-child)::after {
+    content: none;
+  }
+  .system-node-head {
+    grid-template-columns: 1fr;
+  }
+  .system-node-flow {
+    width: max-content;
+  }
+}
+
+/* Interactive dependency graph (explicit tree-depth layout). */
+.codegraph {
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--bg-surface);
+}
+.subsystem-map .codegraph {
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+}
+.codegraph-stage {
+  position: relative;
 }
 .codegraph-canvas {
+  position: relative;
+  overflow: hidden;
   width: 100%;
-  height: 540px;
+  height: 360px;
+  background: var(--bg-muted);
+}
+.codegraph[data-mode="files"] .codegraph-canvas {
+  height: 300px;
+}
+.codegraph[data-mode="symbols"] .codegraph-canvas {
+  height: 300px;
+}
+.codegraph-drilldown {
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+  padding: 10px 14px 12px;
+}
+.codegraph-drilldown-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: start;
+  gap: 10px;
+}
+.codegraph-drilldown-title {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.codegraph-drilldown-title b {
+  font-size: 13px;
+  line-height: 1.25;
+  color: var(--text);
+}
+.codegraph-drilldown-title span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+.codegraph-drilldown-metrics {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 5px;
+  max-width: 280px;
+}
+.codegraph-drilldown-metrics span,
+.codegraph-symbol-more {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.2;
+  padding: 3px 8px;
+  white-space: nowrap;
+}
+.codegraph-drilldown-close {
+  width: 26px;
+  height: 26px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+.codegraph-drilldown-close:hover {
+  border-color: var(--border);
+  background: var(--bg-muted);
+  color: var(--text);
+}
+.codegraph-symbol-list {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 9px;
+}
+.codegraph-symbol-chip {
+  display: inline-grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  max-width: min(100%, 280px);
+  min-height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-muted);
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+  padding: 4px 8px;
+  text-align: left;
+}
+.codegraph-symbol-chip:hover {
+  border-color: var(--border-2);
+  background: var(--bg-surface);
+}
+.codegraph-symbol-chip.root {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+}
+.codegraph-symbol-kind {
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+.codegraph-symbol-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+.codegraph-symbol-line {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1;
+}
+.codegraph-legend {
+  flex: 1;
+  min-width: 210px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.2;
+}
+.codegraph-legend-title {
+  color: var(--text);
+  font-weight: 650;
+}
+.codegraph-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+}
+.codegraph-legend-line {
+  position: relative;
+  display: inline-block;
+  width: 26px;
+  height: 10px;
+  flex: 0 0 26px;
+}
+.codegraph-legend-line::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 3px;
+  top: 50%;
+  border-top: 2px solid var(--text-secondary);
+  transform: translateY(-50%);
+}
+.codegraph-legend-line.exact::after,
+.codegraph-legend-line.aggregate::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 6px solid var(--text-secondary);
+  transform: translateY(-50%);
+}
+.codegraph-legend-line.aggregate::before {
+  border-top-style: dashed;
+  opacity: 0.72;
+}
+.codegraph-legend-line.weight::before {
+  right: 0;
+  border-top-width: 4px;
+  opacity: 0.85;
 }
 
 /* CodeGraph launch button in the breadcrumb (next to the repo name). */
@@ -1236,17 +1875,17 @@ pre {
   margin-left: 10px;
   font-size: 12px;
   font-family: inherit;
-  padding: 3px 10px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--bg);
+  padding: 3px 9px;
+  border: 1px solid var(--accent-border);
+  border-radius: 999px;
+  background: var(--accent-soft);
   color: var(--accent);
   cursor: pointer;
   white-space: nowrap;
 }
 .codegraph-launch:hover {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--accent-border));
+  box-shadow: none;
 }
 
 /* Full-screen graph-explorer modal (the single CodeGraph surface). */
@@ -1305,6 +1944,10 @@ pre {
 .graph-modal-body .codegraph-canvas {
   height: min(74vh, 800px);
 }
+.graph-modal-body .codegraph[data-mode="files"] .codegraph-canvas,
+.graph-modal-body .codegraph[data-mode="symbols"] .codegraph-canvas {
+  height: min(74vh, 800px);
+}
 .codegraph-loading {
   display: grid;
   place-items: center;
@@ -1320,9 +1963,10 @@ pre {
   align-items: center;
   gap: 8px 12px;
   flex-wrap: wrap;
-  padding: 7px 12px;
+  min-height: 44px;
+  padding: 8px 14px;
   border-top: 1px solid var(--border);
-  background: var(--surface);
+  background: var(--bg-surface);
   font-size: 12px;
   color: var(--text);
 }
@@ -1334,41 +1978,9 @@ pre {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* always-on legend — a compact visual key, never truncated */
-.codegraph-legend {
+.codegraph-spacer {
   flex: 1;
-  min-width: 140px;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 3px 14px;
-  color: var(--muted);
-}
-.codegraph-legend > span {
-  display: inline-flex;
-  align-items: center;
-}
-.lk-swatch,
-.lk-ext,
-.lk-grow {
-  display: inline-block;
-  width: 11px;
-  height: 11px;
-  border-radius: 3px;
-  margin-right: 5px;
-}
-.lk-swatch {
-  background: var(--accent);
-}
-.lk-ext {
-  border: 1.5px dashed var(--muted);
-}
-.lk-grow {
-  width: 13px;
-  height: 13px;
-  border-radius: 50%;
-  background: var(--muted);
-  opacity: 0.5;
+  min-width: 24px;
 }
 .codegraph-bar b {
   font-weight: 600;
@@ -1377,46 +1989,23 @@ pre {
   margin-left: 8px;
   padding: 1px 7px;
   border-radius: 6px;
-  background: var(--bg);
+  background: var(--bg-muted);
   border: 1px solid var(--border);
   color: var(--muted);
   font-size: 11px;
 }
 .codegraph-fit {
-  padding: 3px 13px;
+  padding: 4px 12px;
   border: 1px solid var(--border);
   border-radius: 7px;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 12px;
   flex-shrink: 0;
 }
 .codegraph-fit:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-.codegraph-modes {
-  display: inline-flex;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-.codegraph-modes button {
-  border: none;
-  background: var(--bg);
-  color: var(--muted);
-  cursor: pointer;
-  font-size: 12px;
-  font-family: inherit;
-  padding: 3px 12px;
-}
-.codegraph-modes button.on {
-  background: var(--accent);
-  color: #fff;
-}
-.codegraph-modes button:not(.on):hover {
+  border-color: var(--border-2);
   color: var(--text);
 }
 /* Wiki variant: no layout toggle — a static label that this map reads top-down
@@ -1427,17 +2016,62 @@ pre {
   color: var(--muted);
   border: 1px solid var(--border);
   border-radius: 7px;
-  padding: 3px 12px;
+  padding: 4px 12px;
   white-space: nowrap;
+}
+@media (max-width: 760px) {
+  .codegraph-canvas {
+    height: 300px;
+  }
+  .codegraph[data-mode="files"] .codegraph-canvas {
+    height: 280px;
+  }
+  .codegraph[data-mode="symbols"] .codegraph-canvas {
+    height: 300px;
+  }
+  .codegraph-bar {
+    gap: 7px;
+    padding: 8px 10px;
+  }
+  .cg-info {
+    flex-basis: 100%;
+  }
+  .codegraph-depnote {
+    display: none;
+  }
+  .codegraph-drilldown {
+    padding: 10px;
+  }
+  .codegraph-drilldown-head {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+  .codegraph-drilldown-metrics {
+    grid-column: 1 / -1;
+    justify-content: flex-start;
+    max-width: none;
+  }
+  .codegraph-symbol-chip {
+    max-width: 100%;
+  }
+  .codegraph-legend {
+    min-width: 0;
+    flex-basis: 100%;
+    gap: 6px 8px;
+  }
+  .codegraph-legend-item {
+    white-space: normal;
+  }
 }
 
 /* Call-site peek: the exact reference line behind a clicked edge. */
 .callsite-peek {
-  margin: 10px 0 2px;
+  margin: 12px 0 2px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 8px;
   overflow: hidden;
-  background: var(--surface-2);
+  background: var(--bg-surface);
+  scroll-margin-top: calc(var(--top-h) + 12px);
+  scroll-margin-bottom: 112px;
 }
 /* Long definitions/files scroll inside the peek instead of being clipped. */
 .callsite-peek .hl-code {
@@ -1445,24 +2079,45 @@ pre {
   overflow: auto;
 }
 .callsite-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 14px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  font-size: 12px;
+}
+.callsite-heading {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.callsite-eyebrow {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 650;
+}
+.callsite-actions {
   display: flex;
   align-items: center;
-  gap: 10px;
+  justify-content: flex-end;
+  gap: 8px;
   flex-wrap: wrap;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
-  background: var(--surface);
-  font-size: 12px;
+  max-width: 320px;
 }
 .callsite-title {
   color: var(--text);
+  font-size: 13px;
+  overflow-wrap: anywhere;
 }
-.callsite-arrow {
-  color: var(--muted);
+.callsite-dot {
+  color: var(--text-muted);
 }
 .callsite-loc {
-  color: var(--accent);
-  font-weight: 600;
+  color: var(--text-secondary);
+  font-weight: 500;
+  overflow-wrap: anywhere;
 }
 .callsite-pager {
   display: inline-flex;
@@ -1471,89 +2126,141 @@ pre {
   color: var(--muted);
 }
 .callsite-pager button {
-  padding: 1px 8px;
+  padding: 2px 8px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: var(--bg);
-  color: var(--text);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 11px;
   font-family: inherit;
 }
 .callsite-pager button.on {
-  background: var(--accent);
-  color: #fff;
-  border-color: var(--accent);
+  background: var(--indigo-soft);
+  color: var(--indigo-text);
+  border-color: var(--indigo-border);
 }
 .callsite-kindtag {
-  padding: 1px 7px;
-  border-radius: 6px;
-  background: var(--bg);
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--bg-muted);
   border: 1px solid var(--border);
-  color: var(--muted);
+  color: var(--text-secondary);
   font-size: 11px;
+  white-space: nowrap;
 }
-.callsite-focus {
-  padding: 2px 10px;
-  border: 1px solid var(--accent);
+.callsite-focus,
+.callsite-open {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
   border-radius: 6px;
-  background: transparent;
-  color: var(--accent);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
   cursor: pointer;
-  font-size: 11px;
+  font-size: 12px;
   font-family: inherit;
+  line-height: 1.2;
+  text-decoration: none;
 }
-.callsite-focus:hover {
-  background: var(--accent);
-  color: #fff;
+.callsite-focus:hover,
+.callsite-open:hover {
+  border-color: var(--border-2);
+  background: var(--bg-muted);
+  color: var(--text);
+  text-decoration: none;
 }
 
 /* Wiki page rendered as a view over the graph: its symbols' subsystem map. */
 .subsystem-map {
-  margin: 6px 0 22px;
+  margin: 6px 0 24px;
   border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--bg);
-  padding: 6px 10px 10px;
+  border-radius: 8px;
+  background: var(--bg-surface);
+  padding: 0;
+  overflow: hidden;
 }
 .subsystem-map > summary {
   cursor: pointer;
-  font-size: 13px;
-  font-weight: 600;
   color: var(--text);
-  padding: 5px 2px;
+  padding: 14px 16px;
   list-style: none;
+  border-bottom: 1px solid var(--border);
 }
 .subsystem-map > summary::-webkit-details-marker {
   display: none;
 }
 .subsystem-map > summary::before {
-  content: "▸ ";
-  color: var(--muted);
+  content: "";
 }
 .subsystem-map[open] > summary::before {
-  content: "▾ ";
+  content: "";
 }
-.subsystem-hint {
-  font-weight: 400;
-  color: var(--muted);
+.subsystem-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.subsystem-summary::after {
+  content: "Hide";
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+.subsystem-map:not([open]) > .subsystem-summary::after {
+  content: "Show";
+}
+.subsystem-title {
+  font-size: 14px;
+  font-weight: 650;
+  color: var(--text);
+}
+.subsystem-count,
+.subsystem-index {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-muted);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 2px 8px;
 }
 .callsite-close {
-  margin-left: auto;
-  border: none;
+  width: 28px;
+  height: 28px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
   background: transparent;
   color: var(--muted);
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
-  padding: 0 4px;
+  padding: 0;
 }
 .callsite-close:hover {
   color: var(--text);
+  background: var(--bg-muted);
+  border-color: var(--border);
 }
 .callsite-msg {
   padding: 14px;
   margin: 0;
+}
+@media (max-width: 760px) {
+  .callsite-head {
+    grid-template-columns: 1fr;
+  }
+  .callsite-actions {
+    justify-content: flex-start;
+    max-width: none;
+  }
 }
 
 /* ===== Ask "codemap": hierarchical explanation (left) + code pane (right) ===== */
@@ -1912,39 +2619,43 @@ a.codepanel-name:hover {
 .hl-code {
   display: flex;
   overflow-x: auto;
-  background: #fff;
+  background: var(--code-bg);
   position: relative;
 }
 .hl-band {
   position: absolute;
   left: 0;
   right: 0;
-  background: rgba(45, 127, 249, 0.14);
-  border-left: 3px solid var(--accent);
+  background: var(--code-line-active);
+  border-left: 2px solid var(--accent-border);
   pointer-events: none;
-  z-index: 2;
+  z-index: 0;
 }
 .hl-gutter-on {
   color: var(--accent);
   font-weight: 700;
 }
 .hl-gutter {
+  position: relative;
+  z-index: 1;
   flex: 0 0 auto;
   text-align: right;
   user-select: none;
   padding: 10px 10px;
-  color: #b3b3b3;
+  color: var(--text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12.5px;
   line-height: 1.55;
-  background: #fafafa;
+  background: transparent;
   border-right: 1px solid var(--border);
 }
 .hl-pre {
+  position: relative;
+  z-index: 1;
   flex: 1 1 auto;
   margin: 0;
   padding: 10px 14px;
-  background: #fff;
+  background: transparent;
   overflow: visible;
 }
 .hl-pre code.hljs {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -40,16 +40,56 @@ function RepoCard({ r }: { r: RepoInfo }) {
   );
 }
 
+const repoRetryDelays = [0, 1000, 2000, 4000, 8000];
+const sleep = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
 export default function Landing() {
   const router = useRouter();
   const [repos, setRepos] = useState<RepoInfo[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
   const [q, setQ] = useState("");
 
+  const loadRepos = () => {
+    setError(null);
+    setLoading(true);
+    let active = true;
+
+    const run = async () => {
+      let lastError: unknown = null;
+      for (let attempt = 0; attempt < repoRetryDelays.length; attempt += 1) {
+        const delay = repoRetryDelays[attempt];
+        if (delay > 0) {
+          if (active) setError("Connecting to backend; retrying repository list...");
+          await sleep(delay);
+        }
+        if (!active) return;
+        try {
+          const rs = await fetchRepos();
+          if (!active) return;
+          setRepos(rs);
+          setError(null);
+          return;
+        } catch (e) {
+          lastError = e;
+        }
+      }
+      if (!active) return;
+      setError(lastError instanceof Error ? lastError.message : String(lastError));
+    };
+
+    run()
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  };
+
   useEffect(() => {
-    fetchRepos()
-      .then(setRepos)
-      .catch((e) => setError(String(e)));
+    return loadRepos();
   }, []);
 
   const filtered = useMemo(() => {
@@ -101,10 +141,17 @@ export default function Landing() {
 
         {error && (
           <div className="empty">
-            Backend unavailable — start it with <code>codeminer-web</code> after building an index.
+            <p>
+              Backend unavailable — start it with <code>codeminer-web</code> after building an index.
+            </p>
+            <p className="small muted">Request failed: {error}</p>
+            <button type="button" className="codegraph-fit" onClick={loadRepos}>
+              Retry
+            </button>
           </div>
         )}
-        {!error && repos.length === 0 && <div className="empty">Loading repositories…</div>}
+        {!error && loading && repos.length === 0 && <div className="empty">Loading repositories…</div>}
+        {!error && !loading && repos.length === 0 && <div className="empty">No repositories found.</div>}
         {filtered.map((r) => (
           <RepoCard key={r.id} r={r} />
         ))}

--- a/web/components/CodeGraph.tsx
+++ b/web/components/CodeGraph.tsx
@@ -2,20 +2,14 @@
 
 import { useEffect, useRef, useState } from "react";
 import cytoscape, { type Core, type ElementDefinition, type NodeSingular } from "cytoscape";
-import fcose from "cytoscape-fcose";
 import type { CallSite, CodemapResponse } from "@/lib/api";
-
-// Register the compound-aware force layout once (idempotent across HMR reloads).
-const _g = globalThis as unknown as { __cmFcose?: boolean };
-if (!_g.__cmFcose) {
-  cytoscape.use(fcose);
-  _g.__cmFcose = true;
-}
 
 export interface EdgeClickInfo {
   anchors: CallSite[];
   srcLabel: string;
   tgtLabel: string;
+  srcFile?: string;
+  tgtFile?: string;
 }
 
 export interface GraphNodeInfo {
@@ -29,35 +23,206 @@ export interface GraphNodeInfo {
 }
 
 type CMNode = CodemapResponse["nodes"][number];
+type HierarchyNode = NonNullable<CodemapResponse["hierarchy"]>["nodes"][number];
 
-// Fixed, semantic colour per symbol kind — used in the expanded symbol view where
-// the file box already groups by file, so colour is freed up for "what kind".
-const KIND_COLORS: Record<string, string> = {
-  function: "#2d7ff9",
-  method: "#1098ad",
-  class: "#ae3ec9",
-  interface: "#0ca678",
-  trait: "#3b5bdb",
-  struct: "#e8590c",
-  enum: "#9c36b5",
-  type: "#0ca678",
-  field: "#f08c00",
-  var: "#f08c00",
-  const: "#e8590c",
-  module: "#868e96",
-  file: "#868e96",
-};
-function colorForKind(kind: string): string {
-  return KIND_COLORS[kind] || "#868e96";
+// Keep graph color semantic and restrained: most symbols are neutral, roots are
+// the primary focus color, and type/model-like symbols get one muted secondary.
+function toneForKind(kind: string): "model" | "default" {
+  return ["class", "interface", "trait", "struct", "enum", "type"].includes(kind)
+    ? "model"
+    : "default";
 }
 
 // Files-overview model: the map opens with one "pill" per file (a readable
-// overview), and a file expands into its real symbols on click. Ids are namespaced
-// so a pill, its compound box, and its symbols never collide.
+// overview). Symbol detail is shown outside the layout so selecting a file does
+// not mutate the main tree.
 const META = "filemeta::"; // collapsed file pill
 const BOX = "filebox::"; //   expanded file compound box
+const DIR = "dir::"; // directory/package compound box
+const SCOPE = "scopebox::"; // symbol/class compound scope inside an expanded file
 const fileKey = (n: CMNode) => (n.external ? "· external" : n.file || "· external");
 const baseName = (f: string) => (f.startsWith("·") ? f : f.split("/").pop() || f);
+const compactFileName = (f: string) => {
+  if (f.startsWith("·")) return f;
+  const parts = f.split("/");
+  return parts.length > 1 ? parts.slice(-2).join("/") : parts[0] || f;
+};
+const graphFileName = (f: string) => {
+  const name = baseName(f);
+  if (name.length <= 14) return name;
+  const cut = name.lastIndexOf("_");
+  if (cut >= 5 && cut <= name.length - 5) return `${name.slice(0, cut + 1)}\n${name.slice(cut + 1)}`;
+  return name;
+};
+const pathSuffix = (f: string, partCount: number) => fileParts(f).slice(-partCount).join("/");
+const wrapFileLabel = (label: string) => {
+  if (label.startsWith("·")) return label;
+  const parts = label.split("/");
+  if (parts.length > 1) return `${parts.slice(0, -1).join("/")}/\n${parts[parts.length - 1]}`;
+  return graphFileName(label);
+};
+const fileDisplayLabels = (files: string[], compactLabels: boolean): Map<string, string> => {
+  const labels = new Map<string, string>();
+  const byBase = new Map<string, string[]>();
+
+  for (const file of files) {
+    const base = baseName(file);
+    let group = byBase.get(base);
+    if (!group) byBase.set(base, (group = []));
+    group.push(file);
+  }
+
+  for (const [base, group] of byBase) {
+    if (group.length === 1) {
+      const file = group[0];
+      labels.set(file, compactLabels ? wrapFileLabel(compactFileName(file)) : graphFileName(file));
+      continue;
+    }
+
+    for (const file of group) {
+      const parts = fileParts(file);
+      let label = base;
+      for (let count = Math.min(2, parts.length); count <= parts.length; count += 1) {
+        const candidate = pathSuffix(file, count);
+        const unique = group.every((other) => other === file || pathSuffix(other, count) !== candidate);
+        if (unique) {
+          label = candidate;
+          break;
+        }
+      }
+      labels.set(file, wrapFileLabel(label));
+    }
+  }
+
+  return labels;
+};
+const plainGraphLabel = (label: string) => label.replace(/\s*·\d+$/, "").replace(/\n/g, "");
+const symbolName = (s: string) => s.split(":").pop() || s;
+const scopedSymbolName = (s: string, scope?: string) => {
+  const name = symbolName(s);
+  return scope && name.startsWith(`${scope}.`) ? name.slice(scope.length + 1) : name;
+};
+const fileParts = (f: string) => (f.startsWith("·") ? [f] : f.split("/").filter(Boolean));
+const commonSourceRoot = (files: string[]) => {
+  const concrete = files.map(fileParts).filter((p) => p.length > 1 && !p[0].startsWith("·"));
+  if (!concrete.length) return null;
+  const first = concrete[0][0];
+  return concrete.every((p) => p[0] === first) ? first : null;
+};
+const hierarchyPath = (f: string, root: string | null) => {
+  const parts = fileParts(f);
+  return root && parts[0] === root ? parts.slice(1) : parts;
+};
+const dirKeyForFile = (f: string, root: string | null) => {
+  if (f.startsWith("·")) return "· external";
+  const parts = hierarchyPath(f, root);
+  return parts.length > 1 ? parts.slice(0, -1).join("/") : "· root";
+};
+const dirLabel = (d: string) => (d === "· root" ? "root" : d === "· external" ? "external" : `${d}/`);
+const stableHash = (s: string) => {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i += 1) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+};
+const stableOffset = (id: string, radius = 40) => {
+  const h = stableHash(id);
+  const angle = ((h % 360) / 360) * Math.PI * 2;
+  const r = radius * (0.35 + ((h >>> 9) % 1000) / 2000);
+  return { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
+};
+
+type Point = { x: number; y: number };
+
+type DirInfo = { label: string; count: number; external: boolean; parent?: string };
+type HierarchyProjection = { dirs: Map<string, DirInfo>; fileDir: Map<string, string> };
+
+function fallbackHierarchyProjection(
+  files: string[],
+  compactLabels: boolean,
+  hierarchyMode: "files" | "symbols"
+): HierarchyProjection {
+  const root = commonSourceRoot(files);
+  const byDir = new Map<string, string[]>();
+  for (const f of files) {
+    const d = dirKeyForFile(f, root);
+    let arr = byDir.get(d);
+    if (!arr) byDir.set(d, (arr = []));
+    arr.push(f);
+  }
+
+  const dirs = new Map<string, DirInfo>();
+  const fileDir = new Map<string, string>();
+  for (const [d, dirFiles] of byDir) {
+    if ((hierarchyMode === "files" && !compactLabels) || dirFiles.length > 1) {
+      dirs.set(d, {
+        label: dirLabel(d),
+        count: dirFiles.length,
+        external: d === "· external",
+      });
+    }
+  }
+  for (const [d, dirFiles] of byDir) {
+    if (!dirs.has(d)) continue;
+    for (const f of dirFiles) fileDir.set(f, d);
+  }
+  return { dirs, fileDir };
+}
+
+function backendHierarchyProjection(
+  data: CodemapResponse,
+  files: string[],
+  compactLabels: boolean,
+  hierarchyMode: "files" | "symbols"
+): HierarchyProjection | null {
+  const hnodes = data.hierarchy?.nodes;
+  if (!hnodes?.length) return null;
+
+  const fileSet = new Set(files);
+  const byId = new Map(hnodes.map((n) => [n.id, n]));
+  const fileNodes = hnodes.filter((n) => n.kind === "file" && n.file && fileSet.has(n.file));
+  if (!fileNodes.length) return null;
+
+  const fileCountByDir = new Map<string, number>();
+  for (const fnode of fileNodes) {
+    const parent = fnode.parent ? byId.get(fnode.parent) : null;
+    if (parent?.kind !== "directory") continue;
+    fileCountByDir.set(parent.id, (fileCountByDir.get(parent.id) ?? 0) + 1);
+  }
+
+  const dirs = new Map<string, DirInfo>();
+  for (const [id, count] of fileCountByDir) {
+    const node = byId.get(id);
+    if (!node) continue;
+    if ((hierarchyMode === "files" && !compactLabels) || count > 1) {
+      const parent = node.parent && byId.get(node.parent)?.kind === "directory" ? node.parent : undefined;
+      dirs.set(id, {
+        label: node.label,
+        count,
+        external: !!node.external,
+        parent,
+      });
+    }
+  }
+
+  const nearestVisibleDir = (id: string | null | undefined): string | undefined => {
+    let cur = id;
+    while (cur) {
+      if (dirs.has(cur)) return cur;
+      cur = byId.get(cur)?.parent ?? undefined;
+    }
+    return undefined;
+  };
+  const fileDir = new Map<string, string>();
+  for (const fnode of fileNodes) {
+    const visible = nearestVisibleDir(fnode.parent);
+    if (visible && fnode.file) fileDir.set(fnode.file, visible);
+  }
+
+  return { dirs, fileDir };
+}
 
 // Build Cytoscape elements for the current expand state. A collapsed file is a
 // single pill meta-node; an expanded file is a compound box holding its symbols.
@@ -65,7 +230,12 @@ const baseName = (f: string) => (f.startsWith("·") ? f : f.split("/").pop() || 
 // symbol when its file is expanded, else the file pill); edges inside one
 // collapsed file collapse away. Solid edges are exact references; dashed edges
 // (`meta = 1`) are file-level aggregates that you drill into by expanding.
-function buildElements(data: CodemapResponse, expanded: Set<string>): ElementDefinition[] {
+function buildElements(
+  data: CodemapResponse,
+  expanded: Set<string>,
+  compactLabels = false,
+  hierarchyMode: "files" | "symbols" = "files"
+): ElementDefinition[] {
   const byFile = new Map<string, CMNode[]>();
   const fileOfNode = new Map<string, string>();
   for (const n of data.nodes) {
@@ -76,29 +246,128 @@ function buildElements(data: CodemapResponse, expanded: Set<string>): ElementDef
     arr.push(n);
   }
 
+  const files = [...byFile.keys()];
+  const displayLabels = fileDisplayLabels(files, compactLabels);
   const els: ElementDefinition[] = [];
+  const hierarchy =
+    backendHierarchyProjection(data, files, compactLabels, hierarchyMode) ??
+    fallbackHierarchyProjection(files, compactLabels, hierarchyMode);
+  const hierarchyNodes = data.hierarchy?.nodes ?? [];
+  const hierarchyById = new Map(hierarchyNodes.map((n) => [n.id, n]));
+  const hierarchySymbolByNodeId = new Map<string, HierarchyNode>();
+  for (const hnode of hierarchyNodes) {
+    if (hnode.kind === "symbol" && hnode.node_id) hierarchySymbolByNodeId.set(hnode.node_id, hnode);
+  }
+  const scopeBoxIds = new Set<string>();
+  for (const n of data.nodes) {
+    let cur = hierarchySymbolByNodeId.get(n.id)?.parent ?? null;
+    while (cur) {
+      const hnode = hierarchyById.get(cur);
+      if (!hnode) break;
+      if (hnode.kind === "symbol") scopeBoxIds.add(hnode.id);
+      cur = hnode.parent ?? null;
+    }
+  }
+
+  const scopeParentFor = (parentId: string | null | undefined, file: string): string => {
+    let cur = parentId ?? null;
+    while (cur) {
+      const hnode = hierarchyById.get(cur);
+      if (!hnode) break;
+      if (hnode.kind === "symbol" && scopeBoxIds.has(hnode.id)) return SCOPE + hnode.id;
+      if (hnode.kind === "file") return BOX + (hnode.file || file);
+      cur = hnode.parent ?? null;
+    }
+    return BOX + file;
+  };
+
+  for (const [d, info] of hierarchy.dirs) {
+    const parent = info.parent && hierarchy.dirs.has(info.parent) ? DIR + info.parent : undefined;
+    els.push({
+      data: {
+        id: DIR + d,
+        ...(parent ? { parent } : {}),
+        isDirBox: 1,
+        dir: d,
+        dirLabel: info.label,
+        count: info.count,
+        external: info.external ? 1 : 0,
+      },
+    });
+  }
+
   for (const [f, nodes] of byFile) {
+    const dirKey = hierarchy.fileDir.get(f);
+    const dirParent = dirKey ? DIR + dirKey : undefined;
+    const fileDepth = nodes.some((n) => n.is_root)
+      ? 0
+      : Math.min(...nodes.map((n) => (Number.isFinite(n.depth) ? n.depth : 0)));
     if (expanded.has(f)) {
-      els.push({ data: { id: BOX + f, isFileBox: 1, file: f, fileLabel: `${baseName(f)}  ▾` } });
+      els.push({
+        data: {
+          id: BOX + f,
+          ...(dirParent ? { parent: dirParent } : {}),
+          isFileBox: 1,
+          file: f,
+          short: baseName(f),
+          count: nodes.length,
+          fileLabel: displayLabels.get(f) ?? baseName(f),
+          treeDepth: fileDepth,
+        },
+      });
+      const scopeNodes = hierarchyNodes
+        .filter((hnode) => hnode.kind === "symbol" && hnode.file === f && scopeBoxIds.has(hnode.id))
+        .sort((a, b) => (a.depth ?? 0) - (b.depth ?? 0) || a.id.localeCompare(b.id));
+      for (const hnode of scopeNodes) {
+        const short = symbolName(hnode.label || hnode.path || hnode.id);
+        els.push({
+          data: {
+            id: SCOPE + hnode.id,
+            parent: scopeParentFor(hnode.parent, f),
+            isSymbolBox: 1,
+            hierarchyId: hnode.id,
+            file: f,
+            short,
+            scopeLabel: short,
+            count: hnode.symbol_count ?? 0,
+            importance: hnode.importance ?? hnode.doi ?? 0,
+            external: hnode.external ? 1 : 0,
+            treeDepth: hnode.depth ?? fileDepth,
+          },
+        });
+      }
       for (const n of nodes) {
         const hidden = n.hidden_callees || 0;
+        const hnode = hierarchySymbolByNodeId.get(n.id);
+        const parentHnode = hnode?.parent ? hierarchyById.get(hnode.parent) : undefined;
+        const parentScope =
+          parentHnode?.kind === "symbol" ? symbolName(parentHnode.label || parentHnode.path || parentHnode.id) : undefined;
+        const short = scopedSymbolName(n.short, parentScope);
+        const parent =
+          hnode && scopeBoxIds.has(hnode.id)
+            ? SCOPE + hnode.id
+            : hnode
+              ? scopeParentFor(hnode.parent, f)
+              : BOX + f;
         els.push({
           data: {
             id: n.id,
-            parent: BOX + f,
-            short: n.short,
-            glabel: hidden ? `${n.short}  +${hidden}` : n.short, // node label, with hub badge
+            parent,
+            short,
+            glabel: hidden ? `${short}  +${hidden}` : short, // node label, with hub badge
             flabel: n.label, // full unified_name, used to refocus
             file: n.file,
             line: n.line,
             endLine: n.end_line ?? null,
             kind: n.kind,
-            accent: colorForKind(n.kind),
+            tone: toneForKind(n.kind),
+            isConcreteSymbol: 1,
             importance: n.importance ?? 0,
             refCount: n.ref_count ?? 0,
             entryScore: n.entry_score ?? 0,
             root: n.is_root ? 1 : 0,
             external: n.external ? 1 : 0,
+            treeDepth: n.depth ?? fileDepth,
           },
         });
       }
@@ -108,17 +377,19 @@ function buildElements(data: CodemapResponse, expanded: Set<string>): ElementDef
       els.push({
         data: {
           id: META + f,
+          ...(dirParent ? { parent: dirParent } : {}),
           isFileMeta: 1,
           file: f,
           short: baseName(f),
-          glabel: `${baseName(f)}  ·${nodes.length}`,
+          glabel: `${displayLabels.get(f) ?? baseName(f)}  ·${nodes.length}`,
           kind: "file",
-          accent: colorForKind("file"),
+          tone: "file",
           importance: imp,
           count: nodes.length,
           pill: Math.min(1, nodes.length / 20), // clamped size cue: bigger file = bigger pill
           root: nodes.some((n) => n.is_root) ? 1 : 0,
           external: f === "· external" ? 1 : 0,
+          treeDepth: fileDepth,
         },
       });
     }
@@ -131,8 +402,20 @@ function buildElements(data: CodemapResponse, expanded: Set<string>): ElementDef
     return expanded.has(f) ? id : META + f;
   };
   const shortById = new Map(data.nodes.map((n) => [n.id, n.short]));
+  const fileLabel = (file: string | undefined) => (file ? plainGraphLabel(displayLabels.get(file) ?? compactFileName(file)) : "");
 
-  type Agg = { weight: number; anchors: CallSite[]; symbolEdge: boolean; srcShort: string; tgtShort: string };
+  type Agg = {
+    weight: number;
+    anchors: CallSite[];
+    symbolEdge: boolean;
+    srcShort: string;
+    tgtShort: string;
+    srcFile: string;
+    tgtFile: string;
+    srcDisplay: string;
+    tgtDisplay: string;
+    crossFile: boolean;
+  };
   const agg = new Map<string, Agg>();
   for (const e of data.edges) {
     if (!e.source || !e.target) continue;
@@ -142,13 +425,34 @@ function buildElements(data: CodemapResponse, expanded: Set<string>): ElementDef
     const symbolEdge = !vs.startsWith(META) && !vt.startsWith(META);
     const key = `${vs}\u0000${vt}`;
     let a = agg.get(key);
-    if (!a) agg.set(key, (a = { weight: 0, anchors: [], symbolEdge, srcShort: "", tgtShort: "" }));
+    if (!a) {
+      agg.set(
+        key,
+        (a = {
+          weight: 0,
+          anchors: [],
+          symbolEdge,
+          srcShort: "",
+          tgtShort: "",
+          srcFile: fileOfNode.get(e.source) || "",
+          tgtFile: fileOfNode.get(e.target) || "",
+          srcDisplay: "",
+          tgtDisplay: "",
+          crossFile: false,
+        })
+      );
+    }
     a.weight += e.weight ?? e.anchors?.length ?? 0;
     if (symbolEdge && e.anchors) a.anchors.push(...e.anchors);
+    a.crossFile = a.crossFile || !!e.cross_file;
     if (symbolEdge) {
       a.srcShort = shortById.get(e.source) || "";
       a.tgtShort = shortById.get(e.target) || "";
     }
+    a.srcFile ||= fileOfNode.get(e.source) || "";
+    a.tgtFile ||= fileOfNode.get(e.target) || "";
+    a.srcDisplay ||= symbolEdge ? a.srcShort : fileLabel(a.srcFile);
+    a.tgtDisplay ||= symbolEdge ? a.tgtShort : fileLabel(a.tgtFile);
   }
   let i = 0;
   for (const [key, a] of agg) {
@@ -164,74 +468,499 @@ function buildElements(data: CodemapResponse, expanded: Set<string>): ElementDef
         meta: a.symbolEdge ? 0 : 1, // file-level aggregate (dashed) vs exact reference
         srcShort: a.srcShort,
         tgtShort: a.tgtShort,
+        srcFile: a.srcFile,
+        tgtFile: a.tgtFile,
+        srcDisplay: a.srcDisplay || a.srcShort || fileLabel(a.srcFile),
+        tgtDisplay: a.tgtDisplay || a.tgtShort || fileLabel(a.tgtFile),
+        crossFile: a.crossFile ? 1 : 0,
+        scopeRoute: a.symbolEdge && !a.crossFile ? 1 : 0,
       },
     });
   }
   return els;
 }
 
-// The subsystem "spine": the few highest-importance files that actually take part
-// in a cross-file edge. We auto-expand these on load so the default view shows real
-// symbol-level calls through the core, while the long tail of singletons stays as
-// pills — a level-of-detail middle ground between Files and Symbols.
-function spineFiles(data: CodemapResponse, maxFiles = 4, maxSymbols = 16): Set<string> {
-  const fileOf = new Map<string, string>();
-  const score = new Map<string, number>();
-  const size = new Map<string, number>();
-  for (const n of data.nodes) {
-    const f = fileKey(n);
-    if (f === "· external") continue;
-    fileOf.set(n.id, f);
-    score.set(f, Math.max(score.get(f) ?? 0, n.is_root ? 1 : n.importance ?? 0));
-    size.set(f, (size.get(f) ?? 0) + 1);
+// Legacy compact placement helpers kept for file/symbol internals. The main
+// graph layout below is a breadth-first tree, not a force-directed embedder.
+function seedInitialPositions(cy: Core, compact: boolean, structural: boolean): void {
+  const leaves = cy
+    .nodes()
+    .filter((n) => !n.isParent())
+    .sort((a, b) => {
+      const ar = a.data("root") ? 0 : 1;
+      const br = b.data("root") ? 0 : 1;
+      if (ar !== br) return ar - br;
+      return a.id().localeCompare(b.id());
+    });
+  const count = leaves.length;
+  if (count === 0) return;
+
+  const grouped = new Map<string, NodeSingular[]>();
+  leaves.forEach((n) => {
+    const parent = n.parent();
+    const group = parent.nonempty() ? parent.first().id() : "ungrouped";
+    let arr = grouped.get(group);
+    if (!arr) grouped.set(group, (arr = []));
+    arr.push(n);
+  });
+  const groups = [...grouped.entries()].sort((a, b) => {
+    const ar = a[1].some((n) => n.data("root")) ? 0 : 1;
+    const br = b[1].some((n) => n.data("root")) ? 0 : 1;
+    if (ar !== br) return ar - br;
+    if (b[1].length !== a[1].length) return b[1].length - a[1].length;
+    return a[0].localeCompare(b[0]);
+  });
+  const groupCols = compact ? Math.min(2, Math.ceil(Math.sqrt(groups.length))) : Math.ceil(Math.sqrt(groups.length));
+  const groupGapX = compact ? 138 : structural ? 190 : 220;
+  const groupGapY = compact ? 110 : structural ? 140 : 160;
+  const leafGapX = compact ? 72 : structural ? 86 : 104;
+  const leafGapY = compact ? 52 : structural ? 64 : 76;
+  groups.forEach(([group, nodes], gi) => {
+    const groupCol = gi % groupCols;
+    const groupRow = Math.floor(gi / groupCols);
+    const groupX = (groupCol - (groupCols - 1) / 2) * groupGapX;
+    const groupY = (groupRow - (Math.ceil(groups.length / groupCols) - 1) / 2) * groupGapY;
+    const localCols = Math.min(compact ? 2 : 3, Math.ceil(Math.sqrt(nodes.length)));
+    const localRows = Math.ceil(nodes.length / localCols);
+    nodes
+      .sort((a, b) => a.id().localeCompare(b.id()))
+      .forEach((n, i) => {
+        const col = i % localCols;
+        const row = Math.floor(i / localCols);
+        const jitter = stableOffset(`${group}/${n.id()}`, compact ? 7 : 10);
+        n.position({
+          x: groupX + (col - (localCols - 1) / 2) * leafGapX + jitter.x,
+          y: groupY + (row - (localRows - 1) / 2) * leafGapY + jitter.y,
+        });
+      });
+  });
+}
+
+function runCompactFileOverview(cy: Core): boolean {
+  const container = cy.container();
+  const compact = (container?.clientWidth ?? 0) < 500;
+  const graphMode = container?.closest(".codegraph")?.getAttribute("data-mode");
+  if (!compact || graphMode !== "files" || cy.nodes("[isFileBox = 1]").length > 0) return false;
+
+  const leaves = cy.nodes("[isFileMeta = 1]");
+  if (leaves.length === 0) return false;
+
+  const grouped = new Map<string, NodeSingular[]>();
+  leaves.forEach((n) => {
+    const parent = n.parent();
+    const group = parent.nonempty() ? parent.first().id() : n.id();
+    let arr = grouped.get(group);
+    if (!arr) grouped.set(group, (arr = []));
+    arr.push(n);
+  });
+  const groups = [...grouped.entries()].sort((a, b) => {
+    const ar = a[1].some((n) => n.data("root")) ? 0 : a[1].some((n) => n.data("external")) ? 2 : 1;
+    const br = b[1].some((n) => n.data("root")) ? 0 : b[1].some((n) => n.data("external")) ? 2 : 1;
+    if (ar !== br) return ar - br;
+    if (b[1].length !== a[1].length) return b[1].length - a[1].length;
+    return a[0].localeCompare(b[0]);
+  });
+
+  const cols = 2;
+  const cellX = 118;
+  const cellY = 52;
+  const rows: NodeSingular[][] = [];
+  let rowBuf: NodeSingular[] = [];
+  const flushRow = () => {
+    if (rowBuf.length) rows.push(rowBuf);
+    rowBuf = [];
+  };
+
+  groups.forEach(([, nodes]) => {
+    const sorted = nodes.sort((a, b) => {
+      const ar = a.data("root") ? 0 : 1;
+      const br = b.data("root") ? 0 : 1;
+      if (ar !== br) return ar - br;
+      return a.id().localeCompare(b.id());
+    });
+    if (sorted.length > 1) {
+      flushRow();
+      for (let i = 0; i < sorted.length; i += cols) rows.push(sorted.slice(i, i + cols));
+      return;
+    }
+    rowBuf.push(sorted[0]);
+    if (rowBuf.length === cols) flushRow();
+  });
+  flushRow();
+
+  rows.forEach((rowNodes, row) => {
+    const inRow = rowNodes.length;
+    rowNodes.forEach((n, col) => {
+      n.position({
+        x: (col - (inRow - 1) / 2) * cellX,
+        y: (row - (rows.length - 1) / 2) * cellY,
+      });
+    });
+  });
+
+  cy.layout({ name: "preset", animate: false, fit: true, padding: 10 } as any).run();
+  if (cy.zoom() > 1.05) {
+    cy.zoom(1.05);
+    cy.center();
   }
-  // Only files with a cross-file edge — expanding an isolated singleton reveals nothing.
-  const connected = new Set<string>();
-  for (const e of data.edges) {
-    const sf = fileOf.get(e.source);
-    const tf = fileOf.get(e.target);
-    if (sf && tf && sf !== tf) {
-      connected.add(sf);
-      connected.add(tf);
+  ensureGraphVisible(cy, 10);
+  return true;
+}
+
+function runCompactSymbolSpine(cy: Core): boolean {
+  const container = cy.container();
+  const compact = (container?.clientWidth ?? 0) < 500;
+  const graphMode = container?.closest(".codegraph")?.getAttribute("data-mode");
+  if (!compact || graphMode !== "symbols") return false;
+
+  const groups: Array<{ id: string; nodes: NodeSingular[]; rank: number }> = [];
+  cy.nodes("[isFileBox = 1]").forEach((box) => {
+    const symbols = box
+      .children()
+      .filter((n) => !n.isParent())
+      .sort((a, b) => {
+        const ar = a.data("root") ? 0 : 1;
+        const br = b.data("root") ? 0 : 1;
+        if (ar !== br) return ar - br;
+        return a.id().localeCompare(b.id());
+      });
+    const symbolNodes: NodeSingular[] = [];
+    symbols.forEach((n) => {
+      symbolNodes.push(n);
+    });
+    if (symbolNodes.length) groups.push({ id: box.id(), nodes: symbolNodes, rank: 0 });
+  });
+
+  const metaGroups = new Map<string, NodeSingular[]>();
+  cy.nodes("[isFileMeta = 1]").forEach((n) => {
+    const parent = n.parent();
+    const group = parent.nonempty() && parent.first().data("isDirBox") ? parent.first().id() : n.id();
+    let arr = metaGroups.get(group);
+    if (!arr) metaGroups.set(group, (arr = []));
+    arr.push(n);
+  });
+  metaGroups.forEach((nodes, id) => {
+    const rank = nodes.some((n) => n.data("root")) ? 1 : nodes.some((n) => n.data("external")) ? 3 : 2;
+    groups.push({ id, nodes, rank });
+  });
+
+  if (groups.length === 0) return false;
+  groups.sort((a, b) => {
+    if (a.rank !== b.rank) return a.rank - b.rank;
+    if (b.nodes.length !== a.nodes.length) return b.nodes.length - a.nodes.length;
+    return a.id.localeCompare(b.id);
+  });
+
+  const cols = 2;
+  const cellX = 118;
+  const cellY = 52;
+  const rows: NodeSingular[][] = [];
+  let rowBuf: NodeSingular[] = [];
+  const flushRow = () => {
+    if (rowBuf.length) rows.push(rowBuf);
+    rowBuf = [];
+  };
+
+  groups.forEach((group) => {
+    const sorted = group.nodes.sort((a, b) => {
+      const ar = a.data("root") ? 0 : 1;
+      const br = b.data("root") ? 0 : 1;
+      if (ar !== br) return ar - br;
+      return a.id().localeCompare(b.id());
+    });
+    if (group.rank === 0 || sorted.length > 1) {
+      flushRow();
+      for (let i = 0; i < sorted.length; i += cols) rows.push(sorted.slice(i, i + cols));
+      return;
+    }
+    rowBuf.push(sorted[0]);
+    if (rowBuf.length === cols) flushRow();
+  });
+  flushRow();
+
+  rows.forEach((rowNodes, row) => {
+    const inRow = rowNodes.length;
+    rowNodes.forEach((n, col) => {
+      n.position({
+        x: (col - (inRow - 1) / 2) * cellX,
+        y: (row - (rows.length - 1) / 2) * cellY,
+      });
+    });
+  });
+
+  cy.layout({ name: "preset", animate: false, fit: true, padding: 10 } as any).run();
+  if (cy.zoom() > 1.05) {
+    cy.zoom(1.05);
+    cy.center();
+  }
+  ensureGraphVisible(cy, 10);
+  return true;
+}
+
+function runLayout(cy: Core, opts: { stable?: boolean } = {}): void {
+  if (cy.nodes().length === 0) return;
+  const compact = (cy.container()?.clientWidth ?? 0) < 500;
+  const graphMode = cy.container()?.closest(".codegraph")?.getAttribute("data-mode");
+  const structural = graphMode === "symbols" || cy.nodes("[isFileBox = 1]").length > 0;
+  const containerW = cy.container()?.clientWidth ?? 640;
+  const targetCellW = compact ? 108 : structural ? 136 : 120;
+  const maxCols = Math.max(1, Math.min(compact ? 2 : structural ? 4 : 4, Math.floor((containerW - 72) / targetCellW)));
+  const colGap = compact ? 14 : structural ? 18 : 16;
+  const rowGap = compact ? 12 : structural ? 16 : 14;
+  const depthGap = compact ? 10 : 14;
+
+  if (structural) {
+    cy.nodes("[isFileBox = 1]").forEach((box) => {
+      const file = box.data("file");
+      if (typeof file === "string") layoutExpandedFileInternals(cy, file, compact);
+    });
+  }
+
+  const rows = new Map<number, NodeSingular[]>();
+  topLevelLayoutItems(cy).forEach((node) => {
+    const rawDepth = Number(node.data("treeDepth"));
+    const depth = Number.isFinite(rawDepth) ? Math.max(0, Math.round(rawDepth)) : 0;
+    const row = rows.get(depth) ?? [];
+    row.push(node);
+    rows.set(depth, row);
+  });
+
+  const visualRows: Array<{ depth: number; nodes: NodeSingular[] }> = [];
+  [...rows.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .forEach(([depth, nodes]) => {
+      nodes.sort(compareLayoutItems);
+      for (let i = 0; i < nodes.length; i += maxCols) {
+        visualRows.push({ depth, nodes: nodes.slice(i, i + maxCols) });
+      }
+    });
+  if (visualRows.length === 0) return;
+
+  const rowBoxes = visualRows.map(({ nodes }) => nodes.map(layoutItemBox));
+  const rowHeights = rowBoxes.map((boxes) => Math.max(...boxes.map((box) => box.h), 1));
+  const rowY: number[] = [];
+  let cursorY = rowHeights[0] / 2;
+  for (let i = 0; i < visualRows.length; i += 1) {
+    if (i > 0) {
+      cursorY += rowHeights[i - 1] / 2 + rowHeights[i] / 2 + rowGap;
+      if (visualRows[i].depth !== visualRows[i - 1].depth) cursorY += depthGap;
+    }
+    rowY[i] = cursorY;
+  }
+  const totalHeight = cursorY + rowHeights[visualRows.length - 1] / 2;
+  const yOffset = totalHeight / 2;
+
+  cy.batch(() => {
+    visualRows.forEach(({ nodes }, rowIndex) => {
+      const boxes = rowBoxes[rowIndex];
+      const width = boxes.reduce((sum, box) => sum + box.w, 0) + Math.max(0, nodes.length - 1) * colGap;
+      let x = -width / 2;
+      const y = rowY[rowIndex] - yOffset;
+      nodes.forEach((node, index) => {
+        const box = boxes[index];
+        node.position({ x: x + box.w / 2, y });
+        x += box.w + colGap;
+      });
+    });
+  });
+
+  cy.layout({
+    name: "preset",
+    animate: false,
+    fit: !opts.stable,
+    padding: compact ? 10 : structural ? 16 : 20,
+  } as any).run();
+  if (!opts.stable) {
+    const minCompactZoom = graphMode === "files" ? 0 : 0.54;
+    if (compact && minCompactZoom > 0 && cy.zoom() < minCompactZoom) {
+      cy.zoom(minCompactZoom);
+      cy.center();
+    } else if (cy.zoom() > 1.2) {
+      cy.zoom(1.2);
+      cy.center();
     }
   }
-  const ranked = [...connected].sort((a, b) => (score.get(b) ?? 0) - (score.get(a) ?? 0));
-  const out = new Set<string>();
-  let symbols = 0;
-  for (const f of ranked) {
-    if (out.size >= maxFiles || symbols >= maxSymbols) break;
-    out.add(f);
-    symbols += size.get(f) ?? 0;
+}
+
+function ensureGraphVisible(cy: Core, padding = 24): void {
+  const container = cy.container();
+  if (!container || cy.elements().empty()) return;
+  const width = container.clientWidth;
+  const height = container.clientHeight;
+  const bb = cy.elements().renderedBoundingBox({ includeLabels: true });
+  const usableW = Math.max(80, width - padding * 2);
+  const usableH = Math.max(80, height - padding * 2);
+  const needsZoom = bb.w > usableW || bb.h > usableH;
+  const offscreen = bb.x1 < padding || bb.y1 < padding || bb.x2 > width - padding || bb.y2 > height - padding;
+  if (!needsZoom && !offscreen) return;
+
+  const scale = Math.min(1, usableW / Math.max(bb.w, 1), usableH / Math.max(bb.h, 1));
+  if (needsZoom && scale < 1) {
+    cy.zoom({
+      level: Math.max(cy.minZoom(), cy.zoom() * scale),
+      renderedPosition: { x: width / 2, y: height / 2 },
+    });
   }
+  cy.fit(cy.elements(), padding);
+}
+
+function collectionNodes(nodes: cytoscape.NodeCollection): NodeSingular[] {
+  const out: NodeSingular[] = [];
+  nodes.forEach((n) => {
+    out.push(n);
+  });
   return out;
 }
 
-// Lay out the current elements with fcose (compound-aware spring embedder), then
-// fit. packComponents keeps disconnected pieces from sprawling across the canvas.
-// `stable` warm-starts from current positions and skips the refit so expand/
-// collapse stays anchored.
-function runLayout(cy: Core, opts: { stable?: boolean } = {}): void {
-  if (cy.nodes().length === 0) return;
-  cy.layout({
-    name: "fcose",
-    quality: "proof",
-    randomize: !opts.stable,
-    animate: false,
-    fit: !opts.stable,
-    padding: 28,
-    packComponents: true,
-    nodeSeparation: 78,
-    idealEdgeLength: 95,
-    nodeRepulsion: 6500,
-    nestingFactor: 0.1,
-    gravity: 0.3,
-    gravityCompound: 1.2,
-    tile: true,
-  } as any).run();
-  if (!opts.stable && cy.zoom() > 1.2) {
-    cy.zoom(1.2);
-    cy.center();
+function topLevelLayoutItems(cy: Core): NodeSingular[] {
+  const items: NodeSingular[] = [];
+  cy.nodes("[isFileBox = 1]").forEach((node) => {
+    items.push(node);
+  });
+  cy.nodes("[isFileMeta = 1]").forEach((node) => {
+    items.push(node);
+  });
+  if (items.length) return items;
+
+  return collectionNodes(cy.nodes().filter((n) => !n.isParent()));
+}
+
+function subtreeCenter(node: NodeSingular): Point {
+  const box = node.descendants().length
+    ? node.descendants().boundingBox({ includeLabels: true })
+    : node.boundingBox({ includeLabels: true });
+  return { x: (box.x1 + box.x2) / 2, y: (box.y1 + box.y2) / 2 };
+}
+
+function shiftSubtree(node: NodeSingular, dx: number, dy: number): void {
+  node.descendants().forEach((child) => {
+    const p = child.position();
+    child.position({ x: p.x + dx, y: p.y + dy });
+  });
+}
+
+function placeLayoutItem(item: NodeSingular, x: number, y: number): void {
+  if (item.isParent()) {
+    const c = subtreeCenter(item);
+    shiftSubtree(item, x - c.x, y - c.y);
+    return;
   }
+  item.position({ x, y });
+}
+
+function layoutRank(item: NodeSingular): number {
+  return (item.data("root") ? 100 : 0) + Number(item.data("importance") || 0) * 10 + (item.data("isSymbolBox") ? 1 : 0);
+}
+
+function compareLayoutItems(a: NodeSingular, b: NodeSingular): number {
+  const diff = layoutRank(b) - layoutRank(a);
+  return Math.abs(diff) > 0.001 ? diff : a.id().localeCompare(b.id());
+}
+
+function layoutItemBox(item: NodeSingular): { w: number; h: number } {
+  const box = item.isParent()
+    ? item.union(item.descendants()).boundingBox({ includeLabels: true })
+    : item.boundingBox({ includeLabels: true });
+  return { w: Math.max(1, box.w), h: Math.max(1, box.h) };
+}
+
+function arrangeLayoutGrid(items: NodeSingular[], cols: number, center: Point, gapX: number, gapY: number): void {
+  const rows = Math.ceil(items.length / cols);
+  const boxes = items.map(layoutItemBox);
+  const colWidths = Array.from({ length: cols }, () => 0);
+  const rowHeights = Array.from({ length: rows }, () => 0);
+  boxes.forEach((box, i) => {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    colWidths[col] = Math.max(colWidths[col], box.w + gapX);
+    rowHeights[row] = Math.max(rowHeights[row], box.h + gapY);
+  });
+
+  const totalW = colWidths.reduce((sum, w) => sum + w, 0);
+  const totalH = rowHeights.reduce((sum, h) => sum + h, 0);
+  const colStarts: number[] = [];
+  const rowStarts: number[] = [];
+  colWidths.reduce((x, w, i) => {
+    colStarts[i] = x;
+    return x + w;
+  }, center.x - totalW / 2);
+  rowHeights.reduce((y, h, i) => {
+    rowStarts[i] = y;
+    return y + h;
+  }, center.y - totalH / 2);
+
+  items.forEach((item, i) => {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    placeLayoutItem(item, colStarts[col] + colWidths[col] / 2, rowStarts[row] + rowHeights[row] / 2);
+  });
+}
+
+function layoutSymbolScope(scope: NodeSingular, compact: boolean): void {
+  const childScopes = collectionNodes(scope.children("[isSymbolBox = 1]"));
+  childScopes.forEach((child) => layoutSymbolScope(child, compact));
+  const leaves = collectionNodes(scope.children().filter((n) => !n.isParent()));
+  const items = [...childScopes, ...leaves].sort(compareLayoutItems);
+  if (!items.length) return;
+
+  const cols = Math.min(2, Math.ceil(Math.sqrt(items.length)));
+  const center = subtreeCenter(scope);
+  arrangeLayoutGrid(items, cols, center, compact ? 22 : 30, compact ? 14 : 20);
+}
+
+function layoutExpandedFileInternals(cy: Core, file: string, compact: boolean): void {
+  const fileBox = cy.getElementById(BOX + file);
+  if (fileBox.empty()) return;
+
+  const scopes = collectionNodes(fileBox.children("[isSymbolBox = 1]"));
+  scopes.forEach((scope) => layoutSymbolScope(scope, compact));
+  const leaves = collectionNodes(fileBox.children().filter((n) => !n.isParent()));
+  const items = [...scopes, ...leaves].sort(compareLayoutItems);
+  if (!items.length) return;
+
+  const cols = Math.min(compact ? 1 : 2, Math.ceil(Math.sqrt(items.length)));
+  const center = subtreeCenter(fileBox);
+  arrangeLayoutGrid(items, cols, center, compact ? 36 : 54, compact ? 28 : 40);
+}
+
+function layoutExpandedFileContext(cy: Core, file: string, compact: boolean): void {
+  const fileBox = cy.getElementById(BOX + file);
+  if (fileBox.empty()) return;
+  const focus = fileBox.union(fileBox.descendants());
+  const focusIds = new Set<string>();
+  focus.nodes().forEach((n) => {
+    focusIds.add(n.id());
+  });
+  const context = collectionNodes(
+    focus
+      .connectedEdges()
+      .connectedNodes()
+      .filter((n) => !n.isParent() && !focusIds.has(n.id()))
+  ).sort((a, b) => {
+    const ar = a.data("external") ? 1 : 0;
+    const br = b.data("external") ? 1 : 0;
+    if (ar !== br) return ar - br;
+    return a.id().localeCompare(b.id());
+  });
+  if (!context.length) return;
+
+  const box = fileBox.boundingBox({ includeLabels: true });
+  const x = box.x1 - (compact ? 110 : 155);
+  const gapY = compact ? 48 : 58;
+  const startY = (box.y1 + box.y2) / 2 - ((context.length - 1) * gapY) / 2;
+  context.forEach((node, i) => {
+    node.position({ x, y: startY + i * gapY });
+  });
+}
+
+function applySemanticZoom(cy: Core): void {
+  const z = cy.zoom();
+  const level = z < 0.48 ? "zoom-low" : z < 0.82 ? "zoom-mid" : "zoom-high";
+  const classes = "zoom-low zoom-mid zoom-high";
+  cy.batch(() => {
+    cy.nodes("[isConcreteSymbol = 1]").removeClass(classes).addClass(level);
+    cy.edges().removeClass(classes).addClass(level);
+  });
 }
 
 interface HoverInfo {
@@ -241,11 +970,66 @@ interface HoverInfo {
   kind: string;
 }
 
+interface SelectedFileInfo {
+  file: string;
+  short: string;
+  symbols: CMNode[];
+  inbound: number;
+  outbound: number;
+}
+
+type GraphMode = "files";
+type EdgeHoverInfo = {
+  count: number;
+  src: string;
+  tgt: string;
+  aggregate: boolean;
+};
+
+function fileInfo(data: CodemapResponse, file: string | null): SelectedFileInfo | null {
+  if (!file) return null;
+  const symbols = data.nodes.filter((n) => fileKey(n) === file);
+  if (!symbols.length) return null;
+
+  const symbolIds = new Set(symbols.map((n) => n.id));
+  let inbound = 0;
+  let outbound = 0;
+  for (const edge of data.edges) {
+    const sourceInFile = symbolIds.has(edge.source);
+    const targetInFile = symbolIds.has(edge.target);
+    if (sourceInFile && !targetInFile) outbound += edge.weight ?? edge.anchors?.length ?? 1;
+    if (!sourceInFile && targetInFile) inbound += edge.weight ?? edge.anchors?.length ?? 1;
+  }
+
+  return {
+    file,
+    short: baseName(file),
+    inbound,
+    outbound,
+    symbols: [...symbols].sort(compareSymbolsForPanel),
+  };
+}
+
+function compareSymbolsForPanel(a: CMNode, b: CMNode): number {
+  const ar = a.is_root ? 0 : 1;
+  const br = b.is_root ? 0 : 1;
+  if (ar !== br) return ar - br;
+  const imp = (b.importance ?? 0) - (a.importance ?? 0);
+  if (Math.abs(imp) > 0.001) return imp;
+  const refs = (b.ref_count ?? 0) - (a.ref_count ?? 0);
+  if (refs !== 0) return refs;
+  return (a.line ?? Number.MAX_SAFE_INTEGER) - (b.line ?? Number.MAX_SAFE_INTEGER) || a.short.localeCompare(b.short);
+}
+
+function graphFileCount(data: CodemapResponse): number {
+  return new Set(data.nodes.map(fileKey)).size;
+}
+
 /**
  * Interactive dependency graph (Cytoscape). Opens as a files overview — one pill
- * per file — and a file expands into its real symbols on click; click again (or
- * the file box) to collapse. Click a symbol to focus + open its source; click an
- * edge to open the exact SCIP/LSP call site.
+ * per file. Selecting a file keeps the tree stable and opens a separate symbol
+ * drilldown; click a symbol there to open its source. Click an edge to open the
+ * exact SCIP/LSP call site.
  */
 export default function CodeGraph({
   data,
@@ -268,10 +1052,11 @@ export default function CodeGraph({
   // previews don't clobber the focus highlight; Esc / background-tap clears it.
   const focusedRef = useRef<string | null>(null);
   const [hover, setHover] = useState<HoverInfo | null>(null);
-  const [edgeHover, setEdgeHover] = useState<{ count: number; openable: boolean } | null>(null);
-  // View mode: "files" = collapsed files overview (expand on click); "symbols"
-  // = every symbol shown at once (every file expanded), same fcose layout.
-  const [mode, setMode] = useState<"files" | "symbols">("files");
+  const [edgeHover, setEdgeHover] = useState<EdgeHoverInfo | null>(null);
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const mode: GraphMode = "files";
+  const selectedInfo = fileInfo(data, selectedFile);
+  const totalFiles = graphFileCount(data);
 
   // Keep the click callbacks in refs so the cytoscape instance is built once
   // per `data` and is NOT torn down/rebuilt when a parent re-render hands us new
@@ -288,21 +1073,59 @@ export default function CodeGraph({
     if (!box) return;
 
     const dark = document.documentElement.dataset.theme === "dark";
+    const compactGraph = box.clientWidth < 500;
 
-    // "files" opens as the hybrid spine (key files expanded, tail as pills);
-    // "symbols" expands every file.
     const initExpanded = new Set<string>();
-    if (mode === "symbols") for (const n of data.nodes) initExpanded.add(fileKey(n));
-    else for (const f of spineFiles(data)) initExpanded.add(f);
     expandedRef.current = initExpanded;
+    setSelectedFile(null);
 
-    const nodeText = dark ? "#e6e6e6" : "#1f2937";
-    const nodeBg = dark ? "#1b1d21" : "#ffffff";
-    const edgeColor = dark ? "#4b5159" : "#c9ccd1";
+    const palette = dark
+      ? {
+          text: "#E2E8F0",
+          textMuted: "#94A3B8",
+          nodeBg: "#111827",
+          nodeBorder: "#334155",
+          fileBg: "#0F172A",
+          fileBorder: "#334155",
+          modelBg: "#1E1B4B",
+          modelBorder: "#6366F1",
+          modelText: "#C7D2FE",
+          focusBg: "#2563EB",
+          focusBorder: "#60A5FA",
+          selectedBg: "#1E1B4B",
+          selectedBorder: "#A5B4FC",
+          selectedText: "#E0E7FF",
+          externalBg: "#111827",
+          externalBorder: "#475569",
+          externalText: "#94A3B8",
+          edge: "#475569",
+          edgeFocus: "#60A5FA",
+        }
+      : {
+          text: "#1F2937",
+          textMuted: "#52637A",
+          nodeBg: "#F8FAFC",
+          nodeBorder: "#B9C6D8",
+          fileBg: "#F8FAFC",
+          fileBorder: "#B9C6D8",
+          modelBg: "#F5F3FF",
+          modelBorder: "#C4B5FD",
+          modelText: "#5B21B6",
+          focusBg: "#2563EB",
+          focusBorder: "#1D4ED8",
+          selectedBg: "#EEF2FF",
+          selectedBorder: "#A5B4FC",
+          selectedText: "#3730A3",
+          externalBg: "#F9FAFB",
+          externalBorder: "#D1D5DB",
+          externalText: "#6B7280",
+          edge: "#9AA8BA",
+          edgeFocus: "#2563EB",
+        };
 
     const cy = cytoscape({
       container: box,
-      elements: buildElements(data, expandedRef.current),
+      elements: buildElements(data, expandedRef.current, compactGraph, mode),
       wheelSensitivity: 0.2,
       minZoom: 0.2,
       maxZoom: 2.5,
@@ -311,30 +1134,38 @@ export default function CodeGraph({
           selector: "node",
           style: {
             shape: "round-rectangle",
-            "background-color": nodeBg,
-            "border-width": 2,
-            "border-color": "data(accent)",
+            "background-color": palette.nodeBg,
+            "border-width": 1.5,
+            "border-color": palette.nodeBorder,
             label: "data(glabel)",
-            color: nodeText,
+            color: palette.text,
             // Size by importance (PageRank percentile): core symbols read bigger.
-            "font-size": "mapData(importance, 0, 1, 11, 15)",
-            "font-family": "var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif",
+            "font-size": "mapData(importance, 0, 1, 13, 17)",
+            "font-family": "system-ui, -apple-system, Segoe UI, sans-serif",
             "text-valign": "center",
             "text-halign": "center",
             "text-wrap": "wrap",
-            "text-max-width": "180px",
+            "text-max-width": "160px",
             width: "label",
             height: "label",
-            padding: "mapData(importance, 0, 1, 7, 20)",
+            padding: "mapData(importance, 0, 1, 10, 19)",
             "transition-property": "border-width, background-color",
             "transition-duration": 120,
           },
         },
         {
+          selector: "node[tone = 'model']",
+          style: {
+            "background-color": palette.modelBg,
+            "border-color": palette.modelBorder,
+            color: palette.modelText,
+          },
+        },
+        {
           selector: "node[root = 1]",
           style: {
-            "background-color": "#2d7ff9",
-            "border-color": "#1b5fd0",
+            "background-color": palette.focusBg,
+            "border-color": palette.focusBorder,
             color: "#ffffff",
             "font-weight": 600,
           },
@@ -343,9 +1174,36 @@ export default function CodeGraph({
           selector: "node[external = 1]",
           style: {
             "border-style": "dashed",
-            "border-color": dark ? "#4b5159" : "#b3b8c0",
-            color: dark ? "#8b9099" : "#9099a3",
+            "background-color": palette.externalBg,
+            "border-color": palette.externalBorder,
+            color: palette.externalText,
             "font-style": "italic",
+          },
+        },
+        {
+          // Directory/package containers exist for grouping, but stay visual-only
+          // invisible in the map so the user reads one structure: tree rows plus
+          // dependency edges.
+          selector: "node[isDirBox = 1]",
+          style: {
+            shape: "round-rectangle",
+            "background-opacity": 0,
+            "border-width": 0,
+            "border-style": "solid",
+            label: "",
+            "events": "no",
+            "text-valign": "top",
+            "text-halign": "left",
+            "text-background-opacity": 0,
+            padding: "12px",
+            "z-index": 0,
+          },
+        },
+        {
+          selector: "node[isDirBox = 1][external = 1]",
+          style: {
+            "border-style": "dashed",
+            "background-opacity": 0,
           },
         },
         {
@@ -353,20 +1211,52 @@ export default function CodeGraph({
           selector: "node[isFileBox = 1]",
           style: {
             shape: "round-rectangle",
-            "background-color": dark ? "#13161b" : "#faf9f7",
+            "background-color": dark ? "#0B1220" : "#F8FAFC",
             "background-opacity": 1,
             "border-width": 1,
-            "border-color": dark ? "#2a3038" : "#e3e1dc",
-            label: "data(fileLabel)",
-            color: dark ? "#9198a1" : "#8a8880",
-            "font-size": 11,
+            "border-color": dark ? "#1E293B" : "#E2E8F0",
+            label: "",
+            color: palette.text,
+            "font-size": 13,
             "font-weight": 600,
             "font-style": "normal",
             "text-valign": "top",
-            "text-halign": "center",
-            "text-margin-y": 4,
-            padding: "12px",
+            "text-halign": "left",
+            "text-margin-x": 8,
+            "text-margin-y": 7,
+            "text-wrap": "wrap",
+            "text-max-width": "120px",
+            "text-background-color": dark ? "#111827" : "#FFFFFF",
+            "text-background-opacity": 0.92,
+            "text-background-shape": "roundrectangle",
+            "text-background-padding": "4px",
+            padding: "20px",
             "z-index": 0,
+          },
+        },
+        {
+          // Symbol/class scope container inside an expanded file. This is the
+          // semantic-zoom layer between file and concrete symbol nodes.
+          selector: "node[isSymbolBox = 1]",
+          style: {
+            shape: "round-rectangle",
+            "background-color": dark ? "#111827" : "#FFFFFF",
+            "background-opacity": dark ? 0.45 : 0.7,
+            "border-width": 1,
+            "border-style": "dotted",
+            "border-color": dark ? "#334155" : "#CBD5E1",
+            label: "data(scopeLabel)",
+            color: palette.textMuted,
+            "font-size": 11,
+            "font-weight": 600,
+            "text-valign": "top",
+            "text-halign": "left",
+            "text-margin-x": 7,
+            "text-margin-y": 5,
+            "text-wrap": "wrap",
+            "text-max-width": "150px",
+            padding: "16px",
+            "z-index": 1,
           },
         },
         {
@@ -375,18 +1265,15 @@ export default function CodeGraph({
           selector: "node[isFileMeta = 1]",
           style: {
             shape: "round-rectangle",
-            "corner-radius": "11px",
-            "background-color": dark ? "#262b33" : "#f1f5fa",
+            "corner-radius": "8px",
+            "background-color": palette.fileBg,
             "background-opacity": 1,
-            "background-fill": "linear-gradient",
-            "background-gradient-stop-colors": dark ? ["#2a313a", "#20242b"] : ["#f7fafd", "#e8eef5"],
-            "background-gradient-direction": "to-bottom",
-            "border-width": 1.5,
+            "border-width": 1,
             "border-style": "solid",
-            "border-color": dark ? "#3d4654" : "#c3cedd",
+            "border-color": palette.fileBorder,
             label: "data(glabel)",
-            color: dark ? "#dfe4ea" : "#2c3540",
-            "font-size": 13,
+            color: palette.text,
+            "font-size": 14,
             "font-weight": 600,
             "font-style": "normal",
             "text-valign": "center",
@@ -395,7 +1282,39 @@ export default function CodeGraph({
             "text-max-width": "210px",
             width: "label",
             height: "label",
-            padding: "mapData(pill, 0, 1, 13, 23)",
+            padding: "mapData(pill, 0, 1, 13, 20)",
+          },
+        },
+        {
+          // Semantic zoom: when the user is looking at module/file scale, concrete
+          // symbols become small landmarks while file/scope labels keep the map readable.
+          selector: "node[isConcreteSymbol = 1].zoom-low",
+          style: {
+            label: "",
+            width: 12,
+            height: 12,
+            padding: "4px",
+            opacity: 0.78,
+          },
+        },
+        {
+          selector: "node[isConcreteSymbol = 1].zoom-mid",
+          style: {
+            "font-size": 12,
+            "text-max-width": "116px",
+            padding: "9px",
+            opacity: 0.96,
+          },
+        },
+        {
+          selector:
+            "node[isConcreteSymbol = 1].zoom-low[root = 1], node[isConcreteSymbol = 1].zoom-low.reveal-label, node[isConcreteSymbol = 1].zoom-low.focus, node[isConcreteSymbol = 1].zoom-low.hl",
+          style: {
+            label: "data(glabel)",
+            width: "label",
+            height: "label",
+            padding: "10px",
+            opacity: 1,
           },
         },
         // Neighbours of the focused node — kept fully legible (no dim).
@@ -403,14 +1322,15 @@ export default function CodeGraph({
           selector: "node.hl",
           style: { "border-width": 3, opacity: 1 },
         },
-        // The focused node itself: a filled accent so it POPS out of context.
+        // The focused node itself: quiet selected-symbol treatment, not another
+        // competing primary-blue surface.
         {
           selector: "node.focus",
           style: {
-            "border-width": 4,
-            "border-color": "#2563eb",
-            "background-color": dark ? "#1e3a8a" : "#dbeafe",
-            color: dark ? "#ffffff" : "#13367a",
+            "border-width": 3,
+            "border-color": palette.selectedBorder,
+            "background-color": palette.selectedBg,
+            color: palette.selectedText,
             "font-weight": 700,
             "z-index": 30,
           },
@@ -420,27 +1340,64 @@ export default function CodeGraph({
           style: {
             // Width by call-site count (weight): a heavily-used call reads thicker.
             width: "mapData(weight, 1, 12, 1.2, 4.5)",
-            "line-color": edgeColor,
-            "target-arrow-color": edgeColor,
+            "line-color": palette.edge,
+            "target-arrow-color": palette.edge,
             "target-arrow-shape": "triangle",
             "arrow-scale": 0.9,
-            // Gentle arcs (not straight) so edges around a hub fan out cleanly.
-            "curve-style": "unbundled-bezier",
-            "control-point-distances": [30],
-            "control-point-weights": [0.5],
+            "curve-style": "straight",
             opacity: 0.72,
           },
         },
         {
           // File-level aggregate edge (an expand reveals the exact references).
           selector: "edge[meta = 1]",
-          style: { "line-style": "dashed", opacity: 0.55 },
+          style: { "line-style": "dashed", opacity: 0.24 },
+        },
+        {
+          // Same-file references stay visible as plain edges.
+          selector: "edge[scopeRoute = 1]",
+          style: {
+            opacity: 0.48,
+            width: "mapData(weight, 1, 12, 0.8, 2.6)",
+          },
+        },
+        {
+          selector: "edge.zoom-low",
+          style: {
+            opacity: 0.16,
+            width: "mapData(weight, 1, 12, 0.8, 2.4)",
+          },
+        },
+        {
+          selector: "edge.zoom-mid",
+          style: {
+            opacity: 0.42,
+            width: "mapData(weight, 1, 12, 1, 3.2)",
+          },
+        },
+        {
+          selector: "edge[scopeRoute = 1].zoom-low",
+          style: {
+            opacity: 0.1,
+            width: "mapData(weight, 1, 12, 0.65, 2)",
+          },
+        },
+        {
+          selector: "edge[scopeRoute = 1].zoom-mid",
+          style: {
+            opacity: 0.3,
+            width: "mapData(weight, 1, 12, 0.8, 2.5)",
+          },
+        },
+        {
+          selector: "edge[meta = 1].zoom-low",
+          style: { opacity: 0.12 },
         },
         {
           selector: "edge.hl",
           style: {
-            "line-color": "#2563eb",
-            "target-arrow-color": "#2563eb",
+            "line-color": palette.edgeFocus,
+            "target-arrow-color": palette.edgeFocus,
             width: "mapData(weight, 1, 12, 2, 5.5)",
             opacity: 1,
             "z-index": 30,
@@ -453,6 +1410,15 @@ export default function CodeGraph({
       ],
     });
     cyRef.current = cy;
+    let semanticRaf = 0;
+    const scheduleSemanticZoom = () => {
+      if (semanticRaf) return;
+      semanticRaf = requestAnimationFrame(() => {
+        semanticRaf = 0;
+        applySemanticZoom(cy);
+      });
+    };
+    cy.on("zoom resize", scheduleSemanticZoom);
     // Test/e2e seam (dev only): expose the instance on the container so
     // screenshot scripts can drive interactions.
     if (process.env.NODE_ENV !== "production") {
@@ -467,63 +1433,17 @@ export default function CodeGraph({
     const focusNode = (n: NodeSingular) => {
       const nbr = n.closedNeighborhood();
       cy.batch(() => {
-        cy.elements().removeClass("focus hl faded");
+        cy.elements().removeClass("focus hl faded reveal-label");
         cy.edges().not(nbr.edges()).addClass("faded");
-        n.addClass("focus");
-        nbr.nodes().not(n).addClass("hl");
+        n.addClass("focus reveal-label");
+        nbr.nodes().not(n).addClass("hl reveal-label");
         n.connectedEdges().addClass("hl");
       });
     };
     const clearFocus = () => {
       focusedRef.current = null;
-      cy.elements().removeClass("focus hl faded");
-    };
-
-    // Expand/collapse a file: rebuild the element set for the new state and re-lay
-    // it out. Cheap (<=120 nodes) and keeps meta-edge aggregation correct.
-    const toggleFile = (file: string) => {
-      const s = expandedRef.current;
-      const willExpand = !s.has(file);
-
-      // Anchor on the clicked node (pill when expanding, box when collapsing).
-      const anchor = cy.getElementById(willExpand ? META + file : BOX + file);
-      const anchorScreen = anchor.nonempty() ? { ...anchor.renderedPosition() } : null;
-      const anchorModel = anchor.nonempty() ? { ...anchor.position() } : null;
-
-      if (willExpand) s.add(file);
-      else s.delete(file);
-      focusedRef.current = null;
-      setHover(null);
-
-      // Keep surviving nodes where they are; seed the new box + symbols at the
-      // clicked file so they grow out from there instead of the origin.
-      const prev = new Map<string, { x: number; y: number }>();
-      cy.nodes().forEach((n) => {
-        prev.set(n.id(), { ...n.position() });
-      });
-      cy.batch(() => {
-        cy.elements().remove();
-        cy.add(buildElements(data, s));
-        cy.nodes().forEach((n) => {
-          const p = prev.get(n.id());
-          if (p) n.position(p);
-          else if (anchorModel)
-            n.position({
-              x: anchorModel.x + (Math.random() - 0.5) * 40,
-              y: anchorModel.y + (Math.random() - 0.5) * 40,
-            });
-        });
-      });
-      runLayout(cy, { stable: true });
-
-      // Pin the clicked file back where it was clicked so it expands in place.
-      if (anchorScreen) {
-        const after = cy.getElementById(willExpand ? BOX + file : META + file);
-        if (after.nonempty()) {
-          const now = after.renderedPosition();
-          cy.panBy({ x: anchorScreen.x - now.x, y: anchorScreen.y - now.y });
-        }
-      }
+      setSelectedFile(null);
+      cy.elements().removeClass("focus hl faded reveal-label");
     };
 
     // Hover: a transient preview of the node + its neighbours. Suppressed while a
@@ -531,32 +1451,55 @@ export default function CodeGraph({
     cy.on("mouseover", "node", (evt) => {
       const n = evt.target;
       const d = n.data();
-      if (d.isFileBox) return; // the box title is for collapsing, handled on tap
-      box.style.cursor = "pointer";
-      if (d.isFileMeta) {
-        setHover({ short: d.short, file: d.file, line: null, kind: `${d.count} symbols · click to open` });
+      box.style.cursor = d.isDirBox || d.isSymbolBox ? "default" : "pointer";
+      if (d.isFileBox) {
+        setHover({
+          short: d.short,
+          file: d.file,
+          line: null,
+          kind: `${d.count} symbols`,
+        });
+      } else if (d.isDirBox) {
+        setHover({
+          short: d.dirLabel,
+          file: null,
+          line: null,
+          kind: `${d.count} files`,
+        });
+      } else if (d.isSymbolBox) {
+        setHover({
+          short: d.short,
+          file: d.file,
+          line: null,
+          kind: `${d.count} contained symbols`,
+        });
+      } else if (d.isFileMeta) {
+        setHover({ short: d.short, file: d.file, line: null, kind: `${d.count} symbols` });
       } else {
         setHover({ short: d.short, file: d.file, line: d.line, kind: d.kind });
       }
       if (focusedRef.current) return;
       const nbr = n.closedNeighborhood();
       cy.edges().not(nbr.edges()).addClass("faded"); // dim only unrelated edges
-      n.addClass("hl");
-      nbr.nodes().not(n).addClass("hl");
+      n.addClass("hl reveal-label");
+      nbr.nodes().not(n).addClass("hl reveal-label");
       n.connectedEdges().addClass("hl");
     });
     cy.on("mouseout", "node", () => {
       box.style.cursor = "";
       setHover(null);
       if (focusedRef.current) return;
-      cy.elements().removeClass("faded hl");
+      cy.elements().removeClass("faded hl reveal-label");
     });
     // Click a file pill / box → expand or collapse it. Click a symbol → focus it
     // (persistent degree-of-interest) AND open its source peek.
     cy.on("tap", "node", (evt) => {
       const d = evt.target.data();
+      if (d.isDirBox || d.isSymbolBox) return;
       if (d.isFileMeta || d.isFileBox) {
-        toggleFile(d.file);
+        focusedRef.current = d.id;
+        setSelectedFile(d.file);
+        focusNode(evt.target);
         return;
       }
       focusedRef.current = d.id;
@@ -576,24 +1519,35 @@ export default function CodeGraph({
     cy.on("mouseover", "edge", (evt) => {
       const e = evt.target;
       box.style.cursor = e.data("hasAnchor") ? "pointer" : "default";
-      setEdgeHover({ count: e.data("weight") || 0, openable: !!e.data("hasAnchor") });
+      setEdgeHover({
+        count: e.data("weight") || 0,
+        src: e.data("srcDisplay") || e.data("srcShort") || "source",
+        tgt: e.data("tgtDisplay") || e.data("tgtShort") || "target",
+        aggregate: e.data("meta") === 1,
+      });
       if (focusedRef.current) return;
       cy.edges().not(e).addClass("faded"); // dim other edges; leave all nodes legible
       e.addClass("hl");
-      e.connectedNodes().addClass("hl");
+      e.connectedNodes().addClass("hl reveal-label");
     });
     cy.on("mouseout", "edge", () => {
       box.style.cursor = "";
       setEdgeHover(null);
       if (focusedRef.current) return;
-      cy.elements().removeClass("faded hl");
+      cy.elements().removeClass("faded hl reveal-label");
     });
     // Click an exact edge → open its LSP/SCIP call site(s). Aggregate (dashed)
     // edges carry no single site — expand the files to reach them.
     cy.on("tap", "edge", (evt) => {
       const d = evt.target.data();
       if (d.anchors?.length) {
-        onEdgeClickRef.current?.({ anchors: d.anchors, srcLabel: d.srcShort, tgtLabel: d.tgtShort });
+        onEdgeClickRef.current?.({
+          anchors: d.anchors,
+          srcLabel: d.srcShort || d.srcDisplay || "",
+          tgtLabel: d.tgtShort || d.tgtDisplay || "",
+          srcFile: d.srcFile,
+          tgtFile: d.tgtFile,
+        });
       }
     });
     // Click empty canvas → clear focus.
@@ -607,74 +1561,120 @@ export default function CodeGraph({
     document.addEventListener("keydown", onKey);
 
     runLayout(cy); // initial layout
+    if (expandedRef.current.size > 0) {
+      for (const file of expandedRef.current) layoutExpandedFileInternals(cy, file, compactGraph);
+      ensureGraphVisible(cy, compactGraph ? 10 : 20);
+    }
+    applySemanticZoom(cy);
 
     return () => {
       document.removeEventListener("keydown", onKey);
+      cy.off("zoom resize", scheduleSemanticZoom);
+      if (semanticRaf) cancelAnimationFrame(semanticRaf);
       cy.destroy();
       cyRef.current = null;
     };
-  }, [data, mode]); // rebuild on a new graph or a view-mode switch; refs carry callbacks
+  }, [data, mode]); // rebuild on a new graph; refs carry callbacks
+
+  const closeSelectedFile = () => {
+    focusedRef.current = null;
+    setSelectedFile(null);
+    cyRef.current?.elements().removeClass("focus hl faded reveal-label");
+  };
+
+  const openSymbol = (node: CMNode) => {
+    onNodeClickRef.current?.({
+      label: node.label,
+      short: node.short,
+      file: node.file ?? null,
+      line: node.line ?? null,
+      endLine: node.end_line ?? null,
+      kind: node.kind,
+      external: node.external === true,
+    });
+  };
 
   return (
-    <div className="codegraph" data-variant={variant}>
-      <div className="codegraph-canvas" ref={boxRef} aria-label="dependency graph" />
-      <div className="codegraph-bar mono">
+    <div className="codegraph" data-variant={variant} data-mode={mode}>
+      <div className="codegraph-stage">
+        <div className="codegraph-canvas" ref={boxRef} aria-label="dependency graph" />
+      </div>
+      {selectedInfo && (
+        <div className="codegraph-drilldown">
+          <div className="codegraph-drilldown-head">
+            <div className="codegraph-drilldown-title">
+              <b>{selectedInfo.short}</b>
+              <span className="mono">{selectedInfo.file}</span>
+            </div>
+            <div className="codegraph-drilldown-metrics">
+              <span>{selectedInfo.symbols.length} symbols</span>
+              <span>{selectedInfo.inbound} in</span>
+              <span>{selectedInfo.outbound} out</span>
+            </div>
+            <button type="button" className="codegraph-drilldown-close" onClick={closeSelectedFile} aria-label="Close">
+              ×
+            </button>
+          </div>
+          <div className="codegraph-symbol-list">
+            {selectedInfo.symbols.slice(0, 8).map((node) => (
+              <button
+                key={node.id}
+                type="button"
+                className={`codegraph-symbol-chip ${node.is_root ? "root" : ""}`}
+                onClick={() => openSymbol(node)}
+                title={`${node.label}${node.file ? ` (${node.file}:${node.line ?? "?"})` : ""}`}
+              >
+                <span className="codegraph-symbol-kind">{node.kind}</span>
+                <span className="codegraph-symbol-name">{symbolName(node.short)}</span>
+                {node.line != null && <span className="codegraph-symbol-line mono">:{node.line}</span>}
+              </button>
+            ))}
+            {selectedInfo.symbols.length > 8 && (
+              <span className="codegraph-symbol-more">+{selectedInfo.symbols.length - 8}</span>
+            )}
+          </div>
+        </div>
+      )}
+      <div className="codegraph-bar">
         {edgeHover ? (
           <span className="cg-info">
-            <b>
-              {edgeHover.count} call site{edgeHover.count === 1 ? "" : "s"}
-            </b>
-            {edgeHover.openable ? (
-              <span className="muted"> — click the edge to open the exact reference line</span>
-            ) : (
-              <span className="muted"> — expand the files to reach the call sites</span>
-            )}
+            <b>{edgeHover.src} -&gt; {edgeHover.tgt}</b>
+            <span className="muted">
+              {" "}
+              · {edgeHover.count} ref{edgeHover.count === 1 ? "" : "s"}
+              {edgeHover.aggregate ? " · file-level" : " · exact"}
+            </span>
           </span>
         ) : hover ? (
           <span className="cg-info">
-            <b>{hover.short}</b>
+            <b>
+              {hover.short}
+            </b>
             {hover.file ? ` — ${hover.file}${hover.line ? `:${hover.line}` : ""}` : ""}
             <span className="codegraph-kind">{hover.kind}</span>
           </span>
         ) : (
-          <span className="codegraph-legend">
-            <span>
-              <span className="lk-swatch" />
-              each pill = a file
+          <span className="codegraph-legend" aria-label="Graph legend">
+            <span className="codegraph-legend-title">Legend</span>
+            <span className="codegraph-legend-item">
+              <span className="codegraph-legend-line exact" aria-hidden="true" />
+              <span>Exact symbol ref</span>
             </span>
-            <span>
-              <span className="lk-grow" />
-              bigger = more referenced
+            <span className="codegraph-legend-item">
+              <span className="codegraph-legend-line aggregate" aria-hidden="true" />
+              <span>File-level refs</span>
             </span>
-            <span>
-              <span className="lk-ext" />
-              external
+            <span className="codegraph-legend-item">
+              <span className="codegraph-legend-line weight" aria-hidden="true" />
+              <span>Arrow = references</span>
             </span>
           </span>
         )}
-        <div className="codegraph-modes" role="group" aria-label="View mode">
-          <button
-            type="button"
-            className={mode === "files" ? "on" : ""}
-            onClick={() => setMode("files")}
-            title="Overview: key files expanded to symbols, the rest as pills you can expand"
-          >
-            Overview
-          </button>
-          <button
-            type="button"
-            className={mode === "symbols" ? "on" : ""}
-            onClick={() => setMode("symbols")}
-            title="All symbols: every file expanded at once"
-          >
-            All symbols
-          </button>
-        </div>
         <span
           className="codegraph-depnote"
-          title="Solid edges are exact SCIP/LSP references; dashed edges are file-level aggregates you expand to reach."
+          title="SCIP/LSP references"
         >
-          click a file to expand · its box to collapse
+          {selectedInfo ? `${selectedInfo.short} selected` : `${totalFiles} files`}
         </span>
         <button type="button" className="codegraph-fit" onClick={() => cyRef.current?.fit(undefined, 24)}>
           Fit

--- a/web/components/Codemap.tsx
+++ b/web/components/Codemap.tsx
@@ -5,6 +5,7 @@ import GraphView from "@/components/GraphView";
 import { fetchCodemap, type CodemapResponse } from "@/lib/api";
 
 type Direction = "both" | "callees" | "callers";
+type Depth = 1 | 2;
 
 /**
  * Codemap mode: an interactive dependency (call-graph) map for the repo.
@@ -22,6 +23,7 @@ export default function Codemap({
   const [symbol, setSymbol] = useState(initialSymbol ?? "");
   const [query, setQuery] = useState(initialSymbol ?? ""); // last submitted focus symbol
   const [direction, setDirection] = useState<Direction>("both");
+  const [depth, setDepth] = useState<Depth>(1);
   const [data, setData] = useState<CodemapResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -41,8 +43,8 @@ export default function Codemap({
     fetchCodemap(repoId, {
       symbol: query || undefined,
       direction,
-      depth: 2,
-      maxNodes: 18,
+      depth,
+      maxNodes: depth === 1 ? 28 : 40,
     })
       .then((d) => !cancelled && setData(d))
       .catch((e) => !cancelled && setErr(String(e)))
@@ -50,7 +52,7 @@ export default function Codemap({
     return () => {
       cancelled = true;
     };
-  }, [repoId, query, direction]);
+  }, [repoId, query, direction, depth]);
 
   function focus(label: string) {
     setSymbol(label);
@@ -81,6 +83,14 @@ export default function Codemap({
           <option value="both">callers + callees</option>
           <option value="callees">callees (what it calls)</option>
           <option value="callers">callers (what calls it)</option>
+        </select>
+        <select
+          value={depth}
+          onChange={(e) => setDepth(Number(e.target.value) as Depth)}
+          aria-label="Traversal depth"
+        >
+          <option value={1}>1 hop</option>
+          <option value={2}>2 hops</option>
         </select>
         <button type="submit">Map</button>
       </form>

--- a/web/components/GraphView.tsx
+++ b/web/components/GraphView.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import type { EdgeClickInfo, GraphNodeInfo } from "@/components/CodeGraph";
 import HighlightedCode from "@/components/HighlightedCode";
+import SystemMap from "@/components/SystemMap";
 import { fetchSource, repoRelative, type CallSite, type CodemapResponse } from "@/lib/api";
 
-// Cytoscape + dagre (~3MB) load only when a graph is shown, so the wiki
+// Cytoscape loads only when a graph is shown, so the wiki
 // narrative paints first and the graph fills in a beat later.
 const CodeGraph = dynamic(() => import("@/components/CodeGraph"), {
   ssr: false,
@@ -21,6 +22,15 @@ const CodeGraph = dynamic(() => import("@/components/CodeGraph"), {
 // definition. Both resolve to a (file, line) the /source endpoint can open.
 type PeekSource = ({ kind: "edge" } & EdgeClickInfo) | { kind: "node"; node: GraphNodeInfo };
 
+function githubFileUrl(repoFullName: string | undefined, commit: string | undefined, file: string): string | null {
+  if (!repoFullName || !file) return null;
+  return `https://github.com/${repoFullName}/blob/${commit || "HEAD"}/${file}`;
+}
+
+function compactSymbol(label: string): string {
+  return label.split(":").pop() || label;
+}
+
 /**
  * Source peek grounded in the LSP/SCIP index — the payoff of the graph:
  *  - edge → the exact line(s) where the call happens (pager for multiple sites);
@@ -32,12 +42,17 @@ function SourcePeek({
   source,
   onClose,
   onFocus,
+  repoFullName,
+  commit,
 }: {
   repoId: string;
   source: PeekSource;
   onClose: () => void;
   onFocus?: (label: string) => void;
+  repoFullName?: string;
+  commit?: string;
 }) {
+  const peekRef = useRef<HTMLDivElement>(null);
   const isNode = source.kind === "node";
   const nodeEnd = source.kind === "node" ? source.node.endLine : null;
   const sites: CallSite[] = isNode
@@ -53,15 +68,27 @@ function SourcePeek({
   const rel = repoRelative(site.file);
   const line = site.line ?? 1;
   const isExternal = source.kind === "node" && !!source.node.external;
+  const fileName = rel.split("/").pop() || rel;
+  const sourceTitle =
+    source.kind === "edge"
+      ? `${compactSymbol(source.srcLabel)} -> ${compactSymbol(source.tgtLabel)}`
+      : compactSymbol(source.node.short);
+  const sourceMeta = source.kind === "edge" ? "Exact reference" : source.node.kind;
+  const fileUrl = isExternal ? null : githubFileUrl(repoFullName, commit, rel);
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      peekRef.current?.scrollIntoView({ block: "center" });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [source]);
 
   useEffect(() => {
     if (isExternal) return; // external dep — no in-repo source to fetch
     let cancelled = false;
     setState("loading");
-    // A node shows its definition span [line, endLine] plus a few lines of
-    // context on each side, so even a one-line field isn't shown bare (its
-    // own lines are highlighted). A call site (a point, not a span) gets ±6
-    // lines of context. Long spans scroll in the pane (CSS max-height).
+    // Node peeks use the indexed symbol span, plus a little context around it.
+    // Edge peeks remain point locations with context above and below.
     const PAD = 3;
     const symEnd = nodeEnd && nodeEnd >= line ? nodeEnd : line;
     const before = isNode ? PAD : 6;
@@ -80,47 +107,62 @@ function SourcePeek({
   }, [repoId, rel, line, isNode, nodeEnd, isExternal]);
 
   return (
-    <div className="callsite-peek">
-      <div className="callsite-head mono">
-        {source.kind === "edge" ? (
-          <span className="callsite-title">
-            <b>{source.srcLabel}</b> <span className="callsite-arrow">→</span> <b>{source.tgtLabel}</b>
+    <div className="callsite-peek" ref={peekRef}>
+      <div className="callsite-head">
+        <div className="callsite-heading">
+          <span className="callsite-eyebrow">Code Preview</span>
+          <span className="callsite-title mono">
+            <b>{fileName || "external"}</b>
+            <span className="callsite-dot"> · </span>
+            <span>{sourceTitle}</span>
           </span>
-        ) : (
-          <span className="callsite-title">
-            <span className="callsite-kindtag">{source.node.kind}</span> <b>{source.node.short}</b>
+          <span className="callsite-loc mono">
+            {isExternal ? "external dependency" : `${rel}:${line}`}
           </span>
-        )}
-        <span className="callsite-loc">{isExternal ? "external dependency" : `${rel}:${line}`}</span>
-        {source.kind === "edge" && sites.length > 1 && (
-          <span className="callsite-pager">
-            {sites.length} call sites:
-            {sites.map((a, i) => (
-              <button
-                key={i}
-                type="button"
-                className={i === idx ? "on" : ""}
-                onClick={() => setIdx(i)}
-                title={`${repoRelative(a.file)}:${a.line}`}
-              >
-                {a.line}
-              </button>
-            ))}
-          </span>
-        )}
-        {source.kind === "node" && onFocus && (
-          <button
-            type="button"
-            className="callsite-focus"
-            onClick={() => onFocus(source.node.label)}
-            title="Re-root the graph on this symbol"
-          >
-            ⟳ Focus here
+        </div>
+        <div className="callsite-actions">
+          <span className="callsite-kindtag">{sourceMeta}</span>
+          {source.kind === "edge" && sites.length > 1 && (
+            <span className="callsite-pager">
+              {sites.length} call sites:
+              {sites.map((a, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  className={i === idx ? "on" : ""}
+                  onClick={() => setIdx(i)}
+                  title={`${repoRelative(a.file)}:${a.line}`}
+                >
+                  {a.line}
+                </button>
+              ))}
+            </span>
+          )}
+          {source.kind === "node" && onFocus && (
+            <button
+              type="button"
+              className="callsite-focus"
+              onClick={() => onFocus(source.node.label)}
+              title="Re-root the graph on this symbol"
+            >
+              Focus in graph
+            </button>
+          )}
+          {fileUrl && (
+            <a
+              className="callsite-open"
+              href={fileUrl}
+              target="_blank"
+              rel="noreferrer"
+              title={`Open ${rel} on GitHub`}
+            >
+              Open file
+            </a>
+          )}
+          <button type="button" className="callsite-close" onClick={onClose} aria-label="Close">
+            ×
           </button>
-        )}
-        <button type="button" className="callsite-close" onClick={onClose} aria-label="Close">
-          ×
-        </button>
+        </div>
       </div>
       {isExternal ? (
         <p className="muted callsite-msg">
@@ -154,24 +196,36 @@ export default function GraphView({
   data,
   variant = "explore",
   onFocus,
+  repoFullName,
+  commit,
 }: {
   repoId: string;
   data: CodemapResponse;
   // "wiki" = focused top-down dependency map; "explore" = standalone Graph view.
   variant?: "wiki" | "explore";
   onFocus?: (label: string) => void;
+  repoFullName?: string;
+  commit?: string;
 }) {
   const [peek, setPeek] = useState<PeekSource | null>(null);
   useEffect(() => setPeek(null), [data]); // a fresh graph invalidates the open peek
 
   return (
     <>
-      <CodeGraph
-        data={data}
-        variant={variant}
-        onNodeClick={(node) => setPeek({ kind: "node", node })}
-        onEdgeClick={(info) => setPeek({ kind: "edge", ...info })}
-      />
+      {variant === "wiki" ? (
+        <SystemMap
+          data={data}
+          onNodeClick={(node) => setPeek({ kind: "node", node })}
+          onEdgeClick={(info) => setPeek({ kind: "edge", ...info })}
+        />
+      ) : (
+        <CodeGraph
+          data={data}
+          variant={variant}
+          onNodeClick={(node) => setPeek({ kind: "node", node })}
+          onEdgeClick={(info) => setPeek({ kind: "edge", ...info })}
+        />
+      )}
       {peek && (
         <SourcePeek
           key={peek.kind === "node" ? `node:${peek.node.label}` : `${peek.srcLabel}->${peek.tgtLabel}`}
@@ -179,6 +233,8 @@ export default function GraphView({
           source={peek}
           onClose={() => setPeek(null)}
           onFocus={onFocus}
+          repoFullName={repoFullName}
+          commit={commit}
         />
       )}
     </>

--- a/web/components/HighlightedCode.tsx
+++ b/web/components/HighlightedCode.tsx
@@ -55,7 +55,6 @@ export default function HighlightedCode({
     html = code.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c]!);
   }
   const lineCount = code ? code.split("\n").length : 0;
-  // Spotlight band over [highlightLine, highlightEnd], clamped to what's shown.
   const hlA = highlightLine ?? null;
   const hlB = highlightEnd ?? highlightLine ?? null;
   const bandFrom = hlA != null ? Math.max(0, hlA - startLine) : -1;

--- a/web/components/SystemMap.tsx
+++ b/web/components/SystemMap.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+import type { EdgeClickInfo, GraphNodeInfo } from "@/components/CodeGraph";
+import { repoRelative, type CallSite, type CodemapResponse } from "@/lib/api";
+
+type CMNode = CodemapResponse["nodes"][number];
+type CMEdge = CodemapResponse["edges"][number];
+
+interface ComponentGroup {
+  id: string;
+  title: string;
+  subtitle: string;
+  files: string[];
+  nodes: CMNode[];
+  roots: number;
+  inbound: number;
+  outbound: number;
+  stage: StageKey;
+}
+
+interface ComponentLink {
+  key: string;
+  source: string;
+  target: string;
+  weight: number;
+  anchors: CallSite[];
+  srcLabel: string;
+  tgtLabel: string;
+}
+
+type StageKey = "entry" | "core" | "capability" | "evidence";
+
+interface StageColumn {
+  key: StageKey;
+  label: string;
+  groups: ComponentGroup[];
+}
+
+const STAGE_ORDER: StageKey[] = ["entry", "core", "capability", "evidence"];
+const STAGE_LABELS: Record<StageKey, string> = {
+  entry: "Entry",
+  core: "Core",
+  capability: "Capabilities",
+  evidence: "Evidence",
+};
+
+const GENERIC_ROOTS = new Set(["src", "lib", "packages", "package", "modules", "crates", "app"]);
+
+function fileKey(node: CMNode): string {
+  return node.external ? "external" : repoRelative(node.file || "") || "external";
+}
+
+function fileParts(file: string): string[] {
+  return file.split("/").filter(Boolean);
+}
+
+function titleCase(text: string): string {
+  return text
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (ch) => ch.toUpperCase())
+    .trim();
+}
+
+function basename(file: string): string {
+  const parts = fileParts(file);
+  return parts[parts.length - 1] || file;
+}
+
+function compactSymbol(label: string): string {
+  const sym = label.split(":").pop() || label;
+  return sym.length > 46 ? `${sym.slice(0, 43)}...` : sym;
+}
+
+function componentForFile(file: string): { id: string; title: string; subtitle: string } {
+  if (!file || file === "external") {
+    return { id: "external", title: "External APIs", subtitle: "outside repository" };
+  }
+  const parts = fileParts(file);
+  if (parts[0] === "crates" && parts[1]) {
+    const section = parts[2] === "src" && parts[3] ? parts[3].replace(/\.[^.]+$/, "") : "";
+    const crateTitle = titleCase(parts[1]);
+    return {
+      id: section ? `crate:${parts[1]}:${section}` : `crate:${parts[1]}`,
+      title: section ? `${crateTitle} / ${titleCase(section)}` : crateTitle,
+      subtitle: section ? "crate area" : "crate",
+    };
+  }
+  if (parts[0] === "astropy" && parts[1]) {
+    return {
+      id: `astropy:${parts[1]}`,
+      title: titleCase(parts[1]),
+      subtitle: "package",
+    };
+  }
+  if (parts[0] === "modules" && parts[1]) {
+    return {
+      id: `module:${parts[1]}`,
+      title: titleCase(parts[1]),
+      subtitle: "module",
+    };
+  }
+  if (parts[0] === "lib" && parts[1]) {
+    return {
+      id: `lib:${parts[1]}`,
+      title: titleCase(parts[1]),
+      subtitle: "library area",
+    };
+  }
+  const last = parts[parts.length - 1] || "";
+  const fallback = last === "__init__.py" && parts.length > 1 ? parts[parts.length - 2] : last;
+  const firstMeaningful = parts.find((part) => !GENERIC_ROOTS.has(part)) || fallback;
+  const id = firstMeaningful || parts[0] || "root";
+  return {
+    id: `path:${id}`,
+    title: titleCase(id === parts[parts.length - 1] ? id.replace(/\.[^.]+$/, "") : id),
+    subtitle: parts.length > 1 ? "component" : "root",
+  };
+}
+
+function compareNodes(a: CMNode, b: CMNode): number {
+  if (a.is_root !== b.is_root) return a.is_root ? -1 : 1;
+  const imp = (b.importance ?? 0) - (a.importance ?? 0);
+  if (Math.abs(imp) > 0.001) return imp;
+  const refs = (b.ref_count ?? 0) - (a.ref_count ?? 0);
+  if (refs !== 0) return refs;
+  return (a.line ?? Number.MAX_SAFE_INTEGER) - (b.line ?? Number.MAX_SAFE_INTEGER);
+}
+
+function stageForGroup(group: ComponentGroup, rootGroupCount: number): StageKey {
+  const active = group.inbound + group.outbound;
+  if (active === 0) return group.roots > 0 ? "core" : "evidence";
+
+  const strongEntry = group.outbound >= 2 && group.outbound > group.inbound * 1.35;
+  const strongTarget = group.inbound >= 2 && group.inbound > group.outbound * 1.35;
+
+  if (group.roots > 0) {
+    if (rootGroupCount > 1 && strongEntry) return "entry";
+    if (rootGroupCount > 1 && strongTarget) return "capability";
+    return "core";
+  }
+  if (group.outbound > 0 && group.inbound === 0) return "entry";
+  if (group.inbound > 0 && group.outbound === 0) return "capability";
+  if (strongEntry) return "entry";
+  if (strongTarget) return "capability";
+  return "core";
+}
+
+function stageRank(stage: StageKey): number {
+  const idx = STAGE_ORDER.indexOf(stage);
+  return idx === -1 ? STAGE_ORDER.length : idx;
+}
+
+function nodeToInfo(node: CMNode): GraphNodeInfo {
+  return {
+    label: node.label,
+    short: node.short,
+    file: node.file ?? null,
+    line: node.line ?? null,
+    endLine: node.end_line ?? null,
+    kind: node.kind,
+    external: node.external === true,
+  };
+}
+
+function buildMainFlow(groups: ComponentGroup[], links: ComponentLink[]): ComponentGroup[] {
+  const groupById = new Map(groups.map((group) => [group.id, group]));
+  if (!links.length) {
+    return groups
+      .filter((group) => group.roots > 0)
+      .slice(0, 4);
+  }
+
+  const orderedLinks = [...links].sort((a, b) => b.weight - a.weight || a.key.localeCompare(b.key));
+  const path: string[] = [orderedLinks[0].source, orderedLinks[0].target];
+  const seen = new Set(path);
+
+  while (path.length < 5) {
+    const tail = path[path.length - 1];
+    const next = orderedLinks.find((link) => link.source === tail && !seen.has(link.target));
+    if (!next) break;
+    path.push(next.target);
+    seen.add(next.target);
+  }
+  while (path.length < 5) {
+    const head = path[0];
+    const prev = orderedLinks.find((link) => link.target === head && !seen.has(link.source));
+    if (!prev) break;
+    path.unshift(prev.source);
+    seen.add(prev.source);
+  }
+
+  return path
+    .map((id) => groupById.get(id))
+    .filter((group): group is ComponentGroup => Boolean(group));
+}
+
+function buildSystem(data: CodemapResponse): {
+  groups: ComponentGroup[];
+  links: ComponentLink[];
+  stages: StageColumn[];
+  mainFlow: ComponentGroup[];
+} {
+  const groups = new Map<string, ComponentGroup>();
+  const groupByNode = new Map<string, string>();
+  const nodeById = new Map(data.nodes.map((node) => [node.id, node]));
+
+  for (const node of data.nodes) {
+    const file = fileKey(node);
+    const component = componentForFile(file);
+    let group = groups.get(component.id);
+    if (!group) {
+      group = {
+        id: component.id,
+        title: component.title,
+        subtitle: component.subtitle,
+        files: [],
+        nodes: [],
+        roots: 0,
+        inbound: 0,
+        outbound: 0,
+        stage: "evidence",
+      };
+      groups.set(component.id, group);
+    }
+    group.nodes.push(node);
+    if (node.is_root) group.roots += 1;
+    if (!group.files.includes(file)) group.files.push(file);
+    groupByNode.set(node.id, group.id);
+  }
+
+  const links = new Map<string, ComponentLink>();
+  for (const edge of data.edges as CMEdge[]) {
+    const sourceGroup = groupByNode.get(edge.source);
+    const targetGroup = groupByNode.get(edge.target);
+    if (!sourceGroup || !targetGroup || sourceGroup === targetGroup) continue;
+    const key = `${sourceGroup}\u0000${targetGroup}`;
+    const sourceNode = nodeById.get(edge.source);
+    const targetNode = nodeById.get(edge.target);
+    const weight = edge.weight ?? edge.anchors?.length ?? 1;
+    let link = links.get(key);
+    if (!link) {
+      link = {
+        key,
+        source: sourceGroup,
+        target: targetGroup,
+        weight: 0,
+        anchors: [],
+        srcLabel: sourceNode?.short || groups.get(sourceGroup)?.title || sourceGroup,
+        tgtLabel: targetNode?.short || groups.get(targetGroup)?.title || targetGroup,
+      };
+      links.set(key, link);
+    }
+    link.weight += weight;
+    if (edge.anchors) link.anchors.push(...edge.anchors);
+    const source = groups.get(sourceGroup);
+    const target = groups.get(targetGroup);
+    if (source) source.outbound += weight;
+    if (target) target.inbound += weight;
+  }
+
+  const rootGroupCount = [...groups.values()].filter((group) => group.roots > 0).length;
+  for (const group of groups.values()) {
+    group.stage = stageForGroup(group, rootGroupCount);
+  }
+
+  const orderedGroups = [...groups.values()].sort((a, b) => {
+    const stage = stageRank(a.stage) - stageRank(b.stage);
+    if (stage !== 0) return stage;
+    if (b.roots !== a.roots) return b.roots - a.roots;
+    const flow = b.outbound - b.inbound - (a.outbound - a.inbound);
+    if (flow !== 0) return flow;
+    return a.title.localeCompare(b.title);
+  });
+  for (const group of orderedGroups) {
+    group.nodes.sort(compareNodes);
+    group.files.sort();
+  }
+
+  const orderedLinks = [...links.values()]
+    .sort((a, b) => b.weight - a.weight || a.key.localeCompare(b.key))
+    .slice(0, 10);
+
+  const stages = STAGE_ORDER.map((stage) => ({
+    key: stage,
+    label: STAGE_LABELS[stage],
+    groups: orderedGroups.filter((group) => group.stage === stage),
+  })).filter((stage) => stage.groups.length > 0);
+
+  return { groups: orderedGroups, links: orderedLinks, stages, mainFlow: buildMainFlow(orderedGroups, orderedLinks) };
+}
+
+export default function SystemMap({
+  data,
+  onNodeClick,
+  onEdgeClick,
+}: {
+  data: CodemapResponse;
+  onNodeClick?: (node: GraphNodeInfo) => void;
+  onEdgeClick?: (info: EdgeClickInfo) => void;
+}) {
+  const { groups, links, stages, mainFlow } = buildSystem(data);
+  const groupById = new Map(groups.map((group) => [group.id, group]));
+  const totalFiles = new Set(data.nodes.map(fileKey)).size;
+  const citedEntityCount = data.nodes.filter((node) => node.is_root).length;
+  const hasRelationships = links.length > 0;
+
+  return (
+    <div className="system-map">
+      <div className="system-map-head">
+        <div>
+          <div className="system-map-kicker">Core Logic Flow</div>
+          <div className="system-map-title">
+            {hasRelationships && mainFlow.length > 1
+              ? mainFlow.map((group) => group.title).join(" -> ")
+              : `${groups.length} cited component${groups.length === 1 ? "" : "s"}`}
+          </div>
+        </div>
+        <div className="system-map-stats">
+          <span>{citedEntityCount} cited entities</span>
+          <span>{totalFiles} files</span>
+          <span>{links.length} relationships</span>
+        </div>
+      </div>
+
+      {hasRelationships && mainFlow.length > 1 && (
+        <div className="system-flow-strip" aria-label="Primary component flow">
+          {mainFlow.map((group, index) => (
+            <div className="system-flow-step" key={group.id}>
+              <span>{STAGE_LABELS[group.stage]}</span>
+              <b>{group.title}</b>
+              {index < mainFlow.length - 1 && <i aria-hidden="true">-&gt;</i>}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="system-stage-board">
+        {stages.map((stage) => (
+          <section className="system-stage" key={stage.key}>
+            <div className="system-stage-head">
+              <span>{stage.label}</span>
+              <b>{stage.groups.length}</b>
+            </div>
+            <div className="system-stage-body">
+              {stage.groups.map((group) => (
+                <article className={`system-node-card ${group.roots > 0 ? "root" : ""}`} key={group.id}>
+                  <div className="system-node-head">
+                    <div>
+                      <h3>{group.title}</h3>
+                      <p>{group.subtitle}</p>
+                    </div>
+                    <span className="system-node-flow">
+                      {group.outbound} out / {group.inbound} in
+                    </span>
+                  </div>
+
+                  <div className="system-source-row">
+                    {group.files.slice(0, 2).map((file) => (
+                      <span key={file} className="mono" title={file}>
+                        {basename(file)}
+                      </span>
+                    ))}
+                    {group.files.length > 2 && <span>+{group.files.length - 2} files</span>}
+                  </div>
+
+                  <div className="system-symbols">
+                    {group.nodes.slice(0, 4).map((node) => (
+                      <button
+                        key={node.id}
+                        type="button"
+                        className={`system-symbol ${node.is_root ? "root" : ""}`}
+                        onClick={() => onNodeClick?.(nodeToInfo(node))}
+                        title={`${node.label}${node.file ? ` (${repoRelative(node.file)}:${node.line ?? "?"})` : ""}`}
+                      >
+                        <span>{node.kind}</span>
+                        <b>{compactSymbol(node.short)}</b>
+                        {node.file && <em className="mono">{basename(repoRelative(node.file))}:{node.line ?? "?"}</em>}
+                      </button>
+                    ))}
+                    {group.nodes.length > 4 && <div className="system-more">+{group.nodes.length - 4} more cited symbols</div>}
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      {links.length > 0 && (
+        <div className="system-links" aria-label="Exact code relationships">
+          {links.map((link) => {
+            const source = groupById.get(link.source);
+            const target = groupById.get(link.target);
+            const clickable = link.anchors.length > 0 && !!onEdgeClick;
+            return (
+              <button
+                key={link.key}
+                type="button"
+                className="system-link"
+                disabled={!clickable}
+                onClick={() =>
+                  clickable &&
+                  onEdgeClick?.({
+                    anchors: link.anchors,
+                    srcLabel: link.srcLabel,
+                    tgtLabel: link.tgtLabel,
+                  })
+                }
+              >
+                <span className="system-link-main">
+                  <span>{source?.title || link.source}</span>
+                  <b>-&gt;</b>
+                  <span>{target?.title || link.target}</span>
+                </span>
+                <em>{link.weight} refs</em>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,5 +1,17 @@
-export const API_BASE =
-  process.env.NEXT_PUBLIC_API_BASE ?? "http://127.0.0.1:8000";
+const configuredApiBase = process.env.NEXT_PUBLIC_API_BASE ?? "";
+
+function browserApiBase(): string {
+  if (typeof window === "undefined") return configuredApiBase;
+  try {
+    const url = new URL(configuredApiBase);
+    if (url.hostname === "127.0.0.1" || url.hostname === "localhost") return "";
+  } catch {
+    // Empty or relative base already means same-origin.
+  }
+  return configuredApiBase;
+}
+
+export const API_BASE = browserApiBase();
 
 /** Strip an absolute index prefix (e.g. /home/.../repo/) to a repo-relative path. */
 export function repoRelative(path: string | null | undefined): string {
@@ -51,8 +63,8 @@ export interface ChatResponse {
   total_duration_ms: number;
 }
 
-export async function fetchRepos(): Promise<RepoInfo[]> {
-  const res = await fetch(`${API_BASE}/api/repos`);
+export async function fetchRepos(opts: { signal?: AbortSignal } = {}): Promise<RepoInfo[]> {
+  const res = await fetch(`${API_BASE}/api/repos`, { signal: opts.signal });
   if (!res.ok) throw new Error(`Failed to load repos (${res.status})`);
   return res.json();
 }
@@ -166,6 +178,38 @@ export interface CodemapEdge {
   // line where the call happens. Lets the UI jump an edge to its source.
   anchors?: CallSite[];
   weight?: number; // count of distinct call sites (= anchors.length) — drives edge width
+  source_hierarchy?: string;
+  target_hierarchy?: string;
+  bundle_path?: string[]; // containment route used for hierarchical edge bundling
+  bundle_lca?: string;
+  bundle_lca_kind?: string;
+  cross_file?: boolean;
+}
+
+export interface CodemapHierarchyNode {
+  id: string;
+  parent: string | null;
+  kind: "root" | "directory" | "file" | "symbol";
+  label: string;
+  path?: string;
+  file?: string;
+  node_id?: string;
+  line?: number;
+  end_line?: number;
+  depth: number;
+  child_count: number;
+  symbol_count: number;
+  doi: number;
+  importance?: number;
+  open_by_default?: boolean;
+  external?: boolean;
+}
+
+export interface CodemapHierarchy {
+  root: string;
+  nodes: CodemapHierarchyNode[];
+  open_files?: string[];
+  source_root?: string;
 }
 
 export interface CodemapResponse {
@@ -177,6 +221,7 @@ export interface CodemapResponse {
   truncated?: boolean;
   nodes: CodemapNode[];
   edges: CodemapEdge[];
+  hierarchy?: CodemapHierarchy;
   mermaid: string;
   note?: string;
 }

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,6 +1,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    const apiBase =
+      process.env.CODEMINER_API_BASE ||
+      process.env.NEXT_PUBLIC_API_BASE ||
+      "http://127.0.0.1:8000";
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${apiBase}/api/:path*`,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## What changed

This PR turns the wiki/codegraph experience into a more product-ready architecture explorer instead of a raw file/symbol graph.

- Adds a high-level `SystemMap` for wiki pages with Entry/Core/Capabilities/Evidence stages, deterministic component grouping, relationship summaries, and clickable code evidence.
- Adds a reusable hierarchical code graph model that separates containment from dependency overlays and projects hierarchy/route metadata into codemap responses.
- Reworks the CodeGraph frontend around explicit hierarchy/tree layout, source peeks, stable dimensions, source previews, and cleaner graph controls.
- Makes repository runtime loading metadata-first so `/api/repos` stays fast and heavy graph/vector runtime loads are lazy.
- Routes frontend API calls through same-origin `/api` by default and adds a managed `scripts/dev_web.sh` server workflow to avoid localhost/backend confusion.
- Improves wiki retrieval reranking around page outline evidence and disables Gemini 2.5 hidden thinking through LiteLLM’s `thinking` config.

## Why

The previous wiki subsystem view exposed too much raw LSP/SCIP detail. Dense symbol/file graphs, duplicated file labels, bundled routes, and dynamic layouts made the system harder to understand. The new design makes the high-level architecture the first visual layer, keeps code symbols as evidence, and preserves exact source previews for drill-down.

The loading issue came from two separate causes: backend startup/runtime work was too eager, and browser-side API calls could point at `127.0.0.1:8000` instead of the backend when the frontend was accessed through forwarding or a remote browser. The PR addresses both.

## Impact

- Wiki pages now show stable, readable system maps such as `Caddyhttp -> Caddytls` and crate-area flows for larger repos.
- Clicking a component's method/class evidence opens the exact source span.
- The homepage repository list loads through the frontend origin, so users only need the frontend URL exposed.
- Local development has explicit start/stop/status/log commands through the script and Makefile targets.

## Validation

- `python -m pytest test/graph/test_hierarchy.py test/web/test_codemap.py test/wiki/test_agent_wiki.py test/llm/test_litellm_retry.py test/wiki/test_builder.py -q`
- `npm --prefix web run build`
- Manual Playwright checks for homepage loading via same-origin `/api/repos`, Caddy TLS, Ruff linting, Astropy modeling, mobile layout, and code preview drill-down.
