### PR TITLE
[codex] Introduce language metadata registry

### DIFF
--- a/codeminer/agent/compile.py
+++ b/codeminer/agent/compile.py
@@ -29,13 +29,16 @@ from pathlib import Path
 from typing import Dict, FrozenSet, Iterable, Mapping, Optional, Union
 
 from ..compiler.params import SessionContext
+from ..languages import (
+    agent_language_aliases,
+    normalize_agent_language,
+    supported_agent_languages,
+)
 
 logger = logging.getLogger(__name__)
 
 
-SUPPORTED_LANGUAGES: FrozenSet[str] = frozenset(
-    {"python", "go", "rust", "cpp", "c", "typescript", "javascript"}
-)
+SUPPORTED_LANGUAGES: FrozenSet[str] = supported_agent_languages()
 
 
 # Stack-trace regexes. Each pattern matches a *structural* marker that only
@@ -71,18 +74,7 @@ def detect_stacktrace(query: str) -> bool:
     return any(p.search(query) for p in _STACKTRACE_PATTERNS)
 
 
-_LANGUAGE_ALIASES: Dict[str, str] = {
-    "py": "python",
-    "python3": "python",
-    "golang": "go",
-    "rs": "rust",
-    "c++": "cpp",
-    "cxx": "cpp",
-    "ts": "typescript",
-    "tsx": "typescript",
-    "js": "javascript",
-    "jsx": "javascript",
-}
+_LANGUAGE_ALIASES: Dict[str, str] = agent_language_aliases()
 
 
 def normalize_language(raw: Optional[str]) -> Optional[str]:
@@ -93,9 +85,7 @@ def normalize_language(raw: Optional[str]) -> Optional[str]:
     """
     if not raw:
         return None
-    key = raw.strip().lower()
-    key = _LANGUAGE_ALIASES.get(key, key)
-    return key if key in SUPPORTED_LANGUAGES else None
+    return normalize_agent_language(raw)
 
 
 @dataclass(frozen=True, slots=True)

--- a/codeminer/code_chunking/__init__.py
+++ b/codeminer/code_chunking/__init__.py
@@ -6,6 +6,7 @@
 Code chunking module for splitting source code files into semantic chunks.
 """
 
+from ..languages import chunker_language_aliases, normalize_chunker_language
 from .base import BaseCodeChunker, CodeChunk
 from .cpp_chunker import CppCodeChunker
 from .go_chunker import GoCodeChunker
@@ -49,7 +50,13 @@ def create_chunker(
     Raises:
         ValueError: If the language is not supported
     """
-    language = language.lower()
+    raw_language = language
+    language = normalize_chunker_language(language)
+    if language is None:
+        supported = ", ".join(sorted(chunker_language_aliases()))
+        raise ValueError(
+            f"Unsupported language: {raw_language}. Supported: {supported}"
+        )
 
     if language == "python":
         return PythonCodeChunker(
@@ -60,7 +67,7 @@ def create_chunker(
             skeleton_mode=skeleton_mode,
             include_l2_in_file_skeleton=include_l2_in_file_skeleton,
         )
-    elif language in ("cpp", "c++", "cxx"):
+    elif language == "cpp":
         return CppCodeChunker(
             max_lines_per_chunk=max_lines_per_chunk,
             chunk_depth=chunk_depth,
@@ -78,7 +85,7 @@ def create_chunker(
             skeleton_mode=skeleton_mode,
             include_l2_in_file_skeleton=include_l2_in_file_skeleton,
         )
-    elif language in ("go", "golang"):
+    elif language == "go":
         return GoCodeChunker(
             max_lines_per_chunk=max_lines_per_chunk,
             chunk_depth=chunk_depth,
@@ -87,7 +94,7 @@ def create_chunker(
             skeleton_mode=skeleton_mode,
             include_l2_in_file_skeleton=include_l2_in_file_skeleton,
         )
-    elif language in ("javascript", "js", "typescript", "ts"):
+    elif language in ("javascript", "typescript"):
         return JsTsCodeChunker(
             language=language,
             max_lines_per_chunk=max_lines_per_chunk,

--- a/codeminer/dataset/gt_locate.py
+++ b/codeminer/dataset/gt_locate.py
@@ -66,27 +66,14 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from ..code_chunking import create_chunker
 from ..code_chunking.base import CodeChunk
+from ..languages import extension_to_language_map
 from ..log_utils import get_logger
 from .swebench import SwebenchDataset
 
 logger = get_logger(__name__)
 
 # Map file extensions to chunker language identifiers.
-EXTENSION_TO_LANGUAGE: Dict[str, str] = {
-    ".py": "python",
-    ".go": "go",
-    ".rs": "rust",
-    ".c": "cpp",
-    ".cpp": "cpp",
-    ".cc": "cpp",
-    ".cxx": "cpp",
-    ".h": "cpp",
-    ".hpp": "cpp",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".ts": "typescript",
-    ".tsx": "typescript",
-}
+EXTENSION_TO_LANGUAGE: Dict[str, str] = extension_to_language_map("gt")
 
 # Symbol chunk_types that represent meaningful code blocks.
 SYMBOL_CHUNK_TYPES = frozenset(

--- a/codeminer/graph/incremental/graph_patcher.py
+++ b/codeminer/graph/incremental/graph_patcher.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from ...languages import graph_extensions_by_language, normalize_graph_language
 from ...log_utils import get_logger
 from ..code_graph import CodeGraph
 from . import change_mgr
@@ -20,14 +21,7 @@ from .patcher_base import PatcherBase
 logger = get_logger(__name__)
 
 # Language → file extensions
-LANGUAGE_EXTENSIONS = {
-    "rust": {".rs"},
-    "python": {".py"},
-    "typescript": {".ts", ".tsx", ".js", ".jsx"},
-    "ts": {".ts", ".tsx", ".js", ".jsx"},
-    "go": {".go"},
-    "cpp": {".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx"},
-}
+LANGUAGE_EXTENSIONS = graph_extensions_by_language()
 
 
 def _create_patcher(
@@ -42,6 +36,8 @@ def _create_patcher(
     from .patcher_python import PatcherPython
     from .patcher_rust import PatcherRust
     from .patcher_ts import PatcherTS
+
+    language = normalize_graph_language(language) or language
 
     PATCHER_MAP = {
         "rust": PatcherRust,

--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Central language metadata registry.
+
+This module is intentionally declarative.  The existing language support
+surfaces do not all use the same canonical key yet: for example agent compile
+keeps ``c`` distinct from ``cpp``, while graph indexing routes ``c`` through
+the C/C++ backend.  ``LanguageSpec`` records those per-surface choices in one
+place so new language work can add metadata without editing every router by
+hand.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, FrozenSet, Iterable, Literal, Optional, Tuple
+
+ExtensionKind = Literal["chunker", "gt", "graph"]
+
+
+@dataclass(frozen=True, slots=True)
+class LanguageSpec:
+    """Declarative metadata for one CodeMiner language family."""
+
+    key: str
+    display_name: str
+    aliases: Tuple[str, ...] = ()
+    chunker_language: Optional[str] = None
+    chunker_aliases: Tuple[str, ...] = ()
+    chunk_extensions: Tuple[str, ...] = ()
+    gt_language: Optional[str] = None
+    gt_extensions: Tuple[str, ...] = ()
+    graph_language: Optional[str] = None
+    graph_aliases: Tuple[str, ...] = ()
+    graph_extensions: Tuple[str, ...] = ()
+    agent_languages: Tuple[str, ...] = ()
+    agent_aliases: Tuple[Tuple[str, str], ...] = ()
+    cold_start_backend: Optional[str] = None
+    incremental_backend: Optional[str] = None
+    core_decoder: bool = False
+    core_decoder_aliases: Tuple[str, ...] = ()
+
+
+LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
+    LanguageSpec(
+        key="python",
+        display_name="Python",
+        aliases=("py", "python3"),
+        chunker_language="python",
+        chunker_aliases=("python",),
+        chunk_extensions=(".py", ".pyx", ".pyi"),
+        gt_language="python",
+        gt_extensions=(".py",),
+        graph_language="python",
+        graph_aliases=("python", "py"),
+        graph_extensions=(".py",),
+        agent_languages=("python",),
+        agent_aliases=(("python", "python"), ("py", "python"), ("python3", "python")),
+        cold_start_backend="scip",
+        incremental_backend="lsp",
+        core_decoder=True,
+    ),
+    LanguageSpec(
+        key="go",
+        display_name="Go",
+        aliases=("golang",),
+        chunker_language="go",
+        chunker_aliases=("go", "golang"),
+        chunk_extensions=(".go",),
+        gt_language="go",
+        gt_extensions=(".go",),
+        graph_language="go",
+        graph_aliases=("go", "golang"),
+        graph_extensions=(".go",),
+        agent_languages=("go",),
+        agent_aliases=(("go", "go"), ("golang", "go")),
+        cold_start_backend="scip",
+        incremental_backend="lsp",
+        core_decoder=True,
+    ),
+    LanguageSpec(
+        key="rust",
+        display_name="Rust",
+        aliases=("rs",),
+        chunker_language="rust",
+        chunker_aliases=("rust",),
+        chunk_extensions=(".rs",),
+        gt_language="rust",
+        gt_extensions=(".rs",),
+        graph_language="rust",
+        graph_aliases=("rust", "rs"),
+        graph_extensions=(".rs",),
+        agent_languages=("rust",),
+        agent_aliases=(("rust", "rust"), ("rs", "rust")),
+        cold_start_backend="scip",
+        incremental_backend="lsp",
+        core_decoder=True,
+    ),
+    LanguageSpec(
+        key="cpp",
+        display_name="C/C++",
+        aliases=("c", "c++", "cxx"),
+        chunker_language="cpp",
+        chunker_aliases=("cpp", "c++", "cxx"),
+        chunk_extensions=(".cpp", ".cxx", ".cc", ".c", ".hpp", ".h", ".hxx"),
+        gt_language="cpp",
+        gt_extensions=(".c", ".cpp", ".cc", ".cxx", ".h", ".hpp"),
+        graph_language="cpp",
+        graph_aliases=("cpp", "c++", "c"),
+        graph_extensions=(".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx"),
+        agent_languages=("cpp", "c"),
+        agent_aliases=(("cpp", "cpp"), ("c++", "cpp"), ("cxx", "cpp"), ("c", "c")),
+        cold_start_backend="clangd",
+        incremental_backend="clangd",
+    ),
+    LanguageSpec(
+        key="javascript",
+        display_name="JavaScript",
+        aliases=("js", "jsx"),
+        chunker_language="javascript",
+        chunker_aliases=("javascript", "js"),
+        chunk_extensions=(".js", ".jsx", ".mjs"),
+        gt_language="javascript",
+        gt_extensions=(".js", ".jsx"),
+        graph_language="ts",
+        graph_aliases=("javascript", "js"),
+        graph_extensions=(".js", ".jsx"),
+        agent_languages=("javascript",),
+        agent_aliases=(
+            ("javascript", "javascript"),
+            ("js", "javascript"),
+            ("jsx", "javascript"),
+        ),
+        cold_start_backend="scip",
+        incremental_backend="lsp",
+    ),
+    LanguageSpec(
+        key="typescript",
+        display_name="TypeScript",
+        aliases=("ts", "tsx"),
+        chunker_language="typescript",
+        chunker_aliases=("typescript", "ts"),
+        chunk_extensions=(".ts", ".tsx", ".mts", ".cts"),
+        gt_language="typescript",
+        gt_extensions=(".ts", ".tsx"),
+        graph_language="ts",
+        graph_aliases=("typescript", "ts"),
+        graph_extensions=(".ts", ".tsx"),
+        agent_languages=("typescript",),
+        agent_aliases=(
+            ("typescript", "typescript"),
+            ("ts", "typescript"),
+            ("tsx", "typescript"),
+        ),
+        cold_start_backend="scip",
+        incremental_backend="lsp",
+        core_decoder=True,
+        core_decoder_aliases=("ts", "js"),
+    ),
+)
+
+
+def _norm(value: str) -> str:
+    return value.strip().lower()
+
+
+def _unique(values: Iterable[str]) -> Tuple[str, ...]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return tuple(result)
+
+
+SPECS_BY_KEY: Dict[str, LanguageSpec] = {spec.key: spec for spec in LANGUAGE_SPECS}
+
+_GENERAL_ALIASES: Dict[str, str] = {}
+for _spec in LANGUAGE_SPECS:
+    _GENERAL_ALIASES[_spec.key] = _spec.key
+    for _alias in _spec.aliases:
+        _GENERAL_ALIASES[_alias] = _spec.key
+
+_CHUNKER_ALIASES: Dict[str, str] = {}
+for _spec in LANGUAGE_SPECS:
+    if _spec.chunker_language:
+        for _alias in _spec.chunker_aliases:
+            _CHUNKER_ALIASES[_alias] = _spec.chunker_language
+
+_AGENT_ALIASES: Dict[str, str] = {}
+for _spec in LANGUAGE_SPECS:
+    for _alias, _target in _spec.agent_aliases:
+        _AGENT_ALIASES[_alias] = _target
+
+
+def get_language_spec(language: str) -> Optional[LanguageSpec]:
+    """Return the spec for a language key or general alias."""
+
+    key = _GENERAL_ALIASES.get(_norm(language))
+    if key is None:
+        return None
+    return SPECS_BY_KEY[key]
+
+
+def normalize_language(language: str) -> Optional[str]:
+    """Normalize a raw language string to a registry key."""
+
+    spec = get_language_spec(language)
+    return spec.key if spec else None
+
+
+def normalize_chunker_language(language: str) -> Optional[str]:
+    """Normalize a raw language string for ``create_chunker``."""
+
+    return _CHUNKER_ALIASES.get(_norm(language))
+
+
+def normalize_graph_language(language: str) -> Optional[str]:
+    """Normalize a raw language string to the graph/LS backend key."""
+
+    key = graph_language_aliases().get(_norm(language))
+    return key
+
+
+def normalize_agent_language(language: str) -> Optional[str]:
+    """Normalize a raw language string for agent compile scenarios."""
+
+    return _AGENT_ALIASES.get(_norm(language))
+
+
+def supported_agent_languages() -> FrozenSet[str]:
+    """Return language scenario keys accepted by agent compile."""
+
+    return frozenset(lang for spec in LANGUAGE_SPECS for lang in spec.agent_languages)
+
+
+def chunker_language_aliases() -> Dict[str, str]:
+    """Return raw chunker aliases mapped to chunker language keys."""
+
+    return dict(_CHUNKER_ALIASES)
+
+
+def graph_language_aliases() -> Dict[str, str]:
+    """Return raw LS/graph aliases mapped to backend language keys."""
+
+    aliases: Dict[str, str] = {}
+    for spec in LANGUAGE_SPECS:
+        if not spec.graph_language:
+            continue
+        aliases[spec.graph_language] = spec.graph_language
+        for alias in spec.graph_aliases:
+            aliases[alias] = spec.graph_language
+    return aliases
+
+
+def agent_language_aliases() -> Dict[str, str]:
+    """Return raw agent language aliases mapped to scenario keys."""
+
+    return dict(_AGENT_ALIASES)
+
+
+def extension_to_language_map(kind: ExtensionKind) -> Dict[str, str]:
+    """Return an extension-to-language map for the requested surface."""
+
+    result: Dict[str, str] = {}
+    for spec in LANGUAGE_SPECS:
+        language = getattr(spec, f"{kind}_language")
+        extensions = getattr(spec, f"{kind}_extensions")
+        if not language:
+            continue
+        for ext in extensions:
+            result[ext] = language
+    return result
+
+
+def extensions_for_language(language: str, kind: ExtensionKind) -> set[str]:
+    """Return extensions for a language on the requested surface."""
+
+    if kind == "graph":
+        graph_key = normalize_graph_language(language)
+        if graph_key is None:
+            return set()
+        return graph_extensions_by_language().get(graph_key, set())
+
+    spec = get_language_spec(language)
+    if spec is None:
+        return set()
+    return set(getattr(spec, f"{kind}_extensions"))
+
+
+def graph_extensions_by_language(include_aliases: bool = True) -> Dict[str, set[str]]:
+    """Return graph backend language keys mapped to accepted extensions."""
+
+    by_backend: Dict[str, set[str]] = {}
+    for spec in LANGUAGE_SPECS:
+        if not spec.graph_language:
+            continue
+        by_backend.setdefault(spec.graph_language, set()).update(spec.graph_extensions)
+
+    if not include_aliases:
+        return {
+            language: set(extensions) for language, extensions in by_backend.items()
+        }
+
+    result = {language: set(extensions) for language, extensions in by_backend.items()}
+    aliases = graph_language_aliases()
+    for alias, graph_language in aliases.items():
+        if graph_language in by_backend:
+            result[alias] = set(by_backend[graph_language])
+    return result
+
+
+def core_decoder_languages(include_aliases: bool = True) -> Tuple[str, ...]:
+    """Return languages accepted by the optional C++ core decoder."""
+
+    languages: list[str] = []
+    for spec in LANGUAGE_SPECS:
+        if spec.core_decoder:
+            languages.append(spec.key)
+            if include_aliases:
+                languages.extend(spec.core_decoder_aliases)
+    return _unique(languages)
+
+
+__all__ = [
+    "ExtensionKind",
+    "LanguageSpec",
+    "LANGUAGE_SPECS",
+    "SPECS_BY_KEY",
+    "agent_language_aliases",
+    "chunker_language_aliases",
+    "core_decoder_languages",
+    "extension_to_language_map",
+    "extensions_for_language",
+    "get_language_spec",
+    "graph_extensions_by_language",
+    "graph_language_aliases",
+    "normalize_agent_language",
+    "normalize_chunker_language",
+    "normalize_graph_language",
+    "normalize_language",
+    "supported_agent_languages",
+]

--- a/codeminer/ls_router.py
+++ b/codeminer/ls_router.py
@@ -27,37 +27,24 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from .graph.code_graph import CodeGraph
+from .languages import graph_language_aliases, normalize_graph_language
 from .log_utils import get_logger
 from .profiler import Profiler
 
 logger = get_logger("ls_router")
 
-LANGUAGE_ALIASES = {
-    "cpp": "cpp",
-    "c++": "cpp",
-    "c": "cpp",
-    "rust": "rust",
-    "rs": "rust",
-    "typescript": "ts",
-    "ts": "ts",
-    "javascript": "ts",
-    "js": "ts",
-    "python": "python",
-    "py": "python",
-    "go": "go",
-    "golang": "go",
-}
+LANGUAGE_ALIASES = graph_language_aliases()
 
 
 def _normalize_language(language: Optional[str]) -> str:
     """Normalize language string. Defaults to 'python'."""
     if language is None:
         return "python"
-    key = language.lower()
-    if key not in LANGUAGE_ALIASES:
+    key = normalize_graph_language(language)
+    if key is None:
         supported = ", ".join(sorted(set(LANGUAGE_ALIASES.keys())))
         raise ValueError(f"Unsupported language: {language!r}. Supported: {supported}")
-    return LANGUAGE_ALIASES[key]
+    return key
 
 
 # ── LSIndexer ─────────────────────────────────────────────────────────

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the central language metadata registry."""
+
+from codeminer.languages import (
+    core_decoder_languages,
+    extension_to_language_map,
+    graph_extensions_by_language,
+    normalize_agent_language,
+    normalize_chunker_language,
+    normalize_graph_language,
+    supported_agent_languages,
+)
+
+
+def test_c_family_surface_normalization_is_explicit():
+    assert normalize_chunker_language("c") is None
+    assert normalize_chunker_language("c++") == "cpp"
+    assert normalize_graph_language("c") == "cpp"
+    assert normalize_graph_language("c++") == "cpp"
+    assert normalize_agent_language("c") == "c"
+    assert normalize_agent_language("c++") == "cpp"
+
+
+def test_javascript_typescript_share_graph_backend_but_keep_agent_keys():
+    assert normalize_chunker_language("js") == "javascript"
+    assert normalize_chunker_language("ts") == "typescript"
+    assert normalize_graph_language("javascript") == "ts"
+    assert normalize_graph_language("typescript") == "ts"
+    assert normalize_agent_language("jsx") == "javascript"
+    assert normalize_agent_language("tsx") == "typescript"
+
+    graph_extensions = graph_extensions_by_language()
+    assert graph_extensions["ts"] == {".ts", ".tsx", ".js", ".jsx"}
+    assert graph_extensions["javascript"] == graph_extensions["ts"]
+
+
+def test_gt_extensions_preserve_current_supported_set():
+    ext_map = extension_to_language_map("gt")
+    assert ext_map[".py"] == "python"
+    assert ext_map[".c"] == "cpp"
+    assert ext_map[".tsx"] == "typescript"
+    assert ext_map[".jsx"] == "javascript"
+
+    assert ".mjs" not in ext_map
+    assert ".mts" not in ext_map
+    assert ".cts" not in ext_map
+
+
+def test_agent_supported_languages_match_existing_scenarios():
+    assert supported_agent_languages() == {
+        "python",
+        "go",
+        "rust",
+        "cpp",
+        "c",
+        "typescript",
+        "javascript",
+    }
+
+
+def test_core_decoder_languages_only_include_supported_core_aliases():
+    assert core_decoder_languages() == (
+        "python",
+        "go",
+        "rust",
+        "typescript",
+        "ts",
+        "js",
+    )


### PR DESCRIPTION
## Summary

Starts issue #186 by adding a central `LanguageSpec` registry for the languages CodeMiner already supports.

## Changes

- Added `codeminer.languages.LanguageSpec` and registry helpers for chunker, GT, graph/LS, agent, and core-decoder language metadata.
- Updated `create_chunker`, `gt_locate`, `ls_router`, `graph_patcher`, and `agent.compile` to derive existing language maps from the registry.
- Preserved surface-specific semantics, including `agent: c -> c`, `graph: c -> cpp`, and JS/TS sharing the graph backend key `ts`.
- Added registry tests locking current behavior and accepted aliases/extensions.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation recorded for this PR:

- `python -m pytest -q test/test_languages.py test/agent/test_compile.py test/dataset/test_gt_locate.py test/graph/incremental/test_graph_patcher.py::test_ls_indexer_graph_patch_import test/chunker/test_python_chunker.py test/chunker/test_cpp_chunker.py test/chunker/test_go_chunker.py test/chunker/test_rust_chunker.py test/chunker/test_js_chunker.py`
- `python -m pytest -q test/scip/test_scip_indexer.py::test_conda_environment`
- pre-commit hooks during commit: whitespace, TOML/YAML/JSON checks where applicable, black, isort, flake8

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Refs #186