### PR TITLE
refactor(eval): move format diagnostics out of scripts

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -9,6 +9,13 @@ from .contexts import (
     default_agent_skills_dir,
     load_agent_skill_contexts,
 )
+from .format_diagnostics import (
+    FormatArmSummary,
+    FormatDiagnostics,
+    load_format_diagnostics,
+    load_meaningful_cells,
+    summarize_format_cells,
+)
 from .orchestrator import (
     GATE_SYSTEM,
     VERIFY_SYSTEM_PROMPT,
@@ -47,6 +54,8 @@ from .verify_expand import (
 
 __all__ = [
     "AgentSkillContextSpec",
+    "FormatArmSummary",
+    "FormatDiagnostics",
     "GATE_SYSTEM",
     "GraphNav",
     "PreloadQueryPlan",
@@ -65,6 +74,8 @@ __all__ = [
     "graph_compose",
     "interleave_ranked",
     "load_agent_skill_contexts",
+    "load_format_diagnostics",
+    "load_meaningful_cells",
     "load_pareto_cells",
     "prepare_preload_query",
     "query_is_specific",
@@ -74,6 +85,7 @@ __all__ = [
     "scatter_gather_localize",
     "snippet_for_node",
     "summarize_agent_result",
+    "summarize_format_cells",
     "symbol_leaf",
     "verdict_is_yes",
     "verify_query",

--- a/codeminer/eval/agent_runner/format_diagnostics.py
+++ b/codeminer/eval/agent_runner/format_diagnostics.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Answer-format diagnostics for agent-runner evaluation cells."""
+
+from __future__ import annotations
+
+import json
+import statistics as st
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+
+@dataclass(frozen=True)
+class FormatArmSummary:
+    """Summary for one arm after separating format failures."""
+
+    arm: str
+    n: int
+    format_fail_rate: float
+    files_all: float
+    files_formatted: float
+    answer_blocks_all: float
+    answer_blocks_formatted: float
+
+
+@dataclass(frozen=True)
+class FormatDiagnostics:
+    """Format-diagnostics summary for one result directory."""
+
+    result_name: str
+    n_meaningful: int
+    arms: List[FormatArmSummary]
+
+
+def _recall(cell: Dict[str, Any], scope: str, k: int) -> Optional[float]:
+    blocks = (cell.get("metrics") or {}).get(scope) or {}
+    score = blocks.get(k, blocks.get(str(k)))
+    return score.get("recall") if isinstance(score, dict) else None
+
+
+def _mean(values: Sequence[Optional[float]]) -> float:
+    present = [value for value in values if value is not None]
+    return st.fmean(present) if present else 0.0
+
+
+def load_meaningful_cells(result_dir: Union[Path, str]) -> List[Dict[str, Any]]:
+    """Load successful cells whose metrics can be interpreted."""
+
+    root = Path(result_dir)
+    cells: List[Dict[str, Any]] = []
+    for path in sorted(root.joinpath("cells").glob("*.json")):
+        try:
+            cell = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if cell.get("success") and cell.get("metrics_meaningful"):
+            cells.append(cell)
+    return cells
+
+
+def summarize_format_cells(
+    cells: Sequence[Dict[str, Any]], *, k: int = 5
+) -> List[FormatArmSummary]:
+    """Summarize cells by arm while separating unparseable final answers."""
+
+    by_arm: Dict[str, List[Dict[str, Any]]] = {}
+    for cell in cells:
+        by_arm.setdefault(str(cell.get("subset_id")), []).append(cell)
+
+    summaries: List[FormatArmSummary] = []
+    for arm in sorted(by_arm):
+        arm_cells = by_arm[arm]
+        formatted = [cell for cell in arm_cells if not cell.get("format_failed")]
+        format_fail_rate = (
+            sum(1 for cell in arm_cells if cell.get("format_failed")) / len(arm_cells)
+            if arm_cells
+            else 0.0
+        )
+        summaries.append(
+            FormatArmSummary(
+                arm=arm,
+                n=len(arm_cells),
+                format_fail_rate=format_fail_rate,
+                files_all=_mean([_recall(cell, "files", k) for cell in arm_cells]),
+                files_formatted=_mean(
+                    [_recall(cell, "files", k) for cell in formatted]
+                ),
+                answer_blocks_all=_mean(
+                    [_recall(cell, "answer_blocks", k) for cell in arm_cells]
+                ),
+                answer_blocks_formatted=_mean(
+                    [_recall(cell, "answer_blocks", k) for cell in formatted]
+                ),
+            )
+        )
+    return summaries
+
+
+def load_format_diagnostics(
+    result_dir: Union[Path, str], *, k: int = 5
+) -> FormatDiagnostics:
+    """Load and summarize answer-format diagnostics for a result directory."""
+
+    root = Path(result_dir)
+    cells = load_meaningful_cells(root)
+    return FormatDiagnostics(
+        result_name=root.name,
+        n_meaningful=len(cells),
+        arms=summarize_format_cells(cells, k=k),
+    )

--- a/scripts/agent_compile/aggregate_honest.py
+++ b/scripts/agent_compile/aggregate_honest.py
@@ -4,23 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Honest aggregation: separate localization accuracy from format-failure.
+"""CLI wrapper for answer-format diagnostic aggregation.
 
-A cell can score 0 for two very different reasons:
-  1. the agent localized to the WRONG place (a real miss), or
-  2. the agent FOUND the right place but never emitted a parseable
-     Files:/Symbols:/Locations: answer even after the force-schema retries
-     (``format_failed=True``) — an LLM format-following weakness, worst on small
-     models, NOT a localization error.
-
-Burying (2) inside the accuracy denominator conflates the two and unfairly
-punishes pre-load arms (which make weak models more verbose). So this reporter
-prints, per (model-dir, arm):
-  * format_fail_rate                         — honesty: how often we couldn't score
-  * files@5 / answer_blocks@k on ALL cells   — the as-measured number
-  * files@5 / answer_blocks@k on FORMATTED   — localization ability where scorable
-
-Both are shown; neither is hidden. Usage::
+Usage::
 
     python scripts/agent_compile/aggregate_honest.py \
         results/agent_compile/qwen35_4b_base_v2 [more dirs...]
@@ -28,56 +14,34 @@ Both are shown; neither is hidden. Usage::
 
 from __future__ import annotations
 
-import glob
-import json
-import statistics as st
 import sys
-from collections import defaultdict
-from typing import Any, Dict, List, Optional, Sequence
+from pathlib import Path
+from typing import List, Optional, Sequence
 
-
-def _f(cell: Dict[str, Any], scope: str, k: int) -> Optional[float]:
-    b = (cell.get("metrics") or {}).get(scope) or {}
-    s = b.get(k, b.get(str(k)))
-    return s.get("recall") if isinstance(s, dict) else None
-
-
-def _mean(xs: Sequence[Optional[float]]) -> float:
-    v = [x for x in xs if x is not None]
-    return st.fmean(v) if v else 0.0
+from codeminer.eval.agent_runner.format_diagnostics import (
+    FormatDiagnostics,
+    load_format_diagnostics,
+)
 
 
 def report(d: str) -> List[str]:
-    cells = []
-    for p in glob.glob(f"{d}/cells/*.json"):
-        try:
-            c = json.loads(open(p).read())
-        except (OSError, json.JSONDecodeError):
-            continue
-        if c.get("success") and c.get("metrics_meaningful"):
-            cells.append(c)
-    by = defaultdict(list)
-    for c in cells:
-        by[c.get("subset_id")].append(c)
+    return render_report(load_format_diagnostics(Path(d)))
 
-    L = [f"\n## {d.rstrip('/').split('/')[-1]}  (n_meaningful={len(cells)})"]
+
+def render_report(diagnostics: FormatDiagnostics) -> List[str]:
+    L = [f"\n## {diagnostics.result_name}  (n_meaningful={diagnostics.n_meaningful})"]
     L.append(
         f"{'arm':14} {'n':>4} {'fmt_fail':>9} "
         f"{'files@5(all)':>13} {'files@5(fmt)':>13} "
         f"{'ansBlk@5(all)':>14} {'ansBlk@5(fmt)':>14}"
     )
-    for arm in sorted(by):
-        cs = by[arm]
-        fmt_ok = [c for c in cs if not c.get("format_failed")]
-        ff = sum(1 for c in cs if c.get("format_failed")) / len(cs) if cs else 0
-        files_all = _mean([_f(c, "files", 5) for c in cs])
-        files_fmt = _mean([_f(c, "files", 5) for c in fmt_ok])
-        blk_all = _mean([_f(c, "answer_blocks", 5) for c in cs])
-        blk_fmt = _mean([_f(c, "answer_blocks", 5) for c in fmt_ok])
+    for summary in diagnostics.arms:
         L.append(
-            f"{arm:14} {len(cs):>4} {ff * 100:>8.0f}% "
-            f"{files_all:>13.3f} {files_fmt:>13.3f} "
-            f"{blk_all:>14.3f} {blk_fmt:>14.3f}"
+            f"{summary.arm:14} {summary.n:>4} "
+            f"{summary.format_fail_rate * 100:>8.0f}% "
+            f"{summary.files_all:>13.3f} {summary.files_formatted:>13.3f} "
+            f"{summary.answer_blocks_all:>14.3f} "
+            f"{summary.answer_blocks_formatted:>14.3f}"
         )
     return L
 
@@ -88,12 +52,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print("usage: aggregate_honest.py <result-dir> [more...]", file=sys.stderr)
         return 2
     out = [
-        "# Honest report — localization accuracy vs format-failure",
+        "# Honest report - localization accuracy vs format-failure",
         "",
         "`(all)` = scored over every meaningful cell (format-fail counts as 0).",
         "`(fmt)` = scored only where the answer was parseable (true localization "
         "ability). `fmt_fail` = share of cells unscorable after force-schema "
-        "retries — reported, not hidden.",
+        "retries - reported, not hidden.",
     ]
     for d in dirs:
         out += report(d)

--- a/test/agent_compile/test_aggregate_honest_cli.py
+++ b/test/agent_compile/test_aggregate_honest_cli.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI smoke tests for honest format diagnostics."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.agent_compile import aggregate_honest
+
+
+def _write_cell(cells_dir, name, arm, files_recall, answer_recall, format_failed):
+    cells_dir.joinpath(name).write_text(
+        json.dumps(
+            {
+                "success": True,
+                "metrics_meaningful": True,
+                "subset_id": arm,
+                "format_failed": format_failed,
+                "metrics": {
+                    "files": {"5": {"recall": files_recall}},
+                    "answer_blocks": {"5": {"recall": answer_recall}},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_aggregate_honest_cli_reports_format_failures(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    cells_dir = run_dir / "cells"
+    cells_dir.mkdir(parents=True)
+    _write_cell(cells_dir, "ok.json", "preload", 1.0, 1.0, False)
+    _write_cell(cells_dir, "fmt.json", "preload", 0.0, 0.0, True)
+
+    rc = aggregate_honest.main([str(run_dir)])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "# Honest report - localization accuracy vs format-failure" in out
+    assert "preload" in out
+    assert "50%" in out

--- a/test/eval/test_format_diagnostics.py
+++ b/test/eval/test_format_diagnostics.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for answer-format diagnostics."""
+
+from __future__ import annotations
+
+import json
+
+from codeminer.eval.agent_runner.format_diagnostics import (
+    load_format_diagnostics,
+    load_meaningful_cells,
+    summarize_format_cells,
+)
+
+
+def _cell(
+    arm: str,
+    files_recall: float,
+    answer_recall: float,
+    *,
+    format_failed: bool = False,
+    success: bool = True,
+    metrics_meaningful: bool = True,
+):
+    return {
+        "success": success,
+        "metrics_meaningful": metrics_meaningful,
+        "subset_id": arm,
+        "format_failed": format_failed,
+        "metrics": {
+            "files": {"5": {"recall": files_recall}},
+            "answer_blocks": {"5": {"recall": answer_recall}},
+        },
+    }
+
+
+def test_summarize_format_cells_separates_formatted_subset():
+    summaries = summarize_format_cells(
+        [
+            _cell("preload", 1.0, 1.0),
+            _cell("preload", 0.0, 0.0, format_failed=True),
+            _cell("grep_only", 0.5, 0.25),
+        ]
+    )
+
+    by_arm = {summary.arm: summary for summary in summaries}
+
+    preload = by_arm["preload"]
+    assert preload.n == 2
+    assert preload.format_fail_rate == 0.5
+    assert preload.files_all == 0.5
+    assert preload.files_formatted == 1.0
+    assert preload.answer_blocks_all == 0.5
+    assert preload.answer_blocks_formatted == 1.0
+
+    assert by_arm["grep_only"].format_fail_rate == 0.0
+
+
+def test_load_format_diagnostics_filters_unusable_cells(tmp_path):
+    cells_dir = tmp_path / "run" / "cells"
+    cells_dir.mkdir(parents=True)
+    cells_dir.joinpath("good.json").write_text(
+        json.dumps(_cell("grep_only", 0.5, 0.25)),
+        encoding="utf-8",
+    )
+    cells_dir.joinpath("failed.json").write_text(
+        json.dumps(_cell("grep_only", 1.0, 1.0, success=False)),
+        encoding="utf-8",
+    )
+    cells_dir.joinpath("bad.json").write_text("{", encoding="utf-8")
+
+    cells = load_meaningful_cells(tmp_path / "run")
+    diagnostics = load_format_diagnostics(tmp_path / "run")
+
+    assert len(cells) == 1
+    assert diagnostics.result_name == "run"
+    assert diagnostics.n_meaningful == 1
+    assert diagnostics.arms[0].arm == "grep_only"


### PR DESCRIPTION
## Summary
Move answer-format diagnostic aggregation out of `scripts/agent_compile/aggregate_honest.py` into `codeminer.eval.agent_runner`.

## Changes
- Add `codeminer.eval.agent_runner.format_diagnostics` for loading meaningful cells and summarizing format-failure vs formatted-cell localization metrics.
- Keep `scripts/agent_compile/aggregate_honest.py` as CLI/report glue.
- Add eval-package unit tests and script-level CLI smoke coverage.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/eval/test_format_diagnostics.py test/agent_compile/test_aggregate_honest_cli.py test/agent/test_import_boundaries.py -q`

`pre-commit run --files codeminer/eval/agent_runner/format_diagnostics.py scripts/agent_compile/aggregate_honest.py test/eval/test_format_diagnostics.py test/agent_compile/test_aggregate_honest_cli.py codeminer/eval/agent_runner/__init__.py`

## Checklist
- [x] Code follows the project style guidelines
- [x] Tests have been added or updated as appropriate
- [x] Documentation has been updated where needed
- [x] No new warnings or errors introduced