### PR TITLE
fix(eval): honor sweep runtime configuration

### DIFF
--- a/codeminer/eval/agent_runner/contexts.py
+++ b/codeminer/eval/agent_runner/contexts.py
@@ -49,6 +49,7 @@ class AgentSkillContextSpec:
     embedding_model: str
     embedding_dimension: int
     top_k: int
+    embedding_revision: Optional[str] = None
     languages: Sequence[str] = ("python",)
     default_level: str = "l2"
     rebuild: bool = False
@@ -120,6 +121,7 @@ def load_agent_skill_contexts(
         cache_dir=cache_dir,
         skills_dir=skills_dir,
         embedding_model=spec.embedding_model,
+        embedding_revision=spec.embedding_revision,
         embedding_dimension=spec.embedding_dimension,
         default_top_k=spec.top_k,
         default_level=spec.default_level,

--- a/codeminer/eval/agent_runner/sweep.py
+++ b/codeminer/eval/agent_runner/sweep.py
@@ -194,6 +194,7 @@ def load_full_contexts(cfg: SweepConfig, repo_path: str, cache_dir: str):
             # bm25 builds from the prebuilt graph; lang-agnostic.
             languages=["python"],
             embedding_model=cfg.embedding_model,
+            embedding_revision=cfg.embedding_revision,
             embedding_dimension=cfg.embedding_dimension,
             top_k=cfg.topk,
             default_level="l2",
@@ -287,6 +288,7 @@ def run_cell(
     route_context_spec = route_context_spec or {}
     harness_spec = AgentHarnessSpec(
         max_turns=cfg.max_turns,
+        max_context_tokens=cfg.max_context_tokens,
         allow_skills=set(skills),
         include_default_tools=cfg.include_default_tools,
         default_tool_ids=(

--- a/codeminer/eval/agent_runner/sweep_config.py
+++ b/codeminer/eval/agent_runner/sweep_config.py
@@ -46,6 +46,10 @@ class SweepConfig:
     vertex_project: Optional[str] = None
     reps: int = 2
     max_turns: int = 20
+    # Maximum tokens retained in chat history before old tool turns are evicted.
+    # This is lower than the provider context window because tool schemas and the
+    # requested completion budget are added outside the message history.
+    max_context_tokens: Optional[int] = None
     temperature: float = 0.0
     max_tokens: int = 4096
     topk: int = 50
@@ -54,6 +58,9 @@ class SweepConfig:
     split: str = "test"
     prebuilt_dir: str = "/mnt/data/codeminer"
     embedding_model: Optional[str] = None
+    # Optional immutable model revision. Experiments should set this whenever
+    # the provider accepts mutable model ids such as ``main``.
+    embedding_revision: Optional[str] = None
     embedding_dimension: int = 1024
     metrics_k: List[int] = field(default_factory=lambda: [1, 3, 5, 10])
     gt_simplified_symbols: bool = True
@@ -97,6 +104,10 @@ class SweepConfig:
     # Provider-specific raw-call body for the lightweight eager_gated classifier.
     # Keep quirks in config files instead of branching on model names in code.
     gate_llm_extra_body: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        if self.max_context_tokens is not None and self.max_context_tokens <= 0:
+            raise ValueError("max_context_tokens must be positive when set")
 
     @classmethod
     def from_yaml(cls, path: Path) -> "SweepConfig":

--- a/test/eval/test_agent_contexts.py
+++ b/test/eval/test_agent_contexts.py
@@ -87,6 +87,7 @@ def test_load_agent_skill_contexts_loads_metadata_builds_then_reloads(
     spec = AgentSkillContextSpec(
         skill_ids=["embedding_search", "bm25_search"],
         embedding_model="org/embed-small",
+        embedding_revision="model-commit",
         embedding_dimension=256,
         top_k=11,
         languages=["python", "rust"],
@@ -115,6 +116,7 @@ def test_load_agent_skill_contexts_loads_metadata_builds_then_reloads(
         "cache_dir": str(tmp_path / "cache"),
         "skills_dir": str(skills_dir),
         "embedding_model": "org/embed-small",
+        "embedding_revision": "model-commit",
         "embedding_dimension": 256,
         "default_top_k": 11,
         "default_level": "l1",

--- a/test/eval/test_sweep.py
+++ b/test/eval/test_sweep.py
@@ -93,6 +93,7 @@ def test_run_cell_passes_lsp_route_context_options_to_harness(monkeypatch, tmp_p
     cfg = SweepConfig(
         sweep_id="route",
         subsets={"graph": ["lsp_route"]},
+        max_context_tokens=48_000,
         lsp_route_context={
             "graph": {
                 "seed_limit": 4,
@@ -120,9 +121,19 @@ def test_run_cell_passes_lsp_route_context_options_to_harness(monkeypatch, tmp_p
     assert out["trace_summary"]["schema_version"] is None
     assert captured
     spec = captured[0]
+    assert spec.max_context_tokens == 48_000
     assert spec.enable_lsp_route_context is True
     assert spec.lsp_route_seed_limit == 4
     assert spec.lsp_route_seed_policy == "specific"
     assert spec.lsp_route_query_fallback is True
     assert spec.lsp_route_top_k == 9
     assert spec.lsp_route_include_neighbors is False
+
+
+def test_sweep_config_rejects_non_positive_context_budget():
+    with pytest.raises(ValueError, match="max_context_tokens"):
+        SweepConfig(
+            sweep_id="invalid_context_budget",
+            subsets={"grep_only": ["read", "grep"]},
+            max_context_tokens=0,
+        )


### PR DESCRIPTION
## Summary
Propagate reproducibility and context-budget settings through the reusable agent sweep runtime.

## Changes
- Pass an optional immutable embedding revision into skill-context loading.
- Pass the configured chat-history token budget into every agent cell.
- Reject non-positive context budgets at config construction.
- Add focused propagation and validation tests.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/eval/test_agent_contexts.py test/eval/test_sweep.py --tb=short` (11 passed)
- `pre-commit run --files codeminer/eval/agent_runner/contexts.py codeminer/eval/agent_runner/sweep.py codeminer/eval/agent_runner/sweep_config.py test/eval/test_agent_contexts.py test/eval/test_sweep.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published