### PR TITLE
feat(agent): add opt-in lsp route context

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -18,6 +18,12 @@ from .harness import (
 )
 from .history import PlainChatHistory, TokenBudgetedChatHistory, count_message_tokens
 from .rerank_agent import RerankAgent, RerankResult, rerank_nodes_with_query
+from .route_context import (
+    LSPRouteContext,
+    build_lsp_route_context,
+    extract_lsp_symbol_seeds,
+    render_lsp_route_context,
+)
 from .runner import (
     AgentRunner,
     CodeMinerAgentOptions,
@@ -47,6 +53,7 @@ __all__ = [
     "ContextLedgerEntry",
     "KeywordExtraction",
     "KeywordExtractor",
+    "LSPRouteContext",
     "PlainChatHistory",
     "RerankAgent",
     "RerankResult",
@@ -55,10 +62,13 @@ __all__ = [
     "agent_working_directory",
     "compile_repo",
     "count_message_tokens",
+    "build_lsp_route_context",
     "extract_keywords_from_statement",
+    "extract_lsp_symbol_seeds",
     "has_localization_contract",
     "query",
     "rerank_nodes_with_query",
+    "render_lsp_route_context",
     "registry_to_tools",
     "run_agent_in_directory",
     "skill_to_tool_schema",

--- a/codeminer/agent/harness.py
+++ b/codeminer/agent/harness.py
@@ -114,6 +114,10 @@ class AgentHarnessSpec:
     force_localization_contract: bool = False
     compact_after_read: bool = False
     compact_keep_reads: int = 0
+    enable_lsp_route_context: bool = False
+    lsp_route_seed_limit: int = 8
+    lsp_route_top_k: int = 12
+    lsp_route_include_neighbors: bool = True
 
     def __post_init__(self) -> None:
         if self.max_turns <= 0:
@@ -122,6 +126,10 @@ class AgentHarnessSpec:
             raise ValueError("max_context_tokens must be positive when set")
         if self.compact_keep_reads < 0:
             raise ValueError("compact_keep_reads must be non-negative")
+        if self.lsp_route_seed_limit <= 0:
+            raise ValueError("lsp_route_seed_limit must be positive")
+        if self.lsp_route_top_k <= 0:
+            raise ValueError("lsp_route_top_k must be positive")
 
         object.__setattr__(
             self,
@@ -195,6 +203,10 @@ class AgentHarnessSpec:
             "force_localization_contract": self.force_localization_contract,
             "compact_after_read": self.compact_after_read,
             "compact_keep_reads": self.compact_keep_reads,
+            "enable_lsp_route_context": self.enable_lsp_route_context,
+            "lsp_route_seed_limit": self.lsp_route_seed_limit,
+            "lsp_route_top_k": self.lsp_route_top_k,
+            "lsp_route_include_neighbors": self.lsp_route_include_neighbors,
             "session_ctx": session_ctx,
             "manifest": manifest,
             "compile_table": compile_table,

--- a/codeminer/agent/route_context.py
+++ b/codeminer/agent/route_context.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Initial static-graph route context for agent runs.
+
+This module keeps LSP-shaped routing generic and runtime-facing: it extracts
+symbol-like seeds already present in the task, runs a caller-provided
+``lsp_route`` executor, and renders compact, unverified hints for the opening
+agent prompt. It does not read ground truth, score answers, or know about a
+dataset.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Mapping, Sequence
+
+from .boundary import is_line_bearing, to_agent_repr
+
+_BACKTICK = re.compile(r"`([^`\n]{2,100})`")
+_TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}(?:\.[A-Za-z_][A-Za-z0-9_]{2,})*")
+_CODEISH = re.compile(r"_|[a-z][A-Z]|[0-9][A-Z]|[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_]")
+_IDENT_STOP = {"BUG", "TODO", "FIXME", "NOTE", "XXX", "HACK", "WARNING", "ERROR"}
+
+
+@dataclass(frozen=True)
+class LSPRouteContext:
+    """Rendered startup context produced by the static graph route."""
+
+    seeds: tuple[str, ...]
+    nodes: tuple[Any, ...]
+    text: str = ""
+
+
+def extract_lsp_symbol_seeds(
+    *texts: Any,
+    explicit: Any = None,
+    limit: int = 8,
+) -> List[str]:
+    """Extract explicit symbol-like seeds from task text.
+
+    The extractor is intentionally conservative. It keeps user-supplied explicit
+    seeds first, then adds backtick-delimited code names and code-like tokens
+    from the task text. It does not inspect repository contents or benchmark
+    labels.
+    """
+
+    seeds: List[str] = []
+    _add_seed_values(seeds, explicit)
+
+    text = "\n".join(_flatten_text_values(texts))
+    for match in _BACKTICK.findall(text):
+        _add_seed_values(seeds, match)
+    for token in _TOKEN.findall(text):
+        if token.upper() in _IDENT_STOP:
+            continue
+        if _CODEISH.search(token) or (token.isupper() and len(token) >= 3):
+            _add_seed_values(seeds, token)
+
+    seen: set[str] = set()
+    out: List[str] = []
+    max_items = max(1, int(limit or 8))
+    for seed in seeds:
+        key = seed.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(seed)
+        if len(out) >= max_items:
+            break
+    return out
+
+
+def build_lsp_route_context(
+    executor: Any,
+    query: str,
+    *,
+    explicit_seeds: Any = None,
+    seed_limit: int = 8,
+    top_k: int = 12,
+    include_neighbors: bool = True,
+) -> LSPRouteContext:
+    """Run an ``lsp_route`` executor and render startup context."""
+
+    seeds = extract_lsp_symbol_seeds(
+        query,
+        explicit=explicit_seeds,
+        limit=seed_limit,
+    )
+    if not seeds:
+        return LSPRouteContext(seeds=(), nodes=(), text="")
+
+    nodes = tuple(
+        executor(
+            symbols=list(seeds),
+            query=query,
+            top_k=int(top_k or 12),
+            include_neighbors=bool(include_neighbors),
+        )
+        or ()
+    )
+    return LSPRouteContext(
+        seeds=tuple(seeds),
+        nodes=nodes,
+        text=render_lsp_route_context(seeds, nodes),
+    )
+
+
+def render_lsp_route_context(
+    seeds: Sequence[str],
+    nodes: Sequence[Any],
+    *,
+    max_nodes: int | None = None,
+) -> str:
+    """Render route nodes as compact, unverified prompt context."""
+
+    selected = list(nodes)
+    if max_nodes is not None:
+        selected = selected[: max(0, int(max_nodes))]
+    if not selected:
+        return ""
+
+    lines = [
+        "# Static LSP route hints (unverified)",
+        "These graph anchors come from explicit symbol-like names in the task. "
+        "Use them to choose what to read; do not cite them until you read the "
+        "file.",
+        "Seeds: " + ", ".join(seeds),
+        "",
+    ]
+    for index, node in enumerate(selected, 1):
+        data = _node_dict(node)
+        location = _location(data)
+        symbol = str(data.get("node_name") or data.get("node_id") or "(unknown)")
+        node_type = str(data.get("type") or "symbol")
+        relation = str(data.get("content") or "").strip()
+        suffix = f" - {relation}" if relation else ""
+        lines.append(f"{index}. {location} {symbol} [{node_type}]{suffix}")
+    return "\n".join(lines)
+
+
+def _flatten_text_values(values: Iterable[Any]) -> List[str]:
+    out: List[str] = []
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                out.append(text)
+        elif isinstance(value, Mapping):
+            for item in value.values():
+                out.extend(_flatten_text_values([item]))
+        elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+            out.extend(_flatten_text_values(value))
+        else:
+            text = str(value).strip()
+            if text:
+                out.append(text)
+    return out
+
+
+def _add_seed_values(seeds: List[str], value: Any) -> None:
+    if value is None:
+        return
+    if isinstance(value, str):
+        text = value.strip().strip("`'\"")
+        if text:
+            seeds.append(text)
+        return
+    if isinstance(value, Mapping):
+        for item in value.values():
+            _add_seed_values(seeds, item)
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        for item in value:
+            _add_seed_values(seeds, item)
+
+
+def _node_dict(node: Any) -> dict[str, Any]:
+    if is_line_bearing(node):
+        return to_agent_repr(node)
+    if isinstance(node, Mapping):
+        return dict(node)
+    if hasattr(node, "model_dump"):
+        return node.model_dump(exclude_none=True)
+    if hasattr(node, "__dict__"):
+        return dict(node.__dict__)
+    return {"node_name": str(node)}
+
+
+def _location(data: Mapping[str, Any]) -> str:
+    file_path = str(data.get("file") or data.get("file_path") or "(unknown)")
+    start = data.get("start_line")
+    end = data.get("end_line")
+    if start is None:
+        return file_path
+    if end is None:
+        return f"{file_path}:{start}"
+    return f"{file_path}:{start}-{end}"
+
+
+__all__ = [
+    "LSPRouteContext",
+    "build_lsp_route_context",
+    "extract_lsp_symbol_seeds",
+    "render_lsp_route_context",
+]

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -25,6 +25,7 @@ from ..log_utils import get_logger
 from .agent_types import AgentResult, ToolCallRecord
 from .boundary import from_agent_repr_arg, is_line_bearing, to_agent_repr
 from .history import PlainChatHistory, TokenBudgetedChatHistory
+from .route_context import build_lsp_route_context
 from .runtime.trace import AgentRunTrace
 from .skills.loader import SkillLoader
 from .skills.registry import SkillRegistry
@@ -170,6 +171,10 @@ class AgentRunner:
         force_first_turn_only: bool = False,
         compact_after_read: bool = False,
         compact_keep_reads: int = 0,
+        enable_lsp_route_context: bool = False,
+        lsp_route_seed_limit: int = 8,
+        lsp_route_top_k: int = 12,
+        lsp_route_include_neighbors: bool = True,
     ) -> None:
         if llm is not None:
             self.llm = llm
@@ -247,6 +252,14 @@ class AgentRunner:
         # after the collapse (the "re-read tax" observed on 4B). Set by a
         # model-strength router upstream.
         self._compact_keep_reads = compact_keep_reads
+        # Optional startup context over the same static graph exposed by the
+        # lsp_route skill. This is opt-in harness policy: it makes graph route
+        # hints available on turn 1 without depending on the model to discover
+        # the tool, while still requiring normal reads before answering.
+        self._enable_lsp_route_context = bool(enable_lsp_route_context)
+        self._lsp_route_seed_limit = max(1, int(lsp_route_seed_limit or 8))
+        self._lsp_route_top_k = max(1, int(lsp_route_top_k or 12))
+        self._lsp_route_include_neighbors = bool(lsp_route_include_neighbors)
 
         # Resource guard: filter unavailable skills and collect warnings.
         # The "base" allow / exclude are stored so we can recompute the
@@ -411,18 +424,9 @@ class AgentRunner:
                         effective = set(self._base_allow)
                 tools = self._tools_for(effective)
 
-        history = self._new_history()
-        history.add_message({"role": "system", "content": self.system_prompt})
-        for msg in chat_history or []:
-            history.add_message({"role": msg["role"], "content": msg["content"]})
-        history.add_message({"role": "user", "content": query})
         all_tool_calls: List[ToolCallRecord] = []
         usage_tracker = UsageTracker()
         start = time.monotonic()
-        has_read = False  # has the agent read a file yet (gates forced tools)
-        read_paths: List[str] = []  # files the agent read (for schema salvage)
-        read_outputs: List[Dict[str, str]] = []  # successful read transcripts
-        compacted = False  # eager_compact: collapsed to direction seed yet?
         trace = AgentRunTrace()
         trace.add(
             "run_start",
@@ -431,6 +435,58 @@ class AgentRunner:
             max_turns=max_turns,
             tool_count=len(tools or []),
         )
+        user_query = query
+        if self._enable_lsp_route_context:
+            route_context, route_skip_reason = self._initial_lsp_route_context(query)
+            if route_context is not None and route_context.text:
+                user_query = f"{query}\n\n{route_context.text}"
+                seeds = list(route_context.seeds)
+                trace.add(
+                    "lsp_route_context",
+                    0,
+                    status="offered",
+                    seeds=seeds,
+                    route_count=len(route_context.nodes),
+                    context_chars=len(route_context.text),
+                )
+                trace.add_context(
+                    "lsp_route",
+                    "offered",
+                    0,
+                    summary=(
+                        "initial static LSP route context from seeds: "
+                        + ", ".join(seeds)
+                    ),
+                    provenance={
+                        "kind": "initial_context",
+                        "tool": "lsp_route",
+                    },
+                    freshness="fresh",
+                    token_estimate=_estimate_context_tokens(route_context.text),
+                    metadata={
+                        "seeds": seeds,
+                        "route_count": len(route_context.nodes),
+                        "top_k": self._lsp_route_top_k,
+                        "include_neighbors": self._lsp_route_include_neighbors,
+                    },
+                )
+            else:
+                trace.add(
+                    "lsp_route_context",
+                    0,
+                    status="skipped",
+                    reason=route_skip_reason or "empty_route_context",
+                )
+
+        history = self._new_history()
+        history.add_message({"role": "system", "content": self.system_prompt})
+        for msg in chat_history or []:
+            history.add_message({"role": msg["role"], "content": msg["content"]})
+        history.add_message({"role": "user", "content": user_query})
+        has_read = False  # has the agent read a file yet (gates forced tools)
+        read_paths: List[str] = []  # files the agent read (for schema salvage)
+        read_outputs: List[Dict[str, str]] = []  # successful read transcripts
+        compacted = False  # eager_compact: collapsed to direction seed yet?
 
         def _finish_result(
             answer: str,
@@ -690,6 +746,31 @@ class AgentRunner:
             total_turns=max_turns,
             answer_source=answer_source,
         )
+
+    def _initial_lsp_route_context(self, query: str) -> tuple[Any | None, str | None]:
+        """Build optional static graph route context for the opening prompt."""
+
+        meta = self.registry.get("lsp_route")
+        if meta is None or meta.executor_fn is None:
+            return None, "lsp_route_unavailable"
+        try:
+            context = build_lsp_route_context(
+                meta.executor_fn,
+                query,
+                seed_limit=self._lsp_route_seed_limit,
+                top_k=self._lsp_route_top_k,
+                include_neighbors=self._lsp_route_include_neighbors,
+            )
+        except Exception as exc:  # noqa: BLE001 - startup hints are best-effort
+            logger.warning("initial lsp_route context failed: %s", exc)
+            return None, f"lsp_route_error:{type(exc).__name__}"
+        if not context.seeds:
+            return None, "no_symbol_seeds"
+        if not context.nodes:
+            return None, "no_route_nodes"
+        if not context.text:
+            return None, "empty_route_context"
+        return context, None
 
     def _compact_history(
         self,
@@ -1230,6 +1311,10 @@ class CodeMinerAgentOptions:
     system_prompt: Optional[str] = None
     max_turns: int = 10
     max_context_tokens: Optional[int] = None
+    enable_lsp_route_context: bool = False
+    lsp_route_seed_limit: int = 8
+    lsp_route_top_k: int = 12
+    lsp_route_include_neighbors: bool = True
     retry: Optional[RetryConfig] = None
 
     # --- extras for SessionContext.extras ---
@@ -1367,6 +1452,10 @@ def query(
         system_prompt=opts.system_prompt,
         max_turns=opts.max_turns,
         max_context_tokens=opts.max_context_tokens,
+        enable_lsp_route_context=opts.enable_lsp_route_context,
+        lsp_route_seed_limit=opts.lsp_route_seed_limit,
+        lsp_route_top_k=opts.lsp_route_top_k,
+        lsp_route_include_neighbors=opts.lsp_route_include_neighbors,
         retry=opts.retry,
         allow_skills=set(opts.allowed_skills) if opts.allowed_skills else None,
         exclude_skills=set(opts.excluded_skills) if opts.excluded_skills else None,

--- a/codeminer/eval/agent_runner/lsp_baseline.py
+++ b/codeminer/eval/agent_runner/lsp_baseline.py
@@ -6,11 +6,13 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import Any, List, Mapping, Optional, Sequence
 
 from codeminer.agent.lsp_graph import lsp_route
+from codeminer.agent.route_context import (
+    extract_lsp_symbol_seeds as extract_core_lsp_symbol_seeds,
+)
 
 from .baseline import (
     BaselineLocation,
@@ -18,11 +20,6 @@ from .baseline import (
     BaselineTask,
     build_baseline_result_entry,
 )
-
-_BACKTICK = re.compile(r"`([^`\n]{2,100})`")
-_TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
-_CODEISH = re.compile(r"_|[a-z][A-Z]|[0-9][A-Z]|[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_]")
-_IDENT_STOP = {"BUG", "TODO", "FIXME", "NOTE", "XXX", "HACK", "WARNING", "ERROR"}
 
 
 @dataclass(frozen=True)
@@ -47,25 +44,13 @@ def extract_lsp_symbol_seeds(
     by task metadata/context or code-like identifiers in the issue text.
     """
 
-    seeds: List[str] = []
-
-    def add(value: Any) -> None:
-        if value is None:
-            return
-        if isinstance(value, str):
-            text = value.strip().strip("`'\"")
-            if text:
-                seeds.append(text)
-            return
-        if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
-            for item in value:
-                add(item)
+    explicit: List[Any] = []
 
     for source in (task.metadata, task.context):
         if not isinstance(source, Mapping):
             continue
         for key in ("lsp_symbol_seeds", "symbol_seeds", "symbols"):
-            add(source.get(key))
+            explicit.append(source.get(key))
 
     text_parts = [task.query]
     if isinstance(task.context, Mapping):
@@ -73,27 +58,11 @@ def extract_lsp_symbol_seeds(
             value = task.context.get(key)
             if isinstance(value, str):
                 text_parts.append(value)
-    text = "\n".join(part for part in text_parts if part)
-
-    for match in _BACKTICK.findall(text):
-        add(match)
-    for token in _TOKEN.findall(text):
-        if token.upper() in _IDENT_STOP:
-            continue
-        if _CODEISH.search(token) or (token.isupper() and len(token) >= 3):
-            add(token)
-
-    seen: set[str] = set()
-    out: List[str] = []
-    for seed in seeds:
-        key = seed.lower()
-        if key in seen:
-            continue
-        seen.add(key)
-        out.append(seed)
-        if len(out) >= max(1, int(limit or 8)):
-            break
-    return out
+    return extract_core_lsp_symbol_seeds(
+        *text_parts,
+        explicit=explicit,
+        limit=limit,
+    )
 
 
 def locations_from_lsp_nodes(nodes: Sequence[Any]) -> List[BaselineLocation]:

--- a/codeminer/eval/agent_runner/query_sweep.py
+++ b/codeminer/eval/agent_runner/query_sweep.py
@@ -224,6 +224,7 @@ def run_query_sweep(
                     "verify_resolved": out.get("verify_resolved"),
                     "tool_calls": out["tool_calls"],
                     "file_read_paths": out["file_read_paths"],
+                    "trace_summary": out.get("trace_summary"),
                     "answer": out["answer"],
                     "total_turns": out["total_turns"],
                     "total_tokens": out["total_tokens"],

--- a/codeminer/eval/agent_runner/sweep.py
+++ b/codeminer/eval/agent_runner/sweep.py
@@ -22,7 +22,7 @@ import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 from .sweep_config import SweepConfig
 
@@ -107,7 +107,32 @@ def all_index_skill_ids(cfg: SweepConfig) -> List[str]:
             sk = _PRELOAD_RETRIEVER_SKILL.get(retriever)
             if sk and sk not in seen:
                 seen.append(sk)
+    if (
+        cfg.enable_lsp_route_context or cfg.lsp_route_context
+    ) and "lsp_route" not in seen:
+        seen.append("lsp_route")
     return seen
+
+
+def lsp_route_context_for_subset(
+    cfg: SweepConfig,
+    subset_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Return the route-context policy for one arm, or ``None`` when disabled."""
+
+    raw = (cfg.lsp_route_context or {}).get(subset_id)
+    if raw is not None:
+        if raw is True:
+            return {}
+        if isinstance(raw, Mapping):
+            return dict(raw)
+        raise ValueError(
+            f"{cfg.sweep_id}/{subset_id}: lsp_route_context must be a mapping "
+            "or true when present"
+        )
+    if cfg.enable_lsp_route_context:
+        return {}
+    return None
 
 
 def validate_sweep_harness(cfg: SweepConfig) -> None:
@@ -143,6 +168,15 @@ def validate_sweep_harness(cfg: SweepConfig) -> None:
                 f"{cfg.sweep_id}/{arm}: unknown skills {bad} — not a default tool "
                 f"{sorted(defaults)} nor a package under codeminer/agent/skills/."
             )
+    route_arms = set((cfg.lsp_route_context or {}).keys())
+    unknown_route_arms = sorted(route_arms - set(cfg.subsets))
+    if unknown_route_arms:
+        raise ValueError(
+            f"{cfg.sweep_id}: lsp_route_context references unknown subset(s) "
+            f"{unknown_route_arms}; known subsets are {sorted(cfg.subsets)}."
+        )
+    for arm in route_arms:
+        lsp_route_context_for_subset(cfg, arm)
 
 
 def load_full_contexts(cfg: SweepConfig, repo_path: str, cache_dir: str):
@@ -248,6 +282,9 @@ def run_cell(
     # Seed richness is experiment policy. Recipes that use eager_compact should
     # set compact_keep_reads explicitly; absence means the terse default.
     _keep_reads = int((preload_spec or {}).get("compact_keep_reads") or 0)
+    route_context_spec = lsp_route_context_for_subset(cfg, subset_id)
+    route_context_enabled = route_context_spec is not None
+    route_context_spec = route_context_spec or {}
     harness_spec = AgentHarnessSpec(
         max_turns=cfg.max_turns,
         allow_skills=set(skills),
@@ -260,6 +297,17 @@ def run_cell(
         force_localization_contract=cfg.force_localization_contract,
         compact_after_read=(mode == "eager_compact"),
         compact_keep_reads=(_keep_reads if mode == "eager_compact" else 0),
+        enable_lsp_route_context=route_context_enabled,
+        lsp_route_seed_limit=int(
+            route_context_spec.get("seed_limit", cfg.lsp_route_seed_limit)
+        ),
+        lsp_route_top_k=int(route_context_spec.get("top_k", cfg.lsp_route_top_k)),
+        lsp_route_include_neighbors=bool(
+            route_context_spec.get(
+                "include_neighbors",
+                cfg.lsp_route_include_neighbors,
+            )
+        ),
     )
     runner = harness_spec.create_runner(
         llm=llm,
@@ -317,6 +365,7 @@ def run_cell(
         "tool_calls": observations["tool_calls"],
         "file_read_paths": observations["file_read_paths"],
         "file_reads": observations["file_reads"],
+        "trace_summary": observations["trace_summary"],
         "preload_candidates": preload_candidates,
         "answer": observations["answer"],
         "total_turns": accounting.total_turns(fallback=observations["total_turns"]),
@@ -497,6 +546,7 @@ def run_sweep(cfg: SweepConfig, output_dir: Path, *, resume: bool = True) -> Dic
                     "tool_calls": out["tool_calls"],
                     "file_read_paths": out["file_read_paths"],
                     "file_reads": out.get("file_reads", []),
+                    "trace_summary": out.get("trace_summary"),
                     "answer": out["answer"],
                     "total_turns": out["total_turns"],
                     "total_duration_ms": out["total_duration_ms"],

--- a/codeminer/eval/agent_runner/sweep_config.py
+++ b/codeminer/eval/agent_runner/sweep_config.py
@@ -76,6 +76,17 @@ class SweepConfig:
     # answer one-shot under the default "auto" and never exercise the loop; this
     # makes them actually grep/read. None = leave "auto".
     first_turn_tool_choice: Optional[str] = None
+    # Opt-in startup route hints from the static graph-backed lsp_route skill.
+    # This is harness policy, not a default: configs must enable it explicitly
+    # before a sweep can compare route-context behavior.
+    enable_lsp_route_context: bool = False
+    lsp_route_seed_limit: int = 8
+    lsp_route_top_k: int = 12
+    lsp_route_include_neighbors: bool = True
+    # Per-arm route-context policy, keyed by subset id. A mapping entry enables
+    # route context only for that arm and may override seed_limit/top_k/
+    # include_neighbors; an empty mapping uses the defaults above.
+    lsp_route_context: Dict[str, Any] = field(default_factory=dict)
     # AgentRunner does not force localization formatting by default. This eval
     # config explicitly opts into the localization answer contract so historical
     # sweep cells stay comparable while production/default runners remain

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -182,6 +182,13 @@ benchmark cell is currently easiest to improve.
     load and normalize rows, but context reuse, per-query scoring, resume, and
     transient failure persistence belong to the package layer.
 
+15. **M9f: Opt-in initial static LSP route context.**
+    Add a runner/harness option that extracts symbol-like seeds from the task,
+    routes them through the graph-backed `lsp_route` skill, and injects compact
+    unverified route hints into the opening prompt. The context is traced as
+    harness-provided startup context, not as a model tool call, and remains
+    opt-in until promotion evidence shows raw behavior improvement.
+
 ## Current Boundary Decisions
 
 - Localization answer-contract forcing is an opt-in harness policy, not a core
@@ -218,6 +225,11 @@ benchmark cell is currently easiest to improve.
   code-like identifiers supplied by the task context. They must not read ground
   truth targets, mutate answer order for a scorer, or hide graph-display gaps
   with benchmark-specific normalization.
+- Initial `lsp_route` prompt context is a core opt-in harness feature. Seed
+  extraction and route rendering live under `codeminer.agent`; eval baselines
+  may reuse them, but benchmark-specific context fields stay in eval adapters.
+  Runner trace/ledger records this as startup context so it remains distinct
+  from tools selected by the model itself.
 
 ## Promotion Checklist
 

--- a/test/agent/test_harness_spec.py
+++ b/test/agent/test_harness_spec.py
@@ -77,6 +77,8 @@ def test_with_overrides_revalidates_and_rejects_unknown_options():
     assert spec.with_overrides(max_turns=2).max_turns == 2
     with pytest.raises(ValueError, match="max_turns"):
         spec.with_overrides(max_turns=0)
+    with pytest.raises(ValueError, match="lsp_route_top_k"):
+        spec.with_overrides(lsp_route_top_k=0)
     with pytest.raises(TypeError, match="Unknown harness option"):
         spec.with_overrides(experiment_label="baseline")
 
@@ -91,6 +93,10 @@ def test_create_runner_uses_spec_without_mutating_it():
         first_turn_tool_choice="required",
         compact_after_read=True,
         compact_keep_reads=1,
+        enable_lsp_route_context=True,
+        lsp_route_seed_limit=4,
+        lsp_route_top_k=9,
+        lsp_route_include_neighbors=False,
     )
 
     runner = spec.create_runner(
@@ -108,6 +114,10 @@ def test_create_runner_uses_spec_without_mutating_it():
     assert runner.first_turn_tool_choice == "required"
     assert runner._compact_after_read is True
     assert runner._compact_keep_reads == 1
+    assert runner._enable_lsp_route_context is True
+    assert runner._lsp_route_seed_limit == 4
+    assert runner._lsp_route_top_k == 9
+    assert runner._lsp_route_include_neighbors is False
     assert runner.system_prompt.startswith("Subagent prompt")
     assert spec.max_turns == 6
 

--- a/test/agent/test_route_context.py
+++ b/test/agent/test_route_context.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for static LSP route startup context helpers."""
+
+from __future__ import annotations
+
+from codeminer.agent.route_context import (
+    build_lsp_route_context,
+    extract_lsp_symbol_seeds,
+    render_lsp_route_context,
+)
+from codeminer.types import QueriedNode
+
+
+def test_extract_lsp_symbol_seeds_prefers_explicit_and_code_like_tokens():
+    seeds = extract_lsp_symbol_seeds(
+        "Fix `HandleRequest` using NewResolver and pkg.DefaultConfig. "
+        "Ignore ERROR and plain words.",
+        explicit=["ExplicitSeed", "HandleRequest"],
+        limit=5,
+    )
+
+    assert seeds == [
+        "ExplicitSeed",
+        "HandleRequest",
+        "NewResolver",
+        "pkg.DefaultConfig",
+    ]
+
+
+def test_render_lsp_route_context_uses_agent_facing_line_numbers():
+    node = QueriedNode(
+        node_name="svc.HandleRequest",
+        type="method",
+        file="svc.py",
+        start_line=9,
+        end_line=11,
+        content="route endpoint: direct seed HandleRequest",
+    )
+
+    rendered = render_lsp_route_context(["HandleRequest"], [node])
+
+    assert "# Static LSP route hints" in rendered
+    assert "svc.py:10-12 svc.HandleRequest [method]" in rendered
+    assert "route endpoint: direct seed HandleRequest" in rendered
+
+
+def test_build_lsp_route_context_calls_executor_with_extracted_seeds():
+    calls = []
+
+    def executor(**kwargs):
+        calls.append(kwargs)
+        return [
+            QueriedNode(
+                node_name="svc.NewResolver",
+                type="function",
+                file="svc.py",
+                start_line=20,
+                end_line=22,
+                content="route bridge: direct seed NewResolver",
+            )
+        ]
+
+    context = build_lsp_route_context(
+        executor,
+        "Check `NewResolver` cache directory",
+        seed_limit=3,
+        top_k=7,
+        include_neighbors=False,
+    )
+
+    assert context.seeds == ("NewResolver",)
+    assert calls == [
+        {
+            "symbols": ["NewResolver"],
+            "query": "Check `NewResolver` cache directory",
+            "top_k": 7,
+            "include_neighbors": False,
+        }
+    ]
+    assert "svc.py:21-23 svc.NewResolver" in context.text

--- a/test/agent/test_runner_lsp_route_context.py
+++ b/test/agent/test_runner_lsp_route_context.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""AgentRunner wiring for optional static LSP route startup context."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from codeminer.agent.runner import AgentRunner
+from codeminer.agent.skills.core import (
+    SkillInputSpec,
+    SkillMetadata,
+    SkillOutputSpec,
+    SkillType,
+)
+from codeminer.agent.skills.registry import SkillRegistry
+from codeminer.llm.litellm_chat import LiteLLMChat
+from codeminer.types import QueriedNode
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+def _make_llm():
+    return MagicMock(spec=LiteLLMChat)
+
+
+def _make_response(content=None, tool_calls=None):
+    msg = SimpleNamespace(role="assistant", content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+def _lsp_route_registry(calls):
+    def executor(**kwargs):
+        calls.append(kwargs)
+        return [
+            QueriedNode(
+                node_name="svc.HandleRequest",
+                type="method",
+                file="svc.py",
+                start_line=9,
+                end_line=11,
+                content="route endpoint: direct seed HandleRequest",
+            )
+        ]
+
+    reg = SkillRegistry()
+    reg.register(
+        SkillMetadata(
+            skill_id="lsp_route",
+            skill_type=SkillType.EXPAND,
+            inputs=[
+                SkillInputSpec(
+                    name="symbols",
+                    type_hint="List[str]",
+                    required=True,
+                ),
+                SkillInputSpec(name="query", type_hint="str", required=False),
+            ],
+            outputs=SkillOutputSpec(type_hint="List[QueriedNode]"),
+            executor_fn=executor,
+        )
+    )
+    return reg
+
+
+def test_runner_injects_opt_in_lsp_route_context_before_first_llm_call():
+    calls = []
+    llm = _make_llm()
+    llm._call_raw.return_value = _make_response(content="done")
+
+    result = AgentRunner(
+        llm,
+        _lsp_route_registry(calls),
+        include_default_tools=False,
+        enable_lsp_route_context=True,
+        lsp_route_seed_limit=3,
+        lsp_route_top_k=5,
+        lsp_route_include_neighbors=False,
+        force_localization_contract=False,
+    ).run("Fix `HandleRequest` default config")
+
+    assert result.answer == "done"
+    assert result.tool_calls == []
+    assert calls == [
+        {
+            "symbols": ["HandleRequest"],
+            "query": "Fix `HandleRequest` default config",
+            "top_k": 5,
+            "include_neighbors": False,
+        }
+    ]
+    messages = llm._call_raw.call_args.args[0]
+    user_message = next(msg for msg in messages if msg["role"] == "user")["content"]
+    assert "Fix `HandleRequest` default config" in user_message
+    assert "# Static LSP route hints" in user_message
+    assert "svc.py:10-12 svc.HandleRequest [method]" in user_message
+
+    assert result.trace is not None
+    route_events = [
+        event for event in result.trace.events if event.kind == "lsp_route_context"
+    ]
+    assert route_events[0].data["status"] == "offered"
+    assert route_events[0].data["seeds"] == ["HandleRequest"]
+    assert route_events[0].data["route_count"] == 1
+
+    route_entries = [
+        entry for entry in result.trace.context if entry.source == "lsp_route"
+    ]
+    assert route_entries[0].state == "offered"
+    assert route_entries[0].provenance == {
+        "kind": "initial_context",
+        "tool": "lsp_route",
+    }
+    assert route_entries[0].metadata["route_count"] == 1
+
+
+def test_runner_skips_lsp_route_context_when_skill_is_unavailable():
+    llm = _make_llm()
+    llm._call_raw.return_value = _make_response(content="done")
+
+    result = AgentRunner(
+        llm,
+        SkillRegistry(),
+        include_default_tools=False,
+        enable_lsp_route_context=True,
+        force_localization_contract=False,
+    ).run("Fix `HandleRequest`")
+
+    messages = llm._call_raw.call_args.args[0]
+    user_message = next(msg for msg in messages if msg["role"] == "user")["content"]
+    assert user_message == "Fix `HandleRequest`"
+
+    assert result.trace is not None
+    route_events = [
+        event for event in result.trace.events if event.kind == "lsp_route_context"
+    ]
+    assert route_events[0].data == {
+        "status": "skipped",
+        "reason": "lsp_route_unavailable",
+    }
+    assert list(result.trace.context) == []

--- a/test/eval/test_sweep.py
+++ b/test/eval/test_sweep.py
@@ -8,7 +8,13 @@ from __future__ import annotations
 
 import pytest
 
-from codeminer.eval.agent_runner.sweep import validate_sweep_harness
+from codeminer.agent.agent_types import AgentResult
+from codeminer.eval.agent_runner.sweep import (
+    all_index_skill_ids,
+    lsp_route_context_for_subset,
+    run_cell,
+    validate_sweep_harness,
+)
 from codeminer.eval.agent_runner.sweep_config import SweepConfig
 
 
@@ -41,3 +47,78 @@ def test_validate_sweep_harness_rejects_unknown_skill():
 
     with pytest.raises(ValueError, match="unknown skills"):
         validate_sweep_harness(cfg)
+
+
+def test_validate_sweep_harness_rejects_unknown_lsp_route_context_arm():
+    cfg = SweepConfig(
+        sweep_id="bad_route_arm",
+        subsets={"grep_only": ["read", "grep"]},
+        lsp_route_context={"missing": {}},
+    )
+
+    with pytest.raises(ValueError, match="unknown subset"):
+        validate_sweep_harness(cfg)
+
+
+def test_lsp_route_context_loads_graph_skill_without_exposing_it_to_arm():
+    cfg = SweepConfig(
+        sweep_id="route",
+        subsets={
+            "grep_only": ["read", "grep", "glob", "bash"],
+            "route_context": ["read", "grep", "glob", "bash"],
+        },
+        lsp_route_context={"route_context": {"top_k": 8}},
+    )
+
+    assert "lsp_route" in all_index_skill_ids(cfg)
+    assert "lsp_route" not in cfg.subsets["route_context"]
+    assert lsp_route_context_for_subset(cfg, "grep_only") is None
+    assert lsp_route_context_for_subset(cfg, "route_context") == {"top_k": 8}
+
+
+def test_run_cell_passes_lsp_route_context_options_to_harness(monkeypatch, tmp_path):
+    captured = []
+
+    class FakeRunner:
+        def run(self, prompt):
+            return AgentResult(answer=f"done: {prompt}", total_turns=1)
+
+    from codeminer.agent.harness import AgentHarnessSpec
+
+    def fake_create_runner(self, **kwargs):
+        captured.append(self)
+        return FakeRunner()
+
+    monkeypatch.setattr(AgentHarnessSpec, "create_runner", fake_create_runner)
+    cfg = SweepConfig(
+        sweep_id="route",
+        subsets={"graph": ["lsp_route"]},
+        lsp_route_context={
+            "graph": {
+                "seed_limit": 4,
+                "top_k": 9,
+                "include_neighbors": False,
+            }
+        },
+        force_localization_contract=False,
+    )
+
+    out = run_cell(
+        cfg,
+        contexts={},
+        llm=object(),
+        repo_path=str(tmp_path),
+        language_key="python",
+        query="Fix `HandleRequest`",
+        subset_id="graph",
+        skills=["lsp_route"],
+    )
+
+    assert out["answer"] == "done: Fix `HandleRequest`"
+    assert out["trace_summary"]["schema_version"] is None
+    assert captured
+    spec = captured[0]
+    assert spec.enable_lsp_route_context is True
+    assert spec.lsp_route_seed_limit == 4
+    assert spec.lsp_route_top_k == 9
+    assert spec.lsp_route_include_neighbors is False


### PR DESCRIPTION
## Summary
Add an opt-in static LSP route startup context for AgentRunner harnesses.

Depends on #303 conceptually, and #303 has now been merged into `main`; this PR is no longer stacked on a live feature branch.

## Changes
- Add `codeminer.agent.route_context` for generic symbol-seed extraction, static route context construction, and agent-facing route hint rendering.
- Add `enable_lsp_route_context` plus route knobs to `AgentRunner`, `CodeMinerAgentOptions`, and `AgentHarnessSpec`.
- Record startup route hints in runtime trace/ledger as harness-provided context, distinct from model-selected tool calls.
- Expose the same opt-in knobs through `SweepConfig` and `run_cell`, including per-arm `lsp_route_context` specs so a sweep can compare baseline arms against route-context arms.
- Load `lsp_route` as a context-only index skill when a route-context arm needs it, without forcing that arm to expose `lsp_route` as a model-callable tool.
- Persist `trace_summary` in sweep and query-sweep cell records so feedback runs can verify whether route context was actually injected.
- Reuse the core seed extractor from the eval LSP-route baseline instead of keeping duplicate seed logic there.
- Document the new opt-in milestone and boundary decision.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m compileall -q codeminer/agent/route_context.py codeminer/agent/runner.py codeminer/agent/harness.py codeminer/agent/__init__.py codeminer/eval/agent_runner/lsp_baseline.py test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/agent/test_harness_spec.py`
- `python -m compileall -q codeminer/eval/agent_runner/sweep_config.py codeminer/eval/agent_runner/sweep.py codeminer/eval/agent_runner/query_sweep.py test/eval/test_sweep.py`
- `pytest test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/agent/test_harness_spec.py test/eval/test_lsp_baseline.py -q`
- `pytest test/agent/test_runtime_trace.py test/agent/test_lsp_graph.py test/agent/test_runner.py test/agent/test_runner_allow_skills.py test/agent/test_import_boundaries.py -q`
- `pytest test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/agent/test_harness_spec.py test/eval/test_lsp_baseline.py test/agent/test_runtime_trace.py test/agent/test_lsp_graph.py test/agent/test_import_boundaries.py -q`
- `pytest test/eval/test_sweep.py test/eval/test_query_sweep.py test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/agent/test_harness_spec.py test/eval/test_lsp_baseline.py -q`
- `pytest test/eval/test_sweep.py test/eval/test_query_sweep.py test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/agent/test_harness_spec.py test/eval/test_lsp_baseline.py test/agent/test_runtime_trace.py test/agent/test_lsp_graph.py test/agent/test_import_boundaries.py -q`
- `pre-commit run --files codeminer/eval/agent_runner/sweep.py codeminer/eval/agent_runner/query_sweep.py test/eval/test_sweep.py codeminer/eval/agent_runner/sweep_config.py codeminer/agent/route_context.py codeminer/agent/runner.py codeminer/agent/harness.py codeminer/agent/__init__.py codeminer/eval/agent_runner/lsp_baseline.py test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/agent/test_harness_spec.py docs/agent_runner_architecture_goal.md`
- Haiku smoke, 1 instance / 2 arms / 1 rep / max_turns=8: `astral-sh__ruff-15309`, `grep_only` vs per-arm `route_context`. Both reached files@5=1.0; route context was trace-visible (`context_sources.lsp_route=1`) but cost more tokens on this instance (about 59.2k vs 51.7k). This supports keeping the feature opt-in, not default-on.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
