### PR TITLE
refactor(eval): share agent localization scoring

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -18,7 +18,13 @@ from .harness import (
 )
 from .history import PlainChatHistory, TokenBudgetedChatHistory, count_message_tokens
 from .rerank_agent import RerankAgent, RerankResult, rerank_nodes_with_query
-from .runner import AgentRunner, CodeMinerAgentOptions, compile_repo, query
+from .runner import (
+    AgentRunner,
+    CodeMinerAgentOptions,
+    compile_repo,
+    has_localization_contract,
+    query,
+)
 from .runtime import (
     AGENT_TRACE_SCHEMA_VERSION,
     AgentRunTrace,
@@ -48,6 +54,7 @@ __all__ = [
     "compile_repo",
     "count_message_tokens",
     "extract_keywords_from_statement",
+    "has_localization_contract",
     "query",
     "rerank_nodes_with_query",
     "registry_to_tools",

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -64,7 +64,8 @@ _HAS_SYMBOLS_CONTRACT = re.compile(rf"{_LABEL_PREFIX}symbols?[\s*_`]*[:=]")
 _HAS_LOCATIONS_CONTRACT = re.compile(rf"{_LABEL_PREFIX}locations?[\s*_`]*[:=]")
 
 
-def _has_localization_contract(answer: str) -> bool:
+def has_localization_contract(answer: str) -> bool:
+    """Return true when an answer carries the localization output contract."""
     return all(
         pattern.search(answer or "")
         for pattern in (
@@ -73,6 +74,10 @@ def _has_localization_contract(answer: str) -> bool:
             _HAS_LOCATIONS_CONTRACT,
         )
     )
+
+
+def _has_localization_contract(answer: str) -> bool:
+    return has_localization_contract(answer)
 
 
 _DEFAULT_SYSTEM_PROMPT = f"""\

--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -39,6 +39,7 @@ from .preload import (
     snippet_for_node,
 )
 from .results import summarize_agent_result
+from .scoring import AgentLocalizationEvaluation, evaluate_agent_localization
 from .sweep import (
     LANG_GROUP_TO_KEY,
     all_index_skill_ids,
@@ -66,6 +67,7 @@ from .verify_expand import (
 )
 
 __all__ = [
+    "AgentLocalizationEvaluation",
     "AgentSkillContextSpec",
     "FormatArmSummary",
     "FormatDiagnostics",
@@ -90,6 +92,7 @@ __all__ = [
     "candidate_location",
     "converge_query",
     "default_agent_skills_dir",
+    "evaluate_agent_localization",
     "expansion_seeds_from_candidates",
     "graph_verify",
     "load_graph_nav",

--- a/codeminer/eval/agent_runner/scoring.py
+++ b/codeminer/eval/agent_runner/scoring.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared agent-localization scoring for sweep CLIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Sequence
+
+from codeminer.agent import has_localization_contract
+from codeminer.eval.retrieval_eval import (
+    dedup_spans,
+    nodes_to_spans,
+    parse_answer_spans,
+    resolve_symbol_spans,
+    score_agent_localization,
+    score_localization_spans,
+    spans_overlap,
+)
+
+
+@dataclass(frozen=True)
+class AgentLocalizationEvaluation:
+    """Scoring outputs written into an agent sweep cell record."""
+
+    metrics: dict[str, Any]
+    metrics_meaningful: bool
+    target_files: list[str]
+    target_symbols: list[str]
+    gt_code_blocks: list[dict[str, Any]]
+    answer_spans: list[dict[str, Any]]
+    retrieval_spans: list[dict[str, Any]]
+    preload_contribution: Optional[float]
+    format_failed: bool
+
+    def to_record_fields(self) -> dict[str, Any]:
+        """Return JSON-ready fields shared by sweep cell records."""
+        return {
+            "format_failed": self.format_failed,
+            "metrics": self.metrics,
+            "metrics_meaningful": self.metrics_meaningful,
+            "target_files": self.target_files,
+            "target_symbols": self.target_symbols,
+            "gt_code_blocks": self.gt_code_blocks,
+            "answer_spans": self.answer_spans,
+            "retrieval_spans": self.retrieval_spans,
+            "preload_contribution": self.preload_contribution,
+        }
+
+
+def evaluate_agent_localization(
+    *,
+    answer: str,
+    file_read_paths: Sequence[str],
+    nodes: Sequence[Any],
+    target_files: Sequence[str],
+    target_symbols: Sequence[str],
+    gt_blocks: Sequence[Mapping[str, Any]],
+    metrics_k: Sequence[int],
+    repo_path: str,
+    symbol_span_index: Optional[Mapping[tuple[str, str], tuple[int, int]]] = None,
+    preload_candidates: Optional[Sequence[Mapping[str, Any]]] = None,
+    metrics_meaningful: Optional[bool] = None,
+) -> AgentLocalizationEvaluation:
+    """Evaluate one agent answer without applying runtime policy.
+
+    The returned fields keep raw file/symbol metrics, span-overlap metrics,
+    format failure, and pre-load contribution separate so experiment reports can
+    show whether a change improved localization or just repaired formatting.
+    """
+    answer_text = answer or ""
+    target_files_list = list(target_files)
+    target_symbols_list = list(target_symbols)
+    gt_blocks_list = [dict(block) for block in gt_blocks]
+
+    metrics = score_agent_localization(
+        answer=answer_text,
+        file_read_paths=file_read_paths,
+        nodes=nodes,
+        target_files=target_files_list,
+        target_symbols=target_symbols_list,
+        ks=metrics_k,
+        repo_path=repo_path,
+    )
+    answer_spans = parse_answer_spans(answer_text, repo_path)
+    if symbol_span_index:
+        answer_spans += resolve_symbol_spans(answer_text, symbol_span_index, repo_path)
+    retrieval_spans = nodes_to_spans(nodes)
+    metrics.update(
+        score_localization_spans(
+            answer_spans=answer_spans,
+            retrieval_spans=retrieval_spans,
+            gt_blocks=gt_blocks_list,
+            ks=metrics_k,
+        )
+    )
+
+    return AgentLocalizationEvaluation(
+        metrics=metrics,
+        metrics_meaningful=(
+            bool(target_files_list or target_symbols_list or gt_blocks_list)
+            if metrics_meaningful is None
+            else metrics_meaningful
+        ),
+        target_files=target_files_list,
+        target_symbols=target_symbols_list,
+        gt_code_blocks=gt_blocks_list,
+        answer_spans=answer_spans,
+        retrieval_spans=retrieval_spans,
+        preload_contribution=_preload_contribution(
+            answer_spans, preload_candidates or ()
+        ),
+        format_failed=(not has_localization_contract(answer_text) and not answer_spans),
+    )
+
+
+def _preload_contribution(
+    answer_spans: Sequence[Mapping[str, Any]],
+    preload_candidates: Sequence[Mapping[str, Any]],
+) -> Optional[float]:
+    if not answer_spans or not preload_candidates:
+        return None
+    answer_dedup = dedup_spans([dict(span) for span in answer_spans])
+    if not answer_dedup:
+        return None
+    return sum(
+        1
+        for answer_span in answer_dedup
+        if any(
+            spans_overlap(answer_span, candidate) for candidate in preload_candidates
+        )
+    ) / len(answer_dedup)

--- a/scripts/agent_compile/README.md
+++ b/scripts/agent_compile/README.md
@@ -53,10 +53,11 @@ ablation.
 | `aggregate.py` | fold cells into a report: per-arm metrics, skill-invocation histogram, easy/hard split, per-scenario cells, Pareto front → `report.md` + `metrics.json`. |
 | `lib/*.py` | compatibility shims for older experiment notebooks; reusable config/harness code lives in `codeminer.eval.agent_runner`. |
 
-The agent-localization scorer (answer + `read` paths + retrieval nodes →
+The base agent-localization scorer (answer + `read` paths + retrieval nodes →
 files@k / symbols@k) lives in
 `codeminer/eval/retrieval_eval.py:score_agent_localization`, shared by the
-runner and the offline ablations.
+runner and the offline ablations. Sweep cell scoring glue (span metrics, format
+failure, pre-load contribution) lives in `codeminer.eval.agent_runner.scoring`.
 
 **Not here:** the offline *retrieval* ablations (no agent, no LLM) live in
 `scripts/retrieval_ablation/` (`graphrag_retrieve`, `graph_recall_ablation`,

--- a/scripts/agent_compile/run_sweep.py
+++ b/scripts/agent_compile/run_sweep.py
@@ -36,29 +36,14 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from codeminer.eval.agent_runner.prebuilt import (  # noqa: E402
-    has_full_indexes,
-    repo_path_for,
-    stage_prebuilt_indexes,
-)
-from codeminer.eval.agent_runner.sweep import (  # noqa: E402
-    LANG_GROUP_TO_KEY,
-    load_dataset_rows,
-    load_full_contexts,
-    run_cell,
-    scenario_for,
-    slug,
-)
-from codeminer.eval.agent_runner.sweep_config import SweepConfig  # noqa: E402
-from codeminer.eval.agent_runner.symbols import (  # noqa: E402
-    build_prebuilt_symbol_span_index,
-)
+if TYPE_CHECKING:
+    from codeminer.eval.agent_runner.sweep_config import SweepConfig
 
 
 def _validate_harness(cfg: SweepConfig) -> None:
@@ -96,17 +81,22 @@ def _validate_harness(cfg: SweepConfig) -> None:
 
 
 def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dict:
-    from codeminer.eval.retrieval_eval import (
-        collect_target_blocks,
-        collect_targets,
-        dedup_spans,
-        nodes_to_spans,
-        parse_answer_spans,
-        resolve_symbol_spans,
-        score_agent_localization,
-        score_localization_spans,
-        spans_overlap,
+    from codeminer.eval.agent_runner.prebuilt import (
+        has_full_indexes,
+        repo_path_for,
+        stage_prebuilt_indexes,
     )
+    from codeminer.eval.agent_runner.scoring import evaluate_agent_localization
+    from codeminer.eval.agent_runner.sweep import (
+        LANG_GROUP_TO_KEY,
+        load_dataset_rows,
+        load_full_contexts,
+        run_cell,
+        scenario_for,
+        slug,
+    )
+    from codeminer.eval.agent_runner.symbols import build_prebuilt_symbol_span_index
+    from codeminer.eval.retrieval_eval import collect_target_blocks, collect_targets
     from codeminer.llm.litellm_chat import LiteLLMChat
 
     _validate_harness(cfg)
@@ -227,60 +217,18 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                     skills=skills,
                     preload_spec=(cfg.preload or {}).get(subset_id),
                 )
-                metrics = score_agent_localization(
+                evaluation = evaluate_agent_localization(
                     answer=out["answer"],
                     file_read_paths=out["file_read_paths"],
                     nodes=out["nodes"],
                     target_files=target_files,
                     target_symbols=target_symbols,
-                    ks=cfg.metrics_k,
+                    gt_blocks=gt_blocks,
+                    metrics_k=cfg.metrics_k,
                     repo_path=repo_path,
-                )
-                # Line-span localization (overlap-based) — robust to the
-                # symbol-name string-match artifact. ``answer`` = the agent's
-                # deliverable (its ``Locations:`` ranges + ``Symbols:`` resolved
-                # via the graph); ``retrieval`` = the retriever's ranked spans
-                # (the RAG-comparable alignment axis). Neither bounds the other.
-                answer_spans = parse_answer_spans(
-                    out["answer"], repo_path
-                ) + resolve_symbol_spans(out["answer"], symbol_span_index, repo_path)
-                retrieval_spans = nodes_to_spans(out["nodes"])
-                metrics.update(
-                    score_localization_spans(
-                        answer_spans=answer_spans,
-                        retrieval_spans=retrieval_spans,
-                        gt_blocks=gt_blocks,
-                        ks=cfg.metrics_k,
-                    )
-                )
-                # Pre-load contribution: fraction of the agent's committed answer
-                # spans that overlap an injected candidate (vs found by grep).
-                # Distinguishes "pre-load helped" from "ignored, grep did it".
-                preload_candidates = out.get("preload_candidates") or []
-                ans_dedup = dedup_spans(answer_spans)
-                preload_contribution = (
-                    sum(
-                        1
-                        for a in ans_dedup
-                        if any(spans_overlap(a, c) for c in preload_candidates)
-                    )
-                    / len(ans_dedup)
-                    if (ans_dedup and preload_candidates)
-                    else None
-                )
-                # Honesty flag: the agent ran fine but never produced a parseable
-                # localization (no Files:/Symbols:/Locations: contract AND no
-                # resolvable span), even after the force-schema retries. Such a
-                # cell scores 0 NOT because the localization was wrong but because
-                # the answer was unformattable — a known LLM weakness, worst on
-                # small models. Flag it so the aggregator can report localization
-                # accuracy separately from format-failure rate instead of
-                # silently burying these as misses.
-                from codeminer.agent.runner import _has_localization_contract
-
-                format_failed = (
-                    not _has_localization_contract(out["answer"] or "")
-                    and not answer_spans
+                    symbol_span_index=symbol_span_index,
+                    preload_candidates=out.get("preload_candidates") or [],
+                    metrics_meaningful=gt_meaningful,
                 )
                 record = {
                     "cell_id": cell_id,
@@ -292,16 +240,8 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                     "scenario": scenario,
                     "language": language_key,
                     "success": True,
-                    "format_failed": format_failed,
-                    "metrics": metrics,
-                    "metrics_meaningful": gt_meaningful,
-                    "target_files": target_files,
-                    "target_symbols": target_symbols,
-                    "gt_code_blocks": gt_blocks,
-                    "answer_spans": answer_spans,
-                    "retrieval_spans": retrieval_spans,
-                    "preload_candidates": preload_candidates,
-                    "preload_contribution": preload_contribution,
+                    **evaluation.to_record_fields(),
+                    "preload_candidates": out.get("preload_candidates") or [],
                     "tool_calls": out["tool_calls"],
                     "file_read_paths": out["file_read_paths"],
                     "file_reads": out.get("file_reads", []),
@@ -322,7 +262,7 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                 print(
                     f"sweep:   done {cell_id} in {time.time() - t:.1f}s "
                     f"turns={out['total_turns']} tokens={out['total_tokens']} "
-                    f"files@5={metrics.get('files', {}).get(5, {}).get('accuracy')}"
+                    f"files@5={evaluation.metrics.get('files', {}).get(5, {}).get('accuracy')}"
                 )
             except Exception as exc:  # noqa: BLE001
                 traceback.print_exc()
@@ -385,6 +325,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "--vertex-location", default=None, help="Override config vertex_location."
     )
     args = parser.parse_args(argv)
+
+    from codeminer.eval.agent_runner.sweep_config import SweepConfig
 
     cfg = SweepConfig.from_yaml(args.config)
     if args.reps is not None:

--- a/scripts/agent_compile/run_synthesis_sweep.py
+++ b/scripts/agent_compile/run_synthesis_sweep.py
@@ -37,26 +37,14 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
-from codeminer.eval.agent_runner.prebuilt import (  # noqa: E402
-    has_full_indexes,
-    repo_path_for,
-    stage_prebuilt_indexes,
-)
-from codeminer.eval.agent_runner.sweep import (  # noqa: E402
-    load_full_contexts,
-    run_cell,
-    slug,
-)
-from codeminer.eval.agent_runner.sweep_config import SweepConfig  # noqa: E402
-from codeminer.eval.agent_runner.symbols import (  # noqa: E402
-    build_prebuilt_symbol_span_index,
-)
+if TYPE_CHECKING:
+    from codeminer.eval.agent_runner.sweep_config import SweepConfig
 
 # language_group / config -> SessionContext primary_language key.
 _LANG_KEY = {
@@ -103,17 +91,16 @@ def run(
     max_queries: Optional[int],
     resume: bool,
 ) -> Dict:
-    from codeminer.eval.agent_runner.verify_expand import load_graph_nav
-    from codeminer.eval.retrieval_eval import (
-        collect_target_blocks,
-        dedup_spans,
-        nodes_to_spans,
-        parse_answer_spans,
-        resolve_symbol_spans,
-        score_agent_localization,
-        score_localization_spans,
-        spans_overlap,
+    from codeminer.eval.agent_runner.prebuilt import (
+        has_full_indexes,
+        repo_path_for,
+        stage_prebuilt_indexes,
     )
+    from codeminer.eval.agent_runner.scoring import evaluate_agent_localization
+    from codeminer.eval.agent_runner.sweep import load_full_contexts, run_cell, slug
+    from codeminer.eval.agent_runner.symbols import build_prebuilt_symbol_span_index
+    from codeminer.eval.agent_runner.verify_expand import load_graph_nav
+    from codeminer.eval.retrieval_eval import collect_target_blocks
     from codeminer.llm.litellm_chat import LiteLLMChat
 
     needs_verify = any((r or {}).get("verify") for r in (cfg.preload or {}).values())
@@ -209,46 +196,18 @@ def run(
                         ),
                         nav=nav,
                     )
-                    metrics = score_agent_localization(
+                    evaluation = evaluate_agent_localization(
                         answer=out["answer"],
                         file_read_paths=out["file_read_paths"],
                         nodes=out["nodes"],
                         target_files=target_files,
                         target_symbols=target_symbols,
-                        ks=cfg.metrics_k,
+                        gt_blocks=gt_blocks,
+                        metrics_k=cfg.metrics_k,
                         repo_path=repo_path,
-                    )
-                    answer_spans = parse_answer_spans(
-                        out["answer"], repo_path
-                    ) + resolve_symbol_spans(
-                        out["answer"], symbol_span_index, repo_path
-                    )
-                    retrieval_spans = nodes_to_spans(out["nodes"])
-                    metrics.update(
-                        score_localization_spans(
-                            answer_spans=answer_spans,
-                            retrieval_spans=retrieval_spans,
-                            gt_blocks=gt_blocks,
-                            ks=cfg.metrics_k,
-                        )
-                    )
-                    preload_candidates = out.get("preload_candidates") or []
-                    ans_dedup = dedup_spans(answer_spans)
-                    preload_contribution = (
-                        sum(
-                            1
-                            for a in ans_dedup
-                            if any(spans_overlap(a, c) for c in preload_candidates)
-                        )
-                        / len(ans_dedup)
-                        if (ans_dedup and preload_candidates)
-                        else None
-                    )
-                    from codeminer.agent.runner import _has_localization_contract
-
-                    format_failed = (
-                        not _has_localization_contract(out["answer"] or "")
-                        and not answer_spans
+                        symbol_span_index=symbol_span_index,
+                        preload_candidates=out.get("preload_candidates") or [],
+                        metrics_meaningful=bool(target_files or gt_blocks),
                     )
                     record = {
                         "cell_id": cid,
@@ -263,17 +222,9 @@ def run(
                         "rep": rep,
                         "language": _LANG_KEY.get(config_name, "python"),
                         "success": True,
-                        "format_failed": format_failed,
-                        "metrics": metrics,
-                        "metrics_meaningful": bool(target_files or gt_blocks),
+                        **evaluation.to_record_fields(),
                         "query": row["query"],
-                        "target_files": target_files,
-                        "target_symbols": target_symbols,
-                        "gt_code_blocks": gt_blocks,
-                        "answer_spans": answer_spans,
-                        "retrieval_spans": retrieval_spans,
-                        "preload_candidates": preload_candidates,
-                        "preload_contribution": preload_contribution,
+                        "preload_candidates": out.get("preload_candidates") or [],
                         "verify_triggered": out.get("verify_triggered"),
                         "verify_resolved": out.get("verify_resolved"),
                         "tool_calls": out["tool_calls"],
@@ -287,7 +238,11 @@ def run(
                         "error": None,
                     }
                     summary["completed"].append(cid)
-                    ar = metrics.get("answer_blocks", {}).get(5, {}).get("recall")
+                    ar = (
+                        evaluation.metrics.get("answer_blocks", {})
+                        .get(5, {})
+                        .get("recall")
+                    )
                     print(
                         f"synth:   done {cid} [{row.get('category')}] "
                         f"in {time.time() - t:.1f}s turns={out['total_turns']} "
@@ -357,6 +312,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         help="Override config model (e.g. a local openai/ vLLM model).",
     )
     args = p.parse_args(argv)
+
+    from codeminer.eval.agent_runner.sweep_config import SweepConfig
 
     cfg = SweepConfig.from_yaml(args.config)
     if args.reps is not None:

--- a/test/eval/test_agent_scoring.py
+++ b/test/eval/test_agent_scoring.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shared agent-runner scoring helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from codeminer.eval.agent_runner.scoring import evaluate_agent_localization
+
+
+def _node(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def test_evaluate_agent_localization_scores_answer_and_retrieval_spans():
+    evaluation = evaluate_agent_localization(
+        answer=(
+            "Files: src/foo.py\n"
+            "Symbols: src/foo.py:target()\n"
+            "Locations: src/foo.py:10-12"
+        ),
+        file_read_paths=[],
+        nodes=[
+            _node(
+                node_id="src/foo.py:target()",
+                file="/tmp/repo/src/foo.py",
+                node_name="target",
+                start_line=9,
+                end_line=12,
+                score=0.9,
+            )
+        ],
+        target_files=["src/foo.py"],
+        target_symbols=["src/foo.py:target()"],
+        gt_blocks=[
+            {
+                "file": "src/foo.py",
+                "start": 10,
+                "end": 12,
+                "source": "gt",
+            }
+        ],
+        metrics_k=[1],
+        repo_path="/tmp/repo",
+        symbol_span_index={("src/foo.py", "target"): (10, 12)},
+        preload_candidates=[
+            {"file": "src/foo.py", "start": 10, "end": 12, "source": "preload"}
+        ],
+    )
+
+    assert evaluation.metrics["files"][1]["accuracy"] == 1.0
+    assert evaluation.metrics["symbols"][1]["accuracy"] == 1.0
+    assert evaluation.metrics["answer_blocks"][1]["recall"] == 1.0
+    assert evaluation.metrics["retrieval_blocks"][1]["recall"] == 1.0
+    assert evaluation.preload_contribution == 1.0
+    assert not evaluation.format_failed
+    assert evaluation.to_record_fields()["target_files"] == ["src/foo.py"]
+
+
+def test_evaluate_agent_localization_flags_unformatted_answer_without_spans():
+    evaluation = evaluate_agent_localization(
+        answer="The relevant code is probably in foo.",
+        file_read_paths=[],
+        nodes=[],
+        target_files=[],
+        target_symbols=[],
+        gt_blocks=[],
+        metrics_k=[1],
+        repo_path="",
+    )
+
+    assert evaluation.format_failed
+    assert not evaluation.metrics_meaningful
+    assert evaluation.preload_contribution is None
+
+
+def test_evaluate_agent_localization_allows_meaningful_override():
+    evaluation = evaluate_agent_localization(
+        answer="Files: src/foo.py\nSymbols:\nLocations:",
+        file_read_paths=[],
+        nodes=[],
+        target_files=[],
+        target_symbols=[],
+        gt_blocks=[],
+        metrics_k=[1],
+        repo_path="",
+        metrics_meaningful=True,
+    )
+
+    assert evaluation.metrics_meaningful
+    assert not evaluation.format_failed


### PR DESCRIPTION
## Summary
Moves shared agent-localization cell scoring out of the experiment scripts and into the reusable eval package.

## Changes
- Add `codeminer.eval.agent_runner.scoring` for file/symbol metrics, span metrics, format failure classification, and pre-load contribution fields.
- Update `run_sweep.py` and `run_synthesis_sweep.py` to call the shared scoring helper instead of duplicating scorer logic.
- Delay heavy CodeMiner imports in both sweep CLIs so `--help` stays lightweight and does not initialize vector/retrieval dependencies.
- Expose `has_localization_contract` as a public runner contract while keeping the existing private wrapper for internal callers.
- Document where base scoring and sweep cell scoring live, and add focused unit tests.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/eval/test_agent_scoring.py -q`

`pytest test/agent/test_import_boundaries.py test/eval/test_agent_scoring.py -q`

`pytest test/agent/test_runner.py test/eval/test_agent_scoring.py -q`

`python scripts/agent_compile/run_sweep.py --help`

`python scripts/agent_compile/run_synthesis_sweep.py --help`

`python -m compileall -q codeminer/agent codeminer/eval/agent_runner scripts/agent_compile/run_sweep.py scripts/agent_compile/run_synthesis_sweep.py`

`pre-commit run --files codeminer/agent/__init__.py codeminer/agent/runner.py codeminer/eval/agent_runner/__init__.py codeminer/eval/agent_runner/scoring.py scripts/agent_compile/README.md scripts/agent_compile/run_sweep.py scripts/agent_compile/run_synthesis_sweep.py test/eval/test_agent_scoring.py`

`git diff --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
