### PR TITLE
feat(retrieval): add graph-aware fusion operators

### DIFF
--- a/codeminer/graph/code_graph.py
+++ b/codeminer/graph/code_graph.py
@@ -980,12 +980,14 @@ class CodeGraph:
 
         return self.graph.neighbors(vertex)
 
-    def get_successors(self, node_name):
+    def get_successors(self, node_name, edge_types=None):
         """
         Get the successors of a node_name (outgoing edges).
 
         Args:
             node_name: Name of the node
+            edge_types: Optional edge types to retain. Typed traversal returns
+                unique neighbors even when the graph contains multi-edges.
 
         Returns:
             List of successor vertex IDs
@@ -995,14 +997,18 @@ class CodeGraph:
             if vertex is None:
                 return []
 
-        return self.graph.successors(vertex)
+        if edge_types is None:
+            return self.graph.successors(vertex)
+        return self._get_typed_adjacent(vertex, edge_types, mode="out")
 
-    def get_predecessors(self, node_name):
+    def get_predecessors(self, node_name, edge_types=None):
         """
         Get the predecessors of a node_name (incoming edges).
 
         Args:
             node_name: Name of the node
+            edge_types: Optional edge types to retain. Typed traversal returns
+                unique neighbors even when the graph contains multi-edges.
 
         Returns:
             List of predecessor vertex IDs
@@ -1012,7 +1018,25 @@ class CodeGraph:
             if vertex is None:
                 return []
 
-        return self.graph.predecessors(vertex)
+        if edge_types is None:
+            return self.graph.predecessors(vertex)
+        return self._get_typed_adjacent(vertex, edge_types, mode="in")
+
+    def _get_typed_adjacent(self, vertex, edge_types, *, mode):
+        """Return unique adjacent vertices connected by selected edge types."""
+        selected = set(edge_types)
+        seen = set()
+        neighbors = []
+        for edge_id in self.graph.incident(vertex, mode=mode):
+            edge = self.graph.es[edge_id]
+            if edge.attributes().get("type") not in selected:
+                continue
+            neighbor = edge.target if mode == "out" else edge.source
+            if neighbor in seen:
+                continue
+            seen.add(neighbor)
+            neighbors.append(neighbor)
+        return neighbors
 
     def print_graph_basic_info(self):
         """

--- a/codeminer/index/embedding/builders.py
+++ b/codeminer/index/embedding/builders.py
@@ -37,6 +37,7 @@ def build_hierarchical_vector_store(
     embedding_provider: str,
     embedding_dimension: Optional[int],
     embedding_kwargs: Optional[Dict[str, object]] = None,
+    embedding: Optional[object] = None,
     index_metric: str = "ip",
     index_type: str = "flat",
     ivf_nlist: int = 100,
@@ -74,6 +75,7 @@ def build_hierarchical_vector_store(
                 ivf_nprobe=ivf_nprobe,
                 store_path=str(store_path),
                 profiler=profiler,
+                embedding=embedding,
                 **(embedding_kwargs or {}),
             )
             vector_store.load(str(store_path))
@@ -160,6 +162,7 @@ def build_hierarchical_vector_store(
         ivf_nprobe=ivf_nprobe,
         store_path=str(store_path),
         profiler=profiler,
+        embedding=embedding,
         **(embedding_kwargs or {}),
     )
 

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -11,7 +11,7 @@ of code chunks for semantic similarity search.
 import hashlib
 import json
 import pickle
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
@@ -291,6 +291,9 @@ class CodeVectorStore:
             if embedding is not None
             else self._initialize_embedding_model(**embedding_kwargs)
         )
+        self._cached_query_text: Optional[str] = None
+        self._cached_query_vector: Optional[np.ndarray] = None
+        self._query_cache_depth = 0
         self.dimension = self._infer_embedding_dimension(dimension)
 
         # Initialize L0 (file-level skeletons)
@@ -348,6 +351,43 @@ class CodeVectorStore:
         if self.profiler is None:
             return nullcontext()
         return self.profiler.section(label, metadata)
+
+    def _embed_query(self, query: str) -> np.ndarray:
+        """Encode a query, reusing it only inside an explicit request scope."""
+        cached_text = getattr(self, "_cached_query_text", None)
+        cached_vector = getattr(self, "_cached_query_vector", None)
+        cache_active = getattr(self, "_query_cache_depth", 0) > 0
+        if cache_active and cached_text == query and cached_vector is not None:
+            return cached_vector
+
+        vector = np.asarray(
+            self.embedding.embed_query(query), dtype=np.float32
+        ).reshape(-1)
+        if cache_active:
+            self._cached_query_text = query
+            self._cached_query_vector = vector
+        return vector
+
+    @contextmanager
+    def reuse_query_embedding(self):
+        """Reuse one query vector within a composed request, then discard it."""
+
+        depth = getattr(self, "_query_cache_depth", 0)
+        if depth == 0:
+            self.clear_query_cache()
+        self._query_cache_depth = depth + 1
+        try:
+            yield
+        finally:
+            self._query_cache_depth -= 1
+            if self._query_cache_depth == 0:
+                self.clear_query_cache()
+
+    def clear_query_cache(self) -> None:
+        """Clear the single-query embedding reused by consecutive search stages."""
+
+        self._cached_query_text = None
+        self._cached_query_vector = None
 
     def _should_filter_by_threshold(self, score: float, threshold: float) -> bool:
         """
@@ -449,9 +489,7 @@ class CodeVectorStore:
         if index is None or index.ntotal == 0:
             return []
 
-        query_vec = np.array(
-            self.embedding.embed_query(query), dtype=np.float32
-        ).reshape(1, -1)
+        query_vec = self._embed_query(query).reshape(1, -1)
 
         # FAISS search
         k = min(top_k, index.ntotal)
@@ -505,6 +543,9 @@ class CodeVectorStore:
         self.l2_index = None
 
         self.embedding = None
+        self._query_cache_depth = 0
+        self._cached_query_text = None
+        self._cached_query_vector = None
 
         try:
             import torch
@@ -772,7 +813,7 @@ class CodeVectorStore:
             return []
 
         # Encode query
-        query_vec = np.array(self.embedding.embed_query(query), dtype=np.float32)
+        query_vec = self._embed_query(query)
 
         # Reconstruct stored vectors and compute similarity
         results: list[NodeInfo] = []
@@ -797,6 +838,26 @@ class CodeVectorStore:
                 )
             )
 
+        best_by_node = {}
+        for result in results:
+            identity = result.node_id or (
+                result.file,
+                result.node_name,
+                result.start_line,
+                result.end_line,
+            )
+            existing = best_by_node.get(identity)
+            if existing is None:
+                best_by_node[identity] = result
+                continue
+            if self.index_metric == "ip":
+                is_better = result.score > existing.score
+            else:
+                is_better = result.score < existing.score
+            if is_better:
+                best_by_node[identity] = result
+        results = list(best_by_node.values())
+
         # Sort: ip → higher is better; l2 → lower is better
         results.sort(
             key=lambda r: r.score,
@@ -804,7 +865,8 @@ class CodeVectorStore:
         )
 
         logger.debug(
-            "search_within_ids: %d matched, returning top %d",
+            "search_within_ids: %d matched, %d unique, returning top %d",
+            len(matched),
             len(results),
             min(top_k, len(results)),
         )

--- a/codeminer/model/dense_graph_expand_rerank_pipeline.py
+++ b/codeminer/model/dense_graph_expand_rerank_pipeline.py
@@ -10,10 +10,10 @@ from typing import Any, Dict, List, Optional, Sequence
 from ..graph.code_graph import CodeGraph
 from ..ops.expand import ExpandContext, expand_graph_neighbors
 from ..ops.filter import CandidatePredicate, filter_queried_nodes
-from ..ops.rerank import RerankContext, rerank_by_embedding
-from ..ops.retrieve import dedup_queried_nodes
+from ..ops.rerank import RerankContext, rerank_by_embedding, rerank_by_indexed_embedding
+from ..ops.retrieve import dedup_queried_nodes, merge_file_rankings, queried_node_key
 from ..profiler import Profiler
-from ..types import NodeInfo, QueriedNode
+from ..types import EDGE_TYPE_REFERENCE, NodeInfo, QueriedNode
 from .embedding_retrieve_pipeline import EmbeddingRetrievePipeline
 
 
@@ -49,8 +49,12 @@ class DenseGraphExpandRerankPipeline:
         rerank_context: Optional[RerankContext] = None,
         repo_path: Optional[str] = None,
         dense_top_k: int = 20,
+        graph_seed_top_k: Optional[int] = None,
         graph_neighbors_per_seed: int = 5,
         graph_direction: str = "both",
+        graph_edge_types: Optional[Sequence[str]] = (EDGE_TYPE_REFERENCE,),
+        graph_fusion_weight: float = 0.0,
+        graph_fusion_rrf_k: int = 60,
         final_top_k: int = 10,
         candidate_top_k: Optional[int] = None,
         candidate_filters: Optional[Sequence[CandidatePredicate]] = None,
@@ -65,14 +69,28 @@ class DenseGraphExpandRerankPipeline:
             raise ValueError("final_top_k must be positive.")
         if graph_neighbors_per_seed < 0:
             raise ValueError("graph_neighbors_per_seed must be non-negative.")
+        if graph_seed_top_k is not None and graph_seed_top_k <= 0:
+            raise ValueError("graph_seed_top_k must be positive when provided.")
+        if graph_fusion_weight < 0:
+            raise ValueError("graph_fusion_weight must be non-negative.")
+        if graph_fusion_rrf_k <= 0:
+            raise ValueError("graph_fusion_rrf_k must be positive.")
+        if graph_fusion_weight and rerank_context is None:
+            raise ValueError("graph fusion requires a rerank_context.")
 
         self.retriever = retriever
         self.expand_context = ExpandContext(code_graph=code_graph)
         self.rerank_context = rerank_context
         self.repo_path = repo_path
         self.dense_top_k = dense_top_k
+        self.graph_seed_top_k = graph_seed_top_k
         self.graph_neighbors_per_seed = graph_neighbors_per_seed
         self.graph_direction = graph_direction
+        self.graph_edge_types = (
+            None if graph_edge_types is None else tuple(graph_edge_types)
+        )
+        self.graph_fusion_weight = graph_fusion_weight
+        self.graph_fusion_rrf_k = graph_fusion_rrf_k
         self.final_top_k = final_top_k
         self.candidate_top_k = candidate_top_k
         self.candidate_filters = list(candidate_filters or [])
@@ -85,6 +103,7 @@ class DenseGraphExpandRerankPipeline:
         self.last_graph_results: List[QueriedNode] = []
         self.last_filtered_candidates: List[QueriedNode] = []
         self.last_candidates: List[QueriedNode] = []
+        self.last_semantic_results: List[QueriedNode] = []
         self.last_reranked_results: List[QueriedNode] = []
 
     @property
@@ -112,6 +131,31 @@ class DenseGraphExpandRerankPipeline:
         profiler: Optional[Profiler] = None,
     ) -> List[QueriedNode]:
         """Retrieve dense candidates, append graph neighbors, dedup, and rerank."""
+        with self._query_embedding_scope():
+            return self._query_impl(
+                query,
+                top_k=top_k,
+                dense_top_k=dense_top_k,
+                profiler=profiler,
+            )
+
+    def _query_embedding_scope(self):
+        context = self.rerank_context
+        if context is None or context.embedding_source != "index":
+            return nullcontext()
+        store = context.embedding_store
+        if store is None or getattr(self.retriever, "vector_store", None) is not store:
+            return nullcontext()
+        return store.reuse_query_embedding()
+
+    def _query_impl(
+        self,
+        query: str,
+        *,
+        top_k: Optional[int],
+        dense_top_k: Optional[int],
+        profiler: Optional[Profiler],
+    ) -> List[QueriedNode]:
         final_top_k = top_k if top_k is not None else self.final_top_k
         dense_k = dense_top_k if dense_top_k is not None else self.dense_top_k
         if final_top_k <= 0:
@@ -122,23 +166,29 @@ class DenseGraphExpandRerankPipeline:
         with _section(profiler, "query.dense_retrieve", {"top_k": dense_k}):
             dense_results = self.retriever.query(query, top_k=dense_k)
 
+        graph_seed_k = self.graph_seed_top_k or len(dense_results)
+        graph_seeds = dense_results[:graph_seed_k]
+
         with _section(
             profiler,
             "query.graph_neighbor_expand",
             {
+                "seeds": len(graph_seeds),
                 "per_seed": self.graph_neighbors_per_seed,
                 "direction": self.graph_direction,
+                "edge_types": self.graph_edge_types,
             },
         ):
             graph_results = expand_graph_neighbors(
                 self.expand_context,
-                dense_results,
+                graph_seeds,
                 per_seed=self.graph_neighbors_per_seed,
                 direction=self.graph_direction,
                 repo_path=self.repo_path,
                 include_content=self.include_graph_content,
                 symbol_only=self.graph_symbol_only,
                 require_span=self.graph_require_span,
+                edge_types=self.graph_edge_types,
             )
 
         combined = [*dense_results, *graph_results]
@@ -162,6 +212,7 @@ class DenseGraphExpandRerankPipeline:
         self.last_candidates = list(candidates)
 
         if self.rerank_context is None:
+            self.last_semantic_results = []
             self.last_reranked_results = []
             return candidates[:final_top_k]
 
@@ -174,7 +225,27 @@ class DenseGraphExpandRerankPipeline:
             "query.rerank",
             {"candidates": len(rerank_candidates), "top_k": final_top_k},
         ):
-            reranked = self._rerank(query, rerank_candidates, final_top_k)
+            semantic_top_k = (
+                len(rerank_candidates) if self.graph_fusion_weight else final_top_k
+            )
+            reranked = self._rerank(query, rerank_candidates, semantic_top_k)
+            self.last_semantic_results = list(reranked)
+
+            if self.graph_fusion_weight:
+                candidate_keys = {queried_node_key(node) for node in rerank_candidates}
+                graph_branch = dedup_queried_nodes(
+                    [
+                        node
+                        for node in graph_results
+                        if queried_node_key(node) in candidate_keys
+                    ]
+                )
+                reranked = merge_file_rankings(
+                    [reranked, graph_branch],
+                    weights=[1.0, self.graph_fusion_weight],
+                    top_k=final_top_k,
+                    rrf_k=self.graph_fusion_rrf_k,
+                )
 
         self.last_reranked_results = list(reranked)
         return reranked[:final_top_k]
@@ -195,6 +266,13 @@ class DenseGraphExpandRerankPipeline:
             return list(candidates[:top_k])
 
         if context.embedding_store is not None:
+            if context.embedding_source == "index":
+                return rerank_by_indexed_embedding(
+                    query,
+                    candidates,
+                    context.embedding_store,
+                    top_k=top_k,
+                )
             return rerank_by_embedding(
                 query,
                 candidates,

--- a/codeminer/ops/expand.py
+++ b/codeminer/ops/expand.py
@@ -4,13 +4,15 @@
 
 from __future__ import annotations
 
+import subprocess
 from dataclasses import dataclass
+from itertools import zip_longest
 from pathlib import Path
 from typing import Any, List, Optional, Sequence
 
 from ..graph.code_graph import CodeGraph
 from ..log_utils import get_logger
-from ..types import NodeInfo, QueriedNode, is_symbol_node
+from ..types import EDGE_TYPE_REFERENCE, NodeInfo, QueriedNode, is_symbol_node
 
 logger = get_logger(__name__)
 
@@ -54,6 +56,34 @@ def nodeinfo_to_queried(nodes: List[NodeInfo]) -> List[QueriedNode]:
     return results
 
 
+def hydrate_candidate_contents(
+    candidates: Sequence[QueriedNode],
+    *,
+    repo_path: Optional[str],
+    git_commit: Optional[str] = None,
+) -> List[QueriedNode]:
+    """Fill missing candidate content from persisted source spans."""
+    hydrated: List[QueriedNode] = []
+    for candidate in candidates:
+        if candidate.content:
+            hydrated.append(candidate)
+            continue
+        content = _read_span_content(
+            repo_path=repo_path,
+            file_path=candidate.file,
+            start_line=candidate.start_line,
+            end_line=candidate.end_line,
+            git_commit=git_commit,
+        )
+        if not content:
+            hydrated.append(candidate)
+        elif hasattr(candidate, "model_copy"):
+            hydrated.append(candidate.model_copy(update={"content": content}))
+        else:
+            hydrated.append(candidate.copy(update={"content": content}))
+    return hydrated
+
+
 def expand_graph_neighbors(
     context: ExpandContext,
     seeds: Sequence[QueriedNode],
@@ -65,6 +95,7 @@ def expand_graph_neighbors(
     symbol_only: bool = True,
     require_span: bool = True,
     score_scale: float = 0.5,
+    edge_types: Optional[Sequence[str]] = (EDGE_TYPE_REFERENCE,),
 ) -> List[QueriedNode]:
     """Return graph neighbors for retrieval candidates.
 
@@ -72,6 +103,8 @@ def expand_graph_neighbors(
     navigation helpers: keep dense candidates as seeds, append compact graph
     neighbors, and leave ranking to the downstream reranker. Only one-hop
     predecessor/successor expansion is performed; no BFS/PPR is hidden here.
+    Expansion follows reference edges by default so containment does not consume
+    the dependency-neighbor budget.
     """
     graph = context.code_graph
     if graph is None or not seeds:
@@ -84,15 +117,31 @@ def expand_graph_neighbors(
         raise ValueError(f"Unsupported graph expansion direction: {direction!r}")
 
     out: List[QueriedNode] = []
+    selected_edge_types = None if edge_types is None else set(edge_types)
     for seed_rank, seed in enumerate(seeds, 1):
         canonical = _resolve_seed(graph, seed)
         if canonical is None:
             continue
-        neighbor_ids: List[int] = []
-        if direction in ("callees", "successors", "both"):
-            neighbor_ids.extend(graph.get_successors(canonical))
-        if direction in ("callers", "predecessors", "both"):
-            neighbor_ids.extend(graph.get_predecessors(canonical))
+        successor_ids = (
+            list(graph.get_successors(canonical, edge_types=selected_edge_types))
+            if direction in ("callees", "successors", "both")
+            else []
+        )
+        predecessor_ids = (
+            list(graph.get_predecessors(canonical, edge_types=selected_edge_types))
+            if direction in ("callers", "predecessors", "both")
+            else []
+        )
+        if direction == "both":
+            interleaved = (
+                vertex_id
+                for pair in zip_longest(successor_ids, predecessor_ids)
+                for vertex_id in pair
+                if vertex_id is not None
+            )
+            neighbor_ids = list(dict.fromkeys(interleaved))
+        else:
+            neighbor_ids = successor_ids or predecessor_ids
 
         added_for_seed = 0
         for vid in neighbor_ids:
@@ -185,6 +234,7 @@ def _read_span_content(
     file_path: Optional[str],
     start_line: Any,
     end_line: Any,
+    git_commit: Optional[str] = None,
 ) -> Optional[str]:
     if not file_path or start_line is None or end_line is None:
         return None
@@ -194,16 +244,56 @@ def _read_span_content(
     except (TypeError, ValueError):
         return None
     path = Path(file_path)
+    lines: Optional[List[str]] = None
+    if git_commit:
+        if path.is_absolute() or not repo_path:
+            return None
+        lines = _read_git_file_lines(
+            repo_path=repo_path,
+            file_path=path.as_posix(),
+            git_commit=git_commit,
+        )
+        if lines is None:
+            return None
     if not path.is_absolute():
         if not repo_path:
             return None
         path = Path(repo_path) / file_path
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines(True)
-    except OSError:
-        return None
+    if lines is None:
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines(True)
+        except OSError:
+            return None
     start = max(0, start)
     end = min(len(lines) - 1, end)
     if end < start:
         return None
     return "".join(lines[start : end + 1])
+
+
+def _read_git_file_lines(
+    *, repo_path: str, file_path: str, git_commit: str
+) -> Optional[List[str]]:
+    repo = Path(repo_path).resolve()
+    normalized = Path(file_path)
+    if normalized.is_absolute() or ".." in normalized.parts:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-c",
+                f"safe.directory={repo}",
+                "show",
+                f"{git_commit}:{normalized.as_posix()}",
+            ],
+            cwd=repo,
+            check=False,
+            capture_output=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.decode("utf-8", errors="replace").splitlines(True)

--- a/codeminer/ops/rerank.py
+++ b/codeminer/ops/rerank.py
@@ -46,12 +46,15 @@ class CrossEncoderContext:
     def ensure_wrapper(self) -> Any:
         if self._wrapper is None:
             from ..index.rerank.cross_encoder import build_reranker
+
             self._wrapper = build_reranker(
                 self.model_name,
                 backend=self.backend,
                 batch_size=self.batch_size,
             )
-            logger.info("Loaded cross-encoder: %s (backend=%s)", self.model_name, self.backend)
+            logger.info(
+                "Loaded cross-encoder: %s (backend=%s)", self.model_name, self.backend
+            )
         return self._wrapper
 
     def score(self, query: str, docs: List[str]) -> List[float]:
@@ -79,6 +82,7 @@ class RerankContext:
     window_size: Optional[int] = None
     window_step: Optional[int] = None
     listwise_format: Literal["structured", "rankgpt"] = "structured"
+    embedding_source: Literal["content", "index"] = "content"
 
     def ensure_agent(self) -> RerankAgent:
         if self.agent is None:
@@ -139,6 +143,90 @@ def rerank_by_embedding(
     if top_k is not None:
         ranked = ranked[:top_k]
     return [_copy_with_score(candidate, float(score)) for score, candidate in ranked]
+
+
+def rerank_by_indexed_embedding(
+    query: str,
+    candidates: Sequence[QueriedNode],
+    embedding_store: CodeVectorStore,
+    *,
+    top_k: Optional[int] = None,
+    level: str = "l2",
+) -> List[QueriedNode]:
+    """Rerank candidates using vectors already stored in the search index.
+
+    Dense-first graph pipelines expand compact graph nodes identified by the
+    same stable ``node_id`` values persisted in the vector store. Reusing those
+    vectors keeps dense and graph candidates in one calibrated score space and
+    avoids re-embedding potentially very large source spans online. Candidates
+    absent from the index are retained at the end in their original order.
+    """
+
+    from .retrieve import dedup_queried_nodes, to_queried_nodes
+
+    if not candidates:
+        return []
+    mask = {candidate.node_id for candidate in candidates if candidate.node_id}
+    if not mask:
+        fallback = list(candidates)
+        return fallback[:top_k] if top_k is not None else fallback
+    indexed = dedup_queried_nodes(
+        to_queried_nodes(
+            embedding_store.search_within_ids(
+                query,
+                mask_node_ids=mask,
+                top_k=len(candidates),
+                level=level,
+            )
+        )
+    )
+    matched = {candidate.node_id for candidate in indexed if candidate.node_id}
+    unmatched = [
+        candidate
+        for candidate in candidates
+        if not candidate.node_id or candidate.node_id not in matched
+    ]
+    ranked = [*indexed, *unmatched]
+    return ranked[:top_k] if top_k is not None else ranked
+
+
+def rerank_by_cross_encoder(
+    query: str,
+    candidates: Sequence[QueriedNode],
+    context: CrossEncoderContext,
+    *,
+    top_k: Optional[int] = None,
+) -> List[QueriedNode]:
+    """Rerank candidate contents with a shared cross-encoder context."""
+    candidates_with_content = [
+        candidate for candidate in candidates if candidate.content
+    ]
+    if not candidates_with_content:
+        fallback = list(candidates)
+        return fallback[:top_k] if top_k is not None else fallback
+
+    scores = context.score(
+        query,
+        [str(candidate.content) for candidate in candidates_with_content],
+    )
+    if len(scores) != len(candidates_with_content):
+        raise RuntimeError(
+            "cross-encoder returned "
+            f"{len(scores)} scores for {len(candidates_with_content)} candidates"
+        )
+    ranked_with_content = sorted(
+        zip(scores, candidates_with_content, strict=True),
+        key=lambda pair: pair[0],
+        reverse=True,
+    )
+    ranked = [
+        _copy_with_score(candidate, float(score))
+        for score, candidate in ranked_with_content
+    ]
+    ranked.extend(candidate for candidate in candidates if not candidate.content)
+    if top_k is not None:
+        ranked = ranked[:top_k]
+    return ranked
 
 
 def _copy_with_score(candidate: QueriedNode, score: float) -> QueriedNode:

--- a/codeminer/ops/retrieve.py
+++ b/codeminer/ops/retrieve.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 from ..index.embedding.vector_store import CodeVectorStore
 from ..index.regex_idx.regex_idx import RegexNodeIndex
@@ -71,6 +71,49 @@ def merge_hybrid(
     rrf_k: int = 60,
 ) -> List[QueriedNode]:
     """Merge multiple retrieval branches with weighted scoring or RRF."""
+    return _merge_rankings(
+        branches,
+        weights=weights,
+        top_k=top_k,
+        fusion=fusion,
+        rrf_k=rrf_k,
+        key_fn=queried_node_key,
+    )
+
+
+def merge_file_rankings(
+    branches: List[List[QueriedNode]],
+    weights: Optional[List[float]] = None,
+    top_k: Optional[int] = None,
+    *,
+    rrf_k: int = 60,
+) -> List[QueriedNode]:
+    """Fuse ranked branches by unique file using weighted RRF.
+
+    Each branch contributes at most once per file. Stable relative file names
+    embedded in ``node_id`` take precedence over machine-specific absolute
+    paths, which keeps graph and vector artifacts comparable across snapshots.
+    """
+    unique_branches = [dedup_queried_files(branch) for branch in branches]
+    return _merge_rankings(
+        unique_branches,
+        weights=weights,
+        top_k=top_k,
+        fusion="rrf",
+        rrf_k=rrf_k,
+        key_fn=queried_file_key,
+    )
+
+
+def _merge_rankings(
+    branches: List[List[QueriedNode]],
+    weights: Optional[List[float]],
+    top_k: Optional[int],
+    *,
+    fusion: str,
+    rrf_k: int,
+    key_fn: Callable[[QueriedNode], Tuple[Any, ...]],
+) -> List[QueriedNode]:
     if not branches:
         return []
 
@@ -85,7 +128,7 @@ def merge_hybrid(
 
     for weight, results in zip(weights, branches, strict=True):
         for rank, item in enumerate(results, start=1):
-            key = queried_node_key(item)
+            key = key_fn(item)
             weighted = _fusion_score(
                 item,
                 rank=rank,
@@ -127,6 +170,23 @@ def queried_node_key(item: QueriedNode) -> Tuple[Any, ...]:
     )
 
 
+def queried_file_key(item: QueriedNode) -> Tuple[Any, ...]:
+    """Stable file identity across relative graph and absolute index paths."""
+    file_path = (item.file or "").strip().replace("\\", "/")
+    node_id = (item.node_id or "").strip().replace("\\", "/")
+    if node_id and ":" in node_id:
+        node_file = node_id.split(":", 1)[0].removeprefix("./")
+        if (
+            node_file
+            and file_path
+            and (file_path == node_file or file_path.endswith("/" + node_file))
+        ):
+            return ("file", node_file)
+    if file_path:
+        return ("file", file_path)
+    return ("node", *queried_node_key(item))
+
+
 def dedup_queried_nodes(nodes: Sequence[QueriedNode]) -> List[QueriedNode]:
     """Deduplicate nodes while preserving first-seen rank order.
 
@@ -151,6 +211,19 @@ def dedup_queried_nodes(nodes: Sequence[QueriedNode]) -> List[QueriedNode]:
                 existing.score or 0.0,
                 content_override=node.content,
             )
+    return out
+
+
+def dedup_queried_files(nodes: Sequence[QueriedNode]) -> List[QueriedNode]:
+    """Keep the first representative node for each stable file identity."""
+    seen: Set[Tuple[Any, ...]] = set()
+    out: List[QueriedNode] = []
+    for node in nodes:
+        key = queried_file_key(node)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(node)
     return out
 
 

--- a/docs/rag_ops.md
+++ b/docs/rag_ops.md
@@ -19,10 +19,10 @@ Strategy belongs in a planner or named pipeline.
 
 | Module | Role | What belongs here |
 |--------|------|-------------------|
-| `ops.retrieve` | Candidate normalization and fusion | `RetrieveContext`, `to_queried_nodes`, weighted hybrid merge, stable dedup keys |
+| `ops.retrieve` | Candidate normalization and fusion | `RetrieveContext`, `to_queried_nodes`, node/file-level weighted RRF, stable dedup keys |
 | `ops.filter` | Explicit candidate predicates | span/content checks, symbol-only checks, include/exclude path filters, test-path dropping |
-| `ops.expand` | Compact graph neighborhood expansion | one-hop predecessor/successor expansion from existing seeds, optional span content loading |
-| `ops.rerank` | Candidate-only reranking | embedding similarity over a provided candidate set; lazy LLM reranker context |
+| `ops.expand` | Compact graph neighborhood expansion | one-hop predecessor/successor expansion from existing seeds, edge-type filtering, optional span content loading |
+| `ops.rerank` | Candidate-only reranking | online content embeddings or persisted index vectors over a provided candidate set; lazy LLM reranker context |
 | `ops.transform` | Query/code transforms | shared transform resources such as keyword extraction |
 
 This surface is intentionally not a general workflow engine. It does not encode
@@ -38,6 +38,7 @@ The current ops are enough to express the common CodeMiner RAG paths:
 - dense plus sparse fusion, including RRF in `RetrieveRerankPipeline`
 - candidate filtering before rerank
 - dense-first graph neighbor augmentation
+- file-aware semantic/graph rank fusion in `DenseGraphExpandRerankPipeline`
 - sparse-seeded graph expansion through the graph retrieval pipeline
 - embedding or LLM reranking over an assembled candidate set
 
@@ -76,6 +77,12 @@ It records the most recent `last_selected_plan` and `last_planner_trace`
 Use `SparseSeededGraphRetrievePipeline` or `DenseGraphExpandRerankPipeline` when
 you need an experiment-specific graph baseline rather than the general auto
 pipeline.
+
+The dense GraphRAG path defaults to one-hop `reference` edges. Containment is
+excluded from the dependency budget, callers and callees are interleaved, and
+multi-edges are collapsed before the per-seed cap. Its optional file-level RRF
+uses stable relative paths from node IDs so graph artifacts and vector indexes
+built under different checkout roots still fuse correctly.
 
 ## Maintenance Rules
 

--- a/test/graph/test_typed_adjacency.py
+++ b/test/graph/test_typed_adjacency.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from codeminer.graph.code_graph import CodeGraph
+from codeminer.types import EDGE_TYPE_CONTAIN, EDGE_TYPE_REFERENCE
+
+
+def test_typed_adjacency_filters_edges_and_deduplicates_multiedges():
+    graph = CodeGraph()
+    for name in ("seed", "reference", "contained"):
+        graph._add_vertex(name, {"type": "function"})
+    graph._add_edge(
+        "seed",
+        "reference",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="src/a.py",
+        anchor_line=1,
+    )
+    graph._add_edge(
+        "seed",
+        "reference",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="src/a.py",
+        anchor_line=2,
+    )
+    graph._add_edge("seed", "contained", EDGE_TYPE_CONTAIN)
+
+    reference_id = graph.name_to_vertex["reference"]
+    contained_id = graph.name_to_vertex["contained"]
+
+    assert graph.get_successors("seed", {EDGE_TYPE_REFERENCE}) == [reference_id]
+    assert graph.get_successors("seed", {EDGE_TYPE_CONTAIN}) == [contained_id]
+    assert graph.get_predecessors("reference", {EDGE_TYPE_REFERENCE}) == [
+        graph.name_to_vertex["seed"]
+    ]

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from codeminer.index.embedding import builders
+
+
+def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path):
+    source = tmp_path / "source.py"
+    source.write_text("def example():\n    pass\n", encoding="utf-8")
+    chunk = SimpleNamespace(
+        file="source.py",
+        _asdict=lambda: {
+            "file": "source.py",
+            "content": source.read_text(encoding="utf-8"),
+        },
+    )
+
+    class FakeChunker:
+        def __init__(self, **kwargs):
+            pass
+
+        def chunk_repository(self, repo_path):
+            return [chunk]
+
+    captured = {}
+
+    class FakeStore:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.l0_documents = []
+            self.l2_documents = []
+
+        def add_code_chunks(self, chunks, level):
+            self.l2_documents.extend(chunks)
+
+        def save(self, path):
+            pass
+
+    monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
+    monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
+    embedding = object()
+
+    result = builders.build_hierarchical_vector_store(
+        repo_path=str(tmp_path),
+        index_path=str(tmp_path / "index"),
+        languages=["python"],
+        build_levels=["l2"],
+        embedding_model="test-model",
+        embedding_provider="huggingface",
+        embedding_dimension=2,
+        embedding=embedding,
+        force_rebuild=True,
+    )
+
+    assert captured["embedding"] is embedding
+    assert result.l2_documents

--- a/test/index/test_vector_store_candidate_search.py
+++ b/test/index/test_vector_store_candidate_search.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from codeminer.index.embedding.vector_store import CodeVectorStore, _Document
+
+
+class _FakeIndex:
+    ntotal = 3
+
+    def __init__(self, vectors):
+        self.vectors = vectors
+
+    def reconstruct(self, index):
+        return np.asarray(self.vectors[index], dtype=np.float32)
+
+    def search(self, query_vectors, top_k):
+        vectors = np.asarray(self.vectors, dtype=np.float32)
+        scores = vectors @ query_vectors[0]
+        indices = np.argsort(-scores)[:top_k]
+        return scores[indices].reshape(1, -1), indices.reshape(1, -1)
+
+
+class _FakeEmbedding:
+    def __init__(self):
+        self.calls = 0
+
+    def embed_query(self, query):
+        self.calls += 1
+        if query == "query":
+            return [1.0, 0.0]
+        if query == "different query":
+            return [0.0, 1.0]
+        raise AssertionError(f"unexpected query: {query}")
+
+
+def test_search_within_ids_deduplicates_before_top_k():
+    store = CodeVectorStore.__new__(CodeVectorStore)
+    store.index_metric = "ip"
+    store.embedding = _FakeEmbedding()
+    store.l2_index = _FakeIndex([[0.5, 0.0], [0.9, 0.0], [0.8, 0.0]])
+    store.l2_documents = [
+        _Document("old", {"node_id": "a", "name": "a", "file": "a.py"}),
+        _Document("best", {"node_id": "a", "name": "a", "file": "a.py"}),
+        _Document("other", {"node_id": "b", "name": "b", "file": "b.py"}),
+    ]
+
+    result = store.search_within_ids(
+        "query", mask_node_ids={"a", "b"}, top_k=2, level="l2"
+    )
+
+    assert [node.node_id for node in result] == ["a", "b"]
+    assert result[0].content == "best"
+
+
+def test_search_stages_reuse_the_same_query_embedding_within_request_scope():
+    store = CodeVectorStore.__new__(CodeVectorStore)
+    store.index_metric = "ip"
+    store.embedding = _FakeEmbedding()
+    store.l2_index = _FakeIndex([[0.5, 0.0], [0.9, 0.0], [0.8, 0.0]])
+    store.l2_documents = [
+        _Document("old", {"node_id": "a", "name": "a", "file": "a.py"}),
+        _Document("best", {"node_id": "a", "name": "a", "file": "a.py"}),
+        _Document("other", {"node_id": "b", "name": "b", "file": "b.py"}),
+    ]
+
+    with store.reuse_query_embedding():
+        dense = store.search_with_content("query", top_k=3, level="l2")
+        reranked = store.search_within_ids(
+            "query", mask_node_ids={"a", "b"}, top_k=2, level="l2"
+        )
+
+    assert store.embedding.calls == 1
+    assert [node.score for node in dense] == pytest.approx([0.9, 0.8, 0.5])
+    assert [node.node_id for node in reranked] == ["a", "b"]
+
+    store.search_with_content("different query", top_k=3, level="l2")
+    assert store.embedding.calls == 2
+
+
+def test_repeated_requests_do_not_reuse_query_embeddings():
+    store = CodeVectorStore.__new__(CodeVectorStore)
+    store.index_metric = "ip"
+    store.embedding = _FakeEmbedding()
+    store.l2_index = _FakeIndex([[0.5, 0.0], [0.9, 0.0], [0.8, 0.0]])
+    store.l2_documents = [
+        _Document("a", {"node_id": "a", "name": "a", "file": "a.py"}),
+        _Document("b", {"node_id": "b", "name": "b", "file": "b.py"}),
+        _Document("c", {"node_id": "c", "name": "c", "file": "c.py"}),
+    ]
+
+    store.search_with_content("query", top_k=3, level="l2")
+    store.search_with_content("query", top_k=3, level="l2")
+
+    assert store.embedding.calls == 2

--- a/test/model/test_graph_augmented_rerank_pipeline.py
+++ b/test/model/test_graph_augmented_rerank_pipeline.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+
 from codeminer.model import (
     DenseGraphExpandRerankPipeline as ExportedDenseGraphExpandRerankPipeline,
 )
@@ -14,7 +16,7 @@ from codeminer.model.dense_graph_expand_rerank_pipeline import (
 )
 from codeminer.model.graph_augmented_rerank_pipeline import GraphAugmentedRerankPipeline
 from codeminer.ops.rerank import RerankContext
-from codeminer.types import QueriedNode
+from codeminer.types import EDGE_TYPE_REFERENCE, NodeInfo, QueriedNode
 
 
 class _FakeRetriever:
@@ -42,10 +44,12 @@ class _FakeGraph:
     def resolve_symbol(self, symbol):
         return self.resolve.get(symbol), None
 
-    def get_successors(self, node_name):
+    def get_successors(self, node_name, edge_types=None):
+        assert edge_types in (None, {EDGE_TYPE_REFERENCE})
         return self.successors.get(node_name, [])
 
-    def get_predecessors(self, node_name):
+    def get_predecessors(self, node_name, edge_types=None):
+        assert edge_types in (None, {EDGE_TYPE_REFERENCE})
         return self.predecessors.get(node_name, [])
 
     def get_node_info_by_id(self, node_id):
@@ -168,6 +172,74 @@ def test_pipeline_applies_explicit_candidate_filters():
     assert [node.node_name for node in pipeline.last_filtered_candidates] == ["keep"]
 
 
+def test_pipeline_limits_graph_seeds_without_truncating_dense_pool():
+    dense = [
+        QueriedNode(
+            node_name=f"seed{i}",
+            type="function",
+            file=f"src/{i}.py",
+            node_id=f"src/{i}.py:seed{i}",
+            start_line=i,
+            end_line=i,
+            score=1.0 - i / 10,
+        )
+        for i in range(3)
+    ]
+    graph = _FakeGraph(
+        resolve={f"src/{i}.py:seed{i}": f"seed{i}" for i in range(3)},
+        successors={f"seed{i}": [i] for i in range(3)},
+        info={
+            i: {
+                "name": f"neighbor{i}",
+                "unified_name": f"src/n{i}.py:neighbor{i}",
+                "type": "function",
+                "file": f"src/n{i}.py",
+                "start_line": i,
+                "end_line": i,
+            }
+            for i in range(3)
+        },
+    )
+    pipeline = DenseGraphExpandRerankPipeline(
+        retriever=_FakeRetriever(dense),
+        code_graph=graph,
+        dense_top_k=3,
+        graph_seed_top_k=1,
+        graph_neighbors_per_seed=1,
+        final_top_k=10,
+        include_graph_content=False,
+    )
+
+    result = pipeline.query("query")
+
+    assert [node.node_name for node in pipeline.last_dense_results] == [
+        "seed0",
+        "seed1",
+        "seed2",
+    ]
+    assert [node.node_name for node in pipeline.last_graph_results] == [
+        "src/n0.py:neighbor0"
+    ]
+    assert [node.node_name for node in result] == [
+        "seed0",
+        "seed1",
+        "seed2",
+        "src/n0.py:neighbor0",
+    ]
+
+
+def test_pipeline_rejects_non_positive_graph_seed_limit():
+    try:
+        DenseGraphExpandRerankPipeline(
+            retriever=_FakeRetriever([]),
+            graph_seed_top_k=0,
+        )
+    except ValueError as exc:
+        assert "graph_seed_top_k" in str(exc)
+    else:
+        raise AssertionError("expected graph_seed_top_k validation to fail")
+
+
 def test_pipeline_reranks_dense_and_graph_candidates(tmp_path):
     source = tmp_path / "src" / "a.py"
     source.parent.mkdir()
@@ -221,6 +293,126 @@ def test_pipeline_reranks_dense_and_graph_candidates(tmp_path):
         "src/a.py:neighbor",
         "src/a.py:seed",
     ]
+
+
+def test_pipeline_fuses_semantic_and_graph_rankings_by_file():
+    dense = [
+        QueriedNode(
+            node_name="seed",
+            type="function",
+            file="/cache/repo/src/a.py",
+            node_id="src/a.py:seed",
+            score=1.0,
+        ),
+        QueriedNode(
+            node_name="other",
+            type="function",
+            file="/cache/repo/src/b.py",
+            node_id="src/b.py:other",
+            score=0.9,
+        ),
+    ]
+    graph = _FakeGraph(
+        resolve={"src/a.py:seed": "seed"},
+        successors={"seed": [1]},
+        info={
+            1: {
+                "name": "neighbor",
+                "unified_name": "src/c.py:neighbor",
+                "type": "function",
+                "file": "src/c.py",
+                "start_line": 1,
+                "end_line": 2,
+            }
+        },
+    )
+
+    class FakeIndexedStore:
+        def search_within_ids(self, query, mask_node_ids, top_k, level):
+            return [
+                NodeInfo(**dense[0].model_dump()),
+                NodeInfo(**dense[1].model_dump()),
+                NodeInfo(
+                    node_name="neighbor",
+                    node_id="src/c.py:neighbor",
+                    file="src/c.py",
+                    score=0.1,
+                ),
+            ][:top_k]
+
+    pipeline = DenseGraphExpandRerankPipeline(
+        retriever=_FakeRetriever(dense),
+        code_graph=graph,
+        rerank_context=RerankContext(
+            embedding_store=FakeIndexedStore(), embedding_source="index"
+        ),
+        dense_top_k=2,
+        graph_seed_top_k=1,
+        graph_neighbors_per_seed=1,
+        graph_fusion_weight=1.0,
+        final_top_k=3,
+        include_graph_content=False,
+    )
+
+    result = pipeline.query("query")
+
+    assert [node.file for node in result] == [
+        "src/c.py",
+        "/cache/repo/src/a.py",
+        "/cache/repo/src/b.py",
+    ]
+
+
+def test_pipeline_scopes_query_embedding_reuse_to_one_composed_request():
+    dense = QueriedNode(
+        node_name="seed",
+        node_id="src/a.py:seed",
+        file="src/a.py",
+        score=1.0,
+    )
+
+    class ScopedStore:
+        active = False
+        entries = 0
+
+        @contextmanager
+        def reuse_query_embedding(self):
+            assert not self.active
+            self.active = True
+            self.entries += 1
+            try:
+                yield
+            finally:
+                self.active = False
+
+        def search_within_ids(self, query, mask_node_ids, top_k, level):
+            assert self.active
+            return [NodeInfo(**dense.model_dump())]
+
+    store = ScopedStore()
+
+    class ScopedRetriever(_FakeRetriever):
+        vector_store = store
+
+        def query(self, query, top_k=None):
+            assert store.active
+            return super().query(query, top_k=top_k)
+
+    pipeline = DenseGraphExpandRerankPipeline(
+        retriever=ScopedRetriever([dense]),
+        rerank_context=RerankContext(
+            embedding_store=store,
+            embedding_source="index",
+        ),
+        graph_neighbors_per_seed=0,
+        final_top_k=1,
+    )
+
+    result = pipeline.query("query")
+
+    assert [node.node_id for node in result] == ["src/a.py:seed"]
+    assert store.entries == 1
+    assert store.active is False
 
 
 def test_old_graph_augmented_name_remains_compatible():

--- a/test/model/test_retrieval_planner.py
+++ b/test/model/test_retrieval_planner.py
@@ -255,10 +255,12 @@ class _FakeGraph:
     def resolve_symbol(self, symbol):
         return self.resolve.get(symbol), None
 
-    def get_successors(self, node_name):
+    def get_successors(self, node_name, edge_types=None):
+        assert edge_types == {"reference"}
         return self.successors.get(node_name, [])
 
-    def get_predecessors(self, node_name):
+    def get_predecessors(self, node_name, edge_types=None):
+        assert edge_types == {"reference"}
         return self.predecessors.get(node_name, [])
 
     def get_node_info_by_id(self, node_id):

--- a/test/ops/test_expand.py
+++ b/test/ops/test_expand.py
@@ -6,14 +6,17 @@
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from codeminer.ops.expand import (
     ExpandContext,
     expand_graph_neighbors,
+    hydrate_candidate_contents,
     nodeinfo_to_queried,
 )
-from codeminer.types import NodeInfo, QueriedNode
+from codeminer.types import EDGE_TYPE_REFERENCE, NodeInfo, QueriedNode
 
 # ---------------------------------------------------------------------------
 # Helper tests
@@ -74,6 +77,68 @@ class TestExpandContext:
         assert ctx.filter_tests is True
 
 
+def test_hydrate_candidate_contents_reads_only_missing_spans(tmp_path):
+    source = tmp_path / "src" / "example.py"
+    source.parent.mkdir()
+    source.write_text("line 0\nline 1\nline 2\n", encoding="utf-8")
+    candidates = [
+        QueriedNode(
+            node_name="missing",
+            file="src/example.py",
+            start_line=1,
+            end_line=2,
+        ),
+        QueriedNode(
+            node_name="existing",
+            file="src/example.py",
+            start_line=0,
+            end_line=0,
+            content="already loaded",
+        ),
+    ]
+
+    hydrated = hydrate_candidate_contents(candidates, repo_path=str(tmp_path))
+
+    assert hydrated[0].content == "line 1\nline 2\n"
+    assert hydrated[1] is candidates[1]
+
+
+def test_hydrate_candidate_contents_reads_the_requested_git_snapshot(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True
+    )
+    source = tmp_path / "example.py"
+    source.write_text("old 0\nold 1\nold 2\n", encoding="utf-8")
+    subprocess.run(["git", "add", "example.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "fixture"], cwd=tmp_path, check=True)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    source.write_text("new 0\n", encoding="utf-8")
+    candidate = QueriedNode(
+        node_name="old symbol",
+        file="example.py",
+        start_line=1,
+        end_line=2,
+    )
+
+    hydrated = hydrate_candidate_contents(
+        [candidate], repo_path=str(tmp_path), git_commit=commit
+    )
+
+    assert hydrated[0].content == "old 1\nold 2\n"
+
+
 class _FakeGraph:
     def __init__(self, *, resolve=None, successors=None, predecessors=None, info=None):
         self.resolve = resolve or {}
@@ -84,10 +149,12 @@ class _FakeGraph:
     def resolve_symbol(self, symbol):
         return self.resolve.get(symbol), None
 
-    def get_successors(self, node_name):
+    def get_successors(self, node_name, edge_types=None):
+        assert edge_types in (None, {EDGE_TYPE_REFERENCE})
         return self.successors.get(node_name, [])
 
-    def get_predecessors(self, node_name):
+    def get_predecessors(self, node_name, edge_types=None):
+        assert edge_types in (None, {EDGE_TYPE_REFERENCE})
         return self.predecessors.get(node_name, [])
 
     def get_node_info_by_id(self, node_id):
@@ -197,6 +264,68 @@ class TestExpandGraphNeighbors:
         )
 
         assert result[0].content == "l1\nl2\n"
+
+    def test_both_directions_share_the_per_seed_budget(self):
+        graph = _FakeGraph(
+            resolve={"seed": "seed"},
+            successors={"seed": [1, 2, 3]},
+            predecessors={"seed": [4, 5, 6]},
+            info={
+                node_id: {
+                    "name": f"neighbor{node_id}",
+                    "type": "function",
+                    "file": f"src/{node_id}.py",
+                    "start_line": node_id,
+                    "end_line": node_id,
+                }
+                for node_id in range(1, 7)
+            },
+        )
+        seed = QueriedNode(node_name="seed", type="function", score=1.0)
+
+        result = expand_graph_neighbors(
+            ExpandContext(code_graph=graph),
+            [seed],
+            per_seed=4,
+            direction="both",
+        )
+
+        assert [node.node_name for node in result] == [
+            "neighbor1",
+            "neighbor4",
+            "neighbor2",
+            "neighbor5",
+        ]
+
+    def test_both_directions_do_not_repeat_the_same_neighbor(self):
+        graph = _FakeGraph(
+            resolve={"seed": "seed"},
+            successors={"seed": [1, 2]},
+            predecessors={"seed": [1, 3]},
+            info={
+                node_id: {
+                    "name": f"neighbor{node_id}",
+                    "type": "function",
+                    "file": f"src/{node_id}.py",
+                    "start_line": node_id,
+                    "end_line": node_id,
+                }
+                for node_id in range(1, 4)
+            },
+        )
+
+        result = expand_graph_neighbors(
+            ExpandContext(code_graph=graph),
+            [QueriedNode(node_name="seed", type="function")],
+            per_seed=3,
+            direction="both",
+        )
+
+        assert [node.node_name for node in result] == [
+            "neighbor1",
+            "neighbor2",
+            "neighbor3",
+        ]
 
     def test_prefers_seed_node_id_over_bare_node_name(self):
         graph = _FakeGraph(

--- a/test/ops/test_rerank.py
+++ b/test/ops/test_rerank.py
@@ -6,8 +6,12 @@
 
 from __future__ import annotations
 
-from codeminer.ops.rerank import rerank_by_embedding
-from codeminer.types import QueriedNode
+from codeminer.ops.rerank import (
+    rerank_by_cross_encoder,
+    rerank_by_embedding,
+    rerank_by_indexed_embedding,
+)
+from codeminer.types import NodeInfo, QueriedNode
 
 
 class _FakeEmbedding:
@@ -80,3 +84,140 @@ def test_rerank_by_embedding_skips_candidates_without_content():
     result = rerank_by_embedding("query", candidates, store, top_k=5)
 
     assert [node.node_name for node in result] == ["best"]
+
+
+def test_rerank_by_indexed_embedding_reuses_index_and_appends_unmatched():
+    candidates = [
+        QueriedNode(node_name="dense", node_id="a.py:dense", file="a.py"),
+        QueriedNode(node_name="graph", node_id="b.py:graph", file="b.py"),
+        QueriedNode(node_name="missing", node_id="c.py:missing", file="c.py"),
+    ]
+
+    class FakeIndexedStore:
+        def search_within_ids(self, query, mask_node_ids, top_k, level):
+            assert query == "query"
+            assert mask_node_ids == {
+                "a.py:dense",
+                "b.py:graph",
+                "c.py:missing",
+            }
+            assert top_k == 3
+            assert level == "l2"
+            return [
+                NodeInfo(
+                    node_name="graph",
+                    node_id="b.py:graph",
+                    file="b.py",
+                    score=0.9,
+                ),
+                NodeInfo(
+                    node_name="graph duplicate",
+                    node_id="b.py:graph",
+                    file="b.py",
+                    score=0.8,
+                ),
+                NodeInfo(
+                    node_name="dense",
+                    node_id="a.py:dense",
+                    file="a.py",
+                    score=0.7,
+                ),
+            ]
+
+    result = rerank_by_indexed_embedding(
+        "query", candidates, FakeIndexedStore(), top_k=3
+    )
+
+    assert [node.node_id for node in result] == [
+        "b.py:graph",
+        "a.py:dense",
+        "c.py:missing",
+    ]
+
+
+def test_rerank_by_indexed_embedding_does_not_expand_bare_names():
+    candidates = [
+        QueriedNode(node_name="same", node_id="a.py:same", file="a.py"),
+        QueriedNode(node_name="same", file="b.py"),
+    ]
+
+    class FakeIndexedStore:
+        def search_within_ids(self, query, mask_node_ids, top_k, level):
+            assert mask_node_ids == {"a.py:same"}
+            return [
+                NodeInfo(
+                    node_name="same",
+                    node_id="a.py:same",
+                    file="a.py",
+                    score=0.9,
+                )
+            ]
+
+    result = rerank_by_indexed_embedding("query", candidates, FakeIndexedStore())
+
+    assert [(node.file, node.node_id) for node in result] == [
+        ("a.py", "a.py:same"),
+        ("b.py", None),
+    ]
+
+
+def test_rerank_by_cross_encoder_scores_content_and_preserves_metadata():
+    candidates = [
+        QueriedNode(
+            node_name="first",
+            node_id="a.py:first",
+            file="a.py",
+            content="first body",
+        ),
+        QueriedNode(
+            node_name="second",
+            node_id="b.py:second",
+            file="b.py",
+            content="second body",
+        ),
+    ]
+
+    class FakeContext:
+        def score(self, query, docs):
+            assert query == "query"
+            assert docs == ["first body", "second body"]
+            return [0.1, 0.9]
+
+    result = rerank_by_cross_encoder("query", candidates, FakeContext(), top_k=1)
+
+    assert len(result) == 1
+    assert result[0].node_id == "b.py:second"
+    assert result[0].content == "second body"
+    assert result[0].score == 0.9
+
+
+def test_rerank_by_cross_encoder_retains_candidates_without_content():
+    candidates = [
+        QueriedNode(node_name="missing", node_id="a.py:missing"),
+        QueriedNode(node_name="present", node_id="b.py:present", content="body"),
+    ]
+
+    class FakeContext:
+        def score(self, query, docs):
+            assert docs == ["body"]
+            return [0.7]
+
+    result = rerank_by_cross_encoder("query", candidates, FakeContext())
+
+    assert [node.node_id for node in result] == ["b.py:present", "a.py:missing"]
+    assert result[0].score == 0.7
+
+
+def test_rerank_by_cross_encoder_rejects_wrong_score_count():
+    candidate = QueriedNode(node_name="only", content="body")
+
+    class FakeContext:
+        def score(self, query, docs):
+            return []
+
+    try:
+        rerank_by_cross_encoder("query", [candidate], FakeContext())
+    except RuntimeError as exc:
+        assert "scores for 1 candidates" in str(exc)
+    else:
+        raise AssertionError("expected score-count validation to fail")

--- a/test/ops/test_retrieve.py
+++ b/test/ops/test_retrieve.py
@@ -6,7 +6,13 @@
 
 from __future__ import annotations
 
-from codeminer.ops.retrieve import dedup_queried_nodes, merge_hybrid, queried_node_key
+from codeminer.ops.retrieve import (
+    dedup_queried_nodes,
+    merge_file_rankings,
+    merge_hybrid,
+    queried_file_key,
+    queried_node_key,
+)
 from codeminer.types import QueriedNode
 
 
@@ -71,3 +77,44 @@ def test_merge_hybrid_supports_rrf_with_node_id_identity():
 
     assert [node.node_id for node in result] == ["a", "b", "c"]
     assert result[0].score > result[1].score
+
+
+def test_file_rrf_matches_relative_node_ids_to_absolute_artifact_paths():
+    semantic = [
+        QueriedNode(
+            node_name="a1",
+            file="/old/cache/repo/src/a.py",
+            node_id="src/a.py:a1",
+        ),
+        QueriedNode(
+            node_name="a2",
+            file="/old/cache/repo/src/a.py",
+            node_id="src/a.py:a2",
+        ),
+        QueriedNode(
+            node_name="b",
+            file="/old/cache/repo/src/b.py",
+            node_id="src/b.py:b",
+        ),
+    ]
+    graph = [
+        QueriedNode(node_name="c", file="src/c.py", node_id="src/c.py:c"),
+        QueriedNode(node_name="a", file="src/a.py", node_id="src/a.py:a"),
+    ]
+
+    result = merge_file_rankings(
+        [semantic, graph], weights=[1.0, 1.0], top_k=3, rrf_k=60
+    )
+
+    assert queried_file_key(semantic[0]) == ("file", "src/a.py")
+    assert [queried_file_key(node) for node in result] == [
+        ("file", "src/a.py"),
+        ("file", "src/c.py"),
+        ("file", "src/b.py"),
+    ]
+
+
+def test_file_key_does_not_treat_a_symbol_prefix_as_a_file():
+    node = QueriedNode(node_name="method", node_id="Type:method")
+
+    assert queried_file_key(node)[0] == "node"


### PR DESCRIPTION
## Summary
Add reusable graph-aware retrieval operators without coupling core code to a paper-specific benchmark or tuned configuration.

## Changes
- Add edge-type-filtered one-hop graph traversal with balanced caller/callee budgeting and stable deduplication.
- Add node- and file-level RRF, persisted-vector reranking, cross-encoder reranking, and opt-in graph fusion.
- Reuse query embeddings only inside one explicit composed-request scope so repeated requests retain end-to-end embedding cost.
- Allow hierarchical vector builders to reuse a caller-supplied embedding instance.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Local verification: pre-commit passed; 51 focused tests passed; affected unit tier completed with 322 passed, 1 skipped, and 102 deselected.