### PR TITLE
ci(actions): run slow tests after fast lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,8 +532,8 @@ jobs:
   # Job 4 — Slow tests  (LLM API, GPU embeddings, ~15 min)
   # =============================================================
   slow:
-    needs: [preflight, unit]
-    if: needs.preflight.outputs.should-run == 'true'
+    needs: [preflight, unit, integration, integration-serial, scip-core, graph-consumer]
+    if: always() && needs.preflight.outputs.should-run == 'true' && needs.unit.result == 'success' && needs.integration.result == 'success' && (needs.integration-serial.result == 'success' || needs.integration-serial.result == 'skipped') && (needs.scip-core.result == 'success' || needs.scip-core.result == 'skipped') && (needs.graph-consumer.result == 'success' || needs.graph-consumer.result == 'skipped')
     runs-on: self-hosted
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Summary
Move the slow GitHub Actions tier behind the deterministic fast-feedback lanes so it cannot occupy the self-hosted runner before unit, integration, serial, SCIP core, or graph-consumer checks have reported.

## Changes
- Make `slow` depend on `unit`, `integration`, `integration-serial`, `scip-core`, and `graph-consumer` in addition to `preflight`.
- Use an explicit `always()` gate so `slow` still runs when serial-chain jobs are skipped, but only after required fast lanes succeed or skip.

## Type of Change
- ci

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `git diff --check`

## Checklist
- [x] I have run the relevant local checks.
- [x] I have kept the change focused.