### PR TITLE
[codex] Route LS delegates through language registry

### DIFF
--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -38,6 +38,8 @@ class LanguageSpec:
     agent_languages: Tuple[str, ...] = ()
     agent_aliases: Tuple[Tuple[str, str], ...] = ()
     cold_start_backend: Optional[str] = None
+    graph_indexer: Optional[str] = None
+    graph_decoder: Optional[str] = None
     incremental_backend: Optional[str] = None
     incremental_patcher: Optional[str] = None
     core_decoder: bool = False
@@ -60,6 +62,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_languages=("python",),
         agent_aliases=(("python", "python"), ("py", "python"), ("python3", "python")),
         cold_start_backend="scip",
+        graph_indexer="codeminer.scip_interface.scip_indexer_python:SCIPPythonIndexer",
+        graph_decoder="codeminer.scip_interface.scip_decode_python:SCIPPythonGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_python:PatcherPython",
         core_decoder=True,
@@ -79,6 +83,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_languages=("go",),
         agent_aliases=(("go", "go"), ("golang", "go")),
         cold_start_backend="scip",
+        graph_indexer="codeminer.scip_interface.scip_indexer_go:SCIPGoIndexer",
+        graph_decoder="codeminer.scip_interface.scip_decode_go:SCIPGoGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_go:PatcherGo",
         core_decoder=True,
@@ -98,6 +104,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_languages=("rust",),
         agent_aliases=(("rust", "rust"), ("rs", "rust")),
         cold_start_backend="scip",
+        graph_indexer="codeminer.scip_interface.scip_indexer_rust:SCIPRustIndexer",
+        graph_decoder="codeminer.scip_interface.scip_decode_rust:SCIPRustGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_rust:PatcherRust",
         core_decoder=True,
@@ -117,6 +125,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_languages=("cpp", "c"),
         agent_aliases=(("cpp", "cpp"), ("c++", "cpp"), ("cxx", "cpp"), ("c", "c")),
         cold_start_backend="clangd",
+        graph_indexer="codeminer.ls_index.clangd_indexer:ClangdIndexer",
+        graph_decoder="codeminer.ls_index.clangd_decode:ClangdGraphDecoder",
         incremental_backend="clangd",
         incremental_patcher="codeminer.graph.incremental.patcher_cpp:PatcherCpp",
     ),
@@ -139,6 +149,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
             ("jsx", "javascript"),
         ),
         cold_start_backend="scip",
+        graph_indexer="codeminer.scip_interface.scip_indexer_ts:SCIPTypeScriptIndexer",
+        graph_decoder="codeminer.scip_interface.scip_decode_ts:SCIPTypeScriptGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_ts:PatcherTS",
     ),
@@ -161,6 +173,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
             ("tsx", "typescript"),
         ),
         cold_start_backend="scip",
+        graph_indexer="codeminer.scip_interface.scip_indexer_ts:SCIPTypeScriptIndexer",
+        graph_decoder="codeminer.scip_interface.scip_decode_ts:SCIPTypeScriptGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_ts:PatcherTS",
         core_decoder=True,
@@ -336,13 +350,13 @@ def graph_extensions_by_language(include_aliases: bool = True) -> Dict[str, set[
     return result
 
 
-def incremental_patcher_paths(include_aliases: bool = True) -> Dict[str, str]:
-    """Return graph backend language keys mapped to incremental patcher paths."""
-
+def _graph_surface_values(attr: str, include_aliases: bool = True) -> Dict[str, str]:
     by_backend: Dict[str, str] = {}
     for spec in LANGUAGE_SPECS:
-        if spec.graph_language and spec.incremental_patcher:
-            by_backend[spec.graph_language] = spec.incremental_patcher
+        if spec.graph_language:
+            value = getattr(spec, attr)
+            if value:
+                by_backend[spec.graph_language] = value
 
     if not include_aliases:
         return dict(by_backend)
@@ -353,6 +367,57 @@ def incremental_patcher_paths(include_aliases: bool = True) -> Dict[str, str]:
         if graph_language in by_backend:
             result[alias] = by_backend[graph_language]
     return result
+
+
+def graph_indexer_paths(include_aliases: bool = True) -> Dict[str, str]:
+    """Return graph backend language keys mapped to cold-start indexer paths."""
+
+    return _graph_surface_values("graph_indexer", include_aliases=include_aliases)
+
+
+def graph_decoder_paths(include_aliases: bool = True) -> Dict[str, str]:
+    """Return graph backend language keys mapped to graph decoder paths."""
+
+    return _graph_surface_values("graph_decoder", include_aliases=include_aliases)
+
+
+def graph_cold_start_backends(include_aliases: bool = True) -> Dict[str, str]:
+    """Return graph backend language keys mapped to cold-start backend names."""
+
+    return _graph_surface_values("cold_start_backend", include_aliases=include_aliases)
+
+
+def graph_indexer_path(language: str) -> Optional[str]:
+    """Return the cold-start indexer class path for a raw graph language."""
+
+    graph_language = normalize_graph_language(language)
+    if graph_language is None:
+        return None
+    return graph_indexer_paths(include_aliases=False).get(graph_language)
+
+
+def graph_decoder_path(language: str) -> Optional[str]:
+    """Return the graph decoder class path for a raw graph language."""
+
+    graph_language = normalize_graph_language(language)
+    if graph_language is None:
+        return None
+    return graph_decoder_paths(include_aliases=False).get(graph_language)
+
+
+def graph_cold_start_backend(language: str) -> Optional[str]:
+    """Return the cold-start backend name for a raw graph language."""
+
+    graph_language = normalize_graph_language(language)
+    if graph_language is None:
+        return None
+    return graph_cold_start_backends(include_aliases=False).get(graph_language)
+
+
+def incremental_patcher_paths(include_aliases: bool = True) -> Dict[str, str]:
+    """Return graph backend language keys mapped to incremental patcher paths."""
+
+    return _graph_surface_values("incremental_patcher", include_aliases=include_aliases)
 
 
 def incremental_patcher_path(language: str) -> Optional[str]:
@@ -388,7 +453,13 @@ __all__ = [
     "extension_to_language_map",
     "extensions_for_language",
     "get_language_spec",
+    "graph_cold_start_backend",
+    "graph_cold_start_backends",
+    "graph_decoder_path",
+    "graph_decoder_paths",
     "graph_extensions_by_language",
+    "graph_indexer_path",
+    "graph_indexer_paths",
     "graph_language_aliases",
     "incremental_patcher_path",
     "incremental_patcher_paths",

--- a/codeminer/ls_router.py
+++ b/codeminer/ls_router.py
@@ -23,11 +23,18 @@ Example:
     decoder = LSGraphDecoder(index_file_path="/path/to/index.decoded", language="rust")
     graph = decoder.decode()
 """
+from importlib import import_module
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Type, Union
 
 from .graph.code_graph import CodeGraph
-from .languages import graph_language_aliases, normalize_graph_language
+from .languages import (
+    graph_cold_start_backend,
+    graph_decoder_path,
+    graph_indexer_path,
+    graph_language_aliases,
+    normalize_graph_language,
+)
 from .log_utils import get_logger
 from .profiler import Profiler
 
@@ -45,6 +52,19 @@ def _normalize_language(language: Optional[str]) -> str:
         supported = ", ".join(sorted(set(LANGUAGE_ALIASES.keys())))
         raise ValueError(f"Unsupported language: {language!r}. Supported: {supported}")
     return key
+
+
+def _load_class(path: str) -> Type:
+    """Import a class from a ``module:Class`` registry path."""
+
+    module_name, separator, class_name = path.partition(":")
+    if not separator or not module_name or not class_name:
+        raise ValueError(f"Invalid class path: {path!r}")
+    module = import_module(module_name)
+    cls = getattr(module, class_name)
+    if not isinstance(cls, type):
+        raise TypeError(f"Registered object is not a class: {path}")
+    return cls
 
 
 # ── LSIndexer ─────────────────────────────────────────────────────────
@@ -89,63 +109,28 @@ class LSIndexer:
         exclude_patterns,
         profiler,
     ):
-        if self.language == "cpp":
-            from .ls_index.clangd_indexer import ClangdIndexer
-
-            # clangd uses its own .idx format, no SCIP decoder backend choice.
-            if self.decoder_backend is not None:
-                logger.warning(
-                    "decoder_backend=%r ignored for cpp (clangd has no SCIP decoder)",
-                    self.decoder_backend,
-                )
-            return ClangdIndexer(
-                project_root=project_root,
-                output_dir=output_dir,
-                exclude_patterns=exclude_patterns,
-                profiler=profiler,
-            )
-        elif self.language == "rust":
-            from .scip_interface.scip_indexer_rust import SCIPRustIndexer
-
-            return SCIPRustIndexer(
-                project_root=project_root,
-                output_dir=output_dir,
-                exclude_patterns=exclude_patterns,
-                profiler=profiler,
-                decoder_backend=self.decoder_backend,
-            )
-        elif self.language == "ts":
-            from .scip_interface.scip_indexer_ts import SCIPTypeScriptIndexer
-
-            return SCIPTypeScriptIndexer(
-                project_root=project_root,
-                output_dir=output_dir,
-                exclude_patterns=exclude_patterns,
-                profiler=profiler,
-                decoder_backend=self.decoder_backend,
-            )
-        elif self.language == "python":
-            from .scip_interface.scip_indexer_python import SCIPPythonIndexer
-
-            return SCIPPythonIndexer(
-                project_root=project_root,
-                output_dir=output_dir,
-                exclude_patterns=exclude_patterns,
-                profiler=profiler,
-                decoder_backend=self.decoder_backend,
-            )
-        elif self.language == "go":
-            from .scip_interface.scip_indexer_go import SCIPGoIndexer
-
-            return SCIPGoIndexer(
-                project_root=project_root,
-                output_dir=output_dir,
-                exclude_patterns=exclude_patterns,
-                profiler=profiler,
-                decoder_backend=self.decoder_backend,
-            )
-        else:
+        indexer_path = graph_indexer_path(self.language)
+        if indexer_path is None:
             raise ValueError(f"No indexer for language: {self.language}")
+
+        backend = graph_cold_start_backend(self.language)
+        cls = _load_class(indexer_path)
+        kwargs = {
+            "project_root": project_root,
+            "output_dir": output_dir,
+            "exclude_patterns": exclude_patterns,
+            "profiler": profiler,
+        }
+        if backend == "scip":
+            kwargs["decoder_backend"] = self.decoder_backend
+        elif self.decoder_backend is not None:
+            logger.warning(
+                "decoder_backend=%r ignored for %s (%s has no SCIP decoder)",
+                self.decoder_backend,
+                self.language,
+                backend,
+            )
+        return cls(**kwargs)
 
     # ── Delegated methods ─────────────────────────────────────────────
 
@@ -202,7 +187,6 @@ class LSIndexer:
             project_root=str(self.project_root),
             code_graph=graph,
             language=self.language,
-            profiler=self.profiler,
         )
 
         changed = patcher.detect_changed_files(
@@ -238,38 +222,20 @@ class LSGraphDecoder:
         self.code_graph = self._delegate.code_graph
 
     def _create_decoder(self, index_file_path, project_root):
-        if self.language == "cpp":
-            from .ls_index.clangd_decode import ClangdGraphDecoder
+        decoder_path = graph_decoder_path(self.language)
+        if decoder_path is None:
+            raise ValueError(f"No decoder for language: {self.language}")
 
-            return ClangdGraphDecoder(
+        cls = _load_class(decoder_path)
+        backend = graph_cold_start_backend(self.language)
+        if backend == "clangd":
+            return cls(
                 # clangd expects a directory of .idx files, not a single file.
                 # Default: <project_root>/.cache/clangd/index/
                 idx_directory=index_file_path,
                 project_root=project_root,
             )
-        elif self.language == "rust":
-            from .scip_interface.scip_decode_rust import SCIPRustGraphDecoder
-
-            return SCIPRustGraphDecoder(
-                index_file_path=index_file_path,
-                project_root=project_root,
-            )
-        elif self.language == "ts":
-            from .scip_interface.scip_decode_ts import SCIPTypeScriptGraphDecoder
-
-            return SCIPTypeScriptGraphDecoder(
-                index_file_path=index_file_path,
-                project_root=project_root,
-            )
-        elif self.language == "python":
-            from .scip_interface.scip_decode_python import SCIPPythonGraphDecoder
-
-            return SCIPPythonGraphDecoder(
-                index_file_path=index_file_path,
-                project_root=project_root,
-            )
-        else:
-            raise ValueError(f"No decoder for language: {self.language}")
+        return cls(index_file_path=index_file_path, project_root=project_root)
 
     # ── Delegated methods ─────────────────────────────────────────────
 

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -8,7 +8,12 @@ from codeminer.languages import (
     chunker_languages,
     core_decoder_languages,
     extension_to_language_map,
+    graph_cold_start_backend,
+    graph_decoder_path,
+    graph_decoder_paths,
     graph_extensions_by_language,
+    graph_indexer_path,
+    graph_indexer_paths,
     incremental_patcher_path,
     incremental_patcher_paths,
     normalize_agent_language,
@@ -104,3 +109,33 @@ def test_incremental_patcher_paths_follow_graph_language_aliases():
     assert incremental_patcher_path("js") == paths["ts"]
     assert incremental_patcher_path("jsx") is None
     assert incremental_patcher_path("java") is None
+
+
+def test_graph_indexer_and_decoder_paths_follow_graph_language_aliases():
+    indexers = graph_indexer_paths()
+    decoders = graph_decoder_paths()
+
+    assert indexers["python"].endswith("scip_indexer_python:SCIPPythonIndexer")
+    assert decoders["python"].endswith("scip_decode_python:SCIPPythonGraphDecoder")
+    assert indexers["py"] == indexers["python"]
+    assert decoders["py"] == decoders["python"]
+
+    assert indexers["go"].endswith("scip_indexer_go:SCIPGoIndexer")
+    assert decoders["go"].endswith("scip_decode_go:SCIPGoGraphDecoder")
+    assert indexers["golang"] == indexers["go"]
+    assert decoders["golang"] == decoders["go"]
+
+    assert indexers["cpp"].endswith("clangd_indexer:ClangdIndexer")
+    assert decoders["cpp"].endswith("clangd_decode:ClangdGraphDecoder")
+    assert indexers["c"] == indexers["cpp"]
+    assert decoders["c"] == decoders["cpp"]
+
+    assert indexers["ts"].endswith("scip_indexer_ts:SCIPTypeScriptIndexer")
+    assert decoders["ts"].endswith("scip_decode_ts:SCIPTypeScriptGraphDecoder")
+    assert graph_indexer_path("javascript") == indexers["ts"]
+    assert graph_decoder_path("typescript") == decoders["ts"]
+
+    assert graph_cold_start_backend("cpp") == "clangd"
+    assert graph_cold_start_backend("python") == "scip"
+    assert graph_indexer_path("java") is None
+    assert graph_decoder_path("java") is None

--- a/test/test_ls_router_registry.py
+++ b/test/test_ls_router_registry.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for registry-driven LS router delegate selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.ls_router import LSGraphDecoder, LSIndexer
+
+
+@pytest.mark.parametrize(
+    ("language", "delegate_class"),
+    [
+        ("python", "SCIPPythonIndexer"),
+        ("py", "SCIPPythonIndexer"),
+        ("go", "SCIPGoIndexer"),
+        ("golang", "SCIPGoIndexer"),
+        ("rust", "SCIPRustIndexer"),
+        ("rs", "SCIPRustIndexer"),
+        ("typescript", "SCIPTypeScriptIndexer"),
+        ("javascript", "SCIPTypeScriptIndexer"),
+        ("cpp", "ClangdIndexer"),
+        ("c", "ClangdIndexer"),
+    ],
+)
+def test_ls_indexer_uses_registry_delegate(tmp_path, language, delegate_class):
+    indexer = LSIndexer(tmp_path, language=language, output_dir=tmp_path / "out")
+
+    assert indexer._delegate.__class__.__name__ == delegate_class
+
+
+def test_ls_indexer_passes_decoder_backend_only_to_scip(tmp_path):
+    py_indexer = LSIndexer(
+        tmp_path / "py",
+        language="python",
+        output_dir=tmp_path / "py-out",
+        decoder_backend="core",
+    )
+    assert py_indexer._delegate.decoder_backend == "core"
+
+    cpp_indexer = LSIndexer(
+        tmp_path / "cpp",
+        language="cpp",
+        output_dir=tmp_path / "cpp-out",
+        decoder_backend="core",
+    )
+
+    assert cpp_indexer._delegate.__class__.__name__ == "ClangdIndexer"
+    assert not hasattr(cpp_indexer._delegate, "decoder_backend")
+
+
+@pytest.mark.parametrize(
+    ("language", "delegate_class"),
+    [
+        ("python", "SCIPPythonGraphDecoder"),
+        ("go", "SCIPGoGraphDecoder"),
+        ("rust", "SCIPRustGraphDecoder"),
+        ("typescript", "SCIPTypeScriptGraphDecoder"),
+        ("javascript", "SCIPTypeScriptGraphDecoder"),
+        ("cpp", "ClangdGraphDecoder"),
+    ],
+)
+def test_ls_graph_decoder_uses_registry_delegate(tmp_path, language, delegate_class):
+    decoder = LSGraphDecoder(
+        str(tmp_path / "index.decoded"),
+        project_root=str(tmp_path),
+        language=language,
+    )
+
+    assert decoder._delegate.__class__.__name__ == delegate_class
+
+
+def test_ls_indexer_graph_patch_constructs_graph_patcher_without_profiler_kwarg(
+    tmp_path, monkeypatch
+):
+    indexer = LSIndexer(tmp_path, language="python", output_dir=tmp_path / "out")
+    calls = {}
+
+    from codeminer.graph.incremental import graph_patcher
+
+    def fake_detect_changed_files(project_root, base_commit, target_commit, extensions):
+        calls["detect"] = (project_root, base_commit, target_commit, extensions)
+        return {"modified": [], "added": [], "deleted": [], "renamed": []}
+
+    def fake_patch_files(self, changed_files):
+        calls["patch"] = changed_files
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        graph_patcher.GraphPatcher,
+        "detect_changed_files",
+        staticmethod(fake_detect_changed_files),
+    )
+    monkeypatch.setattr(graph_patcher.GraphPatcher, "patch_files", fake_patch_files)
+
+    result = indexer.graph_patch(CodeGraph(str(tmp_path)), "base", "HEAD")
+
+    assert result == {"ok": True}
+    assert calls["detect"][1:] == ("base", "HEAD", {".py"})
+    assert calls["patch"] == {"modified": [], "added": [], "deleted": [], "renamed": []}


### PR DESCRIPTION
## Summary

Routes LS indexer and decoder delegate selection through the language registry on top of #228.

## Changes

- Added graph indexer/decoder class paths and cold-start backend helpers to `LanguageSpec`.
- Refactored `LSIndexer` and `LSGraphDecoder` to lazy-load delegates from the registry instead of maintaining local hard-coded maps.
- Added Go to the unified `LSGraphDecoder` path, matching existing Go indexer/decoder support.
- Fixed `LSIndexer.graph_patch()` so it no longer passes an unsupported `profiler` keyword into `GraphPatcher`.
- Added focused unit coverage for delegate selection, decoder backend handling, Go decoder routing, and graph patch construction.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking the main issue-186 chain:

- Main-chain tip #238 full unit validation: `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1084 passed, 10 skipped`)
- Original focused validation included `test/test_languages.py`, `test/test_ls_router_registry.py`, `test/graph/incremental/test_graph_patcher_registry.py`, and `test/graph/incremental/test_lsp_decoder.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Stacked on #228. Parent is published but not merged yet. Refs #186.