### PR TITLE
chore: fix local GPU demo defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ For the browser UI, start the Next.js frontend separately:
 cd web && npm run dev
 ```
 
+For a no-cloud local GPU LLM setup, copy `qa_config.local.yaml.example` to the
+ignored `qa_config.local.yaml` and follow [Running Locally](docs/running-locally.md).
+
 > **Optional — full code intelligence.** `make scip` installs the SCIP/LSP toolchain
 > (rust-analyzer, scip-clang, scip-typescript, scip-python) for cross-file call graphs.
 

--- a/docs/running-locally.md
+++ b/docs/running-locally.md
@@ -101,14 +101,24 @@ git -C /path/to/repo rev-parse HEAD
 
 ## Step 2 — Configure the LLM
 
-Edit `qa_config.yaml` in the repo root and set:
+No tracked config edit is required. `scripts/start_web.sh` points the backend at
+the local OpenAI-compatible endpoint by exporting:
 
-```yaml
-model: openai/qwen2.5-coder
+```bash
+CODEMINER_DEMO_MODEL=openai/qwen2.5-coder
+OPENAI_API_BASE=http://<gpu-node>:8080/v1
 ```
 
-This tells litellm to use an OpenAI-compatible endpoint. The actual URL is
-passed at runtime via `OPENAI_API_BASE` (set by `start_web.sh`).
+For local-only config changes, copy the template and edit the ignored file:
+
+```bash
+cp qa_config.local.yaml.example qa_config.local.yaml
+```
+
+When present, `scripts/start_web.sh` automatically uses `qa_config.local.yaml`.
+Override `CODEMINER_DEMO_CONFIG` or `CODEMINER_DEMO_MODEL` before running
+`start_web.sh` if your local server exposes a different model name or config
+path.
 
 ---
 

--- a/qa_config.local.yaml.example
+++ b/qa_config.local.yaml.example
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Copy this file to qa_config.local.yaml for local GPU LLM runs.
+# qa_config.local.yaml is ignored by git.
+
+model: openai/qwen2.5-coder
+mode: hybrid
+data_dir: .codeminer_qa
+
+embedding_model: Qwen/Qwen3-Embedding-0.6B
+embedding_dimension: 1024
+max_turns: 8
+max_tokens: 4096
+
+cors_origins:
+  - http://localhost:3000
+  - http://127.0.0.1:3000
+  - http://localhost:3001
+  - http://127.0.0.1:3001

--- a/qa_config.yaml
+++ b/qa_config.yaml
@@ -10,8 +10,7 @@
 # `model` is a litellm model string; override with CODEMINER_DEMO_MODEL.
 # Provider API keys come from the environment (e.g. OPENAI_API_KEY).
 
-# model: vertex_ai/gemini-2.5-flash   # uses gcloud ADC; override via CODEMINER_DEMO_MODEL
-model: openai/qwen2.5-coder #replace it to use local qwen model for testing using ollama
+model: vertex_ai/gemini-2.5-flash   # uses gcloud ADC; override via CODEMINER_DEMO_MODEL
 
 mode: hybrid              # "sparse" (BM25 only) or "hybrid" (BM25 + embeddings)
 data_dir: .codeminer_qa

--- a/scripts/index_repo.py
+++ b/scripts/index_repo.py
@@ -16,38 +16,102 @@ import re
 import subprocess
 import sys
 
-logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(levelname)-8s %(message)s")
+logging.basicConfig(
+    level=logging.INFO, stream=sys.stdout, format="%(levelname)-8s %(message)s"
+)
 
 from codeminer.compiler import IndexCompiler, IndexCompilerConfig
-from codeminer.compiler.index_builders import IndexBuilderRegistry, register_default_builders
+from codeminer.compiler.index_builders import (
+    IndexBuilderRegistry,
+    register_default_builders,
+)
+
+_LANGUAGE_ALIASES = {
+    "python": ["python"],
+    "py": ["python"],
+    "go": ["go"],
+    "golang": ["go"],
+    "rust": ["rust"],
+    "rs": ["rust"],
+    "javascript": ["javascript"],
+    "js": ["javascript"],
+    "typescript": ["typescript"],
+    "ts": ["typescript"],
+    "cpp": ["cpp"],
+    "c++": ["cpp"],
+    "cxx": ["cpp"],
+    "cc": ["cpp"],
+    "c": ["cpp"],
+}
+
+_EXT_LANGS = {
+    ".py": ["python"],
+    ".pyi": ["python"],
+    ".pyx": ["python"],
+    ".go": ["go"],
+    ".rs": ["rust"],
+    ".js": ["javascript"],
+    ".jsx": ["javascript"],
+    ".mjs": ["javascript"],
+    ".ts": ["typescript"],
+    ".tsx": ["typescript"],
+    ".mts": ["typescript"],
+    ".cts": ["typescript"],
+    ".cpp": ["cpp"],
+    ".cc": ["cpp"],
+    ".cxx": ["cpp"],
+    ".c": ["cpp"],
+    ".h": ["cpp"],
+    ".hpp": ["cpp"],
+    ".hxx": ["cpp"],
+}
 
 
 def get_base_commit(repo_dir: str) -> str:
     try:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=repo_dir, capture_output=True, text=True, check=True,
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         return result.stdout.strip()
     except Exception:
         return ""
 
 
-def detect_language(repo_dir: str) -> str:
-    counts: dict = {}
-    ext_map = {
-        ".py": "python", ".go": "go", ".rs": "rust",
-        ".ts": "javascript", ".tsx": "javascript", ".js": "javascript",
-        ".cpp": "cpp", ".cc": "cpp", ".c": "cpp",
-    }
+def _dedupe(languages: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for language in languages:
+        if language not in seen:
+            seen.add(language)
+            result.append(language)
+    return result
+
+
+def normalize_languages(value: str) -> list[str]:
+    languages: list[str] = []
+    for token in re.split(r"[,/]", value or ""):
+        token = token.strip().lower()
+        if not token:
+            continue
+        languages.extend(_LANGUAGE_ALIASES.get(token, [token]))
+    return _dedupe(languages) or ["python"]
+
+
+def detect_languages(repo_dir: str) -> list[str]:
+    counts: dict[str, int] = {}
     for root, _, files in os.walk(repo_dir):
         if "/.git" in root or "/.codeminer" in root:
             continue
         for f in files:
-            lang = ext_map.get(os.path.splitext(f)[1].lower())
-            if lang:
+            for lang in _EXT_LANGS.get(os.path.splitext(f)[1].lower(), []):
                 counts[lang] = counts.get(lang, 0) + 1
-    return max(counts, key=counts.get) if counts else "python"
+    if not counts:
+        return ["python"]
+    return sorted(counts, key=lambda lang: (-counts[lang], lang))
 
 
 def update_registry(registry_path: str, entry: dict) -> None:
@@ -65,7 +129,13 @@ def update_registry(registry_path: str, entry: dict) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Index a repo for CodeMiner web demo")
     parser.add_argument("repo_dir", help="Absolute path to the repo to index")
-    parser.add_argument("--language", help="Language override (auto-detected if omitted)")
+    parser.add_argument(
+        "--language",
+        help=(
+            "Language override (auto-detected if omitted); accepts comma- or "
+            "slash-separated values such as javascript/typescript"
+        ),
+    )
     parser.add_argument(
         "--registry",
         default=".codeminer_qa/qa_registry.json",
@@ -78,13 +148,21 @@ def main() -> None:
         print(f"ERROR: Directory not found: {repo_dir}")
         sys.exit(1)
 
-    language = args.language or detect_language(repo_dir)
-    print(f"Detected language: {language}")
+    languages = (
+        normalize_languages(args.language)
+        if args.language
+        else detect_languages(repo_dir)
+    )
+    language = "/".join(languages)
+    print(f"Target languages: {', '.join(languages)}")
 
     # Build BM25 index
     reg = IndexBuilderRegistry()
-    register_default_builders(reg, languages=[language])
-    manifest = IndexCompiler(reg, IndexCompilerConfig(index_types=["bm25"])).compile_repo(repo_dir)
+    register_default_builders(reg, languages=languages)
+    manifest = IndexCompiler(
+        reg,
+        IndexCompilerConfig(index_types=["bm25"], languages=languages),
+    ).compile_repo(repo_dir)
 
     print("\nIndexes built:")
     for name, idx in manifest.indexes.items():
@@ -94,10 +172,14 @@ def main() -> None:
     try:
         remote = subprocess.run(
             ["git", "remote", "get-url", "origin"],
-            cwd=repo_dir, capture_output=True, text=True,
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
-        m = re.search(r"[:/]([^/]+)/([^/.]+?)(?:\.git)?$", remote)
-        owner, repo = (m.group(1), m.group(2)) if m else ("local", os.path.basename(repo_dir))
+        m = re.search(r"[:/]([^/]+)/([^/]+?)(?:\.git)?$", remote)
+        owner, repo = (
+            (m.group(1), m.group(2)) if m else ("local", os.path.basename(repo_dir))
+        )
     except Exception:
         owner, repo = "local", os.path.basename(repo_dir)
 
@@ -117,7 +199,7 @@ def main() -> None:
     }
 
     update_registry(args.registry, entry)
-    print(f"\nRegistered '{instance_id}' in {args.registry}")
+    print(f"\nRegistered {instance_id!r} in {args.registry}")
     print(f"  repo:    {github_repo}")
     print(f"  commit:  {base_commit[:12] if base_commit else '(unknown)'}")
     print(f"\nDone! Restart the backend to pick up the new repo.")

--- a/scripts/start_web.sh
+++ b/scripts/start_web.sh
@@ -12,6 +12,16 @@ CONDA_ENV="${CONDA_ENV:-codeminer}"
 BACKEND_PORT="${CODEMINER_DEMO_PORT:-8000}"
 LLM_PORT="${LLM_PORT:-8080}"
 DEFAULT_GPU_HOST="vscode-dsmlp-l40s"
+LOCAL_MODEL="${CODEMINER_DEMO_MODEL:-openai/qwen2.5-coder}"
+CONFIG_PATH="${CODEMINER_DEMO_CONFIG:-}"
+
+if [ -z "$CONFIG_PATH" ]; then
+    if [ -f "qa_config.local.yaml" ]; then
+        CONFIG_PATH="qa_config.local.yaml"
+    else
+        CONFIG_PATH="qa_config.yaml"
+    fi
+fi
 
 # ── Prerequisites ────────────────────────────────────────────────────────────
 
@@ -19,11 +29,13 @@ echo "=== CodeMiner Backend ==="
 echo ""
 
 # Must run from repo root
-if [ ! -f "qa_config.yaml" ]; then
-    echo "ERROR: qa_config.yaml not found."
+if [ ! -f "$CONFIG_PATH" ]; then
+    echo "ERROR: config not found: $CONFIG_PATH"
     echo "Run this script from the CodeMiner repo root:"
     echo "  cd ~/projects/CodeMiner/CodeMiner"
     echo "  bash scripts/start_web.sh"
+    echo ""
+    echo "For local overrides, copy qa_config.local.yaml.example to qa_config.local.yaml."
     exit 1
 fi
 
@@ -35,7 +47,14 @@ if ! conda run -n "$CONDA_ENV" python -c "import codeminer" &>/dev/null; then
 fi
 
 # Check qa_registry.json
-REGISTRY=".codeminer_qa/qa_registry.json"
+REGISTRY=$(CODEMINER_DEMO_CONFIG="$CONFIG_PATH" python3 -c "
+import os, yaml
+path = os.environ['CODEMINER_DEMO_CONFIG']
+with open(path) as f:
+    data = yaml.safe_load(f) or {}
+data_dir = os.environ.get('CODEMINER_DEMO_DATA_DIR') or data.get('data_dir', '.codeminer_qa')
+print(os.path.join(os.path.abspath(data_dir), 'qa_registry.json'))
+" 2>/dev/null || echo ".codeminer_qa/qa_registry.json")
 if [ ! -f "$REGISTRY" ]; then
     echo "ERROR: No repo registry found at $REGISTRY"
     echo ""
@@ -80,25 +99,12 @@ else
     [[ "$CONT" =~ ^[Yy]$ ]] || exit 1
 fi
 
-# ── Check qa_config.yaml model ───────────────────────────────────────────────
+# ── Local model override ─────────────────────────────────────────────────────
 
-CURRENT_MODEL=$(python3 -c "import yaml; c=yaml.safe_load(open('qa_config.yaml')); print(c.get('model',''))" 2>/dev/null || echo "")
-if [[ "$CURRENT_MODEL" != openai/* ]]; then
-    echo ""
-    echo "WARNING: qa_config.yaml has model: $CURRENT_MODEL"
-    echo "         For local LLM, it should be: openai/qwen2.5-coder"
-    echo ""
-    read -rp "Update qa_config.yaml automatically? [Y/n]: " FIX
-    if [[ ! "$FIX" =~ ^[Nn]$ ]]; then
-        python3 -c "
-import re, sys
-with open('qa_config.yaml') as f: content = f.read()
-content = re.sub(r'^model:.*$', 'model: openai/qwen2.5-coder', content, flags=re.MULTILINE)
-with open('qa_config.yaml', 'w') as f: f.write(content)
-print('  Updated qa_config.yaml: model: openai/qwen2.5-coder')
-"
-    fi
-fi
+echo ""
+echo "Using local LLM model: $LOCAL_MODEL"
+echo "  Config: $CONFIG_PATH"
+echo "  Override with CODEMINER_DEMO_MODEL or CODEMINER_DEMO_CONFIG if needed."
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 
@@ -106,6 +112,8 @@ echo ""
 echo "Starting CodeMiner backend..."
 echo "  Backend:  http://localhost:$BACKEND_PORT"
 echo "  LLM:      $LLM_BASE"
+echo "  Model:    $LOCAL_MODEL"
+echo "  Config:   $CONFIG_PATH"
 echo ""
 echo "─────────────────────────────────────────────"
 echo "Once backend is up, start the frontend in"
@@ -119,8 +127,12 @@ echo ""
 
 export OPENAI_API_KEY="fake"
 export OPENAI_API_BASE="$LLM_BASE"
+export CODEMINER_DEMO_CONFIG="$CONFIG_PATH"
+export CODEMINER_DEMO_MODEL="$LOCAL_MODEL"
 export CODEMINER_DEMO_PORT="$BACKEND_PORT"
 
 conda run -n "$CONDA_ENV" --no-capture-output \
     env OPENAI_API_KEY=fake OPENAI_API_BASE="$LLM_BASE" \
+    CODEMINER_DEMO_CONFIG="$CONFIG_PATH" \
+    CODEMINER_DEMO_MODEL="$LOCAL_MODEL" \
     python -m codeminer.web.app

--- a/test/scripts/test_index_repo.py
+++ b/test/scripts/test_index_repo.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from scripts import index_repo
+
+
+def test_detect_languages_keeps_typescript_distinct(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.ts").write_text("export const app = 1;\n")
+    (tmp_path / "src" / "component.tsx").write_text("export const C = () => null;\n")
+    (tmp_path / "src" / "config.js").write_text("module.exports = {};\n")
+
+    assert index_repo.detect_languages(str(tmp_path)) == [
+        "typescript",
+        "javascript",
+    ]
+
+
+def test_normalize_languages_accepts_combined_js_ts_override():
+    assert index_repo.normalize_languages("js/ts") == ["javascript", "typescript"]
+    assert index_repo.normalize_languages("C++/C") == ["cpp"]


### PR DESCRIPTION
## Summary

Follow-up fixes for #220 after the local GPU LLM demo scripts landed. The PR restores the standard tracked QA defaults while keeping a local GPU config path available through an example file and runtime environment variables.

## Changes
- Restore `qa_config.yaml` to the standard Vertex/Gemini default so existing `codeminer-web`, `uvicorn`, and `make web-start` flows do not silently switch to a local-only OpenAI-compatible model.
- Add `qa_config.local.yaml.example` as the tracked template for local GPU runs; the real `qa_config.local.yaml` remains ignored.
- Update `scripts/start_web.sh` to use `qa_config.local.yaml` when present, respect `CODEMINER_DEMO_CONFIG`, compute the registry path from the selected config, and pass local model settings through environment variables instead of editing tracked config.
- Fix `scripts/index_repo.py` language detection so TypeScript files are indexed as `typescript` rather than folded into `javascript`, and write the same language list into the compiler config.
- Document the local config flow in `README.md` and `docs/running-locally.md`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Local validation on June 19, 2026:
- `python -m black --check scripts/index_repo.py test/scripts/test_index_repo.py`
- `bash -n scripts/start_llm.sh scripts/start_web.sh`
- `python -m py_compile scripts/index_repo.py`
- `python -m pytest test/scripts/test_index_repo.py test/web/test_repo_registry.py test/compiler/test_index_compiler.py -q` (`27 passed`)
- `git diff --check origin/main...HEAD`

Earlier manual smoke from the PR branch: indexed a temporary mixed JS/TS repo and confirmed BM25 metadata contains `["javascript", "typescript"]` and the registry language is `javascript/typescript`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
