### PR TITLE
refactor(mcp): share LSP line boundary

### DIFF
--- a/codeminer/mcp/tools/lsp.py
+++ b/codeminer/mcp/tools/lsp.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
+from ...agent.boundary import from_agent_repr, to_agent_repr
 from ...agent.lsp_graph import lsp_definition, lsp_references, lsp_route
 
 
@@ -18,17 +19,9 @@ def _coerce_symbols(symbols: Sequence[str] | str) -> list[str]:
 
 
 def _node_to_dict(node: Any) -> dict[str, Any]:
-    if hasattr(node, "model_dump"):
-        payload = node.model_dump(exclude_none=True)
-    elif isinstance(node, dict):
-        payload = {k: v for k, v in node.items() if v is not None}
-    else:
+    if not (hasattr(node, "model_dump") or isinstance(node, dict)):
         return {"node": str(node)}
-    for key in ("start_line", "end_line"):
-        value = payload.get(key)
-        if isinstance(value, int):
-            payload[key] = value + 1
-    return payload
+    return to_agent_repr(node)
 
 
 def _symbol_graph(ctx: Any) -> Any:
@@ -50,7 +43,7 @@ def lsp_definition_impl(
     graph = _symbol_graph(ctx)
     if graph is None:
         return {"error": "symbol_graph index not available"}
-    graph_line = int(line) - 1 if line is not None else None
+    graph_line = from_agent_repr(line)
     try:
         results = lsp_definition(
             graph,
@@ -78,7 +71,7 @@ def lsp_references_impl(
     graph = _symbol_graph(ctx)
     if graph is None:
         return {"error": "symbol_graph index not available"}
-    graph_line = int(line) - 1 if line is not None else None
+    graph_line = from_agent_repr(line)
     try:
         results = lsp_references(
             graph,

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -197,6 +197,17 @@ def test_lsp_references_tool_delegates_to_core():
     assert kwargs["include_declaration"] is False
 
 
+def test_lsp_tools_reuse_agent_line_boundary():
+    """MCP LSP tools share the agent 1-based input boundary."""
+    ctx = MagicMock(symbol_graph=MagicMock())
+    with patch("codeminer.mcp.tools.lsp.lsp_definition") as mock_definition:
+        mock_definition.return_value = []
+
+        lsp_definition_impl(ctx, file_path="caller.py", line=0)
+
+    assert mock_definition.call_args.kwargs["line"] == 0
+
+
 def test_server_status_resource(mock_manifest: Path):
     """Test server_status resource returns correct info."""
     mock_vector = MagicMock(spec=CodeVectorStore)


### PR DESCRIPTION
## Summary
Make MCP LSP-shaped graph tools reuse the same agent boundary helpers for line-number conversion and result serialization.

## Changes
- Replace MCP-local `line - 1` / `+1` conversions in `codeminer.mcp.tools.lsp` with `from_agent_repr` / `to_agent_repr`.
- Keep non-node fallback serialization for unexpected results.
- Add a regression test that clamps invalid 1-based MCP line input the same way the agent boundary does.

## Type of Change
- refactor
- test

## Testing
- `pytest test/mcp/test_mcp_server.py test/agent/test_lsp_graph.py test/agent/test_boundary.py -q`
- `pre-commit run --files codeminer/mcp/tools/lsp.py test/mcp/test_mcp_server.py`
- `git diff --check`

## Checklist
- [x] I have run the relevant local checks.
- [x] I have kept the change focused.
- [x] I have not added AI attribution footers.
