### PR TITLE
test(agent): guard lsp route skill contract

### DIFF
--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -155,9 +155,15 @@ benchmark cell is currently easiest to improve.
    dependency checks before they can leave experiment policy.
 
 10. **M10d: Legacy shim implementation guard.**
-    Keep `scripts/agent_compile/lib` import-only until removal. Tests should
-    fail if compatibility modules regain functions, classes, or non-package
-    imports that would move reusable ownership back into scripts.
+    Landed in #300. `scripts/agent_compile/lib` is guarded as import-only until
+    removal; tests fail if compatibility modules regain functions, classes, or
+    non-package imports that would move reusable ownership back into scripts.
+
+11. **M9e: LSP route agent-tool contract guard.**
+    Lock the agent-facing `lsp_route` skill contract so it remains a static
+    graph-backed tool with symbol-graph requirements, array symbol inputs, and
+    route anchors produced by the shared core helper rather than eval-only
+    baseline code.
 
 ## Current Boundary Decisions
 

--- a/test/agent/test_lsp_graph.py
+++ b/test/agent/test_lsp_graph.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from codeminer.agent import lsp_graph
 from codeminer.agent.skills.loader import SkillLoader
+from codeminer.agent.tool_schema import skill_to_tool_schema
 from codeminer.graph.code_graph import CodeGraph
 from codeminer.ops.expand import ExpandContext
 from codeminer.types import NODE_TYPE_FUNCTION
@@ -183,3 +184,37 @@ def test_lsp_skills_load_and_execute_against_expand_context():
     assert meta.executor_fn is not None
     results = meta.executor_fn(symbol="load_config")
     assert [node.node_name for node in results] == ["callee.py:load_config()"]
+
+
+def test_lsp_route_skill_exposes_static_graph_tool_contract():
+    graph = _RouteGraph()
+    context = {"expand": ExpandContext(code_graph=graph)}
+    loader = SkillLoader()
+
+    meta = loader.load_skill("codeminer/agent/skills/lsp_route", context)
+
+    assert meta is not None
+    assert meta.skill_id == "lsp_route"
+    assert meta.operator == "graph.lsp.route"
+    assert meta.defaults == {"top_k": 12, "include_neighbors": True}
+    assert [req.index_type for req in meta.index_requirements] == ["symbol_graph"]
+    assert "Static-index semantic route map" in meta.skill_doc
+
+    schema = skill_to_tool_schema(meta)
+    props = schema["function"]["parameters"]["properties"]
+    assert schema["function"]["parameters"]["required"] == ["symbols"]
+    assert props["symbols"]["type"] == "array"
+    assert props["symbols"]["items"]["type"] == "string"
+    assert props["include_neighbors"]["type"] == "boolean"
+
+    results = meta.executor_fn(
+        symbols=["HandleRequest", "NewResolver"],
+        query="handle request resolver default config",
+        top_k=3,
+    )
+    assert [node.node_name for node in results] == [
+        "svc.HandleRequest",
+        "svc.NewResolver",
+        "svc.DefaultConfig",
+    ]
+    assert results[0].content == "route endpoint: direct seed HandleRequest"


### PR DESCRIPTION
## Summary

Lock the agent-facing `lsp_route` skill contract so future changes keep it graph-backed and reusable from core agent runtime code.

## Changes

- Add a unit guard for loading `codeminer/agent/skills/lsp_route` through `SkillLoader`.
- Assert the tool schema keeps `symbols` as the required array input and exposes `include_neighbors` as a boolean option.
- Assert the skill declares the `symbol_graph` index requirement and returns route anchors from the shared graph helper.
- Update the architecture goal doc to mark #300 landed and add the M9e guard milestone.

## Type of Change

- test
- docs

## Testing

- `pytest test/agent/test_lsp_graph.py test/agent/test_tool_schema.py test/agent/test_import_boundaries.py -q`
- `python -m compileall -q test/agent/test_lsp_graph.py`
- `git diff --check -- test/agent/test_lsp_graph.py docs/agent_runner_architecture_goal.md`
- `pre-commit run --files test/agent/test_lsp_graph.py docs/agent_runner_architecture_goal.md`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

## Checklist

- [x] Focused scope; no runtime behavior change.
- [x] Keeps reusable ownership in `codeminer.agent`, not `scripts/agent_compile`.
- [x] Adds a general contract guard rather than scorer-specific tuning.
