### PR TITLE
perf(ruby): add core scip decoder

### DIFF
--- a/codeminer/languages.py
+++ b/codeminer/languages.py
@@ -305,6 +305,8 @@ LANGUAGE_SPECS: Tuple[LanguageSpec, ...] = (
         lsp_language_id="ruby",
         lsp_command=("ruby-lsp",),
         lsp_command_env="CODEMINER_RUBY_LSP_CMD",
+        core_decoder=True,
+        core_decoder_aliases=("rb",),
     ),
     LanguageSpec(
         key="php",

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(codeminer_core STATIC
     scip_decode_python.cpp
     scip_decode_go.cpp
     scip_decode_rust.cpp
+    scip_decode_ruby.cpp
     scip_decode_ts.cpp
 )
 

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -34,6 +34,7 @@ using codeminer::core::CodeGraph;
 using codeminer::core::SCIPDecoderBase;
 using codeminer::core::SCIPGoDecoder;
 using codeminer::core::SCIPPythonDecoder;
+using codeminer::core::SCIPRubyDecoder;
 using codeminer::core::SCIPRustDecoder;
 using codeminer::core::SCIPTSDecoder;
 
@@ -51,11 +52,15 @@ make_decoder(const std::string &language, const std::string &index_file,
   if (language == "rust") {
     return std::make_unique<SCIPRustDecoder>(index_file, project_root);
   }
+  if (language == "ruby" || language == "rb") {
+    return std::make_unique<SCIPRubyDecoder>(index_file, project_root);
+  }
   if (language == "typescript" || language == "ts" || language == "js") {
     return std::make_unique<SCIPTSDecoder>(index_file, project_root);
   }
   throw std::invalid_argument("Unknown language: " + language +
-                              " (expected: python | go | rust | typescript)");
+                              " (expected: python | go | rust | ruby | "
+                              "typescript)");
 }
 
 py::dict vertex_to_dict(const CodeGraph::VertexData &v) {
@@ -123,7 +128,8 @@ classify_edge_layers_py(const std::vector<std::string> &edge_types) {
 } // namespace
 
 PYBIND11_MODULE(codeminer_core, m) {
-  m.doc() = "codeminer::core SCIP decoders (Python / Go / Rust / TypeScript).";
+  m.doc() =
+      "codeminer::core SCIP decoders (Python / Go / Rust / Ruby / TypeScript).";
 
   m.def("decode_scip", &decode_scip, py::arg("index_file"),
         py::arg("project_root") = std::optional<std::string>(std::nullopt),
@@ -135,7 +141,7 @@ Args:
     index_file: path to the decoded SCIP index file.
     project_root: project root directory (for language-specific config:
         go.mod / Cargo.toml). May be None.
-    language: one of "python", "go", "rust", "typescript".
+    language: one of "python", "go", "rust", "ruby", "typescript".
 
 Returns:
     dict with:

--- a/core/scip_decode.h
+++ b/core/scip_decode.h
@@ -7,12 +7,13 @@
 #pragma once
 
 // Umbrella header for the core SCIP decoders. Individual language decoders
-// live in `scip_decode_{python,go,rust,ts}.h`.
+// live in `scip_decode_{python,go,rust,ruby,ts}.h`.
 
 #include "scip_decode_base.h"
 #include "scip_decode_common.h"
 #include "scip_decode_go.h"
 #include "scip_decode_python.h"
+#include "scip_decode_ruby.h"
 #include "scip_decode_rust.h"
 #include "scip_decode_ts.h"
 

--- a/core/scip_decode_base.cpp
+++ b/core/scip_decode_base.cpp
@@ -283,6 +283,10 @@ void SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) {
           existing.data.end_line = node.data.end_line;
         if (node.data.unified_name.has_value())
           existing.data.unified_name = node.data.unified_name;
+      } else if (!it->second.is_definition && node.updates_unified_name &&
+                 node.data.unified_name.has_value()) {
+        it->second.data.unified_name = node.data.unified_name;
+        it->second.updates_unified_name = true;
       }
       // else: subsequent ref on existing node — leave attrs alone.
     }

--- a/core/scip_decode_common.cpp
+++ b/core/scip_decode_common.cpp
@@ -4,6 +4,7 @@
 
 #include "scip_decode_common.h"
 
+#include <filesystem>
 #include <utility>
 
 namespace codeminer::core {
@@ -66,6 +67,29 @@ void SubgraphBuilder::add_file_node(const std::string &file_path) {
   reset_scope_to_file(file_path);
 }
 
+void SubgraphBuilder::add_file_hierarchy(const std::string &file_path) {
+  std::filesystem::path file_fs(file_path);
+  auto dir = file_fs.parent_path();
+  while (!dir.empty() && dir != dir.parent_path()) {
+    std::string dir_str = dir.generic_string();
+    if (add_directory_if_needed(dir_str)) {
+      std::string parent = dir.parent_path().generic_string();
+      if (parent.empty()) {
+        parent = ROOT_NODE;
+      }
+      add_edge(parent, dir_str, EDGE_TYPE_CONTAIN);
+    }
+    dir = dir.parent_path();
+  }
+
+  add_file_node(file_path);
+  std::string parent = file_fs.parent_path().generic_string();
+  if (parent.empty()) {
+    parent = ROOT_NODE;
+  }
+  add_edge(parent, file_path, EDGE_TYPE_CONTAIN);
+}
+
 void SubgraphBuilder::add_symbol_node(const std::string &symbol, int line,
                                       std::optional<int> scope_start_line,
                                       std::optional<int> scope_end_line,
@@ -87,6 +111,15 @@ void SubgraphBuilder::add_symbol_reference(
     const std::string &symbol, const std::optional<std::string> &module_path,
     const std::string &symbol_type, std::optional<std::string> anchor_file,
     std::optional<int> anchor_line) {
+  add_symbol_reference_from(current_scope_, symbol, module_path, symbol_type,
+                            std::move(anchor_file), anchor_line);
+}
+
+void SubgraphBuilder::add_symbol_reference_from(
+    const std::string &source, const std::string &symbol,
+    const std::optional<std::string> &module_path,
+    const std::string &symbol_type, std::optional<std::string> anchor_file,
+    std::optional<int> anchor_line) {
   // Serial CodeGraph.add_symbol_reference: only populates attrs on FIRST
   // add. Subsequent refs leave the node alone (defs still overwrite via
   // add_symbol_node).
@@ -105,8 +138,7 @@ void SubgraphBuilder::add_symbol_reference(
   if (!anchor_file.has_value() && !current_file_.empty()) {
     anchor_file = current_file_;
   }
-  add_edge(current_scope_, symbol, EDGE_TYPE_REFERENCE, anchor_file,
-           anchor_line);
+  add_edge(source, symbol, EDGE_TYPE_REFERENCE, anchor_file, anchor_line);
 }
 
 void SubgraphBuilder::add_containment_edge(const std::string &target_symbol) {
@@ -132,6 +164,9 @@ void SubgraphBuilder::set_unified_name(const std::string &symbol,
     return;
   }
   node.data.unified_name = value;
+  if (!only_if_missing) {
+    node.updates_unified_name = true;
+  }
 }
 
 void SubgraphBuilder::update_current_scope(const std::string &symbol,
@@ -163,6 +198,17 @@ void SubgraphBuilder::exit_scopes_by_line(int current_line) {
   } else if (!current_file_.empty()) {
     reset_scope_to_file(current_file_);
   }
+}
+
+bool SubgraphBuilder::has_node(const std::string &name) const {
+  return subgraph_.nodes.find(name) != subgraph_.nodes.end();
+}
+
+const Subgraph::Node *SubgraphBuilder::node(const std::string &name) const {
+  auto it = subgraph_.nodes.find(name);
+  if (it == subgraph_.nodes.end())
+    return nullptr;
+  return &it->second;
 }
 
 void SubgraphBuilder::reset_scope_to_file(const std::string &file_symbol) {

--- a/core/scip_decode_common.h
+++ b/core/scip_decode_common.h
@@ -36,6 +36,7 @@ struct Subgraph {
   struct Node {
     CodeGraph::VertexData data; // includes unified_name
     bool is_definition{true};
+    bool updates_unified_name{false};
   };
 
   std::unordered_map<std::string, Node> nodes;
@@ -53,6 +54,7 @@ public:
   void add_directory_node(const std::string &dir_path);
   bool add_directory_if_needed(const std::string &dir_path);
   void add_file_node(const std::string &file_path);
+  void add_file_hierarchy(const std::string &file_path);
 
   // Definition — always sets type/file/start/end/is_definition.
   void add_symbol_node(const std::string &symbol, int line,
@@ -71,6 +73,12 @@ public:
                        const std::string &symbol_type,
                        std::optional<std::string> anchor_file = std::nullopt,
                        std::optional<int> anchor_line = std::nullopt);
+  void add_symbol_reference_from(
+      const std::string &source, const std::string &symbol,
+      const std::optional<std::string> &module_path,
+      const std::string &symbol_type,
+      std::optional<std::string> anchor_file = std::nullopt,
+      std::optional<int> anchor_line = std::nullopt);
 
   // CONTAIN edges carry no anchor — see CodeGraph::add_containment_edge.
   void add_containment_edge(const std::string &target_symbol);
@@ -92,6 +100,8 @@ public:
 
   const std::string &current_scope() const { return current_scope_; }
   const std::string &current_file() const { return current_file_; }
+  bool has_node(const std::string &name) const;
+  const Subgraph::Node *node(const std::string &name) const;
 
   Subgraph build() { return std::move(subgraph_); }
 

--- a/core/scip_decode_go.cpp
+++ b/core/scip_decode_go.cpp
@@ -195,24 +195,8 @@ SCIPGoDecoder::process_document(const std::string &document_block) const {
   if (ends_with(file_path, "_test.go"))
     return Subgraph{};
 
-  std::filesystem::path file_fs(file_path);
   SubgraphBuilder builder;
-  auto dir = file_fs.parent_path();
-  while (!dir.empty() && dir != dir.parent_path()) {
-    std::string dir_str = dir.generic_string();
-    if (builder.add_directory_if_needed(dir_str)) {
-      std::string parent = dir.parent_path().generic_string();
-      if (parent.empty())
-        parent = ROOT_NODE;
-      builder.add_edge(parent, dir_str, EDGE_TYPE_CONTAIN);
-    }
-    dir = dir.parent_path();
-  }
-  builder.add_file_node(file_path);
-  std::string parent = file_fs.parent_path().generic_string();
-  if (parent.empty())
-    parent = ROOT_NODE;
-  builder.add_edge(parent, file_path, EDGE_TYPE_CONTAIN);
+  builder.add_file_hierarchy(file_path);
 
   auto occurrences = extract_blocks(document_block, "occurrences");
   for (const auto &occ : occurrences)

--- a/core/scip_decode_python.cpp
+++ b/core/scip_decode_python.cpp
@@ -5,7 +5,6 @@
 #include "scip_decode_python.h"
 
 #include <algorithm>
-#include <filesystem>
 #include <re2/re2.h>
 
 namespace codeminer::core {
@@ -53,26 +52,8 @@ SCIPPythonDecoder::process_document(const std::string &document_block) const {
     return Subgraph{};
   }
 
-  std::filesystem::path file_fs_path(file_path);
   SubgraphBuilder builder;
-
-  std::filesystem::path dir_path = file_fs_path.parent_path();
-  while (!dir_path.empty() && dir_path != dir_path.parent_path()) {
-    std::string dir_str = dir_path.generic_string();
-    if (builder.add_directory_if_needed(dir_str)) {
-      std::string parent = dir_path.parent_path().generic_string();
-      if (parent.empty())
-        parent = ROOT_NODE;
-      builder.add_edge(parent, dir_str, EDGE_TYPE_CONTAIN);
-    }
-    dir_path = dir_path.parent_path();
-  }
-
-  builder.add_file_node(file_path);
-  std::string parent = file_fs_path.parent_path().generic_string();
-  if (parent.empty())
-    parent = ROOT_NODE;
-  builder.add_edge(parent, file_path, EDGE_TYPE_CONTAIN);
+  builder.add_file_hierarchy(file_path);
 
   auto occurrences = extract_blocks(document_block, "occurrences");
   for (const auto &occ : occurrences)

--- a/core/scip_decode_ruby.cpp
+++ b/core/scip_decode_ruby.cpp
@@ -1,0 +1,748 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "scip_decode_ruby.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <re2/re2.h>
+#include <sstream>
+#include <utility>
+
+namespace codeminer::core {
+
+namespace {
+
+std::vector<int> extract_integers(const std::string &text,
+                                  const re2::RE2 &pattern) {
+  std::vector<int> results;
+  re2::StringPiece input(text);
+  int value = 0;
+  while (re2::RE2::FindAndConsume(&input, pattern, &value)) {
+    results.push_back(value);
+  }
+  return results;
+}
+
+bool ends_with(const std::string &s, const std::string &suffix) {
+  return s.size() >= suffix.size() &&
+         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+bool starts_with(const std::string &s, const std::string &prefix) {
+  return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
+}
+
+std::string trim(std::string s) {
+  std::size_t start = 0;
+  while (start < s.size() &&
+         std::isspace(static_cast<unsigned char>(s[start]))) {
+    ++start;
+  }
+  std::size_t end = s.size();
+  while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1]))) {
+    --end;
+  }
+  return s.substr(start, end - start);
+}
+
+std::vector<std::string> split_ws(const std::string &s) {
+  std::vector<std::string> out;
+  std::istringstream iss(s);
+  std::string tok;
+  while (iss >> tok)
+    out.push_back(tok);
+  return out;
+}
+
+std::string remove_char(std::string s, char target) {
+  s.erase(std::remove(s.begin(), s.end(), target), s.end());
+  return s;
+}
+
+std::string rstrip_char(std::string s, char target) {
+  while (!s.empty() && s.back() == target)
+    s.pop_back();
+  return s;
+}
+
+std::string replace_char(std::string s, char from, char to) {
+  std::replace(s.begin(), s.end(), from, to);
+  return s;
+}
+
+bool is_symbol_type_with_scope(const std::string &type) {
+  return type == NODE_TYPE_CLASS || type == NODE_TYPE_FUNCTION ||
+         type == NODE_TYPE_METHOD;
+}
+
+std::string file_definition_lookup_key(const std::string &file_path,
+                                       const std::string &symbol_key) {
+  return file_path + "\n" + symbol_key;
+}
+
+std::optional<std::string>
+document_file_path(const std::string &document_block);
+bool is_source_file(const std::string &file_path);
+std::optional<std::string> make_symbol_key(const std::string &symbol);
+std::string normalize_singleton_class_descriptor(std::string descriptor);
+std::string symbol_type_from_block(const std::string &block,
+                                   const std::string &original_symbol);
+std::string symbol_type_from_descriptor(const std::string &symbol);
+std::string display_name_from_block(const std::string &block);
+std::string symbol_display(const std::string &key,
+                           const std::string &symbol_type,
+                           const std::string &display_name = "");
+std::pair<std::string, std::string> split_owner_member(const std::string &key);
+std::string qualified_name(std::string key);
+std::string definition_graph_key(const std::string &key,
+                                 const std::string &symbol_type,
+                                 const std::string &file_path);
+std::pair<std::optional<int>, std::optional<int>>
+scope_lines(int line, const std::vector<int> &enclosing_ranges);
+std::optional<std::pair<std::string, std::string>>
+parse_ruby_alias(const std::string &line);
+std::string clean_alias_token(std::string token);
+
+} // namespace
+
+void SCIPRubyDecoder::prescan(const std::vector<std::string> &document_blocks) {
+  symbols_.clear();
+  definition_lines_by_file_.clear();
+  definition_graph_keys_.clear();
+  document_order_by_file_.clear();
+
+  for (std::size_t i = 0; i < document_blocks.size(); ++i) {
+    const auto &document = document_blocks[i];
+    auto file_path = document_file_path(document);
+    if (!file_path || !is_source_file(*file_path))
+      continue;
+    document_order_by_file_[*file_path] = i;
+    collect_symbol_info(document, *file_path);
+  }
+
+  for (const auto &document : document_blocks) {
+    auto file_path = document_file_path(document);
+    if (!file_path || !is_source_file(*file_path))
+      continue;
+    auto definitions = collect_document_definitions(document, *file_path);
+    for (const auto &definition : definitions) {
+      definition_graph_keys_[file_definition_lookup_key(*file_path,
+                                                        definition.key)] =
+          definition_graph_key(definition.key, definition.symbol_type,
+                               *file_path);
+    }
+    definition_lines_by_file_[*file_path] = std::move(definitions);
+  }
+}
+
+void SCIPRubyDecoder::collect_symbol_info(const std::string &document_block,
+                                          const std::string &file_path) {
+  auto symbol_blocks = extract_blocks(document_block, "symbols");
+  for (const auto &block : symbol_blocks) {
+    auto symbol = extract_symbol(block);
+    if (!symbol)
+      continue;
+    auto key = make_symbol_key(*symbol);
+    if (!key)
+      continue;
+    std::string symbol_type = symbol_type_from_block(block, *symbol);
+    std::string display_name =
+        symbol_display(*key, symbol_type, display_name_from_block(block));
+    symbols_[*key] = SymbolInfo{*key, file_path, display_name, symbol_type};
+  }
+}
+
+Subgraph
+SCIPRubyDecoder::process_document(const std::string &document_block) const {
+  auto file_path = document_file_path(document_block);
+  if (!file_path || !is_source_file(*file_path))
+    return Subgraph{};
+
+  SubgraphBuilder builder;
+  builder.add_file_hierarchy(*file_path);
+
+  DocumentState state;
+  state.file_path = *file_path;
+  auto order_it = document_order_by_file_.find(*file_path);
+  if (order_it != document_order_by_file_.end())
+    state.document_order = order_it->second;
+  auto definitions_it = definition_lines_by_file_.find(*file_path);
+  if (definitions_it != definition_lines_by_file_.end())
+    state.definitions = definitions_it->second;
+  state.source_lines = read_source_lines(*file_path);
+
+  auto occurrences = extract_blocks(document_block, "occurrences");
+  for (const auto &occurrence : occurrences) {
+    process_occurrence(occurrence, *file_path, state, builder);
+  }
+  add_alias_definitions(*file_path, state, builder);
+  return builder.build();
+}
+
+std::vector<SCIPRubyDecoder::DefinitionInfo>
+SCIPRubyDecoder::collect_document_definitions(
+    const std::string &document_block, const std::string &file_path) const {
+  static const re2::RE2 range_re(R"re2(range:\s*(\d+))re2");
+  static const re2::RE2 symbol_roles_re(R"re2(symbol_roles:\s*(\d+))re2");
+
+  std::vector<DefinitionInfo> definitions;
+  auto occurrences = extract_blocks(document_block, "occurrences");
+  for (const auto &occurrence : occurrences) {
+    int roles = 0;
+    re2::RE2::PartialMatch(occurrence, symbol_roles_re, &roles);
+    if (!(roles & 1))
+      continue;
+
+    auto ranges = extract_integers(occurrence, range_re);
+    if (ranges.size() < 3)
+      continue;
+
+    auto symbol = extract_symbol(occurrence);
+    if (!symbol)
+      continue;
+    auto key = make_symbol_key(*symbol);
+    if (!key)
+      continue;
+
+    auto info = symbol_info_for_key(*key, file_path, *symbol);
+    if (!info)
+      continue;
+    definitions.push_back(DefinitionInfo{*key, ranges[0], info->symbol_type});
+  }
+  std::stable_sort(definitions.begin(), definitions.end(),
+                   [](const DefinitionInfo &a, const DefinitionInfo &b) {
+                     return a.line < b.line;
+                   });
+  return definitions;
+}
+
+void SCIPRubyDecoder::process_occurrence(const std::string &occurrence_block,
+                                         const std::string &file_path,
+                                         DocumentState &state,
+                                         SubgraphBuilder &builder) const {
+  static const re2::RE2 range_re(R"re2(range:\s*(\d+))re2");
+  static const re2::RE2 symbol_roles_re(R"re2(symbol_roles:\s*(\d+))re2");
+  static const re2::RE2 enclosing_re(R"re2(enclosing_range:\s*(\d+))re2");
+
+  auto ranges = extract_integers(occurrence_block, range_re);
+  if (ranges.size() < 3)
+    return;
+  int line = ranges[0];
+
+  auto symbol = extract_symbol(occurrence_block);
+  if (!symbol)
+    return;
+  auto key = make_symbol_key(*symbol);
+  if (!key)
+    return;
+
+  int roles = 0;
+  re2::RE2::PartialMatch(occurrence_block, symbol_roles_re, &roles);
+  auto enclosing = extract_integers(occurrence_block, enclosing_re);
+
+  builder.exit_scopes_by_line(line);
+  auto info = symbol_info_for_key(*key, file_path, *symbol);
+  if (!info)
+    return;
+
+  if (roles & 1) {
+    add_definition(*info, file_path, line, enclosing, state, builder);
+  } else {
+    add_reference(*info, line, state, builder);
+  }
+}
+
+void SCIPRubyDecoder::add_definition(const SymbolInfo &info,
+                                     const std::string &file_path, int line,
+                                     const std::vector<int> &enclosing_ranges,
+                                     DocumentState &state,
+                                     SubgraphBuilder &builder) const {
+  std::string graph_key =
+      definition_graph_key(info.key, info.symbol_type, file_path);
+  state.file_definition_keys[file_definition_lookup_key(file_path, info.key)] =
+      graph_key;
+
+  auto [start_line, end_line] = scope_lines(line, enclosing_ranges);
+  builder.add_symbol_node(graph_key, line, start_line, end_line,
+                          info.symbol_type);
+  std::string display_name =
+      definition_display_name(info, file_path, line, state, builder);
+  builder.set_unified_name(
+      graph_key,
+      file_path + ":" + (display_name.empty() ? info.key : display_name));
+
+  std::string parent =
+      containment_parent_in_file(info.key, file_path, state, builder);
+  builder.add_edge(parent, graph_key, EDGE_TYPE_CONTAIN);
+
+  if (is_symbol_type_with_scope(info.symbol_type) && start_line.has_value() &&
+      end_line.has_value()) {
+    builder.update_current_scope(graph_key, start_line, end_line);
+  }
+
+  if (info.symbol_type == NODE_TYPE_FUNCTION ||
+      info.symbol_type == NODE_TYPE_METHOD) {
+    auto [owner, member] = split_owner_member(info.key);
+    if (!owner.empty() && !member.empty()) {
+      state.method_definitions_by_member[member].push_back(
+          MethodDefinition{line, graph_key, info.symbol_type});
+    }
+  }
+}
+
+void SCIPRubyDecoder::add_reference(const SymbolInfo &info, int anchor_line,
+                                    const DocumentState &state,
+                                    SubgraphBuilder &builder) const {
+  std::string source =
+      reference_source(info.file_path, anchor_line, state, builder)
+          .value_or(builder.current_scope());
+  builder.add_symbol_reference_from(source, info.key, info.file_path,
+                                    info.symbol_type,
+                                    /*anchor_file=*/std::nullopt,
+                                    /*anchor_line=*/anchor_line);
+  const Subgraph::Node *node = builder.node(info.key);
+  if (node != nullptr && node->is_definition &&
+      node->data.unified_name.has_value()) {
+    return;
+  }
+  builder.set_unified_name(
+      info.key, info.file_path + ":" +
+                    (info.display_name.empty() ? info.key : info.display_name));
+}
+
+void SCIPRubyDecoder::add_alias_definitions(const std::string &file_path,
+                                            DocumentState &state,
+                                            SubgraphBuilder &builder) const {
+  if (state.source_lines.empty())
+    return;
+
+  for (std::size_t i = 0; i < state.source_lines.size(); ++i) {
+    auto alias_pair = parse_ruby_alias(state.source_lines[i]);
+    if (!alias_pair)
+      continue;
+
+    const std::string &alias_member = alias_pair->first;
+    const std::string &original_member = alias_pair->second;
+    auto it = state.method_definitions_by_member.find(original_member);
+    if (it == state.method_definitions_by_member.end())
+      continue;
+
+    const MethodDefinition *best = nullptr;
+    for (const auto &definition : it->second) {
+      if (definition.line >= static_cast<int>(i))
+        break;
+      best = &definition;
+    }
+    if (best == nullptr)
+      continue;
+
+    auto owner_member = split_owner_member(best->key);
+    const std::string &owner = owner_member.first;
+    if (owner.empty())
+      continue;
+
+    auto parent_it = state.file_definition_keys.find(
+        file_definition_lookup_key(file_path, owner));
+    if (parent_it == state.file_definition_keys.end())
+      continue;
+    const std::string &parent = parent_it->second;
+    if (!builder.has_node(parent))
+      continue;
+
+    std::string alias_key = owner + "#" + alias_member;
+    if (builder.has_node(alias_key))
+      continue;
+
+    std::string display_name = symbol_display(alias_key, best->symbol_type);
+    int line = static_cast<int>(i);
+    builder.add_symbol_node(alias_key, line, line, line, best->symbol_type);
+    builder.set_unified_name(alias_key, file_path + ":" + display_name);
+    builder.add_edge(parent, alias_key, EDGE_TYPE_CONTAIN);
+  }
+}
+
+std::optional<SCIPRubyDecoder::SymbolInfo>
+SCIPRubyDecoder::symbol_info_for_key(const std::string &key,
+                                     const std::string &file_path,
+                                     const std::string &original_symbol) const {
+  auto it = symbols_.find(key);
+  if (it != symbols_.end())
+    return it->second;
+
+  std::string type = symbol_type_from_descriptor(original_symbol);
+  return SymbolInfo{key, file_path, symbol_display(key, type), type};
+}
+
+namespace {
+
+std::optional<std::string>
+document_file_path(const std::string &document_block) {
+  static const re2::RE2 relative_path_regex(
+      R"re2(relative_path:\s*"([^"]+)")re2");
+  std::string file_path;
+  if (!re2::RE2::PartialMatch(document_block, relative_path_regex,
+                              &file_path)) {
+    return std::nullopt;
+  }
+  return file_path;
+}
+
+bool is_source_file(const std::string &file_path) {
+  return ends_with(file_path, ".rb");
+}
+
+std::optional<std::string> make_symbol_key(const std::string &symbol) {
+  if (symbol.empty() || starts_with(symbol, "local "))
+    return std::nullopt;
+  auto parts = split_ws(symbol);
+  if (parts.size() < 5 || parts[0] != "scip-ruby")
+    return std::nullopt;
+
+  std::string descriptor = remove_char(parts.back(), '`');
+  descriptor = rstrip_char(descriptor, '.');
+  descriptor = normalize_singleton_class_descriptor(descriptor);
+  if (ends_with(descriptor, "()"))
+    descriptor.resize(descriptor.size() - 2);
+  if (ends_with(descriptor, "#"))
+    descriptor.resize(descriptor.size() - 1);
+  if (descriptor.empty())
+    return std::nullopt;
+  return descriptor;
+}
+
+std::string normalize_singleton_class_descriptor(std::string descriptor) {
+  static const std::string prefix = "<Class:";
+  if (starts_with(descriptor, prefix)) {
+    auto close = descriptor.find(">#");
+    if (close != std::string::npos) {
+      std::string owner =
+          descriptor.substr(prefix.size(), close - prefix.size());
+      descriptor = owner + "#" + descriptor.substr(close + 2);
+    }
+  }
+
+  while (true) {
+    auto pos = descriptor.find("#<Class:");
+    if (pos == std::string::npos)
+      break;
+    auto close = descriptor.find(">#", pos);
+    if (close == std::string::npos)
+      break;
+    std::string prefix_part = descriptor.substr(0, pos);
+    std::string owner = descriptor.substr(pos + 8, close - (pos + 8));
+    std::string suffix = descriptor.substr(close + 2);
+    descriptor = prefix_part + "#" + owner + "#" + suffix;
+  }
+  return descriptor;
+}
+
+std::string symbol_type_from_block(const std::string &block,
+                                   const std::string &original_symbol) {
+  static const re2::RE2 kind_re(R"re2(kind:\s*(\w+))re2");
+  std::string kind;
+  if (re2::RE2::PartialMatch(block, kind_re, &kind)) {
+    if (kind == "Class" || kind == "Interface" || kind == "Enum" ||
+        kind == "Object" || kind == "Trait") {
+      return NODE_TYPE_CLASS;
+    }
+    if (kind == "Method" || kind == "Constructor")
+      return NODE_TYPE_METHOD;
+    if (kind == "Field" || kind == "Property" || kind == "EnumMember" ||
+        kind == "Constant" || kind == "Variable") {
+      return NODE_TYPE_FIELD;
+    }
+  }
+  return symbol_type_from_descriptor(original_symbol);
+}
+
+std::string symbol_type_from_descriptor(const std::string &symbol) {
+  auto parts = split_ws(symbol);
+  std::string descriptor = parts.empty() ? std::string{} : parts.back();
+  if (ends_with(descriptor, "/"))
+    return NODE_TYPE_CLASS;
+  if (ends_with(descriptor, "#"))
+    return NODE_TYPE_CLASS;
+  if (descriptor.find('#') != std::string::npos &&
+      ends_with(descriptor, "().")) {
+    return NODE_TYPE_METHOD;
+  }
+  if (descriptor.find('#') != std::string::npos && ends_with(descriptor, "."))
+    return NODE_TYPE_FIELD;
+  if (ends_with(descriptor, "()."))
+    return NODE_TYPE_FUNCTION;
+  return NODE_TYPE_SYMBOL;
+}
+
+std::string display_name_from_block(const std::string &block) {
+  static const re2::RE2 display_re(R"re2(display_name:\s*"([^"]*)")re2");
+  std::string display;
+  if (re2::RE2::PartialMatch(block, display_re, &display))
+    return display;
+  return {};
+}
+
+std::string symbol_display(const std::string &key,
+                           const std::string &symbol_type,
+                           const std::string &display_name) {
+  auto [owner, member] = split_owner_member(key);
+  std::string owner_name = qualified_name(owner);
+
+  if (symbol_type == NODE_TYPE_CLASS) {
+    if (!owner_name.empty() && !member.empty())
+      return owner_name + "." + member;
+    return !member.empty() ? member : key;
+  }
+  if (symbol_type == NODE_TYPE_METHOD || symbol_type == NODE_TYPE_FUNCTION) {
+    if (!owner_name.empty() && !member.empty())
+      return owner_name + "." + member + "()";
+    return (!member.empty() ? member
+                            : (!display_name.empty() ? display_name : key)) +
+           "()";
+  }
+  if (symbol_type == NODE_TYPE_FIELD) {
+    if (!owner_name.empty() && !member.empty())
+      return owner_name + "." + member;
+    return !member.empty() ? member
+                           : (!display_name.empty() ? display_name : key);
+  }
+  return !display_name.empty() ? display_name
+                               : (!member.empty() ? member : key);
+}
+
+std::pair<std::string, std::string> split_owner_member(const std::string &key) {
+  auto pos = key.rfind('#');
+  if (pos == std::string::npos)
+    return {"", key};
+  return {key.substr(0, pos), key.substr(pos + 1)};
+}
+
+std::string qualified_name(std::string key) {
+  key = replace_char(std::move(key), '#', '.');
+  while (!key.empty() && key.front() == '.')
+    key.erase(key.begin());
+  while (!key.empty() && key.back() == '.')
+    key.pop_back();
+  return key;
+}
+
+std::string definition_graph_key(const std::string &key,
+                                 const std::string &symbol_type,
+                                 const std::string &file_path) {
+  if (symbol_type == NODE_TYPE_CLASS && key.find('#') == std::string::npos)
+    return file_path + ":" + key;
+  return key;
+}
+
+std::pair<std::optional<int>, std::optional<int>>
+scope_lines(int line, const std::vector<int> &enclosing_ranges) {
+  if (enclosing_ranges.size() >= 4)
+    return {enclosing_ranges[0], enclosing_ranges[2]};
+  if (enclosing_ranges.size() == 3)
+    return {enclosing_ranges[0], enclosing_ranges[0]};
+  return {std::nullopt, std::nullopt};
+}
+
+} // namespace
+
+std::string SCIPRubyDecoder::definition_display_name(
+    const SymbolInfo &info, const std::string &file_path, int line,
+    const DocumentState &state, const SubgraphBuilder &builder) const {
+  auto nested = nested_method_display_name(info, file_path, builder);
+  if (nested)
+    return *nested;
+
+  std::string display = top_level_singleton_display_name(
+      info, file_path, line, info.display_name, state);
+  if (!ends_with(display, "=()"))
+    return display;
+  if (info.symbol_type != NODE_TYPE_FUNCTION &&
+      info.symbol_type != NODE_TYPE_METHOD) {
+    return display;
+  }
+  std::string source = source_line(state, line);
+  if (source.find("attr_accessor") == std::string::npos &&
+      source.find("attr_writer") == std::string::npos) {
+    return display;
+  }
+  display.resize(display.size() - 3);
+  return display + "()";
+}
+
+std::optional<std::string> SCIPRubyDecoder::nested_method_display_name(
+    const SymbolInfo &info, const std::string &file_path,
+    const SubgraphBuilder &builder) const {
+  if (info.symbol_type != NODE_TYPE_FUNCTION &&
+      info.symbol_type != NODE_TYPE_METHOD) {
+    return std::nullopt;
+  }
+  auto parent_display = current_method_scope_display(file_path, builder);
+  if (!parent_display)
+    return std::nullopt;
+  auto owner_member = split_owner_member(info.key);
+  const std::string &member = owner_member.second;
+  if (member.empty())
+    return std::nullopt;
+  return *parent_display + "." + member + "()";
+}
+
+std::optional<std::string> SCIPRubyDecoder::current_method_scope_display(
+    const std::string &file_path, const SubgraphBuilder &builder) const {
+  const std::string &scope = builder.current_scope();
+  if (scope.empty() || scope == builder.current_file())
+    return std::nullopt;
+  const Subgraph::Node *node = builder.node(scope);
+  if (node == nullptr)
+    return std::nullopt;
+  if (node->data.type != NODE_TYPE_FUNCTION &&
+      node->data.type != NODE_TYPE_METHOD) {
+    return std::nullopt;
+  }
+  if (!node->data.unified_name.has_value())
+    return std::nullopt;
+  std::string prefix = file_path + ":";
+  if (!starts_with(*node->data.unified_name, prefix))
+    return std::nullopt;
+  return node->data.unified_name->substr(prefix.size());
+}
+
+std::string SCIPRubyDecoder::top_level_singleton_display_name(
+    const SymbolInfo &info, const std::string &file_path, int line,
+    std::string display_name, const DocumentState &state) const {
+  auto [owner, member] = split_owner_member(info.key);
+  if (owner != "Object" || member.empty() ||
+      (info.symbol_type != NODE_TYPE_FUNCTION &&
+       info.symbol_type != NODE_TYPE_METHOD)) {
+    return display_name;
+  }
+  re2::RE2 def_re("\\bdef\\s+[A-Za-z_]\\w*\\." + re2::RE2::QuoteMeta(member) +
+                  "\\b");
+  if (re2::RE2::PartialMatch(source_line(state, line), def_re))
+    return member + "()";
+  return display_name;
+}
+
+std::string SCIPRubyDecoder::source_line(const DocumentState &state,
+                                         int line) const {
+  if (line < 0 || static_cast<std::size_t>(line) >= state.source_lines.size())
+    return {};
+  return state.source_lines[static_cast<std::size_t>(line)];
+}
+
+std::string SCIPRubyDecoder::containment_parent_in_file(
+    const std::string &key, const std::string &file_path,
+    const DocumentState &state, const SubgraphBuilder &builder) const {
+  auto method_scope = current_method_scope_vertex(file_path, builder);
+  if (method_scope)
+    return *method_scope;
+
+  auto [owner, member] = split_owner_member(key);
+  if (!member.empty()) {
+    auto it = state.file_definition_keys.find(
+        file_definition_lookup_key(file_path, owner));
+    if (it != state.file_definition_keys.end() && builder.has_node(it->second))
+      return it->second;
+  }
+  return builder.current_scope();
+}
+
+std::optional<std::string> SCIPRubyDecoder::current_method_scope_vertex(
+    const std::string &file_path, const SubgraphBuilder &builder) const {
+  if (current_method_scope_display(file_path, builder))
+    return builder.current_scope();
+  return std::nullopt;
+}
+
+std::optional<std::string>
+SCIPRubyDecoder::reference_source(const std::string &file_path, int anchor_line,
+                                  const DocumentState &state,
+                                  const SubgraphBuilder &builder) const {
+  auto definitions_it = definition_lines_by_file_.find(file_path);
+  if (definitions_it == definition_lines_by_file_.end())
+    return std::nullopt;
+
+  auto order_it = document_order_by_file_.find(file_path);
+  if (order_it == document_order_by_file_.end())
+    return std::nullopt;
+  const bool same_document = file_path == state.file_path;
+  if (order_it->second > state.document_order)
+    return std::nullopt;
+
+  const auto &definitions = definitions_it->second;
+  for (auto it = definitions.rbegin(); it != definitions.rend(); ++it) {
+    if (it->line > anchor_line)
+      continue;
+
+    auto key_it = definition_graph_keys_.find(
+        file_definition_lookup_key(file_path, it->key));
+    std::string graph_key =
+        key_it == definition_graph_keys_.end() ? it->key : key_it->second;
+    if (same_document && !builder.has_node(graph_key))
+      continue;
+    if (it->symbol_type == NODE_TYPE_METHOD ||
+        it->symbol_type == NODE_TYPE_FUNCTION ||
+        it->symbol_type == NODE_TYPE_CLASS) {
+      return graph_key;
+    }
+  }
+  return std::nullopt;
+}
+
+namespace {
+
+std::optional<std::pair<std::string, std::string>>
+parse_ruby_alias(const std::string &line) {
+  std::string text = line;
+  auto comment = text.find('#');
+  if (comment != std::string::npos)
+    text = text.substr(0, comment);
+  text = trim(text);
+  if (!starts_with(text, "alias "))
+    return std::nullopt;
+  auto parts = split_ws(text);
+  if (parts.size() != 3)
+    return std::nullopt;
+  std::string alias_member = clean_alias_token(parts[1]);
+  std::string original_member = clean_alias_token(parts[2]);
+  if (alias_member.empty() || original_member.empty())
+    return std::nullopt;
+  return std::make_pair(alias_member, original_member);
+}
+
+std::string clean_alias_token(std::string token) {
+  token = trim(std::move(token));
+  if (!token.empty() && token.front() == ':')
+    token.erase(token.begin());
+  if (token.size() >= 2 && token.front() == token.back() &&
+      (token.front() == '\'' || token.front() == '"')) {
+    token = token.substr(1, token.size() - 2);
+  }
+  return token;
+}
+
+} // namespace
+
+std::vector<std::string>
+SCIPRubyDecoder::read_source_lines(const std::string &file_path) const {
+  if (!project_root_.has_value())
+    return {};
+  std::filesystem::path path =
+      std::filesystem::path(*project_root_) / file_path;
+  std::ifstream input(path);
+  if (!input.is_open())
+    return {};
+
+  std::vector<std::string> lines;
+  std::string line;
+  while (std::getline(input, line)) {
+    if (!line.empty() && line.back() == '\r')
+      line.pop_back();
+    lines.push_back(line);
+  }
+  return lines;
+}
+
+} // namespace codeminer::core

--- a/core/scip_decode_ruby.h
+++ b/core/scip_decode_ruby.h
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "scip_decode_base.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace codeminer::core {
+
+class SCIPRubyDecoder : public SCIPDecoderBase {
+public:
+  using SCIPDecoderBase::SCIPDecoderBase;
+
+protected:
+  Subgraph process_document(const std::string &document_block) const override;
+  void prescan(const std::vector<std::string> &document_blocks) override;
+
+private:
+  struct SymbolInfo {
+    std::string key;
+    std::string file_path;
+    std::string display_name;
+    std::string symbol_type;
+  };
+
+  struct DefinitionInfo {
+    std::string key;
+    int line{0};
+    std::string symbol_type;
+  };
+
+  struct MethodDefinition {
+    int line{0};
+    std::string key;
+    std::string symbol_type;
+  };
+
+  struct DocumentState {
+    std::string file_path;
+    std::size_t document_order{0};
+    std::unordered_map<std::string, std::string> file_definition_keys;
+    std::unordered_map<std::string, std::vector<MethodDefinition>>
+        method_definitions_by_member;
+    std::vector<DefinitionInfo> definitions;
+    std::vector<std::string> source_lines;
+  };
+
+  void collect_symbol_info(const std::string &document_block,
+                           const std::string &file_path);
+  std::vector<DefinitionInfo>
+  collect_document_definitions(const std::string &document_block,
+                               const std::string &file_path) const;
+  void process_occurrence(const std::string &occurrence_block,
+                          const std::string &file_path, DocumentState &state,
+                          SubgraphBuilder &builder) const;
+  void add_definition(const SymbolInfo &info, const std::string &file_path,
+                      int line, const std::vector<int> &enclosing_ranges,
+                      DocumentState &state, SubgraphBuilder &builder) const;
+  void add_reference(const SymbolInfo &info, int anchor_line,
+                     const DocumentState &state,
+                     SubgraphBuilder &builder) const;
+  void add_alias_definitions(const std::string &file_path, DocumentState &state,
+                             SubgraphBuilder &builder) const;
+
+  std::optional<SymbolInfo>
+  symbol_info_for_key(const std::string &key, const std::string &file_path,
+                      const std::string &original_symbol) const;
+
+  std::string definition_display_name(const SymbolInfo &info,
+                                      const std::string &file_path, int line,
+                                      const DocumentState &state,
+                                      const SubgraphBuilder &builder) const;
+  std::optional<std::string>
+  nested_method_display_name(const SymbolInfo &info,
+                             const std::string &file_path,
+                             const SubgraphBuilder &builder) const;
+  std::optional<std::string>
+  current_method_scope_display(const std::string &file_path,
+                               const SubgraphBuilder &builder) const;
+  std::string top_level_singleton_display_name(
+      const SymbolInfo &info, const std::string &file_path, int line,
+      std::string display_name, const DocumentState &state) const;
+  std::string source_line(const DocumentState &state, int line) const;
+  std::string containment_parent_in_file(const std::string &key,
+                                         const std::string &file_path,
+                                         const DocumentState &state,
+                                         const SubgraphBuilder &builder) const;
+  std::optional<std::string>
+  current_method_scope_vertex(const std::string &file_path,
+                              const SubgraphBuilder &builder) const;
+  std::optional<std::string>
+  reference_source(const std::string &file_path, int anchor_line,
+                   const DocumentState &state,
+                   const SubgraphBuilder &builder) const;
+
+  std::vector<std::string>
+  read_source_lines(const std::string &file_path) const;
+
+  std::unordered_map<std::string, SymbolInfo> symbols_;
+  std::unordered_map<std::string, std::vector<DefinitionInfo>>
+      definition_lines_by_file_;
+  std::unordered_map<std::string, std::string> definition_graph_keys_;
+  std::unordered_map<std::string, std::size_t> document_order_by_file_;
+};
+
+} // namespace codeminer::core

--- a/core/scip_decode_rust.cpp
+++ b/core/scip_decode_rust.cpp
@@ -348,24 +348,8 @@ SCIPRustDecoder::process_document(const std::string &document_block) const {
   if (!ends_with(file_path, ".rs"))
     return Subgraph{};
 
-  std::filesystem::path file_fs(file_path);
   SubgraphBuilder builder;
-  auto dir = file_fs.parent_path();
-  while (!dir.empty() && dir != dir.parent_path()) {
-    std::string dir_str = dir.generic_string();
-    if (builder.add_directory_if_needed(dir_str)) {
-      std::string parent = dir.parent_path().generic_string();
-      if (parent.empty())
-        parent = ROOT_NODE;
-      builder.add_edge(parent, dir_str, EDGE_TYPE_CONTAIN);
-    }
-    dir = dir.parent_path();
-  }
-  builder.add_file_node(file_path);
-  std::string parent = file_fs.parent_path().generic_string();
-  if (parent.empty())
-    parent = ROOT_NODE;
-  builder.add_edge(parent, file_path, EDGE_TYPE_CONTAIN);
+  builder.add_file_hierarchy(file_path);
 
   auto occurrences = extract_blocks(document_block, "occurrences");
   for (const auto &occ : occurrences)

--- a/core/scip_decode_ts.cpp
+++ b/core/scip_decode_ts.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <filesystem>
 #include <re2/re2.h>
 #include <sstream>
 
@@ -299,24 +298,8 @@ SCIPTSDecoder::process_document(const std::string &document_block) const {
     return Subgraph{};
   }
 
-  std::filesystem::path file_fs(file_path);
   SubgraphBuilder builder;
-  auto dir = file_fs.parent_path();
-  while (!dir.empty() && dir != dir.parent_path()) {
-    std::string dir_str = dir.generic_string();
-    if (builder.add_directory_if_needed(dir_str)) {
-      std::string parent = dir.parent_path().generic_string();
-      if (parent.empty())
-        parent = ROOT_NODE;
-      builder.add_edge(parent, dir_str, EDGE_TYPE_CONTAIN);
-    }
-    dir = dir.parent_path();
-  }
-  builder.add_file_node(file_path);
-  std::string parent = file_fs.parent_path().generic_string();
-  if (parent.empty())
-    parent = ROOT_NODE;
-  builder.add_edge(parent, file_path, EDGE_TYPE_CONTAIN);
+  builder.add_file_hierarchy(file_path);
 
   auto occurrences = extract_blocks(document_block, "occurrences");
   for (const auto &occ : occurrences)

--- a/core/tests/scip_decode_repo.cpp
+++ b/core/tests/scip_decode_repo.cpp
@@ -16,6 +16,7 @@ using codeminer::core::CodeGraph;
 using codeminer::core::SCIPDecoderBase;
 using codeminer::core::SCIPGoDecoder;
 using codeminer::core::SCIPPythonDecoder;
+using codeminer::core::SCIPRubyDecoder;
 using codeminer::core::SCIPRustDecoder;
 using codeminer::core::SCIPTSDecoder;
 namespace fs = std::filesystem;
@@ -40,7 +41,8 @@ void print_usage(std::string_view prog_name) {
       << "  index.decoded  - Path to decoded SCIP index file\n"
       << "  project_root   - Project root directory (or 'null' for none)\n"
       << "  output.json    - Output JSON file path\n"
-      << "  language       - One of: python (default), go, rust, typescript\n";
+      << "  language       - One of: python (default), go, rust, ruby, "
+         "typescript\n";
 }
 
 bool path_exists(const fs::path &path, std::string_view description) {
@@ -82,8 +84,8 @@ std::optional<ProgramOptions> parse_arguments(int argc, char **argv) {
   }
 
   const auto &lang = options.language;
-  if (lang != "python" && lang != "go" && lang != "rust" &&
-      lang != "typescript" && lang != "ts" && lang != "js") {
+  if (lang != "python" && lang != "go" && lang != "rust" && lang != "ruby" &&
+      lang != "rb" && lang != "typescript" && lang != "ts" && lang != "js") {
     std::cerr << "Error: unknown language '" << lang << "'\n";
     print_usage(argv[0]);
     return std::nullopt;
@@ -107,6 +109,8 @@ make_decoder(const std::string &lang, const std::string &index,
     return std::make_unique<SCIPGoDecoder>(index, root_str);
   if (lang == "rust")
     return std::make_unique<SCIPRustDecoder>(index, root_str);
+  if (lang == "ruby" || lang == "rb")
+    return std::make_unique<SCIPRubyDecoder>(index, root_str);
   if (lang == "typescript")
     return std::make_unique<SCIPTSDecoder>(index, root_str);
   return nullptr;

--- a/docs/contributing-a-language.md
+++ b/docs/contributing-a-language.md
@@ -169,7 +169,6 @@ LSP or tree-sitter-only as final:
 | Language | Candidate | Current active graph | Promotion gate |
 | --- | --- | --- | --- |
 | Kotlin | `scip-java index` | generic LSP / Kotlin LS | JVM smoke, LSP alignment, Kotlin symbol normalization |
-| Ruby | `scip-ruby` | generic LSP / ruby-lsp | real-repo graph quality measurement, Sorbet setup guidance |
 
 Promoted SCIP cold-start routes are still expected to keep their LSP baseline
 reachable through `graph_route="lsp"`:
@@ -246,8 +245,8 @@ The bootstrap targets install tools under `CODEMINER_SCIP_TOOLS_DIR`, defaulting
 to `/tmp/codeminer-scip-tools`, instead of relying on global npm/go/gem/dotnet
 state. `make multilang-tools` is the no-sudo toolchain subset used by the smoke
 targets. It installs active SCIP/LSP tools for Python, Go, Rust, Java, C#,
-Scala, PHP, JavaScript, TypeScript, and C/C++ plus candidate SCIP/LSP tools for
-Kotlin and Ruby, plus Zoekt binaries used by MCP/search integration. The
+Ruby, Scala, PHP, JavaScript, TypeScript, and C/C++ plus candidate SCIP/LSP
+tools for Kotlin, plus Zoekt binaries used by MCP/search integration. The
 TypeScript path also installs local `yarn` and `pnpm` wrappers for workspace
 repositories. Use `make active-scip-env` to print the exact PATH, `GOBIN`,
 `GOPATH`, `DOTNET_ROOT`, and gem environment needed by manual commands.
@@ -335,7 +334,7 @@ Use `make scip-jvm-compat-system-deps-ubuntu` when a compatibility probe needs
 an older JDK such as OpenJDK 11 for legacy Gradle projects.
 
 `make scip-cold-start-tools` installs reproducible local copies of active
-Java/C#/Scala SCIP tools and the Kotlin/Ruby candidate toolchains under
+Java/C#/Ruby/Scala SCIP tools and the Kotlin candidate toolchain under
 `CODEMINER_SCIP_TOOLS_DIR`, defaulting to `/tmp/codeminer-scip-tools`. It
 installs `scip-java`, Gradle, SBT, .NET SDK channels 8.0 and 10.0,
 `scip-dotnet`, `csharp-ls`, Bundler, and `scip-ruby`. Ruby gem installation uses
@@ -428,30 +427,33 @@ display names to match csharp-ls. Local csharp-ls alignment may require a newer
 serial-only until profiling shows Python decode/build time is a material
 fraction of cold-start time.
 
-The Ruby candidate path uses `bundle exec scip-ruby` because the native
-`scip-ruby` binary rejects direct invocation outside Bundler. Its decoder accepts
-`.rb` documents, normalizes Ruby descriptors such as `Smoke#Invoice#total().`,
-and maps singleton class descriptors for `<Class:Smoke>#normalize()` to
-`Smoke.normalize()`. It keeps top-level Ruby class/module reopen definitions
-file-scoped internally so repeated declarations such as per-file `module Rake`
-do not collapse into one graph vertex, and it normalizes source-declared
-`attr_writer`/`attr_accessor` generated writer definitions to the ruby-lsp method
-display without changing explicit `def foo=` setters. Generated ruby-lsp
-alignment now runs on a matching Bundler-shaped project, preserves Ruby module
-parents in the generic LSP decoder, normalizes constructors, instance variables,
-attr-style methods, `class << self`, and `::` names, and is strict-green against
-the SCIP candidate for symbols and containment (`4/4`, no missing or extra
-definitions). The Ruby SCIP route unsets
+The Ruby active hybrid SCIP path uses `bundle exec scip-ruby` because the native
+`scip-ruby` binary rejects direct invocation outside Bundler. Its decoder
+accepts `.rb` documents, normalizes Ruby descriptors such as
+`Smoke#Invoice#total().`, and maps singleton class descriptors for
+`<Class:Smoke>#normalize()` to `Smoke.normalize()`. It keeps top-level Ruby
+class/module reopen definitions file-scoped internally so repeated declarations
+such as per-file `module Rake` do not collapse into one graph vertex, and it
+normalizes source-declared `attr_writer`/`attr_accessor` generated writer
+definitions to the ruby-lsp method display without changing explicit `def foo=`
+setters. Generated ruby-lsp alignment now runs on a matching Bundler-shaped
+project, preserves Ruby module parents in the generic LSP decoder, normalizes
+constructors, instance variables, attr-style methods, `class << self`, and `::`
+names, and is strict-green against the SCIP route for symbols and containment
+(`4/4`, no missing or extra definitions). The Ruby SCIP route unsets
 `GEM_PATH` for Bundler commands and filters generated graphs by `target_dir` and
 `exclude_patterns`, so dependency gems under `vendor/bundle` do not pollute
 source-route alignment. For real repositories that should not have their Gemfile
 mutated, create an overlay such as `.codeminer/Gemfile` with `gemspec path: ".."`
 plus pinned `ruby-lsp` and `scip-ruby`, then export
 `CODEMINER_RUBY_BUNDLE_GEMFILE=/path/to/repo/.codeminer/Gemfile` before running
-LSP or SCIP route gates. Ruby remains candidate until real-repo graph quality
-measurement is green enough for promotion; the current `ruby/rake` gate runs
-end-to-end with only dynamic alias/singleton symbol differences remaining on
-the definition surface.
+LSP or SCIP route gates. The current `ruby/rake` gate promotes Ruby as an active
+hybrid route with one accepted anonymous-module receiver modeling tolerance; all
+other source definitions and containment align, and scip-ruby contributes
+material source references. Ruby is also covered by the C++ core decoder: on the
+same `ruby/rake` decoded index, serial/core parity after `lib/` filtering is
+exact with 815 nodes and 3,466 edges, and local `process_index` time drops from
+7.58s serial to 1.04s through the C++ backend.
 Use `make ruby-project-bundle PROJECT_ROOT=/path/to/ruby/repo` for this overlay
 setup. It creates `.codeminer/Gemfile` only when absent, installs the bundle
 under `.codeminer/vendor/bundle`, and prints the

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -42,8 +42,14 @@ make core-test                # C++ smoke + Python/core parity checks
 The resulting static library and pybind module are placed in `build/core`.
 `make core-test` currently validates the C++ executable smoke tests,
 `graph_layers`, registry-driven core language metadata, and serial/core parity
-for the active accelerated SCIP backends: Python, Go, Rust, TypeScript, and the
-JavaScript/TypeScript aliases.
+for the active accelerated SCIP backends: Python, Go, Rust, Ruby, TypeScript,
+and the JavaScript/TypeScript aliases.
+
+Ruby has a dedicated C++ decoder because real `ruby/rake` profiling showed the
+serial local decode path was the bottleneck after `scip-ruby` produced a large
+text index. On the `ruby/rake` gate, serial `process_index` took 7.58s while the
+C++ backend took 1.04s after filtering to `lib/`; both routes produced 815
+vertices, 3,466 edges, and no vertex-attribute or edge-multiset differences.
 
 Java, C#, PHP, and Scala are active SCIP cold-start routes but intentionally
 remain serial-only in Python. Local profiles show their external indexers

--- a/docs/language_capabilities.md
+++ b/docs/language_capabilities.md
@@ -27,7 +27,7 @@ python scripts/language_capability_matrix.py --check docs/language_capabilities.
 | C/C++ | yes | yes | yes | clangd | none | clangd | yes | no | n/a-no-core-decoder |
 | C# | yes | yes | yes | scip | active | none | yes | no | n/a-no-core-decoder |
 | Java | yes | yes | yes | scip | active | none | yes | no | n/a-no-core-decoder |
-| Ruby | yes | yes | yes | scip | active | none | yes | no | n/a-no-core-decoder |
+| Ruby | yes | yes | yes | scip | active | none | yes | yes | covered |
 | PHP | yes | yes | yes | scip | active | none | yes | no | n/a-no-core-decoder |
 | Kotlin | yes | yes | yes | lsp | candidate | none | yes | no | n/a-no-core-decoder |
 | Swift | yes | yes | yes | none | none | none | no | no | n/a-tree-sitter-only |

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -40,8 +40,9 @@ end:
    matrix.
 2. Promote candidate SCIP cold-start backends only after gated smoke, decode,
    backend-alignment, and documentation work.
-3. Keep active SCIP backends for Python, Go, Rust, C#, Java, JavaScript,
-   TypeScript, and PHP fast and parity-tested where a C++ core decoder exists.
+3. Keep active SCIP backends for Python, Go, Rust, C#, Java, Ruby,
+   JavaScript, TypeScript, and PHP fast and parity-tested where a C++ core
+   decoder exists.
 4. Add C++ acceleration only where profiling shows local decode or graph
    processing is a meaningful bottleneck.
 5. Keep PRs, commits, and issues synchronized with this roadmap so multi-step
@@ -420,6 +421,15 @@ because all other source definitions and containment align, source references
 are materially richer in the SCIP graph, and loose Ruby projects still fall back
 to ruby-lsp.
 
+Ruby C++ acceleration status: the same `ruby/rake` decoded index now has
+serial/core parity through `SCIPRubyGraphDecoder` and `SCIPDecoderCore` with
+`language="ruby"`/`"rb"`. After filtering to `lib/`, both decoders produce 815
+nodes and 3,466 edges with no missing/extra names, no edge-multiset difference,
+and no vertex-attribute difference. Local `process_index` time went from 7.58s
+serial to 1.04s through the C++ backend, so Ruby is covered by the accelerated
+core decoder gate while the active hybrid route still falls back to ruby-lsp
+when a Bundler SCIP setup is not available.
+
 Current PHP active hybrid status: the registry routes PHP through
 `PHPHybridIndexer`. Composer projects prefer `SCIPPHPIndexer`, which runs
 project-local `vendor/bin/scip-php` from the validated
@@ -509,8 +519,8 @@ containment `ref=8 cand=8 missing=0 extra=0`, and references `ref=1 cand=0`.
 
 ### Phase 5: Acceleration And Parity
 
-- [x] Keep existing Python/Go/Rust/JS/TS SCIP C++ parity tests green.
-- [ ] Profile each newly promoted route before adding C++ decoder code.
+- [x] Keep existing Python/Go/Rust/Ruby/JS/TS SCIP C++ parity tests green.
+- [x] Profile each newly promoted route before adding C++ decoder code.
 - [ ] Prefer shared normalization helpers when symbol shapes are language-family
   compatible.
 - [x] Keep C++ files small and purpose-specific: parser/decoder logic,
@@ -522,19 +532,21 @@ numbers, and `core/` remains maintainable.
 
 Current acceleration status: `make core-test` builds the pybind module and
 passes C++ smoke tests, graph-layer tests, registry metadata tests, and
-serial/core parity for the active accelerated SCIP backends. Java, C#, PHP, and
-Scala are active SCIP routes but remain serial-only because profiling shows
-external tooling dominates cold-start time: on `jitpack/maven-simple`,
+serial/core parity for the active accelerated SCIP backends. Ruby now has a
+C++ decoder because `ruby/rake` made local decode the hot path: serial
+`process_index` took 7.58s, the C++ backend took 1.04s, and the filtered
+`lib/` graph matched exactly with 815 nodes, 3,466 edges, zero missing/extra
+names, zero edge-multiset differences, and zero vertex-attribute differences.
+Java, C#, PHP, and Scala are active SCIP routes but remain serial-only because
+profiling shows external tooling dominates cold-start time: on
+`jitpack/maven-simple`,
 `scip-java` indexing took about 5.98s while protoc decode took 0.01s, Python
 graph decode 0.007s, and range-index construction 0.001s; on the recorded C#
 fixture, `scip-dotnet` indexing took about 4.3-4.8s while Python decode/build
 was about 0.01s; on the small PHP Composer gate, LSP document-symbol collection
 took about 16.245s, SCIP indexing took about 0.551s, protoc decode took about
-0.008s, and Python graph decode took about 0.007s; on the `ruby/rake` Ruby gate,
-`scip-ruby` produced richer source references while the active hybrid route kept
-loose-project LSP fallback, and serial `process_index.decode` took about
-7.5-7.9s. Ruby therefore needs a dedicated C++ decoder/parity follow-up before
-it can be called accelerated. On the `sbt/io` Scala gate, `scip-java` indexing
+0.008s, and Python graph decode took about 0.007s. On the `sbt/io` Scala gate,
+`scip-java` indexing
 took about 74.527s while protoc decode took about 0.099s, Python graph decode
 took about 2.156s, and range-index construction took about 0.069s. Kotlin
 remains serial-only until its promotion gate is green and profiling shows local

--- a/test/scip/test_scip_core.py
+++ b/test/scip/test_scip_core.py
@@ -4,7 +4,7 @@
 
 """C++ ``core/`` decoder parity test (pybind11).
 
-For each language with a C++ decoder (python, go, rust, ts):
+For each cached integration language with a C++ decoder (python, go, rust, ts):
 
   1. Locate the serial reference graph at ``~/.codeminer/<instance_id>/graph.pkl``
      and the decoded SCIP index at ``~/.codeminer/<instance_id>/index.decoded``.
@@ -21,7 +21,9 @@ populated ``graph.pkl``. If the cache is missing, the test fails under CI
 (``$CI`` set) since that indicates an ``integration-serial`` regression, and
 skips locally with a pointer to what should have produced it. Running core's
 ``process_index`` with ``output_file=None`` avoids clobbering the serial
-``graph.pkl``.
+``graph.pkl``. Ruby also has a C++ decoder; its CI-stable parity coverage uses a
+synthetic decoded index in this file because the real Bundler/rake fixture is a
+local promotion gate rather than an integration-serial cache.
 """
 
 from __future__ import annotations
@@ -76,6 +78,206 @@ _MULTILINGUAL_KEYWORDS = {
 }
 
 _PYTHON_INSTANCE_FILTER = "^(sympy__sympy-21847)$"
+
+_RUBY_CORE_PARITY_INDEX = """
+metadata {
+  tool_info {
+    name: "scip-ruby"
+    version: "0.4.7"
+  }
+}
+documents {
+  relative_path: "lib/invoice.rb"
+  occurrences {
+    range: 0
+    range: 7
+    range: 12
+    symbol: "scip-ruby gem smoke 0.1 Smoke#"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 1
+    range: 8
+    range: 15
+    symbol: "scip-ruby gem smoke 0.1 Smoke#Invoice#"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 2
+    range: 8
+    range: 13
+    symbol: "scip-ruby gem smoke 0.1 Smoke#Invoice#total()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 7
+    range: 11
+    range: 20
+    symbol: "scip-ruby gem smoke 0.1 `<Class:Smoke>`#normalize()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 8
+    range: 16
+    range: 21
+    symbol: "scip-ruby gem smoke 0.1 Smoke#Invoice#total()."
+  }
+  symbols {
+    symbol: "scip-ruby gem smoke 0.1 Smoke#"
+    documentation: "```ruby\\nmodule Smoke\\n```"
+  }
+  symbols {
+    symbol: "scip-ruby gem smoke 0.1 Smoke#Invoice#"
+    documentation: "```ruby\\nclass Smoke::Invoice\\n```"
+  }
+  symbols {
+    symbol: "scip-ruby gem smoke 0.1 Smoke#Invoice#total()."
+    documentation: "```ruby\\ndef total\\n```"
+  }
+  symbols {
+    symbol: "scip-ruby gem smoke 0.1 `<Class:Smoke>`#normalize()."
+    documentation: "```ruby\\ndef self.normalize\\n```"
+  }
+}
+documents {
+  relative_path: "lib/rake/file_list.rb"
+  occurrences {
+    range: 0
+    range: 7
+    range: 11
+    symbol: "scip-ruby gem smoke 0.1 Rake#"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 1
+    range: 8
+    range: 16
+    symbol: "scip-ruby gem smoke 0.1 Rake#FileList#"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 2
+    range: 8
+    range: 15
+    symbol: "scip-ruby gem smoke 0.1 Rake#FileList#include()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 6
+    range: 8
+    range: 13
+    symbol: "scip-ruby gem smoke 0.1 Rake#FileList#is_a?()."
+    symbol_roles: 1
+  }
+}
+documents {
+  relative_path: "lib/rake/application.rb"
+  occurrences {
+    range: 0
+    range: 6
+    range: 17
+    symbol: "scip-ruby gem smoke 0.1 Rake#Application#"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 1
+    range: 6
+    range: 32
+    symbol: "scip-ruby gem smoke 0.1 Rake#Application#load_debug_at_stop_feature()."
+    symbol_roles: 1
+    enclosing_range: 1
+    enclosing_range: 2
+    enclosing_range: 6
+    enclosing_range: 0
+  }
+  occurrences {
+    range: 3
+    range: 10
+    range: 17
+    symbol: "scip-ruby gem smoke 0.1 Rake#Application#execute()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 8
+    range: 12
+    range: 22
+    symbol: "scip-ruby gem rake 13.3 Rake#Application#`tty_output=`()."
+    symbol_roles: 1
+  }
+}
+documents {
+  relative_path: "lib/rake/phony.rb"
+  occurrences {
+    range: 1
+    range: 4
+    range: 18
+    symbol: "scip-ruby gem smoke 0.1 `<Class:Object>`#timestamp()."
+    symbol_roles: 1
+  }
+}
+""".strip()
+
+
+def _write_ruby_core_parity_project(project_root: Path) -> Path:
+    (project_root / "lib/rake").mkdir(parents=True)
+    (project_root / "lib/invoice.rb").write_text(
+        "\n".join(
+            [
+                "module Smoke",
+                "  class Invoice",
+                "    def total",
+                "      1",
+                "    end",
+                "  end",
+                "",
+                "  def self.normalize(value)",
+                "    Invoice.new.total",
+                "  end",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (project_root / "lib/rake/file_list.rb").write_text(
+        "\n".join(
+            [
+                "module Rake",
+                "  class FileList",
+                "    def include(*filenames)",
+                "    end",
+                "    alias :add :include",
+                "",
+                "    def is_a?(klass)",
+                "    end",
+                "    alias kind_of? is_a?",
+                "  end",
+                "end",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (project_root / "lib/rake/application.rb").write_text(
+        "\n".join(
+            [
+                "class Application",
+                "  def load_debug_at_stop_feature",
+                "    Module.new do",
+                "      def execute(*)",
+                "      end",
+                "    end",
+                "  end",
+                "  attr_writer :tty_output",
+                "end",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (project_root / "lib/rake/phony.rb").write_text(
+        "task = Object.new\n" "def task.timestamp\n" "end\n",
+        encoding="utf-8",
+    )
+    index = project_root / "index.decoded"
+    index.write_text(_RUBY_CORE_PARITY_INDEX, encoding="utf-8")
+    return index
 
 
 def _pick_instance(language: str) -> Tuple[object, dict]:
@@ -269,6 +471,22 @@ def _run_parity(language: str) -> None:
     assert core_graph is not None, f"[{language}] core process_index returned None"
 
     _assert_graph_parity(serial_graph, core_graph, language)
+
+
+def test_core_ruby_synthetic_parity(tmp_path):
+    index = _write_ruby_core_parity_project(tmp_path)
+
+    from codeminer.scip_interface.scip_decode_core import SCIPDecoderCore
+    from codeminer.scip_interface.scip_decode_ruby import SCIPRubyGraphDecoder
+
+    serial_graph = SCIPRubyGraphDecoder(str(index), project_root=str(tmp_path)).decode()
+    core_graph = SCIPDecoderCore(
+        str(index),
+        project_root=str(tmp_path),
+        language="ruby",
+    ).decode()
+
+    _assert_graph_parity(serial_graph, core_graph, "ruby-synthetic")
 
 
 # --------------------------------------------------------------------------

--- a/test/scip/test_scip_core_registry.py
+++ b/test/scip/test_scip_core_registry.py
@@ -23,6 +23,8 @@ def test_core_decoder_supported_languages_come_from_registry():
         "python",
         "go",
         "rust",
+        "ruby",
+        "rb",
         "typescript",
         "ts",
         "js",

--- a/test/test_languages.py
+++ b/test/test_languages.py
@@ -108,6 +108,8 @@ def test_core_decoder_languages_only_include_supported_core_aliases():
         "python",
         "go",
         "rust",
+        "ruby",
+        "rb",
         "typescript",
         "ts",
         "js",
@@ -167,8 +169,8 @@ def test_language_capability_rows_track_parity_applicability():
     assert rows["ruby"].scip_cold_start == "active"
     assert rows["ruby"].incremental_backend is None
     assert rows["ruby"].lsp is True
-    assert rows["ruby"].core_decoder is False
-    assert rows["ruby"].core_parity == "n/a-no-core-decoder"
+    assert rows["ruby"].core_decoder is True
+    assert rows["ruby"].core_parity == "covered"
 
     assert rows["kotlin"].chunker is True
     assert rows["kotlin"].ground_truth is True


### PR DESCRIPTION
## Summary

Folded into #249 (`codex/multilang-scip-cold-start`) as commit `ad3d215`, then superseded there by the updated feature-base head. This draft stacked PR is closed to keep the queue focused; final CI/merge accounting now happens on #249.

Adds a dedicated C++ core SCIP decoder for Ruby and keeps this as part of the multi-language SCIP cold-start stack.

## Changes

- Add `SCIPRubyDecoder` under `core/` and wire it into CMake, pybind, and the core smoke executable.
- Mirror the serial Ruby SCIP decoder semantics for singleton descriptors, file-scoped reopen modules, nested method display names, source-declared aliases, attr writer normalization, reference anchors, and source selection.
- Keep Ruby-specific symbol parsing, display formatting, and alias parsing as file-local C++ helpers so the decoder header exposes only lifecycle/state methods.
- Move repeated C++ file/directory containment construction into `SubgraphBuilder::add_file_hierarchy()` so Python, Go, Rust, Ruby, and TypeScript core decoders share one structural graph path.
- Mark Ruby as core-decoder covered in the language registry and generated capability matrix.
- Add synthetic Ruby serial/core parity coverage and update core/Ruby roadmap documentation with the real `ruby/rake` acceleration result.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] `make core-test`
- [x] `PYTHONPATH="build/core:${PYTHONPATH:-}" python -m pytest -q test/scip/test_scip_ruby.py test/scip/test_scip_core.py test/scip/test_scip_core_registry.py`
- [x] `python -m pytest -q test/scip/test_scip_ruby.py test/scip/test_scip_core.py test/scip/test_scip_core_registry.py`
- [x] `PYTHONPATH="build/core:${PYTHONPATH:-}" python -m pytest -q test/scip/test_scip_core.py::test_core_ruby_synthetic_parity test/scip/test_scip_core_registry.py test/test_languages.py test/test_language_capability_matrix.py`
- [x] `make multilang-registry-check`
- [x] `python scripts/language_capability_matrix.py --check docs/language_capabilities.md`
- [x] `pre-commit run --files codeminer/languages.py core/CMakeLists.txt core/bindings/pybind_module.cpp core/scip_decode.h core/scip_decode_base.cpp core/scip_decode_common.cpp core/scip_decode_common.h core/scip_decode_go.cpp core/scip_decode_python.cpp core/scip_decode_ruby.cpp core/scip_decode_ruby.h core/scip_decode_rust.cpp core/scip_decode_ts.cpp core/tests/scip_decode_repo.cpp docs/contributing-a-language.md docs/core_cpp.md docs/language_capabilities.md docs/scip_multilanguage_roadmap.md test/scip/test_scip_core.py test/scip/test_scip_core_registry.py test/test_languages.py`
- [x] `pre-commit run --files core/scip_decode_ruby.cpp core/scip_decode_ruby.h`
- [x] `git diff --check`
- [x] Real `ruby/rake` serial/core parity after `lib/` filtering: 815 nodes, 3,466 edges, zero missing/extra names, zero edge-multiset diffs, zero vertex-attribute diffs; `process_index` 7.58s serial vs 1.04s core.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published