### PR TITLE
feat(eval): plan small agent feedback slices

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -9,6 +9,7 @@ from .contexts import (
     default_agent_skills_dir,
     load_agent_skill_contexts,
 )
+from .feedback import FeedbackGroup, FeedbackPlan, FeedbackPlanSpec, build_feedback_plan
 from .format_diagnostics import (
     FormatArmSummary,
     FormatDiagnostics,
@@ -68,6 +69,9 @@ __all__ = [
     "AgentSkillContextSpec",
     "FormatArmSummary",
     "FormatDiagnostics",
+    "FeedbackGroup",
+    "FeedbackPlan",
+    "FeedbackPlanSpec",
     "GATE_SYSTEM",
     "GraphNav",
     "LANG_GROUP_TO_KEY",
@@ -82,6 +86,7 @@ __all__ = [
     "analyze_pareto",
     "build_prebuilt_symbol_span_index",
     "build_symbol_span_index",
+    "build_feedback_plan",
     "candidate_location",
     "converge_query",
     "default_agent_skills_dir",

--- a/codeminer/eval/agent_runner/feedback.py
+++ b/codeminer/eval/agent_runner/feedback.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Feedback-plan selection for small agent-runner iterations."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class FeedbackPlanSpec:
+    """Deterministic small-sample plan for iterative agent evaluation.
+
+    ``seed`` is the rotation handle: keep it fixed for the stable smoke gate;
+    change it for a new holdout slice. Selection is stratified by
+    ``group_field`` so a small plan still covers the configured language or
+    dataset groups without hand-picking instances.
+    """
+
+    seed: str = "codeminer-feedback-v1"
+    group_field: str = "language_group"
+    smoke_per_group: int = 1
+    holdout_per_group: int = 2
+    exclude_instances: Sequence[str] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.smoke_per_group < 0:
+            raise ValueError("smoke_per_group must be non-negative")
+        if self.holdout_per_group < 0:
+            raise ValueError("holdout_per_group must be non-negative")
+        if not self.group_field:
+            raise ValueError("group_field must be non-empty")
+        object.__setattr__(
+            self,
+            "exclude_instances",
+            tuple(str(instance_id) for instance_id in self.exclude_instances),
+        )
+
+
+@dataclass(frozen=True)
+class FeedbackGroup:
+    """Selected smoke and holdout instances for one group."""
+
+    smoke: tuple[str, ...]
+    holdout: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FeedbackPlan:
+    """Selected feedback instances plus enough metadata for audit logs."""
+
+    seed: str
+    group_field: str
+    groups: Mapping[str, FeedbackGroup]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "groups", MappingProxyType(dict(self.groups)))
+
+    @property
+    def smoke_instances(self) -> list[str]:
+        return [iid for group in self.groups.values() for iid in group.smoke]
+
+    @property
+    def holdout_instances(self) -> list[str]:
+        return [iid for group in self.groups.values() for iid in group.holdout]
+
+    @property
+    def instances(self) -> list[str]:
+        return self.smoke_instances + self.holdout_instances
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "seed": self.seed,
+            "group_field": self.group_field,
+            "smoke_instances": self.smoke_instances,
+            "holdout_instances": self.holdout_instances,
+            "instances": self.instances,
+            "groups": {
+                group: {
+                    "smoke": list(selected.smoke),
+                    "holdout": list(selected.holdout),
+                }
+                for group, selected in self.groups.items()
+            },
+        }
+
+
+def build_feedback_plan(
+    rows_by_id: Mapping[str, Mapping[str, Any]],
+    spec: FeedbackPlanSpec | None = None,
+) -> FeedbackPlan:
+    """Select deterministic smoke and holdout instances from dataset rows."""
+    spec = spec or FeedbackPlanSpec()
+    excluded = set(spec.exclude_instances or ())
+    grouped: dict[str, list[str]] = {}
+    for instance_id, row in rows_by_id.items():
+        iid = str(row.get("instance_id") or instance_id)
+        if iid in excluded:
+            continue
+        group = str(row.get(spec.group_field) or "unknown")
+        grouped.setdefault(group, []).append(iid)
+
+    groups: dict[str, FeedbackGroup] = {}
+    for group in sorted(grouped):
+        instance_ids = sorted(set(grouped[group]))
+        smoke = tuple(
+            _stable_order(instance_ids, seed=spec.seed, bucket=f"smoke:{group}")[
+                : spec.smoke_per_group
+            ]
+        )
+        smoke_set = set(smoke)
+        remaining = [iid for iid in instance_ids if iid not in smoke_set]
+        holdout = tuple(
+            _stable_order(remaining, seed=spec.seed, bucket=f"holdout:{group}")[
+                : spec.holdout_per_group
+            ]
+        )
+        groups[group] = FeedbackGroup(smoke=smoke, holdout=holdout)
+
+    return FeedbackPlan(seed=spec.seed, group_field=spec.group_field, groups=groups)
+
+
+def _stable_order(instance_ids: Sequence[str], *, seed: str, bucket: str) -> list[str]:
+    return sorted(
+        instance_ids,
+        key=lambda iid: (
+            hashlib.sha256(f"{bucket}\0{seed}\0{iid}".encode("utf-8")).hexdigest(),
+            iid,
+        ),
+    )

--- a/scripts/agent_compile/README.md
+++ b/scripts/agent_compile/README.md
@@ -48,11 +48,10 @@ ablation.
 
 | file | purpose |
 |---|---|
+| `feedback_plan.py` | choose a small deterministic feedback slice: fixed smoke cases plus a seed-rotated holdout, stratified by language/group. Outputs JSON instance lists for `run_sweep.py --instances ...`. |
 | `run_sweep.py` | run the sweep: `{arms} × {instances} × {reps}` agent cells on prebuilt indexes; `cells/<id>.json` + `sweep_summary.json`. Validates the harness (raises on unknown tool/skill ids) before spending. |
 | `aggregate.py` | fold cells into a report: per-arm metrics, skill-invocation histogram, easy/hard split, per-scenario cells, Pareto front → `report.md` + `metrics.json`. |
-| `lib/config.py` | `SweepConfig` (base + per-arm overlay; **empty `instances` = the full split**). |
-| `lib/harness.py` | dataset loading, prebuilt-index staging into agent `contexts`, scenario classification, the one `run_cell` agent call. |
-| `lib/prebuilt.py` | stage offline-built per-instance indexes into the `cache_dir/<type>` layout. |
+| `lib/*.py` | compatibility shims for older experiment notebooks; reusable config/harness code lives in `codeminer.eval.agent_runner`. |
 
 The agent-localization scorer (answer + `read` paths + retrieval nodes →
 files@k / symbols@k) lives in
@@ -75,6 +74,19 @@ python scripts/agent_compile/run_sweep.py \
 python scripts/agent_compile/aggregate.py \
     --cells-dir results/agent_compile/design_space/cells \
     --output-dir results/agent_compile/design_space
+```
+
+For fast iteration, plan a small feedback slice first and pass the emitted
+`instances` list to `run_sweep.py --instances ...`. Keep the same seed for a
+fixed smoke gate; rotate the seed for a fresh holdout.
+
+```bash
+python scripts/agent_compile/feedback_plan.py \
+    --config scripts/agent_compile/configs/design_space.yaml \
+    --seed 2026w27 \
+    --smoke-per-group 1 \
+    --holdout-per-group 2 \
+    --output-json results/agent_compile/feedback_plan.json
 ```
 
 `run_sweep.py` resumes per cell and does not persist transient (rate-limit)

--- a/scripts/agent_compile/feedback_plan.py
+++ b/scripts/agent_compile/feedback_plan.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plan a small smoke + rotating holdout slice for agent-runner iteration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a deterministic smoke + holdout plan for small agent sweeps.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--seed", default="codeminer-feedback-v1")
+    parser.add_argument("--group-field", default="language_group")
+    parser.add_argument("--smoke-per-group", type=int, default=1)
+    parser.add_argument("--holdout-per-group", type=int, default=2)
+    parser.add_argument(
+        "--exclude-instance",
+        action="append",
+        default=[],
+        help="Instance id to exclude; repeat for multiple ids.",
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    from codeminer.eval.agent_runner.feedback import (
+        FeedbackPlanSpec,
+        build_feedback_plan,
+    )
+    from codeminer.eval.agent_runner.sweep import load_dataset_rows
+    from codeminer.eval.agent_runner.sweep_config import SweepConfig
+
+    cfg = SweepConfig.from_yaml(args.config)
+    rows_by_id, _ = load_dataset_rows(cfg)
+    plan = build_feedback_plan(
+        rows_by_id,
+        FeedbackPlanSpec(
+            seed=args.seed,
+            group_field=args.group_field,
+            smoke_per_group=args.smoke_per_group,
+            holdout_per_group=args.holdout_per_group,
+            exclude_instances=tuple(args.exclude_instance or ()),
+        ),
+    )
+    payload = plan.to_dict()
+    text = json.dumps(payload, indent=2, ensure_ascii=False)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/eval/test_feedback_plan.py
+++ b/test/eval/test_feedback_plan.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for small agent feedback plan selection."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.eval.agent_runner.feedback import FeedbackPlanSpec, build_feedback_plan
+
+
+def _rows():
+    return {
+        "py1": {"instance_id": "py1", "language_group": "Python"},
+        "py2": {"instance_id": "py2", "language_group": "Python"},
+        "py3": {"instance_id": "py3", "language_group": "Python"},
+        "go1": {"instance_id": "go1", "language_group": "Go"},
+        "go2": {"instance_id": "go2", "language_group": "Go"},
+        "go3": {"instance_id": "go3", "language_group": "Go"},
+    }
+
+
+def test_feedback_plan_selects_smoke_and_holdout_per_group():
+    plan = build_feedback_plan(
+        _rows(),
+        FeedbackPlanSpec(seed="week-1", smoke_per_group=1, holdout_per_group=2),
+    )
+
+    assert sorted(plan.groups) == ["Go", "Python"]
+    assert len(plan.smoke_instances) == 2
+    assert len(plan.holdout_instances) == 4
+    assert set(plan.smoke_instances).isdisjoint(plan.holdout_instances)
+    assert plan.instances == plan.smoke_instances + plan.holdout_instances
+
+
+def test_feedback_plan_is_deterministic_for_same_seed():
+    spec = FeedbackPlanSpec(seed="week-1", smoke_per_group=1, holdout_per_group=1)
+
+    first = build_feedback_plan(_rows(), spec).to_dict()
+    second = build_feedback_plan(dict(reversed(list(_rows().items()))), spec).to_dict()
+
+    assert first == second
+
+
+def test_feedback_plan_rotates_holdout_when_seed_changes():
+    spec_a = FeedbackPlanSpec(seed="week-1", smoke_per_group=0, holdout_per_group=1)
+    spec_b = FeedbackPlanSpec(seed="week-2", smoke_per_group=0, holdout_per_group=1)
+
+    assert (
+        build_feedback_plan(_rows(), spec_a).holdout_instances
+        != build_feedback_plan(_rows(), spec_b).holdout_instances
+    )
+
+
+def test_feedback_plan_respects_excluded_instances():
+    plan = build_feedback_plan(
+        _rows(),
+        FeedbackPlanSpec(
+            seed="week-1",
+            smoke_per_group=3,
+            holdout_per_group=3,
+            exclude_instances=("py1", "go2"),
+        ),
+    )
+
+    assert "py1" not in plan.instances
+    assert "go2" not in plan.instances
+
+
+def test_feedback_plan_rejects_negative_counts():
+    with pytest.raises(ValueError, match="smoke_per_group"):
+        FeedbackPlanSpec(smoke_per_group=-1)


### PR DESCRIPTION
## Summary
Adds a reusable feedback-plan selector for small agent-runner iterations.

## Changes
- Add `codeminer.eval.agent_runner.feedback` with deterministic smoke and seed-rotated holdout selection stratified by dataset group.
- Add a thin `scripts/agent_compile/feedback_plan.py` CLI that emits JSON instance lists for small sweeps.
- Document the fast feedback workflow and keep older `scripts/agent_compile/lib` modules described as compatibility shims.
- Add unit coverage for deterministic selection, seed rotation, exclusions, and invalid counts.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/eval/test_feedback_plan.py -q`

`python scripts/agent_compile/feedback_plan.py --help`

`python -m compileall -q codeminer/eval/agent_runner scripts/agent_compile/feedback_plan.py`

`pre-commit run --files codeminer/eval/agent_runner/__init__.py codeminer/eval/agent_runner/feedback.py scripts/agent_compile/feedback_plan.py scripts/agent_compile/README.md test/eval/test_feedback_plan.py`

`git diff --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
