### PR TITLE
[codex] clarify historical Kotlin roadmap gate

### DIFF
--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -249,7 +249,7 @@ real modeling differences: symbols `ref=849 cand=1638 missing=146 extra=935`,
 containment `ref=849 cand=1708 missing=146 extra=1005`, references
 `ref=0 cand=7499`. The remaining gap is dominated by Kotlin object/companion
 property modeling, generated getter/property symbols, and symbol display
-normalization; Kotlin therefore remains `candidate`.
+normalization; Kotlin therefore remained `candidate` at this intermediate gate.
 
 A Kotlin-specific decoder follow-up now removes the largest non-source
 definition noise from that same target-dir gate: parameter descriptors including


### PR DESCRIPTION
## Summary
Clarify an intermediate Kotlin roadmap note so it does not contradict the current active Kotlin SCIP status.

## Changes
- Change the historical Kotlin route-alignment note from present tense to past tense.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

- `python -m mkdocs build --strict`
- `pre-commit run --files docs/scip_multilanguage_roadmap.md`
- `git diff --check HEAD`
- `rg -n 'remains candidate|\[ \]' docs/scip_multilanguage_roadmap.md || true`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
