### PR TITLE
[codex] feat(retrieval): add query-aware planner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     branches:
       - "*"
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -33,6 +34,14 @@ on:
         required: false
         default: false
         type: boolean
+      test_tier:
+        description: "Test tier to run"
+        required: false
+        default: "full"
+        type: choice
+        options:
+          - light
+          - full
 
 permissions:
   contents: read
@@ -62,6 +71,7 @@ jobs:
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       run-serial: ${{ steps.serial.outputs.run-serial }}
+      serial-reason: ${{ steps.serial.outputs.serial-reason }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -90,42 +100,74 @@ jobs:
             echo "should-run=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Detect whether any changed file lies OUTSIDE the "light" set (docs,
-      # scripts, examples). Expressed as a catch-all '**' plus '!light'
-      # negations under predicate-quantifier 'every': a file matches `heavy`
-      # only if it matches '**' AND none of the negations exclude it — i.e. it
-      # is outside the light set. Output `heavy` is true iff >=1 heavy file.
-      - name: Detect heavy (serial-chain) source changes
+      # Detect changes that can affect the expensive serial-chain jobs:
+      # repo mutation, SCIP/LSP indexing, graph patching, dataset location, or
+      # C++ decoder parity. Agent/runtime/model/retrieval changes use the
+      # faster unit + integration tier unless a maintainer requests full CI.
+      - name: Detect serial-chain source changes
         id: filter
         uses: dorny/paths-filter@v3
         with:
           base: ${{ github.event_name == 'push' && github.ref || '' }}
-          predicate-quantifier: "every"
           filters: |
-            heavy:
-              - "**"
-              - "!scripts/**"
-              - "!examples/**"
-              - "!docs/**"
-              - "!**/*.md"
-              - "!LICENSE"
-              - "!.gitignore"
+            serial:
+              - ".github/workflows/ci.yml"
+              - ".github/actions/setup-env/**"
+              - "pyproject.toml"
+              - "third_party/**"
+              - "core/**"
+              - "codeminer/code_chunking/**"
+              - "codeminer/dataset/**"
+              - "codeminer/eval/**"
+              - "codeminer/graph/**"
+              - "codeminer/index/**"
+              - "codeminer/ls_index/**"
+              - "codeminer/ls_router.py"
+              - "codeminer/types.py"
+              - "scripts/check_graph_route_alignment.py"
+              - "scripts/smoke_lsp_graph.py"
+              - "scripts/smoke_scip_cold_start.py"
+              - "scripts/swebench_graph_index.py"
+              - "scripts/agent_compile/lib/prebuilt.py"
+              - "test/chunker/**"
+              - "test/dataset/**"
+              - "test/graph/**"
+              - "test/index/**"
+              - "test/ls_index/**"
+              - "test/scip/**"
 
       - name: Compute run-serial
         id: serial
         run: |
-          # Fail closed: run the serial chain unless we are sure it isn't needed.
-          RUN_SERIAL=true
+          RUN_SERIAL=false
+          REASON="not requested and no serial-chain paths changed"
           case "${{ github.event_name }}" in
-            schedule|workflow_dispatch)
-              RUN_SERIAL=true ;;          # forced full run
-            push|pull_request)
-              # Only skip when the filter ran cleanly and found no heavy files.
-              if [[ "${{ steps.filter.outputs.heavy }}" == "false" ]]; then
-                RUN_SERIAL=false
+            schedule)
+              RUN_SERIAL=true
+              REASON="scheduled full run" ;;
+            workflow_dispatch)
+              if [[ "${{ github.event.inputs.test_tier }}" == "full" ]]; then
+                RUN_SERIAL=true
+                REASON="manual full tier"
+              else
+                REASON="manual light tier"
+              fi ;;
+            push)
+              RUN_SERIAL=true
+              REASON="main/master push" ;;
+            pull_request)
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}" == "true" ]] || \
+                 [[ "${{ contains(github.event.pull_request.labels.*.name, 'serial-ci') }}" == "true" ]]; then
+                RUN_SERIAL=true
+                REASON="PR label requested serial/full CI"
+              elif [[ "${{ steps.filter.outputs.serial }}" == "true" ]]; then
+                RUN_SERIAL=true
+                REASON="serial-chain path changed"
               fi ;;
           esac
           echo "run-serial=$RUN_SERIAL" >> "$GITHUB_OUTPUT"
+          echo "serial-reason=$REASON" >> "$GITHUB_OUTPUT"
+          echo "run-serial=$RUN_SERIAL ($REASON)"
 
   # =============================================================
   # Job 1 — Unit tests  (pure logic, mocks only, ~1 min)
@@ -163,7 +205,7 @@ jobs:
 
       - name: Run unit tests
         shell: bash -l {0}
-        run: pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short
+        run: pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short --timeout=180 --durations=20
 
   # =============================================================
   # Job 2 — Integration tests  (read-only, parallel-safe, ~2 min)
@@ -236,6 +278,16 @@ jobs:
             touch "$MARKER"
           fi
 
+      - name: Inspect codeminer cache
+        run: |
+          CACHE_DIR="${{ github.workspace }}/../.cache/codeminer"
+          echo "[cache] dir=$CACHE_DIR"
+          du -sh "$CACHE_DIR" 2>/dev/null || true
+          echo "[cache] graph.pkl count=$(find "$CACHE_DIR" -name graph.pkl 2>/dev/null | wc -l)"
+          echo "[cache] index.scip count=$(find "$CACHE_DIR" -name index.scip 2>/dev/null | wc -l)"
+          echo "[cache] index.decoded count=$(find "$CACHE_DIR" -name index.decoded 2>/dev/null | wc -l)"
+          find "$CACHE_DIR" -maxdepth 2 -mindepth 1 -type d 2>/dev/null | head -40 || true
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -256,7 +308,7 @@ jobs:
         # (e.g. scip-python indexing of sympy, observed hanging ~27 min) fast
         # instead of letting it run out the 45-min job cap and hog the single
         # self-hosted runner. Default (signal) method fails just the hung test.
-        run: pytest -m "integration_serial" -v --tb=short --timeout=900
+        run: pytest -m "integration_serial" -x -v --tb=short --timeout=900 --durations=20
 
   # =============================================================
   # Job 3b — SCIP core  (builds core/ pybind + parity-checks the C++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Run integration tests (parallel)
         shell: bash -l {0}
-        run: pytest -n auto -m "integration" --tb=short
+        run: pytest -n 4 -m "integration" --tb=short --timeout=600 --durations=20
 
   # =============================================================
   # Job 3 — Integration serial  (mutates repos, ~25 min)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,12 @@ jobs:
           base: ${{ github.event_name == 'push' && github.ref || '' }}
           filters: |
             serial:
-              - ".github/workflows/ci.yml"
               - ".github/actions/setup-env/**"
               - "pyproject.toml"
               - "third_party/**"
               - "core/**"
               - "codeminer/code_chunking/**"
               - "codeminer/dataset/**"
-              - "codeminer/eval/**"
               - "codeminer/graph/**"
               - "codeminer/index/**"
               - "codeminer/ls_index/**"
@@ -128,7 +126,6 @@ jobs:
               - "scripts/smoke_lsp_graph.py"
               - "scripts/smoke_scip_cold_start.py"
               - "scripts/swebench_graph_index.py"
-              - "scripts/agent_compile/lib/prebuilt.py"
               - "test/chunker/**"
               - "test/dataset/**"
               - "test/graph/**"

--- a/codeminer/eval/retrieval_eval.py
+++ b/codeminer/eval/retrieval_eval.py
@@ -413,8 +413,10 @@ def dedup_spans(spans: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return kept
 
 
-def nodes_to_spans(nodes: Sequence[QueriedNode]) -> List[Dict[str, Any]]:
-    """Spans from retrieval nodes, ranked by score desc.
+def nodes_to_spans(
+    nodes: Sequence[QueriedNode], *, sort_by_score: bool = True
+) -> List[Dict[str, Any]]:
+    """Spans from retrieval nodes.
 
     Two empirically-verified quirks of retrieval ``QueriedNode``s drive this:
       * ``node.file`` is the absolute *build-time* path baked into the index
@@ -440,7 +442,8 @@ def nodes_to_spans(nodes: Sequence[QueriedNode]) -> List[Dict[str, Any]]:
         )
         if sp:
             out.append(sp)
-    out.sort(key=lambda s: s["score"], reverse=True)
+    if sort_by_score:
+        out.sort(key=lambda s: s["score"], reverse=True)
     return out
 
 

--- a/codeminer/model/__init__.py
+++ b/codeminer/model/__init__.py
@@ -6,9 +6,22 @@
 
 from .agentless_pipeline import AgentlessPipeline
 from .bm25_retrieve_pipeline import BM25RetrievePipeline
+from .dense_graph_expand_rerank_pipeline import DenseGraphExpandRerankPipeline
 from .embedding_retrieve_pipeline import EmbeddingRetrievePipeline
-from .graph_retrieve_pipeline import GraphRetrievePipeline
+from .graph_augmented_rerank_pipeline import GraphAugmentedRerankPipeline
+from .graph_retrieve_pipeline import (
+    GraphRetrievePipeline,
+    SparseSeededGraphRetrievePipeline,
+)
 from .hybrid_retrieve_pipeline import HybridRetrievePipeline
+from .retrieval_planner import (
+    GraphExpansionPlan,
+    RetrievalBudget,
+    RetrievalCapabilities,
+    RetrievalPathPlan,
+    RetrievalPlanner,
+    RetrievalStagePlan,
+)
 from .retrieve_rerank_pipeline import (
     RetrieveRerankPipeline,
     RetrieveStageConfig,
@@ -18,10 +31,19 @@ from .retrieve_rerank_pipeline import (
 __all__ = [
     "AgentlessPipeline",
     "BM25RetrievePipeline",
+    "DenseGraphExpandRerankPipeline",
     "EmbeddingRetrievePipeline",
+    "GraphAugmentedRerankPipeline",
     "GraphRetrievePipeline",
     "HybridRetrievePipeline",
     "RetrieveRerankPipeline",
+    "RetrievalBudget",
+    "RetrievalCapabilities",
+    "RetrievalPathPlan",
+    "RetrievalPlanner",
+    "RetrievalStagePlan",
     "RetrieveStageConfig",
+    "GraphExpansionPlan",
+    "SparseSeededGraphRetrievePipeline",
     "build_retrieve_plan",
 ]

--- a/codeminer/model/dense_graph_expand_rerank_pipeline.py
+++ b/codeminer/model/dense_graph_expand_rerank_pipeline.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from typing import Any, Dict, List, Optional, Sequence
+
+from ..graph.code_graph import CodeGraph
+from ..ops.expand import ExpandContext, expand_graph_neighbors
+from ..ops.filter import CandidatePredicate, filter_queried_nodes
+from ..ops.rerank import RerankContext, rerank_by_embedding
+from ..ops.retrieve import dedup_queried_nodes
+from ..profiler import Profiler
+from ..types import NodeInfo, QueriedNode
+from .embedding_retrieve_pipeline import EmbeddingRetrievePipeline
+
+
+def _section(
+    profiler: Optional[Profiler],
+    label: str,
+    metadata: Optional[Dict[str, Any]] = None,
+):
+    if profiler is None:
+        return nullcontext()
+    return profiler.section(label, metadata)
+
+
+class DenseGraphExpandRerankPipeline:
+    """Dense-first graph expansion retrieval pipeline.
+
+    Stage 1: retrieve dense top-K candidates from the full vector index.
+    Stage 2: append one-hop graph neighbors for those dense candidates.
+    Stage 3: optionally filter and deduplicate the combined candidate set.
+    Stage 4: optionally rerank only the assembled candidates.
+
+    This pipeline is intended for the "embedding baseline plus graph
+    augmentation" experiment family. It is intentionally different from
+    :class:`SparseSeededGraphRetrievePipeline`, which uses sparse/BM25 seeds and
+    ranks inside the graph-expanded set.
+    """
+
+    def __init__(
+        self,
+        retriever: EmbeddingRetrievePipeline,
+        code_graph: Optional[CodeGraph] = None,
+        *,
+        rerank_context: Optional[RerankContext] = None,
+        repo_path: Optional[str] = None,
+        dense_top_k: int = 20,
+        graph_neighbors_per_seed: int = 5,
+        graph_direction: str = "both",
+        final_top_k: int = 10,
+        candidate_top_k: Optional[int] = None,
+        candidate_filters: Optional[Sequence[CandidatePredicate]] = None,
+        include_graph_content: bool = True,
+        graph_symbol_only: bool = True,
+        graph_require_span: bool = True,
+        close_retriever: bool = False,
+    ) -> None:
+        if dense_top_k <= 0:
+            raise ValueError("dense_top_k must be positive.")
+        if final_top_k <= 0:
+            raise ValueError("final_top_k must be positive.")
+        if graph_neighbors_per_seed < 0:
+            raise ValueError("graph_neighbors_per_seed must be non-negative.")
+
+        self.retriever = retriever
+        self.expand_context = ExpandContext(code_graph=code_graph)
+        self.rerank_context = rerank_context
+        self.repo_path = repo_path
+        self.dense_top_k = dense_top_k
+        self.graph_neighbors_per_seed = graph_neighbors_per_seed
+        self.graph_direction = graph_direction
+        self.final_top_k = final_top_k
+        self.candidate_top_k = candidate_top_k
+        self.candidate_filters = list(candidate_filters or [])
+        self.include_graph_content = include_graph_content
+        self.graph_symbol_only = graph_symbol_only
+        self.graph_require_span = graph_require_span
+        self.close_retriever = close_retriever
+
+        self.last_dense_results: List[QueriedNode] = []
+        self.last_graph_results: List[QueriedNode] = []
+        self.last_filtered_candidates: List[QueriedNode] = []
+        self.last_candidates: List[QueriedNode] = []
+        self.last_reranked_results: List[QueriedNode] = []
+
+    @property
+    def code_graph(self) -> Optional[CodeGraph]:
+        return self.expand_context.code_graph
+
+    def load_index(self, index_path: str) -> None:
+        """Hot-swap the backing dense retrieval index."""
+        self.retriever.load_index(index_path)
+
+    def load_graph(
+        self, code_graph: Optional[CodeGraph], *, repo_path: Optional[str] = None
+    ) -> None:
+        """Hot-swap the graph used for neighbor expansion."""
+        self.expand_context.code_graph = code_graph
+        if repo_path is not None:
+            self.repo_path = repo_path
+
+    def query(
+        self,
+        query: str,
+        *,
+        top_k: Optional[int] = None,
+        dense_top_k: Optional[int] = None,
+        profiler: Optional[Profiler] = None,
+    ) -> List[QueriedNode]:
+        """Retrieve dense candidates, append graph neighbors, dedup, and rerank."""
+        final_top_k = top_k if top_k is not None else self.final_top_k
+        dense_k = dense_top_k if dense_top_k is not None else self.dense_top_k
+        if final_top_k <= 0:
+            return []
+        if dense_k <= 0:
+            raise ValueError("dense_top_k must be positive.")
+
+        with _section(profiler, "query.dense_retrieve", {"top_k": dense_k}):
+            dense_results = self.retriever.query(query, top_k=dense_k)
+
+        with _section(
+            profiler,
+            "query.graph_neighbor_expand",
+            {
+                "per_seed": self.graph_neighbors_per_seed,
+                "direction": self.graph_direction,
+            },
+        ):
+            graph_results = expand_graph_neighbors(
+                self.expand_context,
+                dense_results,
+                per_seed=self.graph_neighbors_per_seed,
+                direction=self.graph_direction,
+                repo_path=self.repo_path,
+                include_content=self.include_graph_content,
+                symbol_only=self.graph_symbol_only,
+                require_span=self.graph_require_span,
+            )
+
+        combined = [*dense_results, *graph_results]
+        with _section(
+            profiler,
+            "query.candidate_filter",
+            {"candidates": len(combined), "filters": len(self.candidate_filters)},
+        ):
+            filtered = filter_queried_nodes(combined, self.candidate_filters)
+
+        with _section(
+            profiler,
+            "query.candidate_dedup",
+            {"dense": len(dense_results), "graph": len(graph_results)},
+        ):
+            candidates = dedup_queried_nodes(filtered)
+
+        self.last_dense_results = list(dense_results)
+        self.last_graph_results = list(graph_results)
+        self.last_filtered_candidates = list(filtered)
+        self.last_candidates = list(candidates)
+
+        if self.rerank_context is None:
+            self.last_reranked_results = []
+            return candidates[:final_top_k]
+
+        candidate_cap = self.candidate_top_k or self.rerank_context.candidate_top_k
+        rerank_candidates = (
+            candidates[:candidate_cap] if candidate_cap is not None else candidates
+        )
+        with _section(
+            profiler,
+            "query.rerank",
+            {"candidates": len(rerank_candidates), "top_k": final_top_k},
+        ):
+            reranked = self._rerank(query, rerank_candidates, final_top_k)
+
+        self.last_reranked_results = list(reranked)
+        return reranked[:final_top_k]
+
+    def close(self) -> None:
+        """Release owned resources."""
+        if self.close_retriever:
+            self.retriever.close()
+
+    def _rerank(
+        self,
+        query: str,
+        candidates: Sequence[QueriedNode],
+        top_k: int,
+    ) -> List[QueriedNode]:
+        context = self.rerank_context
+        if context is None:
+            return list(candidates[:top_k])
+
+        if context.embedding_store is not None:
+            return rerank_by_embedding(
+                query,
+                candidates,
+                context.embedding_store,
+                top_k=top_k,
+            )
+
+        agent = context.ensure_agent()
+        nodes = [NodeInfo(**_dump_node(candidate)) for candidate in candidates]
+        return agent.rerank_nodes(
+            query=query,
+            nodes=nodes,
+            top_k=top_k,
+            window_size=context.window_size,
+            window_step=context.window_step,
+            include_content=True,
+        )
+
+
+def _dump_node(node: QueriedNode) -> Dict[str, object]:
+    if hasattr(node, "model_dump"):
+        return dict(node.model_dump())
+    if hasattr(node, "dict"):
+        return dict(node.dict())
+    raise TypeError(f"Object {node!r} does not support model dumping.")

--- a/codeminer/model/graph_augmented_rerank_pipeline.py
+++ b/codeminer/model/graph_augmented_rerank_pipeline.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from .dense_graph_expand_rerank_pipeline import DenseGraphExpandRerankPipeline
+
+
+class GraphAugmentedRerankPipeline(DenseGraphExpandRerankPipeline):
+    """Compatibility alias for :class:`DenseGraphExpandRerankPipeline`.
+
+    The old name was ambiguous: the pipeline is specifically dense-first,
+    graph-expansion-augmented, then reranked. New code should import
+    ``DenseGraphExpandRerankPipeline``.
+    """
+
+
+__all__ = ["GraphAugmentedRerankPipeline"]

--- a/codeminer/model/graph_retrieve_pipeline.py
+++ b/codeminer/model/graph_retrieve_pipeline.py
@@ -28,12 +28,16 @@ def _section(
     return profiler.section(label, metadata)
 
 
-class GraphRetrievePipeline:
-    """Three-stage graph-based retrieval pipeline.
+class SparseSeededGraphRetrievePipeline:
+    """Sparse-seeded graph-first retrieval pipeline.
 
     Stage 1: BM25 sparse search selects a small set of seed nodes.
     Stage 2: Graph expansion via k-hop BFS or Personalized PageRank.
     Stage 3 (optional): Embedding rerank within the expanded set.
+
+    This is a graph-first baseline. It should not be used as the direct
+    comparison point for dense embedding retrieval unless that sparse seeding
+    design is the intended ablation.
 
     Args:
         repo_path: Repository root to index.
@@ -249,3 +253,7 @@ class GraphRetrievePipeline:
         if self.vector_store is not None:
             self.vector_store.close()
             self.vector_store = None
+
+
+class GraphRetrievePipeline(SparseSeededGraphRetrievePipeline):
+    """Compatibility alias for :class:`SparseSeededGraphRetrievePipeline`."""

--- a/codeminer/model/hybrid_retrieve_pipeline.py
+++ b/codeminer/model/hybrid_retrieve_pipeline.py
@@ -59,8 +59,8 @@ characteristics (e.g., BM25's long tail vs embedding's tight cluster).
 
 Contrast with Other Pipelines
 ------------------------------
-- ``GraphRetrievePipeline``: BM25 → **graph expansion** → embedding rerank
-  (adds a graph-walk middle stage; used for graph-RAG experiments)
+- ``SparseSeededGraphRetrievePipeline``: BM25 → **graph expansion** →
+  embedding rerank (adds a graph-walk middle stage; graph-first baseline)
 - Agent A2 (``bm25_search`` + ``embedding_search``): **LLM decides** when/how to
   call each tool (adaptive, but token-expensive and non-deterministic)
 - ``RetrieveRerankPipeline``: parallel **hybrid fusion** with configurable weights
@@ -127,9 +127,10 @@ class HybridRetrievePipeline:
         self.stage2_topk = stage2_topk
 
         # Load skill registry (required before build_skill_contexts)
+        import os as _os
+
         from ..agent.skills.loader import SkillLoader
         from ..agent.skills.registry import SkillRegistry
-        import os as _os
 
         skills_dir = _os.path.join(
             _os.path.dirname(_os.path.dirname(__file__)), "agent", "skills"
@@ -216,7 +217,9 @@ class HybridRetrievePipeline:
         )
 
         # Stage 2: Embedding rerank within BM25 candidates
-        logger.debug("Stage 2: embedding rerank within %d candidates", len(candidate_ids))
+        logger.debug(
+            "Stage 2: embedding rerank within %d candidates", len(candidate_ids)
+        )
         reranked = self.vector_store.search_within_ids(
             query=query,
             mask_node_ids=candidate_ids,

--- a/codeminer/model/retrieval_planner.py
+++ b/codeminer/model/retrieval_planner.py
@@ -1,0 +1,378 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Query- and budget-aware retrieval path planner.
+
+The planner is intentionally deterministic. It does not call an LLM; it turns a
+query, a coarse latency/quality budget, and available backend capabilities into
+a concrete retrieval path that downstream pipelines can execute.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Sequence, Tuple, Union
+
+BudgetInput = Union[str, "RetrievalBudget"]
+
+
+@dataclass(frozen=True)
+class RetrievalStagePlan:
+    """Declarative retrieval branch selected by the planner."""
+
+    engine: str
+    weight: float = 1.0
+    top_k: Optional[int] = None
+    params: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GraphExpansionPlan:
+    """Graph expansion controls for structural retrieval paths."""
+
+    seed_engine: str = "sparse"
+    seed_top_k: int = 8
+    expand_top_k: int = 80
+    hops: int = 2
+    direction: str = "both"
+    use_ppr: bool = False
+
+
+@dataclass(frozen=True)
+class RetrievalBudget:
+    """Coarse retrieval budget used for path selection."""
+
+    tier: str = "balanced"
+    retrieve_top_k: int = 100
+    rerank_candidate_top_k: Optional[int] = 50
+    allow_graph: bool = True
+    allow_rerank: bool = True
+    allow_llm_rerank: bool = False
+    prefer_rrf: bool = True
+
+    def __post_init__(self) -> None:
+        normalized = self.tier.strip().lower()
+        if normalized not in {"fast", "balanced", "thorough"}:
+            raise ValueError(
+                "Retrieval budget tier must be one of: fast, balanced, thorough."
+            )
+        if self.retrieve_top_k <= 0:
+            raise ValueError("retrieve_top_k must be positive.")
+        if self.rerank_candidate_top_k is not None and self.rerank_candidate_top_k <= 0:
+            raise ValueError("rerank_candidate_top_k must be positive when set.")
+        object.__setattr__(self, "tier", normalized)
+
+
+@dataclass(frozen=True)
+class RetrievalCapabilities:
+    """Backends that a planner may use for this pipeline instance."""
+
+    has_dense: bool = True
+    has_sparse: bool = True
+    has_graph: bool = False
+    has_embedding_rerank: bool = True
+    has_llm_rerank: bool = False
+
+
+@dataclass(frozen=True)
+class QuerySignals:
+    """Heuristic query classification features."""
+
+    lexical: bool
+    semantic: bool
+    structural: bool
+
+    @property
+    def mixed(self) -> bool:
+        return sum([self.lexical, self.semantic, self.structural]) >= 2
+
+
+@dataclass(frozen=True)
+class RetrievalPathPlan:
+    """Concrete path selected for a query."""
+
+    name: str
+    intent: str
+    stages: Tuple[RetrievalStagePlan, ...]
+    retrieval_top_k: int
+    fusion: str = "weighted"
+    enable_rerank: bool = False
+    rerank_strategy: Optional[str] = None
+    rerank_candidate_top_k: Optional[int] = None
+    graph: Optional[GraphExpansionPlan] = None
+    rationale: str = ""
+
+    @property
+    def uses_dense(self) -> bool:
+        return any(stage.engine == "dense" for stage in self.stages)
+
+    @property
+    def uses_sparse(self) -> bool:
+        return any(stage.engine == "sparse" for stage in self.stages)
+
+    @property
+    def uses_graph(self) -> bool:
+        return self.graph is not None
+
+
+class RetrievalPlanner:
+    """Select one of CodeMiner's retrieval paths for a query and budget."""
+
+    _BUDGET_PRESETS = {
+        "fast": RetrievalBudget(
+            tier="fast",
+            retrieve_top_k=32,
+            rerank_candidate_top_k=None,
+            allow_graph=False,
+            allow_rerank=False,
+            allow_llm_rerank=False,
+            prefer_rrf=True,
+        ),
+        "balanced": RetrievalBudget(
+            tier="balanced",
+            retrieve_top_k=100,
+            rerank_candidate_top_k=50,
+            allow_graph=True,
+            allow_rerank=True,
+            allow_llm_rerank=False,
+            prefer_rrf=True,
+        ),
+        "thorough": RetrievalBudget(
+            tier="thorough",
+            retrieve_top_k=128,
+            rerank_candidate_top_k=80,
+            allow_graph=True,
+            allow_rerank=True,
+            allow_llm_rerank=True,
+            prefer_rrf=True,
+        ),
+    }
+
+    _STRUCTURAL_PATTERNS = tuple(
+        re.compile(pattern, re.IGNORECASE)
+        for pattern in (
+            r"\bwho\s+calls\b",
+            r"\b(callers?|callees?)\b",
+            r"\b(call\s+graph|dependency|dependencies)\b",
+            r"\b(impact|blast\s+radius|reachable|references?)\b",
+            r"\b(definitions?|usages?)\s+of\b",
+            r"\b(inherits?|subclasses?|overrides?)\b",
+            r"\b(data\s+flow|control\s+flow)\b",
+        )
+    )
+    _LEXICAL_PATTERNS = tuple(
+        re.compile(pattern)
+        for pattern in (
+            r"`[^`]+`",
+            r"\b[A-Za-z_][A-Za-z0-9_]*\([^)]*\)",
+            r"\b[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*\b",
+            r"\b[A-Za-z_][A-Za-z0-9_]*::[A-Za-z_][A-Za-z0-9_]*\b",
+            r"\b[A-Za-z]+_[A-Za-z0-9_]+\b",
+            r"\b[A-Z][A-Za-z0-9]*(Error|Exception|Factory|Manager|Service)\b",
+            r"[\w./-]+\.(py|js|ts|go|rs|java|cpp|c|h|hpp|rb|php|kt|scala)\b",
+        )
+    )
+    _SEMANTIC_WORDS = re.compile(
+        r"\b(how|why|what|when|where|explain|behavior|logic|flow|handle|support)\b",
+        re.IGNORECASE,
+    )
+
+    def normalize_budget(self, budget: BudgetInput = "balanced") -> RetrievalBudget:
+        """Return a validated budget object from a preset name or custom budget."""
+        if isinstance(budget, RetrievalBudget):
+            return budget
+        key = (budget or "balanced").strip().lower()
+        aliases = {
+            "cheap": "fast",
+            "low": "fast",
+            "default": "balanced",
+            "quality": "thorough",
+            "full": "thorough",
+        }
+        key = aliases.get(key, key)
+        try:
+            return self._BUDGET_PRESETS[key]
+        except KeyError as exc:
+            raise ValueError(
+                "Unknown retrieval budget. Choose from: fast, balanced, thorough."
+            ) from exc
+
+    def classify_query(self, query: str) -> QuerySignals:
+        """Classify a query into lexical, semantic, and structural signals."""
+        text = query or ""
+        words = re.findall(r"[A-Za-z0-9_]+", text)
+        structural = any(pattern.search(text) for pattern in self._STRUCTURAL_PATTERNS)
+        lexical = any(pattern.search(text) for pattern in self._LEXICAL_PATTERNS)
+        semantic = bool(self._SEMANTIC_WORDS.search(text)) or len(words) >= 10
+        if not lexical and not semantic and words:
+            lexical = len(words) <= 4
+        return QuerySignals(
+            lexical=lexical,
+            semantic=semantic,
+            structural=structural,
+        )
+
+    def select(
+        self,
+        query: str,
+        budget: BudgetInput = "balanced",
+        capabilities: Optional[RetrievalCapabilities] = None,
+    ) -> RetrievalPathPlan:
+        """Select a concrete retrieval path for *query* under *budget*."""
+        resolved_budget = self.normalize_budget(budget)
+        resolved_caps = capabilities or RetrievalCapabilities()
+        signals = self.classify_query(query)
+
+        if (
+            signals.structural
+            and resolved_budget.allow_graph
+            and resolved_caps.has_graph
+        ):
+            return self._structural_graph_plan(resolved_budget, resolved_caps)
+
+        if resolved_budget.tier == "fast":
+            if signals.lexical and resolved_caps.has_sparse:
+                return self._fast_lexical_plan(resolved_budget)
+            if resolved_caps.has_dense:
+                return self._semantic_plan(
+                    resolved_budget,
+                    resolved_caps,
+                    enable_rerank=False,
+                    rationale="fast budget disables rerank",
+                )
+            if resolved_caps.has_sparse:
+                return self._fast_lexical_plan(resolved_budget)
+
+        if signals.semantic and not signals.lexical and resolved_caps.has_dense:
+            return self._semantic_plan(resolved_budget, resolved_caps)
+
+        if resolved_caps.has_dense and resolved_caps.has_sparse:
+            return self._hybrid_fusion_plan(resolved_budget, resolved_caps, signals)
+
+        if resolved_caps.has_dense:
+            return self._semantic_plan(resolved_budget, resolved_caps)
+
+        if resolved_caps.has_sparse:
+            return self._fast_lexical_plan(resolved_budget)
+
+        raise ValueError("No retrieval backend is available for planning.")
+
+    def _fast_lexical_plan(self, budget: RetrievalBudget) -> RetrievalPathPlan:
+        return RetrievalPathPlan(
+            name="fast_lexical",
+            intent="lexical",
+            stages=(RetrievalStagePlan("sparse", top_k=budget.retrieve_top_k),),
+            retrieval_top_k=budget.retrieve_top_k,
+            fusion="none",
+            enable_rerank=False,
+            rationale="exact-name or low-latency query; BM25 only",
+        )
+
+    def _semantic_plan(
+        self,
+        budget: RetrievalBudget,
+        capabilities: RetrievalCapabilities,
+        *,
+        enable_rerank: Optional[bool] = None,
+        rationale: str = "natural-language query; dense retrieval first",
+    ) -> RetrievalPathPlan:
+        use_rerank = budget.allow_rerank if enable_rerank is None else enable_rerank
+        rerank_strategy = (
+            self._rerank_strategy(budget, capabilities) if use_rerank else None
+        )
+        return RetrievalPathPlan(
+            name="semantic",
+            intent="semantic",
+            stages=(RetrievalStagePlan("dense", top_k=budget.retrieve_top_k),),
+            retrieval_top_k=budget.retrieve_top_k,
+            fusion="none",
+            enable_rerank=bool(rerank_strategy),
+            rerank_strategy=rerank_strategy,
+            rerank_candidate_top_k=budget.rerank_candidate_top_k,
+            rationale=rationale,
+        )
+
+    def _hybrid_fusion_plan(
+        self,
+        budget: RetrievalBudget,
+        capabilities: RetrievalCapabilities,
+        signals: QuerySignals,
+    ) -> RetrievalPathPlan:
+        rerank_strategy = (
+            self._rerank_strategy(budget, capabilities) if budget.allow_rerank else None
+        )
+        fusion = "rrf" if budget.prefer_rrf else "weighted"
+        intent = "hybrid" if signals.mixed else "lexical_semantic"
+        return RetrievalPathPlan(
+            name="hybrid_fusion",
+            intent=intent,
+            stages=(
+                RetrievalStagePlan("dense", weight=0.6, top_k=budget.retrieve_top_k),
+                RetrievalStagePlan("sparse", weight=0.4, top_k=budget.retrieve_top_k),
+            ),
+            retrieval_top_k=budget.retrieve_top_k,
+            fusion=fusion,
+            enable_rerank=bool(rerank_strategy),
+            rerank_strategy=rerank_strategy,
+            rerank_candidate_top_k=budget.rerank_candidate_top_k,
+            rationale="mixed or uncertain query; fuse dense and sparse branches",
+        )
+
+    def _structural_graph_plan(
+        self,
+        budget: RetrievalBudget,
+        capabilities: RetrievalCapabilities,
+    ) -> RetrievalPathPlan:
+        rerank_strategy = (
+            self._rerank_strategy(budget, capabilities) if budget.allow_rerank else None
+        )
+        graph = GraphExpansionPlan(
+            seed_top_k=min(12, max(5, budget.retrieve_top_k // 12)),
+            expand_top_k=budget.retrieve_top_k,
+            hops=2 if budget.tier != "fast" else 1,
+            use_ppr=budget.tier == "thorough",
+        )
+        return RetrievalPathPlan(
+            name="structural_graph",
+            intent="structural",
+            stages=(RetrievalStagePlan("sparse", top_k=graph.seed_top_k),),
+            retrieval_top_k=budget.retrieve_top_k,
+            fusion="none",
+            enable_rerank=bool(rerank_strategy),
+            rerank_strategy=rerank_strategy,
+            rerank_candidate_top_k=budget.rerank_candidate_top_k,
+            graph=graph,
+            rationale="structural query; seed BM25 and expand over the graph",
+        )
+
+    def _rerank_strategy(
+        self,
+        budget: RetrievalBudget,
+        capabilities: RetrievalCapabilities,
+    ) -> Optional[str]:
+        if budget.allow_llm_rerank and capabilities.has_llm_rerank:
+            return "llm"
+        if capabilities.has_embedding_rerank:
+            return "embedding"
+        if capabilities.has_llm_rerank:
+            return "llm"
+        return None
+
+
+def build_planner_preload_stages(
+    capabilities: Optional[RetrievalCapabilities] = None,
+    *,
+    top_k: int = 128,
+) -> Sequence[RetrievalStagePlan]:
+    """Return the index stages worth preloading for dynamic planning."""
+    caps = capabilities or RetrievalCapabilities()
+    stages = []
+    if caps.has_dense:
+        stages.append(RetrievalStagePlan("dense", weight=0.6, top_k=top_k))
+    if caps.has_sparse:
+        stages.append(RetrievalStagePlan("sparse", weight=0.4, top_k=top_k))
+    if not stages:
+        raise ValueError("At least one retrieval backend must be available.")
+    return tuple(stages)

--- a/codeminer/model/retrieval_planner.py
+++ b/codeminer/model/retrieval_planner.py
@@ -229,6 +229,7 @@ class RetrievalPlanner:
             signals.structural
             and resolved_budget.allow_graph
             and resolved_caps.has_graph
+            and resolved_caps.has_sparse
         ):
             return self._structural_graph_plan(resolved_budget, resolved_caps)
 
@@ -356,8 +357,6 @@ class RetrievalPlanner:
             return "llm"
         if capabilities.has_embedding_rerank:
             return "embedding"
-        if capabilities.has_llm_rerank:
-            return "llm"
         return None
 
 

--- a/codeminer/model/retrieve_rerank_pipeline.py
+++ b/codeminer/model/retrieve_rerank_pipeline.py
@@ -9,16 +9,22 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
-import numpy as np
-
 from ..code_chunker import CodeChunker, RepoChunkingConfig
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..llm.litellm_chat import LiteLLMChat
 from ..log_utils import get_logger
-from ..ops.rerank import RerankContext
+from ..ops.rerank import RerankContext, rerank_by_embedding
 from ..ops.retrieve import RetrieveContext
 from ..types import NodeInfo, QueriedNode
+from .retrieval_planner import (
+    BudgetInput,
+    RetrievalCapabilities,
+    RetrievalPathPlan,
+    RetrievalPlanner,
+    RetrievalStagePlan,
+    build_planner_preload_stages,
+)
 
 logger = get_logger(__name__)
 
@@ -46,20 +52,29 @@ class RetrieveStageConfig:
 
 
 def build_retrieve_plan(mode: str = "dense") -> List[RetrieveStageConfig]:
-    """Convenience helper for common retrieval plan presets."""
+    """Convenience helper for common retrieval plan presets.
+
+    ``auto`` returns the dense+sparse preload set used by
+    :class:`RetrievalPlanner`; the per-query path is selected at query time.
+    """
 
     normalized = (mode or "dense").strip().lower()
     if normalized == "dense":
         return [RetrieveStageConfig(engine="dense", top_k=RETRIEVAL_TOP_K)]
     if normalized == "sparse":
         return [RetrieveStageConfig(engine="sparse", top_k=RETRIEVAL_TOP_K)]
+    if normalized == "auto":
+        return [
+            _stage_config_from_planner(stage)
+            for stage in build_planner_preload_stages(top_k=128)
+        ]
     if normalized == "hybrid":
         return [
             RetrieveStageConfig(engine="dense", weight=0.6, top_k=RETRIEVAL_TOP_K),
             RetrieveStageConfig(engine="sparse", weight=0.4, top_k=RETRIEVAL_TOP_K),
         ]
     raise ValueError(
-        f"Unknown retrieval mode {mode!r}. Choose from: dense, sparse, hybrid."
+        f"Unknown retrieval mode {mode!r}. Choose from: auto, dense, sparse, hybrid."
     )
 
 
@@ -97,6 +112,11 @@ class RetrieveRerankPipeline:
         retrieval_plan: Optional[Sequence[RetrieveStageConfig]] = None,
         retrieval_mode: str = "dense",
         retrieval_level: str = "l2",
+        planning_budget: BudgetInput = "balanced",
+        retrieval_planner: Optional[RetrievalPlanner] = None,
+        planner_capabilities: Optional[RetrievalCapabilities] = None,
+        fusion_strategy: str = "weighted",
+        rrf_k: int = 60,
         embedding_model: str = "nomic-ai/CodeRankEmbed",
         embedding_provider: str = "huggingface",
         embedding_dimension: int = 768,
@@ -129,17 +149,38 @@ class RetrieveRerankPipeline:
         self.enable_rerank = enable_rerank
         self.index_metric = "ip"
         self.profiler = None
+        self.retrieval_mode = (retrieval_mode or "dense").strip().lower()
+        self.retrieval_planner = retrieval_planner
+        if self.retrieval_planner is None and self.retrieval_mode == "auto":
+            self.retrieval_planner = RetrievalPlanner()
+        self.planning_budget = planning_budget
+        self.fusion_strategy = _normalize_fusion_strategy(fusion_strategy)
+        if rrf_k <= 0:
+            raise ValueError("rrf_k must be positive.")
+        self.rrf_k = rrf_k
+        self.last_selected_plan: Optional[RetrievalPathPlan] = None
+        self._planner_capabilities_override = planner_capabilities
         if retrieval_level not in ("l0", "l2"):
             raise ValueError(
                 f"Invalid retrieval_level {retrieval_level!r}. Must be 'l0' or 'l2'."
             )
         self.retrieval_level = retrieval_level
 
-        plan = (
-            list(retrieval_plan)
-            if retrieval_plan
-            else build_retrieve_plan(retrieval_mode)
-        )
+        if retrieval_plan:
+            plan = list(retrieval_plan)
+        elif self.retrieval_mode == "auto" and self.retrieval_planner is not None:
+            preload_top_k = max(
+                128,
+                self.retrieval_planner.normalize_budget(
+                    self.planning_budget
+                ).retrieve_top_k,
+            )
+            plan = [
+                _stage_config_from_planner(stage)
+                for stage in build_planner_preload_stages(top_k=preload_top_k)
+            ]
+        else:
+            plan = build_retrieve_plan(self.retrieval_mode)
         if not plan:
             raise ValueError("Retrieval plan must contain at least one stage.")
         self.retrieve_plan: List[RetrieveStageConfig] = plan
@@ -232,15 +273,29 @@ class RetrieveRerankPipeline:
         else:
             self.rerank_context = None
 
+        self.planner_capabilities = (
+            self._planner_capabilities_override
+            if self._planner_capabilities_override is not None
+            else RetrievalCapabilities(
+                has_dense=bool(self.vector_store),
+                has_sparse=bool(self.bm25_index),
+                has_graph=False,
+                has_embedding_rerank=bool(self.vector_store),
+                has_llm_rerank=strategy == "llm",
+            )
+        )
+
         logger.info(
             "RetrieveRerankPipeline initialized",
             extra={
                 "repo": self.repo_path,
                 "index_path": str(self.index_path),
+                "retrieval_mode": self.retrieval_mode,
                 "retrieval_plan": [stage.engine for stage in self.retrieve_plan],
                 "retrieval_level": self.retrieval_level,
                 "dense_index": bool(self.vector_store),
                 "sparse_index": bool(self.bm25_index),
+                "planner": bool(self.retrieval_planner),
                 "rerank_strategy": (
                     self.rerank_strategy if self.enable_rerank else "disabled"
                 ),
@@ -275,7 +330,13 @@ class RetrieveRerankPipeline:
         except Exception:
             pass
 
-    def query(self, query: str, top_k: int = 10) -> List[QueriedNode]:
+    def query(
+        self,
+        query: str,
+        top_k: int = 10,
+        *,
+        budget: Optional[BudgetInput] = None,
+    ) -> List[QueriedNode]:
         """Execute retrieve + rerank plan for the provided query.
 
         Args:
@@ -283,10 +344,25 @@ class RetrieveRerankPipeline:
             top_k: Number of results to return. If rerank is enabled, this controls
                 the rerank output. Retrieval always fetches RETRIEVAL_TOP_K
                 candidates internally.
+            budget: Optional per-query planner budget. Only used when a
+                retrieval planner is configured, including ``retrieval_mode=auto``.
         """
+        selected_plan = self._select_query_plan(query, budget)
+        active_plan = (
+            [_stage_config_from_planner(stage) for stage in selected_plan.stages]
+            if selected_plan is not None
+            else self.retrieve_plan
+        )
+        fusion = selected_plan.fusion if selected_plan is not None else None
+        merge_top_k = (
+            selected_plan.retrieval_top_k
+            if selected_plan is not None
+            else RETRIEVAL_TOP_K
+        )
+
         # Step 1: Run each retrieval branch
         branch_results: List[List[QueriedNode]] = []
-        for stage in self.retrieve_plan:
+        for stage in active_plan:
             results = self._run_retrieval_stage(query, stage)
             branch_results.append(results)
 
@@ -294,14 +370,65 @@ class RetrieveRerankPipeline:
         if len(branch_results) == 1:
             candidates = branch_results[0]
         else:
-            weights = [stage.weight for stage in self.retrieve_plan]
-            candidates = self._merge_hybrid(branch_results, weights, RETRIEVAL_TOP_K)
+            weights = [stage.weight for stage in active_plan]
+            candidates = self._merge_hybrid(
+                branch_results,
+                weights,
+                merge_top_k,
+                fusion=fusion or self.fusion_strategy,
+                rrf_k=self.rrf_k,
+            )
 
         # Step 3: Rerank if enabled
-        if self.enable_rerank and self.rerank_context is not None:
-            candidates = self._run_rerank(query, candidates, top_k)
+        plan_allows_rerank = (
+            selected_plan.enable_rerank if selected_plan is not None else True
+        )
+        if (
+            self.enable_rerank
+            and plan_allows_rerank
+            and self.rerank_context is not None
+        ):
+            candidates = self._run_rerank(
+                query,
+                candidates,
+                top_k,
+                strategy=(
+                    selected_plan.rerank_strategy
+                    if selected_plan is not None
+                    else self.rerank_strategy
+                ),
+                candidate_top_k=(
+                    selected_plan.rerank_candidate_top_k
+                    if selected_plan is not None
+                    else self.rerank_candidate_top_k
+                ),
+            )
 
         return candidates[:top_k]
+
+    def _select_query_plan(
+        self, query: str, budget: Optional[BudgetInput]
+    ) -> Optional[RetrievalPathPlan]:
+        if self.retrieval_planner is None:
+            self.last_selected_plan = None
+            return None
+        selected = self.retrieval_planner.select(
+            query=query,
+            budget=budget or self.planning_budget,
+            capabilities=self.planner_capabilities,
+        )
+        self.last_selected_plan = selected
+        logger.debug(
+            "Planner selected retrieval path",
+            extra={
+                "plan": selected.name,
+                "intent": selected.intent,
+                "fusion": selected.fusion,
+                "rerank": selected.rerank_strategy if selected.enable_rerank else None,
+                "rationale": selected.rationale,
+            },
+        )
+        return selected
 
     # --------------------------------------------------------------------- #
     # Retrieval
@@ -351,8 +478,17 @@ class RetrieveRerankPipeline:
         branches: List[List[QueriedNode]],
         weights: List[float],
         top_k: int,
+        *,
+        fusion: str = "weighted",
+        rrf_k: int = 60,
     ) -> List[QueriedNode]:
-        """Merge multiple retrieval branches with weighted scoring."""
+        """Merge multiple retrieval branches with weighted or RRF scoring."""
+        normalized_fusion = _normalize_fusion_strategy(fusion)
+        if normalized_fusion == "rrf":
+            return RetrieveRerankPipeline._merge_rrf(
+                branches, weights, top_k, rrf_k=rrf_k
+            )
+
         if not weights or len(weights) != len(branches):
             weights = [1.0] * len(branches)
 
@@ -384,22 +520,69 @@ class RetrieveRerankPipeline:
         )
         return merged[:top_k]
 
+    @staticmethod
+    def _merge_rrf(
+        branches: List[List[QueriedNode]],
+        weights: List[float],
+        top_k: int,
+        *,
+        rrf_k: int = 60,
+    ) -> List[QueriedNode]:
+        """Merge branches with weighted reciprocal-rank fusion."""
+        if not weights or len(weights) != len(branches):
+            weights = [1.0] * len(branches)
+
+        accumulator: Dict[
+            Tuple[Optional[str], str, Optional[int], Optional[int]], QueriedNode
+        ] = {}
+
+        for weight, results in zip(weights, branches, strict=True):
+            for rank, item in enumerate(results, start=1):
+                key = (item.file, item.node_name, item.start_line, item.end_line)
+                rrf_score = weight / float(rrf_k + rank)
+                if key not in accumulator:
+                    accumulator[key] = _with_score(item, rrf_score)
+                    continue
+                existing = accumulator[key]
+                content = existing.content or item.content
+                accumulator[key] = _with_score(
+                    existing,
+                    existing.score + rrf_score,
+                    content,
+                )
+
+        merged = sorted(
+            accumulator.values(),
+            key=lambda node: node.score,
+            reverse=True,
+        )
+        return merged[:top_k]
+
     # --------------------------------------------------------------------- #
     # Reranking
     # --------------------------------------------------------------------- #
 
     def _run_rerank(
-        self, query: str, candidates: List[QueriedNode], top_k: int
+        self,
+        query: str,
+        candidates: List[QueriedNode],
+        top_k: int,
+        *,
+        strategy: Optional[str] = None,
+        candidate_top_k: Optional[int] = None,
     ) -> List[QueriedNode]:
         """Rerank candidates using the configured strategy."""
         if not candidates:
             return []
 
-        if self.rerank_candidate_top_k is not None:
-            candidates = candidates[: self.rerank_candidate_top_k]
+        if candidate_top_k is not None:
+            candidates = candidates[:candidate_top_k]
 
-        if self.rerank_strategy == "embedding":
+        active_strategy = strategy or self.rerank_strategy
+        if active_strategy == "embedding":
             return self._rerank_embedding(query, candidates, top_k)
+        if active_strategy != "llm":
+            raise ValueError("rerank strategy must be 'llm' or 'embedding'.")
         return self._rerank_llm(query, candidates, top_k)
 
     def _rerank_llm(
@@ -442,46 +625,7 @@ class RetrieveRerankPipeline:
         store = self.rerank_context.embedding_store
         if store is None:
             raise RuntimeError("Embedding rerank requested but no embedding store.")
-
-        candidates_with_content = [c for c in candidates if c.content]
-        if not candidates_with_content:
-            return []
-
-        query_vec = np.array(store.embedding.embed_query(query), dtype=np.float32)
-        doc_vectors = np.array(
-            store.embedding.embed_documents(
-                [c.content for c in candidates_with_content]
-            ),
-            dtype=np.float32,
-        )
-
-        metric = store.index_metric
-        if metric == "ip":
-            scores = np.dot(doc_vectors, query_vec).tolist()
-        elif metric == "l2":
-            scores = (-np.linalg.norm(doc_vectors - query_vec, axis=1)).tolist()
-        else:
-            raise ValueError(f"Unsupported index metric: {metric!r}")
-
-        ranked = sorted(
-            zip(scores, candidates_with_content, strict=True),
-            key=lambda pair: pair[0],
-            reverse=True,
-        )
-
-        return [
-            QueriedNode(
-                node_name=c.node_name,
-                type=c.type,
-                file=c.file,
-                node_id=c.node_id,
-                start_line=c.start_line,
-                end_line=c.end_line,
-                score=float(score),
-                content=c.content,
-            )
-            for score, c in ranked[:top_k]
-        ]
+        return rerank_by_embedding(query, candidates, store, top_k=top_k)
 
     # --------------------------------------------------------------------- #
     # Internal helpers
@@ -631,6 +775,29 @@ class RetrieveRerankPipeline:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _stage_config_from_planner(stage: RetrievalStagePlan) -> RetrieveStageConfig:
+    return RetrieveStageConfig(
+        engine=stage.engine,
+        weight=stage.weight,
+        top_k=stage.top_k,
+        params=dict(stage.params),
+    )
+
+
+def _normalize_fusion_strategy(value: Optional[str]) -> str:
+    normalized = (value or "weighted").strip().lower().replace("-", "_")
+    aliases = {
+        "linear": "weighted",
+        "linear_combination": "weighted",
+        "weighted_sum": "weighted",
+        "none": "weighted",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in {"weighted", "rrf"}:
+        raise ValueError("fusion_strategy must be 'weighted' or 'rrf'.")
+    return normalized
 
 
 def _to_queried_nodes(results: Sequence[object]) -> List[QueriedNode]:

--- a/codeminer/model/retrieve_rerank_pipeline.py
+++ b/codeminer/model/retrieve_rerank_pipeline.py
@@ -7,18 +7,27 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Dict, List, Optional, Sequence, Set
 
 from ..code_chunker import CodeChunker, RepoChunkingConfig
+from ..graph.code_graph import CodeGraph
+from ..graph.roi_subgraph import ROISubgraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..llm.litellm_chat import LiteLLMChat
 from ..log_utils import get_logger
+from ..ops.expand import ExpandContext, expand_graph_neighbors, nodeinfo_to_queried
 from ..ops.rerank import RerankContext, rerank_by_embedding
-from ..ops.retrieve import RetrieveContext
+from ..ops.retrieve import (
+    RetrieveContext,
+    dedup_queried_nodes,
+    merge_hybrid,
+    to_queried_nodes,
+)
 from ..types import NodeInfo, QueriedNode
 from .retrieval_planner import (
     BudgetInput,
+    RetrievalBudget,
     RetrievalCapabilities,
     RetrievalPathPlan,
     RetrievalPlanner,
@@ -115,6 +124,7 @@ class RetrieveRerankPipeline:
         planning_budget: BudgetInput = "balanced",
         retrieval_planner: Optional[RetrievalPlanner] = None,
         planner_capabilities: Optional[RetrievalCapabilities] = None,
+        code_graph: Optional[CodeGraph] = None,
         fusion_strategy: str = "weighted",
         rrf_k: int = 60,
         embedding_model: str = "nomic-ai/CodeRankEmbed",
@@ -159,7 +169,12 @@ class RetrieveRerankPipeline:
             raise ValueError("rrf_k must be positive.")
         self.rrf_k = rrf_k
         self.last_selected_plan: Optional[RetrievalPathPlan] = None
+        self.last_query_signals = None
+        self.last_planning_budget: Optional[RetrievalBudget] = None
+        self.last_planner_capabilities: Optional[RetrievalCapabilities] = None
+        self.last_planner_trace: Dict[str, object] = {}
         self._planner_capabilities_override = planner_capabilities
+        self.expand_context = ExpandContext(code_graph=code_graph)
         if retrieval_level not in ("l0", "l2"):
             raise ValueError(
                 f"Invalid retrieval_level {retrieval_level!r}. Must be 'l0' or 'l2'."
@@ -279,7 +294,7 @@ class RetrieveRerankPipeline:
             else RetrievalCapabilities(
                 has_dense=bool(self.vector_store),
                 has_sparse=bool(self.bm25_index),
-                has_graph=False,
+                has_graph=bool(self.expand_context.code_graph),
                 has_embedding_rerank=bool(self.vector_store),
                 has_llm_rerank=strategy == "llm",
             )
@@ -295,6 +310,7 @@ class RetrieveRerankPipeline:
                 "retrieval_level": self.retrieval_level,
                 "dense_index": bool(self.vector_store),
                 "sparse_index": bool(self.bm25_index),
+                "graph_index": bool(self.expand_context.code_graph),
                 "planner": bool(self.retrieval_planner),
                 "rerank_strategy": (
                     self.rerank_strategy if self.enable_rerank else "disabled"
@@ -379,6 +395,9 @@ class RetrieveRerankPipeline:
                 rrf_k=self.rrf_k,
             )
 
+        if selected_plan is not None and selected_plan.graph is not None:
+            candidates = self._run_graph_expansion_plan(selected_plan, candidates)
+
         # Step 3: Rerank if enabled
         plan_allows_rerank = (
             selected_plan.enable_rerank if selected_plan is not None else True
@@ -397,27 +416,49 @@ class RetrieveRerankPipeline:
                     if selected_plan is not None
                     else self.rerank_strategy
                 ),
-                candidate_top_k=(
-                    selected_plan.rerank_candidate_top_k
-                    if selected_plan is not None
-                    else self.rerank_candidate_top_k
-                ),
+                candidate_top_k=self._effective_rerank_candidate_top_k(selected_plan),
             )
 
         return candidates[:top_k]
+
+    def _effective_rerank_candidate_top_k(
+        self, selected_plan: Optional[RetrievalPathPlan]
+    ) -> Optional[int]:
+        if self.rerank_candidate_top_k is not None:
+            return self.rerank_candidate_top_k
+        if selected_plan is not None:
+            return selected_plan.rerank_candidate_top_k
+        return None
 
     def _select_query_plan(
         self, query: str, budget: Optional[BudgetInput]
     ) -> Optional[RetrievalPathPlan]:
         if self.retrieval_planner is None:
             self.last_selected_plan = None
+            self.last_query_signals = None
+            self.last_planning_budget = None
+            self.last_planner_capabilities = None
+            self.last_planner_trace = {}
             return None
+        active_budget = self.retrieval_planner.normalize_budget(
+            budget or self.planning_budget
+        )
+        signals = self.retrieval_planner.classify_query(query)
         selected = self.retrieval_planner.select(
             query=query,
-            budget=budget or self.planning_budget,
+            budget=active_budget,
             capabilities=self.planner_capabilities,
         )
         self.last_selected_plan = selected
+        self.last_query_signals = signals
+        self.last_planning_budget = active_budget
+        self.last_planner_capabilities = self.planner_capabilities
+        self.last_planner_trace = _planner_trace(
+            signals=signals,
+            budget=active_budget,
+            capabilities=self.planner_capabilities,
+            plan=selected,
+        )
         logger.debug(
             "Planner selected retrieval path",
             extra={
@@ -425,6 +466,9 @@ class RetrieveRerankPipeline:
                 "intent": selected.intent,
                 "fusion": selected.fusion,
                 "rerank": selected.rerank_strategy if selected.enable_rerank else None,
+                "signals": self.last_planner_trace["signals"],
+                "budget": self.last_planner_trace["budget"],
+                "capabilities": self.last_planner_trace["capabilities"],
                 "rationale": selected.rationale,
             },
         )
@@ -473,6 +517,80 @@ class RetrieveRerankPipeline:
         )
         return _to_queried_nodes(raw_results)
 
+    def _run_graph_expansion_plan(
+        self,
+        selected_plan: RetrievalPathPlan,
+        seeds: List[QueriedNode],
+    ) -> List[QueriedNode]:
+        """Execute the planner's graph expansion plan over retrieved seeds."""
+        graph_plan = selected_plan.graph
+        if graph_plan is None:
+            return seeds
+        if self.expand_context.code_graph is None:
+            raise RuntimeError("Graph expansion requested but no code graph is loaded.")
+
+        seed_cap = graph_plan.seed_top_k or len(seeds)
+        graph_seeds = list(seeds[:seed_cap])
+        if not graph_seeds:
+            return []
+
+        if graph_plan.use_ppr or graph_plan.hops > 1:
+            expanded = self._expand_graph_roi(graph_seeds, graph_plan)
+        else:
+            expanded = []
+
+        if not expanded:
+            expanded = self._expand_graph_neighbors(graph_seeds, graph_plan)
+
+        candidates = dedup_queried_nodes([*graph_seeds, *expanded])
+        return candidates[: graph_plan.expand_top_k]
+
+    def _expand_graph_roi(
+        self, seeds: List[QueriedNode], graph_plan
+    ) -> List[QueriedNode]:
+        graph = self.expand_context.code_graph
+        if graph is None or not hasattr(graph, "name_to_vertex"):
+            return []
+
+        seed_names = _resolve_graph_seed_names(graph, seeds)
+        if not seed_names:
+            return []
+
+        roi = ROISubgraph(graph)
+        if graph_plan.use_ppr:
+            nodes = roi.expand_ppr(
+                seed_names,
+                top_k=graph_plan.expand_top_k,
+                damping=self.expand_context.default_damping,
+                filter_tests=self.expand_context.filter_tests,
+            )
+        else:
+            subgraph = roi.extract_subgraph(
+                seed_names,
+                k_hop=graph_plan.hops,
+                direction=_roi_direction(graph_plan.direction),
+            )
+            nodes = roi.get_filtered_subgraph_nodes(
+                subgraph,
+                filter_tests=self.expand_context.filter_tests,
+            )[: graph_plan.expand_top_k]
+        return nodeinfo_to_queried(nodes)
+
+    def _expand_graph_neighbors(
+        self, seeds: List[QueriedNode], graph_plan
+    ) -> List[QueriedNode]:
+        per_seed = max(1, graph_plan.expand_top_k // max(1, len(seeds)))
+        return expand_graph_neighbors(
+            self.expand_context,
+            seeds,
+            per_seed=per_seed,
+            direction=_neighbor_direction(graph_plan.direction),
+            repo_path=self.repo_path,
+            include_content=True,
+            symbol_only=True,
+            require_span=True,
+        )
+
     @staticmethod
     def _merge_hybrid(
         branches: List[List[QueriedNode]],
@@ -483,42 +601,13 @@ class RetrieveRerankPipeline:
         rrf_k: int = 60,
     ) -> List[QueriedNode]:
         """Merge multiple retrieval branches with weighted or RRF scoring."""
-        normalized_fusion = _normalize_fusion_strategy(fusion)
-        if normalized_fusion == "rrf":
-            return RetrieveRerankPipeline._merge_rrf(
-                branches, weights, top_k, rrf_k=rrf_k
-            )
-
-        if not weights or len(weights) != len(branches):
-            weights = [1.0] * len(branches)
-
-        accumulator: Dict[
-            Tuple[Optional[str], str, Optional[int], Optional[int]], QueriedNode
-        ] = {}
-
-        for weight, results in zip(weights, branches, strict=True):
-            for rank, item in enumerate(results):
-                base_score = item.score or 0.0
-                if base_score == 0.0:
-                    base_score = 1.0 / (rank + 1)
-
-                key = (item.file, item.node_name, item.start_line, item.end_line)
-                weighted = weight * base_score
-
-                if key not in accumulator:
-                    accumulator[key] = _with_score(item, weighted)
-                else:
-                    existing = accumulator[key]
-                    new_score = existing.score + weighted
-                    content = existing.content or item.content
-                    accumulator[key] = _with_score(existing, new_score, content)
-
-        merged = sorted(
-            accumulator.values(),
-            key=lambda node: node.score,
-            reverse=True,
+        return merge_hybrid(
+            branches,
+            weights,
+            top_k=top_k,
+            fusion=fusion,
+            rrf_k=rrf_k,
         )
-        return merged[:top_k]
 
     @staticmethod
     def _merge_rrf(
@@ -529,34 +618,13 @@ class RetrieveRerankPipeline:
         rrf_k: int = 60,
     ) -> List[QueriedNode]:
         """Merge branches with weighted reciprocal-rank fusion."""
-        if not weights or len(weights) != len(branches):
-            weights = [1.0] * len(branches)
-
-        accumulator: Dict[
-            Tuple[Optional[str], str, Optional[int], Optional[int]], QueriedNode
-        ] = {}
-
-        for weight, results in zip(weights, branches, strict=True):
-            for rank, item in enumerate(results, start=1):
-                key = (item.file, item.node_name, item.start_line, item.end_line)
-                rrf_score = weight / float(rrf_k + rank)
-                if key not in accumulator:
-                    accumulator[key] = _with_score(item, rrf_score)
-                    continue
-                existing = accumulator[key]
-                content = existing.content or item.content
-                accumulator[key] = _with_score(
-                    existing,
-                    existing.score + rrf_score,
-                    content,
-                )
-
-        merged = sorted(
-            accumulator.values(),
-            key=lambda node: node.score,
-            reverse=True,
+        return merge_hybrid(
+            branches,
+            weights,
+            top_k=top_k,
+            fusion="rrf",
+            rrf_k=rrf_k,
         )
-        return merged[:top_k]
 
     # --------------------------------------------------------------------- #
     # Reranking
@@ -802,52 +870,84 @@ def _normalize_fusion_strategy(value: Optional[str]) -> str:
 
 def _to_queried_nodes(results: Sequence[object]) -> List[QueriedNode]:
     """Normalize retrieval results to QueriedNode."""
-    converted: List[QueriedNode] = []
-    for rank, item in enumerate(results):
-        if isinstance(item, QueriedNode):
-            converted.append(item)
-            continue
-        if isinstance(item, NodeInfo):
-            data = _dump_model(item)
-            score = data.get("score") or 0.0
-            if not score:
-                score = 1.0 / (rank + 1)
-            data["score"] = score
-            converted.append(QueriedNode(**data))
-            continue
-        if isinstance(item, dict):
-            data = dict(item)
-            score = data.get("score") or 0.0
-            if not score:
-                score = 1.0 / (rank + 1)
-            data["score"] = score
-            data.setdefault("node_name", data.get("name", ""))
-            data.setdefault("content", data.get("content"))
-            converted.append(QueriedNode(**data))
-            continue
-        raise TypeError(f"Unsupported result type: {type(item)}")
-    return converted
+    return to_queried_nodes(results)
 
 
-def _with_score(
-    item: QueriedNode, score: float, content_override: Optional[str] = None
-) -> QueriedNode:
-    """Create a copy of a QueriedNode with an updated score."""
-    update = {"score": score}
-    if content_override is not None:
-        update["content"] = content_override
-    if hasattr(item, "model_copy"):
-        return item.model_copy(update=update)
-    if hasattr(item, "copy"):
-        return item.copy(update=update)
-    data = _dump_model(item)
-    data.update(update)
-    return QueriedNode(**data)
+def _planner_trace(
+    *,
+    signals,
+    budget: RetrievalBudget,
+    capabilities: RetrievalCapabilities,
+    plan: RetrievalPathPlan,
+) -> Dict[str, object]:
+    return {
+        "signals": {
+            "lexical": signals.lexical,
+            "semantic": signals.semantic,
+            "structural": signals.structural,
+            "mixed": signals.mixed,
+        },
+        "budget": {
+            "tier": budget.tier,
+            "retrieve_top_k": budget.retrieve_top_k,
+            "rerank_candidate_top_k": budget.rerank_candidate_top_k,
+            "allow_graph": budget.allow_graph,
+            "allow_rerank": budget.allow_rerank,
+            "allow_llm_rerank": budget.allow_llm_rerank,
+            "prefer_rrf": budget.prefer_rrf,
+        },
+        "capabilities": {
+            "has_dense": capabilities.has_dense,
+            "has_sparse": capabilities.has_sparse,
+            "has_graph": capabilities.has_graph,
+            "has_embedding_rerank": capabilities.has_embedding_rerank,
+            "has_llm_rerank": capabilities.has_llm_rerank,
+        },
+        "plan": {
+            "name": plan.name,
+            "intent": plan.intent,
+            "fusion": plan.fusion,
+            "enable_rerank": plan.enable_rerank,
+            "rerank_strategy": plan.rerank_strategy,
+            "uses_graph": plan.uses_graph,
+            "rationale": plan.rationale,
+        },
+    }
 
 
-def _dump_model(model: object) -> Dict[str, object]:
-    if hasattr(model, "model_dump"):
-        return dict(model.model_dump())
-    if hasattr(model, "dict"):
-        return dict(model.dict())
-    raise TypeError(f"Object {model} does not support model dumping.")
+def _resolve_graph_seed_names(
+    graph: CodeGraph, seeds: Sequence[QueriedNode]
+) -> List[str]:
+    name_to_vertex = getattr(graph, "name_to_vertex", {})
+    out: List[str] = []
+    seen: Set[str] = set()
+    for seed in seeds:
+        candidates = [seed.node_id, seed.node_name]
+        if seed.file and seed.node_name:
+            candidates.append(f"{seed.file}:{seed.node_name}")
+        for candidate in candidates:
+            if candidate and candidate in name_to_vertex and candidate not in seen:
+                seen.add(candidate)
+                out.append(candidate)
+                break
+    return out
+
+
+def _roi_direction(direction: str) -> str:
+    normalized = (direction or "both").strip().lower()
+    if normalized in {"callees", "successors", "forward", "out"}:
+        return "forward"
+    if normalized in {"callers", "predecessors", "backward", "in"}:
+        return "backward"
+    return "both"
+
+
+def _neighbor_direction(direction: str) -> str:
+    normalized = (direction or "both").strip().lower()
+    if normalized in {"forward", "out"}:
+        return "successors"
+    if normalized in {"backward", "in"}:
+        return "predecessors"
+    if normalized in {"callees", "successors", "callers", "predecessors", "both"}:
+        return normalized
+    return "both"

--- a/codeminer/ops/expand.py
+++ b/codeminer/ops/expand.py
@@ -43,6 +43,7 @@ def nodeinfo_to_queried(nodes: List[NodeInfo]) -> List[QueriedNode]:
                 node_name=ni.node_name,
                 type=ni.type,
                 file=ni.file,
+                node_id=ni.node_id or ni.node_name,
                 start_line=ni.start_line,
                 end_line=ni.end_line,
                 score=score,

--- a/codeminer/ops/expand.py
+++ b/codeminer/ops/expand.py
@@ -5,11 +5,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from pathlib import Path
+from typing import Any, List, Optional, Sequence
 
 from ..graph.code_graph import CodeGraph
 from ..log_utils import get_logger
-from ..types import NodeInfo, QueriedNode
+from ..types import NodeInfo, QueriedNode, is_symbol_node
 
 logger = get_logger(__name__)
 
@@ -49,3 +50,158 @@ def nodeinfo_to_queried(nodes: List[NodeInfo]) -> List[QueriedNode]:
             )
         )
     return results
+
+
+def expand_graph_neighbors(
+    context: ExpandContext,
+    seeds: Sequence[QueriedNode],
+    *,
+    per_seed: int = 5,
+    direction: str = "both",
+    repo_path: Optional[str] = None,
+    include_content: bool = False,
+    symbol_only: bool = True,
+    require_span: bool = True,
+    score_scale: float = 0.5,
+) -> List[QueriedNode]:
+    """Return graph neighbors for retrieval candidates.
+
+    This is the retrieval-pipeline counterpart to the agent-facing graph
+    navigation helpers: keep dense candidates as seeds, append compact graph
+    neighbors, and leave ranking to the downstream reranker. Only one-hop
+    predecessor/successor expansion is performed; no BFS/PPR is hidden here.
+    """
+    graph = context.code_graph
+    if graph is None or not seeds:
+        return []
+
+    per_seed = max(0, int(per_seed or 0))
+    if per_seed == 0:
+        return []
+    if direction not in ("callees", "successors", "callers", "predecessors", "both"):
+        raise ValueError(f"Unsupported graph expansion direction: {direction!r}")
+
+    out: List[QueriedNode] = []
+    for seed_rank, seed in enumerate(seeds, 1):
+        canonical = _resolve_seed(graph, seed)
+        if canonical is None:
+            continue
+        neighbor_ids: List[int] = []
+        if direction in ("callees", "successors", "both"):
+            neighbor_ids.extend(graph.get_successors(canonical))
+        if direction in ("callers", "predecessors", "both"):
+            neighbor_ids.extend(graph.get_predecessors(canonical))
+
+        added_for_seed = 0
+        for vid in neighbor_ids:
+            node = _neighbor_to_queried(
+                graph,
+                vid,
+                seed=seed,
+                seed_rank=seed_rank,
+                repo_path=repo_path,
+                include_content=include_content,
+                score_scale=score_scale,
+            )
+            if node is None:
+                continue
+            if symbol_only and not is_symbol_node(node.type):
+                continue
+            if require_span and (
+                node.file is None or node.start_line is None or node.end_line is None
+            ):
+                continue
+            out.append(node)
+            added_for_seed += 1
+            if added_for_seed >= per_seed:
+                break
+    return out
+
+
+def _resolve_seed(graph: CodeGraph, seed: QueriedNode) -> Optional[str]:
+    for value in (seed.node_id, seed.node_name):
+        if not value:
+            continue
+        canonical, _ = graph.resolve_symbol(value)
+        if canonical is not None:
+            return canonical
+    if seed.file and seed.node_name:
+        canonical, _ = graph.resolve_symbol(f"{seed.file}:{seed.node_name}")
+        if canonical is not None:
+            return canonical
+    return None
+
+
+def _neighbor_to_queried(
+    graph: CodeGraph,
+    vertex_id: int,
+    *,
+    seed: QueriedNode,
+    seed_rank: int,
+    repo_path: Optional[str],
+    include_content: bool,
+    score_scale: float,
+) -> Optional[QueriedNode]:
+    info: dict[str, Any] = graph.get_node_info_by_id(vertex_id) or {}
+    name = info.get("name")
+    if not name:
+        return None
+    file_path = info.get("file")
+    display = info.get("unified_name") or name
+    score = (seed.score if seed.score is not None else 1.0 / seed_rank) or 0.0
+    content = None
+    if include_content:
+        content = _read_span_content(
+            repo_path=repo_path,
+            file_path=file_path,
+            start_line=info.get("start_line"),
+            end_line=info.get("end_line"),
+        )
+    return QueriedNode(
+        node_name=display,
+        type=info.get("type", ""),
+        file=file_path,
+        node_id=_node_id(file_path, display),
+        start_line=info.get("start_line"),
+        end_line=info.get("end_line"),
+        score=float(score) * score_scale,
+        content=content,
+    )
+
+
+def _node_id(file_path: Optional[str], display: str) -> str:
+    if not file_path:
+        return display
+    if "/" in display or ":" in display:
+        return display
+    return f"{file_path}:{display}"
+
+
+def _read_span_content(
+    *,
+    repo_path: Optional[str],
+    file_path: Optional[str],
+    start_line: Any,
+    end_line: Any,
+) -> Optional[str]:
+    if not file_path or start_line is None or end_line is None:
+        return None
+    try:
+        start = int(start_line)
+        end = int(end_line)
+    except (TypeError, ValueError):
+        return None
+    path = Path(file_path)
+    if not path.is_absolute():
+        if not repo_path:
+            return None
+        path = Path(repo_path) / file_path
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines(True)
+    except OSError:
+        return None
+    start = max(0, start)
+    end = min(len(lines) - 1, end)
+    if end < start:
+        return None
+    return "".join(lines[start : end + 1])

--- a/codeminer/ops/filter.py
+++ b/codeminer/ops/filter.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import PurePosixPath
+from typing import Callable, Iterable, List, Optional, Sequence
+
+from ..types import QueriedNode, is_symbol_node
+
+CandidatePredicate = Callable[[QueriedNode], bool]
+
+
+def filter_queried_nodes(
+    nodes: Sequence[QueriedNode],
+    predicates: Iterable[CandidatePredicate],
+    *,
+    limit: Optional[int] = None,
+) -> List[QueriedNode]:
+    """Filter retrieval candidates while preserving their existing order."""
+    active = list(predicates)
+    if not active:
+        return list(nodes[:limit] if limit is not None else nodes)
+
+    out: List[QueriedNode] = []
+    for node in nodes:
+        if all(predicate(node) for predicate in active):
+            out.append(node)
+            if limit is not None and len(out) >= limit:
+                break
+    return out
+
+
+def has_span(node: QueriedNode) -> bool:
+    """Return true when a node has file and line-span coordinates."""
+    return (
+        node.file is not None
+        and node.start_line is not None
+        and node.end_line is not None
+    )
+
+
+def has_content(node: QueriedNode) -> bool:
+    """Return true when a node carries non-empty code/content text."""
+    return bool((node.content or "").strip())
+
+
+def is_symbol_candidate(node: QueriedNode) -> bool:
+    """Return true when a node type is a CodeMiner symbol type."""
+    return is_symbol_node(node.type)
+
+
+def include_extensions(extensions: Iterable[str]) -> CandidatePredicate:
+    """Build a predicate that keeps nodes whose file suffix is in *extensions*."""
+    allowed = {
+        ext.lower() if ext.startswith(".") else f".{ext.lower()}"
+        for ext in extensions
+        if ext
+    }
+
+    def predicate(node: QueriedNode) -> bool:
+        if not allowed:
+            return True
+        if not node.file:
+            return False
+        return PurePosixPath(_normalize_path(node.file)).suffix.lower() in allowed
+
+    return predicate
+
+
+def exclude_paths(patterns: Iterable[str]) -> CandidatePredicate:
+    """Build a predicate that drops nodes whose path matches any glob pattern."""
+    globs = [pattern for pattern in patterns if pattern]
+
+    def predicate(node: QueriedNode) -> bool:
+        if not globs:
+            return True
+        path = _normalize_path(node.file or "")
+        if not path:
+            return True
+        return not any(fnmatch(path, pattern) for pattern in globs)
+
+    return predicate
+
+
+def drop_test_files(node: QueriedNode) -> bool:
+    """Return false for common test/spec file paths."""
+    return not is_test_path(node.file)
+
+
+def is_test_path(path: Optional[str]) -> bool:
+    """Heuristic path classifier for test/spec files.
+
+    This is intentionally only a generic filesystem heuristic. Ground-truth or
+    benchmark-specific notions of "actionable" should stay in evaluation code,
+    not in retrieval filtering.
+    """
+    if not path:
+        return False
+    normalized = _normalize_path(path)
+    lower = normalized.lower()
+    parts = [part for part in lower.split("/") if part]
+    if any(
+        part in {"test", "tests", "testing", "spec", "specs", "__tests__"}
+        for part in parts
+    ):
+        return True
+    filename = parts[-1] if parts else lower
+    raw_filename = normalized.split("/")[-1] if normalized else ""
+    stem = filename.rsplit(".", 1)[0]
+    raw_stem = raw_filename.rsplit(".", 1)[0]
+    return (
+        filename.startswith("test_")
+        or filename.endswith("_test.py")
+        or filename.endswith("_tests.py")
+        or ".test." in filename
+        or ".spec." in filename
+        or stem.endswith("_test")
+        or stem.endswith("_tests")
+        or stem.endswith("_spec")
+        or stem.endswith("-test")
+        or stem.endswith("-tests")
+        or stem.endswith("-spec")
+        or raw_stem.endswith("Test")
+        or raw_stem.endswith("Tests")
+        or raw_stem.endswith("Spec")
+    )
+
+
+def build_candidate_filters(
+    *,
+    require_span: bool = False,
+    require_content: bool = False,
+    symbol_only: bool = False,
+    drop_tests: bool = False,
+    include_exts: Optional[Iterable[str]] = None,
+    exclude_globs: Optional[Iterable[str]] = None,
+) -> List[CandidatePredicate]:
+    """Construct a filter list from explicit retrieval-pipeline options."""
+    predicates: List[CandidatePredicate] = []
+    if require_span:
+        predicates.append(has_span)
+    if require_content:
+        predicates.append(has_content)
+    if symbol_only:
+        predicates.append(is_symbol_candidate)
+    if drop_tests:
+        predicates.append(drop_test_files)
+    if include_exts:
+        predicates.append(include_extensions(include_exts))
+    if exclude_globs:
+        predicates.append(exclude_paths(exclude_globs))
+    return predicates
+
+
+def _normalize_path(path: str) -> str:
+    return str(path).replace("\\", "/")

--- a/codeminer/ops/rerank.py
+++ b/codeminer/ops/rerank.py
@@ -5,12 +5,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Dict, List, Literal, Optional, Sequence
+
+import numpy as np
 
 from ..agent.rerank_agent import RerankAgent
 from ..index.embedding.vector_store import CodeVectorStore
 from ..llm.litellm_chat import LiteLLMChat
 from ..log_utils import get_logger
+from ..types import QueriedNode
 
 logger = get_logger(__name__)
 
@@ -41,3 +44,66 @@ class RerankContext:
             )
             self.agent = RerankAgent(llm=self.llm, listwise_format=self.listwise_format)
         return self.agent
+
+
+def rerank_by_embedding(
+    query: str,
+    candidates: Sequence[QueriedNode],
+    embedding_store: CodeVectorStore,
+    *,
+    top_k: Optional[int] = None,
+) -> List[QueriedNode]:
+    """Score candidate contents online with an embedding model.
+
+    This operator intentionally does not search the global vector index. It only
+    re-embeds the provided candidate contents and sorts those candidates by
+    similarity to the query. Use it after retrieval/graph expansion has already
+    assembled the candidate set.
+    """
+    candidates_with_content = [
+        candidate for candidate in candidates if candidate.content
+    ]
+    if not candidates_with_content:
+        return []
+
+    query_vec = np.array(embedding_store.embedding.embed_query(query), dtype=np.float32)
+    doc_vectors = np.array(
+        embedding_store.embedding.embed_documents(
+            [candidate.content for candidate in candidates_with_content]
+        ),
+        dtype=np.float32,
+    )
+
+    metric = embedding_store.index_metric
+    if metric == "ip":
+        scores = np.dot(doc_vectors, query_vec).tolist()
+    elif metric == "l2":
+        scores = (-np.linalg.norm(doc_vectors - query_vec, axis=1)).tolist()
+    else:
+        raise ValueError(f"Unsupported index metric: {metric!r}")
+
+    ranked = sorted(
+        zip(scores, candidates_with_content, strict=True),
+        key=lambda pair: pair[0],
+        reverse=True,
+    )
+    if top_k is not None:
+        ranked = ranked[:top_k]
+    return [_copy_with_score(candidate, float(score)) for score, candidate in ranked]
+
+
+def _copy_with_score(candidate: QueriedNode, score: float) -> QueriedNode:
+    update = {"score": score}
+    if hasattr(candidate, "model_copy"):
+        return candidate.model_copy(update=update)
+    if hasattr(candidate, "copy"):
+        return candidate.copy(update=update)
+    data: Dict[str, object]
+    if hasattr(candidate, "model_dump"):
+        data = dict(candidate.model_dump())
+    elif hasattr(candidate, "dict"):
+        data = dict(candidate.dict())
+    else:
+        raise TypeError(f"Object {candidate!r} does not support model dumping.")
+    data.update(update)
+    return QueriedNode(**data)

--- a/codeminer/ops/retrieve.py
+++ b/codeminer/ops/retrieve.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from ..index.embedding.vector_store import CodeVectorStore
 from ..index.regex_idx.regex_idx import RegexNodeIndex
@@ -104,6 +104,47 @@ def merge_hybrid(
     if top_k:
         merged = merged[:top_k]
     return merged
+
+
+def queried_node_key(item: QueriedNode) -> Tuple[Any, ...]:
+    """Stable identity for deduping candidate nodes across pipeline stages."""
+    node_id = (item.node_id or "").strip()
+    if node_id:
+        return ("node_id", node_id)
+    return (
+        "span",
+        item.file,
+        item.node_name,
+        item.start_line,
+        item.end_line,
+    )
+
+
+def dedup_queried_nodes(nodes: Sequence[QueriedNode]) -> List[QueriedNode]:
+    """Deduplicate nodes while preserving first-seen rank order.
+
+    Retrieval pipelines often concatenate dense hits with graph-expanded
+    neighbors. The dense order is the ranking signal; duplicates should not
+    consume multiple top-k slots. If a later duplicate carries code content and
+    the first copy does not, keep the first rank but attach the content.
+    """
+    by_key: Dict[Tuple[Any, ...], int] = {}
+    out: List[QueriedNode] = []
+    for node in nodes:
+        key = queried_node_key(node)
+        existing_idx = by_key.get(key)
+        if existing_idx is None:
+            by_key[key] = len(out)
+            out.append(node)
+            continue
+        existing = out[existing_idx]
+        if not existing.content and node.content:
+            out[existing_idx] = _with_score(
+                existing,
+                existing.score or 0.0,
+                content_override=node.content,
+            )
+    return out
 
 
 def _with_score(

--- a/codeminer/ops/retrieve.py
+++ b/codeminer/ops/retrieve.py
@@ -66,26 +66,33 @@ def merge_hybrid(
     branches: List[List[QueriedNode]],
     weights: Optional[List[float]] = None,
     top_k: Optional[int] = None,
+    *,
+    fusion: str = "weighted",
+    rrf_k: int = 60,
 ) -> List[QueriedNode]:
-    """Merge multiple retrieval branches with weighted scoring."""
+    """Merge multiple retrieval branches with weighted scoring or RRF."""
     if not branches:
         return []
 
     if not weights or len(weights) != len(branches):
         weights = [1.0] * len(branches)
+    if rrf_k <= 0:
+        raise ValueError("rrf_k must be positive.")
 
-    accumulator: Dict[
-        Tuple[Optional[str], str, Optional[int], Optional[int]], QueriedNode
-    ] = {}
+    normalized_fusion = _normalize_fusion(fusion)
+
+    accumulator: Dict[Tuple[Any, ...], QueriedNode] = {}
 
     for weight, results in zip(weights, branches, strict=True):
-        for rank, item in enumerate(results):
-            base_score = item.score or 0.0
-            if base_score == 0.0:
-                base_score = 1.0 / (rank + 1)
-
-            key = (item.file, item.node_name, item.start_line, item.end_line)
-            weighted = weight * base_score
+        for rank, item in enumerate(results, start=1):
+            key = queried_node_key(item)
+            weighted = _fusion_score(
+                item,
+                rank=rank,
+                weight=weight,
+                fusion=normalized_fusion,
+                rrf_k=rrf_k,
+            )
 
             if key not in accumulator:
                 accumulator[key] = _with_score(item, weighted)
@@ -101,7 +108,7 @@ def merge_hybrid(
         reverse=True,
     )
 
-    if top_k:
+    if top_k is not None:
         merged = merged[:top_k]
     return merged
 
@@ -160,6 +167,37 @@ def _with_score(
     data = _dump_model(item)
     data.update(update)
     return QueriedNode(**data)
+
+
+def _fusion_score(
+    item: QueriedNode,
+    *,
+    rank: int,
+    weight: float,
+    fusion: str,
+    rrf_k: int,
+) -> float:
+    if fusion == "rrf":
+        return weight / float(rrf_k + rank)
+
+    base_score = item.score or 0.0
+    if base_score == 0.0:
+        base_score = 1.0 / rank
+    return weight * base_score
+
+
+def _normalize_fusion(value: str) -> str:
+    normalized = (value or "weighted").strip().lower().replace("-", "_")
+    aliases = {
+        "linear": "weighted",
+        "linear_combination": "weighted",
+        "weighted_sum": "weighted",
+        "none": "weighted",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in {"weighted", "rrf"}:
+        raise ValueError("fusion must be 'weighted' or 'rrf'.")
+    return normalized
 
 
 def _dump_model(model: object) -> Dict[str, object]:

--- a/examples/codeminer_base_rerank_matrix.py
+++ b/examples/codeminer_base_rerank_matrix.py
@@ -41,8 +41,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-import numpy as np
-
 from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
 from codeminer.eval.retrieval_eval import (
     aggregate_metrics,
@@ -54,6 +52,7 @@ from codeminer.eval.retrieval_eval import (
 from codeminer.index.embedding import CodeVectorStore
 from codeminer.log_utils import get_logger
 from codeminer.model.embedding_retrieve_pipeline import EmbeddingRetrievePipeline
+from codeminer.ops.rerank import rerank_by_embedding
 from codeminer.profiler import Profiler
 from codeminer.types import QueriedNode
 
@@ -316,31 +315,7 @@ def _rerank_with_large(
 
     Mirrors ``RetrieveRerankPipeline._rerank_embedding``.
     """
-    candidates_with_content = [c for c in candidates if c.content]
-    if not candidates_with_content:
-        return []
-
-    q_vec = np.array(large_store.embedding.embed_query(query), dtype=np.float32)
-    d_vecs = np.array(
-        large_store.embedding.embed_documents(
-            [c.content for c in candidates_with_content]
-        ),
-        dtype=np.float32,
-    )
-    metric = large_store.index_metric
-    if metric == "ip":
-        scores = np.dot(d_vecs, q_vec).tolist()
-    elif metric == "l2":
-        scores = (-np.linalg.norm(d_vecs - q_vec, axis=1)).tolist()
-    else:
-        raise ValueError(f"Unsupported index metric: {metric!r}")
-
-    ranked = sorted(
-        zip(scores, candidates_with_content, strict=True),
-        key=lambda pair: pair[0],
-        reverse=True,
-    )
-    return [c.model_copy(update={"score": float(score)}) for score, c in ranked[:top_k]]
+    return rerank_by_embedding(query, candidates, large_store, top_k=top_k)
 
 
 def _rerank_with_cross_encoder(

--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Graph-based retrieval baseline script.
+Sparse-seeded graph retrieval baseline script.
 
 This script demonstrates a three-stage retrieval pipeline:
 1. Stage 1: Select a small number of initial nodes (e.g., 5) using BM25.
@@ -14,7 +14,8 @@ This script demonstrates a three-stage retrieval pipeline:
 3. Stage 3 (optional): Use embeddings within the expanded set to rank/select
    the final results.
 
-This is a baseline for comparison with embedding-only retrieval.
+This is a graph-first baseline for comparison with embedding-only retrieval.
+It is not the dense-first graph-augmentation pipeline.
 
 Usage:
     # Graph-only (no embedding rerank)
@@ -35,8 +36,7 @@ Usage:
     python examples/graph_retrieve_baseline.py --dataset codeminer_base \\
         --metrics-k 1 3 5 10
 
-    # Profiling sweep over a fixed corpus CSV (see
-    # scripts/profiling/profile_graph_rag.sh)
+    # Profiling sweep over a fixed corpus CSV
     python examples/graph_retrieve_baseline.py --dataset swebench_lite \\
         --filter-csv examples/selected_instance.csv \\
         --enable-profiler --record-samples --record-memory
@@ -60,7 +60,7 @@ from codeminer.eval.retrieval_eval import (
     extract_predictions,
 )
 from codeminer.log_utils import get_logger
-from codeminer.model import GraphRetrievePipeline
+from codeminer.model import SparseSeededGraphRetrievePipeline
 from codeminer.profiler import Profiler, percentile_from_sorted
 
 logger = get_logger(__name__)
@@ -582,7 +582,7 @@ def parse_args():
         default=None,
         help=(
             "Directory to store runtime profiler summaries "
-            "(default: <index-cache-dir>/profile_log/graph_rag)."
+            "(default: <index-cache-dir>/profile_log/sparse_seed_graph)."
         ),
     )
     parser.add_argument(
@@ -637,6 +637,16 @@ def _resolve_rerank_strategy(args):
     return "embedding" if args.embedding else "none"
 
 
+def _method_label(args, rerank_strategy: str) -> str:
+    """Stable method label for sparse-seeded graph-first baselines."""
+    expansion = "ppr" if args.ppr else "bfs"
+    label = f"sparse_seed_graph_{expansion}"
+    if rerank_strategy != "none":
+        strategy = rerank_strategy.replace("-", "_")
+        label = f"{label}_plus_{strategy}_rerank"
+    return label
+
+
 def run_graph_pipeline(args):
     """Run the graph-based retrieval baseline."""
 
@@ -666,7 +676,7 @@ def run_graph_pipeline(args):
             if args.profile_dir
             else Path(args.index_cache_dir).expanduser().resolve()
             / "profile_log"
-            / "graph_rag"
+            / "sparse_seed_graph"
         )
         base.mkdir(parents=True, exist_ok=True)
         return base
@@ -721,7 +731,7 @@ def run_graph_pipeline(args):
         query_profiler = None
         if profiling_enabled:
             index_profiler = Profiler(
-                name=f"graph_rag[index][{instance_id}]",
+                name=f"sparse_seed_graph[index][{instance_id}]",
                 logger=logger,
                 emit_events=False,
                 summary_level=logging.INFO,
@@ -729,7 +739,7 @@ def run_graph_pipeline(args):
                 record_memory=args.record_memory,
             )
             query_profiler = Profiler(
-                name=f"graph_rag[query][{instance_id}]",
+                name=f"sparse_seed_graph[query][{instance_id}]",
                 logger=logger,
                 emit_events=False,
                 summary_level=logging.INFO,
@@ -748,7 +758,7 @@ def run_graph_pipeline(args):
             # is multi-language; SWE-bench / Loc-Bench fall back to --languages).
             instance_languages = _resolve_instance_languages(instance, args.languages)
 
-            pipeline = GraphRetrievePipeline(
+            pipeline = SparseSeededGraphRetrievePipeline(
                 repo_path=repo_path,
                 index_path=index_path,
                 stage1_topk=args.stage1_topk,
@@ -842,12 +852,11 @@ def run_graph_pipeline(args):
 
             if all_results is not None:
                 unique_files, normalized_symbols = extract_predictions(results)
+                method_label = _method_label(args, rerank_strategy)
                 all_results.append(
                     {
                         "instance_id": instance_id,
-                        "method": (
-                            "graph_ppr_baseline" if args.ppr else "graph_baseline"
-                        ),
+                        "method": method_label,
                         "stage1_topk": args.stage1_topk,
                         "stage2_topk": args.stage2_topk,
                         "k_hop": args.k_hop,
@@ -910,6 +919,7 @@ def run_graph_pipeline(args):
             "k_hop": args.k_hop,
             "ppr_damping": args.ppr_damping,
             "rerank_strategy": rerank_strategy,
+            "method": _method_label(args, rerank_strategy),
             "embedding_model": (
                 args.embedding_model if rerank_strategy == "embedding" else None
             ),
@@ -952,14 +962,12 @@ def run_graph_pipeline(args):
         tag_part = (
             f"__{_sanitize_filename_part(args.profile_tag)}" if args.profile_tag else ""
         )
-        expansion = "ppr" if args.ppr else "bfs"
         # Sanitize args.dataset for symmetry with profile_tag — today
         # `choices=` constrains it to safe values, but if that ever
         # loosens we don't want to write outside the resolved profile dir.
         dataset_part = _sanitize_filename_part(args.dataset)
-        profile_filename = (
-            f"graph_rag_{dataset_part}_{expansion}_{rerank_strategy}{tag_part}.json"
-        )
+        method_part = _method_label(args, rerank_strategy)
+        profile_filename = f"{method_part}_{dataset_part}{tag_part}.json"
         profile_path = profile_dir / profile_filename
         with open(profile_path, "w", encoding="utf-8") as f:
             json.dump(profile_payload, f, indent=2, ensure_ascii=False)

--- a/examples/retrieve_rerank.py
+++ b/examples/retrieve_rerank.py
@@ -247,8 +247,18 @@ def parse_args():
         "--retrieval-mode",
         type=str,
         default="dense",
-        choices=["dense", "sparse", "hybrid"],
-        help="Retrieval plan to run (dense-only, BM25-only, or hybrid).",
+        choices=["auto", "dense", "sparse", "hybrid"],
+        help=(
+            "Retrieval plan to run. 'auto' enables query/budget-aware planning; "
+            "the other modes use fixed dense, BM25, or hybrid presets."
+        ),
+    )
+    parser.add_argument(
+        "--planning-budget",
+        type=str,
+        default="balanced",
+        choices=["fast", "balanced", "thorough"],
+        help="Planner budget used when --retrieval-mode=auto.",
     )
     parser.add_argument(
         "--retrieval-level",
@@ -365,9 +375,12 @@ def _resolve_instance_languages(instance, cli_languages):
 
 
 def _build_method_tag(args) -> str:
+    mode = args.retrieval_mode
+    if mode == "auto":
+        mode = f"auto_{args.planning_budget}"
     if args.retrieval_only:
-        return f"{args.retrieval_mode}_retrieval_only"
-    return f"{args.retrieval_mode}_retrieve_plus_{args.rerank_strategy}_rerank"
+        return f"{mode}_retrieval_only"
+    return f"{mode}_retrieve_plus_{args.rerank_strategy}_rerank"
 
 
 def _sanitize_filename_part(value: str) -> str:
@@ -481,6 +494,7 @@ def run_pipeline(args):
 
     eval_metadata = dataset_obj.load_eval_metadata(args.eval_instances)
     retrieve_plan = build_retrieve_plan(args.retrieval_mode)
+    fixed_retrieve_plan = None if args.retrieval_mode == "auto" else retrieve_plan
     retrieve_top_k = max((stage.top_k or RETRIEVAL_TOP_K) for stage in retrieve_plan)
     aggregate = {}
     metrics_k = sorted(set(args.metrics_k))
@@ -571,8 +585,10 @@ def run_pipeline(args):
                         rerank_embedding_model_kwargs=rerank_embedding_kwargs,
                         languages=instance_languages,
                         max_lines_per_chunk=args.max_lines_per_chunk,
-                        retrieval_plan=retrieve_plan,
+                        retrieval_plan=fixed_retrieve_plan,
+                        retrieval_mode=args.retrieval_mode,
                         retrieval_level=args.retrieval_level,
+                        planning_budget=args.planning_budget,
                         rerank_window_size=args.rerank_window_size,
                         rerank_window_step=args.rerank_window_step,
                         rerank_listwise_format=args.rerank_listwise_format,
@@ -584,6 +600,7 @@ def run_pipeline(args):
                 query = instance["problem_statement"]
                 with instance_profiler.section("pipeline.query"):
                     results = pipeline.query(query=query, top_k=query_top_k)
+                    selected_plan = getattr(pipeline, "last_selected_plan", None)
 
                 with instance_profiler.section("evaluate_predictions"):
                     metrics = evaluate_predictions(
@@ -637,6 +654,16 @@ def run_pipeline(args):
                             else []
                         ),
                         "metrics": metrics,
+                        "retrieval_plan": (
+                            {
+                                "name": selected_plan.name,
+                                "intent": selected_plan.intent,
+                                "fusion": selected_plan.fusion,
+                                "rerank_strategy": selected_plan.rerank_strategy,
+                            }
+                            if selected_plan is not None
+                            else args.retrieval_mode
+                        ),
                     }
                     all_results.append(result_entry)
         finally:
@@ -705,6 +732,7 @@ def run_pipeline(args):
             "split": args.split,
             "filter_instance": args.filter_instance,
             "retrieval_mode": args.retrieval_mode,
+            "planning_budget": args.planning_budget,
             "retrieval_level": args.retrieval_level,
             "retrieval_only": args.retrieval_only,
             "rerank_strategy": None if args.retrieval_only else args.rerank_strategy,
@@ -730,6 +758,8 @@ def main():
     logger.info("Dataset type: %s", args.dataset)
     logger.info("Embedding model: %s", args.embedding_model)
     logger.info("Retrieval mode: %s", args.retrieval_mode)
+    if args.retrieval_mode == "auto":
+        logger.info("Planning budget: %s", args.planning_budget)
     logger.info("Retrieval level: %s", args.retrieval_level)
     if args.retrieval_only:
         logger.info("Mode: Retrieval-only (reranking disabled)")

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -163,19 +163,17 @@ def build_symbol_span_index(prebuilt_dir: str, instance_id: str) -> Dict[Any, An
     Graph vertices are 0-based (tree-sitter); shifted +1 here to match the
     1-based ground-truth blocks. Returns an empty dict when no graph is present.
     """
-    import pickle
-
     from codeminer.eval.retrieval_eval import normalize_file_path
+    from scripts.agent_compile.lib.prebuilt import load_prebuilt_code_graph
 
     path = os.path.join(prebuilt_dir, instance_id, "graph.pkl")
     if not os.path.exists(path):
         return {}
     try:
-        with open(path, "rb") as f:
-            graph = pickle.load(f)
+        graph = load_prebuilt_code_graph(prebuilt_dir, instance_id)
     except Exception:  # noqa: BLE001 — a missing/corrupt graph just disables this
         return {}
-    g = graph.get("graph") if isinstance(graph, dict) else None
+    g = getattr(graph, "graph", None)
     if g is None:
         return {}
     index: Dict[Any, Any] = {}

--- a/scripts/agent_compile/lib/prebuilt.py
+++ b/scripts/agent_compile/lib/prebuilt.py
@@ -18,7 +18,8 @@ layout::
 layout (``bm25/``, ``vector/``, ``symbol_graph/``). This module bridges the
 two by staging a per-instance cache directory:
 
-* ``symbol_graph/graph.pkl`` — symlink to the prebuilt ``graph.pkl``
+* ``symbol_graph/graph.pkl`` — current-schema graph file staged from the
+  prebuilt ``graph.pkl`` (legacy prebuilt bundles are normalized here)
 * ``vector`` — symlink to the instance dir (``CodeVectorStore.load`` reads
   its top-level ``config_<model>.json`` plus ``l0/`` and ``l2/``)
 * ``bm25/`` — built fresh from the prebuilt graph (pure-Python, no model,
@@ -33,7 +34,8 @@ requires the vector index.
 from __future__ import annotations
 
 import os
-from typing import Optional
+import pickle
+from typing import Any, Optional
 
 
 def model_suffix(embedding_model: str) -> str:
@@ -72,6 +74,85 @@ def _symlink(target: str, link: str) -> None:
     os.symlink(target, link)
 
 
+def load_prebuilt_code_graph(prebuilt_root: str, instance_id: str):
+    """Load ``<prebuilt_root>/<instance_id>/graph.pkl`` as a ``CodeGraph``.
+
+    The prebuilt corpus is older than the current on-disk graph cache schema for
+    many instances: those pickles contain the historical flat bundle
+    ``{"graph", "name_to_vertex", "symbol_ranges", "project_root"}`` with no
+    ``schema_version``. Keep ``CodeGraph.load_graph`` strict for ordinary
+    caches, but accept that legacy bundle here because this module's contract is
+    explicitly to consume the external prebuilt tree.
+    """
+    from codeminer.graph.code_graph import _SCHEMA_VERSION, CodeGraph
+
+    path = os.path.join(instance_dir(prebuilt_root, instance_id), "graph.pkl")
+    try:
+        return CodeGraph.load_graph(path)
+    except (AttributeError, ValueError):
+        pass
+
+    with open(path, "rb") as f:
+        data = pickle.load(f)
+
+    if isinstance(data, CodeGraph):
+        graph = data
+    elif isinstance(data, dict) and data.get("graph") is not None:
+        schema_version = data.get("schema_version")
+        if schema_version not in (None, _SCHEMA_VERSION):
+            raise ValueError(
+                f"prebuilt graph.pkl at {path} has unsupported "
+                f"schema_version={schema_version!r}"
+            )
+        graph = CodeGraph(project_root=data.get("project_root"))
+        graph.graph = data["graph"]
+        graph.symbol_ranges = data.get("symbol_ranges", {})
+        graph.name_to_vertex = data.get("name_to_vertex") or _name_to_vertex(
+            graph.graph
+        )
+        graph._file_nodes = data.get("file_nodes", {})
+        graph._file_edge_anchors = data.get("file_edge_anchors", {})
+        graph._unified_to_names = data.get("unified_to_names", {})
+    else:
+        raise ValueError(f"prebuilt graph.pkl at {path} is not a CodeGraph bundle")
+
+    if not graph.name_to_vertex:
+        graph.name_to_vertex = _name_to_vertex(graph.graph)
+    if not graph._file_nodes or not graph._unified_to_names:
+        graph.build_range_indexes()
+    return graph
+
+
+def _name_to_vertex(igraph_obj: Any) -> dict:
+    out = {}
+    for v in igraph_obj.vs:
+        name = v.attributes().get("name")
+        if name:
+            out[name] = v.index
+    return out
+
+
+def _stage_symbol_graph(src: str, dst: str, code_graph: Optional[object]) -> object:
+    """Ensure ``dst`` is loadable by the current strict ``CodeGraph`` loader."""
+    from codeminer.graph.code_graph import CodeGraph
+
+    if os.path.exists(dst) or os.path.islink(dst):
+        try:
+            return CodeGraph.load_graph(dst)
+        except Exception:
+            os.unlink(dst)
+
+    graph = code_graph
+    if graph is None:
+        instance_id = os.path.basename(os.path.dirname(src))
+        prebuilt_root = os.path.dirname(os.path.dirname(src))
+        graph = load_prebuilt_code_graph(prebuilt_root, instance_id)
+
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    graph.save_graph(dst)
+    return graph
+
+
 def stage_prebuilt_indexes(
     prebuilt_root: str,
     instance_id: str,
@@ -91,11 +172,14 @@ def stage_prebuilt_indexes(
 
     os.makedirs(cache_dir, exist_ok=True)
 
-    # symbol_graph/graph.pkl -> prebuilt graph.pkl
-    _symlink(
-        os.path.join(inst, "graph.pkl"),
-        os.path.join(cache_dir, "symbol_graph", "graph.pkl"),
-    )
+    graph_src = os.path.join(inst, "graph.pkl")
+    graph_dst = os.path.join(cache_dir, "symbol_graph", "graph.pkl")
+    graph = None
+    if build_bm25:
+        graph = _stage_symbol_graph(graph_src, graph_dst, code_graph)
+    else:
+        # Lightweight staging for tests / callers that only need the path shape.
+        _symlink(graph_src, graph_dst)
 
     # vector -> the instance dir itself (CodeVectorStore.load scans l0/l2)
     _symlink(inst, os.path.join(cache_dir, "vector"))
@@ -103,10 +187,11 @@ def stage_prebuilt_indexes(
     # bm25/ — build fresh from the prebuilt graph (no embedding model needed)
     bm25_dir = os.path.join(cache_dir, "bm25")
     if build_bm25 and not (os.path.isdir(bm25_dir) and os.listdir(bm25_dir)):
-        from codeminer.graph.code_graph import CodeGraph
         from codeminer.index.sparse_idx.bm25_index import BM25CodeIndexer
 
-        graph = code_graph or CodeGraph.load_graph(os.path.join(inst, "graph.pkl"))
+        graph = (
+            graph or code_graph or load_prebuilt_code_graph(prebuilt_root, instance_id)
+        )
         os.makedirs(bm25_dir, exist_ok=True)
         BM25CodeIndexer(code_graph=graph).save_index(bm25_dir)
 

--- a/scripts/agent_compile/lib/verify_expand.py
+++ b/scripts/agent_compile/lib/verify_expand.py
@@ -18,7 +18,6 @@ agent turns and only when verification fails. See .claude/design/agent-runtime.m
 from __future__ import annotations
 
 import os
-import pickle
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -114,11 +113,12 @@ def load_graph_nav(prebuilt_dir: str, instance_id: str) -> Optional[GraphNav]:
     if not os.path.exists(path):
         return None
     try:
-        with open(path, "rb") as f:
-            bundle = pickle.load(f)
+        from scripts.agent_compile.lib.prebuilt import load_prebuilt_code_graph
+
+        graph = load_prebuilt_code_graph(prebuilt_dir, instance_id)
     except Exception:  # noqa: BLE001 — missing/corrupt graph just disables verify
         return None
-    g = bundle.get("graph") if isinstance(bundle, dict) else None
+    g = getattr(graph, "graph", None)
     return GraphNav(g) if g is not None else None
 
 

--- a/scripts/profiling/profile_graph_rag.sh
+++ b/scripts/profiling/profile_graph_rag.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Profiling sweep for the graph-RAG retrieval pipeline (issue #131, Phase 3).
+# Profiling sweep for the sparse-seeded graph retrieval baseline.
 #
 # Runs examples/graph_retrieve_baseline.py with profiling enabled across the
 # three headline configurations, each over the same fixed corpus
@@ -17,11 +17,11 @@
 #   3. BFS expansion + embedding rerank (Qwen3-Embedding-0.6B, dim 1024)
 #
 # Each run writes one JSON to $PROFILE_DIR:
-#   graph_rag_<dataset>_<expansion>_<rerank>__<tag>.json
+#   sparse_seed_graph_<expansion>[_plus_<rerank>_rerank]_<dataset>__<tag>.json
 #
 # Usage:
 #   scripts/profiling/profile_graph_rag.sh
-#   PROFILE_DIR=/tmp/graphrag CSV=examples/selected_instance.csv \
+#   PROFILE_DIR=/tmp/sparse_seed_graph CSV=examples/selected_instance.csv \
 #       scripts/profiling/profile_graph_rag.sh
 #
 # Optional Phase 4 (LLM rerank) is intentionally NOT run here: LLM listwise
@@ -38,7 +38,7 @@ cd "${REPO_ROOT}"
 DATASET="${DATASET:-swebench_lite}"
 SPLIT="${SPLIT:-test}"
 CSV="${CSV:-examples/selected_instance.csv}"
-PROFILE_DIR="${PROFILE_DIR:-${REPO_ROOT}/profile_log/graph_rag}"
+PROFILE_DIR="${PROFILE_DIR:-${REPO_ROOT}/profile_log/sparse_seed_graph}"
 PROFILE_TAG="${PROFILE_TAG:-sweep}"
 
 # Stage parameters (issue #131: stage1 top-K=5, 2-hop, up to 50 nodes).
@@ -73,7 +73,7 @@ COMMON_ARGS=(
 )
 
 echo "=================================================================="
-echo "graph-RAG profiling sweep"
+echo "sparse-seeded graph profiling sweep"
 echo "  dataset    : ${DATASET} (${SPLIT})"
 echo "  corpus     : ${CSV}"
 echo "  profile dir: ${PROFILE_DIR}"
@@ -99,5 +99,5 @@ echo "[3/3] BFS expansion + embedding rerank (${EMBED_MODEL}, dim ${EMBED_DIM})"
 echo
 echo "=================================================================="
 echo "Done. Profiler JSONs written to ${PROFILE_DIR}:"
-ls -1 "${PROFILE_DIR}"/graph_rag_*"${PROFILE_TAG}".json 2>/dev/null || true
+ls -1 "${PROFILE_DIR}"/sparse_seed_graph_*"${PROFILE_TAG}".json 2>/dev/null || true
 echo "=================================================================="

--- a/scripts/retrieval_ablation/graphrag_retrieve.py
+++ b/scripts/retrieval_ablation/graphrag_retrieve.py
@@ -4,15 +4,15 @@
 
 """GraphRAG retrieval pipeline — run as a SCRIPT, not an agent tool (#133).
 
-The ``codeminer_context`` composer (bm25 ⊕ embedding seeds → call-graph
+The ``codeminer_context`` composer (bm25 + embedding seeds -> call-graph
 expansion → assembled context) is GraphRAG over a code call-graph. The agent
 ablation showed it does not earn its keep as an in-loop agent tool (additive
 overhead). Its honest home is here: a deterministic RETRIEVAL method, evaluated
-as a retriever (files@k recall) alongside the other retrieval baselines — not in
+as a retriever (files/symbols/blocks@k) alongside the other retrieval baselines — not in
 the agent baseline.
 
 This runner loads an instance's prebuilt indexes, runs the pipeline once, and
-reports the ranked candidate files + files@k recall vs ground truth. Use
+reports ranked retrieval metrics vs ground truth. Use
 ``--no-graph`` to compare against search-only (isolates the graph's recall
 contribution, same as the agent-side CODEMINER_COMPOSER_NO_GRAPH ablation but
 with no LLM in the loop).
@@ -46,21 +46,58 @@ def _covers(cands: List[str], target: str) -> bool:
     return any(c == t or c.endswith("/" + t) or t.endswith("/" + c) for c in cands)
 
 
+def _score_ranked(nodes: List[Any]) -> List[Any]:
+    """Score-desc retrieval order, matching the span scorer."""
+    return sorted(nodes, key=lambda n: getattr(n, "score", 0.0) or 0.0, reverse=True)
+
+
+def _actionable_nodes(nodes: List[Any]) -> List[Any]:
+    """Nodes with concrete line spans, matching what block metrics can score."""
+    out: List[Any] = []
+    for node in nodes:
+        if getattr(node, "start_line", None) is None:
+            continue
+        if getattr(node, "end_line", None) is None:
+            continue
+        out.append(node)
+    return out
+
+
+def _node_payload(nodes: List[Any], limit: int = 30) -> List[Dict[str, Any]]:
+    payload: List[Dict[str, Any]] = []
+    for rank, node in enumerate(nodes[:limit], 1):
+        payload.append(
+            {
+                "rank": rank,
+                "node_id": getattr(node, "node_id", None),
+                "node_name": getattr(node, "node_name", None),
+                "type": getattr(node, "type", None),
+                "file": getattr(node, "file", None),
+                "start_line": getattr(node, "start_line", None),
+                "end_line": getattr(node, "end_line", None),
+                "score": getattr(node, "score", None),
+            }
+        )
+    return payload
+
+
 def _retrieve(instance_id: str, cfg: Any, prebuilt_dir: str, cache_root: str):
-    """Run the GraphRAG composer once; return (ranked_files, target_files)."""
+    """Run the GraphRAG composer once; return nodes + target metadata."""
     from codeminer.agent.skills.registry import SkillRegistry
-    from codeminer.eval.retrieval_eval import collect_targets
+    from codeminer.eval.retrieval_eval import collect_target_blocks, collect_targets
     from scripts.agent_compile.lib.harness import load_dataset_rows, load_full_contexts
-    from scripts.agent_compile.lib.prebuilt import stage_prebuilt_indexes
+    from scripts.agent_compile.lib.prebuilt import repo_path_for, stage_prebuilt_indexes
 
     rows_by_id, eval_lookup = load_dataset_rows(cfg)
     row = rows_by_id[instance_id]
     query = row["problem_statement"]
     meta = eval_lookup.get(instance_id, row)
-    target_files, _ = collect_targets(meta, simplified_symbols=True)
+    target_files, target_symbols = collect_targets(meta, simplified_symbols=True)
+    target_blocks = collect_target_blocks(meta)
 
     cache_dir = os.path.join(cache_root, instance_id)
-    repo_path = stage_prebuilt_indexes(prebuilt_dir, instance_id, cache_dir)
+    repo_path = repo_path_for(prebuilt_dir, instance_id)
+    stage_prebuilt_indexes(prebuilt_dir, instance_id, cache_dir)
     load_full_contexts(cfg, repo_path, cache_dir)
     compose = SkillRegistry().get("codeminer_context").executor_fn
     nodes = compose(query=query, seeds=5, max_results=30)
@@ -70,8 +107,11 @@ def _retrieve(instance_id: str, cfg: Any, prebuilt_dir: str, cache_root: str):
         if f and f not in ranked_files:
             ranked_files.append(f)
     return (
+        nodes,
         ranked_files,
         [_norm(t) for t in target_files if t],
+        [_norm(t) for t in target_symbols if t],
+        target_blocks,
         row.get("language_group"),
     )
 
@@ -108,28 +148,100 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     results: List[Dict[str, Any]] = []
     hit_at: Counter = Counter()
+    symbol_hit_at: Counter = Counter()
+    block_hit_at: Counter = Counter()
+    score_symbol_hit_at: Counter = Counter()
+    score_block_hit_at: Counter = Counter()
     scored = 0
     for i, inst in enumerate(instances, 1):
         t0 = time.time()
         try:
-            ranked, targets, lang = _retrieve(inst, cfg, args.prebuilt_dir, cache_root)
+            from codeminer.eval.retrieval_eval import (
+                evaluate_predictions,
+                nodes_to_spans,
+                score_localization_spans,
+            )
+
+            nodes, ranked, targets, target_symbols, target_blocks, lang = _retrieve(
+                inst, cfg, args.prebuilt_dir, cache_root
+            )
+            score_ranked_nodes = _score_ranked(nodes)
+            actionable_nodes = _actionable_nodes(nodes)
+            score_actionable_nodes = _score_ranked(actionable_nodes)
             rec = {
                 f"files@{k}": (
                     bool(targets) and all(_covers(ranked[:k], t) for t in targets)
                 )
                 for k in args.k
             }
+            metrics = evaluate_predictions(nodes, targets, target_symbols, args.k)
+            score_metrics = evaluate_predictions(
+                score_ranked_nodes, targets, target_symbols, args.k
+            )
+            actionable_metrics = evaluate_predictions(
+                actionable_nodes, targets, target_symbols, args.k
+            )
+            score_actionable_metrics = evaluate_predictions(
+                score_actionable_nodes, targets, target_symbols, args.k
+            )
+            block_metrics = score_localization_spans(
+                answer_spans=[],
+                retrieval_spans=nodes_to_spans(nodes, sort_by_score=False),
+                gt_blocks=target_blocks,
+                ks=args.k,
+            )
+            score_block_metrics = score_localization_spans(
+                answer_spans=[],
+                retrieval_spans=nodes_to_spans(score_ranked_nodes),
+                gt_blocks=target_blocks,
+                ks=args.k,
+            )
             r = {
                 "instance_id": inst,
                 "language": lang,
                 "n_targets": len(targets),
+                "n_target_symbols": len(target_symbols),
+                "n_target_blocks": len(target_blocks),
+                "target_files": targets,
+                "target_symbols": target_symbols,
+                "target_blocks": target_blocks,
                 "recall": rec,
+                "metrics": metrics,
+                "score_metrics": score_metrics,
+                "actionable_metrics": actionable_metrics,
+                "score_actionable_metrics": score_actionable_metrics,
+                "block_metrics": block_metrics,
+                "score_block_metrics": score_block_metrics,
                 "n_ranked": len(ranked),
+                "n_ranked_nodes": len(nodes),
+                "n_actionable_nodes": len(actionable_nodes),
+                "ordered_nodes": _node_payload(nodes),
+                "ranked_nodes": _node_payload(score_ranked_nodes),
             }
             if targets:
                 scored += 1
                 for k in args.k:
                     hit_at[k] += int(rec[f"files@{k}"])
+                    symbol_hit_at[k] += int(
+                        actionable_metrics["symbols"][k]["accuracy"]
+                        if target_symbols
+                        else 0
+                    )
+                    block_hit_at[k] += int(
+                        block_metrics["retrieval_blocks"][k]["accuracy"]
+                        if target_blocks
+                        else 0
+                    )
+                    score_symbol_hit_at[k] += int(
+                        score_actionable_metrics["symbols"][k]["accuracy"]
+                        if target_symbols
+                        else 0
+                    )
+                    score_block_hit_at[k] += int(
+                        score_block_metrics["retrieval_blocks"][k]["accuracy"]
+                        if target_blocks
+                        else 0
+                    )
         except Exception as e:  # noqa: BLE001 — keep scanning
             r = {"instance_id": inst, "error": repr(e)}
             traceback.print_exc()
@@ -142,10 +254,27 @@ def main(argv: Optional[List[str]] = None) -> int:
         args.out.write_text(json.dumps(results, indent=2))
 
     mode = "search-only" if args.no_graph else "GraphRAG (search+graph)"
-    print(f"\n=== {mode} retrieval recall over {scored} scored instances ===")
+    print(f"\n=== {mode} retrieval over {scored} scored instances ===")
     for k in args.k:
         pct = 100.0 * hit_at[k] / scored if scored else 0.0
         print(f"  files@{k}: {hit_at[k]}/{scored} = {pct:.0f}%")
+    for k in args.k:
+        pct = 100.0 * symbol_hit_at[k] / scored if scored else 0.0
+        print(f"  actionable_symbols@{k}: {symbol_hit_at[k]}/{scored} = {pct:.0f}%")
+    for k in args.k:
+        pct = 100.0 * block_hit_at[k] / scored if scored else 0.0
+        print(f"  retrieval_blocks@{k}: {block_hit_at[k]}/{scored} = {pct:.0f}%")
+    for k in args.k:
+        pct = 100.0 * score_symbol_hit_at[k] / scored if scored else 0.0
+        print(
+            f"  score_actionable_symbols@{k}: "
+            f"{score_symbol_hit_at[k]}/{scored} = {pct:.0f}%"
+        )
+    for k in args.k:
+        pct = 100.0 * score_block_hit_at[k] / scored if scored else 0.0
+        print(
+            f"  score_retrieval_blocks@{k}: {score_block_hit_at[k]}/{scored} = {pct:.0f}%"
+        )
     return 0
 
 

--- a/scripts/retrieval_ablation/graphrag_retrieve.py
+++ b/scripts/retrieval_ablation/graphrag_retrieve.py
@@ -153,6 +153,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     score_symbol_hit_at: Counter = Counter()
     score_block_hit_at: Counter = Counter()
     scored = 0
+    symbol_scored = 0
+    block_scored = 0
     for i, inst in enumerate(instances, 1):
         t0 = time.time()
         try:
@@ -220,6 +222,10 @@ def main(argv: Optional[List[str]] = None) -> int:
             }
             if targets:
                 scored += 1
+                if target_symbols:
+                    symbol_scored += 1
+                if target_blocks:
+                    block_scored += 1
                 for k in args.k:
                     hit_at[k] += int(rec[f"files@{k}"])
                     symbol_hit_at[k] += int(
@@ -259,21 +265,27 @@ def main(argv: Optional[List[str]] = None) -> int:
         pct = 100.0 * hit_at[k] / scored if scored else 0.0
         print(f"  files@{k}: {hit_at[k]}/{scored} = {pct:.0f}%")
     for k in args.k:
-        pct = 100.0 * symbol_hit_at[k] / scored if scored else 0.0
-        print(f"  actionable_symbols@{k}: {symbol_hit_at[k]}/{scored} = {pct:.0f}%")
-    for k in args.k:
-        pct = 100.0 * block_hit_at[k] / scored if scored else 0.0
-        print(f"  retrieval_blocks@{k}: {block_hit_at[k]}/{scored} = {pct:.0f}%")
-    for k in args.k:
-        pct = 100.0 * score_symbol_hit_at[k] / scored if scored else 0.0
+        pct = 100.0 * symbol_hit_at[k] / symbol_scored if symbol_scored else 0.0
         print(
-            f"  score_actionable_symbols@{k}: "
-            f"{score_symbol_hit_at[k]}/{scored} = {pct:.0f}%"
+            f"  actionable_symbols@{k}: "
+            f"{symbol_hit_at[k]}/{symbol_scored} = {pct:.0f}%"
         )
     for k in args.k:
-        pct = 100.0 * score_block_hit_at[k] / scored if scored else 0.0
+        pct = 100.0 * block_hit_at[k] / block_scored if block_scored else 0.0
         print(
-            f"  score_retrieval_blocks@{k}: {score_block_hit_at[k]}/{scored} = {pct:.0f}%"
+            f"  retrieval_blocks@{k}: " f"{block_hit_at[k]}/{block_scored} = {pct:.0f}%"
+        )
+    for k in args.k:
+        pct = 100.0 * score_symbol_hit_at[k] / symbol_scored if symbol_scored else 0.0
+        print(
+            f"  score_actionable_symbols@{k}: "
+            f"{score_symbol_hit_at[k]}/{symbol_scored} = {pct:.0f}%"
+        )
+    for k in args.k:
+        pct = 100.0 * score_block_hit_at[k] / block_scored if block_scored else 0.0
+        print(
+            f"  score_retrieval_blocks@{k}: "
+            f"{score_block_hit_at[k]}/{block_scored} = {pct:.0f}%"
         )
     return 0
 

--- a/test/agent/test_prebuilt.py
+++ b/test/agent/test_prebuilt.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import pickle
 from pathlib import Path
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -41,6 +42,33 @@ def _make_prebuilt(root: Path, iid: str, model: str, *, full=True):
     if full:
         (l2 / f"documents_{suffix}.pkl").write_text("x")
     return d
+
+
+def _write_legacy_graph(path: Path):
+    from codeminer.graph.code_graph import CodeGraph
+
+    graph = CodeGraph(project_root="repo")
+    graph.add_file_node("pkg/mod.py")
+    graph.add_symbol_node(
+        "pkg.mod.foo",
+        line=0,
+        scope_start_line=0,
+        scope_end_line=2,
+        symbol_type="function",
+    )
+    graph.graph.vs[graph.name_to_vertex["pkg.mod.foo"]][
+        "unified_name"
+    ] = "pkg/mod.py:foo()"
+    with path.open("wb") as f:
+        pickle.dump(
+            {
+                "project_root": graph.project_root,
+                "graph": graph.graph,
+                "symbol_ranges": graph.symbol_ranges,
+                "name_to_vertex": graph.name_to_vertex,
+            },
+            f,
+        )
 
 
 def test_has_full_indexes_true_false(tmp_path):
@@ -97,3 +125,50 @@ def test_stage_missing_instance_raises(tmp_path):
         prebuilt.stage_prebuilt_indexes(
             str(tmp_path), "nope", str(tmp_path / "c"), build_bm25=False
         )
+
+
+def test_load_prebuilt_code_graph_accepts_legacy_bundle(tmp_path):
+    model = "Qwen/Qwen3-Embedding-0.6B"
+    src = _make_prebuilt(tmp_path / "prebuilt", "inst", model, full=True)
+    _write_legacy_graph(src / "graph.pkl")
+
+    graph = prebuilt.load_prebuilt_code_graph(str(tmp_path / "prebuilt"), "inst")
+
+    assert graph.graph.vcount() == 2
+    assert graph.name_to_vertex["pkg.mod.foo"] == 1
+    assert graph._file_nodes["pkg/mod.py"]
+    assert graph._unified_to_names["pkg/mod.py:foo()"] == ["pkg.mod.foo"]
+
+
+def test_load_prebuilt_code_graph_accepts_direct_codegraph_pickle(tmp_path):
+    from codeminer.graph.code_graph import CodeGraph
+
+    model = "Qwen/Qwen3-Embedding-0.6B"
+    src = _make_prebuilt(tmp_path / "prebuilt", "inst", model, full=True)
+    graph = CodeGraph(project_root="repo")
+    graph.add_file_node("pkg/direct.py")
+    with (src / "graph.pkl").open("wb") as f:
+        pickle.dump(graph, f)
+
+    loaded = prebuilt.load_prebuilt_code_graph(str(tmp_path / "prebuilt"), "inst")
+
+    assert loaded.graph.vcount() == 1
+    assert loaded.name_to_vertex["pkg/direct.py"] == 0
+
+
+def test_stage_normalizes_legacy_graph_for_strict_loader(tmp_path):
+    from codeminer.graph.code_graph import CodeGraph
+
+    model = "Qwen/Qwen3-Embedding-0.6B"
+    src = _make_prebuilt(tmp_path / "prebuilt", "inst", model, full=True)
+    _write_legacy_graph(src / "graph.pkl")
+    cache = tmp_path / "cache" / "inst"
+
+    prebuilt.stage_prebuilt_indexes(str(tmp_path / "prebuilt"), "inst", str(cache))
+
+    staged = cache / "symbol_graph" / "graph.pkl"
+    assert staged.exists()
+    assert not staged.is_symlink()
+    loaded = CodeGraph.load_graph(staged)
+    assert loaded.graph.vcount() == 2
+    assert (cache / "bm25").is_dir()

--- a/test/agent/test_query_e2e.py
+++ b/test/agent/test_query_e2e.py
@@ -101,6 +101,17 @@ def codeminer_base_cache(tmp_path_factory) -> Dict[str, Path]:
     return dirs
 
 
+@pytest.fixture
+def codeminer_base_index_cache(request, codeminer_base_cache) -> Path:
+    """Per-test index cache to avoid concurrent BM25 writes under xdist."""
+    safe_node_id = "".join(
+        ch if ch.isalnum() or ch in "._-" else "_" for ch in request.node.nodeid
+    )
+    path = codeminer_base_cache["index"] / safe_node_id
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 @pytest.fixture(scope="module")
 def codeminer_base_first_instance(codeminer_base_cache) -> Dict[str, Any]:
     """Load the first instance of the codeminer-base dataset.
@@ -241,7 +252,9 @@ def _tools_passed_first_turn(llm) -> List[str]:
 
 
 @pytest.mark.integration
-def test_query_runs_end_to_end_on_codeminer_base(prepared_repo, codeminer_base_cache):
+def test_query_runs_end_to_end_on_codeminer_base(
+    prepared_repo, codeminer_base_index_cache
+):
     """Smoke: the full query() facade runs against a real codeminer-base repo."""
     repo_path = prepared_repo["repo_path"]
     language = prepared_repo["language"]
@@ -257,7 +270,7 @@ def test_query_runs_end_to_end_on_codeminer_base(prepared_repo, codeminer_base_c
             allowed_skills=["bm25_search"],  # cheapest skill, no GPU
             primary_language=language,
             languages=(language,),
-            index_cache_dir=str(codeminer_base_cache["index"]),
+            index_cache_dir=str(codeminer_base_index_cache),
             max_turns=3,
         ),
     )
@@ -278,7 +291,7 @@ def test_query_runs_end_to_end_on_codeminer_base(prepared_repo, codeminer_base_c
 
 @pytest.mark.integration
 def test_compile_table_flows_through_query_pipeline(
-    prepared_repo, codeminer_base_cache
+    prepared_repo, codeminer_base_index_cache
 ):
     """End-to-end smoke for the compile_table code path in ``query()``.
 
@@ -320,7 +333,7 @@ def test_compile_table_flows_through_query_pipeline(
             primary_language=language,
             languages=(language,),
             compile_table=table,
-            index_cache_dir=str(codeminer_base_cache["index"]),
+            index_cache_dir=str(codeminer_base_index_cache),
             max_turns=3,
         ),
     )
@@ -351,7 +364,7 @@ def _skip_if_vertex_unconfigured() -> None:
 
 @pytest.mark.slow
 @pytest.mark.parametrize("model", _VERTEX_MODELS)
-def test_query_with_real_vertex_model(prepared_repo, codeminer_base_cache, model):
+def test_query_with_real_vertex_model(prepared_repo, codeminer_base_index_cache, model):
     """End-to-end with a real LLM call via Vertex AI through litellm.
 
     Parametrized over the models declared in ``_VERTEX_MODELS`` (currently
@@ -394,7 +407,7 @@ def test_query_with_real_vertex_model(prepared_repo, codeminer_base_cache, model
             primary_language=language,
             languages=(language,),
             compile_table=table,
-            index_cache_dir=str(codeminer_base_cache["index"]),
+            index_cache_dir=str(codeminer_base_index_cache),
             # Cap turns tightly — the test cares that the wiring works,
             # not that the model produces a brilliant answer.
             max_turns=4,
@@ -429,11 +442,11 @@ def test_query_with_real_vertex_model(prepared_repo, codeminer_base_cache, model
 
 
 @pytest.mark.integration
-def test_query_manifest_mode_e2e(prepared_repo, codeminer_base_cache):
+def test_query_manifest_mode_e2e(prepared_repo, codeminer_base_index_cache):
     """Two-phase AoT round-trip: compile_repo() then query(manifest=...).
 
     Exercises the full prebuilt-index code path: ``compile_repo`` writes
-    a manifest + indexes to ``codeminer_base_cache["index"]``;
+    a manifest + indexes to the per-test index cache;
     ``query(manifest=manifest, ...)`` then loads them via
     :func:`codeminer.compiler.load_contexts_from_manifest`. No inline
     build happens during ``query()`` — verified by the absence of any
@@ -445,7 +458,7 @@ def test_query_manifest_mode_e2e(prepared_repo, codeminer_base_cache):
     repo_path = prepared_repo["repo_path"]
     language = prepared_repo["language"]
     problem_statement = prepared_repo["row"].get("problem_statement") or "fix bug"
-    cache_dir = str(codeminer_base_cache["index"])
+    cache_dir = str(codeminer_base_index_cache)
 
     # Phase 1 — AoT compile (writes repo_manifest.json + bm25/ artifacts).
     manifest = compile_repo(

--- a/test/eval/test_span_localization.py
+++ b/test/eval/test_span_localization.py
@@ -274,6 +274,14 @@ def test_nodes_to_spans_ranked_by_score_desc():
     assert [s["file"] for s in spans] == ["b.py", "a.py"]
 
 
+def test_nodes_to_spans_can_preserve_retrieval_order():
+    spans = nodes_to_spans(
+        [_node("a.py", 1, 2, score=0.1), _node("b.py", 3, 4, score=0.9)],
+        sort_by_score=False,
+    )
+    assert [s["file"] for s in spans] == ["a.py", "b.py"]
+
+
 def test_dedup_collapses_overlapping_region():
     spans = [_span("a.py", 10, 20), _span("a.py", 12, 18), _span("b.py", 1, 2)]
     kept = dedup_spans(spans)

--- a/test/model/test_graph_augmented_rerank_pipeline.py
+++ b/test/model/test_graph_augmented_rerank_pipeline.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dense-first graph expand/rerank pipeline."""
+
+from __future__ import annotations
+
+from codeminer.model import (
+    DenseGraphExpandRerankPipeline as ExportedDenseGraphExpandRerankPipeline,
+)
+from codeminer.model.dense_graph_expand_rerank_pipeline import (
+    DenseGraphExpandRerankPipeline,
+)
+from codeminer.model.graph_augmented_rerank_pipeline import GraphAugmentedRerankPipeline
+from codeminer.ops.rerank import RerankContext
+from codeminer.types import QueriedNode
+
+
+class _FakeRetriever:
+    def __init__(self, results):
+        self.results = results
+        self.loaded_index = None
+
+    def load_index(self, index_path):
+        self.loaded_index = index_path
+
+    def query(self, query, top_k=None):
+        return self.results[:top_k]
+
+    def close(self):
+        pass
+
+
+class _FakeGraph:
+    def __init__(self, *, resolve=None, successors=None, predecessors=None, info=None):
+        self.resolve = resolve or {}
+        self.successors = successors or {}
+        self.predecessors = predecessors or {}
+        self.info = info or {}
+
+    def resolve_symbol(self, symbol):
+        return self.resolve.get(symbol), None
+
+    def get_successors(self, node_name):
+        return self.successors.get(node_name, [])
+
+    def get_predecessors(self, node_name):
+        return self.predecessors.get(node_name, [])
+
+    def get_node_info_by_id(self, node_id):
+        return self.info.get(node_id)
+
+
+class _FakeEmbedding:
+    def __init__(self, vectors):
+        self.vectors = vectors
+
+    def embed_query(self, text):
+        return self.vectors[text]
+
+    def embed_documents(self, texts):
+        return [self.vectors[text] for text in texts]
+
+
+class _FakeStore:
+    def __init__(self, vectors):
+        self.embedding = _FakeEmbedding(vectors)
+        self.index_metric = "ip"
+
+
+def test_pipeline_preserves_dense_topk_and_appends_graph_neighbors():
+    dense = [
+        QueriedNode(
+            node_name="seed",
+            type="function",
+            file="src/a.py",
+            node_id="src/a.py:seed",
+            start_line=0,
+            end_line=2,
+            score=1.0,
+        ),
+        QueriedNode(
+            node_name="dense2",
+            type="function",
+            file="src/b.py",
+            node_id="src/b.py:dense2",
+            start_line=4,
+            end_line=5,
+            score=0.9,
+        ),
+    ]
+    graph = _FakeGraph(
+        resolve={"seed": "seed"},
+        successors={"seed": [1, 2]},
+        info={
+            1: {
+                "name": "dense2",
+                "unified_name": "src/b.py:dense2",
+                "type": "function",
+                "file": "src/b.py",
+                "start_line": 4,
+                "end_line": 5,
+            },
+            2: {
+                "name": "neighbor",
+                "unified_name": "src/c.py:neighbor",
+                "type": "function",
+                "file": "src/c.py",
+                "start_line": 8,
+                "end_line": 10,
+            },
+        },
+    )
+    pipeline = DenseGraphExpandRerankPipeline(
+        retriever=_FakeRetriever(dense),
+        code_graph=graph,
+        dense_top_k=2,
+        graph_neighbors_per_seed=2,
+        final_top_k=5,
+        include_graph_content=False,
+    )
+
+    result = pipeline.query("query")
+
+    assert [node.node_id for node in result] == [
+        "src/a.py:seed",
+        "src/b.py:dense2",
+        "src/c.py:neighbor",
+    ]
+    assert len(pipeline.last_dense_results) == 2
+    assert len(pipeline.last_graph_results) == 2
+    assert len(pipeline.last_candidates) == 3
+
+
+def test_pipeline_applies_explicit_candidate_filters():
+    dense = [
+        QueriedNode(
+            node_name="keep",
+            type="function",
+            file="src/a.py",
+            node_id="src/a.py:keep",
+            start_line=0,
+            end_line=2,
+            score=1.0,
+        ),
+        QueriedNode(
+            node_name="drop",
+            type="function",
+            file="tests/test_a.py",
+            node_id="tests/test_a.py:drop",
+            start_line=4,
+            end_line=5,
+            score=0.9,
+        ),
+    ]
+    pipeline = DenseGraphExpandRerankPipeline(
+        retriever=_FakeRetriever(dense),
+        dense_top_k=2,
+        graph_neighbors_per_seed=0,
+        final_top_k=5,
+        candidate_filters=[lambda node: not node.file.startswith("tests/")],
+    )
+
+    result = pipeline.query("query")
+
+    assert [node.node_name for node in result] == ["keep"]
+    assert [node.node_name for node in pipeline.last_filtered_candidates] == ["keep"]
+
+
+def test_pipeline_reranks_dense_and_graph_candidates(tmp_path):
+    source = tmp_path / "src" / "a.py"
+    source.parent.mkdir()
+    source.write_text("graph best\n", encoding="utf-8")
+    dense = [
+        QueriedNode(
+            node_name="seed",
+            type="function",
+            file="src/a.py",
+            node_id="src/a.py:seed",
+            start_line=0,
+            end_line=0,
+            score=1.0,
+            content="dense low",
+        )
+    ]
+    graph = _FakeGraph(
+        resolve={"seed": "seed"},
+        successors={"seed": [1]},
+        info={
+            1: {
+                "name": "neighbor",
+                "unified_name": "src/a.py:neighbor",
+                "type": "function",
+                "file": "src/a.py",
+                "start_line": 0,
+                "end_line": 0,
+            }
+        },
+    )
+    store = _FakeStore(
+        vectors={
+            "query": [1.0, 0.0],
+            "dense low": [0.1, 0.0],
+            "graph best\n": [0.9, 0.0],
+        }
+    )
+    pipeline = DenseGraphExpandRerankPipeline(
+        retriever=_FakeRetriever(dense),
+        code_graph=graph,
+        rerank_context=RerankContext(embedding_store=store),
+        repo_path=str(tmp_path),
+        dense_top_k=1,
+        graph_neighbors_per_seed=1,
+        final_top_k=2,
+    )
+
+    result = pipeline.query("query")
+
+    assert [node.node_id for node in result] == [
+        "src/a.py:neighbor",
+        "src/a.py:seed",
+    ]
+
+
+def test_old_graph_augmented_name_remains_compatible():
+    assert issubclass(GraphAugmentedRerankPipeline, DenseGraphExpandRerankPipeline)
+
+
+def test_model_exports_new_dense_graph_name():
+    assert ExportedDenseGraphExpandRerankPipeline is DenseGraphExpandRerankPipeline

--- a/test/model/test_retrieval_planner.py
+++ b/test/model/test_retrieval_planner.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import pytest
 
 from codeminer.model import (
+    RetrievalBudget,
     RetrievalCapabilities,
     RetrievalPlanner,
     RetrieveRerankPipeline,
@@ -72,6 +73,44 @@ def test_planner_falls_back_to_hybrid_for_structural_query_without_graph():
     assert plan.name == "hybrid_fusion"
     assert [stage.engine for stage in plan.stages] == ["dense", "sparse"]
     assert plan.fusion == "rrf"
+
+
+def test_planner_does_not_select_structural_graph_without_sparse_seed():
+    planner = RetrievalPlanner()
+
+    plan = planner.select(
+        "who calls RetryManager.handle()",
+        budget="balanced",
+        capabilities=RetrievalCapabilities(
+            has_dense=True,
+            has_sparse=False,
+            has_graph=True,
+            has_embedding_rerank=True,
+        ),
+    )
+
+    assert plan.name == "semantic"
+    assert plan.graph is None
+    assert [stage.engine for stage in plan.stages] == ["dense"]
+
+
+def test_planner_respects_budget_before_llm_rerank():
+    planner = RetrievalPlanner()
+
+    plan = planner.select(
+        "explain retry behavior and failure handling",
+        budget="balanced",
+        capabilities=RetrievalCapabilities(
+            has_dense=True,
+            has_sparse=True,
+            has_graph=False,
+            has_embedding_rerank=False,
+            has_llm_rerank=True,
+        ),
+    )
+
+    assert plan.enable_rerank is False
+    assert plan.rerank_strategy is None
 
 
 def test_auto_pipeline_executes_only_the_selected_fast_branch(monkeypatch):
@@ -161,6 +200,118 @@ def test_auto_pipeline_passes_hybrid_plan_to_rerank(monkeypatch):
     }
 
 
+def test_auto_pipeline_prefers_explicit_rerank_candidate_cap(monkeypatch):
+    pipeline = object.__new__(RetrieveRerankPipeline)
+    pipeline.retrieval_planner = RetrievalPlanner()
+    pipeline.planning_budget = "balanced"
+    pipeline.planner_capabilities = RetrievalCapabilities(
+        has_dense=True,
+        has_sparse=True,
+        has_graph=False,
+        has_embedding_rerank=True,
+        has_llm_rerank=False,
+    )
+    pipeline.retrieve_plan = []
+    pipeline.fusion_strategy = "weighted"
+    pipeline.rrf_k = 60
+    pipeline.enable_rerank = True
+    pipeline.rerank_context = object()
+    pipeline.rerank_strategy = "embedding"
+    pipeline.rerank_candidate_top_k = 7
+    rerank_call = {}
+
+    def fake_retrieve(query, stage):
+        return [_node(stage.engine)]
+
+    def fake_rerank(query, candidates, top_k, *, strategy=None, candidate_top_k=None):
+        rerank_call["candidate_top_k"] = candidate_top_k
+        return list(candidates[:top_k])
+
+    monkeypatch.setattr(pipeline, "_run_retrieval_stage", fake_retrieve)
+    monkeypatch.setattr(pipeline, "_run_rerank", fake_rerank)
+
+    pipeline.query("how does `RetryManager` handle retries?", top_k=2)
+
+    assert pipeline.last_selected_plan.rerank_candidate_top_k == 50
+    assert rerank_call["candidate_top_k"] == 7
+
+
+class _FakeGraph:
+    def __init__(self):
+        self.resolve = {"src/seed.py:seed": "seed", "seed": "seed"}
+        self.successors = {"seed": [1]}
+        self.predecessors = {}
+        self.info = {
+            1: {
+                "name": "neighbor",
+                "unified_name": "src/neighbor.py:neighbor",
+                "type": "function",
+                "file": "src/neighbor.py",
+                "start_line": 3,
+                "end_line": 5,
+            }
+        }
+
+    def resolve_symbol(self, symbol):
+        return self.resolve.get(symbol), None
+
+    def get_successors(self, node_name):
+        return self.successors.get(node_name, [])
+
+    def get_predecessors(self, node_name):
+        return self.predecessors.get(node_name, [])
+
+    def get_node_info_by_id(self, node_id):
+        return self.info.get(node_id)
+
+
+def test_auto_pipeline_executes_structural_graph_plan(monkeypatch):
+    pipeline = object.__new__(RetrieveRerankPipeline)
+    pipeline.retrieval_planner = RetrievalPlanner()
+    pipeline.planning_budget = RetrievalBudget(
+        tier="balanced",
+        retrieve_top_k=20,
+        rerank_candidate_top_k=None,
+        allow_graph=True,
+        allow_rerank=False,
+    )
+    pipeline.planner_capabilities = RetrievalCapabilities(
+        has_dense=True,
+        has_sparse=True,
+        has_graph=True,
+        has_embedding_rerank=False,
+        has_llm_rerank=False,
+    )
+    pipeline.retrieve_plan = []
+    pipeline.fusion_strategy = "weighted"
+    pipeline.rrf_k = 60
+    pipeline.enable_rerank = True
+    pipeline.rerank_context = object()
+    pipeline.rerank_strategy = "llm"
+    pipeline.rerank_candidate_top_k = None
+    pipeline.repo_path = None
+    from codeminer.ops.expand import ExpandContext
+
+    pipeline.expand_context = ExpandContext(code_graph=_FakeGraph())
+
+    def fake_retrieve(query, stage):
+        assert stage.engine == "sparse"
+        return [_node("seed")]
+
+    def fail_rerank(*args, **kwargs):
+        pytest.fail("budget disables rerank")
+
+    monkeypatch.setattr(pipeline, "_run_retrieval_stage", fake_retrieve)
+    monkeypatch.setattr(pipeline, "_run_rerank", fail_rerank)
+
+    result = pipeline.query("who calls seed?", top_k=5)
+
+    assert pipeline.last_selected_plan.name == "structural_graph"
+    assert pipeline.last_planner_trace["signals"]["structural"] is True
+    assert pipeline.last_planner_trace["capabilities"]["has_graph"] is True
+    assert [node.node_name for node in result] == ["seed", "src/neighbor.py:neighbor"]
+
+
 def test_rrf_merge_combines_duplicate_ranks():
     first = [_node("a"), _node("c")]
     second = [_node("b"), _node("a")]
@@ -175,3 +326,38 @@ def test_rrf_merge_combines_duplicate_ranks():
 
     assert [node.node_name for node in merged] == ["a", "b", "c"]
     assert merged[0].score > merged[1].score
+
+
+def test_rrf_merge_dedups_same_node_id_with_different_branch_metadata():
+    dense = QueriedNode(
+        node_name="foo",
+        type="function",
+        file="src/a.py",
+        node_id="src/a.py:foo()",
+        start_line=10,
+        end_line=12,
+        score=0.9,
+        content="def foo(): pass",
+    )
+    sparse = QueriedNode(
+        node_name="src/a.py:foo()",
+        type="function",
+        file="src/a.py",
+        node_id="src/a.py:foo()",
+        start_line=None,
+        end_line=None,
+        score=0.0,
+    )
+
+    merged = RetrieveRerankPipeline._merge_hybrid(
+        [[dense], [sparse]],
+        [1.0, 1.0],
+        top_k=5,
+        fusion="rrf",
+        rrf_k=60,
+    )
+
+    assert len(merged) == 1
+    assert merged[0].node_id == "src/a.py:foo()"
+    assert merged[0].node_name == "foo"
+    assert merged[0].score == pytest.approx(2 / 61)

--- a/test/model/test_retrieval_planner.py
+++ b/test/model/test_retrieval_planner.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.model import (
+    RetrievalCapabilities,
+    RetrievalPlanner,
+    RetrieveRerankPipeline,
+)
+from codeminer.types import QueriedNode
+
+
+def _node(name: str, score: float = 1.0) -> QueriedNode:
+    return QueriedNode(
+        node_name=name,
+        type="function",
+        file=f"src/{name}.py",
+        node_id=f"src/{name}.py:{name}",
+        start_line=0,
+        end_line=1,
+        score=score,
+        content=f"def {name}(): pass",
+    )
+
+
+def test_planner_selects_fast_lexical_for_exact_symbol_budget():
+    planner = RetrievalPlanner()
+
+    plan = planner.select("find `RetryManager`", budget="fast")
+
+    assert plan.name == "fast_lexical"
+    assert [stage.engine for stage in plan.stages] == ["sparse"]
+    assert plan.retrieval_top_k == 32
+    assert plan.enable_rerank is False
+
+
+def test_planner_selects_structural_graph_when_graph_is_available():
+    planner = RetrievalPlanner()
+
+    plan = planner.select(
+        "who calls RetryManager.handle()",
+        budget="thorough",
+        capabilities=RetrievalCapabilities(
+            has_dense=True,
+            has_sparse=True,
+            has_graph=True,
+            has_embedding_rerank=True,
+            has_llm_rerank=True,
+        ),
+    )
+
+    assert plan.name == "structural_graph"
+    assert plan.graph is not None
+    assert plan.graph.seed_engine == "sparse"
+    assert plan.graph.use_ppr is True
+    assert plan.rerank_strategy == "llm"
+
+
+def test_planner_falls_back_to_hybrid_for_structural_query_without_graph():
+    planner = RetrievalPlanner()
+
+    plan = planner.select(
+        "who calls RetryManager.handle()",
+        budget="balanced",
+        capabilities=RetrievalCapabilities(has_graph=False),
+    )
+
+    assert plan.name == "hybrid_fusion"
+    assert [stage.engine for stage in plan.stages] == ["dense", "sparse"]
+    assert plan.fusion == "rrf"
+
+
+def test_auto_pipeline_executes_only_the_selected_fast_branch(monkeypatch):
+    pipeline = object.__new__(RetrieveRerankPipeline)
+    pipeline.retrieval_planner = RetrievalPlanner()
+    pipeline.planning_budget = "fast"
+    pipeline.planner_capabilities = RetrievalCapabilities()
+    pipeline.retrieve_plan = []
+    pipeline.fusion_strategy = "weighted"
+    pipeline.rrf_k = 60
+    pipeline.enable_rerank = True
+    pipeline.rerank_context = object()
+    pipeline.rerank_strategy = "llm"
+    pipeline.rerank_candidate_top_k = None
+    calls = []
+
+    def fake_retrieve(query, stage):
+        calls.append((query, stage.engine, stage.top_k))
+        return [_node(stage.engine)]
+
+    def fail_rerank(*args, **kwargs):
+        pytest.fail("fast budget should not rerank")
+
+    monkeypatch.setattr(pipeline, "_run_retrieval_stage", fake_retrieve)
+    monkeypatch.setattr(pipeline, "_run_rerank", fail_rerank)
+
+    result = pipeline.query("find `RetryManager`", top_k=5)
+
+    assert [node.node_name for node in result] == ["sparse"]
+    assert calls == [("find `RetryManager`", "sparse", 32)]
+    assert pipeline.last_selected_plan.name == "fast_lexical"
+
+
+def test_auto_pipeline_passes_hybrid_plan_to_rerank(monkeypatch):
+    pipeline = object.__new__(RetrieveRerankPipeline)
+    pipeline.retrieval_planner = RetrievalPlanner()
+    pipeline.planning_budget = "balanced"
+    pipeline.planner_capabilities = RetrievalCapabilities(
+        has_dense=True,
+        has_sparse=True,
+        has_graph=False,
+        has_embedding_rerank=True,
+        has_llm_rerank=False,
+    )
+    pipeline.retrieve_plan = []
+    pipeline.fusion_strategy = "weighted"
+    pipeline.rrf_k = 60
+    pipeline.enable_rerank = True
+    pipeline.rerank_context = object()
+    pipeline.rerank_strategy = "llm"
+    pipeline.rerank_candidate_top_k = None
+    retrieved = {
+        "dense": [_node("dense_a"), _node("shared")],
+        "sparse": [_node("shared"), _node("sparse_b")],
+    }
+    rerank_call = {}
+
+    def fake_retrieve(query, stage):
+        return retrieved[stage.engine]
+
+    def fake_rerank(query, candidates, top_k, *, strategy=None, candidate_top_k=None):
+        rerank_call.update(
+            {
+                "query": query,
+                "names": [node.node_name for node in candidates],
+                "top_k": top_k,
+                "strategy": strategy,
+                "candidate_top_k": candidate_top_k,
+            }
+        )
+        return list(candidates[:top_k])
+
+    monkeypatch.setattr(pipeline, "_run_retrieval_stage", fake_retrieve)
+    monkeypatch.setattr(pipeline, "_run_rerank", fake_rerank)
+
+    result = pipeline.query("how does `RetryManager` handle retries?", top_k=2)
+
+    assert pipeline.last_selected_plan.name == "hybrid_fusion"
+    assert pipeline.last_selected_plan.fusion == "rrf"
+    assert [node.node_name for node in result] == ["shared", "dense_a"]
+    assert rerank_call == {
+        "query": "how does `RetryManager` handle retries?",
+        "names": ["shared", "dense_a", "sparse_b"],
+        "top_k": 2,
+        "strategy": "embedding",
+        "candidate_top_k": 50,
+    }
+
+
+def test_rrf_merge_combines_duplicate_ranks():
+    first = [_node("a"), _node("c")]
+    second = [_node("b"), _node("a")]
+
+    merged = RetrieveRerankPipeline._merge_hybrid(
+        [first, second],
+        [1.0, 1.0],
+        top_k=3,
+        fusion="rrf",
+        rrf_k=60,
+    )
+
+    assert [node.node_name for node in merged] == ["a", "b", "c"]
+    assert merged[0].score > merged[1].score

--- a/test/model/test_retrieve_pipeline_indexer_routing.py
+++ b/test/model/test_retrieve_pipeline_indexer_routing.py
@@ -147,3 +147,12 @@ def test_graph_pipeline_routes_languages_to_graph_builder_and_rerank(
 
     [vector_call] = vector_calls
     assert vector_call["languages"] == ["rust", "python"]
+
+
+def test_graph_retrieve_pipeline_name_is_sparse_seeded_alias():
+    from codeminer.model import graph_retrieve_pipeline as pipeline_module
+
+    assert issubclass(
+        pipeline_module.GraphRetrievePipeline,
+        pipeline_module.SparseSeededGraphRetrievePipeline,
+    )

--- a/test/ops/test_expand.py
+++ b/test/ops/test_expand.py
@@ -45,6 +45,7 @@ class TestNodeInfoToQueried:
             node_name="mod.func",
             type="function",
             file="src/mod.py",
+            node_id="src/mod.py:mod.func",
             start_line=10,
             end_line=20,
             content="def func(): pass",
@@ -52,6 +53,7 @@ class TestNodeInfoToQueried:
         result = nodeinfo_to_queried([info])
         node = result[0]
         assert node.node_name == "mod.func"
+        assert node.node_id == "src/mod.py:mod.func"
         assert node.type == "function"
         assert node.file == "src/mod.py"
         assert node.start_line == 10

--- a/test/ops/test_expand.py
+++ b/test/ops/test_expand.py
@@ -6,7 +6,13 @@
 
 from __future__ import annotations
 
-from codeminer.ops.expand import ExpandContext, nodeinfo_to_queried
+import pytest
+
+from codeminer.ops.expand import (
+    ExpandContext,
+    expand_graph_neighbors,
+    nodeinfo_to_queried,
+)
 from codeminer.types import NodeInfo, QueriedNode
 
 # ---------------------------------------------------------------------------
@@ -63,3 +69,174 @@ class TestExpandContext:
         assert ctx.default_method == "bfs"
         assert ctx.default_damping == 0.85
         assert ctx.filter_tests is True
+
+
+class _FakeGraph:
+    def __init__(self, *, resolve=None, successors=None, predecessors=None, info=None):
+        self.resolve = resolve or {}
+        self.successors = successors or {}
+        self.predecessors = predecessors or {}
+        self.info = info or {}
+
+    def resolve_symbol(self, symbol):
+        return self.resolve.get(symbol), None
+
+    def get_successors(self, node_name):
+        return self.successors.get(node_name, [])
+
+    def get_predecessors(self, node_name):
+        return self.predecessors.get(node_name, [])
+
+    def get_node_info_by_id(self, node_id):
+        return self.info.get(node_id)
+
+
+class TestExpandGraphNeighbors:
+    def test_appends_one_hop_symbol_neighbors(self):
+        graph = _FakeGraph(
+            resolve={"src/a.py:seed": "seed"},
+            successors={"seed": [1]},
+            info={
+                1: {
+                    "name": "neighbor",
+                    "unified_name": "src/a.py:neighbor",
+                    "type": "function",
+                    "file": "src/a.py",
+                    "start_line": 2,
+                    "end_line": 4,
+                }
+            },
+        )
+        seed = QueriedNode(
+            node_name="seed",
+            type="function",
+            file="src/a.py",
+            node_id="src/a.py:seed",
+            score=0.8,
+        )
+
+        result = expand_graph_neighbors(
+            ExpandContext(code_graph=graph),
+            [seed],
+            per_seed=3,
+            direction="successors",
+        )
+
+        assert len(result) == 1
+        assert result[0].node_name == "src/a.py:neighbor"
+        assert result[0].node_id == "src/a.py:neighbor"
+        assert result[0].score == 0.4
+
+    def test_filters_non_symbol_and_missing_spans_and_caps_per_seed(self):
+        graph = _FakeGraph(
+            resolve={"seed": "seed"},
+            successors={"seed": [1, 2, 3]},
+            info={
+                1: {
+                    "name": "module",
+                    "type": "file",
+                    "file": "src/a.py",
+                    "start_line": 0,
+                    "end_line": 1,
+                },
+                2: {
+                    "name": "no_span",
+                    "type": "function",
+                    "file": "src/a.py",
+                    "start_line": None,
+                    "end_line": None,
+                },
+                3: {
+                    "name": "kept",
+                    "type": "method",
+                    "file": "src/a.py",
+                    "start_line": 3,
+                    "end_line": 5,
+                },
+            },
+        )
+        seed = QueriedNode(node_name="seed", type="function", score=1.0)
+
+        result = expand_graph_neighbors(
+            ExpandContext(code_graph=graph),
+            [seed],
+            per_seed=1,
+            direction="successors",
+        )
+
+        assert [node.node_name for node in result] == ["kept"]
+
+    def test_reads_neighbor_content_from_repo_span(self, tmp_path):
+        source = tmp_path / "src" / "a.py"
+        source.parent.mkdir()
+        source.write_text("l0\nl1\nl2\nl3\n", encoding="utf-8")
+        graph = _FakeGraph(
+            resolve={"seed": "seed"},
+            successors={"seed": [1]},
+            info={
+                1: {
+                    "name": "kept",
+                    "type": "function",
+                    "file": "src/a.py",
+                    "start_line": 1,
+                    "end_line": 2,
+                }
+            },
+        )
+        seed = QueriedNode(node_name="seed", type="function", score=1.0)
+
+        result = expand_graph_neighbors(
+            ExpandContext(code_graph=graph),
+            [seed],
+            repo_path=str(tmp_path),
+            include_content=True,
+            direction="successors",
+        )
+
+        assert result[0].content == "l1\nl2\n"
+
+    def test_prefers_seed_node_id_over_bare_node_name(self):
+        graph = _FakeGraph(
+            resolve={"seed": "wrong", "src/a.py:seed": "right"},
+            successors={"wrong": [1], "right": [2]},
+            info={
+                1: {
+                    "name": "wrong_neighbor",
+                    "type": "function",
+                    "file": "src/wrong.py",
+                    "start_line": 0,
+                    "end_line": 1,
+                },
+                2: {
+                    "name": "right_neighbor",
+                    "type": "function",
+                    "file": "src/a.py",
+                    "start_line": 2,
+                    "end_line": 3,
+                },
+            },
+        )
+        seed = QueriedNode(
+            node_name="seed",
+            node_id="src/a.py:seed",
+            type="function",
+            score=1.0,
+        )
+
+        result = expand_graph_neighbors(
+            ExpandContext(code_graph=graph),
+            [seed],
+            direction="successors",
+        )
+
+        assert [node.node_name for node in result] == ["right_neighbor"]
+
+    def test_rejects_unknown_direction(self):
+        seed = QueriedNode(node_name="seed", type="function")
+
+        with pytest.raises(ValueError, match="Unsupported graph expansion direction"):
+            expand_graph_neighbors(
+                ExpandContext(code_graph=_FakeGraph()),
+                [seed],
+                direction="sideways",
+            )

--- a/test/ops/test_filter.py
+++ b/test/ops/test_filter.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for candidate filter ops."""
+
+from __future__ import annotations
+
+from codeminer.ops.filter import (
+    build_candidate_filters,
+    drop_test_files,
+    exclude_paths,
+    filter_queried_nodes,
+    has_content,
+    has_span,
+    include_extensions,
+    is_symbol_candidate,
+    is_test_path,
+)
+from codeminer.types import QueriedNode
+
+
+def _node(**kwargs):
+    data = {
+        "node_name": "n",
+        "type": "function",
+        "file": "src/a.py",
+        "start_line": 1,
+        "end_line": 2,
+        "content": "code",
+    }
+    data.update(kwargs)
+    return QueriedNode(**data)
+
+
+def test_filter_queried_nodes_preserves_order_and_limit():
+    nodes = [_node(node_name="a"), _node(node_name="b"), _node(node_name="c")]
+
+    result = filter_queried_nodes(
+        nodes,
+        [lambda node: node.node_name != "b"],
+        limit=1,
+    )
+
+    assert [node.node_name for node in result] == ["a"]
+
+
+def test_basic_predicates_are_explicit():
+    assert has_span(_node())
+    assert not has_span(_node(file=None))
+    assert has_content(_node(content=" x "))
+    assert not has_content(_node(content=" "))
+    assert is_symbol_candidate(_node(type="method"))
+    assert not is_symbol_candidate(_node(type="file"))
+
+
+def test_path_predicates():
+    nodes = [
+        _node(node_name="py", file="src/a.py"),
+        _node(node_name="ts", file="src/a.ts"),
+        _node(node_name="test", file="tests/test_a.py"),
+    ]
+
+    result = filter_queried_nodes(
+        nodes,
+        [include_extensions(["py"]), exclude_paths(["tests/*"]), drop_test_files],
+    )
+
+    assert [node.node_name for node in result] == ["py"]
+
+
+def test_is_test_path_heuristic():
+    assert is_test_path("tests/test_user.py")
+    assert is_test_path("src/user.test.ts")
+    assert is_test_path("src/UserServiceTest.java")
+    assert not is_test_path("src/user.py")
+    assert not is_test_path("src/contest.py")
+
+
+def test_build_candidate_filters_combines_explicit_options():
+    nodes = [
+        _node(node_name="keep", type="function", file="src/a.py", content="code"),
+        _node(node_name="file", type="file", file="src/a.py", content="code"),
+        _node(node_name="empty", type="function", file="src/a.py", content=""),
+        _node(
+            node_name="test", type="function", file="tests/test_a.py", content="code"
+        ),
+    ]
+
+    predicates = build_candidate_filters(
+        require_span=True,
+        require_content=True,
+        symbol_only=True,
+        drop_tests=True,
+    )
+    result = filter_queried_nodes(nodes, predicates)
+
+    assert [node.node_name for node in result] == ["keep"]

--- a/test/ops/test_rerank.py
+++ b/test/ops/test_rerank.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for rerank ops."""
+
+from __future__ import annotations
+
+from codeminer.ops.rerank import rerank_by_embedding
+from codeminer.types import QueriedNode
+
+
+class _FakeEmbedding:
+    def __init__(self, vectors):
+        self.vectors = vectors
+
+    def embed_query(self, text):
+        return self.vectors[text]
+
+    def embed_documents(self, texts):
+        return [self.vectors[text] for text in texts]
+
+
+class _FakeStore:
+    def __init__(self, *, vectors, index_metric="ip"):
+        self.embedding = _FakeEmbedding(vectors)
+        self.index_metric = index_metric
+
+
+def test_rerank_by_embedding_sorts_by_inner_product():
+    store = _FakeStore(
+        vectors={
+            "query": [1.0, 0.0],
+            "best": [0.9, 0.0],
+            "other": [0.1, 1.0],
+        }
+    )
+    candidates = [
+        QueriedNode(node_name="other", type="function", content="other"),
+        QueriedNode(node_name="best", type="function", content="best"),
+    ]
+
+    result = rerank_by_embedding("query", candidates, store, top_k=2)
+
+    assert [node.node_name for node in result] == ["best", "other"]
+    assert result[0].score > result[1].score
+
+
+def test_rerank_by_embedding_sorts_by_negative_l2_distance():
+    store = _FakeStore(
+        vectors={
+            "query": [1.0, 0.0],
+            "near": [1.1, 0.0],
+            "far": [5.0, 0.0],
+        },
+        index_metric="l2",
+    )
+    candidates = [
+        QueriedNode(node_name="far", type="function", content="far"),
+        QueriedNode(node_name="near", type="function", content="near"),
+    ]
+
+    result = rerank_by_embedding("query", candidates, store, top_k=1)
+
+    assert [node.node_name for node in result] == ["near"]
+
+
+def test_rerank_by_embedding_skips_candidates_without_content():
+    store = _FakeStore(
+        vectors={
+            "query": [1.0, 0.0],
+            "best": [1.0, 0.0],
+        }
+    )
+    candidates = [
+        QueriedNode(node_name="empty", type="function"),
+        QueriedNode(node_name="best", type="function", content="best"),
+    ]
+
+    result = rerank_by_embedding("query", candidates, store, top_k=5)
+
+    assert [node.node_name for node in result] == ["best"]

--- a/test/ops/test_retrieve.py
+++ b/test/ops/test_retrieve.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for retrieval ops."""
+
+from __future__ import annotations
+
+from codeminer.ops.retrieve import dedup_queried_nodes, queried_node_key
+from codeminer.types import QueriedNode
+
+
+def test_queried_node_key_prefers_node_id():
+    node = QueriedNode(
+        node_name="symbol",
+        file="src/a.py",
+        node_id="src/a.py:symbol",
+        start_line=1,
+        end_line=2,
+    )
+
+    assert queried_node_key(node) == ("node_id", "src/a.py:symbol")
+
+
+def test_dedup_preserves_first_rank_and_fills_missing_content():
+    dense = QueriedNode(
+        node_name="symbol",
+        file="src/a.py",
+        node_id="src/a.py:symbol",
+        start_line=1,
+        end_line=2,
+        score=10.0,
+    )
+    graph_duplicate = dense.model_copy(
+        update={"score": 0.5, "content": "def f(): pass"}
+    )
+    later = QueriedNode(
+        node_name="other",
+        file="src/b.py",
+        node_id="src/b.py:other",
+        start_line=3,
+        end_line=4,
+        score=5.0,
+        content="def g(): pass",
+    )
+
+    result = dedup_queried_nodes([dense, graph_duplicate, later])
+
+    assert [node.node_id for node in result] == ["src/a.py:symbol", "src/b.py:other"]
+    assert result[0].score == 10.0
+    assert result[0].content == "def f(): pass"

--- a/test/ops/test_retrieve.py
+++ b/test/ops/test_retrieve.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from codeminer.ops.retrieve import dedup_queried_nodes, queried_node_key
+from codeminer.ops.retrieve import dedup_queried_nodes, merge_hybrid, queried_node_key
 from codeminer.types import QueriedNode
 
 
@@ -49,3 +49,25 @@ def test_dedup_preserves_first_rank_and_fills_missing_content():
     assert [node.node_id for node in result] == ["src/a.py:symbol", "src/b.py:other"]
     assert result[0].score == 10.0
     assert result[0].content == "def f(): pass"
+
+
+def test_merge_hybrid_supports_rrf_with_node_id_identity():
+    first = [
+        QueriedNode(node_name="a", type="function", node_id="a", score=10.0),
+        QueriedNode(node_name="c", type="function", node_id="c", score=9.0),
+    ]
+    second = [
+        QueriedNode(node_name="b", type="function", node_id="b", score=1.0),
+        QueriedNode(node_name="a", type="function", node_id="a", score=1.0),
+    ]
+
+    result = merge_hybrid(
+        [first, second],
+        weights=[1.0, 1.0],
+        top_k=3,
+        fusion="rrf",
+        rrf_k=60,
+    )
+
+    assert [node.node_id for node in result] == ["a", "b", "c"]
+    assert result[0].score > result[1].score

--- a/test/scripts/test_graphrag_retrieve.py
+++ b/test/scripts/test_graphrag_retrieve.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the GraphRAG retrieval ablation runner."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from scripts.retrieval_ablation import graphrag_retrieve
+
+
+def test_actionable_nodes_require_line_spans():
+    nodes = [
+        SimpleNamespace(node_id="a.py:a()", start_line=1, end_line=2),
+        SimpleNamespace(node_id="b.py:b()", start_line=None, end_line=3),
+        SimpleNamespace(node_id="c.py:c()", start_line=4, end_line=None),
+    ]
+
+    assert graphrag_retrieve._actionable_nodes(nodes) == [nodes[0]]
+
+
+def test_retrieve_loads_contexts_from_prebuilt_repo_not_staged_cache(
+    monkeypatch, tmp_path
+):
+    iid = "repo__proj-1"
+    prebuilt = tmp_path / "prebuilt"
+    cache_root = tmp_path / "cache"
+    repo = prebuilt / iid / "repo"
+    repo.mkdir(parents=True)
+
+    calls = {}
+
+    def fake_load_dataset_rows(cfg):
+        return (
+            {
+                iid: {
+                    "instance_id": iid,
+                    "problem_statement": "where is target?",
+                    "language_group": "Python",
+                }
+            },
+            {iid: {"gt_files": ["target.py"]}},
+        )
+
+    def fake_stage_prebuilt_indexes(prebuilt_dir, instance_id, cache_dir):
+        calls["stage"] = (prebuilt_dir, instance_id, cache_dir)
+        return cache_dir
+
+    def fake_load_full_contexts(cfg, repo_path, cache_dir):
+        calls["load_full_contexts"] = (repo_path, cache_dir)
+
+    class FakeRegistry:
+        def get(self, skill_id):
+            assert skill_id == "codeminer_context"
+            return SimpleNamespace(
+                executor_fn=lambda query, seeds, max_results: [
+                    SimpleNamespace(
+                        file="target.py",
+                        node_id="target.py:target()",
+                        node_name="target.py:target()",
+                        start_line=9,
+                        end_line=19,
+                        score=1.0,
+                    )
+                ]
+            )
+
+    monkeypatch.setattr(
+        "scripts.agent_compile.lib.harness.load_dataset_rows",
+        fake_load_dataset_rows,
+    )
+    monkeypatch.setattr(
+        "scripts.agent_compile.lib.prebuilt.stage_prebuilt_indexes",
+        fake_stage_prebuilt_indexes,
+    )
+    monkeypatch.setattr(
+        "scripts.agent_compile.lib.harness.load_full_contexts",
+        fake_load_full_contexts,
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.retrieval_eval.collect_targets",
+        lambda meta, simplified_symbols=True: (["target.py"], []),
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.retrieval_eval.collect_target_blocks",
+        lambda meta: [{"file": "target.py", "start": 10, "end": 20}],
+    )
+    monkeypatch.setattr("codeminer.agent.skills.registry.SkillRegistry", FakeRegistry)
+
+    (
+        nodes,
+        ranked,
+        targets,
+        target_symbols,
+        target_blocks,
+        lang,
+    ) = graphrag_retrieve._retrieve(
+        iid, SimpleNamespace(), str(prebuilt), str(cache_root)
+    )
+
+    assert calls["stage"] == (str(prebuilt), iid, str(cache_root / iid))
+    assert calls["load_full_contexts"] == (str(repo), str(cache_root / iid))
+    assert len(nodes) == 1
+    assert ranked == ["target.py"]
+    assert targets == ["target.py"]
+    assert target_symbols == []
+    assert target_blocks == [{"file": "target.py", "start": 10, "end": 20}]
+    assert lang == "Python"


### PR DESCRIPTION
## Summary
Add an explicit query- and budget-aware retrieval planner so CodeMiner can select concrete retrieval paths instead of relying only on fixed presets or emergent agent tool-calling.

## Changes
- Add `RetrievalPlanner` with fast lexical, semantic, hybrid fusion, and structural graph path plans selected from query signals and budget tiers.
- Wire `retrieval_mode="auto"` into `RetrieveRerankPipeline`, including per-query plan selection, RRF fusion, and plan-aware rerank controls.
- Add dense-first graph expansion/rerank pipeline support and shared retrieve/expand/filter/rerank operators used by the new retrieval surfaces.
- Expose `--retrieval-mode auto` and `--planning-budget` in `examples/retrieve_rerank.py` and record selected plan metadata in result output.
- Add focused unit coverage for planner selection, RRF merge behavior, graph-augmented rerank, and shared ops helpers.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Validated with:
- `pre-commit run --files ...` on the changed files
- `pytest test/model/test_retrieval_planner.py test/model/test_graph_augmented_rerank_pipeline.py test/model/test_retrieve_pipeline_indexer_routing.py test/ops/test_retrieve.py test/ops/test_rerank.py test/ops/test_filter.py test/ops/test_expand.py -q`
- `python examples/retrieve_rerank.py --help`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1316 passed, 11 skipped, 161 deselected`)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
