### PR TITLE
fix(scip): tolerate malformed Cargo workspace member globs

### DIFF
--- a/codeminer/scip_interface/scip_decode_rust.py
+++ b/codeminer/scip_interface/scip_decode_rust.py
@@ -188,7 +188,16 @@ class SCIPRustGraphDecoder:
             internal_crates.add(root_pkg_name)
 
         for pattern in member_patterns:
-            for member_dir in self.project_root.glob(pattern):
+            # Malformed member globs ("", trailing slash, absolute paths) make
+            # Path.glob raise on Python 3.12; skip them instead of aborting.
+            pattern = str(pattern).strip().rstrip("/")
+            if not pattern or pattern.startswith("/"):
+                continue
+            try:
+                members = list(self.project_root.glob(pattern))
+            except (ValueError, IndexError, OSError):
+                continue
+            for member_dir in members:
                 if not member_dir.is_dir():
                     continue
                 member_cargo = member_dir / "Cargo.toml"

--- a/test/scip/test_scip_decode_rust.py
+++ b/test/scip/test_scip_decode_rust.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for SCIPRustGraphDecoder workspace-member handling."""
+
+from codeminer.scip_interface.scip_decode_rust import SCIPRustGraphDecoder
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _decoder(tmp_path):
+    return SCIPRustGraphDecoder("unused.scip", project_root=tmp_path)
+
+
+def test_workspace_members_resolve_globs(tmp_path):
+    _write(
+        tmp_path / "Cargo.toml",
+        '[package]\nname = "rootpkg"\n\n[workspace]\nmembers = ["crates/*"]\n',
+    )
+    _write(tmp_path / "crates" / "a" / "Cargo.toml", '[package]\nname = "crate-a"\n')
+
+    assert _decoder(tmp_path)._load_workspace_crates() == {"rootpkg", "crate-a"}
+
+
+def test_workspace_members_tolerate_malformed_globs(tmp_path):
+    """uutils/coreutils-style member lists must not abort the whole decode.
+
+    A trailing-slash pattern makes ``Path.glob`` raise ``IndexError`` on
+    Python 3.12; empty and absolute patterns are equally unusable.
+    """
+    _write(
+        tmp_path / "Cargo.toml",
+        '[package]\nname = "rootpkg"\n\n'
+        '[workspace]\nmembers = ["", "crates/", "/abs/path", "crates/*"]\n',
+    )
+    _write(tmp_path / "crates" / "a" / "Cargo.toml", '[package]\nname = "crate-a"\n')
+
+    assert _decoder(tmp_path)._load_workspace_crates() == {"rootpkg", "crate-a"}


### PR DESCRIPTION
## Summary
Rust symbol-graph decoding aborts entirely when a repo's `[workspace] members`
list contains a malformed glob. On Python 3.12, a trailing-slash pattern (as in
uutils/coreutils) makes `Path.glob` raise `IndexError: tuple index out of range`,
which surfaces as "Error processing SCIP index" and leaves the repo with an
empty graph.

## Changes
- `scip_decode_rust.py`: normalize each workspace member pattern (strip
  whitespace and trailing slash), skip empty/absolute ones, and guard the glob
  call so one bad pattern can't kill the decode.
- `test/scip/test_scip_decode_rust.py`: regression tests for the happy path and
  the malformed-members case.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
<!-- Describe the tests you ran and/or how to test these changes -->
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/scip/test_scip_decode_rust.py` — 2 passed. Also verified on a real
checkout: uutils/coreutils previously decoded 0 nodes; with this fix it loads
114 workspace crates and builds a 16k-node graph.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

Extracted from #327 per review (independent fix, focused PR).
