### PR TITLE
[codex] Route chunkers through language registry

### DIFF
--- a/codeminer/code_chunking/__init__.py
+++ b/codeminer/code_chunking/__init__.py
@@ -6,13 +6,29 @@
 Code chunking module for splitting source code files into semantic chunks.
 """
 
-from ..languages import chunker_language_aliases, normalize_chunker_language
+from importlib import import_module
+from typing import Type
+
+from ..languages import chunker_language_aliases, get_chunker_spec
 from .base import BaseCodeChunker, CodeChunk
 from .cpp_chunker import CppCodeChunker
 from .go_chunker import GoCodeChunker
 from .js_chunker import JsTsCodeChunker
 from .python_chunker import PythonCodeChunker
 from .rust_chunker import RustCodeChunker
+
+
+def _load_chunker_class(path: str) -> Type[BaseCodeChunker]:
+    """Import a chunker class from a ``module:Class`` registry path."""
+
+    module_name, separator, class_name = path.partition(":")
+    if not separator or not module_name or not class_name:
+        raise ValueError(f"Invalid chunker path: {path!r}")
+    module = import_module(module_name)
+    cls = getattr(module, class_name)
+    if not issubclass(cls, BaseCodeChunker):
+        raise TypeError(f"Registered chunker is not a BaseCodeChunker subclass: {path}")
+    return cls
 
 
 # Factory function to create appropriate chunker
@@ -50,62 +66,23 @@ def create_chunker(
     Raises:
         ValueError: If the language is not supported
     """
-    raw_language = language
-    language = normalize_chunker_language(language)
-    if language is None:
+    spec = get_chunker_spec(language)
+    if spec is None or spec.chunker_language is None or spec.chunker_class is None:
         supported = ", ".join(sorted(chunker_language_aliases()))
-        raise ValueError(
-            f"Unsupported language: {raw_language}. Supported: {supported}"
-        )
+        raise ValueError(f"Unsupported language: {language}. Supported: {supported}")
 
-    if language == "python":
-        return PythonCodeChunker(
-            max_lines_per_chunk=max_lines_per_chunk,
-            chunk_depth=chunk_depth,
-            include_header_epilogue=include_header_epilogue,
-            l2_level_exclusive=l2_level_exclusive,
-            skeleton_mode=skeleton_mode,
-            include_l2_in_file_skeleton=include_l2_in_file_skeleton,
-        )
-    elif language == "cpp":
-        return CppCodeChunker(
-            max_lines_per_chunk=max_lines_per_chunk,
-            chunk_depth=chunk_depth,
-            include_header_epilogue=include_header_epilogue,
-            l2_level_exclusive=l2_level_exclusive,
-            skeleton_mode=skeleton_mode,
-            include_l2_in_file_skeleton=include_l2_in_file_skeleton,
-        )
-    elif language == "rust":
-        return RustCodeChunker(
-            max_lines_per_chunk=max_lines_per_chunk,
-            chunk_depth=chunk_depth,
-            include_header_epilogue=include_header_epilogue,
-            l2_level_exclusive=l2_level_exclusive,
-            skeleton_mode=skeleton_mode,
-            include_l2_in_file_skeleton=include_l2_in_file_skeleton,
-        )
-    elif language == "go":
-        return GoCodeChunker(
-            max_lines_per_chunk=max_lines_per_chunk,
-            chunk_depth=chunk_depth,
-            include_header_epilogue=include_header_epilogue,
-            l2_level_exclusive=l2_level_exclusive,
-            skeleton_mode=skeleton_mode,
-            include_l2_in_file_skeleton=include_l2_in_file_skeleton,
-        )
-    elif language in ("javascript", "typescript"):
-        return JsTsCodeChunker(
-            language=language,
-            max_lines_per_chunk=max_lines_per_chunk,
-            chunk_depth=chunk_depth,
-            include_header_epilogue=include_header_epilogue,
-            l2_level_exclusive=l2_level_exclusive,
-            skeleton_mode=skeleton_mode,
-            include_l2_in_file_skeleton=include_l2_in_file_skeleton,
-        )
-    else:
-        raise ValueError(f"Unsupported language: {language}")
+    cls = _load_chunker_class(spec.chunker_class)
+    kwargs = {
+        "max_lines_per_chunk": max_lines_per_chunk,
+        "chunk_depth": chunk_depth,
+        "include_header_epilogue": include_header_epilogue,
+        "l2_level_exclusive": l2_level_exclusive,
+        "skeleton_mode": skeleton_mode,
+        "include_l2_in_file_skeleton": include_l2_in_file_skeleton,
+    }
+    if spec.chunker_pass_language:
+        kwargs["language"] = spec.chunker_language
+    return cls(**kwargs)
 
 
 __all__ = [

--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -32,6 +32,8 @@ class LanguageSpec:
     aliases: Tuple[str, ...] = ()
     chunker_language: Optional[str] = None
     chunker_aliases: Tuple[str, ...] = ()
+    chunker_class: Optional[str] = None
+    chunker_pass_language: bool = False
     chunk_extensions: Tuple[str, ...] = ()
     gt_language: Optional[str] = None
     gt_extensions: Tuple[str, ...] = ()
@@ -60,6 +62,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         aliases=("py", "python3"),
         chunker_language="python",
         chunker_aliases=("python",),
+        chunker_class="codeminer.code_chunking.python_chunker:PythonCodeChunker",
         chunk_extensions=(".py", ".pyx", ".pyi"),
         gt_language="python",
         gt_extensions=(".py",),
@@ -84,6 +87,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         aliases=("golang",),
         chunker_language="go",
         chunker_aliases=("go", "golang"),
+        chunker_class="codeminer.code_chunking.go_chunker:GoCodeChunker",
         chunk_extensions=(".go",),
         gt_language="go",
         gt_extensions=(".go",),
@@ -107,6 +111,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         aliases=("rs",),
         chunker_language="rust",
         chunker_aliases=("rust",),
+        chunker_class="codeminer.code_chunking.rust_chunker:RustCodeChunker",
         chunk_extensions=(".rs",),
         gt_language="rust",
         gt_extensions=(".rs",),
@@ -130,6 +135,7 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         aliases=("c", "c++", "cxx"),
         chunker_language="cpp",
         chunker_aliases=("cpp", "c++", "cxx"),
+        chunker_class="codeminer.code_chunking.cpp_chunker:CppCodeChunker",
         chunk_extensions=(".cpp", ".cxx", ".cc", ".c", ".hpp", ".h", ".hxx"),
         gt_language="cpp",
         gt_extensions=(".c", ".cpp", ".cc", ".cxx", ".h", ".hpp"),
@@ -152,6 +158,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         aliases=("js", "jsx"),
         chunker_language="javascript",
         chunker_aliases=("javascript", "js"),
+        chunker_class="codeminer.code_chunking.js_chunker:JsTsCodeChunker",
+        chunker_pass_language=True,
         chunk_extensions=(".js", ".jsx", ".mjs"),
         gt_language="javascript",
         gt_extensions=(".js", ".jsx"),
@@ -178,6 +186,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         aliases=("ts", "tsx"),
         chunker_language="typescript",
         chunker_aliases=("typescript", "ts"),
+        chunker_class="codeminer.code_chunking.js_chunker:JsTsCodeChunker",
+        chunker_pass_language=True,
         chunk_extensions=(".ts", ".tsx", ".mts", ".cts"),
         gt_language="typescript",
         gt_extensions=(".ts", ".tsx"),
@@ -267,6 +277,18 @@ def normalize_chunker_language(language: str) -> Optional[str]:
     return _CHUNKER_ALIASES.get(_norm(language))
 
 
+def get_chunker_spec(language: str) -> Optional[LanguageSpec]:
+    """Return the LanguageSpec used by the chunker factory."""
+
+    chunker_language = normalize_chunker_language(language)
+    if chunker_language is None:
+        return None
+    for spec in LANGUAGE_SPECS:
+        if spec.chunker_language == chunker_language:
+            return spec
+    return None
+
+
 def normalize_graph_language(language: str) -> Optional[str]:
     """Normalize a raw language string to the graph/LS backend key."""
 
@@ -298,6 +320,33 @@ def chunker_languages() -> Tuple[str, ...]:
     return _unique(
         spec.chunker_language for spec in LANGUAGE_SPECS if spec.chunker_language
     )
+
+
+def chunker_class_paths(include_aliases: bool = True) -> Dict[str, str]:
+    """Return chunker language keys mapped to chunker class paths."""
+
+    by_language: Dict[str, str] = {}
+    for spec in LANGUAGE_SPECS:
+        if spec.chunker_language and spec.chunker_class:
+            by_language[spec.chunker_language] = spec.chunker_class
+
+    if not include_aliases:
+        return dict(by_language)
+
+    result = dict(by_language)
+    for alias, language in chunker_language_aliases().items():
+        if language in by_language:
+            result[alias] = by_language[language]
+    return result
+
+
+def chunker_class_path(language: str) -> Optional[str]:
+    """Return the chunker class path for a raw chunker language."""
+
+    spec = get_chunker_spec(language)
+    if spec is None:
+        return None
+    return spec.chunker_class
 
 
 def graph_language_aliases() -> Dict[str, str]:
@@ -515,9 +564,12 @@ __all__ = [
     "agent_language_aliases",
     "chunker_language_aliases",
     "chunker_languages",
+    "chunker_class_path",
+    "chunker_class_paths",
     "core_decoder_languages",
     "extension_to_language_map",
     "extensions_for_language",
+    "get_chunker_spec",
     "get_language_spec",
     "graph_cold_start_backend",
     "graph_cold_start_backends",

--- a/test/chunker/test_chunker_registry.py
+++ b/test/chunker/test_chunker_registry.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for registry-driven chunker factory routing."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.code_chunking import create_chunker
+
+
+@pytest.mark.parametrize(
+    ("language", "class_name"),
+    [
+        ("python", "PythonCodeChunker"),
+        ("go", "GoCodeChunker"),
+        ("golang", "GoCodeChunker"),
+        ("rust", "RustCodeChunker"),
+        ("cpp", "CppCodeChunker"),
+        ("c++", "CppCodeChunker"),
+        ("javascript", "JsTsCodeChunker"),
+        ("js", "JsTsCodeChunker"),
+        ("typescript", "JsTsCodeChunker"),
+        ("ts", "JsTsCodeChunker"),
+    ],
+)
+def test_create_chunker_uses_language_registry(language, class_name):
+    chunker = create_chunker(
+        language,
+        max_lines_per_chunk=42,
+        chunk_depth=1,
+        include_header_epilogue=True,
+        l2_level_exclusive=False,
+        skeleton_mode=True,
+        include_l2_in_file_skeleton=False,
+    )
+
+    assert chunker.__class__.__name__ == class_name
+    assert chunker.max_lines_per_chunk == 42
+    assert chunker.chunk_depth == 1
+    assert chunker.include_header_epilogue is True
+    assert chunker.l2_level_exclusive is False
+    assert chunker.skeleton_mode is True
+    assert chunker.include_l2_in_file_skeleton is False
+
+
+def test_create_chunker_rejects_unsupported_language():
+    with pytest.raises(ValueError, match=r"Unsupported language: c\. Supported:"):
+        create_chunker("c")

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -5,9 +5,12 @@
 """Tests for the central language metadata registry."""
 
 from codeminer.languages import (
+    chunker_class_path,
+    chunker_class_paths,
     chunker_languages,
     core_decoder_languages,
     extension_to_language_map,
+    get_chunker_spec,
     graph_cold_start_backend,
     graph_decoder_path,
     graph_decoder_paths,
@@ -91,6 +94,30 @@ def test_chunker_languages_are_current_supported_repo_chunkers():
         "javascript",
         "typescript",
     )
+
+
+def test_chunker_class_paths_follow_chunker_language_aliases():
+    paths = chunker_class_paths()
+
+    assert paths["python"].endswith("python_chunker:PythonCodeChunker")
+    assert paths["go"].endswith("go_chunker:GoCodeChunker")
+    assert paths["golang"] == paths["go"]
+    assert paths["rust"].endswith("rust_chunker:RustCodeChunker")
+    assert paths["cpp"].endswith("cpp_chunker:CppCodeChunker")
+    assert paths["c++"] == paths["cpp"]
+    assert paths["javascript"].endswith("js_chunker:JsTsCodeChunker")
+    assert paths["js"] == paths["javascript"]
+    assert paths["typescript"].endswith("js_chunker:JsTsCodeChunker")
+    assert paths["ts"] == paths["typescript"]
+
+    assert chunker_class_path("py") is None
+    assert chunker_class_path("js") == paths["javascript"]
+    assert chunker_class_path("java") is None
+
+    js_spec = get_chunker_spec("javascript")
+    ts_spec = get_chunker_spec("typescript")
+    assert js_spec is not None and js_spec.chunker_pass_language is True
+    assert ts_spec is not None and ts_spec.chunker_pass_language is True
 
 
 def test_incremental_patcher_paths_follow_graph_language_aliases():


### PR DESCRIPTION
## Summary

Routes chunker factory selection through the language registry on top of #230.

## Changes

- Added chunker class metadata to `LanguageSpec`, including the JS/TS constructor language flag.
- Refactored `create_chunker()` to lazy-load the configured chunker class from the registry instead of maintaining a hard-coded branch table.
- Added registry and factory tests for chunker class paths, aliases, unsupported languages, and constructor parameter forwarding.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking the main issue-186 chain:

- Main-chain tip #238 full unit validation: `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1084 passed, 10 skipped`)
- Original focused validation included `test/test_languages.py`, `test/chunker/test_chunker_registry.py`, `test/chunker/test_repo_chunking_config.py`, and `test/chunker`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Stacked on #230. Parent is published but not merged yet. Refs #186.