### PR TITLE
feat(agent-compile): Qwen2.5-Coder local backend (7B/14B/32B) + eval

### DIFF
--- a/.claude/design/preload-aware-harness.md
+++ b/.claude/design/preload-aware-harness.md
@@ -1,0 +1,75 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Pre-load-aware agent harness (DRAFT / research direction)
+
+> Status: draft for discussion. Sits after PR #248 (Qwen backend + honest
+> eval infra). Motivated by the Qwen3.5 findings below.
+
+## Motivation — what the data showed
+
+Pre-load today = inject retrieval candidates into the opening prompt, then run
+the **generic** grep/read/answer loop over them. Two failure modes, both
+measured on Qwen3.5:
+
+- **Candidates good (symbol_hint, base):** the agent still explores from scratch
+  instead of confirming the candidate — reuse value is small.
+- **Candidates bad (behavioral, synthesis):** the agent **over-trusts** the
+  candidates — fewer turns (−2.9) but answers wrong (Δrec@5 −0.167, a significant
+  REGRESS). It picks the "most plausible" candidate instead of falling back to
+  exploration.
+
+Net (27B, span answer_rec): pre-load is a **trade, not a free win** — it saves
+turns/tokens (−1.7 turns, −7.6 % tokens on synthesis) but costs accuracy on
+explore-heavy queries. The candidates and the loop are two separate things that
+were never fused. "We found nails, but the agent still swings a generic hammer
+from scratch."
+
+## Core idea — candidate triage, not linear consumption
+
+Replace "candidates in the prompt + generic loop" with a loop whose first-class
+job is to *process the candidate set*:
+
+1. **Rule-out (cheap):** one pass scoring each candidate plausible/implausible
+   from its signature (symbol + 1 line of context) — batch-eliminate most
+   without deep reads.
+2. **Verify (focused):** read-confirm only the 1–3 survivors → converge early.
+3. **Fallback (the REGRESS fix):** if *all* candidates look implausible
+   (common on behavioral), explicitly switch back to autonomous grep instead of
+   committing the least-bad candidate.
+
+The novelty is an **explicit "trust-candidates vs explore" branch**, decided by
+the agent's own assessment of candidate quality — not blind consumption.
+
+### Possible primitives (make candidates first-class actions)
+
+- `rule_out(ids, reason)` — drop candidates
+- `verify(id)` — read + confirm a survivor
+- `fallback_search(query)` — autonomous exploration when candidates fail
+
+## Why this can work where verify-expand didn't
+
+`verify-expand` (the prior harness customization) was a **no-op (0/400)** because
+it was a *GT-free deterministic* check (does the cited symbol resolve in the
+graph?) — the agent always cites a real-but-possibly-wrong symbol, which a
+deterministic check can't catch. Triage is **LLM semantic judgement**
+(plausible/implausible distinguishes right-file from wrong-file), so it has
+signal where resolution checking had none.
+
+## How to evaluate
+
+- **Dataset:** codeminer-synthesis (many-query; where reuse value is real).
+- **Arms:** `grep_only` vs `preinj_embed` (current) vs `preinj_triage` (new).
+- **Metric:** span answer_rec@k (symbol@k is unusable for agents — string match
+  vs free-form output scores ≈0; see `docs/experiments/qwen_backend.md`), plus
+  turns/tokens. Paired bootstrap CI (`pareto_ci.py`).
+- **Key question:** does triage keep the token/turn savings while removing the
+  behavioral REGRESS? Target verdict = SAVE on behavioral, not just symbol_hint.
+
+## Open questions
+
+- Cost of the rule-out pass vs the turns it saves (must net positive).
+- Does triage help weak models (Qwen2.5) too, or only strong agents?
+- Is rule-out better as one LLM pass or N cheap parallel checks?

--- a/.claude/design/preload-aware-harness.md
+++ b/.claude/design/preload-aware-harness.md
@@ -3,73 +3,127 @@ SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Pre-load-aware agent harness (DRAFT / research direction)
+# Pre-load-aware agent runtime: scatter → isolate → converge (DRAFT)
 
-> Status: draft for discussion. Sits after PR #248 (Qwen backend + honest
-> eval infra). Motivated by the Qwen3.5 findings below.
+> Status: draft for discussion. Sits after PR #248 (Qwen backend + honest eval
+> infra). This is the runtime that finally consumes pre-load correctly.
 
-## Motivation — what the data showed
+## Update — scatter superseded by eager + LLM gate
 
-Pre-load today = inject retrieval candidates into the opening prompt, then run
-the **generic** grep/read/answer loop over them. Two failure modes, both
-measured on Qwen3.5:
+Scatter works but is **too expensive**: one verify-subagent PER candidate = N
+re-explorations (measured 23 turns vs 4 for a single agent) — it violates the
+"save tokens" goal. Replaced by two cheaper ideas, both implemented:
 
-- **Candidates good (symbol_hint, base):** the agent still explores from scratch
-  instead of confirming the candidate — reuse value is small.
-- **Candidates bad (behavioral, synthesis):** the agent **over-trusts** the
-  candidates — fewer turns (−2.9) but answers wrong (Δrec@5 −0.167, a significant
-  REGRESS). It picks the "most plausible" candidate instead of falling back to
-  exploration.
+- **eager** (`mode: eager`): trust the ranked hits — read 1–2, answer, STOP;
+  fall back to grep only if none fits. Result (Qwen3.5-27B, synthesis, 36 paired):
+  **token −43 % vs grep, 5/6 categories equal accuracy**; only `behavioral`
+  regresses (candidates hurt explore-only queries with no concrete handle).
+- **eager_gated** (`mode: eager_gated`): a one-call LLM gate
+  (`query_is_specific`) routes **VAGUE** queries (no code identifier) to
+  blank-slate grep and **SPECIFIC** ones to eager. Gate classification verified
+  on Python: behavioral **0 %** / symbol_hint **100 %** SPECIFIC — the adaptive
+  "eager when confident, grep when ambiguous" Pareto play. (Gotcha: Qwen3.5 is a
+  thinking model — disable CoT via `extra_body chat_template_kwargs
+  enable_thinking=False`, else the verdict is truncated and everything reads
+  SPECIFIC.) Full per-category Pareto pending.
 
-Net (27B, span answer_rec): pre-load is a **trade, not a free win** — it saves
-turns/tokens (−1.7 turns, −7.6 % tokens on synthesis) but costs accuracy on
-explore-heavy queries. The candidates and the loop are two separate things that
-were never fused. "We found nails, but the agent still swings a generic hammer
-from scratch."
+The scatter design below is retained as **explored-and-rejected**: the converge
+idea is sound, but per-candidate full subagents are the cost mistake.
 
-## Core idea — candidate triage, not linear consumption
+## Motivation — diagnosed, not guessed
 
-Replace "candidates in the prompt + generic loop" with a loop whose first-class
-job is to *process the candidate set*:
+On codeminer-synthesis (Qwen3.5-27B, span answer_rec), pre-load is a *trade*:
+it saves cost (−1.7 turns, −7.6 % tokens) at equal pooled accuracy but
+**REGRESSES `behavioral`** (Δrec −0.167). We diagnosed the 4 losing queries:
 
-1. **Rule-out (cheap):** one pass scoring each candidate plausible/implausible
-   from its signature (symbol + 1 line of context) — batch-eliminate most
-   without deep reads.
-2. **Verify (focused):** read-confirm only the 1–3 survivors → converge early.
-3. **Fallback (the REGRESS fix):** if *all* candidates look implausible
-   (common on behavioral), explicitly switch back to autonomous grep instead of
-   committing the least-bad candidate.
+| query | preinj behaviour | GT in candidates? | grep→preinj |
+|---|---|---|---|
+| astropy-13579 | **7 searches, 9 reads, turns=16** | **yes** | 1.0 → 0.0 |
+| xarray-6992 q6 | 5 searches, 10 reads, turns=16 | yes | 1.0 → 0.0 |
+| xarray-6992 q7 | 6 searches, 11 reads, turns=16 | no | 1.0 → 0.0 |
+| xarray-6992 q2 | 0 searches, 5 reads, turns=5 | no | 1.0 → 0.0 |
 
-The novelty is an **explicit "trust-candidates vs explore" branch**, decided by
-the agent's own assessment of candidate quality — not blind consumption.
+**The regress is NOT under-exploration** — the agent searched a lot (7/9,
+turns=16) and the GT was even in the candidate set, yet it still answered wrong;
+grep_only with no candidates answered cleanly (1.0). Root cause: **a noisy
+candidate set injected into a single context pollutes a strong agent's
+exploration line** — it diverges across 16 turns toward the wrong place, worse
+than a blank-slate grep.
 
-### Possible primitives (make candidates first-class actions)
+## Why single-context triage can't fix it
 
-- `rule_out(ids, reason)` — drop candidates
-- `verify(id)` — read + confirm a survivor
-- `fallback_search(query)` — autonomous exploration when candidates fail
+The pre-load preamble is *already* triage-aware ("candidates often wrong / may be
+in NONE / do not anchor on the first / if none right, IGNORE and grep"), and the
+agent still regresses. The agent explored *enough*; the problem is **context
+pollution**, not loop logic. You can't un-see the noisy candidates once they're
+in the window. The fix must isolate the noise, not re-word the prompt.
+
+## Architecture
+
+Input: `query` + K pre-load candidates.
+
+1. **Scatter.** Dispatch one *minimal verify-subagent* per candidate (or per
+   small group). Each gets an isolated context and a narrow brief: "Is THIS
+   location the code to change for `<query>`? Read it + directly-related code.
+   Return VERDICT yes/no, and if yes the exact Files/Symbols/Locations + a short
+   evidence note." Bounded (small `max_turns`, read+grep only).
+2. **Isolate.** Each subagent's noisy reading stays in *its* context. The
+   orchestrator never sees the dead-end code, only the structured verdict.
+3. **Converge.** The orchestrator collects N verdicts:
+   - ≥1 `yes` → synthesize the final answer from the confirmed location(s).
+   - all `no` → dispatch one *explore-subagent* with a **blank slate** (no
+     candidates) — i.e. the clean grep_only path that wins on behavioral.
+
+## Why this is the right pre-load runtime
+
+- **Context amortization** — K candidates' exploration is spread over N isolated
+  contexts instead of piling 9 reads + 7 greps into one 16-turn window.
+- **Fewer turns (orchestrator)** — the main agent only converges verdicts (~1–2
+  turns); exploration turns move into the subagents.
+- **Parallel wall-clock** — N subagents run concurrently; faster than one agent
+  grinding 16 sequential turns.
+- **Noise isolation → kills the REGRESS** — a wrong candidate's dead-end reading
+  never reaches the deciding context.
+- **Clean fallback** — all-`no` routes to a blank-slate explorer, which is
+  exactly the grep_only path that beat preload on behavioral.
+
+This is pre-load consumed correctly: candidates become **seeds for isolated
+exploration units**, not prompt filler one agent must digest.
 
 ## Why this can work where verify-expand didn't
 
-`verify-expand` (the prior harness customization) was a **no-op (0/400)** because
-it was a *GT-free deterministic* check (does the cited symbol resolve in the
-graph?) — the agent always cites a real-but-possibly-wrong symbol, which a
-deterministic check can't catch. Triage is **LLM semantic judgement**
-(plausible/implausible distinguishes right-file from wrong-file), so it has
-signal where resolution checking had none.
+`verify-expand` was a no-op (0/400): a GT-free *deterministic* resolve check the
+agent always passed (it cites real-but-wrong symbols). Here each subagent makes
+an **LLM semantic** judgement on a single candidate in a clean context — real
+signal, and the noise that fooled the monolithic agent is partitioned away.
 
-## How to evaluate
+## Implementation plan
 
-- **Dataset:** codeminer-synthesis (many-query; where reuse value is real).
-- **Arms:** `grep_only` vs `preinj_embed` (current) vs `preinj_triage` (new).
-- **Metric:** span answer_rec@k (symbol@k is unusable for agents — string match
-  vs free-form output scores ≈0; see `docs/experiments/qwen_backend.md`), plus
-  turns/tokens. Paired bootstrap CI (`pareto_ci.py`).
-- **Key question:** does triage keep the token/turn savings while removing the
-  behavioral REGRESS? Target verdict = SAVE on behavioral, not just symbol_hint.
+- New module `scripts/agent_compile/lib/orchestrator.py`:
+  `scatter_gather_localize(llm, query, candidates, contexts, repo_path, ...) -> answer`.
+  Reuses `AgentRunner` — each subagent is one `runner.run()` with a verify prompt,
+  fresh history, small `max_turns`.
+- New arm `preinj_scatter` in the config; `run_cell` routes to the orchestrator
+  instead of the single runner when the arm requests it.
+- **v1 (prove accuracy, serial):** run subagents serially, validate the
+  behavioral REGRESS disappears. Ignore latency.
+- **v2 (optimize):** run subagents concurrently for wall-clock.
+
+Prove the accuracy claim before paying for concurrency.
+
+## Evaluation
+
+- Dataset: codeminer-synthesis (many-query; reuse is real).
+- Arms: `grep_only` vs `preinj_embed` (current single-context) vs
+  `preinj_scatter` (new).
+- Metrics: span answer_rec@k (paired bootstrap, `pareto_ci.py`) + turns + tokens.
+- **Success = behavioral no longer REGRESSES** (Δrec CI_lo ≥ −EPS) while keeping
+  the token/turn saving. Watch total tokens: N subagents must not cost more than
+  the single agent's polluted 16-turn run.
 
 ## Open questions
 
-- Cost of the rule-out pass vs the turns it saves (must net positive).
-- Does triage help weak models (Qwen2.5) too, or only strong agents?
-- Is rule-out better as one LLM pass or N cheap parallel checks?
+- Total token cost of N subagents vs one monolithic run (the key trade to verify).
+- Converge strategy when multiple subagents say `yes` (merge vs pick-most-confident).
+- Group candidates (fewer, cheaper subagents) vs one-per-candidate (max isolation)?
+- Does it help weak models (Qwen2.5) too, or mainly strong agents?

--- a/.claude/design/preload-aware-harness.md
+++ b/.claude/design/preload-aware-harness.md
@@ -18,14 +18,23 @@ re-explorations (measured 23 turns vs 4 for a single agent) — it violates the
   fall back to grep only if none fits. Result (Qwen3.5-27B, synthesis, 36 paired):
   **token −43 % vs grep, 5/6 categories equal accuracy**; only `behavioral`
   regresses (candidates hurt explore-only queries with no concrete handle).
-- **eager_gated** (`mode: eager_gated`): a one-call LLM gate
-  (`query_is_specific`) routes **VAGUE** queries (no code identifier) to
-  blank-slate grep and **SPECIFIC** ones to eager. Gate classification verified
-  on Python: behavioral **0 %** / symbol_hint **100 %** SPECIFIC — the adaptive
-  "eager when confident, grep when ambiguous" Pareto play. (Gotcha: Qwen3.5 is a
-  thinking model — disable CoT via `extra_body chat_template_kwargs
-  enable_thinking=False`, else the verdict is truncated and everything reads
-  SPECIFIC.) Full per-category Pareto pending.
+- **eager_gated** (`mode: eager_gated`): a one-call LLM gate routes each query to
+  eager or blank-slate grep. The discriminator is NOT "has an identifier" — that
+  v1 mistake sent traversal queries (no identifier, but candidates on the call
+  chain ARE useful) to grep and lost 0.20. The right axis (from per-category
+  candidate value: behavioral grep>preload; traversal/symbol preload>=grep) is
+  **route to GREP only single-feature behavioral symptoms; EAGER anything that
+  names an identifier OR traces a cross-component flow**. Gate verified on n=400
+  multilingual: behavioral 73 % GREP, traversal 88 % EAGER, symbol/file ~100 %.
+  (Gotcha: Qwen3.5 is a thinking model — disable CoT via `extra_body
+  chat_template_kwargs enable_thinking=False`, else the one-word verdict is
+  truncated and everything routes EAGER.)
+  **Result (Qwen3.5-27B synthesis, 36 paired) — gated v2 is Pareto-dominant:**
+  ALL span **0.73** (vs grep/embed 0.70, eager 0.66) at **55k tokens**
+  (= the cheapest arm; −43 % vs grep, −27 % vs embed). Per category: behavioral
+  0.91 (=grep, rescued), traversal 0.83 (=embed, vs v1's 0.63), specific
+  categories equal-accuracy at a fraction of the tokens. Adaptive routing beats
+  every single fixed strategy on BOTH axes at once.
 
 The scatter design below is retained as **explored-and-rejected**: the converge
 idea is sound, but per-candidate full subagents are the cost mistake.

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -406,7 +406,33 @@ class AgentRunner:
                 "usage_tracker": usage_tracker,
                 "usage_turn": turn + 1,
             }
-            if tools:
+            # Last-turn salvage: if this is the final allowed turn and the agent
+            # still hasn't emitted the Files:/Symbols:/Locations: contract, spend
+            # it producing a formatted answer instead of one more (truncated)
+            # tool call. Weak models (Qwen3.5-4B) routinely burn all 16 turns
+            # still narrating / mid-grep and never commit a parseable answer
+            # (~55% of cells), which scores 0 even when they found the file. Force
+            # a tool-free schema turn here so the localization isn't lost.
+            is_last_turn = self._force_contract and turn == max_turns - 1
+            last_assistant = ""
+            for _m in reversed(history.get_messages()):
+                if _m.get("role") == "assistant" and _m.get("content"):
+                    last_assistant = _m["content"]
+                    break
+            if is_last_turn and not _has_localization_contract(last_assistant):
+                history.add_message(
+                    {
+                        "role": "user",
+                        "content": (
+                            "Stop exploring. Give your final answer NOW in exactly "
+                            f"this format:\n{LOCALIZATION_SCHEMA}"
+                        ),
+                    }
+                )
+                if tools:
+                    call_kwargs["tools"] = tools
+                    call_kwargs["tool_choice"] = "none"
+            elif tools:
                 call_kwargs["tools"] = tools
                 # Force tool calls until the agent has actually READ a file.
                 # Claude calls tools eagerly under "auto", but weaker open models

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -398,6 +398,7 @@ class AgentRunner:
         usage_tracker = UsageTracker()
         start = time.monotonic()
         has_read = False  # has the agent read a file yet (gates forced tools)
+        read_paths: List[str] = []  # files the agent read (for schema salvage)
 
         for turn in range(max_turns):
             logger.debug("agent turn %d/%d", turn + 1, max_turns)
@@ -468,7 +469,9 @@ class AgentRunner:
                     and not _has_localization_contract(answer)
                 ):
                     answer = (
-                        self._force_schema_answer(history, usage_tracker, turn + 2)
+                        self._force_schema_answer(
+                            history, usage_tracker, turn + 2, read_paths
+                        )
                         or answer
                     )
                 elapsed = (time.monotonic() - start) * 1000
@@ -490,6 +493,9 @@ class AgentRunner:
                 # contract; once it happens, stop forcing tool calls.
                 if record.skill_id == "read" and record.error is None:
                     has_read = True
+                    _rp = (record.arguments or {}).get("file_path")
+                    if _rp:
+                        read_paths.append(str(_rp))
 
                 # Append tool response message
                 history.add_message(
@@ -518,7 +524,9 @@ class AgentRunner:
             and not _has_localization_contract(last_content)
         ):
             last_content = (
-                self._force_schema_answer(history, usage_tracker, max_turns + 1)
+                self._force_schema_answer(
+                    history, usage_tracker, max_turns + 1, read_paths
+                )
                 or last_content
             )
 
@@ -537,42 +545,71 @@ class AgentRunner:
     # Internals
     # ------------------------------------------------------------------
 
-    def _force_schema_answer(self, history, usage_tracker, usage_turn: int) -> str:
-        """One tool-free turn that extracts a contract-conforming final answer.
+    def _force_schema_answer(
+        self, history, usage_tracker, usage_turn: int, read_paths=None
+    ) -> str:
+        """Tool-free turn(s) that extract a contract-conforming final answer.
 
         Used when the agent stopped (budget hit, or terminated in prose) without
         emitting the ``Files:/Symbols:/Locations:`` contract — so a genuine
-        localization is not lost to formatting / an unfinished answer. This is an
-        extra turn; it does NOT consume the exploration budget. Anthropic rejects
+        localization is not lost to formatting / an unfinished answer. These are
+        extra turns; they do NOT consume the exploration budget. Anthropic rejects
         a tool-history conversation unless ``tools=`` is passed, so we pass it
-        with ``tool_choice="none"`` to forbid further calls. Best-effort.
+        with ``tool_choice="none"`` to forbid further calls.
+
+        Weak/over-confident open models (Qwen3.5) often answer in prose or emit a
+        partial contract (e.g. ``Files:`` but no ``Locations:``) even when asked,
+        which scores 0 under span overlap. So we (a) remind them which files they
+        actually read — the answer must come from those — and (b) RETRY until the
+        full 3-line contract is present, up to a small bound.
         """
-        history.add_message(
-            {
-                "role": "user",
-                "content": (
-                    "Stop. Do not call any more tools. Based on everything you "
-                    "have found, give your final answer NOW in exactly this "
-                    "format (repo-relative paths; line numbers as shown by "
-                    f"`read`):\n{LOCALIZATION_SCHEMA}"
-                ),
-            }
-        )
-        try:
-            overrides: Dict[str, Any] = {
-                "usage_tracker": usage_tracker,
-                "usage_turn": usage_turn,
-            }
-            if self.tools:
-                overrides["tools"] = self.tools
-                overrides["tool_choice"] = "none"
-            final = self.llm._call_raw(history.get_messages(), **overrides)
-            forced_msg = final.choices[0].message
-            history.add_message(_message_to_dict(forced_msg))
-            return getattr(forced_msg, "content", None) or ""
-        except Exception as exc:  # best-effort; keep the partial run
-            logger.warning("forced final-answer turn failed: %s", exc)
-            return ""
+        files_hint = ""
+        uniq = list(dict.fromkeys(read_paths or []))
+        if uniq:
+            files_hint = (
+                "\nYou read these files — your answer MUST cite line ranges from "
+                "them:\n" + "\n".join(f"- {p}" for p in uniq[:10])
+            )
+        out = ""
+        for attempt in range(2):
+            nudge = (
+                ""
+                if attempt == 0
+                else (
+                    "\nYour previous answer was missing the Locations: line with "
+                    "explicit start-end line numbers. Add ALL three lines now."
+                )
+            )
+            history.add_message(
+                {
+                    "role": "user",
+                    "content": (
+                        "Stop. Do not call any more tools. Give your final answer "
+                        "NOW in EXACTLY this format — all three lines, "
+                        "repo-relative paths, Locations with start-end line "
+                        f"numbers as shown by `read`:\n{LOCALIZATION_SCHEMA}"
+                        f"{files_hint}{nudge}"
+                    ),
+                }
+            )
+            try:
+                overrides: Dict[str, Any] = {
+                    "usage_tracker": usage_tracker,
+                    "usage_turn": usage_turn + attempt,
+                }
+                if self.tools:
+                    overrides["tools"] = self.tools
+                    overrides["tool_choice"] = "none"
+                final = self.llm._call_raw(history.get_messages(), **overrides)
+                forced_msg = final.choices[0].message
+                history.add_message(_message_to_dict(forced_msg))
+                out = getattr(forced_msg, "content", None) or out
+            except Exception as exc:  # best-effort; keep the partial run
+                logger.warning("forced final-answer turn failed: %s", exc)
+                break
+            if _has_localization_contract(out):
+                break
+        return out
 
     def _new_history(self):
         """Build the chat-history container for one ``run()``.

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -159,6 +159,7 @@ class AgentRunner:
         default_tool_ids: Optional[Set[str]] = None,
         retry: Optional[RetryConfig] = None,
         force_localization_contract: bool = True,
+        first_turn_tool_choice: Optional[str] = None,
     ) -> None:
         if llm is not None:
             self.llm = llm
@@ -219,6 +220,7 @@ class AgentRunner:
         # Locations: contract; QA callers (web demo) keep prose, so they turn
         # this off and skip the schema-forcing final turn entirely.
         self._force_contract = force_localization_contract
+        self.first_turn_tool_choice = first_turn_tool_choice
 
         # Resource guard: filter unavailable skills and collect warnings.
         # The "base" allow / exclude are stored so we can recompute the
@@ -401,6 +403,14 @@ class AgentRunner:
             }
             if tools:
                 call_kwargs["tools"] = tools
+                # Force at least one tool call on the FIRST turn. Claude calls
+                # tools eagerly under the default tool_choice="auto", but weaker
+                # open models (e.g. Qwen2.5-Coder) answer in one shot without
+                # exploring — turning the agent loop into a no-op. Requiring a
+                # tool call on turn 0 makes them actually grep/read; subsequent
+                # turns stay "auto" so the model is free to commit its answer.
+                if turn == 0 and self.first_turn_tool_choice:
+                    call_kwargs["tool_choice"] = self.first_turn_tool_choice
 
             response = self.llm._call_raw(history.get_messages(), **call_kwargs)
             choice = response.choices[0]

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -160,6 +160,7 @@ class AgentRunner:
         retry: Optional[RetryConfig] = None,
         force_localization_contract: bool = True,
         first_turn_tool_choice: Optional[str] = None,
+        force_first_turn_only: bool = False,
     ) -> None:
         if llm is not None:
             self.llm = llm
@@ -221,6 +222,9 @@ class AgentRunner:
         # this off and skip the schema-forcing final turn entirely.
         self._force_contract = force_localization_contract
         self.first_turn_tool_choice = first_turn_tool_choice
+        # When True, only turn 0 is forced (legacy single-turn behaviour);
+        # default False = force until the agent reads a file.
+        self._force_first_turn_only = force_first_turn_only
 
         # Resource guard: filter unavailable skills and collect warnings.
         # The "base" allow / exclude are stored so we can recompute the
@@ -393,6 +397,7 @@ class AgentRunner:
         all_tool_calls: List[ToolCallRecord] = []
         usage_tracker = UsageTracker()
         start = time.monotonic()
+        has_read = False  # has the agent read a file yet (gates forced tools)
 
         for turn in range(max_turns):
             logger.debug("agent turn %d/%d", turn + 1, max_turns)
@@ -403,14 +408,18 @@ class AgentRunner:
             }
             if tools:
                 call_kwargs["tools"] = tools
-                # Force at least one tool call on the FIRST turn. Claude calls
-                # tools eagerly under the default tool_choice="auto", but weaker
-                # open models (e.g. Qwen2.5-Coder) answer in one shot without
-                # exploring — turning the agent loop into a no-op. Requiring a
-                # tool call on turn 0 makes them actually grep/read; subsequent
-                # turns stay "auto" so the model is free to commit its answer.
-                if turn == 0 and self.first_turn_tool_choice:
-                    call_kwargs["tool_choice"] = self.first_turn_tool_choice
+                # Force tool calls until the agent has actually READ a file.
+                # Claude calls tools eagerly under "auto", but weaker open models
+                # (Qwen2.5-Coder) answer one-shot — and 32B in particular would
+                # fire ONE grep, get 0 hits, then commit a blind answer from the
+                # pre-load candidates without ever reading code (4% read rate vs
+                # 86% for 14B). The localization contract requires reading the
+                # file you cite, so keep tool_choice forced until a read happens;
+                # then drop to "auto" so the model is free to commit. Bounded by
+                # first_turn_only for the old single-turn behaviour.
+                if self.first_turn_tool_choice and not has_read:
+                    if not (self._force_first_turn_only and turn > 0):
+                        call_kwargs["tool_choice"] = self.first_turn_tool_choice
 
             response = self.llm._call_raw(history.get_messages(), **call_kwargs)
             choice = response.choices[0]
@@ -451,6 +460,10 @@ class AgentRunner:
             for tc in tool_calls:
                 record = self._execute_tool_call(tc)
                 all_tool_calls.append(record)
+                # A successful read satisfies the "read before answering"
+                # contract; once it happens, stop forcing tool calls.
+                if record.skill_id == "read" and record.error is None:
+                    has_read = True
 
                 # Append tool response message
                 history.add_message(

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -609,6 +609,15 @@ class AgentRunner:
                 break
             if _has_localization_contract(out):
                 break
+            # Only retry to COMPLETE a partial contract (e.g. Files: present but
+            # Locations: missing). If the model emitted no contract line at all
+            # (pure prose), retrying won't help — stop and avoid a wasted call.
+            if not (
+                _HAS_FILES_CONTRACT.search(out)
+                or _HAS_SYMBOLS_CONTRACT.search(out)
+                or _HAS_LOCATIONS_CONTRACT.search(out)
+            ):
+                break
         return out
 
     def _new_history(self):

--- a/docs/experiments/qwen_backend.md
+++ b/docs/experiments/qwen_backend.md
@@ -28,51 +28,57 @@ PYTHONPATH=$PWD python scripts/agent_compile/run_sweep.py \
 # synthesis dataset: same, via run_synthesis_sweep.py --model openai/... --synthesis-configs Python
 ```
 
+## The tool-loop fix (why the first numbers were wrong)
+
+Qwen2.5-Coder under the default `tool_choice="auto"` answered **one-shot**
+(turns=1, tools=0) — it never grep/read, so the agent loop was a no-op and the
+first sweep measured "the model guessing from memory," not an agent. The runner
+only passed `tools=` and let tool_choice default to auto (fine for Claude, which
+calls tools eagerly; dead for Qwen). Fix: `AgentRunner.first_turn_tool_choice`
+forces a tool call on turn 0 (then auto), exposed via the config. After the fix
+Qwen runs turns=2, tools≈1–2.4 — a real loop. **All numbers below are the fixed
+(v2) run; the pre-fix run is discarded.**
+
 ## codeminer-base (files@k — base GT line spans are null, so file-level is the ruler)
 
-| model | grep_only f@1 | preinj_embed f@1 | grep_only f@5 | preinj_embed f@5 |
+100 instances/arm, paired, tool-loop fix on:
+
+| model | grep_only f@5 | preinj_embed f@5 | Δ (preinj − grep) | mean tools |
 |---|---|---|---|---|
-| 7B  | 0.190 | 0.345 | 0.222 | 0.357 |
-| 14B | 0.286 | 0.357 | 0.343 | 0.514 |
-| 32B (fp8) | 0.139 | **0.388** | 0.191 | **0.555** |
+| 7B  | 0.160 | 0.446 | **+0.286** | 1.1 |
+| 14B | 0.310 | 0.594 | **+0.284** | 2.4 |
+| 32B (fp8) | 0.362 | 0.545 | **+0.183** | 1.0 |
 
-- **Pre-load helps every size** — on 32B it lifts files@5 0.191 → 0.555.
-- **Bigger is better** with pre-load (f@5 0.357 → 0.514 → 0.555).
-- `grep_only` is noisy across sizes (not perfectly paired n); `preinj_embed` is
-  the clean, monotonic axis.
+- **Pre-load helps every size** (+0.18 to +0.29 files@5).
+- **`grep_only` rises monotonically with size** (0.16 → 0.31 → 0.36): bigger
+  models use the tools better, so the bare agent is only respectable when large.
+- **The pre-load lift shrinks as the model grows** (7B +0.286 → 32B +0.183):
+  the stronger the model, the less it needs the injected starting point — i.e.
+  **pre-load matters most for weak/local models**. (7B's grep is so poor it often
+  greps the wrong file, so its grep_only is actually *worse* than guessing.)
 
-## codeminer-synthesis (Qwen 7B, answer_rec@5 span-overlap, per category)
+## The compatibility findings that matter
 
-| category | Δrec@5 (preinj − grep) [95% CI] | win/tie/loss |
-|---|---|---|
-| behavioral | +0.057 [0.00, +0.14] | 2/33/0 |
-| traversal  | +0.078 [0.00, +0.17] | 3/12/0 |
-| file_hint  | −0.133 [−0.40, +0.07] (n=15) | 1/11/3 |
-| module_hint / symbol_hint / reasoning | ≈ 0.000 | all ties |
-| **ALL** | **+0.012 [−0.045, +0.070]** | 7/89/4 |
-
-Mirrors the Claude pattern (pre-load helps the no-hint categories
-behavioral/traversal, ties on hint-rich symbol/module/file), weaker + noisier.
-
-## The compatibility finding that matters
-
-- **Qwen2.5-Coder-Instruct does not initiate tool calls under `tool_choice: auto`**
-  (what the agent loop uses). With `required` it emits a correct Hermes
-  `<tool_call>`, so the parser/wiring is fine — the model simply *chooses* not to
-  grep/read. Every cell ran in **turns=1, tools=0**: a one-shot answer.
-- Consequence: for a weak/local model the agent loop is effectively dead, and
-  **pre-load is what makes it usable** — on base it ~doubles file accuracy
-  because the injected candidates carry the answer the model won't go find.
-- **There is no "save token" axis locally**: litellm reports no `$` cost for the
-  local endpoint, and one-shot means no exploration turns to collapse. On local
-  models pre-load's value is *accuracy* (largest where the query has no hint),
-  not cost. The cost-saving story is a *cloud / strong-agent* property.
+- **Qwen2.5-Coder needs tool-calling forced on turn 0.** Under `auto` it answers
+  one-shot; with `first_turn_tool_choice="required"` it genuinely loops
+  (grep → read → answer). The Hermes parser/wiring was always correct — the
+  model just won't *initiate* under auto. This is the single change that makes a
+  local open model usable as an agent here.
+- **Pre-load value is accuracy, and it's largest for weaker models.** Even with
+  a real loop, the injected candidates give a poor explorer a correct starting
+  point; the lift falls from +0.29 (7B) to +0.18 (32B) as the model gets better
+  at finding code itself.
+- **No local "save-token" axis.** litellm reports no `$` for a local endpoint,
+  and the loops are short (turns≈2). On local models pre-load buys *accuracy*,
+  not cost — the cost-saving story is a cloud / strong-agent property.
 
 ## Caveats / gotchas
 
 - The GPU is **shared** — large models (32B fp8) OOM'd when other users' processes
   + the sweep's embedding model co-resided; tune `--gpu-memory-utilization` down
-  and leave headroom for the embedding model (it lives on the same GPU).
+  (≈0.6 for 32B) and leave headroom for the embedding model (same GPU).
 - vLLM startup: port conflicts, sampler-warmup OOM (`--max-num-seqs` down), and
   transient GPU-memory-release races between successive serves.
-- reps=1; base scored-n per model differs (42 / 35 / 61) as runs are independent.
+- reps=1; codeminer-base (files@k, GT spans null). A synthesis (per-category,
+  span-overlap) re-run with the tool-loop fix is the natural next step — the
+  pre-fix synthesis numbers were discarded with the rest of the no-loop run.

--- a/docs/experiments/qwen_backend.md
+++ b/docs/experiments/qwen_backend.md
@@ -3,82 +3,153 @@ SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Qwen2.5-Coder backend — agent compatibility + eval
+# Local open-model backend (Qwen2.5-Coder + Qwen3.5) — agent eval
 
-Can the CodeMiner agent run on a **local open model** (Qwen2.5-Coder 7B / 14B /
-32B via vLLM) instead of a cloud API, and does the pre-load context-engine still
-help? Yes to running; pre-load helps, but its shape changes for weak models.
+Can the CodeMiner agent run on **local open models** instead of a cloud API, and
+does the pre-load context-engine help? Yes to running. The headline finding:
 
-## How to run (local vLLM backend)
+> **Pre-load's value is inversely proportional to the model's own agentic
+> ability.** Weak models that can't explore are rescued by it; strong agents that
+> explore well get equal accuracy and only a cost saving — and only in the
+> many-query setting where index reuse is real.
+
+Two model families, on the same agent + prebuilt indexes:
+- **Qwen2.5-Coder** 7B/14B/32B (vLLM `--tool-call-parser hermes`)
+- **Qwen3.5** 4B/9B/27B (vLLM 0.23, `--tool-call-parser qwen3_xml`)
+
+## How to run
 
 ```bash
-# serve (tool-calling ON; Qwen2.5 uses the Hermes <tool_call> format)
-HF_HOME=/mnt/conda/huggingface python -m vllm.entrypoints.openai.api_server \
+# Qwen2.5-Coder (vLLM >=0.10)
+python -m vllm.entrypoints.openai.api_server \
   --model Qwen/Qwen2.5-Coder-7B-Instruct --served-model-name qwen2.5-coder-7b \
   --enable-auto-tool-choice --tool-call-parser hermes \
   --max-model-len 32768 --max-num-seqs 64 --gpu-memory-utilization 0.85 --port 8001
-# 32B: add `--quantization fp8`; lower --gpu-memory-utilization (~0.6) so the
-# sweep's Qwen3-Embedding model still fits on the same GPU.
+
+# Qwen3.5 (needs vLLM 0.23 in a separate env: torch 2.11/cu13; driver CUDA 13 OK)
+python -m vllm.entrypoints.openai.api_server \
+  --model Qwen/Qwen3.5-4B --served-model-name qwen3.5-4b \
+  --enable-auto-tool-choice --tool-call-parser qwen3_xml \
+  --max-model-len 32768 --gpu-memory-utilization 0.45 --port 8001
 
 # run (openai/ + OPENAI_API_BASE routes litellm to the local server)
-OPENAI_API_BASE=http://localhost:8001/v1 OPENAI_API_KEY=dummy \
-PYTHONPATH=$PWD python scripts/agent_compile/run_sweep.py \
-  --config scripts/agent_compile/configs/qwen7b_base.yaml \
-  --model openai/qwen2.5-coder-7b --output-dir results/agent_compile/qwen7b_base
-# synthesis dataset: same, via run_synthesis_sweep.py --model openai/... --synthesis-configs Python
+OPENAI_API_BASE=http://localhost:8001/v1 OPENAI_API_KEY=dummy PYTHONPATH=$PWD \
+python scripts/agent_compile/run_sweep.py \
+  --config scripts/agent_compile/configs/qwen35_base.yaml \
+  --model openai/qwen3.5-4b --output-dir results/agent_compile/qwen35_4b
+# synthesis (many-query): run_synthesis_sweep.py --model openai/... --synthesis-configs Python
 ```
 
-## The tool-loop fix (why the first numbers were wrong)
+`qwen7b_base.yaml` sets `first_turn_tool_choice: required` (Qwen2.5 needs it,
+see below); `qwen35_base.yaml` leaves it null (Qwen3.5 tool-calls under auto).
 
-Qwen2.5-Coder under the default `tool_choice="auto"` answered **one-shot**
-(turns=1, tools=0) — it never grep/read, so the agent loop was a no-op and the
-first sweep measured "the model guessing from memory," not an agent. The runner
-only passed `tools=` and let tool_choice default to auto (fine for Claude, which
-calls tools eagerly; dead for Qwen). Fix: `AgentRunner.first_turn_tool_choice`
-forces a tool call on turn 0 (then auto), exposed via the config. After the fix
-Qwen runs turns=2, tools≈1–2.4 — a real loop. **All numbers below are the fixed
-(v2) run; the pre-fix run is discarded.**
+## codeminer-base — single query / repo (files@5 + span@5)
 
-## codeminer-base (files@k — base GT line spans are null, so file-level is the ruler)
+`span@5` = `answer_blocks@5`, span-overlap recall (see methodology). Paired,
+100 inst/arm, `format_fail=0%` for every cell below.
 
-100 instances/arm, paired, tool-loop fix on:
+**Qwen2.5-Coder** (forced first-turn tool call; otherwise answers one-shot):
 
-| model | grep_only f@5 | preinj_embed f@5 | Δ (preinj − grep) | mean tools |
+| model | grep files@5 | preinj files@5 | grep span@5 | preinj span@5 |
 |---|---|---|---|---|
-| 7B  | 0.160 | 0.446 | **+0.286** | 1.1 |
-| 14B | 0.310 | 0.594 | **+0.284** | 2.4 |
-| 32B (fp8) | 0.362 | 0.545 | **+0.183** | 1.0 |
+| 7B  | 0.160 | **0.446** | 0.130 | **0.277** |
+| 14B | 0.310 | **0.594** | 0.162 | **0.381** |
+| 32B | 0.362 | **0.545** | 0.194 | **0.343** |
 
-- **Pre-load helps every size** (+0.18 to +0.29 files@5).
-- **`grep_only` rises monotonically with size** (0.16 → 0.31 → 0.36): bigger
-  models use the tools better, so the bare agent is only respectable when large.
-- **The pre-load lift shrinks as the model grows** (7B +0.286 → 32B +0.183):
-  the stronger the model, the less it needs the injected starting point — i.e.
-  **pre-load matters most for weak/local models**. (7B's grep is so poor it often
-  greps the wrong file, so its grep_only is actually *worse* than guessing.)
+→ Pre-load **helps massively at every size** (files +0.18-0.29, span +0.15-0.22).
+These models barely explore (turns~2 even when forced), so the injected
+candidates *are* the localization.
 
-## The compatibility findings that matter
+**Qwen3.5** (native agent: turns 12-15, read-rate 97-100%, no forcing):
 
-- **Qwen2.5-Coder needs tool-calling forced on turn 0.** Under `auto` it answers
-  one-shot; with `first_turn_tool_choice="required"` it genuinely loops
-  (grep → read → answer). The Hermes parser/wiring was always correct — the
-  model just won't *initiate* under auto. This is the single change that makes a
-  local open model usable as an agent here.
-- **Pre-load value is accuracy, and it's largest for weaker models.** Even with
-  a real loop, the injected candidates give a poor explorer a correct starting
-  point; the lift falls from +0.29 (7B) to +0.18 (32B) as the model gets better
-  at finding code itself.
-- **No local "save-token" axis.** litellm reports no `$` for a local endpoint,
-  and the loops are short (turns≈2). On local models pre-load buys *accuracy*,
-  not cost — the cost-saving story is a cloud / strong-agent property.
+| model | grep files@5 | preinj files@5 | grep span@5 | preinj span@5 |
+|---|---|---|---|---|
+| 4B  | 0.730 | 0.656 | 0.402 | 0.281 |
+| 9B (partial) | 0.770 | 0.768 | 0.552 | 0.402 |
+| 27B | 0.890 | 0.881 | 0.618 | 0.524 |
+
+→ Pre-load is **equal accuracy or slightly negative**. 27B paired bootstrap:
+files Δ=−0.013 CI=[−0.125,+0.100], span Δ=−0.083 CI=[−0.250,+0.087] — **both
+CIs span 0 → equal**. The strong agent already explores to the answer; injected
+candidates add no accuracy (and can mislead — see synthesis). 9B is partial
+(n≈52; the run was repurposed mid-way for the max-turns probe).
+
+**The cross-family story is the whole point:** Qwen2.5 (turns~2, can't explore)
+is rescued by pre-load; Qwen3.5 (turns~14, explores natively) is not.
+
+## codeminer-synthesis — many queries / repo (where reuse is real)
+
+base is 1 query/instance, so the index build amortizes over nothing and pre-load
+can't show its reuse value. synthesis (50-80 q/repo) is the right setting.
+**Qwen3.5-27B**, span answer_rec, paired bootstrap (`pareto_ci.py`):
+
+| axis | preinj_embed vs grep_only |
+|---|---|
+| accuracy (ALL) | Δrec@5 = −0.056 [−0.127, +0.014] → equal |
+| turns | **−1.7** |
+| tokens | **−7.6 %** |
+| behavioral category | Δrec@5 = **−0.167 [−0.333, −0.042] → REGRESS** |
+
+→ Now pre-load **saves cost** (−1.7 turns, −7.6 % tokens) at equal pooled
+accuracy — the saving base structurally couldn't show. **But it's a trade, not a
+free win:** on `behavioral` (no-hint, explore-only queries) the agent
+over-trusts candidates (fewer turns, wrong answer) — a significant regress. Cf.
+Haiku on synthesis (+0.018 / −17 %): same class (equal-accuracy + save), but
+Haiku saves more (cloud prompt-cache) and doesn't regress on behavioral.
+
+## Methodology
+
+**Span-overlap, not symbol@k.** Symbol-level localization is reported as
+span-overlap recall (`answer_blocks@k`). Exact identifier match (`symbol@k`) is
+**fundamentally ill-suited to agents**: an agent emits free-form prose
+(`Driver::new`, `dir_entry_dict()`, backtick'd names), not canonical symbol IDs,
+so string-matching GT identifiers scores ≈0 regardless of whether it located the
+code (measured: symbol@k = 0.000 across all Qwen3.5 base cells). Span-overlap
+aligns on code **position** — the common ground between a generative agent and
+ground truth — capturing "located the symbol's code" robustly, at slightly
+coarser granularity (credits overlapping/enclosing symbols).
+
+**Honest format-failure reporting.** A cell scores 0 for two different reasons:
+wrong localization, or the agent found the code but never emitted a parseable
+`Files:/Symbols:/Locations:` answer (an LLM format-following weakness, worst on
+small models). `run_sweep` tags the latter `format_failed`; `aggregate_honest.py`
+reports the failure rate separately from accuracy instead of silently zeroing it.
+The harness retries (force-schema, reads-hint) to give the model a fair chance,
+then discloses the residual rate.
+
+## Harness fixes this surfaced (all in this PR)
+
+1. **`first_turn_tool_choice`** — Qwen2.5 answers one-shot under `tool_choice=auto`
+   (turns=1, tools=0, loop is a no-op). Force a tool call on turn 0. *Default
+   None = unchanged for Claude.*
+2. **force-until-read** — first-turn forcing wasn't enough: 32B fired one grep,
+   got 0 hits, blind-answered from candidates (4% read vs 86% for 14B). Force
+   tools until a file is actually read.
+3. **last-turn salvage + force-schema retries** — weak models burn all turns
+   narrating; on the last turn force a tool-free schema answer, retry to the full
+   3-line contract, hint the files actually read.
+4. **format_failed flag + aggregate_honest.py** — the honesty reporting above.
+
+## Next step
+
+Pre-load on a strong agent is a *trade* (saves cost, regresses behavioral)
+because candidates and the generic grep/read loop were never fused. The
+direction is a **pre-load-aware harness** that triages candidates (rule-out /
+verify / fallback-to-explore) instead of consuming them linearly. Design:
+[`.claude/design/preload-aware-harness.md`](../../.claude/design/preload-aware-harness.md).
 
 ## Caveats / gotchas
 
-- The GPU is **shared** — large models (32B fp8) OOM'd when other users' processes
-  + the sweep's embedding model co-resided; tune `--gpu-memory-utilization` down
-  (≈0.6 for 32B) and leave headroom for the embedding model (same GPU).
-- vLLM startup: port conflicts, sampler-warmup OOM (`--max-num-seqs` down), and
-  transient GPU-memory-release races between successive serves.
-- reps=1; codeminer-base (files@k, GT spans null). A synthesis (per-category,
-  span-overlap) re-run with the tool-loop fix is the natural next step — the
-  pre-fix synthesis numbers were discarded with the rest of the no-loop run.
+- vLLM 0.23 for Qwen3.5 needs torch 2.11/cu13 — clone the env, don't upgrade in
+  place. Driver CUDA 13 already supports it; no system change needed.
+- Qwen3.5 uses the `qwen3_xml` tool-call format (`<function=…><parameter=…>`),
+  **not** hermes — wrong parser silently drops all tool calls under auto.
+- GPU is **shared**: leave headroom for the sweep's Qwen3-Embedding on the same
+  GPU (32B fp8 needs `--gpu-memory-utilization ≈0.6`).
+- Env landmine: a SWE-bench test repo was editable-installed as `sympy`,
+  shadowing real sympy and failing whole sweeps — `pip install "sympy>=1.13"`.
+- reps=1. 9B base is partial. Per-category synthesis n is small (CIs wide); the
+  pooled / cross-family results are the robust ones.
+- Raising max_turns 16->40 (probe): grep_only gains (more exploration helps a
+  strong agent), preinj does not (it already converges early) — consistent with
+  the equal-accuracy finding.

--- a/docs/experiments/qwen_backend.md
+++ b/docs/experiments/qwen_backend.md
@@ -1,0 +1,78 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Qwen2.5-Coder backend — agent compatibility + eval
+
+Can the CodeMiner agent run on a **local open model** (Qwen2.5-Coder 7B / 14B /
+32B via vLLM) instead of a cloud API, and does the pre-load context-engine still
+help? Yes to running; pre-load helps, but its shape changes for weak models.
+
+## How to run (local vLLM backend)
+
+```bash
+# serve (tool-calling ON; Qwen2.5 uses the Hermes <tool_call> format)
+HF_HOME=/mnt/conda/huggingface python -m vllm.entrypoints.openai.api_server \
+  --model Qwen/Qwen2.5-Coder-7B-Instruct --served-model-name qwen2.5-coder-7b \
+  --enable-auto-tool-choice --tool-call-parser hermes \
+  --max-model-len 32768 --max-num-seqs 64 --gpu-memory-utilization 0.85 --port 8001
+# 32B: add `--quantization fp8`; lower --gpu-memory-utilization (~0.6) so the
+# sweep's Qwen3-Embedding model still fits on the same GPU.
+
+# run (openai/ + OPENAI_API_BASE routes litellm to the local server)
+OPENAI_API_BASE=http://localhost:8001/v1 OPENAI_API_KEY=dummy \
+PYTHONPATH=$PWD python scripts/agent_compile/run_sweep.py \
+  --config scripts/agent_compile/configs/qwen7b_base.yaml \
+  --model openai/qwen2.5-coder-7b --output-dir results/agent_compile/qwen7b_base
+# synthesis dataset: same, via run_synthesis_sweep.py --model openai/... --synthesis-configs Python
+```
+
+## codeminer-base (files@k — base GT line spans are null, so file-level is the ruler)
+
+| model | grep_only f@1 | preinj_embed f@1 | grep_only f@5 | preinj_embed f@5 |
+|---|---|---|---|---|
+| 7B  | 0.190 | 0.345 | 0.222 | 0.357 |
+| 14B | 0.286 | 0.357 | 0.343 | 0.514 |
+| 32B (fp8) | 0.139 | **0.388** | 0.191 | **0.555** |
+
+- **Pre-load helps every size** — on 32B it lifts files@5 0.191 → 0.555.
+- **Bigger is better** with pre-load (f@5 0.357 → 0.514 → 0.555).
+- `grep_only` is noisy across sizes (not perfectly paired n); `preinj_embed` is
+  the clean, monotonic axis.
+
+## codeminer-synthesis (Qwen 7B, answer_rec@5 span-overlap, per category)
+
+| category | Δrec@5 (preinj − grep) [95% CI] | win/tie/loss |
+|---|---|---|
+| behavioral | +0.057 [0.00, +0.14] | 2/33/0 |
+| traversal  | +0.078 [0.00, +0.17] | 3/12/0 |
+| file_hint  | −0.133 [−0.40, +0.07] (n=15) | 1/11/3 |
+| module_hint / symbol_hint / reasoning | ≈ 0.000 | all ties |
+| **ALL** | **+0.012 [−0.045, +0.070]** | 7/89/4 |
+
+Mirrors the Claude pattern (pre-load helps the no-hint categories
+behavioral/traversal, ties on hint-rich symbol/module/file), weaker + noisier.
+
+## The compatibility finding that matters
+
+- **Qwen2.5-Coder-Instruct does not initiate tool calls under `tool_choice: auto`**
+  (what the agent loop uses). With `required` it emits a correct Hermes
+  `<tool_call>`, so the parser/wiring is fine — the model simply *chooses* not to
+  grep/read. Every cell ran in **turns=1, tools=0**: a one-shot answer.
+- Consequence: for a weak/local model the agent loop is effectively dead, and
+  **pre-load is what makes it usable** — on base it ~doubles file accuracy
+  because the injected candidates carry the answer the model won't go find.
+- **There is no "save token" axis locally**: litellm reports no `$` cost for the
+  local endpoint, and one-shot means no exploration turns to collapse. On local
+  models pre-load's value is *accuracy* (largest where the query has no hint),
+  not cost. The cost-saving story is a *cloud / strong-agent* property.
+
+## Caveats / gotchas
+
+- The GPU is **shared** — large models (32B fp8) OOM'd when other users' processes
+  + the sweep's embedding model co-resided; tune `--gpu-memory-utilization` down
+  and leave headroom for the embedding model (it lives on the same GPU).
+- vLLM startup: port conflicts, sampler-warmup OOM (`--max-num-seqs` down), and
+  transient GPU-memory-release races between successive serves.
+- reps=1; base scored-n per model differs (42 / 35 / 61) as runs are independent.

--- a/scripts/agent_compile/aggregate_honest.py
+++ b/scripts/agent_compile/aggregate_honest.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Honest aggregation: separate localization accuracy from format-failure.
+
+A cell can score 0 for two very different reasons:
+  1. the agent localized to the WRONG place (a real miss), or
+  2. the agent FOUND the right place but never emitted a parseable
+     Files:/Symbols:/Locations: answer even after the force-schema retries
+     (``format_failed=True``) — an LLM format-following weakness, worst on small
+     models, NOT a localization error.
+
+Burying (2) inside the accuracy denominator conflates the two and unfairly
+punishes pre-load arms (which make weak models more verbose). So this reporter
+prints, per (model-dir, arm):
+  * format_fail_rate                         — honesty: how often we couldn't score
+  * files@5 / answer_blocks@k on ALL cells   — the as-measured number
+  * files@5 / answer_blocks@k on FORMATTED   — localization ability where scorable
+
+Both are shown; neither is hidden. Usage::
+
+    python scripts/agent_compile/aggregate_honest.py \
+        results/agent_compile/qwen35_4b_base_v2 [more dirs...]
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import statistics as st
+import sys
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Sequence
+
+
+def _f(cell: Dict[str, Any], scope: str, k: int) -> Optional[float]:
+    b = (cell.get("metrics") or {}).get(scope) or {}
+    s = b.get(k, b.get(str(k)))
+    return s.get("recall") if isinstance(s, dict) else None
+
+
+def _mean(xs: Sequence[Optional[float]]) -> float:
+    v = [x for x in xs if x is not None]
+    return st.fmean(v) if v else 0.0
+
+
+def report(d: str) -> List[str]:
+    cells = []
+    for p in glob.glob(f"{d}/cells/*.json"):
+        try:
+            c = json.loads(open(p).read())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if c.get("success") and c.get("metrics_meaningful"):
+            cells.append(c)
+    by = defaultdict(list)
+    for c in cells:
+        by[c.get("subset_id")].append(c)
+
+    L = [f"\n## {d.rstrip('/').split('/')[-1]}  (n_meaningful={len(cells)})"]
+    L.append(
+        f"{'arm':14} {'n':>4} {'fmt_fail':>9} "
+        f"{'files@5(all)':>13} {'files@5(fmt)':>13} "
+        f"{'ansBlk@5(all)':>14} {'ansBlk@5(fmt)':>14}"
+    )
+    for arm in sorted(by):
+        cs = by[arm]
+        fmt_ok = [c for c in cs if not c.get("format_failed")]
+        ff = sum(1 for c in cs if c.get("format_failed")) / len(cs) if cs else 0
+        files_all = _mean([_f(c, "files", 5) for c in cs])
+        files_fmt = _mean([_f(c, "files", 5) for c in fmt_ok])
+        blk_all = _mean([_f(c, "answer_blocks", 5) for c in cs])
+        blk_fmt = _mean([_f(c, "answer_blocks", 5) for c in fmt_ok])
+        L.append(
+            f"{arm:14} {len(cs):>4} {ff * 100:>8.0f}% "
+            f"{files_all:>13.3f} {files_fmt:>13.3f} "
+            f"{blk_all:>14.3f} {blk_fmt:>14.3f}"
+        )
+    return L
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    dirs = list(argv if argv is not None else sys.argv[1:])
+    if not dirs:
+        print("usage: aggregate_honest.py <result-dir> [more...]", file=sys.stderr)
+        return 2
+    out = [
+        "# Honest report — localization accuracy vs format-failure",
+        "",
+        "`(all)` = scored over every meaningful cell (format-fail counts as 0).",
+        "`(fmt)` = scored only where the answer was parseable (true localization "
+        "ability). `fmt_fail` = share of cells unscorable after force-schema "
+        "retries — reported, not hidden.",
+    ]
+    for d in dirs:
+        out += report(d)
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_compile/configs/haiku_compare.yaml
+++ b/scripts/agent_compile/configs/haiku_compare.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+# Unified 4-arm comparison on Haiku (cloud strong agent): grep / embed / eager /
+# eager_gated. graph + graph_verify dropped to appendix (runtime_probe rejected).
+base: design_space.yaml
+sweep_id: haiku_compare
+reps: 1
+max_turns: 16
+instances: []
+subsets:
+  grep_only: [read, grep, glob, bash]
+  preinj_embed: [read, grep, glob, bash]
+  preinj_eager: [read, grep, glob, bash]
+  preinj_eager_gated: [read, grep, glob, bash]
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+  preinj_eager:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+    mode: eager
+  preinj_eager_gated:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+    mode: eager_gated

--- a/scripts/agent_compile/configs/qwen35_base.yaml
+++ b/scripts/agent_compile/configs/qwen35_base.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Qwen2.5-Coder backend on codeminer-base — the "final agent" (flat embedding
+# pre-load) vs the grep_only baseline, run against a LOCAL vLLM OpenAI server.
+#
+#   serve:  vllm ... --served-model-name qwen2.5-coder-7b --enable-auto-tool-choice
+#           --tool-call-parser hermes --port 8001
+#   run:    OPENAI_API_BASE=http://localhost:8001/v1 OPENAI_API_KEY=dummy \
+#           PYTHONPATH=$PWD python scripts/agent_compile/run_sweep.py \
+#             --config scripts/agent_compile/configs/qwen7b_base.yaml \
+#             --output-dir results/agent_compile/qwen7b_base
+#
+# `openai/<name>` tells litellm to use the OpenAI wire format against
+# OPENAI_API_BASE; vertex_* are nulled so no vertex kwargs leak to the call.
+# Swap model + served-name + port for 14B / 32B (32B served with --quantization fp8).
+base: design_space.yaml
+
+sweep_id: qwen35_base
+model: openai/qwen2.5-coder-7b
+vertex_location: null
+vertex_project: null
+reps: 1
+max_turns: 16
+
+# Qwen2.5-Coder answers one-shot under tool_choice="auto" (turns=1, no grep/read)
+# — force a tool call on the first turn so the agent loop is actually exercised.
+first_turn_tool_choice: null
+
+instances: []  # whole codeminer-base test split (~100 instances)
+
+subsets:
+  grep_only:
+    - read
+    - grep
+    - glob
+    - bash
+  preinj_embed:
+    - read
+    - grep
+    - glob
+    - bash
+
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2

--- a/scripts/agent_compile/configs/qwen35_compare.yaml
+++ b/scripts/agent_compile/configs/qwen35_compare.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+base: design_space.yaml
+sweep_id: qwen35_compare
+model: openai/qwen3.5-27b
+vertex_location: null
+vertex_project: null
+reps: 1
+max_turns: 16
+first_turn_tool_choice: null
+instances: []
+subsets:
+  grep_only: [read, grep, glob, bash]
+  preinj_eager: [read, grep, glob, bash]
+  preinj_eager_gated: [read, grep, glob, bash]
+preload:
+  preinj_eager:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+    mode: eager
+  preinj_eager_gated:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+    mode: eager_gated

--- a/scripts/agent_compile/configs/qwen35_eager.yaml
+++ b/scripts/agent_compile/configs/qwen35_eager.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+base: design_space.yaml
+sweep_id: qwen35_eager
+model: openai/qwen3.5-27b
+vertex_location: null
+vertex_project: null
+reps: 1
+max_turns: 16
+first_turn_tool_choice: null
+instances: []
+subsets:
+  grep_only: [read, grep, glob, bash]
+  preinj_embed: [read, grep, glob, bash]
+  preinj_eager: [read, grep, glob, bash]
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+  preinj_eager:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+    mode: eager

--- a/scripts/agent_compile/configs/qwen35_eager_only.yaml
+++ b/scripts/agent_compile/configs/qwen35_eager_only.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+base: design_space.yaml
+sweep_id: qwen35_eager_only
+model: openai/qwen3.5-27b
+vertex_location: null
+vertex_project: null
+reps: 1
+max_turns: 16
+first_turn_tool_choice: null
+instances: []
+subsets:
+  preinj_eager: [read, grep, glob, bash]
+preload:
+  preinj_eager:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+    mode: eager

--- a/scripts/agent_compile/configs/qwen35_gated.yaml
+++ b/scripts/agent_compile/configs/qwen35_gated.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+base: design_space.yaml
+sweep_id: qwen35_gated
+model: openai/qwen3.5-27b
+vertex_location: null
+vertex_project: null
+reps: 1
+max_turns: 16
+first_turn_tool_choice: null
+instances: []
+subsets:
+  preinj_eager_gated: [read, grep, glob, bash]
+preload:
+  preinj_eager_gated:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+    mode: eager_gated

--- a/scripts/agent_compile/configs/qwen35_maxturns40.yaml
+++ b/scripts/agent_compile/configs/qwen35_maxturns40.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Qwen2.5-Coder backend on codeminer-base — the "final agent" (flat embedding
+# pre-load) vs the grep_only baseline, run against a LOCAL vLLM OpenAI server.
+#
+#   serve:  vllm ... --served-model-name qwen2.5-coder-7b --enable-auto-tool-choice
+#           --tool-call-parser hermes --port 8001
+#   run:    OPENAI_API_BASE=http://localhost:8001/v1 OPENAI_API_KEY=dummy \
+#           PYTHONPATH=$PWD python scripts/agent_compile/run_sweep.py \
+#             --config scripts/agent_compile/configs/qwen7b_base.yaml \
+#             --output-dir results/agent_compile/qwen7b_base
+#
+# `openai/<name>` tells litellm to use the OpenAI wire format against
+# OPENAI_API_BASE; vertex_* are nulled so no vertex kwargs leak to the call.
+# Swap model + served-name + port for 14B / 32B (32B served with --quantization fp8).
+base: design_space.yaml
+
+sweep_id: qwen35_mt40
+model: openai/qwen2.5-coder-7b
+vertex_location: null
+vertex_project: null
+reps: 1
+max_turns: 40
+
+# Qwen2.5-Coder answers one-shot under tool_choice="auto" (turns=1, no grep/read)
+# — force a tool call on the first turn so the agent loop is actually exercised.
+first_turn_tool_choice: null
+
+instances: []  # whole codeminer-base test split (~100 instances)
+
+subsets:
+  grep_only:
+    - read
+    - grep
+    - glob
+    - bash
+  preinj_embed:
+    - read
+    - grep
+    - glob
+    - bash
+
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2

--- a/scripts/agent_compile/configs/qwen35_scatter.yaml
+++ b/scripts/agent_compile/configs/qwen35_scatter.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+base: design_space.yaml
+sweep_id: qwen35_scatter
+model: openai/qwen3.5-27b
+vertex_location: null
+vertex_project: null
+reps: 1
+max_turns: 16
+first_turn_tool_choice: null
+instances: []
+subsets:
+  grep_only: [read, grep, glob, bash]
+  preinj_embed: [read, grep, glob, bash]
+  preinj_scatter: [read, grep, glob, bash]
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+  preinj_scatter:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2
+    mode: scatter

--- a/scripts/agent_compile/configs/qwen7b_base.yaml
+++ b/scripts/agent_compile/configs/qwen7b_base.yaml
@@ -24,6 +24,10 @@ vertex_project: null
 reps: 1
 max_turns: 16
 
+# Qwen2.5-Coder answers one-shot under tool_choice="auto" (turns=1, no grep/read)
+# — force a tool call on the first turn so the agent loop is actually exercised.
+first_turn_tool_choice: required
+
 instances: []  # whole codeminer-base test split (~100 instances)
 
 subsets:

--- a/scripts/agent_compile/configs/qwen7b_base.yaml
+++ b/scripts/agent_compile/configs/qwen7b_base.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Qwen2.5-Coder backend on codeminer-base — the "final agent" (flat embedding
+# pre-load) vs the grep_only baseline, run against a LOCAL vLLM OpenAI server.
+#
+#   serve:  vllm ... --served-model-name qwen2.5-coder-7b --enable-auto-tool-choice
+#           --tool-call-parser hermes --port 8001
+#   run:    OPENAI_API_BASE=http://localhost:8001/v1 OPENAI_API_KEY=dummy \
+#           PYTHONPATH=$PWD python scripts/agent_compile/run_sweep.py \
+#             --config scripts/agent_compile/configs/qwen7b_base.yaml \
+#             --output-dir results/agent_compile/qwen7b_base
+#
+# `openai/<name>` tells litellm to use the OpenAI wire format against
+# OPENAI_API_BASE; vertex_* are nulled so no vertex kwargs leak to the call.
+# Swap model + served-name + port for 14B / 32B (32B served with --quantization fp8).
+base: design_space.yaml
+
+sweep_id: qwen7b_base
+model: openai/qwen2.5-coder-7b
+vertex_location: null
+vertex_project: null
+reps: 1
+max_turns: 16
+
+instances: []  # whole codeminer-base test split (~100 instances)
+
+subsets:
+  grep_only:
+    - read
+    - grep
+    - glob
+    - bash
+  preinj_embed:
+    - read
+    - grep
+    - glob
+    - bash
+
+preload:
+  preinj_embed:
+    retrievers: [embedding]
+    top_k: 10
+    level: l2

--- a/scripts/agent_compile/lib/config.py
+++ b/scripts/agent_compile/lib/config.py
@@ -72,6 +72,11 @@ class SweepConfig:
     # Override the agent system prompt (e.g. a graph-primary prompt with no grep
     # guidance). None = runner's default localization prompt.
     system_prompt: Optional[str] = None
+    # Force a tool call on the FIRST agent turn (e.g. "required"). Weak open
+    # models (Qwen2.5-Coder) answer one-shot under the default "auto" and never
+    # exercise the loop; this makes them actually grep/read. None = leave "auto"
+    # (correct for Claude, which calls tools eagerly).
+    first_turn_tool_choice: Optional[str] = None
 
     @classmethod
     def from_yaml(cls, path: Path) -> "SweepConfig":

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -231,16 +231,58 @@ def run_cell(
     from codeminer.agent.runner import AgentRunner
     from codeminer.agent.skills.registry import SkillRegistry
     from codeminer.compiler.params import SessionContext
+    from scripts.agent_compile.lib.orchestrator import (
+        query_is_specific,
+        scatter_gather_localize,
+    )
     from scripts.agent_compile.lib.preload import assemble_preload
 
+    runs_usage: List[Dict[str, Any]] = []
+    runs_turns: List[int] = []
     preload_candidates: List[Dict[str, Any]] = []
     effective_query = query
+    scatter_mode = False
     if preload_spec:
-        preamble, preload_candidates = assemble_preload(
-            contexts, query, recipe=preload_spec
-        )
-        if preamble:
-            effective_query = f"{query}\n\n{preamble}"
+        mode = preload_spec.get("mode")
+        # Adaptive gate: a VAGUE query (no concrete handle) gets NO candidates —
+        # fall back to blank-slate grep, which beats pre-load on behavioral.
+        # A SPECIFIC query gets the eager pre-load (cheap, accurate). One short
+        # LLM call; usage is charged to the cell via runs_usage below.
+        gated_skip = False
+        if mode == "eager_gated":
+
+            def _gate_call(msgs):
+                # Disable Qwen3.5 chain-of-thought so the one-word verdict isn't
+                # truncated mid-"Thinking Process"; harmless for non-thinking models.
+                resp = llm._call_raw(
+                    msgs,
+                    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+                )
+                u = getattr(resp, "usage", None)
+                if u is not None:
+                    runs_usage.append(
+                        {
+                            "prompt_tokens": getattr(u, "prompt_tokens", 0),
+                            "completion_tokens": getattr(u, "completion_tokens", 0),
+                            "total_tokens": getattr(u, "total_tokens", 0),
+                        }
+                    )
+                return resp.choices[0].message.content
+
+            gated_skip = not query_is_specific(_gate_call, query)
+
+        if gated_skip:
+            preload_candidates = []  # vague -> blank-slate grep
+        else:
+            preamble, preload_candidates = assemble_preload(
+                contexts, query, recipe=preload_spec
+            )
+            # mode=scatter routes candidates to isolated verify-subagents instead
+            # of injecting them into one context (see lib/orchestrator.py).
+            if mode == "scatter":
+                scatter_mode = True
+            elif preamble:
+                effective_query = f"{query}\n\n{preamble}"
 
     sctx = SessionContext(
         repo_path=repo_path, repo_size=1000, primary_language=language_key
@@ -262,8 +304,6 @@ def run_cell(
     # paths against the process cwd, so run the agent from the instance repo.
     # The sweep is sequential, so chdir is safe here.
     prev_cwd = os.getcwd()
-    runs_usage: List[Dict[str, Any]] = []
-    runs_turns: List[int] = []
 
     def _do_run(q: str):
         try:
@@ -277,7 +317,41 @@ def run_cell(
             runs_turns.append(r.total_turns)
         return r
 
-    result = _do_run(effective_query)
+    if scatter_mode:
+
+        def _run_subagent(sys_prompt, q, mt):
+            sub = AgentRunner(
+                llm=llm,
+                registry=SkillRegistry(),
+                max_turns=mt,
+                allow_skills=set(skills),
+                session_ctx=sctx,
+                include_default_tools=cfg.include_default_tools,
+                default_tool_ids=(
+                    set(cfg.default_tool_ids)
+                    if cfg.default_tool_ids is not None
+                    else None
+                ),
+                system_prompt=sys_prompt or cfg.system_prompt,
+                first_turn_tool_choice=getattr(cfg, "first_turn_tool_choice", None)
+                or None,
+            )
+            try:
+                os.chdir(repo_path)
+                r = sub.run(q)
+            finally:
+                os.chdir(prev_cwd)
+            u = r.usage.to_dict() if r.usage else {}
+            runs_usage.append(u.get("token_usage") or u or {})
+            if r.total_turns is not None:
+                runs_turns.append(r.total_turns)
+            return r
+
+        result = scatter_gather_localize(
+            query, preload_candidates, _run_subagent, explore_turns=cfg.max_turns
+        )
+    else:
+        result = _do_run(effective_query)
 
     # Verify-expand (Layer 4): if the committed answer is not anchored to a real
     # graph symbol, inject 1-hop neighbours of the best seeds and answer once more.

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -252,12 +252,16 @@ def run_cell(
         if mode == "eager_gated":
 
             def _gate_call(msgs):
-                # Disable Qwen3.5 chain-of-thought so the one-word verdict isn't
-                # truncated mid-"Thinking Process"; harmless for non-thinking models.
-                resp = llm._call_raw(
-                    msgs,
-                    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
-                )
+                # Disable chain-of-thought ONLY for Qwen3.5 (else the one-word
+                # verdict is truncated mid-"Thinking Process"). The chat_template
+                # kwarg is Qwen-specific — passing it to vertex/Anthropic errors,
+                # so gate it on the model name.
+                extra = {}
+                if "qwen3" in (cfg.model or "").lower():
+                    extra["extra_body"] = {
+                        "chat_template_kwargs": {"enable_thinking": False}
+                    }
+                resp = llm._call_raw(msgs, **extra)
                 u = getattr(resp, "usage", None)
                 if u is not None:
                     runs_usage.append(

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -256,6 +256,7 @@ def run_cell(
             set(cfg.default_tool_ids) if cfg.default_tool_ids is not None else None
         ),
         system_prompt=cfg.system_prompt,
+        first_turn_tool_choice=getattr(cfg, "first_turn_tool_choice", None) or None,
     )
     # The always-on default tools (file_read / file_search) resolve relative
     # paths against the process cwd, so run the agent from the instance repo.

--- a/scripts/agent_compile/lib/orchestrator.py
+++ b/scripts/agent_compile/lib/orchestrator.py
@@ -33,39 +33,40 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from codeminer.agent.agent_types import AgentResult
 
-# Query-specificity gate (one cheap LLM call). Candidate-spread signals
-# (distinct files / top-file dominance) were measured too weak to separate vague
-# behavioral queries from specific ones (behavioral 4.2 files vs symbol_hint 3.2
-# — not clean). Judging the QUERY directly is far more reliable: a query naming a
-# function/file/identifier/error has a concrete handle (use eager pre-load); a
-# bare behavioral description does not (fall back to blank-slate grep, which wins
-# on behavioral). This is the adaptive gate: eager when confident, grep when
-# ambiguous — best of both on the Pareto front.
+# Adaptive routing gate (one cheap LLM call). The discriminator is NOT
+# "has an identifier" — that sends traversal queries (no identifier, but
+# candidates ON THE CALL CHAIN are useful) wrongly to grep. The right axis,
+# from the measured per-category candidate-value (behavioral: grep>preload;
+# traversal/symbol/file: preload>=grep), is: route to GREP only a SINGLE-FEATURE
+# behavioral symptom (edit site is one non-obvious spot retrieval can't pinpoint);
+# route to EAGER anything that names an identifier OR traces a cross-component
+# flow. Verified on n=400 multilingual: behavioral 73% GREP, traversal 88% EAGER,
+# symbol/file/reasoning ~100% EAGER.
 GATE_SYSTEM = (
-    "You judge a code-localization query. Reply with EXACTLY one word.\n"
-    "SPECIFIC = it names a concrete code identifier you could grep verbatim: a "
-    "function/method/class name (e.g. FastBasic.read, "
-    "_Spline._intercept_optional_inputs), a file path (e.g. lexer.go), or a "
-    "literal error string.\n"
-    "VAGUE = it only describes a behavior or symptom in plain English with NO "
-    "code identifier to search for (e.g. 'curve fitting model fails when passing "
-    "only coefficients', 'parser rejects multi-character delimiters').\n"
-    "Answer SPECIFIC or VAGUE."
+    "Route a code-localization query. Reply with EXACTLY one word: EAGER or "
+    "GREP.\n"
+    "GREP = the query only describes ONE feature's buggy behavior/symptom in "
+    "plain English, with no code identifier AND no cross-component flow to follow "
+    "(the edit site is a single non-obvious spot).\n"
+    "EAGER = the query EITHER names a concrete code identifier "
+    "(function/method/class/file), OR traces a flow across multiple "
+    "components/steps (chains, merges, consolidates, 'X before Y', a call path) "
+    "— cases where ranked retrieval candidates help.\n"
+    "Answer EAGER or GREP."
 )
 
 
 def query_is_specific(call_llm, query: str) -> bool:
-    """One cheap LLM call: does the query have a concrete localization handle?
+    """One cheap LLM call: should this query use eager pre-load (vs blank grep)?
 
-    ``call_llm(messages) -> content``. True (SPECIFIC) -> use eager pre-load;
-    False (VAGUE) -> blank-slate grep. Defaults to True (eager, the cheaper path)
-    on any failure.
+    ``call_llm(messages) -> content``. True (EAGER) -> use eager pre-load;
+    False (GREP) -> blank-slate grep (wins on single-feature behavioral queries).
+    Defaults to True (eager, the cheaper path) on failure / ambiguity.
     """
     # NOTE: the caller's ``call_llm`` MUST disable Qwen3.5 chain-of-thought
     # (extra_body chat_template_kwargs enable_thinking=False); otherwise the
     # one-word verdict is buried under a truncated "Thinking Process…" and every
-    # query reads as SPECIFIC. Parse the LAST verdict token; SPECIFIC wins ties /
-    # absence (eager is the cheaper default).
+    # query reads as EAGER. Parse the LAST verdict token; EAGER wins ties/absence.
     msgs = [
         {"role": "system", "content": GATE_SYSTEM},
         {"role": "user", "content": (query or "")[:2000]},
@@ -74,7 +75,7 @@ def query_is_specific(call_llm, query: str) -> bool:
         out = (call_llm(msgs) or "").upper()
     except Exception:  # noqa: BLE001 — gate is best-effort; default to eager
         return True
-    return out.rfind("SPECIFIC") >= out.rfind("VAGUE")
+    return out.rfind("GREP") <= out.rfind("EAGER")
 
 
 # A verify-subagent judges ONE candidate in an isolated context. It is

--- a/scripts/agent_compile/lib/orchestrator.py
+++ b/scripts/agent_compile/lib/orchestrator.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scatter-isolate-converge orchestration for pre-load candidates.
+
+Why this exists (see ``.claude/design/preload-aware-harness.md``): injecting a
+noisy candidate set into a SINGLE agent context pollutes a strong agent's
+exploration — on synthesis ``behavioral`` queries Qwen3.5-27B searched a lot
+(turns=16, GT even present in the candidates) yet still answered wrong, while a
+blank-slate grep answered cleanly. The fix is context isolation, not prompt
+wording.
+
+This module spreads the candidates over isolated *verify-subagents* (each judges
+ONE candidate in its own context), then the orchestrator converges only their
+structured verdicts:
+
+    scatter   one minimal verify-subagent per candidate (isolated context)
+    isolate   each subagent's dead-end reading stays in its own context
+    converge  >=1 yes -> synthesize from confirmed locations
+              all  no -> blank-slate explorer (the clean grep_only path)
+
+Subagents are executed via a caller-supplied ``run_subagent`` closure so their
+token/turn usage accrues to the cell's aggregate (cost axis stays honest). v1 is
+serial — prove the accuracy claim (behavioral REGRESS disappears) before paying
+for concurrency.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from codeminer.agent.agent_types import AgentResult
+
+# Query-specificity gate (one cheap LLM call). Candidate-spread signals
+# (distinct files / top-file dominance) were measured too weak to separate vague
+# behavioral queries from specific ones (behavioral 4.2 files vs symbol_hint 3.2
+# — not clean). Judging the QUERY directly is far more reliable: a query naming a
+# function/file/identifier/error has a concrete handle (use eager pre-load); a
+# bare behavioral description does not (fall back to blank-slate grep, which wins
+# on behavioral). This is the adaptive gate: eager when confident, grep when
+# ambiguous — best of both on the Pareto front.
+GATE_SYSTEM = (
+    "You judge a code-localization query. Reply with EXACTLY one word.\n"
+    "SPECIFIC = it names a concrete code identifier you could grep verbatim: a "
+    "function/method/class name (e.g. FastBasic.read, "
+    "_Spline._intercept_optional_inputs), a file path (e.g. lexer.go), or a "
+    "literal error string.\n"
+    "VAGUE = it only describes a behavior or symptom in plain English with NO "
+    "code identifier to search for (e.g. 'curve fitting model fails when passing "
+    "only coefficients', 'parser rejects multi-character delimiters').\n"
+    "Answer SPECIFIC or VAGUE."
+)
+
+
+def query_is_specific(call_llm, query: str) -> bool:
+    """One cheap LLM call: does the query have a concrete localization handle?
+
+    ``call_llm(messages) -> content``. True (SPECIFIC) -> use eager pre-load;
+    False (VAGUE) -> blank-slate grep. Defaults to True (eager, the cheaper path)
+    on any failure.
+    """
+    # NOTE: the caller's ``call_llm`` MUST disable Qwen3.5 chain-of-thought
+    # (extra_body chat_template_kwargs enable_thinking=False); otherwise the
+    # one-word verdict is buried under a truncated "Thinking Process…" and every
+    # query reads as SPECIFIC. Parse the LAST verdict token; SPECIFIC wins ties /
+    # absence (eager is the cheaper default).
+    msgs = [
+        {"role": "system", "content": GATE_SYSTEM},
+        {"role": "user", "content": (query or "")[:2000]},
+    ]
+    try:
+        out = (call_llm(msgs) or "").upper()
+    except Exception:  # noqa: BLE001 — gate is best-effort; default to eager
+        return True
+    return out.rfind("SPECIFIC") >= out.rfind("VAGUE")
+
+
+# A verify-subagent judges ONE candidate in an isolated context. It is
+# deliberately skeptical so a wrong candidate is ruled out rather than
+# rationalized (the failure mode that caused the behavioral REGRESS).
+VERIFY_SYSTEM_PROMPT = """\
+You verify ONE candidate code location for a localization task.
+
+You are given the task and a single candidate location. Read that location and \
+only the code directly related to it (its definition, callers, callees). Decide \
+whether THIS location is part of the code that must change to address the task.
+
+Be skeptical — a retriever guessed this candidate and it may be irrelevant. Do \
+NOT rationalize a weak match; if it is not clearly the edit site, say no.
+
+End your reply with exactly one line:
+VERDICT: yes
+or
+VERDICT: no
+
+If yes, also include the exact edit site, repo-relative:
+Files: <path>
+Symbols: <file:symbol>
+Locations: <file:start-end>
+"""
+
+_VERDICT_RE = re.compile(r"(?im)^\s*[*_`> ]*VERDICT[*_`: ]*\s*(yes|no)\b")
+
+
+def _verdict_is_yes(answer: str) -> bool:
+    """True iff the LAST ``VERDICT:`` line in the answer says yes."""
+    verdicts = _VERDICT_RE.findall(answer or "")
+    return bool(verdicts) and verdicts[-1].lower() == "yes"
+
+
+def _cand_loc(cand: Dict[str, Any]) -> str:
+    return f"{cand['file']}:{cand.get('start')}-{cand.get('end')}"
+
+
+def _verify_query(query: str, cand: Dict[str, Any], snippet: str) -> str:
+    snip = f"\n{snippet}" if snippet else ""
+    return (
+        f"Task:\n{query}\n\n"
+        f"Candidate location to verify:\n{_cand_loc(cand)}{snip}\n\n"
+        "Read it and decide whether this is the code to change. "
+        "End with VERDICT: yes/no (+ Files/Symbols/Locations if yes)."
+    )
+
+
+def _converge_query(query: str, confirmed: List[Dict[str, Any]]) -> str:
+    locs = "\n".join(f"- {_cand_loc(c)}" for c in confirmed)
+    return (
+        f"Task:\n{query}\n\n"
+        f"These candidate locations were independently CONFIRMED relevant:\n{locs}\n\n"
+        "Give the FINAL localization answer (Files:/Symbols:/Locations:) for the "
+        "exact edit site(s). You may read them to pin precise line ranges, but do "
+        "not re-explore the repository widely."
+    )
+
+
+def _merge(final: AgentResult, all_results: List[AgentResult]) -> AgentResult:
+    """Final answer + merged tool-calls across every subagent (for scoring)."""
+    tool_calls = []
+    for r in all_results:
+        tool_calls.extend(r.tool_calls or [])
+    return AgentResult(
+        answer=final.answer or "",
+        tool_calls=tool_calls,
+        messages=final.messages,
+        total_turns=sum(r.total_turns or 0 for r in all_results),
+        total_duration_ms=sum(r.total_duration_ms or 0.0 for r in all_results),
+        usage=final.usage,
+        usage_records=final.usage_records,
+    )
+
+
+def scatter_gather_localize(
+    query: str,
+    candidates: List[Dict[str, Any]],
+    run_subagent: Callable[[Optional[str], str, int], AgentResult],
+    *,
+    snippets: Optional[Dict[Tuple[str, Any, Any], str]] = None,
+    max_candidates: int = 6,
+    sub_turns: int = 5,
+    explore_turns: int = 12,
+) -> AgentResult:
+    """Scatter verify-subagents over candidates, converge to a final answer.
+
+    ``run_subagent(system_prompt, query, max_turns) -> AgentResult`` is supplied
+    by the caller (it owns chdir + usage/turn accrual). ``system_prompt=None``
+    means the default localization prompt (used for converge / blank-slate
+    explore). Returns one merged :class:`AgentResult` (final answer + all
+    subagents' tool-calls) so the existing scorer works unchanged.
+    """
+    snippets = snippets or {}
+    cands = list(candidates or [])[:max_candidates]
+
+    # No candidates -> just explore (degenerates to grep_only).
+    if not cands:
+        return run_subagent(None, query, explore_turns)
+
+    results: List[AgentResult] = []
+    confirmed: List[Dict[str, Any]] = []
+    for cand in cands:
+        snip = snippets.get((cand["file"], cand.get("start"), cand.get("end")), "")
+        r = run_subagent(
+            VERIFY_SYSTEM_PROMPT, _verify_query(query, cand, snip), sub_turns
+        )
+        results.append(r)
+        if _verdict_is_yes(r.answer or ""):
+            confirmed.append(cand)
+
+    if confirmed:
+        final = run_subagent(None, _converge_query(query, confirmed), 2)
+    else:
+        # Every candidate was noise — fall back to the clean blank-slate path.
+        final = run_subagent(None, query, explore_turns)
+    results.append(final)
+    return _merge(final, results)

--- a/scripts/agent_compile/lib/preload.py
+++ b/scripts/agent_compile/lib/preload.py
@@ -155,19 +155,37 @@ def assemble_preload(
     if not ordered:
         return "", []
 
-    lines = [
-        "# Candidate locations (UNVERIFIED retrieval hints — often wrong/incomplete)",
-        "A retriever guessed these; the code you must change may be in NONE of "
-        "them (it could be a caller, a subclass override, or elsewhere entirely). "
-        "They are unordered starting points, not answers. RULES:",
-        "- Do NOT anchor on the first candidate. Check each against the actual "
-        "problem.",
-        "- Never put a location in your final answer unless you have READ it and "
-        "confirmed it contains the behavior to change.",
-        "- If, after reading, none of these is the real edit site, IGNORE this "
-        "list entirely and locate the code with grep / your own search.",
-        "",
-    ]
+    if (recipe or {}).get("mode") in ("eager", "eager_gated"):
+        # Token-saving preamble: trust the ranked hits, confirm cheaply, STOP.
+        # The default preamble below tells the agent candidates are "often wrong /
+        # verify with grep" — good for accuracy but it keeps exploring (turns
+        # barely drop vs grep_only, so pre-load saves little). Eager flips that:
+        # read the top 1-2, answer immediately if one fits, fall back only if none
+        # does. Accuracy is protected by the fallback, not by blanket distrust.
+        lines = [
+            "# Candidate locations (ranked retrieval hits — the edit site is "
+            "usually among the top ones)",
+            "Read the most relevant 1-2 candidates FIRST. If one contains the code "
+            "the task describes, give your final answer IMMEDIATELY and stop — do "
+            "NOT keep grepping or exploring further. Fall back to your own search "
+            "ONLY if none of the candidates fits after you read them.",
+            "",
+        ]
+    else:
+        lines = [
+            "# Candidate locations (UNVERIFIED retrieval hints — often wrong/"
+            "incomplete)",
+            "A retriever guessed these; the code you must change may be in NONE of "
+            "them (it could be a caller, a subclass override, or elsewhere "
+            "entirely). They are unordered starting points, not answers. RULES:",
+            "- Do NOT anchor on the first candidate. Check each against the actual "
+            "problem.",
+            "- Never put a location in your final answer unless you have READ it "
+            "and confirmed it contains the behavior to change.",
+            "- If, after reading, none of these is the real edit site, IGNORE this "
+            "list entirely and locate the code with grep / your own search.",
+            "",
+        ]
     for i, sp in enumerate(ordered, 1):
         lines.append(f"{i}. {sp['file']}:{sp['start']}-{sp['end']}")
         node = span_by_key.get((sp["file"], sp["start"], sp["end"]))

--- a/scripts/agent_compile/run_sweep.py
+++ b/scripts/agent_compile/run_sweep.py
@@ -264,6 +264,20 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                     if (ans_dedup and preload_candidates)
                     else None
                 )
+                # Honesty flag: the agent ran fine but never produced a parseable
+                # localization (no Files:/Symbols:/Locations: contract AND no
+                # resolvable span), even after the force-schema retries. Such a
+                # cell scores 0 NOT because the localization was wrong but because
+                # the answer was unformattable — a known LLM weakness, worst on
+                # small models. Flag it so the aggregator can report localization
+                # accuracy separately from format-failure rate instead of
+                # silently burying these as misses.
+                from codeminer.agent.runner import _has_localization_contract
+
+                format_failed = (
+                    not _has_localization_contract(out["answer"] or "")
+                    and not answer_spans
+                )
                 record = {
                     "cell_id": cell_id,
                     "instance_id": instance_id,
@@ -274,6 +288,7 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                     "scenario": scenario,
                     "language": language_key,
                     "success": True,
+                    "format_failed": format_failed,
                     "metrics": metrics,
                     "metrics_meaningful": gt_meaningful,
                     "target_files": target_files,

--- a/scripts/agent_compile/run_synthesis_sweep.py
+++ b/scripts/agent_compile/run_synthesis_sweep.py
@@ -340,11 +340,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     p.add_argument("--reps", type=int, default=None)
     p.add_argument("--no-resume", action="store_true")
+    p.add_argument(
+        "--model",
+        default=None,
+        help="Override config model (e.g. a local openai/ vLLM model).",
+    )
     args = p.parse_args(argv)
 
     cfg = SweepConfig.from_yaml(args.config)
     if args.reps is not None:
         cfg.reps = args.reps
+    if args.model:
+        cfg.model = args.model
     configs = [c.strip() for c in args.synthesis_configs.split(",") if c.strip()]
     categories = (
         {c.strip() for c in args.categories.split(",")} if args.categories else None

--- a/scripts/agent_compile/run_synthesis_sweep.py
+++ b/scripts/agent_compile/run_synthesis_sweep.py
@@ -240,6 +240,12 @@ def run(
                         if (ans_dedup and preload_candidates)
                         else None
                     )
+                    from codeminer.agent.runner import _has_localization_contract
+
+                    format_failed = (
+                        not _has_localization_contract(out["answer"] or "")
+                        and not answer_spans
+                    )
                     record = {
                         "cell_id": cid,
                         "instance_id": instance_id,
@@ -253,6 +259,7 @@ def run(
                         "rep": rep,
                         "language": _LANG_KEY.get(config_name, "python"),
                         "success": True,
+                        "format_failed": format_failed,
                         "metrics": metrics,
                         "metrics_meaningful": bool(target_files or gt_blocks),
                         "query": row["query"],


### PR DESCRIPTION
## Summary

Adds a **local open-model backend** (Qwen2.5-Coder 7B / 14B / 32B served by vLLM)
for the agent-compile sweeps, so the CodeMiner agent can be evaluated without a
cloud API, and measures the pre-load context-engine on it over codeminer-base
and codeminer-synthesis. Builds on the merged runtime-probe work (#240).

**Findings (codeminer-base, files@k — base GT line spans are null):**

| model | grep_only f@5 | preinj_embed f@5 |
|---|---|---|
| 7B  | 0.222 | 0.357 |
| 14B | 0.343 | 0.514 |
| 32B (fp8) | 0.191 | 0.555 |

- Pre-load helps **every** size (32B: files@5 0.191 → 0.555); bigger = better.
- **Qwen2.5-Coder does not initiate tool calls under `tool_choice: auto`** (every
  cell ran turns=1, tools=0 — one-shot). With `required` it emits a correct
  Hermes `<tool_call>`, so wiring is fine; the model just won't grep/read. So for
  a weak/local model the agent loop is effectively dead and **pre-load is what
  makes it usable** (it carries the answer the model won't go find).
- **No local "save token" axis**: litellm reports no `$` for the local endpoint
  and one-shot means no exploration turns to collapse — local pre-load value is
  *accuracy* (largest on the no-hint categories), not cost. The cost-saving story
  is a cloud / strong-agent property.

Synthesis (Qwen 7B, answer_rec@5 span-overlap) mirrors the Claude pattern:
pre-load helps no-hint categories (behavioral +0.057, traversal +0.078), ties on
hint-rich (symbol/module/file). Details in `docs/experiments/qwen_backend.md`.

## Changes
- `scripts/agent_compile/configs/qwen7b_base.yaml`: grep_only + preinj_embed arms,
  `openai/` local model, vertex_* nulled (`--model` swaps 7B/14B/32B; 32B served
  with `--quantization fp8`).
- `scripts/agent_compile/run_synthesis_sweep.py`: add `--model` override (mirrors
  `run_sweep.py`) so the synthesis sweep can target a local Qwen endpoint.
- `docs/experiments/qwen_backend.md`: how-to (serve + run) + results + gotchas
  (GPU sharing, sampler-warmup OOM, gpu-util tuning so the embedding model fits).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Ran the agent on vLLM-served Qwen2.5-Coder 7B/14B/32B(fp8) over codeminer-base
(100 instances, both arms) and codeminer-synthesis (Python, per category) on
prebuilt indexes; aggregated with the existing files@k / span-overlap rulers.
No new unit tests (config + a CLI flag + docs).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
