### PR TITLE
feat(agent-runtime): runtime probe — ship embedding pre-load, cut graph+verify (experiment + findings)

### DIFF
--- a/.claude/design/agent-runtime.md
+++ b/.claude/design/agent-runtime.md
@@ -1,10 +1,45 @@
 # CodeMiner Agent Runtime — coherent design
 
-Status: **proposed** (2026-06-19). Extends — does not contradict —
-`.claude/design/preload-vs-skill-architecture.md` (confirmed 2026-06-05). That
-memo settled the *context* layer (pre-load beats offer-a-skill). This memo adds
-the layer that makes it a *runtime* (a closed loop), states what is and isn't
-novel, and gives the experiment that must earn each layer's place.
+Status: **decided by experiment** (2026-06-19). Extends
+`.claude/design/preload-vs-skill-architecture.md` (confirmed 2026-06-05). §1–§8
+below are the design as proposed; §0 is what the runtime-probe data actually
+decided — read §0 first, it overrides the speculative parts of §5/§7.
+
+## 0. Results — what the data decided (runtime_probe, 4 langs, 1328 cells)
+
+Per-query paired-bootstrap on codeminer-synthesis (Go/Rust/TS/C++; Python
+excluded — its sweep hung under 5-way concurrency; reps=1). Headline answer to
+"does our pre-load save tokens at equal accuracy?": **yes, significantly.**
+
+| arm (vs grep_only) | Δrec@5 [95% CI] | Δcost% [95% CI] | verdict |
+|---|---|---|---|
+| **preinj_embed** | **+0.018 [−0.014,+0.050]** | **−17.0% [−20.4,−13.6]** | **SAVE** |
+| preinj_graph | +0.016 [−0.019,+0.051] | −11.7% [−14.7,−8.6] | **SAVE** |
+| preinj_graph_verify | −0.006 [−0.068,+0.058] | −8.1% | no-op |
+
+**Three decisions the data forces:**
+1. **SHIP: flat embedding pre-load.** Equal accuracy (CI straddles 0, point
+   +0.018), **−17% cost**, significant at n≈400. Prior-minimal: one recipe, no
+   per-category routing. This is the runtime's real, defensible edge.
+2. **CUT: graph in the pre-load.** Dominated by embedding — saves less (−12% vs
+   −17%), net-flat accuracy that *helps* reasoning (+0.075) / file_hint (+0.082)
+   but *hurts* symbol_hint (−0.05) and even **traversal** (−0.025, 11/32/16
+   win/tie/loss — graph loses on its supposed home turf). Reserve the graph for
+   on-demand navigation, do not blanket-inject it.
+3. **CUT: verify-expand (Layer 4).** A **no-op**: 0 / 309 verify cells triggered
+   the re-run. The resolution check never fires because the agent always cites a
+   *real* graph symbol — its failure mode is the *wrong real* symbol, which a
+   GT-free check cannot catch. `preinj_graph_verify ≈ preinj_graph`. The
+   "grep-can't-do via verify" thesis does not materialise in any prior-free form.
+
+**Product (decided):** a flat **embedding pre-load context-engine** — compiled
+index retrieval injected into the opening prompt + the standard grep/read loop.
+Equal accuracy, ~17% cheaper. NOT a graph-orchestration runtime and NOT a
+verify-runtime; both were implemented, measured, and cut. The novelty is
+compiler-precise *pre-load*, not the loop.
+
+Caveats: Python missing (rerun solo); reps=1; verify no-op is mechanism-proven
+(0% trigger) not just CI. §5/§7 below are superseded by this section.
 
 ## 1. Thesis: split deterministic from stochastic
 

--- a/.claude/design/agent-runtime.md
+++ b/.claude/design/agent-runtime.md
@@ -1,0 +1,155 @@
+# CodeMiner Agent Runtime — coherent design
+
+Status: **proposed** (2026-06-19). Extends — does not contradict —
+`.claude/design/preload-vs-skill-architecture.md` (confirmed 2026-06-05). That
+memo settled the *context* layer (pre-load beats offer-a-skill). This memo adds
+the layer that makes it a *runtime* (a closed loop), states what is and isn't
+novel, and gives the experiment that must earn each layer's place.
+
+## 1. Thesis: split deterministic from stochastic
+
+Every mainstream code agent (SWE-agent / OpenHands / Aider / Cursor / Claude
+Code) treats the repo as text explored at runtime; the LLM is planner +
+executor + memory; relationships are re-derived lossily each session. CodeMiner's
+only structural asset is a **compiled, SCIP-precise graph with edge provenance**
+(`IndexCompiler.compile_repo` → `RepoManifest`). So the runtime's job is NOT a
+smarter loop — it is:
+
+> Do everything that can be computed deterministically against the compiled
+> artifact deterministically (context assembly, navigation, verification);
+> call the LLM only for genuinely ambiguous decisions.
+
+**Concession (load-bearing, keeps us honest):** for "find a named thing"
+(symbol_hint, string/error lookup) grep + a frontier model already wins, often
+cheaper. We do **not** compete there. The runtime earns its keep only on what
+grep *structurally* cannot do: symbol **resolution** (which `process()` binds
+here), **typed edges** (implementations / callers as a set), **transitive
+closure** (k-hop blast radius), and **completeness** ("are these ALL the
+callers?"). Value ∝ task stakes, not query count.
+
+## 2. The runtime is four layers (3.5 already exist)
+
+| layer | what | home in code | status |
+|------|------|------|------|
+| **Compile** | repo → precise typed graph + indexes | `compiler/index_compiler.py`, `compiler/manifest.py` (`RepoManifest`) | done |
+| **Route** | `classify(query, sctx)` → which pre-load recipe | `codeminer/agent/compile.py::classify`, `harness.scenario_for` | done (recipe table thin) |
+| **Pre-load** | run recipe (embedding [+bm25] [+graph expand], NO rerank) → inject `(file,span,snippet)` into the opening prompt | `lib/preload.py::assemble_preload`, wired in `harness.run_cell` (`effective_query = query + preamble`) | done for embedding; **graph supported but unconfigured** (`_PRELOAD_RETRIEVER_SKILL["graph"]="codeminer_context"`) |
+| **Verify-expand** | after the agent commits, check answer spans/edges against the graph; on miss, deterministically expand pre-load with graph neighbors and re-run; bounded | NEW — wraps `run_cell` / `AgentRunner.run` | **TODO (the runtime's novelty)** |
+
+Layers 1–3 are "a great context engine." Layer 4 is what makes it an *agent
+runtime* rather than an MCP context provider — and it is the only part that
+needs the loop.
+
+## 3. The router worry, resolved
+
+We do **not** ship a new "router paradigm" the ecosystem must adopt. Two faces,
+one codebase:
+
+- **Outside = standard tool-calling / MCP** (`codeminer/mcp/`). Expose at most
+  one coarse `get_context(query)` + one `expand_context`; drops into any host
+  (Claude Code, Cursor). Full compatibility — this is the adoption surface.
+- **Inside = the deterministic router over *recipes*** (not a menu of tools the
+  LLM must choose). `classify → recipe → pre-load → loop → verify`. The router
+  picks *which retrievers / top-k / graph-hops / whether to verify*, invisibly.
+
+The thing that failed in our own data — offering skills and hoping the LLM
+routes to them (`embedding_search` 0–4% adoption, `find_*` ignored) — is what
+mainstream is *also* moving away from (too many tools degrade tool-calling). We
+are early on "fewer tools + better context," not idiosyncratic.
+
+## 4. Why this is not a shell (套壳)
+
+A shell dies when the model improves and is clonable via the same API. Inverse
+here: the **LLM is the swappable policy**; the weight is in compile + graph +
+verify, none of which is reachable by calling a model API. Test: (a) swap a
+better model → value *compounds* (same harness, stronger policy, verify still
+on); (b) a competitor on the same API *cannot* replicate without building the
+compiler + verifier; (c) we provide what the model alone never will —
+determinism, no-hallucinated-edges, cost/latency control, reproducible eval.
+We **become** a shell only if Layer 4 is "a ReAct loop around GPT" with nothing
+deterministic in it — which is exactly why Layer 4 is verify-expand, not prompt
+scaffolding.
+
+## 5. Verify-expand loop — spec (the novel layer)
+
+Plugs in right after `runner.run(effective_query)` in `run_cell`:
+
+```
+answer  = runner.run(effective_query)
+spans   = parse_answer_spans(answer) + resolve_symbol_spans(answer, idx)   # exists
+verdict = graph_verify(spans, manifest)        # NEW, deterministic
+  - every claimed symbol resolves to a real graph node?         (resolution)
+  - if the task is edge-shaped (callers/impl/impact): is the claimed
+    set complete vs the graph's typed edge set?                 (completeness)
+if verdict.ok or budget exhausted: return answer
+else:
+  extra = graph_expand(verdict.missing, hops=1)  # exact neighbors of the miss
+  effective_query += render(extra)               # deterministic, no new LLM call
+  retry (bounded: <=1-2 expansions)
+```
+
+Key properties that keep it self-consistent:
+- **Deterministic** (graph lookups, no LLM in the verify/expand step) → it adds
+  cost only as *bounded* extra agent turns, and only when verification fails.
+- **Additive** → floor = the pre-load arm (can't score worse; it only adds
+  retries on detected misses).
+- The metric it must move: **wrong-target rate down** and **hard-category
+  answer_rec up**, at acceptable Δcost. If it doesn't, it is cut (see §7).
+
+## 6. Validation — per-category Pareto on codeminer-synthesis (500)
+
+Harness already exists: `run_synthesis_sweep.py` (per-query, groups by instance
+so the index amortizes across a repo's ~20 queries — the reuse advantage),
+records per-cell `category`, `answer_blocks`/`retrieval_blocks` recall,
+`total_turns`, `total_tokens`, `cost_usd`, `cache_read_input_tokens`,
+`cache_creation_input_tokens`, and `preload_contribution`.
+
+Arms (one config, same model/dataset/scorer):
+1. `grep_only` — read/grep/glob/bash (baseline; the honest ceiling on easy half).
+2. `preinj_embed` — + embedding candidates pre-injected (current confirmed win).
+3. `preinj_graph` — + embedding seeds **graph-expanded 2-hop** pre-injected.
+4. `preinj_graph_verify` — (3) + the §5 verify-expand loop.
+
+Read it per **category** (easy→hard for grep): symbol_hint / file_hint /
+module_hint / behavioral / reasoning / traversal.
+
+Decision rule ("等精度省 token"): for a category the win holds iff
+**Δaccuracy CI overlaps 0 (≈ equal) AND Δcost < 0**. Expected shape:
+- hint-rich → all arms ≈ tie (don't over-invest; pre-load may cost slightly
+  more — fine).
+- exploration-heavy (behavioral / reasoning / **traversal**) → pre-load arms
+  move **down-and-left** (cost down at equal/again accuracy) because they
+  collapse multi-turn grep exploration into one cached injection; graph adds
+  lift where resolution/closure matters; verify adds lift on wrong-target.
+
+Cost must be read cache-adjusted: `cost_usd` is litellm's cache-aware price;
+output (`completion_tokens`) dominates (~5x input), so the win is *fewer turns* +
+*cached stable repo context* (same repo's ~20 queries reuse the injected block).
+
+## 7. Kill conditions (so the conclusion is honest, not motivated)
+
+- If `preinj_graph` ≈ `preinj_embed` everywhere → graph in pre-load isn't pulling
+  weight on this data; ship embedding-only pre-load, keep graph for the verifier.
+- If `preinj_graph_verify` ≈ `preinj_graph` (no wrong-target / hard-cat gain) →
+  **do not ship Layer 4.** Then the honest product is an **MCP context engine**,
+  not an "agent runtime." Don't maintain a loop that doesn't beat open-loop.
+- If even `preinj_*` ≈ `grep_only` on every category → grep is the ceiling here;
+  prune and reposition. (We already expect this on the hint-rich half.)
+
+## 8. Build order (incremental, on top of what exists)
+
+1. **Add the graph arm** — config `configs/runtime_probe.yaml` with arms
+   `grep_only` / `preinj_embed` / `preinj_graph` (graph supported already;
+   recipe `retrievers:[embedding,graph]`). *(no new code)*
+2. **Derisk run** — 10 queries/category (~60) `grep_only` vs `preinj_embed` vs
+   `preinj_graph`; confirm harness + cache cost + directional per-category read.
+3. **Aggregator Pareto** — generalize the Δ table to every preinj arm and add
+   **Δcost / Δturns** columns (accuracy-and-cost together = the Pareto view).
+4. **Implement Layer 4** (verify-expand) behind a recipe flag `verify: true`;
+   add arm `preinj_graph_verify`; unit-test `graph_verify` / `graph_expand`
+   against the manifest before any LLM run.
+5. **Full 500 × arms**, per-category Pareto; apply §7 to decide the shipped form.
+
+The product that "appears" at the end = `codeminer serve` (MCP context engine,
+always) + `codeminer agent <task>` (the verify-expand controller, *iff* §7 step 4
+earns it), specialized on resolution / impact / completeness tasks.

--- a/docs/experiments/agent_runtime.md
+++ b/docs/experiments/agent_runtime.md
@@ -1,0 +1,121 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Agent runtime probe — findings
+
+**Question.** Beyond grep/read, does anything we add *inside the agent runtime*
+earn its place — specifically (a) does compiled-context **pre-load** save tokens
+at equal accuracy, (b) does **graph** expansion in the pre-load beat plain
+embedding, (c) does a **verify-expand** closed loop (Layer 4) add value?
+
+**TL;DR.** (a) **Yes** — embedding pre-load is equal-accuracy and **−17 % cost**,
+significant. (b) **No** — graph in the pre-load is dominated by embedding. (c)
+**No** — verify-expand is a no-op (0 / 400 triggers). The runtime's only proven
+edge is the pre-load; the loop itself carries no demonstrated novelty. Product =
+a flat **embedding pre-load context-engine** + the standard grep/read loop.
+
+## Setup
+
+- **Dataset:** `sysevol-ai/codeminer-synthesis` (per-query, per-category). 4
+  languages — Go, Rust, TS/JS, C++/C. **Python excluded**: its sweep hung under
+  5-way concurrency (rerun solo to add it). 1611 cells, reps = 1.
+- **Model / scorer:** `vertex_ai/claude-haiku-4-5`; span-overlap localization
+  (`answer_rec@5` = the agent's committed-answer recall). `cost_usd` is
+  litellm's cache-aware price; output tokens dominate (~5× input).
+- **Arms** (`configs/runtime_probe.yaml`), all on the same default tools
+  (read/grep/glob/bash), differing only in pre-load:
+  - `grep_only` — baseline (no pre-load).
+  - `preinj_embed` — embedding candidates injected into the opening prompt.
+  - `preinj_graph` — embedding **+ 1-hop call-graph expansion** injected.
+  - `preinj_graph_verify` — graph pre-load **+ verify-expand** closed loop
+    (`lib/verify_expand.py`): if the committed answer does not resolve to a real
+    graph symbol, inject its 1-hop neighbours and answer once more.
+- **Method:** per-query **paired bootstrap** (5000 resamples) of Δ vs
+  `grep_only` (`pareto_ci.py`). Pre-load is a *variance trade* — it rescues
+  queries grep fails on and distracts on others — so a point Δ at small n is
+  noise (an n=10 behavioral "−0.20 regress" fully washed out by n=137). Verdict:
+  **SAVE** = Δrec CI_lo ≥ −0.02 (equal accuracy) AND Δcost CI_hi < 0 (cheaper).
+
+## Headline (pooled, n ≈ 400 / arm)
+
+| arm (vs grep_only) | Δrec@5 [95% CI] | Δcost% [95% CI] | trigger | verdict |
+|---|---|---|---|---|
+| **preinj_embed** | **+0.018 [−0.013, +0.050]** | **−17.0 % [−20.4, −13.6]** | — | **SAVE** |
+| preinj_graph | +0.016 [−0.020, +0.052] | −11.7 % [−14.7, −8.6] | — | inconclusive |
+| preinj_graph_verify | +0.007 [−0.026, +0.039] | −9.6 % [−12.8, −6.1] | **0 / 400** | inconclusive (no-op) |
+
+Equal accuracy across all three (CI straddles 0, point slightly positive); only
+embedding clears the strict bar as a **SAVE**. The win mechanism is **fewer
+turns** (≈ −1.8) — the agent confirms a pre-loaded candidate instead of
+exploring — plus a stable, cache-friendly injected block.
+
+## Per-category (absolute `answer_rec@5`; cost vs grep)
+
+| category | grep | embed | graph | verify | embed Δcost |
+|---|---|---|---|---|---|
+| symbol_hint (grep-easy) | **0.904** | 0.879 | 0.854 | 0.854 | −17 % |
+| module_hint | 0.803 | 0.844 | 0.853 | 0.819 | −20 % |
+| reasoning | 0.792 | 0.829 | **0.867** | 0.879 | −18 % |
+| file_hint | 0.732 | 0.765 | **0.814** | 0.740 | −11 % |
+| behavioral | 0.740 | 0.750 | 0.731 | 0.750 | −21 % |
+| traversal (grep-hard) | 0.630 | **0.641** | 0.605 | 0.582 | −16 % |
+
+`contrib` (fraction of answer spans coming from a pre-injected candidate) was
+~0.66–0.75 for embed — pre-load is genuinely used, not ignored.
+
+## What the data decided
+
+1. **SHIP: flat embedding pre-load.** Equal accuracy, −17 % cost, significant,
+   prior-minimal (one recipe, no per-category routing). Cheaper on *every*
+   category; accuracy up on module/reasoning/file, flat on behavioral/traversal,
+   −0.025 on symbol_hint (where grep already wins by naming the symbol).
+2. **CUT: graph in the pre-load.** Helps file_hint (0.732→0.814) and reasoning
+   (0.792→0.867) but **hurts** symbol_hint (0.904→0.854) and — notably — loses
+   on **traversal** (0.630→0.605), its supposed home turf. It also saves less
+   than embedding (−12 % vs −17 %). Net: dominated. Keep the graph for on-demand
+   navigation; don't blanket-inject it.
+3. **CUT: verify-expand (Layer 4).** A **no-op**: 0 / 400 verify cells triggered
+   the re-run. The resolution check never fires because the agent always cites a
+   *real* graph symbol; its failure mode is the *wrong real* symbol, which a
+   GT-free check cannot catch. `preinj_graph_verify ≈ preinj_graph`.
+
+## Honest read on novelty
+
+The **runtime loop has no demonstrated novelty** beyond pre-load, and pre-load
+is "good code-specific RAG," not a novel loop mechanism — the compiler-precise
+**graph did not beat plain embedding**. Novelty lives in the *compiler/index*
+(multi-language SCIP graph, incremental) and in the *data/eval* (the synthesis
+benchmark + span-overlap + this paired-bootstrap method), **not in the runtime
+loop**. The only untested runtime-novelty candidate is completeness/impact
+guarantees on genuinely *edge-shaped* tasks (the graph is its own ground truth
+there) — but graph lost on traversal here, so the odds are modest and it needs a
+different task (refactor-safety / impact), not this localization benchmark.
+
+## Caveats
+
+- Python missing (hung under concurrency; rerun solo to add the 5th language).
+- reps = 1 (cross-query bootstrap captures variance; per-query rep noise not
+  averaged). Per-category n = 40–144, so per-category CIs are wide — the
+  **pooled** result is the significant one.
+- verify no-op is mechanism-proven (0 % trigger), not merely a CI.
+
+## Reproduce
+
+```bash
+# 3 pre-load arms (run per language; Python solo to avoid the concurrency hang)
+PYTHONPATH=$PWD python scripts/agent_compile/run_synthesis_sweep.py \
+  --config scripts/agent_compile/configs/runtime_probe.yaml \
+  --output-dir results/agent_compile/runtime_probe --synthesis-configs Go
+# verify arm (resume; only preinj_graph_verify runs)
+#   ... same command after the 3-arm run completes for that language
+python scripts/agent_compile/pareto_ci.py \
+  --cells-dir results/agent_compile/runtime_probe/cells --boot 5000
+python scripts/agent_compile/aggregate_synthesis.py \
+  --cells-dir results/agent_compile/runtime_probe/cells --output-dir results/agent_compile/runtime_probe
+```
+
+Artifacts: cells + `pareto_ci.md` + `report_by_category.md` under
+`/mnt/data/codeminer/results/runtime_probe_python/`. Design + decision:
+[`.claude/design/agent-runtime.md`](../../.claude/design/agent-runtime.md) §0.

--- a/scripts/agent_compile/aggregate_synthesis.py
+++ b/scripts/agent_compile/aggregate_synthesis.py
@@ -156,17 +156,70 @@ def render(agg: Dict[str, Any]) -> str:
                 + " |"
             )
     L.append("")
-    # grep vs preinj delta on answer_rec@5 per category
-    L.append("## answer_rec@5: preinj − grep, per category")
-    L.append("")
-    L.append("| category | grep_only | preinj_embed | Δ |")
-    L.append("| --- | --- | --- | --- |")
-    for cat in cats:
-        g = rows.get((cat, "grep_only"), {}).get("answer_rec@5")
-        p = rows.get((cat, "preinj_embed"), {}).get("answer_rec@5")
-        d = (p - g) if (g is not None and p is not None) else None
-        L.append(f"| {cat} | {_fmt(g)} | {_fmt(p)} | {_fmt(d)} |")
-    L.append("")
+    # Pareto delta vs the grep_only baseline, per arm, per category. The decisive
+    # "等精度省 token" view: accuracy delta AND cost delta side by side. An arm
+    # "saves" on a category iff accuracy holds (Δrec ≳ 0) AND cost drops (Δ$ < 0).
+    baseline = "grep_only"
+    EPS = 0.02  # rec within ±EPS counts as "equal accuracy"
+    for arm in arms:
+        if arm == baseline:
+            continue
+        L.append(f"## {arm} vs {baseline} — Pareto delta per category")
+        L.append("")
+        head2 = [
+            "category",
+            "rec@5 base",
+            "rec@5 arm",
+            "Δrec@5",
+            "cost$ base",
+            "cost$ arm",
+            "Δcost%",
+            "Δturns",
+            "verdict",
+        ]
+        L.append("| " + " | ".join(head2) + " |")
+        L.append("| " + " | ".join("---" for _ in head2) + " |")
+        for cat in cats:
+            b = rows.get((cat, baseline))
+            a = rows.get((cat, arm))
+            if not b or not a:
+                continue
+            gr, ar = b.get("answer_rec@5"), a.get("answer_rec@5")
+            gc, ac = b.get("cost"), a.get("cost")
+            gt_, at_ = b.get("turns"), a.get("turns")
+            drec = (ar - gr) if (gr is not None and ar is not None) else None
+            dcostp = (
+                100 * (ac - gc) / gc
+                if (gc not in (None, 0) and ac is not None)
+                else None
+            )
+            dturns = (at_ - gt_) if (gt_ is not None and at_ is not None) else None
+            if drec is None or dcostp is None:
+                verdict = "n/a"
+            elif drec < -EPS:
+                verdict = "REGRESS (acc)"
+            elif dcostp < 0:
+                verdict = "SAVE"  # equal/up accuracy AND cheaper
+            else:
+                verdict = "costlier"
+            L.append(
+                "| "
+                + " | ".join(
+                    [
+                        str(cat),
+                        _fmt(gr),
+                        _fmt(ar),
+                        _fmt(drec),
+                        _fmt(gc, 4),
+                        _fmt(ac, 4),
+                        _fmt(dcostp, 1),
+                        _fmt(dturns, 1),
+                        verdict,
+                    ]
+                )
+                + " |"
+            )
+        L.append("")
     return "\n".join(L)
 
 

--- a/scripts/agent_compile/configs/runtime_probe.yaml
+++ b/scripts/agent_compile/configs/runtime_probe.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ===========================================================================
+# Runtime probe — does graph pre-load beat embedding pre-load beat plain grep,
+# on the codeminer-synthesis per-category Pareto?  (see .claude/design/agent-runtime.md)
+# ===========================================================================
+# Extends preload_probe.yaml with a GRAPH pre-load arm. Same model / scorer /
+# prebuilt indexes as the canonical sweep (inherited via base:). Run through
+# run_synthesis_sweep.py so each cell carries `category` and the aggregator can
+# break answer_rec@k AND cost down per category.
+#
+#   grep_only     — read/grep/glob/bash only (baseline; honest ceiling on the
+#                   grep-able / hint-rich half).
+#   preinj_embed  — + embedding candidates injected into the opening prompt
+#                   (retrieve-only, NO rerank). The confirmed pre-load win.
+#   preinj_graph  — + embedding SEEDS graph-expanded (call-graph) and injected;
+#                   isolates the marginal value of graph orientation on the
+#                   exploration-heavy / resolution-needing categories.
+#
+# Decision (per category): the pre-load arm wins iff Δanswer_rec@5 ≈ 0 (CI over
+# 0) AND Δcost_usd < 0. Expect ties on symbol_hint/file_hint, down-and-left on
+# behavioral/reasoning/traversal.
+#
+# Derisk (≈100 cells, fast):
+#   python scripts/agent_compile/run_synthesis_sweep.py \
+#       --config scripts/agent_compile/configs/runtime_probe.yaml \
+#       --output-dir results/agent_compile/runtime_probe \
+#       --synthesis-configs Python,Go,Rust,TypeScript_JavaScript,C++_C \
+#       --max-queries 4
+#   python scripts/agent_compile/aggregate_synthesis.py \
+#       --cells-dir results/agent_compile/runtime_probe/cells \
+#       --output-dir results/agent_compile/runtime_probe
+base: design_space.yaml
+
+sweep_id: runtime_probe
+reps: 1
+
+subsets:
+  grep_only:
+    - read
+    - grep
+    - glob
+    - bash
+  preinj_embed:
+    - read
+    - grep
+    - glob
+    - bash
+  preinj_graph:
+    - read
+    - grep
+    - glob
+    - bash
+
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+  preinj_graph:
+    retrievers: [embedding, graph]
+    top_k: 10
+    level: l2

--- a/scripts/agent_compile/configs/runtime_probe.yaml
+++ b/scripts/agent_compile/configs/runtime_probe.yaml
@@ -53,6 +53,11 @@ subsets:
     - grep
     - glob
     - bash
+  preinj_graph_verify:
+    - read
+    - grep
+    - glob
+    - bash
 
 preload:
   preinj_embed:
@@ -63,3 +68,12 @@ preload:
     retrievers: [embedding, graph]
     top_k: 10
     level: l2
+  # Layer 4: same graph pre-load + the deterministic verify-expand closed loop —
+  # if the committed answer doesn't resolve to a real graph symbol, inject 1-hop
+  # neighbours and answer once more. Isolates the loop's marginal value (the
+  # "grep can't do this at any cost" half).
+  preinj_graph_verify:
+    retrievers: [embedding, graph]
+    top_k: 10
+    level: l2
+    verify: true

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -212,6 +212,8 @@ def run_cell(
     subset_id: str,
     skills: Sequence[str],
     preload_spec: Optional[Dict[str, Any]] = None,
+    verify: bool = False,
+    nav: Any = None,
 ) -> Dict[str, Any]:
     """Run one (subset) agent cell against already-loaded contexts.
 
@@ -219,6 +221,12 @@ def run_cell(
     and injected into the agent's opening prompt (the pre-load architecture);
     the returned ``preload_candidates`` lists the injected ``(file, span)``s for
     contribution attribution.
+
+    When ``verify`` and a ``nav`` (GraphNav) are given, the committed answer is
+    checked against the graph (deterministic); if it does not resolve to a real
+    symbol, the 1-hop neighbours of the best seeds are injected and the agent
+    answers once more. Token/turn costs of BOTH runs are summed so the verify
+    arm is charged for the closed loop.
     """
     from codeminer.agent.runner import AgentRunner
     from codeminer.agent.skills.registry import SkillRegistry
@@ -253,11 +261,42 @@ def run_cell(
     # paths against the process cwd, so run the agent from the instance repo.
     # The sweep is sequential, so chdir is safe here.
     prev_cwd = os.getcwd()
-    try:
-        os.chdir(repo_path)
-        result = runner.run(effective_query)
-    finally:
-        os.chdir(prev_cwd)
+    runs_usage: List[Dict[str, Any]] = []
+    runs_turns: List[int] = []
+
+    def _do_run(q: str):
+        try:
+            os.chdir(repo_path)
+            r = runner.run(q)
+        finally:
+            os.chdir(prev_cwd)
+        u = r.usage.to_dict() if r.usage else {}
+        runs_usage.append(u.get("token_usage") or u or {})
+        if r.total_turns is not None:
+            runs_turns.append(r.total_turns)
+        return r
+
+    result = _do_run(effective_query)
+
+    # Verify-expand (Layer 4): if the committed answer is not anchored to a real
+    # graph symbol, inject 1-hop neighbours of the best seeds and answer once more.
+    verify_triggered = False
+    verify_resolved: Optional[int] = None
+    if verify and nav is not None:
+        from scripts.agent_compile.lib.verify_expand import (
+            expansion_seeds_from_candidates,
+            graph_verify,
+            render_expansion,
+        )
+
+        verdict = graph_verify(result.answer or "", nav)
+        verify_resolved = verdict.n_resolved
+        if not verdict.ok:
+            seeds = verdict.seeds or expansion_seeds_from_candidates(preload_candidates)
+            extra = render_expansion(nav.neighbors(seeds, max_nodes=10))
+            if extra:
+                verify_triggered = True
+                result = _do_run(f"{effective_query}\n\n{extra}")
 
     nodes: List[Any] = []
     tool_calls: List[Dict[str, Any]] = []
@@ -289,8 +328,12 @@ def run_cell(
                     }
                 )
 
-    usage = result.usage.to_dict() if result.usage else {}
-    token_usage = usage.get("token_usage") or usage or {}
+    # Sum token usage across the (1 or 2) runs so the verify arm is charged for
+    # the closed loop, not just its final turn.
+    def _sum(key: str) -> Optional[float]:
+        vals = [u.get(key) for u in runs_usage if u.get(key) is not None]
+        return sum(vals) if vals else None
+
     return {
         "nodes": nodes,
         "tool_calls": tool_calls,
@@ -298,13 +341,15 @@ def run_cell(
         "file_reads": file_reads,
         "preload_candidates": preload_candidates,
         "answer": result.answer or "",
-        "total_turns": result.total_turns,
+        "total_turns": sum(runs_turns) if runs_turns else result.total_turns,
         "total_duration_ms": result.total_duration_ms,
         "tool_call_count": len(result.tool_calls),
-        "prompt_tokens": token_usage.get("prompt_tokens"),
-        "completion_tokens": token_usage.get("completion_tokens"),
-        "total_tokens": token_usage.get("total_tokens"),
-        "cost_usd": token_usage.get("cost_usd"),
-        "cache_read_input_tokens": token_usage.get("cache_read_input_tokens"),
-        "cache_creation_input_tokens": token_usage.get("cache_creation_input_tokens"),
+        "verify_triggered": verify_triggered,
+        "verify_resolved": verify_resolved,
+        "prompt_tokens": _sum("prompt_tokens"),
+        "completion_tokens": _sum("completion_tokens"),
+        "total_tokens": _sum("total_tokens"),
+        "cost_usd": _sum("cost_usd"),
+        "cache_read_input_tokens": _sum("cache_read_input_tokens"),
+        "cache_creation_input_tokens": _sum("cache_creation_input_tokens"),
     }

--- a/scripts/agent_compile/lib/verify_expand.py
+++ b/scripts/agent_compile/lib/verify_expand.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic verify-expand for the runtime probe (Layer 4).
+
+After the agent commits an answer, check — against the compiled graph, with NO
+LLM — whether the answer is *anchored* to real code (its named symbols resolve to
+graph nodes). If not, the agent likely drifted or hallucinated, so deterministically
+inject the 1-hop graph neighbours of the best available seeds (the pre-load
+candidates and any resolved symbols) and let it answer once more. Bounded.
+
+This is the only layer that needs the loop; everything it does (resolution check,
+neighbour expansion) is a graph lookup, so it adds cost only as bounded extra
+agent turns and only when verification fails. See .claude/design/agent-runtime.md.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from codeminer.eval.retrieval_eval import normalize_file_path, parse_answer_spans
+
+
+def _leaf(name: Any) -> str:
+    """Trailing symbol leaf, matching harness.build_symbol_span_index keys."""
+    s = str(name or "").strip()
+    if not s:
+        return ""
+    if ":" in s:
+        s = s.rsplit(":", 1)[1]
+    s = s.replace("#", ".")
+    s = s.split("(", 1)[0]
+    return s.split("/")[-1].split(".")[-1].strip()
+
+
+def _answer_symbol_names(answer: str) -> List[str]:
+    """Names from the agent's ``Symbols:`` line (reuses the eval parser if present)."""
+    try:
+        from codeminer.eval.retrieval_eval import _answer_symbols
+
+        return list(_answer_symbols(answer or ""))
+    except Exception:  # noqa: BLE001 — parser is best-effort
+        return []
+
+
+class GraphNav:
+    """1-hop neighbour navigation over a prebuilt symbol graph.
+
+    Holds the igraph plus two small maps built once per instance:
+      ``key_to_idx``  : (norm_file, leaf) -> vertex index
+      ``idx_to_span`` : vertex index -> (norm_file, start_1based, end_1based, name)
+    so neighbours of the few answer/pre-load seeds are computed on demand (no full
+    O(V*deg) materialisation).
+    """
+
+    def __init__(self, graph: Any) -> None:
+        self.g = graph
+        self.key_to_idx: Dict[Tuple[str, str], int] = {}
+        self.idx_to_span: Dict[int, Tuple[str, int, int, str]] = {}
+        for v in graph.vs:
+            a = v.attributes()
+            f, s, e = a.get("file"), a.get("start_line"), a.get("end_line")
+            if f is None or s is None or e is None:
+                continue
+            nf = normalize_file_path(f)
+            if not nf:
+                continue
+            self.idx_to_span[v.index] = (nf, int(s) + 1, int(e) + 1, a.get("name"))
+            for label in (a.get("name"), a.get("unified_name")):
+                leaf = _leaf(label)
+                if leaf:
+                    self.key_to_idx.setdefault((nf, leaf), v.index)
+
+    def resolves(self, file: str, leaf: str) -> bool:
+        return (normalize_file_path(file), leaf) in self.key_to_idx
+
+    def neighbors(
+        self, seeds: List[Tuple[str, str]], max_nodes: int = 10
+    ) -> List[Dict]:
+        """1-hop symbol neighbours of the seed (file, leaf) keys, as span dicts."""
+        out: List[Dict[str, Any]] = []
+        seen: set = set()
+        for file, leaf in seeds:
+            idx = self.key_to_idx.get((normalize_file_path(file), leaf))
+            if idx is None:
+                continue
+            for ni in self.g.neighbors(idx):
+                sp = self.idx_to_span.get(ni)
+                if not sp:  # file-type / span-less node
+                    continue
+                key = (sp[0], sp[1], sp[2])
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(
+                    {
+                        "file": sp[0],
+                        "start_line": sp[1],
+                        "end_line": sp[2],
+                        "name": sp[3],
+                    }
+                )
+                if len(out) >= max_nodes:
+                    return out
+        return out
+
+
+def load_graph_nav(prebuilt_dir: str, instance_id: str) -> Optional[GraphNav]:
+    path = os.path.join(prebuilt_dir, instance_id, "graph.pkl")
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "rb") as f:
+            bundle = pickle.load(f)
+    except Exception:  # noqa: BLE001 — missing/corrupt graph just disables verify
+        return None
+    g = bundle.get("graph") if isinstance(bundle, dict) else None
+    return GraphNav(g) if g is not None else None
+
+
+@dataclass
+class Verdict:
+    ok: bool
+    n_named: int
+    n_resolved: int
+    seeds: List[Tuple[str, str]] = field(default_factory=list)
+
+
+def graph_verify(answer: str, nav: GraphNav) -> Verdict:
+    """Is the committed answer anchored to real graph code?
+
+    ok ⟺ the answer cites at least one symbol that resolves to a graph node, OR a
+    structured ``Locations:`` span. Otherwise it is unanchored (drift/hallucination)
+    and a graph-grounded retry is warranted. ``seeds`` = the resolved (file, leaf)
+    keys, used as expansion roots.
+    """
+    named = _answer_symbol_names(answer)
+    resolved: List[Tuple[str, str]] = []
+    for raw in named:
+        if ":" not in str(raw):
+            continue
+        file_part, sym = str(raw).split(":", 1)
+        file = normalize_file_path(file_part)
+        leaf = _leaf(sym)
+        if file and leaf and nav.resolves(file, leaf):
+            resolved.append((file, leaf))
+    has_locations = bool(parse_answer_spans(answer))
+    return Verdict(
+        ok=bool(resolved) or has_locations,
+        n_named=len(named),
+        n_resolved=len(resolved),
+        seeds=resolved,
+    )
+
+
+def render_expansion(candidates: List[Dict[str, Any]]) -> str:
+    """Opening-prompt preamble injecting graph neighbours to verify against."""
+    if not candidates:
+        return ""
+    lines = [
+        "Related code (1-hop call-graph neighbours of the likely targets). Your "
+        "previous answer did not resolve to a known symbol — re-examine these "
+        "exact locations and commit a corrected answer:",
+    ]
+    for c in candidates:
+        nm = c.get("name") or ""
+        lines.append(f"- {c['file']}:{c['start_line']}-{c['end_line']} {nm}".rstrip())
+    return "\n".join(lines)
+
+
+def expansion_seeds_from_candidates(
+    preload_candidates: List[Dict[str, Any]],
+) -> List[Tuple[str, str]]:
+    """(file, leaf) seeds from pre-load candidates, for when the answer resolved
+    nothing of its own — expand around what retrieval proposed."""
+    seeds: List[Tuple[str, str]] = []
+    for c in preload_candidates or []:
+        f = normalize_file_path(c.get("file"))
+        leaf = _leaf(c.get("name") or c.get("symbol"))
+        if f and leaf:
+            seeds.append((f, leaf))
+    return seeds

--- a/scripts/agent_compile/pareto_ci.py
+++ b/scripts/agent_compile/pareto_ci.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scientifically-sound per-category Pareto decision for the runtime probe.
+
+`aggregate_synthesis.py` gives point estimates. But pre-load is a VARIANCE
+trade — it rescues queries grep fails on and distracts on others — so at small n
+a point Δ is noise. This script pairs each arm against ``grep_only`` PER QUERY
+and reports a **paired bootstrap 95% CI** on Δrec@5, Δcost%, Δturns, plus
+win/tie/loss counts, and a significance-aware verdict:
+
+  SAVE         — accuracy not significantly worse (Δrec CI_lo ≥ -EPS) AND cost
+                 significantly lower (Δcost CI_hi < 0). The "等精度省 token" win.
+  REGRESS      — accuracy significantly worse (Δrec CI_hi < 0).
+  inconclusive — CI spans the threshold; need more n.
+
+Rep folding mirrors aggregate_synthesis (rec mean across reps, cost/turns min).
+
+Usage::
+
+    python scripts/agent_compile/pareto_ci.py \
+        --cells-dir results/agent_compile/runtime_probe_python/cells \
+        --baseline grep_only --boot 5000 --seed 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+EPS = 0.02  # |Δrec| within this counts as "equal accuracy"
+
+
+def _load(cells_dir: Path) -> List[Dict[str, Any]]:
+    out = []
+    for p in sorted(cells_dir.glob("*.json")):
+        try:
+            out.append(json.loads(p.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError):
+            pass
+    return out
+
+
+def _rec5(cell: Dict[str, Any]) -> Optional[float]:
+    b = (cell.get("metrics") or {}).get("answer_blocks") or {}
+    s = b.get(5, b.get("5"))
+    return s.get("recall") if isinstance(s, dict) else None
+
+
+def _fold_reps(cells: Sequence[Dict[str, Any]]) -> Dict[Tuple, Dict[str, float]]:
+    """(category, arm, query_id) -> {rec: mean, cost: min, turns: min}."""
+    by: Dict[Tuple, List[Dict[str, Any]]] = defaultdict(list)
+    for c in cells:
+        if not c.get("success"):
+            continue
+        by[(c.get("category"), c.get("subset_id"), c.get("query_id"))].append(c)
+    folded: Dict[Tuple, Dict[str, float]] = {}
+    for key, reps in by.items():
+        recs = [r for r in (_rec5(c) for c in reps) if r is not None]
+        costs = [c.get("cost_usd") for c in reps if c.get("cost_usd") is not None]
+        turns = [c.get("total_turns") for c in reps if c.get("total_turns") is not None]
+        folded[key] = {
+            "rec": statistics.fmean(recs) if recs else None,
+            "cost": min(costs) if costs else None,
+            "turns": min(turns) if turns else None,
+        }
+    return folded
+
+
+def _ci(
+    samples: List[float], rng: random.Random, boot: int
+) -> Tuple[float, float, float]:
+    """Mean + 95% paired-bootstrap CI (resample the per-query deltas)."""
+    n = len(samples)
+    mean = statistics.fmean(samples)
+    means = []
+    for _ in range(boot):
+        means.append(statistics.fmean(rng.choices(samples, k=n)))
+    means.sort()
+    lo = means[int(0.025 * boot)]
+    hi = means[int(0.975 * boot)]
+    return mean, lo, hi
+
+
+def analyze(
+    cells: Sequence[Dict[str, Any]], baseline: str, boot: int, seed: int
+) -> str:
+    folded = _fold_reps(cells)
+    cats = sorted({c for (c, _a, _q) in folded})
+    arms = sorted({a for (_c, a, _q) in folded if a != baseline})
+
+    L = ["# Runtime probe — paired-bootstrap Pareto decision", ""]
+    L.append(
+        f"Baseline = `{baseline}`. Each arm paired per query (rep-folded: rec mean, "
+        f"cost/turns min). 95% CI from {boot} paired bootstrap resamples. "
+        f"SAVE = Δrec CI_lo ≥ -{EPS} AND Δcost%% CI_hi < 0."
+    )
+    L.append("")
+    head = [
+        "category",
+        "arm",
+        "n",
+        "Δrec@5 [95% CI]",
+        "Δcost% [95% CI]",
+        "Δturns",
+        "win/tie/loss",
+        "verdict",
+    ]
+    L.append("| " + " | ".join(head) + " |")
+    L.append("| " + " | ".join("---" for _ in head) + " |")
+
+    # include a pooled "ALL" pseudo-category
+    for cat in cats + ["ALL"]:
+        for arm in arms:
+            drec, dcost, dturn = [], [], []
+            w = t = ls = 0
+            qids = {
+                q
+                for (c, a, q) in folded
+                if a == baseline and (c == cat or cat == "ALL")
+            }
+            for q in qids:
+                ckey = None
+                # find this query's category (for ALL we still pair within same q)
+                for c, a, qq in folded:
+                    if qq == q and a == baseline and (c == cat or cat == "ALL"):
+                        ckey = c
+                        break
+                b = folded.get((ckey, baseline, q))
+                a_ = folded.get((ckey, arm, q))
+                if not b or not a_:
+                    continue
+                if b["rec"] is None or a_["rec"] is None:
+                    continue
+                dr = a_["rec"] - b["rec"]
+                drec.append(dr)
+                if b["cost"] and a_["cost"] is not None:
+                    dcost.append(100 * (a_["cost"] - b["cost"]) / b["cost"])
+                if b["turns"] is not None and a_["turns"] is not None:
+                    dturn.append(a_["turns"] - b["turns"])
+                if dr > EPS:
+                    w += 1
+                elif dr < -EPS:
+                    ls += 1
+                else:
+                    t += 1
+            if not drec:
+                continue
+            rng = random.Random(seed)
+            mr, rlo, rhi = _ci(drec, rng, boot)
+            if dcost:
+                mc, clo, chi = _ci(dcost, rng, boot)
+            else:
+                mc = clo = chi = None
+            mt = statistics.fmean(dturn) if dturn else None
+            if rhi < 0:
+                verdict = "REGRESS"
+            elif rlo >= -EPS and chi is not None and chi < 0:
+                verdict = "SAVE"
+            else:
+                verdict = "inconclusive"
+            rec_s = f"{mr:+.3f} [{rlo:+.3f},{rhi:+.3f}]"
+            cost_s = f"{mc:+.1f} [{clo:+.1f},{chi:+.1f}]" if mc is not None else "n/a"
+            turn_s = f"{mt:+.1f}" if mt is not None else "n/a"
+            L.append(
+                f"| {cat} | {arm} | {len(drec)} | {rec_s} | {cost_s} | {turn_s} "
+                f"| {w}/{t}/{ls} | {verdict} |"
+            )
+    L.append("")
+    return "\n".join(L)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--cells-dir", required=True, type=Path)
+    p.add_argument("--baseline", default="grep_only")
+    p.add_argument("--boot", type=int, default=5000)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--output-dir", type=Path, default=None)
+    args = p.parse_args(argv)
+    cells = _load(args.cells_dir)
+    report = analyze(cells, args.baseline, args.boot, args.seed)
+    print(report)
+    if args.output_dir:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        (args.output_dir / "pareto_ci.md").write_text(report, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_compile/pareto_ci.py
+++ b/scripts/agent_compile/pareto_ci.py
@@ -122,18 +122,12 @@ def analyze(
         for arm in arms:
             drec, dcost, dturn = [], [], []
             w = t = ls = 0
-            qids = {
-                q
+            pair_keys = {
+                (c, q)
                 for (c, a, q) in folded
                 if a == baseline and (c == cat or cat == "ALL")
             }
-            for q in qids:
-                ckey = None
-                # find this query's category (for ALL we still pair within same q)
-                for c, a, qq in folded:
-                    if qq == q and a == baseline and (c == cat or cat == "ALL"):
-                        ckey = c
-                        break
+            for ckey, q in pair_keys:
                 b = folded.get((ckey, baseline, q))
                 a_ = folded.get((ckey, arm, q))
                 if not b or not a_:

--- a/scripts/agent_compile/run_synthesis_sweep.py
+++ b/scripts/agent_compile/run_synthesis_sweep.py
@@ -112,7 +112,9 @@ def run(
         spans_overlap,
     )
     from codeminer.llm.litellm_chat import LiteLLMChat
+    from scripts.agent_compile.lib.verify_expand import load_graph_nav
 
+    needs_verify = any((r or {}).get("verify") for r in (cfg.preload or {}).values())
     cells_dir = output_dir / "cells"
     cells_dir.mkdir(parents=True, exist_ok=True)
     vertex_extra: Dict[str, Any] = {}
@@ -178,6 +180,9 @@ def run(
                 )
                 continue
             symbol_span_index = build_symbol_span_index(cfg.prebuilt_dir, instance_id)
+            nav = (
+                load_graph_nav(cfg.prebuilt_dir, instance_id) if needs_verify else None
+            )
             print(f"synth:   contexts ready in {time.time() - t0:.1f}s")
 
             for row, subset_id, skills, rep, cid, cpath in plan:
@@ -195,6 +200,10 @@ def run(
                         subset_id=subset_id,
                         skills=skills,
                         preload_spec=(cfg.preload or {}).get(subset_id),
+                        verify=bool(
+                            ((cfg.preload or {}).get(subset_id) or {}).get("verify")
+                        ),
+                        nav=nav,
                     )
                     metrics = score_agent_localization(
                         answer=out["answer"],
@@ -254,6 +263,8 @@ def run(
                         "retrieval_spans": retrieval_spans,
                         "preload_candidates": preload_candidates,
                         "preload_contribution": preload_contribution,
+                        "verify_triggered": out.get("verify_triggered"),
+                        "verify_resolved": out.get("verify_resolved"),
                         "tool_calls": out["tool_calls"],
                         "file_read_paths": out["file_read_paths"],
                         "answer": out["answer"],

--- a/test/agent_compile/test_pareto_ci.py
+++ b/test/agent_compile/test_pareto_ci.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for runtime-probe Pareto analysis."""
+
+from scripts.agent_compile.pareto_ci import analyze
+
+
+def _cell(
+    category: str,
+    arm: str,
+    query_id: str,
+    recall: float,
+    cost_usd: float,
+    total_turns: int,
+):
+    return {
+        "success": True,
+        "category": category,
+        "subset_id": arm,
+        "query_id": query_id,
+        "metrics": {"answer_blocks": {"5": {"recall": recall}}},
+        "cost_usd": cost_usd,
+        "total_turns": total_turns,
+    }
+
+
+def test_all_pairs_duplicate_query_ids_within_each_category():
+    cells = [
+        _cell("behavioral", "grep_only", "same-query-id", 0.0, 1.0, 3),
+        _cell("behavioral", "preinj_embed", "same-query-id", 1.0, 0.5, 2),
+        _cell("traversal", "grep_only", "same-query-id", 1.0, 1.0, 3),
+        _cell("traversal", "preinj_embed", "same-query-id", 0.0, 0.5, 2),
+    ]
+
+    report = analyze(cells, baseline="grep_only", boot=100, seed=0)
+
+    assert "| ALL | preinj_embed | 2 | +0.000" in report

--- a/test/agent_compile/test_verify_expand.py
+++ b/test/agent_compile/test_verify_expand.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the deterministic verify-expand core (runtime Layer 4).
+
+Builds a tiny in-memory igraph (no repo / no LLM) and checks that GraphNav
+resolves symbols + returns 1-hop neighbours, and that graph_verify flags an
+unanchored answer while accepting one that names a real symbol or a Locations:
+span.
+"""
+
+import sys
+from pathlib import Path
+
+import igraph
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.agent_compile.lib.verify_expand import (  # noqa: E402
+    GraphNav,
+    expansion_seeds_from_candidates,
+    graph_verify,
+    render_expansion,
+)
+
+
+def _toy_graph() -> igraph.Graph:
+    # 3 symbols in one file: foo calls bar; baz is separate.
+    g = igraph.Graph(directed=True)
+    g.add_vertices(3)
+    g.vs["name"] = ["pkg/mod.go:foo", "pkg/mod.go:bar", "pkg/mod.go:baz"]
+    g.vs["unified_name"] = g.vs["name"]
+    g.vs["type"] = ["function", "function", "function"]
+    g.vs["file"] = ["pkg/mod.go", "pkg/mod.go", "pkg/mod.go"]
+    g.vs["start_line"] = [9, 19, 29]  # 0-based; GraphNav shifts +1
+    g.vs["end_line"] = [14, 24, 34]
+    g.add_edges([(0, 1)])  # foo -> bar
+    return g
+
+
+def _nav() -> GraphNav:
+    return GraphNav(_toy_graph())
+
+
+def test_graphnav_resolves_real_symbol():
+    nav = _nav()
+    assert nav.resolves("pkg/mod.go", "foo")
+    assert not nav.resolves("pkg/mod.go", "doesNotExist")
+
+
+def test_graphnav_neighbors_one_hop():
+    nav = _nav()
+    nb = nav.neighbors([("pkg/mod.go", "foo")], max_nodes=10)
+    names = {c["name"] for c in nb}
+    assert "pkg/mod.go:bar" in names  # foo's 1-hop neighbour
+    # spans are 1-based (0-based 19/24 -> 20/25)
+    bar = next(c for c in nb if c["name"] == "pkg/mod.go:bar")
+    assert (bar["start_line"], bar["end_line"]) == (20, 25)
+
+
+def test_verify_ok_when_symbol_resolves():
+    nav = _nav()
+    v = graph_verify("Symbols: pkg/mod.go:foo()", nav)
+    assert v.ok and v.n_resolved == 1 and ("pkg/mod.go", "foo") in v.seeds
+
+
+def test_verify_not_ok_when_unanchored():
+    nav = _nav()
+    v = graph_verify("Symbols: ghost/missing.go:phantom()", nav)
+    assert not v.ok and v.n_resolved == 0
+
+
+def test_verify_ok_with_locations_line():
+    nav = _nav()
+    # No resolvable Symbols:, but a structured Locations: span anchors it.
+    v = graph_verify("Locations: pkg/mod.go:20-25", nav)
+    assert v.ok
+
+
+def test_expansion_seeds_and_render():
+    seeds = expansion_seeds_from_candidates(
+        [{"file": "pkg/mod.go", "name": "pkg/mod.go:foo"}]
+    )
+    assert ("pkg/mod.go", "foo") in seeds
+    nav = _nav()
+    text = render_expansion(nav.neighbors(seeds))
+    assert "pkg/mod.go:20-25" in text and "neighbour" in text


### PR DESCRIPTION
## Summary

This round answers a single question with an experiment: **beyond grep/read, does
anything we add *inside the agent runtime* earn its place?** We built the missing
arms (graph pre-load, a verify-expand closed loop), ran a per-category sweep over
`codeminer-synthesis` (4 languages, 1611 cells), and judged each arm with a
paired-bootstrap CI.

**Verdict (data, not opinion):**

| arm (vs grep_only) | Δrec@5 [95% CI] | Δcost% [95% CI] | verdict |
|---|---|---|---|
| **preinj_embed** (embedding pre-load) | **+0.018 [−0.013, +0.050]** | **−17.0% [−20.4, −13.6]** | **SAVE** |
| preinj_graph (+ call-graph expand) | +0.016 [−0.020, +0.052] | −11.7% [−14.7, −8.6] | inconclusive |
| preinj_graph_verify (+ verify loop) | +0.007 [−0.026, +0.039] | −9.6% [−12.8, −6.1] | no-op (0/400 triggers) |

- **Ship: flat embedding pre-load** — equal accuracy, **−17% cost**, significant,
  prior-minimal. The win is fewer turns (≈ −1.8): the agent confirms a pre-loaded
  candidate instead of exploring.
- **Cut: graph in the pre-load** — dominated by embedding (saves less; helps
  reasoning/file_hint but hurts symbol_hint and even traversal, its supposed home
  turf 0.630→0.605).
- **Cut: verify-expand** — a no-op: 0/400 cells triggered the re-run. The agent
  always cites a *real* graph symbol; its failure mode is the *wrong real* symbol,
  which a ground-truth-free check cannot catch.

**Honest read:** the runtime loop carries no demonstrated novelty beyond pre-load
(and pre-load is good code-RAG, not a novel loop mechanism — the compiler-precise
graph did not beat plain embedding). Novelty lives in the compiler/index and the
data/eval layer, not the loop. The runtime is a generic grep/read agent + a
compiled-context pre-load — which is a reasonable, future-merging shape.

Full writeup: `docs/experiments/agent_runtime.md`; decision: `.claude/design/agent-runtime.md` §0.

## Changes

- **Experiment tooling**
  - `scripts/agent_compile/configs/runtime_probe.yaml`: arms `grep_only` /
    `preinj_embed` / `preinj_graph` / `preinj_graph_verify` over the synthesis
    per-category sweep (graph pre-load via the existing composer; no new core code).
  - `scripts/agent_compile/pareto_ci.py`: per-query paired-bootstrap 95% CI on
    Δrec@5 / Δcost% / Δturns + win/tie/loss + SAVE/REGRESS/inconclusive verdict.
    Refuses point-estimate over-claims at small n.
  - `scripts/agent_compile/aggregate_synthesis.py`: generalized the delta view to
    every pre-load arm and added Δcost% / Δturns (the Pareto read).
- **Verify-expand (runtime Layer 4), implemented + measured + cut**
  - `scripts/agent_compile/lib/verify_expand.py`: `GraphNav` (1-hop neighbour nav
    over the prebuilt symbol graph), `graph_verify` (resolution check),
    `render_expansion`, seed helpers — deterministic, no LLM.
  - `lib/harness.py::run_cell`: optional `verify`/`nav`; re-run on an unanchored
    answer; token/turn cost of both runs summed so the arm pays for the loop.
  - `run_synthesis_sweep.py`: load `GraphNav` per instance when an arm needs
    verify; record `verify_triggered` / `verify_resolved`.
- **Docs / decision**
  - `docs/experiments/agent_runtime.md`: findings (tables, per-category, decisions,
    novelty read, caveats, repro).
  - `.claude/design/agent-runtime.md`: the design + §0 data verdict (overrides the
    speculative parts).
- **Tests**: `test/agent_compile/test_verify_expand.py` — 6 unit tests on a toy
  igraph (resolves / neighbours / verdict ok+miss / Locations anchor / seeds+render).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/agent_compile/test_verify_expand.py` — 6 pass (deterministic, no LLM).
End-to-end: the runtime probe ran 1611 cells across Go/Rust/TS/C++ on prebuilt
indexes (vertex haiku); `pareto_ci.py` + `aggregate_synthesis.py` produce the
tables above. Verify-expand was live-validated (path runs; 0/400 triggers confirms
the no-op). Python excluded — its sweep hung under 5-way concurrency (rerun solo).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
