### PR TITLE
[codex] Summarize agent runtime traces

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -55,6 +55,7 @@ from .symbols import (
     build_symbol_span_index,
     symbol_leaf,
 )
+from .trace_summary import AgentTraceSummary, summarize_agent_trace
 from .verify_expand import (
     GraphNav,
     Verdict,
@@ -69,6 +70,7 @@ from .verify_expand import (
 __all__ = [
     "AgentLocalizationEvaluation",
     "AgentSkillContextSpec",
+    "AgentTraceSummary",
     "FormatArmSummary",
     "FormatDiagnostics",
     "FeedbackGroup",
@@ -119,6 +121,7 @@ __all__ = [
     "snippet_for_node",
     "slug",
     "summarize_agent_result",
+    "summarize_agent_trace",
     "summarize_format_cells",
     "symbol_leaf",
     "usable_cells",

--- a/codeminer/eval/agent_runner/results.py
+++ b/codeminer/eval/agent_runner/results.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Mapping
 
+from .trace_summary import summarize_agent_trace
+
 
 def summarize_agent_result(result: Any) -> Dict[str, Any]:
     """Return evaluation-friendly observations from an ``AgentResult``.
@@ -59,6 +61,7 @@ def summarize_agent_result(result: Any) -> Dict[str, Any]:
         "tool_calls": tool_calls,
         "file_read_paths": file_read_paths,
         "file_reads": file_reads,
+        "trace_summary": summarize_agent_trace(result).to_dict(),
         "answer": getattr(result, "answer", None) or "",
         "total_turns": getattr(result, "total_turns", None),
         "total_duration_ms": getattr(result, "total_duration_ms", None),

--- a/codeminer/eval/agent_runner/trace_summary.py
+++ b/codeminer/eval/agent_runner/trace_summary.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trace replay summaries for agent-runner evaluations."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class AgentTraceSummary:
+    """Evaluation-friendly summary of one agent runtime trace."""
+
+    schema_version: Optional[int]
+    event_count: int
+    max_turn: int
+    tool_call_count: int
+    tool_error_count: int
+    tools: Dict[str, int]
+    tool_errors: Dict[str, int]
+    read_count: int
+    read_paths: List[str]
+    context_entry_count: int
+    context_tokens_estimate: int
+    context_by_state: Dict[str, int]
+    context_sources: Dict[str, int]
+    compaction_count: int
+    max_turns_exhausted: bool
+    forced_final_answer: bool
+    answer_contract_present: Optional[bool]
+    final_answer_source: Optional[str]
+    failure_categories: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "event_count": self.event_count,
+            "max_turn": self.max_turn,
+            "tool_call_count": self.tool_call_count,
+            "tool_error_count": self.tool_error_count,
+            "tools": dict(self.tools),
+            "tool_errors": dict(self.tool_errors),
+            "read_count": self.read_count,
+            "read_paths": list(self.read_paths),
+            "context_entry_count": self.context_entry_count,
+            "context_tokens_estimate": self.context_tokens_estimate,
+            "context_by_state": dict(self.context_by_state),
+            "context_sources": dict(self.context_sources),
+            "compaction_count": self.compaction_count,
+            "max_turns_exhausted": self.max_turns_exhausted,
+            "forced_final_answer": self.forced_final_answer,
+            "answer_contract_present": self.answer_contract_present,
+            "final_answer_source": self.final_answer_source,
+            "failure_categories": list(self.failure_categories),
+        }
+
+
+def summarize_agent_trace(trace_or_result: Any) -> AgentTraceSummary:
+    """Summarize runtime trace events without applying scorer normalization."""
+
+    trace = _extract_trace(trace_or_result)
+    schema_version = _schema_version(trace)
+    events = list(_iter_events(trace))
+    contexts = list(_iter_context_entries(trace))
+
+    tools: Counter[str] = Counter()
+    tool_errors: Counter[str] = Counter()
+    read_paths: List[str] = []
+    max_turn = 0
+    tool_call_count = 0
+    compaction_count = 0
+    max_turns_exhausted = False
+    forced_final_answer = False
+    answer_contract_present: Optional[bool] = None
+    final_answer_source: Optional[str] = None
+
+    for event in events:
+        kind = _event_kind(event)
+        turn = _event_turn(event)
+        if turn is not None:
+            max_turn = max(max_turn, turn)
+        data = _event_data(event)
+
+        if kind == "tool_call":
+            tool_call_count += 1
+            tool = str(data.get("tool") or "(unknown)")
+            tools[tool] += 1
+            if data.get("status") == "error":
+                tool_errors[tool] += 1
+        elif kind == "read" and data.get("status") == "ok":
+            path = data.get("path")
+            if path:
+                read_paths.append(str(path))
+        elif kind == "context_compacted":
+            compaction_count += 1
+        elif kind == "max_turns_exhausted":
+            max_turns_exhausted = True
+        elif kind == "final_answer_forced":
+            forced_final_answer = True
+        elif kind == "final_answer":
+            if "has_contract" in data:
+                answer_contract_present = bool(data.get("has_contract"))
+            final_answer_source = (
+                str(data["source"]) if data.get("source") is not None else None
+            )
+
+    context_by_state: Counter[str] = Counter()
+    context_sources: Counter[str] = Counter()
+    context_tokens_estimate = 0
+    for entry in contexts:
+        state = entry.get("state")
+        if state:
+            context_by_state[str(state)] += 1
+        source = entry.get("source")
+        if source:
+            context_sources[str(source)] += 1
+        token_estimate = entry.get("token_estimate")
+        if isinstance(token_estimate, int):
+            context_tokens_estimate += token_estimate
+
+    failure_categories: List[str] = []
+    if tool_errors:
+        failure_categories.append("tool_error")
+    if max_turns_exhausted:
+        failure_categories.append("turn_budget_exhausted")
+    if answer_contract_present is False:
+        failure_categories.append("answer_contract_missing")
+    if tool_call_count and not read_paths:
+        failure_categories.append("no_successful_read")
+
+    return AgentTraceSummary(
+        schema_version=schema_version,
+        event_count=len(events),
+        max_turn=max_turn,
+        tool_call_count=tool_call_count,
+        tool_error_count=sum(tool_errors.values()),
+        tools=_sorted_counts(tools),
+        tool_errors=_sorted_counts(tool_errors),
+        read_count=len(read_paths),
+        read_paths=list(dict.fromkeys(read_paths)),
+        context_entry_count=len(contexts),
+        context_tokens_estimate=context_tokens_estimate,
+        context_by_state=_sorted_counts(context_by_state),
+        context_sources=_sorted_counts(context_sources),
+        compaction_count=compaction_count,
+        max_turns_exhausted=max_turns_exhausted,
+        forced_final_answer=forced_final_answer,
+        answer_contract_present=answer_contract_present,
+        final_answer_source=final_answer_source,
+        failure_categories=failure_categories,
+    )
+
+
+def _extract_trace(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, Mapping) and ("events" in value or "context" in value):
+        return value
+    return getattr(value, "trace", value)
+
+
+def _schema_version(trace: Any) -> Optional[int]:
+    if trace is None:
+        return None
+    if isinstance(trace, Mapping):
+        raw = trace.get("schema_version")
+        return raw if isinstance(raw, int) else None
+    if hasattr(trace, "to_dict"):
+        raw = trace.to_dict().get("schema_version")
+        return raw if isinstance(raw, int) else None
+    return None
+
+
+def _iter_events(trace: Any) -> Iterable[Any]:
+    if trace is None:
+        return []
+    if isinstance(trace, Mapping):
+        events = trace.get("events")
+        return events if isinstance(events, list) else []
+    return list(getattr(trace, "events", []) or [])
+
+
+def _iter_context_entries(trace: Any) -> Iterable[Mapping[str, Any]]:
+    if trace is None:
+        return []
+    if isinstance(trace, Mapping):
+        entries = trace.get("context")
+    else:
+        entries = getattr(trace, "context", None)
+    if entries is None:
+        return []
+    return [_entry_to_mapping(entry) for entry in entries]
+
+
+def _entry_to_mapping(entry: Any) -> Mapping[str, Any]:
+    if isinstance(entry, Mapping):
+        return entry
+    if hasattr(entry, "to_dict"):
+        return entry.to_dict()
+    return {
+        "source": getattr(entry, "source", None),
+        "state": getattr(entry, "state", None),
+        "token_estimate": getattr(entry, "token_estimate", None),
+    }
+
+
+def _event_kind(event: Any) -> Optional[str]:
+    if isinstance(event, Mapping):
+        raw = event.get("kind")
+    else:
+        raw = getattr(event, "kind", None)
+    return str(raw) if raw is not None else None
+
+
+def _event_turn(event: Any) -> Optional[int]:
+    if isinstance(event, Mapping):
+        raw = event.get("turn")
+    else:
+        raw = getattr(event, "turn", None)
+    return raw if isinstance(raw, int) else None
+
+
+def _event_data(event: Any) -> Mapping[str, Any]:
+    if isinstance(event, Mapping):
+        data = event.get("data")
+    else:
+        data = getattr(event, "data", None)
+    return data if isinstance(data, Mapping) else {}
+
+
+def _sorted_counts(counter: Counter[str]) -> Dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+__all__ = ["AgentTraceSummary", "summarize_agent_trace"]

--- a/test/eval/test_agent_results.py
+++ b/test/eval/test_agent_results.py
@@ -55,6 +55,7 @@ def test_summarize_agent_result_collects_tool_and_read_observations():
     assert summary["total_turns"] == 3
     assert summary["total_duration_ms"] == 42.5
     assert summary["tool_call_count"] == 3
+    assert summary["trace_summary"]["event_count"] == 0
 
 
 def test_summarize_agent_result_handles_empty_or_partial_result_shape():
@@ -70,3 +71,4 @@ def test_summarize_agent_result_handles_empty_or_partial_result_shape():
     assert summary["file_read_paths"] == []
     assert summary["file_reads"] == []
     assert summary["tool_call_count"] == 0
+    assert summary["trace_summary"]["schema_version"] is None

--- a/test/eval/test_trace_summary.py
+++ b/test/eval/test_trace_summary.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for agent runtime trace summaries."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from codeminer.agent.runtime import AGENT_TRACE_SCHEMA_VERSION, AgentRunTrace
+from codeminer.eval.agent_runner.trace_summary import summarize_agent_trace
+
+
+def _trace_with_runtime_signals() -> AgentRunTrace:
+    trace = AgentRunTrace()
+    trace.add("run_start", 0)
+    trace.add(
+        "tool_call",
+        1,
+        tool="grep",
+        status="ok",
+    )
+    trace.add(
+        "tool_call",
+        2,
+        tool="read",
+        status="ok",
+    )
+    trace.add("read", 2, path="pkg/a.py", status="ok")
+    trace.add(
+        "tool_call",
+        3,
+        tool="embedding_search",
+        status="error",
+    )
+    trace.add("context_compacted", 3)
+    trace.add("final_answer_forced", 4)
+    trace.add("max_turns_exhausted", 4)
+    trace.add("final_answer", 4, source="forced_schema", has_contract=False)
+    trace.add_context(
+        "grep",
+        "offered",
+        1,
+        token_estimate=10,
+    )
+    trace.add_context(
+        "read",
+        "read",
+        2,
+        path="pkg/a.py",
+        token_estimate=20,
+    )
+    return trace
+
+
+def test_summarize_agent_trace_counts_runtime_signals():
+    summary = summarize_agent_trace(_trace_with_runtime_signals())
+
+    assert summary.schema_version == AGENT_TRACE_SCHEMA_VERSION
+    assert summary.event_count == 9
+    assert summary.max_turn == 4
+    assert summary.tool_call_count == 3
+    assert summary.tool_error_count == 1
+    assert summary.tools == {"embedding_search": 1, "grep": 1, "read": 1}
+    assert summary.tool_errors == {"embedding_search": 1}
+    assert summary.read_count == 1
+    assert summary.read_paths == ["pkg/a.py"]
+    assert summary.context_entry_count == 2
+    assert summary.context_tokens_estimate == 30
+    assert summary.context_by_state == {"offered": 1, "read": 1}
+    assert summary.context_sources == {"grep": 1, "read": 1}
+    assert summary.compaction_count == 1
+    assert summary.max_turns_exhausted is True
+    assert summary.forced_final_answer is True
+    assert summary.answer_contract_present is False
+    assert summary.final_answer_source == "forced_schema"
+    assert summary.failure_categories == [
+        "tool_error",
+        "turn_budget_exhausted",
+        "answer_contract_missing",
+    ]
+
+
+def test_summarize_agent_trace_accepts_result_or_dict_shapes():
+    trace = _trace_with_runtime_signals()
+
+    from_result = summarize_agent_trace(SimpleNamespace(trace=trace))
+    from_dict = summarize_agent_trace(trace.to_dict())
+
+    assert from_result.to_dict() == from_dict.to_dict()
+
+
+def test_summarize_agent_trace_handles_missing_trace():
+    summary = summarize_agent_trace(None)
+
+    assert summary.schema_version is None
+    assert summary.event_count == 0
+    assert summary.tool_call_count == 0
+    assert summary.failure_categories == []


### PR DESCRIPTION
## Summary
Add reusable eval-side trace summaries so agent-runner reports can explain tool use, context ledger state, budget exhaustion, forced finalization, and answer-contract signals without parsing provider logs or adding logic under scripts.

Originally stacked on #291. #291 has merged, and this PR is now based on main.

## Changes
- Added AgentTraceSummary and summarize_agent_trace under codeminer.eval.agent_runner.
- Summarizes tool counts, tool errors, read paths, context states/sources, context token estimates, compaction, turn-budget exhaustion, forced final answers, and trace-derived failure categories.
- Attached trace_summary to summarize_agent_result output so sweep cells can persist diagnostics through package APIs.
- Added tests for object traces, dict traces, result wrappers, missing traces, and result summary integration.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Local checks:
- pytest test/eval/test_trace_summary.py test/eval/test_agent_results.py test/agent/test_context_ledger.py test/agent/test_runtime_trace.py test/agent/test_import_boundaries.py -q
- python -m compileall -q codeminer/eval/agent_runner/trace_summary.py codeminer/eval/agent_runner/results.py codeminer/eval/agent_runner/__init__.py test/eval/test_trace_summary.py test/eval/test_agent_results.py
- pre-commit run --files codeminer/eval/agent_runner/__init__.py codeminer/eval/agent_runner/results.py codeminer/eval/agent_runner/trace_summary.py test/eval/test_agent_results.py test/eval/test_trace_summary.py
- git diff --check
- pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short
- pytest -m integration --tb=short

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published