### PR TITLE
fix(kotlin): normalize scip decoder symbols

### DIFF
--- a/codeminer/scip_interface/scip_decode_java.py
+++ b/codeminer/scip_interface/scip_decode_java.py
@@ -12,12 +12,16 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from tree_sitter import Parser
+from tree_sitter_language_pack import get_language
+
 from ..graph.code_graph import CodeGraph
 from ..log_utils import get_logger, register_scip_logger
 from ..types import (
     EDGE_TYPE_CONTAIN,
     NODE_TYPE_CLASS,
     NODE_TYPE_FIELD,
+    NODE_TYPE_FILE,
     NODE_TYPE_FUNCTION,
     NODE_TYPE_METHOD,
     NODE_TYPE_SYMBOL,
@@ -497,3 +501,533 @@ class SCIPJavaGraphDecoder:
 
     def save_graph(self, output_path):
         self.code_graph.save_graph(output_path)
+
+
+class SCIPKotlinGraphDecoder(SCIPJavaGraphDecoder):
+    """Kotlin-specific normalization on top of scip-java's JVM output."""
+
+    _LOG_LANGUAGE = "Kotlin"
+    _KOTLIN_PARAMETER_DESCRIPTOR_RE = re.compile(r"(?:\(\)|\(\+\d+\))\.\([^)]+\)$")
+    _KOTLIN_TYPE_PARAMETER_DESCRIPTOR_RE = re.compile(r"(?:#|\.)\[[^\]]+\]$")
+    _KOTLIN_SYNTHETIC_GETTER_DESCRIPTOR_RE = re.compile(r"#get[A-Z][^/#.]*\(\)\.$")
+    _KOTLIN_OVERLOAD_DESCRIPTOR_RE = re.compile(r"\(\+\d+\)\.$")
+    _kotlin_parser = None
+
+    def _collect_symbol_info(self, documents: list[str]) -> None:
+        self._kotlin_generated_enum_helper_descriptors = (
+            self._collect_generated_enum_helper_descriptors(documents)
+        )
+        super()._collect_symbol_info(documents)
+
+    def decode(self) -> CodeGraph:
+        graph = super().decode()
+        for file_path in self._decoded_kotlin_files():
+            self._add_missing_enum_entries(file_path)
+            self._add_missing_top_level_functions(file_path)
+            self._add_missing_explicit_property_accessors(file_path)
+            self._add_missing_top_level_object_override_aliases(file_path)
+        return graph
+
+    def _make_symbol_key(self, symbol: str | None) -> str | None:
+        descriptor = self._symbol_descriptor(symbol)
+        if not descriptor or self._is_kotlin_non_graph_descriptor(descriptor):
+            return None
+        key = super()._make_symbol_key(symbol)
+        if key and (
+            key.endswith("#Companion")
+            or key.endswith("#Companion#<init>")
+            or key.endswith("#Companion#Companion")
+        ):
+            return None
+        return key
+
+    def _symbol_display(
+        self,
+        key: str,
+        symbol_type: str,
+        *,
+        display_name: str = "",
+        signature_text: str = "",
+    ) -> str:
+        owner, member = self._split_owner_member(key)
+        owner_name = self._owner_display_name(owner)
+        member_name = self._clean_member_display(display_name or member)
+        if (
+            symbol_type == NODE_TYPE_METHOD
+            and owner_name
+            and member_name in {"<init>", owner_name.rsplit(".", 1)[-1]}
+        ):
+            return f"{owner_name}.constructor()"
+        return super()._symbol_display(
+            key,
+            symbol_type,
+            display_name=display_name,
+            signature_text=signature_text,
+        )
+
+    def _owner_display_name(self, owner: str) -> str:
+        display_name = super()._owner_display_name(owner)
+        parts = [
+            part for part in display_name.split(".") if part and part != "Companion"
+        ]
+        return ".".join(parts)
+
+    def _symbol_descriptor(self, symbol: str | None) -> str:
+        if not symbol:
+            return ""
+        parts = symbol.split(" ")
+        if len(parts) < 5 or parts[0] not in self._SCIP_SYMBOL_PREFIXES:
+            return ""
+        return parts[-1].replace("`", "")
+
+    def _is_kotlin_non_graph_descriptor(self, descriptor: str) -> bool:
+        normalized = descriptor.rstrip(".")
+        return bool(
+            self._KOTLIN_PARAMETER_DESCRIPTOR_RE.search(normalized)
+            or self._KOTLIN_TYPE_PARAMETER_DESCRIPTOR_RE.search(normalized)
+            or self._KOTLIN_SYNTHETIC_GETTER_DESCRIPTOR_RE.search(descriptor)
+            or descriptor
+            in getattr(self, "_kotlin_generated_enum_helper_descriptors", set())
+        )
+
+    def _collect_generated_enum_helper_descriptors(
+        self, documents: list[str]
+    ) -> set[str]:
+        descriptors: set[str] = set()
+        for document in documents:
+            file_path = self._document_file_path(document)
+            if not file_path or not self._is_source_file(file_path):
+                continue
+            for block in extract_scip_blocks(document, "symbols"):
+                symbol = extract_symbol(block)
+                descriptor = self._symbol_descriptor(symbol)
+                if descriptor and self._is_generated_enum_helper_block(
+                    descriptor,
+                    block,
+                ):
+                    descriptors.add(descriptor)
+        return descriptors
+
+    def _is_generated_enum_helper_block(self, descriptor: str, block: str) -> bool:
+        if descriptor.endswith("#entries."):
+            return "static val entries: EnumEntries<" in block
+        if descriptor.endswith("#values()."):
+            return "static fun values(): Array<" in block
+        if descriptor.endswith("#valueOf()."):
+            return "static fun valueOf(value: String):" in block
+        return False
+
+    def _is_constructor_key(self, key: str) -> bool:
+        return False
+
+    def _symbol_type_from_descriptor(self, symbol: str) -> str:
+        descriptor = symbol.split(" ")[-1] if symbol else ""
+        if self._KOTLIN_OVERLOAD_DESCRIPTOR_RE.search(descriptor):
+            return NODE_TYPE_METHOD if "#" in descriptor else NODE_TYPE_FUNCTION
+        return super()._symbol_type_from_descriptor(symbol)
+
+    def _add_missing_enum_entries(self, file_path: str) -> None:
+        source_path = self._source_path(file_path)
+        if source_path is None:
+            return
+
+        try:
+            source = source_path.read_bytes()
+            root = self._get_kotlin_parser().parse(source).root_node
+        except Exception as exc:
+            self.logger.warning(
+                "Could not parse Kotlin source %s for enum entries: %s",
+                file_path,
+                exc,
+            )
+            return
+
+        self.code_graph.current_file = file_path
+        for enum_key, enum_display, entry in self._iter_enum_entries(root, source):
+            entry_name = self._node_text(
+                self._first_child(entry, "simple_identifier"),
+                source,
+            )
+            if not entry_name:
+                continue
+            base_key = f"{enum_key}#{entry_name}"
+            unified_name = f"{file_path}:{enum_display}.{entry_name}"
+            if self._has_unified_name(unified_name):
+                continue
+            key = self._source_supplement_key(
+                base_key,
+                file_path=file_path,
+                display_name=f"{enum_display}.{entry_name}",
+                line=entry.start_point[0],
+            )
+            self.code_graph.add_symbol_node(
+                key,
+                entry.start_point[0],
+                entry.start_point[0],
+                entry.end_point[0],
+                NODE_TYPE_CLASS,
+            )
+            vid = self.code_graph.name_to_vertex[key]
+            self.code_graph.graph.vs[vid]["unified_name"] = unified_name
+            self.code_graph._add_edge(enum_key, key, EDGE_TYPE_CONTAIN)
+
+    def _add_missing_top_level_functions(self, file_path: str) -> None:
+        source_path = self._source_path(file_path)
+        if source_path is None:
+            return
+
+        try:
+            source = source_path.read_bytes()
+            root = self._get_kotlin_parser().parse(source).root_node
+        except Exception as exc:
+            self.logger.warning(
+                "Could not parse Kotlin source %s for top-level functions: %s",
+                file_path,
+                exc,
+            )
+            return
+
+        self.code_graph.current_file = file_path
+        for function in self._iter_top_level_functions(root):
+            name = self._node_text(
+                self._first_child(function, "simple_identifier"),
+                source,
+            )
+            if not name:
+                continue
+            unified_name = f"{file_path}:{name}()"
+            if self._has_unified_name(unified_name):
+                continue
+            key = self._source_supplement_key(
+                f"{file_path}:{name}()",
+                file_path=file_path,
+                display_name=f"{name}()",
+                line=function.start_point[0],
+            )
+            self.code_graph.add_symbol_node(
+                key,
+                function.start_point[0],
+                function.start_point[0],
+                function.end_point[0],
+                NODE_TYPE_FUNCTION,
+            )
+            vid = self.code_graph.name_to_vertex[key]
+            self.code_graph.graph.vs[vid]["unified_name"] = unified_name
+            self.code_graph._add_edge(file_path, key, EDGE_TYPE_CONTAIN)
+
+    def _add_missing_explicit_property_accessors(self, file_path: str) -> None:
+        source_path = self._source_path(file_path)
+        if source_path is None:
+            return
+
+        try:
+            source = source_path.read_bytes()
+            root = self._get_kotlin_parser().parse(source).root_node
+        except Exception as exc:
+            self.logger.warning(
+                "Could not parse Kotlin source %s for explicit property accessors: %s",
+                file_path,
+                exc,
+            )
+            return
+
+        self.code_graph.current_file = file_path
+        for owners, property_node, getter in self._iter_explicit_getter_properties(
+            root,
+            source,
+        ):
+            property_name = self._property_name(property_node, source)
+            if not property_name:
+                continue
+            display_name = (
+                ".".join((*owners, property_name)) if owners else property_name
+            )
+            property_unified = f"{file_path}:{display_name}"
+            property_key = self._key_for_unified_name(property_unified)
+            if property_key is None:
+                property_key = self._source_supplement_key(
+                    f"{file_path}:{display_name}",
+                    file_path=file_path,
+                    display_name=display_name,
+                    line=property_node.start_point[0],
+                )
+                self.code_graph.add_symbol_node(
+                    property_key,
+                    property_node.start_point[0],
+                    property_node.start_point[0],
+                    property_node.end_point[0],
+                    NODE_TYPE_FIELD,
+                )
+                vid = self.code_graph.name_to_vertex[property_key]
+                self.code_graph.graph.vs[vid]["unified_name"] = property_unified
+                self.code_graph._add_edge(
+                    self._property_owner_key(file_path, owners),
+                    property_key,
+                    EDGE_TYPE_CONTAIN,
+                )
+
+            getter_unified = f"{property_unified}.get()"
+            if self._has_unified_name(getter_unified):
+                continue
+            getter_key = self._source_supplement_key(
+                f"{property_key}#get",
+                file_path=file_path,
+                display_name=f"{display_name}.get()",
+                line=getter.start_point[0],
+            )
+            self.code_graph.add_symbol_node(
+                getter_key,
+                getter.start_point[0],
+                getter.start_point[0],
+                getter.end_point[0],
+                NODE_TYPE_METHOD if owners else NODE_TYPE_FUNCTION,
+            )
+            vid = self.code_graph.name_to_vertex[getter_key]
+            self.code_graph.graph.vs[vid]["unified_name"] = getter_unified
+            self.code_graph._add_edge(property_key, getter_key, EDGE_TYPE_CONTAIN)
+
+    def _add_missing_top_level_object_override_aliases(self, file_path: str) -> None:
+        source_path = self._source_path(file_path)
+        if source_path is None:
+            return
+
+        try:
+            source = source_path.read_bytes()
+            root = self._get_kotlin_parser().parse(source).root_node
+        except Exception as exc:
+            self.logger.warning(
+                "Could not parse Kotlin source %s for top-level object aliases: %s",
+                file_path,
+                exc,
+            )
+            return
+
+        self.code_graph.current_file = file_path
+        for object_name, function in self._iter_top_level_object_override_functions(
+            root,
+            source,
+        ):
+            name = self._node_text(
+                self._first_child(function, "simple_identifier"),
+                source,
+            )
+            if not name:
+                continue
+            object_unified = f"{file_path}:{object_name}.{name}()"
+            if not self._has_unified_name(object_unified):
+                continue
+            alias_unified = f"{file_path}:{name}()"
+            if self._has_unified_name(alias_unified):
+                continue
+            key = self._source_supplement_key(
+                f"{file_path}:{name}()",
+                file_path=file_path,
+                display_name=f"{name}()",
+                line=function.start_point[0],
+            )
+            self.code_graph.add_symbol_node(
+                key,
+                function.start_point[0],
+                function.start_point[0],
+                function.end_point[0],
+                NODE_TYPE_FUNCTION,
+            )
+            vid = self.code_graph.name_to_vertex[key]
+            self.code_graph.graph.vs[vid]["unified_name"] = alias_unified
+            self.code_graph._add_edge(file_path, key, EDGE_TYPE_CONTAIN)
+
+    def _source_supplement_key(
+        self,
+        base_key: str,
+        *,
+        file_path: str,
+        display_name: str,
+        line: int,
+    ) -> str:
+        if base_key not in self.code_graph.name_to_vertex:
+            return base_key
+        return f"{file_path}:{display_name}:{line}"
+
+    def _decoded_kotlin_files(self) -> list[str]:
+        return sorted(
+            vertex["name"]
+            for vertex in self.code_graph.graph.vs
+            if vertex.attributes().get("type") == NODE_TYPE_FILE
+            and str(vertex["name"]).endswith(".kt")
+        )
+
+    def _iter_enum_entries(self, root, source: bytes):
+        yield from self._iter_class_nodes(root, source, ())
+
+    def _iter_top_level_functions(self, root):
+        for child in root.children:
+            if child.type == "function_declaration":
+                yield child
+
+    def _iter_top_level_object_override_functions(self, root, source: bytes):
+        for child in root.children:
+            if child.type != "object_declaration":
+                continue
+            object_name = self._node_text(
+                self._first_child(child, "type_identifier")
+                or self._first_child(child, "simple_identifier"),
+                source,
+            )
+            if not object_name:
+                continue
+            body = self._first_child(child, "class_body")
+            if body is None:
+                continue
+            for member in body.children:
+                if member.type == "function_declaration" and self._has_modifier(
+                    member,
+                    "override",
+                    source,
+                ):
+                    yield object_name, member
+
+    def _iter_explicit_getter_properties(
+        self,
+        node,
+        source: bytes,
+        owners: tuple[str, ...] = (),
+    ):
+        if node.type == "class_declaration":
+            name = self._node_text(self._first_child(node, "type_identifier"), source)
+            next_owners = (*owners, name) if name else owners
+            body = self._first_child(node, "class_body")
+            if body is not None:
+                yield from self._iter_explicit_getter_properties(
+                    body,
+                    source,
+                    next_owners,
+                )
+            return
+        if node.type == "object_declaration":
+            name = self._node_text(self._first_child(node, "type_identifier"), source)
+            if not name:
+                name = self._node_text(
+                    self._first_child(node, "simple_identifier"),
+                    source,
+                )
+            next_owners = (*owners, name) if name else owners
+            body = self._first_child(node, "class_body")
+            if body is not None:
+                yield from self._iter_explicit_getter_properties(
+                    body,
+                    source,
+                    next_owners,
+                )
+            return
+
+        children = list(node.children)
+        for index, child in enumerate(children):
+            if child.type == "property_declaration":
+                getter = self._first_child(child, "getter")
+                if getter is None and index + 1 < len(children):
+                    next_child = children[index + 1]
+                    if next_child.type == "getter":
+                        getter = next_child
+                if getter is not None:
+                    yield owners, child, getter
+                continue
+            if child.type != "getter":
+                yield from self._iter_explicit_getter_properties(
+                    child,
+                    source,
+                    owners,
+                )
+
+    def _iter_class_nodes(self, node, source: bytes, owners: tuple[str, ...]):
+        if node.type == "class_declaration":
+            name = self._node_text(self._first_child(node, "type_identifier"), source)
+            if name:
+                display = ".".join((*owners, name))
+                key = self._key_for_display(display)
+                next_owners = (*owners, name)
+                if key and any(child.type == "enum" for child in node.children):
+                    body = self._first_child(node, "enum_class_body")
+                    if body is not None:
+                        for entry in body.children:
+                            if entry.type == "enum_entry":
+                                yield key, display, entry
+                for child in node.children:
+                    yield from self._iter_class_nodes(child, source, next_owners)
+                return
+
+        for child in node.children:
+            yield from self._iter_class_nodes(child, source, owners)
+
+    def _key_for_display(self, display: str) -> str | None:
+        suffix = f":{display}"
+        for vertex in self.code_graph.graph.vs:
+            unified_name = vertex.attributes().get("unified_name")
+            if isinstance(unified_name, str) and unified_name.endswith(suffix):
+                return vertex["name"]
+        return None
+
+    def _key_for_unified_name(self, unified_name: str) -> str | None:
+        for vertex in self.code_graph.graph.vs:
+            if vertex.attributes().get("unified_name") == unified_name:
+                return vertex["name"]
+        return None
+
+    def _property_owner_key(self, file_path: str, owners: tuple[str, ...]) -> str:
+        if not owners:
+            return file_path
+        return self._key_for_display(".".join(owners)) or file_path
+
+    def _has_unified_name(self, unified_name: str) -> bool:
+        for vertex in self.code_graph.graph.vs:
+            attrs = vertex.attributes()
+            if (
+                attrs.get("unified_name") == unified_name
+                and attrs.get("start_line") is not None
+            ):
+                return True
+        return False
+
+    def _source_path(self, file_path: str) -> Path | None:
+        if self.project_root is None:
+            return None
+        source_path = self.project_root / file_path
+        return source_path if source_path.is_file() else None
+
+    @classmethod
+    def _get_kotlin_parser(cls):
+        if cls._kotlin_parser is None:
+            language = get_language("kotlin")
+            try:
+                cls._kotlin_parser = Parser(language)
+            except TypeError:
+                parser = Parser()
+                if hasattr(parser, "set_language"):
+                    parser.set_language(language)
+                else:
+                    parser.language = language
+                cls._kotlin_parser = parser
+        return cls._kotlin_parser
+
+    def _first_child(self, node, node_type: str):
+        for child in node.children:
+            if child.type == node_type:
+                return child
+        return None
+
+    def _has_modifier(self, node, modifier: str, source: bytes) -> bool:
+        modifiers = self._first_child(node, "modifiers")
+        if modifiers is None:
+            return False
+        return modifier in self._node_text(modifiers, source).split()
+
+    def _property_name(self, node, source: bytes) -> str:
+        declaration = self._first_child(node, "variable_declaration")
+        return self._node_text(
+            self._first_child(declaration, "simple_identifier"),
+            source,
+        )
+
+    def _node_text(self, node, source: bytes) -> str:
+        if node is None:
+            return ""
+        return source[node.start_byte : node.end_byte].decode("utf-8")

--- a/codeminer/scip_interface/scip_indexer_java.py
+++ b/codeminer/scip_interface/scip_indexer_java.py
@@ -174,6 +174,11 @@ class SCIPKotlinIndexer(SCIPJavaIndexer):
             scip_language="kotlin",
         )
 
+    def _get_decoder_class(self):
+        from .scip_decode_java import SCIPKotlinGraphDecoder
+
+        return SCIPKotlinGraphDecoder
+
 
 class SCIPScalaIndexer(SCIPJavaIndexer):
     """Candidate scip-java indexer for Scala projects."""

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -244,11 +244,40 @@ KotlinPoet's candidate route can be compared against the same
 KotlinPoet 2.2.0 decoded SCIP artifact with that target reduced the candidate
 graph to 2,749 vertices, 9,835 edges, and 7,499 reference edges. Against the
 matching LSP graph, alignment is still not promotion-green but is now scoped to
-real modeling differences: symbols `ref=877 cand=1638 missing=179 extra=940`,
-containment `ref=877 cand=1708 missing=179 extra=1010`, references
+real modeling differences: symbols `ref=849 cand=1638 missing=146 extra=935`,
+containment `ref=849 cand=1708 missing=146 extra=1005`, references
 `ref=0 cand=7499`. The remaining gap is dominated by Kotlin object/companion
 property modeling, generated getter/property symbols, and symbol display
 normalization; Kotlin therefore remains `candidate`.
+
+A Kotlin-specific decoder follow-up now removes the largest non-source
+definition noise from that same target-dir gate: parameter descriptors including
+overloaded `(+n)` parameters, type-parameter descriptors, companion object
+classes/constructors, synthetic companion getters such as `getEMPTY()`, and
+JVM overload descriptors that scip-java encodes without normal method syntax,
+and metadata-confirmed enum helpers such as `entries`, `valueOf()`, and
+`values()`. It also flattens companion members to the containing Kotlin type and
+keeps Kotlin `<init>` constructors as `constructor()` definitions instead of
+applying Java's default-constructor skip. A subsequent source supplement adds
+enum entries, top-level functions, explicit property getter nodes, and
+top-level `object` override function aliases from `.kt` source when scip-java
+omits the LSP-facing definition surface, using file-scoped keys when an
+external/reference vertex already owns the raw SCIP key. Reprocessing the saved
+KotlinPoet 2.2.0 decoded artifact with the real source checkout reduced the
+filtered candidate graph to 1,562 vertices and 5,923 edges. Alignment is
+improved but still not promotion-green because containment and extra-symbol
+tolerances remain open: symbols `ref=849 cand=936 missing=0 extra=87`,
+containment `ref=849 cand=941 missing=66 extra=158`, references
+`ref=0 cand=4725`. The remaining candidate work is now dominated by extra
+synthetic/public members and containment differences, not missing definition
+symbols. The current extra-symbol surface includes data-class/object generated
+members such as `copy()` and `componentN()`, top-level constants, and
+implementation-detail methods that Kotlin LS omits from its document-symbol
+surface. A broad "generate getters for every field" rule was rejected because
+it cuts missing symbols at the cost of a much larger extra-symbol surface.
+Filtering top-level constants is also not accepted yet because those are often
+useful retrieval symbols even when the LSP baseline does not report them.
+Kotlin therefore remains `candidate`.
 
 Current Scala active status: the generated Gradle Scala 2.13 smoke runs
 through `scip-java index`, decodes `index.scip`, and builds a CodeGraph via the

--- a/test/scip/test_scip_java.py
+++ b/test/scip/test_scip_java.py
@@ -10,7 +10,10 @@ import sys
 
 from codeminer.graph.code_graph import CodeGraph
 from codeminer.scip_interface import scip_indexer_java
-from codeminer.scip_interface.scip_decode_java import SCIPJavaGraphDecoder
+from codeminer.scip_interface.scip_decode_java import (
+    SCIPJavaGraphDecoder,
+    SCIPKotlinGraphDecoder,
+)
 from codeminer.scip_interface.scip_indexer_java import (
     SCIPJavaIndexer,
     SCIPKotlinIndexer,
@@ -239,7 +242,7 @@ def test_scip_kotlin_indexer_uses_kotlin_registry_command(tmp_path, monkeypatch)
         "--output",
         str(tmp_path / "out/index.scip"),
     ]
-    assert indexer._get_decoder_class() is SCIPJavaGraphDecoder
+    assert indexer._get_decoder_class() is SCIPKotlinGraphDecoder
 
 
 def test_scip_kotlin_indexer_filters_target_dir_after_decode(tmp_path):
@@ -463,6 +466,407 @@ documents {
         _target=graph.name_to_vertex["app/Invoice#total"],
     )
     assert contain["type"] == EDGE_TYPE_CONTAIN
+
+
+def test_scip_kotlin_decoder_normalizes_companion_constructor_and_locals(
+    tmp_path,
+):
+    source_file = tmp_path / "src/main/kotlin/app/Invoice.kt"
+    source_file.parent.mkdir(parents=True)
+    source_file.write_text(
+        """
+class Invoice {
+  val code: String get() = "paid"
+
+  enum class Kind {
+    STANDARD,
+    SPECIAL,
+  }
+}
+
+fun normalize(): String = "ok"
+
+val String.invoiceId: Boolean
+  get() = startsWith("INV")
+
+object Dynamic {
+  override fun copy(): String = "copy"
+  override fun emit(): String = "emit"
+}
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    index = tmp_path / "index.decoded"
+    index.write_text(
+        """
+documents {
+  relative_path: "src/main/kotlin/app/Invoice.kt"
+  occurrences {
+    range: 0
+    range: 6
+    range: 13
+    symbol: "semanticdb maven . . app/Invoice#"
+    symbol_roles: 1
+    enclosing_range: 0
+    enclosing_range: 0
+    enclosing_range: 8
+    enclosing_range: 1
+  }
+  occurrences {
+    range: 1
+    range: 14
+    range: 21
+    symbol: "semanticdb maven . . app/Invoice#`<init>`()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 2
+    range: 12
+    range: 21
+    symbol: "semanticdb maven . . app/Invoice#Companion#"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 1
+    range: 13
+    range: 17
+    symbol: "semanticdb maven . . app/Invoice#Kind#"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 12
+    symbol: "semanticdb maven . . app/Invoice#Kind#STANDARD."
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 12
+    symbol: "semanticdb maven . . app/Invoice#Kind#values()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 12
+    symbol: "semanticdb maven . . app/Invoice#Kind#valueOf()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 2
+    range: 4
+    range: 12
+    symbol: "semanticdb maven . . app/Invoice#Kind#entries."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 3
+    range: 8
+    range: 15
+    symbol: "semanticdb maven . . app/Invoice#Companion#builder()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 4
+    range: 8
+    range: 13
+    symbol: "semanticdb maven . . app/Invoice#Companion#EMPTY."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 4
+    range: 8
+    range: 16
+    symbol: "semanticdb maven . . app/Invoice#Companion#getEMPTY()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 5
+    range: 8
+    range: 11
+    symbol: "semanticdb maven . . app/Invoice#Companion#get(+1)."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 3
+    range: 16
+    range: 20
+    symbol: "semanticdb maven . . app/Invoice#Companion#builder().(name)"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 5
+    range: 16
+    range: 23
+    symbol: "semanticdb maven . . app/Invoice#Companion#builder(+1).(altName)"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 0
+    range: 14
+    range: 15
+    symbol: "semanticdb maven . . app/Invoice#[T]"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 12
+    range: 7
+    range: 14
+    symbol: "semanticdb maven . . app/Dynamic#"
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 13
+    range: 15
+    range: 19
+    symbol: "semanticdb maven . . app/Dynamic#copy()."
+    symbol_roles: 1
+  }
+  occurrences {
+    range: 14
+    range: 15
+    range: 19
+    symbol: "semanticdb maven . . app/Dynamic#emit()."
+    symbol_roles: 1
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#"
+    kind: Class
+    display_name: "Invoice"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#`<init>`()."
+    kind: Method
+    display_name: "<init>"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Companion#"
+    kind: Object
+    display_name: "Companion"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Kind#"
+    kind: Enum
+    display_name: "Kind"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Kind#values()."
+    documentation: "static fun values(): Array<Invoice.Kind>"
+    display_name: "values"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Kind#valueOf()."
+    documentation: "static fun valueOf(value: String): Invoice.Kind"
+    display_name: "valueOf"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Kind#entries."
+    documentation: "static val entries: EnumEntries<Invoice.Kind>"
+    display_name: "entries"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Companion#builder()."
+    kind: Method
+    display_name: "builder"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Companion#EMPTY."
+    display_name: "EMPTY"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Companion#getEMPTY()."
+    kind: Method
+    display_name: "getEMPTY"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Companion#get(+1)."
+    display_name: "get"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Companion#builder().(name)"
+    display_name: "name"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#Companion#builder(+1).(altName)"
+    display_name: "altName"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Invoice#[T]"
+    display_name: "FirTypeParameterSymbol T"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Dynamic#"
+    kind: Object
+    display_name: "Dynamic"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Dynamic#copy()."
+    kind: Method
+    display_name: "copy"
+  }
+  symbols {
+    symbol: "semanticdb maven . . app/Dynamic#emit()."
+    kind: Method
+    display_name: "emit"
+  }
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    graph = SCIPKotlinGraphDecoder(str(index), project_root=str(tmp_path)).decode()
+
+    constructor = graph.graph.vs[graph.name_to_vertex["app/Invoice#<init>"]]
+    kind = graph.graph.vs[graph.name_to_vertex["app/Invoice#Kind"]]
+    builder = graph.graph.vs[graph.name_to_vertex["app/Invoice#Companion#builder"]]
+    empty = graph.graph.vs[graph.name_to_vertex["app/Invoice#Companion#EMPTY"]]
+    overload = graph.graph.vs[graph.name_to_vertex["app/Invoice#Companion#get(+1)"]]
+    assert constructor["unified_name"] == (
+        "src/main/kotlin/app/Invoice.kt:Invoice.constructor()"
+    )
+    assert kind["unified_name"] == "src/main/kotlin/app/Invoice.kt:Invoice.Kind"
+    assert builder["unified_name"] == "src/main/kotlin/app/Invoice.kt:Invoice.builder()"
+    assert empty["unified_name"] == "src/main/kotlin/app/Invoice.kt:Invoice.EMPTY"
+    assert overload["unified_name"] == "src/main/kotlin/app/Invoice.kt:Invoice.get()"
+    standard_defs = [
+        vertex
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("unified_name")
+        == "src/main/kotlin/app/Invoice.kt:Invoice.Kind.STANDARD"
+        and vertex.attributes().get("start_line") is not None
+    ]
+    assert len(standard_defs) == 1
+    standard_name = standard_defs[0]["name"]
+    assert standard_name != "app/Invoice#Kind#STANDARD"
+    assert (
+        graph.graph.vs[graph.name_to_vertex["app/Invoice#Kind#SPECIAL"]]["unified_name"]
+        == "src/main/kotlin/app/Invoice.kt:Invoice.Kind.SPECIAL"
+    )
+    normalize_defs = [
+        vertex
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("unified_name")
+        == "src/main/kotlin/app/Invoice.kt:normalize()"
+        and vertex.attributes().get("start_line") is not None
+    ]
+    assert len(normalize_defs) == 1
+    assert "app/Invoice#Companion" not in graph.name_to_vertex
+    assert "app/Invoice#Companion#getEMPTY" not in graph.name_to_vertex
+    assert "app/Invoice#Companion#builder().(name)" not in graph.name_to_vertex
+    assert "app/Invoice#Companion#builder(+1).(altName)" not in graph.name_to_vertex
+    assert "app/Invoice#[T]" not in graph.name_to_vertex
+    assert "app/Invoice#Kind#values" not in graph.name_to_vertex
+    assert "app/Invoice#Kind#valueOf" not in graph.name_to_vertex
+    assert "app/Invoice#Kind#entries" not in graph.name_to_vertex
+    assert (
+        graph.graph.vs[graph.name_to_vertex["app/Dynamic#copy"]]["unified_name"]
+        == "src/main/kotlin/app/Invoice.kt:Dynamic.copy()"
+    )
+    assert (
+        graph.graph.vs[graph.name_to_vertex["app/Dynamic#emit"]]["unified_name"]
+        == "src/main/kotlin/app/Invoice.kt:Dynamic.emit()"
+    )
+
+    contain = graph.graph.es.find(
+        _source=graph.name_to_vertex["app/Invoice"],
+        _target=graph.name_to_vertex["app/Invoice#Companion#builder"],
+    )
+    assert contain["type"] == EDGE_TYPE_CONTAIN
+
+    enum_contain = graph.graph.es.find(
+        _source=graph.name_to_vertex["app/Invoice#Kind"],
+        _target=graph.name_to_vertex[standard_name],
+    )
+    assert enum_contain["type"] == EDGE_TYPE_CONTAIN
+
+    function_contain = graph.graph.es.find(
+        _source=graph.name_to_vertex["src/main/kotlin/app/Invoice.kt"],
+        _target=normalize_defs[0].index,
+    )
+    assert function_contain["type"] == EDGE_TYPE_CONTAIN
+
+    property_defs = [
+        vertex
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("unified_name")
+        == "src/main/kotlin/app/Invoice.kt:Invoice.code"
+        and vertex.attributes().get("start_line") is not None
+    ]
+    assert len(property_defs) == 1
+    property_contain = graph.graph.es.find(
+        _source=graph.name_to_vertex["app/Invoice"],
+        _target=property_defs[0].index,
+    )
+    assert property_contain["type"] == EDGE_TYPE_CONTAIN
+    getter_defs = [
+        vertex
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("unified_name")
+        == "src/main/kotlin/app/Invoice.kt:Invoice.code.get()"
+        and vertex.attributes().get("start_line") is not None
+    ]
+    assert len(getter_defs) == 1
+    getter_contain = graph.graph.es.find(
+        _source=property_defs[0].index,
+        _target=getter_defs[0].index,
+    )
+    assert getter_contain["type"] == EDGE_TYPE_CONTAIN
+
+    extension_property_defs = [
+        vertex
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("unified_name")
+        == "src/main/kotlin/app/Invoice.kt:invoiceId"
+        and vertex.attributes().get("start_line") is not None
+    ]
+    assert len(extension_property_defs) == 1
+    extension_property_contain = graph.graph.es.find(
+        _source=graph.name_to_vertex["src/main/kotlin/app/Invoice.kt"],
+        _target=extension_property_defs[0].index,
+    )
+    assert extension_property_contain["type"] == EDGE_TYPE_CONTAIN
+    extension_getter_defs = [
+        vertex
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("unified_name")
+        == "src/main/kotlin/app/Invoice.kt:invoiceId.get()"
+        and vertex.attributes().get("start_line") is not None
+    ]
+    assert len(extension_getter_defs) == 1
+    extension_getter_contain = graph.graph.es.find(
+        _source=extension_property_defs[0].index,
+        _target=extension_getter_defs[0].index,
+    )
+    assert extension_getter_contain["type"] == EDGE_TYPE_CONTAIN
+
+    copy_alias_defs = [
+        vertex
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("unified_name")
+        == "src/main/kotlin/app/Invoice.kt:copy()"
+        and vertex.attributes().get("start_line") is not None
+    ]
+    assert len(copy_alias_defs) == 1
+    copy_alias_contain = graph.graph.es.find(
+        _source=graph.name_to_vertex["src/main/kotlin/app/Invoice.kt"],
+        _target=copy_alias_defs[0].index,
+    )
+    assert copy_alias_contain["type"] == EDGE_TYPE_CONTAIN
+    emit_alias_defs = [
+        vertex
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("unified_name")
+        == "src/main/kotlin/app/Invoice.kt:emit()"
+        and vertex.attributes().get("start_line") is not None
+    ]
+    assert len(emit_alias_defs) == 1
+    emit_alias_contain = graph.graph.es.find(
+        _source=graph.name_to_vertex["src/main/kotlin/app/Invoice.kt"],
+        _target=emit_alias_defs[0].index,
+    )
+    assert emit_alias_contain["type"] == EDGE_TYPE_CONTAIN
 
 
 def test_scip_java_decoder_normalizes_nested_kotlin_owner_and_overload_suffix(


### PR DESCRIPTION
## Summary

Folded into #249 (`codex/multilang-scip-cold-start`) as commit `2c9a2a1`. This draft stacked PR is closed to keep the queue focused; final CI/merge accounting now happens on #249.

Kotlin SCIP remains a candidate backend, but this tightens the decoder normalization and targeted source supplementation needed for the next real-repo alignment gate.

## Changes

- Add a Kotlin-specific SCIP graph decoder that filters scip-java parameter/type-parameter noise, flattens companion members, keeps Kotlin constructors, normalizes overload descriptors, and removes metadata-confirmed generated enum helpers such as `entries`, `valueOf()`, and `values()`.
- Supplement omitted Kotlin enum entries, top-level functions, explicit property getter nodes, and top-level `object` override function aliases from `.kt` source using file-scoped keys when raw SCIP keys are already occupied.
- Keep ordinary property getters out of the supplement path; only source properties with explicit `get()` accessors are synthesized.
- Require an existing object-owned SCIP definition before adding a file-level alias for a top-level object override method.
- Record the updated KotlinPoet 2.2.0 target-dir alignment baseline in the multi-language SCIP roadmap.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `python -m pytest -q test/scip/test_scip_java.py`
- [x] `python -m pytest -q test/scip/test_scip_java.py test/scip/test_scip_php.py test/scip/test_scip_csharp.py test/scripts/test_graph_route_alignment.py test/test_ls_router_registry.py`
- [x] `make multilang-registry-check`
- [x] `git diff --check`
- [x] `pre-commit run --files codeminer/scip_interface/scip_decode_java.py codeminer/scip_interface/scip_indexer_java.py test/scip/test_scip_java.py docs/scip_multilanguage_roadmap.md`
- [x] KotlinPoet 2.2.0 saved decoded reprocess vs LSP target `kotlinpoet/src/jvmMain/kotlin`: normalized SCIP `vertices=1562 edges=5923`; LSP `vertices=1108 edges=1107`; alignment `symbols ref=849 cand=936 missing=0 extra=87`, `contain ref=849 cand=941 missing=66 extra=158`, `refs ref=0 cand=4725`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published