### PR TITLE
Serving config: DGX Spark hybrid demo (FP8+MTP Qwen Ask, Vertex wiki, dense embeddings)

### DIFF
--- a/SERVING.md
+++ b/SERVING.md
@@ -36,9 +36,17 @@ Public: frontend **http://stable-spark1.ucsd.edu:3000**, backend `:8000`.
 
 | Role | Model string | Backend |
 |---|---|---|
-| Ask (interactive agent) | `openai/qwen3.6-35b` | vLLM `:8080` |
+| Ask (interactive agent) | `openai/qwen3.6-35b` (served from `Qwen3.6-35B-A3B-FP8` + MTP) | vLLM `:8080` |
 | Wiki prose + edge labels | `vertex_ai/claude-haiku-4-5@20251001` | Vertex (ADC) |
 | Dense embeddings (hybrid retrieval) | `Qwen/Qwen3-Embedding-0.6B` (openai provider) | vLLM `:8081` |
+
+**Ask throughput (GB10 is bandwidth-bound):** bf16 ~20 tok/s → **FP8 + MTP ~50-65 tok/s**
+(~3×). MTP `num_speculative_tokens=1` (this model has one MTP layer; 2 is *slower*).
+NVFP4 was tried but the vLLM `qwen3_5` loader can't map its expert scales, so FP8 is the
+path. Qwen3.6 is a *thinking* model — thinking is disabled for the agent (it otherwise
+emits a plain-text "Here's a thinking process:" preamble that breaks answers and wastes
+tokens); the agent also force-synthesizes a final answer if it runs out of turns
+mid-exploration. See `codeminer/llm/litellm_chat.py` + `codeminer/agent/runner.py`.
 
 ## 0. One-time env
 
@@ -52,13 +60,14 @@ gcloud auth application-default login             # Vertex ADC
 ## 1. vLLM containers (docker, GPU)
 
 ```bash
-# Ask model — thinking MoE, qwen3_xml tool parser
+# Ask model — FP8 MoE + MTP speculative decoding, qwen3_xml tool parser
 docker run -d --name vllm-qwen36 --restart unless-stopped --gpus all --ipc=host \
   -p 8080:8000 -v ~/.cache/huggingface:/root/.cache/huggingface \
   vllm/vllm-openai:cu130-nightly \
-  Qwen/Qwen3.6-35B-A3B --served-model-name qwen3.6-35b \
+  Qwen/Qwen3.6-35B-A3B-FP8 --served-model-name qwen3.6-35b \
   --max-model-len 65536 --gpu-memory-utilization 0.80 --max-num-seqs 2 \
-  --enable-auto-tool-choice --tool-call-parser qwen3_xml
+  --enable-auto-tool-choice --tool-call-parser qwen3_xml \
+  --speculative-config '{"method": "mtp", "num_speculative_tokens": 1}'
 
 # Embedding model — pooling runner, small GPU slice
 docker run -d --name vllm-embed --restart unless-stopped --gpus all --ipc=host \
@@ -127,7 +136,9 @@ The wiki is generated on-demand (Vertex Haiku) and cached to
 - tmux sessions survive SSH drops, not reboots. Docker containers auto-restart.
 - Shared HF cache `~/.cache/huggingface/hub` is root-owned (vLLM writes as root);
   for user-side HF downloads (e.g. `datasets`) set `HF_HOME=~/data/hf-cache`.
-- Ask answers are grounded in symbol names + dense-retrieved code; the thinking
-  model (Qwen3.6-35B) narrates its reasoning, so answers are correct but verbose.
+- Ask answers are grounded in BM25 + dense-retrieved code (hybrid). Thinking is
+  disabled and the agent force-synthesizes a final answer, so replies are clean
+  and complete (verified on requests + matplotlib).
 - **Known issue:** wiki outline generation returns 0 pages for the largest repos
   (astropy, matplotlib, scikit-learn, sympy) — under investigation.
+- **Known issue:** sympy is BM25-only (a chunk exceeds the 32768-token embed limit).

--- a/SERVING.md
+++ b/SERVING.md
@@ -1,0 +1,71 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Serving runbook (`serving-config` branch)
+
+Server deployment of the CodeMiner web demo: FastAPI backend + **Claude Haiku 4.5 on
+Vertex AI** for the Ask/QA + wiki generation. Config lives in `qa_config.yaml`.
+
+> The qwen vLLM on `:8000` is a **separate** serving endpoint and is not used here.
+> The backend runs on `:8080` to avoid that collision.
+
+## 0. One-time env setup
+
+```bash
+conda activate codeminer-backend            # env with litellm / faiss / uvicorn
+pip install -U "google-cloud-aiplatform>=1.38"   # litellm's Vertex path needs `vertexai`
+gcloud auth application-default login        # Google ADC (once per machine)
+```
+
+Sanity-check Vertex works:
+```bash
+VERTEXAI_PROJECT=ucsd-cse-stable-gcp VERTEXAI_LOCATION=us-east5 \
+python -c "import litellm; print(litellm.completion(model='vertex_ai/claude-haiku-4-5@20251001', messages=[{'role':'user','content':'say OK'}], max_tokens=8).choices[0].message.content)"
+```
+
+## 1. Index one or more repos (sparse / BM25)
+
+`index_repo.py` clones-free: point it at an already-cloned repo; it builds the BM25
+index and registers the repo in `.codeminer_qa/qa_registry.json`.
+
+```bash
+# small repo first, to validate the pipeline
+git clone --depth 1 https://github.com/psf/requests ~/repos/requests
+python scripts/index_repo.py ~/repos/requests
+
+# then any others (vllm is large; expect a longer index)
+# git clone --depth 1 https://github.com/vllm-project/vllm ~/repos/vllm
+# python scripts/index_repo.py ~/repos/vllm
+```
+
+## 2. Start the backend (port 8080, reachable by anyone)
+
+```bash
+VERTEXAI_PROJECT=ucsd-cse-stable-gcp \
+VERTEXAI_LOCATION=us-east5 \
+CODEMINER_DEMO_HOST=0.0.0.0 \
+CODEMINER_DEMO_PORT=8080 \
+CODEMINER_DEMO_CONFIG=qa_config.yaml \
+python -m codeminer.web.app
+```
+
+Run it inside `tmux` (e.g. `tmux new -s cm-backend`) so it survives SSH disconnects.
+
+## 3. Verify
+
+```bash
+curl -s http://localhost:8080/api/repos     # lists the repos you indexed (not [])
+```
+
+## 4. Frontend (optional, same server)
+
+```bash
+cd web
+NEXT_PUBLIC_API_BASE=http://<server-host>:8080 npm run dev -- -H 0.0.0.0 -p 3000
+```
+
+`NEXT_PUBLIC_API_BASE` must be a URL the browser can reach (the server's public host,
+not `localhost`). Later, put both behind a same-origin Caddy reverse proxy
+(`/` -> :3000, `/api` -> :8080) to drop CORS and get automatic HTTPS.

--- a/SERVING.md
+++ b/SERVING.md
@@ -112,8 +112,40 @@ python ~/build_vectors.py ~/data/codeminer-index/repos/<owner>_<repo>
 and runs `IndexCompiler(... index_types=["bm25","vector"]).compile_repo(...)`. A repo's
 manifest then reports `hybrid_search: true`. **Restart `cm-backend` after (re)indexing.**
 
-Currently indexed (6): `requests` + the 5 Python repos from
-`sysevol-ai/codeminer-synthesis` (astropy, matplotlib, xarray, scikit-learn, sympy).
+Indexed: 26 repos — `psf/requests` + all 5 language configs of
+`sysevol-ai/codeminer-synthesis` (5 repos each: Python, C/C++, Go, Rust, TS/JS),
+default branch, all `hybrid_search: true`.
+
+## 2b. Symbol graph (codemap / figures) — SCIP toolchain
+
+The wiki **graph/figure** views need the `symbol_graph` index (SCIP static analysis —
+**no LLM**). `index_repo.py` and `build_vectors.py` do NOT build it; `~/build_full.py`
+adds it (registers `SymbolGraphBuilder` and compiles `["bm25","vector","symbol_graph"]`
+together — building `symbol_graph` alone would overwrite the manifest and drop bm25/vector).
+
+Per-language tools, all installed **without sudo** under `~/codeminer-scip-tools`
+(`CODEMINER_SCIP_TOOLS_DIR`) + a `scip-env` miniconda env. This box is **aarch64**:
+
+| Lang | Tool | Install (aarch64) |
+|---|---|---|
+| Python | `scip-python` + miniconda `scip-env` + `protoc` | npm `@sourcegraph/scip-python`; miniconda (`conda tos accept` the default channels; `scip-env` = py3.11+pip+nodejs); protoc release binary |
+| Go | `scip-go` | go1.26.4 linux-arm64 tarball → `go install github.com/scip-code/scip-go/cmd/scip-go@v0.2.7` |
+| TS/JS | `scip-typescript` | npm `@sourcegraph/scip-typescript` (no per-repo `npm install` needed) |
+| Rust | `rust-analyzer` | `rustup component add rust-analyzer`; set `CODEMINER_RUST_TOOLCHAIN=stable` (indexer defaults to nightly) |
+| C/C++ | `clangd` | **NOT scip-clang** (no linux-arm64 build). CodeMiner routes C/C++ through clangd; install via `conda install -n scip-env -c conda-forge clang-tools clangdev` (arm64). No `compile_commands.json` needed — clangd background-indexes. |
+
+Build (env sets tool PATH + conda + protoc; graph lang is the 2nd arg):
+
+```bash
+export CODEMINER_SCIP_TOOLS_DIR=~/codeminer-scip-tools GOROOT=$CODEMINER_SCIP_TOOLS_DIR/go \
+  GOPATH=$CODEMINER_SCIP_TOOLS_DIR/go-tools CODEMINER_RUST_TOOLCHAIN=stable
+export PATH="$CODEMINER_SCIP_TOOLS_DIR/bin:$CODEMINER_SCIP_TOOLS_DIR/go-tools/bin:$CODEMINER_SCIP_TOOLS_DIR/go/bin:$CODEMINER_SCIP_TOOLS_DIR/node-tools/node_modules/.bin:$CODEMINER_SCIP_TOOLS_DIR:$HOME/.cargo/bin:$HOME/miniconda3/envs/scip-env/bin:$PATH:$HOME/miniconda3/bin"
+python ~/build_full.py <repo_dir> <python|go|typescript|rust|cpp>
+```
+
+Manifest then reports `symbol_navigation: true` and `/api/repos/<id>/codemap` returns
+nodes/edges/mermaid. Driver scripts: `~/run_symgraph_py.sh`, `~/run_symgraph_multi.sh`
+(Go/TS/Rust), `~/run_symgraph_cpp.sh`. **Restart `cm-backend` after building graphs.**
 
 ## 3. Config — `qa_config.yaml`
 

--- a/SERVING.md
+++ b/SERVING.md
@@ -23,14 +23,59 @@ Browser
 
 ## Ports & processes
 
-| What | How it runs | Port |
+| What | How it runs | Bind |
 |---|---|---|
-| Frontend (`next start`, prod build) | tmux `cm-frontend` | 3000 |
-| Backend (`codeminer.web.app`) | tmux `cm-backend` | 8000 |
-| vLLM Ask model (Qwen3.6-35B-A3B) | docker `vllm-qwen36` | 8080 |
-| vLLM embeddings (Qwen3-Embedding-0.6B) | docker `vllm-embed` | 8081 |
+| Caddy reverse proxy (tunnel origin) | tmux `cm-caddy` | **127.0.0.1:7860** |
+| Frontend (`next start`, prod build) | tmux `cm-frontend` | **127.0.0.1:3000** |
+| Backend (`codeminer.web.app`) | tmux `cm-backend` | **127.0.0.1:8000** |
+| vLLM Ask model (Qwen3.6-35B-A3B) | docker `vllm-qwen36` | **127.0.0.1:8080** |
+| vLLM embeddings (Qwen3-Embedding-0.6B) | docker `vllm-embed` | **127.0.0.1:8081** |
 
-Public: frontend **http://stable-spark1.ucsd.edu:3000**, backend `:8000`.
+## Public access & security (Cloudflare tunnel)
+
+Public URL: **https://demo.codenib.ai** — served through a Cloudflare tunnel
+(`dgx-codewiki`, token-managed; DNS/TLS/route configured in the Cloudflare dashboard,
+pointing the hostname at `http://localhost:7860`).
+
+**Everything binds `127.0.0.1` — nothing is on the public IP.** The only inbound path
+is the Cloudflare tunnel (outbound-only from the DGX). This closes the bypass where
+`132.239.17.29:<port>` would otherwise hit a service directly, skipping Cloudflare.
+
+```
+Internet ─HTTPS─► Cloudflare ─tunnel(outbound)─► Caddy 127.0.0.1:7860
+                                                    ├─ /api/* → backend 127.0.0.1:8000
+                                                    └─ /*     → frontend 127.0.0.1:3000
+                                                                     └─ vLLM 127.0.0.1:8080 / :8081
+```
+
+Caddy (`~/Caddyfile`, tmux `cm-caddy`) does same-origin routing so the browser only ever
+talks to `demo.codenib.ai` (no mixed content, no CORS):
+
+```
+:7860 {
+    bind 127.0.0.1                       # loopback only — NOT ":7860" alone (that binds *:7860)
+    handle /api/* { reverse_proxy 127.0.0.1:8000 }
+    handle       { reverse_proxy 127.0.0.1:3000 }
+}
+```
+
+Key details:
+- **`bind 127.0.0.1`** is required. A bare `:7860` site binds `*:7860` (all interfaces) —
+  the exact public bypass we're closing. Verify with `ss -tlnp | grep 7860` → must show
+  `127.0.0.1:7860`, never `*:7860` / `0.0.0.0:7860`.
+- Site address is **`:7860` (any Host)**, not `http://127.0.0.1:7860` — Caddy matches sites
+  by Host header, and the tunnel sends `Host: demo.codenib.ai`; a `127.0.0.1` site returns
+  an empty 200 for tunnel traffic.
+- Frontend is built with **`NEXT_PUBLIC_API_BASE=http://127.0.0.1:7860`**: `web/lib/api.ts`
+  same-origins in the browser when the base host is `127.0.0.1`/`localhost` (so the browser
+  calls `demo.codenib.ai/api/...`), while SSR uses the full `127.0.0.1:7860` URL.
+- **Docker port maps must carry the IP** (`-p 127.0.0.1:8080:8000`); a bare `-p 8080:8000`
+  binds `0.0.0.0` and bypasses the firewall, exposing the GPU endpoints publicly.
+- Backend reaches vLLM via `localhost:8080` / `:8081`, so loopback binding is transparent.
+
+Bindings are enforced at process start: `run_backend.sh` (`CODEMINER_DEMO_HOST=127.0.0.1`),
+`run_frontend.sh` (`next start -H 127.0.0.1`), `run_caddy.sh` (Caddyfile `bind 127.0.0.1`),
+and the docker `-p 127.0.0.1:...` maps (containers are `--restart unless-stopped`).
 
 ## Models
 

--- a/SERVING.md
+++ b/SERVING.md
@@ -5,86 +5,129 @@ SPDX-License-Identifier: Apache-2.0
 
 # Serving runbook (`serving-config` branch)
 
-Server deployment of the CodeMiner web demo, with two LLM backends split by role
-(config: `qa_config.yaml`):
+DGX Spark deployment of the CodeMiner DeepWiki demo. Everything runs on
+`stable-spark1.ucsd.edu` as user `boqin`, in a **venv** (no conda, no sudo):
+`source ~/codeminer-backend/bin/activate`.
 
-| Role | Model | Backend |
-|---|---|---|
-| **Ask** (interactive agent) | `openai/qwen3-coder-next` | local vLLM on `:8000` |
-| **Wiki prose + edge labels** | `vertex_ai/claude-haiku-4-5@20251001` | Vertex AI (gcloud ADC) |
+## Architecture
 
-Backend runs on `:8080` (vLLM owns `:8000`). Indexes live under
-`/home/boqin/data/codeminer-index`.
-
-> **Note:** indexing (`scripts/index_repo.py`, BM25) calls **no LLM** — it's pure
-> local compute. The two models above are only used at serve time.
-
-> **Heads-up on Ask + qwen:** the Ask agent accumulates context over up to
-> `max_turns` turns with no cap, so it can exceed the vLLM `--max-model-len`
-> (65536) on large repos/long sessions. If you hit "maximum context length",
-> lower `max_turns` / retrieval `top_k`, or move Ask to a larger-context model.
-
-## 0. One-time env setup
-
-```bash
-conda activate codeminer-backend
-pip install -U "google-cloud-aiplatform>=1.38"   # litellm's Vertex path needs `vertexai`
-gcloud auth application-default login             # Google ADC (once per machine)
+```
+Browser
+  └─ Frontend  (Next.js, :3000, production build)
+       └─ Backend  (FastAPI, :8000)
+            ├─ Ask agent        → vLLM  Qwen3.6-35B-A3B      (:8080, docker)   answers
+            ├─ Wiki + edge labels → Vertex  Claude Haiku 4.5  (ADC)            wiki prose
+            └─ Retrieval (hybrid) → BM25 (local)  +  Qwen3-Embedding-0.6B      dense search
+                                                     (vLLM :8081, docker)
 ```
 
-The vLLM qwen server must be running on `:8000` for Ask to work (separate process).
+## Ports & processes
 
-## 1. Index one or more repos (into your index dir)
+| What | How it runs | Port |
+|---|---|---|
+| Frontend (`next start`, prod build) | tmux `cm-frontend` | 3000 |
+| Backend (`codeminer.web.app`) | tmux `cm-backend` | 8000 |
+| vLLM Ask model (Qwen3.6-35B-A3B) | docker `vllm-qwen36` | 8080 |
+| vLLM embeddings (Qwen3-Embedding-0.6B) | docker `vllm-embed` | 8081 |
 
-`index_repo.py` builds BM25 for an already-cloned repo and registers it. Keep the
-repos and the registry under `data_dir` so everything is in one place:
+Public: frontend **http://stable-spark1.ucsd.edu:3000**, backend `:8000`.
+
+## Models
+
+| Role | Model string | Backend |
+|---|---|---|
+| Ask (interactive agent) | `openai/qwen3.6-35b` | vLLM `:8080` |
+| Wiki prose + edge labels | `vertex_ai/claude-haiku-4-5@20251001` | Vertex (ADC) |
+| Dense embeddings (hybrid retrieval) | `Qwen/Qwen3-Embedding-0.6B` (openai provider) | vLLM `:8081` |
+
+## 0. One-time env
 
 ```bash
-mkdir -p ~/data/codeminer-index/repos
+source ~/codeminer-backend/bin/activate
+pip install -U "google-cloud-aiplatform>=1.38"   # Vertex via litellm
+gcloud auth application-default login             # Vertex ADC
+# node via nvm (frontend): curl -o- .../nvm/install.sh | bash ; nvm install --lts
+```
 
-git clone --depth 1 https://github.com/psf/requests ~/data/codeminer-index/repos/requests
-python scripts/index_repo.py ~/data/codeminer-index/repos/requests \
+## 1. vLLM containers (docker, GPU)
+
+```bash
+# Ask model — thinking MoE, qwen3_xml tool parser
+docker run -d --name vllm-qwen36 --restart unless-stopped --gpus all --ipc=host \
+  -p 8080:8000 -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm/vllm-openai:cu130-nightly \
+  Qwen/Qwen3.6-35B-A3B --served-model-name qwen3.6-35b \
+  --max-model-len 65536 --gpu-memory-utilization 0.80 --max-num-seqs 2 \
+  --enable-auto-tool-choice --tool-call-parser qwen3_xml
+
+# Embedding model — pooling runner, small GPU slice
+docker run -d --name vllm-embed --restart unless-stopped --gpus all --ipc=host \
+  -p 8081:8000 -v ~/.cache/huggingface:/root/.cache/huggingface \
+  vllm/vllm-openai:cu130-nightly \
+  Qwen/Qwen3-Embedding-0.6B --runner pooling --gpu-memory-utilization 0.08
+```
+
+## 2. Index repos (hybrid = BM25 + dense vectors)
+
+Indexes live under `~/data/codeminer-index` (`data_dir`). BM25 is pure-local;
+the dense vectors are embedded through the `:8081` endpoint (GPU, not CPU — the
+in-process SentenceTransformer path needs python-dev headers we can't `sudo`-install).
+
+```bash
+# a) clone default branch + build BM25 (registers the repo)
+git clone --depth 1 https://github.com/<owner>/<repo> ~/data/codeminer-index/repos/<owner>_<repo>
+python scripts/index_repo.py ~/data/codeminer-index/repos/<owner>_<repo> \
   --registry ~/data/codeminer-index/qa_registry.json
 
-# repeat for other repos (vllm is large; expect a longer index)
+# b) add the dense vector index (rebuilds bm25 + vector via the embedding endpoint)
+python ~/build_vectors.py ~/data/codeminer-index/repos/<owner>_<repo>
 ```
 
-Result:
-```
-~/data/codeminer-index/
-  qa_registry.json                    # registry (absolute paths — don't move repos after)
-  wiki_cache/                         # wiki + edge-label cache (created at serve time)
-  repos/requests/.codeminer_cache/    # BM25 index artifacts
-```
+`~/build_vectors.py` registers a `VectorIndexBuilder` with
+`embedding_provider="openai"`, `embedding_kwargs={"base_url":"http://localhost:8081/v1","api_key":"dummy"}`
+and runs `IndexCompiler(... index_types=["bm25","vector"]).compile_repo(...)`. A repo's
+manifest then reports `hybrid_search: true`. **Restart `cm-backend` after (re)indexing.**
 
-## 2. Start the backend (port 8080, reachable by anyone)
+Currently indexed (6): `requests` + the 5 Python repos from
+`sysevol-ai/codeminer-synthesis` (astropy, matplotlib, xarray, scikit-learn, sympy).
+
+## 3. Config — `qa_config.yaml`
+
+Key fields for hybrid serving (already set on this branch):
+`mode: hybrid`, `embedding_model: Qwen/Qwen3-Embedding-0.6B`, `embedding_dimension: 1024`,
+`embedding_provider: openai`, `embedding_base_url: http://localhost:8081/v1`,
+`model: openai/qwen3.6-35b`, `api_base: http://localhost:8080/v1`,
+`wiki_model: vertex_ai/claude-haiku-4-5@20251001`, `data_dir: /home/boqin/data/codeminer-index`.
+
+## 4. Serve
 
 ```bash
-VERTEXAI_PROJECT=ucsd-cse-stable-gcp \
-VERTEXAI_LOCATION=us-east5 \
-CODEMINER_DEMO_HOST=0.0.0.0 \
-CODEMINER_DEMO_PORT=8080 \
+# backend (tmux cm-backend) — Vertex env for the wiki model; qwen/embed creds come from the yaml
+VERTEXAI_PROJECT=ucsd-cse-stable-gcp VERTEXAI_LOCATION=us-east5 \
+CODEMINER_DEMO_HOST=0.0.0.0 CODEMINER_DEMO_PORT=8000 \
 CODEMINER_DEMO_CONFIG=qa_config.yaml \
 python -m codeminer.web.app
+
+# frontend (tmux cm-frontend) — production build (not `next dev`; dev compiles per-visit)
+cd web && NEXT_PUBLIC_API_BASE=http://stable-spark1.ucsd.edu:8000 npm run build
+NEXT_PUBLIC_API_BASE=http://stable-spark1.ucsd.edu:8000 npm run start -- -H 0.0.0.0 -p 3000
 ```
 
-Vertex creds come from the `VERTEXAI_*` env + ADC (for the wiki model). The qwen
-creds (`OPENAI_API_BASE` / `OPENAI_API_KEY`) come from `qa_config.yaml`
-(`api_base` / `api_key`). Run inside `tmux` (e.g. `tmux new -s cm-backend`).
+Helper scripts on the box: `~/run_backend.sh`, `~/run_frontend.sh`. Logs:
+`~/cm-backend.log`, `~/cm-frontend.log`.
 
-## 3. Verify
+## 5. Pre-generate wikis (so first repo-open is instant)
 
-```bash
-curl -s http://localhost:8080/api/repos     # lists the repos you indexed (not [])
-```
+The wiki is generated on-demand (Vertex Haiku) and cached to
+`~/data/codeminer-index/wiki_cache/`. Pre-warm all repos with `~/pregen_wiki.sh`
+(walks `/api/repos/<id>/wiki` + every page). Only the Ask answer stays on-demand.
 
-## 4. Frontend (optional, same server)
+## Notes / gotchas
 
-```bash
-cd web
-NEXT_PUBLIC_API_BASE=http://<server-host>:8080 npm run dev -- -H 0.0.0.0 -p 3000
-```
-
-`NEXT_PUBLIC_API_BASE` must be a URL the browser can reach (the server's public host,
-not `localhost`). Later, put both behind a same-origin Caddy reverse proxy
-(`/` -> :3000, `/api` -> :8080) to drop CORS and get automatic HTTPS.
+- tmux sessions survive SSH drops, not reboots. Docker containers auto-restart.
+- Shared HF cache `~/.cache/huggingface/hub` is root-owned (vLLM writes as root);
+  for user-side HF downloads (e.g. `datasets`) set `HF_HOME=~/data/hf-cache`.
+- Ask answers are grounded in symbol names + dense-retrieved code; the thinking
+  model (Qwen3.6-35B) narrates its reasoning, so answers are correct but verbose.
+- **Known issue:** wiki outline generation returns 0 pages for the largest repos
+  (astropy, matplotlib, scikit-learn, sympy) — under investigation.

--- a/SERVING.md
+++ b/SERVING.md
@@ -48,6 +48,21 @@ emits a plain-text "Here's a thinking process:" preamble that breaks answers and
 tokens); the agent also force-synthesizes a final answer if it runs out of turns
 mid-exploration. See `codeminer/llm/litellm_chat.py` + `codeminer/agent/runner.py`.
 
+## Agent runtime & compiler (which project components this uses)
+
+- **Agent runtime:** `codeminer/agent/runner.py::AgentRunner` — built per repo in
+  `codeminer/web/repo_registry.py` and driven by `POST /api/chat` → `bundle.runner.run()`.
+  Wiki prose + edge labels run on a separate model via `wiki_model` (not the agent).
+  This branch extends the runtime: `AgentRunner._force_final_answer` (synthesize a real
+  answer when a run ends mid-exploration) and disabling Qwen thinking in
+  `codeminer/llm/litellm_chat.py`.
+- **Compiler:** `codeminer/compiler/IndexCompiler` → `RepoManifest`. BM25 is built by
+  `scripts/index_repo.py`; the dense vector index by `~/build_vectors.py` (mirrors
+  `scripts/build_qa_index.py`'s `VectorIndexBuilder` registration). Both call
+  `IndexCompiler.compile_repo()` and write `.codeminer_cache/repo_manifest.json`, which
+  the backend serves from. This uses the base `IndexCompiler` — **not** the
+  `scripts/agent_compile/` RFC phase-lineage / compiled-subset tooling.
+
 ## 0. One-time env
 
 ```bash

--- a/SERVING.md
+++ b/SERVING.md
@@ -5,39 +5,56 @@ SPDX-License-Identifier: Apache-2.0
 
 # Serving runbook (`serving-config` branch)
 
-Server deployment of the CodeMiner web demo: FastAPI backend + **Claude Haiku 4.5 on
-Vertex AI** for the Ask/QA + wiki generation. Config lives in `qa_config.yaml`.
+Server deployment of the CodeMiner web demo, with two LLM backends split by role
+(config: `qa_config.yaml`):
 
-> The qwen vLLM on `:8000` is a **separate** serving endpoint and is not used here.
-> The backend runs on `:8080` to avoid that collision.
+| Role | Model | Backend |
+|---|---|---|
+| **Ask** (interactive agent) | `openai/qwen3-coder-next` | local vLLM on `:8000` |
+| **Wiki prose + edge labels** | `vertex_ai/claude-haiku-4-5@20251001` | Vertex AI (gcloud ADC) |
+
+Backend runs on `:8080` (vLLM owns `:8000`). Indexes live under
+`/home/boqin/data/codeminer-index`.
+
+> **Note:** indexing (`scripts/index_repo.py`, BM25) calls **no LLM** — it's pure
+> local compute. The two models above are only used at serve time.
+
+> **Heads-up on Ask + qwen:** the Ask agent accumulates context over up to
+> `max_turns` turns with no cap, so it can exceed the vLLM `--max-model-len`
+> (65536) on large repos/long sessions. If you hit "maximum context length",
+> lower `max_turns` / retrieval `top_k`, or move Ask to a larger-context model.
 
 ## 0. One-time env setup
 
 ```bash
-conda activate codeminer-backend            # env with litellm / faiss / uvicorn
+conda activate codeminer-backend
 pip install -U "google-cloud-aiplatform>=1.38"   # litellm's Vertex path needs `vertexai`
-gcloud auth application-default login        # Google ADC (once per machine)
+gcloud auth application-default login             # Google ADC (once per machine)
 ```
 
-Sanity-check Vertex works:
+The vLLM qwen server must be running on `:8000` for Ask to work (separate process).
+
+## 1. Index one or more repos (into your index dir)
+
+`index_repo.py` builds BM25 for an already-cloned repo and registers it. Keep the
+repos and the registry under `data_dir` so everything is in one place:
+
 ```bash
-VERTEXAI_PROJECT=ucsd-cse-stable-gcp VERTEXAI_LOCATION=us-east5 \
-python -c "import litellm; print(litellm.completion(model='vertex_ai/claude-haiku-4-5@20251001', messages=[{'role':'user','content':'say OK'}], max_tokens=8).choices[0].message.content)"
+mkdir -p ~/data/codeminer-index/repos
+
+git clone --depth 1 https://github.com/psf/requests ~/data/codeminer-index/repos/requests
+python scripts/index_repo.py ~/data/codeminer-index/repos/requests \
+  --registry ~/data/codeminer-index/qa_registry.json
+
+# repeat for other repos (vllm is large; expect a longer index)
 ```
 
-## 1. Index one or more repos (sparse / BM25)
-
-`index_repo.py` clones-free: point it at an already-cloned repo; it builds the BM25
-index and registers the repo in `.codeminer_qa/qa_registry.json`.
-
-```bash
-# small repo first, to validate the pipeline
-git clone --depth 1 https://github.com/psf/requests ~/repos/requests
-python scripts/index_repo.py ~/repos/requests
-
-# then any others (vllm is large; expect a longer index)
-# git clone --depth 1 https://github.com/vllm-project/vllm ~/repos/vllm
-# python scripts/index_repo.py ~/repos/vllm
+Result:
+```
+~/data/codeminer-index/
+  qa_registry.json                    # registry (absolute paths — don't move repos after)
+  wiki_cache/                         # wiki + edge-label cache (created at serve time)
+  repos/requests/.codeminer_cache/    # BM25 index artifacts
 ```
 
 ## 2. Start the backend (port 8080, reachable by anyone)
@@ -51,7 +68,9 @@ CODEMINER_DEMO_CONFIG=qa_config.yaml \
 python -m codeminer.web.app
 ```
 
-Run it inside `tmux` (e.g. `tmux new -s cm-backend`) so it survives SSH disconnects.
+Vertex creds come from the `VERTEXAI_*` env + ADC (for the wiki model). The qwen
+creds (`OPENAI_API_BASE` / `OPENAI_API_KEY`) come from `qa_config.yaml`
+(`api_base` / `api_key`). Run inside `tmux` (e.g. `tmux new -s cm-backend`).
 
 ## 3. Verify
 

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -92,6 +92,22 @@ def _has_localization_contract(answer: str) -> bool:
     return has_localization_contract(answer)
 
 
+def _looks_incomplete(text: str) -> bool:
+    """True when *text* is mid-exploration narration, not a synthesized reply.
+
+    Weak/agentic models often leave chatter like "Let me look at models.py:"
+    when they run out of turns; the demo should replace that with a real
+    forced answer rather than surface it to the user.
+    """
+    t = (text or "").strip()
+    if len(t) < 200:
+        return True
+    low = t.lower()
+    return low.startswith(
+        ("let me", "let's", "i'll", "i will", "now i", "first, let", "next, ")
+    ) or t.endswith(":")
+
+
 _DEFAULT_SYSTEM_PROMPT = f"""\
 You are a code localization agent. Find the code locations (files and \
 symbols) relevant to the request, then give a concise answer naming them.
@@ -670,6 +686,15 @@ class AgentRunner:
                         or answer
                     )
                     answer_source = "forced_schema"
+                elif (
+                    not self._force_contract
+                    and all_tool_calls
+                    and _looks_incomplete(answer)
+                ):
+                    forced = self._force_final_answer(history, usage_tracker, turn + 2)
+                    if forced.strip():
+                        answer = forced
+                        answer_source = "forced_answer"
                 return _finish_result(
                     answer=answer,
                     total_turns=turn + 1,
@@ -801,6 +826,16 @@ class AgentRunner:
                 or last_content
             )
             answer_source = "forced_schema"
+        elif (
+            not self._force_contract
+            and all_tool_calls
+            and _looks_incomplete(last_content)
+        ):
+            trace.add("final_answer_forced", max_turns, reason="max_turns_exhausted")
+            forced = self._force_final_answer(history, usage_tracker, max_turns + 1)
+            if forced.strip():
+                last_content = forced
+                answer_source = "forced_answer"
 
         return _finish_result(
             answer=last_content,
@@ -914,6 +949,42 @@ class AgentRunner:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    def _force_final_answer(self, history, usage_tracker, usage_turn: int) -> str:
+        """Tool-free turn that extracts a synthesized natural-language answer.
+
+        Demo counterpart to ``_force_schema_answer``: when the agent runs out of
+        turns still exploring (last message is chatter like "Let me look at ..."),
+        spend one extra tool-free turn asking it to answer from what it already
+        gathered, so the user gets a real answer instead of mid-search narration.
+        These are extra turns; they do NOT consume the exploration budget.
+        """
+        history.add_message(
+            {
+                "role": "user",
+                "content": (
+                    "Stop searching and do not call any more tools. Using "
+                    "everything you have already read, write your complete final "
+                    "answer to the user's question now, citing the relevant files "
+                    "and symbols."
+                ),
+            }
+        )
+        try:
+            overrides: Dict[str, Any] = {
+                "usage_tracker": usage_tracker,
+                "usage_turn": usage_turn,
+            }
+            if self.tools:
+                overrides["tools"] = self.tools
+                overrides["tool_choice"] = "none"
+            final = self.llm._call_raw(history.get_messages(), **overrides)
+            forced_msg = final.choices[0].message
+            history.add_message(_message_to_dict(forced_msg))
+            return getattr(forced_msg, "content", None) or ""
+        except Exception as exc:  # noqa: BLE001 - best-effort; keep the partial run
+            logger.warning("forced final answer failed: %s", exc)
+            return ""
 
     def _force_schema_answer(
         self, history, usage_tracker, usage_turn: int, read_paths=None

--- a/codeminer/index/embedding/vector_store.py
+++ b/codeminer/index/embedding/vector_store.py
@@ -191,6 +191,14 @@ class _HuggingFaceEmbeddingWrapper:
         return vecs.tolist()
 
 
+# Embedding servers cap input length (e.g. Qwen3-Embedding-0.6B: 32768 tokens) and
+# large batches. A few code chunks (huge generated files) exceed the token cap and
+# 400 the whole request, so clip each input to a safe char budget (>=1 char/token
+# guarantees it fits) and split into bounded batches.
+_MAX_EMBED_CHARS = 28000
+_EMBED_BATCH = 256
+
+
 class _OpenAIEmbeddingWrapper:
     """Wraps the OpenAI SDK to expose ``embed_query`` / ``embed_documents``."""
 
@@ -201,12 +209,18 @@ class _OpenAIEmbeddingWrapper:
         self._client = OpenAI(**kwargs)
 
     def embed_query(self, text: str) -> List[float]:
-        resp = self._client.embeddings.create(input=[text], model=self._model)
+        resp = self._client.embeddings.create(
+            input=[text[:_MAX_EMBED_CHARS]], model=self._model
+        )
         return resp.data[0].embedding
 
     def embed_documents(self, texts: List[str]) -> List[List[float]]:
-        resp = self._client.embeddings.create(input=texts, model=self._model)
-        return [d.embedding for d in sorted(resp.data, key=lambda x: x.index)]
+        out: List[List[float]] = []
+        for i in range(0, len(texts), _EMBED_BATCH):
+            batch = [t[:_MAX_EMBED_CHARS] for t in texts[i : i + _EMBED_BATCH]]
+            resp = self._client.embeddings.create(input=batch, model=self._model)
+            out.extend(d.embedding for d in sorted(resp.data, key=lambda x: x.index))
+        return out
 
 
 def _to_document(obj: Any) -> _Document:

--- a/codeminer/llm/litellm_chat.py
+++ b/codeminer/llm/litellm_chat.py
@@ -121,10 +121,17 @@ def _no_thinking_kwargs(model: str) -> Dict[str, Any]:
     (``finish_reason="length"``). LiteLLM maps Anthropic-style ``thinking`` to
     Gemini's ``thinkingConfig``; a zero budget turns thinking off so the budget
     goes to the answer. No-op for non-thinking providers.
+
+    vLLM-served Qwen thinking models emit a verbose ``Here's a thinking
+    process:`` preamble (plain text, not ``<think>`` tags) before the answer,
+    which derails the agent's answer extraction and wastes tokens. Disable it
+    via the chat template so the model answers directly.
     """
     m = (model or "").lower()
     if "gemini-2.5" in m or "gemini-2-5" in m:
         return {"thinking": {"type": "disabled", "budget_tokens": 0}}
+    if "qwen" in m and "embed" not in m:
+        return {"extra_body": {"chat_template_kwargs": {"enable_thinking": False}}}
     return {}
 
 

--- a/codeminer/scip_interface/scip_decode_rust.py
+++ b/codeminer/scip_interface/scip_decode_rust.py
@@ -188,7 +188,18 @@ class SCIPRustGraphDecoder:
             internal_crates.add(root_pkg_name)
 
         for pattern in member_patterns:
-            for member_dir in self.project_root.glob(pattern):
+            # Normalize the workspace member glob: a trailing slash, an empty
+            # string, or an absolute pattern makes Path.glob raise (e.g.
+            # ``IndexError: tuple index out of range`` on Python 3.12). Skip
+            # those rather than aborting the whole decode.
+            pattern = str(pattern).strip().rstrip("/")
+            if not pattern or pattern.startswith("/"):
+                continue
+            try:
+                members = list(self.project_root.glob(pattern))
+            except (ValueError, IndexError, OSError):
+                continue
+            for member_dir in members:
                 if not member_dir.is_dir():
                     continue
                 member_cargo = member_dir / "Cargo.toml"

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -154,12 +154,17 @@ async def list_repos() -> list[RepoInfo]:
 @app.get("/api/repos/{repo_id}/wiki")
 async def wiki_tree(repo_id: str) -> dict:
     builder = _wiki(repo_id)
-    return {"repo": _bundle(repo_id).entry.repo, "pages": builder.page_tree()}
+    # page_tree() may generate the outline (a blocking LLM call on a cold repo);
+    # run it off the event loop so a cold page-gen doesn't stall other requests.
+    pages = await asyncio.to_thread(builder.page_tree)
+    return {"repo": _bundle(repo_id).entry.repo, "pages": pages}
 
 
 @app.get("/api/repos/{repo_id}/wiki/{page_id}")
 async def wiki_page(repo_id: str, page_id: str) -> dict:
-    page = _wiki(repo_id).page(page_id)
+    # page() may generate the page (a blocking LLM call on a cache miss) — offload
+    # it so cached reads for other users stay instant instead of serializing.
+    page = await asyncio.to_thread(_wiki(repo_id).page, page_id)
     if page is None:
         raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
     return page
@@ -172,7 +177,7 @@ async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
     Lets a wiki page render as a *view over the graph* (subsystem symbols + how
     they connect), using the same ``{nodes, edges}`` payload as ``/codemap``.
     """
-    page = _wiki(repo_id).page(page_id)
+    page = await asyncio.to_thread(_wiki(repo_id).page, page_id)
     if page is None:
         raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
     bundle = _bundle(repo_id)

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -54,7 +54,9 @@ async def lifespan(app: FastAPI):
     # Shared LLM narrator for DeepWiki-style prose; cached on disk, fails soft
     # to templated text when no model/creds are available.
     wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
-    app.state.narrator = Narrator(model=config.model, cache_dir=wiki_cache)
+    app.state.narrator = Narrator(
+        model=config.wiki_model or config.model, cache_dir=wiki_cache
+    )
     logger.info(
         "Wiki narrator: model=%s enabled=%s cache=%s",
         app.state.narrator.model,
@@ -99,7 +101,9 @@ def _wiki(repo_id: str):
 
             wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
             cache[repo_id] = AgentWiki(
-                _bundle(repo_id), config.model, cache_dir=wiki_cache
+                _bundle(repo_id),
+                config.wiki_model or config.model,
+                cache_dir=wiki_cache,
             )
         else:
             cache[repo_id] = WikiBuilder(
@@ -120,7 +124,7 @@ def _edge_labeler(repo_id: str):
         namespace = f"{bundle.entry.instance_id}@{bundle.entry.commit_short}"
         cache[repo_id] = EdgeLabeler(
             source_fn=_wiki(repo_id).source,
-            model=config.edge_label_model or config.model,
+            model=config.edge_label_model or config.wiki_model or config.model,
             cache_dir=wiki_cache,
             cache_namespace=namespace,
         )

--- a/codeminer/web/config.py
+++ b/codeminer/web/config.py
@@ -49,6 +49,8 @@ class QAConfig:
 
     # litellm model string for the agent. Env ``CODEMINER_DEMO_MODEL`` wins.
     model: str = "gpt-4o"
+    api_base: Optional[str] = None
+    api_key: Optional[str] = None
     # "sparse" (BM25 only) or "hybrid" (BM25 + vector embeddings).
     mode: str = "sparse"
     embedding_model: str = "BAAI/bge-small-en-v1.5"
@@ -120,6 +122,8 @@ def load_config(path: Optional[str] = None) -> QAConfig:
 
     cfg = QAConfig(
         model=data.get("model", QAConfig.model),
+        api_base=data.get("api_base", None),
+        api_key=data.get("api_key", None),
         mode=data.get("mode", QAConfig.mode),
         embedding_model=data.get("embedding_model", QAConfig.embedding_model),
         embedding_dimension=data.get(
@@ -164,6 +168,14 @@ def load_config(path: Optional[str] = None) -> QAConfig:
         cfg.edge_labels = _env_edge.strip().lower() in ("1", "true", "yes", "on")
     if os.environ.get("CODEMINER_EDGE_MODEL"):
         cfg.edge_label_model = os.environ["CODEMINER_EDGE_MODEL"]
+
+    # litellm reads OPENAI_API_BASE / OPENAI_API_KEY from the environment, so
+    # export the YAML values here. An env var already set (e.g. by
+    # scripts/start_web.sh) wins, matching the model precedence above.
+    if cfg.api_base and not os.environ.get("OPENAI_API_BASE"):
+        os.environ["OPENAI_API_BASE"] = cfg.api_base
+    if cfg.api_key and not os.environ.get("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = cfg.api_key
 
     return cfg
 

--- a/codeminer/web/config.py
+++ b/codeminer/web/config.py
@@ -47,8 +47,12 @@ class RepoEntry:
 class QAConfig:
     """Top-level demo configuration."""
 
-    # litellm model string for the agent. Env ``CODEMINER_DEMO_MODEL`` wins.
+    # litellm model string for the Ask agent. Env ``CODEMINER_DEMO_MODEL`` wins.
     model: str = "gpt-4o"
+    # Optional separate model for wiki prose + edge labels (the offline
+    # "generation" side). None -> falls back to ``model``. Lets the interactive
+    # Ask agent and the wiki run on different backends.
+    wiki_model: Optional[str] = None
     api_base: Optional[str] = None
     api_key: Optional[str] = None
     # "sparse" (BM25 only) or "hybrid" (BM25 + vector embeddings).
@@ -122,6 +126,7 @@ def load_config(path: Optional[str] = None) -> QAConfig:
 
     cfg = QAConfig(
         model=data.get("model", QAConfig.model),
+        wiki_model=data.get("wiki_model", None),
         api_base=data.get("api_base", None),
         api_key=data.get("api_key", None),
         mode=data.get("mode", QAConfig.mode),

--- a/codeminer/web/config.py
+++ b/codeminer/web/config.py
@@ -59,6 +59,11 @@ class QAConfig:
     mode: str = "sparse"
     embedding_model: str = "BAAI/bge-small-en-v1.5"
     embedding_dimension: int = 384
+    # Embedding backend: "huggingface" (in-process SentenceTransformer) or
+    # "openai" (remote OpenAI-compatible /v1/embeddings, e.g. a vLLM server).
+    embedding_provider: str = "huggingface"
+    embedding_base_url: Optional[str] = None  # required when provider=openai
+    embedding_api_key: Optional[str] = None
     # Where checked-out repos + indexes + the registry live.
     data_dir: str = ".codeminer_qa"
     # Optional read-only tree of pre-built per-instance artifacts:
@@ -134,6 +139,9 @@ def load_config(path: Optional[str] = None) -> QAConfig:
         embedding_dimension=data.get(
             "embedding_dimension", QAConfig.embedding_dimension
         ),
+        embedding_provider=data.get("embedding_provider", "huggingface"),
+        embedding_base_url=data.get("embedding_base_url", None),
+        embedding_api_key=data.get("embedding_api_key", None),
         data_dir=data.get("data_dir", QAConfig.data_dir),
         prebuilt_dir=data.get("prebuilt_dir", QAConfig.prebuilt_dir),
         max_turns=data.get("max_turns", QAConfig.max_turns),

--- a/codeminer/web/repo_registry.py
+++ b/codeminer/web/repo_registry.py
@@ -314,12 +314,20 @@ class RepoRegistry:
             emb_dim = vec_entry.config.get(
                 "embedding_dimension", self._config.embedding_dimension
             )
+            emb_provider = self._config.embedding_provider
+            emb_extra: Dict[str, object] = {}
+            if emb_provider == "openai" and self._config.embedding_base_url:
+                emb_extra = {
+                    "base_url": self._config.embedding_base_url,
+                    "api_key": self._config.embedding_api_key or "dummy",
+                }
             vector_store = CodeVectorStore(
                 embedding_model=emb_model,
-                embedding_provider="huggingface",
+                embedding_provider=emb_provider,
                 dimension=emb_dim,
                 store_path=vec_entry.path,
                 embedding=self._embeddings.get(emb_model),
+                **emb_extra,
             )
             # Cache the (possibly just-loaded) model so the next repo reuses it.
             self._embeddings[emb_model] = vector_store.embedding

--- a/codeminer/wiki/outline.py
+++ b/codeminer/wiki/outline.py
@@ -93,7 +93,9 @@ def _format_symbols(symbols: List[Symbol]) -> str:
     return "\n".join(f"- {s.name} — {s.file} — {s.type}" for s in symbols)
 
 
-def generate_outline(bundle: Any, model: str, max_tokens: int = 4096) -> Dict[str, Any]:
+def generate_outline(
+    bundle: Any, model: str, max_tokens: int = 16000
+) -> Dict[str, Any]:
     """Produce a conceptual wiki page tree for *bundle* using *model*.
 
     Returns ``{"pages": [...]}``. On a model/parse failure returns

--- a/qa_config.yaml
+++ b/qa_config.yaml
@@ -3,21 +3,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Code-QA SERVING config (server deployment).
-#   Index repos:  python scripts/index_repo.py /path/to/cloned/repo
+#   Index repos:  python scripts/index_repo.py /path/to/repo --registry <data_dir>/qa_registry.json
 #   Serve:        CODEMINER_DEMO_CONFIG=qa_config.yaml python -m codeminer.web.app
 # Full runbook: SERVING.md
 
-# --- LLM backend: Claude Haiku 4.5 on Vertex AI ---
-# litellm model string. Vertex uses gcloud ADC + VERTEXAI_PROJECT / VERTEXAI_LOCATION
-# (export before launch; see SERVING.md). Override with CODEMINER_DEMO_MODEL.
-model: vertex_ai/claude-haiku-4-5@20251001
+# --- LLM backends (two models, split by role) ---
+# Ask (interactive agent) -> local vLLM qwen coder. `api_base`/`api_key` export
+# to OPENAI_API_BASE/KEY. Override the Ask model with CODEMINER_DEMO_MODEL.
+model: openai/qwen3-coder-next
+api_base: http://localhost:8000/v1      # co-located vLLM (8000); backend runs on 8080
+api_key: dummy                          # vLLM ignores it; litellm just needs one set
+
+# Wiki prose + edge labels (offline generation) -> Claude Haiku 4.5 on Vertex AI.
+# Vertex uses gcloud ADC + VERTEXAI_PROJECT / VERTEXAI_LOCATION (export at launch).
+wiki_model: vertex_ai/claude-haiku-4-5@20251001
+
 max_turns: 8
 max_tokens: 4096
 
 # --- retrieval: sparse (BM25 only); repos indexed locally via scripts/index_repo.py ---
 mode: sparse
-data_dir: .codeminer_qa
-prebuilt_dir: null        # no pre-built vector tree on this host
+data_dir: /home/boqin/data/codeminer-index   # registry + wiki_cache live here
+prebuilt_dir: null                            # no pre-built vector tree on this host
 
 cors_origins:
-  - "*"                   # open for the demo; tighten once behind a same-origin proxy
+  - "*"                                       # open for the demo; tighten behind a proxy

--- a/qa_config.yaml
+++ b/qa_config.yaml
@@ -2,29 +2,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Code-QA SERVING config (server deployment).
-#   Index repos:  python scripts/index_repo.py /path/to/repo --registry <data_dir>/qa_registry.json
-#   Serve:        CODEMINER_DEMO_CONFIG=qa_config.yaml python -m codeminer.web.app
-# Full runbook: SERVING.md
+# Code-QA SERVING config (DGX Spark deployment). Full runbook: SERVING.md
+#   Index:  scripts/index_repo.py <dir> --registry <data_dir>/qa_registry.json ; then ~/build_vectors.py <dir>
+#   Serve:  CODEMINER_DEMO_CONFIG=qa_config.yaml python -m codeminer.web.app
 
-# --- LLM backends (two models, split by role) ---
-# Ask (interactive agent) -> local vLLM qwen coder. `api_base`/`api_key` export
-# to OPENAI_API_BASE/KEY. Override the Ask model with CODEMINER_DEMO_MODEL.
-model: openai/qwen3-coder-next
-api_base: http://localhost:8000/v1      # co-located vLLM (8000); backend runs on 8080
-api_key: dummy                          # vLLM ignores it; litellm just needs one set
-
-# Wiki prose + edge labels (offline generation) -> Claude Haiku 4.5 on Vertex AI.
-# Vertex uses gcloud ADC + VERTEXAI_PROJECT / VERTEXAI_LOCATION (export at launch).
+# --- LLM backends (split by role) ---
+# Ask (interactive agent) -> local vLLM (Qwen3.6-35B) on :8080.
+model: openai/qwen3.6-35b
+api_base: http://localhost:8080/v1
+api_key: dummy
+# Wiki prose + edge labels -> Claude Haiku 4.5 on Vertex (ADC + VERTEXAI_* env).
 wiki_model: vertex_ai/claude-haiku-4-5@20251001
-
 max_turns: 8
 max_tokens: 4096
 
-# --- retrieval: sparse (BM25 only); repos indexed locally via scripts/index_repo.py ---
-mode: sparse
-data_dir: /home/boqin/data/codeminer-index   # registry + wiki_cache live here
-prebuilt_dir: null                            # no pre-built vector tree on this host
+# --- retrieval: hybrid (BM25 + dense) ---
+mode: hybrid
+# Dense embeddings served by a second vLLM container on :8081 (openai-compatible).
+embedding_model: Qwen/Qwen3-Embedding-0.6B
+embedding_dimension: 1024
+embedding_provider: openai
+embedding_base_url: http://localhost:8081/v1
+embedding_api_key: dummy
+data_dir: /home/boqin/data/codeminer-index
+prebuilt_dir: null
 
 cors_origins:
-  - "*"                                       # open for the demo; tighten behind a proxy
+  - "*"

--- a/qa_config.yaml
+++ b/qa_config.yaml
@@ -2,73 +2,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Code-QA demo configuration.
-#
-# Build indexes:   python scripts/build_qa_index.py   (needs network: HF + git)
-# Serve:           codeminer-web                       (or: uvicorn codeminer.web.app:app)
-#
-# `model` is a litellm model string; override with CODEMINER_DEMO_MODEL.
-# Provider API keys come from the environment (e.g. OPENAI_API_KEY).
+# Code-QA SERVING config (server deployment).
+#   Index repos:  python scripts/index_repo.py /path/to/cloned/repo
+#   Serve:        CODEMINER_DEMO_CONFIG=qa_config.yaml python -m codeminer.web.app
+# Full runbook: SERVING.md
 
-model: vertex_ai/gemini-2.5-flash   # uses gcloud ADC; override via CODEMINER_DEMO_MODEL
-
-mode: hybrid              # "sparse" (BM25 only) or "hybrid" (BM25 + embeddings)
-data_dir: .codeminer_qa
-# Reuse pre-built per-instance indexes (source @ base_commit + L0/L2 vectors)
-# from this read-only tree. BM25 is still built locally under data_dir.
-prebuilt_dir: /mnt/data/codeminer
-# Must match the embedding model whose files live under
-# <prebuilt_dir>/<instance_id>/{l0,l2}/index_<model_suffix>.faiss
-embedding_model: Qwen/Qwen3-Embedding-0.6B
-embedding_dimension: 1024
+# --- LLM backend: Claude Haiku 4.5 on Vertex AI ---
+# litellm model string. Vertex uses gcloud ADC + VERTEXAI_PROJECT / VERTEXAI_LOCATION
+# (export before launch; see SERVING.md). Override with CODEMINER_DEMO_MODEL.
+model: vertex_ai/claude-haiku-4-5@20251001
 max_turns: 8
-max_tokens: 4096   # generous: gemini-2.5 is a thinking model (we disable thinking, but keep headroom)
+max_tokens: 4096
 
-# Show short LLM-written dependency phrases on graph edges (hover/click in the
-# interactive graph view). Off by default: each first-seen edge triggers one
-# small LLM call, then the phrase is cached on disk. Env override:
-# CODEMINER_EDGE_LABELS=1.
-edge_labels: false
-# edge_label_model: openai/gpt-4o-mini   # optional cheaper model for these short calls
-
-# ── Rerank strategy ─────────────────────────────────────────────────────────────
-# Controls how retrieved candidates are re-scored before the LLM writes its answer.
-# Restart the backend after changing (no reindex needed).
-#
-#   "embedding"    — dot-product against pre-indexed FAISS vectors (~16ms, default)
-#                    no extra VRAM, fast, good enough for most use cases
-#   "crossencoder" — neural pair scoring: model sees (query + doc) jointly
-#                    more accurate; ~108ms @ N=25 with Qwen3-Reranker-0.6B (+550MB VRAM)
-#
-# crossencoder_model options (all Qwen3-Reranker-* use the yes/no logit trick;
-# others e.g. mxbai-rerank-large-v2 use sentence-transformers CrossEncoder):
-#   Qwen/Qwen3-Reranker-0.6B          ~108ms @ N=25   ★ recommended
-#   Qwen/Qwen3-Reranker-4B            ~400ms @ N=25     higher quality
-#   mixedbread-ai/mxbai-rerank-large-v2  ~800ms @ N=25  not recommended (batching ceiling)
-#
-# See: codeminer/web/config.py (QAConfig), codeminer/ops/rerank.py (CrossEncoderContext)
-#      index/rerank/cross_encoder.py (build_reranker auto-detects backend from model name)
-rerank_strategy: embedding
-# crossencoder_model: Qwen/Qwen3-Reranker-0.6B
-# crossencoder_batch_size: 8
+# --- retrieval: sparse (BM25 only); repos indexed locally via scripts/index_repo.py ---
+mode: sparse
+data_dir: .codeminer_qa
+prebuilt_dir: null        # no pre-built vector tree on this host
 
 cors_origins:
-  - http://localhost:3000
-  - http://127.0.0.1:3000
-  # next dev auto-bumps to 3001 when 3000 is busy; allow it so the fallback works
-  - http://localhost:3001
-  - http://127.0.0.1:3001
-
-# --- which repos to feature (from the codeminer-base-dataset) ---
-dataset: fishmingyu/codeminer-base-dataset
-split: test
-
-# Either pin explicit instance ids here:
-instances: []
-# …or, when `instances` is empty, sample this many instances per language group:
-per_language: 1
-languages:
-  - python
-  - javascript
-  - go
-  - rust
+  - "*"                   # open for the demo; tighten once behind a same-origin proxy

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -324,9 +324,13 @@ pre {
 .repo-card .repo-card-footer {
   margin-top: auto;
   padding-top: 12px;
+  /* reserve space for the absolutely-positioned go-arrow so the commit hash
+     never slides under it */
+  padding-right: 40px;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  gap: 6px 10px;
   font-size: 12px;
   color: var(--muted);
 }
@@ -373,6 +377,7 @@ pre {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  white-space: nowrap;
 }
 
 /* language tag */
@@ -383,6 +388,9 @@ pre {
   border: 1px solid var(--border-2);
   color: var(--muted);
   white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .landing .empty {


### PR DESCRIPTION
## Summary
DGX Spark serving configuration for the CodeMiner DeepWiki demo, plus the code
changes needed to make it work end-to-end: a dual-vLLM setup (Qwen3.6-35B-A3B-FP8
with MTP speculative decoding for the Ask agent, Qwen3-Embedding-0.6B for hybrid
dense retrieval), Vertex Claude Haiku 4.5 for wiki generation, and a production
Next.js frontend. Answers are grounded (hybrid BM25 + dense) and Ask throughput
is ~3x faster than bf16.

## Changes
- **Split wiki vs Ask model** (`web/config.py`, `web/app.py`): new `wiki_model` so
  wiki prose + edge labels run on a different backend than the interactive agent.
- **OpenAI-compatible embedding provider** (`web/config.py`, `web/repo_registry.py`):
  `embedding_provider` / `embedding_base_url` / `embedding_api_key` let dense
  embeddings come from a remote vLLM `/v1/embeddings` endpoint instead of an
  in-process SentenceTransformer (needed on this box — the in-process path triggers
  a Triton CUDA JIT that needs python-dev headers we can't `sudo`-install).
- **`api_base` / `api_key` in the demo config** (`web/config.py`): point an
  `openai/`-prefixed model at any OpenAI-compatible endpoint (e.g. a local vLLM),
  exported to `OPENAI_API_BASE` / `OPENAI_API_KEY`.
- **Reliable Qwen answers** (`llm/litellm_chat.py`, `agent/runner.py`): disable
  thinking for vLLM Qwen models (they emit a plain-text "Here's a thinking process:"
  preamble that derails answer extraction and wastes tokens), and add
  `_force_final_answer` — when a demo run ends mid-exploration (last message is
  "Let me look at..." chatter), spend one tool-free turn synthesizing a real answer.
- **`qa_config.yaml` + `SERVING.md`**: the DGX Spark hybrid serving config and full
  runbook (ports, FP8+MTP container, throughput, hybrid index build, prod frontend).

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [ ] Tests

## Testing
<!-- Describe the tests you ran and/or how to test these changes -->
- [ ] Tests pass locally
- [ ] Added new tests for the changes

Verified end-to-end on the live DGX Spark deployment (not via the pytest suite —
this is a serving/config branch):
- Hybrid retrieval active: the agent fires both `bm25_search` and `embedding_search`
  (dense via the `:8081` endpoint, ~30-44ms).
- Real Ask questions on `psf/requests` and `matplotlib/matplotlib` return coherent,
  grounded answers (~3.5-6.8k chars, correct file/symbol references).
- Ask throughput measured from vLLM logs: bf16 ~20 tok/s → FP8 ~49 → **FP8 + MTP(1)
  ~50-65 tok/s**; a full multi-turn Ask completes in ~35-60s.
- Pre-commit (black / isort / flake8) passes.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

**Reviewer note:** `qa_config.yaml` and `SERVING.md` are deployment-specific to the
DGX Spark box (absolute `/home/boqin` paths, host-specific ports/project). The
reusable, mergeable pieces are the code changes under `codeminer/` (wiki-model split,
embedding provider, `api_base`/`api_key`, thinking-off, forced final answer). MTP uses
`num_speculative_tokens=1` (this model has one MTP layer; 2 is slower). NVFP4 was
attempted but the vLLM `qwen3_5` loader can't map its expert scales.
