### PR TITLE
docs(readme): realign project entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,26 @@ SPDX-License-Identifier: Apache-2.0
 
 # CodeMiner
 
-**Graph-enhanced code retrieval for LLM agents** — LSP-precise symbol graphs, hybrid search, and a Model Context Protocol server, across six languages.
+**Source-linked code intelligence for LLM tools** — multi-language indexing,
+hybrid retrieval, dependency graphs, and a Model Context Protocol server.
 
 [![CI](https://github.com/sysevol-ai/CodeMiner/actions/workflows/ci.yml/badge.svg)](https://github.com/sysevol-ai/CodeMiner/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](pyproject.toml)
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-526CFE.svg)](docs/index.md)
 
-CodeMiner parses a codebase with tree-sitter, builds an **LSP-oriented symbol graph whose every edge traces back to an exact source span**, and serves **hybrid retrieval** (BM25 + dense embeddings + regex/trigram + LLM re-ranking) to LLM code agents — exposed both as composable agent skills and over the **Model Context Protocol**. Incremental graph patching keeps the graph current without a full re-index.
+CodeMiner builds reusable indexes over a repository, then serves those indexes
+to agents, web UIs, and evaluation harnesses. The core surfaces are:
 
-Languages: **Python · Go · Rust · C/C++ · JavaScript · TypeScript**.
+- source chunking and repository manifests;
+- BM25, dense-vector, regex/trigram, Zoekt, and rerank retrieval;
+- SCIP/LSP-backed symbol graphs with source-linked nodes and edges;
+- a stdio **Model Context Protocol** server for agent tools;
+- a DeepWiki-style web UI for browsing indexed repositories.
+
+Language coverage varies by surface. See the generated
+[Language Capabilities](docs/language_capabilities.md) matrix for the current
+chunking, graph, incremental, and C++ core parity status.
 
 ## Quickstart
 
@@ -23,7 +33,7 @@ Languages: **Python · Go · Rust · C/C++ · JavaScript · TypeScript**.
 pip install -e .
 ```
 
-Build a query-only index for a repo, then serve it to any MCP-capable agent:
+Build an index for a repository:
 
 ```python
 from codeminer.compiler import IndexCompiler, IndexCompilerConfig
@@ -37,42 +47,53 @@ IndexCompiler(
 ).compile_repo("/path/to/repo")  # writes <repo>/.codeminer_cache/repo_manifest.json
 ```
 
+Serve that manifest to any MCP-capable agent:
+
 ```bash
 codeminer-mcp /path/to/repo/.codeminer_cache/repo_manifest.json   # stdio MCP server
-codeminer-web                                                      # DeepWiki backend API
 ```
 
-For the browser UI, start the Next.js frontend separately:
+For the browser UI, start the managed backend and frontend:
 
 ```bash
-cd web && npm run dev
+make web-deps
+make web-start                                                     # backend :8000, frontend :3000
 ```
 
 For a no-cloud local GPU LLM setup, copy `qa_config.local.yaml.example` to the
 ignored `qa_config.local.yaml` and follow [Running Locally](docs/running-locally.md).
 
-> **Optional — full code intelligence.** `make scip` installs the SCIP/LSP toolchain
-> (rust-analyzer, scip-clang, scip-typescript, scip-python) for cross-file call graphs.
+> **Optional — full graph indexing.** `make scip` installs the active SCIP/LSP
+> toolchain used by the graph backends. `make multilang-tools` installs the wider
+> cold-start smoke toolchains tracked in the language matrix.
 
 ## Why CodeMiner
 
 | | |
 |---|---|
-| **Edges you can trace** | The symbol graph is compiler-precise: every dependency edge resolves to an exact source location, so impact analysis and graph navigation point at real code — not fuzzy guesses. |
-| **Built for LLM agents** | Retrieval ships as gated, composable [agent skills](docs/agent_skills.md) and as an [MCP server](docs/mcp.md) — drop CodeMiner into an agent without bespoke glue. |
-| **Hybrid by default** | BM25, dense vectors, regex/trigram, and LLM re-ranking combine so name lookups, conceptual queries, and structural patterns all land. |
-| **Stays fresh** | [Incremental graph patching](docs/incremental_graph/index.md) updates the graph in place from a diff instead of re-indexing the world. |
+| **Reusable index substrate** | Build once with `IndexCompiler`, then reuse the same manifest from MCP, the web UI, tests, and eval scripts. |
+| **Retrieval before orchestration** | BM25, dense vectors, regex/trigram, Zoekt, and rerank paths are first-class. Agent skills are an integration surface, not the only way to use the system. |
+| **Source-linked graph context** | SCIP/LSP graph backends preserve symbol names, locations, and dependency edges so graph navigation points back to real code spans. |
+| **Operationally testable** | CI is split into unit, integration, serial integration, core, graph-consumer, and slow tiers so heavy graph/LLM work is explicit. |
 
 ## Features
 
 | Area | What it does | Docs |
 |------|--------------|------|
+| Index compiler | Builds manifests and index artifacts for downstream tools | [MCP Server](docs/mcp.md) |
+| Search and retrieval | BM25, semantic, regex, Zoekt, and rerank retrieval over indexed code | [MCP Server](docs/mcp.md) |
+| Dependency graph | Symbol graph queries, source-linked edges, and incremental patching where supported | [Graph Range Query](docs/graph_query.md), [Incremental Graph](docs/incremental_graph/index.md) |
 | Web demo | DeepWiki-style wiki + Ask over indexed repos, with an interactive code-dependency graph | [Web Demo](docs/web_demo.md) |
 | MCP server | Semantic / BM25 / regex / Zoekt search + dependency subgraphs over MCP | [MCP Server](docs/mcp.md) |
-| Agent skills | Retrieval / rerank / trace skills with `allow_skills` gating and index-aware guards | [Agent Skills](docs/agent_skills.md) |
-| Symbol graph | LSP-aligned line-range and symbol queries with typed results | [Graph Range Query](docs/graph_query.md) |
-| Indexing | SCIP / language-server indexing with a tiered cache | [SCIP Index](docs/scip_index.md) |
+| Agent and eval harness | Optional skills, traces, sweeps, and experiments built on top of the same indexes | [Agent Skills](docs/agent_skills.md), [Experiments](docs/experiments/agent_compile.md) |
 | Datasets | SWE-bench ground-truth extraction + query synthesis pipeline | [Synthesis Pipeline](docs/synthesis_pipeline.md) |
+
+## Project Boundaries
+
+The main product path is index -> retrieve/query -> serve. Experimental agent
+harnesses, graph-routing studies, and SCIP cold-start roadmaps live in the docs
+because they guide development, but they are not prerequisites for using
+CodeMiner as an MCP server or web-backed code browser.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,44 +6,73 @@ SPDX-License-Identifier: Apache-2.0
 
 # CodeMiner
 
-A code analysis agent with graph-enhancement for multi-language codebases.
+CodeMiner is a source-linked indexing and retrieval layer for code tools. It
+builds repository manifests, search indexes, and SCIP/LSP-backed symbol graphs,
+then serves them through MCP, a web UI, and optional agent/eval harnesses.
 
-## Overview
+Language support varies by surface. Start with the generated
+[Language Capabilities](language_capabilities.md) matrix when you need to know
+which languages support chunking, graph indexing, incremental patching, or C++
+core decoder parity.
 
-CodeMiner provides tools for structural code analysis, symbol-level change detection, and graph-based code intelligence. Language support varies by surface; see the [Language Capabilities](language_capabilities.md) matrix for chunking, graph, incremental, and core parity coverage.
+## Start Here
 
-### Key Components
+| Goal | Read |
+|------|------|
+| Build an index and expose it to an agent | [MCP Server](mcp.md) |
+| Browse indexed repos in the DeepWiki-style UI | [Web Demo](web_demo.md) |
+| Run without cloud-hosted LLM APIs | [Running Locally](running-locally.md) |
+| Understand language support and gaps | [Language Capabilities](language_capabilities.md) |
+| Add or promote a language backend | [Contributing a Language](contributing-a-language.md) |
 
-| Component | Description |
-|-----------|-------------|
-| [Web Demo](web_demo.md) | DeepWiki-style wiki + Ask site with an interactive code-dependency graph over indexed repos |
-| [MCP Server](mcp.md) | Serve semantic/BM25/regex/Zoekt search and dependency subgraphs to LLM agents over MCP |
-| [Agent Skills](agent_skills.md) | Composable retrieval/rerank/trace skills with index-aware gating |
-| [Agent Runner Architecture Goal](agent_runner_architecture_goal.md) | Milestones and guardrails for extracting runner core from spike experiments |
-| [Language Capabilities](language_capabilities.md) | Registry-derived support matrix across chunking, graph, incremental, and core parity surfaces |
-| [SCIP Multi-Language Roadmap](scip_multilanguage_roadmap.md) | Long-running goal and gates for SCIP cold-start promotion and C++ acceleration |
-| [GT Locator](gt_locator.md) | Extract symbol-level ground truth from SWE-bench patches |
-| [Incremental Graph](incremental_graph/index.md) | Update CodeGraph in-place without full re-indexing |
-| [Graph Range Query](graph_query.md) | LSP-aligned line-range / symbol queries with typed results |
-| [Regex Index](regex_index.md) | Fast regex search across CodeGraph nodes |
-| [SCIP Index](scip_index.md) | Code intelligence via the SCIP protocol |
-| [Graph Cache](graph_cache_usage.md) | Caching system for SCIP indexing |
-| [Core C++ Backend](core_cpp.md) | libigraph-based decoder mirroring the Python pipeline |
+## Core Surfaces
 
-### Guides
+| Surface | Description |
+|---------|-------------|
+| [Index and MCP](mcp.md) | Build manifests with `IndexCompiler`; serve BM25, semantic, regex, Zoekt, and dependency-subgraph tools over MCP |
+| [Web Demo](web_demo.md) | DeepWiki-style wiki + Ask site over indexed repos, backed by the same graph and search artifacts |
+| [Graph Range Query](graph_query.md) | LSP-aligned line-range and symbol queries with typed, source-linked results |
+| [Incremental Graph](incremental_graph/index.md) | Update a graph in place after a diff where the language backend supports it |
+| [SCIP Index](scip_index.md) | SCIP and language-server graph indexing details, cache levels, and backend behavior |
+| [Core C++ Backend](core_cpp.md) | libigraph-based decoder acceleration and parity boundaries |
 
+## Developer Guides
+
+- [CI/CD](ci_cd.md) — local and remote test tiers, including serial, graph-consumer, core, and slow jobs
+- [Agent Skills](agent_skills.md) — optional retrieval/rerank/trace skills built on top of the index substrate
 - [Collecting SWE-bench Instances](collect_swebench.md) — sample representative instances across languages
 - [Synthesis Pipeline](synthesis_pipeline.md) — synthesize traversal/behavior/multiply queries and build the CodeMiner dataset
 - [Uploading to HuggingFace](upload_dataset_to_huggingface.md) — build and publish the dataset
-- [CI/CD](ci_cd.md) — pipeline setup and test tiers
 - [Diagnose Query Leak](diagnose_query_leak.md) — detect lexical/semantic leakage in synthesized queries
-- [Contributing a Language](contributing-a-language.md) — add language support through the registry, chunker, graph, and parity layers
-- [SCIP Multi-Language Roadmap](scip_multilanguage_roadmap.md) — track the long-running SCIP cold-start and acceleration program
+
+## Research And Roadmaps
+
+These documents guide development decisions, but they are not required for the
+normal index -> retrieve/query -> serve path.
+
+- [SCIP Multi-Language Roadmap](scip_multilanguage_roadmap.md) — cold-start backend promotion, C++ acceleration gates, and long-running language work
+- [Agent Runner Architecture Goal](agent_runner_architecture_goal.md) — milestones and guardrails for extracting runner core from spike experiments
+- [Agent Compile Design](agent_compile_design.md) — historical design notes for scenario-gated agent skill selection
+- [Agent Compile Sweep](experiments/agent_compile.md) — experiment log and ablations for agent harness behavior
 
 ## Quick Start
 
 ```bash
 pip install -e ".[dev]"
+```
+
+Build a repository manifest with `IndexCompiler`; see [MCP Server](mcp.md) for
+the full example and index options.
+
+```bash
+codeminer-mcp /path/to/repo/.codeminer_cache/repo_manifest.json
+```
+
+For the browser UI:
+
+```bash
+make web-deps
+make web-start
 ```
 
 ## Serving Docs Locally

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 site_name: CodeMiner
-site_description: A code analysis agent with graph-enhancement
+site_description: Source-linked code intelligence for LLM tools
 repo_url: https://github.com/sysevol-ai/CodeMiner
 repo_name: sysevol-ai/CodeMiner
 
@@ -58,30 +58,34 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Getting Started:
+      - MCP Server: mcp.md
+      - Web Demo: web_demo.md
+      - Running Locally: running-locally.md
+      - Language Capabilities: language_capabilities.md
+  - Core Concepts:
+      - SCIP Index: scip_index.md
+      - Graph Range Query: graph_query.md
+      - Regex Index: regex_index.md
+      - Graph Cache: graph_cache_usage.md
+      - Incremental Graph:
+          - Overview: incremental_graph/index.md
+          - Interactive Demo: incremental_graph/interactive.md
+      - Core C++ Backend: core_cpp.md
   - Guides:
       - SWE-bench Collection: collect_swebench.md
       - Synthesis Pipeline: synthesis_pipeline.md
       - Upload to HuggingFace: upload_dataset_to_huggingface.md
-      - CI/CD: ci_cd.md
       - Diagnose Query Leak: diagnose_query_leak.md
       - Contributing a Language: contributing-a-language.md
-      - SCIP Multi-Language Roadmap: scip_multilanguage_roadmap.md
-  - Components:
-      - Web Demo: web_demo.md
-      - MCP Server: mcp.md
+  - Agent And Retrieval:
       - Agent Skills: agent_skills.md
       - Agent Runner Architecture Goal: agent_runner_architecture_goal.md
       - Agent Compile (Design): agent_compile_design.md
-      - Language Capabilities: language_capabilities.md
       - GT Locator: gt_locator.md
-      - Incremental Graph:
-          - Overview: incremental_graph/index.md
-          - Interactive Demo: incremental_graph/interactive.md
-      - Graph Range Query: graph_query.md
-      - Regex Index: regex_index.md
-      - SCIP Index: scip_index.md
-      - Graph Cache: graph_cache_usage.md
-      - Core C++ Backend: core_cpp.md
+  - Operations:
+      - CI/CD: ci_cd.md
+      - SCIP Multi-Language Roadmap: scip_multilanguage_roadmap.md
   - Experiments:
       - Agent Compile Sweep: experiments/agent_compile.md
       - Compact Pre-load: experiments/compact_preload.md


### PR DESCRIPTION
## Summary
Realign the README and docs landing page around CodeMiner as a reusable indexing and retrieval substrate rather than an agent-harness-first project.

## Changes
- Reframe the README around index -> retrieve/query -> serve and remove stale six-language wording.
- Rework docs/index.md into Start Here, Core Surfaces, Developer Guides, and Research/Roadmaps sections.
- Reorganize mkdocs navigation so product entry points come before agent/eval research material.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Validated with:
- `python -m mkdocs build --strict --site-dir /tmp/codeminer-docs-entry-site`
- `git diff --check -- README.md docs/index.md mkdocs.yml`
- Pre-commit on commit: whitespace, line endings, merge conflicts, YAML syntax.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
