### PR TITLE
feat(eval): add content-locked artifact bundles

### DIFF
--- a/codeminer/eval/artifact_bundle.py
+++ b/codeminer/eval/artifact_bundle.py
@@ -1,0 +1,322 @@
+"""Build content-locked evaluation bundles from explicit local sources."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .artifact_integrity import (
+    FileRecord,
+    SelectionIdentity,
+    create_archive,
+    select_source,
+    selection_identity,
+    sha256_file,
+    source_path,
+    verify_bundle,
+    write_checksums,
+)
+from .artifact_manifest import (
+    LOCK_FILE,
+    LOCK_SCHEMA_VERSION,
+    MANIFEST_FILE,
+    PROVENANCE_FILE,
+    PROVENANCE_SCHEMA_VERSION,
+    ArtifactBundleError,
+    ArtifactIntegrityError,
+    BundleManifest,
+    SourceSpec,
+    load_manifest,
+    load_source_lock,
+    parse_root_arguments,
+)
+
+
+def write_source_lock(
+    manifest: BundleManifest,
+    roots: Mapping[str, Path | str],
+    output: Path | str,
+) -> dict[str, Any]:
+    """Hash every selected source and write a reviewable content lock."""
+
+    resolved_roots = _resolve_roots(manifest, roots)
+    resolved_sources = {
+        spec.source_id: source_path(spec, resolved_roots[spec.root])
+        for spec in manifest.sources
+    }
+    output_path = Path(output).expanduser().resolve(strict=False)
+    _validate_output_location(output_path, resolved_sources)
+    identities = {
+        spec.source_id: selection_identity(
+            select_source(spec, resolved_roots[spec.root])
+        ).as_dict()
+        for spec in manifest.sources
+    }
+    payload = {
+        "schema_version": LOCK_SCHEMA_VERSION,
+        "manifest_sha256": manifest.sha256,
+        "sources": identities,
+    }
+    if output_path.exists():
+        raise ArtifactBundleError(f"source lock already exists: {output_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    _write_json(output_path, payload)
+    return payload
+
+
+def build_bundle(
+    manifest: BundleManifest,
+    roots: Mapping[str, Path | str],
+    output: Path | str,
+    *,
+    source_lock: Path | str | None = None,
+) -> dict[str, Any]:
+    """Atomically stage a bundle and verify its complete checksum inventory."""
+
+    output_path = Path(output).expanduser().resolve(strict=False)
+    if output_path.exists():
+        raise ArtifactBundleError(f"bundle output already exists: {output_path}")
+    resolved_roots = _resolve_roots(manifest, roots)
+    resolved_sources = {
+        spec.source_id: source_path(spec, resolved_roots[spec.root])
+        for spec in manifest.sources
+    }
+    _validate_output_location(output_path, resolved_sources)
+
+    lock_payload = (
+        load_source_lock(source_lock, manifest) if source_lock is not None else None
+    )
+    lock_path = (
+        Path(source_lock).expanduser().resolve(strict=True) if source_lock else None
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    staging = output_path.parent / f".{output_path.name}.tmp-{uuid.uuid4().hex}"
+    staging.mkdir()
+    try:
+        provenance_sources = []
+        for spec in manifest.sources:
+            records = select_source(spec, resolved_roots[spec.root])
+            identity = selection_identity(records)
+            if lock_payload is not None:
+                _check_locked_identity(lock_payload, spec.source_id, identity)
+            _copy_selection(
+                spec,
+                records,
+                staging,
+                source_is_file=resolved_sources[spec.source_id].is_file(),
+            )
+            provenance_sources.append(
+                {
+                    "id": spec.source_id,
+                    "root": spec.root,
+                    "path": spec.path.as_posix(),
+                    "destination": spec.destination.as_posix(),
+                    "identity": identity.as_dict(),
+                }
+            )
+
+        (staging / MANIFEST_FILE).write_bytes(manifest.raw)
+        lock_sha256 = None
+        if lock_path is not None:
+            lock_bytes = lock_path.read_bytes()
+            (staging / LOCK_FILE).write_bytes(lock_bytes)
+            lock_sha256 = hashlib.sha256(lock_bytes).hexdigest()
+        provenance = {
+            "schema_version": PROVENANCE_SCHEMA_VERSION,
+            "bundle": {"name": manifest.name, "version": manifest.version},
+            "manifest_sha256": manifest.sha256,
+            "source_lock_sha256": lock_sha256,
+            "roots": {
+                name: _root_provenance(path)
+                for name, path in sorted(resolved_roots.items())
+            },
+            "sources": provenance_sources,
+        }
+        _write_json(staging / PROVENANCE_FILE, provenance)
+        write_checksums(staging)
+        verification = verify_bundle(staging)
+        os.replace(staging, output_path)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    return {
+        "bundle": str(output_path),
+        "files": verification["files"],
+        "bytes": verification["bytes"],
+        "manifest_sha256": manifest.sha256,
+        "source_lock_sha256": lock_sha256,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Command-line entry point for source locking, staging, and verification."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    lock_parser = subparsers.add_parser("lock", help="hash selected source trees")
+    _add_manifest_and_roots(lock_parser)
+    lock_parser.add_argument("--output", type=Path, required=True)
+
+    build_parser = subparsers.add_parser("build", help="stage an artifact bundle")
+    _add_manifest_and_roots(build_parser)
+    build_parser.add_argument("--source-lock", type=Path)
+    build_parser.add_argument("--output", type=Path, required=True)
+    build_parser.add_argument("--archive", type=Path)
+
+    verify_parser = subparsers.add_parser("verify", help="verify a staged bundle")
+    verify_parser.add_argument("--bundle", type=Path, required=True)
+
+    archive_parser = subparsers.add_parser(
+        "archive", help="archive an already verified bundle"
+    )
+    archive_parser.add_argument("--bundle", type=Path, required=True)
+    archive_parser.add_argument("--output", type=Path, required=True)
+
+    args = parser.parse_args(argv)
+    if args.command == "verify":
+        result = verify_bundle(args.bundle)
+    elif args.command == "archive":
+        result = create_archive(args.bundle, args.output)
+    else:
+        manifest = load_manifest(args.manifest)
+        roots = parse_root_arguments(args.root)
+        if args.command == "lock":
+            result = write_source_lock(manifest, roots, args.output)
+        else:
+            result = build_bundle(
+                manifest,
+                roots,
+                args.output,
+                source_lock=args.source_lock,
+            )
+            if args.archive:
+                result["archive"] = create_archive(args.output, args.archive)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def _resolve_roots(
+    manifest: BundleManifest, roots: Mapping[str, Path | str]
+) -> dict[str, Path]:
+    required = {source.root for source in manifest.sources}
+    missing = sorted(required - set(roots))
+    if missing:
+        raise ArtifactBundleError(f"missing source roots: {missing}")
+    resolved = {}
+    for name in sorted(required):
+        path = Path(roots[name]).expanduser().resolve(strict=True)
+        if not path.is_dir():
+            raise ArtifactBundleError(
+                f"source root {name!r} is not a directory: {path}"
+            )
+        resolved[name] = path
+    return resolved
+
+
+def _validate_output_location(output: Path, sources: Mapping[str, Path]) -> None:
+    resolved_output = output.resolve(strict=False)
+    for source_id, source in sources.items():
+        if source.is_dir() and _filesystem_contains(source, resolved_output):
+            raise ArtifactBundleError(
+                f"bundle output is inside selected source {source_id!r}"
+            )
+        if _filesystem_contains(resolved_output, source):
+            raise ArtifactBundleError(
+                f"selected source {source_id!r} is inside bundle output"
+            )
+
+
+def _copy_selection(
+    spec: SourceSpec,
+    records: Sequence[FileRecord],
+    staging: Path,
+    *,
+    source_is_file: bool,
+) -> None:
+    for record in records:
+        destination = staging / Path(*spec.destination.parts)
+        if not source_is_file:
+            destination = destination / Path(*record.relative_path.parts)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(record.source, destination)
+        if destination.stat().st_size != record.size:
+            raise ArtifactIntegrityError(
+                f"source changed while copying {spec.source_id!r}: "
+                f"{record.relative_path}"
+            )
+        if sha256_file(destination) != record.sha256:
+            raise ArtifactIntegrityError(
+                f"source changed while copying {spec.source_id!r}: "
+                f"{record.relative_path}"
+            )
+
+
+def _check_locked_identity(
+    lock: Mapping[str, Any], source_id: str, identity: SelectionIdentity
+) -> None:
+    expected = lock["sources"][source_id]
+    if not isinstance(expected, Mapping):
+        raise ArtifactBundleError(f"invalid lock entry for source {source_id!r}")
+    actual = identity.as_dict()
+    if dict(expected) != actual:
+        raise ArtifactIntegrityError(
+            f"source {source_id!r} differs from lock; "
+            f"expected={dict(expected)}, actual={actual}"
+        )
+
+
+def _root_provenance(root: Path) -> dict[str, Any]:
+    try:
+        top_level = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        commit = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return {"git_commit": None}
+    try:
+        root.resolve().relative_to(Path(top_level).resolve())
+    except ValueError:
+        return {"git_commit": None}
+    return {"git_commit": commit}
+
+
+def _add_manifest_and_roots(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument(
+        "--root",
+        action="append",
+        default=[],
+        metavar="NAME=PATH",
+        help="bind a manifest root name to a local directory; repeat as needed",
+    )
+
+
+def _filesystem_contains(parent: Path, child: Path) -> bool:
+    return parent == child or parent in child.parents
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codeminer/eval/artifact_integrity.py
+++ b/codeminer/eval/artifact_integrity.py
@@ -322,8 +322,10 @@ def _add_archive_tree(archive: tarfile.TarFile, root: Path) -> None:
         info.mtime = 0
         info.pax_headers = {}
         if path.is_dir():
+            info.mode = 0o755
             archive.addfile(info)
         elif path.is_file():
+            info.mode = 0o755 if path.stat().st_mode & 0o111 else 0o644
             with path.open("rb") as handle:
                 archive.addfile(info, handle)
         else:

--- a/codeminer/eval/artifact_integrity.py
+++ b/codeminer/eval/artifact_integrity.py
@@ -1,0 +1,330 @@
+"""Content selection, checksums, and deterministic evaluation archives."""
+
+from __future__ import annotations
+
+import fnmatch
+import gzip
+import hashlib
+import os
+import re
+import tarfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Sequence
+
+from .artifact_manifest import (
+    CHECKSUM_FILE,
+    ArtifactBundleError,
+    ArtifactIntegrityError,
+    SourceSpec,
+)
+
+_HASH_DOMAIN = b"codeminer-artifact-selection-v1\0"
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    """Content identity for one selected source file."""
+
+    source: Path
+    relative_path: PurePosixPath
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class SelectionIdentity:
+    """Canonical identity for a selected file set."""
+
+    files: int
+    bytes: int
+    sha256: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"files": self.files, "bytes": self.bytes, "sha256": self.sha256}
+
+
+def source_path(spec: SourceSpec, root: Path) -> Path:
+    """Resolve one source without permitting symbolic-link or root escape."""
+
+    source = root / Path(*spec.path.parts)
+    current = root
+    for part in spec.path.parts:
+        current = current / part
+        if current.is_symlink():
+            raise ArtifactBundleError(
+                f"source {spec.source_id!r} traverses symbolic link {current}"
+            )
+    try:
+        source.resolve(strict=False).relative_to(root)
+    except ValueError as exc:
+        raise ArtifactBundleError(
+            f"source {spec.source_id!r} escapes root {spec.root!r}"
+        ) from exc
+    return source
+
+
+def select_source(spec: SourceSpec, root: Path) -> tuple[FileRecord, ...]:
+    """Select and hash files for one source specification."""
+
+    source = source_path(spec, root)
+    if source.is_symlink():
+        raise ArtifactBundleError(f"source {spec.source_id!r} is a symbolic link")
+    if source.is_file():
+        relative = PurePosixPath(source.name)
+        if not _included(relative, spec.include, spec.exclude):
+            raise ArtifactBundleError(
+                f"source {spec.source_id!r} file is excluded by its own patterns"
+            )
+        return (_file_record(source, relative),)
+    if not source.is_dir():
+        raise ArtifactBundleError(
+            f"source {spec.source_id!r} does not exist: {spec.path.as_posix()}"
+        )
+
+    records = []
+    excluded_dirs = set(spec.exclude_dir_names)
+    for current, dirnames, filenames in os.walk(source, topdown=True):
+        current_path = Path(current)
+        kept_dirs = []
+        for dirname in sorted(dirnames):
+            child = current_path / dirname
+            relative = PurePosixPath(child.relative_to(source).as_posix())
+            if dirname in excluded_dirs or _matches(relative, spec.exclude):
+                continue
+            if child.is_symlink():
+                raise ArtifactBundleError(
+                    f"source {spec.source_id!r} contains symbolic link {relative}"
+                )
+            kept_dirs.append(dirname)
+        dirnames[:] = kept_dirs
+        for filename in sorted(filenames):
+            child = current_path / filename
+            relative = PurePosixPath(child.relative_to(source).as_posix())
+            if not _included(relative, spec.include, spec.exclude):
+                continue
+            if child.is_symlink():
+                raise ArtifactBundleError(
+                    f"source {spec.source_id!r} contains symbolic link {relative}"
+                )
+            if not child.is_file():
+                raise ArtifactBundleError(
+                    f"source {spec.source_id!r} contains non-regular file {relative}"
+                )
+            records.append(_file_record(child, relative))
+    if not records:
+        raise ArtifactBundleError(f"source {spec.source_id!r} selected no files")
+    return tuple(sorted(records, key=lambda record: record.relative_path.as_posix()))
+
+
+def selection_identity(records: Sequence[FileRecord]) -> SelectionIdentity:
+    """Return a path-sensitive canonical identity for selected files."""
+
+    digest = hashlib.sha256()
+    digest.update(_HASH_DOMAIN)
+    total_bytes = 0
+    for record in records:
+        relative = record.relative_path.as_posix()
+        if "\n" in relative or "\0" in relative:
+            raise ArtifactBundleError(f"unsupported source filename: {relative!r}")
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(record.size).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(record.sha256.encode("ascii"))
+        digest.update(b"\0")
+        total_bytes += record.size
+    return SelectionIdentity(
+        files=len(records), bytes=total_bytes, sha256=digest.hexdigest()
+    )
+
+
+def write_checksums(root: Path | str) -> dict[str, str]:
+    """Write a complete SHA-256 inventory for regular files below ``root``."""
+
+    root_path = Path(root).resolve(strict=True)
+    checksum_path = root_path / CHECKSUM_FILE
+    if checksum_path.exists():
+        raise ArtifactBundleError(f"checksum file already exists: {checksum_path}")
+    checksums = {}
+    for path in _bundle_files(root_path, exclude_checksum=True):
+        relative = path.relative_to(root_path).as_posix()
+        checksums[relative] = sha256_file(path)
+    checksum_path.write_text(
+        "".join(f"{digest}  {relative}\n" for relative, digest in checksums.items()),
+        encoding="utf-8",
+    )
+    return checksums
+
+
+def verify_bundle(root: Path | str) -> dict[str, Any]:
+    """Verify all files in a bundle, rejecting missing and unlisted payloads."""
+
+    root_path = Path(root).expanduser().resolve(strict=True)
+    checksum_path = root_path / CHECKSUM_FILE
+    if not checksum_path.is_file():
+        raise ArtifactIntegrityError(f"missing {CHECKSUM_FILE} in {root_path}")
+    expected = _read_checksums(checksum_path)
+    actual_paths = {
+        path.relative_to(root_path).as_posix(): path
+        for path in _bundle_files(root_path, exclude_checksum=True)
+    }
+    if set(expected) != set(actual_paths):
+        missing = sorted(set(expected) - set(actual_paths))
+        extra = sorted(set(actual_paths) - set(expected))
+        raise ArtifactIntegrityError(
+            f"bundle inventory differs; missing={missing}, unlisted={extra}"
+        )
+    total_bytes = 0
+    for relative, path in actual_paths.items():
+        if sha256_file(path) != expected[relative]:
+            raise ArtifactIntegrityError(f"checksum mismatch: {relative}")
+        total_bytes += path.stat().st_size
+    return {"files": len(actual_paths), "bytes": total_bytes}
+
+
+def create_archive(root: Path | str, output: Path | str) -> dict[str, Any]:
+    """Create a deterministic ``.tar.gz`` archive from a verified bundle."""
+
+    root_path = Path(root).expanduser().resolve(strict=True)
+    verification = verify_bundle(root_path)
+    output_path = Path(output).expanduser().absolute()
+    if output_path.suffixes[-2:] != [".tar", ".gz"]:
+        raise ArtifactBundleError("archive output must end in .tar.gz")
+    sidecar = Path(f"{output_path}.sha256")
+    if output_path.exists() or sidecar.exists():
+        raise ArtifactBundleError(f"archive output already exists: {output_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output_path.parent / f".{output_path.name}.tmp-{uuid.uuid4().hex}"
+    try:
+        with temporary.open("wb") as raw:
+            with gzip.GzipFile(
+                filename="", mode="wb", compresslevel=9, fileobj=raw, mtime=0
+            ) as compressed:
+                with tarfile.open(
+                    fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT
+                ) as archive:
+                    _add_archive_tree(archive, root_path)
+        os.replace(temporary, output_path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    digest = sha256_file(output_path)
+    sidecar.write_text(f"{digest}  {output_path.name}\n", encoding="utf-8")
+    return {
+        "archive": str(output_path),
+        "sha256": digest,
+        "bytes": output_path.stat().st_size,
+        "bundle_files": verification["files"],
+    }
+
+
+def sha256_file(path: Path) -> str:
+    """Hash a regular file without loading it into memory."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _file_record(path: Path, relative: PurePosixPath) -> FileRecord:
+    stat = path.stat()
+    return FileRecord(
+        source=path,
+        relative_path=relative,
+        size=stat.st_size,
+        sha256=sha256_file(path),
+    )
+
+
+def _matches(path: PurePosixPath, patterns: Sequence[str]) -> bool:
+    value = path.as_posix()
+    return any(
+        fnmatch.fnmatchcase(value, pattern)
+        or ("/" not in pattern and fnmatch.fnmatchcase(path.name, pattern))
+        for pattern in patterns
+    )
+
+
+def _included(
+    path: PurePosixPath, include: Sequence[str], exclude: Sequence[str]
+) -> bool:
+    return _matches(path, include) and not _matches(path, exclude)
+
+
+def _bundle_files(root: Path, *, exclude_checksum: bool) -> list[Path]:
+    files = []
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise ArtifactIntegrityError(f"bundle contains symbolic link: {relative}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise ArtifactIntegrityError(
+                f"bundle contains non-regular file: {relative}"
+            )
+        if exclude_checksum and relative == CHECKSUM_FILE:
+            continue
+        if "\n" in relative:
+            raise ArtifactIntegrityError(f"unsupported bundle filename: {relative!r}")
+        files.append(path)
+    return files
+
+
+def _read_checksums(path: Path) -> dict[str, str]:
+    checksums = {}
+    for line_number, raw_line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not raw_line:
+            continue
+        try:
+            digest, relative = raw_line.split("  ", 1)
+        except ValueError as exc:
+            raise ArtifactIntegrityError(
+                f"invalid checksum line {line_number}"
+            ) from exc
+        if not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ArtifactIntegrityError(f"invalid checksum on line {line_number}")
+        relative_path = PurePosixPath(relative)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ArtifactIntegrityError(
+                f"checksum path must stay relative: {relative!r}"
+            )
+        relative = relative_path.as_posix()
+        if relative in checksums:
+            raise ArtifactIntegrityError(f"duplicate checksum path: {relative}")
+        if relative == CHECKSUM_FILE:
+            raise ArtifactIntegrityError(f"{CHECKSUM_FILE} cannot checksum itself")
+        checksums[relative] = digest
+    if not checksums:
+        raise ArtifactIntegrityError("checksum inventory is empty")
+    return checksums
+
+
+def _add_archive_tree(archive: tarfile.TarFile, root: Path) -> None:
+    paths = [root, *sorted(root.rglob("*"), key=lambda item: item.as_posix())]
+    for path in paths:
+        if path.is_symlink():
+            raise ArtifactIntegrityError(f"cannot archive symbolic link: {path}")
+        arcname = root.name
+        if path != root:
+            arcname = f"{root.name}/{path.relative_to(root).as_posix()}"
+        info = archive.gettarinfo(str(path), arcname=arcname)
+        info.uid = 0
+        info.gid = 0
+        info.uname = ""
+        info.gname = ""
+        info.mtime = 0
+        info.pax_headers = {}
+        if path.is_dir():
+            archive.addfile(info)
+        elif path.is_file():
+            with path.open("rb") as handle:
+                archive.addfile(info, handle)
+        else:
+            raise ArtifactIntegrityError(f"cannot archive non-regular path: {path}")

--- a/codeminer/eval/artifact_manifest.py
+++ b/codeminer/eval/artifact_manifest.py
@@ -1,0 +1,236 @@
+"""Schema and validation for content-locked evaluation bundle manifests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping, Sequence
+
+MANIFEST_SCHEMA_VERSION = 1
+LOCK_SCHEMA_VERSION = 1
+PROVENANCE_SCHEMA_VERSION = 1
+CHECKSUM_FILE = "SHA256SUMS"
+MANIFEST_FILE = "BUNDLE_MANIFEST.json"
+LOCK_FILE = "SOURCE_LOCK.json"
+PROVENANCE_FILE = "PROVENANCE.json"
+_RESERVED_PATHS = frozenset({CHECKSUM_FILE, MANIFEST_FILE, LOCK_FILE, PROVENANCE_FILE})
+_ROOT_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
+
+
+class ArtifactBundleError(ValueError):
+    """Raised when a bundle manifest, source, or payload is invalid."""
+
+
+class ArtifactIntegrityError(ArtifactBundleError):
+    """Raised when content does not match its lock or checksum manifest."""
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    """One selected source tree and its destination inside a bundle."""
+
+    source_id: str
+    root: str
+    path: PurePosixPath
+    destination: PurePosixPath
+    include: tuple[str, ...] = ("**",)
+    exclude: tuple[str, ...] = ()
+    exclude_dir_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BundleManifest:
+    """Validated artifact bundle manifest."""
+
+    path: Path
+    raw: bytes
+    name: str
+    version: str
+    sources: tuple[SourceSpec, ...]
+
+    @property
+    def sha256(self) -> str:
+        return hashlib.sha256(self.raw).hexdigest()
+
+
+def load_manifest(path: Path | str) -> BundleManifest:
+    """Load and validate a JSON bundle manifest."""
+
+    manifest_path = Path(path).expanduser().resolve(strict=True)
+    raw = manifest_path.read_bytes()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ArtifactBundleError(f"invalid JSON manifest: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise ArtifactBundleError("bundle manifest must be a JSON object")
+    if payload.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise ArtifactBundleError(
+            f"unsupported bundle manifest schema: {payload.get('schema_version')!r}"
+        )
+
+    bundle = payload.get("bundle")
+    if not isinstance(bundle, Mapping):
+        raise ArtifactBundleError("bundle manifest requires a 'bundle' object")
+    name = _required_string(bundle, "name", context="bundle")
+    version = _required_string(bundle, "version", context="bundle")
+
+    raw_sources = payload.get("sources")
+    if not isinstance(raw_sources, list) or not raw_sources:
+        raise ArtifactBundleError("bundle manifest requires a non-empty source list")
+    sources = tuple(
+        _parse_source(item, index) for index, item in enumerate(raw_sources)
+    )
+    _validate_source_set(sources)
+    return BundleManifest(
+        path=manifest_path,
+        raw=raw,
+        name=name,
+        version=version,
+        sources=sources,
+    )
+
+
+def load_source_lock(path: Path | str, manifest: BundleManifest) -> Mapping[str, Any]:
+    """Load a source lock and ensure it belongs to the supplied manifest."""
+
+    lock_path = Path(path).expanduser().resolve(strict=True)
+    try:
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ArtifactBundleError(f"invalid JSON source lock: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise ArtifactBundleError("source lock must be a JSON object")
+    if payload.get("schema_version") != LOCK_SCHEMA_VERSION:
+        raise ArtifactBundleError(
+            f"unsupported source lock schema: {payload.get('schema_version')!r}"
+        )
+    if payload.get("manifest_sha256") != manifest.sha256:
+        raise ArtifactIntegrityError("source lock does not match the bundle manifest")
+    sources = payload.get("sources")
+    if not isinstance(sources, Mapping):
+        raise ArtifactBundleError("source lock requires a 'sources' object")
+    expected_ids = {spec.source_id for spec in manifest.sources}
+    locked_ids = set(sources)
+    if locked_ids != expected_ids:
+        missing = sorted(expected_ids - locked_ids)
+        extra = sorted(locked_ids - expected_ids)
+        raise ArtifactIntegrityError(
+            f"source lock IDs differ; missing={missing}, extra={extra}"
+        )
+    return payload
+
+
+def parse_root_arguments(values: Iterable[str]) -> dict[str, Path]:
+    """Parse repeated ``NAME=PATH`` command-line root bindings."""
+
+    roots = {}
+    for value in values:
+        if "=" not in value:
+            raise ArtifactBundleError(f"invalid --root {value!r}; expected NAME=/path")
+        name, raw_path = value.split("=", 1)
+        if not _ROOT_NAME.fullmatch(name) or not raw_path:
+            raise ArtifactBundleError(f"invalid --root {value!r}; expected NAME=/path")
+        if name in roots:
+            raise ArtifactBundleError(f"duplicate --root name: {name}")
+        roots[name] = Path(raw_path)
+    return roots
+
+
+def _parse_source(payload: Any, index: int) -> SourceSpec:
+    if not isinstance(payload, Mapping):
+        raise ArtifactBundleError(f"source {index} must be a JSON object")
+    context = f"source {index}"
+    source_id = _required_string(payload, "id", context=context)
+    root = _required_string(payload, "root", context=context)
+    if not _ROOT_NAME.fullmatch(root):
+        raise ArtifactBundleError(f"{context} has invalid root name {root!r}")
+    path = _relative_path(_required_string(payload, "path", context=context), "path")
+    destination = _relative_path(
+        _required_string(payload, "destination", context=context), "destination"
+    )
+    if destination == PurePosixPath("."):
+        raise ArtifactBundleError(f"{context} destination cannot be the bundle root")
+    return SourceSpec(
+        source_id=source_id,
+        root=root,
+        path=path,
+        destination=destination,
+        include=_patterns(payload.get("include", ["**"]), "include", context),
+        exclude=_patterns(payload.get("exclude", []), "exclude", context),
+        exclude_dir_names=_directory_names(
+            payload.get("exclude_dir_names", []), context
+        ),
+    )
+
+
+def _validate_source_set(sources: Sequence[SourceSpec]) -> None:
+    ids = [source.source_id for source in sources]
+    duplicates = sorted({source_id for source_id in ids if ids.count(source_id) > 1})
+    if duplicates:
+        raise ArtifactBundleError(f"duplicate source IDs: {duplicates}")
+    destinations = []
+    for source in sources:
+        destination = source.destination
+        if destination.parts[0] in _RESERVED_PATHS:
+            raise ArtifactBundleError(
+                f"source {source.source_id!r} uses reserved destination {destination}"
+            )
+        for other_id, other in destinations:
+            if _path_contains(destination, other) or _path_contains(other, destination):
+                raise ArtifactBundleError(
+                    "overlapping bundle destinations: "
+                    f"{other_id!r}={other} and {source.source_id!r}={destination}"
+                )
+        destinations.append((source.source_id, destination))
+
+
+def _required_string(payload: Mapping[str, Any], key: str, *, context: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ArtifactBundleError(f"{context} requires non-empty string {key!r}")
+    return value.strip()
+
+
+def _relative_path(value: str, field: str) -> PurePosixPath:
+    if "\\" in value:
+        raise ArtifactBundleError(f"{field} must use POSIX separators: {value!r}")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise ArtifactBundleError(f"{field} must stay relative: {value!r}")
+    return path if path.parts else PurePosixPath(".")
+
+
+def _patterns(value: Any, field: str, context: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise ArtifactBundleError(f"{context} {field} must be a string list")
+    for pattern in value:
+        if pattern.startswith("/") or ".." in PurePosixPath(pattern).parts:
+            raise ArtifactBundleError(
+                f"{context} {field} pattern must stay relative: {pattern!r}"
+            )
+    return tuple(value)
+
+
+def _directory_names(value: Any, context: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str)
+        and item
+        and "/" not in item
+        and "\\" not in item
+        and item not in {".", ".."}
+        for item in value
+    ):
+        raise ArtifactBundleError(
+            f"{context} exclude_dir_names must contain plain directory names"
+        )
+    return tuple(value)
+
+
+def _path_contains(parent: PurePosixPath, child: PurePosixPath) -> bool:
+    return parent == child or parent in child.parents

--- a/docs/evaluation_artifacts.md
+++ b/docs/evaluation_artifacts.md
@@ -1,0 +1,93 @@
+# Evaluation Artifact Bundles
+
+`codeminer-artifact-bundle` stages content-locked evaluation releases from
+explicit local sources. It is intended for retained experiment records that
+are too large or too environment-specific to keep in Git.
+
+The bundle manifest contains only named roots and relative paths. Machine paths
+are supplied at runtime with repeated `--root NAME=PATH` arguments. This keeps
+storage layout out of the release contract while making the selected files
+reviewable.
+
+## Manifest
+
+```json
+{
+  "schema_version": 1,
+  "bundle": {
+    "name": "example evaluation",
+    "version": "v1"
+  },
+  "sources": [
+    {
+      "id": "reports",
+      "root": "results",
+      "path": "batch-v1",
+      "destination": "inputs/reports",
+      "include": ["*.json", "*.log"],
+      "exclude": ["debug-*.log"],
+      "exclude_dir_names": ["cache", "__pycache__"]
+    },
+    {
+      "id": "readme",
+      "root": "release",
+      "path": "README.md",
+      "destination": "README.md"
+    }
+  ]
+}
+```
+
+A directory source preserves paths below `destination`. A file source is copied
+to the exact destination path. The builder rejects absolute paths, `..`,
+overlapping destinations, symbolic links, non-regular files, empty selections,
+and outputs nested inside selected sources.
+
+## Freeze Inputs
+
+Create a source lock after the experiment inputs are final:
+
+```bash
+codeminer-artifact-bundle lock \
+  --manifest bundle-manifest.json \
+  --root results=/path/to/results \
+  --root release=/path/to/release-files \
+  --output source-lock.json
+```
+
+The lock stores a path-sensitive SHA-256 identity plus file and byte counts for
+every source. Commit the manifest and reviewed lock, not the bound local paths.
+Any later input change causes a locked build to fail.
+
+## Build And Verify
+
+```bash
+codeminer-artifact-bundle build \
+  --manifest bundle-manifest.json \
+  --source-lock source-lock.json \
+  --root results=/path/to/results \
+  --root release=/path/to/release-files \
+  --output /path/to/staged-bundle
+
+codeminer-artifact-bundle verify --bundle /path/to/staged-bundle
+```
+
+The builder writes to a temporary sibling, copies each selected file while
+checking for concurrent changes, generates `BUNDLE_MANIFEST.json`,
+`SOURCE_LOCK.json`, `PROVENANCE.json`, and a complete `SHA256SUMS`, verifies the
+payload, then atomically renames it into place. Verification rejects both
+missing files and unlisted additions.
+
+Create a portable, deterministic archive only after all release-specific
+checks pass:
+
+```bash
+codeminer-artifact-bundle archive \
+  --bundle /path/to/staged-bundle \
+  --output /path/to/staged-bundle.tar.gz
+```
+
+The archive normalizes timestamps and ownership, uses a single top-level
+directory, and writes a sibling `.sha256` file. Generated analyses should be
+written outside the staged bundle unless they were selected by the manifest;
+otherwise the complete-inventory verifier will reject the modified copy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - GT Locator: gt_locator.md
   - Operations:
       - CI/CD: ci_cd.md
+      - Evaluation Artifact Bundles: evaluation_artifacts.md
       - SCIP Multi-Language Roadmap: scip_multilanguage_roadmap.md
   - Experiments:
       - Agent Compile Sweep: experiments/agent_compile.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ codeminer-lsp-provider-protocol-check = "codeminer.eval.agent_runner.lsp_agent_a
 codeminer-lsp-agent-study-manifest = "codeminer.eval.agent_runner.lsp_agent_study_manifest:main"
 codeminer-lsp-agent-study-artifacts = "codeminer.eval.agent_runner.lsp_agent_study_artifacts:main"
 codeminer-lsp-agent-study-run = "codeminer.eval.agent_runner.lsp_agent_study_runner:main"
+codeminer-artifact-bundle = "codeminer.eval.artifact_bundle:main"
 
 [project.optional-dependencies]
 dev = [

--- a/test/eval/test_artifact_bundle.py
+++ b/test/eval/test_artifact_bundle.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from codeminer.eval.artifact_bundle import (
+    ArtifactBundleError,
+    ArtifactIntegrityError,
+    build_bundle,
+    create_archive,
+    load_manifest,
+    verify_bundle,
+    write_source_lock,
+)
+
+
+def _write_manifest(path: Path, sources: list[dict[str, object]]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "bundle": {"name": "test bundle", "version": "v1"},
+                "sources": sources,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _source(
+    source_id: str,
+    path: str,
+    destination: str,
+    **extra: object,
+) -> dict[str, object]:
+    return {
+        "id": source_id,
+        "root": "data",
+        "path": path,
+        "destination": destination,
+        **extra,
+    }
+
+
+def test_build_bundle_applies_selection_and_verifies_complete_inventory(
+    tmp_path: Path,
+) -> None:
+    data = tmp_path / "data"
+    selected = data / "results"
+    selected.mkdir(parents=True)
+    (selected / "keep.json").write_text('{"ok": true}\n', encoding="utf-8")
+    (selected / "skip.log").write_text("skip\n", encoding="utf-8")
+    cache = selected / "cache"
+    cache.mkdir()
+    (cache / "large.bin").write_bytes(b"not bundled")
+    readme = data / "README.md"
+    readme.write_text("artifact\n", encoding="utf-8")
+
+    manifest = load_manifest(
+        _write_manifest(
+            tmp_path / "manifest.json",
+            [
+                _source(
+                    "results",
+                    "results",
+                    "inputs/results",
+                    include=["*.json"],
+                    exclude_dir_names=["cache"],
+                ),
+                _source("readme", "README.md", "README.md"),
+            ],
+        )
+    )
+    lock_path = tmp_path / "source-lock.json"
+    lock = write_source_lock(manifest, {"data": data}, lock_path)
+    output = tmp_path / "bundle"
+
+    result = build_bundle(manifest, {"data": data}, output, source_lock=lock_path)
+
+    assert lock["sources"]["results"]["files"] == 1
+    assert (output / "inputs/results/keep.json").is_file()
+    assert not (output / "inputs/results/skip.log").exists()
+    assert not (output / "inputs/results/cache").exists()
+    assert (output / "README.md").read_text(encoding="utf-8") == "artifact\n"
+    assert result["files"] == verify_bundle(output)["files"]
+    provenance = json.loads((output / "PROVENANCE.json").read_text())
+    commit = provenance["roots"]["data"].get("git_commit")
+    assert commit is None or "/" not in commit
+    assert "tmp" not in json.dumps(provenance)
+
+
+def test_source_lock_rejects_changed_content(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    source = data / "result.json"
+    source.write_text('{"value": 1}\n', encoding="utf-8")
+    manifest = load_manifest(
+        _write_manifest(
+            tmp_path / "manifest.json",
+            [_source("result", "result.json", "inputs/result.json")],
+        )
+    )
+    lock_path = tmp_path / "source-lock.json"
+    write_source_lock(manifest, {"data": data}, lock_path)
+    source.write_text('{"value": 2}\n', encoding="utf-8")
+
+    with pytest.raises(ArtifactIntegrityError, match="differs from lock"):
+        build_bundle(
+            manifest,
+            {"data": data},
+            tmp_path / "bundle",
+            source_lock=lock_path,
+        )
+
+
+def test_verify_bundle_rejects_mutated_and_unlisted_files(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "result.json").write_text("{}\n", encoding="utf-8")
+    manifest = load_manifest(
+        _write_manifest(
+            tmp_path / "manifest.json",
+            [_source("result", "result.json", "result.json")],
+        )
+    )
+    output = tmp_path / "bundle"
+    build_bundle(manifest, {"data": data}, output)
+    (output / "result.json").write_text('{"changed": true}\n', encoding="utf-8")
+    with pytest.raises(ArtifactIntegrityError, match="checksum mismatch"):
+        verify_bundle(output)
+
+    (output / "result.json").write_text("{}\n", encoding="utf-8")
+    (output / "extra.txt").write_text("extra\n", encoding="utf-8")
+    with pytest.raises(ArtifactIntegrityError, match="unlisted"):
+        verify_bundle(output)
+
+
+def test_manifest_rejects_unsafe_and_overlapping_destinations(tmp_path: Path) -> None:
+    unsafe = _write_manifest(
+        tmp_path / "unsafe.json",
+        [_source("unsafe", "../outside", "input")],
+    )
+    with pytest.raises(ArtifactBundleError, match="stay relative"):
+        load_manifest(unsafe)
+
+    overlapping = _write_manifest(
+        tmp_path / "overlap.json",
+        [
+            _source("parent", "a", "inputs"),
+            _source("child", "b", "inputs/child"),
+        ],
+    )
+    with pytest.raises(ArtifactBundleError, match="overlapping"):
+        load_manifest(overlapping)
+
+
+def test_build_rejects_symbolic_links_and_existing_output(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    tree = data / "tree"
+    tree.mkdir(parents=True)
+    target = data / "target.txt"
+    target.write_text("target\n", encoding="utf-8")
+    (tree / "link.txt").symlink_to(target)
+    manifest = load_manifest(
+        _write_manifest(
+            tmp_path / "manifest.json",
+            [_source("tree", "tree", "tree")],
+        )
+    )
+    with pytest.raises(ArtifactBundleError, match="symbolic link"):
+        build_bundle(manifest, {"data": data}, tmp_path / "bundle")
+
+    output = tmp_path / "existing"
+    output.mkdir()
+    with pytest.raises(ArtifactBundleError, match="already exists"):
+        build_bundle(manifest, {"data": data}, output)
+
+
+def test_build_rejects_top_level_source_symlink(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    real = data / "real"
+    real.mkdir(parents=True)
+    (real / "result.json").write_text("{}\n", encoding="utf-8")
+    (data / "linked").symlink_to(real, target_is_directory=True)
+    manifest = load_manifest(
+        _write_manifest(
+            tmp_path / "manifest.json",
+            [_source("linked", "linked", "inputs/linked")],
+        )
+    )
+
+    with pytest.raises(ArtifactBundleError, match="traverses symbolic link"):
+        build_bundle(manifest, {"data": data}, tmp_path / "bundle")
+
+
+def test_archive_is_deterministic_and_contains_one_bundle_root(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "result.json").write_text("{}\n", encoding="utf-8")
+    manifest = load_manifest(
+        _write_manifest(
+            tmp_path / "manifest.json",
+            [_source("result", "result.json", "result.json")],
+        )
+    )
+    output = tmp_path / "bundle"
+    build_bundle(manifest, {"data": data}, output)
+    first = create_archive(output, tmp_path / "first.tar.gz")
+    second = create_archive(output, tmp_path / "second.tar.gz")
+
+    assert first["sha256"] == second["sha256"]
+    with tarfile.open(tmp_path / "first.tar.gz", "r:gz") as archive:
+        names = archive.getnames()
+    assert names[0] == "bundle"
+    assert "bundle/result.json" in names

--- a/test/eval/test_artifact_bundle.py
+++ b/test/eval/test_artifact_bundle.py
@@ -212,6 +212,8 @@ def test_archive_is_deterministic_and_contains_one_bundle_root(tmp_path: Path) -
     output = tmp_path / "bundle"
     build_bundle(manifest, {"data": data}, output)
     first = create_archive(output, tmp_path / "first.tar.gz")
+    output.chmod(0o700)
+    (output / "result.json").chmod(0o600)
     second = create_archive(output, tmp_path / "second.tar.gz")
 
     assert first["sha256"] == second["sha256"]


### PR DESCRIPTION
## Summary
Add a reusable, machine-path-independent release pipeline for retained evaluation artifacts. The PR intentionally contains no paper-specific datasets, model revisions, plotting programs, or release inventory.

## Changes
- Add a validated manifest schema with named runtime roots and explicit source selections.
- Add reviewable content locks using path-sensitive SHA-256 identities and file/byte counts.
- Add atomic staging, concurrent-source-change checks, complete checksum inventories, and strict verification of unlisted files.
- Add deterministic `.tar.gz` archives with normalized metadata and checksum sidecars.
- Add a CLI, project documentation, and focused unit coverage for integrity and path-safety boundaries.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/eval/test_artifact_bundle.py --tb=short` (7 passed)

`python -m flake8 codeminer/eval/artifact_manifest.py codeminer/eval/artifact_integrity.py codeminer/eval/artifact_bundle.py test/eval/test_artifact_bundle.py`

`mkdocs build --strict`

Pre-commit hooks passed on both commits.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published