### PR TITLE
test(agent): guard deprecated compile shims

### DIFF
--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -149,10 +149,15 @@ benchmark cell is currently easiest to improve.
    compatibility wrapper only.
 
 9. **M10c: Promotion evidence contract.**
-   Add a typed evaluation contract for runtime promotion evidence so future
-   runner defaults require raw-behavior evidence, smoke and holdout slices,
-   failure category attribution, and explicit scorer/benchmark dependency
-   checks before they can leave experiment policy.
+   Landed in #299. Runtime promotion evidence now has a typed evaluation
+   contract so future runner defaults require raw-behavior evidence, smoke and
+   holdout slices, failure category attribution, and explicit scorer/benchmark
+   dependency checks before they can leave experiment policy.
+
+10. **M10d: Legacy shim implementation guard.**
+    Keep `scripts/agent_compile/lib` import-only until removal. Tests should
+    fail if compatibility modules regain functions, classes, or non-package
+    imports that would move reusable ownership back into scripts.
 
 ## Current Boundary Decisions
 
@@ -173,6 +178,9 @@ benchmark cell is currently easiest to improve.
 - Promotion evidence records live under `codeminer.eval.agent_runner` and must
   keep scorer dependencies and named benchmark dependencies explicit. Runtime
   defaults should not be promoted when either dependency set is non-empty.
+- Legacy modules under `scripts/agent_compile/lib` are import-only
+  compatibility shims. They may re-export package APIs but must not define
+  functions, classes, or new reusable policy.
 - External-agent and LSP baseline task/result envelopes live in
   `codeminer.eval.agent_runner`. Client wrappers and examples may adapt their
   SDK-specific inputs to that envelope, but they should not own reusable scoring

--- a/test/agent_compile/test_compat_shims.py
+++ b/test/agent_compile/test_compat_shims.py
@@ -6,10 +6,15 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import sys
+from pathlib import Path
 
 import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SHIM_DIR = PROJECT_ROOT / "scripts" / "agent_compile" / "lib"
 
 
 def test_agent_compile_lib_import_warns_deprecated():
@@ -19,3 +24,28 @@ def test_agent_compile_lib_import_warns_deprecated():
         module = importlib.import_module("scripts.agent_compile.lib")
 
     assert "deprecated" in module._DEPRECATION_MESSAGE
+
+
+def test_agent_compile_lib_files_are_import_only_shims():
+    """Legacy lib modules must not regain reusable implementation ownership."""
+    offenders = []
+    for path in sorted(SHIM_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                offenders.append(f"{path.relative_to(PROJECT_ROOT)}:{node.lineno}")
+                continue
+            if isinstance(node, ast.Import):
+                if any(alias.name != "warnings" for alias in node.names):
+                    offenders.append(f"{path.relative_to(PROJECT_ROOT)}:{node.lineno}")
+                continue
+            if isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if (
+                    module != "__future__"
+                    and module != "warnings"
+                    and not module.startswith("codeminer.eval.agent_runner")
+                ):
+                    offenders.append(f"{path.relative_to(PROJECT_ROOT)}:{node.lineno}")
+
+    assert offenders == []


### PR DESCRIPTION
## Summary
Add a unit guard that keeps `scripts/agent_compile/lib` as import-only compatibility shims and mark the promotion evidence milestone as landed.

## Changes
- Add an AST-based test that fails if deprecated shim modules regain functions, classes, broad imports, or reusable implementation ownership.
- Allow only the deprecation `warnings` import plus re-exports from `codeminer.eval.agent_runner`.
- Update the architecture goal doc to mark M10c landed in #299 and define M10d as the shim implementation guard.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `pytest test/agent_compile/test_compat_shims.py test/agent/test_import_boundaries.py -q`
- `pre-commit run --files test/agent_compile/test_compat_shims.py docs/agent_runner_architecture_goal.md`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

Promotion checklist:
- Reusable contract changed: none; this prevents deprecated compatibility modules from becoming reusable ownership again.
- Raw behavior improved: future drift back into `scripts/agent_compile/lib` fails unit tests.
- Smoke/holdout used: not a runtime behavior promotion; covered by boundary/unit tests.
- Models/external agents compared: none.
- Failure category targeted: architecture drift in experiment scripts.
- Not tied to a benchmark instance or scorer field: this is an import/ownership guard.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published