### PR TITLE
[codex] Track language capability matrix

### DIFF
--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -55,6 +55,22 @@ class LanguageSpec:
     core_decoder_aliases: Tuple[str, ...] = ()
 
 
+@dataclass(frozen=True, slots=True)
+class LanguageCapability:
+    """Derived support matrix row for one registered language."""
+
+    key: str
+    display_name: str
+    chunker: bool
+    ground_truth: bool
+    agent: bool
+    graph_backend: Optional[str]
+    incremental_backend: Optional[str]
+    lsp: bool
+    core_decoder: bool
+    core_parity: str
+
+
 LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
     LanguageSpec(
         key="python",
@@ -619,8 +635,64 @@ def core_decoder_languages(include_aliases: bool = True) -> Tuple[str, ...]:
     return _unique(languages)
 
 
+def language_capability_rows() -> Tuple[LanguageCapability, ...]:
+    """Return a registry-derived language support matrix.
+
+    The matrix intentionally distinguishes tree-sitter-only languages from
+    graph-capable languages with no core decoder.  This makes serial-only/core
+    parity coverage explicit instead of relying on skipped tests as a signal.
+    """
+
+    core_graph_languages = {
+        spec.graph_language
+        for spec in LANGUAGE_SPECS
+        if spec.core_decoder and spec.graph_language
+    }
+    rows: list[LanguageCapability] = []
+    for spec in LANGUAGE_SPECS:
+        has_graph = bool(
+            spec.graph_language and spec.graph_indexer and spec.graph_decoder
+        )
+        has_core = bool(
+            spec.core_decoder
+            or (spec.graph_language and spec.graph_language in core_graph_languages)
+        )
+        if has_core:
+            core_parity = "covered"
+        elif has_graph:
+            core_parity = "n/a-no-core-decoder"
+        else:
+            core_parity = "n/a-tree-sitter-only"
+
+        rows.append(
+            LanguageCapability(
+                key=spec.key,
+                display_name=spec.display_name,
+                chunker=bool(spec.chunker_language and spec.chunker_class),
+                ground_truth=bool(spec.gt_language and spec.gt_extensions),
+                agent=bool(spec.agent_languages),
+                graph_backend=spec.cold_start_backend if has_graph else None,
+                incremental_backend=(
+                    spec.incremental_backend if spec.incremental_patcher else None
+                ),
+                lsp=bool(
+                    spec.lsp_language_id
+                    and (
+                        spec.lsp_command
+                        or spec.lsp_command_env
+                        or spec.lsp_command_factory
+                    )
+                ),
+                core_decoder=has_core,
+                core_parity=core_parity,
+            )
+        )
+    return tuple(rows)
+
+
 __all__ = [
     "ExtensionKind",
+    "LanguageCapability",
     "LanguageSpec",
     "LANGUAGE_SPECS",
     "SPECS_BY_KEY",
@@ -644,6 +716,7 @@ __all__ = [
     "graph_language_aliases",
     "incremental_patcher_path",
     "incremental_patcher_paths",
+    "language_capability_rows",
     "lsp_command_for_language",
     "lsp_language_id_for_language",
     "normalize_agent_language",

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ A code analysis agent with graph-enhancement for multi-language codebases.
 
 ## Overview
 
-CodeMiner provides tools for structural code analysis, symbol-level change detection, and graph-based code intelligence. It supports **Python, Go, Rust, C/C++, JavaScript, and TypeScript**.
+CodeMiner provides tools for structural code analysis, symbol-level change detection, and graph-based code intelligence. Language support varies by surface; see the [Language Capabilities](language_capabilities.md) matrix for chunking, graph, incremental, and core parity coverage.
 
 ### Key Components
 
@@ -19,6 +19,7 @@ CodeMiner provides tools for structural code analysis, symbol-level change detec
 | [Web Demo](web_demo.md) | DeepWiki-style wiki + Ask site with an interactive code-dependency graph over indexed repos |
 | [MCP Server](mcp.md) | Serve semantic/BM25/regex/Zoekt search and dependency subgraphs to LLM agents over MCP |
 | [Agent Skills](agent_skills.md) | Composable retrieval/rerank/trace skills with index-aware gating |
+| [Language Capabilities](language_capabilities.md) | Registry-derived support matrix across chunking, graph, incremental, and core parity surfaces |
 | [GT Locator](gt_locator.md) | Extract symbol-level ground truth from SWE-bench patches |
 | [Incremental Graph](incremental_graph/index.md) | Update CodeGraph in-place without full re-indexing |
 | [Graph Range Query](graph_query.md) | LSP-aligned line-range / symbol queries with typed results |

--- a/docs/language_capabilities.md
+++ b/docs/language_capabilities.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Language Capabilities
+
+This matrix is generated from `codeminer.languages.LanguageSpec`. It tracks
+which surfaces are enabled for each registered language and makes core parity
+coverage explicit for languages that are graph-capable, serial-only, or
+tree-sitter-only.
+
+Update the registry first, then refresh this table:
+
+```bash
+python scripts/language_capability_matrix.py --write docs/language_capabilities.md
+python scripts/language_capability_matrix.py --check docs/language_capabilities.md
+```
+
+<!-- BEGIN CODEMINER_LANGUAGE_CAPABILITIES -->
+| Language | Chunker | GT | Agent | Graph backend | Incremental | LSP command | Core decoder | Core parity |
+|----------|---------|----|-------|---------------|-------------|-------------|--------------|-------------|
+| Python | yes | yes | yes | scip | lsp | yes | yes | covered |
+| Go | yes | yes | yes | scip | lsp | yes | yes | covered |
+| Rust | yes | yes | yes | scip | lsp | yes | yes | covered |
+| C/C++ | yes | yes | yes | clangd | clangd | yes | no | n/a-no-core-decoder |
+| C# | yes | yes | yes | none | none | no | no | n/a-tree-sitter-only |
+| Java | yes | yes | yes | none | none | no | no | n/a-tree-sitter-only |
+| Ruby | yes | yes | yes | none | none | no | no | n/a-tree-sitter-only |
+| PHP | yes | yes | yes | none | none | no | no | n/a-tree-sitter-only |
+| Kotlin | yes | yes | yes | none | none | no | no | n/a-tree-sitter-only |
+| JavaScript | yes | yes | yes | scip | lsp | yes | yes | covered |
+| TypeScript | yes | yes | yes | scip | lsp | yes | yes | covered |
+<!-- END CODEMINER_LANGUAGE_CAPABILITIES -->
+
+## Parity States
+
+| State | Meaning |
+|-------|---------|
+| `covered` | The language has an enabled C++ core decoder and belongs in the strict serial/core parity suite. |
+| `n/a-no-core-decoder` | The language has a graph backend but no C++ core decoder; parity is not applicable by construction. |
+| `n/a-tree-sitter-only` | The language currently supports chunking/retrieval surfaces only; graph/core parity is not applicable yet. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - MCP Server: mcp.md
       - Agent Skills: agent_skills.md
       - Agent Compile (Design): agent_compile_design.md
+      - Language Capabilities: language_capabilities.md
       - GT Locator: gt_locator.md
       - Incremental Graph:
           - Overview: incremental_graph/index.md

--- a/scripts/language_capability_matrix.py
+++ b/scripts/language_capability_matrix.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render or check the language capability matrix from the registry."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+_LANGUAGES_PATH = _PROJECT_ROOT / "codeminer" / "languages.py"
+
+BEGIN_MARKER = "<!-- BEGIN CODEMINER_LANGUAGE_CAPABILITIES -->"
+END_MARKER = "<!-- END CODEMINER_LANGUAGE_CAPABILITIES -->"
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _language_capability_rows():
+    spec = importlib.util.spec_from_file_location(
+        "_codeminer_languages_for_matrix", _LANGUAGES_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {_LANGUAGES_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.language_capability_rows()
+
+
+def render_matrix() -> str:
+    """Return the Markdown table for the current language registry."""
+
+    lines = [
+        "| Language | Chunker | GT | Agent | Graph backend | Incremental "
+        "| LSP command | Core decoder | Core parity |",
+        "|----------|---------|----|-------|---------------|-------------|-------------|--------------|-------------|",
+    ]
+    for row in _language_capability_rows():
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    row.display_name,
+                    _yes_no(row.chunker),
+                    _yes_no(row.ground_truth),
+                    _yes_no(row.agent),
+                    row.graph_backend or "none",
+                    row.incremental_backend or "none",
+                    _yes_no(row.lsp),
+                    _yes_no(row.core_decoder),
+                    row.core_parity,
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def render_block() -> str:
+    """Return the full generated Markdown block including markers."""
+
+    return "\n".join([BEGIN_MARKER, render_matrix(), END_MARKER])
+
+
+def replace_block(text: str, block: str) -> str:
+    """Replace the generated block in ``text`` with ``block``."""
+
+    before, begin, tail = text.partition(BEGIN_MARKER)
+    if not begin:
+        raise ValueError(f"missing marker: {BEGIN_MARKER}")
+    _, end, after = tail.partition(END_MARKER)
+    if not end:
+        raise ValueError(f"missing marker: {END_MARKER}")
+    return before.rstrip() + "\n\n" + block + after
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render/check docs/language_capabilities.md from LanguageSpec."
+    )
+    parser.add_argument(
+        "--write", type=Path, help="Update the generated block in a file"
+    )
+    parser.add_argument(
+        "--check",
+        type=Path,
+        help="Fail if the generated block in a file is out of date",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    block = render_block()
+
+    if args.write and args.check:
+        raise SystemExit("--write and --check are mutually exclusive")
+
+    if args.write:
+        path = args.write
+        path.write_text(
+            replace_block(path.read_text(encoding="utf-8"), block), encoding="utf-8"
+        )
+        return 0
+
+    if args.check:
+        path = args.check
+        expected = replace_block(path.read_text(encoding="utf-8"), block)
+        actual = path.read_text(encoding="utf-8")
+        if actual != expected:
+            print(f"{path} language capability matrix is out of date", file=sys.stderr)
+            print(
+                f"Run: python {Path(__file__).as_posix()} --write {path}",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    print(block)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_language_capability_matrix.py
+++ b/test/test_language_capability_matrix.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the generated language capability matrix documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.language_capability_matrix import render_block, replace_block
+
+
+def test_language_capability_doc_is_current():
+    path = Path("docs/language_capabilities.md")
+    text = path.read_text(encoding="utf-8")
+
+    assert replace_block(text, render_block()) == text

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -19,6 +19,7 @@ from codeminer.languages import (
     graph_indexer_paths,
     incremental_patcher_path,
     incremental_patcher_paths,
+    language_capability_rows,
     lsp_command_for_language,
     lsp_language_id_for_language,
     normalize_agent_language,
@@ -98,6 +99,31 @@ def test_core_decoder_languages_only_include_supported_core_aliases():
         "ts",
         "js",
     )
+
+
+def test_language_capability_rows_track_parity_applicability():
+    rows = {row.key: row for row in language_capability_rows()}
+
+    assert rows["python"].graph_backend == "scip"
+    assert rows["python"].core_decoder is True
+    assert rows["python"].core_parity == "covered"
+
+    assert rows["cpp"].graph_backend == "clangd"
+    assert rows["cpp"].core_decoder is False
+    assert rows["cpp"].core_parity == "n/a-no-core-decoder"
+
+    assert rows["javascript"].graph_backend == "scip"
+    assert rows["javascript"].core_decoder is True
+    assert rows["javascript"].core_parity == "covered"
+
+    for language in ("csharp", "java", "ruby", "php", "kotlin"):
+        assert rows[language].chunker is True
+        assert rows[language].ground_truth is True
+        assert rows[language].agent is True
+        assert rows[language].graph_backend is None
+        assert rows[language].incremental_backend is None
+        assert rows[language].core_decoder is False
+        assert rows[language].core_parity == "n/a-tree-sitter-only"
 
 
 def test_chunker_languages_are_current_supported_repo_chunkers():


### PR DESCRIPTION
## Summary

Adds a generated language capability matrix on top of #237.

## Changes

- Added registry-derived `LanguageCapability` rows so language support surfaces and core parity applicability are explicit in code.
- Added `scripts/language_capability_matrix.py` to render/check the generated documentation table without importing the full `codeminer` package.
- Added `docs/language_capabilities.md`, linked it from the docs index/MkDocs nav, and tested that the generated block stays in sync with `LanguageSpec`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validation after restacking the main issue-186 chain:

- Main-chain tip #238 full unit validation: `python -m pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1084 passed, 10 skipped`)
- Original focused validation included `scripts/language_capability_matrix.py --check`, `test/test_language_capability_matrix.py`, `test/scip/test_scip_core_registry.py`, chunker coverage, agent compile tests, and GT extraction tests.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

Stacked on #237. Parent is published but not merged yet. Refs #186.