### PR TITLE
docs(retrieval): document query-aware planner and LSP skills

### DIFF
--- a/docs/agent_skills.md
+++ b/docs/agent_skills.md
@@ -86,6 +86,9 @@ exposed, or `include_default_tools=False` to withhold them).
 | `find_callers` | expand | Incoming call-graph edges of a symbol (who calls X). |
 | `find_callees` | expand | Outgoing call-graph edges of a symbol (what X calls). |
 | `trace` | expand | Shortest call path between two symbols. |
+| `lsp_route` | expand | Symbol-name semantic navigation over the static symbol graph: ranks endpoint/bridge/provider/type route anchors for a query, optionally with one-hop neighbors. |
+| `lsp_definition` | expand | LSP-compatible go-to-definition for the identifier at an exact source position (repo-relative `file_path`, 1-based `line`, 0-based `character`), served by the runtime's selected semantic provider — static SCIP occurrences by default, live LSP when injected. |
+| `lsp_references` | expand | LSP-compatible find-references at an exact source position, with optional `include_declaration`; same position contract and provider selection as `lsp_definition`. |
 | `llm_rerank` | rerank | High-precision LLM-judged reranking to refine top results. |
 | `code_to_query` | transform | Packs retrieved code nodes into a reusable follow-up search query. |
 
@@ -116,6 +119,11 @@ site per direction:
 - **Input** — a skill input declared `is_line_number: true` in its
   `config.yaml` is passed through `from_agent_repr` (`-1`) by the runner before
   the executor sees it, so executors keep working in 0-based internals.
+
+The native LSP skills follow the same contract: `lsp_definition` /
+`lsp_references` declare their `line` input `is_line_number: true` (1-based
+in, 0-based internally), while `character` stays **0-based** end to end,
+matching the native LSP wire convention.
 
 ### Authoring a skill that accepts line numbers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ core decoder parity.
 
 - [CI/CD](ci_cd.md) — local and remote test tiers, including serial, graph-consumer, core, and slow jobs
 - [Agent Skills](agent_skills.md) — optional retrieval/rerank/trace skills built on top of the index substrate
+- [RAG Ops And Planner](rag_ops.md) — retrieval operator boundaries, query-aware planner behavior, and graph-plan limits
 - [Collecting SWE-bench Instances](collect_swebench.md) — sample representative instances across languages
 - [Synthesis Pipeline](synthesis_pipeline.md) — synthesize traversal/behavior/multiply queries and build the CodeMiner dataset
 - [Uploading to HuggingFace](upload_dataset_to_huggingface.md) — build and publish the dataset

--- a/docs/rag_ops.md
+++ b/docs/rag_ops.md
@@ -1,0 +1,88 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# RAG Ops And Planner
+
+CodeMiner keeps RAG behavior in two layers:
+
+- `codeminer/ops/` contains small retrieval operators and typed contexts.
+- `codeminer/model/` chooses and executes pipeline policy.
+
+The ops layer should stay simple. It should normalize, merge, filter, expand, or
+rerank candidates without deciding which retrieval strategy a query deserves.
+Strategy belongs in a planner or named pipeline.
+
+## Operator Surface
+
+| Module | Role | What belongs here |
+|--------|------|-------------------|
+| `ops.retrieve` | Candidate normalization and fusion | `RetrieveContext`, `to_queried_nodes`, weighted hybrid merge, stable dedup keys |
+| `ops.filter` | Explicit candidate predicates | span/content checks, symbol-only checks, include/exclude path filters, test-path dropping |
+| `ops.expand` | Compact graph neighborhood expansion | one-hop predecessor/successor expansion from existing seeds, optional span content loading |
+| `ops.rerank` | Candidate-only reranking | embedding similarity over a provided candidate set; lazy LLM reranker context |
+| `ops.transform` | Query/code transforms | shared transform resources such as keyword extraction |
+
+This surface is intentionally not a general workflow engine. It does not encode
+arbitrary DAGs, loops, index building, or long graph traversals. Those stay in
+dedicated pipelines and graph components.
+
+## Expressiveness
+
+The current ops are enough to express the common CodeMiner RAG paths:
+
+- dense-only semantic retrieval
+- sparse/BM25 lexical retrieval
+- dense plus sparse fusion, including RRF in `RetrieveRerankPipeline`
+- candidate filtering before rerank
+- dense-first graph neighbor augmentation
+- sparse-seeded graph expansion through the graph retrieval pipeline
+- embedding or LLM reranking over an assembled candidate set
+
+The current deliberate limits are:
+
+- `expand_graph_neighbors` performs one-hop neighbor expansion only; k-hop BFS
+  and PPR live in `SparseSeededGraphRetrievePipeline`.
+- `RetrieveRerankPipeline` executes dense/sparse stages and, when constructed
+  with a loaded `code_graph`, consumes `GraphExpansionPlan` for structural
+  queries selected by the planner.
+- Index construction is outside ops. Build indexes through compiler/indexer
+  surfaces, then pass loaded resources through context objects.
+
+## Query-Aware Planner
+
+`RetrievalPlanner` is deterministic. It does not call an LLM. It maps three
+inputs to a `RetrievalPathPlan`:
+
+- query signals: lexical, semantic, structural
+- budget: `fast`, `balanced`, or `thorough`
+- capabilities: dense, sparse, graph, embedding rerank, LLM rerank
+
+The selected plan is declarative:
+
+| Plan | Intent | Typical execution |
+|------|--------|-------------------|
+| `fast_lexical` | exact names, low latency | BM25 only, no rerank |
+| `semantic` | natural-language behavior queries | dense retrieval, optional rerank |
+| `hybrid_fusion` | mixed or uncertain queries | dense + sparse, usually RRF, optional rerank |
+| `structural_graph` | callers/callees/impact/dependency queries | sparse seeds plus graph expansion, optional rerank |
+
+`RetrieveRerankPipeline(retrieval_mode="auto")` wires the planner into query
+execution for dense, sparse, hybrid fusion, graph expansion, and rerank control.
+It records the most recent `last_selected_plan` and `last_planner_trace`
+(`signals`, `budget`, `capabilities`, and `plan`) for evaluation/debugging.
+Use `SparseSeededGraphRetrievePipeline` or `DenseGraphExpandRerankPipeline` when
+you need an experiment-specific graph baseline rather than the general auto
+pipeline.
+
+## Maintenance Rules
+
+- Add ops only when a repeated pipeline step needs a reusable, typed boundary.
+- Keep query classification and budget logic in `RetrievalPlanner`, not in skill
+  executors or individual ops.
+- Keep long graph traversal policy in graph pipelines unless the same operation
+  is reused by multiple retrieval surfaces.
+- New GPU/HuggingFace embedding tests belong in the `slow` tier, not the
+  parallel `integration` tier.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - Contributing a Language: contributing-a-language.md
   - Agent And Retrieval:
       - Agent Skills: agent_skills.md
+      - RAG Ops And Planner: rag_ops.md
       - Agent Runner Architecture Goal: agent_runner_architecture_goal.md
       - Agent Compile (Design): agent_compile_design.md
       - GT Locator: gt_locator.md


### PR DESCRIPTION
## Summary

Close two documentation gaps against recently merged retrieval work: the
query-aware `RetrievalPlanner` (#265) had zero coverage anywhere in the docs,
and the native LSP skills (`lsp_route`, plus `lsp_definition` /
`lsp_references` from #314) were missing from the agent-skills reference.

## Changes

- Add `docs/rag_ops.md` — retrieval operator boundaries (`ops.retrieve` /
  `filter` / `expand` / `rerank` / `transform`), what the ops layer
  deliberately does not do, the deterministic `RetrievalPlanner` plan table
  (`fast_lexical` / `semantic` / `hybrid_fusion` / `structural_graph`), and
  how `RetrieveRerankPipeline(retrieval_mode="auto")` records
  `last_selected_plan` / `last_planner_trace`.
- `docs/agent_skills.md`: add `lsp_route`, `lsp_definition`, and
  `lsp_references` to the Available skills table, and document their
  position contract (1-based `line` via `is_line_number`, 0-based
  `character`) in the line-numbering section.
- `mkdocs.yml` + `docs/index.md`: link the new page under Agent And
  Retrieval (additive only; no nav entries removed).

## Type of Change

- [x] Documentation update

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

- `python -m mkdocs build --strict` passes; the only pages outside `nav`
  are generated run/report artifacts (plus the pages #315 adds on its own
  branch).
- Skill descriptions cross-checked against
  `codeminer/agent/skills/lsp_*/config.yaml` and `skill.md`, and planner
  names against `codeminer/model/retrieval_planner.py` /
  `retrieve_rerank_pipeline.py` on `main`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
