### PR TITLE
[codex] Add PHP tree-sitter chunker

### DIFF
--- a/codeminer/agent/compile.py
+++ b/codeminer/agent/compile.py
@@ -72,6 +72,8 @@ _STACKTRACE_PATTERNS = (
         r"^\s+at\s+\S+\.\S+\([^()\n]*\)\s+in\s+[^:\n]+\.cs:line\s+\d+\s*$",
         re.MULTILINE,
     ),
+    # PHP — "#0 /app/src/Foo.php(42): Class->method(...)"
+    re.compile(r"^#\d+\s+[^()\n]+\.php\(\d+\):\s+\S+", re.MULTILINE),
     # C/C++ — addr2line / backtrace lines look like "#0 0x... in fn at file:42"
     re.compile(r"^#\d+\s+0x[0-9a-fA-F]+\s+in\s+\S+", re.MULTILINE),
 )

--- a/codeminer/code_chunker.py
+++ b/codeminer/code_chunker.py
@@ -40,6 +40,7 @@ class RepoChunkingConfig:
     go_extensions: Optional[Set[str]] = None
     java_extensions: Optional[Set[str]] = None
     ruby_extensions: Optional[Set[str]] = None
+    php_extensions: Optional[Set[str]] = None
     javascript_extensions: Optional[Set[str]] = None
     typescript_extensions: Optional[Set[str]] = None
 
@@ -79,6 +80,9 @@ class RepoChunkingConfig:
 
         if self.ruby_extensions is None:
             self.ruby_extensions = extensions_for_language("ruby", "chunker")
+
+        if self.php_extensions is None:
+            self.php_extensions = extensions_for_language("php", "chunker")
 
         if self.javascript_extensions is None:
             self.javascript_extensions = extensions_for_language(

--- a/codeminer/code_chunking/CLAUDE.md
+++ b/codeminer/code_chunking/CLAUDE.md
@@ -1,6 +1,6 @@
 # code_chunking/ — rules
 
-Tree-sitter chunkers, one per language (`python`, `go`, `cpp`, `csharp`, `rust`, `java`, `ruby`, `js`).
+Tree-sitter chunkers, one per language (`python`, `go`, `cpp`, `csharp`, `rust`, `java`, `ruby`, `php`, `js`).
 The authoritative reference for chunk depths and the full per-language
 `chunk_type` tables is [`README.md`](./README.md) — read it before adding or
 changing a chunker. This file is the short list of rules that bite.
@@ -14,10 +14,10 @@ changing a chunker. This file is the short list of rules that bite.
 - **`.c` files use the `cpp` chunker.** There is no separate C chunker; the
   language→chunker map sends `.c` to `cpp`. Forgetting this produces empty
   `code_blocks` (the bug that silently broke redis/jqlang instances).
-- **C#, Java, and Ruby are chunker/GT/agent-only for now.** The `.cs`, `.java`,
-  and `.rb` chunkers are registered for tree-sitter chunking and ground-truth
-  extraction, but graph/LSP/core backend support is still intentionally unset
-  in the language registry.
+- **C#, Java, Ruby, and PHP are chunker/GT/agent-only for now.** The `.cs`,
+  `.java`, `.rb`, and `.php` chunkers are registered for tree-sitter chunking
+  and ground-truth extraction, but graph/LSP/core backend support is still
+  intentionally unset in the language registry.
 - **Chunk depth** (`chunk_depth` on `BaseCodeChunker`): L0 = whole file
   (skeleton when `skeleton_mode`), L1 = top-level symbols, L2 = nested
   methods/members (default; with `l2_level_exclusive=True` the L1 containers are
@@ -26,7 +26,7 @@ changing a chunker. This file is the short list of rules that bite.
   `module`, `struct`, `type`, `interface`, `object`, `enum`, `trait`, `impl`, `var`,
   `const`, `static`, `declaration`, `macro`, `variable`, `record`, `property`. Per-language L1
   var/const kinds: Go `var`/`const`; Rust `const`/`static`/`type`; C++
-  `declaration`/`macro`; C# `property`; Java `record`; Ruby `module`;
+  `declaration`/`macro`; C#/PHP `property`; Java `record`; Ruby `module`;
   JS/TS `variable`.
 
 ## When adding a language / chunk type

--- a/codeminer/code_chunking/README.md
+++ b/codeminer/code_chunking/README.md
@@ -97,6 +97,18 @@ Controlled by the `chunk_depth` parameter in `BaseCodeChunker`:
 | `function` | L1 | top-level `method` / `singleton_method` | `def top_level` |
 | `method` | L2 | nested `method` / `singleton_method` | `def total`, `def self.build` |
 
+### PHP (`php_chunker.py`)
+
+| chunk_type | Level | AST node | Example |
+|------------|-------|----------|---------|
+| `class` | L1 | `class_declaration` | `class Invoice {}` |
+| `interface` | L1 | `interface_declaration` | `interface Printable {}` |
+| `trait` | L1 | `trait_declaration` | `trait Timestamped {}` |
+| `enum` | L1 | `enum_declaration` | `enum Status {}` |
+| `function` | L1 | `function_definition` | `function normalize() {}` |
+| `method` | L2 | `method_declaration` | `public function total() {}` |
+| `property` | L2 | `property_declaration` | `public int $total = 0;` |
+
 ### JavaScript / TypeScript (`js_chunker.py`)
 
 | chunk_type | Level | AST node | Example |
@@ -148,5 +160,6 @@ Used by `gt_locate.py` to select the correct chunker:
 | `.cs` | `csharp` |
 | `.java` | `java` |
 | `.rb` | `ruby` |
+| `.php`, `.phtml` | `php` |
 | `.js`, `.jsx` | `javascript` |
 | `.ts`, `.tsx` | `typescript` |

--- a/codeminer/code_chunking/__init__.py
+++ b/codeminer/code_chunking/__init__.py
@@ -16,6 +16,7 @@ from .csharp_chunker import CSharpCodeChunker
 from .go_chunker import GoCodeChunker
 from .java_chunker import JavaCodeChunker
 from .js_chunker import JsTsCodeChunker
+from .php_chunker import PhpCodeChunker
 from .python_chunker import PythonCodeChunker
 from .ruby_chunker import RubyCodeChunker
 from .rust_chunker import RustCodeChunker
@@ -98,6 +99,7 @@ __all__ = [
     "GoCodeChunker",
     "JavaCodeChunker",
     "RubyCodeChunker",
+    "PhpCodeChunker",
     "JsTsCodeChunker",
     "create_chunker",
 ]

--- a/codeminer/code_chunking/php_chunker.py
+++ b/codeminer/code_chunking/php_chunker.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PHP-specific code chunker implementation.
+"""
+
+from typing import List, Optional, Tuple
+
+from .base import BaseCodeChunker
+
+
+class PhpCodeChunker(BaseCodeChunker):
+    """
+    Code chunker for PHP source files.
+
+    L1 entities: classes, interfaces, traits, enums, and top-level functions.
+    L2 entities: methods and properties inside type declarations.
+    Skeleton mode: file skeleton lists type declarations and member signatures.
+    """
+
+    _TYPE_NODES = {
+        "class_declaration": "class",
+        "interface_declaration": "interface",
+        "trait_declaration": "trait",
+        "enum_declaration": "enum",
+    }
+    _BODY_NODES = {"declaration_list", "enum_declaration_list"}
+    _MEMBER_NODES = {
+        "method_declaration": "method",
+        "property_declaration": "property",
+    }
+
+    def __init__(
+        self,
+        max_lines_per_chunk: Optional[int] = None,
+        chunk_depth: int = 2,
+        l2_level_exclusive: bool = True,
+        **kwargs,
+    ):
+        super().__init__(
+            "php",
+            max_lines_per_chunk=max_lines_per_chunk,
+            chunk_depth=chunk_depth,
+            l2_level_exclusive=l2_level_exclusive,
+            **kwargs,
+        )
+
+    def _find_top_level_definitions(
+        self, root_node, include_l2_in_file_skeleton: bool = False
+    ) -> List[Tuple]:
+        definitions: List[Tuple] = []
+
+        include_type_level = self.chunk_depth < 2 or not self.l2_level_exclusive
+        include_members = self.chunk_depth >= 2 or include_l2_in_file_skeleton
+
+        for child in self._iter_top_level_declarations(root_node):
+            if child.type in self._TYPE_NODES:
+                name = self._extract_type_name(child)
+                if not name:
+                    continue
+                if include_type_level:
+                    definitions.append((child, name, self._TYPE_NODES[child.type]))
+                if include_members:
+                    definitions.extend(self._find_member_definitions(child, (name,)))
+                continue
+
+            if child.type == "function_definition":
+                name = self._extract_function_name(child)
+                if name:
+                    definitions.append((child, name, "function"))
+
+        definitions.sort(key=lambda entry: entry[0].start_point[0])
+        return definitions
+
+    def _extract_signature_text(self, node, def_type: str, code_content: str) -> str:
+        stop_types = {
+            "class": ("declaration_list",),
+            "interface": ("declaration_list",),
+            "trait": ("declaration_list",),
+            "enum": ("enum_declaration_list",),
+            "function": ("compound_statement",),
+            "method": ("compound_statement",),
+            "property": (),
+        }.get(def_type, ("compound_statement",))
+        return self._extract_signature_text_default(node, stop_types, code_content)
+
+    def _build_file_skeleton(
+        self,
+        definitions: List[Tuple],
+        code_content: str,
+        include_l2: Optional[bool] = None,
+    ) -> str:
+        include_l2 = (
+            self.include_l2_in_file_skeleton if include_l2 is None else include_l2
+        )
+        container_names = {
+            name
+            for _, name, def_type in definitions
+            if def_type in {"class", "interface", "trait", "enum"}
+        }
+        entries: List[str] = []
+        for node, name, def_type in definitions:
+            if def_type in {"method", "property"}:
+                if not include_l2:
+                    continue
+                parent = name.split(".", 1)[0] if "." in name else None
+                if parent and parent in container_names:
+                    continue
+                signature = self._extract_signature_text(node, def_type, code_content)
+                if signature:
+                    entries.append(self._indent_lines(signature))
+                continue
+
+            skeleton = self._build_definition_skeleton(
+                node,
+                def_type,
+                code_content=code_content,
+                include_children=include_l2,
+            )
+            if skeleton:
+                entries.append(skeleton)
+        return "\n".join(entries)
+
+    def _iter_top_level_declarations(self, node):
+        for child in node.children:
+            if child.type in ("php_tag", "ERROR"):
+                continue
+            if child.type == "namespace_definition":
+                yield from self._iter_namespace_declarations(child)
+                continue
+            yield child
+
+    def _iter_namespace_declarations(self, namespace_node):
+        for child in namespace_node.children:
+            if child.type == "compound_statement":
+                for member in child.children:
+                    if member.type not in ("{", "}"):
+                        yield member
+
+    def _extract_function_name(self, node) -> Optional[str]:
+        return self._extract_name_child(node)
+
+    def _extract_class_name(self, node) -> Optional[str]:
+        return self._extract_type_name(node)
+
+    def _extract_type_name(self, node) -> Optional[str]:
+        return self._extract_name_child(node)
+
+    def _extract_method_name(self, node) -> Optional[str]:
+        if node.type == "property_declaration":
+            return self._extract_property_name(node)
+        return self._extract_name_child(node)
+
+    def _extract_name_child(self, node) -> Optional[str]:
+        for child in node.children:
+            if child.type in ("name", "qualified_name"):
+                return child.text.decode("utf-8").replace("\\", ".")
+        return None
+
+    def _extract_property_name(self, node) -> Optional[str]:
+        for prop in self._find_nodes_by_type(node, "property_element"):
+            for child in prop.children:
+                if child.type == "variable_name":
+                    return child.text.decode("utf-8").lstrip("$")
+        return None
+
+    def _find_member_definitions(self, type_node, parents: Tuple[str, ...]):
+        definitions: List[Tuple] = []
+        for body in type_node.children:
+            if body.type not in self._BODY_NODES:
+                continue
+            definitions.extend(self._find_body_member_definitions(body, parents))
+        return definitions
+
+    def _find_body_member_definitions(self, body_node, parents: Tuple[str, ...]):
+        definitions: List[Tuple] = []
+        for member in body_node.children:
+            if member.type in self._MEMBER_NODES:
+                member_name = self._extract_method_name(member)
+                if member_name:
+                    definitions.append(
+                        (
+                            member,
+                            ".".join((*parents, member_name)),
+                            self._MEMBER_NODES[member.type],
+                        )
+                    )
+                continue
+
+            if member.type in self._BODY_NODES:
+                definitions.extend(self._find_body_member_definitions(member, parents))
+        return definitions
+
+    def _get_child_definitions(self, node, def_type: str):
+        if def_type not in {"class", "interface", "trait", "enum"}:
+            return []
+        name = self._extract_type_name(node)
+        if not name:
+            return []
+        return self._find_member_definitions(node, (name,))

--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -191,6 +191,18 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         agent_aliases=(("ruby", "ruby"), ("rb", "ruby")),
     ),
     LanguageSpec(
+        key="php",
+        display_name="PHP",
+        chunker_language="php",
+        chunker_aliases=("php",),
+        chunker_class="codeminer.code_chunking.php_chunker:PhpCodeChunker",
+        chunk_extensions=(".php", ".phtml"),
+        gt_language="php",
+        gt_extensions=(".php", ".phtml"),
+        agent_languages=("php",),
+        agent_aliases=(("php", "php"),),
+    ),
+    LanguageSpec(
         key="javascript",
         display_name="JavaScript",
         aliases=("js", "jsx"),

--- a/codeminer/wiki/agent_wiki.py
+++ b/codeminer/wiki/agent_wiki.py
@@ -44,6 +44,7 @@ _EXT_LANG = {
     "cs": "csharp",
     "java": "java",
     "rb": "ruby",
+    "php": "php",
 }
 _MAX_CONTEXT_CHARS = 9000
 

--- a/docs/agent_compile_design.md
+++ b/docs/agent_compile_design.md
@@ -98,7 +98,7 @@ keep cells statistically meaningful at N=30):
 
 | Dimension | Values | Source |
 |-----------|--------|--------|
-| `language` | python / go / rust / cpp / c / csharp / java / ruby / typescript / javascript / unknown | `SessionContext.primary_language` → `normalize_language()` |
+| `language` | python / go / rust / cpp / c / csharp / java / ruby / php / typescript / javascript / unknown | `SessionContext.primary_language` → `normalize_language()` |
 | `has_stacktrace` | True / False | `detect_stacktrace(query)` — regex sweep over the query |
 
 Dropped vs v1: `query_length_bucket`, `query_concreteness` (latter was

--- a/docs/gt_locator.md
+++ b/docs/gt_locator.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 
 Extract symbol-level ground truth changes (functions, classes, methods) from SWE-bench unified diff patches. Identifies which symbols were modified, added, or deleted.
 
-Supports Python, Go, Rust, C/C++, C#, Java, Ruby, JavaScript, and TypeScript.
+Supports Python, Go, Rust, C/C++, C#, Java, Ruby, PHP, JavaScript, and TypeScript.
 
 ## How It Works
 

--- a/scripts/build_qa_index.py
+++ b/scripts/build_qa_index.py
@@ -75,6 +75,7 @@ _LANG_MAP: Dict[str, List[str]] = {
     "c++": ["cpp"],
     "java": ["java"],
     "ruby": ["ruby"],
+    "php": ["php"],
 }
 
 

--- a/test/agent/test_compile.py
+++ b/test/agent/test_compile.py
@@ -82,6 +82,14 @@ class TestDetectStacktrace:
         )
         assert detect_stacktrace(query) is True
 
+    def test_php_stack_frame(self):
+        query = (
+            "Fatal error: Uncaught Error: Call to a member function run() on null\n"
+            "#0 /app/src/Invoice.php(42): Billing\\Invoice->total()\n"
+            "#1 /app/index.php(8): main()\n"
+        )
+        assert detect_stacktrace(query) is True
+
     def test_ruby_stack_frame(self):
         query = (
             "NoMethodError: undefined method `name' for nil:NilClass\n"
@@ -142,6 +150,7 @@ class TestNormalizeLanguage:
             ("Java", "java"),
             ("Ruby", "ruby"),
             ("rb", "ruby"),
+            ("PHP", "php"),
             ("TypeScript", "typescript"),
             ("ts", "typescript"),
             ("JavaScript", "javascript"),

--- a/test/chunker/test_chunker_registry.py
+++ b/test/chunker/test_chunker_registry.py
@@ -26,6 +26,7 @@ from codeminer.code_chunking import create_chunker
         ("java", "JavaCodeChunker"),
         ("ruby", "RubyCodeChunker"),
         ("rb", "RubyCodeChunker"),
+        ("php", "PhpCodeChunker"),
         ("javascript", "JsTsCodeChunker"),
         ("js", "JsTsCodeChunker"),
         ("typescript", "JsTsCodeChunker"),

--- a/test/chunker/test_php_chunker.py
+++ b/test/chunker/test_php_chunker.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the PHP tree-sitter chunker."""
+
+from __future__ import annotations
+
+from codeminer.code_chunker import CodeChunker, RepoChunkingConfig
+
+PHP_SAMPLE = """<?php
+
+namespace Billing\\Core;
+
+interface Printable {
+    public function print(): void;
+}
+
+trait Timestamped {
+    public function touch(): void {}
+}
+
+enum Status {
+    case Draft;
+
+    public function label(): string {
+        return $this->name;
+    }
+}
+
+class Invoice implements Printable {
+    use Timestamped;
+
+    public int $total = 0;
+
+    public function __construct(int $total) {
+        $this->total = $total;
+    }
+
+    public function total(): int {
+        return $this->total;
+    }
+
+    public static function create(int $total): self {
+        return new self($total);
+    }
+}
+
+function normalize(string $value): string {
+    return trim($value);
+}
+"""
+
+
+def test_php_chunker_level_one_types_and_functions(tmp_path):
+    src = tmp_path / "src" / "Billing" / "Invoice.php"
+    src.parent.mkdir(parents=True)
+    src.write_text(PHP_SAMPLE, encoding="utf-8")
+
+    chunker = CodeChunker(language="php", chunk_depth=1)
+    chunks = chunker.chunk_file(str(src), relative_path="src/Billing/Invoice.php")
+
+    assert [(chunk.chunk_type, chunk.name) for chunk in chunks] == [
+        ("interface", "Printable"),
+        ("trait", "Timestamped"),
+        ("enum", "Status"),
+        ("class", "Invoice"),
+        ("function", "normalize"),
+    ]
+    assert chunks[3].node_id == "src/Billing/Invoice.php:Invoice"
+    assert chunks[-1].node_id == "src/Billing/Invoice.php:normalize()"
+
+
+def test_php_chunker_level_two_members(tmp_path):
+    src = tmp_path / "Invoice.php"
+    src.write_text(PHP_SAMPLE, encoding="utf-8")
+
+    chunker = CodeChunker(language="php")
+    chunks = chunker.chunk_file(str(src), relative_path="Invoice.php")
+
+    assert [(chunk.chunk_type, chunk.name) for chunk in chunks] == [
+        ("method", "Printable.print"),
+        ("method", "Timestamped.touch"),
+        ("method", "Status.label"),
+        ("property", "Invoice.total"),
+        ("method", "Invoice.__construct"),
+        ("method", "Invoice.total"),
+        ("method", "Invoice.create"),
+        ("function", "normalize"),
+    ]
+    assert "public function total(): int" in chunks[5].content
+    assert chunks[3].node_id == "Invoice.php:Invoice.total"
+    assert chunks[5].node_id == "Invoice.php:Invoice.total()"
+
+
+def test_php_chunker_file_skeleton_includes_member_signatures(tmp_path):
+    src = tmp_path / "Invoice.php"
+    src.write_text(PHP_SAMPLE, encoding="utf-8")
+
+    chunker = CodeChunker(language="php", chunk_depth=0, skeleton_mode=True)
+    chunks = chunker.chunk_file(str(src), relative_path="Invoice.php")
+
+    assert len(chunks) == 1
+    assert chunks[0].chunk_type == "file"
+    assert "interface Printable" in chunks[0].content
+    assert "public function print(): void;" in chunks[0].content
+    assert "enum Status" in chunks[0].content
+    assert "public int $total = 0;" in chunks[0].content
+    assert "function normalize(string $value): string" in chunks[0].content
+
+
+def test_php_repo_chunking_discovery(tmp_path):
+    src = tmp_path / "src" / "App.php"
+    src.parent.mkdir(parents=True)
+    src.write_text("<?php\nclass App { public function run() {} }\n", encoding="utf-8")
+
+    cfg = RepoChunkingConfig(languages=["php"], filter_tests=False)
+    chunker = CodeChunker(language="php", repo_config=cfg)
+
+    chunks = chunker.chunk_repository(str(tmp_path))
+
+    assert [chunk.name for chunk in chunks] == ["App.run"]
+    assert chunks[0].node_id == "src/App.php:App.run()"

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -20,6 +20,7 @@ def test_repo_chunking_config_defaults_come_from_language_registry():
     assert cfg.go_extensions == extensions_for_language("go", "chunker")
     assert cfg.java_extensions == extensions_for_language("java", "chunker")
     assert cfg.ruby_extensions == extensions_for_language("ruby", "chunker")
+    assert cfg.php_extensions == extensions_for_language("php", "chunker")
     assert cfg.javascript_extensions == extensions_for_language("javascript", "chunker")
     assert cfg.typescript_extensions == extensions_for_language("typescript", "chunker")
 
@@ -67,6 +68,7 @@ def test_repo_language_detection_uses_registered_chunk_extensions(tmp_path: Path
     (tmp_path / "Program.cs").write_text("class Program {}\n")
     (tmp_path / "App.java").write_text("class App {}\n")
     (tmp_path / "app.rb").write_text("class App\nend\n")
+    (tmp_path / "index.php").write_text("<?php\nfunction index() {}\n")
 
     chunker = CodeChunker(language="python")
 
@@ -75,6 +77,7 @@ def test_repo_language_detection_uses_registered_chunk_extensions(tmp_path: Path
         "go",
         "java",
         "javascript",
+        "php",
         "ruby",
         "typescript",
     ]

--- a/test/dataset/test_gt_locate.py
+++ b/test/dataset/test_gt_locate.py
@@ -39,6 +39,7 @@ class TestLanguageForFile:
             ("src/Billing/Invoice.cs", "csharp"),
             ("src/main/java/App.java", "java"),
             ("lib/billing/invoice.rb", "ruby"),
+            ("src/Billing/Invoice.php", "php"),
             ("src/app.ts", "typescript"),
             ("src/index.js", "javascript"),
             ("src/component.tsx", "typescript"),
@@ -344,6 +345,39 @@ class TestExtractSymbolsRuby:
         assert "lib/billing/invoice.rb:Billing.Invoice.total()" in symbols
         assert "lib/billing/invoice.rb:Billing.normalize()" in symbols
         assert "module" in SYMBOL_CHUNK_TYPES
+
+
+class TestExtractSymbolsPhp:
+    @pytest.fixture()
+    def locator(self, tmp_path):
+        return GTLocator(work_dir=str(tmp_path))
+
+    def test_php_methods_and_properties(self, locator, tmp_path):
+        php_file = tmp_path / "src" / "Billing" / "Invoice.php"
+        php_file.parent.mkdir(parents=True, exist_ok=True)
+        php_file.write_text(
+            "\n".join(
+                [
+                    "<?php",
+                    "class Invoice {",
+                    "    public int $total = 0;",
+                    "",
+                    "    public function total(): int {",
+                    "        return $this->total;",
+                    "    }",
+                    "}",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        symbols = locator.extract_symbols_from_file(
+            str(php_file), relative_path="src/Billing/Invoice.php"
+        )
+
+        assert "src/Billing/Invoice.php:Invoice.total" in symbols
+        assert "src/Billing/Invoice.php:Invoice.total()" in symbols
+        assert "property" in SYMBOL_CHUNK_TYPES
 
 
 # ===================================================================

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -62,6 +62,7 @@ def test_gt_extensions_preserve_current_supported_set():
     assert ext_map[".cs"] == "csharp"
     assert ext_map[".java"] == "java"
     assert ext_map[".rb"] == "ruby"
+    assert ext_map[".php"] == "php"
     assert ext_map[".tsx"] == "typescript"
     assert ext_map[".jsx"] == "javascript"
 
@@ -80,6 +81,7 @@ def test_agent_supported_languages_match_existing_scenarios():
         "csharp",
         "java",
         "ruby",
+        "php",
         "typescript",
         "javascript",
     }
@@ -105,6 +107,7 @@ def test_chunker_languages_are_current_supported_repo_chunkers():
         "csharp",
         "java",
         "ruby",
+        "php",
         "javascript",
         "typescript",
     )
@@ -125,6 +128,7 @@ def test_chunker_class_paths_follow_chunker_language_aliases():
     assert paths["java"].endswith("java_chunker:JavaCodeChunker")
     assert paths["ruby"].endswith("ruby_chunker:RubyCodeChunker")
     assert paths["rb"] == paths["ruby"]
+    assert paths["php"].endswith("php_chunker:PhpCodeChunker")
     assert paths["javascript"].endswith("js_chunker:JsTsCodeChunker")
     assert paths["js"] == paths["javascript"]
     assert paths["typescript"].endswith("js_chunker:JsTsCodeChunker")
@@ -135,6 +139,7 @@ def test_chunker_class_paths_follow_chunker_language_aliases():
     assert chunker_class_path("c#") == paths["csharp"]
     assert chunker_class_path("java") == paths["java"]
     assert chunker_class_path("rb") == paths["ruby"]
+    assert chunker_class_path("php") == paths["php"]
 
     js_spec = get_chunker_spec("javascript")
     ts_spec = get_chunker_spec("typescript")
@@ -162,6 +167,7 @@ def test_incremental_patcher_paths_follow_graph_language_aliases():
     assert incremental_patcher_path("csharp") is None
     assert incremental_patcher_path("java") is None
     assert incremental_patcher_path("ruby") is None
+    assert incremental_patcher_path("php") is None
 
 
 def test_graph_indexer_and_decoder_paths_follow_graph_language_aliases():
@@ -196,6 +202,8 @@ def test_graph_indexer_and_decoder_paths_follow_graph_language_aliases():
     assert graph_decoder_path("java") is None
     assert graph_indexer_path("ruby") is None
     assert graph_decoder_path("ruby") is None
+    assert graph_indexer_path("php") is None
+    assert graph_decoder_path("php") is None
 
 
 def test_lsp_metadata_follows_graph_language_aliases(monkeypatch):
@@ -220,3 +228,5 @@ def test_lsp_metadata_follows_graph_language_aliases(monkeypatch):
     assert lsp_command_for_language("java") is None
     assert lsp_language_id_for_language("ruby") is None
     assert lsp_command_for_language("ruby") is None
+    assert lsp_language_id_for_language("php") is None
+    assert lsp_command_for_language("php") is None


### PR DESCRIPTION
## Summary

Adds PHP tree-sitter chunking and registry coverage on top of #235.

## Changes

- Added a PHP tree-sitter chunker for classes, interfaces, traits, enums, top-level functions, methods, and properties.
- Registered PHP for chunking, GT lookup, QA demo mapping, wiki labels, and agent stacktrace classification while leaving graph, LSP, incremental, and core decoder support unset.
- Added PHP chunker, registry, GT symbol extraction, repository discovery, and stacktrace tests.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking the main issue-186 chain:

- Main-chain tip #238 full unit validation: `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1084 passed, 10 skipped`)
- Original focused validation included `test/chunker/test_php_chunker.py`, chunker registry/config tests, agent compile tests, PHP GT extraction tests, and full `test/chunker` coverage.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Stacked on #235. Parent is published but not merged yet. Refs #186.