### PR TITLE
[codex] Summarize agent feedback cells

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -25,6 +25,14 @@ from .contexts import (
     load_agent_skill_contexts,
 )
 from .feedback import FeedbackGroup, FeedbackPlan, FeedbackPlanSpec, build_feedback_plan
+from .feedback_summary import (
+    FeedbackArmDelta,
+    FeedbackArmSummary,
+    FeedbackSummary,
+    load_feedback_summary,
+    summarize_feedback_arm,
+    summarize_feedback_cells,
+)
 from .format_diagnostics import (
     FormatArmSummary,
     FormatDiagnostics,
@@ -121,6 +129,9 @@ __all__ = [
     "FeedbackGroup",
     "FeedbackPlan",
     "FeedbackPlanSpec",
+    "FeedbackArmDelta",
+    "FeedbackArmSummary",
+    "FeedbackSummary",
     "GATE_SYSTEM",
     "GraphNav",
     "LANG_GROUP_TO_KEY",
@@ -161,6 +172,7 @@ __all__ = [
     "load_cell_jsons",
     "load_dataset_rows",
     "load_format_diagnostics",
+    "load_feedback_summary",
     "load_full_contexts",
     "load_prebuilt_lsp_graph",
     "locations_from_lsp_nodes",
@@ -188,6 +200,8 @@ __all__ = [
     "slug",
     "summarize_agent_result",
     "summarize_agent_trace",
+    "summarize_feedback_arm",
+    "summarize_feedback_cells",
     "summarize_format_cells",
     "symbol_leaf",
     "unique_location_files",

--- a/codeminer/eval/agent_runner/feedback_summary.py
+++ b/codeminer/eval/agent_runner/feedback_summary.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small-run feedback summaries for agent-runner iterations."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+
+from .metrics import load_cell_jsons, metric_at_k, safe_mean
+
+Cell = Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class FeedbackArmSummary:
+    """Raw behavior summary for one harness arm."""
+
+    arm: str
+    n: int
+    success_rate: float
+    metrics_meaningful_rate: float
+    format_fail_rate: Optional[float]
+    files_recall_at_k: Optional[float]
+    answer_blocks_recall_at_k: Optional[float]
+    total_tokens_mean: Optional[float]
+    prompt_tokens_mean: Optional[float]
+    cost_usd_mean: Optional[float]
+    total_turns_mean: Optional[float]
+    context_tokens_mean: Optional[float]
+    tool_calls_mean: Optional[float]
+    reads_mean: Optional[float]
+    context_sources: Dict[str, int]
+    trace_failure_categories: Dict[str, int]
+    failure_groups: Dict[str, int]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "arm": self.arm,
+            "n": self.n,
+            "success_rate": self.success_rate,
+            "metrics_meaningful_rate": self.metrics_meaningful_rate,
+            "format_fail_rate": self.format_fail_rate,
+            "files_recall_at_k": self.files_recall_at_k,
+            "answer_blocks_recall_at_k": self.answer_blocks_recall_at_k,
+            "total_tokens_mean": self.total_tokens_mean,
+            "prompt_tokens_mean": self.prompt_tokens_mean,
+            "cost_usd_mean": self.cost_usd_mean,
+            "total_turns_mean": self.total_turns_mean,
+            "context_tokens_mean": self.context_tokens_mean,
+            "tool_calls_mean": self.tool_calls_mean,
+            "reads_mean": self.reads_mean,
+            "context_sources": dict(self.context_sources),
+            "trace_failure_categories": dict(self.trace_failure_categories),
+            "failure_groups": dict(self.failure_groups),
+        }
+
+
+@dataclass(frozen=True)
+class FeedbackArmDelta:
+    """Difference between one arm summary and a baseline summary."""
+
+    arm: str
+    baseline: str
+    success_rate_delta: Optional[float]
+    files_recall_delta: Optional[float]
+    answer_blocks_recall_delta: Optional[float]
+    total_tokens_delta: Optional[float]
+    cost_usd_delta: Optional[float]
+    total_turns_delta: Optional[float]
+    context_tokens_delta: Optional[float]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "arm": self.arm,
+            "baseline": self.baseline,
+            "success_rate_delta": self.success_rate_delta,
+            "files_recall_delta": self.files_recall_delta,
+            "answer_blocks_recall_delta": self.answer_blocks_recall_delta,
+            "total_tokens_delta": self.total_tokens_delta,
+            "cost_usd_delta": self.cost_usd_delta,
+            "total_turns_delta": self.total_turns_delta,
+            "context_tokens_delta": self.context_tokens_delta,
+        }
+
+
+@dataclass(frozen=True)
+class FeedbackSummary:
+    """Feedback report for a small sweep or query-sweep result set."""
+
+    k: int
+    cell_count: int
+    baseline: Optional[str]
+    arms: List[FeedbackArmSummary]
+    deltas: List[FeedbackArmDelta]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "k": self.k,
+            "cell_count": self.cell_count,
+            "baseline": self.baseline,
+            "arms": [arm.to_dict() for arm in self.arms],
+            "deltas": [delta.to_dict() for delta in self.deltas],
+        }
+
+
+def summarize_feedback_cells(
+    cells: Sequence[Cell],
+    *,
+    baseline: Optional[str] = None,
+    k: int = 5,
+    arm_field: str = "subset_id",
+) -> FeedbackSummary:
+    """Summarize small-run cells without scorer-specific answer repair."""
+
+    by_arm: Dict[str, List[Cell]] = {}
+    for cell in cells:
+        arm = str(cell.get(arm_field) or cell.get("arm") or "(unknown)")
+        by_arm.setdefault(arm, []).append(cell)
+
+    arms = [summarize_feedback_arm(arm, by_arm[arm], k=k) for arm in sorted(by_arm)]
+    baseline_summary = next((arm for arm in arms if arm.arm == baseline), None)
+    deltas = (
+        [
+            _delta_from_baseline(arm, baseline_summary)
+            for arm in arms
+            if arm.arm != baseline_summary.arm
+        ]
+        if baseline_summary is not None
+        else []
+    )
+    return FeedbackSummary(
+        k=int(k),
+        cell_count=len(cells),
+        baseline=baseline if baseline_summary is not None else None,
+        arms=arms,
+        deltas=deltas,
+    )
+
+
+def summarize_feedback_arm(
+    arm: str,
+    cells: Sequence[Cell],
+    *,
+    k: int = 5,
+) -> FeedbackArmSummary:
+    """Summarize raw behavior for one arm."""
+
+    arm_cells = list(cells)
+    n = len(arm_cells)
+    successful = [cell for cell in arm_cells if cell.get("success")]
+    meaningful = [cell for cell in successful if cell.get("metrics_meaningful")]
+
+    context_sources: Counter[str] = Counter()
+    trace_failures: Counter[str] = Counter()
+    failure_groups: Counter[str] = Counter()
+    for cell in arm_cells:
+        trace_summary = _trace_summary(cell)
+        context_sources.update(_counter_from_mapping(trace_summary, "context_sources"))
+        trace_failure_categories = _string_list(trace_summary.get("failure_categories"))
+        trace_failures.update(trace_failure_categories)
+        failure_groups.update(_failure_groups(cell, trace_failure_categories))
+
+    return FeedbackArmSummary(
+        arm=arm,
+        n=n,
+        success_rate=(len(successful) / n if n else 0.0),
+        metrics_meaningful_rate=(len(meaningful) / n if n else 0.0),
+        format_fail_rate=(
+            sum(1 for cell in meaningful if cell.get("format_failed")) / len(meaningful)
+            if meaningful
+            else None
+        ),
+        files_recall_at_k=safe_mean(
+            [metric_at_k(cell, "files", k, field="recall") for cell in meaningful]
+        ),
+        answer_blocks_recall_at_k=safe_mean(
+            [
+                metric_at_k(cell, "answer_blocks", k, field="recall")
+                for cell in meaningful
+            ]
+        ),
+        total_tokens_mean=_mean_field(successful, "total_tokens"),
+        prompt_tokens_mean=_mean_field(successful, "prompt_tokens"),
+        cost_usd_mean=_mean_field(successful, "cost_usd"),
+        total_turns_mean=_mean_field(successful, "total_turns"),
+        context_tokens_mean=safe_mean(
+            [
+                _number(_trace_summary(cell).get("context_tokens_estimate"))
+                for cell in successful
+            ]
+        ),
+        tool_calls_mean=safe_mean(
+            [
+                _number(_trace_summary(cell).get("tool_call_count"))
+                for cell in successful
+            ]
+        ),
+        reads_mean=safe_mean(
+            [_number(_trace_summary(cell).get("read_count")) for cell in successful]
+        ),
+        context_sources=dict(sorted(context_sources.items())),
+        trace_failure_categories=dict(sorted(trace_failures.items())),
+        failure_groups=dict(sorted(failure_groups.items())),
+    )
+
+
+def load_feedback_summary(
+    result_dir: Union[Path, str],
+    *,
+    baseline: Optional[str] = None,
+    k: int = 5,
+    arm_field: str = "subset_id",
+) -> FeedbackSummary:
+    """Load ``cells/*.json`` from a result directory and summarize them."""
+
+    cells = load_cell_jsons(Path(result_dir).joinpath("cells"))
+    return summarize_feedback_cells(
+        cells,
+        baseline=baseline,
+        k=k,
+        arm_field=arm_field,
+    )
+
+
+def _delta_from_baseline(
+    arm: FeedbackArmSummary,
+    baseline: FeedbackArmSummary,
+) -> FeedbackArmDelta:
+    return FeedbackArmDelta(
+        arm=arm.arm,
+        baseline=baseline.arm,
+        success_rate_delta=_delta(arm.success_rate, baseline.success_rate),
+        files_recall_delta=_delta(
+            arm.files_recall_at_k,
+            baseline.files_recall_at_k,
+        ),
+        answer_blocks_recall_delta=_delta(
+            arm.answer_blocks_recall_at_k,
+            baseline.answer_blocks_recall_at_k,
+        ),
+        total_tokens_delta=_delta(arm.total_tokens_mean, baseline.total_tokens_mean),
+        cost_usd_delta=_delta(arm.cost_usd_mean, baseline.cost_usd_mean),
+        total_turns_delta=_delta(arm.total_turns_mean, baseline.total_turns_mean),
+        context_tokens_delta=_delta(
+            arm.context_tokens_mean,
+            baseline.context_tokens_mean,
+        ),
+    )
+
+
+def _trace_summary(cell: Mapping[str, Any]) -> Mapping[str, Any]:
+    trace_summary = cell.get("trace_summary")
+    return trace_summary if isinstance(trace_summary, Mapping) else {}
+
+
+def _counter_from_mapping(data: Mapping[str, Any], key: str) -> Counter[str]:
+    raw = data.get(key)
+    counter: Counter[str] = Counter()
+    if not isinstance(raw, Mapping):
+        return counter
+    for item, count in raw.items():
+        if isinstance(count, int):
+            counter[str(item)] += count
+    return counter
+
+
+def _failure_groups(
+    cell: Mapping[str, Any],
+    trace_failure_categories: Sequence[str],
+) -> List[str]:
+    groups: set[str] = set()
+    if not cell.get("success"):
+        groups.add("infrastructure")
+    if (
+        cell.get("format_failed")
+        or "answer_contract_missing" in trace_failure_categories
+    ):
+        groups.add("format")
+    if any(
+        category in trace_failure_categories
+        for category in ("tool_error", "turn_budget_exhausted", "no_successful_read")
+    ):
+        groups.add("context_runtime")
+    return sorted(groups)
+
+
+def _mean_field(cells: Sequence[Mapping[str, Any]], field: str) -> Optional[float]:
+    return safe_mean([_number(cell.get(field)) for cell in cells])
+
+
+def _delta(value: Optional[float], baseline: Optional[float]) -> Optional[float]:
+    if value is None or baseline is None:
+        return None
+    return value - baseline
+
+
+def _number(value: Any) -> Optional[float]:
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _string_list(value: Any) -> List[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray, str)):
+        return []
+    out: List[str] = []
+    for item in value:
+        if item is None:
+            continue
+        text = str(item).strip()
+        if text:
+            out.append(text)
+    return out
+
+
+__all__ = [
+    "FeedbackArmDelta",
+    "FeedbackArmSummary",
+    "FeedbackSummary",
+    "load_feedback_summary",
+    "summarize_feedback_arm",
+    "summarize_feedback_cells",
+]

--- a/docs/agent_runner_architecture_goal.md
+++ b/docs/agent_runner_architecture_goal.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 # Agent Runner Architecture Goal
 
 Status: Active architecture program
-Last revised: 2026-07-04
+Last revised: 2026-07-05
 
 This page is the durable plan for the post-#271 agent runner work. PR #271 stays
 as a spike and evidence bundle, not as a merge candidate. The useful pieces must
@@ -200,6 +200,10 @@ benchmark cell is currently easiest to improve.
   failure, span metrics, or preload contribution logic.
 - Small feedback slices are selected by deterministic smoke plus rotated
   holdout plans, not by hand-picking named project instances.
+- Small-run feedback summaries live in
+  `codeminer.eval.agent_runner.feedback_summary`. Scripts may render or persist
+  them, but arm grouping, baseline deltas, context-source counts, and runtime
+  failure grouping should remain package APIs.
 - The old `scripts/agent_compile/lib` compatibility namespace has been removed.
   New code must import reusable helpers from `codeminer.eval.agent_runner`.
 - External localization baseline helpers live under

--- a/scripts/agent_compile/README.md
+++ b/scripts/agent_compile/README.md
@@ -51,6 +51,7 @@ ablation.
 | `feedback_plan.py` | choose a small deterministic feedback slice: fixed smoke cases plus a seed-rotated holdout, stratified by language/group. Outputs JSON instance lists for `run_sweep.py --instances ...`. |
 | `run_sweep.py` | thin CLI for `codeminer.eval.agent_runner.sweep.run_sweep`: `{arms} × {instances} × {reps}` agent cells on prebuilt indexes; `cells/<id>.json` + `sweep_summary.json`. |
 | `run_synthesis_sweep.py` | thin CLI for `codeminer.eval.agent_runner.query_sweep.run_query_sweep`: many query rows per prebuilt repo, loaded from `sysevol-ai/codeminer-synthesis`; `cells/<id>.json` + `synthesis_summary.json`. |
+| `feedback_summary.py` | thin report CLI for `codeminer.eval.agent_runner.feedback_summary`: arm summaries, baseline deltas, context-source counts, and runtime failure groups for small feedback runs. |
 | `aggregate.py` | fold cells into a report: per-arm metrics, skill-invocation histogram, easy/hard split, per-scenario cells, Pareto front → `report.md` + `metrics.json`. |
 
 The base agent-localization scorer (answer + `read` paths + retrieval nodes →
@@ -88,6 +89,11 @@ python scripts/agent_compile/feedback_plan.py \
     --smoke-per-group 1 \
     --holdout-per-group 2 \
     --output-json results/agent_compile/feedback_plan.json
+
+python scripts/agent_compile/feedback_summary.py \
+    results/agent_compile/design_space \
+    --baseline defaults_only \
+    --output-json results/agent_compile/design_space/feedback_summary.json
 ```
 
 `run_sweep.py` resumes per cell and does not persist transient (rate-limit)

--- a/scripts/agent_compile/feedback_summary.py
+++ b/scripts/agent_compile/feedback_summary.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render small-run feedback summaries for agent-runner result directories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, List, Optional, Sequence
+
+from codeminer.eval.agent_runner.feedback_summary import (
+    FeedbackSummary,
+    load_feedback_summary,
+)
+
+
+def render_report(result_name: str, summary: FeedbackSummary) -> List[str]:
+    """Render a compact Markdown report for one feedback summary."""
+
+    lines = [
+        f"## {result_name}",
+        "",
+        f"- cells: {summary.cell_count}",
+        f"- baseline: {summary.baseline or 'n/a'}",
+        f"- metric cutoff: @{summary.k}",
+        "",
+        "| arm | n | success | meaningful | fmt_fail | files | answer_blocks | "
+        "tokens | cost | turns | ctx_tokens | ctx_sources | failures |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | "
+        "---: | --- | --- |",
+    ]
+    for arm in summary.arms:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    arm.arm,
+                    str(arm.n),
+                    _pct(arm.success_rate),
+                    _pct(arm.metrics_meaningful_rate),
+                    _pct(arm.format_fail_rate),
+                    _num(arm.files_recall_at_k),
+                    _num(arm.answer_blocks_recall_at_k),
+                    _num(arm.total_tokens_mean, ndigits=0),
+                    _num(arm.cost_usd_mean, ndigits=4),
+                    _num(arm.total_turns_mean),
+                    _num(arm.context_tokens_mean, ndigits=0),
+                    _counts(arm.context_sources),
+                    _counts(arm.failure_groups),
+                ]
+            )
+            + " |"
+        )
+
+    if summary.deltas:
+        lines.extend(
+            [
+                "",
+                "| arm | baseline | d_success | d_files | d_answer_blocks | "
+                "d_tokens | d_cost | d_turns | d_ctx_tokens |",
+                "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+            ]
+        )
+        for delta in summary.deltas:
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        delta.arm,
+                        delta.baseline,
+                        _signed_pct(delta.success_rate_delta),
+                        _signed(delta.files_recall_delta),
+                        _signed(delta.answer_blocks_recall_delta),
+                        _signed(delta.total_tokens_delta, ndigits=0),
+                        _signed(delta.cost_usd_delta, ndigits=4),
+                        _signed(delta.total_turns_delta),
+                        _signed(delta.context_tokens_delta, ndigits=0),
+                    ]
+                )
+                + " |"
+            )
+    return lines
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Summarize small agent feedback result directories.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("result_dirs", nargs="+", type=Path)
+    parser.add_argument("--baseline", default=None)
+    parser.add_argument("--k", type=int, default=5)
+    parser.add_argument("--arm-field", default="subset_id")
+    parser.add_argument("--output-json", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    payload: List[dict[str, Any]] = []
+    report = ["# Agent feedback summary", ""]
+    for result_dir in args.result_dirs:
+        summary = load_feedback_summary(
+            result_dir,
+            baseline=args.baseline,
+            k=args.k,
+            arm_field=args.arm_field,
+        )
+        payload.append(
+            {
+                "result_name": result_dir.name,
+                "result_dir": str(result_dir),
+                "summary": summary.to_dict(),
+            }
+        )
+        report.extend(render_report(result_dir.name, summary))
+        report.append("")
+
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps({"results": payload}, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print("\n".join(report).rstrip())
+    return 0
+
+
+def _pct(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value * 100:.0f}%"
+
+
+def _signed_pct(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value * 100:+.0f}pp"
+
+
+def _num(value: Optional[float], *, ndigits: int = 3) -> str:
+    return "n/a" if value is None else f"{value:.{ndigits}f}"
+
+
+def _signed(value: Optional[float], *, ndigits: int = 3) -> str:
+    return "n/a" if value is None else f"{value:+.{ndigits}f}"
+
+
+def _counts(counts: dict[str, int]) -> str:
+    if not counts:
+        return "-"
+    return ", ".join(f"{key}:{value}" for key, value in sorted(counts.items()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/agent_compile/test_feedback_summary_cli.py
+++ b/test/agent_compile/test_feedback_summary_cli.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI smoke tests for small-run feedback summaries."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.agent_compile import feedback_summary
+
+
+def _write_cell(cells_dir, name, arm, recall, tokens, context_sources=None):
+    cells_dir.joinpath(name).write_text(
+        json.dumps(
+            {
+                "success": True,
+                "metrics_meaningful": True,
+                "subset_id": arm,
+                "format_failed": False,
+                "metrics": {
+                    "files": {"5": {"recall": recall}},
+                    "answer_blocks": {"5": {"recall": recall}},
+                },
+                "total_tokens": tokens,
+                "prompt_tokens": tokens - 10,
+                "cost_usd": 0.01,
+                "total_turns": 2,
+                "trace_summary": {
+                    "context_tokens_estimate": 25 if context_sources else 0,
+                    "context_sources": context_sources or {},
+                    "failure_categories": [],
+                    "tool_call_count": 1,
+                    "read_count": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_feedback_summary_cli_prints_report_and_writes_json(tmp_path, capsys):
+    run_dir = tmp_path / "run"
+    cells_dir = run_dir / "cells"
+    output_json = run_dir / "feedback_summary.json"
+    cells_dir.mkdir(parents=True)
+    _write_cell(cells_dir, "base.json", "grep_only", 0.5, 100)
+    _write_cell(
+        cells_dir,
+        "route.json",
+        "route_context",
+        1.0,
+        130,
+        context_sources={"lsp_route": 1},
+    )
+
+    rc = feedback_summary.main(
+        [
+            str(run_dir),
+            "--baseline",
+            "grep_only",
+            "--output-json",
+            str(output_json),
+        ]
+    )
+
+    out = capsys.readouterr().out
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert "# Agent feedback summary" in out
+    assert "| route_context | 1 | 100%" in out
+    assert "lsp_route:1" in out
+    assert "+0.500" in out
+    assert payload["results"][0]["summary"]["baseline"] == "grep_only"

--- a/test/eval/test_feedback_summary.py
+++ b/test/eval/test_feedback_summary.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for small-run agent feedback summaries."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codeminer.eval.agent_runner.feedback_summary import (
+    load_feedback_summary,
+    summarize_feedback_cells,
+)
+
+
+def _cell(
+    arm,
+    *,
+    files,
+    answer_blocks,
+    tokens,
+    cost,
+    turns,
+    context_tokens=0,
+    context_sources=None,
+    success=True,
+    metrics_meaningful=True,
+    format_failed=False,
+    trace_failures=None,
+):
+    return {
+        "subset_id": arm,
+        "success": success,
+        "metrics_meaningful": metrics_meaningful,
+        "format_failed": format_failed,
+        "metrics": {
+            "files": {5: {"recall": files}},
+            "answer_blocks": {5: {"recall": answer_blocks}},
+        },
+        "total_tokens": tokens,
+        "prompt_tokens": tokens - 100,
+        "cost_usd": cost,
+        "total_turns": turns,
+        "trace_summary": {
+            "context_tokens_estimate": context_tokens,
+            "context_sources": context_sources or {},
+            "failure_categories": trace_failures or [],
+            "tool_call_count": 2,
+            "read_count": 1,
+        },
+    }
+
+
+def test_feedback_summary_groups_arms_and_reports_baseline_deltas():
+    cells = [
+        _cell(
+            "grep_only",
+            files=0.5,
+            answer_blocks=0.25,
+            tokens=1000,
+            cost=0.01,
+            turns=3,
+        ),
+        _cell(
+            "route_context",
+            files=1.0,
+            answer_blocks=0.75,
+            tokens=1200,
+            cost=0.012,
+            turns=2,
+            context_tokens=50,
+            context_sources={"lsp_route": 1},
+        ),
+    ]
+
+    summary = summarize_feedback_cells(cells, baseline="grep_only", k=5)
+
+    assert summary.cell_count == 2
+    assert summary.baseline == "grep_only"
+    arms = {arm.arm: arm for arm in summary.arms}
+    assert arms["route_context"].files_recall_at_k == 1.0
+    assert arms["route_context"].answer_blocks_recall_at_k == 0.75
+    assert arms["route_context"].context_sources == {"lsp_route": 1}
+
+    assert len(summary.deltas) == 1
+    delta = summary.deltas[0]
+    assert delta.arm == "route_context"
+    assert delta.files_recall_delta == 0.5
+    assert delta.answer_blocks_recall_delta == 0.5
+    assert delta.total_tokens_delta == 200
+    assert delta.cost_usd_delta == pytest.approx(0.002)
+    assert delta.total_turns_delta == -1
+    assert delta.context_tokens_delta == 50
+
+
+def test_feedback_summary_keeps_runtime_failure_groups_separate():
+    cells = [
+        _cell(
+            "graph",
+            files=0.0,
+            answer_blocks=0.0,
+            tokens=0,
+            cost=0.0,
+            turns=0,
+            success=False,
+            metrics_meaningful=False,
+            trace_failures=["tool_error", "answer_contract_missing"],
+        ),
+        _cell(
+            "graph",
+            files=0.0,
+            answer_blocks=0.0,
+            tokens=500,
+            cost=0.005,
+            turns=4,
+            format_failed=True,
+        ),
+    ]
+
+    summary = summarize_feedback_cells(cells, k=5)
+    arm = summary.arms[0]
+
+    assert arm.success_rate == 0.5
+    assert arm.metrics_meaningful_rate == 0.5
+    assert arm.format_fail_rate == 1.0
+    assert arm.trace_failure_categories == {
+        "answer_contract_missing": 1,
+        "tool_error": 1,
+    }
+    assert arm.failure_groups == {
+        "context_runtime": 1,
+        "format": 2,
+        "infrastructure": 1,
+    }
+
+
+def test_load_feedback_summary_reads_cells_directory(tmp_path):
+    cells_dir = tmp_path / "cells"
+    cells_dir.mkdir()
+    (cells_dir / "a.json").write_text(
+        json.dumps(
+            _cell(
+                "grep_only",
+                files=1.0,
+                answer_blocks=1.0,
+                tokens=100,
+                cost=0.001,
+                turns=1,
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    summary = load_feedback_summary(tmp_path, baseline="grep_only")
+
+    assert summary.to_dict()["cell_count"] == 1
+    assert summary.to_dict()["arms"][0]["arm"] == "grep_only"


### PR DESCRIPTION
## Summary
Add a reusable eval-layer summary for small agent feedback runs, plus a thin script CLI, so smoke/holdout sweeps can report raw arm behavior, baseline deltas, context-source counts, and runtime failure grouping without script-local parsing.

## Changes
- Add `codeminer.eval.agent_runner.feedback_summary` with dataclasses and helpers for arm summaries, baseline deltas, and result-dir loading.
- Export feedback-summary APIs from `codeminer.eval.agent_runner`.
- Add `scripts/agent_compile/feedback_summary.py` as report glue that calls the package API and can emit Markdown plus JSON.
- Group runtime observations into feedback-friendly failure groups while preserving raw trace failure categories.
- Document the package boundary and script entrypoint for small-run feedback summaries.
- Add unit and CLI smoke tests for arm grouping, baseline deltas, failure grouping, `cells/*.json` loading, and JSON report output.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Commands run:
- `python -m compileall -q codeminer/eval/agent_runner/feedback_summary.py test/eval/test_feedback_summary.py codeminer/eval/agent_runner/__init__.py`
- `python -m compileall -q scripts/agent_compile/feedback_summary.py test/agent_compile/test_feedback_summary_cli.py codeminer/eval/agent_runner/feedback_summary.py`
- `pytest test/eval/test_feedback_summary.py test/eval/test_feedback_plan.py test/eval/test_agent_metrics.py -q`
- `pytest test/eval/test_feedback_summary.py test/agent_compile/test_feedback_summary_cli.py -q`
- `pre-commit run --files codeminer/eval/agent_runner/__init__.py codeminer/eval/agent_runner/feedback_summary.py scripts/agent_compile/feedback_summary.py scripts/agent_compile/README.md test/eval/test_feedback_summary.py test/agent_compile/test_feedback_summary_cli.py docs/agent_runner_architecture_goal.md`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published