### PR TITLE
refactor(agent): make localization formatting opt-in

### DIFF
--- a/codeminer/agent/harness.py
+++ b/codeminer/agent/harness.py
@@ -111,7 +111,7 @@ class AgentHarnessSpec:
     system_prompt: Optional[str] = None
     first_turn_tool_choice: Optional[str] = None
     force_first_turn_only: bool = False
-    force_localization_contract: bool = True
+    force_localization_contract: bool = False
     compact_after_read: bool = False
     compact_keep_reads: int = 0
 

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -164,7 +164,7 @@ class AgentRunner:
         include_default_tools: bool = True,
         default_tool_ids: Optional[Set[str]] = None,
         retry: Optional[RetryConfig] = None,
-        force_localization_contract: bool = True,
+        force_localization_contract: bool = False,
         first_turn_tool_choice: Optional[str] = None,
         force_first_turn_only: bool = False,
         compact_after_read: bool = False,

--- a/codeminer/eval/agent_runner/sweep.py
+++ b/codeminer/eval/agent_runner/sweep.py
@@ -216,6 +216,7 @@ def run_cell(
         ),
         system_prompt=cfg.system_prompt,
         first_turn_tool_choice=getattr(cfg, "first_turn_tool_choice", None) or None,
+        force_localization_contract=cfg.force_localization_contract,
         compact_after_read=(mode == "eager_compact"),
         compact_keep_reads=(_keep_reads if mode == "eager_compact" else 0),
     )

--- a/codeminer/eval/agent_runner/sweep_config.py
+++ b/codeminer/eval/agent_runner/sweep_config.py
@@ -76,6 +76,11 @@ class SweepConfig:
     # answer one-shot under the default "auto" and never exercise the loop; this
     # makes them actually grep/read. None = leave "auto".
     first_turn_tool_choice: Optional[str] = None
+    # AgentRunner does not force localization formatting by default. This eval
+    # config explicitly opts into the localization answer contract so historical
+    # sweep cells stay comparable while production/default runners remain
+    # benchmark-agnostic.
+    force_localization_contract: bool = True
     # Provider-specific raw-call body for the lightweight eager_gated classifier.
     # Keep quirks in config files instead of branching on model names in code.
     gate_llm_extra_body: Optional[Dict[str, Any]] = None

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -103,6 +103,18 @@ Current operating order:
 
 Any proposed optimization that cannot pass this order stays experiment-only.
 
+### Current Boundary Decisions
+
+- Localization answer-contract forcing is an opt-in harness policy, not a core
+  runtime default. `AgentRunner` and `AgentHarnessSpec` default to no forced
+  schema turn; `SweepConfig` opts in explicitly so localization evaluations stay
+  comparable while non-benchmark agent use is not shaped by scorer formatting.
+- Sweep cell scoring lives in `codeminer.eval.agent_runner.scoring`. Scripts
+  may write the resulting fields to JSON, but they should not reimplement
+  format failure, span metrics, or pre-load contribution logic.
+- Small feedback slices must be selected by deterministic smoke plus rotated
+  holdout plans, not by hand-picking named project instances.
+
 ### M0: Freeze And Audit #271
 
 Objective: preserve #271 as a spike and classify its contents before extracting

--- a/test/agent/test_harness_spec.py
+++ b/test/agent/test_harness_spec.py
@@ -50,6 +50,13 @@ def test_harness_spec_preserves_empty_allow_set_for_runner_warning():
     assert spec.to_runner_kwargs()["allow_skills"] == set()
 
 
+def test_harness_spec_does_not_force_localization_contract_by_default():
+    spec = AgentHarnessSpec()
+
+    assert not spec.force_localization_contract
+    assert not spec.to_runner_kwargs()["force_localization_contract"]
+
+
 def test_runner_kwargs_are_copied_from_immutable_spec():
     spec = AgentHarnessSpec(
         allow_skills=["bm25_search"],

--- a/test/agent/test_runner.py
+++ b/test/agent/test_runner.py
@@ -142,13 +142,33 @@ class TestAgentRunner:
             ),
         ]
 
-        runner = AgentRunner(llm, echo_registry)
+        runner = AgentRunner(
+            llm,
+            echo_registry,
+            force_localization_contract=True,
+        )
         result = runner.run("Echo hello")
 
         assert result.total_turns == 2
         assert result.answer.endswith("Locations: src/a.py:10-20")
         assert llm._call_raw.call_count == 3
         assert llm._call_raw.call_args.kwargs.get("tool_choice") == "none"
+
+    def test_partial_contract_answer_is_not_forced_by_default(self, echo_registry):
+        """Generic runner defaults do not repair localization formatting."""
+        llm = _make_llm()
+        tc = _make_tool_call("call_1", "echo", '{"text": "hello"}')
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(content="Files: src/a.py"),
+        ]
+
+        runner = AgentRunner(llm, echo_registry)
+        result = runner.run("Echo hello")
+
+        assert result.total_turns == 2
+        assert result.answer == "Files: src/a.py"
+        assert llm._call_raw.call_count == 2
 
     def test_multiple_tool_calls_in_one_response(self, echo_registry):
         """LLM returns multiple tool calls in a single response."""
@@ -197,7 +217,12 @@ class TestAgentRunner:
             _make_response(content="Best-effort summary."),
         ]
 
-        runner = AgentRunner(llm, echo_registry, max_turns=3)
+        runner = AgentRunner(
+            llm,
+            echo_registry,
+            max_turns=3,
+            force_localization_contract=True,
+        )
         result = runner.run("loop forever")
 
         assert result.total_turns == 3

--- a/test/agent/test_runner_usage.py
+++ b/test/agent/test_runner_usage.py
@@ -371,7 +371,12 @@ class TestAgentRunnerUsage:
 
         llm._call_raw.side_effect = _call_raw
 
-        runner = AgentRunner(llm, echo_registry, max_turns=2)
+        runner = AgentRunner(
+            llm,
+            echo_registry,
+            max_turns=2,
+            force_localization_contract=True,
+        )
         result = runner.run("loop forever")
 
         # Budget exhausted with no prose → the runner makes one forced

--- a/test/agent_compile/test_config.py
+++ b/test/agent_compile/test_config.py
@@ -36,6 +36,26 @@ gate_llm_extra_body:
     assert cfg.gate_llm_extra_body == {
         "chat_template_kwargs": {"enable_thinking": False}
     }
+    assert cfg.force_localization_contract
+
+
+def test_sweep_config_can_disable_localization_contract_for_ablation(tmp_path):
+    config = tmp_path / "cfg.yaml"
+    config.write_text(
+        """
+sweep_id: no_contract
+model: test/model
+embedding_model: test/embedding
+subsets:
+  defaults_only: [read, grep]
+force_localization_contract: false
+""",
+        encoding="utf-8",
+    )
+
+    cfg = SweepConfig.from_yaml(config)
+
+    assert not cfg.force_localization_contract
 
 
 def test_eager_compact_recipes_pin_compact_keep_reads():


### PR DESCRIPTION
## Summary
Makes localization answer-format forcing an explicit evaluation harness policy instead of a generic runtime default.

## Changes
- Change `AgentRunner` and `AgentHarnessSpec` defaults so forced localization schema turns are off unless a harness opts in.
- Add `SweepConfig.force_localization_contract` with a default of `true`, preserving existing localization sweep behavior while making the eval opt-in explicit.
- Pass the sweep config flag through `run_cell` when constructing `AgentHarnessSpec`.
- Document the M6 boundary decision in the agent runner architecture goal.
- Update runner, harness, usage, and config tests to cover default-off runtime behavior and explicit eval opt-in.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/agent/test_runner.py test/agent/test_harness_spec.py test/agent_compile/test_config.py -q`

`pytest test/agent/test_runner.py test/agent/test_harness_spec.py test/agent/test_runtime_trace.py test/agent/test_runner_usage.py test/agent/test_default_tools.py test/agent_compile/test_config.py -q`

`pytest test/agent/test_runner.py test/agent/test_harness_spec.py test/agent_compile/test_config.py test/agent/test_import_boundaries.py -q`

`python scripts/agent_compile/run_sweep.py --help`

`python -m compileall -q codeminer/agent codeminer/eval/agent_runner test/agent/test_runner.py test/agent/test_harness_spec.py test/agent/test_runner_usage.py test/agent_compile/test_config.py`

`pre-commit run --files codeminer/agent/harness.py codeminer/agent/runner.py codeminer/eval/agent_runner/sweep.py codeminer/eval/agent_runner/sweep_config.py docs/agent_runner_architecture_goal.md test/agent/test_harness_spec.py test/agent/test_runner.py test/agent/test_runner_usage.py test/agent_compile/test_config.py`

`git diff --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
