### PR TITLE
feat(index): reuse snapshot-addressed artifacts

### DIFF
--- a/codeminer/compiler/snapshot_store.py
+++ b/codeminer/compiler/snapshot_store.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Content-addressed repository snapshots and reusable analysis artifacts.
+
+Benchmark instances are not artifact identities. Several instances, generated
+queries, or agent runs may refer to the same repository commit. This module
+stores that source snapshot once, stores analysis artifacts under an explicit
+profile, and binds arbitrary instance IDs to the shared profile with symlinks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
+
+from ..languages import normalize_language
+
+SNAPSHOT_STORE_VERSION = "1"
+_SNAPSHOT_DIR = ".snapshots"
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _digest(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def normalize_repo(repo: str) -> str:
+    """Normalize common GitHub URL and slug forms to ``owner/repo``."""
+    value = repo.strip().rstrip("/")
+    if value.startswith("git@") and ":" in value:
+        value = value.split(":", 1)[1]
+    elif "://" in value:
+        value = urlparse(value).path.lstrip("/")
+    if value.endswith(".git"):
+        value = value[:-4]
+    value = value.strip("/").lower()
+    if not value or ".." in value.split("/"):
+        raise ValueError(f"invalid repository identity: {repo!r}")
+    return value
+
+
+def _normalize_languages(languages: Sequence[str]) -> tuple[str, ...]:
+    normalized = set()
+    for language in languages:
+        value = language.strip().lower()
+        if value:
+            normalized.add(normalize_language(value) or value)
+    if not normalized:
+        raise ValueError("an artifact profile requires at least one language")
+    return tuple(sorted(normalized))
+
+
+@dataclass(frozen=True, slots=True)
+class SourceSnapshot:
+    """Immutable source identity independent of benchmark instance IDs."""
+
+    repo: str
+    commit: str
+
+    def payload(self) -> dict[str, Any]:
+        commit = self.commit.strip().lower()
+        if not commit:
+            raise ValueError("snapshot commit must not be empty")
+        return {
+            "version": SNAPSHOT_STORE_VERSION,
+            "repo": normalize_repo(self.repo),
+            "commit": commit,
+        }
+
+    @property
+    def snapshot_id(self) -> str:
+        return _digest(self.payload())
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactProfile:
+    """Analysis configuration that determines artifact compatibility."""
+
+    languages: tuple[str, ...]
+    name: str = "default"
+    schema_versions: Mapping[str, str] = field(default_factory=dict)
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def create(
+        cls,
+        languages: Sequence[str],
+        *,
+        name: str = "default",
+        schema_versions: Mapping[str, str] | None = None,
+        options: Mapping[str, Any] | None = None,
+    ) -> ArtifactProfile:
+        return cls(
+            languages=_normalize_languages(languages),
+            name=name,
+            schema_versions=dict(schema_versions or {}),
+            options=dict(options or {}),
+        )
+
+    def payload(self) -> dict[str, Any]:
+        if not self.name.strip():
+            raise ValueError("artifact profile name must not be empty")
+        return {
+            "version": SNAPSHOT_STORE_VERSION,
+            "name": self.name.strip(),
+            "languages": list(_normalize_languages(self.languages)),
+            "schema_versions": dict(self.schema_versions),
+            "options": dict(self.options),
+        }
+
+    @property
+    def profile_id(self) -> str:
+        return _digest(self.payload())
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotBinding:
+    """Resolved paths and cache state for one instance binding."""
+
+    instance_id: str
+    snapshot_id: str
+    profile_id: str
+    snapshot_dir: Path
+    profile_dir: Path
+    instance_path: Path
+    snapshot_hit: bool
+    profile_hit: bool
+    alias_hit: bool
+
+
+class SnapshotArtifactStore:
+    """Bind benchmark instances to content-addressed snapshot artifacts."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root).expanduser().resolve()
+        self.snapshots_dir = self.root / _SNAPSHOT_DIR
+
+    def bind(
+        self,
+        instance_id: str,
+        snapshot: SourceSnapshot,
+        profile: ArtifactProfile,
+    ) -> SnapshotBinding:
+        snapshot_payload = snapshot.payload()
+        profile_payload = profile.payload()
+        snapshot_id = snapshot.snapshot_id
+        profile_id = profile.profile_id
+        snapshot_dir = self.snapshots_dir / snapshot_id
+        profile_dir = snapshot_dir / "profiles" / profile_id
+        instance_path = self.root / self._instance_name(instance_id)
+
+        snapshot_hit = (snapshot_dir / "snapshot.json").is_file()
+        profile_hit = (profile_dir / "profile.json").is_file()
+        alias_hit = instance_path.is_symlink()
+
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        self._write_identity(snapshot_dir / "snapshot.json", snapshot_payload)
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        self._write_identity(profile_dir / "profile.json", profile_payload)
+        self._ensure_repo_link(profile_dir, snapshot_dir)
+        self._bind_alias(instance_path, profile_dir)
+
+        return SnapshotBinding(
+            instance_id=instance_id,
+            snapshot_id=snapshot_id,
+            profile_id=profile_id,
+            snapshot_dir=snapshot_dir,
+            profile_dir=profile_dir,
+            instance_path=instance_path,
+            snapshot_hit=snapshot_hit,
+            profile_hit=profile_hit,
+            alias_hit=alias_hit,
+        )
+
+    def ensure_worktree(
+        self,
+        binding: SnapshotBinding,
+        *,
+        source_repo: str | Path,
+        commit: str,
+    ) -> Path:
+        """Create a durable detached worktree for the snapshot if absent."""
+        target = binding.snapshot_dir / "repo"
+        if target.exists():
+            actual = self._git_output(target, "rev-parse", "HEAD")
+            expected = self._git_output(
+                source_repo, "rev-parse", f"{commit}^{{commit}}"
+            )
+            if actual != expected:
+                raise ValueError(
+                    f"snapshot worktree mismatch: expected {expected}, found {actual}"
+                )
+            return target
+
+        expected = self._git_output(source_repo, "rev-parse", f"{commit}^{{commit}}")
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(source_repo),
+                "worktree",
+                "add",
+                "--detach",
+                str(target),
+                expected,
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return target
+
+    def resolve(self, instance_id: str) -> Path:
+        path = self.root / self._instance_name(instance_id)
+        if not path.exists():
+            raise FileNotFoundError(f"no snapshot artifact binding for {instance_id}")
+        return path.resolve()
+
+    @staticmethod
+    def _instance_name(instance_id: str) -> str:
+        name = instance_id.replace("/", "__")
+        if (
+            not name
+            or name in {".", ".."}
+            or not re.fullmatch(r"[A-Za-z0-9_.-]+", name)
+        ):
+            raise ValueError(f"invalid instance id: {instance_id!r}")
+        return name
+
+    @staticmethod
+    def _write_identity(path: Path, payload: Mapping[str, Any]) -> None:
+        if path.exists():
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            comparable = {k: existing.get(k) for k in payload}
+            if comparable != dict(payload):
+                raise ValueError(f"artifact identity mismatch at {path}")
+            return
+        body = dict(payload)
+        body["created_at"] = datetime.now(timezone.utc).isoformat()
+        path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _ensure_repo_link(profile_dir: Path, snapshot_dir: Path) -> None:
+        link = profile_dir / "repo"
+        target = snapshot_dir / "repo"
+        if link.is_symlink():
+            if link.resolve(strict=False) != target.resolve(strict=False):
+                raise ValueError(
+                    f"profile repo link points at the wrong snapshot: {link}"
+                )
+            return
+        if link.exists():
+            raise FileExistsError(f"profile repo path is not a symlink: {link}")
+        link.symlink_to(
+            os.path.relpath(target, start=profile_dir), target_is_directory=True
+        )
+
+    @staticmethod
+    def _bind_alias(instance_path: Path, profile_dir: Path) -> None:
+        if instance_path.is_symlink():
+            if instance_path.resolve(strict=False) != profile_dir.resolve(strict=False):
+                raise ValueError(
+                    f"instance alias already targets another profile: {instance_path}"
+                )
+            return
+        if instance_path.exists():
+            raise FileExistsError(
+                f"instance path already exists in legacy layout: {instance_path}"
+            )
+        instance_path.parent.mkdir(parents=True, exist_ok=True)
+        instance_path.symlink_to(
+            os.path.relpath(profile_dir, start=instance_path.parent),
+            target_is_directory=True,
+        )
+
+    @staticmethod
+    def _git_output(repo: str | Path, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+
+
+__all__ = [
+    "ArtifactProfile",
+    "SNAPSHOT_STORE_VERSION",
+    "SnapshotArtifactStore",
+    "SnapshotBinding",
+    "SourceSnapshot",
+    "normalize_repo",
+]

--- a/codeminer/ls_index/index_quality.py
+++ b/codeminer/ls_index/index_quality.py
@@ -248,8 +248,11 @@ def assess_index_quality(
                 graph, project_root=Path(project_root).resolve()
             )
             graph_compdb_count = len(compdb_files & graph_files)
+            # Clangd symbol graphs are often header-centric. Validate that graph
+            # translation units belong to the compdb, not that every compdb unit
+            # contributes a range-bearing symbol.
             graph_compdb_coverage = (
-                graph_compdb_count / len(compdb_files) if compdb_files else None
+                graph_compdb_count / len(graph_files) if graph_files else None
             )
             compdb_stats.update(
                 {

--- a/docs/experiments/system_paper_plan.md
+++ b/docs/experiments/system_paper_plan.md
@@ -1,0 +1,178 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CodeMiner systems paper plan
+
+## Thesis
+
+CodeMiner is a snapshot-indexed semantic service for software-engineering
+agents. It compiles an immutable repository snapshot once, exposes the result
+through retrieval, graph-navigation, and LSP-shaped interfaces, and reuses the
+same artifacts across benchmark instances, queries, models, agent arms, and
+repetitions. Context compaction is a consumer-side optimization built on that
+service, not the paper's primary contribution.
+
+A defensible claim is:
+
+> Under an agent-visible equivalence guard, a reusable static repository index
+> amortizes semantic analysis across agent workloads and serves supported LSP
+> requests and context assembly with lower latency than per-session dynamic
+> analysis, without degrading a pre-specified task-quality margin.
+
+The system does not claim universal LSP equivalence. Unsaved buffers,
+workspace-dependent build state, refactors, and unsupported request classes
+must use an explicit live-server fallback.
+
+## System boundary
+
+1. **Snapshot compilation.** `(repository, commit)` identifies immutable source.
+   An analysis profile separately identifies languages, schema versions, and
+   indexer options. Benchmark instance IDs are aliases, not cache keys.
+2. **Shared semantic service.** One profile can contain SCIP/LSP/clangd graph,
+   dense and sparse retrieval, and range metadata. Static providers expose
+   definition, references, route, retrieval, and graph operations.
+3. **Compatibility and freshness.** Requests use stable agent/MCP contracts.
+   Static results are promoted only when their agent-visible fingerprints match
+   a live reference; unsupported or stale cases fall back explicitly.
+4. **Agent runtime.** Multiple queries and trajectories reuse loaded contexts.
+   Preload and compact modes control what reaches the model, independently of
+   how the semantic evidence was produced.
+
+The source/profile split follows established content-addressed build-cache
+principles rather than using an instance ID as artifact identity. Bazel, for
+example, separates action metadata from content-addressed outputs. SCIP already
+provides a language-neutral static code-intelligence representation. The
+CodeMiner contribution is the agent systems layer joining reusable snapshot
+artifacts, compatibility-guarded serving, and context lifecycle management.
+
+## Research questions
+
+### RQ1: Reuse and amortization
+
+How much index build time, workspace preparation, and storage does
+snapshot/profile reuse remove under real agent workloads?
+
+Report cold build, warm bind, warm load, cache-hit rate, unique snapshots,
+artifact bytes, and amortized build seconds per query. Compare:
+
+- legacy per-instance artifact layout;
+- snapshot-addressed layout with one profile per exact source snapshot;
+- snapshot layout plus incremental update for adjacent commits, as a separate
+  optimization when exact final-snapshot parity holds.
+
+### RQ2: Compatible LSP acceleration
+
+For the same file-position request, when can the static provider replace live
+JSON-RPC LSP work?
+
+Report equivalence coverage, fallback rate, static and live p50/p95/p99 latency,
+language-server startup separately from steady state, throughput, and errors.
+Latency comparisons include only equivalent rows; equivalence and fallback are
+first-class outcomes, not filtered failures.
+
+### RQ3: End-to-end agent efficiency
+
+With model, task, prompt, tools, and output contract fixed, does the shared
+semantic service reduce agent wall time, billed cost, raw tokens, and turns?
+
+Primary comparison: live/dynamic semantic backend versus CodeMiner static
+backend. Grep-only, eager preload, and compact context are secondary ablations.
+Task quality is a non-inferiority guard, not inferred from a non-significant
+difference.
+
+### RQ4: Generality and scaling
+
+How do reuse and serving gains vary with language, repository size, graph size,
+query multiplicity, cache warmth, and model size? Use repository-level strata
+and report per-language failure causes instead of averaging them away.
+
+## Existing exploratory evidence
+
+The snapshot-reuse profiler produces the following exact counts:
+
+```bash
+python scripts/profiling/analyze_snapshot_reuse.py \
+  --dataset fishmingyu/codeminer-base-dataset \
+  --dataset sysevol-ai/codeminer-synthesis
+```
+
+| workload | records | instances | repositories | snapshots | reuse | records/snapshot |
+|---|---:|---:|---:|---:|---:|---:|
+| CodeMiner base | 100 | 100 | 25 | 100 | 0% | 1.0 |
+| synthesis | 500 | 25 | 25 | 25 | 95% | 20.0 |
+| combined | 600 | 100 | 25 | 100 | 83.3% | 6.0 |
+
+For the Qwen3-Embedding-0.6B profiles currently under
+`/mnt/data/codeminer/profile_log`, the 100 base snapshots required 16,180
+observed build seconds (4.49 hours; median 113.9 seconds/snapshot). The 25
+snapshots used by synthesis required 4,472 seconds once, or 8.94 amortized
+seconds across each of 500 queries. These are measurements of the current
+machine and artifacts, not yet a controlled baseline comparison.
+
+Existing agent results are supporting evidence only:
+
+- synthesis establishes compact-versus-grep non-inferiority at a 5-point
+  margin under a repository-clustered bootstrap while reducing Haiku USD and
+  wall time;
+- the 100-instance base set does not have enough repository-level precision to
+  establish the same non-inferiority margin;
+- all current base and synthesis results use the same 25 repositories and one
+  stochastic repetition, so they are development evidence rather than an
+  independent confirmatory test;
+- current latency runs used fixed arm order, and the synthesis compact arm ran
+  separately from its baselines. They cannot be the final controlled latency
+  result.
+
+## Confirmatory protocol
+
+Freeze the artifact profile, compact policy, metrics, and 5-point
+non-inferiority margin before running held-out repositories.
+
+1. Select new repositories from SWE-bench Multilingual without inspecting
+   agent outcomes. Keep inclusion rules based on indexability and valid ground
+   truth.
+2. Use one exact snapshot artifact for every query, arm, model, and repetition.
+   Record snapshot/profile IDs and cache-hit state in every result.
+3. Interleave or deterministically randomize arm order. Run microbenchmarks at
+   least five times after declared warmups; run stochastic agent cells with at
+   least three repetitions on the confirmatory subset.
+4. Cluster task statistics by repository. For generated queries, resample
+   repositories first and queries within repository second.
+5. Report completion and fallback rates. Do not silently remove malformed
+   model responses, missing indexes, LSP errors, or unsupported capabilities.
+6. Separate raw token volume, cache-read tokens, billed USD, wall time, server
+   startup, index build, and index load. None is a substitute for the others.
+
+## Required experiment matrix
+
+| experiment | workload | primary metric | guardrail |
+|---|---|---|---|
+| snapshot build/reuse | 20-40 held-out multilingual snapshots, repeated consumers | total and amortized build time; bytes | exact snapshot/profile identity |
+| LSP replay | real definition/reference traces from those snapshots | equivalent-row p50/p95 latency | fingerprint equivalence and fallback rate |
+| agent backend A/B | same model and agent, live versus static semantic provider | wall time and USD | files@5/block@5 non-inferiority |
+| context ablation | grep, eager, compact over the static provider | USD, tokens, turns | same non-inferiority margin |
+| scale analysis | language, graph size, repository size, queries/snapshot | slope and break-even query count | completion rate |
+
+## Related systems and differentiation
+
+- [SWE-agent](https://arxiv.org/abs/2405.15793) establishes that the
+  agent-computer interface materially affects software-agent behavior.
+- [OpenHands](https://arxiv.org/abs/2407.16741) provides a general agent
+  platform and benchmark integration.
+- [Agentless](https://arxiv.org/abs/2407.01489) and
+  [AutoCodeRover](https://arxiv.org/abs/2404.05427) emphasize structured
+  localization and cost.
+- [RepoGraph](https://arxiv.org/abs/2410.14684) and
+  [LocAgent](https://aclanthology.org/2025.acl-long.426/) inject repository
+  graphs into localization workflows.
+- [SCIP](https://github.com/sourcegraph/scip) is the static code-intelligence
+  substrate for definition/reference-style navigation.
+- [Bazel remote caching](https://bazel.build/remote/caching) is prior art for
+  reusable content-addressed build outputs.
+
+CodeMiner should therefore be evaluated as an amortized semantic service for
+agents, not as a claim that static indexing, code graphs, or content-addressed
+caching are individually new.

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -29,14 +29,26 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-from codeminer.index.embedding import build_hierarchical_vector_store
-from codeminer.log_utils import get_logger
-from codeminer.profiler import Profiler
+project_root = Path(__file__).resolve().parents[2]
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from codeminer.compiler.snapshot_store import ArtifactProfile  # noqa: E402
+from codeminer.compiler.snapshot_store import SnapshotArtifactStore, SourceSnapshot
+from codeminer.index.embedding import build_hierarchical_vector_store  # noqa: E402
+from codeminer.log_utils import get_logger  # noqa: E402
+from codeminer.profiler import Profiler  # noqa: E402
 
 logger = get_logger(__name__)
 
-project_root = Path(__file__).parent.parent
-sys.path.insert(0, str(project_root))
+DEFAULT_MULTILINGUAL_REPO_LANG_CSV = (
+    project_root
+    / "codeminer"
+    / "dataset"
+    / "collect"
+    / "data"
+    / "swebench_multilingual_repos.csv"
+)
 
 
 def parse_args():
@@ -50,7 +62,7 @@ def parse_args():
     parser.add_argument(
         "--dataset-class",
         type=str,
-        choices=["swebench", "codeminer_base"],
+        choices=["swebench", "swebench_multilingual", "codeminer_base"],
         default="swebench",
         help=(
             "Dataset class to use. 'swebench' for SWE-bench Lite/Verified, "
@@ -161,6 +173,12 @@ def parse_args():
         help="Programming languages to process",
     )
     parser.add_argument(
+        "--multilingual-repo-language-csv",
+        type=str,
+        default=str(DEFAULT_MULTILINGUAL_REPO_LANG_CSV),
+        help="Repo-to-language map for SWE-bench Multilingual rows.",
+    )
+    parser.add_argument(
         "--max-lines-per-chunk",
         type=int,
         default=None,
@@ -190,6 +208,20 @@ def parse_args():
         type=str,
         default="/mnt/data/codeminer",
         help="Base directory to store embeddings",
+    )
+    parser.add_argument(
+        "--artifact-layout",
+        choices=["instance", "snapshot"],
+        default="instance",
+        help=(
+            "Store each instance separately or bind it to a shared, "
+            "content-addressed repository snapshot."
+        ),
+    )
+    parser.add_argument(
+        "--artifact-profile",
+        default="benchmark-v1",
+        help="Compatibility profile name used by snapshot-addressed artifacts.",
     )
     parser.add_argument(
         "--force-rebuild",
@@ -238,6 +270,7 @@ def parse_args():
 
 _DATASET_DEFAULTS = {
     "swebench": "princeton-nlp/SWE-bench_Lite",
+    "swebench_multilingual": "SWE-bench/SWE-bench_Multilingual",
     "codeminer_base": "fishmingyu/codeminer-base-dataset",
 }
 
@@ -256,6 +289,8 @@ def _map_language_group(label: Optional[str], fallback: str = "python") -> List[
     text = label.lower()
     if "rust" in text:
         return ["rust"]
+    if text == "go" or "golang" in text:
+        return ["go"]
     if "javascript" in text and "typescript" in text:
         return ["ts", "js"]
     if "typescript" in text or text == "ts":
@@ -264,20 +299,47 @@ def _map_language_group(label: Optional[str], fallback: str = "python") -> List[
         return ["js"]
     if "c++" in text or text in ("cpp", "c"):
         return ["cpp"]
-    if "go" in text or text == "golang":
-        return ["go"]
+    if "c#" in text or "csharp" in text:
+        return ["csharp"]
+    if "java" in text:
+        return ["java"]
+    if "kotlin" in text:
+        return ["kotlin"]
+    if "ruby" in text:
+        return ["ruby"]
+    if "php" in text:
+        return ["php"]
+    if "scala" in text:
+        return ["scala"]
     if "python" in text:
         return ["python"]
     return [fallback]
 
 
-def _resolve_languages(instance: dict, cli_languages: List[str]) -> List[str]:
+def _load_repo_language_map(path: str) -> dict[str, str]:
+    import csv
+
+    with Path(path).expanduser().open(encoding="utf-8") as fp:
+        return {
+            row["repo"]: row["language"]
+            for row in csv.DictReader(fp)
+            if row.get("repo") and row.get("language")
+        }
+
+
+def _resolve_languages(
+    instance: dict,
+    cli_languages: List[str],
+    repo_languages: Optional[dict[str, str]] = None,
+) -> List[str]:
     """Return the language list for a single instance.
 
     If the instance has a ``language_group`` column (codeminer-base), derive
     the chunker language from it.  Otherwise fall back to ``cli_languages``.
     """
-    lang_group = instance.get("language_group")
+    lang_group = instance.get("language_group") or (repo_languages or {}).get(
+        instance.get("repo", "")
+    )
     if lang_group:
         return _map_language_group(lang_group, fallback=cli_languages[0])
     return list(cli_languages)
@@ -291,6 +353,15 @@ def _load_dataset(args):
         from codeminer.dataset.codeminer_base import CodeMinerBaseDataset
 
         return CodeMinerBaseDataset(
+            dataset=dataset_name,
+            split=args.split,
+            filter_instance=args.filter_instance,
+        )
+
+    if args.dataset_class == "swebench_multilingual":
+        from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
+
+        return SwebenchMultilingualDataset(
             dataset=dataset_name,
             split=args.split,
             filter_instance=args.filter_instance,
@@ -322,6 +393,12 @@ def build_embeddings(args):
     logger.info(f"Loaded {len(dataset_instances)} instance(s)")
     logger.info(f"Dataset class: {args.dataset_class}")
     logger.info(f"Embeddings will be stored in: {args.storage_dir}")
+    repo_languages = _load_repo_language_map(args.multilingual_repo_language_csv)
+    snapshot_store = (
+        SnapshotArtifactStore(args.storage_dir)
+        if args.artifact_layout == "snapshot"
+        else None
+    )
 
     # Setup profile output directory
     profile_output_dir = (
@@ -357,15 +434,46 @@ def build_embeddings(args):
             dataset_obj.process_instance(instance)
             repo_path = dataset_obj.get_repo_path(instance)
 
-            # Convert instance_id to directory name (replace / with __)
-            instance_dir_name = instance_id.replace("/", "__")
-
-            # Set final directory for this instance
-            instance_final_dir = Path(args.storage_dir) / instance_dir_name
-            instance_final_dir.mkdir(parents=True, exist_ok=True)
-
             # Resolve per-instance language (uses language_group when available)
-            instance_languages = _resolve_languages(instance, args.languages)
+            instance_languages = _resolve_languages(
+                instance,
+                args.languages,
+                repo_languages,
+            )
+
+            if snapshot_store is not None:
+                binding = snapshot_store.bind(
+                    instance_id,
+                    SourceSnapshot(
+                        repo=instance["repo"],
+                        commit=instance["base_commit"],
+                    ),
+                    ArtifactProfile.create(
+                        instance_languages,
+                        name=args.artifact_profile,
+                    ),
+                )
+                repo_path = str(
+                    snapshot_store.ensure_worktree(
+                        binding,
+                        source_repo=repo_path,
+                        commit=instance["base_commit"],
+                    )
+                )
+                instance_final_dir = binding.profile_dir
+                logger.info(
+                    "Snapshot artifact: snapshot=%s profile=%s "
+                    "snapshot_hit=%s profile_hit=%s alias_hit=%s",
+                    binding.snapshot_id,
+                    binding.profile_id,
+                    binding.snapshot_hit,
+                    binding.profile_hit,
+                    binding.alias_hit,
+                )
+            else:
+                instance_dir_name = instance_id.replace("/", "__")
+                instance_final_dir = Path(args.storage_dir) / instance_dir_name
+                instance_final_dir.mkdir(parents=True, exist_ok=True)
 
             logger.info(f"Repository path: {repo_path}")
             logger.info(f"Target directory: {instance_final_dir}")

--- a/scripts/profiling/analyze_snapshot_reuse.py
+++ b/scripts/profiling/analyze_snapshot_reuse.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Measure exact repository-snapshot reuse in benchmark datasets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from codeminer.compiler.snapshot_store import SourceSnapshot  # noqa: E402
+from codeminer.compiler.snapshot_store import normalize_repo
+
+
+def summarize_snapshot_reuse(rows: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    records = [row for row in rows if row.get("repo") and row.get("base_commit")]
+    snapshot_ids = [
+        SourceSnapshot(str(row["repo"]), str(row["base_commit"])).snapshot_id
+        for row in records
+    ]
+    instances = {str(row.get("instance_id") or "") for row in records}
+    instances.discard("")
+    repos = {normalize_repo(str(row["repo"])) for row in records}
+    counts = Counter(snapshot_ids)
+    per_snapshot = sorted(counts.values())
+    unique_snapshots = len(counts)
+    record_count = len(records)
+    return {
+        "records": record_count,
+        "instances": len(instances),
+        "repositories": len(repos),
+        "unique_snapshots": unique_snapshots,
+        "duplicate_records": record_count - unique_snapshots,
+        "snapshot_reuse_fraction": (
+            1.0 - unique_snapshots / record_count if record_count else 0.0
+        ),
+        "records_per_snapshot_mean": (
+            record_count / unique_snapshots if unique_snapshots else 0.0
+        ),
+        "records_per_snapshot_median": (
+            statistics.median(per_snapshot) if per_snapshot else 0.0
+        ),
+        "records_per_snapshot_max": max(per_snapshot, default=0),
+    }
+
+
+def _load_hf(dataset: str, configs: Sequence[str], split: str) -> list[dict[str, Any]]:
+    from datasets import get_dataset_config_names, load_dataset
+
+    selected = list(configs)
+    if not selected:
+        available = get_dataset_config_names(dataset)
+        selected = available if len(available) > 1 else [""]
+    rows: list[dict[str, Any]] = []
+    for config in selected:
+        loaded = load_dataset(dataset, config or None, split=split)
+        rows.extend(dict(row) for row in loaded)
+    return rows
+
+
+def _load_json(path: Path) -> list[dict[str, Any]]:
+    if path.suffix == ".jsonl":
+        return [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError(f"expected a JSON array at {path}")
+    return [dict(row) for row in payload]
+
+
+def _markdown(label: str, summary: Mapping[str, Any]) -> str:
+    return "\n".join(
+        [
+            f"## {label}",
+            "",
+            "| records | instances | repos | snapshots | avoided builds "
+            "| reuse | records/snapshot |",
+            "|---:|---:|---:|---:|---:|---:|---:|",
+            (
+                f"| {summary['records']} | {summary['instances']} "
+                f"| {summary['repositories']} | {summary['unique_snapshots']} "
+                f"| {summary['duplicate_records']} "
+                f"| {summary['snapshot_reuse_fraction']:.1%} "
+                f"| {summary['records_per_snapshot_mean']:.2f} |"
+            ),
+        ]
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--dataset",
+        action="append",
+        help="Hugging Face dataset name; repeat to measure cross-dataset reuse",
+    )
+    source.add_argument("--input", type=Path, help="JSON or JSONL records")
+    parser.add_argument("--config", action="append", default=[])
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--label", default=None)
+    parser.add_argument("--output-json", type=Path)
+    args = parser.parse_args(argv)
+
+    if args.dataset:
+        rows = []
+        for dataset in args.dataset:
+            rows.extend(_load_hf(dataset, args.config, args.split))
+        label = args.label or " + ".join(args.dataset)
+    else:
+        rows = _load_json(args.input)
+        label = args.label or str(args.input)
+    summary = summarize_snapshot_reuse(rows)
+    summary["label"] = label
+    print(_markdown(label, summary))
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/swebench_graph_index.py
+++ b/scripts/swebench_graph_index.py
@@ -19,16 +19,26 @@ import csv
 import json
 import logging
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
-from codeminer.dataset.locbench import LocbenchDataset
-from codeminer.dataset.swebench import SwebenchDataset
-from codeminer.dataset.swebench_multilingual import SwebenchMultilingualDataset
-from codeminer.log_utils import get_logger
-from codeminer.ls_router import LSIndexer
-from codeminer.profiler import Profiler
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from codeminer.compiler.snapshot_store import ArtifactProfile  # noqa: E402
+from codeminer.compiler.snapshot_store import SnapshotArtifactStore, SourceSnapshot
+from codeminer.dataset.locbench import LocbenchDataset  # noqa: E402
+from codeminer.dataset.swebench import SwebenchDataset  # noqa: E402
+from codeminer.dataset.swebench_multilingual import (  # noqa: E402
+    SwebenchMultilingualDataset,
+)
+from codeminer.languages import language_capability_rows  # noqa: E402
+from codeminer.log_utils import get_logger  # noqa: E402
+from codeminer.ls_router import LSIndexer  # noqa: E402
+from codeminer.profiler import Profiler  # noqa: E402
 
 logger = get_logger(__name__)
 
@@ -39,6 +49,9 @@ DEFAULT_MULTILINGUAL_REPO_LANG_CSV = (
     / "collect"
     / "data"
     / "swebench_multilingual_repos.csv"
+)
+GRAPH_LANGUAGES = sorted(
+    row.key for row in language_capability_rows() if row.graph_backend is not None
 )
 
 
@@ -161,15 +174,29 @@ def parse_args() -> argparse.Namespace:
         "--language",
         type=str,
         default="auto",
-        choices=["auto", "python", "rust", "ts", "cpp"],
+        choices=["auto", *GRAPH_LANGUAGES, "js", "ts"],
         help="SCIP index language. Use auto to infer per instance.",
     )
     parser.add_argument(
         "--default-language",
         type=str,
         default="python",
-        choices=["python", "rust", "ts", "cpp"],
+        choices=GRAPH_LANGUAGES,
         help="Fallback language when auto inference is inconclusive.",
+    )
+    parser.add_argument(
+        "--artifact-layout",
+        choices=["instance", "snapshot"],
+        default="instance",
+        help=(
+            "Store each instance separately or bind it to a shared, "
+            "content-addressed repository snapshot."
+        ),
+    )
+    parser.add_argument(
+        "--artifact-profile",
+        default="benchmark-v1",
+        help="Compatibility profile name used by snapshot-addressed artifacts.",
     )
     parser.add_argument(
         "--multilingual-repo-language-csv",
@@ -196,13 +223,33 @@ def _map_language_label(label: Optional[str], default_language: str) -> str:
     text = label.lower()
     if "rust" in text:
         return "rust"
+    if text == "go" or "golang" in text:
+        return "go"
     if "javascript" in text or "typescript" in text or text == "ts" or text == "js":
-        return "ts"
+        return "typescript"
     if "c++" in text or text == "cpp" or text == "c":
         return "cpp"
+    if "c#" in text or "csharp" in text:
+        return "csharp"
+    if "java" in text:
+        return "java"
+    if "kotlin" in text:
+        return "kotlin"
+    if "ruby" in text:
+        return "ruby"
+    if "php" in text:
+        return "php"
+    if "scala" in text:
+        return "scala"
     if "python" in text:
         return "python"
     return default_language
+
+
+def _profile_languages(language: str) -> List[str]:
+    if language in {"js", "ts", "javascript", "typescript"}:
+        return ["javascript", "typescript"]
+    return [language]
 
 
 def _load_repo_language_map(csv_path: Path) -> Dict[str, str]:
@@ -479,6 +526,11 @@ def main() -> None:
         args.force,
         effective_skip_level if effective_skip_level is not None else "none",
     )
+    snapshot_store = (
+        SnapshotArtifactStore(output_path)
+        if args.artifact_layout == "snapshot"
+        else None
+    )
 
     failures: List[str] = []
     for idx, task in enumerate(tasks):
@@ -503,8 +555,35 @@ def main() -> None:
             )
             logger.info("Repository checked out at: %s", repo_path)
 
-            instance_output_dir = output_path / instance_id.replace("/", "__")
-            instance_output_dir.mkdir(parents=True, exist_ok=True)
+            if snapshot_store is not None:
+                binding = snapshot_store.bind(
+                    instance_id,
+                    SourceSnapshot(repo=repo, commit=base_commit),
+                    ArtifactProfile.create(
+                        _profile_languages(task.language),
+                        name=args.artifact_profile,
+                    ),
+                )
+                repo_path = str(
+                    snapshot_store.ensure_worktree(
+                        binding,
+                        source_repo=repo_path,
+                        commit=base_commit,
+                    )
+                )
+                instance_output_dir = binding.profile_dir
+                logger.info(
+                    "Snapshot artifact: snapshot=%s profile=%s "
+                    "snapshot_hit=%s profile_hit=%s alias_hit=%s",
+                    binding.snapshot_id,
+                    binding.profile_id,
+                    binding.snapshot_hit,
+                    binding.profile_hit,
+                    binding.alias_hit,
+                )
+            else:
+                instance_output_dir = output_path / instance_id.replace("/", "__")
+                instance_output_dir.mkdir(parents=True, exist_ok=True)
 
             profiler = Profiler(
                 name=f"scip_indexer[{instance_id}]",

--- a/test/compiler/test_snapshot_store.py
+++ b/test/compiler/test_snapshot_store.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from codeminer.compiler.snapshot_store import (
+    ArtifactProfile,
+    SnapshotArtifactStore,
+    SourceSnapshot,
+    normalize_repo,
+)
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def _make_repo(path):
+    path.mkdir()
+    _git(path, "init")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test User")
+    (path / "main.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(path, "add", "main.py")
+    _git(path, "commit", "-m", "initial")
+    return _git(path, "rev-parse", "HEAD")
+
+
+def test_normalize_repo_accepts_slug_and_git_urls():
+    assert normalize_repo("Org/Repo") == "org/repo"
+    assert normalize_repo("https://github.com/Org/Repo.git") == "org/repo"
+    assert normalize_repo("git@github.com:Org/Repo.git") == "org/repo"
+
+
+def test_bind_reuses_snapshot_and_profile_across_instances(tmp_path):
+    store = SnapshotArtifactStore(tmp_path / "artifacts")
+    snapshot = SourceSnapshot("org/repo", "a" * 40)
+    profile = ArtifactProfile.create(["python"], name="paper-v1")
+
+    first = store.bind("org__repo-1", snapshot, profile)
+    second = store.bind("org__repo-2", snapshot, profile)
+
+    assert first.snapshot_hit is False
+    assert first.profile_hit is False
+    assert second.snapshot_hit is True
+    assert second.profile_hit is True
+    assert first.profile_dir == second.profile_dir
+    assert first.instance_path.resolve() == second.instance_path.resolve()
+    assert store.resolve("org__repo-1") == first.profile_dir
+
+
+def test_bind_keeps_profiles_separate(tmp_path):
+    store = SnapshotArtifactStore(tmp_path / "artifacts")
+    snapshot = SourceSnapshot("org/repo", "b" * 40)
+
+    python = store.bind(
+        "org__repo-python",
+        snapshot,
+        ArtifactProfile.create(["python"], name="paper-v1"),
+    )
+    java = store.bind(
+        "org__repo-java",
+        snapshot,
+        ArtifactProfile.create(["java"], name="paper-v1"),
+    )
+
+    assert python.snapshot_dir == java.snapshot_dir
+    assert python.profile_dir != java.profile_dir
+
+
+def test_rebinding_instance_to_different_snapshot_fails(tmp_path):
+    store = SnapshotArtifactStore(tmp_path / "artifacts")
+    profile = ArtifactProfile.create(["python"])
+    store.bind("org__repo-1", SourceSnapshot("org/repo", "a" * 40), profile)
+
+    with pytest.raises(ValueError, match="another profile"):
+        store.bind("org__repo-1", SourceSnapshot("org/repo", "b" * 40), profile)
+
+
+def test_ensure_worktree_is_durable_and_idempotent(tmp_path):
+    source = tmp_path / "source"
+    commit = _make_repo(source)
+    store = SnapshotArtifactStore(tmp_path / "artifacts")
+    binding = store.bind(
+        "org__repo-1",
+        SourceSnapshot("org/repo", commit),
+        ArtifactProfile.create(["python"]),
+    )
+
+    worktree = store.ensure_worktree(binding, source_repo=source, commit=commit)
+    again = store.ensure_worktree(binding, source_repo=source, commit=commit)
+
+    assert again == worktree
+    assert (worktree / "main.py").read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert _git(worktree, "rev-parse", "HEAD") == commit
+    assert (binding.profile_dir / "repo").resolve() == worktree

--- a/test/eval/test_prebuilt.py
+++ b/test/eval/test_prebuilt.py
@@ -10,6 +10,11 @@ import os
 import pickle
 from pathlib import Path
 
+from codeminer.compiler.snapshot_store import (
+    ArtifactProfile,
+    SnapshotArtifactStore,
+    SourceSnapshot,
+)
 from codeminer.eval.agent_runner import prebuilt
 
 
@@ -70,6 +75,28 @@ def test_has_full_indexes_true_false(tmp_path):
 def test_repo_and_instance_paths(tmp_path):
     assert prebuilt.instance_dir(str(tmp_path), "i").endswith("/i")
     assert prebuilt.repo_path_for(str(tmp_path), "i").endswith("/i/repo")
+
+
+def test_prebuilt_consumer_follows_snapshot_profile_alias(tmp_path):
+    model = "org/embed-small"
+    store = SnapshotArtifactStore(tmp_path)
+    binding = store.bind(
+        "org__repo-1",
+        SourceSnapshot("org/repo", "a" * 40),
+        ArtifactProfile.create(["python"]),
+    )
+    (binding.snapshot_dir / "repo").mkdir()
+    (binding.profile_dir / "graph.pkl").write_text("x")
+    suffix = prebuilt.model_suffix(model)
+    l2 = binding.profile_dir / "l2"
+    l2.mkdir()
+    (l2 / f"index_{suffix}.faiss").write_text("x")
+    (l2 / f"documents_{suffix}.pkl").write_text("x")
+
+    assert prebuilt.has_full_indexes(str(tmp_path), "org__repo-1", model)
+    assert Path(prebuilt.repo_path_for(str(tmp_path), "org__repo-1")).resolve() == (
+        binding.snapshot_dir / "repo"
+    )
 
 
 def test_stage_creates_symlinks_without_bm25(tmp_path):

--- a/test/ls_index/test_index_quality.py
+++ b/test/ls_index/test_index_quality.py
@@ -135,6 +135,37 @@ def test_quality_accepts_graph_covering_compilation_database(tmp_path):
     assert report["compile_db"]["graph_compdb_coverage"] == 1.0
 
 
+def test_quality_accepts_header_centric_graph_aligned_with_compdb(tmp_path):
+    sources = []
+    for index in range(4):
+        source = tmp_path / "src" / f"unit_{index}.cc"
+        source.parent.mkdir(exist_ok=True)
+        source.write_text("int value;\n", encoding="utf-8")
+        sources.append(source)
+    header = tmp_path / "include" / "api.h"
+    header.parent.mkdir()
+    header.write_text("int api();\n", encoding="utf-8")
+    compdb = tmp_path / "compile_commands.json"
+    _write_compdb(compdb, sources)
+    graph = _Graph(
+        vertices=40,
+        edges=80,
+        range_files=["src/unit_0.cc", "include/api.h"],
+    )
+
+    report = assess_index_quality(
+        graph,
+        project_root=tmp_path,
+        language="cpp",
+        compdb_path=compdb,
+    )
+
+    assert report["passed"] is True
+    assert report["compile_db"]["translation_unit_count"] == 4
+    assert report["compile_db"]["graph_translation_unit_count"] == 1
+    assert report["compile_db"]["graph_compdb_coverage"] == 1.0
+
+
 def test_subdirectory_bear_accepts_compdb_even_when_build_fails(tmp_path, monkeypatch):
     project = tmp_path / "repo"
     subdir = project / "ports" / "unix"

--- a/test/scripts/test_analyze_snapshot_reuse.py
+++ b/test/scripts/test_analyze_snapshot_reuse.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from scripts.profiling.analyze_snapshot_reuse import summarize_snapshot_reuse
+
+
+def test_summarize_snapshot_reuse_deduplicates_repo_commit_not_instance():
+    rows = [
+        {
+            "repo": "Org/Repo",
+            "base_commit": "a" * 40,
+            "instance_id": "issue-1",
+        },
+        {
+            "repo": "https://github.com/org/repo.git",
+            "base_commit": "a" * 40,
+            "instance_id": "issue-2",
+        },
+        {
+            "repo": "org/repo",
+            "base_commit": "b" * 40,
+            "instance_id": "issue-3",
+        },
+    ]
+
+    summary = summarize_snapshot_reuse(rows)
+
+    assert summary["records"] == 3
+    assert summary["instances"] == 3
+    assert summary["repositories"] == 1
+    assert summary["unique_snapshots"] == 2
+    assert summary["duplicate_records"] == 1
+    assert summary["records_per_snapshot_mean"] == 1.5

--- a/test/scripts/test_snapshot_artifact_builders.py
+++ b/test/scripts/test_snapshot_artifact_builders.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from codeminer.compiler.snapshot_store import ArtifactProfile
+from scripts import swebench_graph_index
+from scripts.embeddings import build_embeddings
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Go", "go"),
+        ("Java", "java"),
+        ("Ruby", "ruby"),
+        ("PHP", "php"),
+        ("TypeScript/JavaScript", "typescript"),
+        ("C++/C", "cpp"),
+    ],
+)
+def test_graph_index_maps_multilingual_labels(label, expected):
+    assert swebench_graph_index._map_language_label(label, "python") == expected
+
+
+def test_graph_and_embedding_use_same_typescript_profile():
+    graph_languages = swebench_graph_index._profile_languages("typescript")
+    embedding_languages = build_embeddings._map_language_group("TypeScript/JavaScript")
+
+    assert (
+        ArtifactProfile.create(graph_languages).profile_id
+        == ArtifactProfile.create(embedding_languages).profile_id
+    )
+
+
+def test_embedding_resolves_language_from_multilingual_repo_map():
+    instance = {"repo": "google/gson"}
+
+    assert build_embeddings._resolve_languages(
+        instance,
+        ["python"],
+        {"google/gson": "Java"},
+    ) == ["java"]


### PR DESCRIPTION
## Summary

Make immutable `(repository, commit)` snapshots, not benchmark instance IDs, the durable identity for reusable CodeMiner artifacts. This is the first system layer above #312 and lets repeated queries, models, and dataset aliases share one prepared repository and analysis profile.

Depends on #312. This PR intentionally targets `codex/lsp-provider-experiment`; it should be retargeted to `main` after #312 lands.

## Changes

- Add `SourceSnapshot`, `ArtifactProfile`, and `SnapshotArtifactStore` with deterministic content-addressed paths and instance aliases.
- Prepare one detached worktree per source snapshot and bind multiple instance IDs to the same profile artifacts.
- Wire graph and embedding builders to snapshot/profile paths while preserving legacy layouts.
- Add reuse analysis for CodeMiner base and synthesis workloads.
- Document the system boundary between source identity, analysis profile, and benchmark aliases.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Validated on the fully restacked tree with the snapshot, prebuilt, LSP provider, replay, index-quality, and core parity suites: 91 passed, 1 skipped. Commit-time black, isort, flake8, and pre-commit checks passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
