### PR TITLE
[codex] Add graph backend alignment harness

### DIFF
--- a/codeminer/graph/backend_alignment.py
+++ b/codeminer/graph/backend_alignment.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-alignment checks for CodeGraph-producing indexers.
+
+Serial/core parity is intentionally strict and bit-for-bit.  Backend alignment
+is different: SCIP, clangd, and generic LSP backends may use different internal
+vertex identities, but their definition surface should agree on readable
+``unified_name`` symbols and containment hierarchy before reference edges are
+trusted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ..types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_FILE,
+    is_symbol_node,
+)
+from .code_graph import CodeGraph
+
+
+@dataclass(frozen=True, slots=True)
+class BackendAlignmentTolerances:
+    """Allowed graph-surface differences between two backends."""
+
+    max_missing_symbols: int = 0
+    max_extra_symbols: int = 0
+    max_missing_containment: int = 0
+    max_extra_containment: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class BackendAlignmentReport:
+    """Structured result for backend-alignment comparison."""
+
+    reference_symbols: int
+    candidate_symbols: int
+    missing_symbols: tuple[str, ...]
+    extra_symbols: tuple[str, ...]
+    reference_containment: int
+    candidate_containment: int
+    missing_containment: tuple[tuple[str, str], ...]
+    extra_containment: tuple[tuple[str, str], ...]
+    reference_references: int
+    candidate_references: int
+    tolerances: BackendAlignmentTolerances
+
+    @property
+    def ok(self) -> bool:
+        t = self.tolerances
+        return (
+            len(self.missing_symbols) <= t.max_missing_symbols
+            and len(self.extra_symbols) <= t.max_extra_symbols
+            and len(self.missing_containment) <= t.max_missing_containment
+            and len(self.extra_containment) <= t.max_extra_containment
+        )
+
+    def summary(self, *, sample: int = 5) -> str:
+        status = "ok" if self.ok else "mismatch"
+        return (
+            f"backend alignment {status}: "
+            f"symbols ref={self.reference_symbols} cand={self.candidate_symbols} "
+            f"missing={len(self.missing_symbols)} extra={len(self.extra_symbols)}; "
+            f"contain ref={self.reference_containment} "
+            f"cand={self.candidate_containment} "
+            f"missing={len(self.missing_containment)} "
+            f"extra={len(self.extra_containment)}; "
+            f"refs ref={self.reference_references} "
+            f"cand={self.candidate_references}; "
+            f"sample_missing_symbols={self.missing_symbols[:sample]} "
+            f"sample_extra_symbols={self.extra_symbols[:sample]}"
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "ok": self.ok,
+            "reference_symbols": self.reference_symbols,
+            "candidate_symbols": self.candidate_symbols,
+            "missing_symbols": list(self.missing_symbols),
+            "extra_symbols": list(self.extra_symbols),
+            "reference_containment": self.reference_containment,
+            "candidate_containment": self.candidate_containment,
+            "missing_containment": [list(edge) for edge in self.missing_containment],
+            "extra_containment": [list(edge) for edge in self.extra_containment],
+            "reference_references": self.reference_references,
+            "candidate_references": self.candidate_references,
+            "tolerances": {
+                "max_missing_symbols": self.tolerances.max_missing_symbols,
+                "max_extra_symbols": self.tolerances.max_extra_symbols,
+                "max_missing_containment": self.tolerances.max_missing_containment,
+                "max_extra_containment": self.tolerances.max_extra_containment,
+            },
+        }
+
+
+def compare_backend_graphs(
+    reference: CodeGraph,
+    candidate: CodeGraph,
+    tolerances: Optional[BackendAlignmentTolerances] = None,
+) -> BackendAlignmentReport:
+    """Compare two backend graphs on the stable definition surface."""
+
+    tolerances = tolerances or BackendAlignmentTolerances()
+
+    ref_symbols = _definition_symbols(reference)
+    cand_symbols = _definition_symbols(candidate)
+    ref_contain = _definition_containment_edges(reference)
+    cand_contain = _definition_containment_edges(candidate)
+
+    return BackendAlignmentReport(
+        reference_symbols=len(ref_symbols),
+        candidate_symbols=len(cand_symbols),
+        missing_symbols=tuple(sorted(ref_symbols - cand_symbols)),
+        extra_symbols=tuple(sorted(cand_symbols - ref_symbols)),
+        reference_containment=len(ref_contain),
+        candidate_containment=len(cand_contain),
+        missing_containment=tuple(sorted(ref_contain - cand_contain)),
+        extra_containment=tuple(sorted(cand_contain - ref_contain)),
+        reference_references=_edge_count(reference, EDGE_TYPE_REFERENCE),
+        candidate_references=_edge_count(candidate, EDGE_TYPE_REFERENCE),
+        tolerances=tolerances,
+    )
+
+
+def _definition_symbols(graph: CodeGraph) -> set[str]:
+    result: set[str] = set()
+    for vertex in graph.graph.vs:
+        key = _definition_key(vertex)
+        if key:
+            result.add(key)
+    return result
+
+
+def _definition_containment_edges(graph: CodeGraph) -> set[tuple[str, str]]:
+    edges: set[tuple[str, str]] = set()
+    vertices = graph.graph.vs
+    for edge in graph.graph.es:
+        if edge.attributes().get("type") != EDGE_TYPE_CONTAIN:
+            continue
+        target = _definition_key(vertices[edge.target])
+        if not target:
+            continue
+        source = _node_key(vertices[edge.source])
+        if source:
+            edges.add((source, target))
+    return edges
+
+
+def _definition_key(vertex) -> Optional[str]:
+    attrs = vertex.attributes()
+    if not is_symbol_node(attrs.get("type", "")):
+        return None
+    if attrs.get("file") is None or attrs.get("start_line") is None:
+        return None
+    return attrs.get("unified_name") or vertex["name"]
+
+
+def _node_key(vertex) -> Optional[str]:
+    attrs = vertex.attributes()
+    node_type = attrs.get("type")
+    if is_symbol_node(node_type):
+        return _definition_key(vertex)
+    if node_type == NODE_TYPE_FILE:
+        return vertex["name"]
+    return None
+
+
+def _edge_count(graph: CodeGraph, edge_type: str) -> int:
+    return sum(
+        1 for edge in graph.graph.es if edge.attributes().get("type") == edge_type
+    )
+
+
+__all__ = [
+    "BackendAlignmentReport",
+    "BackendAlignmentTolerances",
+    "compare_backend_graphs",
+]

--- a/docs/contributing-a-language.md
+++ b/docs/contributing-a-language.md
@@ -133,6 +133,20 @@ the current CodeGraph contract:
 - line bases handled deliberately (`CodeChunk` uses 0-based lines, graph query
   APIs use the CodeGraph conventions documented in `docs/graph_query.md`).
 
+When two backends exist for the same language, compare them before trusting the
+new backend's graph surface:
+
+```bash
+python scripts/check_backend_alignment.py \
+  --reference /path/to/scip-or-clangd/graph.pkl \
+  --candidate /path/to/lsp/graph.pkl
+```
+
+The alignment harness compares definition symbols by `unified_name` and the
+symbol containment hierarchy. It reports reference-edge counts but does not
+require reference parity by default; server-specific reference/call edges need
+explicit tolerances before they are treated as a blocking signal.
+
 ## Step 4: Add Incremental Graph Patching
 
 Add `codeminer/graph/incremental/patcher_{lang}.py` only after graph support

--- a/scripts/check_backend_alignment.py
+++ b/scripts/check_backend_alignment.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare two CodeGraph pickles on the backend-alignment surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from codeminer.graph.backend_alignment import (
+    BackendAlignmentTolerances,
+    compare_backend_graphs,
+)
+from codeminer.graph.code_graph import CodeGraph
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reference", required=True, type=Path)
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--max-missing-symbols", type=int, default=0)
+    parser.add_argument("--max-extra-symbols", type=int, default=0)
+    parser.add_argument("--max-missing-containment", type=int, default=0)
+    parser.add_argument("--max-extra-containment", type=int, default=0)
+    parser.add_argument("--json", action="store_true", help="emit JSON report")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    tolerances = BackendAlignmentTolerances(
+        max_missing_symbols=args.max_missing_symbols,
+        max_extra_symbols=args.max_extra_symbols,
+        max_missing_containment=args.max_missing_containment,
+        max_extra_containment=args.max_extra_containment,
+    )
+    report = compare_backend_graphs(
+        CodeGraph.load_graph(str(args.reference)),
+        CodeGraph.load_graph(str(args.candidate)),
+        tolerances=tolerances,
+    )
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(report.summary())
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/graph/test_backend_alignment.py
+++ b/test/graph/test_backend_alignment.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for backend-alignment graph comparisons."""
+
+from __future__ import annotations
+
+from codeminer.graph.backend_alignment import (
+    BackendAlignmentTolerances,
+    compare_backend_graphs,
+)
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FILE,
+    NODE_TYPE_METHOD,
+)
+
+
+def _graph(prefix: str = "") -> CodeGraph:
+    graph = CodeGraph(project_root="/tmp/repo")
+    graph._add_vertex("src/Foo.java", {"type": NODE_TYPE_FILE})
+    graph._add_vertex(
+        f"{prefix}Foo",
+        {
+            "type": NODE_TYPE_CLASS,
+            "file": "src/Foo.java",
+            "start_line": 1,
+            "end_line": 20,
+            "unified_name": "src/Foo.java:Foo",
+        },
+    )
+    graph._add_vertex(
+        f"{prefix}Foo.run",
+        {
+            "type": NODE_TYPE_METHOD,
+            "file": "src/Foo.java",
+            "start_line": 4,
+            "end_line": 8,
+            "unified_name": "src/Foo.java:Foo.run()",
+        },
+    )
+    graph._add_edge("src/Foo.java", f"{prefix}Foo", EDGE_TYPE_CONTAIN)
+    graph._add_edge(f"{prefix}Foo", f"{prefix}Foo.run", EDGE_TYPE_CONTAIN)
+    graph.build_range_indexes()
+    return graph
+
+
+def test_alignment_matches_on_unified_names_not_vertex_identities():
+    reference = _graph(prefix="scip:")
+    candidate = _graph(prefix="lsp:")
+
+    report = compare_backend_graphs(reference, candidate)
+
+    assert report.ok
+    assert report.reference_symbols == 2
+    assert report.candidate_symbols == 2
+    assert report.missing_symbols == ()
+    assert report.extra_symbols == ()
+
+
+def test_alignment_reports_missing_symbols_and_containment():
+    reference = _graph(prefix="scip:")
+    candidate = _graph(prefix="lsp:")
+    candidate.graph.delete_vertices([candidate.name_to_vertex["lsp:Foo.run"]])
+    candidate.name_to_vertex = {v["name"]: v.index for v in candidate.graph.vs}
+
+    report = compare_backend_graphs(reference, candidate)
+
+    assert not report.ok
+    assert report.missing_symbols == ("src/Foo.java:Foo.run()",)
+    assert report.missing_containment == (
+        ("src/Foo.java:Foo", "src/Foo.java:Foo.run()"),
+    )
+
+
+def test_alignment_tolerances_allow_known_backend_gaps():
+    reference = _graph(prefix="scip:")
+    candidate = _graph(prefix="lsp:")
+    candidate.graph.delete_vertices([candidate.name_to_vertex["lsp:Foo.run"]])
+    candidate.name_to_vertex = {v["name"]: v.index for v in candidate.graph.vs}
+
+    report = compare_backend_graphs(
+        reference,
+        candidate,
+        tolerances=BackendAlignmentTolerances(
+            max_missing_symbols=1,
+            max_missing_containment=1,
+        ),
+    )
+
+    assert report.ok
+
+
+def test_reference_edges_are_reported_but_not_required_by_default():
+    reference = _graph(prefix="scip:")
+    candidate = _graph(prefix="lsp:")
+    reference._add_edge(
+        "scip:Foo.run",
+        "scip:Foo",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="src/Foo.java",
+        anchor_line=6,
+    )
+
+    report = compare_backend_graphs(reference, candidate)
+
+    assert report.ok
+    assert report.reference_references == 1
+    assert report.candidate_references == 0


### PR DESCRIPTION
## Summary
- add a backend-alignment library for comparing CodeGraph definition symbols and containment hierarchy across backends
- add scripts/check_backend_alignment.py for comparing two graph.pkl files with explicit tolerances
- document the alignment step in the language contribution workflow

## Validation
- python -m black --check codeminer/graph/backend_alignment.py scripts/check_backend_alignment.py test/graph/test_backend_alignment.py
- python -m flake8 codeminer/graph/backend_alignment.py scripts/check_backend_alignment.py test/graph/test_backend_alignment.py
- python -m pytest -q test/graph/test_backend_alignment.py test/ls_index/test_lsp_indexer.py test/test_languages.py test/test_language_capability_matrix.py
- python -m compileall -q codeminer/graph/backend_alignment.py scripts/check_backend_alignment.py
- python -m mkdocs build --strict

## Notes
- alignment is intentionally weaker than serial/core parity: it compares definition symbols by unified_name and symbol containment edges
- reference edges are reported as counts only until per-server tolerances are defined