### PR TITLE
[codex] promote graph-layer core API

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -48,6 +48,7 @@ pkg_check_modules(RE2 REQUIRED re2)
 
 add_library(codeminer_core STATIC
     code_graph.cpp
+    graph_layers.cpp
     scip_decode_common.cpp
     scip_decode_base.cpp
     scip_decode_python.cpp
@@ -77,6 +78,12 @@ add_executable(scip_decode_test
 
 target_link_libraries(scip_decode_test PRIVATE codeminer_core)
 
+add_executable(graph_layers_test
+    tests/graph_layers_test.cpp
+)
+
+target_link_libraries(graph_layers_test PRIVATE codeminer_core)
+
 add_executable(scip_decode_repo
     tests/scip_decode_repo.cpp
 )
@@ -90,6 +97,9 @@ if(CODEMINER_ENABLE_O3)
     endif()
     if(TARGET scip_decode_repo)
         target_compile_options(scip_decode_repo PRIVATE -O3)
+    endif()
+    if(TARGET graph_layers_test)
+        target_compile_options(graph_layers_test PRIVATE -O3)
     endif()
 endif()
 
@@ -156,5 +166,10 @@ if(CODEMINER_ENABLE_DEBUG)
     if(TARGET scip_decode_repo)
         target_compile_definitions(scip_decode_repo PRIVATE CODEMINER_DEBUG=1)
         target_compile_options(scip_decode_repo PRIVATE ${_codeminer_debug_flags})
+    endif()
+
+    if(TARGET graph_layers_test)
+        target_compile_definitions(graph_layers_test PRIVATE CODEMINER_DEBUG=1)
+        target_compile_options(graph_layers_test PRIVATE ${_codeminer_debug_flags})
     endif()
 endif()

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -18,6 +18,7 @@
 // serialization cost across the C++/Python boundary is just one igraph vcount +
 // ecount worth of tuples/dicts.
 
+#include "graph_layers.h"
 #include "scip_decode.h"
 
 #include <memory>
@@ -26,7 +27,6 @@
 #include <pybind11/stl.h>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace py = pybind11;
@@ -114,44 +114,10 @@ py::dict decode_scip(const std::string &index_file,
   return result;
 }
 
-std::unordered_map<std::string, std::vector<std::size_t>>
-classify_edge_layers(const std::vector<std::string> &edge_types) {
-  std::unordered_map<std::string, std::vector<std::size_t>> result;
-  result[codeminer::core::GRAPH_LAYER_ALL].reserve(edge_types.size());
-  result[codeminer::core::GRAPH_LAYER_CONTAINMENT];
-  result[codeminer::core::GRAPH_LAYER_DEPENDENCY];
-  result[codeminer::core::GRAPH_LAYER_REFERENCE];
-  result[codeminer::core::GRAPH_LAYER_IMPORT];
-  result[codeminer::core::GRAPH_LAYER_TYPE_USE];
-
-  auto &all = result[codeminer::core::GRAPH_LAYER_ALL];
-  auto &containment = result[codeminer::core::GRAPH_LAYER_CONTAINMENT];
-  auto &dependency = result[codeminer::core::GRAPH_LAYER_DEPENDENCY];
-  auto &reference = result[codeminer::core::GRAPH_LAYER_REFERENCE];
-  auto &import_layer = result[codeminer::core::GRAPH_LAYER_IMPORT];
-  auto &type_use = result[codeminer::core::GRAPH_LAYER_TYPE_USE];
-
+codeminer::core::LayerBuckets
+classify_edge_layers_py(const std::vector<std::string> &edge_types) {
   py::gil_scoped_release release;
-
-  for (std::size_t i = 0; i < edge_types.size(); ++i) {
-    const auto &type = edge_types[i];
-    all.push_back(i);
-    if (type == codeminer::core::EDGE_TYPE_CONTAIN) {
-      containment.push_back(i);
-    }
-    if (type == codeminer::core::EDGE_TYPE_REFERENCE) {
-      reference.push_back(i);
-      dependency.push_back(i);
-    } else if (type == codeminer::core::EDGE_TYPE_IMPORT) {
-      import_layer.push_back(i);
-      dependency.push_back(i);
-    } else if (type == codeminer::core::EDGE_TYPE_TYPE_USE) {
-      type_use.push_back(i);
-      dependency.push_back(i);
-    }
-  }
-
-  return result;
+  return codeminer::core::classify_edge_layers(edge_types);
 }
 
 } // namespace
@@ -181,7 +147,7 @@ Returns:
       - "project_root": the effective project_root used.
 )pbdoc");
 
-  m.def("classify_edge_layers", &classify_edge_layers, py::arg("edge_types"),
+  m.def("classify_edge_layers", &classify_edge_layers_py, py::arg("edge_types"),
         R"pbdoc(
 Classify edge-type strings into overlapping CodeGraph layer id buckets.
 

--- a/core/graph_layers.cpp
+++ b/core/graph_layers.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "graph_layers.h"
+
+#include "code_graph.h"
+
+namespace codeminer::core {
+namespace {
+
+LayerBuckets make_empty_buckets(std::size_t edge_count) {
+  LayerBuckets buckets;
+  buckets[GRAPH_LAYER_ALL].reserve(edge_count);
+  buckets[GRAPH_LAYER_CONTAINMENT];
+  buckets[GRAPH_LAYER_DEPENDENCY];
+  buckets[GRAPH_LAYER_REFERENCE];
+  buckets[GRAPH_LAYER_IMPORT];
+  buckets[GRAPH_LAYER_TYPE_USE];
+  return buckets;
+}
+
+} // namespace
+
+LayerBuckets classify_edge_layers(const std::vector<std::string> &edge_types) {
+  LayerBuckets buckets = make_empty_buckets(edge_types.size());
+
+  auto &all = buckets[GRAPH_LAYER_ALL];
+  auto &containment = buckets[GRAPH_LAYER_CONTAINMENT];
+  auto &dependency = buckets[GRAPH_LAYER_DEPENDENCY];
+  auto &reference = buckets[GRAPH_LAYER_REFERENCE];
+  auto &import_layer = buckets[GRAPH_LAYER_IMPORT];
+  auto &type_use = buckets[GRAPH_LAYER_TYPE_USE];
+
+  for (EdgeId edge_id = 0; edge_id < edge_types.size(); ++edge_id) {
+    const std::string &type = edge_types[edge_id];
+    all.push_back(edge_id);
+
+    if (type == EDGE_TYPE_CONTAIN) {
+      containment.push_back(edge_id);
+      continue;
+    }
+
+    if (type == EDGE_TYPE_REFERENCE) {
+      reference.push_back(edge_id);
+      dependency.push_back(edge_id);
+      continue;
+    }
+
+    if (type == EDGE_TYPE_IMPORT) {
+      import_layer.push_back(edge_id);
+      dependency.push_back(edge_id);
+      continue;
+    }
+
+    if (type == EDGE_TYPE_TYPE_USE) {
+      type_use.push_back(edge_id);
+      dependency.push_back(edge_id);
+    }
+  }
+
+  return buckets;
+}
+
+} // namespace codeminer::core

--- a/core/graph_layers.h
+++ b/core/graph_layers.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace codeminer::core {
+
+using EdgeId = std::size_t;
+using LayerEdgeIds = std::vector<EdgeId>;
+using LayerBuckets = std::unordered_map<std::string, LayerEdgeIds>;
+
+// Classify edge ids into CodeGraph's default overlapping layer buckets.
+//
+// This is deliberately language-agnostic: SCIP, clangd, and generic-LSP
+// decoders all normalize into the same edge-type strings before this point.
+LayerBuckets classify_edge_layers(const std::vector<std::string> &edge_types);
+
+} // namespace codeminer::core

--- a/core/tests/graph_layers_test.cpp
+++ b/core/tests/graph_layers_test.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "graph_layers.h"
+
+#include "code_graph.h"
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+using codeminer::core::EDGE_TYPE_CONTAIN;
+using codeminer::core::EDGE_TYPE_IMPORT;
+using codeminer::core::EDGE_TYPE_REFERENCE;
+using codeminer::core::EDGE_TYPE_TYPE_USE;
+using codeminer::core::GRAPH_LAYER_ALL;
+using codeminer::core::GRAPH_LAYER_CONTAINMENT;
+using codeminer::core::GRAPH_LAYER_DEPENDENCY;
+using codeminer::core::GRAPH_LAYER_IMPORT;
+using codeminer::core::GRAPH_LAYER_REFERENCE;
+using codeminer::core::GRAPH_LAYER_TYPE_USE;
+using codeminer::core::LayerEdgeIds;
+
+namespace {
+
+void assert_layer(const codeminer::core::LayerBuckets &buckets,
+                  const std::string &layer, const LayerEdgeIds &expected) {
+  const auto it = buckets.find(layer);
+  assert(it != buckets.end());
+  assert(it->second == expected);
+}
+
+} // namespace
+
+int main() {
+  const std::vector<std::string> edge_types = {
+      EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE,
+      EDGE_TYPE_IMPORT,  EDGE_TYPE_TYPE_USE,
+      "custom",          EDGE_TYPE_REFERENCE,
+  };
+
+  const auto buckets = codeminer::core::classify_edge_layers(edge_types);
+
+  assert_layer(buckets, GRAPH_LAYER_ALL, {0, 1, 2, 3, 4, 5});
+  assert_layer(buckets, GRAPH_LAYER_CONTAINMENT, {0});
+  assert_layer(buckets, GRAPH_LAYER_REFERENCE, {1, 5});
+  assert_layer(buckets, GRAPH_LAYER_IMPORT, {2});
+  assert_layer(buckets, GRAPH_LAYER_TYPE_USE, {3});
+  assert_layer(buckets, GRAPH_LAYER_DEPENDENCY, {1, 2, 3, 5});
+
+  const auto empty = codeminer::core::classify_edge_layers({});
+  assert_layer(empty, GRAPH_LAYER_ALL, {});
+  assert_layer(empty, GRAPH_LAYER_CONTAINMENT, {});
+  assert_layer(empty, GRAPH_LAYER_DEPENDENCY, {});
+  assert_layer(empty, GRAPH_LAYER_REFERENCE, {});
+  assert_layer(empty, GRAPH_LAYER_IMPORT, {});
+  assert_layer(empty, GRAPH_LAYER_TYPE_USE, {});
+
+  return 0;
+}

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -16,11 +16,14 @@ for higher throughput on large `.decoded` SCIP index files.
 
 - `code_graph.h` / `code_graph.cpp` — graph container (vertices, edges, metadata)
   compatible with the Python implementation.
+- `graph_layers.h` / `graph_layers.cpp` — language-agnostic default layer
+  classification for CodeGraph edge types. This is shared by SCIP, clangd, and
+  generic-LSP graphs after they have normalized into the common schema.
 - `scip_decode.h` / `scip_decode.cpp` — translates a `.decoded` SCIP index into the C++
   `CodeGraph`.
 - `bindings/pybind_module.cpp` — exposes `decode_scip(...)` and the optional
-  `classify_edge_layers(...)` helper used by Python multi-graph layer indexing
-  when the extension is built.
+  `classify_edge_layers(...)` binding. The binding delegates to the core
+  `graph_layers` module; it should not own graph algorithms.
 - `CMakeLists.txt` — builds the static library `codeminer_core`, suitable for wrapping
   with pybind11 or another binding layer.
 
@@ -48,11 +51,11 @@ Latest local sample:
 
 ```json
 {
-  "core_seconds_min": 0.10373123199678957,
+  "core_seconds_min": 0.1028488609008491,
   "edges": 1000000,
   "parity": true,
-  "python_seconds_min": 0.35562897310592234,
-  "speedup_vs_python": 3.42836931809437
+  "python_seconds_min": 0.3491414119489491,
+  "speedup_vs_python": 3.3947037321641997
 }
 ```
 

--- a/docs/experiments/lsp_core_acceleration.md
+++ b/docs/experiments/lsp_core_acceleration.md
@@ -19,7 +19,9 @@ language-server latency.
 Current C++ acceleration for layered graph work is intentionally narrower:
 `codeminer_core.classify_edge_layers(...)` classifies default graph layers for
 the Python `MultiGraphIndex` when the pybind extension is present. This is a
-query/index helper, not a generic LSP graph decoder.
+query/index helper, not a generic LSP graph decoder. The implementation lives
+in `core/graph_layers.{h,cpp}` so it is a real core API rather than binding
+glue embedded in `bindings/pybind_module.cpp`.
 
 Profile the shared graph-layer helper separately:
 
@@ -32,11 +34,11 @@ Latest graph-layer sample:
 
 ```json
 {
-  "core_seconds_min": 0.10373123199678957,
+  "core_seconds_min": 0.1028488609008491,
   "edges": 1000000,
   "parity": true,
-  "python_seconds_min": 0.35562897310592234,
-  "speedup_vs_python": 3.42836931809437
+  "python_seconds_min": 0.3491414119489491,
+  "speedup_vs_python": 3.3947037321641997
 }
 ```
 


### PR DESCRIPTION
## Summary
Promote the graph-layer classifier from pybind glue into a real `core/` module, with a native C++ test. This addresses the engineering concern from #245: the shared acceleration path should live in the C++ core library, not inside `bindings/pybind_module.cpp`.

## Changes
- Adds `core/graph_layers.h` and `core/graph_layers.cpp` for language-agnostic default CodeGraph layer classification.
- Adds `core/tests/graph_layers_test.cpp` and wires it into CMake.
- Reduces `core/bindings/pybind_module.cpp` so it only releases the GIL and delegates to the core API.
- Updates docs to clarify that this accelerates a shared graph hot path for SCIP, clangd, and generic-LSP graphs after schema normalization, while per-language LSP C++ decoders remain gated by profiling.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `cmake -S core -B build/core && cmake --build build/core -j 2`
- `build/core/graph_layers_test && build/core/scip_decode_test`
- `PYTHONPATH=build/core:$PYTHONPATH python -m pytest -q test/graph/test_layers.py test/scripts/test_profile_graph_layers.py`
- `PYTHONPATH=build/core:$PYTHONPATH python scripts/profiling/profile_graph_layers.py --edges 1000000 --reps 3`
- `python -m mkdocs build --strict`
- `pre-commit run --files core/graph_layers.h core/graph_layers.cpp core/tests/graph_layers_test.cpp core/CMakeLists.txt core/bindings/pybind_module.cpp docs/core_cpp.md docs/experiments/lsp_core_acceleration.md`
- `git diff --check` and `git diff --cached --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
