### PR TITLE
refactor(eval): move loc baseline runner into agent package

### DIFF
--- a/codeminer/eval/agent_runner/loc_baseline.py
+++ b/codeminer/eval/agent_runner/loc_baseline.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dataset adapter and CLI glue for external localization baseline runners.
+
+Used by ``examples/claude_loc_agent.py`` and ``examples/codex_loc_agent.py``.
+Holds:
+
+- ``BUILTIN_DATASET_CHOICES`` and ``build_dataset(args)`` — same shape as
+  the existing retrieval-baseline scripts (e.g. embedding_retrieve_baseline.py)
+- ``already_done_ids(path)`` — skim a JSONL result file for completed IDs
+- ``build_result_entry(...)`` — per-instance record with ``metric_k_files`` /
+  ``metric_k_node_ids`` and per-scope/per-k ``metrics``, so it joins cleanly
+  against the internal harness (see retrieve_rerank.py)
+- ``run_agent_baseline(args, agent_factory, agent_name)`` — dataset-specific
+  driver that prepares :class:`BaselineTask` inputs and delegates the reusable
+  execution / JSONL / metrics loop to ``codeminer.eval.agent_runner.batch``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set
+
+from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
+from codeminer.dataset.locbench import LocbenchDataset
+from codeminer.dataset.swebench import SwebenchDataset
+from codeminer.eval.agent_runner.baseline import (
+    BaselineLocation,
+    BaselineTask,
+    build_baseline_result_entry,
+    location_symbol_ids,
+    score_baseline_predictions,
+    unique_location_files,
+)
+from codeminer.eval.agent_runner.batch import baseline_done_ids, run_baseline_batch
+from codeminer.eval.retrieval_eval import collect_targets
+from codeminer.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+BUILTIN_DATASET_CHOICES = ["codeminer_base", "swebench_lite", "locbench_v1"]
+DEFAULT_METRICS_K = [1, 3, 5, 10]
+
+
+def build_dataset(args):
+    """Mirror of embedding_retrieve_baseline._build_dataset()."""
+    if args.dataset == "codeminer_base":
+        return CodeMinerBaseDataset(
+            dataset="fishmingyu/codeminer-base-dataset",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=os.path.expanduser(args.repo_cache_dir),
+        )
+    if args.dataset == "swebench_lite":
+        return SwebenchDataset(
+            dataset="princeton-nlp/SWE-bench_Lite",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=os.path.expanduser(args.repo_cache_dir),
+        )
+    if args.dataset == "locbench_v1":
+        return LocbenchDataset(
+            dataset="czlll/Loc-Bench_V1",
+            split=args.split,
+            filter_instance=args.filter_instance,
+            repo_root=os.path.expanduser(args.repo_cache_dir),
+        )
+    raise ValueError(f"Unsupported dataset: {args.dataset}")
+
+
+def already_done_ids(result_path: Path) -> Set[str]:
+    """Return instance_ids already present in an existing JSONL result file."""
+    return baseline_done_ids(result_path)
+
+
+def _unique_files(locations) -> List[str]:
+    return unique_location_files([BaselineLocation.from_raw(sym) for sym in locations])
+
+
+def _agent_symbol_id(file_path: str, name: str) -> Optional[str]:
+    """Compose an agent ``(file_path, name)`` into the GT ``file:symbol`` form.
+
+    GT (from ``codeminer/code_chunking/``) is exactly one of:
+        ``<file>:bare_function()``
+        ``<file>:Class.method()``
+        ``<file>:ClassName``
+
+    The agents' ``name`` field is constrained to this same canonical shape by
+    the JSON-Schema ``pattern`` on ``LOC_OUTPUT_SCHEMA`` (at most one ``.``,
+    no ``::``, no signatures) plus the system-prompt format rules. So scoring
+    is just exact string match against GT — no candidate generation, no FP
+    risk from over-permissive normalization.
+    """
+    if not name or not file_path:
+        return None
+    return BaselineLocation(name=name, type="", file_path=file_path).symbol_id()
+
+
+def _agent_symbol_ids(locations) -> List[str]:
+    """Build the predicted symbol id list in agent-output order."""
+    return location_symbol_ids([BaselineLocation.from_raw(sym) for sym in locations])
+
+
+def _score_predictions(
+    predicted_files: Sequence[str],
+    predicted_symbols: Sequence[str],
+    target_files: Sequence[str],
+    target_symbols: Sequence[str],
+    ks: Sequence[int],
+) -> Dict[str, Dict[int, Dict[str, float]]]:
+    """``{files, symbols}`` × k metric dict via retrieval_eval.compute_metrics."""
+    return score_baseline_predictions(
+        predicted_files,
+        predicted_symbols,
+        target_files,
+        target_symbols,
+        ks,
+    )
+
+
+def build_result_entry(
+    *,
+    instance_id: str,
+    agent_name: str,
+    model: Optional[str],
+    result,
+    target_files: Sequence[str],
+    target_symbols: Sequence[str],
+    metrics_k: Sequence[int],
+    error: Optional[str] = None,
+) -> Dict[str, Any]:
+    """One JSONL record: predictions + GT + per-scope/per-k metrics."""
+    task = BaselineTask(
+        instance_id=instance_id,
+        query="",
+        repo_path=str(getattr(result, "repo_path", "") or ""),
+        target_files=tuple(target_files),
+        target_symbols=tuple(target_symbols),
+    )
+    return build_baseline_result_entry(
+        task=task,
+        agent_name=agent_name,
+        model=model,
+        result=result,
+        metrics_k=metrics_k,
+        error=error,
+    )
+
+
+def _log_aggregate_table(
+    averaged: Mapping[str, Mapping[int, Mapping[str, float]]],
+    eval_count: int,
+) -> None:
+    """Pretty-print aggregate file and symbol metrics to the logger."""
+    if eval_count == 0:
+        logger.info("No instances were scored (eval_count=0).")
+        return
+    logger.info("Aggregate metrics over %d scored instance(s):", eval_count)
+    for scope in ("files", "symbols"):
+        per_k = averaged.get(scope, {})
+        if not per_k:
+            continue
+        for k in sorted(per_k):
+            stats = per_k[k]
+            logger.info(
+                "  [%s] k=%-2d  accuracy=%.3f  precision=%.3f  recall=%.3f  "
+                "avg_hits=%.2f",
+                scope,
+                k,
+                stats["accuracy"],
+                stats["precision"],
+                stats["recall"],
+                stats["avg_hits"],
+            )
+
+
+def _task_from_instance(
+    inst: Mapping[str, Any],
+    *,
+    eval_metadata: Mapping[str, Any],
+    simplified_symbols: bool,
+) -> BaselineTask:
+    instance_id = str(inst["instance_id"])
+    metadata = eval_metadata.get(instance_id)
+    if metadata is None:
+        target_files: List[str] = []
+        target_symbols: List[str] = []
+    else:
+        target_files, target_symbols = collect_targets(
+            metadata,
+            simplified_symbols=simplified_symbols,
+        )
+    return BaselineTask(
+        instance_id=instance_id,
+        query=str(inst.get("problem_statement") or ""),
+        repo_path="",
+        target_files=tuple(target_files),
+        target_symbols=tuple(target_symbols),
+        repo_name=str(inst.get("repo") or "") or None,
+    )
+
+
+async def run_agent_baseline(
+    args,
+    *,
+    agent_factory: Callable[[], Any],
+    agent_name: str,
+    model_label: Optional[str] = None,
+) -> int:
+    """Iterate dataset, call agent.locate_code on each instance, append JSONL.
+
+    Per-instance: score against GT (``target_files`` + ``target_symbols``)
+    via ``codeminer.eval.retrieval_eval.compute_metrics`` for the configured
+    ``--metrics-k`` cutoffs and embed the result in the JSONL row. At the
+    end, aggregate + log the dataset-level table.
+    """
+    dataset_obj = build_dataset(args)
+    instances = dataset_obj.load()
+    if len(instances) == 0:
+        raise ValueError(
+            f"No instances matched filter {args.filter_instance!r} "
+            f"on dataset {args.dataset!r}"
+        )
+    if getattr(args, "limit", None):
+        instances = instances.select(range(min(args.limit, len(instances))))
+    instance_rows = list(instances)
+    logger.info("Loaded %d instance(s) from %s", len(instance_rows), args.dataset)
+
+    eval_metadata = dataset_obj.load_eval_metadata(args.eval_instances or "")
+    simplified_symbols = getattr(dataset_obj, "simplified_symbols", True)
+    metrics_k = list(args.metrics_k)
+
+    tasks = [
+        _task_from_instance(
+            inst,
+            eval_metadata=eval_metadata,
+            simplified_symbols=simplified_symbols,
+        )
+        for inst in instance_rows
+    ]
+    instances_by_id = {
+        task.instance_id: inst for task, inst in zip(tasks, instance_rows, strict=True)
+    }
+
+    result_path = Path(args.result_path).expanduser().resolve()
+    done = baseline_done_ids(result_path) if args.resume else set()
+    if done:
+        logger.info(
+            "Resuming — %d instance(s) already in %s, will skip",
+            len(done),
+            result_path,
+        )
+
+    agent = agent_factory()
+
+    async def locate(task: BaselineTask):
+        inst = instances_by_id[task.instance_id]
+        dataset_obj.process_instance(inst)
+        repo = dataset_obj.get_repo_path(inst)
+        call_task = BaselineTask.from_dataset_instance(
+            inst,
+            repo_path=repo,
+            target_files=task.target_files,
+            target_symbols=task.target_symbols,
+        )
+        return await agent.locate_code(**call_task.to_agent_call())
+
+    summary = await run_baseline_batch(
+        tasks,
+        runner=locate,
+        agent_name=agent_name,
+        model=model_label,
+        metrics_k=metrics_k,
+        result_path=result_path,
+        resume=args.resume,
+    )
+
+    _log_aggregate_table(summary.metrics, summary.scored)
+
+    logger.info(
+        "Done. success=%d failed=%d skipped=%d scored=%d total=%d result=%s",
+        summary.succeeded,
+        summary.failed,
+        summary.skipped,
+        summary.scored,
+        summary.total,
+        summary.result_path,
+    )
+    return 0 if summary.failed == 0 else 1
+
+
+def add_common_args(parser) -> None:
+    """Attach the shared dataset / output / resume / scoring flags."""
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        choices=BUILTIN_DATASET_CHOICES,
+    )
+    parser.add_argument("--split", type=str, default="test")
+    parser.add_argument("--filter-instance", type=str, default=".*")
+    parser.add_argument(
+        "--repo-cache-dir",
+        type=str,
+        default="~/.codeminer/",
+    )
+    parser.add_argument(
+        "--result-path",
+        type=str,
+        required=True,
+        help="Path to JSONL result file (one instance per line, appended).",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip instance_ids already present in --result-path.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap number of instances to process (post-filter).",
+    )
+    parser.add_argument(
+        "--eval-instances",
+        type=str,
+        default="",
+        help=(
+            "Path to JSON file with eval annotations (target_files, symbols_*). "
+            "Leave empty for codeminer_base — GT is projected from dataset columns."
+        ),
+    )
+    parser.add_argument(
+        "--metrics-k",
+        type=int,
+        nargs="+",
+        default=DEFAULT_METRICS_K,
+        help="Cutoffs for file and symbol metric reporting.",
+    )
+
+
+__all__ = [
+    "BUILTIN_DATASET_CHOICES",
+    "DEFAULT_METRICS_K",
+    "add_common_args",
+    "already_done_ids",
+    "build_dataset",
+    "build_result_entry",
+    "run_agent_baseline",
+]

--- a/codeminer/eval/loc_agent_runner.py
+++ b/codeminer/eval/loc_agent_runner.py
@@ -2,342 +2,36 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared loop + I/O for agentic localization baseline runners (#150).
-
-Used by ``examples/claude_loc_agent.py`` and ``examples/codex_loc_agent.py``.
-Holds:
-
-- ``BUILTIN_DATASET_CHOICES`` and ``build_dataset(args)`` — same shape as
-  the existing retrieval-baseline scripts (e.g. embedding_retrieve_baseline.py)
-- ``already_done_ids(path)`` — skim a JSONL result file for completed IDs
-- ``build_result_entry(...)`` — per-instance record with ``metric_k_files`` /
-  ``metric_k_node_ids`` and per-scope/per-k ``metrics``, so it joins cleanly
-  against the internal harness (see retrieve_rerank.py)
-- ``run_agent_baseline(args, agent_factory, agent_name)`` — dataset-specific
-  driver that prepares :class:`BaselineTask` inputs and delegates the reusable
-  execution / JSONL / metrics loop to ``codeminer.eval.agent_runner.batch``.
-"""
+"""Deprecated compatibility wrapper for external LOC baseline helpers."""
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set
+import warnings
 
-from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
-from codeminer.dataset.locbench import LocbenchDataset
-from codeminer.dataset.swebench import SwebenchDataset
-from codeminer.eval.agent_runner.baseline import (
-    BaselineLocation,
-    BaselineTask,
-    build_baseline_result_entry,
-    location_symbol_ids,
-    score_baseline_predictions,
-    unique_location_files,
+from codeminer.eval.agent_runner.loc_baseline import (
+    BUILTIN_DATASET_CHOICES,
+    DEFAULT_METRICS_K,
+    add_common_args,
+    already_done_ids,
+    build_dataset,
+    build_result_entry,
+    run_agent_baseline,
 )
-from codeminer.eval.agent_runner.batch import baseline_done_ids, run_baseline_batch
-from codeminer.eval.retrieval_eval import collect_targets
-from codeminer.log_utils import get_logger
 
-logger = get_logger(__name__)
+_DEPRECATION_MESSAGE = (
+    "codeminer.eval.loc_agent_runner is deprecated; import external "
+    "localization baseline helpers from "
+    "codeminer.eval.agent_runner.loc_baseline instead."
+)
 
+warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
 
-BUILTIN_DATASET_CHOICES = ["codeminer_base", "swebench_lite", "locbench_v1"]
-DEFAULT_METRICS_K = [1, 3, 5, 10]
-
-
-def build_dataset(args):
-    """Mirror of embedding_retrieve_baseline._build_dataset()."""
-    if args.dataset == "codeminer_base":
-        return CodeMinerBaseDataset(
-            dataset="fishmingyu/codeminer-base-dataset",
-            split=args.split,
-            filter_instance=args.filter_instance,
-            repo_root=os.path.expanduser(args.repo_cache_dir),
-        )
-    if args.dataset == "swebench_lite":
-        return SwebenchDataset(
-            dataset="princeton-nlp/SWE-bench_Lite",
-            split=args.split,
-            filter_instance=args.filter_instance,
-            repo_root=os.path.expanduser(args.repo_cache_dir),
-        )
-    if args.dataset == "locbench_v1":
-        return LocbenchDataset(
-            dataset="czlll/Loc-Bench_V1",
-            split=args.split,
-            filter_instance=args.filter_instance,
-            repo_root=os.path.expanduser(args.repo_cache_dir),
-        )
-    raise ValueError(f"Unsupported dataset: {args.dataset}")
-
-
-def already_done_ids(result_path: Path) -> Set[str]:
-    """Return instance_ids already present in an existing JSONL result file."""
-    return baseline_done_ids(result_path)
-
-
-def _unique_files(locations) -> List[str]:
-    return unique_location_files([BaselineLocation.from_raw(sym) for sym in locations])
-
-
-def _agent_symbol_id(file_path: str, name: str) -> Optional[str]:
-    """Compose an agent ``(file_path, name)`` into the GT ``file:symbol`` form.
-
-    GT (from ``codeminer/code_chunking/``) is exactly one of:
-        ``<file>:bare_function()``
-        ``<file>:Class.method()``
-        ``<file>:ClassName``
-
-    The agents' ``name`` field is constrained to this same canonical shape by
-    the JSON-Schema ``pattern`` on ``LOC_OUTPUT_SCHEMA`` (at most one ``.``,
-    no ``::``, no signatures) plus the system-prompt format rules. So scoring
-    is just exact string match against GT — no candidate generation, no FP
-    risk from over-permissive normalization.
-    """
-    if not name or not file_path:
-        return None
-    return BaselineLocation(name=name, type="", file_path=file_path).symbol_id()
-
-
-def _agent_symbol_ids(locations) -> List[str]:
-    """Build the predicted symbol id list in agent-output order."""
-    return location_symbol_ids([BaselineLocation.from_raw(sym) for sym in locations])
-
-
-def _score_predictions(
-    predicted_files: Sequence[str],
-    predicted_symbols: Sequence[str],
-    target_files: Sequence[str],
-    target_symbols: Sequence[str],
-    ks: Sequence[int],
-) -> Dict[str, Dict[int, Dict[str, float]]]:
-    """``{files, symbols}`` × k metric dict via retrieval_eval.compute_metrics."""
-    return score_baseline_predictions(
-        predicted_files,
-        predicted_symbols,
-        target_files,
-        target_symbols,
-        ks,
-    )
-
-
-def build_result_entry(
-    *,
-    instance_id: str,
-    agent_name: str,
-    model: Optional[str],
-    result,
-    target_files: Sequence[str],
-    target_symbols: Sequence[str],
-    metrics_k: Sequence[int],
-    error: Optional[str] = None,
-) -> Dict[str, Any]:
-    """One JSONL record: predictions + GT + per-scope/per-k metrics."""
-    task = BaselineTask(
-        instance_id=instance_id,
-        query="",
-        repo_path=str(getattr(result, "repo_path", "") or ""),
-        target_files=tuple(target_files),
-        target_symbols=tuple(target_symbols),
-    )
-    return build_baseline_result_entry(
-        task=task,
-        agent_name=agent_name,
-        model=model,
-        result=result,
-        metrics_k=metrics_k,
-        error=error,
-    )
-
-
-def _log_aggregate_table(
-    averaged: Mapping[str, Mapping[int, Mapping[str, float]]],
-    eval_count: int,
-) -> None:
-    """Pretty-print the aggregated files@k / symbols@k table to the logger."""
-    if eval_count == 0:
-        logger.info("No instances were scored (eval_count=0).")
-        return
-    logger.info("Aggregate metrics over %d scored instance(s):", eval_count)
-    for scope in ("files", "symbols"):
-        per_k = averaged.get(scope, {})
-        if not per_k:
-            continue
-        for k in sorted(per_k):
-            stats = per_k[k]
-            logger.info(
-                "  [%s] k=%-2d  accuracy=%.3f  precision=%.3f  recall=%.3f  "
-                "avg_hits=%.2f",
-                scope,
-                k,
-                stats["accuracy"],
-                stats["precision"],
-                stats["recall"],
-                stats["avg_hits"],
-            )
-
-
-def _task_from_instance(
-    inst: Mapping[str, Any],
-    *,
-    eval_metadata: Mapping[str, Any],
-    simplified_symbols: bool,
-) -> BaselineTask:
-    instance_id = str(inst["instance_id"])
-    metadata = eval_metadata.get(instance_id)
-    if metadata is None:
-        target_files: List[str] = []
-        target_symbols: List[str] = []
-    else:
-        target_files, target_symbols = collect_targets(
-            metadata,
-            simplified_symbols=simplified_symbols,
-        )
-    return BaselineTask(
-        instance_id=instance_id,
-        query=str(inst.get("problem_statement") or ""),
-        repo_path="",
-        target_files=tuple(target_files),
-        target_symbols=tuple(target_symbols),
-        repo_name=str(inst.get("repo") or "") or None,
-    )
-
-
-async def run_agent_baseline(
-    args,
-    *,
-    agent_factory: Callable[[], Any],
-    agent_name: str,
-    model_label: Optional[str] = None,
-) -> int:
-    """Iterate dataset, call agent.locate_code on each instance, append JSONL.
-
-    Per-instance: score against GT (``target_files`` + ``target_symbols``)
-    via ``codeminer.eval.retrieval_eval.compute_metrics`` for the configured
-    ``--metrics-k`` cutoffs and embed the result in the JSONL row. At the
-    end, aggregate + log the dataset-level table.
-    """
-    dataset_obj = build_dataset(args)
-    instances = dataset_obj.load()
-    if len(instances) == 0:
-        raise ValueError(
-            f"No instances matched filter {args.filter_instance!r} "
-            f"on dataset {args.dataset!r}"
-        )
-    if getattr(args, "limit", None):
-        instances = instances.select(range(min(args.limit, len(instances))))
-    instance_rows = list(instances)
-    logger.info("Loaded %d instance(s) from %s", len(instance_rows), args.dataset)
-
-    eval_metadata = dataset_obj.load_eval_metadata(args.eval_instances or "")
-    simplified_symbols = getattr(dataset_obj, "simplified_symbols", True)
-    metrics_k = list(args.metrics_k)
-
-    tasks = [
-        _task_from_instance(
-            inst,
-            eval_metadata=eval_metadata,
-            simplified_symbols=simplified_symbols,
-        )
-        for inst in instance_rows
-    ]
-    instances_by_id = {
-        task.instance_id: inst for task, inst in zip(tasks, instance_rows, strict=True)
-    }
-
-    result_path = Path(args.result_path).expanduser().resolve()
-    done = baseline_done_ids(result_path) if args.resume else set()
-    if done:
-        logger.info(
-            "Resuming — %d instance(s) already in %s, will skip",
-            len(done),
-            result_path,
-        )
-
-    agent = agent_factory()
-
-    async def locate(task: BaselineTask):
-        inst = instances_by_id[task.instance_id]
-        dataset_obj.process_instance(inst)
-        repo = dataset_obj.get_repo_path(inst)
-        call_task = BaselineTask.from_dataset_instance(
-            inst,
-            repo_path=repo,
-            target_files=task.target_files,
-            target_symbols=task.target_symbols,
-        )
-        return await agent.locate_code(**call_task.to_agent_call())
-
-    summary = await run_baseline_batch(
-        tasks,
-        runner=locate,
-        agent_name=agent_name,
-        model=model_label,
-        metrics_k=metrics_k,
-        result_path=result_path,
-        resume=args.resume,
-    )
-
-    _log_aggregate_table(summary.metrics, summary.scored)
-
-    logger.info(
-        "Done. success=%d failed=%d skipped=%d scored=%d total=%d result=%s",
-        summary.succeeded,
-        summary.failed,
-        summary.skipped,
-        summary.scored,
-        summary.total,
-        summary.result_path,
-    )
-    return 0 if summary.failed == 0 else 1
-
-
-def add_common_args(parser) -> None:
-    """Attach the shared dataset / output / resume / scoring flags."""
-    parser.add_argument(
-        "--dataset",
-        type=str,
-        required=True,
-        choices=BUILTIN_DATASET_CHOICES,
-    )
-    parser.add_argument("--split", type=str, default="test")
-    parser.add_argument("--filter-instance", type=str, default=".*")
-    parser.add_argument(
-        "--repo-cache-dir",
-        type=str,
-        default="~/.codeminer/",
-    )
-    parser.add_argument(
-        "--result-path",
-        type=str,
-        required=True,
-        help="Path to JSONL result file (one instance per line, appended).",
-    )
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Skip instance_ids already present in --result-path.",
-    )
-    parser.add_argument(
-        "--limit",
-        type=int,
-        default=None,
-        help="Cap number of instances to process (post-filter).",
-    )
-    parser.add_argument(
-        "--eval-instances",
-        type=str,
-        default="",
-        help=(
-            "Path to JSON file with eval annotations (target_files, symbols_*). "
-            "Leave empty for codeminer_base — GT is projected from dataset columns."
-        ),
-    )
-    parser.add_argument(
-        "--metrics-k",
-        type=int,
-        nargs="+",
-        default=DEFAULT_METRICS_K,
-        help="Cutoffs for files@k / symbols@k reporting.",
-    )
+__all__ = [
+    "BUILTIN_DATASET_CHOICES",
+    "DEFAULT_METRICS_K",
+    "add_common_args",
+    "already_done_ids",
+    "build_dataset",
+    "build_result_entry",
+    "run_agent_baseline",
+]

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -137,10 +137,16 @@ benchmark cell is currently easiest to improve.
    the driver layer.
 
 7. **M10a: Legacy script shim cleanup.**
-   Mark `scripts/agent_compile/lib` as deprecated compatibility for old
-   notebooks. Internal scripts and reusable tests should continue importing
-   package APIs directly, and the compatibility layer should be removed once the
-   migration window closes.
+   Landed in #297. `scripts/agent_compile/lib` is deprecated compatibility for
+   old notebooks. Internal scripts and reusable tests import package APIs
+   directly, and the compatibility layer should be removed once the migration
+   window closes.
+
+8. **M10b: External LOC baseline ownership.**
+   Move reusable external localization baseline helpers into
+   `codeminer.eval.agent_runner.loc_baseline`, update maintained examples to
+   import that package API, and leave `codeminer.eval.loc_agent_runner` as a
+   deprecated compatibility wrapper only.
 
 ## Current Boundary Decisions
 
@@ -155,6 +161,9 @@ benchmark cell is currently easiest to improve.
   holdout plans, not by hand-picking named project instances.
 - Compatibility shims under `scripts/agent_compile/lib` are deprecated and are
   not core ownership. New code should not import them.
+- External localization baseline helpers live under
+  `codeminer.eval.agent_runner.loc_baseline`; the old
+  `codeminer.eval.loc_agent_runner` module is deprecated compatibility only.
 - External-agent and LSP baseline task/result envelopes live in
   `codeminer.eval.agent_runner`. Client wrappers and examples may adapt their
   SDK-specific inputs to that envelope, but they should not own reusable scoring

--- a/examples/claude_loc_agent.py
+++ b/examples/claude_loc_agent.py
@@ -37,7 +37,7 @@ import argparse
 import asyncio
 
 from codeminer.clients.claude_agent import ClaudeLocAgent
-from codeminer.eval.loc_agent_runner import add_common_args, run_agent_baseline
+from codeminer.eval.agent_runner.loc_baseline import add_common_args, run_agent_baseline
 from codeminer.log_utils import get_logger
 
 logger = get_logger(__name__)

--- a/examples/codex_loc_agent.py
+++ b/examples/codex_loc_agent.py
@@ -46,7 +46,7 @@ import argparse
 import asyncio
 
 from codeminer.clients.codex_agent import CodexLocAgent
-from codeminer.eval.loc_agent_runner import add_common_args, run_agent_baseline
+from codeminer.eval.agent_runner.loc_baseline import add_common_args, run_agent_baseline
 from codeminer.log_utils import get_logger
 
 logger = get_logger(__name__)

--- a/test/eval/test_baseline.py
+++ b/test/eval/test_baseline.py
@@ -7,8 +7,12 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import json
+import sys
 from types import SimpleNamespace
+
+import pytest
 
 from codeminer.eval.agent_runner.baseline import (
     BaselineRunResult,
@@ -17,7 +21,10 @@ from codeminer.eval.agent_runner.baseline import (
     location_symbol_ids,
     unique_location_files,
 )
-from codeminer.eval.loc_agent_runner import build_result_entry, run_agent_baseline
+from codeminer.eval.agent_runner.loc_baseline import (
+    build_result_entry,
+    run_agent_baseline,
+)
 
 
 def _success_result():
@@ -160,6 +167,16 @@ def test_loc_agent_runner_build_result_entry_delegates_to_envelope():
     assert entry["locations"][0]["name"] == "Parser.parse()"
 
 
+def test_loc_agent_runner_legacy_import_warns_deprecated():
+    sys.modules.pop("codeminer.eval.loc_agent_runner", None)
+
+    with pytest.warns(DeprecationWarning, match="agent_runner.loc_baseline"):
+        module = importlib.import_module("codeminer.eval.loc_agent_runner")
+
+    assert module.run_agent_baseline is run_agent_baseline
+    assert "deprecated" in module._DEPRECATION_MESSAGE
+
+
 def test_build_baseline_result_entry_handles_failures():
     task = BaselineTask(
         instance_id="demo__repo-1",
@@ -224,7 +241,7 @@ def test_run_agent_baseline_uses_baseline_task_envelope(monkeypatch, tmp_path):
             return _success_result()
 
     monkeypatch.setattr(
-        "codeminer.eval.loc_agent_runner.build_dataset",
+        "codeminer.eval.agent_runner.loc_baseline.build_dataset",
         lambda _args: FakeDataset(),
     )
     args = SimpleNamespace(
@@ -331,7 +348,7 @@ def test_run_agent_baseline_resume_skips_processing_done_instances(
             return _success_result()
 
     monkeypatch.setattr(
-        "codeminer.eval.loc_agent_runner.build_dataset",
+        "codeminer.eval.agent_runner.loc_baseline.build_dataset",
         lambda _args: dataset,
     )
     result_path = tmp_path / "baseline.jsonl"


### PR DESCRIPTION
## Summary
Move the reusable external localization baseline runner implementation into `codeminer.eval.agent_runner.loc_baseline` so the maintained baseline harness lives with the rest of the agent-runner evaluation package. Keep `codeminer.eval.loc_agent_runner` as a deprecated compatibility wrapper.

## Changes
- Move the external LOC baseline implementation into `codeminer.eval.agent_runner.loc_baseline`.
- Leave `codeminer.eval.loc_agent_runner` as a thin `DeprecationWarning` compatibility wrapper.
- Update Claude/Codex baseline examples and tests to import the package-owned API directly.
- Update the architecture goal doc with M10b and the new ownership boundary.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m compileall -q codeminer/eval/agent_runner/loc_baseline.py codeminer/eval/loc_agent_runner.py test/eval/test_baseline.py examples/claude_loc_agent.py examples/codex_loc_agent.py`
- `pytest test/eval/test_baseline.py test/eval/test_baseline_batch.py test/eval/test_lsp_baseline.py -q`
- `pytest test/agent/test_import_boundaries.py -q`
- `pre-commit run --files codeminer/eval/agent_runner/loc_baseline.py codeminer/eval/loc_agent_runner.py examples/claude_loc_agent.py examples/codex_loc_agent.py test/eval/test_baseline.py docs/agent_runner_architecture_goal.md`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

Promotion checklist:
- Reusable contract changed: external LOC baseline helpers now live under `codeminer.eval.agent_runner.loc_baseline`; the old module is compatibility only.
- Raw behavior improved: maintained examples and tests use package-owned APIs directly; no runtime scoring policy changed.
- Smoke/holdout used: not a model behavior promotion; covered by focused baseline tests, import-boundary tests, and full unit tier.
- Models/external agents compared: none.
- Failure category targeted: architecture drift and stale module ownership.
- Not tied to a benchmark instance or scorer field: this moves ownership and preserves existing JSONL/metric behavior.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings beyond the intentional deprecation warning for the compatibility import
- [x] Any dependent changes have been merged and published