### PR TITLE
feat(web): configure serving backends

### DIFF
--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -54,7 +54,9 @@ async def lifespan(app: FastAPI):
     # Shared LLM narrator for DeepWiki-style prose; cached on disk, fails soft
     # to templated text when no model/creds are available.
     wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
-    app.state.narrator = Narrator(model=config.model, cache_dir=wiki_cache)
+    app.state.narrator = Narrator(
+        model=config.wiki_generation_model, cache_dir=wiki_cache
+    )
     logger.info(
         "Wiki narrator: model=%s enabled=%s cache=%s",
         app.state.narrator.model,
@@ -99,7 +101,9 @@ def _wiki(repo_id: str):
 
             wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
             cache[repo_id] = AgentWiki(
-                _bundle(repo_id), config.model, cache_dir=wiki_cache
+                _bundle(repo_id),
+                config.wiki_generation_model,
+                cache_dir=wiki_cache,
             )
         else:
             cache[repo_id] = WikiBuilder(
@@ -120,7 +124,7 @@ def _edge_labeler(repo_id: str):
         namespace = f"{bundle.entry.instance_id}@{bundle.entry.commit_short}"
         cache[repo_id] = EdgeLabeler(
             source_fn=_wiki(repo_id).source,
-            model=config.edge_label_model or config.model,
+            model=config.edge_label_model or config.wiki_generation_model,
             cache_dir=wiki_cache,
             cache_namespace=namespace,
         )
@@ -150,12 +154,13 @@ async def list_repos() -> list[RepoInfo]:
 @app.get("/api/repos/{repo_id}/wiki")
 async def wiki_tree(repo_id: str) -> dict:
     builder = _wiki(repo_id)
-    return {"repo": _bundle(repo_id).entry.repo, "pages": builder.page_tree()}
+    pages = await asyncio.to_thread(builder.page_tree)
+    return {"repo": _bundle(repo_id).entry.repo, "pages": pages}
 
 
 @app.get("/api/repos/{repo_id}/wiki/{page_id}")
 async def wiki_page(repo_id: str, page_id: str) -> dict:
-    page = _wiki(repo_id).page(page_id)
+    page = await asyncio.to_thread(_wiki(repo_id).page, page_id)
     if page is None:
         raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
     return page
@@ -168,7 +173,7 @@ async def wiki_page_graph(repo_id: str, page_id: str) -> dict:
     Lets a wiki page render as a *view over the graph* (subsystem symbols + how
     they connect), using the same ``{nodes, edges}`` payload as ``/codemap``.
     """
-    page = _wiki(repo_id).page(page_id)
+    page = await asyncio.to_thread(_wiki(repo_id).page, page_id)
     if page is None:
         raise HTTPException(status_code=404, detail=f"Unknown wiki page: {page_id!r}")
     bundle = _bundle(repo_id)

--- a/codeminer/web/config.py
+++ b/codeminer/web/config.py
@@ -47,12 +47,23 @@ class RepoEntry:
 class QAConfig:
     """Top-level demo configuration."""
 
-    # litellm model string for the agent. Env ``CODEMINER_DEMO_MODEL`` wins.
+    # LiteLLM model string for the interactive Ask agent.
     model: str = "gpt-4o"
+    # Wiki prose and edge labels may use a separate provider/model. When unset,
+    # they use ``model``.
+    wiki_model: Optional[str] = None
+    # Optional OpenAI-compatible endpoint for the Ask agent. Provider-native
+    # models (for example Vertex or Anthropic) normally leave these unset.
+    model_api_base: Optional[str] = None
+    model_api_key: Optional[str] = field(default=None, repr=False)
     # "sparse" (BM25 only) or "hybrid" (BM25 + vector embeddings).
     mode: str = "sparse"
     embedding_model: str = "BAAI/bge-small-en-v1.5"
     embedding_dimension: int = 384
+    # Embeddings can run in-process or through an OpenAI-compatible endpoint.
+    embedding_provider: str = "huggingface"
+    embedding_base_url: Optional[str] = None
+    embedding_api_key: Optional[str] = field(default=None, repr=False)
     # Where checked-out repos + indexes + the registry live.
     data_dir: str = ".codeminer_qa"
     # Optional read-only tree of pre-built per-instance artifacts:
@@ -109,6 +120,11 @@ class QAConfig:
     def repo_dir(self, instance_id: str) -> str:
         return os.path.join(os.path.abspath(self.data_dir), "repos", instance_id)
 
+    @property
+    def wiki_generation_model(self) -> str:
+        """Model used by wiki and edge-label generation."""
+        return self.wiki_model or self.model
+
 
 def load_config(path: Optional[str] = None) -> QAConfig:
     """Load demo config from YAML, applying env overrides."""
@@ -120,11 +136,17 @@ def load_config(path: Optional[str] = None) -> QAConfig:
 
     cfg = QAConfig(
         model=data.get("model", QAConfig.model),
+        wiki_model=data.get("wiki_model"),
+        model_api_base=data.get("model_api_base"),
+        model_api_key=data.get("model_api_key"),
         mode=data.get("mode", QAConfig.mode),
         embedding_model=data.get("embedding_model", QAConfig.embedding_model),
         embedding_dimension=data.get(
             "embedding_dimension", QAConfig.embedding_dimension
         ),
+        embedding_provider=data.get("embedding_provider", "huggingface"),
+        embedding_base_url=data.get("embedding_base_url"),
+        embedding_api_key=data.get("embedding_api_key"),
         data_dir=data.get("data_dir", QAConfig.data_dir),
         prebuilt_dir=data.get("prebuilt_dir", QAConfig.prebuilt_dir),
         max_turns=data.get("max_turns", QAConfig.max_turns),
@@ -155,6 +177,12 @@ def load_config(path: Optional[str] = None) -> QAConfig:
 
     if os.environ.get("CODEMINER_DEMO_MODEL"):
         cfg.model = os.environ["CODEMINER_DEMO_MODEL"]
+    if os.environ.get("CODEMINER_DEMO_WIKI_MODEL"):
+        cfg.wiki_model = os.environ["CODEMINER_DEMO_WIKI_MODEL"]
+    if os.environ.get("CODEMINER_DEMO_API_BASE"):
+        cfg.model_api_base = os.environ["CODEMINER_DEMO_API_BASE"]
+    if os.environ.get("CODEMINER_DEMO_API_KEY"):
+        cfg.model_api_key = os.environ["CODEMINER_DEMO_API_KEY"]
     if os.environ.get("CODEMINER_DEMO_DATA_DIR"):
         cfg.data_dir = os.environ["CODEMINER_DEMO_DATA_DIR"]
     if os.environ.get("CODEMINER_DEMO_PREBUILT_DIR"):
@@ -164,6 +192,19 @@ def load_config(path: Optional[str] = None) -> QAConfig:
         cfg.edge_labels = _env_edge.strip().lower() in ("1", "true", "yes", "on")
     if os.environ.get("CODEMINER_EDGE_MODEL"):
         cfg.edge_label_model = os.environ["CODEMINER_EDGE_MODEL"]
+
+    if os.environ.get("CODEMINER_EMBEDDING_PROVIDER"):
+        cfg.embedding_provider = os.environ["CODEMINER_EMBEDDING_PROVIDER"]
+    if os.environ.get("CODEMINER_EMBEDDING_MODEL"):
+        cfg.embedding_model = os.environ["CODEMINER_EMBEDDING_MODEL"]
+    if os.environ.get("CODEMINER_EMBEDDING_BASE_URL"):
+        cfg.embedding_base_url = os.environ["CODEMINER_EMBEDDING_BASE_URL"]
+    if os.environ.get("CODEMINER_EMBEDDING_API_KEY"):
+        cfg.embedding_api_key = os.environ["CODEMINER_EMBEDDING_API_KEY"]
+
+    cfg.embedding_provider = cfg.embedding_provider.strip().lower()
+    if cfg.embedding_provider not in {"huggingface", "openai"}:
+        raise ValueError("embedding_provider must be either 'huggingface' or 'openai'")
 
     return cfg
 

--- a/codeminer/web/repo_registry.py
+++ b/codeminer/web/repo_registry.py
@@ -17,7 +17,7 @@ import os
 import re
 from dataclasses import dataclass
 from threading import Lock
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ..agent.runner import AgentRunner
 from ..agent.skills.loader import SkillLoader
@@ -259,7 +259,7 @@ class RepoRegistry:
         self._bundles: Dict[str, RepoBundle] = {}
         # One embedding model per model name, shared across repos: the GPU model
         # is loaded once instead of once per CodeVectorStore (one per repo).
-        self._embeddings: Dict[str, object] = {}
+        self._embeddings: Dict[Tuple[str, str, Optional[str]], object] = {}
 
     def load_all(self) -> None:
         """Load every dataset repo in the registry whose manifest exists."""
@@ -294,6 +294,44 @@ class RepoRegistry:
             runtime_loader=self._load_repo_runtime,
         )
 
+    def _load_vector_store(self, vec_entry: Any) -> CodeVectorStore:
+        """Load a manifest vector view with the configured embedding backend."""
+        emb_model = vec_entry.config.get(
+            "embedding_model", self._config.embedding_model
+        )
+        emb_dim = vec_entry.config.get(
+            "embedding_dimension", self._config.embedding_dimension
+        )
+        provider = self._config.embedding_provider
+        cache_key = (provider, emb_model, self._config.embedding_base_url)
+        client_kwargs: Dict[str, object] = {}
+        if self._config.embedding_base_url:
+            client_kwargs["base_url"] = self._config.embedding_base_url
+        if self._config.embedding_api_key:
+            client_kwargs["api_key"] = self._config.embedding_api_key
+
+        vector_store = CodeVectorStore(
+            embedding_model=emb_model,
+            embedding_provider=provider,
+            dimension=emb_dim,
+            store_path=vec_entry.path,
+            embedding=self._embeddings.get(cache_key),
+            **client_kwargs,
+        )
+        self._embeddings[cache_key] = vector_store.embedding
+        vector_store.load(vec_entry.path)
+        return vector_store
+
+    def _create_ask_llm(self) -> LiteLLMChat:
+        """Create the interactive model without mutating process-wide config."""
+        return LiteLLMChat(
+            model=self._config.model,
+            temperature=0.0,
+            max_tokens=self._config.max_tokens,
+            api_base=self._config.model_api_base,
+            api_key=self._config.model_api_key,
+        )
+
     def _load_repo_runtime(self, bundle: RepoBundle) -> None:
         entry = bundle.entry
         manifest = bundle.manifest
@@ -308,22 +346,7 @@ class RepoRegistry:
 
         vec_entry = manifest.indexes.get("vector")
         if vec_entry is not None and vec_entry.status == "fresh":
-            emb_model = vec_entry.config.get(
-                "embedding_model", self._config.embedding_model
-            )
-            emb_dim = vec_entry.config.get(
-                "embedding_dimension", self._config.embedding_dimension
-            )
-            vector_store = CodeVectorStore(
-                embedding_model=emb_model,
-                embedding_provider="huggingface",
-                dimension=emb_dim,
-                store_path=vec_entry.path,
-                embedding=self._embeddings.get(emb_model),
-            )
-            # Cache the (possibly just-loaded) model so the next repo reuses it.
-            self._embeddings[emb_model] = vector_store.embedding
-            vector_store.load(vec_entry.path)
+            vector_store = self._load_vector_store(vec_entry)
 
         retrieve_ctx = RetrieveContext(
             bm25=bm25_index,
@@ -347,11 +370,7 @@ class RepoRegistry:
             ),
         )
 
-        llm = LiteLLMChat(
-            model=self._config.model,
-            temperature=0.0,
-            max_tokens=self._config.max_tokens,
-        )
+        llm = self._create_ask_llm()
         runner = AgentRunner(
             llm=llm,
             registry=registry,

--- a/qa_config.yaml
+++ b/qa_config.yaml
@@ -7,22 +7,29 @@
 # Build indexes:   python scripts/build_qa_index.py   (needs network: HF + git)
 # Serve:           codeminer-web                       (or: uvicorn codeminer.web.app:app)
 #
-# `model` is a litellm model string; override with CODEMINER_DEMO_MODEL.
-# Provider API keys come from the environment (e.g. OPENAI_API_KEY).
+# `model` is a LiteLLM model string; override with CODEMINER_DEMO_MODEL.
+# Keep secrets in environment variables, not this file.
 
-model: vertex_ai/gemini-2.5-flash   # uses gcloud ADC; override via CODEMINER_DEMO_MODEL
+model: gpt-4o
+# Optional: use a different model for generated wiki prose and edge labels.
+# wiki_model: vertex_ai/gemini-2.5-flash
+# Optional: point the Ask model at an OpenAI-compatible endpoint. Prefer the
+# CODEMINER_DEMO_API_BASE and CODEMINER_DEMO_API_KEY environment variables.
+# model_api_base: http://127.0.0.1:8080/v1
 
-mode: hybrid              # "sparse" (BM25 only) or "hybrid" (BM25 + embeddings)
+mode: sparse              # "sparse" (BM25 only) or "hybrid" (BM25 + embeddings)
 data_dir: .codeminer_qa
 # Reuse pre-built per-instance indexes (source @ base_commit + L0/L2 vectors)
 # from this read-only tree. BM25 is still built locally under data_dir.
-prebuilt_dir: /mnt/data/codeminer
-# Must match the embedding model whose files live under
-# <prebuilt_dir>/<instance_id>/{l0,l2}/index_<model_suffix>.faiss
-embedding_model: Qwen/Qwen3-Embedding-0.6B
-embedding_dimension: 1024
+prebuilt_dir: null
+embedding_model: BAAI/bge-small-en-v1.5
+embedding_dimension: 384
+# Remote embeddings use an OpenAI-compatible endpoint. Prefer the
+# CODEMINER_EMBEDDING_* environment variables for endpoint and credentials.
+# embedding_provider: openai
+# embedding_base_url: http://127.0.0.1:8081/v1
 max_turns: 8
-max_tokens: 4096   # generous: gemini-2.5 is a thinking model (we disable thinking, but keep headroom)
+max_tokens: 4096
 
 # Show short LLM-written dependency phrases on graph edges (hover/click in the
 # interactive graph view). Off by default: each first-seen edge triggers one

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for non-blocking web runtime behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import codeminer.web.app as web_app
+
+
+def test_wiki_generation_runs_off_event_loop(monkeypatch):
+    calls = []
+
+    class Builder:
+        def page_tree(self):
+            return [{"id": "overview"}]
+
+        def page(self, page_id):
+            return {"id": page_id}
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append((func.__name__, args))
+        return func(*args, **kwargs)
+
+    builder = Builder()
+    monkeypatch.setattr(web_app, "_wiki", lambda _repo_id: builder)
+    monkeypatch.setattr(
+        web_app,
+        "_bundle",
+        lambda _repo_id: SimpleNamespace(entry=SimpleNamespace(repo="org/repo")),
+    )
+    monkeypatch.setattr(web_app.asyncio, "to_thread", fake_to_thread)
+
+    tree = asyncio.run(web_app.wiki_tree("repo"))
+    page = asyncio.run(web_app.wiki_page("repo", "overview"))
+
+    assert tree == {"repo": "org/repo", "pages": [{"id": "overview"}]}
+    assert page == {"id": "overview"}
+    assert calls == [("page_tree", ()), ("page", ("overview",))]

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -4,6 +4,10 @@
 
 """Tests for per-repo skill-registry isolation, config, and the QA registry."""
 
+from types import SimpleNamespace
+
+import pytest
+
 from codeminer.agent.skills.registry import SkillRegistry
 from codeminer.web.config import (
     QAConfig,
@@ -12,7 +16,7 @@ from codeminer.web.config import (
     load_registry,
     save_registry,
 )
-from codeminer.web.repo_registry import _fresh_registry
+from codeminer.web.repo_registry import RepoRegistry, _fresh_registry
 
 
 def test_fresh_registry_is_isolated_from_singleton():
@@ -42,7 +46,11 @@ def test_load_config_from_yaml(tmp_path):
     cfg_file = tmp_path / "qa.yaml"
     cfg_file.write_text(
         "model: my-model\n"
+        "wiki_model: wiki-model\n"
+        "model_api_base: http://ask.example/v1\n"
         "mode: hybrid\n"
+        "embedding_provider: openai\n"
+        "embedding_base_url: http://embed.example/v1\n"
         "dataset: foo/bar\n"
         "per_language: 2\n"
         "languages: [python, go]\n"
@@ -50,11 +58,109 @@ def test_load_config_from_yaml(tmp_path):
     )
     cfg = load_config(str(cfg_file))
     assert cfg.model == "my-model"
+    assert cfg.wiki_generation_model == "wiki-model"
+    assert cfg.model_api_base == "http://ask.example/v1"
     assert cfg.mode == "hybrid"
+    assert cfg.embedding_provider == "openai"
+    assert cfg.embedding_base_url == "http://embed.example/v1"
     assert cfg.dataset == "foo/bar"
     assert cfg.per_language == 2
     assert cfg.languages == ["python", "go"]
     assert cfg.instances == ["a__a-1", "b__b-2"]
+
+
+def test_backend_environment_overrides_yaml(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "qa.yaml"
+    cfg_file.write_text(
+        "model: yaml-ask\n"
+        "wiki_model: yaml-wiki\n"
+        "embedding_provider: huggingface\n"
+    )
+    monkeypatch.setenv("CODEMINER_DEMO_MODEL", "env-ask")
+    monkeypatch.setenv("CODEMINER_DEMO_WIKI_MODEL", "env-wiki")
+    monkeypatch.setenv("CODEMINER_DEMO_API_BASE", "http://ask.local/v1")
+    monkeypatch.setenv("CODEMINER_EMBEDDING_PROVIDER", "OPENAI")
+    monkeypatch.setenv("CODEMINER_EMBEDDING_BASE_URL", "http://embed.local/v1")
+
+    cfg = load_config(str(cfg_file))
+
+    assert cfg.model == "env-ask"
+    assert cfg.wiki_generation_model == "env-wiki"
+    assert cfg.model_api_base == "http://ask.local/v1"
+    assert cfg.embedding_provider == "openai"
+    assert cfg.embedding_base_url == "http://embed.local/v1"
+
+
+def test_rejects_unknown_embedding_provider(tmp_path):
+    cfg_file = tmp_path / "qa.yaml"
+    cfg_file.write_text("embedding_provider: custom\n")
+
+    with pytest.raises(ValueError, match="embedding_provider"):
+        load_config(str(cfg_file))
+
+
+def test_vector_store_uses_provider_config_and_reuses_client(monkeypatch):
+    created = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.embedding = kwargs.get("embedding") or object()
+            self.loaded = None
+            created.append(self)
+
+        def load(self, path):
+            self.loaded = path
+
+    monkeypatch.setattr("codeminer.web.repo_registry.CodeVectorStore", FakeVectorStore)
+    cfg = QAConfig(
+        embedding_provider="openai",
+        embedding_model="embed-model",
+        embedding_dimension=768,
+        embedding_base_url="http://embed.local/v1",
+        embedding_api_key="secret",
+    )
+    registry = RepoRegistry(cfg)
+    entry = SimpleNamespace(path="/tmp/vector", config={})
+
+    first = registry._load_vector_store(entry)
+    second = registry._load_vector_store(entry)
+
+    assert first.loaded == "/tmp/vector"
+    assert first.kwargs["embedding_provider"] == "openai"
+    assert first.kwargs["base_url"] == "http://embed.local/v1"
+    assert first.kwargs["api_key"] == "secret"
+    assert first.kwargs["dimension"] == 768
+    assert second.kwargs["embedding"] is first.embedding
+
+
+def test_ask_model_receives_its_own_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_chat(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("codeminer.web.repo_registry.LiteLLMChat", fake_chat)
+    registry = RepoRegistry(
+        QAConfig(
+            model="openai/ask-model",
+            wiki_model="vertex_ai/wiki-model",
+            model_api_base="http://ask.local/v1",
+            model_api_key="ask-secret",
+            max_tokens=2048,
+        )
+    )
+
+    registry._create_ask_llm()
+
+    assert captured == {
+        "model": "openai/ask-model",
+        "temperature": 0.0,
+        "max_tokens": 2048,
+        "api_base": "http://ask.local/v1",
+        "api_key": "ask-secret",
+    }
 
 
 def test_registry_round_trip(tmp_path):


### PR DESCRIPTION
## Summary
Extract the reusable serving pieces from #327 without carrying deployment-specific state or changing the default agent contract.

## Changes
- Separate the interactive Ask model from wiki and edge-label generation.
- Pass Ask and OpenAI-compatible embedding endpoints explicitly to clients.
- Cache embedding clients by provider, model, and endpoint.
- Offload cold wiki outline/page generation from the FastAPI event loop.
- Restore `qa_config.yaml` to portable defaults and document optional backend fields.
- Add focused config, client wiring, cache reuse, and async endpoint tests.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1629 passed, 10 skipped, 170 deselected`)

`pre-commit run --files codeminer/web/app.py codeminer/web/config.py codeminer/web/repo_registry.py qa_config.yaml test/web/test_repo_registry.py test/web/test_app_runtime.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
