### PR TITLE
refactor(scip): share decoder normalization helpers

### DIFF
--- a/codeminer/scip_interface/scip_decode_java.py
+++ b/codeminer/scip_interface/scip_decode_java.py
@@ -27,6 +27,11 @@ from ..types import (
     NODE_TYPE_SYMBOL,
     ROOT_NODE,
 )
+from .scip_decode_utils import (
+    format_unified_name,
+    normalize_scip_descriptor,
+    scip_symbol_descriptor,
+)
 from .scip_indexer_base import extract_scip_blocks, extract_symbol
 
 
@@ -290,10 +295,10 @@ class SCIPJavaGraphDecoder:
         if info.key not in self.code_graph.name_to_vertex:
             return
         vid = self.code_graph.name_to_vertex[info.key]
-        self.code_graph.graph.vs[vid]["unified_name"] = (
-            f"{info.file_path}:{info.display_name}"
-            if info.file_path and info.display_name
-            else info.display_name or info.key
+        self.code_graph.graph.vs[vid]["unified_name"] = format_unified_name(
+            info.file_path,
+            info.display_name,
+            info.key,
         )
 
     def _fallback_symbol_info(
@@ -314,20 +319,15 @@ class SCIPJavaGraphDecoder:
     def _make_symbol_key(self, symbol: str | None) -> str | None:
         if not symbol or symbol.startswith("local "):
             return None
-        parts = symbol.split(" ")
-        if len(parts) < 5 or parts[0] not in self._SCIP_SYMBOL_PREFIXES:
+        descriptor = scip_symbol_descriptor(symbol, self._SCIP_SYMBOL_PREFIXES)
+        if not descriptor:
             return None
-        descriptor = parts[-1].replace("`", "")
         if descriptor.endswith("/"):
             namespace = descriptor[:-1]
             return namespace if self._KEEP_NAMESPACE_SYMBOLS and namespace else None
         if "/" not in descriptor:
             return None
-        descriptor = descriptor.rstrip(".")
-        if descriptor.endswith("()"):
-            descriptor = descriptor[:-2]
-        if descriptor.endswith("#"):
-            descriptor = descriptor[:-1]
+        descriptor = normalize_scip_descriptor(descriptor)
         if not descriptor:
             return None
         return descriptor
@@ -596,12 +596,7 @@ class SCIPKotlinGraphDecoder(SCIPJavaGraphDecoder):
         return "#".join(parts) or None
 
     def _symbol_descriptor(self, symbol: str | None) -> str:
-        if not symbol:
-            return ""
-        parts = symbol.split(" ")
-        if len(parts) < 5 or parts[0] not in self._SCIP_SYMBOL_PREFIXES:
-            return ""
-        return parts[-1].replace("`", "")
+        return scip_symbol_descriptor(symbol, self._SCIP_SYMBOL_PREFIXES)
 
     def _is_kotlin_non_graph_descriptor(self, descriptor: str) -> bool:
         normalized = descriptor.rstrip(".")

--- a/codeminer/scip_interface/scip_decode_php.py
+++ b/codeminer/scip_interface/scip_decode_php.py
@@ -16,6 +16,7 @@ from tree_sitter_language_pack import get_language
 
 from ..types import EDGE_TYPE_CONTAIN, NODE_TYPE_CLASS, NODE_TYPE_FUNCTION
 from .scip_decode_java import SCIPJavaGraphDecoder, _SymbolInfo
+from .scip_decode_utils import format_unified_name
 from .scip_indexer_base import extract_scip_blocks
 
 
@@ -68,9 +69,11 @@ class SCIPPHPGraphDecoder(SCIPJavaGraphDecoder):
         )
         vid = self.code_graph.name_to_vertex[namespace_key]
         namespace_display = namespace.replace("/", "\\")
-        self.code_graph.graph.vs[vid][
-            "unified_name"
-        ] = f"{info.file_path}:{namespace_display}"
+        self.code_graph.graph.vs[vid]["unified_name"] = format_unified_name(
+            info.file_path,
+            namespace_display,
+            namespace_key,
+        )
         self.code_graph._add_edge(info.file_path, namespace_key, EDGE_TYPE_CONTAIN)
 
     def _namespace_key(self, file_path: str, namespace: str) -> str:

--- a/codeminer/scip_interface/scip_decode_ruby.py
+++ b/codeminer/scip_interface/scip_decode_ruby.py
@@ -18,6 +18,11 @@ from ..types import (
     NODE_TYPE_METHOD,
 )
 from .scip_decode_java import SCIPJavaGraphDecoder
+from .scip_decode_utils import (
+    format_unified_name,
+    normalize_scip_descriptor,
+    scip_symbol_descriptor,
+)
 from .scip_indexer_base import extract_symbol
 
 
@@ -136,18 +141,22 @@ class SCIPRubyGraphDecoder(SCIPJavaGraphDecoder):
         return None
 
     def _make_symbol_key(self, symbol: str | None) -> str | None:
-        if not symbol or symbol.startswith("local "):
+        if symbol and symbol.startswith("local "):
             return None
-        parts = symbol.split(" ")
-        if len(parts) < 5 or parts[0] not in self._SCIP_SYMBOL_PREFIXES:
+        descriptor = scip_symbol_descriptor(symbol, self._SCIP_SYMBOL_PREFIXES)
+        if not descriptor:
             return None
 
-        descriptor = parts[-1].replace("`", "").rstrip(".")
+        descriptor = normalize_scip_descriptor(
+            descriptor,
+            strip_empty_call=False,
+            strip_trailing_hash=False,
+        )
         descriptor = _normalize_singleton_class_descriptor(descriptor)
-        if descriptor.endswith("()"):
-            descriptor = descriptor[:-2]
-        if descriptor.endswith("#"):
-            descriptor = descriptor[:-1]
+        descriptor = normalize_scip_descriptor(
+            descriptor,
+            strip_trailing_dot=False,
+        )
         return descriptor or None
 
     def _set_unified_name(self, info) -> None:
@@ -394,10 +403,10 @@ class SCIPRubyGraphDecoder(SCIPJavaGraphDecoder):
             return
         vid = self.code_graph.name_to_vertex[graph_key]
         display_name = display_name or info.display_name
-        self.code_graph.graph.vs[vid]["unified_name"] = (
-            f"{file_path}:{display_name}"
-            if file_path and display_name
-            else display_name or info.key
+        self.code_graph.graph.vs[vid]["unified_name"] = format_unified_name(
+            file_path,
+            display_name,
+            info.key,
         )
 
     def _containment_parent_in_file(self, key: str, file_path: str) -> str:

--- a/codeminer/scip_interface/scip_decode_utils.py
+++ b/codeminer/scip_interface/scip_decode_utils.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared normalization helpers for SCIP TextFormat decoders."""
+
+from __future__ import annotations
+
+from collections.abc import Container
+
+
+def scip_symbol_descriptor(
+    symbol: str | None,
+    accepted_prefixes: Container[str],
+) -> str:
+    """Return the raw SCIP descriptor when the symbol belongs to a known tool."""
+    if not symbol:
+        return ""
+    parts = symbol.split(" ")
+    if len(parts) < 5 or parts[0] not in accepted_prefixes:
+        return ""
+    return parts[-1].replace("`", "")
+
+
+def normalize_scip_descriptor(
+    descriptor: str,
+    *,
+    strip_trailing_dot: bool = True,
+    strip_empty_call: bool = True,
+    strip_trailing_hash: bool = True,
+) -> str:
+    """Normalize descriptor suffixes shared by SCIP text decoders."""
+    if strip_trailing_dot:
+        descriptor = descriptor.rstrip(".")
+    if strip_empty_call and descriptor.endswith("()"):
+        descriptor = descriptor[:-2]
+    if strip_trailing_hash and descriptor.endswith("#"):
+        descriptor = descriptor[:-1]
+    return descriptor
+
+
+def format_unified_name(
+    file_path: str,
+    display_name: str,
+    fallback: str,
+) -> str:
+    """Format the CodeMiner unified_name attribute consistently."""
+    if file_path and display_name:
+        return f"{file_path}:{display_name}"
+    return display_name or fallback

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -561,7 +561,7 @@ containment `ref=8 cand=8 missing=0 extra=0`, and references `ref=1 cand=0`.
 
 - [x] Keep existing Python/Go/Rust/Ruby/JS/TS SCIP C++ parity tests green.
 - [x] Profile each newly promoted route before adding C++ decoder code.
-- [ ] Prefer shared normalization helpers when symbol shapes are language-family
+- [x] Prefer shared normalization helpers when symbol shapes are language-family
   compatible.
 - [x] Keep C++ files small and purpose-specific: parser/decoder logic,
   graph-layer helpers, pybind exposure, and tests should remain separated.
@@ -598,6 +598,12 @@ end-to-end Kotlin cold-start graph time, so Kotlin does not cross the 20% C++
 acceleration gate yet. Kotlin, PHP, and Scala should get C++ acceleration only
 after larger real-repo profiles show local decode/build is a material
 bottleneck.
+
+Python SCIP decoders now share descriptor extraction, descriptor suffix
+normalization, and `unified_name` formatting helpers in
+`codeminer.scip_interface.scip_decode_utils` where symbol shapes are compatible.
+Language-specific handling, such as Ruby singleton-class descriptors and Kotlin
+synthetic symbol filters, stays in the owning decoder.
 
 ### Phase 6: Multi-Graph Python Surface
 

--- a/test/scip/test_scip_decode_utils.py
+++ b/test/scip/test_scip_decode_utils.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit coverage for shared SCIP decoder normalization helpers."""
+
+from codeminer.scip_interface.scip_decode_utils import (
+    format_unified_name,
+    normalize_scip_descriptor,
+    scip_symbol_descriptor,
+)
+
+
+def test_scip_symbol_descriptor_filters_unknown_tools():
+    symbol = "semanticdb maven app app 1.0 app/Foo#run()."
+
+    assert scip_symbol_descriptor(symbol, {"semanticdb"}) == "app/Foo#run()."
+    assert scip_symbol_descriptor(symbol, {"scip-ruby"}) == ""
+    assert scip_symbol_descriptor("local 0", {"semanticdb"}) == ""
+    assert scip_symbol_descriptor(None, {"semanticdb"}) == ""
+
+
+def test_normalize_scip_descriptor_strips_common_suffixes():
+    assert normalize_scip_descriptor("app/Foo#run().") == "app/Foo#run"
+    assert normalize_scip_descriptor("app/Foo#") == "app/Foo"
+    assert (
+        normalize_scip_descriptor(
+            "app/Foo#run().",
+            strip_empty_call=False,
+            strip_trailing_hash=False,
+        )
+        == "app/Foo#run()"
+    )
+
+
+def test_format_unified_name_uses_display_when_possible():
+    assert format_unified_name("src/Foo.java", "Foo.run()", "app/Foo#run") == (
+        "src/Foo.java:Foo.run()"
+    )
+    assert format_unified_name("", "Foo", "app/Foo") == "Foo"
+    assert format_unified_name("", "", "app/Foo") == "app/Foo"


### PR DESCRIPTION
## Summary

Share SCIP decoder normalization helpers for descriptor extraction, descriptor suffix cleanup, and `unified_name` formatting where Java/JVM, Ruby, and PHP symbol shapes are compatible.

## Changes

- Add `codeminer.scip_interface.scip_decode_utils` with shared descriptor and unified-name helpers.
- Route Java/JVM, Kotlin descriptor reads, Ruby descriptor cleanup, and PHP namespace unified names through the shared helpers while keeping language-specific normalization local.
- Add unit coverage for the shared helper behavior.
- Mark the roadmap Phase 5 shared-normalization item complete with the explicit boundary for language-specific logic.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `python -m pytest -q test/scip/test_scip_decode_utils.py test/scip/test_scip_java.py test/scip/test_scip_csharp.py test/scip/test_scip_php.py test/scip/test_scip_ruby.py` (`45 passed`)
- [x] `make multilang-registry-check` (`71 passed`)
- [x] `python scripts/language_capability_matrix.py --check docs/language_capabilities.md`
- [x] `pre-commit run --files codeminer/scip_interface/scip_decode_utils.py codeminer/scip_interface/scip_decode_java.py codeminer/scip_interface/scip_decode_ruby.py codeminer/scip_interface/scip_decode_php.py test/scip/test_scip_decode_utils.py docs/scip_multilanguage_roadmap.md`
- [x] `python -m mkdocs build --strict`
- [x] `git diff --check`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
