### PR TITLE
perf(eval): stage only required sweep indexes

### DIFF
--- a/codeminer/eval/agent_runner/prebuilt.py
+++ b/codeminer/eval/agent_runner/prebuilt.py
@@ -39,7 +39,7 @@ import pickle
 import shutil
 import sys
 import tempfile
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 # External experiment artifacts were written with schema 3 before exact SCIP
 # declaration lines were persisted. They remain valid for retrieval and graph
@@ -74,6 +74,35 @@ def has_full_indexes(
         os.path.join("l2", f"documents_{suffix}.pkl"),
     ]
     return all(os.path.exists(os.path.join(d, r)) for r in required)
+
+
+def has_required_indexes(
+    prebuilt_root: str,
+    instance_id: str,
+    embedding_model: str,
+    index_types: Iterable[str],
+) -> bool:
+    """Return whether a bundle can satisfy the declared index requirements.
+
+    The repository snapshot is always required because default file tools run
+    against it. BM25 may be built from that snapshot at load time, while vector
+    and symbol-graph requirements must have their durable artifacts present.
+    """
+
+    required = set(index_types)
+    instance = instance_dir(prebuilt_root, instance_id)
+    paths = [os.path.join(instance, "repo")]
+    if "symbol_graph" in required:
+        paths.append(os.path.join(instance, "graph.pkl"))
+    if "vector" in required:
+        suffix = model_suffix(embedding_model)
+        paths.extend(
+            [
+                os.path.join(instance, "l2", f"index_{suffix}.faiss"),
+                os.path.join(instance, "l2", f"documents_{suffix}.pkl"),
+            ]
+        )
+    return all(os.path.exists(path) for path in paths)
 
 
 def _symlink(target: str, link: str) -> None:
@@ -333,11 +362,13 @@ def stage_prebuilt_indexes(
     *,
     build_bm25: bool = True,
     code_graph: Optional[object] = None,
+    required_index_types: Optional[Iterable[str]] = None,
 ) -> str:
-    """Stage prebuilt vector + symbol graph (and build BM25) under *cache_dir*.
+    """Stage declared durable indexes under *cache_dir*.
 
     Returns ``cache_dir``. Idempotent: re-staging an already-staged cache is
-    a no-op except that BM25 is rebuilt only when its index dir is empty.
+    a no-op except that BM25 is built only when requested and absent. Omitting
+    ``required_index_types`` preserves the historical graph+vector+BM25 path.
     """
     inst = instance_dir(prebuilt_root, instance_id)
     if not os.path.isdir(inst):
@@ -345,21 +376,37 @@ def stage_prebuilt_indexes(
 
     os.makedirs(cache_dir, exist_ok=True)
 
+    legacy_all = required_index_types is None
+    required = (
+        {"bm25", "symbol_graph", "vector"}
+        if legacy_all
+        else set(required_index_types or ())
+    )
     graph_src = os.path.join(inst, "graph.pkl")
     graph_dst = os.path.join(cache_dir, "symbol_graph", "graph.pkl")
     graph = None
-    if build_bm25:
+    graph_available = os.path.isfile(graph_src) or code_graph is not None
+    should_stage_graph = "symbol_graph" in required or (
+        "bm25" in required and build_bm25 and graph_available
+    )
+    if should_stage_graph and build_bm25:
         graph = _stage_symbol_graph(graph_src, graph_dst, code_graph)
-    else:
+    elif should_stage_graph or legacy_all:
         # Lightweight staging for tests / callers that only need the path shape.
         _symlink(graph_src, graph_dst)
 
     # vector -> the instance dir itself (CodeVectorStore.load scans l0/l2)
-    _symlink(inst, os.path.join(cache_dir, "vector"))
+    if "vector" in required:
+        _symlink(inst, os.path.join(cache_dir, "vector"))
 
     # bm25/ — build fresh from the prebuilt graph (no embedding model needed)
     bm25_dir = os.path.join(cache_dir, "bm25")
-    if build_bm25 and not (os.path.isdir(bm25_dir) and os.listdir(bm25_dir)):
+    if (
+        "bm25" in required
+        and build_bm25
+        and graph_available
+        and not (os.path.isdir(bm25_dir) and os.listdir(bm25_dir))
+    ):
         from codeminer.index.sparse_idx.bm25_index import BM25CodeIndexer
 
         graph = (

--- a/codeminer/eval/agent_runner/query_sweep.py
+++ b/codeminer/eval/agent_runner/query_sweep.py
@@ -126,18 +126,30 @@ def run_query_sweep(
     summary_filename: str = "query_sweep_summary.json",
 ) -> Dict[str, Any]:
     """Run a per-query sweep against already-normalized query rows."""
+    from codeminer.compiler.skill_context import required_index_types
+    from codeminer.eval.agent_runner.contexts import default_agent_skills_dir
     from codeminer.eval.agent_runner.prebuilt import (
-        has_full_indexes,
+        has_required_indexes,
         repo_path_for,
         stage_prebuilt_indexes,
     )
     from codeminer.eval.agent_runner.scoring import evaluate_agent_localization
-    from codeminer.eval.agent_runner.sweep import load_full_contexts, run_cell, slug
+    from codeminer.eval.agent_runner.sweep import (
+        all_index_skill_ids,
+        load_full_contexts,
+        run_cell,
+        slug,
+        validate_sweep_harness,
+    )
     from codeminer.eval.agent_runner.symbols import build_prebuilt_symbol_span_index
     from codeminer.eval.agent_runner.verify_expand import load_graph_nav
     from codeminer.eval.retrieval_eval import collect_target_blocks
     from codeminer.llm.litellm_chat import LiteLLMChat
 
+    validate_sweep_harness(cfg)
+    index_types = required_index_types(
+        all_index_skill_ids(cfg), skills_dir=str(default_agent_skills_dir())
+    )
     filtered_rows = select_query_rows(
         rows,
         categories=categories,
@@ -147,6 +159,8 @@ def run_query_sweep(
     needs_verify = any(
         (recipe or {}).get("verify") for recipe in (cfg.preload or {}).values()
     )
+    if needs_verify:
+        index_types.add("symbol_graph")
     cells_dir = output_dir / "cells"
     cells_dir.mkdir(parents=True, exist_ok=True)
 
@@ -162,14 +176,24 @@ def run_query_sweep(
         max_tokens=cfg.max_tokens,
         extra_kwargs=vertex_extra,
     )
-    summary: Dict[str, Any] = {"completed": [], "skipped": [], "failed": []}
+    summary: Dict[str, Any] = {
+        "required_index_types": sorted(index_types),
+        "completed": [],
+        "skipped": [],
+        "failed": [],
+    }
 
     for instance_id, instance_rows in group_query_rows_by_instance(
         filtered_rows
     ).items():
         if max_queries:
             instance_rows = instance_rows[:max_queries]
-        if not has_full_indexes(cfg.prebuilt_dir, instance_id, cfg.embedding_model):
+        if not has_required_indexes(
+            cfg.prebuilt_dir,
+            instance_id,
+            cfg.embedding_model,
+            index_types,
+        ):
             print(f"query-sweep: WARN {instance_id} missing prebuilt; skipping")
             summary["skipped"].append(
                 {"instance_id": instance_id, "reason": "no-prebuilt"}
@@ -191,7 +215,7 @@ def run_query_sweep(
             continue
 
         repo_path = repo_path_for(cfg.prebuilt_dir, instance_id)
-        cache_dir = repo_path
+        cache_dir = str(output_dir / "cache" / slug(instance_id))
         source = instance_rows[0].get("source_config") if instance_rows else ""
         started = time.time()
         print(
@@ -199,7 +223,12 @@ def run_query_sweep(
             f"({len(plan)} cells over {len(instance_rows)} queries)"
         )
         try:
-            stage_prebuilt_indexes(cfg.prebuilt_dir, instance_id, cache_dir)
+            stage_prebuilt_indexes(
+                cfg.prebuilt_dir,
+                instance_id,
+                cache_dir,
+                required_index_types=index_types,
+            )
             contexts = load_full_contexts(cfg, repo_path, cache_dir)
         except Exception as exc:  # noqa: BLE001
             print(f"query-sweep: FAIL load {instance_id}: {exc}", file=sys.stderr)
@@ -207,8 +236,10 @@ def run_query_sweep(
                 {"instance_id": instance_id, "reason": f"load:{exc}"}
             )
             continue
-        symbol_span_index = build_prebuilt_symbol_span_index(
-            cfg.prebuilt_dir, instance_id
+        symbol_span_index = (
+            build_prebuilt_symbol_span_index(cfg.prebuilt_dir, instance_id)
+            if "symbol_graph" in index_types
+            else None
         )
         nav = load_graph_nav(cfg.prebuilt_dir, instance_id) if needs_verify else None
         print(f"query-sweep:   contexts ready in {time.time() - started:.1f}s")

--- a/test/eval/test_prebuilt.py
+++ b/test/eval/test_prebuilt.py
@@ -72,6 +72,23 @@ def test_has_full_indexes_true_false(tmp_path):
     assert prebuilt.has_full_indexes(str(tmp_path), "missing", model) is False
 
 
+def test_has_required_indexes_only_checks_declared_resources(tmp_path):
+    model = "org/embed-small"
+    instance = tmp_path / "vector-only"
+    (instance / "repo").mkdir(parents=True)
+    suffix = prebuilt.model_suffix(model)
+    (instance / "l2").mkdir()
+    (instance / "l2" / f"index_{suffix}.faiss").write_text("x")
+    (instance / "l2" / f"documents_{suffix}.pkl").write_text("x")
+
+    assert prebuilt.has_required_indexes(
+        str(tmp_path), "vector-only", model, {"vector"}
+    )
+    assert not prebuilt.has_required_indexes(
+        str(tmp_path), "vector-only", model, {"symbol_graph", "vector"}
+    )
+
+
 def test_repo_and_instance_paths(tmp_path):
     assert prebuilt.instance_dir(str(tmp_path), "i").endswith("/i")
     assert prebuilt.repo_path_for(str(tmp_path), "i").endswith("/i/repo")
@@ -116,6 +133,24 @@ def test_stage_creates_symlinks_without_bm25(tmp_path):
     vec = cache / "vector"
     assert vec.is_symlink()
     assert os.path.realpath(vec) == os.path.realpath(src)
+
+
+def test_stage_vector_only_does_not_require_or_stage_graph(tmp_path):
+    model = "org/embed-small"
+    src = _make_prebuilt(tmp_path / "prebuilt", "inst", model, full=True)
+    (src / "graph.pkl").unlink()
+    cache = tmp_path / "cache" / "inst"
+
+    prebuilt.stage_prebuilt_indexes(
+        str(tmp_path / "prebuilt"),
+        "inst",
+        str(cache),
+        required_index_types={"vector"},
+    )
+
+    assert (cache / "vector").is_symlink()
+    assert not (cache / "symbol_graph").exists()
+    assert not (cache / "bm25").exists()
 
 
 def test_stage_is_idempotent(tmp_path):

--- a/test/eval/test_query_sweep.py
+++ b/test/eval/test_query_sweep.py
@@ -6,13 +6,17 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from codeminer.eval.agent_runner.query_sweep import (
     filter_query_rows,
     group_query_rows_by_instance,
     language_key_for_query_row,
     query_targets,
+    run_query_sweep,
     select_query_rows,
 )
+from codeminer.eval.agent_runner.sweep_config import SweepConfig
 
 
 def test_query_targets_normalizes_files_and_simplified_symbols():
@@ -102,3 +106,116 @@ def test_language_key_for_query_row_prefers_explicit_then_language_group():
         "typescript"
     )
     assert language_key_for_query_row({"source_config": "Python"}) == "python"
+
+
+def test_run_query_sweep_stages_only_declared_indexes(monkeypatch, tmp_path):
+    calls = {}
+
+    def has_required(prebuilt_dir, instance_id, embedding_model, index_types):
+        calls["preflight"] = (
+            prebuilt_dir,
+            instance_id,
+            embedding_model,
+            set(index_types),
+        )
+        return True
+
+    def stage(prebuilt_dir, instance_id, cache_dir, *, required_index_types):
+        calls["stage"] = (
+            prebuilt_dir,
+            instance_id,
+            cache_dir,
+            set(required_index_types),
+        )
+        return cache_dir
+
+    def unexpected_symbol_graph(*_args, **_kwargs):
+        raise AssertionError("vector-only sweeps must not load the symbol graph")
+
+    monkeypatch.setattr(
+        "codeminer.eval.agent_runner.prebuilt.has_required_indexes", has_required
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.agent_runner.prebuilt.repo_path_for",
+        lambda _root, _instance: "/snapshots/repo",
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.agent_runner.prebuilt.stage_prebuilt_indexes", stage
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.agent_runner.sweep.load_full_contexts",
+        lambda _cfg, _repo, _cache: {},
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.agent_runner.sweep.run_cell",
+        lambda *_args, **_kwargs: {
+            "answer": "",
+            "file_read_paths": [],
+            "nodes": [],
+            "preload_candidates": [],
+            "verify_triggered": False,
+            "verify_resolved": False,
+            "tool_calls": [],
+            "trace_summary": {},
+            "total_turns": 1,
+            "total_tokens": 1,
+            "cost_usd": 0.0,
+            "cache_read_input_tokens": 0,
+        },
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.agent_runner.symbols.build_prebuilt_symbol_span_index",
+        unexpected_symbol_graph,
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.agent_runner.scoring.evaluate_agent_localization",
+        lambda **_kwargs: SimpleNamespace(
+            metrics={"answer_blocks": {5: {"recall": 0.0}}},
+            to_record_fields=lambda: {},
+        ),
+    )
+    monkeypatch.setattr(
+        "codeminer.eval.retrieval_eval.collect_target_blocks", lambda _row: []
+    )
+    monkeypatch.setattr(
+        "codeminer.llm.litellm_chat.LiteLLMChat", lambda **_kwargs: object()
+    )
+
+    cfg = SweepConfig(
+        sweep_id="vector-only",
+        subsets={"vector": ["embedding_search"]},
+        model="provider/model",
+        embedding_model="org/embed-small",
+        prebuilt_dir=str(tmp_path / "prebuilt"),
+        reps=1,
+    )
+    output_dir = tmp_path / "results"
+
+    summary = run_query_sweep(
+        cfg,
+        output_dir,
+        [
+            {
+                "instance_id": "org__repo-1",
+                "query_id": "query-1",
+                "query": "Locate the implementation",
+                "gt_files": [],
+                "gt_symbols": [],
+            }
+        ],
+        resume=False,
+    )
+
+    assert summary["required_index_types"] == ["vector"]
+    assert calls["preflight"] == (
+        str(tmp_path / "prebuilt"),
+        "org__repo-1",
+        "org/embed-small",
+        {"vector"},
+    )
+    assert calls["stage"] == (
+        str(tmp_path / "prebuilt"),
+        "org__repo-1",
+        str(output_dir / "cache" / "org__repo-1"),
+        {"vector"},
+    )


### PR DESCRIPTION
## Summary
Make reusable query sweeps stage and validate only the indexes declared by their configured skills.

## Changes
- Derive required index types from bundled skill metadata before each sweep.
- Validate vector and graph artifacts independently instead of requiring every prebuilt index.
- Stage indexes in a dedicated output cache and skip symbol-graph loading for graph-free arms.
- Preserve the historical all-index staging behavior for existing callers.
- Add vector-only preflight, staging, and end-to-end sweep tests.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/eval/test_prebuilt.py test/eval/test_query_sweep.py test/scripts/test_graphrag_retrieve.py --tb=short` (25 passed)
- `pre-commit run --files codeminer/eval/agent_runner/prebuilt.py codeminer/eval/agent_runner/query_sweep.py test/eval/test_prebuilt.py test/eval/test_query_sweep.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published