### PR TITLE
feat(eval): add baseline batch runner

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -13,6 +13,12 @@ from .baseline import (
     score_baseline_predictions,
     unique_location_files,
 )
+from .batch import (
+    BaselineBatchSummary,
+    BaselineTaskRunner,
+    baseline_done_ids,
+    run_baseline_batch,
+)
 from .contexts import (
     AgentSkillContextSpec,
     default_agent_skills_dir,
@@ -90,6 +96,8 @@ __all__ = [
     "AgentTraceSummary",
     "BaselineLocation",
     "BaselineRunResult",
+    "BaselineBatchSummary",
+    "BaselineTaskRunner",
     "BaselineTask",
     "FormatArmSummary",
     "FormatDiagnostics",
@@ -109,6 +117,7 @@ __all__ = [
     "assemble_preload",
     "all_index_skill_ids",
     "analyze_pareto",
+    "baseline_done_ids",
     "build_prebuilt_symbol_span_index",
     "build_symbol_span_index",
     "build_feedback_plan",
@@ -139,6 +148,7 @@ __all__ = [
     "query_is_specific",
     "render_expansion",
     "retrieve_candidates",
+    "run_baseline_batch",
     "run_cell",
     "run_lsp_route_baseline",
     "run_verify_expand",

--- a/codeminer/eval/agent_runner/batch.py
+++ b/codeminer/eval/agent_runner/batch.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic batch runner for agent-runner baseline tasks."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Sequence, Set
+
+from codeminer.eval.retrieval_eval import aggregate_metrics, average_metrics
+
+from .baseline import BaselineTask, build_baseline_result_entry
+
+BaselineTaskRunner = Callable[[BaselineTask], Any | Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class BaselineBatchSummary:
+    """Summary of a baseline batch run."""
+
+    total: int
+    attempted: int
+    succeeded: int
+    failed: int
+    skipped: int
+    scored: int
+    metrics: Mapping[str, Mapping[int, Mapping[str, float]]]
+    result_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total": self.total,
+            "attempted": self.attempted,
+            "succeeded": self.succeeded,
+            "failed": self.failed,
+            "skipped": self.skipped,
+            "scored": self.scored,
+            "metrics": {
+                scope: {int(k): dict(values) for k, values in per_k.items()}
+                for scope, per_k in self.metrics.items()
+            },
+            "result_path": self.result_path,
+        }
+
+
+def baseline_done_ids(result_path: str | Path) -> Set[str]:
+    """Return instance_ids already present in a baseline JSONL file."""
+
+    path = Path(result_path)
+    if not path.exists():
+        return set()
+    done: Set[str] = set()
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            instance_id = obj.get("instance_id")
+            if instance_id:
+                done.add(str(instance_id))
+    return done
+
+
+async def run_baseline_batch(
+    tasks: Sequence[BaselineTask],
+    *,
+    runner: BaselineTaskRunner,
+    agent_name: str,
+    model: Optional[str],
+    metrics_k: Sequence[int],
+    result_path: str | Path | None = None,
+    resume: bool = False,
+) -> BaselineBatchSummary:
+    """Run a sync or async baseline runner over tasks and write JSONL records."""
+
+    done = baseline_done_ids(result_path) if result_path and resume else set()
+    aggregate = _empty_aggregate(metrics_k)
+    result_file = _open_result_file(result_path)
+
+    attempted = succeeded = failed = skipped = scored = 0
+    try:
+        for task in tasks:
+            if task.instance_id in done:
+                skipped += 1
+                continue
+
+            attempted += 1
+            try:
+                raw_result = runner(task)
+                if inspect.isawaitable(raw_result):
+                    raw_result = await raw_result
+                entry = build_baseline_result_entry(
+                    task=task,
+                    agent_name=agent_name,
+                    model=model,
+                    result=raw_result,
+                    metrics_k=metrics_k,
+                )
+            except Exception as exc:  # noqa: BLE001 - record and continue
+                entry = build_baseline_result_entry(
+                    task=task,
+                    agent_name=agent_name,
+                    model=model,
+                    result=None,
+                    metrics_k=metrics_k,
+                    error=str(exc),
+                )
+
+            if entry["success"]:
+                succeeded += 1
+            else:
+                failed += 1
+            if entry["success"] and entry["metrics"] is not None:
+                aggregate_metrics(aggregate, entry["metrics"])
+                scored += 1
+            _write_entry(result_file, entry)
+    finally:
+        if result_file is not None:
+            result_file.close()
+
+    return BaselineBatchSummary(
+        total=len(tasks),
+        attempted=attempted,
+        succeeded=succeeded,
+        failed=failed,
+        skipped=skipped,
+        scored=scored,
+        metrics=average_metrics(aggregate, scored),
+        result_path=(
+            str(Path(result_path).expanduser().resolve())
+            if result_path is not None
+            else None
+        ),
+    )
+
+
+def _empty_aggregate(ks: Sequence[int]) -> Dict[str, Dict[int, Dict[str, float]]]:
+    return {
+        scope: {
+            int(k): {"accuracy": 0.0, "precision": 0.0, "recall": 0.0, "hits": 0.0}
+            for k in ks
+        }
+        for scope in ("files", "symbols")
+    }
+
+
+def _open_result_file(path: str | Path | None):
+    if path is None:
+        return None
+    result_path = Path(path).expanduser().resolve()
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    return result_path.open("a", encoding="utf-8")
+
+
+def _write_entry(result_file: Any, entry: Mapping[str, Any]) -> None:
+    if result_file is None:
+        return
+    result_file.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    result_file.flush()
+
+
+__all__ = [
+    "BaselineBatchSummary",
+    "BaselineTaskRunner",
+    "baseline_done_ids",
+    "run_baseline_batch",
+]

--- a/codeminer/eval/loc_agent_runner.py
+++ b/codeminer/eval/loc_agent_runner.py
@@ -36,6 +36,7 @@ from codeminer.eval.agent_runner.baseline import (
     score_baseline_predictions,
     unique_location_files,
 )
+from codeminer.eval.agent_runner.batch import baseline_done_ids
 from codeminer.eval.retrieval_eval import (
     aggregate_metrics,
     average_metrics,
@@ -78,22 +79,7 @@ def build_dataset(args):
 
 def already_done_ids(result_path: Path) -> Set[str]:
     """Return instance_ids already present in an existing JSONL result file."""
-    if not result_path.exists():
-        return set()
-    done: Set[str] = set()
-    with result_path.open(encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                obj = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            iid = obj.get("instance_id")
-            if iid:
-                done.add(iid)
-    return done
+    return baseline_done_ids(result_path)
 
 
 def _unique_files(locations) -> List[str]:

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -122,12 +122,17 @@ benchmark cell is currently easiest to improve.
    envelope and JSONL record builder.
 
 4. **M9b: Graph-backed LSP route baseline.**
-   Add a reusable eval-layer adapter that routes explicit symbol seeds through
-   the static graph LSP API and emits the shared baseline result envelope. This
-   should measure graph/LSP harness value without adding scorer repairs or
-   external-agent-specific scripts.
+   Landed in #294. Static graph LSP-route runs now emit the shared baseline
+   result envelope without adding scorer repairs or external-agent-specific
+   scripts.
 
-5. **M10a: Legacy script shim cleanup.**
+5. **M9c: Generic baseline batch runner.**
+   Move reusable task iteration, resume, exception capture, JSONL writing, and
+   aggregate metric accounting into `codeminer.eval.agent_runner`, so LSP,
+   Codex, Claude Code, and OpenCode-style clients can share the same feedback
+   loop.
+
+6. **M10a: Legacy script shim cleanup.**
    Keep `scripts/agent_compile/lib` only as long as needed for old notebooks.
    Internal scripts and reusable tests should continue importing package APIs
    directly, and the compatibility layer should be removed once the migration

--- a/test/eval/test_baseline_batch.py
+++ b/test/eval/test_baseline_batch.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for generic baseline batch execution."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from codeminer.eval.agent_runner.baseline import BaselineTask
+from codeminer.eval.agent_runner.batch import baseline_done_ids, run_baseline_batch
+
+
+def _task(instance_id: str, *, target_symbol: str = "pkg/mod.py:foo()"):
+    return BaselineTask(
+        instance_id=instance_id,
+        query="Fix foo",
+        repo_path="/repo",
+        target_files=("pkg/mod.py",),
+        target_symbols=(target_symbol,),
+    )
+
+
+def _result(name: str = "foo()"):
+    return SimpleNamespace(
+        success=True,
+        repo_path="/repo",
+        locations=[
+            SimpleNamespace(
+                name=name,
+                type="function",
+                file_path="pkg/mod.py",
+                line_start=1,
+                line_end=5,
+                action="modify",
+                description="candidate",
+            )
+        ],
+        usage={"backend": "fake"},
+    )
+
+
+def test_run_baseline_batch_writes_jsonl_and_aggregates_metrics(tmp_path):
+    result_path = tmp_path / "baseline.jsonl"
+
+    async def runner(task):
+        assert task.repo_path == "/repo"
+        return _result()
+
+    summary = asyncio.run(
+        run_baseline_batch(
+            [_task("one"), _task("two")],
+            runner=runner,
+            agent_name="fake",
+            model="model-a",
+            metrics_k=[1],
+            result_path=result_path,
+        )
+    )
+
+    assert summary.to_dict() == {
+        "total": 2,
+        "attempted": 2,
+        "succeeded": 2,
+        "failed": 0,
+        "skipped": 0,
+        "scored": 2,
+        "metrics": {
+            "files": {
+                1: {
+                    "accuracy": 1.0,
+                    "precision": 1.0,
+                    "recall": 1.0,
+                    "avg_hits": 1.0,
+                }
+            },
+            "symbols": {
+                1: {
+                    "accuracy": 1.0,
+                    "precision": 1.0,
+                    "recall": 1.0,
+                    "avg_hits": 1.0,
+                }
+            },
+        },
+        "result_path": str(result_path.resolve()),
+    }
+    rows = [json.loads(line) for line in result_path.read_text().splitlines()]
+    assert [row["instance_id"] for row in rows] == ["one", "two"]
+    assert rows[0]["agent"] == "fake"
+    assert rows[0]["metric_k_node_ids"] == ["pkg/mod.py:foo()"]
+
+
+def test_run_baseline_batch_records_runner_exceptions():
+    def runner(_task):
+        raise RuntimeError("tool unavailable")
+
+    summary = asyncio.run(
+        run_baseline_batch(
+            [_task("one")],
+            runner=runner,
+            agent_name="fake",
+            model=None,
+            metrics_k=[1],
+        )
+    )
+
+    assert summary.failed == 1
+    assert summary.succeeded == 0
+    assert summary.scored == 0
+    assert summary.metrics["files"][1]["accuracy"] == 0.0
+
+
+def test_run_baseline_batch_resumes_existing_jsonl(tmp_path):
+    result_path = tmp_path / "baseline.jsonl"
+    result_path.write_text(
+        json.dumps({"instance_id": "one", "success": True}) + "\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def runner(task):
+        calls.append(task.instance_id)
+        return _result()
+
+    summary = asyncio.run(
+        run_baseline_batch(
+            [_task("one"), _task("two")],
+            runner=runner,
+            agent_name="fake",
+            model=None,
+            metrics_k=[1],
+            result_path=result_path,
+            resume=True,
+        )
+    )
+
+    assert baseline_done_ids(result_path) == {"one", "two"}
+    assert calls == ["two"]
+    assert summary.skipped == 1
+    assert summary.attempted == 1
+    rows = [json.loads(line) for line in result_path.read_text().splitlines()]
+    assert [row["instance_id"] for row in rows] == ["one", "two"]


### PR DESCRIPTION
## Summary
Add a generic eval-layer batch runner for baseline task sequences so external-agent, LSP, and future OpenCode-style baselines can share task iteration, JSONL writing, resume, exception capture, and aggregate metrics.

## Changes
- Add `codeminer.eval.agent_runner.batch` with `BaselineBatchSummary`, `BaselineTaskRunner`, `baseline_done_ids`, and `run_baseline_batch`.
- Export the batch runner helpers from `codeminer.eval.agent_runner`.
- Delegate `codeminer.eval.loc_agent_runner.already_done_ids` to the shared JSONL helper while preserving its public function.
- Add unit tests for async/sync runner support, JSONL output, aggregate metrics, exception records, and resume behavior.
- Update the architecture goal doc to mark M9b landed and define M9c.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `pytest test/eval/test_baseline_batch.py test/eval/test_baseline.py test/eval/test_lsp_baseline.py -q`
- `pre-commit run --files codeminer/eval/agent_runner/__init__.py codeminer/eval/agent_runner/batch.py codeminer/eval/loc_agent_runner.py test/eval/test_baseline_batch.py docs/agent_runner_architecture_goal.md`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

Promotion checklist:
- Reusable contract changed: generic eval batch execution for `BaselineTask` runners.
- Raw behavior improved: runner exceptions and raw success/failure records are captured before metric aggregation.
- Smoke/holdout used: not a runtime default; covered by focused unit tests and the full unit tier.
- Models/external agents compared: none in this PR; it prepares shared execution for LSP/Codex/Claude/OpenCode-style baselines.
- Failure category targeted: context/runtime and infrastructure observability for baseline feedback loops.
- Not tied to a benchmark instance or scorer field: the runner only consumes task targets through the shared scoring envelope and has no dataset-specific logic.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published