### PR TITLE
[codex] Add context ledger runtime contract

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -29,6 +29,7 @@ from .runtime import (
     AGENT_TRACE_SCHEMA_VERSION,
     AgentRunTrace,
     AgentTraceEvent,
+    ContextLedger,
     ContextLedgerEntry,
 )
 from .tool_schema import registry_to_tools, skill_to_tool_schema
@@ -42,6 +43,7 @@ __all__ = [
     "AGENT_TRACE_SCHEMA_VERSION",
     "AgentHarnessSpec",
     "CodeMinerAgentOptions",
+    "ContextLedger",
     "ContextLedgerEntry",
     "KeywordExtraction",
     "KeywordExtractor",

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -131,6 +131,7 @@ it and answer rather than exhaustively reading every candidate.
 
 # Maximum characters for a single tool result to avoid context blowup.
 _MAX_RESULT_CHARS = 16_000
+_CHARS_PER_TOKEN_ESTIMATE = 4
 
 
 class AgentRunner:
@@ -1090,8 +1091,25 @@ def _context_ledger_data(
         "summary": summary,
         "path": path,
         "tool_call_id": record.tool_call_id,
+        "provenance": {
+            "kind": "tool_result",
+            "tool": record.skill_id,
+            "tool_call_id": record.tool_call_id,
+        },
+        "freshness": "fresh",
+        "token_estimate": _estimate_context_tokens(serialized_result),
         "metadata": metadata,
     }
+
+
+def _estimate_context_tokens(text: str) -> int:
+    """Cheap token estimate for ledger accounting, matching history fallback."""
+
+    if not text:
+        return 0
+    return max(
+        1, (len(text) + _CHARS_PER_TOKEN_ESTIMATE - 1) // _CHARS_PER_TOKEN_ESTIMATE
+    )
 
 
 def _context_summary(

--- a/codeminer/agent/runtime/__init__.py
+++ b/codeminer/agent/runtime/__init__.py
@@ -4,15 +4,12 @@
 
 """Runtime support types for agent execution."""
 
-from .trace import (
-    AGENT_TRACE_SCHEMA_VERSION,
-    AgentRunTrace,
-    AgentTraceEvent,
-    ContextLedgerEntry,
-)
+from .context import ContextLedger, ContextLedgerEntry
+from .trace import AGENT_TRACE_SCHEMA_VERSION, AgentRunTrace, AgentTraceEvent
 
 __all__ = [
     "AGENT_TRACE_SCHEMA_VERSION",
+    "ContextLedger",
     "AgentRunTrace",
     "AgentTraceEvent",
     "ContextLedgerEntry",

--- a/codeminer/agent/runtime/context.py
+++ b/codeminer/agent/runtime/context.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Context ledger contract for agent runtime observability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Sequence
+
+
+@dataclass
+class ContextLedgerEntry:
+    """Bounded summary of context produced, retained, or consumed by a run."""
+
+    source: str
+    state: str
+    turn: int
+    summary: str = ""
+    path: str | None = None
+    tool_call_id: str | None = None
+    entry_id: str | None = None
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    freshness: str | None = None
+    token_estimate: int | None = None
+    cost_estimate: float | None = None
+    consumed_by: List[str] = field(default_factory=list)
+    consumed_turn: int | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.turn < 0:
+            raise ValueError("turn must be non-negative")
+        if self.consumed_turn is not None and self.consumed_turn < 0:
+            raise ValueError("consumed_turn must be non-negative when set")
+        if self.token_estimate is not None and self.token_estimate < 0:
+            raise ValueError("token_estimate must be non-negative when set")
+        if self.cost_estimate is not None and self.cost_estimate < 0:
+            raise ValueError("cost_estimate must be non-negative when set")
+        self.provenance = dict(self.provenance or {})
+        self.metadata = dict(self.metadata or {})
+        self.consumed_by = list(self.consumed_by or [])
+
+    def mark_consumed(self, *, turn: int, consumer: str) -> None:
+        """Record that this context entry was consumed by a later runtime step."""
+
+        if turn < 0:
+            raise ValueError("turn must be non-negative")
+        self.state = "consumed"
+        self.consumed_turn = turn
+        if consumer and consumer not in self.consumed_by:
+            self.consumed_by.append(consumer)
+
+    def mark_expired(self, *, turn: int, reason: str | None = None) -> None:
+        """Record that this context entry left the active working set."""
+
+        if turn < 0:
+            raise ValueError("turn must be non-negative")
+        self.state = "expired"
+        self.consumed_turn = turn
+        if reason:
+            self.metadata["expiration_reason"] = reason
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "source": self.source,
+            "state": self.state,
+            "turn": self.turn,
+            "summary": self.summary,
+            "metadata": dict(self.metadata),
+        }
+        if self.path is not None:
+            payload["path"] = self.path
+        if self.tool_call_id is not None:
+            payload["tool_call_id"] = self.tool_call_id
+        if self.entry_id is not None:
+            payload["entry_id"] = self.entry_id
+        if self.provenance:
+            payload["provenance"] = dict(self.provenance)
+        if self.freshness is not None:
+            payload["freshness"] = self.freshness
+        if self.token_estimate is not None:
+            payload["token_estimate"] = self.token_estimate
+        if self.cost_estimate is not None:
+            payload["cost_estimate"] = self.cost_estimate
+        if self.consumed_by:
+            payload["consumed_by"] = list(self.consumed_by)
+        if self.consumed_turn is not None:
+            payload["consumed_turn"] = self.consumed_turn
+        return payload
+
+
+class ContextLedger:
+    """Append-only collection of context ledger entries for one agent run."""
+
+    def __init__(self, entries: Sequence[ContextLedgerEntry] | None = None) -> None:
+        self._entries: List[ContextLedgerEntry] = list(entries or [])
+
+    def __iter__(self) -> Iterator[ContextLedgerEntry]:
+        return iter(self._entries)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __getitem__(self, index: int) -> ContextLedgerEntry:
+        return self._entries[index]
+
+    @property
+    def entries(self) -> tuple[ContextLedgerEntry, ...]:
+        return tuple(self._entries)
+
+    def add(
+        self,
+        source: str,
+        state: str,
+        turn: int,
+        *,
+        summary: str = "",
+        path: str | None = None,
+        tool_call_id: str | None = None,
+        entry_id: str | None = None,
+        provenance: Dict[str, Any] | None = None,
+        freshness: str | None = None,
+        token_estimate: int | None = None,
+        cost_estimate: float | None = None,
+        consumed_by: Sequence[str] | None = None,
+        consumed_turn: int | None = None,
+        metadata: Dict[str, Any] | None = None,
+    ) -> ContextLedgerEntry:
+        entry = ContextLedgerEntry(
+            source=source,
+            state=state,
+            turn=turn,
+            summary=summary,
+            path=path,
+            tool_call_id=tool_call_id,
+            entry_id=entry_id or f"context_{len(self._entries) + 1}",
+            provenance=dict(provenance or {}),
+            freshness=freshness,
+            token_estimate=token_estimate,
+            cost_estimate=cost_estimate,
+            consumed_by=list(consumed_by or []),
+            consumed_turn=consumed_turn,
+            metadata=dict(metadata or {}),
+        )
+        self._entries.append(entry)
+        return entry
+
+    def by_state(self, state: str) -> List[ContextLedgerEntry]:
+        return [entry for entry in self._entries if entry.state == state]
+
+    def find(self, entry_id: str) -> ContextLedgerEntry | None:
+        for entry in self._entries:
+            if entry.entry_id == entry_id:
+                return entry
+        return None
+
+    def mark_consumed(
+        self,
+        entry_id: str,
+        *,
+        turn: int,
+        consumer: str,
+    ) -> ContextLedgerEntry:
+        entry = self.find(entry_id)
+        if entry is None:
+            raise KeyError(f"Unknown context ledger entry: {entry_id}")
+        entry.mark_consumed(turn=turn, consumer=consumer)
+        return entry
+
+    def mark_expired(
+        self,
+        entry_id: str,
+        *,
+        turn: int,
+        reason: str | None = None,
+    ) -> ContextLedgerEntry:
+        entry = self.find(entry_id)
+        if entry is None:
+            raise KeyError(f"Unknown context ledger entry: {entry_id}")
+        entry.mark_expired(turn=turn, reason=reason)
+        return entry
+
+    def to_list(self) -> List[Dict[str, Any]]:
+        return [entry.to_dict() for entry in self._entries]
+
+
+__all__ = ["ContextLedger", "ContextLedgerEntry"]

--- a/codeminer/agent/runtime/trace.py
+++ b/codeminer/agent/runtime/trace.py
@@ -2,14 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Stable trace and context-ledger schema for agent runtime observability."""
+"""Stable trace schema for agent runtime observability."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
-AGENT_TRACE_SCHEMA_VERSION = 2
+from .context import ContextLedger, ContextLedgerEntry
+
+AGENT_TRACE_SCHEMA_VERSION = 3
 
 
 @dataclass
@@ -34,38 +36,11 @@ class AgentTraceEvent:
 
 
 @dataclass
-class ContextLedgerEntry:
-    """Bounded summary of context produced or consumed during a run."""
-
-    source: str
-    state: str
-    turn: int
-    summary: str = ""
-    path: str | None = None
-    tool_call_id: str | None = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
-
-    def to_dict(self) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {
-            "source": self.source,
-            "state": self.state,
-            "turn": self.turn,
-            "summary": self.summary,
-            "metadata": dict(self.metadata),
-        }
-        if self.path is not None:
-            payload["path"] = self.path
-        if self.tool_call_id is not None:
-            payload["tool_call_id"] = self.tool_call_id
-        return payload
-
-
-@dataclass
 class AgentRunTrace:
     """Durable event log for one ``AgentRunner.run()`` invocation."""
 
     events: List[AgentTraceEvent] = field(default_factory=list)
-    context: List[ContextLedgerEntry] = field(default_factory=list)
+    context: ContextLedger = field(default_factory=ContextLedger)
 
     def add(self, kind: str, turn: int, **data: Any) -> AgentTraceEvent:
         event = AgentTraceEvent(kind=kind, turn=turn, data=dict(data))
@@ -81,23 +56,35 @@ class AgentRunTrace:
         summary: str = "",
         path: str | None = None,
         tool_call_id: str | None = None,
+        entry_id: str | None = None,
+        provenance: Dict[str, Any] | None = None,
+        freshness: str | None = None,
+        token_estimate: int | None = None,
+        cost_estimate: float | None = None,
+        consumed_by: List[str] | None = None,
+        consumed_turn: int | None = None,
         metadata: Dict[str, Any] | None = None,
     ) -> ContextLedgerEntry:
-        entry = ContextLedgerEntry(
+        return self.context.add(
             source=source,
             state=state,
             turn=turn,
             summary=summary,
             path=path,
             tool_call_id=tool_call_id,
-            metadata=dict(metadata or {}),
+            entry_id=entry_id,
+            provenance=provenance,
+            freshness=freshness,
+            token_estimate=token_estimate,
+            cost_estimate=cost_estimate,
+            consumed_by=consumed_by,
+            consumed_turn=consumed_turn,
+            metadata=metadata,
         )
-        self.context.append(entry)
-        return entry
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "schema_version": AGENT_TRACE_SCHEMA_VERSION,
             "events": [event.to_dict() for event in self.events],
-            "context": [entry.to_dict() for entry in self.context],
+            "context": self.context.to_list(),
         }

--- a/test/agent/test_context_ledger.py
+++ b/test/agent/test_context_ledger.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Context ledger contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.agent.runtime import ContextLedger, ContextLedgerEntry
+
+
+def test_context_ledger_records_provenance_and_cost_fields():
+    ledger = ContextLedger()
+
+    entry = ledger.add(
+        "grep",
+        "offered",
+        1,
+        summary="grep returned 2 matches",
+        provenance={"kind": "tool_result", "tool": "grep"},
+        freshness="fresh",
+        token_estimate=42,
+        cost_estimate=0.001,
+        metadata={"result_count": 2},
+    )
+
+    assert entry.entry_id == "context_1"
+    assert ledger.entries == (entry,)
+    assert ledger.to_list() == [
+        {
+            "source": "grep",
+            "state": "offered",
+            "turn": 1,
+            "summary": "grep returned 2 matches",
+            "metadata": {"result_count": 2},
+            "entry_id": "context_1",
+            "provenance": {"kind": "tool_result", "tool": "grep"},
+            "freshness": "fresh",
+            "token_estimate": 42,
+            "cost_estimate": 0.001,
+        }
+    ]
+
+
+def test_context_ledger_tracks_consumed_and_expired_state():
+    ledger = ContextLedger()
+    first = ledger.add("read", "read", 1, entry_id="read_1")
+    second = ledger.add("runtime.compaction", "summarized", 2, entry_id="summary_1")
+
+    consumed = ledger.mark_consumed("read_1", turn=3, consumer="final_answer")
+    expired = ledger.mark_expired(
+        "summary_1",
+        turn=4,
+        reason="history_budget",
+    )
+
+    assert consumed is first
+    assert consumed.state == "consumed"
+    assert consumed.consumed_turn == 3
+    assert consumed.consumed_by == ["final_answer"]
+    assert ledger.by_state("consumed") == [first]
+
+    assert expired is second
+    assert expired.state == "expired"
+    assert expired.consumed_turn == 4
+    assert expired.metadata["expiration_reason"] == "history_budget"
+
+
+def test_context_ledger_validates_accounting_fields():
+    with pytest.raises(ValueError, match="turn"):
+        ContextLedgerEntry("tool", "offered", -1)
+
+    with pytest.raises(ValueError, match="token_estimate"):
+        ContextLedgerEntry("tool", "offered", 1, token_estimate=-1)
+
+    with pytest.raises(KeyError, match="Unknown context ledger entry"):
+        ContextLedger().mark_consumed("missing", turn=1, consumer="answer")

--- a/test/agent/test_runtime_trace.py
+++ b/test/agent/test_runtime_trace.py
@@ -118,6 +118,13 @@ def test_trace_summarizes_successful_tool_call():
     assert entry.tool_call_id == "call_1"
     assert entry.summary == "echo returned str (11 chars)"
     assert "echo: hello" not in entry.summary
+    assert entry.provenance == {
+        "kind": "tool_result",
+        "tool": "echo",
+        "tool_call_id": "call_1",
+    }
+    assert entry.freshness == "fresh"
+    assert entry.token_estimate == 3
     assert entry.metadata["arguments"] == {"text": "hello"}
 
 
@@ -154,6 +161,9 @@ def test_trace_records_default_read_events(tmp_path):
     assert entry.state == "read"
     assert entry.path == str(target)
     assert entry.summary.startswith(f"read {target}")
+    assert entry.provenance["kind"] == "tool_result"
+    assert entry.freshness == "fresh"
+    assert entry.token_estimate > 0
     assert entry.metadata["arguments"] == {
         "file_path": str(target),
         "offset": 1,


### PR DESCRIPTION
## Summary
Add a first-class runtime context ledger contract so agent traces can carry provenance, freshness, token estimates, cost estimates, and consumption state without moving evaluation or scorer policy into the runner.

## Changes
- Added codeminer.agent.runtime.ContextLedger and ContextLedgerEntry as the reusable context accounting API.
- Updated AgentRunTrace to own a ContextLedger while preserving iterable trace.context access and JSON serialization.
- Recorded tool-result provenance, freshness, and approximate token cost in runner context ledger entries.
- Exported ContextLedger from codeminer.agent and added focused ledger/runtime trace tests.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Local checks:
- pytest test/agent/test_context_ledger.py test/agent/test_runtime_trace.py test/agent/test_import_boundaries.py -q
- python -m compileall -q codeminer/agent test/agent/test_context_ledger.py test/agent/test_runtime_trace.py
- pre-commit run --files codeminer/agent/__init__.py codeminer/agent/runner.py codeminer/agent/runtime/__init__.py codeminer/agent/runtime/context.py codeminer/agent/runtime/trace.py test/agent/test_context_ledger.py test/agent/test_runtime_trace.py
- pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published