### PR TITLE
[codex] Derive core decoder languages from registry

### DIFF
--- a/codeminer/scip_interface/scip_decode_core.py
+++ b/codeminer/scip_interface/scip_decode_core.py
@@ -19,6 +19,7 @@ import time
 from typing import Dict, List, Optional
 
 from ..graph.code_graph import CodeGraph
+from ..languages import core_decoder_languages
 from ..log_utils import get_logger
 
 logger = get_logger(__name__)
@@ -38,8 +39,10 @@ else:
     _IMPORT_ERR = None
 
 
-# Languages accepted by the C++ backend (also accepts "ts"/"js" aliases).
-SUPPORTED_LANGUAGES = ("python", "go", "rust", "typescript")
+# Canonical languages accepted by the C++ backend. Aliases such as "ts" and
+# "js" are configured in LanguageSpec.core_decoder_aliases.
+SUPPORTED_LANGUAGES = core_decoder_languages(include_aliases=False)
+ACCEPTED_LANGUAGES = core_decoder_languages(include_aliases=True)
 
 
 def _ensure_available() -> None:
@@ -131,7 +134,7 @@ class SCIPDecoderCore:
     Args:
         index_file_path: path to index.decoded
         project_root: project root (for Go/Rust config file parsing)
-        language: one of {"python", "go", "rust", "typescript"}.
+        language: one of the registry languages with core decoder support.
     """
 
     def __init__(
@@ -140,14 +143,14 @@ class SCIPDecoderCore:
         project_root: Optional[str] = None,
         language: str = "python",
     ):
-        _ensure_available()
         self.index_file_path = index_file_path
         self.project_root = str(project_root) if project_root else None
         self.language = language.lower()
-        if self.language not in SUPPORTED_LANGUAGES + ("ts", "js"):
+        if self.language not in ACCEPTED_LANGUAGES:
             raise ValueError(
                 f"Unknown language {language!r}. " f"Supported: {SUPPORTED_LANGUAGES}."
             )
+        _ensure_available()
         self.timings: Dict[str, float] = {}
         self.code_graph: Optional[CodeGraph] = None
 

--- a/test/scip/test_scip_core_registry.py
+++ b/test/scip/test_scip_core_registry.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit coverage for registry-driven core decoder language metadata."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.languages import core_decoder_languages
+from codeminer.scip_interface import scip_decode_core
+
+
+def test_core_decoder_supported_languages_come_from_registry():
+    assert scip_decode_core.SUPPORTED_LANGUAGES == core_decoder_languages(
+        include_aliases=False
+    )
+    assert scip_decode_core.ACCEPTED_LANGUAGES == core_decoder_languages(
+        include_aliases=True
+    )
+    assert scip_decode_core.ACCEPTED_LANGUAGES == (
+        "python",
+        "go",
+        "rust",
+        "typescript",
+        "ts",
+        "js",
+    )
+
+
+def test_core_decoder_rejects_non_registry_language_before_availability_check(
+    monkeypatch,
+):
+    def fail_available():
+        raise AssertionError("_ensure_available should not run for invalid languages")
+
+    monkeypatch.setattr(scip_decode_core, "_ensure_available", fail_available)
+
+    with pytest.raises(ValueError, match="Unknown language 'java'"):
+        scip_decode_core.SCIPDecoderCore(
+            index_file_path="index.decoded",
+            project_root=None,
+            language="java",
+        )


### PR DESCRIPTION
## Summary

Derives optional SCIP core decoder language support from registry metadata on top of #231.

## Changes

- Derived `SCIPDecoderCore` canonical and accepted languages from `LanguageSpec.core_decoder` metadata.
- Kept TypeScript aliases (`ts`, `js`) in `LanguageSpec.core_decoder_aliases` instead of local tuple logic.
- Validated unsupported languages before checking optional C++ backend availability, so registry errors are not hidden by missing native builds.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking the main issue-186 chain:

- Main-chain tip #238 full unit validation: `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1084 passed, 10 skipped`)
- Original focused validation included `test/test_languages.py` and `test/scip/test_scip_core_registry.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Stacked on #231. Parent is published but not merged yet. Refs #186.