### PR TITLE
refactor(eval): move pareto diagnostics out of scripts

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -19,6 +19,7 @@ from .orchestrator import (
     verdict_is_yes,
     verify_query,
 )
+from .pareto import analyze_pareto, load_pareto_cells
 from .preload import (
     PreloadQueryPlan,
     assemble_preload,
@@ -53,6 +54,7 @@ __all__ = [
     "VerifyExpandRun",
     "VERIFY_SYSTEM_PROMPT",
     "assemble_preload",
+    "analyze_pareto",
     "build_prebuilt_symbol_span_index",
     "build_symbol_span_index",
     "candidate_location",
@@ -63,6 +65,7 @@ __all__ = [
     "graph_compose",
     "interleave_ranked",
     "load_agent_skill_contexts",
+    "load_pareto_cells",
     "prepare_preload_query",
     "query_is_specific",
     "render_expansion",

--- a/codeminer/eval/agent_runner/pareto.py
+++ b/codeminer/eval/agent_runner/pareto.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime-probe Pareto diagnostics for agent-runner evaluation.
+
+``aggregate_synthesis.py`` gives point estimates. But pre-load is a variance
+trade: it rescues queries grep fails on and distracts on others. At small n,
+a point delta is noise. This module pairs each arm against ``grep_only`` per query
+and reports a paired bootstrap 95% CI on recall@5, cost delta, turns delta, plus
+win/tie/loss counts, and a significance-aware verdict:
+
+  SAVE         - accuracy is not significantly worse and cost is significantly
+                 lower.
+  REGRESS      - accuracy is significantly worse.
+  inconclusive - CI spans the threshold; need more n.
+
+Rep folding mirrors aggregate_synthesis (rec mean across reps, cost/turns min).
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+EPS = 0.02  # Recall deltas within this count as equal accuracy.
+
+
+def load_pareto_cells(cells_dir: Path) -> List[Dict[str, Any]]:
+    out = []
+    for p in sorted(cells_dir.glob("*.json")):
+        try:
+            out.append(json.loads(p.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError):
+            pass
+    return out
+
+
+def _rec5(cell: Dict[str, Any]) -> Optional[float]:
+    b = (cell.get("metrics") or {}).get("answer_blocks") or {}
+    s = b.get(5, b.get("5"))
+    return s.get("recall") if isinstance(s, dict) else None
+
+
+def _fold_reps(cells: Sequence[Dict[str, Any]]) -> Dict[Tuple, Dict[str, float]]:
+    """(category, arm, query_id) -> {rec: mean, cost: min, turns: min}."""
+    by: Dict[Tuple, List[Dict[str, Any]]] = defaultdict(list)
+    for c in cells:
+        if not c.get("success"):
+            continue
+        by[(c.get("category"), c.get("subset_id"), c.get("query_id"))].append(c)
+    folded: Dict[Tuple, Dict[str, float]] = {}
+    for key, reps in by.items():
+        recs = [r for r in (_rec5(c) for c in reps) if r is not None]
+        costs = [c.get("cost_usd") for c in reps if c.get("cost_usd") is not None]
+        turns = [c.get("total_turns") for c in reps if c.get("total_turns") is not None]
+        folded[key] = {
+            "rec": statistics.fmean(recs) if recs else None,
+            "cost": min(costs) if costs else None,
+            "turns": min(turns) if turns else None,
+        }
+    return folded
+
+
+def _ci(
+    samples: List[float], rng: random.Random, boot: int
+) -> Tuple[float, float, float]:
+    """Mean + 95% paired-bootstrap CI (resample the per-query deltas)."""
+    n = len(samples)
+    mean = statistics.fmean(samples)
+    means = []
+    for _ in range(boot):
+        means.append(statistics.fmean(rng.choices(samples, k=n)))
+    means.sort()
+    lo = means[int(0.025 * boot)]
+    hi = means[int(0.975 * boot)]
+    return mean, lo, hi
+
+
+def analyze_pareto(
+    cells: Sequence[Dict[str, Any]], baseline: str, boot: int, seed: int
+) -> str:
+    folded = _fold_reps(cells)
+    cats = sorted({c for (c, _a, _q) in folded})
+    arms = sorted({a for (_c, a, _q) in folded if a != baseline})
+
+    L = ["# Runtime probe - paired-bootstrap Pareto decision", ""]
+    L.append(
+        f"Baseline = `{baseline}`. Each arm paired per query (rep-folded: rec mean, "
+        f"cost/turns min). 95% CI from {boot} paired bootstrap resamples. "
+        f"SAVE = recall delta CI_lo >= -{EPS} AND cost delta % CI_hi < 0."
+    )
+    L.append("")
+    head = [
+        "category",
+        "arm",
+        "n",
+        "delta recall@5 [95% CI]",
+        "delta cost% [95% CI]",
+        "delta turns",
+        "win/tie/loss",
+        "verdict",
+    ]
+    L.append("| " + " | ".join(head) + " |")
+    L.append("| " + " | ".join("---" for _ in head) + " |")
+
+    # include a pooled "ALL" pseudo-category
+    for cat in cats + ["ALL"]:
+        for arm in arms:
+            drec, dcost, dturn = [], [], []
+            w = t = ls = 0
+            pair_keys = {
+                (c, q)
+                for (c, a, q) in folded
+                if a == baseline and (c == cat or cat == "ALL")
+            }
+            for ckey, q in pair_keys:
+                b = folded.get((ckey, baseline, q))
+                a_ = folded.get((ckey, arm, q))
+                if not b or not a_:
+                    continue
+                if b["rec"] is None or a_["rec"] is None:
+                    continue
+                dr = a_["rec"] - b["rec"]
+                drec.append(dr)
+                if b["cost"] and a_["cost"] is not None:
+                    dcost.append(100 * (a_["cost"] - b["cost"]) / b["cost"])
+                if b["turns"] is not None and a_["turns"] is not None:
+                    dturn.append(a_["turns"] - b["turns"])
+                if dr > EPS:
+                    w += 1
+                elif dr < -EPS:
+                    ls += 1
+                else:
+                    t += 1
+            if not drec:
+                continue
+            rng = random.Random(seed)
+            mr, rlo, rhi = _ci(drec, rng, boot)
+            if dcost:
+                mc, clo, chi = _ci(dcost, rng, boot)
+            else:
+                mc = clo = chi = None
+            mt = statistics.fmean(dturn) if dturn else None
+            if rhi < 0:
+                verdict = "REGRESS"
+            elif rlo >= -EPS and chi is not None and chi < 0:
+                verdict = "SAVE"
+            else:
+                verdict = "inconclusive"
+            rec_s = f"{mr:+.3f} [{rlo:+.3f},{rhi:+.3f}]"
+            cost_s = f"{mc:+.1f} [{clo:+.1f},{chi:+.1f}]" if mc is not None else "n/a"
+            turn_s = f"{mt:+.1f}" if mt is not None else "n/a"
+            L.append(
+                f"| {cat} | {arm} | {len(drec)} | {rec_s} | {cost_s} | {turn_s} "
+                f"| {w}/{t}/{ls} | {verdict} |"
+            )
+    L.append("")
+    return "\n".join(L)
+
+
+analyze = analyze_pareto

--- a/scripts/agent_compile/pareto_ci.py
+++ b/scripts/agent_compile/pareto_ci.py
@@ -4,184 +4,34 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Scientifically-sound per-category Pareto decision for the runtime probe.
-
-`aggregate_synthesis.py` gives point estimates. But pre-load is a VARIANCE
-trade — it rescues queries grep fails on and distracts on others — so at small n
-a point Δ is noise. This script pairs each arm against ``grep_only`` PER QUERY
-and reports a **paired bootstrap 95% CI** on Δrec@5, Δcost%, Δturns, plus
-win/tie/loss counts, and a significance-aware verdict:
-
-  SAVE         — accuracy not significantly worse (Δrec CI_lo ≥ -EPS) AND cost
-                 significantly lower (Δcost CI_hi < 0). The "等精度省 token" win.
-  REGRESS      — accuracy significantly worse (Δrec CI_hi < 0).
-  inconclusive — CI spans the threshold; need more n.
-
-Rep folding mirrors aggregate_synthesis (rec mean across reps, cost/turns min).
-
-Usage::
-
-    python scripts/agent_compile/pareto_ci.py \
-        --cells-dir results/agent_compile/runtime_probe_python/cells \
-        --baseline grep_only --boot 5000 --seed 0
-"""
+"""CLI wrapper for runtime-probe Pareto diagnostics."""
 
 from __future__ import annotations
 
 import argparse
-import json
-import random
-import statistics
-from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Optional, Sequence
 
-EPS = 0.02  # |Δrec| within this counts as "equal accuracy"
+from codeminer.eval.agent_runner.pareto import analyze_pareto, load_pareto_cells
 
-
-def _load(cells_dir: Path) -> List[Dict[str, Any]]:
-    out = []
-    for p in sorted(cells_dir.glob("*.json")):
-        try:
-            out.append(json.loads(p.read_text(encoding="utf-8")))
-        except (OSError, json.JSONDecodeError):
-            pass
-    return out
-
-
-def _rec5(cell: Dict[str, Any]) -> Optional[float]:
-    b = (cell.get("metrics") or {}).get("answer_blocks") or {}
-    s = b.get(5, b.get("5"))
-    return s.get("recall") if isinstance(s, dict) else None
-
-
-def _fold_reps(cells: Sequence[Dict[str, Any]]) -> Dict[Tuple, Dict[str, float]]:
-    """(category, arm, query_id) -> {rec: mean, cost: min, turns: min}."""
-    by: Dict[Tuple, List[Dict[str, Any]]] = defaultdict(list)
-    for c in cells:
-        if not c.get("success"):
-            continue
-        by[(c.get("category"), c.get("subset_id"), c.get("query_id"))].append(c)
-    folded: Dict[Tuple, Dict[str, float]] = {}
-    for key, reps in by.items():
-        recs = [r for r in (_rec5(c) for c in reps) if r is not None]
-        costs = [c.get("cost_usd") for c in reps if c.get("cost_usd") is not None]
-        turns = [c.get("total_turns") for c in reps if c.get("total_turns") is not None]
-        folded[key] = {
-            "rec": statistics.fmean(recs) if recs else None,
-            "cost": min(costs) if costs else None,
-            "turns": min(turns) if turns else None,
-        }
-    return folded
-
-
-def _ci(
-    samples: List[float], rng: random.Random, boot: int
-) -> Tuple[float, float, float]:
-    """Mean + 95% paired-bootstrap CI (resample the per-query deltas)."""
-    n = len(samples)
-    mean = statistics.fmean(samples)
-    means = []
-    for _ in range(boot):
-        means.append(statistics.fmean(rng.choices(samples, k=n)))
-    means.sort()
-    lo = means[int(0.025 * boot)]
-    hi = means[int(0.975 * boot)]
-    return mean, lo, hi
-
-
-def analyze(
-    cells: Sequence[Dict[str, Any]], baseline: str, boot: int, seed: int
-) -> str:
-    folded = _fold_reps(cells)
-    cats = sorted({c for (c, _a, _q) in folded})
-    arms = sorted({a for (_c, a, _q) in folded if a != baseline})
-
-    L = ["# Runtime probe — paired-bootstrap Pareto decision", ""]
-    L.append(
-        f"Baseline = `{baseline}`. Each arm paired per query (rep-folded: rec mean, "
-        f"cost/turns min). 95% CI from {boot} paired bootstrap resamples. "
-        f"SAVE = Δrec CI_lo ≥ -{EPS} AND Δcost%% CI_hi < 0."
-    )
-    L.append("")
-    head = [
-        "category",
-        "arm",
-        "n",
-        "Δrec@5 [95% CI]",
-        "Δcost% [95% CI]",
-        "Δturns",
-        "win/tie/loss",
-        "verdict",
-    ]
-    L.append("| " + " | ".join(head) + " |")
-    L.append("| " + " | ".join("---" for _ in head) + " |")
-
-    # include a pooled "ALL" pseudo-category
-    for cat in cats + ["ALL"]:
-        for arm in arms:
-            drec, dcost, dturn = [], [], []
-            w = t = ls = 0
-            pair_keys = {
-                (c, q)
-                for (c, a, q) in folded
-                if a == baseline and (c == cat or cat == "ALL")
-            }
-            for ckey, q in pair_keys:
-                b = folded.get((ckey, baseline, q))
-                a_ = folded.get((ckey, arm, q))
-                if not b or not a_:
-                    continue
-                if b["rec"] is None or a_["rec"] is None:
-                    continue
-                dr = a_["rec"] - b["rec"]
-                drec.append(dr)
-                if b["cost"] and a_["cost"] is not None:
-                    dcost.append(100 * (a_["cost"] - b["cost"]) / b["cost"])
-                if b["turns"] is not None and a_["turns"] is not None:
-                    dturn.append(a_["turns"] - b["turns"])
-                if dr > EPS:
-                    w += 1
-                elif dr < -EPS:
-                    ls += 1
-                else:
-                    t += 1
-            if not drec:
-                continue
-            rng = random.Random(seed)
-            mr, rlo, rhi = _ci(drec, rng, boot)
-            if dcost:
-                mc, clo, chi = _ci(dcost, rng, boot)
-            else:
-                mc = clo = chi = None
-            mt = statistics.fmean(dturn) if dturn else None
-            if rhi < 0:
-                verdict = "REGRESS"
-            elif rlo >= -EPS and chi is not None and chi < 0:
-                verdict = "SAVE"
-            else:
-                verdict = "inconclusive"
-            rec_s = f"{mr:+.3f} [{rlo:+.3f},{rhi:+.3f}]"
-            cost_s = f"{mc:+.1f} [{clo:+.1f},{chi:+.1f}]" if mc is not None else "n/a"
-            turn_s = f"{mt:+.1f}" if mt is not None else "n/a"
-            L.append(
-                f"| {cat} | {arm} | {len(drec)} | {rec_s} | {cost_s} | {turn_s} "
-                f"| {w}/{t}/{ls} | {verdict} |"
-            )
-    L.append("")
-    return "\n".join(L)
+analyze = analyze_pareto
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
-    p = argparse.ArgumentParser()
-    p.add_argument("--cells-dir", required=True, type=Path)
-    p.add_argument("--baseline", default="grep_only")
-    p.add_argument("--boot", type=int, default=5000)
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--output-dir", type=Path, default=None)
-    args = p.parse_args(argv)
-    cells = _load(args.cells_dir)
-    report = analyze(cells, args.baseline, args.boot, args.seed)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cells-dir", required=True, type=Path)
+    parser.add_argument("--baseline", default="grep_only")
+    parser.add_argument("--boot", type=int, default=5000)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    report = analyze_pareto(
+        load_pareto_cells(args.cells_dir),
+        baseline=args.baseline,
+        boot=args.boot,
+        seed=args.seed,
+    )
     print(report)
     if args.output_dir:
         args.output_dir.mkdir(parents=True, exist_ok=True)

--- a/test/agent_compile/test_pareto_ci_cli.py
+++ b/test/agent_compile/test_pareto_ci_cli.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI smoke tests for the runtime-probe Pareto wrapper."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.agent_compile import pareto_ci
+
+
+def _write_cell(cells_dir, name, category, arm, recall, cost_usd, total_turns):
+    cells_dir.joinpath(name).write_text(
+        json.dumps(
+            {
+                "success": True,
+                "category": category,
+                "subset_id": arm,
+                "query_id": "q",
+                "metrics": {"answer_blocks": {"5": {"recall": recall}}},
+                "cost_usd": cost_usd,
+                "total_turns": total_turns,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_pareto_ci_cli_writes_report(tmp_path, capsys):
+    cells_dir = tmp_path / "cells"
+    output_dir = tmp_path / "out"
+    cells_dir.mkdir()
+    _write_cell(cells_dir, "base.json", "behavioral", "grep_only", 0.5, 1.0, 3)
+    _write_cell(cells_dir, "arm.json", "behavioral", "preload", 0.5, 0.5, 2)
+
+    rc = pareto_ci.main(
+        [
+            "--cells-dir",
+            str(cells_dir),
+            "--baseline",
+            "grep_only",
+            "--boot",
+            "20",
+            "--seed",
+            "0",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert rc == 0
+    assert "| behavioral | preload | 1 | +0.000" in capsys.readouterr().out
+    assert (output_dir / "pareto_ci.md").exists()

--- a/test/eval/test_agent_pareto.py
+++ b/test/eval/test_agent_pareto.py
@@ -4,7 +4,7 @@
 
 """Tests for runtime-probe Pareto analysis."""
 
-from scripts.agent_compile.pareto_ci import analyze
+from codeminer.eval.agent_runner.pareto import analyze_pareto
 
 
 def _cell(
@@ -34,6 +34,6 @@ def test_all_pairs_duplicate_query_ids_within_each_category():
         _cell("traversal", "preinj_embed", "same-query-id", 0.0, 0.5, 2),
     ]
 
-    report = analyze(cells, baseline="grep_only", boot=100, seed=0)
+    report = analyze_pareto(cells, baseline="grep_only", boot=100, seed=0)
 
     assert "| ALL | preinj_embed | 2 | +0.000" in report


### PR DESCRIPTION
## Summary
Move the runtime-probe Pareto diagnostics into `codeminer.eval.agent_runner` so reusable evaluation analysis no longer lives in `scripts/agent_compile`.

## Changes
- Add `codeminer.eval.agent_runner.pareto` with cell loading and paired-bootstrap Pareto analysis.
- Keep `scripts/agent_compile/pareto_ci.py` as a thin CLI wrapper with the previous `analyze` compatibility export.
- Move the reusable analysis test under `test/eval` and add a small script-level CLI smoke test.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/eval/test_agent_pareto.py test/agent_compile/test_pareto_ci_cli.py test/agent_compile/test_config.py test/agent/test_import_boundaries.py -q`

`pre-commit run --files codeminer/eval/agent_runner/__init__.py codeminer/eval/agent_runner/pareto.py scripts/agent_compile/pareto_ci.py test/eval/test_agent_pareto.py test/agent_compile/test_pareto_ci_cli.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
