### PR TITLE
[codex] Gate LSP route context seeds

### DIFF
--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -22,6 +22,9 @@ from .route_context import (
     LSPRouteContext,
     build_lsp_route_context,
     extract_lsp_symbol_seeds,
+    filter_lsp_symbol_seeds,
+    is_specific_lsp_symbol_seed,
+    normalize_lsp_route_seed_policy,
     render_lsp_route_context,
 )
 from .runner import (
@@ -65,7 +68,10 @@ __all__ = [
     "build_lsp_route_context",
     "extract_keywords_from_statement",
     "extract_lsp_symbol_seeds",
+    "filter_lsp_symbol_seeds",
     "has_localization_contract",
+    "is_specific_lsp_symbol_seed",
+    "normalize_lsp_route_seed_policy",
     "query",
     "rerank_nodes_with_query",
     "render_lsp_route_context",

--- a/codeminer/agent/harness.py
+++ b/codeminer/agent/harness.py
@@ -30,6 +30,7 @@ from typing import (
 )
 
 from ..llm.usage import TokenUsage
+from .route_context import normalize_lsp_route_seed_policy
 
 USAGE_TOTAL_KEYS = (
     "prompt_tokens",
@@ -116,6 +117,7 @@ class AgentHarnessSpec:
     compact_keep_reads: int = 0
     enable_lsp_route_context: bool = False
     lsp_route_seed_limit: int = 8
+    lsp_route_seed_policy: str = "all"
     lsp_route_top_k: int = 12
     lsp_route_include_neighbors: bool = True
 
@@ -130,6 +132,11 @@ class AgentHarnessSpec:
             raise ValueError("lsp_route_seed_limit must be positive")
         if self.lsp_route_top_k <= 0:
             raise ValueError("lsp_route_top_k must be positive")
+        object.__setattr__(
+            self,
+            "lsp_route_seed_policy",
+            normalize_lsp_route_seed_policy(self.lsp_route_seed_policy),
+        )
 
         object.__setattr__(
             self,
@@ -205,6 +212,7 @@ class AgentHarnessSpec:
             "compact_keep_reads": self.compact_keep_reads,
             "enable_lsp_route_context": self.enable_lsp_route_context,
             "lsp_route_seed_limit": self.lsp_route_seed_limit,
+            "lsp_route_seed_policy": self.lsp_route_seed_policy,
             "lsp_route_top_k": self.lsp_route_top_k,
             "lsp_route_include_neighbors": self.lsp_route_include_neighbors,
             "session_ctx": session_ctx,

--- a/codeminer/agent/route_context.py
+++ b/codeminer/agent/route_context.py
@@ -23,6 +23,9 @@ _BACKTICK = re.compile(r"`([^`\n]{2,100})`")
 _TOKEN = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}(?:\.[A-Za-z_][A-Za-z0-9_]{2,})*")
 _CODEISH = re.compile(r"_|[a-z][A-Z]|[0-9][A-Z]|[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_]")
 _IDENT_STOP = {"BUG", "TODO", "FIXME", "NOTE", "XXX", "HACK", "WARNING", "ERROR"}
+_SEED_POLICIES = frozenset({"all", "specific"})
+_QUALIFIED_SEED = re.compile(r"[._:#/]")
+_CAMEL_SEED = re.compile(r"[a-z][A-Z]")
 
 
 @dataclass(frozen=True)
@@ -73,12 +76,62 @@ def extract_lsp_symbol_seeds(
     return out
 
 
+def normalize_lsp_route_seed_policy(seed_policy: str | None = "all") -> str:
+    """Normalize and validate the startup route seed policy."""
+
+    policy = (seed_policy or "all").strip().lower()
+    if policy not in _SEED_POLICIES:
+        raise ValueError(
+            f"Unsupported lsp_route seed_policy {seed_policy!r}; "
+            f"supported values are {sorted(_SEED_POLICIES)}"
+        )
+    return policy
+
+
+def is_specific_lsp_symbol_seed(seed: str) -> bool:
+    """Return whether *seed* is specific enough for gated startup routing."""
+
+    text = (seed or "").strip().strip("`'\"")
+    if not text:
+        return False
+    if _QUALIFIED_SEED.search(text):
+        return True
+    if _CAMEL_SEED.search(text):
+        return True
+    if text.isupper() and len(text) >= 3:
+        return True
+    if text[:1].isupper() and any(ch.islower() for ch in text[1:]):
+        return True
+    if (
+        any(ch.isalpha() for ch in text)
+        and any(ch.isdigit() for ch in text)
+        and not text.islower()
+    ):
+        return True
+    return False
+
+
+def filter_lsp_symbol_seeds(
+    seeds: Iterable[str],
+    *,
+    seed_policy: str | None = "all",
+) -> List[str]:
+    """Apply a route startup seed policy while preserving seed order."""
+
+    policy = normalize_lsp_route_seed_policy(seed_policy)
+    out = list(seeds)
+    if policy == "all":
+        return out
+    return [seed for seed in out if is_specific_lsp_symbol_seed(seed)]
+
+
 def build_lsp_route_context(
     executor: Any,
     query: str,
     *,
     explicit_seeds: Any = None,
     seed_limit: int = 8,
+    seed_policy: str | None = "all",
     top_k: int = 12,
     include_neighbors: bool = True,
 ) -> LSPRouteContext:
@@ -89,6 +142,7 @@ def build_lsp_route_context(
         explicit=explicit_seeds,
         limit=seed_limit,
     )
+    seeds = filter_lsp_symbol_seeds(seeds, seed_policy=seed_policy)
     if not seeds:
         return LSPRouteContext(seeds=(), nodes=(), text="")
 
@@ -206,5 +260,8 @@ __all__ = [
     "LSPRouteContext",
     "build_lsp_route_context",
     "extract_lsp_symbol_seeds",
+    "filter_lsp_symbol_seeds",
+    "is_specific_lsp_symbol_seed",
+    "normalize_lsp_route_seed_policy",
     "render_lsp_route_context",
 ]

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -25,7 +25,7 @@ from ..log_utils import get_logger
 from .agent_types import AgentResult, ToolCallRecord
 from .boundary import from_agent_repr_arg, is_line_bearing, to_agent_repr
 from .history import PlainChatHistory, TokenBudgetedChatHistory
-from .route_context import build_lsp_route_context
+from .route_context import build_lsp_route_context, normalize_lsp_route_seed_policy
 from .runtime.trace import AgentRunTrace
 from .skills.loader import SkillLoader
 from .skills.registry import SkillRegistry
@@ -173,6 +173,7 @@ class AgentRunner:
         compact_keep_reads: int = 0,
         enable_lsp_route_context: bool = False,
         lsp_route_seed_limit: int = 8,
+        lsp_route_seed_policy: str = "all",
         lsp_route_top_k: int = 12,
         lsp_route_include_neighbors: bool = True,
     ) -> None:
@@ -258,6 +259,9 @@ class AgentRunner:
         # the tool, while still requiring normal reads before answering.
         self._enable_lsp_route_context = bool(enable_lsp_route_context)
         self._lsp_route_seed_limit = max(1, int(lsp_route_seed_limit or 8))
+        self._lsp_route_seed_policy = normalize_lsp_route_seed_policy(
+            lsp_route_seed_policy
+        )
         self._lsp_route_top_k = max(1, int(lsp_route_top_k or 12))
         self._lsp_route_include_neighbors = bool(lsp_route_include_neighbors)
 
@@ -446,6 +450,7 @@ class AgentRunner:
                     0,
                     status="offered",
                     seeds=seeds,
+                    seed_policy=self._lsp_route_seed_policy,
                     route_count=len(route_context.nodes),
                     context_chars=len(route_context.text),
                 )
@@ -465,6 +470,7 @@ class AgentRunner:
                     token_estimate=_estimate_context_tokens(route_context.text),
                     metadata={
                         "seeds": seeds,
+                        "seed_policy": self._lsp_route_seed_policy,
                         "route_count": len(route_context.nodes),
                         "top_k": self._lsp_route_top_k,
                         "include_neighbors": self._lsp_route_include_neighbors,
@@ -758,6 +764,7 @@ class AgentRunner:
                 meta.executor_fn,
                 query,
                 seed_limit=self._lsp_route_seed_limit,
+                seed_policy=self._lsp_route_seed_policy,
                 top_k=self._lsp_route_top_k,
                 include_neighbors=self._lsp_route_include_neighbors,
             )
@@ -1313,6 +1320,7 @@ class CodeMinerAgentOptions:
     max_context_tokens: Optional[int] = None
     enable_lsp_route_context: bool = False
     lsp_route_seed_limit: int = 8
+    lsp_route_seed_policy: str = "all"
     lsp_route_top_k: int = 12
     lsp_route_include_neighbors: bool = True
     retry: Optional[RetryConfig] = None
@@ -1454,6 +1462,7 @@ def query(
         max_context_tokens=opts.max_context_tokens,
         enable_lsp_route_context=opts.enable_lsp_route_context,
         lsp_route_seed_limit=opts.lsp_route_seed_limit,
+        lsp_route_seed_policy=opts.lsp_route_seed_policy,
         lsp_route_top_k=opts.lsp_route_top_k,
         lsp_route_include_neighbors=opts.lsp_route_include_neighbors,
         retry=opts.retry,

--- a/codeminer/eval/agent_runner/sweep.py
+++ b/codeminer/eval/agent_runner/sweep.py
@@ -301,6 +301,9 @@ def run_cell(
         lsp_route_seed_limit=int(
             route_context_spec.get("seed_limit", cfg.lsp_route_seed_limit)
         ),
+        lsp_route_seed_policy=str(
+            route_context_spec.get("seed_policy", cfg.lsp_route_seed_policy)
+        ),
         lsp_route_top_k=int(route_context_spec.get("top_k", cfg.lsp_route_top_k)),
         lsp_route_include_neighbors=bool(
             route_context_spec.get(

--- a/codeminer/eval/agent_runner/sweep_config.py
+++ b/codeminer/eval/agent_runner/sweep_config.py
@@ -81,11 +81,12 @@ class SweepConfig:
     # before a sweep can compare route-context behavior.
     enable_lsp_route_context: bool = False
     lsp_route_seed_limit: int = 8
+    lsp_route_seed_policy: str = "all"
     lsp_route_top_k: int = 12
     lsp_route_include_neighbors: bool = True
     # Per-arm route-context policy, keyed by subset id. A mapping entry enables
-    # route context only for that arm and may override seed_limit/top_k/
-    # include_neighbors; an empty mapping uses the defaults above.
+    # route context only for that arm and may override seed_limit/seed_policy/
+    # top_k/include_neighbors; an empty mapping uses the defaults above.
     lsp_route_context: Dict[str, Any] = field(default_factory=dict)
     # AgentRunner does not force localization formatting by default. This eval
     # config explicitly opts into the localization answer contract so historical

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -183,11 +183,19 @@ benchmark cell is currently easiest to improve.
     transient failure persistence belong to the package layer.
 
 15. **M9f: Opt-in initial static LSP route context.**
-    Add a runner/harness option that extracts symbol-like seeds from the task,
-    routes them through the graph-backed `lsp_route` skill, and injects compact
+    Landed in #304. Runner/harness can extract symbol-like seeds from the task,
+    route them through the graph-backed `lsp_route` skill, and inject compact
     unverified route hints into the opening prompt. The context is traced as
     harness-provided startup context, not as a model tool call, and remains
     opt-in until promotion evidence shows raw behavior improvement.
+
+16. **M9g: Route-context seed specificity policy.**
+    Add a core seed policy for opt-in route context so experiments can compare
+    all extracted seeds against a specific-symbol gate without hard-coding
+    instance names or scorer behavior. Generic lowercase seeds such as
+    backticked common words should not trigger graph route startup context under
+    the specific policy; qualified, CamelCase, all-caps, or mixed alpha-digit
+    symbols may still route.
 
 ## Current Boundary Decisions
 
@@ -228,6 +236,9 @@ benchmark cell is currently easiest to improve.
 - Initial `lsp_route` prompt context is a core opt-in harness feature. Seed
   extraction and route rendering live under `codeminer.agent`; eval baselines
   may reuse them, but benchmark-specific context fields stay in eval adapters.
+- Route-context seed gating is harness policy. The default stays `all` for
+  compatibility, while `specific` gives sweeps a cheap feedback path for
+  suppressing low-information seeds before paying the route-context token cost.
   Runner trace/ledger records this as startup context so it remains distinct
   from tools selected by the model itself.
 

--- a/test/agent/test_harness_spec.py
+++ b/test/agent/test_harness_spec.py
@@ -79,6 +79,8 @@ def test_with_overrides_revalidates_and_rejects_unknown_options():
         spec.with_overrides(max_turns=0)
     with pytest.raises(ValueError, match="lsp_route_top_k"):
         spec.with_overrides(lsp_route_top_k=0)
+    with pytest.raises(ValueError, match="seed_policy"):
+        spec.with_overrides(lsp_route_seed_policy="benchmark_magic")
     with pytest.raises(TypeError, match="Unknown harness option"):
         spec.with_overrides(experiment_label="baseline")
 
@@ -95,6 +97,7 @@ def test_create_runner_uses_spec_without_mutating_it():
         compact_keep_reads=1,
         enable_lsp_route_context=True,
         lsp_route_seed_limit=4,
+        lsp_route_seed_policy="specific",
         lsp_route_top_k=9,
         lsp_route_include_neighbors=False,
     )
@@ -116,6 +119,7 @@ def test_create_runner_uses_spec_without_mutating_it():
     assert runner._compact_keep_reads == 1
     assert runner._enable_lsp_route_context is True
     assert runner._lsp_route_seed_limit == 4
+    assert runner._lsp_route_seed_policy == "specific"
     assert runner._lsp_route_top_k == 9
     assert runner._lsp_route_include_neighbors is False
     assert runner.system_prompt.startswith("Subagent prompt")

--- a/test/agent/test_route_context.py
+++ b/test/agent/test_route_context.py
@@ -6,9 +6,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from codeminer.agent.route_context import (
     build_lsp_route_context,
     extract_lsp_symbol_seeds,
+    filter_lsp_symbol_seeds,
     render_lsp_route_context,
 )
 from codeminer.types import QueriedNode
@@ -81,3 +84,46 @@ def test_build_lsp_route_context_calls_executor_with_extracted_seeds():
         }
     ]
     assert "svc.py:21-23 svc.NewResolver" in context.text
+
+
+def test_specific_seed_policy_filters_generic_lowercase_seeds():
+    seeds = extract_lsp_symbol_seeds(
+        "Fix `format` in `HandleRequest` near pkg.DefaultConfig and `F523`",
+        limit=8,
+    )
+
+    assert "format" in seeds
+    filtered = filter_lsp_symbol_seeds(seeds, seed_policy="specific")
+
+    assert "format" not in filtered
+    assert "HandleRequest" in filtered
+    assert "pkg.DefaultConfig" in filtered
+    assert "F523" in filtered
+
+
+def test_build_lsp_route_context_specific_policy_skips_generic_seed():
+    calls = []
+
+    def executor(**kwargs):
+        calls.append(kwargs)
+        return []
+
+    context = build_lsp_route_context(
+        executor,
+        "Fix `format` behavior",
+        seed_policy="specific",
+    )
+
+    assert context.seeds == ()
+    assert context.nodes == ()
+    assert context.text == ""
+    assert calls == []
+
+
+def test_lsp_route_context_rejects_unknown_seed_policy():
+    with pytest.raises(ValueError, match="seed_policy"):
+        build_lsp_route_context(
+            lambda **kwargs: [],
+            "Fix `HandleRequest`",
+            seed_policy="benchmark_magic",
+        )

--- a/test/agent/test_runner_lsp_route_context.py
+++ b/test/agent/test_runner_lsp_route_context.py
@@ -111,6 +111,7 @@ def test_runner_injects_opt_in_lsp_route_context_before_first_llm_call():
     ]
     assert route_events[0].data["status"] == "offered"
     assert route_events[0].data["seeds"] == ["HandleRequest"]
+    assert route_events[0].data["seed_policy"] == "all"
     assert route_events[0].data["route_count"] == 1
 
     route_entries = [
@@ -121,7 +122,38 @@ def test_runner_injects_opt_in_lsp_route_context_before_first_llm_call():
         "kind": "initial_context",
         "tool": "lsp_route",
     }
+    assert route_entries[0].metadata["seed_policy"] == "all"
     assert route_entries[0].metadata["route_count"] == 1
+
+
+def test_runner_specific_lsp_route_seed_policy_skips_generic_seed():
+    calls = []
+    llm = _make_llm()
+    llm._call_raw.return_value = _make_response(content="done")
+
+    result = AgentRunner(
+        llm,
+        _lsp_route_registry(calls),
+        include_default_tools=False,
+        enable_lsp_route_context=True,
+        lsp_route_seed_policy="specific",
+        force_localization_contract=False,
+    ).run("Fix `format` behavior")
+
+    assert calls == []
+    messages = llm._call_raw.call_args.args[0]
+    user_message = next(msg for msg in messages if msg["role"] == "user")["content"]
+    assert user_message == "Fix `format` behavior"
+
+    assert result.trace is not None
+    route_events = [
+        event for event in result.trace.events if event.kind == "lsp_route_context"
+    ]
+    assert route_events[0].data == {
+        "status": "skipped",
+        "reason": "no_symbol_seeds",
+    }
+    assert list(result.trace.context) == []
 
 
 def test_runner_skips_lsp_route_context_when_skill_is_unavailable():

--- a/test/eval/test_sweep.py
+++ b/test/eval/test_sweep.py
@@ -96,6 +96,7 @@ def test_run_cell_passes_lsp_route_context_options_to_harness(monkeypatch, tmp_p
         lsp_route_context={
             "graph": {
                 "seed_limit": 4,
+                "seed_policy": "specific",
                 "top_k": 9,
                 "include_neighbors": False,
             }
@@ -120,5 +121,6 @@ def test_run_cell_passes_lsp_route_context_options_to_harness(monkeypatch, tmp_p
     spec = captured[0]
     assert spec.enable_lsp_route_context is True
     assert spec.lsp_route_seed_limit == 4
+    assert spec.lsp_route_seed_policy == "specific"
     assert spec.lsp_route_top_k == 9
     assert spec.lsp_route_include_neighbors is False


### PR DESCRIPTION
## Summary
Add an opt-in `specific` seed policy for initial LSP route context so sweeps can suppress low-information generic seeds before paying route-context token cost.

## Changes
- Add core route-context seed policy helpers under `codeminer.agent.route_context`.
- Thread `lsp_route_seed_policy` through `AgentRunner`, `AgentHarnessSpec`, `CodeMinerAgentOptions`, and sweep config/per-arm route context options.
- Record the active seed policy in route-context trace metadata.
- Document M9g route-context specificity as a core harness policy rather than script-level experiment glue.
- Add unit coverage for seed filtering, runner skip behavior, harness validation, and sweep wiring.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m compileall -q codeminer/agent/route_context.py codeminer/agent/runner.py codeminer/agent/harness.py codeminer/eval/agent_runner/sweep_config.py codeminer/eval/agent_runner/sweep.py test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/agent/test_harness_spec.py test/eval/test_sweep.py`
- `pytest test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/agent/test_harness_spec.py test/eval/test_sweep.py -q`
- `pre-commit run --files codeminer/agent/__init__.py codeminer/agent/harness.py codeminer/agent/route_context.py codeminer/agent/runner.py codeminer/eval/agent_runner/sweep.py codeminer/eval/agent_runner/sweep_config.py test/agent/test_harness_spec.py test/agent/test_route_context.py test/agent/test_runner_lsp_route_context.py test/eval/test_sweep.py docs/agent_runner_architecture_goal.md`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published