### PR TITLE
fix(index): skip source-less regex content reads

### DIFF
--- a/codeminer/index/regex_idx/regex_idx.py
+++ b/codeminer/index/regex_idx/regex_idx.py
@@ -12,7 +12,7 @@ from typing import List, Optional
 
 from ...graph.code_graph import CodeGraph
 from ...log_utils import get_logger
-from ...types import NodeInfo
+from ...types import NODE_TYPE_FILE, NodeInfo
 
 logger = get_logger(__name__)
 
@@ -41,6 +41,7 @@ class RegexNodeIndex:
     def _build_index(self):
         """Build index from CodeGraph."""
         vs = self.code_graph.get_graph().vs
+        content_failures = 0
 
         for v in vs:
             vid = v.index
@@ -48,13 +49,17 @@ class RegexNodeIndex:
 
             # Get content from the node
             content: Optional[str] = None
-            try:
-                content = self.code_graph.get_node_content(vid)
-                if content:
-                    content = content[:MAX_CONTENT_CHARS]
-            except Exception as e:
-                logger.debug(f"Failed to get content for node {vid}: {e}")
-                content = None
+            has_source_range = (
+                attrs.get("start_line") is not None
+                and attrs.get("end_line") is not None
+            )
+            if attrs.get("type") == NODE_TYPE_FILE or has_source_range:
+                try:
+                    content = self.code_graph.get_node_content(vid)
+                    if content:
+                        content = content[:MAX_CONTENT_CHARS]
+                except Exception:  # malformed source metadata is non-fatal here
+                    content_failures += 1
 
             # Create NodeInfo object
             node = NodeInfo(
@@ -68,6 +73,11 @@ class RegexNodeIndex:
             self.nodes.append(node)
 
         logger.info(f"Built index with {len(vs)} nodes")
+        if content_failures:
+            logger.debug(
+                "Skipped content for %d nodes with unreadable source metadata",
+                content_failures,
+            )
 
     def search(
         self,

--- a/test/index/test_regex_idx_unit.py
+++ b/test/index/test_regex_idx_unit.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from codeminer.index.regex_idx import RegexNodeIndex
+
+
+class _Vertex:
+    def __init__(self, index, **attributes):
+        self.index = index
+        self._attributes = attributes
+
+    def attributes(self):
+        return dict(self._attributes)
+
+    def __getitem__(self, key):
+        return self._attributes[key]
+
+
+class _Graph:
+    def __init__(self):
+        self.vertices = [
+            _Vertex(
+                0,
+                name="external-symbol",
+                type="symbol",
+                file=None,
+                start_line=None,
+                end_line=None,
+            ),
+            _Vertex(
+                1,
+                name="local-symbol",
+                type="function",
+                file="src/example.py",
+                start_line=2,
+                end_line=3,
+            ),
+        ]
+        self.content_calls = []
+
+    def get_graph(self):
+        return SimpleNamespace(vs=self.vertices)
+
+    def get_node_content(self, node_id):
+        self.content_calls.append(node_id)
+        return "needle" if node_id == 1 else None
+
+
+def test_regex_index_skips_content_lookup_for_nodes_without_source_ranges():
+    graph = _Graph()
+
+    index = RegexNodeIndex(graph)
+
+    assert graph.content_calls == [1]
+    assert len(index.nodes) == 2
+    assert [node.node_name for node in index.search("needle")] == ["local-symbol"]


### PR DESCRIPTION
## Summary
Avoid content lookups for graph nodes that cannot map to source text.

## Changes
- Read content only for file nodes or nodes with a source range.
- Aggregate malformed-source failures into one debug message.
- Add a focused unit test covering source-less external symbols.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/index/test_regex_idx_unit.py test/mcp_server/test_context.py test/mcp_server/test_tools_search.py --tb=short` (24 passed)
- `pre-commit run --files codeminer/index/regex_idx/regex_idx.py test/index/test_regex_idx_unit.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published