### PR TITLE
chore(agent): deprecate agent compile shims

### DIFF
--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -132,15 +132,15 @@ benchmark cell is currently easiest to improve.
    `codeminer.eval.agent_runner`.
 
 6. **M9d: External loc baseline driver migration.**
-   Route the existing Codex/Claude localization baseline driver through the
-   shared batch runner while keeping dataset selection and CLI flags in the
-   driver layer.
+   Landed in #296. The existing Codex/Claude localization baseline driver now
+   uses the shared batch runner while keeping dataset selection and CLI flags in
+   the driver layer.
 
 7. **M10a: Legacy script shim cleanup.**
-   Keep `scripts/agent_compile/lib` only as long as needed for old notebooks.
-   Internal scripts and reusable tests should continue importing package APIs
-   directly, and the compatibility layer should be removed once the migration
-   window closes.
+   Mark `scripts/agent_compile/lib` as deprecated compatibility for old
+   notebooks. Internal scripts and reusable tests should continue importing
+   package APIs directly, and the compatibility layer should be removed once the
+   migration window closes.
 
 ## Current Boundary Decisions
 
@@ -153,8 +153,8 @@ benchmark cell is currently easiest to improve.
   failure, span metrics, or preload contribution logic.
 - Small feedback slices are selected by deterministic smoke plus rotated
   holdout plans, not by hand-picking named project instances.
-- Compatibility shims under `scripts/agent_compile/lib` are not core ownership.
-  New code should not import them.
+- Compatibility shims under `scripts/agent_compile/lib` are deprecated and are
+  not core ownership. New code should not import them.
 - External-agent and LSP baseline task/result envelopes live in
   `codeminer.eval.agent_runner`. Client wrappers and examples may adapt their
   SDK-specific inputs to that envelope, but they should not own reusable scoring

--- a/scripts/agent_compile/README.md
+++ b/scripts/agent_compile/README.md
@@ -51,7 +51,7 @@ ablation.
 | `feedback_plan.py` | choose a small deterministic feedback slice: fixed smoke cases plus a seed-rotated holdout, stratified by language/group. Outputs JSON instance lists for `run_sweep.py --instances ...`. |
 | `run_sweep.py` | run the sweep: `{arms} × {instances} × {reps}` agent cells on prebuilt indexes; `cells/<id>.json` + `sweep_summary.json`. Validates the harness (raises on unknown tool/skill ids) before spending. |
 | `aggregate.py` | fold cells into a report: per-arm metrics, skill-invocation histogram, easy/hard split, per-scenario cells, Pareto front → `report.md` + `metrics.json`. |
-| `lib/*.py` | compatibility shims for older experiment notebooks; reusable config/harness code lives in `codeminer.eval.agent_runner`. |
+| `lib/*.py` | deprecated compatibility shims for older experiment notebooks; reusable config/harness code lives in `codeminer.eval.agent_runner`. |
 
 The base agent-localization scorer (answer + `read` paths + retrieval nodes →
 files@k / symbols@k) lives in
@@ -93,6 +93,13 @@ python scripts/agent_compile/feedback_plan.py \
 `run_sweep.py` resumes per cell and does not persist transient (rate-limit)
 failures, so a re-run retries them. Instances without prebuilt indexes are
 skipped and recorded in `sweep_summary.json`.
+
+## Compatibility Shims
+
+`scripts/agent_compile/lib` is a deprecated import path. New scripts, tests, and
+reusable code should import from `codeminer.eval.agent_runner` directly. The shim
+package remains only for old notebooks and ad hoc experiment commands during the
+migration window.
 
 ## How indexes reach the agent
 

--- a/scripts/agent_compile/lib/__init__.py
+++ b/scripts/agent_compile/lib/__init__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compatibility namespace for the agent-compile cost study.
+"""Deprecated compatibility namespace for the agent-compile cost study.
 
 Reusable sweep configuration and harness helpers now live in
 ``codeminer.eval.agent_runner``. This package remains so older experiment
@@ -19,3 +19,16 @@ Modules:
 * :mod:`prebuilt` — stage offline-built per-instance indexes into the
   ``cache_dir/<type>`` layout ``build_skill_contexts`` expects.
 """
+
+from __future__ import annotations
+
+import warnings
+
+_DEPRECATION_MESSAGE = (
+    "scripts.agent_compile.lib is deprecated; import reusable agent-runner "
+    "helpers from codeminer.eval.agent_runner instead."
+)
+
+warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
+
+__all__ = ["_DEPRECATION_MESSAGE"]

--- a/test/agent_compile/test_compat_shims.py
+++ b/test/agent_compile/test_compat_shims.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for deprecated agent-compile compatibility shims."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def test_agent_compile_lib_import_warns_deprecated():
+    sys.modules.pop("scripts.agent_compile.lib", None)
+
+    with pytest.warns(DeprecationWarning, match="codeminer.eval.agent_runner"):
+        module = importlib.import_module("scripts.agent_compile.lib")
+
+    assert "deprecated" in module._DEPRECATION_MESSAGE


### PR DESCRIPTION
## Summary
Mark `scripts.agent_compile.lib` as deprecated compatibility and document that reusable agent-runner code should import `codeminer.eval.agent_runner` directly.

## Changes
- Emit a `DeprecationWarning` when `scripts.agent_compile.lib` is imported.
- Document the deprecated shim path in `scripts/agent_compile/README.md`.
- Update the architecture goal doc to mark #296 landed and define M10a as shim deprecation/cleanup.
- Add a unit test that locks in the deprecation warning.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `pytest test/agent_compile/test_compat_shims.py test/agent/test_import_boundaries.py -q`
- `pre-commit run --files scripts/agent_compile/lib/__init__.py scripts/agent_compile/README.md docs/agent_runner_architecture_goal.md test/agent_compile/test_compat_shims.py`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

Promotion checklist:
- Reusable contract changed: none; this explicitly deprecates a compatibility import path.
- Raw behavior improved: internal code already avoids the shim path, and imports now surface deprecation state.
- Smoke/holdout used: not a runtime default; covered by focused unit/import-boundary tests and full unit tier.
- Models/external agents compared: none.
- Failure category targeted: architecture drift in experiment scripts.
- Not tied to a benchmark instance or scorer field: this only constrains module ownership/import paths.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings beyond the intentional deprecation warning for the shim import
- [x] Any dependent changes have been merged and published