### PR TITLE
[codex] Decode generic LSP reference edges

### DIFF
--- a/codeminer/ls_index/lsp_graph_decode.py
+++ b/codeminer/ls_index/lsp_graph_decode.py
@@ -4,10 +4,10 @@
 
 """Generic LSP documentSymbol decoder.
 
-This decoder intentionally builds the conservative part of an LSP graph:
-file nodes, definition symbols, and CONTAIN edges.  Cross-file REFERENCE edges
-are server-specific enough that they belong behind a backend-alignment harness
-rather than being inferred in this first generic path.
+This decoder always builds the conservative part of an LSP graph: file nodes,
+definition symbols, and CONTAIN edges.  Cross-file REFERENCE edges are decoded
+only when the index payload explicitly carries LSP reference locations; callers
+can keep the backend symbol-only until a language has alignment tolerances.
 """
 
 from __future__ import annotations
@@ -15,10 +15,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Iterable, Mapping, Optional
+from urllib.parse import unquote, urlparse
 
 from ..graph.code_graph import CodeGraph
 from ..types import (
     EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
     NODE_TYPE_CLASS,
     NODE_TYPE_DIRECTORY,
     NODE_TYPE_FIELD,
@@ -92,6 +94,13 @@ class GenericLSPGraphDecoder:
                     parent_unified_part="",
                 )
 
+        graph.build_range_indexes()
+        with graph.batch_edges():
+            _add_reference_edges(
+                graph,
+                payload.get("files", []),
+                project_root=self.project_root,
+            )
         graph.build_range_indexes()
         self.code_graph = graph
         return graph
@@ -200,10 +209,143 @@ def _process_symbol_tree(
             )
 
 
+def iter_lsp_symbol_definitions(
+    file_path: str,
+    symbols: list[dict],
+    parent_unified_part: str = "",
+) -> Iterable[dict]:
+    """Yield definition metadata using the generic decoder naming rules."""
+
+    for symbol in symbols or []:
+        name = symbol.get("name") or ""
+        kind = int(symbol.get("kind") or 0)
+        range_data = symbol.get("range") or {}
+        sel_range = symbol.get("selectionRange") or range_data
+        start_line = _line(range_data, "start", default=0)
+        end_line = _line(range_data, "end", default=start_line)
+
+        if _is_local_symbol(kind, parent_unified_part):
+            child_parent = parent_unified_part
+        elif kind in _GRAPH_SYMBOL_KINDS:
+            unified_name = _build_unified_name(
+                file_path=file_path,
+                name=name,
+                parent_unified_part=parent_unified_part,
+                kind=kind,
+            )
+            yield {
+                "vertex_name": f"{unified_name}:{start_line}",
+                "unified_name": unified_name,
+                "kind": kind,
+                "start_line": start_line,
+                "end_line": end_line,
+                "selection_line": _line(sel_range, "start", default=start_line),
+                "selection_character": _character(sel_range, "start", default=0),
+            }
+            child_parent = (
+                parent_unified_part if kind == 2 else unified_name.split(":", 1)[1]
+            )
+        else:
+            child_parent = parent_unified_part
+
+        yield from iter_lsp_symbol_definitions(
+            file_path,
+            symbol.get("children") or [],
+            parent_unified_part=child_parent,
+        )
+
+
+def _add_reference_edges(
+    graph: CodeGraph,
+    file_entries: list[dict],
+    *,
+    project_root: Optional[Path],
+) -> None:
+    for entry in file_entries:
+        for refs in entry.get("references") or []:
+            target = _target_vertex_name(refs)
+            if target not in graph.name_to_vertex:
+                continue
+            target_file = refs.get("target_file")
+            target_start = refs.get("target_start_line")
+            for location in refs.get("locations") or []:
+                rel_path, anchor_line = _location_anchor(location, project_root)
+                if rel_path is None or anchor_line is None:
+                    continue
+                if rel_path == target_file and anchor_line == target_start:
+                    continue
+                source = _scope_at_line(graph, rel_path, anchor_line)
+                if source is None:
+                    continue
+                graph._add_edge(
+                    source,
+                    target,
+                    EDGE_TYPE_REFERENCE,
+                    anchor_file=rel_path,
+                    anchor_line=anchor_line,
+                )
+
+
+def _target_vertex_name(refs: dict) -> str:
+    return f"{refs.get('target_unified_name')}:{refs.get('target_start_line')}"
+
+
+def _location_anchor(
+    location: dict,
+    project_root: Optional[Path],
+) -> tuple[Optional[str], Optional[int]]:
+    uri = location.get("uri") or location.get("targetUri")
+    range_data = location.get("range") or location.get("targetSelectionRange") or {}
+    if not uri:
+        return None, None
+    rel_path = _uri_to_relpath(uri, project_root)
+    if rel_path is None:
+        return None, None
+    return rel_path, _line(range_data, "start", default=-1)
+
+
+def _uri_to_relpath(uri: str, project_root: Optional[Path]) -> Optional[str]:
+    parsed = urlparse(uri)
+    if parsed.scheme != "file":
+        return None
+    path = Path(unquote(parsed.path))
+    if project_root is not None:
+        try:
+            return path.resolve().relative_to(project_root).as_posix()
+        except ValueError:
+            return None
+    return path.as_posix()
+
+
+def _scope_at_line(graph: CodeGraph, file_path: str, line: int) -> Optional[str]:
+    if line < 0:
+        return None
+    candidates = []
+    for start, end, vid in graph._file_nodes.get(file_path, []):
+        if start <= line <= end:
+            vertex = graph.graph.vs[vid]
+            attrs = vertex.attributes()
+            if attrs.get("type") == NODE_TYPE_FILE:
+                continue
+            candidates.append((end - start, start, vertex["name"]))
+    if candidates:
+        candidates.sort(key=lambda item: (item[0], -item[1]))
+        return candidates[0][2]
+    if file_path in graph.name_to_vertex:
+        return file_path
+    return None
+
+
 def _line(range_data: dict, key: str, *, default: int) -> int:
     point = range_data.get(key) or {}
     line = point.get("line")
     return int(line) if isinstance(line, int) else default
+
+
+def _character(range_data: dict, key: str, *, default: int) -> int:
+    point = range_data.get(key) or {}
+    character = point.get("character")
+    return int(character) if isinstance(character, int) else default
 
 
 def _node_type(kind: int) -> str:
@@ -231,4 +373,4 @@ def _build_unified_name(
     return f"{file_path}:{display}"
 
 
-__all__ = ["GenericLSPGraphDecoder"]
+__all__ = ["GenericLSPGraphDecoder", "iter_lsp_symbol_definitions"]

--- a/codeminer/ls_index/lsp_indexer.py
+++ b/codeminer/ls_index/lsp_indexer.py
@@ -23,7 +23,7 @@ from ..graph.incremental.lsp_client import LSPClient
 from ..languages import extensions_for_language, lsp_command_for_language
 from ..log_utils import get_logger
 from ..profiler import Profiler
-from .lsp_graph_decode import GenericLSPGraphDecoder
+from .lsp_graph_decode import GenericLSPGraphDecoder, iter_lsp_symbol_definitions
 
 logger = get_logger("generic_lsp_indexer")
 
@@ -72,6 +72,7 @@ class GenericLSPIndexer:
         logger.info(
             "Collecting document symbols for %d %s files", len(files), self.language
         )
+        include_references = bool(kwargs.get("include_references", False))
         try:
             with self.profiler.section("generate_index.lsp_document_symbols"):
                 with LSPClient(
@@ -82,9 +83,14 @@ class GenericLSPIndexer:
                         symbols = client.document_symbol(
                             str(self.project_root / rel_path)
                         )
-                        records.append(
-                            {"path": rel_path.as_posix(), "symbols": symbols}
-                        )
+                        record = {"path": rel_path.as_posix(), "symbols": symbols}
+                        if include_references:
+                            record["references"] = self._collect_references(
+                                client,
+                                rel_path,
+                                symbols,
+                            )
+                        records.append(record)
         except Exception as exc:
             logger.error("LSP index generation failed for %s: %s", self.language, exc)
             return False
@@ -185,6 +191,32 @@ class GenericLSPIndexer:
             if self._is_excluded(rel_path):
                 continue
             yield rel_path
+
+    def _collect_references(
+        self,
+        client: LSPClient,
+        rel_path: Path,
+        symbols: list[dict],
+    ) -> list[dict]:
+        references = []
+        for definition in iter_lsp_symbol_definitions(rel_path.as_posix(), symbols):
+            locations = client.references(
+                str(self.project_root / rel_path),
+                definition["selection_line"],
+                definition["selection_character"],
+                include_declaration=False,
+            )
+            if not locations:
+                continue
+            references.append(
+                {
+                    "target_unified_name": definition["unified_name"],
+                    "target_start_line": definition["start_line"],
+                    "target_file": rel_path.as_posix(),
+                    "locations": locations,
+                }
+            )
+        return references
 
     def _is_excluded(self, rel_path: Path) -> bool:
         text = rel_path.as_posix()

--- a/test/ls_index/test_lsp_indexer.py
+++ b/test/ls_index/test_lsp_indexer.py
@@ -7,10 +7,20 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
-from codeminer.ls_index.lsp_graph_decode import GenericLSPGraphDecoder
+from codeminer.ls_index.lsp_graph_decode import (
+    GenericLSPGraphDecoder,
+    iter_lsp_symbol_definitions,
+)
+from codeminer.ls_index.lsp_indexer import GenericLSPIndexer
 from codeminer.ls_router import LSIndexer
-from codeminer.types import EDGE_TYPE_CONTAIN, NODE_TYPE_CLASS, NODE_TYPE_METHOD
+from codeminer.types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_METHOD,
+)
 
 
 def _sym(name, kind, start, end, children=None):
@@ -81,3 +91,99 @@ def test_lsindexer_routes_java_to_generic_lsp_backend(tmp_path):
     assert indexer.language == "java"
     assert indexer._delegate.__class__.__name__ == "GenericLSPIndexer"
     assert indexer._delegate.index_file.name == "index.lsp.json"
+
+
+def test_generic_lsp_decoder_adds_reference_edges(tmp_path):
+    foo = tmp_path / "src/main/java/app/Foo.java"
+    bar = tmp_path / "src/main/java/app/Bar.java"
+    foo.parent.mkdir(parents=True)
+    foo.write_text("class Foo { void run() {} }\n", encoding="utf-8")
+    bar.write_text("class Bar { void call() { new Foo().run(); } }\n", encoding="utf-8")
+
+    foo_symbols = [_sym("Foo", 5, 0, 10, children=[_sym("run", 6, 2, 4)])]
+    bar_symbols = [_sym("Bar", 5, 0, 10, children=[_sym("call", 6, 2, 8)])]
+    target = list(
+        iter_lsp_symbol_definitions("src/main/java/app/Foo.java", foo_symbols)
+    )[1]
+
+    index = tmp_path / "index.lsp.json"
+    index.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "language": "java",
+                "files": [
+                    {
+                        "path": "src/main/java/app/Foo.java",
+                        "symbols": foo_symbols,
+                        "references": [
+                            {
+                                "target_unified_name": target["unified_name"],
+                                "target_start_line": target["start_line"],
+                                "target_file": "src/main/java/app/Foo.java",
+                                "locations": [
+                                    {
+                                        "uri": bar.as_uri(),
+                                        "range": {
+                                            "start": {"line": 3, "character": 35},
+                                            "end": {"line": 3, "character": 38},
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "path": "src/main/java/app/Bar.java",
+                        "symbols": bar_symbols,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    graph = GenericLSPGraphDecoder(str(index), project_root=str(tmp_path)).decode()
+
+    source = "src/main/java/app/Bar.java:Bar.call():2"
+    target_name = "src/main/java/app/Foo.java:Foo.run():2"
+    edge = graph.graph.es.find(
+        _source=graph.name_to_vertex[source],
+        _target=graph.name_to_vertex[target_name],
+    )
+
+    assert edge["type"] == EDGE_TYPE_REFERENCE
+    assert edge["anchor_file"] == "src/main/java/app/Bar.java"
+    assert edge["anchor_line"] == 3
+
+
+def test_generic_lsp_indexer_collects_references_from_selection_range(tmp_path):
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        def references(self, file_path, line, character, include_declaration=False):
+            self.calls.append((file_path, line, character, include_declaration))
+            return [
+                {
+                    "uri": (tmp_path / "src/Foo.java").as_uri(),
+                    "range": {
+                        "start": {"line": 7, "character": 12},
+                        "end": {"line": 7, "character": 15},
+                    },
+                }
+            ]
+
+    symbols = [_sym("Foo", 5, 0, 10, children=[_sym("run", 6, 3, 5)])]
+    indexer = GenericLSPIndexer(tmp_path, language="java")
+    fake = FakeClient()
+
+    refs = indexer._collect_references(fake, Path("src/Foo.java"), symbols)
+
+    assert fake.calls == [
+        (str(tmp_path / "src/Foo.java"), 0, 4, False),
+        (str(tmp_path / "src/Foo.java"), 3, 4, False),
+    ]
+    assert refs[1]["target_unified_name"] == "src/Foo.java:Foo.run()"
+    assert refs[1]["target_start_line"] == 3
+    assert refs[1]["locations"][0]["range"]["start"]["line"] == 7


### PR DESCRIPTION
## Summary
- let generic LSP index payloads carry per-symbol reference locations
- decode those locations into anchored CodeGraph REFERENCE edges by resolving source scope from line ranges
- add fake-LSP tests for reference collection and decoding without requiring jdtls

## Validation
- python -m black --check codeminer/ls_index/lsp_graph_decode.py codeminer/ls_index/lsp_indexer.py test/ls_index/test_lsp_indexer.py
- python -m flake8 codeminer/ls_index/lsp_graph_decode.py codeminer/ls_index/lsp_indexer.py test/ls_index/test_lsp_indexer.py
- python -m pytest -q -m "not integration and not integration_serial and not integration_serial_consumer and not slow" test/ls_index/test_lsp_indexer.py test/graph/test_backend_alignment.py test/test_languages.py test/test_language_capability_matrix.py test/graph/incremental/test_graph_patcher_registry.py test/scip/test_scip_core_registry.py test/compiler/test_index_compiler.py
- python -m compileall -q codeminer/ls_index/lsp_graph_decode.py codeminer/ls_index/lsp_indexer.py

## Notes
- references are collected only when callers pass include_references=True; symbol-only graph generation remains available
- backend alignment tolerances should still gate whether a language treats these reference edges as a blocking signal