### PR TITLE
docs(make): refresh scip cold-start env copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ scip-candidates-all: scip-cold-start-tools-all
 
 scip-cold-start-env:
 	@echo "SCIP cold-start tools installed under: $(CODEMINER_SCIP_TOOLS_DIR)"
-	@echo "Use this environment for active Java/C#/Scala/PHP and candidate Kotlin/Ruby smoke runs:"
+	@echo "Use this environment for active Java/Kotlin/Scala/C#/Ruby/PHP smoke runs:"
 	@echo "  export CODEMINER_SCIP_TOOLS_DIR=$(CODEMINER_SCIP_TOOLS_DIR)"
 	@echo "  export DOTNET_ROOT=$(CODEMINER_SCIP_TOOLS_DIR)/dotnet"
 	@echo "  export GEM_HOME=$(CODEMINER_SCIP_TOOLS_DIR)/gems"


### PR DESCRIPTION
## Summary
Refresh the SCIP cold-start environment hint so it matches the now-active Java/Kotlin/Scala/C#/Ruby/PHP smoke route set.

## Changes
- Update `make scip-cold-start-env` output to stop describing Kotlin and Ruby as candidate-only smoke routes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Ran:
- `make scip-cold-start-env`
- `pre-commit run --files Makefile`
- `git diff --check HEAD`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published