### PR TITLE
ci: add strict docs build workflow and retier astropy MCP tests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "**.md"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "**.md"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "mkdocs-material>=9.5.0"
+
+      - name: Build docs
+        run: python -m mkdocs build --strict

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -6,8 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 # CI/CD
 
-GitHub Actions pipeline (`.github/workflows/ci.yml`) that runs on every push to
-`main`/`master`, on all pull requests, on a daily cron, and on manual dispatch.
+GitHub Actions has two maintenance workflows:
+
+- `.github/workflows/ci.yml` runs the Python, graph, SCIP, slow, and C++ parity
+  test tiers.
+- `.github/workflows/docs.yml` runs a lightweight strict documentation build for
+  docs-only changes that the main CI intentionally ignores.
 
 ## Triggers
 
@@ -17,6 +21,17 @@ GitHub Actions pipeline (`.github/workflows/ci.yml`) that runs on every push to
 | `pull_request` to any branch (`"*"`) | Subject to `paths-ignore`. Concurrency cancels older in-flight runs for the same PR head ref. |
 | `schedule` — `cron: "0 7 * * *"` | 07:00 UTC daily. Forces a **full serial-chain run** so the `graph.pkl` cache and C++ parity never silently rot on light-only weeks. |
 | `workflow_dispatch` | Manual run with a `skip_tests` boolean input. |
+
+The separate docs workflow runs on pushes/PRs that touch Markdown, `docs/**`,
+`mkdocs.yml`, `pyproject.toml`, or the docs workflow itself. It installs
+`mkdocs-material` on `ubuntu-latest` and runs:
+
+```bash
+python -m mkdocs build --strict
+```
+
+This keeps docs-only PRs covered without forcing the self-hosted test runner to
+run unit, integration, slow, or serial graph jobs for prose-only edits.
 
 !!! note "Concurrency"
     The concurrency group is keyed by `github.head_ref || github.run_id`, and
@@ -106,9 +121,11 @@ running in this tier.
 
 ### integration
 
-Read-only, parallel-safe tests (~2 min): chunkers and fixture-based SCIP. Uses
-the shared `./.github/actions/setup-env` composite action (with `install-clangd`
-and `install-bear`), then runs:
+Read-only, parallel-safe tests (~2 min): chunkers and fixture-based SCIP. This
+tier runs with `pytest-xdist`, so tests that load HuggingFace embedding models,
+consume GPU memory, or depend on LLM credentials do **not** belong here; mark
+those `slow` instead. Uses the shared `./.github/actions/setup-env` composite
+action (with `install-clangd` and `install-bear`), then runs:
 
 ```bash
 pytest -n auto -m "integration" --tb=short
@@ -173,8 +190,11 @@ pytest -m "integration_serial_consumer" -v --tb=short
 
 ### slow
 
-LLM API calls and GPU embeddings (~15 min). Depends on `preflight` and `unit`
-(not on the serial chain). Sets up GCP credentials and `VERTEXAI_PROJECT`, then:
+LLM API calls, HuggingFace downloads, and GPU embeddings (~15 min). Depends on
+`preflight` and `unit` (not on the serial chain). This tier is intentionally not
+xdist-parallelized because embedding model loads can exhaust shared GPU memory
+when started by multiple workers. Sets up GCP credentials and
+`VERTEXAI_PROJECT`, then:
 
 ```bash
 pytest -m "slow" --tb=short
@@ -270,6 +290,17 @@ use the `./.github/actions/setup-env` composite action, which provisions:
 - **clangd** — optional, via `install-clangd` (enabled for the integration /
   serial / core / consumer jobs).
 - **bear** — optional C/C++ compilation-database tool, via `install-bear`.
+
+## Failure triage
+
+Two CI failure modes are easy to confuse:
+
+- A self-hosted job that is `cancelled` with no steps and no `runner_name` did
+  not fail tests. It sat in the self-hosted runner queue until GitHub cancelled
+  it. Check runner availability before changing code.
+- An `integration` failure with `torch.OutOfMemoryError` means a GPU/HuggingFace
+  embedding test is in the wrong tier or is running concurrently with another
+  GPU workload. Move that test to `slow` or make it use a mock/vector fixture.
 
 ## Pre-commit hooks
 

--- a/test/mcp/test_mcp_e2e.py
+++ b/test/mcp/test_mcp_e2e.py
@@ -25,7 +25,6 @@ TEST_REPO = "astropy__astropy-12907"
 TEST_REPO_PATH = CODEMINER_DATA / TEST_REPO
 
 
-@pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.skipif(
     not TEST_REPO_PATH.exists(),

--- a/test/mcp/test_search_semantic_integration.py
+++ b/test/mcp/test_search_semantic_integration.py
@@ -23,7 +23,6 @@ TEST_REPO = "astropy__astropy-12907"
 TEST_REPO_PATH = CODEMINER_DATA / TEST_REPO
 
 
-@pytest.mark.integration
 @pytest.mark.slow
 @pytest.mark.skipif(
     not TEST_REPO_PATH.exists(),


### PR DESCRIPTION
## Summary

Two CI hygiene changes that close gaps the main pipeline cannot see:

- The main CI `paths-ignore`s `**.md` and `docs/**`, so a broken mkdocs
  build (dangling nav entry, bad link) can land on `main` unnoticed —
  exactly what #315 had to clean up after the fact. Add a lightweight
  docs workflow that runs `mkdocs build --strict` for doc-touching
  changes.
- The astropy-backed MCP tests carried both `integration` and `slow`
  markers. The `integration` tier runs under `pytest-xdist`, and these
  tests load HuggingFace embedding models — parallel model loads can
  exhaust the shared GPU. Retier them to `slow`-only, where the run is
  intentionally serialized.

## Changes

- Add `.github/workflows/docs.yml`: `python -m mkdocs build --strict` on
  `ubuntu-latest` (10-min timeout, pip-cached) for pushes/PRs touching
  Markdown, `docs/**`, `mkdocs.yml`, `pyproject.toml`, or the workflow
  itself.
- `test/mcp/test_mcp_e2e.py`, `test/mcp/test_search_semantic_integration.py`:
  drop `@pytest.mark.integration`, keeping `@pytest.mark.slow`.
- `docs/ci_cd.md`: document the two-workflow split, the
  "HF/GPU/LLM tests do not belong in the xdist `integration` tier" rule,
  why `slow` is not xdist-parallelized, and a new failure-triage section
  (queued-then-cancelled self-hosted jobs vs `torch.OutOfMemoryError`).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

- `pytest --collect-only -m integration` on the two files selects 0
  (7 deselected); `-m slow` still selects all 7.
- `python -m mkdocs build --strict` passes.
- This PR touches docs paths, so it exercises the new workflow on itself.
- pre-commit (black/isort/flake8/yaml) passed at commit time.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
