### PR TITLE
refactor(eval): share agent metric primitives

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -16,6 +16,7 @@ from .format_diagnostics import (
     load_meaningful_cells,
     summarize_format_cells,
 )
+from .metrics import load_cell_jsons, metric_at_k, safe_mean, safe_min, usable_cells
 from .orchestrator import (
     GATE_SYSTEM,
     VERIFY_SYSTEM_PROMPT,
@@ -74,19 +75,24 @@ __all__ = [
     "graph_compose",
     "interleave_ranked",
     "load_agent_skill_contexts",
+    "load_cell_jsons",
     "load_format_diagnostics",
     "load_meaningful_cells",
     "load_pareto_cells",
+    "metric_at_k",
     "prepare_preload_query",
     "query_is_specific",
     "render_expansion",
     "retrieve_candidates",
     "run_verify_expand",
     "scatter_gather_localize",
+    "safe_mean",
+    "safe_min",
     "snippet_for_node",
     "summarize_agent_result",
     "summarize_format_cells",
     "symbol_leaf",
+    "usable_cells",
     "verdict_is_yes",
     "verify_query",
 ]

--- a/codeminer/eval/agent_runner/format_diagnostics.py
+++ b/codeminer/eval/agent_runner/format_diagnostics.py
@@ -6,11 +6,11 @@
 
 from __future__ import annotations
 
-import json
-import statistics as st
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Sequence, Union
+
+from .metrics import load_cell_jsons, metric_at_k, safe_mean, usable_cells
 
 
 @dataclass(frozen=True)
@@ -35,30 +35,14 @@ class FormatDiagnostics:
     arms: List[FormatArmSummary]
 
 
-def _recall(cell: Dict[str, Any], scope: str, k: int) -> Optional[float]:
-    blocks = (cell.get("metrics") or {}).get(scope) or {}
-    score = blocks.get(k, blocks.get(str(k)))
-    return score.get("recall") if isinstance(score, dict) else None
-
-
-def _mean(values: Sequence[Optional[float]]) -> float:
-    present = [value for value in values if value is not None]
-    return st.fmean(present) if present else 0.0
-
-
 def load_meaningful_cells(result_dir: Union[Path, str]) -> List[Dict[str, Any]]:
     """Load successful cells whose metrics can be interpreted."""
 
     root = Path(result_dir)
-    cells: List[Dict[str, Any]] = []
-    for path in sorted(root.joinpath("cells").glob("*.json")):
-        try:
-            cell = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if cell.get("success") and cell.get("metrics_meaningful"):
-            cells.append(cell)
-    return cells
+    return usable_cells(
+        load_cell_jsons(root.joinpath("cells")),
+        require_metrics_meaningful=True,
+    )
 
 
 def summarize_format_cells(
@@ -84,15 +68,33 @@ def summarize_format_cells(
                 arm=arm,
                 n=len(arm_cells),
                 format_fail_rate=format_fail_rate,
-                files_all=_mean([_recall(cell, "files", k) for cell in arm_cells]),
-                files_formatted=_mean(
-                    [_recall(cell, "files", k) for cell in formatted]
+                files_all=safe_mean(
+                    [
+                        metric_at_k(cell, "files", k, field="recall")
+                        for cell in arm_cells
+                    ],
+                    default=0.0,
                 ),
-                answer_blocks_all=_mean(
-                    [_recall(cell, "answer_blocks", k) for cell in arm_cells]
+                files_formatted=safe_mean(
+                    [
+                        metric_at_k(cell, "files", k, field="recall")
+                        for cell in formatted
+                    ],
+                    default=0.0,
                 ),
-                answer_blocks_formatted=_mean(
-                    [_recall(cell, "answer_blocks", k) for cell in formatted]
+                answer_blocks_all=safe_mean(
+                    [
+                        metric_at_k(cell, "answer_blocks", k, field="recall")
+                        for cell in arm_cells
+                    ],
+                    default=0.0,
+                ),
+                answer_blocks_formatted=safe_mean(
+                    [
+                        metric_at_k(cell, "answer_blocks", k, field="recall")
+                        for cell in formatted
+                    ],
+                    default=0.0,
                 ),
             )
         )

--- a/codeminer/eval/agent_runner/metrics.py
+++ b/codeminer/eval/agent_runner/metrics.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable metric helpers for agent-runner evaluation cells."""
+
+from __future__ import annotations
+
+import json
+import statistics
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+Cell = Dict[str, Any]
+
+
+def load_cell_jsons(cells_dir: Union[Path, str]) -> List[Cell]:
+    """Load JSON cell dictionaries from a directory, skipping unreadable files."""
+
+    cells: List[Cell] = []
+    for path in sorted(Path(cells_dir).glob("*.json")):
+        try:
+            cell = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(cell, dict):
+            cells.append(cell)
+    return cells
+
+
+def usable_cells(
+    cells: Sequence[Cell],
+    *,
+    require_success: bool = True,
+    require_metrics_meaningful: bool = False,
+) -> List[Cell]:
+    """Filter cells to the subset usable for a diagnostic calculation."""
+
+    out: List[Cell] = []
+    for cell in cells:
+        if require_success and not cell.get("success"):
+            continue
+        if require_metrics_meaningful and not cell.get("metrics_meaningful"):
+            continue
+        out.append(cell)
+    return out
+
+
+def metric_at_k(
+    cell: Cell,
+    scope: str,
+    k: int,
+    *,
+    field: str = "accuracy",
+) -> Optional[float]:
+    """Read a numeric metric field for one scope and cutoff."""
+
+    bucket = (cell.get("metrics") or {}).get(scope) or {}
+    stats = bucket.get(k, bucket.get(str(k)))
+    if isinstance(stats, dict):
+        value = stats.get(field)
+    elif field == "accuracy":
+        value = stats
+    else:
+        value = None
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def safe_mean(values: Sequence[Optional[float]], *, default: Optional[float] = None):
+    """Mean over present numeric values, returning default for an empty input."""
+
+    present = [value for value in values if isinstance(value, (int, float))]
+    return statistics.fmean(present) if present else default
+
+
+def safe_min(values: Sequence[Optional[float]], *, default: Optional[float] = None):
+    """Minimum over present numeric values, returning default for an empty input."""
+
+    present = [value for value in values if isinstance(value, (int, float))]
+    return min(present) if present else default

--- a/codeminer/eval/agent_runner/pareto.py
+++ b/codeminer/eval/agent_runner/pareto.py
@@ -20,30 +20,19 @@ Rep folding mirrors aggregate_synthesis (rec mean across reps, cost/turns min).
 
 from __future__ import annotations
 
-import json
 import random
 import statistics
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
+
+from .metrics import load_cell_jsons, metric_at_k, safe_mean, safe_min
 
 EPS = 0.02  # Recall deltas within this count as equal accuracy.
 
 
 def load_pareto_cells(cells_dir: Path) -> List[Dict[str, Any]]:
-    out = []
-    for p in sorted(cells_dir.glob("*.json")):
-        try:
-            out.append(json.loads(p.read_text(encoding="utf-8")))
-        except (OSError, json.JSONDecodeError):
-            pass
-    return out
-
-
-def _rec5(cell: Dict[str, Any]) -> Optional[float]:
-    b = (cell.get("metrics") or {}).get("answer_blocks") or {}
-    s = b.get(5, b.get("5"))
-    return s.get("recall") if isinstance(s, dict) else None
+    return load_cell_jsons(cells_dir)
 
 
 def _fold_reps(cells: Sequence[Dict[str, Any]]) -> Dict[Tuple, Dict[str, float]]:
@@ -55,13 +44,12 @@ def _fold_reps(cells: Sequence[Dict[str, Any]]) -> Dict[Tuple, Dict[str, float]]
         by[(c.get("category"), c.get("subset_id"), c.get("query_id"))].append(c)
     folded: Dict[Tuple, Dict[str, float]] = {}
     for key, reps in by.items():
-        recs = [r for r in (_rec5(c) for c in reps) if r is not None]
-        costs = [c.get("cost_usd") for c in reps if c.get("cost_usd") is not None]
-        turns = [c.get("total_turns") for c in reps if c.get("total_turns") is not None]
         folded[key] = {
-            "rec": statistics.fmean(recs) if recs else None,
-            "cost": min(costs) if costs else None,
-            "turns": min(turns) if turns else None,
+            "rec": safe_mean(
+                [metric_at_k(cell, "answer_blocks", 5, field="recall") for cell in reps]
+            ),
+            "cost": safe_min([cell.get("cost_usd") for cell in reps]),
+            "turns": safe_min([cell.get("total_turns") for cell in reps]),
         }
     return folded
 

--- a/scripts/agent_compile/aggregate.py
+++ b/scripts/agent_compile/aggregate.py
@@ -38,11 +38,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import statistics
 import sys
 from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
+
+from codeminer.eval.agent_runner.metrics import metric_at_k, safe_mean, safe_min
 
 EASY_FILES_AT_5 = 0.5  # baseline-arm mean-rep files@5 >= this => "easy" instance
 
@@ -75,30 +76,22 @@ def load_cells(cells_dir: Path) -> List[Dict[str, Any]]:
 
 
 def _at_k(cell: Dict[str, Any], scope: str, k: int) -> Optional[float]:
-    bucket = (cell.get("metrics") or {}).get(scope) or {}
-    stats = bucket.get(k, bucket.get(str(k)))
-    if isinstance(stats, dict):
-        return stats.get("accuracy")
-    return stats
+    return metric_at_k(cell, scope, k)
 
 
 def _field_at_k(
     cell: Dict[str, Any], scope: str, k: int, field: str
 ) -> Optional[float]:
     """Read an arbitrary metric field (precision/recall/...) at cutoff k."""
-    bucket = (cell.get("metrics") or {}).get(scope) or {}
-    stats = bucket.get(k, bucket.get(str(k)))
-    return stats.get(field) if isinstance(stats, dict) else None
+    return metric_at_k(cell, scope, k, field=field)
 
 
 def _safe_mean(xs: Sequence[Optional[float]]) -> Optional[float]:
-    vals = [x for x in xs if x is not None]
-    return statistics.fmean(vals) if vals else None
+    return safe_mean(xs)
 
 
 def _safe_min(xs: Sequence[Optional[float]]) -> Optional[float]:
-    vals = [x for x in xs if x is not None]
-    return min(vals) if vals else None
+    return safe_min(xs)
 
 
 def _fmt(v: Optional[float], nd: int) -> str:

--- a/scripts/agent_compile/aggregate_synthesis.py
+++ b/scripts/agent_compile/aggregate_synthesis.py
@@ -32,38 +32,34 @@ from __future__ import annotations
 
 import argparse
 import json
-import statistics
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
+
+from codeminer.eval.agent_runner.metrics import (
+    load_cell_jsons,
+    metric_at_k,
+    safe_mean,
+    safe_min,
+)
 
 KS = [1, 3, 5, 10]
 
 
 def _load(cells_dir: Path) -> List[Dict[str, Any]]:
-    out = []
-    for p in sorted(cells_dir.glob("*.json")):
-        try:
-            out.append(json.loads(p.read_text(encoding="utf-8")))
-        except (OSError, json.JSONDecodeError):
-            pass
-    return out
+    return load_cell_jsons(cells_dir)
 
 
 def _field(cell: Dict[str, Any], scope: str, k: int, field: str) -> Optional[float]:
-    b = (cell.get("metrics") or {}).get(scope) or {}
-    s = b.get(k, b.get(str(k)))
-    return s.get(field) if isinstance(s, dict) else None
+    return metric_at_k(cell, scope, k, field=field)
 
 
 def _mean(xs: Sequence[Optional[float]]) -> Optional[float]:
-    v = [x for x in xs if x is not None]
-    return statistics.fmean(v) if v else None
+    return safe_mean(xs)
 
 
 def _min(xs: Sequence[Optional[float]]) -> Optional[float]:
-    v = [x for x in xs if x is not None]
-    return min(v) if v else None
+    return safe_min(xs)
 
 
 def _fmt(v: Optional[float], nd: int = 3) -> str:

--- a/test/eval/test_agent_metrics.py
+++ b/test/eval/test_agent_metrics.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shared agent-runner metric helpers."""
+
+from __future__ import annotations
+
+import json
+
+from codeminer.eval.agent_runner.metrics import (
+    load_cell_jsons,
+    metric_at_k,
+    safe_mean,
+    safe_min,
+    usable_cells,
+)
+
+
+def test_load_cell_jsons_skips_invalid_files(tmp_path):
+    tmp_path.joinpath("ok.json").write_text(
+        json.dumps({"success": True}),
+        encoding="utf-8",
+    )
+    tmp_path.joinpath("bad.json").write_text("{", encoding="utf-8")
+    tmp_path.joinpath("list.json").write_text("[]", encoding="utf-8")
+
+    assert load_cell_jsons(tmp_path) == [{"success": True}]
+
+
+def test_usable_cells_filters_success_and_meaningful_metrics():
+    cells = [
+        {"success": True, "metrics_meaningful": True, "id": "keep"},
+        {"success": True, "metrics_meaningful": False, "id": "drop_metrics"},
+        {"success": False, "metrics_meaningful": True, "id": "drop_failure"},
+    ]
+
+    usable = usable_cells(cells, require_metrics_meaningful=True)
+
+    assert [cell["id"] for cell in usable] == ["keep"]
+
+
+def test_metric_at_k_reads_dict_and_scalar_shapes():
+    cell = {
+        "metrics": {
+            "files": {
+                "1": {"accuracy": 0.25, "recall": 0.5},
+                5: 1.0,
+            }
+        }
+    }
+
+    assert metric_at_k(cell, "files", 1) == 0.25
+    assert metric_at_k(cell, "files", 1, field="recall") == 0.5
+    assert metric_at_k(cell, "files", 5) == 1.0
+    assert metric_at_k(cell, "files", 5, field="recall") is None
+    assert metric_at_k(cell, "missing", 1) is None
+
+
+def test_safe_aggregates_ignore_missing_values():
+    values = [None, 1.0, 3.0]
+
+    assert safe_mean(values) == 2.0
+    assert safe_min(values) == 1.0
+    assert safe_mean([None], default=0.0) == 0.0
+    assert safe_min([None]) is None


### PR DESCRIPTION
## Summary
Add reusable metric primitives for agent-runner evaluation cells and use them from diagnostics and aggregate scripts.

## Changes
- Add `codeminer.eval.agent_runner.metrics` for loading cell JSON, filtering usable cells, reading metric fields, and safe aggregate helpers.
- Refactor format diagnostics and Pareto diagnostics to reuse the shared primitives.
- Refactor `aggregate.py` and `aggregate_synthesis.py` helper wrappers to call the package API while keeping experiment-specific reports in scripts.
- Add direct unit coverage for the shared metric helpers.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/eval/test_agent_metrics.py test/eval/test_format_diagnostics.py test/eval/test_agent_pareto.py test/agent_compile/test_aggregate_honest_cli.py test/agent_compile/test_pareto_ci_cli.py test/agent/test_import_boundaries.py -q`

`pre-commit run --files codeminer/eval/agent_runner/metrics.py codeminer/eval/agent_runner/format_diagnostics.py codeminer/eval/agent_runner/pareto.py codeminer/eval/agent_runner/__init__.py scripts/agent_compile/aggregate.py scripts/agent_compile/aggregate_synthesis.py test/eval/test_agent_metrics.py`

## Checklist
- [x] Code follows the project style guidelines
- [x] Tests have been added or updated as appropriate
- [x] Documentation has been updated where needed
- [x] No new warnings or errors introduced