### PR TITLE
fix(compiler): enforce durable artifact contracts

### DIFF
--- a/codeminer/compiler/index_builders.py
+++ b/codeminer/compiler/index_builders.py
@@ -34,6 +34,7 @@ class IndexBuilder(Protocol):
     """Protocol for index build tools the compiler can invoke."""
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus: ...
+
     def incremental_update(self, scope: str, **kwargs: Any) -> IndexStatus: ...
 
 
@@ -115,6 +116,17 @@ class VectorIndexBuilder:
     build_levels: List[str] = field(default_factory=lambda: ["l0", "l2"])
     max_lines_per_chunk: int = 300
     index_metric: str = "ip"
+
+    def _artifact_identity(self) -> Dict[str, Any]:
+        """Return the embedding contract required to reopen this artifact."""
+        return {
+            "embedding_model": self.embedding_model,
+            "embedding_provider": self.embedding_provider,
+            "embedding_dimension": self.embedding_dimension,
+            "dimension": self.embedding_dimension,
+            "embedding_kwargs": dict(self.embedding_kwargs),
+            "index_metric": self.index_metric,
+        }
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
@@ -233,7 +245,7 @@ class VectorIndexBuilder:
             scope=scope,
             path=output_dir,
             metadata={
-                "embedding_model": self.embedding_model,
+                **self._artifact_identity(),
                 "levels": list(self.build_levels),
                 "document_count": doc_count,
                 "last_commit": head_commit,
@@ -381,7 +393,7 @@ class VectorIndexBuilder:
             scope=scope,
             path=output_dir,
             metadata={
-                "embedding_model": self.embedding_model,
+                **self._artifact_identity(),
                 "levels": list(self.build_levels),
                 "document_count": doc_count,
                 "chunks_reembedded": result.chunks_reembedded,
@@ -489,9 +501,11 @@ class SymbolGraphBuilder:
             graph_route=self.graph_route,
         )
 
-        node_count = 0
-        if graph is not None and hasattr(graph, "graph"):
-            node_count = len(graph.graph.vs)
+        if graph is None or not hasattr(graph, "graph"):
+            raise RuntimeError("symbol graph builder returned no graph")
+        node_count = len(graph.graph.vs)
+        if node_count == 0:
+            raise RuntimeError("symbol graph builder returned an empty graph")
 
         return IndexStatus(
             index_type="symbol_graph",
@@ -523,8 +537,11 @@ def register_default_builders(
     languages: Optional[List[str]] = None,
     graph_route: str = "active",
     embedding_model: str = "nomic-ai/CodeRankEmbed",
+    embedding_revision: Optional[str] = None,
     embedding_dimension: int = 768,
     trust_remote_code: bool = False,
+    embedding_batch_size: Optional[int] = None,
+    embedding_max_seq_length: Optional[int] = None,
 ) -> None:
     """Register all standard index builders with sensible defaults."""
     langs = languages or ["python"]
@@ -534,6 +551,12 @@ def register_default_builders(
     embedding_kwargs = {}
     if trust_remote_code:
         embedding_kwargs = {"model_kwargs": {"trust_remote_code": True}}
+    if embedding_batch_size is not None:
+        embedding_kwargs["encode_kwargs"] = {"batch_size": embedding_batch_size}
+    if embedding_max_seq_length is not None:
+        embedding_kwargs["max_seq_length"] = embedding_max_seq_length
+    if embedding_revision is not None:
+        embedding_kwargs["revision"] = embedding_revision
 
     registry.register(
         "vector",

--- a/codeminer/compiler/skill_context.py
+++ b/codeminer/compiler/skill_context.py
@@ -290,21 +290,28 @@ def _load_vector(
     index_path: str,
     *,
     embedding_model: str,
+    embedding_provider: str,
     embedding_dimension: int,
+    embedding_revision: Optional[str] = None,
+    index_metric: str = "ip",
+    embedding_kwargs: Optional[Dict[str, Any]] = None,
     trust_remote_code: bool = False,
     default_batch_size: Optional[int] = None,
 ):
     """Load a FAISS vector store from an arbitrary directory path."""
     from ..index.embedding.vector_store import CodeVectorStore
 
-    kwargs = {}
+    kwargs = dict(embedding_kwargs or {})
+    if embedding_revision is not None:
+        kwargs["revision"] = embedding_revision
     if default_batch_size is not None:
         kwargs["default_batch_size"] = default_batch_size
 
     store = CodeVectorStore(
         embedding_model=embedding_model,
-        embedding_provider="huggingface",
+        embedding_provider=embedding_provider,
         dimension=embedding_dimension,
+        index_metric=index_metric,
         trust_remote_code=trust_remote_code,
         **kwargs,
     )
@@ -353,12 +360,14 @@ def build_skill_contexts(
     skill_registry: Optional[SkillRegistry] = None,
     builder_registry: Optional[IndexBuilderRegistry] = None,
     embedding_model: str = "nomic-ai/CodeRankEmbed",
+    embedding_revision: Optional[str] = None,
     embedding_dimension: int = 768,
     default_top_k: int = 10,
     default_level: str = "l2",
     rebuild: bool = False,
     trust_remote_code: bool = False,
     embedding_batch_size: Optional[int] = None,
+    embedding_max_seq_length: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Build the union of indexes required by *skill_ids* and package them.
 
@@ -414,8 +423,11 @@ def build_skill_contexts(
                     registry,
                     languages=list(languages),
                     embedding_model=embedding_model,
+                    embedding_revision=embedding_revision,
                     embedding_dimension=embedding_dimension,
                     trust_remote_code=trust_remote_code,
+                    embedding_batch_size=embedding_batch_size,
+                    embedding_max_seq_length=embedding_max_seq_length,
                 )
             logger.info("Building missing indexes %s under %s", missing, cache_dir)
             _run_compiler(
@@ -440,7 +452,14 @@ def build_skill_contexts(
         loaded["vector"] = _load_vector(
             _index_dir(cache_dir, "vector"),
             embedding_model=embedding_model,
+            embedding_provider="huggingface",
             embedding_dimension=embedding_dimension,
+            embedding_revision=embedding_revision,
+            embedding_kwargs=(
+                {"max_seq_length": embedding_max_seq_length}
+                if embedding_max_seq_length is not None
+                else None
+            ),
             trust_remote_code=trust_remote_code,
             default_batch_size=embedding_batch_size,
         )
@@ -532,12 +551,28 @@ def load_contexts_from_manifest(
         vec_entry = manifest.indexes["vector"]
         # Prefer the embedding config that was used at build time so the
         # load uses a compatible tokenizer/dimension.
-        emb_model = vec_entry.config.get("embedding_model", "nomic-ai/CodeRankEmbed")
-        emb_dim = vec_entry.config.get("embedding_dimension", 768)
+        emb_model = vec_entry.config.get("embedding_model")
+        emb_provider = vec_entry.config.get("embedding_provider")
+        emb_dim = vec_entry.config.get(
+            "dimension", vec_entry.config.get("embedding_dimension")
+        )
+        embedding_kwargs = vec_entry.config.get("embedding_kwargs") or {}
+        if not isinstance(embedding_kwargs, dict):
+            raise ValueError("vector manifest has invalid embedding kwargs")
+        if (
+            not emb_model
+            or not emb_provider
+            or not isinstance(emb_dim, int)
+            or emb_dim <= 0
+        ):
+            raise ValueError("vector manifest has incomplete embedding identity")
         loaded["vector"] = _load_vector(
             vec_entry.path,
             embedding_model=emb_model,
+            embedding_provider=emb_provider,
             embedding_dimension=emb_dim,
+            index_metric=vec_entry.config.get("index_metric", "ip"),
+            embedding_kwargs=embedding_kwargs,
         )
     if "symbol_graph" in needed:
         loaded["symbol_graph"] = _load_symbol_graph(

--- a/codeminer/mcp/context.py
+++ b/codeminer/mcp/context.py
@@ -146,14 +146,28 @@ class ServerContext:
 
         try:
             cfg = entry.config
+            embedding_model = cfg.get("embedding_model")
+            embedding_provider = cfg.get("embedding_provider")
+            dimension = cfg.get("dimension", cfg.get("embedding_dimension"))
+            embedding_kwargs = cfg.get("embedding_kwargs") or {}
+            if not isinstance(embedding_kwargs, dict):
+                raise ValueError("vector manifest has invalid embedding kwargs")
+            if (
+                not embedding_model
+                or not embedding_provider
+                or not isinstance(dimension, int)
+                or dimension <= 0
+            ):
+                raise ValueError("vector manifest has incomplete embedding identity")
 
             # Create CodeVectorStore with embedding model from manifest
             self.vector = CodeVectorStore(
-                embedding_model=cfg["embedding_model"],
-                embedding_provider=cfg["embedding_provider"],
-                dimension=cfg.get("dimension"),
+                embedding_model=embedding_model,
+                embedding_provider=embedding_provider,
+                dimension=dimension,
                 index_metric=cfg.get("index_metric", "ip"),
                 store_path=entry.path,
+                **embedding_kwargs,
             )
 
             # Load FAISS index from disk
@@ -161,7 +175,7 @@ class ServerContext:
 
             # Validate model consistency
             loaded_model = self.vector.embedding_model
-            manifest_model = cfg["embedding_model"]
+            manifest_model = embedding_model
             if loaded_model != manifest_model:
                 raise RuntimeError(
                     f"Embedding model mismatch: manifest specifies "
@@ -174,7 +188,7 @@ class ServerContext:
                 "Loaded vector index from %s (%d docs, model=%s)",
                 entry.path,
                 stats["total_documents"],
-                cfg["embedding_model"],
+                embedding_model,
             )
         except Exception as exc:
             self.vector = None

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -11,6 +11,8 @@ import os
 import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from codeminer.compiler.index_builders import (
     BM25IndexBuilder,
     IndexBuilderRegistry,
@@ -149,8 +151,30 @@ class TestVectorIndexBuilder:
         assert status.index_type == "vector"
         assert status.state == IndexState.FRESH
         assert status.metadata["embedding_model"] == "test-model"
+        assert status.metadata["embedding_provider"] == "huggingface"
+        assert status.metadata["embedding_dimension"] == 384
+        assert status.metadata["dimension"] == 384
+        assert status.metadata["embedding_kwargs"] == {}
+        assert status.metadata["index_metric"] == "ip"
         assert status.metadata["document_count"] == {"l0": 2, "l2": 3}
         mock_build_fn.assert_called_once()
+
+    def test_artifact_identity_is_shared_by_full_and_incremental_statuses(self):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+            embedding_kwargs={"revision": "model-commit"},
+            index_metric="l2",
+        )
+
+        assert builder._artifact_identity() == {
+            "embedding_model": "test-model",
+            "embedding_provider": "huggingface",
+            "embedding_dimension": 384,
+            "dimension": 384,
+            "embedding_kwargs": {"revision": "model-commit"},
+            "index_metric": "l2",
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +225,7 @@ class TestSymbolGraphBuilder:
             )
         ]
 
-    def test_build_handles_none_graph(self, monkeypatch, tmp_path):
+    def test_build_rejects_none_graph(self, monkeypatch, tmp_path):
         from codeminer import ls_router
 
         monkeypatch.setattr(
@@ -212,19 +236,18 @@ class TestSymbolGraphBuilder:
 
         builder = SymbolGraphBuilder()
         output = str(tmp_path / "graph")
-        status = builder.build(
-            scope="current_repo",
-            repo_path="/fake/repo",
-            output_dir=output,
-        )
-
-        assert status.metadata["node_count"] == 0
+        with pytest.raises(RuntimeError, match="returned no graph"):
+            builder.build(
+                scope="current_repo",
+                repo_path="/fake/repo",
+                output_dir=output,
+            )
 
     def test_build_forwards_multiple_languages(self, monkeypatch, tmp_path):
         from codeminer import ls_router
 
         mock_graph = MagicMock()
-        mock_graph.graph.vs = []
+        mock_graph.graph.vs = [MagicMock()]
         calls = []
 
         def fake_build_graph_for_languages(*args, **kwargs):
@@ -254,7 +277,7 @@ class TestSymbolGraphBuilder:
         from codeminer import ls_router
 
         mock_graph = MagicMock()
-        mock_graph.graph.vs = []
+        mock_graph.graph.vs = [MagicMock()]
         calls = []
 
         def fake_build_graph_for_languages(*args, **kwargs):
@@ -301,7 +324,10 @@ class TestRegisterDefaultBuilders:
             languages=["rust", "python"],
             graph_route="scip-candidate",
             embedding_model="custom-model",
+            embedding_revision="model-commit",
             embedding_dimension=512,
+            embedding_batch_size=4,
+            embedding_max_seq_length=8192,
         )
 
         bm25 = registry.get("bm25")
@@ -312,6 +338,11 @@ class TestRegisterDefaultBuilders:
         assert isinstance(vector, VectorIndexBuilder)
         assert vector.embedding_model == "custom-model"
         assert vector.embedding_dimension == 512
+        assert vector.embedding_kwargs == {
+            "encode_kwargs": {"batch_size": 4},
+            "max_seq_length": 8192,
+            "revision": "model-commit",
+        }
 
         symbol_graph = registry.get("symbol_graph")
         assert isinstance(symbol_graph, SymbolGraphBuilder)

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -198,10 +198,11 @@ def mocked_build(monkeypatch):
     on the build/load call pattern (e.g. "missing types triggered build,
     already-built types did not").
     """
-    calls = {"compile": [], "loaded": []}
+    calls = {"compile": [], "loaded": [], "registries": [], "vector_kwargs": []}
 
     def fake_run_compiler(repo_path, index_types, cache_dir, **kwargs):
         calls["compile"].append(tuple(sorted(index_types)))
+        calls["registries"].append(kwargs["builder_registry"])
 
     def fake_load_bm25(cache_dir):
         calls["loaded"].append("bm25")
@@ -209,6 +210,7 @@ def mocked_build(monkeypatch):
 
     def fake_load_vector(cache_dir, **kwargs):
         calls["loaded"].append("vector")
+        calls["vector_kwargs"].append(kwargs)
         return object()
 
     def fake_load_graph(cache_dir):
@@ -365,6 +367,38 @@ def test_rebuild_forces_full_recompile(registry, mocked_build, tmp_path):
         rebuild=True,
     )
     assert mocked_build["compile"] == [("bm25", "vector")]
+
+
+def test_embedding_resource_limits_reach_builder_and_loader(
+    registry, mocked_build, tmp_path
+):
+    skill_context.build_skill_contexts(
+        repo_path=str(tmp_path),
+        skill_ids=["embedding_search"],
+        cache_dir=str(tmp_path / "cache"),
+        skill_registry=registry,
+        embedding_revision="model-revision",
+        embedding_batch_size=4,
+        embedding_max_seq_length=8192,
+    )
+
+    vector_builder = mocked_build["registries"][0].get("vector")
+    assert vector_builder.embedding_kwargs == {
+        "encode_kwargs": {"batch_size": 4},
+        "max_seq_length": 8192,
+        "revision": "model-revision",
+    }
+    assert mocked_build["vector_kwargs"] == [
+        {
+            "embedding_model": "nomic-ai/CodeRankEmbed",
+            "embedding_provider": "huggingface",
+            "embedding_dimension": 768,
+            "embedding_revision": "model-revision",
+            "embedding_kwargs": {"max_seq_length": 8192},
+            "trust_remote_code": False,
+            "default_batch_size": 4,
+        }
+    ]
 
 
 def test_partial_cache_only_rebuilds_missing(registry, mocked_build, tmp_path):

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -107,6 +107,53 @@ def test_skip_non_fresh_index(tmp_path: Path) -> None:
     assert "bm25" not in ctx.errors
 
 
+def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
+    vector_dir = tmp_path / "vector"
+    vector_dir.mkdir()
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path=str(vector_dir),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=0.0,
+                status="fresh",
+                config={
+                    "embedding_model": "test-model",
+                    "embedding_provider": "huggingface",
+                    "embedding_dimension": 384,
+                    "embedding_kwargs": {
+                        "max_seq_length": 8192,
+                        "revision": "model-commit",
+                    },
+                    "index_metric": "ip",
+                },
+            ),
+        },
+    )
+    manifest.save(tmp_path / "repo_manifest.json")
+
+    vector = MagicMock()
+    vector.embedding_model = "test-model"
+    vector.get_stats.return_value = {"total_documents": 3}
+    with patch("codeminer.mcp.context.CodeVectorStore", return_value=vector) as cls:
+        ctx = ServerContext.load(tmp_path / "repo_manifest.json")
+
+    cls.assert_called_once_with(
+        embedding_model="test-model",
+        embedding_provider="huggingface",
+        dimension=384,
+        index_metric="ip",
+        store_path=str(vector_dir),
+        max_seq_length=8192,
+        revision="model-commit",
+    )
+    vector.load.assert_called_once_with()
+    assert ctx.vector is vector
+    assert "vector" not in ctx.errors
+
+
 def test_regex_index_built_when_graph_available(manifest_dir: Path) -> None:
     """RegexNodeIndex is built when symbol_graph loads successfully."""
     graph_dir = manifest_dir / "symbol_graph"


### PR DESCRIPTION
## Summary
Ensure compiled repository artifacts are marked fresh only when they carry enough identity to be reopened by the runtime.

## Changes
- Persist embedding provider, dimension, metric, and model kwargs for both full and incremental vector builds.
- Reconstruct vector stores from the recorded manifest contract in skill and MCP runtimes, rejecting incomplete identities.
- Reject missing or empty symbol graphs instead of recording low-coverage builds as successful.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Local verification: `pre-commit run --files ...`; `pytest -q test/compiler/test_index_compiler.py test/compiler/test_skill_context.py test/mcp_server/test_context.py --tb=short` (67 passed).