### PR TITLE
[codex] Derive repo chunking languages from registry

### DIFF
--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -16,6 +16,11 @@ from typing import Any, Dict, List, Optional, Set
 
 # Import from the new modular code chunking system
 from .code_chunking import CodeChunk, create_chunker
+from .languages import (
+    chunker_languages,
+    extensions_for_language,
+    normalize_chunker_language,
+)
 from .log_utils import get_logger
 from .utils import is_test_file
 
@@ -28,12 +33,12 @@ class RepoChunkingConfig:
 
     languages: List[str] = field(default_factory=list)
     # File type configurations
-    python_extensions: Set[str] = None
-    cpp_extensions: Set[str] = None
-    rust_extensions: Set[str] = None
-    go_extensions: Set[str] = None
-    javascript_extensions: Set[str] = None
-    typescript_extensions: Set[str] = None
+    python_extensions: Optional[Set[str]] = None
+    cpp_extensions: Optional[Set[str]] = None
+    rust_extensions: Optional[Set[str]] = None
+    go_extensions: Optional[Set[str]] = None
+    javascript_extensions: Optional[Set[str]] = None
+    typescript_extensions: Optional[Set[str]] = None
 
     # Directory filtering
     ignore_dirs: Set[str] = None
@@ -52,22 +57,26 @@ class RepoChunkingConfig:
             self.languages = []
 
         if self.python_extensions is None:
-            self.python_extensions = {".py", ".pyx", ".pyi"}
+            self.python_extensions = extensions_for_language("python", "chunker")
 
         if self.cpp_extensions is None:
-            self.cpp_extensions = {".cpp", ".cxx", ".cc", ".c", ".hpp", ".h", ".hxx"}
+            self.cpp_extensions = extensions_for_language("cpp", "chunker")
 
         if self.rust_extensions is None:
-            self.rust_extensions = {".rs"}
+            self.rust_extensions = extensions_for_language("rust", "chunker")
 
         if self.go_extensions is None:
-            self.go_extensions = {".go"}
+            self.go_extensions = extensions_for_language("go", "chunker")
 
         if self.javascript_extensions is None:
-            self.javascript_extensions = {".js", ".jsx", ".mjs"}
+            self.javascript_extensions = extensions_for_language(
+                "javascript", "chunker"
+            )
 
         if self.typescript_extensions is None:
-            self.typescript_extensions = {".ts", ".tsx", ".mts", ".cts"}
+            self.typescript_extensions = extensions_for_language(
+                "typescript", "chunker"
+            )
 
         if self.ignore_dirs is None:
             self.ignore_dirs = {
@@ -146,7 +155,7 @@ class CodeChunker:
             include_l2_in_file_skeleton: When chunk_depth is 0, include member
                 signatures in file-level skeletons. Default: True.
         """
-        self.language = language
+        self.language = normalize_chunker_language(language) or language
         self.max_lines_per_chunk = max_lines_per_chunk
         self.chunk_depth = chunk_depth
         self.include_header_epilogue = include_header_epilogue
@@ -165,9 +174,9 @@ class CodeChunker:
         if repo_config is None:
             repo_config = RepoChunkingConfig()
         if not repo_config.languages:
-            repo_config.languages = [language]
+            repo_config.languages = [self.language]
         self.repo_config = repo_config
-        self._chunkers = {language: self._chunker}  # Cache chunkers by language
+        self._chunkers = {self.language: self._chunker}  # Cache chunkers by language
         self.nodes = (
             []
         )  # List of node IDs in code graph format (dir/file.py:A.b(), dir/file.py:A)
@@ -355,29 +364,15 @@ class CodeChunker:
         """
         files_to_process = []
 
-        # Get extension mappings for requested languages
-        extension_to_language = {}
+        extension_to_language: Dict[str, str] = {}
         for language in languages:
-            if language.lower() == "python":
-                for ext in self.repo_config.python_extensions:
-                    extension_to_language[ext] = "python"
-            elif language.lower() in ("cpp", "c++", "cxx"):
-                for ext in self.repo_config.cpp_extensions:
-                    extension_to_language[ext] = "cpp"
-            elif language.lower() == "rust":
-                for ext in self.repo_config.rust_extensions:
-                    extension_to_language[ext] = "rust"
-            elif language.lower() in ("go", "golang"):
-                for ext in self.repo_config.go_extensions:
-                    extension_to_language[ext] = "go"
-            elif language.lower() in ("javascript", "js"):
-                for ext in self.repo_config.javascript_extensions:
-                    extension_to_language[ext] = "javascript"
-            elif language.lower() in ("typescript", "ts"):
-                for ext in self.repo_config.typescript_extensions:
-                    extension_to_language[ext] = "typescript"
-            else:
+            normalized = normalize_chunker_language(language)
+            if normalized is None:
                 logger.warning("Language %r not supported yet", language)
+                continue
+            extensions = self._extensions_for_chunker_language(normalized)
+            for ext in extensions:
+                extension_to_language[ext] = normalized
 
         # Walk through repository
         for root, dirs, files in os.walk(repo_path):
@@ -517,6 +512,16 @@ class CodeChunker:
         else:
             return chunker.chunk_file(str(file_path), skeleton_mode=self.skeleton_mode)
 
+    def _extensions_for_chunker_language(self, language: str) -> Set[str]:
+        """Return configured repository extensions for a chunker language."""
+
+        normalized = normalize_chunker_language(language)
+        if normalized is None:
+            return set()
+        attr_name = f"{normalized}_extensions"
+        extensions = getattr(self.repo_config, attr_name, None)
+        return set(extensions or ())
+
     def chunk_swebench_instance(
         self,
         instance: Dict[str, Any],
@@ -589,12 +594,8 @@ class CodeChunker:
             List of detected languages
         """
         language_extensions = {
-            "python": {".py", ".pyx", ".pyi"},
-            "cpp": {".cpp", ".cxx", ".cc", ".c", ".hpp", ".h", ".hxx"},
-            "java": {".java"},
-            "javascript": {".js", ".jsx", ".ts", ".tsx"},
-            "rust": {".rs"},
-            "go": {".go"},
+            language: self._extensions_for_chunker_language(language)
+            for language in chunker_languages()
         }
 
         detected_languages = set()

--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -176,6 +176,14 @@ def _unique(values: Iterable[str]) -> Tuple[str, ...]:
     return tuple(result)
 
 
+def _language_attr(kind: ExtensionKind) -> str:
+    return "chunker_language" if kind == "chunker" else f"{kind}_language"
+
+
+def _extensions_attr(kind: ExtensionKind) -> str:
+    return "chunk_extensions" if kind == "chunker" else f"{kind}_extensions"
+
+
 SPECS_BY_KEY: Dict[str, LanguageSpec] = {spec.key: spec for spec in LANGUAGE_SPECS}
 
 _GENERAL_ALIASES: Dict[str, str] = {}
@@ -243,6 +251,14 @@ def chunker_language_aliases() -> Dict[str, str]:
     return dict(_CHUNKER_ALIASES)
 
 
+def chunker_languages() -> Tuple[str, ...]:
+    """Return canonical language keys accepted by repository chunking."""
+
+    return _unique(
+        spec.chunker_language for spec in LANGUAGE_SPECS if spec.chunker_language
+    )
+
+
 def graph_language_aliases() -> Dict[str, str]:
     """Return raw LS/graph aliases mapped to backend language keys."""
 
@@ -267,8 +283,8 @@ def extension_to_language_map(kind: ExtensionKind) -> Dict[str, str]:
 
     result: Dict[str, str] = {}
     for spec in LANGUAGE_SPECS:
-        language = getattr(spec, f"{kind}_language")
-        extensions = getattr(spec, f"{kind}_extensions")
+        language = getattr(spec, _language_attr(kind))
+        extensions = getattr(spec, _extensions_attr(kind))
         if not language:
             continue
         for ext in extensions:
@@ -288,7 +304,7 @@ def extensions_for_language(language: str, kind: ExtensionKind) -> set[str]:
     spec = get_language_spec(language)
     if spec is None:
         return set()
-    return set(getattr(spec, f"{kind}_extensions"))
+    return set(getattr(spec, _extensions_attr(kind)))
 
 
 def graph_extensions_by_language(include_aliases: bool = True) -> Dict[str, set[str]]:
@@ -332,6 +348,7 @@ __all__ = [
     "SPECS_BY_KEY",
     "agent_language_aliases",
     "chunker_language_aliases",
+    "chunker_languages",
     "core_decoder_languages",
     "extension_to_language_map",
     "extensions_for_language",

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for repository-level chunking language metadata."""
+
+from pathlib import Path
+
+from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+from codeminer.languages import extensions_for_language
+
+
+def test_repo_chunking_config_defaults_come_from_language_registry():
+    cfg = RepoChunkingConfig()
+
+    assert cfg.python_extensions == extensions_for_language("python", "chunker")
+    assert cfg.cpp_extensions == extensions_for_language("cpp", "chunker")
+    assert cfg.rust_extensions == extensions_for_language("rust", "chunker")
+    assert cfg.go_extensions == extensions_for_language("go", "chunker")
+    assert cfg.javascript_extensions == extensions_for_language("javascript", "chunker")
+    assert cfg.typescript_extensions == extensions_for_language("typescript", "chunker")
+
+
+def test_repo_discovery_normalizes_language_aliases(tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.mjs").write_text("export const x = 1;\n")
+    (tmp_path / "src" / "app.mts").write_text("export const y: number = 1;\n")
+
+    cfg = RepoChunkingConfig(languages=["js", "ts"], filter_tests=False)
+    chunker = CodeChunker(language="javascript", repo_config=cfg)
+
+    files = chunker._discover_files(tmp_path, cfg.languages)
+    discovered = {
+        (path.relative_to(tmp_path).as_posix(), language) for path, language in files
+    }
+
+    assert discovered == {
+        ("src/app.mjs", "javascript"),
+        ("src/app.mts", "typescript"),
+    }
+
+
+def test_repo_discovery_respects_custom_extension_overrides(tmp_path: Path):
+    (tmp_path / "tool.py").write_text("def ignored():\n    pass\n")
+    (tmp_path / "tool.pyw").write_text("def included():\n    pass\n")
+
+    cfg = RepoChunkingConfig(
+        languages=["python"],
+        python_extensions={".pyw"},
+        filter_tests=False,
+    )
+    chunker = CodeChunker(language="python", repo_config=cfg)
+
+    stats = chunker.get_repository_stats(str(tmp_path))
+
+    assert stats["total_files"] == 1
+    assert stats["files_by_language"]["python"][0]["path"] == "tool.pyw"
+
+
+def test_repo_language_detection_uses_registered_chunk_extensions(tmp_path: Path):
+    (tmp_path / "app.jsx").write_text("export const x = () => 1;\n")
+    (tmp_path / "types.cts").write_text("export const y: number = 1;\n")
+    (tmp_path / "main.go").write_text("package main\n")
+
+    chunker = CodeChunker(language="python")
+
+    assert sorted(chunker._detect_repo_language(tmp_path)) == [
+        "go",
+        "javascript",
+        "typescript",
+    ]

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -5,6 +5,7 @@
 """Tests for the central language metadata registry."""
 
 from codeminer.languages import (
+    chunker_languages,
     core_decoder_languages,
     extension_to_language_map,
     graph_extensions_by_language,
@@ -69,4 +70,15 @@ def test_core_decoder_languages_only_include_supported_core_aliases():
         "typescript",
         "ts",
         "js",
+    )
+
+
+def test_chunker_languages_are_current_supported_repo_chunkers():
+    assert chunker_languages() == (
+        "python",
+        "go",
+        "rust",
+        "cpp",
+        "javascript",
+        "typescript",
     )


### PR DESCRIPTION
## Summary

Stacks on the language registry work from #224 and moves repository-level chunking metadata onto `codeminer.languages`.

## Changes

- Default `RepoChunkingConfig` extension sets now come from `LanguageSpec.chunk_extensions`.
- Repository file discovery normalizes requested language aliases through the registry instead of a local if/elif chain.
- Repository language detection uses registered chunker languages/extensions instead of a second hard-coded extension table.
- Added unit coverage for default extension derivation, alias handling, custom extension overrides, and JS/TS detection.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking on latest `main`:

- `python -m pytest -q test/test_languages.py test/chunker/test_repo_chunking_config.py test/agent/test_compile.py test/dataset/test_gt_locate.py test/incremental` (`87 passed`)
- `python -m compileall -q codeminer/languages.py codeminer/code_chunker.py test/chunker/test_repo_chunking_config.py test/test_languages.py`
- `python -m pytest -q test/chunker/test_python_chunker.py test/chunker/test_cpp_chunker.py test/chunker/test_go_chunker.py test/chunker/test_rust_chunker.py test/chunker/test_js_chunker.py` (`20 passed`)
- `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`976 passed, 10 skipped`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Refs #186