### PR TITLE
[codex] Add Java tree-sitter chunker

### DIFF
--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -37,6 +37,7 @@ class RepoChunkingConfig:
     cpp_extensions: Optional[Set[str]] = None
     rust_extensions: Optional[Set[str]] = None
     go_extensions: Optional[Set[str]] = None
+    java_extensions: Optional[Set[str]] = None
     javascript_extensions: Optional[Set[str]] = None
     typescript_extensions: Optional[Set[str]] = None
 
@@ -67,6 +68,9 @@ class RepoChunkingConfig:
 
         if self.go_extensions is None:
             self.go_extensions = extensions_for_language("go", "chunker")
+
+        if self.java_extensions is None:
+            self.java_extensions = extensions_for_language("java", "chunker")
 
         if self.javascript_extensions is None:
             self.javascript_extensions = extensions_for_language(

--- a/codeminer/code_chunking/CLAUDE.md
+++ b/codeminer/code_chunking/CLAUDE.md
@@ -1,6 +1,6 @@
 # code_chunking/ — rules
 
-Tree-sitter chunkers, one per language (`python`, `go`, `cpp`, `rust`, `js`).
+Tree-sitter chunkers, one per language (`python`, `go`, `cpp`, `rust`, `java`, `js`).
 The authoritative reference for chunk depths and the full per-language
 `chunk_type` tables is [`README.md`](./README.md) — read it before adding or
 changing a chunker. This file is the short list of rules that bite.
@@ -14,15 +14,18 @@ changing a chunker. This file is the short list of rules that bite.
 - **`.c` files use the `cpp` chunker.** There is no separate C chunker; the
   language→chunker map sends `.c` to `cpp`. Forgetting this produces empty
   `code_blocks` (the bug that silently broke redis/jqlang instances).
+- **Java is chunker/GT/agent-only for now.** The `.java` chunker is registered
+  for tree-sitter chunking and ground-truth extraction, but graph/LSP/core
+  backend support is still intentionally unset in the language registry.
 - **Chunk depth** (`chunk_depth` on `BaseCodeChunker`): L0 = whole file
   (skeleton when `skeleton_mode`), L1 = top-level symbols, L2 = nested
   methods/members (default; with `l2_level_exclusive=True` the L1 containers are
   dropped, keeping only their L2 members).
 - **Symbol chunk types** (`SYMBOL_CHUNK_TYPES`): `function`, `method`, `class`,
   `struct`, `type`, `interface`, `object`, `enum`, `trait`, `impl`, `var`,
-  `const`, `static`, `declaration`, `macro`, `variable`. Per-language L1
+  `const`, `static`, `declaration`, `macro`, `variable`, `record`. Per-language L1
   var/const kinds: Go `var`/`const`; Rust `const`/`static`/`type`; C++
-  `declaration`/`macro`; JS/TS `variable`.
+  `declaration`/`macro`; Java `record`; JS/TS `variable`.
 
 ## When adding a language / chunk type
 

--- a/codeminer/code_chunking/README.md
+++ b/codeminer/code_chunking/README.md
@@ -65,6 +65,16 @@ Controlled by the `chunk_depth` parameter in `BaseCodeChunker`:
 | `macro` | L1 | `preproc_def`, `preproc_function_def` | `#define MAX 100` |
 | `method` | L2 | method inside class body | `void start() {}` |
 
+### Java (`java_chunker.py`)
+
+| chunk_type | Level | AST node | Example |
+|------------|-------|----------|---------|
+| `class` | L1 | `class_declaration` | `class App {}` |
+| `interface` | L1 | `interface_declaration` | `interface Runner {}` |
+| `enum` | L1 | `enum_declaration` | `enum Mode { FAST }` |
+| `record` | L1 | `record_declaration` | `record Point(int x, int y) {}` |
+| `method` | L2 | `method_declaration`, `constructor_declaration` | `void run() {}`, `App() {}` |
+
 ### JavaScript / TypeScript (`js_chunker.py`)
 
 | chunk_type | Level | AST node | Example |
@@ -113,5 +123,6 @@ Used by `gt_locate.py` to select the correct chunker:
 | `.go` | `go` |
 | `.rs` | `rust` |
 | `.c`, `.cpp`, `.cc`, `.cxx`, `.h`, `.hpp` | `cpp` |
+| `.java` | `java` |
 | `.js`, `.jsx` | `javascript` |
 | `.ts`, `.tsx` | `typescript` |

--- a/codeminer/code_chunking/__init__.py
+++ b/codeminer/code_chunking/__init__.py
@@ -13,6 +13,7 @@ from ..languages import chunker_language_aliases, get_chunker_spec
 from .base import BaseCodeChunker, CodeChunk
 from .cpp_chunker import CppCodeChunker
 from .go_chunker import GoCodeChunker
+from .java_chunker import JavaCodeChunker
 from .js_chunker import JsTsCodeChunker
 from .python_chunker import PythonCodeChunker
 from .rust_chunker import RustCodeChunker
@@ -92,6 +93,7 @@ __all__ = [
     "CppCodeChunker",
     "RustCodeChunker",
     "GoCodeChunker",
+    "JavaCodeChunker",
     "JsTsCodeChunker",
     "create_chunker",
 ]

--- a/codeminer/code_chunking/java_chunker.py
+++ b/codeminer/code_chunking/java_chunker.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Java-specific code chunker implementation.
+"""
+
+from typing import List, Optional, Tuple
+
+from .base import BaseCodeChunker
+
+
+class JavaCodeChunker(BaseCodeChunker):
+    """
+    Code chunker for Java source files.
+
+    L1 entities: top-level classes, interfaces, enums, and records.
+    L2 entities: methods and constructors inside those containers.
+    Skeleton mode: file skeleton lists L1 declarations and member signatures.
+    """
+
+    _TYPE_NODES = {
+        "class_declaration": "class",
+        "interface_declaration": "interface",
+        "enum_declaration": "enum",
+        "record_declaration": "record",
+    }
+
+    _BODY_NODES = {
+        "class_body",
+        "interface_body",
+        "enum_body",
+        "enum_body_declarations",
+        "record_body",
+    }
+
+    def __init__(
+        self,
+        max_lines_per_chunk: Optional[int] = None,
+        chunk_depth: int = 2,
+        l2_level_exclusive: bool = True,
+        **kwargs,
+    ):
+        super().__init__(
+            "java",
+            max_lines_per_chunk=max_lines_per_chunk,
+            chunk_depth=chunk_depth,
+            l2_level_exclusive=l2_level_exclusive,
+            **kwargs,
+        )
+
+    def _find_top_level_definitions(
+        self, root_node, include_l2_in_file_skeleton: bool = False
+    ) -> List[Tuple]:
+        definitions: List[Tuple] = []
+
+        include_type_level = self.chunk_depth < 2 or not self.l2_level_exclusive
+        include_methods = self.chunk_depth >= 2 or include_l2_in_file_skeleton
+
+        for child in root_node.children:
+            if child.type in self._TYPE_NODES:
+                name = self._extract_type_name(child)
+                if not name:
+                    continue
+                if include_type_level:
+                    definitions.append((child, name, self._TYPE_NODES[child.type]))
+                if include_methods:
+                    definitions.extend(self._find_member_definitions(child, (name,)))
+                continue
+
+            if child.type == "method_declaration":
+                name = self._extract_method_name(child)
+                if name:
+                    definitions.append((child, name, "function"))
+
+        definitions.sort(key=lambda entry: entry[0].start_point[0])
+        return definitions
+
+    def _extract_signature_text(self, node, def_type: str, code_content: str) -> str:
+        stop_types = {
+            "class": ("class_body",),
+            "interface": ("interface_body",),
+            "enum": ("enum_body",),
+            "record": ("class_body", "record_body"),
+            "function": ("block",),
+            "method": ("block", "constructor_body"),
+        }.get(def_type, ("block",))
+        return self._extract_signature_text_default(node, stop_types, code_content)
+
+    def _build_file_skeleton(
+        self,
+        definitions: List[Tuple],
+        code_content: str,
+        include_l2: Optional[bool] = None,
+    ) -> str:
+        include_l2 = (
+            self.include_l2_in_file_skeleton if include_l2 is None else include_l2
+        )
+        container_names = {
+            name
+            for _, name, def_type in definitions
+            if def_type in {"class", "interface", "enum", "record"}
+        }
+        entries: List[str] = []
+        for node, name, def_type in definitions:
+            if def_type == "method":
+                if not include_l2:
+                    continue
+                parent = name.split(".", 1)[0] if "." in name else None
+                if parent and parent in container_names:
+                    continue
+                signature = self._extract_signature_text(node, def_type, code_content)
+                if signature:
+                    entries.append(self._indent_lines(signature))
+                continue
+
+            skeleton = self._build_definition_skeleton(
+                node,
+                def_type,
+                code_content=code_content,
+                include_children=include_l2,
+            )
+            if skeleton:
+                entries.append(skeleton)
+        return "\n".join(entries)
+
+    def _extract_function_name(self, node) -> Optional[str]:
+        return self._extract_method_name(node)
+
+    def _extract_class_name(self, node) -> Optional[str]:
+        return self._extract_type_name(node)
+
+    def _extract_type_name(self, node) -> Optional[str]:
+        for child in node.children:
+            if child.type == "identifier":
+                return child.text.decode("utf-8")
+        return None
+
+    def _extract_method_name(self, node) -> Optional[str]:
+        for child in node.children:
+            if child.type == "identifier":
+                return child.text.decode("utf-8")
+        return None
+
+    def _find_member_definitions(self, container_node, parents: Tuple[str, ...]):
+        definitions: List[Tuple] = []
+        for body in container_node.children:
+            if body.type not in self._BODY_NODES:
+                continue
+            definitions.extend(self._find_body_member_definitions(body, parents))
+        return definitions
+
+    def _find_body_member_definitions(self, body_node, parents: Tuple[str, ...]):
+        definitions: List[Tuple] = []
+        for member in body_node.children:
+            if member.type in ("method_declaration", "constructor_declaration"):
+                method_name = self._extract_method_name(member)
+                if method_name:
+                    definitions.append(
+                        (member, ".".join((*parents, method_name)), "method")
+                    )
+                continue
+
+            if member.type in self._TYPE_NODES:
+                nested_name = self._extract_type_name(member)
+                if nested_name:
+                    definitions.extend(
+                        self._find_member_definitions(
+                            member,
+                            (*parents, nested_name),
+                        )
+                    )
+                continue
+
+            if member.type in self._BODY_NODES:
+                definitions.extend(self._find_body_member_definitions(member, parents))
+        return definitions
+
+    def _get_child_definitions(self, node, def_type: str):
+        if def_type not in {"class", "interface", "enum", "record"}:
+            return []
+        name = self._extract_type_name(node)
+        if not name:
+            return []
+        return self._find_member_definitions(node, (name,))

--- a/codeminer/dataset/gt_locate.py
+++ b/codeminer/dataset/gt_locate.py
@@ -86,6 +86,7 @@ SYMBOL_CHUNK_TYPES = frozenset(
         "interface",
         "object",
         "enum",
+        "record",
         "trait",
         "impl",  # Rust (pre-existing, now registered)
         "var",

--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -153,6 +153,18 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         lsp_command=("clangd",),
     ),
     LanguageSpec(
+        key="java",
+        display_name="Java",
+        chunker_language="java",
+        chunker_aliases=("java",),
+        chunker_class="codeminer.code_chunking.java_chunker:JavaCodeChunker",
+        chunk_extensions=(".java",),
+        gt_language="java",
+        gt_extensions=(".java",),
+        agent_languages=("java",),
+        agent_aliases=(("java", "java"),),
+    ),
+    LanguageSpec(
         key="javascript",
         display_name="JavaScript",
         aliases=("js", "jsx"),

--- a/docs/agent_compile_design.md
+++ b/docs/agent_compile_design.md
@@ -98,7 +98,7 @@ keep cells statistically meaningful at N=30):
 
 | Dimension | Values | Source |
 |-----------|--------|--------|
-| `language` | python / go / rust / cpp / c / typescript / javascript / unknown | `SessionContext.primary_language` → `normalize_language()` |
+| `language` | python / go / rust / cpp / c / java / typescript / javascript / unknown | `SessionContext.primary_language` → `normalize_language()` |
 | `has_stacktrace` | True / False | `detect_stacktrace(query)` — regex sweep over the query |
 
 Dropped vs v1: `query_length_bucket`, `query_concreteness` (latter was

--- a/docs/gt_locator.md
+++ b/docs/gt_locator.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 
 Extract symbol-level ground truth changes (functions, classes, methods) from SWE-bench unified diff patches. Identifies which symbols were modified, added, or deleted.
 
-Supports Python, Go, Rust, C/C++, JavaScript, and TypeScript.
+Supports Python, Go, Rust, C/C++, Java, JavaScript, and TypeScript.
 
 ## How It Works
 

--- a/test/agent/test_compile.py
+++ b/test/agent/test_compile.py
@@ -121,6 +121,7 @@ class TestNormalizeLanguage:
             ("C++", "cpp"),
             ("cxx", "cpp"),
             ("C", "c"),
+            ("Java", "java"),
             ("TypeScript", "typescript"),
             ("ts", "typescript"),
             ("JavaScript", "javascript"),

--- a/test/chunker/test_chunker_registry.py
+++ b/test/chunker/test_chunker_registry.py
@@ -20,6 +20,7 @@ from codeminer.code_chunking import create_chunker
         ("rust", "RustCodeChunker"),
         ("cpp", "CppCodeChunker"),
         ("c++", "CppCodeChunker"),
+        ("java", "JavaCodeChunker"),
         ("javascript", "JsTsCodeChunker"),
         ("js", "JsTsCodeChunker"),
         ("typescript", "JsTsCodeChunker"),

--- a/test/chunker/test_java_chunker.py
+++ b/test/chunker/test_java_chunker.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Java tree-sitter chunker."""
+
+from __future__ import annotations
+
+from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+
+JAVA_SAMPLE = """package com.example;
+
+public class Greeter {
+    private final String name;
+
+    public Greeter(String name) {
+        this.name = name;
+    }
+
+    public String greet(String target) {
+        return "Hello " + target;
+    }
+
+    static class Nested {
+        void run() {}
+    }
+}
+
+interface Runner {
+    void run();
+}
+
+enum Mode {
+    FAST,
+    SLOW;
+
+    boolean isFast() {
+        return this == FAST;
+    }
+}
+
+record Point(int x, int y) {
+    public int sum() {
+        return x + y;
+    }
+}
+"""
+
+
+def test_java_chunker_level_one_containers(tmp_path):
+    src = tmp_path / "src" / "main" / "java" / "com" / "example" / "Greeter.java"
+    src.parent.mkdir(parents=True)
+    src.write_text(JAVA_SAMPLE, encoding="utf-8")
+
+    chunker = CodeChunker(language="java", chunk_depth=1)
+    chunks = chunker.chunk_file(str(src), relative_path="src/main/java/Greeter.java")
+
+    assert [(chunk.chunk_type, chunk.name) for chunk in chunks] == [
+        ("class", "Greeter"),
+        ("interface", "Runner"),
+        ("enum", "Mode"),
+        ("record", "Point"),
+    ]
+    assert chunks[0].node_id == "src/main/java/Greeter.java:Greeter"
+
+
+def test_java_chunker_level_two_methods(tmp_path):
+    src = tmp_path / "Greeter.java"
+    src.write_text(JAVA_SAMPLE, encoding="utf-8")
+
+    chunker = CodeChunker(language="java")
+    chunks = chunker.chunk_file(str(src), relative_path="Greeter.java")
+
+    assert [(chunk.chunk_type, chunk.name) for chunk in chunks] == [
+        ("method", "Greeter.Greeter"),
+        ("method", "Greeter.greet"),
+        ("method", "Greeter.Nested.run"),
+        ("method", "Runner.run"),
+        ("method", "Mode.isFast"),
+        ("method", "Point.sum"),
+    ]
+    assert "public String greet(String target)" in chunks[1].content
+    assert chunks[1].node_id == "Greeter.java:Greeter.greet()"
+
+
+def test_java_chunker_file_skeleton_includes_member_signatures(tmp_path):
+    src = tmp_path / "Greeter.java"
+    src.write_text(JAVA_SAMPLE, encoding="utf-8")
+
+    chunker = CodeChunker(language="java", chunk_depth=0, skeleton_mode=True)
+    chunks = chunker.chunk_file(str(src), relative_path="Greeter.java")
+
+    assert len(chunks) == 1
+    assert chunks[0].chunk_type == "file"
+    assert "public class Greeter" in chunks[0].content
+    assert "public Greeter(String name)" in chunks[0].content
+    assert "interface Runner" in chunks[0].content
+    assert "record Point(int x, int y)" in chunks[0].content
+
+
+def test_java_repo_chunking_discovery(tmp_path):
+    src = tmp_path / "src" / "main" / "java" / "App.java"
+    src.parent.mkdir(parents=True)
+    src.write_text("class App { void run() {} }\n", encoding="utf-8")
+
+    cfg = RepoChunkingConfig(languages=["java"], filter_tests=False)
+    chunker = CodeChunker(language="java", repo_config=cfg)
+
+    chunks = chunker.chunk_repository(str(tmp_path))
+
+    assert [chunk.name for chunk in chunks] == ["App.run"]
+    assert chunks[0].node_id == "src/main/java/App.java:App.run()"

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -17,6 +17,7 @@ def test_repo_chunking_config_defaults_come_from_language_registry():
     assert cfg.cpp_extensions == extensions_for_language("cpp", "chunker")
     assert cfg.rust_extensions == extensions_for_language("rust", "chunker")
     assert cfg.go_extensions == extensions_for_language("go", "chunker")
+    assert cfg.java_extensions == extensions_for_language("java", "chunker")
     assert cfg.javascript_extensions == extensions_for_language("javascript", "chunker")
     assert cfg.typescript_extensions == extensions_for_language("typescript", "chunker")
 
@@ -61,11 +62,13 @@ def test_repo_language_detection_uses_registered_chunk_extensions(tmp_path: Path
     (tmp_path / "app.jsx").write_text("export const x = () => 1;\n")
     (tmp_path / "types.cts").write_text("export const y: number = 1;\n")
     (tmp_path / "main.go").write_text("package main\n")
+    (tmp_path / "App.java").write_text("class App {}\n")
 
     chunker = CodeChunker(language="python")
 
     assert sorted(chunker._detect_repo_language(tmp_path)) == [
         "go",
+        "java",
         "javascript",
         "typescript",
     ]

--- a/test/dataset/test_gt_locate.py
+++ b/test/dataset/test_gt_locate.py
@@ -16,6 +16,7 @@ import pytest
 
 from codeminer.code_chunking.base import CodeChunk
 from codeminer.dataset.gt_locate import (
+    SYMBOL_CHUNK_TYPES,
     GTLocator,
     _chunk_to_code_block,
     language_for_file,
@@ -35,6 +36,7 @@ class TestLanguageForFile:
             ("lib/parser.rs", "rust"),
             ("src/engine.cpp", "cpp"),
             ("include/engine.h", "cpp"),
+            ("src/main/java/App.java", "java"),
             ("src/app.ts", "typescript"),
             ("src/index.js", "javascript"),
             ("src/component.tsx", "typescript"),
@@ -237,6 +239,40 @@ class TestExtractSymbolsJsTs:
         assert "src/expression.js:fromExport()" in symbols
         assert "src/expression.js:fromVar()" in symbols
         assert "src/expression.js:fromAssign()" in symbols
+
+
+class TestExtractSymbolsJava:
+    @pytest.fixture()
+    def locator(self, tmp_path):
+        return GTLocator(work_dir=str(tmp_path))
+
+    def test_java_methods_and_records(self, locator, tmp_path):
+        java_file = tmp_path / "src" / "main" / "java" / "Point.java"
+        java_file.parent.mkdir(parents=True, exist_ok=True)
+        java_file.write_text(
+            "\n".join(
+                [
+                    "record Point(int x, int y) {",
+                    "    public int sum() {",
+                    "        return x + y;",
+                    "    }",
+                    "}",
+                    "",
+                    "class App {",
+                    "    void run() {}",
+                    "}",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        symbols = locator.extract_symbols_from_file(
+            str(java_file), relative_path="src/main/java/Point.java"
+        )
+
+        assert "src/main/java/Point.java:Point.sum()" in symbols
+        assert "src/main/java/Point.java:App.run()" in symbols
+        assert "record" in SYMBOL_CHUNK_TYPES
 
 
 # ===================================================================

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -54,6 +54,7 @@ def test_gt_extensions_preserve_current_supported_set():
     ext_map = extension_to_language_map("gt")
     assert ext_map[".py"] == "python"
     assert ext_map[".c"] == "cpp"
+    assert ext_map[".java"] == "java"
     assert ext_map[".tsx"] == "typescript"
     assert ext_map[".jsx"] == "javascript"
 
@@ -69,6 +70,7 @@ def test_agent_supported_languages_match_existing_scenarios():
         "rust",
         "cpp",
         "c",
+        "java",
         "typescript",
         "javascript",
     }
@@ -91,6 +93,7 @@ def test_chunker_languages_are_current_supported_repo_chunkers():
         "go",
         "rust",
         "cpp",
+        "java",
         "javascript",
         "typescript",
     )
@@ -105,6 +108,7 @@ def test_chunker_class_paths_follow_chunker_language_aliases():
     assert paths["rust"].endswith("rust_chunker:RustCodeChunker")
     assert paths["cpp"].endswith("cpp_chunker:CppCodeChunker")
     assert paths["c++"] == paths["cpp"]
+    assert paths["java"].endswith("java_chunker:JavaCodeChunker")
     assert paths["javascript"].endswith("js_chunker:JsTsCodeChunker")
     assert paths["js"] == paths["javascript"]
     assert paths["typescript"].endswith("js_chunker:JsTsCodeChunker")
@@ -112,7 +116,7 @@ def test_chunker_class_paths_follow_chunker_language_aliases():
 
     assert chunker_class_path("py") is None
     assert chunker_class_path("js") == paths["javascript"]
-    assert chunker_class_path("java") is None
+    assert chunker_class_path("java") == paths["java"]
 
     js_spec = get_chunker_spec("javascript")
     ts_spec = get_chunker_spec("typescript")


### PR DESCRIPTION
## Summary

Adds Java tree-sitter chunking and registry coverage on top of #232.

## Changes

- Added a Java tree-sitter chunker for classes, interfaces, enums, records, methods, constructors, nested type methods, and file skeletons.
- Registered Java for chunking, ground-truth extraction, and agent language classification while leaving graph/LSP/incremental/core backend capability unset.
- Added Java repo discovery defaults, GT symbol extraction coverage, and docs for the new chunker surface.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking the main issue-186 chain:

- Main-chain tip #238 full unit validation: `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1084 passed, 10 skipped`)
- Original focused validation included `test/chunker/test_java_chunker.py`, chunker registry/config tests, agent compile tests, and Java GT extraction tests.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Stacked on #232. Parent is published but not merged yet. Refs #186.