### PR TITLE
feat(lsp): add provider validation CLI

### DIFF
--- a/codeminer/eval/agent_runner/__init__.py
+++ b/codeminer/eval/agent_runner/__init__.py
@@ -63,9 +63,11 @@ from .lsp_provider_validation import (
     LSPProviderCall,
     LSPProviderComparison,
     LSPProviderRequest,
+    LSPProviderValidationSummary,
     compare_static_lsp_provider,
     fingerprint_lsp_start_locations,
     render_lsp_provider_validation_markdown,
+    summarize_lsp_provider_validation,
 )
 from .metrics import load_cell_jsons, metric_at_k, safe_mean, safe_min, usable_cells
 from .orchestrator import (
@@ -158,6 +160,7 @@ __all__ = [
     "LSPProviderCall",
     "LSPProviderComparison",
     "LSPProviderRequest",
+    "LSPProviderValidationSummary",
     "LiveLSPReferenceProvider",
     "FAILURE_CATEGORIES",
     "PreloadQueryPlan",
@@ -214,6 +217,7 @@ __all__ = [
     "render_expansion",
     "render_lsp_route_latency_markdown",
     "render_lsp_provider_validation_markdown",
+    "summarize_lsp_provider_validation",
     "retrieve_candidates",
     "replay_lsp_route_latency",
     "run_baseline_batch",

--- a/codeminer/eval/agent_runner/lsp_provider_cli.py
+++ b/codeminer/eval/agent_runner/lsp_provider_cli.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI for validating static-index LSP calls against live JSON-RPC LSP."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from codeminer.graph.code_graph import CodeGraph
+
+from .live_lsp_provider import compare_static_to_live_lsp_provider
+from .lsp_provider_validation import (
+    LSPProviderComparison,
+    LSPProviderRequest,
+    render_lsp_provider_validation_markdown,
+    summarize_lsp_provider_validation,
+)
+from .prebuilt import load_prebuilt_code_graph, repo_path_for
+
+
+def load_lsp_provider_requests(path: str | Path) -> list[LSPProviderRequest]:
+    """Load provider validation requests from JSON or JSONL."""
+
+    request_path = Path(path)
+    text = request_path.read_text(encoding="utf-8")
+    if request_path.suffix.lower() == ".jsonl":
+        rows = [
+            json.loads(line)
+            for line in text.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+    else:
+        data = json.loads(text)
+        if isinstance(data, Mapping) and isinstance(data.get("requests"), list):
+            rows = data["requests"]
+        elif isinstance(data, list):
+            rows = data
+        elif isinstance(data, Mapping):
+            rows = [data]
+        else:
+            raise ValueError(f"unsupported request JSON shape in {request_path}")
+    return [_coerce_request(row) for row in rows]
+
+
+def run_lsp_provider_validation_from_args(
+    args: argparse.Namespace,
+) -> list[LSPProviderComparison]:
+    """Run static-vs-live validation from parsed CLI arguments."""
+
+    graph = _load_graph_from_args(args)
+    project_root = _project_root_from_args(args)
+    requests = load_lsp_provider_requests(args.requests)
+    return compare_static_to_live_lsp_provider(
+        requests,
+        graph=graph,
+        project_root=project_root,
+        language=args.language,
+        command=_command_from_arg(args.command),
+        skip_probe=args.skip_probe,
+    )
+
+
+def write_lsp_provider_validation_report(
+    comparisons: Sequence[LSPProviderComparison],
+    *,
+    output_json: str | Path | None = None,
+    output_markdown: str | Path | None = None,
+) -> dict[str, Any]:
+    """Write JSON/markdown reports and return the JSON payload."""
+
+    summary = summarize_lsp_provider_validation(comparisons)
+    payload = {
+        "summary": summary.to_dict(),
+        "comparisons": [comparison.to_dict() for comparison in comparisons],
+    }
+    if output_json:
+        _write_text(output_json, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    markdown = render_lsp_provider_validation_markdown(comparisons)
+    if output_markdown:
+        _write_text(output_markdown, markdown)
+    return payload
+
+
+def exit_code_for_lsp_provider_summary(
+    summary: Mapping[str, Any],
+    *,
+    require_promotion: bool = False,
+    fail_on_fallback: bool = False,
+) -> int:
+    """Return a process exit code for validation gates."""
+
+    if int(summary.get("mismatch_count") or 0) > 0:
+        return 2
+    if int(summary.get("error_count") or 0) > 0:
+        return 2
+    if fail_on_fallback and int(summary.get("fallback_count") or 0) > 0:
+        return 3
+    if require_promotion and not bool(summary.get("promotion_ready")):
+        return 4
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--graph", help="Path to a CodeGraph graph.pkl")
+    source.add_argument(
+        "--prebuilt-root", help="Prebuilt root containing instance dirs"
+    )
+    parser.add_argument("--instance-id", help="Required with --prebuilt-root")
+    parser.add_argument(
+        "--project-root",
+        help="Repository root for live LSP. Defaults to prebuilt instance repo.",
+    )
+    parser.add_argument("--language", required=True, help="Graph/LSP language key")
+    parser.add_argument(
+        "--requests",
+        required=True,
+        help="JSON or JSONL file of graph-facing LSP requests",
+    )
+    parser.add_argument(
+        "--command",
+        help="Optional live LSP command string, for example 'pyright-langserver --stdio'",
+    )
+    parser.add_argument(
+        "--skip-probe",
+        action="store_true",
+        help="Pass skip_probe=True when starting the live LSP client",
+    )
+    parser.add_argument("--output-json", help="Write machine-readable report")
+    parser.add_argument("--output-markdown", help="Write markdown report")
+    parser.add_argument(
+        "--require-promotion",
+        action="store_true",
+        help="Exit non-zero unless every row is equivalent_static_faster",
+    )
+    parser.add_argument(
+        "--fail-on-fallback",
+        action="store_true",
+        help="Exit non-zero when any static row requires fallback",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Do not print markdown to stdout when no markdown output path is set",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        comparisons = run_lsp_provider_validation_from_args(args)
+        payload = write_lsp_provider_validation_report(
+            comparisons,
+            output_json=args.output_json,
+            output_markdown=args.output_markdown,
+        )
+    except Exception as exc:  # noqa: BLE001 - CLI should report cleanly.
+        parser.exit(1, f"codeminer-lsp-provider-validate: {exc}\n")
+
+    if not args.quiet and not args.output_markdown:
+        sys.stdout.write(render_lsp_provider_validation_markdown(comparisons))
+
+    return exit_code_for_lsp_provider_summary(
+        payload["summary"],
+        require_promotion=args.require_promotion,
+        fail_on_fallback=args.fail_on_fallback,
+    )
+
+
+def _coerce_request(raw: Any) -> LSPProviderRequest:
+    if isinstance(raw, LSPProviderRequest):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"LSP provider request must be a mapping, got {type(raw)}")
+    capability = str(raw.get("capability") or raw.get("lsp_method") or "")
+    arguments = raw.get("arguments") or raw.get("resolved_arguments") or {}
+    if not capability:
+        raise ValueError(f"LSP provider request is missing capability: {raw}")
+    if not isinstance(arguments, Mapping):
+        raise ValueError(f"LSP provider request arguments must be a mapping: {raw}")
+    request_id = raw.get("request_id")
+    return LSPProviderRequest(
+        capability=capability,
+        arguments=dict(arguments),
+        request_id=str(request_id) if request_id is not None else None,
+    )
+
+
+def _load_graph_from_args(args: argparse.Namespace) -> Any:
+    if args.graph:
+        return CodeGraph.load_graph(str(args.graph))
+    if not args.instance_id:
+        raise ValueError("--instance-id is required with --prebuilt-root")
+    return load_prebuilt_code_graph(str(args.prebuilt_root), str(args.instance_id))
+
+
+def _project_root_from_args(args: argparse.Namespace) -> str:
+    if args.project_root:
+        return str(Path(args.project_root).resolve())
+    if args.prebuilt_root and args.instance_id:
+        return repo_path_for(str(args.prebuilt_root), str(args.instance_id))
+    raise ValueError("--project-root is required when using --graph")
+
+
+def _command_from_arg(command: str | None) -> list[str] | None:
+    if not command:
+        return None
+    parsed = shlex.split(command)
+    if not parsed:
+        raise ValueError("--command cannot be empty")
+    return parsed
+
+
+def _write_text(path: str | Path, text: str) -> None:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "build_parser",
+    "exit_code_for_lsp_provider_summary",
+    "load_lsp_provider_requests",
+    "main",
+    "run_lsp_provider_validation_from_args",
+    "write_lsp_provider_validation_report",
+]

--- a/codeminer/eval/agent_runner/lsp_provider_validation.py
+++ b/codeminer/eval/agent_runner/lsp_provider_validation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterable, List, Mapping, Optional, Sequence
 
@@ -117,6 +118,34 @@ class LSPProviderComparison:
         return out
 
 
+@dataclass(frozen=True)
+class LSPProviderValidationSummary:
+    """Machine-readable gate summary for static-vs-reference validation."""
+
+    total: int
+    verdict_counts: Mapping[str, int]
+    same_result_count: int
+    mismatch_count: int
+    fallback_count: int
+    error_count: int
+    static_faster_count: int
+    static_not_faster_count: int
+    promotion_ready: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "verdict_counts": dict(self.verdict_counts),
+            "same_result_count": self.same_result_count,
+            "mismatch_count": self.mismatch_count,
+            "fallback_count": self.fallback_count,
+            "error_count": self.error_count,
+            "static_faster_count": self.static_faster_count,
+            "static_not_faster_count": self.static_not_faster_count,
+            "promotion_ready": self.promotion_ready,
+        }
+
+
 def compare_static_lsp_provider(
     requests: Iterable[LSPProviderRequest | Mapping[str, Any]],
     *,
@@ -172,6 +201,38 @@ def compare_static_lsp_provider(
     return comparisons
 
 
+def summarize_lsp_provider_validation(
+    comparisons: Sequence[LSPProviderComparison | Mapping[str, Any]],
+) -> LSPProviderValidationSummary:
+    """Summarize whether static provider rows are ready for fast-path routing."""
+
+    rows = [_comparison_dict(row) for row in comparisons]
+    verdicts = Counter(str(row.get("verdict") or "unknown") for row in rows)
+    error_count = sum(
+        1
+        for row in rows
+        if str(row.get("verdict") or "")
+        in {"static_error", "reference_error", "unknown"}
+    )
+    same_result_count = sum(1 for row in rows if row.get("same_result") is True)
+    mismatch_count = verdicts.get("mismatch", 0)
+    fallback_count = verdicts.get("fallback_required", 0)
+    static_faster_count = verdicts.get("equivalent_static_faster", 0)
+    static_not_faster_count = verdicts.get("equivalent_static_not_faster", 0)
+    promotion_ready = bool(rows) and static_faster_count == len(rows)
+    return LSPProviderValidationSummary(
+        total=len(rows),
+        verdict_counts=dict(sorted(verdicts.items())),
+        same_result_count=same_result_count,
+        mismatch_count=mismatch_count,
+        fallback_count=fallback_count,
+        error_count=error_count,
+        static_faster_count=static_faster_count,
+        static_not_faster_count=static_not_faster_count,
+        promotion_ready=promotion_ready,
+    )
+
+
 def render_lsp_provider_validation_markdown(
     comparisons: Sequence[LSPProviderComparison | Mapping[str, Any]],
 ) -> str:
@@ -213,6 +274,9 @@ def render_lsp_provider_validation_markdown(
             str(static_call.get("fallback_reason") or ""),
         ]
         lines.append("| " + " | ".join(rendered) + " |")
+    lines.append("")
+    summary = summarize_lsp_provider_validation(comparisons)
+    lines.append(f"Promotion ready: {_yes_no(summary.promotion_ready)}")
     lines.append("")
     return "\n".join(lines)
 
@@ -476,7 +540,9 @@ __all__ = [
     "LSPProviderCall",
     "LSPProviderComparison",
     "LSPProviderRequest",
+    "LSPProviderValidationSummary",
     "compare_static_lsp_provider",
     "fingerprint_lsp_start_locations",
     "render_lsp_provider_validation_markdown",
+    "summarize_lsp_provider_validation",
 ]

--- a/docs/experiments/lsp_core_acceleration.md
+++ b/docs/experiments/lsp_core_acceleration.md
@@ -83,6 +83,30 @@ executors after the agent boundary conversion. Symbol-only static lookups are
 not valid live-LSP comparison requests because JSON-RPC definition/references
 operate on file positions.
 
+For repeatable feedback loops, prefer the package CLI over ad hoc scripts:
+
+```bash
+cat > /tmp/lsp-provider-requests.jsonl <<'EOF'
+{"request_id":"demo-definition","capability":"textDocument/definition","arguments":{"file_path":"caller.py","line":41,"character":12}}
+EOF
+
+codeminer-lsp-provider-validate \
+  --graph /path/to/graph.pkl \
+  --project-root /path/to/repo \
+  --language python \
+  --requests /tmp/lsp-provider-requests.jsonl \
+  --output-json /tmp/lsp-provider-report.json \
+  --output-markdown /tmp/lsp-provider-report.md \
+  --require-promotion
+```
+
+Use `--prebuilt-root ... --instance-id ...` instead of `--graph` when running
+against agent-runner prebuilt artifacts. The default exit code fails on
+mismatches and provider errors. `--require-promotion` additionally fails unless
+every row is `equivalent_static_faster`; `--fail-on-fallback` makes unsupported
+or unavailable static rows fail instead of recording them as explicit fallback
+cases.
+
 The live path requires an installed language server or an override such as
 `CODEMINER_PYTHON_LSP_CMD`. If no server command is available, use the fake
 client unit path only; do not claim live equivalence from it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 [project.scripts]
 codeminer-mcp = "codeminer.mcp.server:main"
 codeminer-web = "codeminer.web.app:main"
+codeminer-lsp-provider-validate = "codeminer.eval.agent_runner.lsp_provider_cli:main"
 
 [project.optional-dependencies]
 dev = [

--- a/test/eval/test_lsp_provider_cli.py
+++ b/test/eval/test_lsp_provider_cli.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the LSP provider validation CLI."""
+
+from __future__ import annotations
+
+import json
+
+from codeminer.eval.agent_runner import lsp_provider_cli
+from codeminer.eval.agent_runner.lsp_provider_validation import (
+    LSPProviderCall,
+    LSPProviderComparison,
+    LSPProviderRequest,
+)
+
+
+def _comparison(verdict: str, *, same_result: bool | None = True):
+    request = LSPProviderRequest(
+        capability="textDocument/definition",
+        arguments={"file_path": "caller.py", "line": 2, "character": 4},
+        request_id="caller-definition",
+    )
+    return LSPProviderComparison(
+        request=request,
+        static_call=LSPProviderCall(
+            provider="codeminer_static_index",
+            capability="definition",
+            status="ok",
+            duration_ms=1.0,
+            result_count=1,
+            result_fingerprint="static",
+        ),
+        reference_call=LSPProviderCall(
+            provider="json_rpc",
+            capability="definition",
+            status="ok",
+            duration_ms=5.0,
+            result_count=1,
+            result_fingerprint="static" if same_result else "live",
+        ),
+        same_result=same_result,
+        verdict=verdict,
+        latency_saved_ms=4.0,
+        speedup_ratio=5.0,
+    )
+
+
+def test_load_lsp_provider_requests_accepts_jsonl(tmp_path):
+    path = tmp_path / "requests.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                "# comment",
+                json.dumps(
+                    {
+                        "lsp_method": "textDocument/definition",
+                        "resolved_arguments": {
+                            "file_path": "caller.py",
+                            "line": 2,
+                            "character": 4,
+                        },
+                        "request_id": "caller-definition",
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    requests = lsp_provider_cli.load_lsp_provider_requests(path)
+
+    assert len(requests) == 1
+    assert requests[0].normalized_capability == "definition"
+    assert requests[0].arguments == {
+        "file_path": "caller.py",
+        "line": 2,
+        "character": 4,
+    }
+    assert requests[0].request_id == "caller-definition"
+
+
+def test_cli_writes_reports_and_requires_promotion(tmp_path, monkeypatch):
+    requests_path = tmp_path / "requests.json"
+    output_json = tmp_path / "report.json"
+    output_md = tmp_path / "report.md"
+    requests_path.write_text(
+        json.dumps(
+            [
+                {
+                    "capability": "textDocument/definition",
+                    "arguments": {"file_path": "caller.py", "line": 2},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    sentinel_graph = object()
+    seen = {}
+
+    def fake_load_graph(args):
+        return sentinel_graph
+
+    def fake_compare(requests, **kwargs):
+        seen["requests"] = requests
+        seen["kwargs"] = kwargs
+        return [_comparison("equivalent_static_faster")]
+
+    monkeypatch.setattr(lsp_provider_cli, "_load_graph_from_args", fake_load_graph)
+    monkeypatch.setattr(
+        lsp_provider_cli, "compare_static_to_live_lsp_provider", fake_compare
+    )
+
+    code = lsp_provider_cli.main(
+        [
+            "--graph",
+            str(tmp_path / "graph.pkl"),
+            "--project-root",
+            str(tmp_path),
+            "--language",
+            "python",
+            "--requests",
+            str(requests_path),
+            "--output-json",
+            str(output_json),
+            "--output-markdown",
+            str(output_md),
+            "--require-promotion",
+            "--quiet",
+        ]
+    )
+
+    assert code == 0
+    assert seen["kwargs"]["graph"] is sentinel_graph
+    assert seen["kwargs"]["language"] == "python"
+    assert seen["requests"][0].normalized_capability == "definition"
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["summary"]["promotion_ready"] is True
+    assert payload["summary"]["verdict_counts"] == {"equivalent_static_faster": 1}
+    assert "Promotion ready: yes" in output_md.read_text(encoding="utf-8")
+
+
+def test_exit_code_for_lsp_provider_summary_blocks_mismatch_and_fallback():
+    assert (
+        lsp_provider_cli.exit_code_for_lsp_provider_summary(
+            {"mismatch_count": 1, "error_count": 0}
+        )
+        == 2
+    )
+    assert (
+        lsp_provider_cli.exit_code_for_lsp_provider_summary(
+            {"mismatch_count": 0, "error_count": 0, "fallback_count": 1},
+            fail_on_fallback=True,
+        )
+        == 3
+    )
+    assert (
+        lsp_provider_cli.exit_code_for_lsp_provider_summary(
+            {
+                "mismatch_count": 0,
+                "error_count": 0,
+                "fallback_count": 0,
+                "promotion_ready": False,
+            },
+            require_promotion=True,
+        )
+        == 4
+    )

--- a/test/eval/test_lsp_provider_validation.py
+++ b/test/eval/test_lsp_provider_validation.py
@@ -13,6 +13,7 @@ from codeminer.eval.agent_runner.lsp_provider_validation import (
     LSPProviderRequest,
     compare_static_lsp_provider,
     render_lsp_provider_validation_markdown,
+    summarize_lsp_provider_validation,
 )
 from codeminer.graph.code_graph import CodeGraph
 from codeminer.types import NODE_TYPE_FUNCTION
@@ -121,3 +122,33 @@ def test_compare_static_lsp_provider_marks_fallback_when_graph_unavailable():
     assert row.static_call.status == "unavailable"
     assert row.static_call.fallback_reason == "symbol_graph_unavailable"
     assert row.reference_call.status == "ok"
+
+
+def test_summarize_lsp_provider_validation_marks_promotion_ready():
+    graph = _range_graph()
+
+    def reference_provider(capability, arguments):
+        return list(StaticLSPProvider(graph).definition(**arguments))
+
+    rows = compare_static_lsp_provider(
+        [
+            LSPProviderRequest(
+                capability="definition",
+                arguments={"symbol": "load_config"},
+                request_id="jump-load-config",
+            )
+        ],
+        graph=graph,
+        reference_provider=reference_provider,
+        clock=_clock([1.0, 1.001, 2.0, 2.004]),
+    )
+
+    summary = summarize_lsp_provider_validation(rows)
+
+    assert summary.total == 1
+    assert summary.verdict_counts == {"equivalent_static_faster": 1}
+    assert summary.same_result_count == 1
+    assert summary.mismatch_count == 0
+    assert summary.fallback_count == 0
+    assert summary.error_count == 0
+    assert summary.promotion_ready is True


### PR DESCRIPTION
## Summary
Add a repeatable provider-level validation loop for routing LSP-shaped agent calls through CodeMiner's static graph index instead of live JSON-RPC LSP when the agent-visible result is equivalent and faster.

## Changes
- Add a machine-readable validation summary with promotion-ready verdict counts.
- Add `codeminer-lsp-provider-validate` for JSON/JSONL request replay against static and live LSP providers.
- Document the CLI feedback loop and gate options in the LSP core acceleration note.
- Cover request parsing, report output, exit-code gates, and promotion summaries with unit tests.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

Validated with:
- `pre-commit run --files pyproject.toml docs/experiments/lsp_core_acceleration.md codeminer/eval/agent_runner/lsp_provider_validation.py codeminer/eval/agent_runner/lsp_provider_cli.py codeminer/eval/agent_runner/__init__.py test/eval/test_lsp_provider_validation.py test/eval/test_lsp_provider_cli.py`
- `pytest test/eval/test_lsp_provider_validation.py test/eval/test_lsp_provider_cli.py test/eval/test_live_lsp_provider.py test/agent/test_lsp_provider.py test/agent/test_lsp_graph.py -q`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`
- `python -m mkdocs build --strict --site-dir /tmp/codeminer-lsp-provider-fastpath-site`

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
