### PR TITLE
[codex] Add context ledger summaries

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -13,7 +13,12 @@ from .extract_agent import (
 from .history import PlainChatHistory, TokenBudgetedChatHistory, count_message_tokens
 from .rerank_agent import RerankAgent, RerankResult, rerank_nodes_with_query
 from .runner import AgentRunner, CodeMinerAgentOptions, compile_repo, query
-from .runtime import AGENT_TRACE_SCHEMA_VERSION, AgentRunTrace, AgentTraceEvent
+from .runtime import (
+    AGENT_TRACE_SCHEMA_VERSION,
+    AgentRunTrace,
+    AgentTraceEvent,
+    ContextLedgerEntry,
+)
 from .tool_schema import registry_to_tools, skill_to_tool_schema
 
 __all__ = [
@@ -23,6 +28,7 @@ __all__ = [
     "AgentRunner",
     "AGENT_TRACE_SCHEMA_VERSION",
     "CodeMinerAgentOptions",
+    "ContextLedgerEntry",
     "KeywordExtraction",
     "KeywordExtractor",
     "PlainChatHistory",

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -588,6 +588,12 @@ class AgentRunner:
                         limit=(record.arguments or {}).get("limit"),
                         status="ok" if successful_read else "error",
                     )
+                trace.add_context(
+                    record.skill_id,
+                    _context_state(record, tool_content, successful_read),
+                    turn + 1,
+                    **_context_ledger_data(record, tool_content),
+                )
                 if successful_read:
                     has_read = True
                     _rp = (record.arguments or {}).get("file_path")
@@ -627,6 +633,19 @@ class AgentRunner:
                         turn + 1,
                         read_paths=list(dict.fromkeys(read_paths)),
                         keep_reads=self._compact_keep_reads,
+                    )
+                    trace.add_context(
+                        "runtime.compaction",
+                        "summarized",
+                        turn + 1,
+                        summary=(
+                            "Compacted conversation after reads: "
+                            + (", ".join(dict.fromkeys(read_paths)) or "(none)")
+                        ),
+                        metadata={
+                            "read_paths": list(dict.fromkeys(read_paths)),
+                            "keep_reads": self._compact_keep_reads,
+                        },
                     )
                     logger.debug("eager_compact: collapsed to distilled direction seed")
 
@@ -1029,6 +1048,74 @@ def _trace_tool_call_data(
     if record.error is not None:
         data["error"] = record.error
     return data
+
+
+def _context_state(
+    record: ToolCallRecord,
+    serialized_result: str,
+    successful_read: bool,
+) -> str:
+    if record.skill_id == "read":
+        return "read" if successful_read else "rejected"
+    if record.error is not None:
+        return "rejected"
+    if serialized_result.lstrip().startswith("Error"):
+        return "rejected"
+    return "offered"
+
+
+def _context_ledger_data(
+    record: ToolCallRecord,
+    serialized_result: str,
+) -> Dict[str, Any]:
+    event_data = _trace_tool_call_data(record, serialized_result)
+    path = None
+    if record.skill_id == "read":
+        path_arg = (record.arguments or {}).get("file_path")
+        path = str(path_arg) if path_arg is not None else None
+
+    metadata = {
+        key: value
+        for key, value in event_data.items()
+        if key
+        not in {
+            "tool_call_id",
+            "tool",
+            "arguments",
+        }
+    }
+    metadata["arguments"] = dict(record.arguments or {})
+
+    summary = _context_summary(record, event_data, serialized_result)
+    return {
+        "summary": summary,
+        "path": path,
+        "tool_call_id": record.tool_call_id,
+        "metadata": metadata,
+    }
+
+
+def _context_summary(
+    record: ToolCallRecord,
+    event_data: Mapping[str, Any],
+    serialized_result: str,
+) -> str:
+    tool = record.skill_id
+    result_chars = event_data.get("result_chars", 0)
+    if record.error is not None:
+        return f"{tool} error: {record.error}"
+    if serialized_result.lstrip().startswith("Error"):
+        first_line = serialized_result.strip().splitlines()[0]
+        return f"{tool} rejected: {first_line[:160]}"
+    if tool == "read":
+        path = (record.arguments or {}).get("file_path") or "(unknown)"
+        return f"read {path} ({result_chars} chars)"
+    if "result_count" in event_data:
+        return (
+            f"{tool} returned {event_data['result_count']} item(s) "
+            f"({result_chars} chars)"
+        )
+    return f"{tool} returned {event_data.get('result_type', 'result')} ({result_chars} chars)"
 
 
 # ---------------------------------------------------------------------------

--- a/codeminer/agent/runtime/__init__.py
+++ b/codeminer/agent/runtime/__init__.py
@@ -4,10 +4,16 @@
 
 """Runtime support types for agent execution."""
 
-from .trace import AGENT_TRACE_SCHEMA_VERSION, AgentRunTrace, AgentTraceEvent
+from .trace import (
+    AGENT_TRACE_SCHEMA_VERSION,
+    AgentRunTrace,
+    AgentTraceEvent,
+    ContextLedgerEntry,
+)
 
 __all__ = [
     "AGENT_TRACE_SCHEMA_VERSION",
     "AgentRunTrace",
     "AgentTraceEvent",
+    "ContextLedgerEntry",
 ]

--- a/codeminer/agent/runtime/trace.py
+++ b/codeminer/agent/runtime/trace.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Stable trace event schema for agent runtime observability."""
+"""Stable trace and context-ledger schema for agent runtime observability."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
-AGENT_TRACE_SCHEMA_VERSION = 1
+AGENT_TRACE_SCHEMA_VERSION = 2
 
 
 @dataclass
@@ -34,18 +34,70 @@ class AgentTraceEvent:
 
 
 @dataclass
+class ContextLedgerEntry:
+    """Bounded summary of context produced or consumed during a run."""
+
+    source: str
+    state: str
+    turn: int
+    summary: str = ""
+    path: str | None = None
+    tool_call_id: str | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "source": self.source,
+            "state": self.state,
+            "turn": self.turn,
+            "summary": self.summary,
+            "metadata": dict(self.metadata),
+        }
+        if self.path is not None:
+            payload["path"] = self.path
+        if self.tool_call_id is not None:
+            payload["tool_call_id"] = self.tool_call_id
+        return payload
+
+
+@dataclass
 class AgentRunTrace:
     """Durable event log for one ``AgentRunner.run()`` invocation."""
 
     events: List[AgentTraceEvent] = field(default_factory=list)
+    context: List[ContextLedgerEntry] = field(default_factory=list)
 
     def add(self, kind: str, turn: int, **data: Any) -> AgentTraceEvent:
         event = AgentTraceEvent(kind=kind, turn=turn, data=dict(data))
         self.events.append(event)
         return event
 
+    def add_context(
+        self,
+        source: str,
+        state: str,
+        turn: int,
+        *,
+        summary: str = "",
+        path: str | None = None,
+        tool_call_id: str | None = None,
+        metadata: Dict[str, Any] | None = None,
+    ) -> ContextLedgerEntry:
+        entry = ContextLedgerEntry(
+            source=source,
+            state=state,
+            turn=turn,
+            summary=summary,
+            path=path,
+            tool_call_id=tool_call_id,
+            metadata=dict(metadata or {}),
+        )
+        self.context.append(entry)
+        return entry
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "schema_version": AGENT_TRACE_SCHEMA_VERSION,
             "events": [event.to_dict() for event in self.events],
+            "context": [entry.to_dict() for entry in self.context],
         }

--- a/test/agent/test_runtime_trace.py
+++ b/test/agent/test_runtime_trace.py
@@ -58,6 +58,11 @@ def _events(result, kind):
     return [event for event in result.trace.events if event.kind == kind]
 
 
+def _context(result, source):
+    assert result.trace is not None
+    return [entry for entry in result.trace.context if entry.source == source]
+
+
 def test_trace_records_direct_answer_contract():
     llm = _make_llm()
     llm._call_raw.return_value = _make_response(content="done")
@@ -70,6 +75,7 @@ def test_trace_records_direct_answer_contract():
 
     assert result.trace is not None
     assert result.trace.to_dict()["schema_version"] == AGENT_TRACE_SCHEMA_VERSION
+    assert result.trace.to_dict()["context"] == []
     assert [event.kind for event in result.trace.events] == [
         "run_start",
         "llm_call",
@@ -107,6 +113,13 @@ def test_trace_summarizes_successful_tool_call():
     assert tool_event.data["result_type"] == "str"
     assert tool_event.data["result_chars"] == len("echo: hello")
 
+    entry = _context(result, "echo")[0]
+    assert entry.state == "offered"
+    assert entry.tool_call_id == "call_1"
+    assert entry.summary == "echo returned str (11 chars)"
+    assert "echo: hello" not in entry.summary
+    assert entry.metadata["arguments"] == {"text": "hello"}
+
 
 def test_trace_records_default_read_events(tmp_path):
     target = tmp_path / "target.py"
@@ -137,6 +150,15 @@ def test_trace_records_default_read_events(tmp_path):
         "status": "ok",
     }
     assert _events(result, "tool_call")[0].data["tool"] == "read"
+    entry = _context(result, "read")[0]
+    assert entry.state == "read"
+    assert entry.path == str(target)
+    assert entry.summary.startswith(f"read {target}")
+    assert entry.metadata["arguments"] == {
+        "file_path": str(target),
+        "offset": 1,
+        "limit": 3,
+    }
 
 
 def test_trace_records_tool_errors():
@@ -157,6 +179,9 @@ def test_trace_records_tool_errors():
     assert tool_event.data["status"] == "error"
     assert tool_event.data["result_type"] == "error"
     assert "not available" in tool_event.data["error"]
+    entry = _context(result, "missing_tool")[0]
+    assert entry.state == "rejected"
+    assert "not available" in entry.summary
 
 
 def test_trace_records_context_compaction(tmp_path):
@@ -184,3 +209,8 @@ def test_trace_records_context_compaction(tmp_path):
     compaction = _events(result, "context_compacted")[0]
     assert compaction.data["read_paths"] == [str(target)]
     assert compaction.data["keep_reads"] == 1
+    read_entry = _context(result, "read")[0]
+    assert read_entry.state == "read"
+    compact_entry = _context(result, "runtime.compaction")[0]
+    assert compact_entry.state == "summarized"
+    assert compact_entry.metadata["read_paths"] == [str(target)]


### PR DESCRIPTION
## Summary
Add the M3b runtime context ledger: bounded summaries of context produced or consumed during an agent run, attached to the existing `AgentRunTrace` without copying raw tool output or embedding evaluator policy.

## Changes
- Extend `AgentRunTrace` with `ContextLedgerEntry` and `context` serialization.
- Record tool results as context entries with `offered`, `read`, `rejected`, or `summarized` state.
- Add replay-facing summaries and metadata for tool outputs, reads, read failures, and context compaction.
- Extend runtime trace tests to cover ledger state and bounded summaries.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m pytest test/agent/test_runtime_trace.py test/agent/test_runner.py test/agent/test_runner_usage.py -q`
- `python -m pytest test/web/test_schemas.py test/agent/test_runner_history_retry.py test/agent/test_boundary.py -q`
- `python -m pytest test/agent -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -q`
- `python -m black --check codeminer/agent/runtime codeminer/agent/agent_types.py codeminer/agent/__init__.py codeminer/agent/runner.py test/agent/test_runtime_trace.py`
- `python -m isort --profile black --check-only codeminer/agent/runtime codeminer/agent/agent_types.py codeminer/agent/__init__.py codeminer/agent/runner.py test/agent/test_runtime_trace.py`
- `pre-commit run --files codeminer/agent/runtime/__init__.py codeminer/agent/runtime/trace.py codeminer/agent/__init__.py codeminer/agent/runner.py test/agent/test_runtime_trace.py`
- `git diff --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
