### PR TITLE
ci: gate slow tier behind explicit triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
   pull_request:
     branches:
       - "*"
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -76,6 +76,8 @@ jobs:
       should-run: ${{ steps.check.outputs.should-run }}
       run-serial: ${{ steps.serial.outputs.run-serial }}
       serial-reason: ${{ steps.serial.outputs.serial-reason }}
+      run-slow: ${{ steps.slow.outputs.run-slow }}
+      slow-reason: ${{ steps.slow.outputs.slow-reason }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -172,6 +174,33 @@ jobs:
           echo "run-serial=$RUN_SERIAL" >> "$GITHUB_OUTPUT"
           echo "serial-reason=$REASON" >> "$GITHUB_OUTPUT"
           echo "run-serial=$RUN_SERIAL ($REASON)"
+
+      - name: Compute run-slow
+        id: slow
+        run: |
+          RUN_SLOW=false
+          REASON="not requested"
+          case "${{ github.event_name }}" in
+            schedule)
+              RUN_SLOW=true
+              REASON="scheduled full run" ;;
+            workflow_dispatch)
+              if [[ "${{ github.event.inputs.test_tier }}" == "full" ]]; then
+                RUN_SLOW=true
+                REASON="manual full tier"
+              else
+                REASON="manual light tier"
+              fi ;;
+            pull_request)
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}" == "true" ]] || \
+                 [[ "${{ contains(github.event.pull_request.labels.*.name, 'slow-ci') }}" == "true" ]]; then
+                RUN_SLOW=true
+                REASON="PR label requested slow/full CI"
+              fi ;;
+          esac
+          echo "run-slow=$RUN_SLOW" >> "$GITHUB_OUTPUT"
+          echo "slow-reason=$REASON" >> "$GITHUB_OUTPUT"
+          echo "run-slow=$RUN_SLOW ($REASON)"
 
   # =============================================================
   # Job 1 — Unit tests  (pure logic, mocks only, ~1 min)
@@ -533,7 +562,7 @@ jobs:
   # =============================================================
   slow:
     needs: [preflight, unit, integration, integration-serial, scip-core, graph-consumer]
-    if: always() && needs.preflight.outputs.should-run == 'true' && needs.unit.result == 'success' && needs.integration.result == 'success' && (needs.integration-serial.result == 'success' || needs.integration-serial.result == 'skipped') && (needs.scip-core.result == 'success' || needs.scip-core.result == 'skipped') && (needs.graph-consumer.result == 'success' || needs.graph-consumer.result == 'skipped')
+    if: always() && needs.preflight.outputs.should-run == 'true' && needs.preflight.outputs.run-slow == 'true' && needs.unit.result == 'success' && needs.integration.result == 'success' && (needs.integration-serial.result == 'success' || needs.integration-serial.result == 'skipped') && (needs.scip-core.result == 'success' || needs.scip-core.result == 'skipped') && (needs.graph-consumer.result == 'success' || needs.graph-consumer.result == 'skipped')
     runs-on: self-hosted
     timeout-minutes: 60
     env:

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -237,6 +237,9 @@ fires, or the serial chain is gated off) and **explicit** (`should-run=false`).
   `graph-consumer` for changes confined to `scripts/**`, `examples/**`,
   `docs/**`, `**/*.md`, `LICENSE`, or `.gitignore`. See
   [preflight](#preflight-the-decision-job).
+- **Slow tier gating** — `slow` is skipped by default on PR and push events.
+  It runs for scheduled full CI, `workflow_dispatch` with `test_tier=full`, or
+  PRs labeled `full-ci` or `slow-ci`.
 
 ### Explicit (sets `should-run=false`)
 


### PR DESCRIPTION
## Summary

Reduce PR feedback latency by skipping the slow LLM/embedding tier unless it is explicitly requested or part of a scheduled/manual full run.

## Changes

- Remove `ready_for_review` from CI pull request triggers to avoid rerunning full CI when a draft PR is marked ready.
- Add `run-slow` and `slow-reason` preflight outputs.
- Run the `slow` job only for scheduled full CI, `workflow_dispatch` with `test_tier=full`, or PRs labeled `full-ci` or `slow-ci`.
- Document the slow-tier gate in `docs/ci_cd.md`.

## Type of Change

- ci
- docs

## Testing

- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text())"`
- `git diff --check -- .github/workflows/ci.yml docs/ci_cd.md`
- `pre-commit run --files .github/workflows/ci.yml docs/ci_cd.md`
- `actionlint` not available in the local environment.

## Checklist

- [x] Keeps unit and integration required on normal PRs.
- [x] Keeps serial-chain jobs gated by existing path/label logic.
- [x] Preserves scheduled/manual full CI coverage for slow tests.
