### PR TITLE
refactor(core): share SCIP decode helpers, add large-repo profiling gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,11 @@ GRAPH_ALIGNMENT_SKIP_LEVEL ?= none
 GRAPH_ALIGNMENT_TARGET_DIR ?=
 GRAPH_ALIGNMENT_EXCLUDE_PATTERNS ?=
 GRAPH_ALIGNMENT_EXTRA_ARGS ?=
+LARGE_SCIP_PROFILE_MANIFEST ?= scripts/profiling/large_scip_repos.yml
+LARGE_SCIP_PROFILE_CACHE_ROOT ?= /tmp/codeminer-large-scip-repos
+LARGE_SCIP_PROFILE_OUTPUT_DIR ?= /tmp/codeminer-large-scip-profile
+LARGE_SCIP_PROFILE_TIMEOUT ?= 1800
+LARGE_SCIP_PROFILE_EXTRA_ARGS ?=
 PROJECT_LANGUAGE ?=
 PROJECT_ROOT ?=
 hash := \#
@@ -178,7 +183,7 @@ endef
 .PHONY: scip-cold-start-tools scip-cold-start-tools-all scip-cold-start-env scip-cold-start-system-deps-ubuntu
 .PHONY: scip-candidates scip-candidates-all scip-candidate-env scip-candidate-system-deps-ubuntu
 .PHONY: scip-jvm-compat-system-deps-ubuntu
-.PHONY: scip-cold-start-smoke scip-candidate-smoke scip-project-smoke-tools scip-project-smoke lsp-smoke lsp-project-smoke graph-route-alignment-tools graph-route-alignment multilang-smoke multilang-registry-check
+.PHONY: scip-cold-start-smoke scip-candidate-smoke scip-project-smoke-tools scip-project-smoke lsp-smoke lsp-project-smoke graph-route-alignment-tools graph-route-alignment large-scip-profile multilang-smoke multilang-registry-check
 .PHONY: scip-java-tool gradle-tool sbt-tool dotnet-tool scip-dotnet-tool scip-ruby-tool
 .PHONY: scip-ruby-system-deps-ubuntu ruby-project-bundle
 .PHONY: scip-php-info scip-php-tool scip-php-docker-tool scip-php-system-deps-ubuntu php-project-scip-tool
@@ -681,6 +686,14 @@ graph-route-alignment: graph-route-alignment-tools
 		$(if $(GRAPH_ALIGNMENT_TARGET_DIR),--target-dir "$(GRAPH_ALIGNMENT_TARGET_DIR)",) \
 		$(foreach pattern,$(GRAPH_ALIGNMENT_EXCLUDE_PATTERNS),--exclude-pattern "$(pattern)") \
 		--json $(GRAPH_ALIGNMENT_EXTRA_ARGS)
+
+large-scip-profile:
+	$(CODEMINER_TOOL_ENV) python scripts/profiling/profile_large_scip_repos.py \
+		--manifest "$(LARGE_SCIP_PROFILE_MANIFEST)" \
+		--cache-root "$(LARGE_SCIP_PROFILE_CACHE_ROOT)" \
+		--output-dir "$(LARGE_SCIP_PROFILE_OUTPUT_DIR)" \
+		--timeout "$(LARGE_SCIP_PROFILE_TIMEOUT)" \
+		$(LARGE_SCIP_PROFILE_EXTRA_ARGS)
 
 multilang-smoke: scip-cold-start-smoke lsp-smoke
 

--- a/core/README.md
+++ b/core/README.md
@@ -17,7 +17,10 @@ files.
 - `code_graph.h` / `code_graph.cpp` – graph container that stores vertices, edges, and metadata compatible with the Python implementation.
 - `graph_layers.h` / `graph_layers.cpp` – shared graph-layer classification
   used by Python graph indexing when the pybind module is available.
-- `scip_decode.h`, `scip_decoder_registry.{h,cpp}`, and the language-specific
+- `scip_decode_common.h` / `scip_decode_common.cpp` – shared SCIP decoder
+  subgraph builders and language-neutral text/string parsing helpers.
+- `scip_decode.h`, `scip_decode_base.{h,cpp}`,
+  `scip_decoder_registry.{h,cpp}`, and the language-specific
   `scip_decode_*.{h,cpp}` files – translate `.decoded` SCIP indexes into the
   C++ `CodeGraph` and keep core decoder aliases/factory wiring centralized.
 - `bindings/pybind_module.cpp` – exposes `decode_scip(...)` and
@@ -45,6 +48,25 @@ make core-test
 ```
 
 The resulting library and Python extension are placed in `build/core`.
+
+## Decoder Engineering Contract
+
+Add C++ decoder code only after profiling shows local decode/build is a real
+bottleneck, not just because a language has an active SCIP cold-start route.
+New decoders should:
+
+- Reuse `SCIPDecoderBase` for file loading, document extraction, parallel
+  document processing, merge order, and post-processing hooks.
+- Use `SubgraphBuilder` for node/edge construction instead of writing directly
+  to `CodeGraph` from language parsers.
+- Put only language-neutral SCIP text helpers in `scip_decode_common.h` /
+  `scip_decode_common.cpp`. Language policy, metadata loading, and symbol
+  normalization stay in `scip_decode_<language>.cpp`.
+- Register canonical language names and aliases in `scip_decoder_registry.cpp`
+  and keep the Python registry parity tests green before advertising a decoder
+  as accepted.
+- Prove serial/core parity for the relevant fixture before recording a speedup
+  in docs.
 
 ## Using the Decoder
 

--- a/core/scip_decode_common.cpp
+++ b/core/scip_decode_common.cpp
@@ -4,10 +4,85 @@
 
 #include "scip_decode_common.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
+#include <sstream>
 #include <utility>
 
 namespace codeminer::core {
+
+std::vector<int> extract_integers(const std::string &text,
+                                  const re2::RE2 &pattern) {
+  std::vector<int> results;
+  re2::StringPiece input(text);
+  int value = 0;
+  while (re2::RE2::FindAndConsume(&input, pattern, &value)) {
+    results.push_back(value);
+  }
+  return results;
+}
+
+bool ends_with(const std::string &s, const std::string &suffix) {
+  return s.size() >= suffix.size() &&
+         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+std::string rstrip_chars(std::string s, const std::string &chars) {
+  while (!s.empty() && chars.find(s.back()) != std::string::npos)
+    s.pop_back();
+  return s;
+}
+
+std::string strip_backticks(std::string s) {
+  s.erase(std::remove(s.begin(), s.end(), '`'), s.end());
+  return s;
+}
+
+std::vector<std::string> split_ws(const std::string &s) {
+  std::vector<std::string> out;
+  std::istringstream iss(s);
+  std::string tok;
+  while (iss >> tok)
+    out.push_back(tok);
+  return out;
+}
+
+std::vector<std::string> split_ws_limit(const std::string &s, int limit) {
+  if (limit <= 1) {
+    std::string value = s;
+    std::size_t start = 0;
+    while (start < value.size() &&
+           std::isspace(static_cast<unsigned char>(value[start]))) {
+      ++start;
+    }
+    value = value.substr(start);
+    while (!value.empty() &&
+           std::isspace(static_cast<unsigned char>(value.back()))) {
+      value.pop_back();
+    }
+    return value.empty() ? std::vector<std::string>{}
+                         : std::vector<std::string>{std::move(value)};
+  }
+
+  std::vector<std::string> out;
+  std::size_t i = 0;
+  while (i < s.size() && static_cast<int>(out.size()) < limit - 1) {
+    while (i < s.size() && std::isspace(static_cast<unsigned char>(s[i])))
+      ++i;
+    std::size_t start = i;
+    while (i < s.size() && !std::isspace(static_cast<unsigned char>(s[i])))
+      ++i;
+    if (start < i)
+      out.emplace_back(s.substr(start, i - start));
+  }
+
+  while (i < s.size() && std::isspace(static_cast<unsigned char>(s[i])))
+    ++i;
+  if (i < s.size())
+    out.emplace_back(s.substr(i));
+  return out;
+}
 
 Subgraph::Node &SubgraphBuilder::ensure_node(const std::string &name) {
   auto it = subgraph_.nodes.find(name);

--- a/core/scip_decode_common.h
+++ b/core/scip_decode_common.h
@@ -9,12 +9,23 @@
 #include "code_graph.h"
 
 #include <optional>
+#include <re2/re2.h>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 namespace codeminer::core {
+
+// Reusable language-neutral helpers for SCIP text-format decoders. Keep
+// language policy in language decoders; put only syntax/string primitives here.
+std::vector<int> extract_integers(const std::string &text,
+                                  const re2::RE2 &pattern);
+bool ends_with(const std::string &s, const std::string &suffix);
+std::string rstrip_chars(std::string s, const std::string &chars);
+std::string strip_backticks(std::string s);
+std::vector<std::string> split_ws(const std::string &s);
+std::vector<std::string> split_ws_limit(const std::string &s, int limit);
 
 // Per-document result produced by each language decoder worker. Language-
 // agnostic (symbol payload lives in VertexData + extras). Merged by

--- a/core/scip_decode_go.cpp
+++ b/core/scip_decode_go.cpp
@@ -8,42 +8,10 @@
 #include <filesystem>
 #include <fstream>
 #include <re2/re2.h>
-#include <sstream>
 
 namespace codeminer::core {
 
 namespace {
-
-std::vector<int> extract_integers(const std::string &text,
-                                  const re2::RE2 &pattern) {
-  std::vector<int> results;
-  re2::StringPiece input(text);
-  int value = 0;
-  while (re2::RE2::FindAndConsume(&input, pattern, &value)) {
-    results.push_back(value);
-  }
-  return results;
-}
-
-std::vector<std::string> split_ws(const std::string &s) {
-  std::vector<std::string> out;
-  std::istringstream iss(s);
-  std::string tok;
-  while (iss >> tok)
-    out.push_back(tok);
-  return out;
-}
-
-bool ends_with(const std::string &s, const std::string &suffix) {
-  return s.size() >= suffix.size() &&
-         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
-std::string rstrip_chars(std::string s, const std::string &chars) {
-  while (!s.empty() && chars.find(s.back()) != std::string::npos)
-    s.pop_back();
-  return s;
-}
 
 // Strip backtick-module-prefix: `github.com/user/proj/calc`/Sym... -> Sym...
 std::string strip_backtick_prefix(const std::string &descriptor) {

--- a/core/scip_decode_python.cpp
+++ b/core/scip_decode_python.cpp
@@ -29,17 +29,6 @@ bool contains_function_parentheses(const std::string &symbol) {
          symbol.find('(') != std::string::npos;
 }
 
-std::vector<int> extract_integers(const std::string &text,
-                                  const re2::RE2 &pattern) {
-  std::vector<int> results;
-  re2::StringPiece input(text);
-  int value = 0;
-  while (re2::RE2::FindAndConsume(&input, pattern, &value)) {
-    results.push_back(value);
-  }
-  return results;
-}
-
 } // namespace
 
 Subgraph

--- a/core/scip_decode_ruby.cpp
+++ b/core/scip_decode_ruby.cpp
@@ -9,28 +9,11 @@
 #include <filesystem>
 #include <fstream>
 #include <re2/re2.h>
-#include <sstream>
 #include <utility>
 
 namespace codeminer::core {
 
 namespace {
-
-std::vector<int> extract_integers(const std::string &text,
-                                  const re2::RE2 &pattern) {
-  std::vector<int> results;
-  re2::StringPiece input(text);
-  int value = 0;
-  while (re2::RE2::FindAndConsume(&input, pattern, &value)) {
-    results.push_back(value);
-  }
-  return results;
-}
-
-bool ends_with(const std::string &s, const std::string &suffix) {
-  return s.size() >= suffix.size() &&
-         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
 
 bool starts_with(const std::string &s, const std::string &prefix) {
   return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
@@ -47,15 +30,6 @@ std::string trim(std::string s) {
     --end;
   }
   return s.substr(start, end - start);
-}
-
-std::vector<std::string> split_ws(const std::string &s) {
-  std::vector<std::string> out;
-  std::istringstream iss(s);
-  std::string tok;
-  while (iss >> tok)
-    out.push_back(tok);
-  return out;
 }
 
 std::string remove_char(std::string s, char target) {

--- a/core/scip_decode_rust.cpp
+++ b/core/scip_decode_rust.cpp
@@ -4,63 +4,14 @@
 
 #include "scip_decode_rust.h"
 
-#include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <re2/re2.h>
-#include <sstream>
 
 namespace codeminer::core {
 
 namespace {
-
-std::vector<int> extract_integers(const std::string &text,
-                                  const re2::RE2 &pattern) {
-  std::vector<int> results;
-  re2::StringPiece input(text);
-  int value = 0;
-  while (re2::RE2::FindAndConsume(&input, pattern, &value)) {
-    results.push_back(value);
-  }
-  return results;
-}
-
-std::vector<std::string> split_ws_limit(const std::string &s, int limit) {
-  std::vector<std::string> out;
-  std::size_t i = 0;
-  while (i < s.size() && static_cast<int>(out.size()) < limit - 1) {
-    while (i < s.size() && std::isspace(static_cast<unsigned char>(s[i])))
-      ++i;
-    std::size_t start = i;
-    while (i < s.size() && !std::isspace(static_cast<unsigned char>(s[i])))
-      ++i;
-    if (start < i)
-      out.emplace_back(s.substr(start, i - start));
-  }
-  // rest as single token
-  while (i < s.size() && std::isspace(static_cast<unsigned char>(s[i])))
-    ++i;
-  if (i < s.size())
-    out.emplace_back(s.substr(i));
-  return out;
-}
-
-bool ends_with(const std::string &s, const std::string &suffix) {
-  return s.size() >= suffix.size() &&
-         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
-std::string rstrip_chars(std::string s, const std::string &chars) {
-  while (!s.empty() && chars.find(s.back()) != std::string::npos)
-    s.pop_back();
-  return s;
-}
-
-std::string strip_backticks(std::string s) {
-  s.erase(std::remove(s.begin(), s.end(), '`'), s.end());
-  return s;
-}
 
 // Very small TOML-ish parser: pulls "name" from [package] and "members"
 // (array of strings) from [workspace]. Works on the subset of Cargo.toml

--- a/core/scip_decode_ts.cpp
+++ b/core/scip_decode_ts.cpp
@@ -4,7 +4,6 @@
 
 #include "scip_decode_ts.h"
 
-#include <algorithm>
 #include <cctype>
 #include <re2/re2.h>
 #include <sstream>
@@ -12,58 +11,6 @@
 namespace codeminer::core {
 
 namespace {
-
-std::vector<int> extract_integers(const std::string &text,
-                                  const re2::RE2 &pattern) {
-  std::vector<int> results;
-  re2::StringPiece input(text);
-  int value = 0;
-  while (re2::RE2::FindAndConsume(&input, pattern, &value)) {
-    results.push_back(value);
-  }
-  return results;
-}
-
-bool ends_with(const std::string &s, const std::string &suffix) {
-  return s.size() >= suffix.size() &&
-         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
-std::string rstrip_chars(std::string s, const std::string &chars) {
-  while (!s.empty() && chars.find(s.back()) != std::string::npos)
-    s.pop_back();
-  return s;
-}
-
-std::string strip_backticks(std::string s) {
-  s.erase(std::remove(s.begin(), s.end(), '`'), s.end());
-  return s;
-}
-
-std::vector<std::string> split_ws(const std::string &s) {
-  std::vector<std::string> out;
-  std::istringstream iss(s);
-  std::string tok;
-  while (iss >> tok)
-    out.push_back(tok);
-  return out;
-}
-
-std::vector<std::string> all_backtick_segments(const std::string &text) {
-  std::vector<std::string> out;
-  std::size_t p = 0;
-  while (p < text.size()) {
-    auto a = text.find('`', p);
-    if (a == std::string::npos)
-      break;
-    auto b = text.find('`', a + 1);
-    if (b == std::string::npos)
-      break;
-    out.emplace_back(text.substr(a + 1, b - a - 1));
-    p = b + 1;
-  }
-  return out;
-}
 
 bool is_stdlib_symbol(const std::string &symbol) {
   static const char *const needles[] = {" typescript ", "node_modules/",

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -19,6 +19,9 @@ files.
 - `graph_layers.h` / `graph_layers.cpp` — language-agnostic default layer
   classification for CodeGraph edge types. This is shared by SCIP, clangd, and
   generic-LSP graphs after they have normalized into the common schema.
+- `scip_decode_common.h` / `scip_decode_common.cpp` — shared per-document
+  `SubgraphBuilder` utilities and language-neutral SCIP text/string helpers
+  used by the accelerated decoders.
 - `scip_decode.h`, `scip_decoder_registry.{h,cpp}`, and the
   language-specific `scip_decode_*.{h,cpp}` files — translate `.decoded` SCIP
   indexes into the C++ `CodeGraph` and keep decoder aliases/factory wiring out
@@ -55,18 +58,58 @@ text index. On the `ruby/rake` gate, serial `process_index` took 7.58s while the
 C++ backend took 1.04s after filtering to `lib/`; both routes produced 815
 vertices, 3,466 edges, and no vertex-attribute or edge-multiset differences.
 
-Java, C#, PHP, and Scala are active SCIP cold-start routes but intentionally
-remain serial-only in Python. Local profiles show their external indexers
-dominate cold-start time: `scip-java` on `jitpack/maven-simple` took about 5.98s
-to index while protoc decode took 0.01s, Python graph decode 0.007s, and
-range-index construction 0.001s; `scip-dotnet` on the recorded C# fixture took
-about 4.3-4.8s while Python decode/build was about 0.01s; the small PHP Composer
-gate spent about 0.551s in SCIP indexing, 0.008s in protoc decode, and 0.007s in
-Python graph decode; the `sbt/io` Scala gate spent about 74.527s in `scip-java`
-indexing, 0.099s in protoc decode, 2.156s in Python graph decode, and 0.069s in
-range-index construction. Adding C++ decoder files for those languages is not
-justified until a larger profile shows local decode/build time crossing the 20%
-acceleration gate.
+Java, C#, Kotlin, PHP, and Scala are active SCIP cold-start routes but
+intentionally remain serial-only in Python. Local profiles show their external
+indexers dominate cold-start time: `scip-java` on `jitpack/maven-simple` took
+about 5.98s to index while protoc decode took 0.01s, Python graph decode
+0.007s, and range-index construction 0.001s; `scip-dotnet` on the recorded C#
+fixture took about 4.3-4.8s while Python decode/build was about 0.01s; the
+KotlinPoet 2.2.0 gate spent 61.914s in `scip-java`, 0.150s in protoc decode,
+6.931s in Python graph decode, and 0.008s in range-index construction; the
+small PHP Composer gate spent about 0.551s in SCIP indexing, 0.008s in protoc
+decode, and 0.007s in Python graph decode; the `sbt/io` Scala gate spent about
+74.527s in `scip-java` indexing, 0.099s in protoc decode, 2.156s in Python
+graph decode, and 0.069s in range-index construction. Adding C++ decoder files
+for those languages is not justified until a larger profile shows local
+decode/build time crossing the 20% acceleration gate.
+
+## Decoder Engineering Contract
+
+The accepted C++ decoder set is deliberately smaller than the active SCIP
+cold-start set. A new language should be added to `core/` only after the
+profiling gate above is met and the implementation follows these boundaries:
+
+- Start from `SCIPDecoderBase` for file loading, document extraction, parallel
+  worker execution, merge ordering, and post-processing hooks.
+- Build nodes and edges through `SubgraphBuilder`; language decoders should not
+  write directly to the graph container.
+- Put language-neutral SCIP text primitives in `scip_decode_common.h` /
+  `scip_decode_common.cpp`. Current shared helpers cover integer extraction,
+  whitespace splitting, suffix checks, trailing-character stripping, and
+  backtick removal.
+- Keep language policy in the owning decoder file: metadata discovery,
+  standard-library filtering, symbol normalization, scope rules, and display
+  naming are not generic helpers.
+- Update `scip_decoder_registry.cpp`, Python registry metadata, and
+  serial/core parity tests together before documenting the language as
+  core-accelerated.
+
+Large-repo acceleration decisions should use the manifest-driven harness before
+new decoder work starts:
+
+```bash
+# Inspect the selected large-repo targets without cloning or indexing.
+make large-scip-profile LARGE_SCIP_PROFILE_EXTRA_ARGS="--dry-run"
+
+# Profile one serial-only active language on the checked-in large-repo targets.
+make large-scip-profile LARGE_SCIP_PROFILE_EXTRA_ARGS="--language java"
+```
+
+The default manifest is `scripts/profiling/large_scip_repos.yml`. Results are
+written to `LARGE_SCIP_PROFILE_OUTPUT_DIR` as `large_scip_profile.json` and
+`large_scip_profile.md`. Each row reports external index time, protoc decode
+time, serial graph decode/build time, optional core decode time for accepted
+C++ languages, and whether the 20% local decode/build gate is crossed.
 
 ## Profiling Shared Helpers
 

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -72,6 +72,11 @@ C++ acceleration for a newly promoted language is a separate gate:
 - A C++ decoder or helper mirrors the Python path with parity tests.
 - The C++ implementation is a reusable core module under `core/`, not logic
   embedded only in pybind bindings.
+- New decoder code starts from `SCIPDecoderBase`, `SubgraphBuilder`, and the
+  language-neutral helpers in `core/scip_decode_common.h`; language-specific
+  symbol policy stays in the owning `scip_decode_<language>.cpp` file.
+- Decoder registration, aliases, and Python/C++ registry metadata must be
+  updated together before the language is advertised as core-accelerated.
 
 ## Work Queue
 
@@ -568,7 +573,15 @@ containment `ref=8 cand=8 missing=0 extra=0`, and references `ref=1 cand=0`.
 - [x] Keep C++ decoder registration and language aliases centralized so pybind
   bindings, smoke CLIs, and future language decoders do not duplicate dispatch
   logic.
+- [x] Keep language-neutral SCIP text/string helpers in
+  `core/scip_decode_common.h`/`.cpp` so Python, Go, Rust, Ruby, and TypeScript
+  decoders share one implementation for common parsing primitives.
+- [x] Keep language-specific normalization in the owning decoder file instead
+  of hiding symbol policy in generic helpers.
 - [x] Record speedup and parity in `docs/core_cpp.md` or an experiment doc.
+- [x] Keep a manifest-driven large-repository profiling harness for active
+  SCIP languages whose C++ acceleration status is still serial-only or needs
+  revalidation.
 
 Exit condition: acceleration claims are backed by parity tests and profile
 numbers, and `core/` remains maintainable.
@@ -618,6 +631,25 @@ normalization, and `unified_name` formatting helpers in
 `codeminer.scip_interface.scip_decode_utils` where symbol shapes are compatible.
 Language-specific handling, such as Ruby singleton-class descriptors and Kotlin
 synthetic symbol filters, stays in the owning decoder.
+
+C++ SCIP decoders now follow the same boundary: common text-format primitives
+such as integer extraction, whitespace splitting, suffix checks, trailing
+character stripping, and backtick removal live in `core/scip_decode_common.h`
+and `core/scip_decode_common.cpp`; each language decoder keeps only its
+language policy, metadata loading, and symbol normalization. New accelerated
+languages should extend that shared helper surface only for language-neutral
+operations and must add registry/parity coverage before becoming accepted core
+languages.
+
+Large-repo acceleration watch status: `scripts/profiling/large_scip_repos.yml`
+records representative real repositories for Java, C#, Kotlin, Scala, PHP, and
+Ruby. Run `make large-scip-profile` with language/repo filters to clone those
+targets, profile SCIP index generation, protoc decode, serial graph decode/build,
+and optional C++ core decode, then write JSON and Markdown reports under
+`LARGE_SCIP_PROFILE_OUTPUT_DIR`. The harness applies the same 20% local
+decode/build gate before recommending any new C++ decoder work. This is the
+preferred path for proving that a serial-only active language has outgrown its
+current Python decoder.
 
 ### Phase 6: Multi-Graph Python Surface
 

--- a/scripts/profiling/large_scip_repos.yml
+++ b/scripts/profiling/large_scip_repos.yml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Representative large-repo SCIP profiling targets. The profiling harness
+# records the resolved commit for every run, so branch refs are acceptable for
+# exploration; pin to a commit once a repo becomes a promotion or acceleration
+# gate.
+repos:
+  - name: java-spring-framework
+    language: java
+    url: https://github.com/spring-projects/spring-framework.git
+    ref: main
+    target_dir: spring-core/src/main/java
+    expected_min_source_files: 100
+    notes: Large Java framework surface for checking whether JVM serial decode
+      becomes material outside tiny Maven fixtures.
+
+  - name: csharp-roslyn
+    language: csharp
+    url: https://github.com/dotnet/roslyn.git
+    ref: main
+    target_dir: src/Compilers/CSharp/Portable
+    expected_min_source_files: 100
+    notes: Large C# compiler surface; use to validate whether scip-dotnet still
+      dominates cold-start on real compiler-scale code.
+
+  - name: kotlin-kotlinpoet
+    language: kotlin
+    url: https://github.com/square/kotlinpoet.git
+    ref: 2.2.0
+    target_dir: kotlinpoet/src/jvmMain/kotlin
+    expected_min_source_files: 50
+    notes: Known successful Kotlin gate from the roadmap; rerun as the stable
+      Kotlin acceleration watch target before trying larger Kotlin repos.
+
+  - name: scala-sbt
+    language: scala
+    url: https://github.com/sbt/sbt.git
+    ref: 1.10.x
+    target_dir: main/src/main/scala
+    expected_min_source_files: 100
+    notes: Larger Scala 2.x SBT surface for testing whether JVM decode crosses
+      the local decode/build threshold.
+
+  - name: php-symfony
+    language: php
+    url: https://github.com/symfony/symfony.git
+    ref: 7.3
+    target_dir: src/Symfony/Component
+    expected_min_source_files: 100
+    notes: Large Composer project for checking whether PHP serial decode remains
+      negligible after dependency/tooling setup.
+
+  - name: ruby-rails
+    language: ruby
+    url: https://github.com/rails/rails.git
+    ref: main
+    target_dir: activerecord/lib
+    expected_min_source_files: 100
+    notes: Large Ruby target for validating the existing Ruby C++ decoder on a
+      framework-scale repository.

--- a/scripts/profiling/profile_large_scip_repos.py
+++ b/scripts/profiling/profile_large_scip_repos.py
@@ -330,7 +330,11 @@ def ensure_checkout(repo: LargeScipRepo, repo_root: Path, *, timeout: int) -> No
             timeout=timeout,
         )
 
-    run_command(["git", "fetch", "--depth=1", "origin", repo.ref], cwd=repo_root)
+    run_command(
+        ["git", "fetch", "--depth=1", "origin", repo.ref],
+        cwd=repo_root,
+        timeout=timeout,
+    )
     run_command(["git", "checkout", "--force", "FETCH_HEAD"], cwd=repo_root)
     run_command(["git", "clean", "-fd"], cwd=repo_root)
     if repo.submodules:
@@ -348,7 +352,6 @@ def run_serial_profile(
     *,
     timeout: int,
 ) -> BackendProfile:
-    from codeminer.ls_router import LSIndexer
     from codeminer.profiler import Profiler
 
     profile = BackendProfile(backend="serial", status="failed")
@@ -359,11 +362,10 @@ def run_serial_profile(
         emit_events=False,
         record_samples=True,
     )
-    indexer = LSIndexer(
+    indexer = create_profile_indexer(
+        repo,
         repo_root,
-        output_dir=serial_output,
-        exclude_patterns=list(repo.exclude_patterns),
-        language=repo.language,
+        serial_output,
         decoder_backend="serial",
         profiler=profiler,
     )
@@ -379,15 +381,7 @@ def run_serial_profile(
             raise RuntimeError("protoc did not produce index.decoded")
 
         set_target_dir(indexer, repo.target_dir)
-        graph_box: dict[str, Any] = {}
-        profile.timings["process_index_total"] = time_step(
-            lambda: graph_box.setdefault(
-                "graph", indexer.process_index(output_file=str(indexer.graph_file))
-            )
-        )
-        graph = graph_box.get("graph")
-        if graph is None:
-            raise RuntimeError("serial graph processing returned None")
+        graph = process_profile_graph(indexer, profile)
         profile.graph = graph_stats(graph)
         profile.artifacts = artifact_stats(indexer)
         profile.timings.update(profiler_sections(profiler))
@@ -407,7 +401,6 @@ def run_core_profile(
     timeout: int,
 ) -> BackendProfile:
     from codeminer.languages import core_decoder_languages
-    from codeminer.ls_router import LSIndexer
     from codeminer.profiler import Profiler
 
     profile = BackendProfile(backend="core", status="skipped")
@@ -438,25 +431,16 @@ def run_core_profile(
         emit_events=False,
         record_samples=True,
     )
-    indexer = LSIndexer(
+    indexer = create_profile_indexer(
+        repo,
         repo_root,
-        output_dir=core_output,
-        exclude_patterns=list(repo.exclude_patterns),
-        language=repo.language,
+        core_output,
         decoder_backend="core",
         profiler=profiler,
     )
     try:
         set_target_dir(indexer, repo.target_dir)
-        graph_box: dict[str, Any] = {}
-        profile.timings["process_index_total"] = time_step(
-            lambda: graph_box.setdefault(
-                "graph", indexer.process_index(output_file=str(indexer.graph_file))
-            )
-        )
-        graph = graph_box.get("graph")
-        if graph is None:
-            raise RuntimeError("core graph processing returned None")
+        graph = process_profile_graph(indexer, profile)
         profile.graph = graph_stats(graph)
         profile.artifacts = artifact_stats(indexer)
         profile.timings.update(profiler_sections(profiler))
@@ -466,6 +450,29 @@ def run_core_profile(
         profile.error = str(exc)
         profile.artifacts = artifact_stats(indexer)
     return profile
+
+
+def create_profile_indexer(
+    repo: LargeScipRepo,
+    repo_root: Path,
+    output_dir: Path,
+    *,
+    decoder_backend: str,
+    profiler: Any,
+) -> Any:
+    """Create the SCIP route whose decoder backend is being measured."""
+
+    from codeminer.ls_router import SCIP_CANDIDATE_GRAPH_ROUTE, LSIndexer
+
+    return LSIndexer(
+        repo_root,
+        output_dir=output_dir,
+        exclude_patterns=list(repo.exclude_patterns),
+        language=repo.language,
+        decoder_backend=decoder_backend,
+        graph_route=SCIP_CANDIDATE_GRAPH_ROUTE,
+        profiler=profiler,
+    )
 
 
 def call_generate_index(indexer: Any, *, timeout: int) -> bool:
@@ -482,8 +489,39 @@ def call_generate_index(indexer: Any, *, timeout: int) -> bool:
 def set_target_dir(indexer: Any, target_dir: str | None) -> None:
     if not target_dir:
         return
-    delegate = getattr(indexer, "_delegate", indexer)
+    delegate = indexer
+    seen: set[int] = set()
+    while id(delegate) not in seen:
+        seen.add(id(delegate))
+        nested = getattr(delegate, "_delegate", None)
+        if nested is None or nested is delegate:
+            break
+        delegate = nested
     delegate._target_dir = target_dir
+
+
+def process_profile_graph(indexer: Any, profile: BackendProfile) -> Any:
+    """Measure graph construction separately from artifact persistence."""
+
+    graph_box: dict[str, Any] = {}
+    profile.timings["process_index_total"] = time_step(
+        lambda: graph_box.setdefault("graph", indexer.process_index(output_file=None))
+    )
+    graph = graph_box.get("graph")
+    if graph is None:
+        raise RuntimeError(f"{profile.backend} graph processing returned None")
+    profile.timings["save_graph"] = time_step(
+        lambda: save_profile_graph(indexer, graph)
+    )
+    return graph
+
+
+def save_profile_graph(indexer: Any, graph: Any) -> None:
+    output_path = Path(indexer.graph_file)
+    graph.save_graph(str(output_path))
+    occurrence_index = getattr(graph, "lsp_occurrence_index", None)
+    if occurrence_index is not None:
+        occurrence_index.save(output_path.with_name("lsp_index.pkl"))
 
 
 def time_step(fn: Any) -> float:

--- a/scripts/profiling/profile_large_scip_repos.py
+++ b/scripts/profiling/profile_large_scip_repos.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Profile large real repositories for SCIP acceleration decisions.
+
+The generated report answers one specific question per repository: is local
+SCIP decode/build time large enough to justify a C++ decoder, or is cold-start
+time still dominated by the external language indexer?
+
+This script is intentionally manifest-driven. It supports ``--dry-run`` so the
+repo list and gate configuration can be checked in unit/CI without cloning or
+indexing large upstream projects.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Sequence
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+_CORE = _PROJECT_ROOT / "build" / "core"
+if _CORE.exists() and str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+DEFAULT_MANIFEST = Path(__file__).with_name("large_scip_repos.yml")
+DEFAULT_CACHE_ROOT = Path("/tmp/codeminer-large-scip-repos")
+DEFAULT_OUTPUT_DIR = Path("/tmp/codeminer-large-scip-profile")
+DEFAULT_TIMEOUT_S = 1800
+DEFAULT_ACCELERATION_THRESHOLD = 0.20
+
+LANGUAGE_EXTENSIONS: dict[str, tuple[str, ...]] = {
+    "csharp": (".cs",),
+    "java": (".java",),
+    "kotlin": (".kt", ".kts"),
+    "php": (".php", ".phtml"),
+    "ruby": (".rb",),
+    "scala": (".scala", ".sc"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class LargeScipRepo:
+    name: str
+    language: str
+    url: str
+    ref: str = "HEAD"
+    target_dir: str | None = None
+    exclude_patterns: tuple[str, ...] = ()
+    expected_min_source_files: int = 0
+    notes: str = ""
+    submodules: bool = False
+
+    def to_plan_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "language": self.language,
+            "url": self.url,
+            "ref": self.ref,
+            "target_dir": self.target_dir,
+            "exclude_patterns": list(self.exclude_patterns),
+            "expected_min_source_files": self.expected_min_source_files,
+            "submodules": self.submodules,
+            "notes": self.notes,
+        }
+
+
+@dataclass(slots=True)
+class BackendProfile:
+    backend: str
+    status: str = "skipped"
+    timings: dict[str, float] = field(default_factory=dict)
+    graph: dict[str, int] = field(default_factory=dict)
+    artifacts: dict[str, str | int | None] = field(default_factory=dict)
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> list[LargeScipRepo]:
+    """Load and validate a large-repo profiling manifest."""
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    rows = data.get("repos")
+    if not isinstance(rows, list):
+        raise ValueError("large SCIP manifest must contain a 'repos' list.")
+
+    repos: list[LargeScipRepo] = []
+    names: set[str] = set()
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"manifest repo #{idx + 1} must be a mapping.")
+        missing = [key for key in ("name", "language", "url") if not row.get(key)]
+        if missing:
+            raise ValueError(
+                f"manifest repo #{idx + 1} missing required keys: {missing}"
+            )
+        name = str(row["name"])
+        if name in names:
+            raise ValueError(f"duplicate large SCIP repo name: {name}")
+        names.add(name)
+        repos.append(
+            LargeScipRepo(
+                name=name,
+                language=str(row["language"]).strip().lower(),
+                url=str(row["url"]),
+                ref=str(row.get("ref") or "HEAD"),
+                target_dir=(
+                    str(row["target_dir"]).strip()
+                    if row.get("target_dir") is not None
+                    else None
+                ),
+                exclude_patterns=tuple(str(v) for v in row.get("exclude_patterns", ())),
+                expected_min_source_files=int(
+                    row.get("expected_min_source_files") or 0
+                ),
+                notes=str(row.get("notes") or ""),
+                submodules=bool(row.get("submodules", False)),
+            )
+        )
+    return repos
+
+
+def select_repos(
+    repos: Sequence[LargeScipRepo],
+    *,
+    names: Sequence[str] = (),
+    languages: Sequence[str] = (),
+    max_repos: int | None = None,
+) -> list[LargeScipRepo]:
+    """Filter manifest rows by repo name and/or language."""
+
+    name_set = {name.strip() for name in names if name.strip()}
+    language_set = {language.strip().lower() for language in languages if language}
+    selected = [
+        repo
+        for repo in repos
+        if (not name_set or repo.name in name_set)
+        and (not language_set or repo.language in language_set)
+    ]
+    if max_repos is not None:
+        selected = selected[: max(0, max_repos)]
+    return selected
+
+
+def dry_run_plan(
+    repos: Sequence[LargeScipRepo],
+    *,
+    threshold: float = DEFAULT_ACCELERATION_THRESHOLD,
+) -> dict[str, Any]:
+    """Return a serializable execution plan without touching the network."""
+
+    return {
+        "mode": "dry-run",
+        "acceleration_threshold": threshold,
+        "repo_count": len(repos),
+        "repos": [repo.to_plan_dict() for repo in repos],
+    }
+
+
+def acceleration_decision(
+    *,
+    generate_seconds: float | None,
+    protoc_decode_seconds: float | None,
+    serial_process_seconds: float | None,
+    threshold: float = DEFAULT_ACCELERATION_THRESHOLD,
+) -> dict[str, Any]:
+    """Return the C++ acceleration gate decision for one serial profile."""
+
+    if serial_process_seconds is None:
+        return {
+            "threshold": threshold,
+            "crossed": False,
+            "local_decode_build_fraction": None,
+            "recommendation": "no-decision",
+            "reason": "serial graph processing did not complete",
+        }
+
+    cold_start = sum(
+        value or 0.0
+        for value in (generate_seconds, protoc_decode_seconds, serial_process_seconds)
+    )
+    if cold_start <= 0:
+        return {
+            "threshold": threshold,
+            "crossed": False,
+            "local_decode_build_fraction": None,
+            "recommendation": "no-decision",
+            "reason": "cold-start timing is unavailable",
+        }
+
+    fraction = serial_process_seconds / cold_start
+    crossed = fraction >= threshold
+    return {
+        "threshold": threshold,
+        "crossed": crossed,
+        "local_decode_build_fraction": fraction,
+        "cold_start_seconds": cold_start,
+        "local_decode_build_seconds": serial_process_seconds,
+        "recommendation": (
+            "profile-core-decoder" if crossed else "keep-serial-until-larger-profile"
+        ),
+        "reason": (
+            "local decode/build crosses acceleration gate"
+            if crossed
+            else "external indexing dominates cold-start time"
+        ),
+    }
+
+
+def profile_repositories(
+    repos: Sequence[LargeScipRepo],
+    *,
+    cache_root: Path = DEFAULT_CACHE_ROOT,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    backend_mode: str = "both",
+    threshold: float = DEFAULT_ACCELERATION_THRESHOLD,
+    timeout: int = DEFAULT_TIMEOUT_S,
+    skip_clone: bool = False,
+) -> dict[str, Any]:
+    """Clone/profile selected repositories and write artifacts under output_dir."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    records = []
+    for repo in repos:
+        records.append(
+            profile_repository(
+                repo,
+                cache_root=cache_root,
+                output_dir=output_dir,
+                backend_mode=backend_mode,
+                threshold=threshold,
+                timeout=timeout,
+                skip_clone=skip_clone,
+            )
+        )
+
+    report = {
+        "mode": "profile",
+        "acceleration_threshold": threshold,
+        "repo_count": len(records),
+        "records": records,
+    }
+    (output_dir / "large_scip_profile.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "large_scip_profile.md").write_text(
+        render_markdown_report(report),
+        encoding="utf-8",
+    )
+    return report
+
+
+def profile_repository(
+    repo: LargeScipRepo,
+    *,
+    cache_root: Path,
+    output_dir: Path,
+    backend_mode: str,
+    threshold: float,
+    timeout: int,
+    skip_clone: bool = False,
+) -> dict[str, Any]:
+    repo_root = cache_root / repo.name
+    if not skip_clone:
+        ensure_checkout(repo, repo_root, timeout=timeout)
+    elif not repo_root.exists():
+        raise FileNotFoundError(
+            f"{repo_root} does not exist; omit --skip-clone to clone it"
+        )
+
+    commit = git_output(["rev-parse", "HEAD"], cwd=repo_root, timeout=60)
+    source_files = count_source_files(repo_root, repo.language, repo.target_dir)
+    repo_output = output_dir / repo.name
+    repo_output.mkdir(parents=True, exist_ok=True)
+
+    serial = run_serial_profile(repo, repo_root, repo_output, timeout=timeout)
+    backends: dict[str, Any] = {"serial": serial.to_dict()}
+    if backend_mode in {"both", "core"}:
+        backends["core"] = run_core_profile(
+            repo, repo_root, repo_output, serial=serial, timeout=timeout
+        ).to_dict()
+
+    serial_timings = serial.timings
+    gate = acceleration_decision(
+        generate_seconds=serial_timings.get("generate_index"),
+        protoc_decode_seconds=serial_timings.get("decode_index"),
+        serial_process_seconds=serial_timings.get("process_index_total"),
+        threshold=threshold,
+    )
+
+    return {
+        "repo": repo.to_plan_dict(),
+        "commit": commit,
+        "source_files": source_files,
+        "source_file_gate": {
+            "expected_min_source_files": repo.expected_min_source_files,
+            "passed": source_files >= repo.expected_min_source_files,
+        },
+        "backends": backends,
+        "acceleration_gate": gate,
+    }
+
+
+def ensure_checkout(repo: LargeScipRepo, repo_root: Path, *, timeout: int) -> None:
+    """Clone or update one manifest repository to the requested ref."""
+
+    if not repo_root.exists():
+        repo_root.parent.mkdir(parents=True, exist_ok=True)
+        run_command(
+            ["git", "clone", "--filter=blob:none", repo.url, str(repo_root)],
+            timeout=timeout,
+        )
+
+    run_command(["git", "fetch", "--depth=1", "origin", repo.ref], cwd=repo_root)
+    run_command(["git", "checkout", "--force", "FETCH_HEAD"], cwd=repo_root)
+    run_command(["git", "clean", "-fd"], cwd=repo_root)
+    if repo.submodules:
+        run_command(
+            ["git", "submodule", "update", "--init", "--recursive", "--depth=1"],
+            cwd=repo_root,
+            timeout=timeout,
+        )
+
+
+def run_serial_profile(
+    repo: LargeScipRepo,
+    repo_root: Path,
+    repo_output: Path,
+    *,
+    timeout: int,
+) -> BackendProfile:
+    from codeminer.ls_router import LSIndexer
+    from codeminer.profiler import Profiler
+
+    profile = BackendProfile(backend="serial", status="failed")
+    serial_output = repo_output / "serial"
+    reset_output_dir(serial_output)
+    profiler = Profiler(
+        f"large_scip_{repo.name}_serial",
+        emit_events=False,
+        record_samples=True,
+    )
+    indexer = LSIndexer(
+        repo_root,
+        output_dir=serial_output,
+        exclude_patterns=list(repo.exclude_patterns),
+        language=repo.language,
+        decoder_backend="serial",
+        profiler=profiler,
+    )
+    try:
+        profile.timings["generate_index"] = time_step(
+            lambda: call_generate_index(indexer, timeout=timeout)
+        )
+        if not indexer.index_file.exists():
+            raise RuntimeError("indexer did not produce index.scip")
+
+        profile.timings["decode_index"] = time_step(indexer.decode_index)
+        if not indexer.decoded_file.exists():
+            raise RuntimeError("protoc did not produce index.decoded")
+
+        set_target_dir(indexer, repo.target_dir)
+        graph_box: dict[str, Any] = {}
+        profile.timings["process_index_total"] = time_step(
+            lambda: graph_box.setdefault(
+                "graph", indexer.process_index(output_file=str(indexer.graph_file))
+            )
+        )
+        graph = graph_box.get("graph")
+        if graph is None:
+            raise RuntimeError("serial graph processing returned None")
+        profile.graph = graph_stats(graph)
+        profile.artifacts = artifact_stats(indexer)
+        profile.timings.update(profiler_sections(profiler))
+        profile.status = "ok"
+    except Exception as exc:  # pragma: no cover - exercised by live profiles
+        profile.error = str(exc)
+        profile.artifacts = artifact_stats(indexer)
+    return profile
+
+
+def run_core_profile(
+    repo: LargeScipRepo,
+    repo_root: Path,
+    repo_output: Path,
+    *,
+    serial: BackendProfile,
+    timeout: int,
+) -> BackendProfile:
+    from codeminer.languages import core_decoder_languages
+    from codeminer.ls_router import LSIndexer
+    from codeminer.profiler import Profiler
+
+    profile = BackendProfile(backend="core", status="skipped")
+    if repo.language not in core_decoder_languages(include_aliases=True):
+        profile.error = f"{repo.language} has no accepted C++ core decoder"
+        return profile
+    if importlib.util.find_spec("codeminer_core") is None:
+        profile.error = "codeminer_core pybind module is not importable"
+        return profile
+    if serial.status != "ok":
+        profile.error = "serial profile did not complete; no decoded file to reuse"
+        return profile
+
+    serial_decoded = repo_output / "serial" / "index.decoded"
+    serial_index = repo_output / "serial" / "index.scip"
+    if not serial_decoded.exists():
+        profile.error = "serial decoded artifact is missing"
+        return profile
+
+    core_output = repo_output / "core"
+    reset_output_dir(core_output)
+    shutil.copy2(serial_decoded, core_output / "index.decoded")
+    if serial_index.exists():
+        shutil.copy2(serial_index, core_output / "index.scip")
+
+    profiler = Profiler(
+        f"large_scip_{repo.name}_core",
+        emit_events=False,
+        record_samples=True,
+    )
+    indexer = LSIndexer(
+        repo_root,
+        output_dir=core_output,
+        exclude_patterns=list(repo.exclude_patterns),
+        language=repo.language,
+        decoder_backend="core",
+        profiler=profiler,
+    )
+    try:
+        set_target_dir(indexer, repo.target_dir)
+        graph_box: dict[str, Any] = {}
+        profile.timings["process_index_total"] = time_step(
+            lambda: graph_box.setdefault(
+                "graph", indexer.process_index(output_file=str(indexer.graph_file))
+            )
+        )
+        graph = graph_box.get("graph")
+        if graph is None:
+            raise RuntimeError("core graph processing returned None")
+        profile.graph = graph_stats(graph)
+        profile.artifacts = artifact_stats(indexer)
+        profile.timings.update(profiler_sections(profiler))
+        profile.status = "ok"
+    except Exception as exc:  # pragma: no cover - exercised by live profiles
+        profile.status = "failed"
+        profile.error = str(exc)
+        profile.artifacts = artifact_stats(indexer)
+    return profile
+
+
+def call_generate_index(indexer: Any, *, timeout: int) -> bool:
+    """Call generate_index with timeout when the indexer supports it."""
+
+    try:
+        return bool(indexer.generate_index(timeout=timeout))
+    except TypeError as exc:
+        if "timeout" not in str(exc):
+            raise
+        return bool(indexer.generate_index())
+
+
+def set_target_dir(indexer: Any, target_dir: str | None) -> None:
+    if not target_dir:
+        return
+    delegate = getattr(indexer, "_delegate", indexer)
+    delegate._target_dir = target_dir
+
+
+def time_step(fn: Any) -> float:
+    start = time.perf_counter()
+    result = fn()
+    elapsed = time.perf_counter() - start
+    if result is False:
+        raise RuntimeError("profile step returned False")
+    return elapsed
+
+
+def profiler_sections(profiler: Any) -> dict[str, float]:
+    sections = profiler.report(reset=False)
+    return {f"section.{label}": stats.total for label, stats in sections}
+
+
+def graph_stats(graph: Any) -> dict[str, int]:
+    edges = graph.graph.es
+    references = 0
+    for edge in edges:
+        try:
+            if edge.attributes().get("type") == "reference":
+                references += 1
+        except AttributeError:
+            if edge["type"] == "reference":
+                references += 1
+    return {
+        "vertices": graph.graph.vcount(),
+        "edges": graph.graph.ecount(),
+        "references": references,
+    }
+
+
+def artifact_stats(indexer: Any) -> dict[str, str | int | None]:
+    def size(path: Path) -> int:
+        return path.stat().st_size if path.exists() else 0
+
+    return {
+        "output_dir": str(indexer.output_dir),
+        "index_path": str(indexer.index_file) if indexer.index_file.exists() else None,
+        "decoded_path": (
+            str(indexer.decoded_file) if indexer.decoded_file.exists() else None
+        ),
+        "graph_path": str(indexer.graph_file) if indexer.graph_file.exists() else None,
+        "index_bytes": size(indexer.index_file),
+        "decoded_bytes": size(indexer.decoded_file),
+        "graph_bytes": size(indexer.graph_file),
+    }
+
+
+def count_source_files(
+    repo_root: Path, language: str, target_dir: str | None = None
+) -> int:
+    root = repo_root / target_dir if target_dir else repo_root
+    if not root.exists():
+        return 0
+    exts = LANGUAGE_EXTENSIONS.get(language, ())
+    if not exts:
+        return 0
+    return sum(1 for path in root.rglob("*") if path.is_file() and path.suffix in exts)
+
+
+def reset_output_dir(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def git_output(args: Sequence[str], *, cwd: Path, timeout: int = 120) -> str:
+    result = run_command(["git", *args], cwd=cwd, timeout=timeout)
+    return result.stdout.strip()
+
+
+def run_command(
+    cmd: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    timeout: int = 120,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(cmd),
+        cwd=str(cwd) if cwd is not None else None,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    rows = [
+        "# Large SCIP Repository Profile",
+        "",
+        f"Acceleration threshold: {report['acceleration_threshold']:.0%}",
+        "",
+        "| Repository | Language | Source files | Serial process | Gate fraction | Decision |",
+        "| --- | --- | ---: | ---: | ---: | --- |",
+    ]
+    for record in report.get("records", []):
+        repo = record["repo"]
+        serial = record["backends"].get("serial", {})
+        gate = record["acceleration_gate"]
+        process_s = serial.get("timings", {}).get("process_index_total")
+        fraction = gate.get("local_decode_build_fraction")
+        rows.append(
+            "| {name} | {language} | {files} | {process} | {fraction} | {decision} |".format(
+                name=repo["name"],
+                language=repo["language"],
+                files=record.get("source_files", 0),
+                process=fmt_seconds(process_s),
+                fraction=fmt_percent(fraction),
+                decision=gate.get("recommendation", "unknown"),
+            )
+        )
+    rows.append("")
+    return "\n".join(rows)
+
+
+def fmt_seconds(value: Any) -> str:
+    return "" if value is None else f"{float(value):.3f}s"
+
+
+def fmt_percent(value: Any) -> str:
+    return "" if value is None else f"{float(value):.1%}"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--repo", action="append", default=[])
+    parser.add_argument("--language", action="append", default=[])
+    parser.add_argument("--max-repos", type=int)
+    parser.add_argument("--cache-root", type=Path, default=DEFAULT_CACHE_ROOT)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_S)
+    parser.add_argument(
+        "--acceleration-threshold",
+        type=float,
+        default=DEFAULT_ACCELERATION_THRESHOLD,
+    )
+    parser.add_argument(
+        "--backend",
+        choices=("serial", "core", "both"),
+        default="both",
+        help="which decoder backend profiles to run after cloning",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate and print the selected manifest plan without cloning",
+    )
+    parser.add_argument(
+        "--skip-clone",
+        action="store_true",
+        help="reuse existing checkouts under --cache-root",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repos = select_repos(
+        load_manifest(args.manifest),
+        names=args.repo,
+        languages=args.language,
+        max_repos=args.max_repos,
+    )
+    if args.dry_run:
+        print(
+            json.dumps(
+                dry_run_plan(repos, threshold=args.acceleration_threshold),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    report = profile_repositories(
+        repos,
+        cache_root=args.cache_root,
+        output_dir=args.output_dir,
+        backend_mode=args.backend,
+        threshold=args.acceleration_threshold,
+        timeout=args.timeout,
+        skip_clone=args.skip_clone,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scripts/test_profile_large_scip_repos.py
+++ b/test/scripts/test_profile_large_scip_repos.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from scripts.profiling import profile_large_scip_repos
@@ -88,3 +90,97 @@ def test_dry_run_plan_is_serializable():
     assert plan["acceleration_threshold"] == 0.25
     assert plan["repo_count"] == 1
     assert plan["repos"][0]["target_dir"] == "src/main/java"
+
+
+def test_ensure_checkout_applies_configured_timeout_to_fetch(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    calls = []
+
+    def fake_run_command(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(stdout="")
+
+    monkeypatch.setattr(profile_large_scip_repos, "run_command", fake_run_command)
+    repo = profile_large_scip_repos.LargeScipRepo(
+        name="large",
+        language="java",
+        url="https://example.invalid/large.git",
+        ref="main",
+    )
+
+    profile_large_scip_repos.ensure_checkout(repo, repo_root, timeout=987)
+
+    fetch = next(call for call in calls if call[0][:2] == ["git", "fetch"])
+    assert fetch[1]["timeout"] == 987
+
+
+def test_create_profile_indexer_forces_scip_candidate_route(tmp_path, monkeypatch):
+    captured = {}
+    sentinel = object()
+
+    def fake_indexer(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr("codeminer.ls_router.LSIndexer", fake_indexer)
+    repo = profile_large_scip_repos.LargeScipRepo(
+        name="ruby-large",
+        language="ruby",
+        url="https://example.invalid/ruby.git",
+        exclude_patterns=("vendor/**",),
+    )
+
+    result = profile_large_scip_repos.create_profile_indexer(
+        repo,
+        tmp_path,
+        tmp_path / "out",
+        decoder_backend="serial",
+        profiler=object(),
+    )
+
+    assert result is sentinel
+    assert captured["kwargs"]["graph_route"] == "scip-candidate"
+    assert captured["kwargs"]["decoder_backend"] == "serial"
+    assert captured["kwargs"]["exclude_patterns"] == ["vendor/**"]
+
+
+def test_set_target_dir_reaches_leaf_delegate():
+    leaf = SimpleNamespace(_target_dir=None)
+    wrapper = SimpleNamespace(_delegate=SimpleNamespace(_delegate=leaf))
+
+    profile_large_scip_repos.set_target_dir(wrapper, "src/main")
+
+    assert leaf._target_dir == "src/main"
+
+
+def test_process_profile_graph_excludes_artifact_persistence(tmp_path):
+    saved = []
+    occurrences = []
+
+    class FakeGraph:
+        lsp_occurrence_index = SimpleNamespace(
+            save=lambda path: occurrences.append(path)
+        )
+
+        def save_graph(self, path):
+            saved.append(path)
+
+    graph = FakeGraph()
+
+    class FakeIndexer:
+        graph_file = tmp_path / "graph.pkl"
+
+        def process_index(self, output_file):
+            assert output_file is None
+            return graph
+
+    profile = profile_large_scip_repos.BackendProfile(backend="serial")
+
+    result = profile_large_scip_repos.process_profile_graph(FakeIndexer(), profile)
+
+    assert result is graph
+    assert set(profile.timings) == {"process_index_total", "save_graph"}
+    assert saved == [str(tmp_path / "graph.pkl")]
+    assert occurrences == [tmp_path / "lsp_index.pkl"]

--- a/test/scripts/test_profile_large_scip_repos.py
+++ b/test/scripts/test_profile_large_scip_repos.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for large-repo SCIP profiling manifest and gate logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.profiling import profile_large_scip_repos
+
+
+def test_default_manifest_covers_serial_only_active_languages():
+    repos = profile_large_scip_repos.load_manifest()
+    by_language = {repo.language for repo in repos}
+
+    assert {"java", "csharp", "kotlin", "scala", "php"} <= by_language
+    assert "ruby" in by_language
+    assert all(repo.url.startswith("https://github.com/") for repo in repos)
+    assert all(repo.expected_min_source_files > 0 for repo in repos)
+
+
+def test_select_repos_filters_by_name_and_language():
+    repos = [
+        profile_large_scip_repos.LargeScipRepo(
+            name="java-one",
+            language="java",
+            url="https://example.invalid/java.git",
+        ),
+        profile_large_scip_repos.LargeScipRepo(
+            name="ruby-one",
+            language="ruby",
+            url="https://example.invalid/ruby.git",
+        ),
+    ]
+
+    assert [
+        repo.name
+        for repo in profile_large_scip_repos.select_repos(repos, languages=["java"])
+    ] == ["java-one"]
+    assert [
+        repo.name
+        for repo in profile_large_scip_repos.select_repos(repos, names=["ruby-one"])
+    ] == ["ruby-one"]
+
+
+def test_acceleration_decision_crosses_threshold_when_decode_is_hot():
+    decision = profile_large_scip_repos.acceleration_decision(
+        generate_seconds=6.0,
+        protoc_decode_seconds=1.0,
+        serial_process_seconds=3.0,
+        threshold=0.20,
+    )
+
+    assert decision["crossed"] is True
+    assert decision["local_decode_build_fraction"] == pytest.approx(0.30)
+    assert decision["recommendation"] == "profile-core-decoder"
+
+
+def test_acceleration_decision_keeps_serial_when_indexer_dominates():
+    decision = profile_large_scip_repos.acceleration_decision(
+        generate_seconds=90.0,
+        protoc_decode_seconds=2.0,
+        serial_process_seconds=8.0,
+        threshold=0.20,
+    )
+
+    assert decision["crossed"] is False
+    assert decision["local_decode_build_fraction"] == pytest.approx(0.08)
+    assert decision["recommendation"] == "keep-serial-until-larger-profile"
+
+
+def test_dry_run_plan_is_serializable():
+    repos = [
+        profile_large_scip_repos.LargeScipRepo(
+            name="java-one",
+            language="java",
+            url="https://example.invalid/java.git",
+            ref="main",
+            target_dir="src/main/java",
+        )
+    ]
+
+    plan = profile_large_scip_repos.dry_run_plan(repos, threshold=0.25)
+
+    assert plan["mode"] == "dry-run"
+    assert plan["acceleration_threshold"] == 0.25
+    assert plan["repo_count"] == 1
+    assert plan["repos"][0]["target_dir"] == "src/main/java"


### PR DESCRIPTION
## Summary

Two related pieces of SCIP-decoder acceleration hygiene:

- The five accelerated C++ decoders (Go, Python, Ruby, Rust, TypeScript)
  each carried private copies of the same language-neutral text-format
  primitives. Deduplicate them into `core/scip_decode_common.{h,cpp}` so
  the next promoted language starts from the shared surface instead of
  copying a sibling decoder.
- The roadmap gates new C++ decoder work on real large-repo profiles
  (local decode/build must exceed 20% of cold-start), but there was no
  reproducible harness to produce that evidence. Add a manifest-driven
  large-repository profiling gate for the serial-only languages
  (Java, C#, Kotlin, Scala, PHP, Ruby).

## Changes

- `core/scip_decode_common.{h,cpp}`: absorb integer extraction,
  whitespace splitting, suffix checks, trailing-character stripping, and
  backtick removal; `core/scip_decode_{go,python,ruby,rust,ts}.cpp` drop
  their local static copies (−171 lines). Language symbol policy stays
  in the owning decoder file.
- `core/README.md` + `docs/core_cpp.md`: document the helper/policy
  boundary for future decoders; drop the superseded ad-hoc serial-only
  profile notes in favor of the harness below.
- Add `scripts/profiling/profile_large_scip_repos.py` +
  `scripts/profiling/large_scip_repos.yml` and a `make
  large-scip-profile` target: clones pinned large repositories, times
  SCIP indexing / protoc decode / serial graph decode+build and optional
  C++ core decode, applies the 20% gate, writes JSON/Markdown reports.
- `docs/scip_multilanguage_roadmap.md`: record the shared-helper
  boundary rules and the large-repo acceleration watch status (additive;
  the #312/#314 status blocks are untouched).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `make core-build && make core-test`: `scip_decode_test` and
  `graph_layers_test` both exit 0 against the deduplicated helpers.
- `pytest test/scripts/test_profile_large_scip_repos.py`: 5 passed.
- `pytest test/scip/test_scip_core.py`: skips locally (needs the
  installed extension); the `scip-core` CI tier covers the
  Python/C++ parity path.
- Sentinel checks against `origin/main`: no `selection_line` /
  graph-schema-v4 lines removed under `core/`; the roadmap retains the
  #312 clangd-artifact-status and #314 100-snapshot replay blocks;
  `Makefile` diff is additive (`large-scip-profile`) with `bench-rerank`
  untouched.
- `python -m mkdocs build --strict` passes; pre-commit (clang-format,
  black, isort, flake8) passed on both commits.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
