### PR TITLE
[codex] Move LSP metadata into language registry

### DIFF
--- a/codeminer/graph/incremental/lsp_client.py
+++ b/codeminer/graph/incremental/lsp_client.py
@@ -24,8 +24,9 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+from ...languages import lsp_command_for_language, normalize_graph_language
 from ...log_utils import get_logger
-from ...scip_interface.rust_analyzer import rust_analyzer_command, rust_toolchain
+from ...scip_interface.rust_analyzer import rust_toolchain
 
 logger = get_logger(__name__)
 
@@ -118,23 +119,6 @@ SYMBOL_KIND_NAMES = {
     24: "Event",
     25: "Operator",
     26: "TypeParameter",
-}
-
-# Default LSP server commands per language
-LSP_COMMANDS = {
-    "python": ["basedpyright-langserver", "--stdio"],
-    "rust": ["rust-analyzer"],
-    "typescript": ["typescript-language-server", "--stdio"],
-    "ts": ["typescript-language-server", "--stdio"],
-    "go": ["gopls", "serve"],
-    "cpp": ["clangd"],
-    "c": ["clangd"],
-    "c++": ["clangd"],
-}
-
-# Alternative LSP servers (e.g. pylsp supports semanticTokens, pyright does not)
-LSP_COMMANDS_ALT = {
-    "python": ["pylsp"],
 }
 
 # Common locations to search for LSP binaries not on PATH
@@ -1203,18 +1187,11 @@ class LSPClient:
     @staticmethod
     def get_lsp_command(language: str) -> Optional[list[str]]:
         """Get the default LSP server command for a language."""
-        if language == "rust":
-            return rust_analyzer_command()
-        cmd = LSP_COMMANDS.get(language)
+        cmd = lsp_command_for_language(language)
         if not cmd:
             return None
         binary = cmd[0]
-        resolved = shutil.which(binary)
-        if not resolved:
-            # Check inside the running Python environment's bin dir
-            env_bin = Path(sys.executable).parent / binary
-            if env_bin.exists():
-                resolved = str(env_bin)
+        resolved = resolve_lsp_binary(binary)
         if resolved:
             return [resolved] + cmd[1:]
         return cmd
@@ -1222,10 +1199,13 @@ class LSPClient:
     @staticmethod
     def check_lsp_available(language: str) -> bool:
         """Check if the LSP server binary is available."""
-        if language == "rust":
+        cmd = LSPClient.get_lsp_command(language)
+        if not cmd:
+            return False
+        if normalize_graph_language(language) == "rust":
             try:
                 subprocess.run(
-                    rust_analyzer_command("--version"),
+                    cmd + ["--version"],
                     check=True,
                     capture_output=True,
                     text=True,
@@ -1238,10 +1218,7 @@ class LSPClient:
                 subprocess.TimeoutExpired,
             ):
                 return False
-        cmd = LSP_COMMANDS.get(language)
-        if not cmd:
-            return False
-        return resolve_lsp_binary(cmd[0]) is not None
+        return Path(cmd[0]).exists() or resolve_lsp_binary(cmd[0]) is not None
 
 
 def uri_to_relpath(uri: str, project_root: str) -> Optional[str]:

--- a/codeminer/graph/incremental/patcher_base.py
+++ b/codeminer/graph/incremental/patcher_base.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Optional
 
+from ...languages import lsp_command_for_language, lsp_language_id_for_language
 from ...log_utils import get_logger
 from ...profiler import Profiler
 from ...types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE
@@ -37,9 +38,10 @@ class PatcherBase(SubgraphMgr):
     Subclasses must implement:
     - _build_unified_name: construct unified_name from LSP symbol info
     - _get_crossfile_token_types: which semanticToken types to query
-    - get_lsp_command: LSP server command
 
     Subclasses may override:
+    - get_lsp_command: custom LSP server command
+    - _language_id: custom LSP language id
     - flatten_symbols: convert LSP documentSymbol to flat dict (default provided)
     - get_old_symbols: extract old symbols from graph (default provided)
     - GRAPH_SYMBOL_KINDS: which SymbolKinds to process (default provided)
@@ -64,6 +66,7 @@ class PatcherBase(SubgraphMgr):
             25,  # Operator
         }
     )
+    REGISTRY_LANGUAGE: str | None = None
 
     def __init__(
         self,
@@ -93,9 +96,19 @@ class PatcherBase(SubgraphMgr):
     # Abstract methods — language-specific
     # ═══════════════════════════════════════════════════════════
 
-    @abstractmethod
     def get_lsp_command(self) -> list[str]:
         """Return the LSP server command for this language."""
+        if not self.REGISTRY_LANGUAGE:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} must define REGISTRY_LANGUAGE "
+                "or override get_lsp_command()."
+            )
+        command = lsp_command_for_language(self.REGISTRY_LANGUAGE)
+        if command is None:
+            raise ValueError(
+                f"No LSP command registered for {self.REGISTRY_LANGUAGE!r}"
+            )
+        return command
 
     @abstractmethod
     def flatten_symbols(
@@ -238,7 +251,9 @@ class PatcherBase(SubgraphMgr):
 
     def _language_id(self) -> str:
         """Return the LSP language ID. Override if needed."""
-        return "unknown"
+        if not self.REGISTRY_LANGUAGE:
+            return "unknown"
+        return lsp_language_id_for_language(self.REGISTRY_LANGUAGE) or "unknown"
 
     # ═══════════════════════════════════════════════════════════
     # Top-level patch entry point

--- a/codeminer/graph/incremental/patcher_cpp.py
+++ b/codeminer/graph/incremental/patcher_cpp.py
@@ -32,11 +32,7 @@ logger = get_logger(__name__)
 class PatcherCpp(PatcherBase):
     """C/C++ incremental patcher using clangd .idx files."""
 
-    def get_lsp_command(self):
-        return ["clangd"]
-
-    def _language_id(self):
-        return "cpp"
+    REGISTRY_LANGUAGE = "cpp"
 
     def _get_crossfile_token_types(self):
         return {

--- a/codeminer/graph/incremental/patcher_go.py
+++ b/codeminer/graph/incremental/patcher_go.py
@@ -15,11 +15,7 @@ from .patcher_base import PatcherBase
 class PatcherGo(PatcherBase):
     """Go incremental patcher. Matches SCIPGoGraphDecoder naming."""
 
-    def get_lsp_command(self):
-        return ["gopls", "serve"]
-
-    def _language_id(self):
-        return "go"
+    REGISTRY_LANGUAGE = "go"
 
     def _should_skip_path(self, path: str) -> bool:
         """SCIP-go skips ``*_test.go`` files (see scip_decode_go.py:92).

--- a/codeminer/graph/incremental/patcher_python.py
+++ b/codeminer/graph/incremental/patcher_python.py
@@ -13,20 +13,7 @@ from .patcher_base import PatcherBase
 class PatcherPython(PatcherBase):
     """Python incremental patcher. Matches SCIPPythonGraphDecoder naming."""
 
-    def get_lsp_command(self):
-        # ty 0.0.33 is faster on small queries but hangs on some larger
-        # workspaces (observed on xarray bin=300, 36min+ no response).
-        # basedpyright is slower but reliable; default to it. Override via
-        # ``CODEMINER_PYTHON_LSP_CMD=ty\ server`` to experiment with ty.
-        import os
-
-        cmd = os.environ.get("CODEMINER_PYTHON_LSP_CMD")
-        if cmd:
-            return cmd.split()
-        return ["basedpyright-langserver", "--stdio"]
-
-    def _language_id(self):
-        return "python"
+    REGISTRY_LANGUAGE = "python"
 
     def _get_crossfile_token_types(self):
         return {

--- a/codeminer/graph/incremental/patcher_rust.py
+++ b/codeminer/graph/incremental/patcher_rust.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import re
 
-from ...scip_interface.rust_analyzer import rust_analyzer_command
 from ...types import NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
 from .patcher_base import PatcherBase
 
@@ -16,11 +15,7 @@ from .patcher_base import PatcherBase
 class PatcherRust(PatcherBase):
     """Rust incremental patcher. Matches SCIPRustGraphDecoder naming."""
 
-    def get_lsp_command(self):
-        return rust_analyzer_command()
-
-    def _language_id(self):
-        return "rust"
+    REGISTRY_LANGUAGE = "rust"
 
     def _get_crossfile_token_types(self):
         return {

--- a/codeminer/graph/incremental/patcher_ts.py
+++ b/codeminer/graph/incremental/patcher_ts.py
@@ -13,11 +13,7 @@ from .patcher_base import PatcherBase
 class PatcherTS(PatcherBase):
     """TS/JS incremental patcher. Matches SCIPTypeScriptGraphDecoder naming."""
 
-    def get_lsp_command(self):
-        return ["typescript-language-server", "--stdio"]
-
-    def _language_id(self):
-        return "typescript"
+    REGISTRY_LANGUAGE = "ts"
 
     def _get_crossfile_token_types(self):
         return {

--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -14,7 +14,10 @@ hand.
 
 from __future__ import annotations
 
+import os
+import shlex
 from dataclasses import dataclass
+from importlib import import_module
 from typing import Dict, FrozenSet, Iterable, Literal, Optional, Tuple
 
 ExtensionKind = Literal["chunker", "gt", "graph"]
@@ -42,6 +45,10 @@ class LanguageSpec:
     graph_decoder: Optional[str] = None
     incremental_backend: Optional[str] = None
     incremental_patcher: Optional[str] = None
+    lsp_language_id: Optional[str] = None
+    lsp_command: Tuple[str, ...] = ()
+    lsp_command_env: Optional[str] = None
+    lsp_command_factory: Optional[str] = None
     core_decoder: bool = False
     core_decoder_aliases: Tuple[str, ...] = ()
 
@@ -66,6 +73,9 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         graph_decoder="codeminer.scip_interface.scip_decode_python:SCIPPythonGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_python:PatcherPython",
+        lsp_language_id="python",
+        lsp_command=("basedpyright-langserver", "--stdio"),
+        lsp_command_env="CODEMINER_PYTHON_LSP_CMD",
         core_decoder=True,
     ),
     LanguageSpec(
@@ -87,6 +97,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         graph_decoder="codeminer.scip_interface.scip_decode_go:SCIPGoGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_go:PatcherGo",
+        lsp_language_id="go",
+        lsp_command=("gopls", "serve"),
         core_decoder=True,
     ),
     LanguageSpec(
@@ -108,6 +120,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         graph_decoder="codeminer.scip_interface.scip_decode_rust:SCIPRustGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_rust:PatcherRust",
+        lsp_language_id="rust",
+        lsp_command_factory="codeminer.scip_interface.rust_analyzer:rust_analyzer_command",
         core_decoder=True,
     ),
     LanguageSpec(
@@ -129,6 +143,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         graph_decoder="codeminer.ls_index.clangd_decode:ClangdGraphDecoder",
         incremental_backend="clangd",
         incremental_patcher="codeminer.graph.incremental.patcher_cpp:PatcherCpp",
+        lsp_language_id="cpp",
+        lsp_command=("clangd",),
     ),
     LanguageSpec(
         key="javascript",
@@ -153,6 +169,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         graph_decoder="codeminer.scip_interface.scip_decode_ts:SCIPTypeScriptGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_ts:PatcherTS",
+        lsp_language_id="typescript",
+        lsp_command=("typescript-language-server", "--stdio"),
     ),
     LanguageSpec(
         key="typescript",
@@ -177,6 +195,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         graph_decoder="codeminer.scip_interface.scip_decode_ts:SCIPTypeScriptGraphDecoder",
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_ts:PatcherTS",
+        lsp_language_id="typescript",
+        lsp_command=("typescript-language-server", "--stdio"),
         core_decoder=True,
         core_decoder_aliases=("ts", "js"),
     ),
@@ -414,6 +434,52 @@ def graph_cold_start_backend(language: str) -> Optional[str]:
     return graph_cold_start_backends(include_aliases=False).get(graph_language)
 
 
+def lsp_language_id_for_language(language: str) -> Optional[str]:
+    """Return the LSP language id for a raw graph language."""
+
+    graph_language = normalize_graph_language(language)
+    if graph_language is None:
+        return None
+    return _graph_surface_values("lsp_language_id", include_aliases=False).get(
+        graph_language
+    )
+
+
+def _call_no_arg_factory(path: str) -> list[str]:
+    module_name, separator, func_name = path.partition(":")
+    if not separator or not module_name or not func_name:
+        raise ValueError(f"Invalid factory path: {path!r}")
+    module = import_module(module_name)
+    func = getattr(module, func_name)
+    result = func()
+    return list(result)
+
+
+def lsp_command_for_language(language: str) -> Optional[list[str]]:
+    """Return the configured LSP command for a raw graph language."""
+
+    graph_language = normalize_graph_language(language)
+    if graph_language is None:
+        return None
+
+    spec = next(
+        (spec for spec in LANGUAGE_SPECS if spec.graph_language == graph_language),
+        None,
+    )
+    if spec is None:
+        return None
+
+    if spec.lsp_command_env:
+        override = os.environ.get(spec.lsp_command_env)
+        if override:
+            return shlex.split(override)
+    if spec.lsp_command_factory:
+        return _call_no_arg_factory(spec.lsp_command_factory)
+    if spec.lsp_command:
+        return list(spec.lsp_command)
+    return None
+
+
 def incremental_patcher_paths(include_aliases: bool = True) -> Dict[str, str]:
     """Return graph backend language keys mapped to incremental patcher paths."""
 
@@ -463,6 +529,8 @@ __all__ = [
     "graph_language_aliases",
     "incremental_patcher_path",
     "incremental_patcher_paths",
+    "lsp_command_for_language",
+    "lsp_language_id_for_language",
     "normalize_agent_language",
     "normalize_chunker_language",
     "normalize_graph_language",

--- a/test/graph/incremental/test_graph_patcher_registry.py
+++ b/test/graph/incremental/test_graph_patcher_registry.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 
 import pytest
 
+from codeminer.graph.code_graph import CodeGraph
 from codeminer.graph.incremental.graph_patcher import GraphPatcher
+from codeminer.graph.incremental.patcher_cpp import PatcherCpp
+from codeminer.graph.incremental.patcher_go import PatcherGo
+from codeminer.graph.incremental.patcher_python import PatcherPython
+from codeminer.graph.incremental.patcher_rust import PatcherRust
+from codeminer.graph.incremental.patcher_ts import PatcherTS
 
 
 @pytest.mark.parametrize(
@@ -39,3 +45,60 @@ def test_graph_patcher_routes_through_language_registry(
 def test_graph_patcher_rejects_unregistered_language(tmp_path):
     with pytest.raises(ValueError, match="Unsupported language: java"):
         GraphPatcher(str(tmp_path), None, "java")
+
+
+@pytest.mark.parametrize(
+    ("patcher_cls", "command", "language_id"),
+    [
+        (PatcherPython, ["basedpyright-langserver", "--stdio"], "python"),
+        (PatcherGo, ["gopls", "serve"], "go"),
+        (PatcherTS, ["typescript-language-server", "--stdio"], "typescript"),
+        (PatcherCpp, ["clangd"], "cpp"),
+    ],
+)
+def test_patcher_lsp_metadata_comes_from_language_registry(
+    tmp_path, patcher_cls, command, language_id
+):
+    patcher = patcher_cls(str(tmp_path), CodeGraph(str(tmp_path)))
+
+    assert patcher.get_lsp_command() == command
+    assert patcher._language_id() == language_id
+
+
+def test_python_patcher_lsp_command_allows_registry_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("CODEMINER_PYTHON_LSP_CMD", "ty server")
+
+    patcher = PatcherPython(str(tmp_path), CodeGraph(str(tmp_path)))
+
+    assert patcher.get_lsp_command() == ["ty", "server"]
+
+
+def test_rust_patcher_lsp_command_uses_registry_factory(tmp_path, monkeypatch):
+    import codeminer.scip_interface.rust_analyzer as rust_analyzer
+
+    monkeypatch.setattr(
+        rust_analyzer,
+        "rust_analyzer_command",
+        lambda *args: ["rustup", "run", "stable", "rust-analyzer", *args],
+    )
+
+    patcher = PatcherRust(str(tmp_path), CodeGraph(str(tmp_path)))
+
+    assert patcher.get_lsp_command() == [
+        "rustup",
+        "run",
+        "stable",
+        "rust-analyzer",
+    ]
+    assert patcher._language_id() == "rust"
+
+
+def test_lsp_client_command_lookup_uses_language_registry(monkeypatch):
+    from codeminer.graph.incremental import lsp_client
+
+    monkeypatch.setattr(lsp_client, "resolve_lsp_binary", lambda _binary: None)
+    monkeypatch.setenv("CODEMINER_PYTHON_LSP_CMD", "ty server")
+
+    assert lsp_client.LSPClient.get_lsp_command("python") == ["ty", "server"]
+    assert lsp_client.LSPClient.get_lsp_command("go") == ["gopls", "serve"]
+    assert lsp_client.LSPClient.get_lsp_command("java") is None

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -16,6 +16,8 @@ from codeminer.languages import (
     graph_indexer_paths,
     incremental_patcher_path,
     incremental_patcher_paths,
+    lsp_command_for_language,
+    lsp_language_id_for_language,
     normalize_agent_language,
     normalize_chunker_language,
     normalize_graph_language,
@@ -139,3 +141,23 @@ def test_graph_indexer_and_decoder_paths_follow_graph_language_aliases():
     assert graph_cold_start_backend("python") == "scip"
     assert graph_indexer_path("java") is None
     assert graph_decoder_path("java") is None
+
+
+def test_lsp_metadata_follows_graph_language_aliases(monkeypatch):
+    assert lsp_language_id_for_language("python") == "python"
+    assert lsp_command_for_language("python") == ["basedpyright-langserver", "--stdio"]
+
+    monkeypatch.setenv("CODEMINER_PYTHON_LSP_CMD", "ty server")
+    assert lsp_command_for_language("py") == ["ty", "server"]
+
+    assert lsp_language_id_for_language("go") == "go"
+    assert lsp_command_for_language("golang") == ["gopls", "serve"]
+
+    assert lsp_language_id_for_language("cpp") == "cpp"
+    assert lsp_command_for_language("c++") == ["clangd"]
+
+    assert lsp_language_id_for_language("javascript") == "typescript"
+    assert lsp_command_for_language("ts") == ["typescript-language-server", "--stdio"]
+
+    assert lsp_language_id_for_language("java") is None
+    assert lsp_command_for_language("java") is None


### PR DESCRIPTION
## Summary

Moves LSP command and language-id metadata into `LanguageSpec` on top of #229.

## Changes

- Added LSP language id, command, env override, and command-factory metadata to `LanguageSpec`.
- Moved patcher LSP command/language id defaults into `PatcherBase` registry helpers.
- Removed duplicated `LSP_COMMANDS` tables from `LSPClient` and routed command lookup through the registry.
- Preserved Python `CODEMINER_PYTHON_LSP_CMD` override and Rust `rust_analyzer_command()` behavior through registry metadata.
- Added focused coverage for registry command lookup, patcher command/language-id defaults, env overrides, and `LSPClient.get_lsp_command()`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking the main issue-186 chain:

- Main-chain tip #238 full unit validation: `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1084 passed, 10 skipped`)
- Original focused validation included `test/test_languages.py`, `test/graph/incremental/test_graph_patcher_registry.py`, `test/graph/incremental/test_lsp_decoder.py`, and `test/test_ls_router_registry.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Stacked on #229. Parent is published but not merged yet. Refs #186.