### PR TITLE
[codex] Graph-backed LSP route tools

### DIFF
--- a/codeminer/agent/lsp_graph.py
+++ b/codeminer/agent/lsp_graph.py
@@ -1,0 +1,686 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph-backed LSP-shaped navigation helpers.
+
+These helpers expose static CodeGraph data through familiar LSP concepts:
+definition, references, and a compact route map over related symbols. They are
+pure graph utilities used by both agent skills and MCP tools; they do not know
+about SWE-bench scoring, answer formats, or experiment feedback gates.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Optional, Sequence
+
+from ..types import (
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FIELD,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    QueriedNode,
+)
+
+_WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_CAMEL_RE = re.compile(r"[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)|\d+")
+_STOPWORDS = {
+    "and",
+    "arg",
+    "args",
+    "bool",
+    "case",
+    "class",
+    "ctx",
+    "data",
+    "dict",
+    "else",
+    "err",
+    "error",
+    "false",
+    "file",
+    "func",
+    "int",
+    "kwargs",
+    "list",
+    "none",
+    "null",
+    "object",
+    "return",
+    "self",
+    "str",
+    "string",
+    "true",
+    "type",
+}
+_QUERY_SYNONYMS = {
+    "cached": {"cache"},
+    "caching": {"cache"},
+    "directory": {"dir", "location", "path"},
+    "directories": {"dir", "location", "path"},
+    "fetch": {"download", "retrieve"},
+    "fetches": {"download", "retrieve"},
+    "fetching": {"download", "retrieve"},
+    "location": {"path"},
+    "locations": {"path"},
+    "placeholder": {"replace", "replacer", "replacement", "template"},
+    "placeholders": {"replace", "replacer", "replacement", "template"},
+    "property": {"provider", "value"},
+    "properties": {"provider", "value"},
+    "retrieval": {"retrieve", "download", "cache"},
+    "retrieve": {"download", "cache"},
+    "retrieves": {"download", "cache"},
+    "retrieving": {"download", "cache"},
+    "resolution": {"resolve", "resolver", "replace", "replacer"},
+    "resolved": {"resolve", "resolver", "replace", "replacer"},
+    "substitution": {"replace", "replacer", "replacement"},
+    "substitute": {"replace", "replacer", "replacement"},
+    "token": {"replace", "replacer", "replacement", "template"},
+    "tokens": {"replace", "replacer", "replacement", "template"},
+    "variable": {"replace", "replacer", "replacement"},
+    "variables": {"replace", "replacer", "replacement"},
+}
+_BRIDGE_TERMS = {
+    "adapter",
+    "build",
+    "builder",
+    "download",
+    "factory",
+    "fetch",
+    "make",
+    "new",
+    "open",
+    "replace",
+    "replacement",
+    "resolver",
+    "retrieve",
+    "template",
+}
+_PROVIDER_TERMS = {
+    "cache",
+    "config",
+    "default",
+    "directory",
+    "env",
+    "location",
+    "path",
+    "provider",
+    "property",
+    "setting",
+    "url",
+    "value",
+}
+_ENDPOINT_TERMS = {
+    "apply",
+    "check",
+    "detect",
+    "handle",
+    "handler",
+    "main",
+    "process",
+    "run",
+    "validate",
+}
+
+
+def display_name(graph: Any, name: str) -> str:
+    """Return a readable graph-node label, preferring ``unified_name``."""
+    info = graph.get_node_info_by_name(name) or {}
+    return info.get("unified_name") or name
+
+
+def _bare(symbol: str) -> str:
+    return symbol.split(":")[-1].split(".")[-1].split("#")[-1].rstrip("()").strip()
+
+
+def _node_id(file_path: Optional[str], display: str) -> str:
+    if not file_path:
+        return display
+    if "/" in display or ":" in display:
+        return display
+    return f"{file_path}:{display}"
+
+
+def _terms(text: Any) -> set[str]:
+    out: set[str] = set()
+    for word in _WORD_RE.findall(str(text or "")):
+        for part in re.split(r"[_\W]+", word):
+            if not part:
+                continue
+            for piece in _CAMEL_RE.findall(part) or [part]:
+                lowered = piece.lower()
+                if len(lowered) >= 3 and lowered not in _STOPWORDS:
+                    out.add(lowered)
+                    for suffix in ("ing", "ers", "er", "ments", "ment", "es", "s"):
+                        if len(lowered) > len(suffix) + 2 and lowered.endswith(suffix):
+                            out.add(lowered[: -len(suffix)])
+    return out
+
+
+def _query_terms(query: Optional[str]) -> set[str]:
+    terms = _terms(query or "")
+    expanded = set(terms)
+    for term in terms:
+        expanded.update(_QUERY_SYNONYMS.get(term, set()))
+    return expanded
+
+
+def _unified_index(graph: Any) -> dict[str, list[str]]:
+    cache = getattr(graph, "_lsp_graph_unified_index", None)
+    if cache is not None:
+        return cache
+
+    index: dict[str, list[str]] = {}
+
+    def add(key: str, name: str) -> None:
+        if key:
+            index.setdefault(key, []).append(name)
+
+    prebuilt = getattr(graph, "_unified_to_names", None) or {}
+    if prebuilt:
+        for display, names in prebuilt.items():
+            for name in names:
+                add(str(display), str(name))
+                add(_bare(str(display)), str(name))
+    else:
+        for name in getattr(graph, "name_to_vertex", {}) or {}:
+            info = graph.get_node_info_by_name(name) or {}
+            display = info.get("unified_name")
+            if display:
+                add(str(display), str(name))
+                add(_bare(str(display)), str(name))
+
+    try:
+        graph._lsp_graph_unified_index = index
+    except Exception:  # noqa: BLE001 - graph may disallow dynamic attributes
+        pass
+    return index
+
+
+def resolve_symbol_candidates(graph: Any, symbol: str, limit: int = 8) -> list[str]:
+    """Return canonical node names that match a user-facing symbol seed."""
+    names = getattr(graph, "name_to_vertex", {}) or {}
+    seed = (symbol or "").strip().strip("`'\"")
+    if not seed:
+        return []
+    if seed in names:
+        return [seed]
+
+    if hasattr(graph, "resolve_symbol"):
+        canonical, candidates = graph.resolve_symbol(seed)
+        if canonical:
+            return [canonical]
+        if candidates:
+            out: list[str] = []
+            for candidate in candidates:
+                text = str(candidate)
+                if text in names:
+                    out.append(text)
+                    continue
+                out.extend(_names_from_unified(graph, text))
+            if out:
+                return _dedupe_names(out, limit)
+
+    for key in (seed, seed + "()", _bare(seed)):
+        matches = _unified_index(graph).get(key)
+        if matches:
+            return _dedupe_names(matches, limit)
+
+    bare = _bare(seed)
+    suffix = [
+        name for name in names if name.endswith("." + seed) or _bare(name) == bare
+    ]
+    if suffix:
+        return suffix[:limit]
+    substring = [name for name in names if bare and bare.lower() in name.lower()]
+    return substring[:limit]
+
+
+def _names_from_unified(graph: Any, display: str) -> list[str]:
+    out: list[str] = []
+    index = _unified_index(graph)
+    for key in (display, display + "()", _bare(display)):
+        out.extend(index.get(key) or [])
+    return out
+
+
+def _dedupe_names(names: Iterable[str], limit: int) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for name in names:
+        if name in seen:
+            continue
+        seen.add(name)
+        out.append(name)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _resolve_one(graph: Any, symbol: str) -> tuple[Optional[str], list[str]]:
+    candidates = resolve_symbol_candidates(graph, symbol)
+    if len(candidates) == 1:
+        return candidates[0], [display_name(graph, candidates[0])]
+    return None, [display_name(graph, candidate) for candidate in candidates]
+
+
+def _compact_node(graph: Any, name: str, relation: str, *, score: float = 1.0):
+    info = graph.get_node_info_by_name(name) or {}
+    file_path = info.get("file")
+    display = info.get("unified_name") or name
+    return QueriedNode(
+        node_name=display,
+        type=info.get("type", ""),
+        file=file_path,
+        node_id=_node_id(file_path, display),
+        start_line=info.get("start_line"),
+        end_line=info.get("end_line"),
+        score=score,
+        content=relation,
+    )
+
+
+def _compact_reference(
+    graph: Any,
+    *,
+    target_name: str,
+    source_vid: Optional[int],
+    file_path: Optional[str],
+    line: Optional[int],
+):
+    target_label = display_name(graph, target_name)
+    source_label = ""
+    if source_vid is not None:
+        source = graph.get_node_info_by_id(source_vid) or {}
+        source_label = source.get("unified_name") or source.get("name") or ""
+    label = source_label or target_label
+    display_line = int(line) + 1 if line is not None else None
+    node_id = (
+        f"{file_path}:{display_line}:ref:{target_label}"
+        if file_path and display_line is not None
+        else label
+    )
+    return QueriedNode(
+        node_name=label,
+        type="reference",
+        file=file_path,
+        start_line=line,
+        end_line=line,
+        node_id=node_id,
+        score=1.0,
+        content=f"reference to {target_label}",
+    )
+
+
+def _dedupe_nodes(nodes: Iterable[QueriedNode], limit: int) -> list[QueriedNode]:
+    seen: set[tuple[Any, ...]] = set()
+    out: list[QueriedNode] = []
+    for node in nodes:
+        key = (node.file, node.start_line, node.end_line, node.node_name, node.content)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(node)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _ensure_range_index(graph: Any) -> None:
+    if not hasattr(graph, "build_range_indexes"):
+        return
+    if getattr(graph, "_file_nodes", None) and getattr(
+        graph, "_file_edge_anchors", None
+    ):
+        return
+    graph.build_range_indexes()
+
+
+def _node_name_for_vid(graph: Any, vid: int) -> Optional[str]:
+    info = graph.get_node_info_by_id(vid) or {}
+    return info.get("name")
+
+
+def _definitions_for_symbol(graph: Any, symbol: str, limit: int) -> list[QueriedNode]:
+    name, candidates = _resolve_one(graph, symbol)
+    if name is None:
+        if candidates:
+            raise ValueError(
+                f"symbol {symbol!r} is ambiguous; candidates: {candidates}. "
+                "Call again with one exact name."
+            )
+        raise ValueError(
+            f"symbol {symbol!r} not found in the code graph. Use a name from "
+            "a search result or read output."
+        )
+    label = display_name(graph, name)
+    return [_compact_node(graph, name, f"definition of {label}")][:limit]
+
+
+def lsp_definition(
+    graph: Any,
+    *,
+    file_path: Optional[str] = None,
+    line: Optional[int] = None,
+    character: Optional[int] = None,
+    symbol: Optional[str] = None,
+    top_k: int = 8,
+) -> list[QueriedNode]:
+    """Static-index analogue of LSP ``textDocument/definition``.
+
+    ``line`` is the graph's 0-based line number. Agent-facing skill schemas mark
+    line inputs as 1-based, so the runner performs the boundary conversion.
+    """
+    del character  # CodeGraph anchors are line-granular today.
+    limit = max(1, int(top_k or 8))
+    if symbol:
+        return _definitions_for_symbol(graph, symbol, limit)
+    if not file_path or line is None:
+        raise ValueError("lsp_definition requires either symbol or file_path + line")
+    if not hasattr(graph, "query_range"):
+        raise ValueError("code graph does not support range queries")
+
+    _ensure_range_index(graph)
+    query = graph.query_range(file_path, int(line), int(line))
+
+    target_names: list[str] = []
+    for edge in getattr(query, "outgoing", []) or []:
+        name = _node_name_for_vid(graph, edge.target_vid)
+        if name:
+            target_names.append(name)
+
+    if not target_names:
+        defined = sorted(
+            list(getattr(query, "defined", []) or []),
+            key=lambda node: (
+                (getattr(node, "end_line", 0) or 0)
+                - (getattr(node, "start_line", 0) or 0),
+                getattr(node, "start_line", 0) or 0,
+            ),
+        )
+        target_names = [node.name for node in defined if getattr(node, "name", None)]
+
+    if not target_names:
+        raise ValueError(f"no indexed definition at {file_path}:{int(line) + 1}")
+
+    nodes = [
+        _compact_node(graph, name, f"definition of {display_name(graph, name)}")
+        for name in target_names
+    ]
+    return _dedupe_nodes(nodes, limit)
+
+
+def lsp_references(
+    graph: Any,
+    *,
+    file_path: Optional[str] = None,
+    line: Optional[int] = None,
+    character: Optional[int] = None,
+    symbol: Optional[str] = None,
+    include_declaration: bool = True,
+    top_k: int = 40,
+) -> list[QueriedNode]:
+    """Static-index analogue of LSP ``textDocument/references``."""
+    limit = max(1, int(top_k or 40))
+    targets: list[str] = []
+    if symbol:
+        name, candidates = _resolve_one(graph, symbol)
+        if name is None:
+            if candidates:
+                raise ValueError(
+                    f"symbol {symbol!r} is ambiguous; candidates: {candidates}. "
+                    "Call again with one exact name."
+                )
+            raise ValueError(
+                f"symbol {symbol!r} not found in the code graph. Use a name "
+                "from a search result or read output."
+            )
+        targets = [name]
+    else:
+        if not file_path or line is None:
+            raise ValueError(
+                "lsp_references requires either symbol or file_path + line"
+            )
+        definitions = lsp_definition(
+            graph,
+            file_path=file_path,
+            line=line,
+            character=character,
+            top_k=limit,
+        )
+        for definition in definitions:
+            name, _ = _resolve_one(graph, definition.node_name)
+            if name:
+                targets.append(name)
+
+    nodes: list[QueriedNode] = []
+    for name in targets:
+        label = display_name(graph, name)
+        if include_declaration:
+            nodes.append(_compact_node(graph, name, f"definition of {label}"))
+
+        vid = getattr(graph, "name_to_vertex", {}).get(name)
+        if vid is None or not hasattr(graph, "graph"):
+            continue
+        for eid in graph.graph.incident(vid, mode="in"):
+            edge = graph.graph.es[eid]
+            attrs = edge.attributes()
+            if attrs.get("type") != EDGE_TYPE_REFERENCE:
+                continue
+            nodes.append(
+                _compact_reference(
+                    graph,
+                    target_name=name,
+                    source_vid=edge.source,
+                    file_path=attrs.get("anchor_file"),
+                    line=attrs.get("anchor_line"),
+                )
+            )
+    return _dedupe_nodes(nodes, limit)
+
+
+def _graph_names_for_ids(graph: Any, vertex_ids: Sequence[int]) -> list[str]:
+    out = []
+    for vid in vertex_ids:
+        name = _node_name_for_vid(graph, vid)
+        if name:
+            out.append(name)
+    return out
+
+
+def _node_text(graph: Any, name: str) -> str:
+    info = graph.get_node_info_by_name(name) or {}
+    return f"{info.get('file') or ''} {display_name(graph, name)} {name}"
+
+
+def _span_len(graph: Any, name: str) -> int:
+    info = graph.get_node_info_by_name(name) or {}
+    try:
+        start = int(info.get("start_line") or 0)
+        end = int(info.get("end_line") or start)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, end - start + 1)
+
+
+def _role(graph: Any, name: str, *, query_terms: set[str]) -> str:
+    info = graph.get_node_info_by_name(name) or {}
+    node_type = str(info.get("type") or "")
+    label = display_name(graph, name)
+    leaf = _bare(label or name)
+    lower_leaf = leaf.lower()
+    terms = _terms(_node_text(graph, name))
+    overlap = terms & query_terms
+
+    if node_type in {NODE_TYPE_CLASS, NODE_TYPE_FIELD}:
+        return "type"
+    if lower_leaf.startswith(("get", "default")) or (
+        terms & _PROVIDER_TERMS and overlap
+    ):
+        return "provider"
+    if lower_leaf.startswith(("new", "make", "build")) or (
+        terms & _BRIDGE_TERMS and overlap
+    ):
+        return "bridge"
+    if node_type in {NODE_TYPE_FUNCTION, NODE_TYPE_METHOD} and (
+        _span_len(graph, name) > 1 or terms & _ENDPOINT_TERMS
+    ):
+        return "endpoint"
+    return "support"
+
+
+def _candidate_score(
+    graph: Any,
+    candidate: dict[str, Any],
+    *,
+    query_terms: set[str],
+) -> float:
+    name = str(candidate.get("name") or "")
+    role = str(candidate.get("role") or "support")
+    source = str(candidate.get("source") or "")
+    terms = _terms(_node_text(graph, name))
+    score = 5.0 * len(terms & query_terms)
+
+    if source == "direct_seed":
+        score += max(0, 8 - int(candidate.get("direct_rank") or 0))
+    else:
+        score += 3.0
+
+    if role == "endpoint":
+        score += 4.0
+    elif role == "bridge":
+        score += 3.0
+    elif role == "provider":
+        score += 2.0
+    elif role == "type":
+        score += 1.0
+
+    return score
+
+
+def _route_neighbors(graph: Any, name: str) -> list[tuple[str, str]]:
+    neighbors: list[tuple[str, str]] = []
+    if hasattr(graph, "get_successors"):
+        neighbors.extend(
+            (neighbor, "successor")
+            for neighbor in _graph_names_for_ids(graph, graph.get_successors(name))
+        )
+    if hasattr(graph, "get_predecessors"):
+        neighbors.extend(
+            (neighbor, "predecessor")
+            for neighbor in _graph_names_for_ids(graph, graph.get_predecessors(name))
+        )
+    return neighbors
+
+
+def _include_neighbor(
+    graph: Any, name: str, *, role: str, query_terms: set[str]
+) -> bool:
+    if role not in {"endpoint", "bridge", "provider", "type"}:
+        return False
+    if not query_terms:
+        return role in {"endpoint", "bridge"}
+    return bool(_terms(_node_text(graph, name)) & query_terms) or role in {
+        "endpoint",
+        "bridge",
+    }
+
+
+def _route_node(graph: Any, candidate: dict[str, Any]) -> QueriedNode:
+    name = str(candidate.get("name") or "")
+    role = str(candidate.get("role") or "support")
+    source = str(candidate.get("source") or "direct_seed")
+    seed = str(candidate.get("seed") or display_name(graph, name))
+    via = str(candidate.get("via") or "")
+    direction = str(candidate.get("direction") or "")
+    if source == "direct_seed":
+        relation = f"route {role}: direct seed {seed}"
+    elif via:
+        relation = f"route {role}: {direction} via {via}"
+    else:
+        relation = f"route {role}: graph neighbor"
+    return _compact_node(
+        graph,
+        name,
+        relation,
+        score=float(candidate.get("score") or 0.0),
+    )
+
+
+def lsp_route(
+    graph: Any,
+    *,
+    symbols: Sequence[str],
+    query: Optional[str] = None,
+    top_k: int = 12,
+    include_neighbors: bool = True,
+) -> list[QueriedNode]:
+    """Return compact graph route anchors for one or more symbol seeds.
+
+    Route roles are derived from node type, query-term overlap, and local graph
+    neighborhood. This function intentionally avoids benchmark instance names or
+    scorer-specific answer ordering.
+    """
+    limit = max(1, int(top_k or 12))
+    query_terms = _query_terms(query)
+    candidates: list[dict[str, Any]] = []
+
+    for rank, seed in enumerate(symbols or []):
+        for name in resolve_symbol_candidates(graph, str(seed), limit=4):
+            role = _role(graph, name, query_terms=query_terms)
+            candidate = {
+                "name": name,
+                "role": role,
+                "source": "direct_seed",
+                "seed": seed,
+                "direct_rank": rank,
+            }
+            candidate["score"] = _candidate_score(
+                graph, candidate, query_terms=query_terms
+            )
+            candidates.append(candidate)
+
+            if not include_neighbors:
+                continue
+            for neighbor, direction in _route_neighbors(graph, name):
+                neighbor_role = _role(graph, neighbor, query_terms=query_terms)
+                if not _include_neighbor(
+                    graph, neighbor, role=neighbor_role, query_terms=query_terms
+                ):
+                    continue
+                neighbor_candidate = {
+                    "name": neighbor,
+                    "role": neighbor_role,
+                    "source": "neighbor",
+                    "via": display_name(graph, name),
+                    "direction": direction,
+                    "direct_rank": rank + len(candidates),
+                }
+                neighbor_candidate["score"] = _candidate_score(
+                    graph, neighbor_candidate, query_terms=query_terms
+                )
+                candidates.append(neighbor_candidate)
+
+    role_rank = {"endpoint": 0, "bridge": 1, "provider": 2, "type": 3, "support": 4}
+    candidates.sort(
+        key=lambda item: (
+            role_rank.get(str(item.get("role") or "support"), 5),
+            -float(item.get("score") or 0.0),
+            int(item.get("direct_rank") or 0),
+            display_name(graph, str(item.get("name") or "")),
+        )
+    )
+
+    seen: set[str] = set()
+    selected: list[QueriedNode] = []
+    for candidate in candidates:
+        name = str(candidate.get("name") or "")
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        selected.append(_route_node(graph, candidate))
+        if len(selected) >= limit:
+            break
+    return selected

--- a/codeminer/agent/skills/lsp_definition/config.yaml
+++ b/codeminer/agent/skills/lsp_definition/config.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+skill_id: lsp_definition
+skill_type: expand
+operator: graph.lsp.definition
+cost: low
+defaults:
+  top_k: 8
+inputs:
+  - name: file_path
+    type: str
+    required: false
+    description: Repo-relative file path from a read/grep result. Provide with line when jumping from a location.
+  - name: line
+    type: int
+    required: false
+    is_line_number: true
+    description: 1-based source line as shown by read/grep output. Internally converted to the graph's 0-based line.
+  - name: character
+    type: int
+    required: false
+    description: Optional 0-based column hint. Current static graph anchors are line-granular, so this is best-effort.
+  - name: symbol
+    type: str
+    required: false
+    description: Optional exact or fuzzy symbol/display name. Use instead of file_path+line when you already know the symbol.
+  - name: top_k
+    type: int
+    required: false
+    description: Maximum number of candidate definitions to return.
+outputs:
+  type: List[QueriedNode]
+  description: Compact definition candidates from the static symbol graph. No source bodies; read returned files before answering.
+index_requirements:
+  - type: symbol_graph
+    max_age_seconds: 3600
+    scope: current_repo
+resources: []

--- a/codeminer/agent/skills/lsp_definition/executor.py
+++ b/codeminer/agent/skills/lsp_definition/executor.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+if TYPE_CHECKING:
+    from ....ops.expand import ExpandContext
+    from ....types import QueriedNode
+
+
+def create_executor(context: "ExpandContext") -> Callable[..., List["QueriedNode"]]:
+    """Return a static-index implementation of textDocument/definition."""
+    from ...lsp_graph import lsp_definition
+
+    def execute(
+        file_path: Optional[str] = None,
+        line: Optional[int] = None,
+        character: Optional[int] = None,
+        symbol: Optional[str] = None,
+        top_k: int = 8,
+        **kwargs: Any,
+    ) -> List["QueriedNode"]:
+        if context is None or context.code_graph is None:
+            raise RuntimeError("Symbol graph not available")
+        return lsp_definition(
+            context.code_graph,
+            file_path=file_path,
+            line=line,
+            character=character,
+            symbol=symbol,
+            top_k=int(top_k or 8),
+        )
+
+    return execute

--- a/codeminer/agent/skills/lsp_definition/skill.md
+++ b/codeminer/agent/skills/lsp_definition/skill.md
@@ -1,0 +1,15 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# lsp_definition
+
+Static-index "go to definition" backed by CodeMiner's symbol graph, not a live
+LSP server. Use it when you have a file+line from `read`/`grep` or a symbol
+name and want the definition target without fanning out through raw grep.
+
+Inputs are agent-facing: `line` is 1-based like `read` output. Results are
+compact node locations only. Read the returned file/range before using it in a
+final answer.

--- a/codeminer/agent/skills/lsp_references/config.yaml
+++ b/codeminer/agent/skills/lsp_references/config.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+skill_id: lsp_references
+skill_type: expand
+operator: graph.lsp.references
+cost: low
+defaults:
+  top_k: 40
+  include_declaration: true
+inputs:
+  - name: file_path
+    type: str
+    required: false
+    description: Repo-relative file path from a read/grep result. Provide with line when finding references from a location.
+  - name: line
+    type: int
+    required: false
+    is_line_number: true
+    description: 1-based source line as shown by read/grep output. Internally converted to the graph's 0-based line.
+  - name: character
+    type: int
+    required: false
+    description: Optional 0-based column hint. Current static graph anchors are line-granular, so this is best-effort.
+  - name: symbol
+    type: str
+    required: false
+    description: Optional exact or fuzzy symbol/display name. Use instead of file_path+line when you already know the symbol.
+  - name: include_declaration
+    type: bool
+    required: false
+    description: Include the definition span alongside reference sites.
+  - name: top_k
+    type: int
+    required: false
+    description: Maximum number of reference locations to return.
+outputs:
+  type: List[QueriedNode]
+  description: Compact definition/reference locations from the static symbol graph. No source bodies; read returned files before answering.
+index_requirements:
+  - type: symbol_graph
+    max_age_seconds: 3600
+    scope: current_repo
+resources: []

--- a/codeminer/agent/skills/lsp_references/executor.py
+++ b/codeminer/agent/skills/lsp_references/executor.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+if TYPE_CHECKING:
+    from ....ops.expand import ExpandContext
+    from ....types import QueriedNode
+
+
+def create_executor(context: "ExpandContext") -> Callable[..., List["QueriedNode"]]:
+    """Return a static-index implementation of textDocument/references."""
+    from ...lsp_graph import lsp_references
+
+    def execute(
+        file_path: Optional[str] = None,
+        line: Optional[int] = None,
+        character: Optional[int] = None,
+        symbol: Optional[str] = None,
+        include_declaration: bool = True,
+        top_k: int = 40,
+        **kwargs: Any,
+    ) -> List["QueriedNode"]:
+        if context is None or context.code_graph is None:
+            raise RuntimeError("Symbol graph not available")
+        return lsp_references(
+            context.code_graph,
+            file_path=file_path,
+            line=line,
+            character=character,
+            symbol=symbol,
+            include_declaration=bool(include_declaration),
+            top_k=int(top_k or 40),
+        )
+
+    return execute

--- a/codeminer/agent/skills/lsp_references/skill.md
+++ b/codeminer/agent/skills/lsp_references/skill.md
@@ -1,0 +1,15 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# lsp_references
+
+Static-index "find references" backed by CodeMiner's symbol graph, not a live
+LSP server. Use it when you need call/use sites for a symbol or for the symbol
+at a file+line from `read`/`grep`.
+
+Inputs are agent-facing: `line` is 1-based like `read` output. Results are
+compact definition/reference locations only. Read the returned file/range
+before using it in a final answer.

--- a/codeminer/agent/skills/lsp_route/config.yaml
+++ b/codeminer/agent/skills/lsp_route/config.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+skill_id: lsp_route
+skill_type: expand
+operator: graph.lsp.route
+cost: low
+defaults:
+  top_k: 12
+  include_neighbors: true
+inputs:
+  - name: symbols
+    type: List[str]
+    required: true
+    description: Symbol/display names from search, read, or LSP results to seed a static graph route map.
+  - name: query
+    type: str
+    required: false
+    description: Original user request or local search intent, used to rank endpoint/bridge/provider/type route roles.
+  - name: top_k
+    type: int
+    required: false
+    description: Maximum number of compact route anchors to return.
+  - name: include_neighbors
+    type: bool
+    required: false
+    description: Include query-relevant one-hop graph neighbors with via markers.
+outputs:
+  type: List[QueriedNode]
+  description: Compact semantic route anchors from the static symbol graph. No source bodies; read returned files before answering.
+index_requirements:
+  - type: symbol_graph
+    max_age_seconds: 3600
+    scope: current_repo
+resources: []

--- a/codeminer/agent/skills/lsp_route/executor.py
+++ b/codeminer/agent/skills/lsp_route/executor.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
+
+if TYPE_CHECKING:
+    from ....ops.expand import ExpandContext
+    from ....types import QueriedNode
+
+
+def create_executor(context: "ExpandContext") -> Callable[..., List["QueriedNode"]]:
+    """Return a semantic route-map implementation over the static graph."""
+    from ...lsp_graph import lsp_route
+
+    def execute(
+        symbols: List[str],
+        query: Optional[str] = None,
+        top_k: int = 12,
+        include_neighbors: bool = True,
+        **kwargs: Any,
+    ) -> List["QueriedNode"]:
+        if context is None or context.code_graph is None:
+            raise RuntimeError("Symbol graph not available")
+        return lsp_route(
+            context.code_graph,
+            symbols=list(symbols or []),
+            query=query,
+            top_k=int(top_k or 12),
+            include_neighbors=bool(include_neighbors),
+        )
+
+    return execute

--- a/codeminer/agent/skills/lsp_route/skill.md
+++ b/codeminer/agent/skills/lsp_route/skill.md
@@ -1,0 +1,15 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# lsp_route
+
+Static-index semantic route map backed by CodeMiner's symbol graph, not a live
+LSP server. Use it when several symbols or a read/search result look related
+and you need a compact map of likely endpoint, bridge/factory, provider/value,
+and type anchors.
+
+Results are compact node locations with role and `via` markers only. Read the
+returned files/ranges before using them in a final answer.

--- a/codeminer/mcp/README.md
+++ b/codeminer/mcp/README.md
@@ -84,6 +84,10 @@ Optional `--log-level {DEBUG,INFO,WARNING,ERROR}` (default `INFO`); logs go to s
 | `search_bm25` | `bm25` | symbol | exact-name / keyword lookups |
 | `search_regex` | `symbol_graph` | symbol | structural pattern matching |
 | `search_zoekt` | `zoekt` | file | fast substring/regex across raw repo contents |
+| `dependency_subgraph` | `symbol_graph` | call graph | structural dependency / impact analysis |
+| `lsp_definition` | `symbol_graph` | location | static graph analogue of go-to-definition |
+| `lsp_references` | `symbol_graph` | locations | static graph analogue of find-references |
+| `lsp_route` | `symbol_graph` | locations | compact route anchors for related symbols |
 | `get_manifest` | — | — | repo metadata: path, commit, languages, capabilities |
 
 ### `search_semantic`
@@ -124,6 +128,15 @@ file-level (`type="file"`).
 - `top_k` (int, default 20).
 - `file_filter` (str, default `""`): glob/regex appended as `file:<expr>`.
 
+### `lsp_definition` / `lsp_references` / `lsp_route`
+Static LSP-shaped navigation over the loaded `symbol_graph`. These tools return
+compact locations only; clients should read source before finalizing.
+
+- `lsp_definition`: provide either `symbol` or `file_path` + 1-based `line`.
+- `lsp_references`: same inputs, with optional `include_declaration`.
+- `lsp_route`: provide one or more `symbols` plus optional `query` to rank
+  endpoint, bridge/factory, provider/value, and type anchors.
+
 ### `get_manifest`
 Returns the repo manifest as a dict: path, commit, languages, available indexes, and
 derived capabilities.
@@ -140,7 +153,7 @@ derived capabilities.
 - **`ServerContext`** (`context.py`): loads the manifest and hydrates available indexes.
 - **Phase 1 (indexing)**: `IndexCompiler` builds indexes and writes the manifest.
 - **Phase 2 (query)**: this server loads the manifest and serves the search tools.
-- **Tool implementations** live in `tools/search.py`; the `@mcp.tool` wrappers and CLI
+- **Tool implementations** live in `tools/*.py`; the `@mcp.tool` wrappers and CLI
   live in `server.py`.
 
 ## Development

--- a/codeminer/mcp/server.py
+++ b/codeminer/mcp/server.py
@@ -30,6 +30,7 @@ from mcp.server.fastmcp import FastMCP
 from .context import ServerContext
 from .prompts import CODEMINER_GUIDE
 from .tools.dependency import dependency_subgraph_impl
+from .tools.lsp import lsp_definition_impl, lsp_references_impl, lsp_route_impl
 from .tools.search import search_bm25_impl, search_regex_impl
 from .tools.search import search_semantic as _search_semantic_impl
 from .tools.search import search_zoekt_impl
@@ -54,7 +55,9 @@ mcp = FastMCP(
         "Use search_semantic for vector/embedding similarity, "
         "search_bm25 for keyword lookups, search_regex for symbol-level "
         "pattern matching, and search_zoekt for fast trigram-based "
-        "substring/regex search across raw file contents."
+        "substring/regex search across raw file contents. Use "
+        "lsp_definition, lsp_references, and lsp_route for graph-backed "
+        "LSP-shaped symbol navigation."
     ),
 )
 
@@ -198,6 +201,94 @@ async def dependency_subgraph(
         raise RuntimeError("Server not initialized")
     return await asyncio.to_thread(
         dependency_subgraph_impl, _ctx, symbol, direction, depth, max_nodes
+    )
+
+
+@mcp.tool(
+    name="lsp_definition",
+    description=(
+        "Return compact definition locations from CodeMiner's static symbol "
+        "graph. Provide either symbol or file_path + 1-based line. Results are "
+        "locations only; read source before finalizing."
+    ),
+)
+async def lsp_definition(
+    file_path: str = "",
+    line: int | None = None,
+    character: int | None = None,
+    symbol: str = "",
+    top_k: int = 8,
+) -> list[dict[str, Any]] | dict[str, str]:
+    """Graph-backed definition lookup over the static symbol graph."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    return await asyncio.to_thread(
+        lsp_definition_impl,
+        _ctx,
+        file_path,
+        line,
+        character,
+        symbol,
+        top_k,
+    )
+
+
+@mcp.tool(
+    name="lsp_references",
+    description=(
+        "Return compact definition/reference locations from CodeMiner's static "
+        "symbol graph. Provide either symbol or file_path + 1-based line. "
+        "Results are locations only; read source before finalizing."
+    ),
+)
+async def lsp_references(
+    file_path: str = "",
+    line: int | None = None,
+    character: int | None = None,
+    symbol: str = "",
+    include_declaration: bool = True,
+    top_k: int = 40,
+) -> list[dict[str, Any]] | dict[str, str]:
+    """Graph-backed reference lookup over the static symbol graph."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    return await asyncio.to_thread(
+        lsp_references_impl,
+        _ctx,
+        file_path,
+        line,
+        character,
+        symbol,
+        include_declaration,
+        top_k,
+    )
+
+
+@mcp.tool(
+    name="lsp_route",
+    description=(
+        "Return compact route anchors from CodeMiner's static symbol graph for "
+        "one or more symbol seeds. Use this when multiple symbols need a route "
+        "map across endpoint, bridge/factory, provider/value, or type anchors. "
+        "Results are locations only; read source before finalizing."
+    ),
+)
+async def lsp_route(
+    symbols: list[str],
+    query: str = "",
+    top_k: int = 12,
+    include_neighbors: bool = True,
+) -> list[dict[str, Any]] | dict[str, str]:
+    """Graph-backed route map over the static symbol graph."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    return await asyncio.to_thread(
+        lsp_route_impl,
+        _ctx,
+        symbols,
+        query,
+        top_k,
+        include_neighbors,
     )
 
 

--- a/codeminer/mcp/tools/lsp.py
+++ b/codeminer/mcp/tools/lsp.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""LSP-shaped graph navigation tools for MCP clients."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from ...agent.lsp_graph import lsp_definition, lsp_references, lsp_route
+
+
+def _coerce_symbols(symbols: Sequence[str] | str) -> list[str]:
+    if isinstance(symbols, str):
+        return [s.strip() for s in symbols.split(",") if s.strip()]
+    return [str(s).strip() for s in symbols or [] if str(s).strip()]
+
+
+def _node_to_dict(node: Any) -> dict[str, Any]:
+    if hasattr(node, "model_dump"):
+        payload = node.model_dump(exclude_none=True)
+    elif isinstance(node, dict):
+        payload = {k: v for k, v in node.items() if v is not None}
+    else:
+        return {"node": str(node)}
+    for key in ("start_line", "end_line"):
+        value = payload.get(key)
+        if isinstance(value, int):
+            payload[key] = value + 1
+    return payload
+
+
+def _symbol_graph(ctx: Any) -> Any:
+    graph = getattr(ctx, "symbol_graph", None)
+    if graph is None:
+        return None
+    return graph
+
+
+def lsp_definition_impl(
+    ctx: Any,
+    file_path: str = "",
+    line: int | None = None,
+    character: int | None = None,
+    symbol: str = "",
+    top_k: int = 8,
+) -> list[dict[str, Any]] | dict[str, str]:
+    """Return graph-backed definition locations."""
+    graph = _symbol_graph(ctx)
+    if graph is None:
+        return {"error": "symbol_graph index not available"}
+    graph_line = int(line) - 1 if line is not None else None
+    try:
+        results = lsp_definition(
+            graph,
+            file_path=file_path or None,
+            line=graph_line,
+            character=character,
+            symbol=symbol or None,
+            top_k=max(1, int(top_k or 8)),
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}
+    return [_node_to_dict(node) for node in results]
+
+
+def lsp_references_impl(
+    ctx: Any,
+    file_path: str = "",
+    line: int | None = None,
+    character: int | None = None,
+    symbol: str = "",
+    include_declaration: bool = True,
+    top_k: int = 40,
+) -> list[dict[str, Any]] | dict[str, str]:
+    """Return graph-backed reference locations."""
+    graph = _symbol_graph(ctx)
+    if graph is None:
+        return {"error": "symbol_graph index not available"}
+    graph_line = int(line) - 1 if line is not None else None
+    try:
+        results = lsp_references(
+            graph,
+            file_path=file_path or None,
+            line=graph_line,
+            character=character,
+            symbol=symbol or None,
+            include_declaration=bool(include_declaration),
+            top_k=max(1, int(top_k or 40)),
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}
+    return [_node_to_dict(node) for node in results]
+
+
+def lsp_route_impl(
+    ctx: Any,
+    symbols: Sequence[str] | str,
+    query: str = "",
+    top_k: int = 12,
+    include_neighbors: bool = True,
+) -> list[dict[str, Any]] | dict[str, str]:
+    """Return graph-backed route anchors for one or more symbol seeds."""
+    graph = _symbol_graph(ctx)
+    if graph is None:
+        return {"error": "symbol_graph index not available"}
+    seeds = _coerce_symbols(symbols)
+    if not seeds:
+        return []
+    results = lsp_route(
+        graph,
+        symbols=seeds,
+        query=query or None,
+        top_k=max(1, int(top_k or 12)),
+        include_neighbors=bool(include_neighbors),
+    )
+    return [_node_to_dict(node) for node in results]

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -54,6 +54,9 @@ Transport is stdio; logs go to stderr (`--log-level` to adjust).
 | `search_regex` | `symbol_graph` | symbol | structural pattern matching |
 | `search_zoekt` | `zoekt` | file | fast substring/regex across raw file contents |
 | `dependency_subgraph` | `symbol_graph` | call graph | structural "who calls X / what does X reach" — `impact` (transitive callers / blast radius), `dependencies` (transitive callees), or `both` (1-hop neighborhood); returns nodes+edges JSON |
+| `lsp_definition` | `symbol_graph` | location | static graph analogue of go-to-definition from a symbol or file+line |
+| `lsp_references` | `symbol_graph` | locations | static graph analogue of find-references from a symbol or file+line |
+| `lsp_route` | `symbol_graph` | locations | compact route anchors for related endpoint / bridge / provider / type symbols |
 | `get_manifest` | — | — | repo metadata: path, commit, languages, capabilities |
 
 A `codeminer-guide` prompt returns guidance on choosing between these tools.

--- a/test/agent/test_lsp_graph.py
+++ b/test/agent/test_lsp_graph.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codeminer.agent import lsp_graph
+from codeminer.agent.skills.loader import SkillLoader
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.ops.expand import ExpandContext
+from codeminer.types import NODE_TYPE_FUNCTION
+
+
+def _range_graph() -> CodeGraph:
+    graph = CodeGraph()
+    graph.add_file_node("caller.py")
+    graph.add_symbol_node(
+        "caller.run",
+        line=0,
+        scope_start_line=0,
+        scope_end_line=3,
+        symbol_type=NODE_TYPE_FUNCTION,
+    )
+    graph.graph.vs[graph.name_to_vertex["caller.run"]][
+        "unified_name"
+    ] = "caller.py:run()"
+    graph.update_current_scope("caller.run", start_line=0, end_line=3)
+    graph.add_symbol_reference(
+        "callee.load_config",
+        module_path="callee.py",
+        symbol_type=NODE_TYPE_FUNCTION,
+        anchor_file="caller.py",
+        anchor_line=1,
+    )
+
+    graph.add_file_node("callee.py")
+    graph.add_symbol_node(
+        "callee.load_config",
+        line=4,
+        scope_start_line=4,
+        scope_end_line=8,
+        symbol_type=NODE_TYPE_FUNCTION,
+    )
+    graph.graph.vs[graph.name_to_vertex["callee.load_config"]][
+        "unified_name"
+    ] = "callee.py:load_config()"
+    graph.build_range_indexes()
+    return graph
+
+
+def test_lsp_definition_jumps_from_reference_anchor_to_definition():
+    graph = _range_graph()
+
+    results = lsp_graph.lsp_definition(graph, file_path="caller.py", line=1)
+
+    assert [node.node_name for node in results] == ["callee.py:load_config()"]
+    assert results[0].file == "callee.py"
+    assert results[0].start_line == 4
+    assert results[0].content == "definition of callee.py:load_config()"
+
+
+def test_lsp_definition_accepts_symbol_seed():
+    graph = _range_graph()
+
+    results = lsp_graph.lsp_definition(graph, symbol="load_config")
+
+    assert [node.node_name for node in results] == ["callee.py:load_config()"]
+
+
+def test_lsp_references_returns_declaration_and_reference_site():
+    graph = _range_graph()
+
+    results = lsp_graph.lsp_references(
+        graph, symbol="load_config", include_declaration=True
+    )
+
+    assert [(node.file, node.start_line, node.content) for node in results] == [
+        ("callee.py", 4, "definition of callee.py:load_config()"),
+        ("caller.py", 1, "reference to callee.py:load_config()"),
+    ]
+    assert results[1].node_id == "caller.py:2:ref:callee.py:load_config()"
+
+
+class _RouteGraph:
+    def __init__(self):
+        self.name_to_vertex = {
+            "svc.HandleRequest": 0,
+            "svc.NewResolver": 1,
+            "svc.DefaultConfig": 2,
+            "svc.Config": 3,
+        }
+        self._attr = {
+            0: {
+                "name": "svc.HandleRequest",
+                "type": "function",
+                "file": "service.py",
+                "start_line": 20,
+                "end_line": 50,
+            },
+            1: {
+                "name": "svc.NewResolver",
+                "type": "function",
+                "file": "resolver.py",
+                "start_line": 5,
+                "end_line": 15,
+            },
+            2: {
+                "name": "svc.DefaultConfig",
+                "type": "function",
+                "file": "config.py",
+                "start_line": 2,
+                "end_line": 8,
+            },
+            3: {
+                "name": "svc.Config",
+                "type": "class",
+                "file": "config.py",
+                "start_line": 1,
+                "end_line": 12,
+            },
+        }
+        self._succ = {
+            "svc.HandleRequest": [1],
+            "svc.NewResolver": [2, 3],
+        }
+        self._pred = {}
+
+    def get_node_info_by_name(self, name):
+        return self._attr.get(self.name_to_vertex.get(name))
+
+    def get_node_info_by_id(self, vertex_id):
+        return self._attr.get(vertex_id)
+
+    def get_successors(self, name):
+        return self._succ.get(name, [])
+
+    def get_predecessors(self, name):
+        return self._pred.get(name, [])
+
+
+def test_lsp_route_returns_general_roles_without_instance_hacks():
+    route = lsp_graph.lsp_route(
+        _RouteGraph(),
+        symbols=["HandleRequest", "NewResolver"],
+        query="handle request resolver default config",
+        top_k=4,
+    )
+
+    assert [node.node_name for node in route] == [
+        "svc.HandleRequest",
+        "svc.NewResolver",
+        "svc.DefaultConfig",
+        "svc.Config",
+    ]
+    assert route[0].content == "route endpoint: direct seed HandleRequest"
+    assert route[1].content == "route bridge: direct seed NewResolver"
+    assert route[2].content == "route provider: successor via svc.NewResolver"
+    assert route[3].content == "route type: successor via svc.NewResolver"
+
+
+def test_lsp_route_skips_missing_symbols_but_uses_resolved_ones():
+    route = lsp_graph.lsp_route(
+        _RouteGraph(),
+        symbols=["absent_symbol", "HandleRequest"],
+        query="handle request",
+        top_k=2,
+    )
+
+    assert [node.node_name for node in route] == [
+        "svc.HandleRequest",
+        "svc.NewResolver",
+    ]
+
+
+def test_lsp_skills_load_and_execute_against_expand_context():
+    graph = _range_graph()
+    context = {"expand": ExpandContext(code_graph=graph)}
+    loader = SkillLoader()
+
+    meta = loader.load_skill("codeminer/agent/skills/lsp_definition", context)
+
+    assert meta is not None
+    assert meta.executor_fn is not None
+    results = meta.executor_fn(symbol="load_config")
+    assert [node.node_name for node in results] == ["callee.py:load_config()"]

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -21,6 +21,7 @@ import pytest
 import codeminer.mcp.server as server_module
 from codeminer.index.embedding.vector_store import CodeVectorStore
 from codeminer.mcp.context import ServerContext
+from codeminer.mcp.tools.lsp import lsp_definition_impl, lsp_references_impl
 
 
 @pytest.fixture
@@ -138,6 +139,62 @@ def test_semantic_search_tool_with_vector_index(mock_manifest: Path):
     assert len(result) == 1
     assert result[0]["node_id"] == "test_node"
     assert result[0]["score"] == 0.95
+
+
+def test_lsp_definition_tool_no_symbol_graph():
+    """Test lsp_definition returns an error when symbol_graph is unavailable."""
+    result = lsp_definition_impl(MagicMock(symbol_graph=None), symbol="load_config")
+
+    assert result == {"error": "symbol_graph index not available"}
+
+
+def test_lsp_definition_tool_serializes_one_based_lines():
+    """Test MCP serialization converts internal graph lines to 1-based lines."""
+    mock_graph = MagicMock()
+    from codeminer.types import QueriedNode
+
+    mock_graph.query_range.side_effect = ValueError("should not be called")
+    ctx = MagicMock(symbol_graph=mock_graph)
+    with patch("codeminer.mcp.tools.lsp.lsp_definition") as mock_definition:
+        mock_definition.return_value = [
+            QueriedNode(
+                node_name="load_config",
+                file="config.py",
+                start_line=4,
+                end_line=8,
+                content="definition of load_config",
+            )
+        ]
+        result = lsp_definition_impl(ctx, symbol="load_config")
+
+    assert result[0]["start_line"] == 5
+    assert result[0]["end_line"] == 9
+
+
+def test_lsp_references_tool_delegates_to_core():
+    """Test lsp_references wrapper calls the core graph helper."""
+    from codeminer.types import QueriedNode
+
+    ctx = MagicMock(symbol_graph=MagicMock())
+    with patch("codeminer.mcp.tools.lsp.lsp_references") as mock_references:
+        mock_references.return_value = [
+            QueriedNode(
+                node_name="caller",
+                file="caller.py",
+                start_line=1,
+                end_line=1,
+                content="reference to load_config",
+            )
+        ]
+        result = lsp_references_impl(
+            ctx, file_path="caller.py", line=2, symbol="", include_declaration=False
+        )
+
+    assert result[0]["start_line"] == 2
+    kwargs = mock_references.call_args.kwargs
+    assert kwargs["file_path"] == "caller.py"
+    assert kwargs["line"] == 1
+    assert kwargs["include_declaration"] is False
 
 
 def test_server_status_resource(mock_manifest: Path):


### PR DESCRIPTION
## Summary
Extracts the generally useful graph-backed LSP tools from the #271 spike into a small core PR. This adds static symbol-graph analogues of definition, references, and route-map navigation without bringing over route lifecycle feedback gates, answer rewrites, or scorer-specific behavior.

## Changes
- Add `codeminer.agent.lsp_graph` as the shared core implementation for graph-backed `lsp_definition`, `lsp_references`, and `lsp_route`.
- Add agent skill packages for `lsp_definition`, `lsp_references`, and `lsp_route` using `symbol_graph` / `ExpandContext`.
- Add MCP implementations and server registrations for the three LSP-shaped tools.
- Document the new MCP tools and fix two existing docs links so strict docs build passes.
- Add unit tests over small synthetic graphs and MCP serialization/delegation.

Not included by design:
- route lifecycle feedback gates
- final-answer or `Locations:` rewriting
- benchmark promotion logic
- `scripts/agent_compile` imports or reusable harness code

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m pytest test/agent/test_lsp_graph.py test/mcp/test_mcp_server.py -q`
- `python -m pytest test/agent/test_lsp_graph.py test/mcp/test_mcp_server.py test/compiler/test_skill_loader.py -q`
- `python -m pytest test/agent/test_graph_nav.py test/agent/test_lsp_graph.py -q`
- `python -m pytest test/mcp -q`
- `python -m black --check codeminer/agent/lsp_graph.py codeminer/mcp/tools/lsp.py codeminer/agent/skills/lsp_definition/executor.py codeminer/agent/skills/lsp_references/executor.py codeminer/agent/skills/lsp_route/executor.py test/agent/test_lsp_graph.py test/mcp/test_mcp_server.py`
- `python -m isort --profile black --check-only codeminer/agent/lsp_graph.py codeminer/mcp/tools/lsp.py codeminer/agent/skills/lsp_definition/executor.py codeminer/agent/skills/lsp_references/executor.py codeminer/agent/skills/lsp_route/executor.py test/agent/test_lsp_graph.py test/mcp/test_mcp_server.py`
- `mkdocs build --strict`
- `git diff --check`
- `rg -n "scripts\.agent_compile|from scripts|import scripts" codeminer/agent/lsp_graph.py codeminer/mcp/tools/lsp.py codeminer/agent/skills/lsp_* test/agent/test_lsp_graph.py test/mcp/test_mcp_server.py`
- commit pre-commit hooks

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
