### PR TITLE
refactor(core): centralize scip decoder registry

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -49,6 +49,7 @@ pkg_check_modules(RE2 REQUIRED re2)
 add_library(codeminer_core STATIC
     code_graph.cpp
     graph_layers.cpp
+    scip_decoder_registry.cpp
     scip_decode_common.cpp
     scip_decode_base.cpp
     scip_decode_python.cpp

--- a/core/README.md
+++ b/core/README.md
@@ -17,8 +17,9 @@ files.
 - `code_graph.h` / `code_graph.cpp` – graph container that stores vertices, edges, and metadata compatible with the Python implementation.
 - `graph_layers.h` / `graph_layers.cpp` – shared graph-layer classification
   used by Python graph indexing when the pybind module is available.
-- `scip_decode.h` and the language-specific `scip_decode_*.{h,cpp}` files –
-  translate `.decoded` SCIP indexes into the C++ `CodeGraph`.
+- `scip_decode.h`, `scip_decoder_registry.{h,cpp}`, and the language-specific
+  `scip_decode_*.{h,cpp}` files – translate `.decoded` SCIP indexes into the
+  C++ `CodeGraph` and keep core decoder aliases/factory wiring centralized.
 - `bindings/pybind_module.cpp` – exposes `decode_scip(...)` and
   `classify_edge_layers(...)`; binding code should delegate algorithms to core
   modules.

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -126,6 +126,18 @@ Returns:
       - "project_root": the effective project_root used.
 )pbdoc");
 
+  m.def("canonical_scip_decoder_languages",
+        &codeminer::core::canonical_scip_decoder_languages,
+        R"pbdoc(
+Return the canonical language names implemented by the C++ SCIP decoder.
+)pbdoc");
+
+  m.def("accepted_scip_decoder_languages",
+        &codeminer::core::accepted_scip_decoder_languages,
+        R"pbdoc(
+Return canonical language names plus aliases accepted by the C++ SCIP decoder.
+)pbdoc");
+
   m.def("classify_edge_layers", &classify_edge_layers_py, py::arg("edge_types"),
         R"pbdoc(
 Classify edge-type strings into overlapping CodeGraph layer id buckets.

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -31,37 +31,8 @@
 
 namespace py = pybind11;
 using codeminer::core::CodeGraph;
-using codeminer::core::SCIPDecoderBase;
-using codeminer::core::SCIPGoDecoder;
-using codeminer::core::SCIPPythonDecoder;
-using codeminer::core::SCIPRubyDecoder;
-using codeminer::core::SCIPRustDecoder;
-using codeminer::core::SCIPTSDecoder;
 
 namespace {
-
-std::unique_ptr<SCIPDecoderBase>
-make_decoder(const std::string &language, const std::string &index_file,
-             const std::optional<std::string> &project_root) {
-  if (language == "python") {
-    return std::make_unique<SCIPPythonDecoder>(index_file, project_root);
-  }
-  if (language == "go") {
-    return std::make_unique<SCIPGoDecoder>(index_file, project_root);
-  }
-  if (language == "rust") {
-    return std::make_unique<SCIPRustDecoder>(index_file, project_root);
-  }
-  if (language == "ruby" || language == "rb") {
-    return std::make_unique<SCIPRubyDecoder>(index_file, project_root);
-  }
-  if (language == "typescript" || language == "ts" || language == "js") {
-    return std::make_unique<SCIPTSDecoder>(index_file, project_root);
-  }
-  throw std::invalid_argument("Unknown language: " + language +
-                              " (expected: python | go | rust | ruby | "
-                              "typescript)");
-}
 
 py::dict vertex_to_dict(const CodeGraph::VertexData &v) {
   py::dict d;
@@ -79,7 +50,8 @@ py::dict vertex_to_dict(const CodeGraph::VertexData &v) {
 py::dict decode_scip(const std::string &index_file,
                      std::optional<std::string> project_root,
                      const std::string &language) {
-  auto decoder = make_decoder(language, index_file, project_root);
+  auto decoder =
+      codeminer::core::make_scip_decoder(language, index_file, project_root);
 
   // Release the GIL while the C++ decoder runs (it does its own
   // std::thread-based parallelism; we don't call back into Python).
@@ -141,7 +113,8 @@ Args:
     index_file: path to the decoded SCIP index file.
     project_root: project root directory (for language-specific config:
         go.mod / Cargo.toml). May be None.
-    language: one of "python", "go", "rust", "ruby", "typescript".
+    language: one of "python", "go", "rust", "ruby", "typescript"; aliases
+        "rb", "ts", and "js" are accepted.
 
 Returns:
     dict with:

--- a/core/scip_decode.h
+++ b/core/scip_decode.h
@@ -16,6 +16,7 @@
 #include "scip_decode_ruby.h"
 #include "scip_decode_rust.h"
 #include "scip_decode_ts.h"
+#include "scip_decoder_registry.h"
 
 namespace codeminer::core {
 // Backward-compat alias (old tests may still reference this name).

--- a/core/scip_decoder_registry.cpp
+++ b/core/scip_decoder_registry.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "scip_decoder_registry.h"
+
+#include "scip_decode_go.h"
+#include "scip_decode_python.h"
+#include "scip_decode_ruby.h"
+#include "scip_decode_rust.h"
+#include "scip_decode_ts.h"
+
+#include <stdexcept>
+#include <utility>
+
+namespace codeminer::core {
+
+namespace {
+
+std::string join_languages(const std::vector<std::string> &languages) {
+  std::string result;
+  for (const auto &language : languages) {
+    if (!result.empty())
+      result += ", ";
+    result += language;
+  }
+  return result;
+}
+
+} // namespace
+
+std::vector<std::string> canonical_scip_decoder_languages() {
+  return {"python", "go", "rust", "ruby", "typescript"};
+}
+
+std::vector<std::string> accepted_scip_decoder_languages() {
+  return {"python", "go", "rust", "ruby", "rb", "typescript", "ts", "js"};
+}
+
+std::string accepted_scip_decoder_languages_help() {
+  return join_languages(accepted_scip_decoder_languages());
+}
+
+std::optional<std::string>
+canonical_scip_decoder_language(std::string_view language) {
+  if (language == "python" || language == "go" || language == "rust" ||
+      language == "ruby" || language == "typescript") {
+    return std::string(language);
+  }
+  if (language == "rb")
+    return std::string("ruby");
+  if (language == "ts" || language == "js")
+    return std::string("typescript");
+  return std::nullopt;
+}
+
+bool is_scip_decoder_language_supported(std::string_view language) {
+  return canonical_scip_decoder_language(language).has_value();
+}
+
+std::unique_ptr<SCIPDecoderBase>
+make_scip_decoder(std::string_view language, const std::string &index_file,
+                  std::optional<std::string> project_root) {
+  auto canonical = canonical_scip_decoder_language(language);
+  if (!canonical) {
+    throw std::invalid_argument(
+        "Unknown language: " + std::string(language) +
+        " (expected one of: " + accepted_scip_decoder_languages_help() + ")");
+  }
+
+  if (*canonical == "python")
+    return std::make_unique<SCIPPythonDecoder>(index_file,
+                                               std::move(project_root));
+  if (*canonical == "go")
+    return std::make_unique<SCIPGoDecoder>(index_file, std::move(project_root));
+  if (*canonical == "rust")
+    return std::make_unique<SCIPRustDecoder>(index_file,
+                                             std::move(project_root));
+  if (*canonical == "ruby")
+    return std::make_unique<SCIPRubyDecoder>(index_file,
+                                             std::move(project_root));
+  if (*canonical == "typescript")
+    return std::make_unique<SCIPTSDecoder>(index_file, std::move(project_root));
+
+  throw std::logic_error("Unhandled canonical SCIP decoder language: " +
+                         *canonical);
+}
+
+} // namespace codeminer::core

--- a/core/scip_decoder_registry.h
+++ b/core/scip_decoder_registry.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "scip_decode_base.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace codeminer::core {
+
+std::vector<std::string> canonical_scip_decoder_languages();
+std::vector<std::string> accepted_scip_decoder_languages();
+std::string accepted_scip_decoder_languages_help();
+
+std::optional<std::string>
+canonical_scip_decoder_language(std::string_view language);
+bool is_scip_decoder_language_supported(std::string_view language);
+
+std::unique_ptr<SCIPDecoderBase>
+make_scip_decoder(std::string_view language, const std::string &index_file,
+                  std::optional<std::string> project_root = std::nullopt);
+
+} // namespace codeminer::core

--- a/core/tests/scip_decode_repo.cpp
+++ b/core/tests/scip_decode_repo.cpp
@@ -7,18 +7,11 @@
 #include <array>
 #include <filesystem>
 #include <iostream>
-#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 
 using codeminer::core::CodeGraph;
-using codeminer::core::SCIPDecoderBase;
-using codeminer::core::SCIPGoDecoder;
-using codeminer::core::SCIPPythonDecoder;
-using codeminer::core::SCIPRubyDecoder;
-using codeminer::core::SCIPRustDecoder;
-using codeminer::core::SCIPTSDecoder;
 namespace fs = std::filesystem;
 
 namespace {
@@ -41,8 +34,9 @@ void print_usage(std::string_view prog_name) {
       << "  index.decoded  - Path to decoded SCIP index file\n"
       << "  project_root   - Project root directory (or 'null' for none)\n"
       << "  output.json    - Output JSON file path\n"
-      << "  language       - One of: python (default), go, rust, ruby, "
-         "typescript\n";
+      << "  language       - One of: "
+      << codeminer::core::accepted_scip_decoder_languages_help()
+      << " (default: python)\n";
 }
 
 bool path_exists(const fs::path &path, std::string_view description) {
@@ -83,37 +77,16 @@ std::optional<ProgramOptions> parse_arguments(int argc, char **argv) {
       return std::nullopt;
   }
 
-  const auto &lang = options.language;
-  if (lang != "python" && lang != "go" && lang != "rust" && lang != "ruby" &&
-      lang != "rb" && lang != "typescript" && lang != "ts" && lang != "js") {
-    std::cerr << "Error: unknown language '" << lang << "'\n";
+  auto canonical =
+      codeminer::core::canonical_scip_decoder_language(options.language);
+  if (!canonical) {
+    std::cerr << "Error: unknown language '" << options.language << "'\n";
     print_usage(argv[0]);
     return std::nullopt;
   }
-  if (lang == "ts" || lang == "js")
-    options.language = "typescript";
+  options.language = *canonical;
 
   return options;
-}
-
-std::unique_ptr<SCIPDecoderBase>
-make_decoder(const std::string &lang, const std::string &index,
-             const std::optional<fs::path> &root) {
-  std::optional<std::string> root_str;
-  if (root.has_value())
-    root_str = root->string();
-
-  if (lang == "python")
-    return std::make_unique<SCIPPythonDecoder>(index, root_str);
-  if (lang == "go")
-    return std::make_unique<SCIPGoDecoder>(index, root_str);
-  if (lang == "rust")
-    return std::make_unique<SCIPRustDecoder>(index, root_str);
-  if (lang == "ruby" || lang == "rb")
-    return std::make_unique<SCIPRubyDecoder>(index, root_str);
-  if (lang == "typescript")
-    return std::make_unique<SCIPTSDecoder>(index, root_str);
-  return nullptr;
 }
 
 } // namespace
@@ -134,10 +107,11 @@ int main(int argc, char **argv) {
             << "Output file:  " << options->output << "\n\n";
 
   try {
-    auto decoder = make_decoder(options->language, options->index.string(),
-                                options->project_root);
-    if (!decoder)
-      throw std::runtime_error("unknown language: " + options->language);
+    std::optional<std::string> root_str;
+    if (options->project_root.has_value())
+      root_str = options->project_root->string();
+    auto decoder = codeminer::core::make_scip_decoder(
+        options->language, options->index.string(), root_str);
 
     std::cout << "Decoding SCIP index...\n";
     CodeGraph graph = decoder->decode();

--- a/core/tests/scip_decode_test.cpp
+++ b/core/tests/scip_decode_test.cpp
@@ -9,8 +9,10 @@
 #include <filesystem>
 #include <fstream>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <system_error>
+#include <vector>
 
 using codeminer::core::CodeGraph;
 using codeminer::core::NODE_TYPE_CLASS;
@@ -127,9 +129,40 @@ write_test_index(const std::filesystem::path &project_root) {
   return index_path;
 }
 
+void assert_decoder_registry() {
+  auto rb = codeminer::core::canonical_scip_decoder_language("rb");
+  assert(rb.has_value());
+  assert(*rb == "ruby");
+
+  auto js = codeminer::core::canonical_scip_decoder_language("js");
+  assert(js.has_value());
+  assert(*js == "typescript");
+
+  assert(codeminer::core::is_scip_decoder_language_supported("python"));
+  assert(!codeminer::core::is_scip_decoder_language_supported("java"));
+
+  const std::vector<std::string> accepted =
+      codeminer::core::accepted_scip_decoder_languages();
+  assert(accepted.size() == 8);
+  assert(accepted.front() == "python");
+  assert(accepted.back() == "js");
+
+  try {
+    (void)codeminer::core::make_scip_decoder("java", "index.decoded",
+                                             std::nullopt);
+    assert(false && "unknown languages must throw");
+  } catch (const std::invalid_argument &error) {
+    const std::string message = error.what();
+    assert(message.find("python") != std::string::npos);
+    assert(message.find("typescript") != std::string::npos);
+  }
+}
+
 } // namespace
 
 int main(int argc, char **argv) {
+  assert_decoder_registry();
+
   if (argc > 1) {
     std::filesystem::path external_index = argv[1];
     assert(std::filesystem::exists(external_index));

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -19,8 +19,10 @@ files.
 - `graph_layers.h` / `graph_layers.cpp` — language-agnostic default layer
   classification for CodeGraph edge types. This is shared by SCIP, clangd, and
   generic-LSP graphs after they have normalized into the common schema.
-- `scip_decode.h` / `scip_decode.cpp` — translates a `.decoded` SCIP index into the C++
-  `CodeGraph`.
+- `scip_decode.h`, `scip_decoder_registry.{h,cpp}`, and the
+  language-specific `scip_decode_*.{h,cpp}` files — translate `.decoded` SCIP
+  indexes into the C++ `CodeGraph` and keep decoder aliases/factory wiring out
+  of bindings and smoke-test CLIs.
 - `bindings/pybind_module.cpp` — exposes `decode_scip(...)` and the optional
   `classify_edge_layers(...)` binding. The binding delegates to the core
   `graph_layers` module; it should not own graph algorithms.
@@ -41,9 +43,9 @@ make core-test                # C++ smoke + Python/core parity checks
 
 The resulting static library and pybind module are placed in `build/core`.
 `make core-test` currently validates the C++ executable smoke tests,
-`graph_layers`, registry-driven core language metadata, and serial/core parity
-for the active accelerated SCIP backends: Python, Go, Rust, Ruby, TypeScript,
-and the JavaScript/TypeScript aliases.
+`graph_layers`, registry-driven Python and C++ core language metadata, and
+serial/core parity for the active accelerated SCIP backends: Python, Go, Rust,
+Ruby, TypeScript, and the JavaScript/TypeScript aliases.
 
 Ruby has a dedicated C++ decoder because real `ruby/rake` profiling showed the
 serial local decode path was the bottleneck after `scip-ruby` produced a large

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -46,6 +46,8 @@ The resulting static library and pybind module are placed in `build/core`.
 `graph_layers`, registry-driven Python and C++ core language metadata, and
 serial/core parity for the active accelerated SCIP backends: Python, Go, Rust,
 Ruby, TypeScript, and the JavaScript/TypeScript aliases.
+The pybind module also exposes the C++ decoder registry so tests can compare it
+directly with `codeminer.languages.core_decoder_languages(...)`.
 
 Ruby has a dedicated C++ decoder because real `ruby/rake` profiling showed the
 serial local decode path was the bottleneck after `scip-ruby` produced a large

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -565,6 +565,9 @@ containment `ref=8 cand=8 missing=0 extra=0`, and references `ref=1 cand=0`.
   compatible.
 - [x] Keep C++ files small and purpose-specific: parser/decoder logic,
   graph-layer helpers, pybind exposure, and tests should remain separated.
+- [x] Keep C++ decoder registration and language aliases centralized so pybind
+  bindings, smoke CLIs, and future language decoders do not duplicate dispatch
+  logic.
 - [x] Record speedup and parity in `docs/core_cpp.md` or an experiment doc.
 
 Exit condition: acceleration claims are backed by parity tests and profile

--- a/test/scip/test_scip_core_registry.py
+++ b/test/scip/test_scip_core_registry.py
@@ -31,6 +31,18 @@ def test_core_decoder_supported_languages_come_from_registry():
     )
 
 
+def test_cpp_core_decoder_registry_matches_python_registry():
+    if scip_decode_core._cpp is None:
+        pytest.skip("codeminer_core pybind module not built")
+
+    assert tuple(
+        scip_decode_core._cpp.canonical_scip_decoder_languages()
+    ) == core_decoder_languages(include_aliases=False)
+    assert tuple(
+        scip_decode_core._cpp.accepted_scip_decoder_languages()
+    ) == core_decoder_languages(include_aliases=True)
+
+
 def test_core_decoder_rejects_non_registry_language_before_availability_check(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
Centralize C++ SCIP decoder language registration so pybind bindings and the repository smoke CLI share the same canonical language and alias rules.

This follows the merged multi-language SCIP cold-start work from #249 and is intended as a small core hygiene step before any future C++ decoder promotion.

## Changes
- Add `core/scip_decoder_registry.{h,cpp}` with canonical language lookup, accepted aliases, help text, and decoder factory construction.
- Route `codeminer_core.decode_scip(...)` and `scip_decode_repo` through the shared registry instead of duplicating language dispatch.
- Expose the C++ decoder registry through pybind so Python tests can compare it directly with `codeminer.languages.core_decoder_languages(...)`.
- Add C++ smoke coverage for registry aliases and unknown-language errors.
- Update core docs and the multi-language roadmap to record the centralized core decoder registration layer.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `make core-build`
- `make core-test`
- `make core-test` after rebasing onto merged `origin/main` (`8 passed`)
- `make multilang-registry-check` after rebasing onto merged `origin/main` (`71 passed`)
- `python scripts/language_capability_matrix.py --check docs/language_capabilities.md` after rebasing onto merged `origin/main`
- `git diff --check origin/main..HEAD` after rebasing onto merged `origin/main`
- `PYTHONPATH="build/core:$PYTHONPATH" python -m pytest -q test/test_languages.py test/scip/test_scip_core_registry.py` (`16 passed`)
- `python -m mkdocs build --strict`
- `python -m pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1280 passed, 11 skipped, 161 deselected` on the restacked #253 branch)
- `git diff --check`
- `pre-commit run --files core/scip_decoder_registry.h core/scip_decoder_registry.cpp core/scip_decode.h core/CMakeLists.txt core/bindings/pybind_module.cpp core/tests/scip_decode_repo.cpp core/tests/scip_decode_test.cpp core/README.md docs/core_cpp.md docs/scip_multilanguage_roadmap.md`
- `pre-commit run --files core/bindings/pybind_module.cpp test/scip/test_scip_core_registry.py docs/core_cpp.md`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Dependency note: #249 has landed; this PR is now based directly on `main`.


