### PR TITLE
[codex] track SCIP cold-start options

### DIFF
--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -21,6 +21,24 @@ from importlib import import_module
 from typing import Dict, FrozenSet, Iterable, Literal, Optional, Tuple
 
 ExtensionKind = Literal["chunker", "gt", "graph"]
+ScipColdStartStatus = Literal["active", "candidate", "deferred"]
+
+
+@dataclass(frozen=True, slots=True)
+class ScipColdStartOption:
+    """SCIP cold-start backend status for one language.
+
+    ``active`` means the language's current cold-start graph backend is SCIP.
+    ``candidate`` means a known SCIP indexer exists, but CodeMiner has not yet
+    promoted it to the primary backend because smoke, backend-alignment, decoder,
+    and parity gates are still open.
+    """
+
+    tool: str
+    status: ScipColdStartStatus
+    command: Tuple[str, ...] = ()
+    command_env: Optional[str] = None
+    note: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,6 +63,7 @@ class LanguageSpec:
     cold_start_backend: Optional[str] = None
     graph_indexer: Optional[str] = None
     graph_decoder: Optional[str] = None
+    scip_cold_start: Optional[ScipColdStartOption] = None
     incremental_backend: Optional[str] = None
     incremental_patcher: Optional[str] = None
     lsp_language_id: Optional[str] = None
@@ -65,6 +84,7 @@ class LanguageCapability:
     ground_truth: bool
     agent: bool
     graph_backend: Optional[str]
+    scip_cold_start: str
     incremental_backend: Optional[str]
     lsp: bool
     core_decoder: bool
@@ -90,6 +110,12 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="scip",
         graph_indexer="codeminer.scip_interface.scip_indexer_python:SCIPPythonIndexer",
         graph_decoder="codeminer.scip_interface.scip_decode_python:SCIPPythonGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-python",
+            status="active",
+            command=("scip-python", "index"),
+            note="Primary cold-start backend with serial/core parity coverage.",
+        ),
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_python:PatcherPython",
         lsp_language_id="python",
@@ -115,6 +141,12 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="scip",
         graph_indexer="codeminer.scip_interface.scip_indexer_go:SCIPGoIndexer",
         graph_decoder="codeminer.scip_interface.scip_decode_go:SCIPGoGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-go",
+            status="active",
+            command=("scip-go",),
+            note="Primary cold-start backend with serial/core parity coverage.",
+        ),
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_go:PatcherGo",
         lsp_language_id="go",
@@ -139,6 +171,12 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="scip",
         graph_indexer="codeminer.scip_interface.scip_indexer_rust:SCIPRustIndexer",
         graph_decoder="codeminer.scip_interface.scip_decode_rust:SCIPRustGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="rust-analyzer scip",
+            status="active",
+            command=("rust-analyzer", "scip"),
+            note="Primary cold-start backend with serial/core parity coverage.",
+        ),
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_rust:PatcherRust",
         lsp_language_id="rust",
@@ -186,6 +224,16 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="lsp",
         graph_indexer="codeminer.ls_index.lsp_indexer:GenericLSPIndexer",
         graph_decoder="codeminer.ls_index.lsp_graph_decode:GenericLSPGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-dotnet",
+            status="candidate",
+            command=("scip-dotnet",),
+            command_env="CODEMINER_CSHARP_SCIP_CMD",
+            note=(
+                "Evaluate as C#/VB cold-start after .sln/.csproj restore "
+                "smoke and LSP alignment."
+            ),
+        ),
         lsp_language_id="csharp",
         lsp_command=("csharp-ls",),
         lsp_command_env="CODEMINER_CSHARP_LSP_CMD",
@@ -207,6 +255,16 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="lsp",
         graph_indexer="codeminer.ls_index.lsp_indexer:GenericLSPIndexer",
         graph_decoder="codeminer.ls_index.lsp_graph_decode:GenericLSPGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-java",
+            status="candidate",
+            command=("scip-java", "index"),
+            command_env="CODEMINER_JAVA_SCIP_CMD",
+            note=(
+                "Evaluate as JVM cold-start for Maven/Gradle/sbt before "
+                "promoting over JDT LS."
+            ),
+        ),
         lsp_language_id="java",
         lsp_command=("jdtls",),
         lsp_command_env="CODEMINER_JAVA_LSP_CMD",
@@ -229,6 +287,16 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="lsp",
         graph_indexer="codeminer.ls_index.lsp_indexer:GenericLSPIndexer",
         graph_decoder="codeminer.ls_index.lsp_graph_decode:GenericLSPGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-ruby",
+            status="candidate",
+            command=("scip-ruby",),
+            command_env="CODEMINER_RUBY_SCIP_CMD",
+            note=(
+                "Experimental Ruby cold-start candidate; graph quality must "
+                "be measured on real repos."
+            ),
+        ),
         lsp_language_id="ruby",
         lsp_command=("ruby-lsp",),
         lsp_command_env="CODEMINER_RUBY_LSP_CMD",
@@ -250,6 +318,16 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="lsp",
         graph_indexer="codeminer.ls_index.lsp_indexer:GenericLSPIndexer",
         graph_decoder="codeminer.ls_index.lsp_graph_decode:GenericLSPGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-php",
+            status="candidate",
+            command=("scip-php",),
+            command_env="CODEMINER_PHP_SCIP_CMD",
+            note=(
+                "Community PHP cold-start candidate; require smoke and "
+                "alignment before enabling."
+            ),
+        ),
         lsp_language_id="php",
         lsp_command=("intelephense", "--stdio"),
         lsp_command_env="CODEMINER_PHP_LSP_CMD",
@@ -272,6 +350,13 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="lsp",
         graph_indexer="codeminer.ls_index.lsp_indexer:GenericLSPIndexer",
         graph_decoder="codeminer.ls_index.lsp_graph_decode:GenericLSPGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-java",
+            status="candidate",
+            command=("scip-java", "index"),
+            command_env="CODEMINER_KOTLIN_SCIP_CMD",
+            note="Evaluate through the JVM scip-java path before promoting over Kotlin LSP.",
+        ),
         lsp_language_id="kotlin",
         lsp_command=("kotlin-language-server", "--stdio"),
         lsp_command_env="CODEMINER_KOTLIN_LSP_CMD",
@@ -299,6 +384,13 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         gt_extensions=(".scala", ".sc"),
         agent_languages=("scala",),
         agent_aliases=(("scala", "scala"),),
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-java",
+            status="candidate",
+            command=("scip-java", "index"),
+            command_env="CODEMINER_SCALA_SCIP_CMD",
+            note="Evaluate through the JVM scip-java path before enabling graph support.",
+        ),
     ),
     LanguageSpec(
         key="lua",
@@ -336,6 +428,15 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="scip",
         graph_indexer="codeminer.scip_interface.scip_indexer_ts:SCIPTypeScriptIndexer",
         graph_decoder="codeminer.scip_interface.scip_decode_ts:SCIPTypeScriptGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-typescript",
+            status="active",
+            command=("scip-typescript", "index"),
+            note=(
+                "Shared JavaScript/TypeScript cold-start backend with parity "
+                "via TypeScript core decoder."
+            ),
+        ),
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_ts:PatcherTS",
         lsp_language_id="typescript",
@@ -364,6 +465,12 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         cold_start_backend="scip",
         graph_indexer="codeminer.scip_interface.scip_indexer_ts:SCIPTypeScriptIndexer",
         graph_decoder="codeminer.scip_interface.scip_decode_ts:SCIPTypeScriptGraphDecoder",
+        scip_cold_start=ScipColdStartOption(
+            tool="scip-typescript",
+            status="active",
+            command=("scip-typescript", "index"),
+            note="Primary cold-start backend with serial/core parity coverage.",
+        ),
         incremental_backend="lsp",
         incremental_patcher="codeminer.graph.incremental.patcher_ts:PatcherTS",
         lsp_language_id="typescript",
@@ -644,6 +751,54 @@ def graph_cold_start_backend(language: str) -> Optional[str]:
     return graph_cold_start_backends(include_aliases=False).get(graph_language)
 
 
+def scip_cold_start_options(
+    include_aliases: bool = True,
+) -> Dict[str, ScipColdStartOption]:
+    """Return languages mapped to configured SCIP cold-start options.
+
+    Candidate entries are intentionally returned even when a language's active
+    graph backend is still LSP or tree-sitter-only. They are planning metadata,
+    not an enabled router path.
+    """
+
+    result: Dict[str, ScipColdStartOption] = {}
+    for spec in LANGUAGE_SPECS:
+        option = spec.scip_cold_start
+        if option is None:
+            continue
+        result[spec.key] = option
+        if include_aliases:
+            for alias in spec.aliases:
+                result[alias] = option
+            if spec.graph_language:
+                result[spec.graph_language] = option
+                for alias in spec.graph_aliases:
+                    result[alias] = option
+    return result
+
+
+def scip_cold_start_option(language: str) -> Optional[ScipColdStartOption]:
+    """Return SCIP cold-start metadata for a language key or alias."""
+
+    return scip_cold_start_options(include_aliases=True).get(_norm(language))
+
+
+def scip_cold_start_command_for_language(language: str) -> Optional[list[str]]:
+    """Return the configured SCIP cold-start command for a language or alias."""
+
+    option = scip_cold_start_option(language)
+    if option is None:
+        return None
+
+    if option.command_env:
+        override = os.environ.get(option.command_env)
+        if override:
+            return shlex.split(override)
+    if option.command:
+        return list(option.command)
+    return [option.tool] if option.tool else None
+
+
 def lsp_language_id_for_language(language: str) -> Optional[str]:
     """Return the LSP language id for a raw graph language."""
 
@@ -754,6 +909,9 @@ def language_capability_rows() -> Tuple[LanguageCapability, ...]:
                 ground_truth=bool(spec.gt_language and spec.gt_extensions),
                 agent=bool(spec.agent_languages),
                 graph_backend=spec.cold_start_backend if has_graph else None,
+                scip_cold_start=(
+                    spec.scip_cold_start.status if spec.scip_cold_start else "none"
+                ),
                 incremental_backend=(
                     spec.incremental_backend if spec.incremental_patcher else None
                 ),
@@ -778,6 +936,8 @@ __all__ = [
     "LanguageSpec",
     "LANGUAGE_SPECS",
     "SPECS_BY_KEY",
+    "ScipColdStartOption",
+    "ScipColdStartStatus",
     "agent_language_aliases",
     "chunker_language_aliases",
     "chunker_languages",
@@ -805,5 +965,8 @@ __all__ = [
     "normalize_chunker_language",
     "normalize_graph_language",
     "normalize_language",
+    "scip_cold_start_option",
+    "scip_cold_start_command_for_language",
+    "scip_cold_start_options",
     "supported_agent_languages",
 ]

--- a/docs/contributing-a-language.md
+++ b/docs/contributing-a-language.md
@@ -35,6 +35,10 @@ Choose backends per language, not globally.
 - `cold_start_backend`: the source for a fresh full-repo graph. Use SCIP where
   the indexer is mature, clangd for C/C++, and generic LSP only when it is the
   best available cold-start source.
+- `scip_cold_start`: records active or candidate SCIP cold-start tools even
+  when the language currently uses LSP or tree-sitter-only graph support. A
+  `candidate` is planning metadata; it is not routed by `LSIndexer` until SCIP
+  smoke, backend alignment, decoder support, and parity gates are green.
 - `incremental_backend`: the source for patching or filling gaps after a repo
   changes. LSP is often a better fit here because servers already maintain
   workspace state.
@@ -67,6 +71,13 @@ LanguageSpec(
     agent_languages=("example",),
     agent_aliases=(("example", "example"), ("ex", "example")),
     cold_start_backend="lsp",
+    scip_cold_start=ScipColdStartOption(
+        tool="example-scip",
+        status="candidate",
+        command=("example-scip", "index"),
+        command_env="CODEMINER_EXAMPLE_SCIP_CMD",
+        note="Promote only after SCIP smoke, backend alignment, and parity gates pass.",
+    ),
     incremental_backend="lsp",
     lsp_language_id="example",
     lsp_command=("example-language-server", "--stdio"),
@@ -132,6 +143,24 @@ Pick one cold-start backend:
   `codeminer.ls_index.lsp_indexer:GenericLSPIndexer`, `graph_decoder` to
   `codeminer.ls_index.lsp_graph_decode:GenericLSPGraphDecoder`, and register
   `lsp_language_id`, `lsp_command`, and an optional `lsp_command_env` override.
+
+Do not drop a known SCIP cold-start path just because the first implementation
+uses LSP. Record it as `scip_cold_start=ScipColdStartOption(...,
+status="candidate")` until it is proven.
+Use `codeminer.languages.scip_cold_start_command_for_language()` to consume the
+registered command and any `CODEMINER_*_SCIP_CMD` override in smoke scripts.
+
+Current SCIP cold-start candidates that should be evaluated before treating LSP
+as final:
+
+| Language | Candidate | Current active graph | Promotion gate |
+| --- | --- | --- | --- |
+| Java | `scip-java index` | generic LSP / JDT LS | Maven/Gradle/sbt smoke, LSP alignment, serial decoder, optional core parity |
+| Kotlin | `scip-java index` | generic LSP / Kotlin LS | JVM smoke, LSP alignment, Kotlin symbol normalization |
+| Scala | `scip-java index` | tree-sitter-only | JVM smoke, graph decoder, LSP/Metals alignment decision |
+| C# | `scip-dotnet` | generic LSP / csharp-ls | `.sln`/`.csproj` restore smoke, LSP alignment, decoder support |
+| Ruby | `scip-ruby` | generic LSP / ruby-lsp | real-repo graph quality measurement, Sorbet setup guidance |
+| PHP | `scip-php` | generic LSP / Intelephense | community indexer smoke, schema alignment, reference quality threshold |
 
 Current generic LSP cold-start graph commands are:
 

--- a/docs/language_capabilities.md
+++ b/docs/language_capabilities.md
@@ -19,23 +19,31 @@ python scripts/language_capability_matrix.py --check docs/language_capabilities.
 ```
 
 <!-- BEGIN CODEMINER_LANGUAGE_CAPABILITIES -->
-| Language | Chunker | GT | Agent | Graph backend | Incremental | LSP command | Core decoder | Core parity |
-|----------|---------|----|-------|---------------|-------------|-------------|--------------|-------------|
-| Python | yes | yes | yes | scip | lsp | yes | yes | covered |
-| Go | yes | yes | yes | scip | lsp | yes | yes | covered |
-| Rust | yes | yes | yes | scip | lsp | yes | yes | covered |
-| C/C++ | yes | yes | yes | clangd | clangd | yes | no | n/a-no-core-decoder |
-| C# | yes | yes | yes | lsp | none | yes | no | n/a-no-core-decoder |
-| Java | yes | yes | yes | lsp | none | yes | no | n/a-no-core-decoder |
-| Ruby | yes | yes | yes | lsp | none | yes | no | n/a-no-core-decoder |
-| PHP | yes | yes | yes | lsp | none | yes | no | n/a-no-core-decoder |
-| Kotlin | yes | yes | yes | lsp | none | yes | no | n/a-no-core-decoder |
-| Swift | yes | yes | yes | none | none | no | no | n/a-tree-sitter-only |
-| Scala | yes | yes | yes | none | none | no | no | n/a-tree-sitter-only |
-| Lua | yes | yes | yes | none | none | no | no | n/a-tree-sitter-only |
-| JavaScript | yes | yes | yes | scip | lsp | yes | yes | covered |
-| TypeScript | yes | yes | yes | scip | lsp | yes | yes | covered |
+| Language | Chunker | GT | Agent | Graph backend | SCIP cold-start | Incremental | LSP command | Core decoder | Core parity |
+|----------|---------|----|-------|---------------|-----------------|-------------|-------------|--------------|-------------|
+| Python | yes | yes | yes | scip | active | lsp | yes | yes | covered |
+| Go | yes | yes | yes | scip | active | lsp | yes | yes | covered |
+| Rust | yes | yes | yes | scip | active | lsp | yes | yes | covered |
+| C/C++ | yes | yes | yes | clangd | none | clangd | yes | no | n/a-no-core-decoder |
+| C# | yes | yes | yes | lsp | candidate | none | yes | no | n/a-no-core-decoder |
+| Java | yes | yes | yes | lsp | candidate | none | yes | no | n/a-no-core-decoder |
+| Ruby | yes | yes | yes | lsp | candidate | none | yes | no | n/a-no-core-decoder |
+| PHP | yes | yes | yes | lsp | candidate | none | yes | no | n/a-no-core-decoder |
+| Kotlin | yes | yes | yes | lsp | candidate | none | yes | no | n/a-no-core-decoder |
+| Swift | yes | yes | yes | none | none | none | no | no | n/a-tree-sitter-only |
+| Scala | yes | yes | yes | none | candidate | none | no | no | n/a-tree-sitter-only |
+| Lua | yes | yes | yes | none | none | none | no | no | n/a-tree-sitter-only |
+| JavaScript | yes | yes | yes | scip | active | lsp | yes | yes | covered |
+| TypeScript | yes | yes | yes | scip | active | lsp | yes | yes | covered |
 <!-- END CODEMINER_LANGUAGE_CAPABILITIES -->
+
+## SCIP Cold-Start States
+
+| State | Meaning |
+|-------|---------|
+| `active` | The active cold-start graph backend is SCIP and the language is routed through a SCIP indexer/decoder today. |
+| `candidate` | A known SCIP indexer should be evaluated before treating the current LSP or tree-sitter-only path as final. It is not routed until smoke, backend alignment, decoder support, and parity gates pass. |
+| `none` | No SCIP cold-start option is currently tracked for the language. |
 
 ## Parity States
 

--- a/scripts/language_capability_matrix.py
+++ b/scripts/language_capability_matrix.py
@@ -41,9 +41,9 @@ def render_matrix() -> str:
     """Return the Markdown table for the current language registry."""
 
     lines = [
-        "| Language | Chunker | GT | Agent | Graph backend | Incremental "
+        "| Language | Chunker | GT | Agent | Graph backend | SCIP cold-start | Incremental "
         "| LSP command | Core decoder | Core parity |",
-        "|----------|---------|----|-------|---------------|-------------|-------------|--------------|-------------|",
+        "|----------|---------|----|-------|---------------|-----------------|-------------|-------------|--------------|-------------|",
     ]
     for row in _language_capability_rows():
         lines.append(
@@ -55,6 +55,7 @@ def render_matrix() -> str:
                     _yes_no(row.ground_truth),
                     _yes_no(row.agent),
                     row.graph_backend or "none",
+                    row.scip_cold_start,
                     row.incremental_backend or "none",
                     _yes_no(row.lsp),
                     _yes_no(row.core_decoder),

--- a/scripts/scaffold_language.py
+++ b/scripts/scaffold_language.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import shlex
 import sys
 import textwrap
 from dataclasses import dataclass
@@ -45,6 +46,9 @@ class ScaffoldConfig:
     aliases: tuple[str, ...] = ()
     chunker: bool = True
     graph_backend: str = "none"
+    scip_cold_start_candidate: str | None = None
+    scip_cold_start_command: tuple[str, ...] = ()
+    scip_cold_start_env: str | None = None
     incremental_backend: str = "none"
     core_decoder: bool = False
     root: Path = PROJECT_ROOT
@@ -113,6 +117,10 @@ def _pair_tuple_literal(values: Sequence[tuple[str, str]]) -> str:
     return f"({rendered})"
 
 
+def _default_scip_env(key: str) -> str:
+    return f"CODEMINER_{key.upper()}_SCIP_CMD"
+
+
 def render_language_spec(config: ScaffoldConfig) -> str:
     """Return the LanguageSpec block to paste into codeminer/languages.py."""
 
@@ -179,6 +187,25 @@ def render_language_spec(config: ScaffoldConfig) -> str:
             f"    agent_languages={_tuple_literal((config.key,))},",
             f"    agent_aliases={_pair_tuple_literal(agent_aliases)},",
             f"    cold_start_backend={cold_start_backend!r},",
+        ]
+    )
+    if config.scip_cold_start_candidate:
+        command = config.scip_cold_start_command or (config.scip_cold_start_candidate,)
+        lines.extend(
+            [
+                "    scip_cold_start=ScipColdStartOption(",
+                f"        tool={config.scip_cold_start_candidate!r},",
+                "        status='candidate',",
+                f"        command={_tuple_literal(command)},",
+                "        command_env="
+                f"{(config.scip_cold_start_env or _default_scip_env(config.key))!r},",
+                "        note='Candidate cold-start backend; promote only after "
+                "smoke, backend alignment, and parity gates pass.',",
+                "    ),",
+            ]
+        )
+    lines.extend(
+        [
             f"    incremental_backend={incremental_backend!r},",
             f"    core_decoder={config.core_decoder!r},",
             "),",
@@ -728,6 +755,11 @@ def _manual_wiring(config: ScaffoldConfig) -> list[str]:
             "Use GenericLSPIndexer/GenericLSPGraphDecoder in LanguageSpec; "
             "add a custom indexer/decoder only for server-specific behavior."
         )
+        if config.scip_cold_start_candidate:
+            items.append(
+                "Keep the SCIP cold-start candidate disabled until its SCIP "
+                "smoke, LSP/backend alignment, and serial/core parity gates land."
+            )
     elif config.graph_backend != "none":
         items.append("Route the graph backend through codeminer/ls_router.py.")
     if config.incremental_backend != "none":
@@ -820,6 +852,19 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         help="cold-start graph backend to scaffold",
     )
     parser.add_argument(
+        "--scip-cold-start-candidate",
+        metavar="TOOL",
+        help="record a SCIP cold-start candidate tool without enabling it",
+    )
+    parser.add_argument(
+        "--scip-cold-start-command",
+        help="candidate SCIP command, shell-split before rendering",
+    )
+    parser.add_argument(
+        "--scip-cold-start-env",
+        help="environment variable that can override the candidate command",
+    )
+    parser.add_argument(
         "--incremental-backend",
         choices=INCREMENTAL_BACKENDS,
         default="none",
@@ -879,6 +924,10 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
 
     if args.core_decoder and args.graph_backend != "scip":
         parser.error("--core-decoder currently requires --graph-backend scip")
+    if args.scip_cold_start_command and not args.scip_cold_start_candidate:
+        parser.error("--scip-cold-start-command requires --scip-cold-start-candidate")
+    if args.scip_cold_start_env and not args.scip_cold_start_candidate:
+        parser.error("--scip-cold-start-env requires --scip-cold-start-candidate")
     if args.incremental_backend != "none" and args.graph_backend == "none":
         parser.error("--incremental-backend requires a non-none --graph-backend")
     if _language_exists(args.language, args.root) and not args.allow_existing:
@@ -899,6 +948,13 @@ def config_from_args(args: argparse.Namespace) -> ScaffoldConfig:
         aliases=_unique(args.aliases),
         chunker=not args.no_chunker,
         graph_backend=args.graph_backend,
+        scip_cold_start_candidate=args.scip_cold_start_candidate,
+        scip_cold_start_command=(
+            tuple(shlex.split(args.scip_cold_start_command))
+            if args.scip_cold_start_command
+            else ()
+        ),
+        scip_cold_start_env=args.scip_cold_start_env,
         incremental_backend=args.incremental_backend,
         core_decoder=args.core_decoder,
         root=args.root,

--- a/test/scripts/test_scaffold_language.py
+++ b/test/scripts/test_scaffold_language.py
@@ -81,6 +81,26 @@ def test_lsp_plan_uses_generic_lsp_registry_paths():
     assert "CODEMINER_ZIG_LSP_CMD" in rendered
 
 
+def test_lsp_plan_can_record_scip_cold_start_candidate():
+    cfg = _config(
+        graph_backend="lsp",
+        scip_cold_start_candidate="scip-zig",
+        scip_cold_start_command=("scip-zig", "index"),
+    )
+
+    paths = {str(file.path) for file in scaffold.build_plan(cfg)}
+    rendered = scaffold.render_language_spec(cfg)
+    plan = scaffold.render_plan(cfg, scaffold.build_plan(cfg))
+
+    assert "codeminer/scip_interface/scip_indexer_zig.py" not in paths
+    assert "ScipColdStartOption(" in rendered
+    assert "tool='scip-zig'" in rendered
+    assert "status='candidate'" in rendered
+    assert "command=('scip-zig', 'index')" in rendered
+    assert "CODEMINER_ZIG_SCIP_CMD" in rendered
+    assert "candidate disabled" in plan
+
+
 def test_main_dry_run_prints_without_writing(tmp_path, capsys):
     rc = scaffold.main(
         [
@@ -129,6 +149,26 @@ def test_main_validates_core_backend(capsys):
 
     assert (
         "--core-decoder currently requires --graph-backend scip"
+        in capsys.readouterr().err
+    )
+
+
+def test_main_validates_scip_candidate_command(capsys):
+    with pytest.raises(SystemExit):
+        scaffold.main(
+            [
+                "zig",
+                "--extension",
+                ".zig",
+                "--graph-backend",
+                "lsp",
+                "--scip-cold-start-command",
+                "scip-zig index",
+            ]
+        )
+
+    assert (
+        "--scip-cold-start-command requires --scip-cold-start-candidate"
         in capsys.readouterr().err
     )
 

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -25,6 +25,9 @@ from codeminer.languages import (
     normalize_agent_language,
     normalize_chunker_language,
     normalize_graph_language,
+    scip_cold_start_command_for_language,
+    scip_cold_start_option,
+    scip_cold_start_options,
     supported_agent_languages,
 )
 
@@ -113,18 +116,22 @@ def test_language_capability_rows_track_parity_applicability():
     rows = {row.key: row for row in language_capability_rows()}
 
     assert rows["python"].graph_backend == "scip"
+    assert rows["python"].scip_cold_start == "active"
     assert rows["python"].core_decoder is True
     assert rows["python"].core_parity == "covered"
 
     assert rows["cpp"].graph_backend == "clangd"
+    assert rows["cpp"].scip_cold_start == "none"
     assert rows["cpp"].core_decoder is False
     assert rows["cpp"].core_parity == "n/a-no-core-decoder"
 
     assert rows["javascript"].graph_backend == "scip"
+    assert rows["javascript"].scip_cold_start == "active"
     assert rows["javascript"].core_decoder is True
     assert rows["javascript"].core_parity == "covered"
 
     assert rows["java"].graph_backend == "lsp"
+    assert rows["java"].scip_cold_start == "candidate"
     assert rows["java"].incremental_backend is None
     assert rows["java"].lsp is True
     assert rows["java"].core_decoder is False
@@ -135,18 +142,56 @@ def test_language_capability_rows_track_parity_applicability():
         assert rows[language].ground_truth is True
         assert rows[language].agent is True
         assert rows[language].graph_backend == "lsp"
+        assert rows[language].scip_cold_start == "candidate"
         assert rows[language].incremental_backend is None
         assert rows[language].core_decoder is False
         assert rows[language].core_parity == "n/a-no-core-decoder"
 
-    for language in ("swift", "scala", "lua"):
+    for language in ("swift", "lua"):
         assert rows[language].chunker is True
         assert rows[language].ground_truth is True
         assert rows[language].agent is True
         assert rows[language].graph_backend is None
+        assert rows[language].scip_cold_start == "none"
         assert rows[language].incremental_backend is None
         assert rows[language].core_decoder is False
         assert rows[language].core_parity == "n/a-tree-sitter-only"
+
+    assert rows["scala"].graph_backend is None
+    assert rows["scala"].scip_cold_start == "candidate"
+    assert rows["scala"].core_parity == "n/a-tree-sitter-only"
+
+
+def test_scip_cold_start_options_track_active_and_candidate_paths(monkeypatch):
+    options = scip_cold_start_options()
+
+    assert options["python"].status == "active"
+    assert options["python"].tool == "scip-python"
+    assert options["typescript"].status == "active"
+    assert options["ts"].tool == "scip-typescript"
+
+    assert options["java"].status == "candidate"
+    assert options["java"].tool == "scip-java"
+    assert options["kotlin"].tool == "scip-java"
+    assert options["scala"].tool == "scip-java"
+    assert options["csharp"].tool == "scip-dotnet"
+    assert options["c#"].tool == "scip-dotnet"
+    assert options["ruby"].tool == "scip-ruby"
+    assert options["php"].tool == "scip-php"
+
+    assert scip_cold_start_option("kt").command_env == "CODEMINER_KOTLIN_SCIP_CMD"
+    assert scip_cold_start_command_for_language("java") == ["scip-java", "index"]
+    assert scip_cold_start_command_for_language("c#") == ["scip-dotnet"]
+    monkeypatch.setenv("CODEMINER_CSHARP_SCIP_CMD", "dotnet tool run scip-dotnet")
+    assert scip_cold_start_command_for_language("csharp") == [
+        "dotnet",
+        "tool",
+        "run",
+        "scip-dotnet",
+    ]
+    assert scip_cold_start_option("swift") is None
+    assert scip_cold_start_command_for_language("swift") is None
+    assert scip_cold_start_option("lua") is None
 
 
 def test_chunker_languages_are_current_supported_repo_chunkers():


### PR DESCRIPTION
## Summary
Add explicit SCIP cold-start option metadata for tier-2 languages so LSP-first support no longer implies SCIP was ignored. The active router remains unchanged; unverified SCIP paths are recorded as candidates until smoke, backend alignment, decoder, and parity gates pass.

## Changes
- Adds `ScipColdStartOption` to `LanguageSpec`, plus `scip_cold_start_option(s)` and `scip_cold_start_command_for_language()` helpers.
- Marks existing SCIP-backed languages as `active` and Java, Kotlin, Scala, C#, Ruby, and PHP as `candidate` SCIP cold-start paths.
- Adds a `SCIP cold-start` column to the generated language capability matrix.
- Updates the language scaffold to emit disabled SCIP candidate metadata for LSP-first languages.
- Documents promotion gates and candidate tools in `docs/contributing-a-language.md`.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `pre-commit run --files codeminer/languages.py scripts/language_capability_matrix.py scripts/scaffold_language.py test/test_languages.py test/scripts/test_scaffold_language.py docs/contributing-a-language.md docs/language_capabilities.md`
- `python -m pytest -q test/test_languages.py test/test_language_capability_matrix.py test/scripts/test_scaffold_language.py`
- `python scripts/language_capability_matrix.py --check docs/language_capabilities.md`
- `python -m mkdocs build --strict`
- `git diff --check` and `git diff --cached --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
