### PR TITLE
[codex] Route graph patchers through language registry

### DIFF
--- a/codeminer/graph/incremental/graph_patcher.py
+++ b/codeminer/graph/incremental/graph_patcher.py
@@ -10,9 +10,10 @@ Maintains backward-compatible API.
 
 from __future__ import annotations
 
-from typing import Optional
+from importlib import import_module
+from typing import Optional, Type
 
-from ...languages import graph_extensions_by_language, normalize_graph_language
+from ...languages import graph_extensions_by_language, incremental_patcher_path
 from ...log_utils import get_logger
 from ..code_graph import CodeGraph
 from . import change_mgr
@@ -24,6 +25,19 @@ logger = get_logger(__name__)
 LANGUAGE_EXTENSIONS = graph_extensions_by_language()
 
 
+def _load_patcher_class(path: str) -> Type[PatcherBase]:
+    """Import a patcher class from a ``module:Class`` registry path."""
+
+    module_name, separator, class_name = path.partition(":")
+    if not separator or not module_name or not class_name:
+        raise ValueError(f"Invalid patcher path: {path!r}")
+    module = import_module(module_name)
+    cls = getattr(module, class_name)
+    if not issubclass(cls, PatcherBase):
+        raise TypeError(f"Registered patcher is not a PatcherBase subclass: {path}")
+    return cls
+
+
 def _create_patcher(
     language: str,
     project_root: str,
@@ -31,27 +45,10 @@ def _create_patcher(
     mode: str = "symbol",
 ) -> PatcherBase:
     """Factory: create language-specific patcher."""
-    from .patcher_cpp import PatcherCpp
-    from .patcher_go import PatcherGo
-    from .patcher_python import PatcherPython
-    from .patcher_rust import PatcherRust
-    from .patcher_ts import PatcherTS
-
-    language = normalize_graph_language(language) or language
-
-    PATCHER_MAP = {
-        "rust": PatcherRust,
-        "python": PatcherPython,
-        "typescript": PatcherTS,
-        "ts": PatcherTS,
-        "go": PatcherGo,
-        "cpp": PatcherCpp,
-        "c": PatcherCpp,
-    }
-
-    cls = PATCHER_MAP.get(language)
-    if cls is None:
+    patcher_path = incremental_patcher_path(language)
+    if patcher_path is None:
         raise ValueError(f"Unsupported language: {language}")
+    cls = _load_patcher_class(patcher_path)
     return cls(project_root, code_graph or CodeGraph(project_root), mode=mode)
 
 

--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -39,6 +39,7 @@ class LanguageSpec:
     agent_aliases: Tuple[Tuple[str, str], ...] = ()
     cold_start_backend: Optional[str] = None
     incremental_backend: Optional[str] = None
+    incremental_patcher: Optional[str] = None
     core_decoder: bool = False
     core_decoder_aliases: Tuple[str, ...] = ()
 
@@ -60,6 +61,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_aliases=(("python", "python"), ("py", "python"), ("python3", "python")),
         cold_start_backend="scip",
         incremental_backend="lsp",
+        incremental_patcher="codeminer.graph.incremental.patcher_python:PatcherPython",
         core_decoder=True,
     ),
     LanguageSpec(
@@ -78,6 +80,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_aliases=(("go", "go"), ("golang", "go")),
         cold_start_backend="scip",
         incremental_backend="lsp",
+        incremental_patcher="codeminer.graph.incremental.patcher_go:PatcherGo",
         core_decoder=True,
     ),
     LanguageSpec(
@@ -96,6 +99,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_aliases=(("rust", "rust"), ("rs", "rust")),
         cold_start_backend="scip",
         incremental_backend="lsp",
+        incremental_patcher="codeminer.graph.incremental.patcher_rust:PatcherRust",
         core_decoder=True,
     ),
     LanguageSpec(
@@ -114,6 +118,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_aliases=(("cpp", "cpp"), ("c++", "cpp"), ("cxx", "cpp"), ("c", "c")),
         cold_start_backend="clangd",
         incremental_backend="clangd",
+        incremental_patcher="codeminer.graph.incremental.patcher_cpp:PatcherCpp",
     ),
     LanguageSpec(
         key="javascript",
@@ -135,6 +140,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         ),
         cold_start_backend="scip",
         incremental_backend="lsp",
+        incremental_patcher="codeminer.graph.incremental.patcher_ts:PatcherTS",
     ),
     LanguageSpec(
         key="typescript",
@@ -156,6 +162,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         ),
         cold_start_backend="scip",
         incremental_backend="lsp",
+        incremental_patcher="codeminer.graph.incremental.patcher_ts:PatcherTS",
         core_decoder=True,
         core_decoder_aliases=("ts", "js"),
     ),
@@ -329,6 +336,34 @@ def graph_extensions_by_language(include_aliases: bool = True) -> Dict[str, set[
     return result
 
 
+def incremental_patcher_paths(include_aliases: bool = True) -> Dict[str, str]:
+    """Return graph backend language keys mapped to incremental patcher paths."""
+
+    by_backend: Dict[str, str] = {}
+    for spec in LANGUAGE_SPECS:
+        if spec.graph_language and spec.incremental_patcher:
+            by_backend[spec.graph_language] = spec.incremental_patcher
+
+    if not include_aliases:
+        return dict(by_backend)
+
+    result = dict(by_backend)
+    aliases = graph_language_aliases()
+    for alias, graph_language in aliases.items():
+        if graph_language in by_backend:
+            result[alias] = by_backend[graph_language]
+    return result
+
+
+def incremental_patcher_path(language: str) -> Optional[str]:
+    """Return the incremental patcher class path for a raw graph language."""
+
+    graph_language = normalize_graph_language(language)
+    if graph_language is None:
+        return None
+    return incremental_patcher_paths(include_aliases=False).get(graph_language)
+
+
 def core_decoder_languages(include_aliases: bool = True) -> Tuple[str, ...]:
     """Return languages accepted by the optional C++ core decoder."""
 
@@ -355,6 +390,8 @@ __all__ = [
     "get_language_spec",
     "graph_extensions_by_language",
     "graph_language_aliases",
+    "incremental_patcher_path",
+    "incremental_patcher_paths",
     "normalize_agent_language",
     "normalize_chunker_language",
     "normalize_graph_language",

--- a/test/graph/incremental/test_graph_patcher_registry.py
+++ b/test/graph/incremental/test_graph_patcher_registry.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for registry-driven GraphPatcher routing."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.graph.incremental.graph_patcher import GraphPatcher
+
+
+@pytest.mark.parametrize(
+    ("language", "module_suffix", "class_name"),
+    [
+        ("python", "patcher_python", "PatcherPython"),
+        ("py", "patcher_python", "PatcherPython"),
+        ("go", "patcher_go", "PatcherGo"),
+        ("golang", "patcher_go", "PatcherGo"),
+        ("rust", "patcher_rust", "PatcherRust"),
+        ("rs", "patcher_rust", "PatcherRust"),
+        ("cpp", "patcher_cpp", "PatcherCpp"),
+        ("c", "patcher_cpp", "PatcherCpp"),
+        ("typescript", "patcher_ts", "PatcherTS"),
+        ("javascript", "patcher_ts", "PatcherTS"),
+        ("js", "patcher_ts", "PatcherTS"),
+    ],
+)
+def test_graph_patcher_routes_through_language_registry(
+    tmp_path, language, module_suffix, class_name
+):
+    patcher = GraphPatcher(str(tmp_path), None, language)
+
+    assert patcher._impl.__class__.__name__ == class_name
+    assert patcher._impl.__class__.__module__.endswith(module_suffix)
+
+
+def test_graph_patcher_rejects_unregistered_language(tmp_path):
+    with pytest.raises(ValueError, match="Unsupported language: java"):
+        GraphPatcher(str(tmp_path), None, "java")

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -9,6 +9,8 @@ from codeminer.languages import (
     core_decoder_languages,
     extension_to_language_map,
     graph_extensions_by_language,
+    incremental_patcher_path,
+    incremental_patcher_paths,
     normalize_agent_language,
     normalize_chunker_language,
     normalize_graph_language,
@@ -82,3 +84,23 @@ def test_chunker_languages_are_current_supported_repo_chunkers():
         "javascript",
         "typescript",
     )
+
+
+def test_incremental_patcher_paths_follow_graph_language_aliases():
+    paths = incremental_patcher_paths()
+
+    assert paths["python"].endswith("patcher_python:PatcherPython")
+    assert paths["py"] == paths["python"]
+    assert paths["go"].endswith("patcher_go:PatcherGo")
+    assert paths["golang"] == paths["go"]
+    assert paths["rust"].endswith("patcher_rust:PatcherRust")
+    assert paths["rs"] == paths["rust"]
+    assert paths["cpp"].endswith("patcher_cpp:PatcherCpp")
+    assert paths["c"] == paths["cpp"]
+    assert paths["ts"].endswith("patcher_ts:PatcherTS")
+    assert paths["javascript"] == paths["ts"]
+    assert paths["typescript"] == paths["ts"]
+
+    assert incremental_patcher_path("js") == paths["ts"]
+    assert incremental_patcher_path("jsx") is None
+    assert incremental_patcher_path("java") is None


### PR DESCRIPTION
## Summary

Routes incremental graph patcher selection through the language registry on top of #225.

## Changes

- Added `incremental_patcher` metadata and helper lookups to `LanguageSpec`.
- Replaced the local hard-coded `GraphPatcher` map with lazy loading from registry paths.
- Added unit coverage for registry alias handling and GraphPatcher routing without starting LSP servers.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking the main issue-186 chain:

- Main-chain tip #238 full unit validation: `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1084 passed, 10 skipped`)
- Original focused validation included `test/test_languages.py`, `test/graph/incremental/test_graph_patcher_registry.py`, and `test/graph/incremental/test_lsp_decoder.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Stacked on #225. Parent is published but not merged yet. Refs #186.