### PR TITLE
feat(eval): add graph lsp baseline adapter

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -26,6 +26,14 @@ from .format_diagnostics import (
     load_meaningful_cells,
     summarize_format_cells,
 )
+from .lsp_baseline import (
+    LSPRouteBaselineConfig,
+    build_lsp_route_result_entry,
+    extract_lsp_symbol_seeds,
+    load_prebuilt_lsp_graph,
+    locations_from_lsp_nodes,
+    run_lsp_route_baseline,
+)
 from .metrics import load_cell_jsons, metric_at_k, safe_mean, safe_min, usable_cells
 from .orchestrator import (
     GATE_SYSTEM,
@@ -91,6 +99,7 @@ __all__ = [
     "GATE_SYSTEM",
     "GraphNav",
     "LANG_GROUP_TO_KEY",
+    "LSPRouteBaselineConfig",
     "PreloadQueryPlan",
     "SampleConfig",
     "SweepConfig",
@@ -104,11 +113,13 @@ __all__ = [
     "build_symbol_span_index",
     "build_feedback_plan",
     "build_baseline_result_entry",
+    "build_lsp_route_result_entry",
     "candidate_location",
     "converge_query",
     "default_agent_skills_dir",
     "evaluate_agent_localization",
     "expansion_seeds_from_candidates",
+    "extract_lsp_symbol_seeds",
     "graph_verify",
     "load_graph_nav",
     "graph_compose",
@@ -118,6 +129,8 @@ __all__ = [
     "load_dataset_rows",
     "load_format_diagnostics",
     "load_full_contexts",
+    "load_prebuilt_lsp_graph",
+    "locations_from_lsp_nodes",
     "location_symbol_ids",
     "load_meaningful_cells",
     "load_pareto_cells",
@@ -127,6 +140,7 @@ __all__ = [
     "render_expansion",
     "retrieve_candidates",
     "run_cell",
+    "run_lsp_route_baseline",
     "run_verify_expand",
     "scatter_gather_localize",
     "safe_mean",

--- a/codeminer/eval/agent_runner/lsp_baseline.py
+++ b/codeminer/eval/agent_runner/lsp_baseline.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph-backed LSP baseline adapters for agent-runner evaluation."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, List, Mapping, Optional, Sequence
+
+from codeminer.agent.lsp_graph import lsp_route
+
+from .baseline import (
+    BaselineLocation,
+    BaselineRunResult,
+    BaselineTask,
+    build_baseline_result_entry,
+)
+
+_BACKTICK = re.compile(r"`([^`\n]{2,100})`")
+_TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+_CODEISH = re.compile(r"_|[a-z][A-Z]|[0-9][A-Z]|[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_]")
+_IDENT_STOP = {"BUG", "TODO", "FIXME", "NOTE", "XXX", "HACK", "WARNING", "ERROR"}
+
+
+@dataclass(frozen=True)
+class LSPRouteBaselineConfig:
+    """Configuration for the static-graph LSP route baseline."""
+
+    top_k: int = 12
+    seed_limit: int = 8
+    include_neighbors: bool = True
+    agent_name: str = "lsp_route"
+
+
+def extract_lsp_symbol_seeds(
+    task: BaselineTask,
+    *,
+    limit: int = 8,
+) -> List[str]:
+    """Extract explicit symbol seeds from a task without using ground truth.
+
+    The baseline intentionally does not search the repository and never reads
+    ``target_files`` or ``target_symbols``. It routes from symbols already named
+    by task metadata/context or code-like identifiers in the issue text.
+    """
+
+    seeds: List[str] = []
+
+    def add(value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, str):
+            text = value.strip().strip("`'\"")
+            if text:
+                seeds.append(text)
+            return
+        if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+            for item in value:
+                add(item)
+
+    for source in (task.metadata, task.context):
+        if not isinstance(source, Mapping):
+            continue
+        for key in ("lsp_symbol_seeds", "symbol_seeds", "symbols"):
+            add(source.get(key))
+
+    text_parts = [task.query]
+    if isinstance(task.context, Mapping):
+        for key in ("issue_title", "issue_body", "hints"):
+            value = task.context.get(key)
+            if isinstance(value, str):
+                text_parts.append(value)
+    text = "\n".join(part for part in text_parts if part)
+
+    for match in _BACKTICK.findall(text):
+        add(match)
+    for token in _TOKEN.findall(text):
+        if token.upper() in _IDENT_STOP:
+            continue
+        if _CODEISH.search(token) or (token.isupper() and len(token) >= 3):
+            add(token)
+
+    seen: set[str] = set()
+    out: List[str] = []
+    for seed in seeds:
+        key = seed.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(seed)
+        if len(out) >= max(1, int(limit or 8)):
+            break
+    return out
+
+
+def locations_from_lsp_nodes(nodes: Sequence[Any]) -> List[BaselineLocation]:
+    """Convert LSP-shaped graph nodes into baseline output locations."""
+
+    locations: List[BaselineLocation] = []
+    for node in nodes:
+        file_path = _node_value(node, "file") or _node_value(node, "file_path")
+        node_name = str(
+            _node_value(node, "node_name") or _node_value(node, "node_id") or ""
+        )
+        if not file_path:
+            file_path, node_name = _split_file_symbol(node_name)
+        name = _symbol_name(node_name, file_path)
+        if not name or not file_path:
+            continue
+        locations.append(
+            BaselineLocation(
+                name=name,
+                type=str(_node_value(node, "type") or ""),
+                file_path=str(file_path),
+                line_start=_agent_line(_node_value(node, "start_line")),
+                line_end=_agent_line(_node_value(node, "end_line")),
+                action="modify",
+                description=str(_node_value(node, "content") or ""),
+            )
+        )
+    return locations
+
+
+def run_lsp_route_baseline(
+    *,
+    task: BaselineTask,
+    graph: Any,
+    config: LSPRouteBaselineConfig | None = None,
+) -> BaselineRunResult:
+    """Run the static-graph LSP route baseline for one task."""
+
+    cfg = config or LSPRouteBaselineConfig()
+    if graph is None:
+        return BaselineRunResult(
+            success=False,
+            error_message="symbol graph unavailable",
+            repo_path=task.repo_path,
+        )
+
+    seeds = extract_lsp_symbol_seeds(task, limit=cfg.seed_limit)
+    if not seeds:
+        return BaselineRunResult(
+            success=True,
+            locations=(),
+            usage=_usage(cfg, seeds=seeds, route_count=0),
+            repo_path=task.repo_path,
+        )
+
+    try:
+        nodes = lsp_route(
+            graph,
+            symbols=seeds,
+            query=task.query,
+            top_k=cfg.top_k,
+            include_neighbors=cfg.include_neighbors,
+        )
+    except Exception as exc:  # noqa: BLE001 - baseline records failures per task
+        return BaselineRunResult(
+            success=False,
+            error_message=str(exc),
+            repo_path=task.repo_path,
+        )
+
+    locations = tuple(locations_from_lsp_nodes(nodes))
+    return BaselineRunResult(
+        success=True,
+        locations=locations,
+        usage=_usage(cfg, seeds=seeds, route_count=len(nodes)),
+        repo_path=task.repo_path,
+        raw_output=nodes,
+    )
+
+
+def build_lsp_route_result_entry(
+    *,
+    task: BaselineTask,
+    graph: Any,
+    metrics_k: Sequence[int],
+    config: LSPRouteBaselineConfig | None = None,
+) -> dict[str, Any]:
+    """Build a JSON-ready result row for one static-graph LSP baseline run."""
+
+    cfg = config or LSPRouteBaselineConfig()
+    result = run_lsp_route_baseline(task=task, graph=graph, config=cfg)
+    return build_baseline_result_entry(
+        task=task,
+        agent_name=cfg.agent_name,
+        model=None,
+        result=result,
+        metrics_k=metrics_k,
+    )
+
+
+def load_prebuilt_lsp_graph(prebuilt_root: str, instance_id: str) -> Any:
+    """Load the prebuilt graph artifact used by LSP-route baselines."""
+
+    from .prebuilt import load_prebuilt_code_graph
+
+    return load_prebuilt_code_graph(prebuilt_root, instance_id)
+
+
+def _usage(
+    config: LSPRouteBaselineConfig,
+    *,
+    seeds: Sequence[str],
+    route_count: int,
+) -> dict[str, Any]:
+    return {
+        "backend": "static_graph_lsp_route",
+        "top_k": config.top_k,
+        "seed_limit": config.seed_limit,
+        "include_neighbors": config.include_neighbors,
+        "symbol_seeds": list(seeds),
+        "route_count": route_count,
+    }
+
+
+def _node_value(node: Any, key: str) -> Any:
+    if isinstance(node, Mapping):
+        return node.get(key)
+    return getattr(node, key, None)
+
+
+def _agent_line(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value) + 1
+    except (TypeError, ValueError):
+        return None
+
+
+def _split_file_symbol(text: str) -> tuple[Optional[str], str]:
+    if ":" not in text:
+        return None, text
+    left, right = text.split(":", 1)
+    if "/" in left or "." in left:
+        return left, right
+    return None, text
+
+
+def _symbol_name(display: str, file_path: Any) -> str:
+    text = (display or "").strip()
+    file_text = str(file_path or "").strip()
+    if file_text and text.startswith(file_text + ":"):
+        text = text[len(file_text) + 1 :]
+    return text.strip()
+
+
+__all__ = [
+    "LSPRouteBaselineConfig",
+    "build_lsp_route_result_entry",
+    "extract_lsp_symbol_seeds",
+    "load_prebuilt_lsp_graph",
+    "locations_from_lsp_nodes",
+    "run_lsp_route_baseline",
+]

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -118,11 +118,16 @@ benchmark cell is currently easiest to improve.
    final answer spans from structured records.
 
 3. **M9a: Baseline task adapter.**
-   Define a task input/output envelope for external agents and LSP workflows.
-   The goal is to compare harness capability, not to force every agent into
-   CodeMiner's localization answer schema.
+   Landed in #293. External agents and LSP workflows now share a task/result
+   envelope and JSONL record builder.
 
-4. **M10a: Legacy script shim cleanup.**
+4. **M9b: Graph-backed LSP route baseline.**
+   Add a reusable eval-layer adapter that routes explicit symbol seeds through
+   the static graph LSP API and emits the shared baseline result envelope. This
+   should measure graph/LSP harness value without adding scorer repairs or
+   external-agent-specific scripts.
+
+5. **M10a: Legacy script shim cleanup.**
    Keep `scripts/agent_compile/lib` only as long as needed for old notebooks.
    Internal scripts and reusable tests should continue importing package APIs
    directly, and the compatibility layer should be removed once the migration
@@ -145,6 +150,10 @@ benchmark cell is currently easiest to improve.
   `codeminer.eval.agent_runner`. Client wrappers and examples may adapt their
   SDK-specific inputs to that envelope, but they should not own reusable scoring
   or JSONL record construction.
+- Static graph LSP baselines should route from explicit symbol seeds or
+  code-like identifiers supplied by the task context. They must not read ground
+  truth targets, mutate answer order for a scorer, or hide graph-display gaps
+  with benchmark-specific normalization.
 
 ## Promotion Checklist
 

--- a/test/eval/test_lsp_baseline.py
+++ b/test/eval/test_lsp_baseline.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for graph-backed LSP baseline adapters."""
+
+from __future__ import annotations
+
+from codeminer.eval.agent_runner.baseline import BaselineTask
+from codeminer.eval.agent_runner.lsp_baseline import (
+    LSPRouteBaselineConfig,
+    build_lsp_route_result_entry,
+    extract_lsp_symbol_seeds,
+    locations_from_lsp_nodes,
+    run_lsp_route_baseline,
+)
+from codeminer.types import QueriedNode
+
+
+class _RouteGraph:
+    def __init__(self):
+        self.name_to_vertex = {
+            "svc.HandleRequest": 0,
+            "svc.NewResolver": 1,
+            "svc.DefaultConfig": 2,
+        }
+        self._attr = {
+            0: {
+                "name": "svc.HandleRequest",
+                "unified_name": "service.py:HandleRequest()",
+                "type": "function",
+                "file": "service.py",
+                "start_line": 19,
+                "end_line": 49,
+            },
+            1: {
+                "name": "svc.NewResolver",
+                "unified_name": "resolver.py:NewResolver()",
+                "type": "function",
+                "file": "resolver.py",
+                "start_line": 4,
+                "end_line": 14,
+            },
+            2: {
+                "name": "svc.DefaultConfig",
+                "unified_name": "config.py:DefaultConfig()",
+                "type": "function",
+                "file": "config.py",
+                "start_line": 1,
+                "end_line": 7,
+            },
+        }
+        self._succ = {
+            "svc.HandleRequest": [1],
+            "svc.NewResolver": [2],
+        }
+        self._pred = {}
+
+    def get_node_info_by_name(self, name):
+        return self._attr.get(self.name_to_vertex.get(name))
+
+    def get_node_info_by_id(self, vertex_id):
+        return self._attr.get(vertex_id)
+
+    def get_successors(self, name):
+        return self._succ.get(name, [])
+
+    def get_predecessors(self, name):
+        return self._pred.get(name, [])
+
+
+def test_extract_lsp_symbol_seeds_uses_explicit_context_before_query():
+    task = BaselineTask(
+        instance_id="demo__repo-1",
+        query="Fix `HandleRequest` when HTTP2Mode is enabled",
+        repo_path="/repo",
+        context={
+            "symbol_seeds": ["NewResolver", "HandleRequest"],
+            "issue_body": "HTTP2Mode fails in `HandleRequest`",
+        },
+        target_symbols=("service.py:GroundTruthOnly()",),
+    )
+
+    assert extract_lsp_symbol_seeds(task, limit=4) == [
+        "NewResolver",
+        "HandleRequest",
+        "HTTP2Mode",
+    ]
+
+
+def test_locations_from_lsp_nodes_converts_lines_and_unified_names():
+    locations = locations_from_lsp_nodes(
+        [
+            QueriedNode(
+                node_name="service.py:HandleRequest()",
+                type="function",
+                file="service.py",
+                start_line=19,
+                end_line=49,
+                content="route endpoint: direct seed HandleRequest",
+            )
+        ]
+    )
+
+    assert [location.to_dict() for location in locations] == [
+        {
+            "name": "HandleRequest()",
+            "type": "function",
+            "file_path": "service.py",
+            "line_start": 20,
+            "line_end": 50,
+            "action": "modify",
+            "description": "route endpoint: direct seed HandleRequest",
+        }
+    ]
+
+
+def test_lsp_route_baseline_returns_locations_and_usage():
+    task = BaselineTask(
+        instance_id="demo__repo-1",
+        query="Fix HandleRequest resolver default config",
+        repo_path="/repo",
+        context={"symbol_seeds": ["HandleRequest", "NewResolver"]},
+        target_files=("service.py",),
+        target_symbols=("service.py:HandleRequest()",),
+    )
+
+    result = run_lsp_route_baseline(
+        task=task,
+        graph=_RouteGraph(),
+        config=LSPRouteBaselineConfig(top_k=3),
+    )
+
+    assert result.success is True
+    assert [location.symbol_id() for location in result.locations] == [
+        "service.py:HandleRequest()",
+        "resolver.py:NewResolver()",
+        "config.py:DefaultConfig()",
+    ]
+    assert result.usage == {
+        "backend": "static_graph_lsp_route",
+        "top_k": 3,
+        "seed_limit": 8,
+        "include_neighbors": True,
+        "symbol_seeds": ["HandleRequest", "NewResolver"],
+        "route_count": 3,
+    }
+
+
+def test_build_lsp_route_result_entry_scores_with_baseline_envelope():
+    task = BaselineTask(
+        instance_id="demo__repo-1",
+        query="Fix HandleRequest resolver default config",
+        repo_path="/repo",
+        context={"symbol_seeds": ["HandleRequest", "NewResolver"]},
+        target_files=("service.py",),
+        target_symbols=("service.py:HandleRequest()",),
+    )
+
+    entry = build_lsp_route_result_entry(
+        task=task,
+        graph=_RouteGraph(),
+        metrics_k=[1, 3],
+        config=LSPRouteBaselineConfig(top_k=3),
+    )
+
+    assert entry["agent"] == "lsp_route"
+    assert entry["model"] is None
+    assert entry["metric_k_files"] == ["service.py", "resolver.py", "config.py"]
+    assert entry["metric_k_node_ids"] == [
+        "service.py:HandleRequest()",
+        "resolver.py:NewResolver()",
+        "config.py:DefaultConfig()",
+    ]
+    assert entry["metrics"]["files"][1]["accuracy"] == 1.0
+    assert entry["metrics"]["symbols"][1]["accuracy"] == 1.0
+
+
+def test_lsp_route_baseline_without_seeds_is_successful_empty_result():
+    task = BaselineTask(
+        instance_id="demo__repo-1",
+        query="Fix the resolver behavior",
+        repo_path="/repo",
+        target_files=("service.py",),
+        target_symbols=("service.py:HandleRequest()",),
+    )
+
+    result = run_lsp_route_baseline(task=task, graph=_RouteGraph())
+
+    assert result.success is True
+    assert result.locations == ()
+    assert result.usage["symbol_seeds"] == []
+    assert result.usage["route_count"] == 0
+
+
+def test_lsp_route_baseline_records_missing_graph_as_failure():
+    task = BaselineTask(
+        instance_id="demo__repo-1",
+        query="Fix `HandleRequest`",
+        repo_path="/repo",
+    )
+
+    result = run_lsp_route_baseline(task=task, graph=None)
+
+    assert result.success is False
+    assert result.error_message == "symbol graph unavailable"


### PR DESCRIPTION
## Summary
Add an eval-layer graph-backed LSP route baseline adapter for the M9 external-agent/LSP baseline milestone.

## Changes
- Add `codeminer.eval.agent_runner.lsp_baseline` with `LSPRouteBaselineConfig`, seed extraction, LSP node-to-baseline location conversion, static graph route execution, prebuilt graph loading, and JSONL result-entry construction through the shared baseline envelope.
- Export the new LSP baseline helpers from `codeminer.eval.agent_runner`.
- Add unit tests covering seed extraction without ground-truth leakage, 0-based graph line to 1-based baseline location conversion, shared metric scoring, empty-seed behavior, and missing graph failures.
- Update the architecture goal doc to mark M9a landed and define M9b boundaries.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `pytest test/eval/test_lsp_baseline.py test/eval/test_baseline.py test/agent/test_lsp_graph.py -q`
- `pre-commit run --files codeminer/eval/agent_runner/__init__.py codeminer/eval/agent_runner/lsp_baseline.py test/eval/test_lsp_baseline.py docs/agent_runner_architecture_goal.md`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

Promotion checklist:
- Reusable contract changed: eval baseline adapter for static graph LSP route results.
- Raw behavior measured: route locations emitted before shared baseline scoring.
- Smoke/holdout used: not promoted as a runtime default; covered by unit tests only.
- Models/external agents compared: none in this PR; this creates the non-LLM LSP baseline adapter for later comparison.
- Failure category targeted: context/runtime and harness-comparison observability.
- Not tied to a benchmark instance or scorer field: seeds come from task metadata/context or code-like issue text, never from ground truth targets.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published