### PR TITLE
fix(graph): match cold-start symbols by line attrs

### DIFF
--- a/codeminer/graph/incremental/subgraph_mgr.py
+++ b/codeminer/graph/incremental/subgraph_mgr.py
@@ -966,6 +966,23 @@ class SubgraphMgr(ABC):
     # Location matching
     # ═══════════════════════════════════════════════════════════
 
+    def _vertex_line_range(self, vid: int) -> tuple[int, int] | None:
+        """Return a vertex's source line range from indexes or attributes."""
+        g = self.code_graph
+        v = g.graph.vs[vid]
+        sr = g.symbol_ranges.get(v["name"])
+        if sr is not None:
+            return sr
+
+        attrs = v.attributes()
+        start_line = attrs.get("start_line")
+        if start_line is None:
+            return None
+        end_line = attrs.get("end_line", start_line)
+        if end_line is None:
+            end_line = start_line
+        return start_line, end_line
+
     def match_location_to_vertex(self, file_path: str, line: int) -> Optional[str]:
         """Match an LSP location to an existing graph vertex.
 
@@ -981,7 +998,7 @@ class SubgraphMgr(ABC):
         candidates = []
         for vid in vids:
             vname = g.graph.vs[vid]["name"]
-            sr = g.symbol_ranges.get(vname)
+            sr = self._vertex_line_range(vid)
             if sr and sr[0] == line:
                 candidates.append(vname)
         if len(candidates) == 1:
@@ -995,7 +1012,7 @@ class SubgraphMgr(ABC):
         candidates = []
         for vid in vids:
             vname = g.graph.vs[vid]["name"]
-            sr = g.symbol_ranges.get(vname)
+            sr = self._vertex_line_range(vid)
             if sr and sr[0] <= line <= sr[1]:
                 candidates.append((vname, sr[1] - sr[0]))
 

--- a/test/graph/incremental/test_subgraph_mgr.py
+++ b/test/graph/incremental/test_subgraph_mgr.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.graph.incremental.patcher_ts import PatcherTS
+from codeminer.types import NODE_TYPE_FIELD
+
+
+def test_location_matcher_falls_back_to_vertex_line_attributes(tmp_path):
+    graph = CodeGraph(str(tmp_path))
+    graph.add_file_node("src/constants.js")
+    graph._add_vertex(
+        "pkg:src/constants.js:EMPTY_OBJ",
+        {
+            "type": NODE_TYPE_FIELD,
+            "file": "src/constants.js",
+            "start_line": 0,
+            "end_line": 0,
+            "unified_name": "src/constants.js:EMPTY_OBJ",
+        },
+    )
+    graph._add_vertex(
+        "pkg:src/constants.js:EMPTY_ARR",
+        {
+            "type": NODE_TYPE_FIELD,
+            "file": "src/constants.js",
+            "start_line": 1,
+            "end_line": 1,
+            "unified_name": "src/constants.js:EMPTY_ARR",
+        },
+    )
+
+    patcher = PatcherTS(str(tmp_path), graph)
+    patcher.build_indexes()
+
+    assert "pkg:src/constants.js:EMPTY_OBJ" not in graph.symbol_ranges
+    assert (
+        patcher.match_location_to_vertex("src/constants.js", 0)
+        == "pkg:src/constants.js:EMPTY_OBJ"
+    )
+    assert (
+        patcher.match_location_to_scope("src/constants.js", 1)
+        == "pkg:src/constants.js:EMPTY_ARR"
+    )


### PR DESCRIPTION
## Summary
Fix the post-merge `integration-serial` failure where TypeScript incremental graph patching resolved `EMPTY_OBJ` references to the `src/constants.js` file node instead of the exported constant symbol.

## Changes
- Fall back to vertex `start_line`/`end_line` attributes when `symbol_ranges` does not contain a cold-start symbol.
- Apply the fallback to exact target matching and innermost scope matching.
- Add a unit regression test for cold-start-style symbols without `symbol_ranges` entries.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands:
- `pytest test/graph/incremental/test_subgraph_mgr.py -q`
- `PATH="/tmp/codeminer-scip-tools/node-tools/node_modules/.bin:/tmp/codeminer-scip-tools:$PATH" pytest test/graph/incremental/test_graph_patcher.py::TestSWEBenchTypeScript::test_graph_patch -v --tb=short --timeout=900`
- `python -m black --check codeminer/graph/incremental/subgraph_mgr.py test/graph/incremental/test_subgraph_mgr.py`
- `git diff --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published