### PR TITLE
fix(web): repo card footer overflow on multi-language repos

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -324,9 +324,13 @@ pre {
 .repo-card .repo-card-footer {
   margin-top: auto;
   padding-top: 12px;
+  /* reserve space for the absolutely-positioned go-arrow so the commit hash
+     never slides under it */
+  padding-right: 40px;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
+  gap: 6px 10px;
   font-size: 12px;
   color: var(--muted);
 }
@@ -373,6 +377,7 @@ pre {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  white-space: nowrap;
 }
 
 /* language tag */
@@ -383,6 +388,9 @@ pre {
   border: 1px solid var(--border-2);
   color: var(--muted);
   white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .landing .empty {


### PR DESCRIPTION
## Summary
On the landing page, repo cards with a long language tag (e.g.
`python/rust/typescript/javascript`) plus a large file count overflow the card
footer: the file count wraps to two lines and the commit hash slides under the
absolutely-positioned go-arrow.

## Changes
- `web/app/globals.css`: keep the file count on one line, reserve footer space
  for the go-arrow, let the footer row wrap cleanly, and truncate over-long
  language pills with an ellipsis.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
<!-- Describe the tests you ran and/or how to test these changes -->
- [ ] Tests pass locally
- [ ] Added new tests for the changes

CSS-only change; no pytest surface. Verified visually on a production
`next build` against a registry containing multi-language repos (ruff,
nushell, bat): footers no longer wrap or clip at desktop and mobile widths.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

Extracted from #327 per review (independent fix, focused PR).
