### PR TITLE
[codex] Add runtime trace events

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -13,11 +13,15 @@ from .extract_agent import (
 from .history import PlainChatHistory, TokenBudgetedChatHistory, count_message_tokens
 from .rerank_agent import RerankAgent, RerankResult, rerank_nodes_with_query
 from .runner import AgentRunner, CodeMinerAgentOptions, compile_repo, query
+from .runtime import AGENT_TRACE_SCHEMA_VERSION, AgentRunTrace, AgentTraceEvent
 from .tool_schema import registry_to_tools, skill_to_tool_schema
 
 __all__ = [
     "AgentResult",
+    "AgentRunTrace",
+    "AgentTraceEvent",
     "AgentRunner",
+    "AGENT_TRACE_SCHEMA_VERSION",
     "CodeMinerAgentOptions",
     "KeywordExtraction",
     "KeywordExtractor",

--- a/codeminer/agent/agent_types.py
+++ b/codeminer/agent/agent_types.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from ..llm.usage import TokenUsage, UsageRecord
+from .runtime.trace import AgentRunTrace
 
 
 @dataclass
@@ -35,3 +36,4 @@ class AgentResult:
     total_duration_ms: float = 0.0
     usage: Optional[TokenUsage] = None
     usage_records: List[UsageRecord] = field(default_factory=list)
+    trace: Optional[AgentRunTrace] = None

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -25,6 +25,7 @@ from ..log_utils import get_logger
 from .agent_types import AgentResult, ToolCallRecord
 from .boundary import from_agent_repr_arg, is_line_bearing, to_agent_repr
 from .history import PlainChatHistory, TokenBudgetedChatHistory
+from .runtime.trace import AgentRunTrace
 from .skills.loader import SkillLoader
 from .skills.registry import SkillRegistry
 from .skills.typecheck import coerce_args
@@ -416,6 +417,46 @@ class AgentRunner:
         read_paths: List[str] = []  # files the agent read (for schema salvage)
         read_outputs: List[Dict[str, str]] = []  # successful read transcripts
         compacted = False  # eager_compact: collapsed to direction seed yet?
+        trace = AgentRunTrace()
+        trace.add(
+            "run_start",
+            0,
+            query_chars=len(query or ""),
+            max_turns=max_turns,
+            tool_count=len(tools or []),
+        )
+
+        def _finish_result(
+            answer: str,
+            *,
+            total_turns: int,
+            answer_source: str,
+        ) -> AgentResult:
+            elapsed = (time.monotonic() - start) * 1000
+            trace.add(
+                "final_answer",
+                total_turns,
+                source=answer_source,
+                answer_chars=len(answer or ""),
+                has_contract=_has_localization_contract(answer or ""),
+            )
+            trace.add(
+                "run_end",
+                total_turns,
+                duration_ms=elapsed,
+                tool_calls=len(all_tool_calls),
+                usage_records=len(usage_tracker.records),
+            )
+            return AgentResult(
+                answer=answer,
+                tool_calls=all_tool_calls,
+                messages=history.get_messages(),
+                total_turns=total_turns,
+                total_duration_ms=elapsed,
+                usage=usage_tracker.totals(),
+                usage_records=list(usage_tracker.records),
+                trace=trace,
+            )
 
         for turn in range(max_turns):
             logger.debug("agent turn %d/%d", turn + 1, max_turns)
@@ -465,6 +506,13 @@ class AgentRunner:
                     if not (self._force_first_turn_only and turn > 0):
                         call_kwargs["tool_choice"] = self.first_turn_tool_choice
 
+            trace.add(
+                "llm_call",
+                turn + 1,
+                message_count=len(history.get_messages()),
+                tool_count=len(call_kwargs.get("tools") or []),
+                tool_choice=call_kwargs.get("tool_choice", "auto"),
+            )
             response = self.llm._call_raw(history.get_messages(), **call_kwargs)
             choice = response.choices[0]
             assistant_msg = choice.message
@@ -475,31 +523,40 @@ class AgentRunner:
 
             # Check for tool calls
             tool_calls = getattr(assistant_msg, "tool_calls", None)
+            trace.add(
+                "llm_response",
+                turn + 1,
+                content_chars=len(getattr(assistant_msg, "content", None) or ""),
+                tool_call_count=len(tool_calls or []),
+            )
             if not tool_calls:
                 # Terminal: LLM stopped calling tools. If it answered in prose
                 # without the contract (it explored but didn't format), force one
                 # schema turn so a genuine localization isn't lost to formatting.
                 answer = getattr(assistant_msg, "content", None) or ""
+                answer_source = "assistant"
                 if (
                     self._force_contract
                     and all_tool_calls
                     and not _has_localization_contract(answer)
                 ):
+                    trace.add(
+                        "final_answer_forced",
+                        turn + 1,
+                        reason="missing_contract",
+                        read_paths=list(dict.fromkeys(read_paths)),
+                    )
                     answer = (
                         self._force_schema_answer(
                             history, usage_tracker, turn + 2, read_paths
                         )
                         or answer
                     )
-                elapsed = (time.monotonic() - start) * 1000
-                return AgentResult(
+                    answer_source = "forced_schema"
+                return _finish_result(
                     answer=answer,
-                    tool_calls=all_tool_calls,
-                    messages=history.get_messages(),
                     total_turns=turn + 1,
-                    total_duration_ms=elapsed,
-                    usage=usage_tracker.totals(),
-                    usage_records=list(usage_tracker.records),
+                    answer_source=answer_source,
                 )
 
             # Execute each tool call
@@ -509,13 +566,29 @@ class AgentRunner:
                 tool_content = _serialize_result(
                     record.result if record.error is None else record.error
                 )
+                trace.add(
+                    "tool_call",
+                    turn + 1,
+                    **_trace_tool_call_data(record, tool_content),
+                )
                 # A successful read satisfies the "read before answering"
                 # contract; once it happens, stop forcing tool calls.
-                if (
+                successful_read = (
                     record.skill_id == "read"
                     and record.error is None
                     and not tool_content.lstrip().startswith("Error")
-                ):
+                )
+                if record.skill_id == "read":
+                    trace.add(
+                        "read",
+                        turn + 1,
+                        tool_call_id=record.tool_call_id,
+                        path=str((record.arguments or {}).get("file_path") or ""),
+                        offset=(record.arguments or {}).get("offset"),
+                        limit=(record.arguments or {}).get("limit"),
+                        status="ok" if successful_read else "error",
+                    )
+                if successful_read:
                     has_read = True
                     _rp = (record.arguments or {}).get("file_path")
                     if _rp:
@@ -549,9 +622,21 @@ class AgentRunner:
                     self._compact_keep_reads,
                     read_outputs=read_outputs,
                 ):
+                    trace.add(
+                        "context_compacted",
+                        turn + 1,
+                        read_paths=list(dict.fromkeys(read_paths)),
+                        keep_reads=self._compact_keep_reads,
+                    )
                     logger.debug("eager_compact: collapsed to distilled direction seed")
 
         # Max turns exhausted. Prefer the last textual assistant message.
+        trace.add(
+            "max_turns_exhausted",
+            max_turns,
+            tool_calls=len(all_tool_calls),
+            has_read=has_read,
+        )
         last_content = ""
         for msg in reversed(history.get_messages()):
             if msg.get("role") == "assistant" and msg.get("content"):
@@ -561,27 +646,30 @@ class AgentRunner:
         # Budget exhausted. A capped agent usually left mid-exploration chatter
         # ("Let me check…"), so force a schema-conforming final answer unless it
         # already emitted the contract.
+        answer_source = "max_turns"
         if (
             self._force_contract
             and all_tool_calls
             and not _has_localization_contract(last_content)
         ):
+            trace.add(
+                "final_answer_forced",
+                max_turns,
+                reason="max_turns_exhausted",
+                read_paths=list(dict.fromkeys(read_paths)),
+            )
             last_content = (
                 self._force_schema_answer(
                     history, usage_tracker, max_turns + 1, read_paths
                 )
                 or last_content
             )
+            answer_source = "forced_schema"
 
-        elapsed = (time.monotonic() - start) * 1000
-        return AgentResult(
+        return _finish_result(
             answer=last_content,
-            tool_calls=all_tool_calls,
-            messages=history.get_messages(),
             total_turns=max_turns,
-            total_duration_ms=elapsed,
-            usage=usage_tracker.totals(),
-            usage_records=list(usage_tracker.records),
+            answer_source=answer_source,
         )
 
     def _compact_history(
@@ -905,6 +993,42 @@ def _serialize_result(result: Any) -> str:
     if len(text) > _MAX_RESULT_CHARS:
         text = text[:_MAX_RESULT_CHARS] + "\n... (truncated)"
     return text
+
+
+def _trace_tool_call_data(
+    record: ToolCallRecord,
+    serialized_result: str,
+) -> Dict[str, Any]:
+    """Summarize a tool call for runtime trace events."""
+
+    status = "error" if record.error is not None else "ok"
+    result = record.result
+    result_count: Optional[int] = None
+    if isinstance(result, (list, tuple)):
+        result_type = "sequence"
+        result_count = len(result)
+    elif isinstance(result, Mapping):
+        result_type = "mapping"
+    elif result is None:
+        result_type = "none"
+    else:
+        result_type = type(result).__name__
+
+    data: Dict[str, Any] = {
+        "tool_call_id": record.tool_call_id,
+        "tool": record.skill_id,
+        "arguments": dict(record.arguments or {}),
+        "status": status,
+        "duration_ms": record.duration_ms,
+        "result_type": "error" if status == "error" else result_type,
+        "result_chars": len(serialized_result or ""),
+        "truncated": bool(serialized_result.endswith("\n... (truncated)")),
+    }
+    if result_count is not None:
+        data["result_count"] = result_count
+    if record.error is not None:
+        data["error"] = record.error
+    return data
 
 
 # ---------------------------------------------------------------------------

--- a/codeminer/agent/runtime/__init__.py
+++ b/codeminer/agent/runtime/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime support types for agent execution."""
+
+from .trace import AGENT_TRACE_SCHEMA_VERSION, AgentRunTrace, AgentTraceEvent
+
+__all__ = [
+    "AGENT_TRACE_SCHEMA_VERSION",
+    "AgentRunTrace",
+    "AgentTraceEvent",
+]

--- a/codeminer/agent/runtime/trace.py
+++ b/codeminer/agent/runtime/trace.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable trace event schema for agent runtime observability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+AGENT_TRACE_SCHEMA_VERSION = 1
+
+
+@dataclass
+class AgentTraceEvent:
+    """A replay-oriented event emitted by an agent run.
+
+    The trace is intentionally descriptive, not prescriptive: events explain what
+    happened during runtime without encoding benchmark scoring or promotion
+    policy.
+    """
+
+    kind: str
+    turn: int
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "turn": self.turn,
+            "data": dict(self.data),
+        }
+
+
+@dataclass
+class AgentRunTrace:
+    """Durable event log for one ``AgentRunner.run()`` invocation."""
+
+    events: List[AgentTraceEvent] = field(default_factory=list)
+
+    def add(self, kind: str, turn: int, **data: Any) -> AgentTraceEvent:
+        event = AgentTraceEvent(kind=kind, turn=turn, data=dict(data))
+        self.events.append(event)
+        return event
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": AGENT_TRACE_SCHEMA_VERSION,
+            "events": [event.to_dict() for event in self.events],
+        }

--- a/test/agent/test_runtime_trace.py
+++ b/test/agent/test_runtime_trace.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime trace contract tests for ``AgentRunner``."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.runtime import AGENT_TRACE_SCHEMA_VERSION
+from codeminer.agent.skills.core import (
+    SkillInputSpec,
+    SkillMetadata,
+    SkillOutputSpec,
+    SkillType,
+)
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.llm.litellm_chat import LiteLLMChat
+
+
+def _make_llm():
+    return MagicMock(spec=LiteLLMChat)
+
+
+def _make_response(content=None, tool_calls=None):
+    msg = SimpleNamespace(role="assistant", content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+def _make_tool_call(tc_id, name, arguments_json):
+    return SimpleNamespace(
+        id=tc_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments_json),
+    )
+
+
+def _echo_registry() -> SkillRegistry:
+    reg = SkillRegistry()
+    reg.register(
+        SkillMetadata(
+            skill_id="echo",
+            skill_type=SkillType.CUSTOM,
+            inputs=[SkillInputSpec(name="text", type_hint="str", required=True)],
+            outputs=SkillOutputSpec(type_hint="str"),
+            executor_fn=lambda text: f"echo: {text}",
+        )
+    )
+    return reg
+
+
+def _events(result, kind):
+    assert result.trace is not None
+    return [event for event in result.trace.events if event.kind == kind]
+
+
+def test_trace_records_direct_answer_contract():
+    llm = _make_llm()
+    llm._call_raw.return_value = _make_response(content="done")
+
+    result = AgentRunner(
+        llm,
+        SkillRegistry(),
+        force_localization_contract=False,
+    ).run("answer directly")
+
+    assert result.trace is not None
+    assert result.trace.to_dict()["schema_version"] == AGENT_TRACE_SCHEMA_VERSION
+    assert [event.kind for event in result.trace.events] == [
+        "run_start",
+        "llm_call",
+        "llm_response",
+        "final_answer",
+        "run_end",
+    ]
+    assert _events(result, "final_answer")[0].data == {
+        "source": "assistant",
+        "answer_chars": 4,
+        "has_contract": False,
+    }
+
+
+def test_trace_summarizes_successful_tool_call():
+    llm = _make_llm()
+    tc = _make_tool_call("call_1", "echo", '{"text": "hello"}')
+    llm._call_raw.side_effect = [
+        _make_response(tool_calls=[tc]),
+        _make_response(content="done"),
+    ]
+
+    result = AgentRunner(
+        llm,
+        _echo_registry(),
+        force_localization_contract=False,
+    ).run("echo")
+
+    tool_event = _events(result, "tool_call")[0]
+    assert tool_event.turn == 1
+    assert tool_event.data["tool_call_id"] == "call_1"
+    assert tool_event.data["tool"] == "echo"
+    assert tool_event.data["arguments"] == {"text": "hello"}
+    assert tool_event.data["status"] == "ok"
+    assert tool_event.data["result_type"] == "str"
+    assert tool_event.data["result_chars"] == len("echo: hello")
+
+
+def test_trace_records_default_read_events(tmp_path):
+    target = tmp_path / "target.py"
+    target.write_text("value = 1\n", encoding="utf-8")
+    read_call = _make_tool_call(
+        "call_read",
+        "read",
+        json.dumps({"file_path": str(target), "offset": 1, "limit": 3}),
+    )
+    llm = _make_llm()
+    llm._call_raw.side_effect = [
+        _make_response(tool_calls=[read_call]),
+        _make_response(content="done"),
+    ]
+
+    result = AgentRunner(
+        llm,
+        SkillRegistry(),
+        force_localization_contract=False,
+    ).run("read file")
+
+    read_event = _events(result, "read")[0]
+    assert read_event.data == {
+        "tool_call_id": "call_read",
+        "path": str(target),
+        "offset": 1,
+        "limit": 3,
+        "status": "ok",
+    }
+    assert _events(result, "tool_call")[0].data["tool"] == "read"
+
+
+def test_trace_records_tool_errors():
+    llm = _make_llm()
+    missing = _make_tool_call("call_missing", "missing_tool", "{}")
+    llm._call_raw.side_effect = [
+        _make_response(tool_calls=[missing]),
+        _make_response(content="done"),
+    ]
+
+    result = AgentRunner(
+        llm,
+        SkillRegistry(),
+        force_localization_contract=False,
+    ).run("call missing tool")
+
+    tool_event = _events(result, "tool_call")[0]
+    assert tool_event.data["status"] == "error"
+    assert tool_event.data["result_type"] == "error"
+    assert "not available" in tool_event.data["error"]
+
+
+def test_trace_records_context_compaction(tmp_path):
+    target = tmp_path / "target.py"
+    target.write_text("secret_value = 7\n", encoding="utf-8")
+    read_call = _make_tool_call(
+        "call_read",
+        "read",
+        json.dumps({"file_path": str(target)}),
+    )
+    llm = _make_llm()
+    llm._call_raw.side_effect = [
+        _make_response(tool_calls=[read_call]),
+        _make_response(content="done"),
+    ]
+
+    result = AgentRunner(
+        llm,
+        SkillRegistry(),
+        compact_after_read=True,
+        compact_keep_reads=1,
+        force_localization_contract=False,
+    ).run("locate value")
+
+    compaction = _events(result, "context_compacted")[0]
+    assert compaction.data["read_paths"] == [str(target)]
+    assert compaction.data["keep_reads"] == 1


### PR DESCRIPTION
## Summary
Add the first M3 runtime observability slice: a stable, core `AgentRunTrace` event log attached to `AgentResult` without moving evaluator policy into the runner.

## Changes
- Add `codeminer.agent.runtime.trace` with `AgentTraceEvent`, `AgentRunTrace`, and a schema version.
- Attach optional `trace` data to `AgentResult` and export the runtime trace types from `codeminer.agent`.
- Record run, LLM call/response, tool call, read, compaction, max-turn, forced-final, final-answer, and run-end events in `AgentRunner`.
- Add focused runtime trace tests over mocked LLM/tool flows.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m pytest test/agent/test_runtime_trace.py test/agent/test_runner.py test/agent/test_runner_usage.py -q`
- `python -m pytest test/web/test_schemas.py test/agent/test_runner_history_retry.py test/agent/test_boundary.py -q`
- `python -m pytest test/agent -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -q`
- `python -m black --check codeminer/agent/runtime codeminer/agent/agent_types.py codeminer/agent/__init__.py codeminer/agent/runner.py test/agent/test_runtime_trace.py`
- `python -m isort --profile black --check-only codeminer/agent/runtime codeminer/agent/agent_types.py codeminer/agent/__init__.py codeminer/agent/runner.py test/agent/test_runtime_trace.py`
- `pre-commit run --files codeminer/agent/runtime/__init__.py codeminer/agent/runtime/trace.py codeminer/agent/agent_types.py codeminer/agent/__init__.py codeminer/agent/runner.py test/agent/test_runtime_trace.py`
- `git diff --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
