### PR TITLE
feat(eval): record reproducible sweep protocols

### DIFF
--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -234,11 +234,8 @@ class AgentRunner:
         # Loss-safe for localization (answers need path/symbol/line, not source).
         self._compact_after_read = compact_after_read
         # Seed richness for eager_compact: how many successful read outputs to
-        # keep VERBATIM in the collapse seed. 0 still carries the latest read
-        # transcript so the model can see the file it just requested; higher
-        # values inline additional recent reads so weaker models don't re-read
-        # after the collapse (the "re-read tax" observed on 4B). Set by a
-        # model-strength router upstream.
+        # keep VERBATIM in the collapse seed. For backward compatibility, 0 is
+        # an alias for the minimum of one read; values 2+ retain more history.
         self._compact_keep_reads = compact_keep_reads
         # Optional startup context over the same static graph exposed by the
         # lsp_route skill. This is opt-in harness policy: it makes graph route
@@ -894,14 +891,12 @@ limited tool budget, so converge once the implementing location is confirmed.
         of the run (re-sending them every turn is the dominant prompt cost, ~97%
         of spend). The continuation works the "correct path" from a small seed.
 
-        ``keep_reads`` is the seed-richness dial set by a model-strength router.
         The latest successful read is always inlined because this collapse runs
         immediately after the read result enters history; without that transcript
         the next model turn would never see the file it just asked to inspect.
-        N>0 inlines up to the last N successful read outputs (not grep/glob/bash
-        output) so a WEAK model does not re-read them after the collapse (the
-        "re-read tax" seen on 4B). It trades some token saving for fewer re-read
-        turns.
+        ``keep_reads`` therefore has a minimum effective value of one: 0 and 1
+        retain the latest read, while N>1 retains the last N successful reads
+        (never grep/glob/bash output).
 
         Loss-safe for localization: the seed names the files judged relevant plus
         the agent's own assessment; answers need path/symbol/line, not source.

--- a/codeminer/eval/agent_runner/query_sweep.py
+++ b/codeminer/eval/agent_runner/query_sweep.py
@@ -114,6 +114,52 @@ def group_query_rows_by_instance(
     return grouped
 
 
+def limit_instance_query_rows(
+    rows: Sequence[Mapping[str, Any]],
+    max_queries: Optional[int],
+    *,
+    strategy: str = "dataset_order",
+    category_offset: int = 0,
+) -> List[Dict[str, Any]]:
+    """Cap one instance's queries with a reproducible selection strategy."""
+    selected = [dict(row) for row in rows]
+    if max_queries is None:
+        return selected
+    if max_queries < 1:
+        raise ValueError("max_queries must be positive")
+    if strategy == "dataset_order":
+        return selected[:max_queries]
+    if strategy != "category_round_robin":
+        raise ValueError(f"unknown query selection strategy: {strategy}")
+
+    buckets: Dict[str, List[Dict[str, Any]]] = {}
+    for row in selected:
+        buckets.setdefault(str(row.get("category") or ""), []).append(row)
+    if not buckets:
+        return []
+
+    categories = sorted(buckets)
+    offset = category_offset % len(categories)
+    categories = categories[offset:] + categories[:offset]
+    positions = {category: 0 for category in categories}
+    limited: List[Dict[str, Any]] = []
+    while len(limited) < max_queries:
+        made_progress = False
+        for category in categories:
+            position = positions[category]
+            bucket = buckets[category]
+            if position >= len(bucket):
+                continue
+            limited.append(bucket[position])
+            positions[category] += 1
+            made_progress = True
+            if len(limited) >= max_queries:
+                break
+        if not made_progress:
+            break
+    return limited
+
+
 def run_query_sweep(
     cfg: SweepConfig,
     output_dir: Path,
@@ -122,6 +168,7 @@ def run_query_sweep(
     categories: Optional[Set[str]] = None,
     max_queries: Optional[int] = None,
     max_instances: Optional[int] = None,
+    query_selection: str = "dataset_order",
     resume: bool = True,
     summary_filename: str = "query_sweep_summary.json",
 ) -> Dict[str, Any]:
@@ -178,16 +225,45 @@ def run_query_sweep(
     )
     summary: Dict[str, Any] = {
         "required_index_types": sorted(index_types),
+        "query_selection": query_selection,
+        "protocol": {
+            "sweep_id": cfg.sweep_id,
+            "model": cfg.model,
+            "model_revision": cfg.model_revision,
+            "dataset": cfg.dataset,
+            "dataset_revision": cfg.dataset_revision,
+            "split": cfg.split,
+            "subsets": cfg.subsets,
+            "preload": cfg.preload,
+            "reps": cfg.reps,
+            "max_turns": cfg.max_turns,
+            "max_context_tokens": cfg.max_context_tokens,
+            "max_tokens": cfg.max_tokens,
+            "temperature": cfg.temperature,
+            "embedding_model": cfg.embedding_model,
+            "embedding_revision": cfg.embedding_revision,
+            "topk": cfg.topk,
+            "categories": sorted(categories) if categories else None,
+            "max_queries": max_queries,
+            "max_instances": max_instances,
+            "query_selection": query_selection,
+            "run_metadata": cfg.run_metadata,
+        },
         "completed": [],
+        "cached": [],
         "skipped": [],
         "failed": [],
     }
 
-    for instance_id, instance_rows in group_query_rows_by_instance(
-        filtered_rows
-    ).items():
-        if max_queries:
-            instance_rows = instance_rows[:max_queries]
+    for instance_index, (instance_id, instance_rows) in enumerate(
+        group_query_rows_by_instance(filtered_rows).items()
+    ):
+        instance_rows = limit_instance_query_rows(
+            instance_rows,
+            max_queries,
+            strategy=query_selection,
+            category_offset=instance_index,
+        )
         if not has_required_indexes(
             cfg.prebuilt_dir,
             instance_id,
@@ -207,6 +283,7 @@ def run_query_sweep(
                     cell_id = f"{row['query_id']}__{subset_id}__rep{rep}"
                     cell_path = cells_dir / f"{slug(cell_id)}.json"
                     if resume and cell_path.exists():
+                        summary["cached"].append(cell_id)
                         continue
                     plan.append((row, subset_id, list(skills), rep, cell_id, cell_path))
         if not plan:

--- a/codeminer/eval/agent_runner/sweep_config.py
+++ b/codeminer/eval/agent_runner/sweep_config.py
@@ -13,6 +13,7 @@ deltas (see :meth:`SweepConfig.from_yaml`).
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -42,6 +43,10 @@ class SweepConfig:
     # so arms are directly comparable on the same instances.
     instances: List[str] = field(default_factory=list)
     model: Optional[str] = None
+    # Provider or model-server revision recorded for experiment provenance.
+    # Immutable local revisions must also be enforced when launching the server.
+    model_revision: Optional[str] = None
+    run_metadata: Dict[str, Any] = field(default_factory=dict)
     vertex_location: Optional[str] = None
     vertex_project: Optional[str] = None
     reps: int = 2
@@ -55,6 +60,7 @@ class SweepConfig:
     topk: int = 50
     num_retries: int = 8
     dataset: str = "fishmingyu/codeminer-base-dataset"
+    dataset_revision: Optional[str] = None
     split: str = "test"
     prebuilt_dir: str = "/mnt/data/codeminer"
     embedding_model: Optional[str] = None
@@ -108,6 +114,12 @@ class SweepConfig:
     def __post_init__(self) -> None:
         if self.max_context_tokens is not None and self.max_context_tokens <= 0:
             raise ValueError("max_context_tokens must be positive when set")
+        try:
+            json.dumps(self.run_metadata)
+        except TypeError as exc:
+            raise ValueError(
+                "run_metadata must contain JSON-serializable values"
+            ) from exc
 
     @classmethod
     def from_yaml(cls, path: Path) -> "SweepConfig":

--- a/test/eval/test_query_sweep.py
+++ b/test/eval/test_query_sweep.py
@@ -8,15 +8,36 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from codeminer.eval.agent_runner.query_sweep import (
     filter_query_rows,
     group_query_rows_by_instance,
     language_key_for_query_row,
+    limit_instance_query_rows,
     query_targets,
     run_query_sweep,
     select_query_rows,
 )
 from codeminer.eval.agent_runner.sweep_config import SweepConfig
+
+
+def test_sweep_config_rejects_non_json_run_metadata(tmp_path):
+    config = tmp_path / "cfg.yaml"
+    config.write_text(
+        """
+sweep_id: invalid_metadata
+model: test/model
+embedding_model: test/embedding
+subsets: {defaults: []}
+run_metadata:
+  unquoted_date: 2026-07-20
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="JSON-serializable"):
+        SweepConfig.from_yaml(config)
 
 
 def test_query_targets_normalizes_files_and_simplified_symbols():
@@ -98,6 +119,38 @@ def test_group_query_rows_by_instance_preserves_order_and_skips_missing_ids():
 
     assert [row["query_id"] for row in grouped["i1"]] == ["q1", "q2"]
     assert [row["query_id"] for row in grouped["i2"]] == ["q3"]
+
+
+def test_limit_instance_query_rows_round_robins_categories_with_offset():
+    rows = [
+        {"query_id": "b1", "category": "behavioral"},
+        {"query_id": "b2", "category": "behavioral"},
+        {"query_id": "f1", "category": "file_hint"},
+        {"query_id": "f2", "category": "file_hint"},
+        {"query_id": "s1", "category": "symbol_hint"},
+    ]
+
+    first = limit_instance_query_rows(
+        rows, 4, strategy="category_round_robin", category_offset=0
+    )
+    shifted = limit_instance_query_rows(
+        rows, 4, strategy="category_round_robin", category_offset=1
+    )
+
+    assert [row["query_id"] for row in first] == ["b1", "f1", "s1", "b2"]
+    assert [row["query_id"] for row in shifted] == ["f1", "s1", "b1", "f2"]
+
+
+def test_limit_instance_query_rows_preserves_dataset_order_by_default():
+    rows = [
+        {"query_id": "b1", "category": "behavioral"},
+        {"query_id": "b2", "category": "behavioral"},
+        {"query_id": "f1", "category": "file_hint"},
+    ]
+
+    selected = limit_instance_query_rows(rows, 2)
+
+    assert [row["query_id"] for row in selected] == ["b1", "b2"]
 
 
 def test_language_key_for_query_row_prefers_explicit_then_language_group():
@@ -207,6 +260,10 @@ def test_run_query_sweep_stages_only_declared_indexes(monkeypatch, tmp_path):
     )
 
     assert summary["required_index_types"] == ["vector"]
+    assert summary["protocol"]["model"] == "provider/model"
+    assert summary["protocol"]["embedding_model"] == "org/embed-small"
+    assert summary["protocol"]["query_selection"] == "dataset_order"
+    assert summary["cached"] == []
     assert calls["preflight"] == (
         str(tmp_path / "prebuilt"),
         "org__repo-1",
@@ -219,3 +276,21 @@ def test_run_query_sweep_stages_only_declared_indexes(monkeypatch, tmp_path):
         str(output_dir / "cache" / "org__repo-1"),
         {"vector"},
     )
+
+    resumed = run_query_sweep(
+        cfg,
+        output_dir,
+        [
+            {
+                "instance_id": "org__repo-1",
+                "query_id": "query-1",
+                "query": "Locate the implementation",
+                "gt_files": [],
+                "gt_symbols": [],
+            }
+        ],
+        resume=True,
+    )
+
+    assert resumed["completed"] == []
+    assert resumed["cached"] == ["query-1__vector__rep1"]


### PR DESCRIPTION
## Summary
Record enough protocol and selection metadata to reproduce agent query sweeps and audit resumed cells.

## Changes
- add immutable dataset/model revision and JSON-safe run metadata fields
- add deterministic dataset-order and category-round-robin query selection
- persist protocol controls and cached cell IDs in sweep summaries
- clarify the existing minimum one-read compact-history behavior

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/eval/test_query_sweep.py test/agent/test_runner.py test/agent/test_runner_usage.py --tb=short` (46 passed)

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (1622 passed, 10 skipped)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published