### PR TITLE
feat(agent): add harness spec

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -10,6 +10,7 @@ from .extract_agent import (
     KeywordExtractor,
     extract_keywords_from_statement,
 )
+from .harness import AgentHarnessSpec
 from .history import PlainChatHistory, TokenBudgetedChatHistory, count_message_tokens
 from .rerank_agent import RerankAgent, RerankResult, rerank_nodes_with_query
 from .runner import AgentRunner, CodeMinerAgentOptions, compile_repo, query
@@ -22,6 +23,7 @@ __all__ = [
     "AgentTraceEvent",
     "AgentRunner",
     "AGENT_TRACE_SCHEMA_VERSION",
+    "AgentHarnessSpec",
     "CodeMinerAgentOptions",
     "KeywordExtraction",
     "KeywordExtractor",

--- a/codeminer/agent/harness.py
+++ b/codeminer/agent/harness.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declarative agent harness configuration.
+
+The runner owns execution. This module owns the reusable contract that says
+which tools, prompts, and loop controls a harness exposes. Dataset selection,
+benchmark scoring, model-specific routing, and experiment policy stay outside
+this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, Collection, Dict, FrozenSet, Iterable, Mapping, Optional
+
+
+def _normalize_names(
+    values: Optional[Iterable[str]],
+    *,
+    field_name: str,
+    empty_is_none: bool,
+) -> Optional[FrozenSet[str]]:
+    if values is None:
+        return None
+    names = []
+    for value in values:
+        if not isinstance(value, str):
+            raise TypeError(f"{field_name} entries must be strings")
+        name = value.strip()
+        if not name:
+            raise ValueError(f"{field_name} entries must be non-empty strings")
+        names.append(name)
+    if not names and empty_is_none:
+        return None
+    return frozenset(names)
+
+
+@dataclass(frozen=True)
+class AgentHarnessSpec:
+    """Stable runner-facing harness contract.
+
+    This deliberately mirrors generic :class:`AgentRunner` controls only. It
+    does not encode benchmark arms, scorer fields, model names, or dataset
+    identifiers, so experiments can compare policies without leaking those
+    policies into the core runtime API.
+    """
+
+    max_turns: int = 10
+    max_context_tokens: Optional[int] = None
+    allow_skills: Optional[Collection[str]] = None
+    exclude_skills: Optional[Collection[str]] = None
+    include_default_tools: bool = True
+    default_tool_ids: Optional[Collection[str]] = None
+    system_prompt: Optional[str] = None
+    first_turn_tool_choice: Optional[str] = None
+    force_first_turn_only: bool = False
+    force_localization_contract: bool = True
+    compact_after_read: bool = False
+    compact_keep_reads: int = 0
+
+    def __post_init__(self) -> None:
+        if self.max_turns <= 0:
+            raise ValueError("max_turns must be positive")
+        if self.max_context_tokens is not None and self.max_context_tokens <= 0:
+            raise ValueError("max_context_tokens must be positive when set")
+        if self.compact_keep_reads < 0:
+            raise ValueError("compact_keep_reads must be non-negative")
+
+        object.__setattr__(
+            self,
+            "allow_skills",
+            _normalize_names(
+                self.allow_skills,
+                field_name="allow_skills",
+                empty_is_none=False,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "exclude_skills",
+            _normalize_names(
+                self.exclude_skills,
+                field_name="exclude_skills",
+                empty_is_none=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "default_tool_ids",
+            _normalize_names(
+                self.default_tool_ids,
+                field_name="default_tool_ids",
+                empty_is_none=True,
+            ),
+        )
+
+    def with_overrides(self, **overrides: Any) -> "AgentHarnessSpec":
+        """Return a copy with selected fields replaced and revalidated."""
+        data = {field.name: getattr(self, field.name) for field in fields(self)}
+        unknown = set(overrides) - set(data)
+        if unknown:
+            raise TypeError(f"Unknown harness option(s): {sorted(unknown)}")
+        data.update(overrides)
+        return type(self)(**data)
+
+    def to_runner_kwargs(
+        self,
+        *,
+        session_ctx: Optional[Any] = None,
+        manifest: Optional[Any] = None,
+        compile_table: Optional[Any] = None,
+        extra: Optional[Mapping[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return ``AgentRunner`` keyword arguments for this harness.
+
+        Collection fields are copied into mutable sets because ``AgentRunner``
+        treats them as constructor inputs and may derive internal sets from
+        them. The spec remains immutable and reusable across cells/subagents.
+        """
+        kwargs: Dict[str, Any] = {
+            "max_turns": self.max_turns,
+            "max_context_tokens": self.max_context_tokens,
+            "allow_skills": (
+                set(self.allow_skills) if self.allow_skills is not None else None
+            ),
+            "exclude_skills": (
+                set(self.exclude_skills) if self.exclude_skills is not None else None
+            ),
+            "include_default_tools": self.include_default_tools,
+            "default_tool_ids": (
+                set(self.default_tool_ids)
+                if self.default_tool_ids is not None
+                else None
+            ),
+            "system_prompt": self.system_prompt,
+            "first_turn_tool_choice": self.first_turn_tool_choice,
+            "force_first_turn_only": self.force_first_turn_only,
+            "force_localization_contract": self.force_localization_contract,
+            "compact_after_read": self.compact_after_read,
+            "compact_keep_reads": self.compact_keep_reads,
+            "session_ctx": session_ctx,
+            "manifest": manifest,
+            "compile_table": compile_table,
+        }
+        if extra:
+            kwargs.update(extra)
+        return kwargs
+
+    def create_runner(
+        self,
+        *,
+        llm: Optional[Any] = None,
+        model: Optional[str] = None,
+        registry: Optional[Any] = None,
+        session_ctx: Optional[Any] = None,
+        manifest: Optional[Any] = None,
+        compile_table: Optional[Any] = None,
+        **overrides: Any,
+    ) -> Any:
+        """Build an ``AgentRunner`` using this harness.
+
+        ``overrides`` are one-off runner keyword overrides for cases like
+        subagents with a shorter turn budget. They do not mutate the spec.
+        """
+        from .runner import AgentRunner
+
+        kwargs = self.to_runner_kwargs(
+            session_ctx=session_ctx,
+            manifest=manifest,
+            compile_table=compile_table,
+            extra=overrides,
+        )
+        return AgentRunner(llm=llm, model=model, registry=registry, **kwargs)

--- a/scripts/agent_compile/lib/harness.py
+++ b/scripts/agent_compile/lib/harness.py
@@ -226,7 +226,7 @@ def run_cell(
     answers once more. Token/turn costs of BOTH runs are summed so the verify
     arm is charged for the closed loop.
     """
-    from codeminer.agent.runner import AgentRunner
+    from codeminer.agent.harness import AgentHarnessSpec
     from codeminer.agent.skills.registry import SkillRegistry
     from codeminer.compiler.params import SessionContext
     from scripts.agent_compile.lib.orchestrator import (
@@ -305,12 +305,9 @@ def run_cell(
         _mt = _re.search(r"(\d+(?:\.\d+)?)\s*b\b", (cfg.model or "").lower())
         _sz = float(_mt.group(1)) if _mt else 999.0
         _keep_reads = 1 if _sz <= 7 else 0
-    runner = AgentRunner(
-        llm=llm,
-        registry=SkillRegistry(),
+    harness_spec = AgentHarnessSpec(
         max_turns=cfg.max_turns,
         allow_skills=set(skills),
-        session_ctx=sctx,
         include_default_tools=cfg.include_default_tools,
         default_tool_ids=(
             set(cfg.default_tool_ids) if cfg.default_tool_ids is not None else None
@@ -319,6 +316,11 @@ def run_cell(
         first_turn_tool_choice=getattr(cfg, "first_turn_tool_choice", None) or None,
         compact_after_read=(mode == "eager_compact"),
         compact_keep_reads=(int(_keep_reads) if mode == "eager_compact" else 0),
+    )
+    runner = harness_spec.create_runner(
+        llm=llm,
+        registry=SkillRegistry(),
+        session_ctx=sctx,
     )
     # The always-on default tools (file_read / file_search) resolve relative
     # paths against the process cwd, so run the agent from the instance repo.
@@ -340,21 +342,12 @@ def run_cell(
     if scatter_mode:
 
         def _run_subagent(sys_prompt, q, mt):
-            sub = AgentRunner(
+            sub = harness_spec.create_runner(
                 llm=llm,
                 registry=SkillRegistry(),
                 max_turns=mt,
-                allow_skills=set(skills),
                 session_ctx=sctx,
-                include_default_tools=cfg.include_default_tools,
-                default_tool_ids=(
-                    set(cfg.default_tool_ids)
-                    if cfg.default_tool_ids is not None
-                    else None
-                ),
                 system_prompt=sys_prompt or cfg.system_prompt,
-                first_turn_tool_choice=getattr(cfg, "first_turn_tool_choice", None)
-                or None,
             )
             try:
                 os.chdir(repo_path)

--- a/test/agent/test_harness_spec.py
+++ b/test/agent/test_harness_spec.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the declarative agent harness contract."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.agent.harness import AgentHarnessSpec
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.llm.litellm_chat import LiteLLMChat
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+def test_harness_spec_normalizes_runner_collections():
+    spec = AgentHarnessSpec(
+        allow_skills=[" embedding_search ", "bm25_search", "bm25_search"],
+        exclude_skills=[],
+        default_tool_ids=[],
+    )
+
+    assert spec.allow_skills == frozenset({"embedding_search", "bm25_search"})
+    assert spec.exclude_skills is None
+    assert spec.default_tool_ids is None
+
+
+def test_harness_spec_preserves_empty_allow_set_for_runner_warning():
+    spec = AgentHarnessSpec(allow_skills=[])
+
+    assert spec.allow_skills == frozenset()
+    assert spec.to_runner_kwargs()["allow_skills"] == set()
+
+
+def test_runner_kwargs_are_copied_from_immutable_spec():
+    spec = AgentHarnessSpec(
+        allow_skills=["bm25_search"],
+        default_tool_ids=["read"],
+    )
+
+    kwargs = spec.to_runner_kwargs()
+    kwargs["allow_skills"].add("embedding_search")
+    kwargs["default_tool_ids"].add("grep")
+
+    assert spec.allow_skills == frozenset({"bm25_search"})
+    assert spec.default_tool_ids == frozenset({"read"})
+
+
+def test_with_overrides_revalidates_and_rejects_unknown_options():
+    spec = AgentHarnessSpec(max_turns=4)
+
+    assert spec.with_overrides(max_turns=2).max_turns == 2
+    with pytest.raises(ValueError, match="max_turns"):
+        spec.with_overrides(max_turns=0)
+    with pytest.raises(TypeError, match="Unknown harness option"):
+        spec.with_overrides(experiment_label="baseline")
+
+
+def test_create_runner_uses_spec_without_mutating_it():
+    llm = MagicMock(spec=LiteLLMChat)
+    session_ctx = SimpleNamespace(repo_path=None)
+    spec = AgentHarnessSpec(
+        max_turns=6,
+        allow_skills=["echo"],
+        include_default_tools=False,
+        first_turn_tool_choice="required",
+        compact_after_read=True,
+        compact_keep_reads=1,
+    )
+
+    runner = spec.create_runner(
+        llm=llm,
+        registry=SkillRegistry(),
+        session_ctx=session_ctx,
+        max_turns=2,
+        system_prompt="Subagent prompt",
+    )
+
+    assert isinstance(runner, AgentRunner)
+    assert runner.max_turns == 2
+    assert runner._base_allow == {"echo"}
+    assert runner._include_defaults is False
+    assert runner.first_turn_tool_choice == "required"
+    assert runner._compact_after_read is True
+    assert runner._compact_keep_reads == 1
+    assert runner.system_prompt.startswith("Subagent prompt")
+    assert spec.max_turns == 6


### PR DESCRIPTION
## Summary
Adds a core `AgentHarnessSpec` that captures reusable runner-facing harness controls without encoding benchmark policy, dataset choices, model-specific routing, or scorer behavior.

## Changes
- Add `codeminer.agent.harness.AgentHarnessSpec` with immutable normalized skill/default-tool controls, validation, runner kwargs, and runner factory helpers.
- Export the spec from `codeminer.agent`.
- Update `scripts/agent_compile/lib/harness.py` to construct its main agent and scatter subagents through the core spec while keeping experimental preload/gating/verification policy in scripts.
- Add unit coverage for normalization, empty allow-list behavior, immutable kwargs copies, override validation, and runner construction.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m pytest test/agent/test_harness_spec.py test/agent/test_runner.py test/agent/test_runner_usage.py test/agent/test_default_tools.py test/agent_compile/test_verify_expand.py test/agent_compile/test_pareto_ci.py test/agent_compile/test_aggregate_compact_results.py test/agent/test_prebuilt.py -q`
- `pre-commit run --files codeminer/agent/harness.py codeminer/agent/__init__.py scripts/agent_compile/lib/harness.py test/agent/test_harness_spec.py`
- `git diff --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published