### PR TITLE
[codex] refresh SCIP roadmap issue triage

### DIFF
--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -670,17 +670,13 @@ Issue triage rules:
 
 Current issue triage notes from June 20, 2026:
 
-- PR #248 is not ready to merge. It is non-draft and mergeable, but the latest
-  `unit` check failed because the self-hosted runner's login profile activated a
-  global Anaconda Python where `tree_sitter_language_pack` could not load the
-  `python` grammar. The local fix sets `remove-profiles: true` for the unit job
-  and shared setup action; merge only after the PR or its base includes that CI
-  environment fix and the unit check is rerun green.
-- #198 is not ready to close. One concrete blocker is fixed locally: BM25 and
-  graph retrieve pipelines now build graphs through `LSIndexer` instead of
-  instantiating abstract SCIP base classes, and regression tests cover language
-  routing. The broader baseline-evaluation issue still has remaining acceptance
-  criteria.
+- PR #248 remains open and is outside this SCIP roadmap. It is an
+  agent-compile/Qwen backend PR with green CodeQL checks; its `unit` job is
+  still queued on the offline self-hosted runner, so it should be evaluated as
+  agent-compile work rather than merged as part of this roadmap.
+- #198 is closed. It no longer has open roadmap action for the multi-language
+  SCIP cold-start and acceleration program.
+- #252 is a Repository Guardian RFC and remains open.
 - #199 is an enterprise index-storage RFC and remains open.
 - #133 is an agent-compile RFC and remains open because the query-time
   skill-selection mechanism is still tracked as follow-up work.


### PR DESCRIPTION
## Summary
Refresh the SCIP multi-language roadmap issue triage notes so they match the current GitHub state after the latest merge batch.

## Changes
- Mark PR #248 as out of scope for the SCIP roadmap and note its self-hosted unit queue state.
- Record #198 as closed with no remaining SCIP roadmap action.
- Add #252 to the current open RFC list.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

- `python -m mkdocs build --strict`
- `pre-commit run --files docs/scip_multilanguage_roadmap.md`
- `git diff --check HEAD`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
