### PR TITLE
docs: fix dangling NOTICE link and add orphan pages to mkdocs nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ cloning. The test suite is split into tiered pytest markers run as separate CI j
 
 CodeMiner is licensed under the [Apache License, Version 2.0](LICENSE).
 Contributions previously made under the MIT License are retained under the terms of
-Section 4 of Apache 2.0; see [NOTICE](NOTICE) for full attribution.
+Section 4 of Apache 2.0.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,3 +95,4 @@ nav:
       - Local Model Backend: experiments/qwen_backend.md
       - LSP Core Acceleration Gate: experiments/lsp_core_acceleration.md
       - LSP-route Adoption: experiments/lsp_route_adoption.md
+      - Systems Paper Plan: experiments/system_paper_plan.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - Language Capabilities: language_capabilities.md
   - Core Concepts:
       - SCIP Index: scip_index.md
+      - CodeGraph Hierarchy Model: codegraph_hierarchy_model.md
       - Graph Range Query: graph_query.md
       - Regex Index: regex_index.md
       - Graph Cache: graph_cache_usage.md
@@ -90,3 +91,7 @@ nav:
   - Experiments:
       - Agent Compile Sweep: experiments/agent_compile.md
       - Compact Pre-load: experiments/compact_preload.md
+      - Agent Runtime Probe: experiments/agent_runtime.md
+      - Local Model Backend: experiments/qwen_backend.md
+      - LSP Core Acceleration Gate: experiments/lsp_core_acceleration.md
+      - LSP-route Adoption: experiments/lsp_route_adoption.md


### PR DESCRIPTION
## Summary

Two documentation consistency fixes found while checking the README/mkdocs:

- The README License section linked to a `NOTICE` file that was deleted
  pre-release (`a7a38a0`, #164), leaving a broken relative link.
- Six authored docs existed under `docs/` but were absent from the
  mkdocs `nav`, so they were unreachable from the site navigation
  (one of them, `experiments/system_paper_plan.md`, landed via #313/#314
  after this branch was first cut).

## Changes

- `README.md`: drop the dangling `[NOTICE](NOTICE)` link; the
  MIT-retention clause (Section 4 of Apache 2.0) now stands on its own.
- `mkdocs.yml`: add to `nav`
  - Core Concepts → CodeGraph Hierarchy Model (`codegraph_hierarchy_model.md`)
  - Experiments → Agent Runtime Probe (`experiments/agent_runtime.md`)
  - Experiments → Local Model Backend (`experiments/qwen_backend.md`)
  - Experiments → LSP Core Acceleration Gate (`experiments/lsp_core_acceleration.md`)
  - Experiments → LSP-route Adoption (`experiments/lsp_route_adoption.md`)
  - Experiments → Systems Paper Plan (`experiments/system_paper_plan.md`)
- Merge `main` into the branch so the nav entry for the newly landed
  systems-paper-plan page resolves.

## Type of Change

- [x] Documentation update

## Testing

- `mkdocs build --strict` passes with no warnings or errors.
- The only pages still outside `nav` are generated report artifacts —
  `experiments/agent_compile_runs/*/phase2_report.md` and
  `experiments/artifacts/lsp_replay_base_v3_100/aggregate.md`
  (INFO-level, intentionally not nav pages).
- Verified README no longer references the removed `NOTICE` file.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
