### PR TITLE
[codex] Add baseline task envelope

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -4,6 +4,15 @@
 
 """Reusable evaluation helpers for agent-runner experiments."""
 
+from .baseline import (
+    BaselineLocation,
+    BaselineRunResult,
+    BaselineTask,
+    build_baseline_result_entry,
+    location_symbol_ids,
+    score_baseline_predictions,
+    unique_location_files,
+)
 from .contexts import (
     AgentSkillContextSpec,
     default_agent_skills_dir,
@@ -71,6 +80,9 @@ __all__ = [
     "AgentLocalizationEvaluation",
     "AgentSkillContextSpec",
     "AgentTraceSummary",
+    "BaselineLocation",
+    "BaselineRunResult",
+    "BaselineTask",
     "FormatArmSummary",
     "FormatDiagnostics",
     "FeedbackGroup",
@@ -91,6 +103,7 @@ __all__ = [
     "build_prebuilt_symbol_span_index",
     "build_symbol_span_index",
     "build_feedback_plan",
+    "build_baseline_result_entry",
     "candidate_location",
     "converge_query",
     "default_agent_skills_dir",
@@ -105,6 +118,7 @@ __all__ = [
     "load_dataset_rows",
     "load_format_diagnostics",
     "load_full_contexts",
+    "location_symbol_ids",
     "load_meaningful_cells",
     "load_pareto_cells",
     "metric_at_k",
@@ -117,6 +131,7 @@ __all__ = [
     "scatter_gather_localize",
     "safe_mean",
     "safe_min",
+    "score_baseline_predictions",
     "scenario_for",
     "snippet_for_node",
     "slug",
@@ -124,6 +139,7 @@ __all__ = [
     "summarize_agent_trace",
     "summarize_format_cells",
     "symbol_leaf",
+    "unique_location_files",
     "usable_cells",
     "verdict_is_yes",
     "verify_query",

--- a/codeminer/eval/agent_runner/baseline.py
+++ b/codeminer/eval/agent_runner/baseline.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared task and result contracts for agent-runner baselines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from codeminer.eval.retrieval_eval import compute_metrics, normalize_file_path
+
+
+@dataclass(frozen=True)
+class BaselineTask:
+    """One localization task handed to an internal or external agent."""
+
+    instance_id: str
+    query: str
+    repo_path: str
+    context: Mapping[str, Any] = field(default_factory=dict)
+    target_files: Tuple[str, ...] = ()
+    target_symbols: Tuple[str, ...] = ()
+    repo_name: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dataset_instance(
+        cls,
+        instance: Mapping[str, Any],
+        *,
+        repo_path: str,
+        target_files: Sequence[str] = (),
+        target_symbols: Sequence[str] = (),
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "BaselineTask":
+        instance_id = str(instance["instance_id"])
+        repo_name = str(instance.get("repo") or "")
+        query = str(instance.get("problem_statement") or "")
+        context: Dict[str, Any] = {
+            "issue_title": f"[{instance_id}] {repo_name}" if repo_name else instance_id,
+            "issue_body": query,
+        }
+        if instance.get("hints_text"):
+            context["hints"] = instance["hints_text"]
+        return cls(
+            instance_id=instance_id,
+            query=query,
+            repo_path=str(repo_path),
+            context=context,
+            target_files=tuple(target_files),
+            target_symbols=tuple(target_symbols),
+            repo_name=repo_name or None,
+            metadata=dict(metadata or {}),
+        )
+
+    def to_agent_call(self) -> Dict[str, Any]:
+        """Return the standard ``locate_code`` call payload for this task."""
+
+        return {
+            "query_text": self.query,
+            "repo_path": self.repo_path,
+            "context": dict(self.context),
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "instance_id": self.instance_id,
+            "query": self.query,
+            "repo_path": self.repo_path,
+            "context": dict(self.context),
+            "target_files": list(self.target_files),
+            "target_symbols": list(self.target_symbols),
+            "repo_name": self.repo_name,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class BaselineLocation:
+    """One location emitted by a baseline agent."""
+
+    name: str
+    type: str
+    file_path: str
+    line_start: Optional[int] = None
+    line_end: Optional[int] = None
+    action: Optional[str] = None
+    description: str = ""
+
+    @classmethod
+    def from_raw(cls, value: Any) -> "BaselineLocation":
+        return cls(
+            name=str(_field(value, "name") or ""),
+            type=str(_field(value, "type") or ""),
+            file_path=str(_field(value, "file_path") or ""),
+            line_start=_optional_int(_field(value, "line_start")),
+            line_end=_optional_int(_field(value, "line_end")),
+            action=_optional_str(_field(value, "action")),
+            description=str(_field(value, "description") or ""),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "type": self.type,
+            "file_path": self.file_path,
+            "line_start": self.line_start,
+            "line_end": self.line_end,
+            "action": self.action,
+            "description": self.description,
+        }
+
+    def symbol_id(self) -> Optional[str]:
+        if not self.name or not self.file_path:
+            return None
+        file_norm = normalize_file_path(self.file_path)
+        if not file_norm:
+            return None
+        return f"{file_norm}:{self.name}"
+
+
+@dataclass(frozen=True)
+class BaselineRunResult:
+    """Normalized result returned by an internal, external, or LSP baseline."""
+
+    success: bool
+    locations: Tuple[BaselineLocation, ...] = ()
+    usage: Optional[Mapping[str, Any]] = None
+    error_message: Optional[str] = None
+    repo_path: Optional[str] = None
+    raw_output: Any = None
+
+    @classmethod
+    def from_raw(
+        cls,
+        result: Any,
+        *,
+        error: Optional[str] = None,
+    ) -> "BaselineRunResult":
+        if error or result is None or not bool(getattr(result, "success", False)):
+            return cls(
+                success=False,
+                error_message=error
+                or (getattr(result, "error_message", None) if result else None)
+                or "no result",
+                repo_path=getattr(result, "repo_path", None) if result else None,
+                raw_output=result,
+            )
+
+        return cls(
+            success=True,
+            locations=tuple(
+                BaselineLocation.from_raw(item)
+                for item in (getattr(result, "locations", None) or [])
+            ),
+            usage=getattr(result, "usage", None),
+            repo_path=getattr(result, "repo_path", None),
+            raw_output=result,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "success": self.success,
+            "locations": [location.to_dict() for location in self.locations],
+            "usage": dict(self.usage) if isinstance(self.usage, Mapping) else None,
+            "error_message": self.error_message,
+            "repo_path": self.repo_path,
+        }
+
+
+def build_baseline_result_entry(
+    *,
+    task: BaselineTask,
+    agent_name: str,
+    model: Optional[str],
+    result: Any,
+    metrics_k: Sequence[int],
+    error: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build one JSON-ready baseline record with predictions and metrics."""
+
+    normalized = BaselineRunResult.from_raw(result, error=error)
+    base = {
+        "instance_id": task.instance_id,
+        "agent": agent_name,
+        "model": model,
+        "target_files": list(task.target_files),
+        "target_symbols": list(task.target_symbols),
+    }
+    if not normalized.success:
+        base.update(
+            {
+                "success": False,
+                "error": normalized.error_message or "no result",
+                "metric_k_files": [],
+                "metric_k_node_ids": [],
+                "locations": [],
+                "usage": None,
+                "metrics": None,
+            }
+        )
+        return base
+
+    predicted_files = unique_location_files(normalized.locations)
+    predicted_symbols = location_symbol_ids(normalized.locations)
+    metrics = score_baseline_predictions(
+        predicted_files,
+        predicted_symbols,
+        task.target_files,
+        task.target_symbols,
+        metrics_k,
+    )
+    base.update(
+        {
+            "success": True,
+            "metric_k_files": predicted_files,
+            "metric_k_node_ids": predicted_symbols,
+            "locations": [location.to_dict() for location in normalized.locations],
+            "usage": normalized.usage,
+            "metrics": metrics,
+            "error": None,
+        }
+    )
+    return base
+
+
+def unique_location_files(locations: Sequence[BaselineLocation]) -> List[str]:
+    """Return unique location file paths in prediction order."""
+
+    seen = set()
+    out: List[str] = []
+    for location in locations:
+        if location.file_path and location.file_path not in seen:
+            out.append(location.file_path)
+            seen.add(location.file_path)
+    return out
+
+
+def location_symbol_ids(locations: Sequence[BaselineLocation]) -> List[str]:
+    """Return ``file:symbol`` predictions in baseline output order."""
+
+    out: List[str] = []
+    for location in locations:
+        symbol_id = location.symbol_id()
+        if symbol_id is not None:
+            out.append(symbol_id)
+    return out
+
+
+def score_baseline_predictions(
+    predicted_files: Sequence[str],
+    predicted_symbols: Sequence[str],
+    target_files: Sequence[str],
+    target_symbols: Sequence[str],
+    ks: Sequence[int],
+) -> Dict[str, Dict[int, Dict[str, float]]]:
+    """Score baseline file and symbol predictions at each requested cutoff."""
+
+    metrics: Dict[str, Dict[int, Dict[str, float]]] = {"files": {}, "symbols": {}}
+    for k in ks:
+        metrics["files"][k] = compute_metrics(list(predicted_files[:k]), target_files)
+        metrics["symbols"][k] = compute_metrics(
+            list(predicted_symbols[:k]), target_symbols
+        )
+    return metrics
+
+
+def _field(value: Any, name: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return str(value)
+
+
+__all__ = [
+    "BaselineLocation",
+    "BaselineRunResult",
+    "BaselineTask",
+    "build_baseline_result_entry",
+    "location_symbol_ids",
+    "score_baseline_predictions",
+    "unique_location_files",
+]

--- a/codeminer/eval/loc_agent_runner.py
+++ b/codeminer/eval/loc_agent_runner.py
@@ -28,12 +28,18 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set
 from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
 from codeminer.dataset.locbench import LocbenchDataset
 from codeminer.dataset.swebench import SwebenchDataset
+from codeminer.eval.agent_runner.baseline import (
+    BaselineLocation,
+    BaselineTask,
+    build_baseline_result_entry,
+    location_symbol_ids,
+    score_baseline_predictions,
+    unique_location_files,
+)
 from codeminer.eval.retrieval_eval import (
     aggregate_metrics,
     average_metrics,
     collect_targets,
-    compute_metrics,
-    normalize_file_path,
 )
 from codeminer.log_utils import get_logger
 
@@ -91,13 +97,7 @@ def already_done_ids(result_path: Path) -> Set[str]:
 
 
 def _unique_files(locations) -> List[str]:
-    seen = set()
-    out: List[str] = []
-    for sym in locations:
-        if sym.file_path and sym.file_path not in seen:
-            out.append(sym.file_path)
-            seen.add(sym.file_path)
-    return out
+    return unique_location_files([BaselineLocation.from_raw(sym) for sym in locations])
 
 
 def _agent_symbol_id(file_path: str, name: str) -> Optional[str]:
@@ -116,20 +116,12 @@ def _agent_symbol_id(file_path: str, name: str) -> Optional[str]:
     """
     if not name or not file_path:
         return None
-    file_norm = normalize_file_path(file_path)
-    if not file_norm:
-        return None
-    return f"{file_norm}:{name}"
+    return BaselineLocation(name=name, type="", file_path=file_path).symbol_id()
 
 
 def _agent_symbol_ids(locations) -> List[str]:
     """Build the predicted symbol id list in agent-output order."""
-    out: List[str] = []
-    for sym in locations:
-        sid = _agent_symbol_id(sym.file_path, sym.name)
-        if sid is not None:
-            out.append(sid)
-    return out
+    return location_symbol_ids([BaselineLocation.from_raw(sym) for sym in locations])
 
 
 def _score_predictions(
@@ -140,13 +132,13 @@ def _score_predictions(
     ks: Sequence[int],
 ) -> Dict[str, Dict[int, Dict[str, float]]]:
     """``{files, symbols}`` × k metric dict via retrieval_eval.compute_metrics."""
-    metrics: Dict[str, Dict[int, Dict[str, float]]] = {"files": {}, "symbols": {}}
-    for k in ks:
-        metrics["files"][k] = compute_metrics(list(predicted_files[:k]), target_files)
-        metrics["symbols"][k] = compute_metrics(
-            list(predicted_symbols[:k]), target_symbols
-        )
-    return metrics
+    return score_baseline_predictions(
+        predicted_files,
+        predicted_symbols,
+        target_files,
+        target_symbols,
+        ks,
+    )
 
 
 def build_result_entry(
@@ -161,61 +153,21 @@ def build_result_entry(
     error: Optional[str] = None,
 ) -> Dict[str, Any]:
     """One JSONL record: predictions + GT + per-scope/per-k metrics."""
-    base = {
-        "instance_id": instance_id,
-        "agent": agent_name,
-        "model": model,
-        "target_files": list(target_files),
-        "target_symbols": list(target_symbols),
-    }
-    if error or result is None or not result.success:
-        base.update(
-            {
-                "success": False,
-                "error": error or (result.error_message if result else "no result"),
-                "metric_k_files": [],
-                "metric_k_node_ids": [],
-                "locations": [],
-                "usage": None,
-                "metrics": None,
-            }
-        )
-        return base
-
-    locations_payload = [
-        {
-            "name": sym.name,
-            "type": sym.type,
-            "file_path": sym.file_path,
-            "line_start": sym.line_start,
-            "line_end": sym.line_end,
-            "action": sym.action,
-            "description": sym.description,
-        }
-        for sym in result.locations
-    ]
-    predicted_files = _unique_files(result.locations)
-    predicted_symbols = _agent_symbol_ids(result.locations)
-    metrics = _score_predictions(
-        predicted_files,
-        predicted_symbols,
-        target_files,
-        target_symbols,
-        metrics_k,
+    task = BaselineTask(
+        instance_id=instance_id,
+        query="",
+        repo_path=str(getattr(result, "repo_path", "") or ""),
+        target_files=tuple(target_files),
+        target_symbols=tuple(target_symbols),
     )
-
-    base.update(
-        {
-            "success": True,
-            "metric_k_files": predicted_files,
-            "metric_k_node_ids": predicted_symbols,
-            "locations": locations_payload,
-            "usage": result.usage,
-            "metrics": metrics,
-            "error": None,
-        }
+    return build_baseline_result_entry(
+        task=task,
+        agent_name=agent_name,
+        model=model,
+        result=result,
+        metrics_k=metrics_k,
+        error=error,
     )
-    return base
 
 
 def _empty_aggregate(ks: Sequence[int]) -> Dict[str, Dict[int, Dict[str, float]]]:
@@ -327,25 +279,29 @@ async def run_agent_baseline(
                 )
 
             logger.info("[%d/%d] %s", i + 1, len(instances), instance_id)
+            task = BaselineTask(
+                instance_id=instance_id,
+                query=str(inst.get("problem_statement") or ""),
+                repo_path="",
+                target_files=tuple(target_files),
+                target_symbols=tuple(target_symbols),
+                repo_name=str(inst.get("repo") or "") or None,
+            )
             try:
                 dataset_obj.process_instance(inst)
                 repo = dataset_obj.get_repo_path(inst)
-                context = {
-                    "issue_title": f"[{instance_id}] {inst['repo']}",
-                    "issue_body": inst["problem_statement"],
-                }
-                if inst.get("hints_text"):
-                    context["hints"] = inst["hints_text"]
-                result = await agent.locate_code(
-                    inst["problem_statement"], repo, context=context
+                task = BaselineTask.from_dataset_instance(
+                    inst,
+                    repo_path=repo,
+                    target_files=target_files,
+                    target_symbols=target_symbols,
                 )
-                entry = build_result_entry(
-                    instance_id=instance_id,
+                result = await agent.locate_code(**task.to_agent_call())
+                entry = build_baseline_result_entry(
+                    task=task,
                     agent_name=agent_name,
                     model=model_label,
                     result=result,
-                    target_files=target_files,
-                    target_symbols=target_symbols,
                     metrics_k=metrics_k,
                 )
                 if entry["success"]:
@@ -354,13 +310,11 @@ async def run_agent_baseline(
                     n_failed += 1
             except Exception as e:  # noqa: BLE001 — record + continue
                 logger.exception("[%s] failed", instance_id)
-                entry = build_result_entry(
-                    instance_id=instance_id,
+                entry = build_baseline_result_entry(
+                    task=task,
                     agent_name=agent_name,
                     model=model_label,
                     result=None,
-                    target_files=target_files,
-                    target_symbols=target_symbols,
                     metrics_k=metrics_k,
                     error=str(e),
                 )

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -97,9 +97,9 @@ would catch regressions independent of a single scorer result.
 | M4: Deterministic feedback slices | Landed in #287 | Smoke plus seed-rotated holdout planning | A small run can be selected without hand-picking project names |
 | M5: Shared localization scoring | Landed in #288 | Answer/retrieval/preload scoring glue lives in eval package | Sweep scripts no longer duplicate scoring logic |
 | M6: Quarantine scorer-shaped runtime defaults | Landed in #289 | Localization schema forcing becomes opt-in harness policy | Production/default runners are not shaped by localization scorer formatting |
-| M7: Context ledger runtime contract | Next | First-class context items with provenance, token/cost accounting, freshness, and consumption state | Unit tests can explain why context was injected, used, skipped, or expired |
-| M8: Trace replay and diagnostics | Next | Eval package reconstructs tool use, context consumption, answer spans, and failure category from trace records | Reports diagnose behavior without provider logs or script-specific parsing |
-| M9: External-agent and LSP baseline harness | Planned | Comparable task runner for CodeMiner, Codex, Claude Code, and OpenCode-style LSP workflows | Baseline reports separate harness advantage from answer-format compliance |
+| M7: Context ledger runtime contract | Landed in #291 | First-class context items with provenance, token/cost accounting, freshness, and consumption state | Unit tests can explain why context was injected, used, skipped, or expired |
+| M8: Trace replay and diagnostics | Landed in #292 | Eval package reconstructs tool use, context consumption, answer spans, and failure category from trace records | Reports diagnose behavior without provider logs or script-specific parsing |
+| M9: External-agent and LSP baseline harness | In progress | Comparable task runner for CodeMiner, Codex, Claude Code, and OpenCode-style LSP workflows | Baseline reports separate harness advantage from answer-format compliance |
 | M10: Promotion gates and cleanup | Planned | Raw/normalized metrics, held-out gates, and deprecation/removal of legacy script shims | Runtime defaults require smoke plus holdout evidence; scripts stay thin |
 
 ## Immediate PR Queue
@@ -141,6 +141,10 @@ benchmark cell is currently easiest to improve.
   holdout plans, not by hand-picking named project instances.
 - Compatibility shims under `scripts/agent_compile/lib` are not core ownership.
   New code should not import them.
+- External-agent and LSP baseline task/result envelopes live in
+  `codeminer.eval.agent_runner`. Client wrappers and examples may adapt their
+  SDK-specific inputs to that envelope, but they should not own reusable scoring
+  or JSONL record construction.
 
 ## Promotion Checklist
 

--- a/test/eval/test_baseline.py
+++ b/test/eval/test_baseline.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for reusable baseline task/result envelopes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from codeminer.eval.agent_runner.baseline import (
+    BaselineRunResult,
+    BaselineTask,
+    build_baseline_result_entry,
+    location_symbol_ids,
+    unique_location_files,
+)
+from codeminer.eval.loc_agent_runner import build_result_entry, run_agent_baseline
+
+
+def _success_result():
+    return SimpleNamespace(
+        success=True,
+        repo_path="/repos/demo",
+        locations=[
+            SimpleNamespace(
+                name="Parser.parse()",
+                type="method",
+                file_path="./pkg/parser.py",
+                line_start=10,
+                line_end=20,
+                action="modify",
+                description="parse entry point",
+            ),
+            {
+                "name": "helper()",
+                "type": "function",
+                "file_path": "pkg/parser.py",
+                "line_start": "30",
+                "line_end": "32",
+                "action": "modify",
+                "description": "helper path",
+            },
+        ],
+        usage={"input_tokens": 10},
+    )
+
+
+def test_baseline_task_from_dataset_instance_builds_agent_call():
+    task = BaselineTask.from_dataset_instance(
+        {
+            "instance_id": "demo__repo-1",
+            "repo": "demo/repo",
+            "problem_statement": "Fix parser edge case",
+            "hints_text": "Look at parser helpers",
+        },
+        repo_path="/repos/demo",
+        target_files=["pkg/parser.py"],
+        target_symbols=["pkg/parser.py:Parser.parse()"],
+        metadata={"dataset": "codeminer_base"},
+    )
+
+    assert task.to_agent_call() == {
+        "query_text": "Fix parser edge case",
+        "repo_path": "/repos/demo",
+        "context": {
+            "issue_title": "[demo__repo-1] demo/repo",
+            "issue_body": "Fix parser edge case",
+            "hints": "Look at parser helpers",
+        },
+    }
+    assert task.to_dict()["target_files"] == ["pkg/parser.py"]
+    assert task.to_dict()["metadata"] == {"dataset": "codeminer_base"}
+
+
+def test_baseline_run_result_normalizes_locations_and_predictions():
+    normalized = BaselineRunResult.from_raw(_success_result())
+
+    assert normalized.success is True
+    assert normalized.usage == {"input_tokens": 10}
+    assert [location.to_dict() for location in normalized.locations] == [
+        {
+            "name": "Parser.parse()",
+            "type": "method",
+            "file_path": "./pkg/parser.py",
+            "line_start": 10,
+            "line_end": 20,
+            "action": "modify",
+            "description": "parse entry point",
+        },
+        {
+            "name": "helper()",
+            "type": "function",
+            "file_path": "pkg/parser.py",
+            "line_start": 30,
+            "line_end": 32,
+            "action": "modify",
+            "description": "helper path",
+        },
+    ]
+    assert unique_location_files(normalized.locations) == [
+        "./pkg/parser.py",
+        "pkg/parser.py",
+    ]
+    assert location_symbol_ids(normalized.locations) == [
+        "pkg/parser.py:Parser.parse()",
+        "pkg/parser.py:helper()",
+    ]
+
+
+def test_build_baseline_result_entry_matches_existing_json_shape():
+    task = BaselineTask(
+        instance_id="demo__repo-1",
+        query="Fix parser edge case",
+        repo_path="/repos/demo",
+        target_files=("pkg/parser.py",),
+        target_symbols=("pkg/parser.py:Parser.parse()",),
+    )
+
+    entry = build_baseline_result_entry(
+        task=task,
+        agent_name="external",
+        model="model-a",
+        result=_success_result(),
+        metrics_k=[1, 2],
+    )
+
+    assert entry["instance_id"] == "demo__repo-1"
+    assert entry["agent"] == "external"
+    assert entry["model"] == "model-a"
+    assert entry["success"] is True
+    assert entry["metric_k_files"] == ["./pkg/parser.py", "pkg/parser.py"]
+    assert entry["metric_k_node_ids"] == [
+        "pkg/parser.py:Parser.parse()",
+        "pkg/parser.py:helper()",
+    ]
+    assert entry["metrics"]["symbols"][1]["accuracy"] == 1.0
+    assert entry["usage"] == {"input_tokens": 10}
+    assert entry["error"] is None
+
+
+def test_loc_agent_runner_build_result_entry_delegates_to_envelope():
+    entry = build_result_entry(
+        instance_id="demo__repo-1",
+        agent_name="claude",
+        model="sonnet",
+        result=_success_result(),
+        target_files=["pkg/parser.py"],
+        target_symbols=["pkg/parser.py:Parser.parse()"],
+        metrics_k=[1],
+    )
+
+    assert entry["agent"] == "claude"
+    assert entry["metric_k_node_ids"] == [
+        "pkg/parser.py:Parser.parse()",
+        "pkg/parser.py:helper()",
+    ]
+    assert entry["locations"][0]["name"] == "Parser.parse()"
+
+
+def test_build_baseline_result_entry_handles_failures():
+    task = BaselineTask(
+        instance_id="demo__repo-1",
+        query="Fix parser edge case",
+        repo_path="/repos/demo",
+    )
+
+    entry = build_baseline_result_entry(
+        task=task,
+        agent_name="lsp",
+        model=None,
+        result=None,
+        metrics_k=[1],
+        error="tool unavailable",
+    )
+
+    assert entry["success"] is False
+    assert entry["error"] == "tool unavailable"
+    assert entry["metric_k_files"] == []
+    assert entry["metrics"] is None
+
+
+def test_run_agent_baseline_uses_baseline_task_envelope(monkeypatch, tmp_path):
+    calls = []
+    instance = {
+        "instance_id": "demo__repo-1",
+        "repo": "demo/repo",
+        "problem_statement": "Fix parser edge case",
+        "hints_text": "Look at parser helpers",
+    }
+
+    class FakeDataset:
+        simplified_symbols = True
+
+        def load(self):
+            return [instance]
+
+        def load_eval_metadata(self, _path):
+            return {
+                "demo__repo-1": {
+                    "target_files": ["pkg/parser.py"],
+                    "symbols_modified": ["pkg/parser.py:Parser.parse()"],
+                    "symbols_deleted": [],
+                }
+            }
+
+        def process_instance(self, _instance):
+            return None
+
+        def get_repo_path(self, _instance):
+            return "/repos/demo"
+
+    class FakeAgent:
+        async def locate_code(self, query_text, repo_path, context):
+            calls.append(
+                {
+                    "query_text": query_text,
+                    "repo_path": repo_path,
+                    "context": context,
+                }
+            )
+            return _success_result()
+
+    monkeypatch.setattr(
+        "codeminer.eval.loc_agent_runner.build_dataset",
+        lambda _args: FakeDataset(),
+    )
+    args = SimpleNamespace(
+        dataset="codeminer_base",
+        split="test",
+        filter_instance=".*",
+        repo_cache_dir="",
+        result_path=str(tmp_path / "baseline.jsonl"),
+        resume=False,
+        limit=None,
+        eval_instances="",
+        metrics_k=[1],
+    )
+
+    rc = asyncio.run(
+        run_agent_baseline(
+            args,
+            agent_factory=FakeAgent,
+            agent_name="fake",
+            model_label="model-a",
+        )
+    )
+
+    assert rc == 0
+    assert calls == [
+        {
+            "query_text": "Fix parser edge case",
+            "repo_path": "/repos/demo",
+            "context": {
+                "issue_title": "[demo__repo-1] demo/repo",
+                "issue_body": "Fix parser edge case",
+                "hints": "Look at parser helpers",
+            },
+        }
+    ]
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "baseline.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert rows[0]["instance_id"] == "demo__repo-1"
+    assert rows[0]["agent"] == "fake"
+    assert rows[0]["success"] is True


### PR DESCRIPTION
## Summary
Add a reusable eval-side baseline task/result envelope so external agents and future LSP baselines share the same task shape, result normalization, JSONL record construction, and scoring helpers.

## Changes
- Added BaselineTask, BaselineLocation, BaselineRunResult, and build_baseline_result_entry under codeminer.eval.agent_runner.
- Exported the baseline envelope APIs from codeminer.eval.agent_runner.
- Rewired codeminer.eval.loc_agent_runner to build BaselineTask objects and delegate record/scoring construction to the eval package while preserving the existing public entrypoints.
- Added unit coverage for dataset-task conversion, raw result normalization, JSONL record shape, failure records, and the mocked external-agent baseline loop.
- Updated the architecture goal to mark M7/M8 landed and record external baseline envelope ownership for M9.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Local checks:
- pytest test/eval/test_baseline.py test/eval/test_agent_results.py test/eval/test_trace_summary.py test/agent/test_import_boundaries.py -q
- python -m compileall -q codeminer/eval/agent_runner/baseline.py codeminer/eval/agent_runner/__init__.py codeminer/eval/loc_agent_runner.py test/eval/test_baseline.py
- pre-commit run --files codeminer/eval/agent_runner/__init__.py codeminer/eval/agent_runner/baseline.py codeminer/eval/loc_agent_runner.py test/eval/test_baseline.py docs/agent_runner_architecture_goal.md
- git diff --check
- pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published