### PR TITLE
feat(eval): add agent promotion evidence gate

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -61,6 +61,13 @@ from .preload import (
     retrieve_candidates,
     snippet_for_node,
 )
+from .promotion import (
+    FAILURE_CATEGORIES,
+    EvidenceSlice,
+    PromotionEvidence,
+    PromotionGateResult,
+    evaluate_promotion_evidence,
+)
 from .results import summarize_agent_result
 from .scoring import AgentLocalizationEvaluation, evaluate_agent_localization
 from .sweep import (
@@ -99,6 +106,7 @@ __all__ = [
     "BaselineBatchSummary",
     "BaselineTaskRunner",
     "BaselineTask",
+    "EvidenceSlice",
     "FormatArmSummary",
     "FormatDiagnostics",
     "FeedbackGroup",
@@ -108,7 +116,10 @@ __all__ = [
     "GraphNav",
     "LANG_GROUP_TO_KEY",
     "LSPRouteBaselineConfig",
+    "FAILURE_CATEGORIES",
     "PreloadQueryPlan",
+    "PromotionEvidence",
+    "PromotionGateResult",
     "SampleConfig",
     "SweepConfig",
     "Verdict",
@@ -127,6 +138,7 @@ __all__ = [
     "converge_query",
     "default_agent_skills_dir",
     "evaluate_agent_localization",
+    "evaluate_promotion_evidence",
     "expansion_seeds_from_candidates",
     "extract_lsp_symbol_seeds",
     "graph_verify",

--- a/codeminer/eval/agent_runner/promotion.py
+++ b/codeminer/eval/agent_runner/promotion.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Promotion evidence contracts for agent-runner behavior changes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+FAILURE_CATEGORIES = frozenset(
+    {
+        "content",
+        "rank",
+        "path_alias",
+        "format",
+        "context_runtime",
+        "infrastructure",
+    }
+)
+
+
+@dataclass(frozen=True)
+class EvidenceSlice:
+    """One evaluated slice used to support a promotion decision."""
+
+    name: str
+    role: str
+    instance_count: int
+    report_path: Optional[str] = None
+    seed: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("evidence slice name must be non-empty")
+        if self.role not in {"smoke", "holdout"}:
+            raise ValueError("evidence slice role must be 'smoke' or 'holdout'")
+        if self.instance_count < 0:
+            raise ValueError("evidence slice instance_count must be non-negative")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "role": self.role,
+            "instance_count": self.instance_count,
+            "report_path": self.report_path,
+            "seed": self.seed,
+        }
+
+
+@dataclass(frozen=True)
+class PromotionEvidence:
+    """Evidence required before experiment behavior becomes a runtime default."""
+
+    runtime_contract: str
+    raw_behavior_delta: str
+    failure_category: str
+    slices: Tuple[EvidenceSlice, ...] = ()
+    compared_models: Tuple[str, ...] = ()
+    compared_agents: Tuple[str, ...] = ()
+    model_specific: bool = False
+    scorer_dependencies: Tuple[str, ...] = ()
+    benchmark_dependencies: Tuple[str, ...] = ()
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "runtime_contract", self.runtime_contract.strip())
+        object.__setattr__(
+            self,
+            "raw_behavior_delta",
+            self.raw_behavior_delta.strip(),
+        )
+        object.__setattr__(self, "failure_category", self.failure_category.strip())
+        object.__setattr__(self, "slices", tuple(self.slices))
+        object.__setattr__(
+            self,
+            "compared_models",
+            _normalized_tuple(self.compared_models),
+        )
+        object.__setattr__(
+            self,
+            "compared_agents",
+            _normalized_tuple(self.compared_agents),
+        )
+        object.__setattr__(
+            self,
+            "scorer_dependencies",
+            _normalized_tuple(self.scorer_dependencies),
+        )
+        object.__setattr__(
+            self,
+            "benchmark_dependencies",
+            _normalized_tuple(self.benchmark_dependencies),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "runtime_contract": self.runtime_contract,
+            "raw_behavior_delta": self.raw_behavior_delta,
+            "failure_category": self.failure_category,
+            "slices": [item.to_dict() for item in self.slices],
+            "compared_models": list(self.compared_models),
+            "compared_agents": list(self.compared_agents),
+            "model_specific": self.model_specific,
+            "scorer_dependencies": list(self.scorer_dependencies),
+            "benchmark_dependencies": list(self.benchmark_dependencies),
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True)
+class PromotionGateResult:
+    """Validation result for a promotion evidence record."""
+
+    ready: bool
+    failures: Tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ready": self.ready,
+            "failures": list(self.failures),
+        }
+
+
+def evaluate_promotion_evidence(
+    evidence: PromotionEvidence,
+) -> PromotionGateResult:
+    """Validate promotion evidence without reading benchmark-specific context."""
+
+    failures: list[str] = []
+    if not evidence.runtime_contract:
+        failures.append("runtime_contract is required")
+    if not evidence.raw_behavior_delta:
+        failures.append("raw_behavior_delta is required")
+    if evidence.failure_category not in FAILURE_CATEGORIES:
+        failures.append("failure_category must be one of the allowed categories")
+
+    smoke = [item for item in evidence.slices if item.role == "smoke"]
+    holdout = [item for item in evidence.slices if item.role == "holdout"]
+    if not _has_non_empty_slice(smoke):
+        failures.append("at least one non-empty smoke slice is required")
+    if not _has_non_empty_slice(holdout):
+        failures.append("at least one non-empty holdout slice is required")
+
+    compared_systems = len(set(evidence.compared_models + evidence.compared_agents))
+    if evidence.model_specific and compared_systems < 2:
+        failures.append("model_specific changes require at least two compared systems")
+
+    if evidence.scorer_dependencies:
+        failures.append("promotion must not depend on scorer-specific fields")
+    if evidence.benchmark_dependencies:
+        failures.append("promotion must not depend on named benchmark instances")
+
+    return PromotionGateResult(ready=not failures, failures=tuple(failures))
+
+
+def _has_non_empty_slice(slices: Sequence[EvidenceSlice]) -> bool:
+    return any(item.instance_count > 0 for item in slices)
+
+
+def _normalized_tuple(values: Sequence[str]) -> Tuple[str, ...]:
+    return tuple(str(value).strip() for value in values if str(value).strip())
+
+
+__all__ = [
+    "FAILURE_CATEGORIES",
+    "EvidenceSlice",
+    "PromotionEvidence",
+    "PromotionGateResult",
+    "evaluate_promotion_evidence",
+]

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -143,10 +143,16 @@ benchmark cell is currently easiest to improve.
    window closes.
 
 8. **M10b: External LOC baseline ownership.**
-   Move reusable external localization baseline helpers into
-   `codeminer.eval.agent_runner.loc_baseline`, update maintained examples to
-   import that package API, and leave `codeminer.eval.loc_agent_runner` as a
-   deprecated compatibility wrapper only.
+   Landed in #298. Reusable external localization baseline helpers live in
+   `codeminer.eval.agent_runner.loc_baseline`; maintained examples import that
+   package API, and `codeminer.eval.loc_agent_runner` is a deprecated
+   compatibility wrapper only.
+
+9. **M10c: Promotion evidence contract.**
+   Add a typed evaluation contract for runtime promotion evidence so future
+   runner defaults require raw-behavior evidence, smoke and holdout slices,
+   failure category attribution, and explicit scorer/benchmark dependency
+   checks before they can leave experiment policy.
 
 ## Current Boundary Decisions
 
@@ -164,6 +170,9 @@ benchmark cell is currently easiest to improve.
 - External localization baseline helpers live under
   `codeminer.eval.agent_runner.loc_baseline`; the old
   `codeminer.eval.loc_agent_runner` module is deprecated compatibility only.
+- Promotion evidence records live under `codeminer.eval.agent_runner` and must
+  keep scorer dependencies and named benchmark dependencies explicit. Runtime
+  defaults should not be promoted when either dependency set is non-empty.
 - External-agent and LSP baseline task/result envelopes live in
   `codeminer.eval.agent_runner`. Client wrappers and examples may adapt their
   SDK-specific inputs to that envelope, but they should not own reusable scoring

--- a/test/eval/test_promotion.py
+++ b/test/eval/test_promotion.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for agent-runner promotion evidence gates."""
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.eval.agent_runner.promotion import (
+    EvidenceSlice,
+    PromotionEvidence,
+    evaluate_promotion_evidence,
+)
+
+
+def _base_evidence(**overrides):
+    values = {
+        "runtime_contract": "Context items include provenance and consumption state",
+        "raw_behavior_delta": "Agents consume fewer stale context items in traces",
+        "failure_category": "context_runtime",
+        "slices": (
+            EvidenceSlice(
+                name="weekly-smoke",
+                role="smoke",
+                instance_count=3,
+                seed="stable",
+            ),
+            EvidenceSlice(
+                name="weekly-holdout",
+                role="holdout",
+                instance_count=6,
+                seed="week-12",
+            ),
+        ),
+    }
+    values.update(overrides)
+    return PromotionEvidence(**values)
+
+
+def test_promotion_evidence_ready_with_smoke_and_holdout():
+    result = evaluate_promotion_evidence(_base_evidence())
+
+    assert result.ready is True
+    assert result.failures == ()
+
+
+def test_promotion_evidence_requires_holdout_slice():
+    evidence = _base_evidence(
+        slices=(
+            EvidenceSlice(
+                name="weekly-smoke",
+                role="smoke",
+                instance_count=3,
+            ),
+        )
+    )
+
+    result = evaluate_promotion_evidence(evidence)
+
+    assert result.ready is False
+    assert "at least one non-empty holdout slice is required" in result.failures
+
+
+def test_promotion_evidence_rejects_scorer_and_instance_dependencies():
+    evidence = _base_evidence(
+        scorer_dependencies=("answer_order_field",),
+        benchmark_dependencies=("project-x__case-1",),
+    )
+
+    result = evaluate_promotion_evidence(evidence)
+
+    assert result.ready is False
+    assert "promotion must not depend on scorer-specific fields" in result.failures
+    assert "promotion must not depend on named benchmark instances" in result.failures
+
+
+def test_model_specific_evidence_requires_comparison_surface():
+    evidence = _base_evidence(
+        model_specific=True,
+        compared_models=("model-a",),
+    )
+
+    result = evaluate_promotion_evidence(evidence)
+
+    assert result.ready is False
+    assert (
+        "model_specific changes require at least two compared systems"
+        in result.failures
+    )
+
+
+def test_promotion_evidence_serializes_normalized_values():
+    evidence = _base_evidence(
+        compared_models=(" model-a ", ""),
+        compared_agents=("agent-b",),
+        notes="kept as evaluation policy",
+    )
+
+    assert evidence.to_dict() == {
+        "runtime_contract": "Context items include provenance and consumption state",
+        "raw_behavior_delta": "Agents consume fewer stale context items in traces",
+        "failure_category": "context_runtime",
+        "slices": [
+            {
+                "name": "weekly-smoke",
+                "role": "smoke",
+                "instance_count": 3,
+                "report_path": None,
+                "seed": "stable",
+            },
+            {
+                "name": "weekly-holdout",
+                "role": "holdout",
+                "instance_count": 6,
+                "report_path": None,
+                "seed": "week-12",
+            },
+        ],
+        "compared_models": ["model-a"],
+        "compared_agents": ["agent-b"],
+        "model_specific": False,
+        "scorer_dependencies": [],
+        "benchmark_dependencies": [],
+        "notes": "kept as evaluation policy",
+    }
+
+
+def test_evidence_slice_rejects_invalid_role():
+    with pytest.raises(ValueError, match="role"):
+        EvidenceSlice(name="bad", role="training", instance_count=1)


### PR DESCRIPTION
## Summary
Add a reusable promotion evidence contract for agent-runner behavior changes so future runtime defaults can be checked against smoke/holdout evidence, raw behavior evidence, failure category attribution, and scorer/benchmark dependency risks.

## Changes
- Add `EvidenceSlice`, `PromotionEvidence`, and `PromotionGateResult` under `codeminer.eval.agent_runner.promotion`.
- Add `evaluate_promotion_evidence()` to validate promotion evidence without benchmark-specific context.
- Export the promotion contract through `codeminer.eval.agent_runner`.
- Update the architecture goal doc to mark #298 landed and define M10c.
- Add unit coverage for ready evidence, missing holdout, scorer/instance dependencies, model-specific comparison requirements, serialization, and invalid slice roles.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m compileall -q codeminer/eval/agent_runner/promotion.py test/eval/test_promotion.py`
- `pytest test/eval/test_promotion.py test/eval/test_feedback_plan.py test/agent/test_import_boundaries.py -q`
- `pre-commit run --files codeminer/eval/agent_runner/promotion.py codeminer/eval/agent_runner/__init__.py test/eval/test_promotion.py docs/agent_runner_architecture_goal.md`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

Promotion checklist:
- Reusable contract changed: added a typed promotion evidence gate under `codeminer.eval.agent_runner`.
- Raw behavior improved: future promotion candidates can be rejected before runtime defaults absorb scorer or benchmark dependencies.
- Smoke/holdout used: this is the evidence contract itself; unit tests cover required smoke and holdout records.
- Models/external agents compared: none; model-specific changes now require multiple compared systems in the contract.
- Failure category targeted: context/runtime governance and benchmark-overfit prevention.
- Not tied to a benchmark instance or scorer field: the gate explicitly fails when scorer or named benchmark dependencies are declared.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published