### PR TITLE
feat: make incremental view maintenance reachable from the product

### DIFF
--- a/.claude/design/incremental-in-product-plan.md
+++ b/.claude/design/incremental-in-product-plan.md
@@ -1,0 +1,153 @@
+# Making the paper's incremental mechanisms real in the product
+
+**Status:** agreed, not started. **Target:** launch week (paper + code + HF + app).
+**Owner:** Yash. **Written:** 2026-07-22.
+
+Goal: move the paper's incremental machinery from *evaluated* to *running in the
+shipped system*, so the demo demonstrates the contribution rather than
+describing it.
+
+---
+
+## Where things actually stand (verified 2026-07-22)
+
+The architecture already anticipates all of this. The decision layer is built;
+the execution layer is stubbed.
+
+| Layer | State | Evidence |
+|---|---|---|
+| Freshness **decision** | ✅ built | `resources.py:251-256` returns `ResourceDecision(state=STALE, action="incremental_update")` |
+| Manifest commit tracking | ✅ built | `RepoManifest.commit`, `.last_indexed_commit` |
+| Vector incremental **state** | ✅ built | `IncrementalState.load()` auto-resolves `last_commit`; falls back to full build |
+| Graph patcher | ✅ built, 5 languages | `PatcherBase` (1293 lines) + per-language subclasses; measured 13–24x |
+| Graph patcher **wired to compiler** | ❌ | `SymbolGraphBuilder.incremental_update` → `return self.build()` |
+| Vector incremental **called by demo** | ❌ | demo only ever calls `build()` |
+| Exactness guard | ❌ **not in this repo** | searched `codeminer/`, `test/`, `scripts/` — lives in the eval artifact bundle |
+| BM25 / Zoekt incremental | ❌ | both `return self.build()` |
+
+**The one thing currently exercising the graph patcher in product code is
+`scripts/build_commit_window.py`.** Everything else routes to a full rebuild.
+
+---
+
+## Decisions
+
+| Decision | Choice | Reasoning |
+|---|---|---|
+| **Guard source** | Ask Zhongming for the eval implementation | The demo's guard should *be* the paper's guard. A re-implementation could admit at a different rate than published, which is worse than waiting. |
+| **Worktree policy** | Compiler manages a disposable `git worktree` | Proven in `build_commit_window.py`. The patcher reads bodies off disk (`lsp_client.py:371`), so a checkout is required — and the served tree must never move under live requests. |
+| **Ask scope** | Make Ask commit-aware too | Per-commit BM25 + vector is ~3s/commit (BM25 0.81s + vector incremental ~2.3s). Cheap, and it makes the commit selector change *answers*, not just the graph. |
+| **BM25 incremental** | **Out of scope** | `langchain BM25Retriever` (rank_bm25) has no add/remove, and BM25 scoring is corpus-global. Median build is **0.81s** — engineering around an immutable backend to save <1s is not justified. Say so explicitly rather than leaving it looking unfinished. |
+
+---
+
+## The dependency problem, and how we break it
+
+`C` (guard) is blocked on Zhongming. `A` (compiler wiring) *should* be gated by
+the guard — shipping "we patch instead of rebuilding" without verification is
+exactly the claim the paper refuses to make.
+
+**Resolution:** define the guard as an interface now and ship `A` behind it.
+
+```python
+class UpdateVerifier(Protocol):
+    def verify(self, patched: CodeGraph, fresh: CodeGraph) -> VerificationResult: ...
+
+class NullVerifier:      # ships now: admits nothing, always reports "unverified"
+class ExactnessVerifier: # drops in when Zhongming's code lands
+```
+
+Policy on the compiler: `incremental_update` runs the patch, asks the verifier,
+and **falls back to a full rebuild when verification fails or is unavailable**
+unless explicitly told otherwise. So the default is always correct; the fast
+path is opt-in and provable. `A` proceeds today; `C` upgrades it without
+re-architecting.
+
+---
+
+## Work items
+
+### B — vector incremental in the demo (unblocked, smallest, do first)
+The implementation already exists (`index_builders.py:255`) and manages its own
+`IncrementalState`. Work is calling it: have the web/compile path pass
+`last_commit` and choose `incremental_update` when the manifest's
+`last_indexed_commit` differs from HEAD. Lights up the 25.44x result.
+
+### A — graph patcher into the compiler (unblocked)
+1. `SymbolGraphBuilder.incremental_update` → resolve `last_indexed_commit`,
+   prepare a disposable worktree at the target commit, run `GraphPatcher` per
+   language, persist.
+2. Reuse the failure isolation already proven in `build_commit_window.py`: a
+   language that cannot cold-build or whose LSP will not start is dropped, not
+   fatal.
+3. Route the result through the verifier (above).
+4. Requires the LSP toolchain on the serving host — see *Prerequisites*.
+
+### C — exactness guard (blocked on Zhongming)
+Port the eval implementation. Paper definition (Sec. 4.2) for reference:
+`F(G)` = tagged multiset of vertex identities, types, source/selection lines,
+and typed edges with source anchors; **plus** a serving replay of deterministic
+definition/reference requests after persistence and reload. Both must be exact.
+
+Note when porting: vertex identity is `unified_name`, **not** the igraph vertex
+key. The patcher writes keys as `{unified_name}:{start_line}` to keep keys
+unique while the cold build does not — comparing raw keys produces false
+differences (verified: 251 spurious vs 54 real).
+
+### D — Zoekt incremental (unblocked, small)
+`zoekt-git-index` maintains incremental shards natively. Likely wiring, not
+algorithm work. Confirm before estimating.
+
+### E — BM25 incremental — **dropped**, see Decisions.
+
+### Ask commit-aware (depends on B)
+Per-commit BM25 + vector indexes keyed by commit, mirroring how
+`commit_window.py` serves per-commit graphs. Extend the window manifest to
+record index paths per commit; thread `commit` through `/api/chat`.
+
+---
+
+## Prerequisites
+
+Serving host needs the language servers, because patching requires live LSP:
+
+```bash
+make python-lsp-tool CODEMINER_SCIP_TOOLS_DIR=$HOME/.codeminer-tools   # basedpyright
+make typescript-lsp-tool gopls-tool scip-go-tool CODEMINER_SCIP_TOOLS_DIR=...
+```
+
+`CODEMINER_SCIP_TOOLS_DIR` defaults to `/tmp/codeminer-scip-tools` — **ephemeral
+and world-writable on a shared box**. Always override it to a persistent path.
+
+---
+
+## Sequence
+
+1. **Send the ask to Zhongming** (unblocks C; everything else proceeds meanwhile).
+2. **B** — vector incremental in the demo. Smallest real win.
+3. **Verifier interface + `NullVerifier`** — the seam C plugs into.
+4. **A** — compiler wiring behind the verifier, rebuild-on-unverified default.
+5. **Ask commit-aware** on top of B.
+6. **C** when the eval code arrives; swap `NullVerifier` → `ExactnessVerifier`.
+7. **D** if time allows.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| C never arrives before launch | `NullVerifier` ships; default stays full-rebuild. We claim speed only where verified — never an unverified claim. |
+| A destabilizes the compile path days before launch | Incremental is opt-in; `build()` remains the default path. Every change lands behind the manifest's commit comparison. |
+| LSP missing on the serving host | Patch attempt fails soft → full rebuild. Same isolation already proven in the window builder. |
+| Per-commit indexes blow up storage | Cap the window (currently 5). Graph ~2.9 MB/commit; measure vector before committing to a number. |
+| Rust/TS patches fail the guard (paper: 0/9) | Expected. Those fall back to rebuild — correct behaviour, not a bug. |
+
+---
+
+## Explicitly not claimed
+
+- BM25 and Zoekt are not incremental (BM25 deliberately).
+- Without C, no correctness claim about patched graphs — only measured latency.
+- The paper's guard admits Go/Python but **not** Rust/TS; the product will
+  inherit that, and should surface it rather than hide it.

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ results/
 
 # Code-QA demo (dir or symlink to a shared data dir)
 .codeminer_qa
+# Compiled index artifacts (manifest, graph pickles, commit-window snapshots).
+.codeminer_cache
 
 # Cloned repos for local demo (gitignored — add via: python scripts/index_repo.py repos/<name>)
 repos/

--- a/codeminer/compiler/index_builders.py
+++ b/codeminer/compiler/index_builders.py
@@ -25,6 +25,9 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from .resources import IndexState, IndexStatus
+from .verification import NullVerifier, UpdateVerifier, VerificationResult
+
+logger = logging.getLogger(__name__)
 
 
 def _git_output(repo_path: str, *args: str) -> str:
@@ -39,9 +42,6 @@ def _git_output(repo_path: str, *args: str) -> str:
     except Exception:  # noqa: BLE001 - git absent or hung: treat as unknown
         return ""
     return result.stdout.strip() if result.returncode == 0 else ""
-
-
-logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -507,7 +507,7 @@ class SymbolGraphBuilder:
     # Admission control for incremental updates. The default proves nothing and
     # says so, which combined with require_verification=True means the builder
     # behaves exactly like a full rebuild until a real verifier is configured.
-    verifier: Optional[Any] = None
+    verifier: Optional[UpdateVerifier] = None
     # When True, an update that is not positively verified is discarded and the
     # graph is rebuilt. Callers that knowingly accept unverified incremental
     # results (e.g. a local demo) set this False; the manifest still records
@@ -627,7 +627,6 @@ class SymbolGraphBuilder:
         """Run the LSP patcher over every configured language. None = rebuild."""
         from ..graph.code_graph import CodeGraph
         from ..graph.incremental.graph_patcher import LANGUAGE_EXTENSIONS, GraphPatcher
-        from .verification import NullVerifier
 
         graph_path = os.path.join(output_dir, "graph.pkl")
         graph = CodeGraph.load_graph(graph_path)
@@ -637,7 +636,7 @@ class SymbolGraphBuilder:
         started: List[Any] = []
         changed_total = 0
         per_language: Dict[str, Any] = {}
-        start = time.time()
+        start = time.monotonic()
         try:
             for lang in graph_languages:
                 exts = LANGUAGE_EXTENSIONS.get(lang)
@@ -646,9 +645,7 @@ class SymbolGraphBuilder:
                 changed = GraphPatcher.detect_changed_files(
                     repo_path, last_commit, head, extensions=exts
                 )
-                count = sum(len(v) for k, v in changed.items() if k != "renamed") + len(
-                    changed.get("renamed", [])
-                )
+                count = sum(len(paths) for paths in changed.values())
                 if not count:
                     continue
 
@@ -676,19 +673,25 @@ class SymbolGraphBuilder:
 
         if changed_total == 0:
             logger.info("symbol_graph: no source changes for configured languages")
-
-        verifier = self.verifier or NullVerifier()
-        result = verifier.verify(
-            index_type="symbol_graph",
-            patched=graph,
-            fresh=None,
-            context={
-                "repo_path": repo_path,
-                "earlier_commit": last_commit,
-                "later_commit": head,
-                "languages": list(graph_languages),
-            },
-        )
+            result = VerificationResult(
+                verified=True,
+                checked=True,
+                reason="no changed source files for configured languages",
+                details={"method": "empty-relevant-diff"},
+            )
+        else:
+            verifier = self.verifier or NullVerifier()
+            result = verifier.verify(
+                index_type="symbol_graph",
+                patched=graph,
+                fresh=None,
+                context={
+                    "repo_path": repo_path,
+                    "earlier_commit": last_commit,
+                    "later_commit": head,
+                    "languages": list(graph_languages),
+                },
+            )
         if self.require_verification and not result.verified:
             logger.info(
                 "symbol_graph: update not admitted (%s); rebuilding", result.reason
@@ -696,7 +699,7 @@ class SymbolGraphBuilder:
             return None
 
         graph.save_graph(graph_path)
-        elapsed = time.time() - start
+        elapsed = time.monotonic() - start
         node_count = len(graph.graph.vs)
         return IndexStatus(
             index_type="symbol_graph",

--- a/codeminer/compiler/index_builders.py
+++ b/codeminer/compiler/index_builders.py
@@ -26,6 +26,21 @@ from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
 
 from .resources import IndexState, IndexStatus
 
+
+def _git_output(repo_path: str, *args: str) -> str:
+    """Run git in *repo_path* and return stripped stdout ("" on any failure)."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo_path, *args],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception:  # noqa: BLE001 - git absent or hung: treat as unknown
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -478,11 +493,26 @@ class ZoektIndexBuilder:
 
 @dataclass
 class SymbolGraphBuilder:
-    """Build a registry-backed symbol graph."""
+    """Build a registry-backed symbol graph.
+
+    Supports LSP-assisted incremental repair between commits. Every failure
+    path -- missing base graph, moved/dirty worktree, absent language server,
+    patch error, or an update that verification will not admit -- falls back to
+    a full rebuild, so the artifact is always correct and only the cost varies.
+    """
 
     language: str = "python"
     languages: Optional[List[str]] = None
     graph_route: str = "active"
+    # Admission control for incremental updates. The default proves nothing and
+    # says so, which combined with require_verification=True means the builder
+    # behaves exactly like a full rebuild until a real verifier is configured.
+    verifier: Optional[Any] = None
+    # When True, an update that is not positively verified is discarded and the
+    # graph is rebuilt. Callers that knowingly accept unverified incremental
+    # results (e.g. a local demo) set this False; the manifest still records
+    # that the result was never checked.
+    require_verification: bool = True
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
@@ -523,7 +553,172 @@ class SymbolGraphBuilder:
         )
 
     def incremental_update(self, scope: str, **kwargs: Any) -> IndexStatus:
-        return self.build(scope, **kwargs)
+        """Repair the existing graph from ``last_commit`` to the repo's HEAD.
+
+        Required kwargs
+        ---------------
+        repo_path : str
+            Repository root. Must be checked out at the target commit; the
+            patcher reads file bodies from disk.
+        output_dir : str
+            Directory holding ``graph.pkl``.
+        last_commit : str
+            Commit the existing graph was built from. Empty forces a rebuild.
+
+        Falls back to :meth:`build` whenever the incremental path is
+        unavailable or its result is not admitted.
+        """
+        repo_path: str = kwargs["repo_path"]
+        output_dir: str = kwargs["output_dir"]
+        last_commit: str = kwargs.get("last_commit", "") or ""
+
+        reason = self._incremental_blocker(repo_path, output_dir, last_commit)
+        if reason:
+            logger.info("symbol_graph: full rebuild (%s)", reason)
+            return self.build(
+                scope, **{k: v for k, v in kwargs.items() if k != "last_commit"}
+            )
+
+        try:
+            status = self._patch_graph(scope, repo_path, output_dir, last_commit)
+        except Exception as exc:  # noqa: BLE001 - any patch failure means rebuild
+            logger.warning("symbol_graph: patch failed (%s); rebuilding", exc)
+            return self.build(
+                scope, **{k: v for k, v in kwargs.items() if k != "last_commit"}
+            )
+
+        if status is None:
+            return self.build(
+                scope, **{k: v for k, v in kwargs.items() if k != "last_commit"}
+            )
+        return status
+
+    # -- incremental helpers ------------------------------------------------
+
+    def _incremental_blocker(
+        self, repo_path: str, output_dir: str, last_commit: str
+    ) -> Optional[str]:
+        """Return why the incremental path cannot run, or None if it can."""
+        if not last_commit:
+            return "no previously indexed commit"
+        if not os.path.isfile(os.path.join(output_dir, "graph.pkl")):
+            return "no existing graph.pkl to patch"
+        head = _git_output(repo_path, "rev-parse", "HEAD")
+        if not head:
+            return "repository HEAD could not be resolved"
+        if head == last_commit:
+            return "already at the indexed commit"
+        # The patcher reads bodies from the working tree, so a *modified tracked*
+        # file would be silently indexed as though it were part of the target
+        # commit. Rebuilding is correct and simpler than reasoning about that.
+        #
+        # Untracked files are deliberately ignored: the index output directory
+        # normally lives inside the repo (.codeminer_cache/), so counting
+        # untracked paths here would report every repo as dirty and disable the
+        # incremental path entirely. Untracked files also never appear in the
+        # commit-to-commit diff the patcher works from.
+        if _git_output(repo_path, "status", "--porcelain", "--untracked-files=no"):
+            return "working tree has uncommitted changes to tracked files"
+        return None
+
+    def _patch_graph(
+        self, scope: str, repo_path: str, output_dir: str, last_commit: str
+    ) -> Optional[IndexStatus]:
+        """Run the LSP patcher over every configured language. None = rebuild."""
+        from ..graph.code_graph import CodeGraph
+        from ..graph.incremental.graph_patcher import LANGUAGE_EXTENSIONS, GraphPatcher
+        from .verification import NullVerifier
+
+        graph_path = os.path.join(output_dir, "graph.pkl")
+        graph = CodeGraph.load_graph(graph_path)
+        graph_languages = self.languages or [self.language]
+        head = _git_output(repo_path, "rev-parse", "HEAD")
+
+        started: List[Any] = []
+        changed_total = 0
+        per_language: Dict[str, Any] = {}
+        start = time.time()
+        try:
+            for lang in graph_languages:
+                exts = LANGUAGE_EXTENSIONS.get(lang)
+                if not exts:
+                    continue
+                changed = GraphPatcher.detect_changed_files(
+                    repo_path, last_commit, head, extensions=exts
+                )
+                count = sum(len(v) for k, v in changed.items() if k != "renamed") + len(
+                    changed.get("renamed", [])
+                )
+                if not count:
+                    continue
+
+                patcher = GraphPatcher(
+                    project_root=repo_path, code_graph=graph, language=lang
+                )
+                try:
+                    patcher.start_lsp()
+                except Exception as exc:  # noqa: BLE001 - missing server
+                    logger.warning(
+                        "symbol_graph: %s language server unavailable (%s)", lang, exc
+                    )
+                    return None
+                started.append(patcher)
+                per_language[lang] = patcher.patch_files(
+                    changed, earlier_commit=last_commit, later_commit=head
+                )
+                changed_total += count
+        finally:
+            for patcher in started:
+                try:
+                    patcher.stop_lsp()
+                except Exception as exc:  # noqa: BLE001 - shutdown is best-effort
+                    logger.warning("symbol_graph: stop_lsp: %s", exc)
+
+        if changed_total == 0:
+            logger.info("symbol_graph: no source changes for configured languages")
+
+        verifier = self.verifier or NullVerifier()
+        result = verifier.verify(
+            index_type="symbol_graph",
+            patched=graph,
+            fresh=None,
+            context={
+                "repo_path": repo_path,
+                "earlier_commit": last_commit,
+                "later_commit": head,
+                "languages": list(graph_languages),
+            },
+        )
+        if self.require_verification and not result.verified:
+            logger.info(
+                "symbol_graph: update not admitted (%s); rebuilding", result.reason
+            )
+            return None
+
+        graph.save_graph(graph_path)
+        elapsed = time.time() - start
+        node_count = len(graph.graph.vs)
+        return IndexStatus(
+            index_type="symbol_graph",
+            state=IndexState.FRESH,
+            last_built=time.time(),
+            age_seconds=0.0,
+            scope=scope,
+            path=output_dir,
+            metadata={
+                "node_count": node_count,
+                "language": graph_languages[0],
+                "languages": list(graph_languages),
+                "graph_route": self.graph_route,
+                "update_mode": "incremental",
+                "changed_files": changed_total,
+                "patch_seconds": round(elapsed, 3),
+                "earlier_commit": last_commit,
+                "later_commit": head,
+                "patch_stats": per_language,
+                **result.to_metadata(),
+            },
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/codeminer/compiler/index_compiler.py
+++ b/codeminer/compiler/index_compiler.py
@@ -138,16 +138,39 @@ class IndexCompiler:
                 repo_path, index_types=index_types, cache_dir=cache_dir
             )
 
-        previous = existing.last_indexed_commit or existing.commit
+        types_to_update = index_types or self._config.index_types
+        incomplete = [
+            idx_type
+            for idx_type in types_to_update
+            if idx_type not in existing.indexes
+            or existing.indexes[idx_type].status != "fresh"
+        ]
+        # An explicitly empty last_indexed_commit means the previous full build
+        # never established a usable baseline. RepoManifest.from_dict() already
+        # maps legacy manifests that lack this field to `commit`, so falling
+        # back here would only hide a recorded failure.
+        previous = existing.last_indexed_commit
         head_commit = self._get_head_commit(repo_path)
         if not previous:
-            logger.info("Manifest records no indexed commit; rebuilding")
+            logger.info(
+                "Manifest records no complete indexed commit; rebuilding %s",
+                types_to_update,
+            )
             return self.compile_repo(
                 repo_path, index_types=index_types, cache_dir=cache_dir
             )
-        if head_commit and previous == head_commit:
+        if head_commit and previous == head_commit and not incomplete:
             logger.info("Indexes already at %s; nothing to update", head_commit[:8])
             return existing
+        if head_commit and previous == head_commit:
+            logger.info(
+                "Retrying incomplete indexes at %s: %s",
+                head_commit[:8],
+                incomplete,
+            )
+            return self.compile_repo(
+                repo_path, index_types=index_types, cache_dir=cache_dir
+            )
 
         logger.info(
             "Updating indexes %s -> %s", previous[:8], (head_commit or "HEAD")[:8]

--- a/codeminer/compiler/index_compiler.py
+++ b/codeminer/compiler/index_compiler.py
@@ -182,6 +182,7 @@ class IndexCompiler:
             languages=list(self._config.languages),
             file_count=self._count_files(repo_path),
         )
+        all_succeeded = True
 
         for idx_type in types_to_build:
             builder = self._builders.get(idx_type)
@@ -211,6 +212,21 @@ class IndexCompiler:
                 entry.metadata["error"] = result.error
 
             manifest.indexes[idx_type] = entry
+            if not result.success:
+                all_succeeded = False
+
+        # Only claim HEAD as indexed when every requested index actually reached
+        # it. Otherwise update_repo() would see `last_indexed_commit == HEAD` on
+        # its next run, report "nothing to update", and leave the failed index
+        # stale forever -- a recoverable failure turned into a silent permanent
+        # one. Leaving the previous commit recorded means the next run retries.
+        if not all_succeeded:
+            manifest.last_indexed_commit = last_commit or ""
+            logger.warning(
+                "Not all indexes reached %s; last_indexed_commit left at %r",
+                (head_commit or "HEAD")[:8],
+                manifest.last_indexed_commit[:8] or "(none)",
+            )
 
         manifest.derive_capabilities()
         now = datetime.now(timezone.utc)

--- a/codeminer/compiler/index_compiler.py
+++ b/codeminer/compiler/index_compiler.py
@@ -94,6 +94,80 @@ class IndexCompiler:
         Returns:
             The completed ``RepoManifest``.
         """
+        return self._compile(
+            repo_path, index_types=index_types, cache_dir=cache_dir, last_commit=None
+        )
+
+    def update_repo(
+        self,
+        repo_path: str,
+        *,
+        index_types: Optional[List[str]] = None,
+        cache_dir: Optional[str] = None,
+    ) -> RepoManifest:
+        """
+        Advance an existing manifest to the repo's current HEAD.
+
+        Each builder is asked for an incremental update rather than a full
+        build. Builders without a real delta path fall back to a rebuild
+        internally, so the result is always correct -- only the cost differs.
+
+        Falls back to a full :meth:`compile_repo` when there is no existing
+        manifest, or when the previously indexed commit cannot be determined.
+        Returns the existing manifest untouched when HEAD has not moved.
+        """
+        repo_path = os.path.abspath(repo_path)
+        cache = cache_dir or os.path.join(repo_path, self._config.cache_dir_name)
+        manifest_path = os.path.join(cache, MANIFEST_FILENAME)
+
+        if not os.path.isfile(manifest_path):
+            logger.info(
+                "No manifest at %s; falling back to a full build", manifest_path
+            )
+            return self.compile_repo(
+                repo_path, index_types=index_types, cache_dir=cache_dir
+            )
+
+        try:
+            existing = RepoManifest.load(manifest_path)
+        except Exception as exc:  # noqa: BLE001 - unreadable manifest: rebuild
+            logger.warning(
+                "Manifest at %s unusable (%s); rebuilding", manifest_path, exc
+            )
+            return self.compile_repo(
+                repo_path, index_types=index_types, cache_dir=cache_dir
+            )
+
+        previous = existing.last_indexed_commit or existing.commit
+        head_commit = self._get_head_commit(repo_path)
+        if not previous:
+            logger.info("Manifest records no indexed commit; rebuilding")
+            return self.compile_repo(
+                repo_path, index_types=index_types, cache_dir=cache_dir
+            )
+        if head_commit and previous == head_commit:
+            logger.info("Indexes already at %s; nothing to update", head_commit[:8])
+            return existing
+
+        logger.info(
+            "Updating indexes %s -> %s", previous[:8], (head_commit or "HEAD")[:8]
+        )
+        return self._compile(
+            repo_path,
+            index_types=index_types,
+            cache_dir=cache_dir,
+            last_commit=previous,
+        )
+
+    def _compile(
+        self,
+        repo_path: str,
+        *,
+        index_types: Optional[List[str]],
+        cache_dir: Optional[str],
+        last_commit: Optional[str],
+    ) -> RepoManifest:
+        """Shared build loop. ``last_commit`` selects the incremental path."""
         repo_path = os.path.abspath(repo_path)
         cache = cache_dir or os.path.join(repo_path, self._config.cache_dir_name)
         os.makedirs(cache, exist_ok=True)
@@ -116,7 +190,9 @@ class IndexCompiler:
                 continue
 
             output_dir = os.path.join(cache, idx_type)
-            result = self._build_one(builder, idx_type, repo_path, output_dir)
+            result = self._build_one(
+                builder, idx_type, repo_path, output_dir, last_commit=last_commit
+            )
 
             now = datetime.now(timezone.utc)
             entry = IndexEntry(
@@ -153,15 +229,30 @@ class IndexCompiler:
         index_type: str,
         repo_path: str,
         output_dir: str,
+        *,
+        last_commit: Optional[str] = None,
     ) -> BuildResult:
-        """Build a single index, catching errors."""
+        """Build a single index, catching errors.
+
+        When *last_commit* is given, the builder's ``incremental_update`` path is
+        used instead of ``build``. Builders without a real delta implementation
+        fall back to a full rebuild internally, so passing it is always safe.
+        """
         start = time.monotonic()
         try:
-            status = builder.build(
-                scope="current_repo",
-                repo_path=repo_path,
-                output_dir=output_dir,
-            )
+            if last_commit:
+                status = builder.incremental_update(
+                    scope="current_repo",
+                    repo_path=repo_path,
+                    output_dir=output_dir,
+                    last_commit=last_commit,
+                )
+            else:
+                status = builder.build(
+                    scope="current_repo",
+                    repo_path=repo_path,
+                    output_dir=output_dir,
+                )
             elapsed = time.monotonic() - start
             return BuildResult(
                 index_type=index_type,

--- a/codeminer/compiler/verification.py
+++ b/codeminer/compiler/verification.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Admission control for incrementally updated indexes.
+
+An incremental update is only *admissible* when the patched artifact is
+equivalent to what a fresh rebuild would have produced. This module defines
+that check as a pluggable contract so the compiler can decide, per update,
+whether to keep the patched result or discard it and rebuild.
+
+Two implementations ship here:
+
+``NullVerifier``
+    Cannot prove anything, and says so. Every result comes back
+    ``verified=False`` with ``reason="no verifier configured"``. This is the
+    default: it makes "we did not check" explicit rather than silent.
+
+``AlwaysAdmitVerifier``
+    Admits without checking. Only for environments that have accepted the
+    risk deliberately -- it exists so that choice is a visible configuration
+    value rather than a missing code path.
+
+The real exactness check (fact-projection equality plus serving replay) lives
+in the evaluation harness and is intended to drop in here as a third
+implementation without changing any caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+
+@dataclass(slots=True)
+class VerificationResult:
+    """Outcome of checking a patched artifact against its fresh target.
+
+    Attributes:
+        verified: True only when the patched artifact was *proven* equivalent.
+            False covers both "checked and differs" and "could not check".
+        reason: Human-readable explanation, always populated when not verified.
+        checked: Whether a real comparison ran at all. Distinguishes "no
+            verifier available" (``checked=False``) from "compared and found
+            different" (``checked=True, verified=False``) -- these have very
+            different implications and should never be conflated in reporting.
+        details: Optional verifier-specific metrics (edge F1, mismatch counts).
+    """
+
+    verified: bool
+    reason: str = ""
+    checked: bool = False
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_metadata(self) -> Dict[str, Any]:
+        """Flatten into manifest metadata so admission is auditable on disk."""
+        meta: Dict[str, Any] = {
+            "verified": self.verified,
+            "verification_checked": self.checked,
+        }
+        if self.reason:
+            meta["verification_reason"] = self.reason
+        if self.details:
+            meta["verification_details"] = dict(self.details)
+        return meta
+
+
+@runtime_checkable
+class UpdateVerifier(Protocol):
+    """Decides whether a patched artifact may be kept.
+
+    Implementations must be side-effect free: returning ``verified=False``
+    tells the caller to discard the patch and rebuild, so a verifier that
+    mutated state would corrupt that fallback.
+    """
+
+    def verify(
+        self,
+        *,
+        index_type: str,
+        patched: Any,
+        fresh: Optional[Any] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> VerificationResult:
+        """Check *patched*, optionally against a freshly built *fresh*."""
+        ...
+
+
+class NullVerifier:
+    """Default verifier: proves nothing and reports that honestly."""
+
+    name = "null"
+
+    def verify(
+        self,
+        *,
+        index_type: str,
+        patched: Any,
+        fresh: Optional[Any] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> VerificationResult:
+        return VerificationResult(
+            verified=False,
+            checked=False,
+            reason="no verifier configured; incremental result unverified",
+        )
+
+
+class AlwaysAdmitVerifier:
+    """Admits every update without checking.
+
+    Use only where the correctness risk has been accepted knowingly. The
+    result still records ``checked=False`` so downstream reporting cannot
+    mistake this for a proof.
+    """
+
+    name = "always-admit"
+
+    def verify(
+        self,
+        *,
+        index_type: str,
+        patched: Any,
+        fresh: Optional[Any] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> VerificationResult:
+        return VerificationResult(
+            verified=True,
+            checked=False,
+            reason="admitted without verification by configuration",
+        )

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -51,6 +51,7 @@ async def lifespan(app: FastAPI):
     app.state.registry = registry
     app.state.wiki_builders = {}
     app.state.edge_labelers = {}
+    app.state.commit_windows = {}
     # Shared LLM narrator for DeepWiki-style prose; cached on disk, fails soft
     # to templated text when no model/creds are available.
     wiki_cache = os.path.join(os.path.abspath(config.data_dir), "wiki_cache")
@@ -131,6 +132,16 @@ def _edge_labeler(repo_id: str):
     return cache[repo_id]
 
 
+def _commit_window(repo_id: str):
+    """Lazily build + cache this repo's per-commit graph window."""
+    cache = app.state.commit_windows
+    if repo_id not in cache:
+        from .commit_window import CommitWindow
+
+        cache[repo_id] = CommitWindow(_bundle(repo_id).entry.repo_dir)
+    return cache[repo_id]
+
+
 @app.get("/api/health")
 async def health() -> dict:
     registry = getattr(app.state, "registry", None)
@@ -201,6 +212,18 @@ async def source(
     return result
 
 
+@app.get("/api/repos/{repo_id}/commits")
+async def commits(repo_id: str) -> dict:
+    """Commits selectable in the graph view, newest first.
+
+    Backed by ``scripts/build_commit_window.py``. Repos without a prebuilt
+    window return ``available=False`` and the UI keeps its single-commit label.
+    """
+    _bundle(repo_id)  # 404 on unknown repo
+    window = _commit_window(repo_id)
+    return await asyncio.to_thread(window.summary)
+
+
 @app.get("/api/repos/{repo_id}/codemap")
 async def codemap(
     repo_id: str,
@@ -208,6 +231,7 @@ async def codemap(
     direction: str = "both",
     depth: int = 2,
     max_nodes: int = 40,
+    commit: str | None = None,
 ) -> dict:
     """Dependency subgraph ("codemap") around *symbol* (or a central default).
 
@@ -215,7 +239,24 @@ async def codemap(
     field renders directly in the frontend's existing diagram component.
     """
     bundle = _bundle(repo_id)
-    graph = await asyncio.to_thread(bundle.code_graph)
+    # Prefer a commit-window snapshot when one exists: an explicit ``commit``
+    # selects that point in history, and an absent one still defaults to the
+    # window's newest commit so the graph matches the selector's default.
+    window = _commit_window(repo_id)
+    graph = None
+    selected_commit = None
+    if window.available:
+        entry = window.resolve(commit)
+        if entry is None and commit:
+            raise HTTPException(
+                status_code=404, detail=f"Unknown commit for this repo: {commit!r}"
+            )
+        graph = await asyncio.to_thread(window.graph_for, commit)
+        if entry is not None:
+            selected_commit = entry.get("sha")
+    if graph is None:
+        graph = await asyncio.to_thread(bundle.code_graph)
+        selected_commit = selected_commit or bundle.entry.base_commit
     if graph is None:
         return {
             "available": False,
@@ -225,7 +266,7 @@ async def codemap(
             "mermaid": "",
             "note": "This repo has no symbol graph.",
         }
-    return await asyncio.to_thread(
+    result = await asyncio.to_thread(
         build_codemap,
         graph,
         symbol,
@@ -235,6 +276,10 @@ async def codemap(
         repo_dir=bundle.entry.repo_dir,
         hierarchy_graph=await asyncio.to_thread(bundle.hierarchical_graph),
     )
+    # Let the client confirm which snapshot it is looking at.
+    if isinstance(result, dict):
+        result["commit"] = selected_commit
+    return result
 
 
 @app.post("/api/repos/{repo_id}/edge-label", response_model=EdgeLabelResponse)

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -245,6 +245,7 @@ async def codemap(
     window = _commit_window(repo_id)
     graph = None
     selected_commit = None
+    fell_back = False
     if window.available:
         entry = window.resolve(commit)
         if entry is None and commit:
@@ -252,11 +253,16 @@ async def codemap(
                 status_code=404, detail=f"Unknown commit for this repo: {commit!r}"
             )
         graph = await asyncio.to_thread(window.graph_for, commit)
-        if entry is not None:
+        if entry is not None and graph is not None:
             selected_commit = entry.get("sha")
     if graph is None:
+        # The snapshot was absent or unloadable (e.g. a graph.pkl written under
+        # an older schema_version). Serving the repo's default graph is fine;
+        # reporting it as the requested commit is not -- the client would render
+        # one commit's graph under another commit's label.
         graph = await asyncio.to_thread(bundle.code_graph)
-        selected_commit = selected_commit or bundle.entry.base_commit
+        selected_commit = bundle.entry.base_commit
+        fell_back = window.available
     if graph is None:
         return {
             "available": False,
@@ -276,9 +282,13 @@ async def codemap(
         repo_dir=bundle.entry.repo_dir,
         hierarchy_graph=await asyncio.to_thread(bundle.hierarchical_graph),
     )
-    # Let the client confirm which snapshot it is looking at.
+    # Let the client confirm which snapshot it is looking at. ``fell_back``
+    # marks the case where a window exists but its snapshot could not be served,
+    # so the UI can say so instead of implying the selection took effect.
     if isinstance(result, dict):
         result["commit"] = selected_commit
+        if fell_back:
+            result["fell_back"] = True
     return result
 
 

--- a/codeminer/web/commit_window.py
+++ b/codeminer/web/commit_window.py
@@ -123,12 +123,22 @@ class CommitWindow:
         if not commit:
             return commits[0]
         needle = commit.strip().lower()
+        exact = []
         for entry in commits:
             sha = str(entry.get("sha", "")).lower()
             short = str(entry.get("short", "")).lower()
-            if needle in (sha, short) or (len(needle) >= 4 and sha.startswith(needle)):
-                return entry
-        return None
+            if needle in (sha, short):
+                exact.append(entry)
+        if exact:
+            return exact[0]
+        if len(needle) < 4:
+            return None
+        prefixes = [
+            entry
+            for entry in commits
+            if str(entry.get("sha", "")).lower().startswith(needle)
+        ]
+        return prefixes[0] if len(prefixes) == 1 else None
 
     # -- graphs -----------------------------------------------------------
 

--- a/codeminer/web/commit_window.py
+++ b/codeminer/web/commit_window.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serve per-commit symbol graphs produced by ``scripts/build_commit_window.py``.
+
+The builder writes one graph snapshot per commit plus a ``commit_window.json``
+manifest. This module is the read side: it locates that manifest for a repo,
+exposes the selectable commits, and loads (and caches) the graph for a chosen
+commit.
+
+Kept separate from ``repo_registry`` on purpose -- that module carries local,
+uncommitted operator changes, so feature code lives here instead.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from typing import Dict, List, Optional
+
+from ..graph.code_graph import CodeGraph
+
+logger = logging.getLogger(__name__)
+
+CACHE_DIRNAME = ".codeminer_cache"
+WINDOW_DIRNAME = "commit_window"
+MANIFEST_NAME = "commit_window.json"
+
+
+def window_dir(repo_dir: str) -> str:
+    """Directory holding a repo's commit-window artifacts."""
+    return os.path.join(os.path.abspath(repo_dir), CACHE_DIRNAME, WINDOW_DIRNAME)
+
+
+def manifest_path(repo_dir: str) -> str:
+    return os.path.join(window_dir(repo_dir), MANIFEST_NAME)
+
+
+class CommitWindow:
+    """Read-only view over one repo's per-commit graph snapshots.
+
+    Graphs are loaded lazily and cached by commit SHA. A repo with no window
+    on disk yields ``available == False`` and callers fall back to the single
+    manifest-linked graph.
+    """
+
+    def __init__(self, repo_dir: str) -> None:
+        self.repo_dir = os.path.abspath(repo_dir)
+        self._manifest: Optional[dict] = None
+        self._loaded = False
+        self._graphs: Dict[str, Optional[CodeGraph]] = {}
+        self._lock = threading.Lock()
+
+    # -- manifest ---------------------------------------------------------
+
+    def _load_manifest(self) -> Optional[dict]:
+        if self._loaded:
+            return self._manifest
+        self._loaded = True
+        path = manifest_path(self.repo_dir)
+        if not os.path.isfile(path):
+            logger.debug("commit-window: no manifest at %s", path)
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                self._manifest = json.load(fh)
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 - a bad manifest just disables the feature
+            logger.warning("commit-window: unusable manifest %s: %s", path, exc)
+            self._manifest = None
+        return self._manifest
+
+    @property
+    def available(self) -> bool:
+        m = self._load_manifest()
+        return bool(m and m.get("commits"))
+
+    def commits(self) -> List[dict]:
+        """Selectable commits, newest first (UI order)."""
+        m = self._load_manifest()
+        if not m:
+            return []
+        return list(m.get("commits") or [])
+
+    def newest(self) -> Optional[dict]:
+        commits = self.commits()
+        return commits[0] if commits else None
+
+    def resolve(self, commit: Optional[str]) -> Optional[dict]:
+        """Find a commit entry by full or short SHA.
+
+        ``None`` selects the newest commit, so callers can pass an absent query
+        parameter straight through.
+        """
+        commits = self.commits()
+        if not commits:
+            return None
+        if not commit:
+            return commits[0]
+        needle = commit.strip().lower()
+        for entry in commits:
+            sha = str(entry.get("sha", "")).lower()
+            short = str(entry.get("short", "")).lower()
+            if needle in (sha, short) or (len(needle) >= 4 and sha.startswith(needle)):
+                return entry
+        return None
+
+    # -- graphs -----------------------------------------------------------
+
+    def graph_for(self, commit: Optional[str]) -> Optional[CodeGraph]:
+        """Load (and cache) the graph snapshot for *commit*.
+
+        Returns ``None`` when the window is absent or the commit is unknown, so
+        the caller can fall back to the repo's default graph.
+        """
+        entry = self.resolve(commit)
+        if entry is None:
+            return None
+        sha = str(entry.get("sha", ""))
+        with self._lock:
+            if sha in self._graphs:
+                return self._graphs[sha]
+
+            path = entry.get("graph_path")
+            # Manifests record absolute paths at build time; tolerate a moved
+            # cache directory by also probing the expected filename.
+            candidates = [
+                p
+                for p in (
+                    path,
+                    os.path.join(
+                        window_dir(self.repo_dir), f"graph_{entry.get('short')}.pkl"
+                    ),
+                )
+                if p
+            ]
+            graph: Optional[CodeGraph] = None
+            for candidate in candidates:
+                if not os.path.isfile(candidate):
+                    continue
+                try:
+                    graph = CodeGraph.load_graph(candidate)
+                    logger.info(
+                        "commit-window: loaded graph %s (%s)",
+                        entry.get("short"),
+                        candidate,
+                    )
+                    break
+                except Exception as exc:  # noqa: BLE001 - stale/old-format snapshot
+                    logger.warning(
+                        "commit-window: graph at %s unusable: %s", candidate, exc
+                    )
+            if graph is None:
+                logger.warning(
+                    "commit-window: no usable snapshot for %s", entry.get("short")
+                )
+            self._graphs[sha] = graph
+            return graph
+
+    def summary(self) -> dict:
+        """Payload for the commit selector."""
+        m = self._load_manifest()
+        if not m or not m.get("commits"):
+            return {"available": False, "commits": [], "selected": None}
+        commits = [
+            {
+                "sha": c.get("sha"),
+                "short": c.get("short"),
+                "subject": c.get("subject"),
+                "date": c.get("date"),
+                "author": c.get("author"),
+                "method": c.get("method"),
+                "build_seconds": c.get("build_seconds"),
+                "node_count": c.get("node_count"),
+                "edge_count": c.get("edge_count"),
+                "changed_files": c.get("changed_files"),
+            }
+            for c in m["commits"]
+        ]
+        # Newer manifests record every language actually built; older ones only
+        # carry the single `language` field.
+        languages = m.get("languages") or ([m["language"]] if m.get("language") else [])
+        return {
+            "available": True,
+            "ref": m.get("ref"),
+            "language": m.get("language"),
+            "languages": languages,
+            "lsp_startup_seconds": m.get("lsp_startup_seconds"),
+            "commits": commits,
+            "selected": commits[0]["sha"] if commits else None,
+        }

--- a/codeminer/web/commit_window.py
+++ b/codeminer/web/commit_window.py
@@ -50,29 +50,50 @@ class CommitWindow:
     def __init__(self, repo_dir: str) -> None:
         self.repo_dir = os.path.abspath(repo_dir)
         self._manifest: Optional[dict] = None
-        self._loaded = False
+        self._mtime: Optional[float] = None
         self._graphs: Dict[str, Optional[CodeGraph]] = {}
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
     # -- manifest ---------------------------------------------------------
 
     def _load_manifest(self) -> Optional[dict]:
-        if self._loaded:
-            return self._manifest
-        self._loaded = True
+        """Load the manifest, re-reading it when it changes on disk.
+
+        Held under the lock for the whole read: publishing "loaded" before the
+        parse finishes would let a concurrent request observe an empty manifest
+        and report the window as unavailable. Endpoints reach this through
+        ``asyncio.to_thread``, so concurrent first-requests are the normal case,
+        not a rare one.
+
+        Keyed on mtime so re-running ``build_commit_window.py`` against a live
+        server takes effect without a restart -- otherwise the first request
+        after startup pins the window for the process's lifetime.
+        """
         path = manifest_path(self.repo_dir)
-        if not os.path.isfile(path):
-            logger.debug("commit-window: no manifest at %s", path)
-            return None
         try:
-            with open(path, "r", encoding="utf-8") as fh:
-                self._manifest = json.load(fh)
-        except (
-            Exception
-        ) as exc:  # noqa: BLE001 - a bad manifest just disables the feature
-            logger.warning("commit-window: unusable manifest %s: %s", path, exc)
-            self._manifest = None
-        return self._manifest
+            mtime: Optional[float] = os.path.getmtime(path)
+        except OSError:
+            mtime = None
+
+        with self._lock:
+            if mtime is not None and mtime == self._mtime:
+                return self._manifest
+
+            self._mtime = mtime
+            self._graphs.clear()
+            if mtime is None:
+                logger.debug("commit-window: no manifest at %s", path)
+                self._manifest = None
+                return None
+            try:
+                with open(path, "r", encoding="utf-8") as fh:
+                    self._manifest = json.load(fh)
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 - a bad manifest just disables the feature
+                logger.warning("commit-window: unusable manifest %s: %s", path, exc)
+                self._manifest = None
+            return self._manifest
 
     @property
     def available(self) -> bool:

--- a/scripts/build_commit_window.py
+++ b/scripts/build_commit_window.py
@@ -1,0 +1,537 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a window of per-commit symbol graphs using incremental patching.
+
+Produces the artifacts behind the web demo's commit selector: one graph
+snapshot per commit for the last ``--n`` first-parent commits of a ref.
+
+Only the *oldest* commit in the window pays a full cold (SCIP) build. Every
+later commit is reached by patching the previous graph forward through the
+LSP-backed incremental patcher -- the mechanism this project's incremental
+maintenance results are about. That is also why the window is walked
+oldest-to-newest even though the UI presents it newest-first: the patcher only
+moves forward from an existing base graph.
+
+The repository is never checked out in place. A dedicated detached ``git
+worktree`` is created and advanced commit by commit, so a live checkout being
+served (or actively developed in) is untouched.
+
+Example::
+
+    python scripts/build_commit_window.py \\
+        --repo-dir /home/intern/yashJ/CodeMiner \\
+        --n 5 --ref origin/main --language paper
+
+``--language`` takes a comma-separated list; ``paper`` expands to the languages
+the incremental-maintenance experiment covers (go, python, rust, typescript).
+Languages that are not buildable in the target repo are dropped with a warning.
+
+Requires each language's LSP on PATH (Python: ``basedpyright-langserver`` via
+``make python-lsp-tool``; TypeScript: ``typescript-language-server``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from typing import List, Optional
+
+logger = logging.getLogger("build_commit_window")
+
+# Written next to the snapshots; the web layer reads this to populate the
+# commit selector without re-shelling out to git.
+MANIFEST_NAME = "commit_window.json"
+
+
+@dataclass
+class CommitEntry:
+    """One selectable point in the window."""
+
+    sha: str
+    short: str
+    subject: str
+    date: str
+    author: str
+    graph_path: str
+    # "cold" for the anchor, "patched" for every incrementally reached commit.
+    method: str
+    build_seconds: float
+    node_count: int
+    edge_count: int
+    # Files the transition touched (empty for the anchor).
+    changed_files: int
+    # Populated only when a patch reports stats.
+    patch_stats: Optional[dict] = None
+
+
+def _git(repo: str, *args: str) -> str:
+    """Run git in *repo* and return stripped stdout."""
+    out = subprocess.check_output(
+        ["git", "-C", repo, *args],
+        text=True,
+        stderr=subprocess.PIPE,
+    )
+    return out.strip()
+
+
+def resolve_window(repo: str, ref: str, n: int) -> List[dict]:
+    """Return the last *n* first-parent commits of *ref*, newest first."""
+    sep = "\x1f"
+    fmt = sep.join(["%H", "%h", "%s", "%ad", "%an"])
+    raw = _git(
+        repo,
+        "log",
+        "--first-parent",
+        f"-{n}",
+        f"--format={fmt}",
+        "--date=short",
+        ref,
+    )
+    commits = []
+    for line in raw.splitlines():
+        sha, short, subject, date, author = line.split(sep)
+        commits.append(
+            {
+                "sha": sha,
+                "short": short,
+                "subject": subject,
+                "date": date,
+                "author": author,
+            }
+        )
+    return commits
+
+
+def ensure_worktree(repo: str, path: str, sha: str) -> None:
+    """Create (or reset) a detached worktree of *repo* at *sha*.
+
+    Never touches ``repo``'s own working tree.
+    """
+    if os.path.isdir(os.path.join(path, ".git")) or os.path.isfile(
+        os.path.join(path, ".git")
+    ):
+        logger.info("reusing worktree %s", path)
+        _git(repo, "worktree", "repair", path)
+        subprocess.check_call(
+            ["git", "-C", path, "checkout", "--detach", "--force", sha],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Drop any stray files a previous patch run left behind so the tree is
+        # a faithful checkout of `sha`.
+        subprocess.check_call(
+            ["git", "-C", path, "clean", "-qfdx"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return
+
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    # A previous run whose directory was deleted out from under git leaves a
+    # "prunable" registration behind, and `worktree add` refuses that path until
+    # it is cleared.
+    subprocess.call(
+        ["git", "-C", repo, "worktree", "prune"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    logger.info("creating worktree %s @ %s", path, sha[:8])
+    subprocess.check_call(
+        ["git", "-C", repo, "worktree", "add", "--detach", path, sha],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+
+
+def advance_worktree(path: str, sha: str) -> None:
+    """Move the worktree to *sha* (detached, discarding local state)."""
+    subprocess.check_call(
+        ["git", "-C", path, "checkout", "--detach", "--force", sha],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _counts(graph) -> tuple:
+    try:
+        return len(graph.graph.vs), len(graph.graph.es)
+    except Exception:  # noqa: BLE001 - counts are informational only
+        return 0, 0
+
+
+# Languages the paper's incremental-maintenance experiment covers. C/C++ has a
+# patcher but is absent from that experiment, so it is not included here.
+PAPER_INCREMENTAL_LANGUAGES = ("go", "python", "rust", "typescript")
+
+
+def parse_languages(raw: str) -> List[str]:
+    """Expand the --language value into an ordered, de-duplicated list."""
+    if raw.strip().lower() in {"paper", "all"}:
+        return list(PAPER_INCREMENTAL_LANGUAGES)
+    out: List[str] = []
+    for part in raw.split(","):
+        name = part.strip().lower()
+        if name and name not in out:
+            out.append(name)
+    return out
+
+
+# ls_router reports an unbuildable language as
+# "Failed to build code graph for language 'go' under '<path>'".
+_LANG_FAILURE = re.compile(r"language '([^']+)'")
+
+
+def build_anchor(worktree: str, out_dir: str, languages: List[str], graph_route: str):
+    """Cold-build the oldest commit's graph, mirroring SymbolGraphBuilder.
+
+    A language whose cold build fails is dropped and the build retried with the
+    rest. This mirrors ``IndexCompiler``'s treatment of optional builders: a
+    repository that merely *contains* a few Go or Rust files but is not a Go or
+    Rust project (no ``go.mod`` / ``Cargo.toml``) should still get a graph for
+    the languages it really is written in, rather than no graph at all.
+
+    Returns ``(graph, languages_actually_built)``.
+    """
+    from codeminer.ls_router import build_graph_for_languages
+
+    os.makedirs(out_dir, exist_ok=True)
+    remaining = list(languages)
+    dropped: List[str] = []
+
+    while remaining:
+        try:
+            graph = build_graph_for_languages(
+                worktree,
+                out_dir,
+                languages=list(remaining),
+                project_name=os.path.basename(os.path.abspath(worktree)),
+                skip_level=None,
+                graph_route=graph_route,
+            )
+        except RuntimeError as exc:
+            match = _LANG_FAILURE.search(str(exc))
+            failed = match.group(1) if match else None
+            if failed is None or failed not in remaining:
+                # Not an isolatable per-language failure: surface it.
+                raise
+            remaining.remove(failed)
+            dropped.append(failed)
+            logger.warning(
+                "cold build: %r not buildable here (%s); continuing without it",
+                failed,
+                str(exc).splitlines()[0][:120],
+            )
+            continue
+
+        if graph is None or not hasattr(graph, "graph"):
+            raise RuntimeError("cold graph build returned no graph")
+        if len(graph.graph.vs) == 0:
+            raise RuntimeError("cold graph build returned an empty graph")
+        if dropped:
+            logger.warning("cold build skipped language(s): %s", ", ".join(dropped))
+        return graph, remaining
+
+    raise RuntimeError(
+        f"no language could be cold-built here (tried: {', '.join(languages)})"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-dir", required=True, help="git repo to read history from")
+    ap.add_argument(
+        "--n", type=int, default=5, help="commits in the window (default 5)"
+    )
+    ap.add_argument("--ref", default="HEAD", help="ref to walk (default HEAD)")
+    ap.add_argument(
+        "--language",
+        default="python",
+        help=(
+            "comma-separated graph/patcher languages. Defaults to python; "
+            "'--language paper' expands to the languages evaluated by the "
+            "incremental-maintenance experiment (go,python,rust,typescript)."
+        ),
+    )
+    ap.add_argument(
+        "--out-dir",
+        default=None,
+        help="where snapshots land (default <repo>/.codeminer_cache/commit_window)",
+    )
+    ap.add_argument(
+        "--worktree",
+        default=None,
+        help="worktree path (default <out-dir>/_worktree)",
+    )
+    ap.add_argument(
+        "--graph-route", default="active", help="graph route (default: active)"
+    )
+    ap.add_argument(
+        "--keep-worktree",
+        action="store_true",
+        help="leave the worktree on disk (default: remove when finished)",
+    )
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    repo = os.path.abspath(args.repo_dir)
+    out_dir = os.path.abspath(
+        args.out_dir or os.path.join(repo, ".codeminer_cache", "commit_window")
+    )
+    worktree = os.path.abspath(args.worktree or os.path.join(out_dir, "_worktree"))
+    os.makedirs(out_dir, exist_ok=True)
+
+    if args.n < 1:
+        logger.error("--n must be >= 1")
+        return 2
+
+    languages = parse_languages(args.language)
+    if not languages:
+        logger.error("--language resolved to no languages")
+        return 2
+    logger.info("languages: %s", ", ".join(languages))
+
+    # Newest first (UI order); we build oldest first (patcher order).
+    window = resolve_window(repo, args.ref, args.n)
+    if not window:
+        logger.error("no commits found for ref %r", args.ref)
+        return 2
+    chain = list(reversed(window))
+    anchor = chain[0]
+
+    logger.info(
+        "window: %d commits %s..%s (anchor %s)",
+        len(chain),
+        chain[0]["short"],
+        chain[-1]["short"],
+        anchor["short"],
+    )
+
+    from codeminer.graph.incremental.graph_patcher import (
+        LANGUAGE_EXTENSIONS,
+        GraphPatcher,
+    )
+
+    ensure_worktree(repo, worktree, anchor["sha"])
+
+    entries: List[CommitEntry] = []
+
+    # --- anchor: the one cold build -------------------------------------
+    anchor_out = os.path.join(out_dir, f"graph_{anchor['short']}")
+    t0 = time.time()
+    logger.info(
+        "[1/%d] cold build @ %s (%s)",
+        len(chain),
+        anchor["short"],
+        anchor["subject"][:60],
+    )
+    graph, languages = build_anchor(worktree, anchor_out, languages, args.graph_route)
+    cold_s = time.time() - t0
+    anchor_pkl = os.path.join(out_dir, f"graph_{anchor['short']}.pkl")
+    graph.save_graph(anchor_pkl)
+    nv, ne = _counts(graph)
+    logger.info("      cold build %.1fs -> %d nodes / %d edges", cold_s, nv, ne)
+    entries.append(
+        CommitEntry(
+            sha=anchor["sha"],
+            short=anchor["short"],
+            subject=anchor["subject"],
+            date=anchor["date"],
+            author=anchor["author"],
+            graph_path=anchor_pkl,
+            method="cold",
+            build_seconds=round(cold_s, 3),
+            node_count=nv,
+            edge_count=ne,
+            changed_files=0,
+        )
+    )
+
+    # --- patch forward through the rest of the chain ---------------------
+    # One patcher (and one language server) per language, all sharing the same
+    # CodeGraph: each patches its own slice of a transition in place. A language
+    # whose server will not start is dropped rather than failing the window --
+    # its files simply stop contributing graph updates.
+    patchers: List[tuple] = []
+    lsp_startup = 0.0
+    for lang in languages:
+        exts = LANGUAGE_EXTENSIONS.get(lang)
+        if not exts:
+            logger.warning("no graph extensions registered for %r; skipping", lang)
+            continue
+        patcher = GraphPatcher(
+            project_root=worktree,
+            code_graph=graph,
+            language=lang,
+        )
+        lsp_t0 = time.time()
+        try:
+            patcher.start_lsp()
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 - a missing server disables one language
+            logger.warning(
+                "%s: LSP failed to start (%s: %s); this language will not be patched",
+                lang,
+                type(exc).__name__,
+                exc,
+            )
+            continue
+        took = time.time() - lsp_t0
+        lsp_startup += took
+        patchers.append((lang, patcher, exts))
+        logger.info("      LSP[%s] started in %.1fs", lang, took)
+
+    if not patchers:
+        logger.error("no language server started; cannot patch the chain")
+        return 1
+    logger.info(
+        "      %d language server(s) up in %.1fs total, amortized over %d transitions",
+        len(patchers),
+        lsp_startup,
+        max(len(chain) - 1, 1),
+    )
+
+    try:
+        for i, commit in enumerate(chain[1:], start=2):
+            prev = chain[i - 2]
+            logger.info(
+                "[%d/%d] patch %s -> %s (%s)",
+                i,
+                len(chain),
+                prev["short"],
+                commit["short"],
+                commit["subject"][:60],
+            )
+            # Detect per language first so we know whether this transition
+            # touches anything we can patch at all.
+            per_lang = []
+            n_changed = 0
+            for lang, patcher, exts in patchers:
+                changed = GraphPatcher.detect_changed_files(
+                    worktree, prev["sha"], commit["sha"], extensions=exts
+                )
+                count = sum(len(v) for k, v in changed.items() if k != "renamed") + len(
+                    changed.get("renamed", [])
+                )
+                if count:
+                    per_lang.append((lang, patcher, changed, count))
+                    n_changed += count
+
+            # The patcher reads file bodies off disk, so the tree must be at
+            # the target commit before we sync files into any language server.
+            advance_worktree(worktree, commit["sha"])
+
+            t1 = time.time()
+            stats: dict = {}
+            for lang, patcher, changed, count in per_lang:
+                try:
+                    # earlier_commit lets the patcher pull pre-edit file bodies
+                    # from git to build its line-shift map; post-edit bodies
+                    # come from the worktree we just advanced.
+                    lang_stats = patcher.patch_files(
+                        changed,
+                        earlier_commit=prev["sha"],
+                        later_commit=commit["sha"],
+                    )
+                except Exception as exc:  # noqa: BLE001 - keep the window building
+                    logger.warning(
+                        "      %s: patch failed (%s: %s); leaving its facts unchanged",
+                        lang,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    continue
+                stats[lang] = {"changed_files": count, "stats": lang_stats}
+                logger.info("        %-11s %d file(s)", lang, count)
+            patch_s = time.time() - t1
+
+            pkl = os.path.join(out_dir, f"graph_{commit['short']}.pkl")
+            graph.save_graph(pkl)
+            nv, ne = _counts(graph)
+            logger.info(
+                "      %d changed file(s), patch %.2fs -> %d nodes / %d edges",
+                n_changed,
+                patch_s,
+                nv,
+                ne,
+            )
+            entries.append(
+                CommitEntry(
+                    sha=commit["sha"],
+                    short=commit["short"],
+                    subject=commit["subject"],
+                    date=commit["date"],
+                    author=commit["author"],
+                    graph_path=pkl,
+                    method="patched",
+                    build_seconds=round(patch_s, 3),
+                    node_count=nv,
+                    edge_count=ne,
+                    changed_files=n_changed,
+                    patch_stats=stats if isinstance(stats, dict) else None,
+                )
+            )
+    finally:
+        for lang, patcher, _ in patchers:
+            try:
+                patcher.stop_lsp()
+            except Exception as exc:  # noqa: BLE001 - shutdown is best-effort
+                logger.warning("stop_lsp[%s]: %s", lang, exc)
+
+    # UI order is newest-first; entries were produced oldest-first.
+    entries.reverse()
+    manifest = {
+        "repo_dir": repo,
+        "ref": args.ref,
+        "languages": languages,
+        "language": languages[0] if languages else None,
+        "graph_route": args.graph_route,
+        "generated_at": time.time(),
+        "lsp_startup_seconds": round(lsp_startup, 3),
+        "commits": [asdict(e) for e in entries],
+    }
+    manifest_path = os.path.join(out_dir, MANIFEST_NAME)
+    with open(manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2)
+
+    if not args.keep_worktree:
+        logger.info("removing worktree %s", worktree)
+        shutil.rmtree(worktree, ignore_errors=True)
+        subprocess.call(
+            ["git", "-C", repo, "worktree", "prune"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    cold = next((e for e in entries if e.method == "cold"), None)
+    patched = [e for e in entries if e.method == "patched"]
+    logger.info("wrote %s", manifest_path)
+    if cold and patched:
+        avg_patch = sum(e.build_seconds for e in patched) / len(patched)
+        logger.info(
+            "cold %.1fs vs mean patch %.2fs over %d transitions (%.1fx)",
+            cold.build_seconds,
+            avg_patch,
+            len(patched),
+            (cold.build_seconds / avg_patch) if avg_patch else float("nan"),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_commit_window.py
+++ b/scripts/build_commit_window.py
@@ -117,9 +117,23 @@ def ensure_worktree(repo: str, path: str, sha: str) -> None:
 
     Never touches ``repo``'s own working tree.
     """
-    if os.path.isdir(os.path.join(path, ".git")) or os.path.isfile(
-        os.path.join(path, ".git")
-    ):
+    dotgit = os.path.join(path, ".git")
+    if os.path.exists(dotgit):
+        # A *linked* worktree records `.git` as a file pointing at the parent's
+        # gitdir; a primary checkout has it as a directory. We refuse the
+        # directory case outright, because the reuse path below runs
+        # `checkout --force` and `clean -qfdx`, which against someone's real
+        # checkout discards uncommitted work and deletes ignored files (.env,
+        # node_modules, .codeminer_cache). The module contract is that the
+        # served or developed tree is never touched -- enforce it here rather
+        # than relying on the caller passing a sane --worktree.
+        if os.path.isdir(dotgit):
+            raise RuntimeError(
+                f"refusing to use {path!r} as a worktree: it looks like a "
+                "primary git checkout, and preparing it would discard "
+                "uncommitted and ignored files. Pass --worktree pointing at a "
+                "disposable path instead."
+            )
         logger.info("reusing worktree %s", path)
         _git(repo, "worktree", "repair", path)
         subprocess.check_call(
@@ -200,7 +214,12 @@ def build_anchor(worktree: str, out_dir: str, languages: List[str], graph_route:
     Rust project (no ``go.mod`` / ``Cargo.toml``) should still get a graph for
     the languages it really is written in, rather than no graph at all.
 
-    Returns ``(graph, languages_actually_built)``.
+    Returns ``(graph, languages_actually_built, build_seconds)``.
+
+    ``build_seconds`` times only the *successful* build, not the failed attempts
+    that preceded it. Those attempts cover languages the patch path never
+    touches, so charging them to the cold baseline would inflate every
+    cold-vs-patch comparison derived from this window.
     """
     from codeminer.ls_router import build_graph_for_languages
 
@@ -209,6 +228,7 @@ def build_anchor(worktree: str, out_dir: str, languages: List[str], graph_route:
     dropped: List[str] = []
 
     while remaining:
+        attempt_start = time.time()
         try:
             graph = build_graph_for_languages(
                 worktree,
@@ -233,13 +253,14 @@ def build_anchor(worktree: str, out_dir: str, languages: List[str], graph_route:
             )
             continue
 
+        build_seconds = time.time() - attempt_start
         if graph is None or not hasattr(graph, "graph"):
             raise RuntimeError("cold graph build returned no graph")
         if len(graph.graph.vs) == 0:
             raise RuntimeError("cold graph build returned an empty graph")
         if dropped:
             logger.warning("cold build skipped language(s): %s", ", ".join(dropped))
-        return graph, remaining
+        return graph, remaining, build_seconds
 
     raise RuntimeError(
         f"no language could be cold-built here (tried: {', '.join(languages)})"
@@ -332,15 +353,15 @@ def main() -> int:
 
     # --- anchor: the one cold build -------------------------------------
     anchor_out = os.path.join(out_dir, f"graph_{anchor['short']}")
-    t0 = time.time()
     logger.info(
         "[1/%d] cold build @ %s (%s)",
         len(chain),
         anchor["short"],
         anchor["subject"][:60],
     )
-    graph, languages = build_anchor(worktree, anchor_out, languages, args.graph_route)
-    cold_s = time.time() - t0
+    graph, languages, cold_s = build_anchor(
+        worktree, anchor_out, languages, args.graph_route
+    )
     anchor_pkl = os.path.join(out_dir, f"graph_{anchor['short']}.pkl")
     graph.save_graph(anchor_pkl)
     nv, ne = _counts(graph)
@@ -523,12 +544,30 @@ def main() -> int:
     logger.info("wrote %s", manifest_path)
     if cold and patched:
         avg_patch = sum(e.build_seconds for e in patched) / len(patched)
+        # Both sides now cover the same language set: `languages` was narrowed
+        # by build_anchor to what actually cold-built, and the patchers were
+        # started from that same list.
+        if avg_patch > 0:
+            logger.info(
+                "cold %.1fs vs mean patch %.2fs over %d transitions (%.1fx) [%s]",
+                cold.build_seconds,
+                avg_patch,
+                len(patched),
+                cold.build_seconds / avg_patch,
+                ", ".join(languages),
+            )
+        else:
+            logger.info(
+                "cold %.1fs vs mean patch %.2fs over %d transitions "
+                "(no ratio: mean patch time is zero) [%s]",
+                cold.build_seconds,
+                avg_patch,
+                len(patched),
+                ", ".join(languages),
+            )
         logger.info(
-            "cold %.1fs vs mean patch %.2fs over %d transitions (%.1fx)",
-            cold.build_seconds,
-            avg_patch,
-            len(patched),
-            (cold.build_seconds / avg_patch) if avg_patch else float("nan"),
+            "      LSP startup %.1fs is excluded from patch times above",
+            lsp_startup,
         )
     return 0
 

--- a/scripts/build_qa_index.py
+++ b/scripts/build_qa_index.py
@@ -287,8 +287,34 @@ def build_one(cfg, row, force: bool) -> RepoEntry:
     repo_path = ds.get_repo_path(row, repo_root=repo_root)
 
     manifest_path = os.path.join(repo_path, CACHE_DIR_NAME, "repo_manifest.json")
-    if os.path.exists(manifest_path) and not force:
-        print(f"  [skip] manifest exists at {manifest_path}")
+    manifest_exists = os.path.exists(manifest_path)
+    if manifest_exists and not force:
+        # Advance the existing indexes to HEAD instead of skipping outright.
+        # Builders with a real delta path (vector) do incremental work; the
+        # others fall back to a rebuild internally, and an unchanged HEAD is a
+        # no-op, so this stays cheap when there is nothing to do.
+        languages = _chunker_languages(language)
+        index_types = cfg.index_types()
+        builders = IndexBuilderRegistry()
+        builders.register("bm25", BM25IndexBuilder(languages=languages))
+        if "vector" in index_types:
+            builders.register(
+                "vector",
+                VectorIndexBuilder(
+                    languages=languages,
+                    embedding_model=cfg.embedding_model,
+                    embedding_dimension=cfg.embedding_dimension,
+                ),
+            )
+        compiler = IndexCompiler(
+            builders,
+            IndexCompilerConfig(index_types=index_types, languages=languages),
+        )
+        print(f"  [update] advancing indexes to HEAD ({index_types})")
+        manifest = compiler.update_repo(
+            repo_path, cache_dir=os.path.join(repo_path, CACHE_DIR_NAME)
+        )
+        print(f"  [done] {manifest.file_count} files, caps={manifest.capabilities}")
     else:
         languages = _chunker_languages(language)
         index_types = cfg.index_types()

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import time
 from unittest.mock import MagicMock, patch
 
@@ -616,3 +617,122 @@ class TestTwoPhaseIntegration:
 
         assert not plan.can_execute
         assert "vector" in plan.blocking_builds
+
+
+# ---------------------------------------------------------------------------
+# IndexCompiler.update_repo — incremental advance of an existing manifest
+# ---------------------------------------------------------------------------
+
+
+def _recording_builder(calls: list):
+    """Builder that records whether build or incremental_update was invoked."""
+
+    class RecordingBuilder:
+        def build(self, scope: str, **kwargs) -> IndexStatus:
+            output_dir = kwargs.get("output_dir", "/tmp/rec")
+            os.makedirs(output_dir, exist_ok=True)
+            calls.append(("build", kwargs.get("last_commit")))
+            return IndexStatus(
+                index_type="rec",
+                state=IndexState.FRESH,
+                last_built=time.time(),
+                age_seconds=0.0,
+                scope=scope,
+                path=output_dir,
+                metadata={},
+            )
+
+        def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
+            calls.append(("incremental_update", kwargs.get("last_commit")))
+            rest = {k: v for k, v in kwargs.items() if k != "last_commit"}
+            return self.build(scope, **rest)
+
+    return RecordingBuilder()
+
+
+def _git_repo(path) -> str:
+    """Init a git repo with one commit; return the commit sha."""
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)
+    (path / "a.py").write_text("def a():\n    pass\n")
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-qm", "one"], check=True)
+    return subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _commit(path, name: str) -> str:
+    (path / name).write_text("def b():\n    pass\n")
+    subprocess.run(["git", "-C", str(path), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-qm", name], check=True)
+    return subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+class TestUpdateRepo:
+    def _compiler(self, calls):
+        registry = IndexBuilderRegistry()
+        registry.register("rec", _recording_builder(calls))
+        return IndexCompiler(
+            registry,
+            IndexCompilerConfig(index_types=["rec"], languages=["python"]),
+        )
+
+    def test_falls_back_to_full_build_without_manifest(self, tmp_path):
+        _git_repo(tmp_path)
+        calls: list = []
+        self._compiler(calls).update_repo(str(tmp_path))
+        assert calls == [("build", None)]
+
+    def test_noop_when_head_unchanged(self, tmp_path):
+        _git_repo(tmp_path)
+        calls: list = []
+        compiler = self._compiler(calls)
+        compiler.compile_repo(str(tmp_path))
+        assert len(calls) == 1
+        compiler.update_repo(str(tmp_path))
+        # HEAD did not move, so no builder should run again.
+        assert len(calls) == 1
+
+    def test_uses_incremental_path_when_head_moved(self, tmp_path):
+        first = _git_repo(tmp_path)
+        calls: list = []
+        compiler = self._compiler(calls)
+        compiler.compile_repo(str(tmp_path))
+        second = _commit(tmp_path, "b.py")
+        assert first != second
+
+        compiler.update_repo(str(tmp_path))
+        assert calls[-2] == ("incremental_update", first)
+
+    def test_manifest_records_new_commit_after_update(self, tmp_path):
+        _git_repo(tmp_path)
+        calls: list = []
+        compiler = self._compiler(calls)
+        compiler.compile_repo(str(tmp_path))
+        second = _commit(tmp_path, "b.py")
+
+        manifest = compiler.update_repo(str(tmp_path))
+        assert manifest.commit == second
+        assert manifest.last_indexed_commit == second
+
+    def test_rebuilds_when_manifest_unreadable(self, tmp_path):
+        _git_repo(tmp_path)
+        calls: list = []
+        compiler = self._compiler(calls)
+        compiler.compile_repo(str(tmp_path))
+        cache = tmp_path / ".codeminer_cache"
+        (cache / "repo_manifest.json").write_text("{not json")
+
+        calls.clear()
+        compiler.update_repo(str(tmp_path))
+        assert calls == [("build", None)]

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -737,6 +737,55 @@ class TestUpdateRepo:
         compiler.update_repo(str(tmp_path))
         assert calls == [("build", None)]
 
+    def test_failed_build_does_not_advance_indexed_commit(self, tmp_path):
+        """A failed index must leave last_indexed_commit behind.
+
+        Otherwise the next update_repo() sees HEAD == last_indexed_commit,
+        reports "nothing to update", and the broken index stays stale forever.
+        """
+        first = _git_repo(tmp_path)
+        calls: list = []
+        compiler = self._compiler(calls)
+        compiler.compile_repo(str(tmp_path))
+        second = _commit(tmp_path, "b.py")
+        assert first != second
+
+        builder = compiler._builders.get("rec")
+
+        def boom(scope, **kwargs):
+            raise RuntimeError("builder exploded")
+
+        builder.incremental_update = boom
+
+        manifest = compiler.update_repo(str(tmp_path))
+        assert manifest.commit == second
+        # HEAD moved, but nothing successfully indexed it.
+        assert manifest.last_indexed_commit == first
+        assert manifest.indexes["rec"].status == "failed"
+
+    def test_failed_build_leaves_repo_updatable(self, tmp_path):
+        """The retry after a failure must reach the builder, not short-circuit."""
+        _git_repo(tmp_path)
+        calls: list = []
+        compiler = self._compiler(calls)
+        compiler.compile_repo(str(tmp_path))
+        _commit(tmp_path, "b.py")
+
+        builder = compiler._builders.get("rec")
+        healthy = builder.incremental_update
+
+        def boom(scope, **kwargs):
+            raise RuntimeError("builder exploded")
+
+        builder.incremental_update = boom
+        compiler.update_repo(str(tmp_path))
+
+        builder.incremental_update = healthy
+        calls.clear()
+        compiler.update_repo(str(tmp_path))
+        # Not a no-op: the failure left work to do.
+        assert calls, "update_repo short-circuited after a failed build"
+
 
 # ---------------------------------------------------------------------------
 # SymbolGraphBuilder incremental repair + admission control

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -786,6 +786,39 @@ class TestUpdateRepo:
         # Not a no-op: the failure left work to do.
         assert calls, "update_repo short-circuited after a failed build"
 
+    def test_failed_initial_build_retries_at_unchanged_head(self, tmp_path):
+        """An empty baseline after a failed full build must not alias HEAD."""
+        head = _git_repo(tmp_path)
+        attempts = []
+
+        class FailOnceBuilder:
+            def build(self, scope: str, **kwargs) -> IndexStatus:
+                attempts.append("build")
+                if len(attempts) == 1:
+                    raise RuntimeError("transient build failure")
+                return _mock_builder("rec").build(scope, **kwargs)
+
+            def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
+                attempts.append("incremental_update")
+                return _mock_builder("rec").build(scope, **kwargs)
+
+        registry = IndexBuilderRegistry()
+        registry.register("rec", FailOnceBuilder())
+        compiler = IndexCompiler(
+            registry,
+            IndexCompilerConfig(index_types=["rec"], languages=["python"]),
+        )
+
+        failed = compiler.compile_repo(str(tmp_path))
+        assert failed.commit == head
+        assert failed.last_indexed_commit == ""
+        assert failed.indexes["rec"].status == "failed"
+
+        recovered = compiler.update_repo(str(tmp_path))
+        assert attempts == ["build", "build"]
+        assert recovered.last_indexed_commit == head
+        assert recovered.indexes["rec"].status == "fresh"
+
 
 # ---------------------------------------------------------------------------
 # SymbolGraphBuilder incremental repair + admission control
@@ -939,3 +972,41 @@ class TestSymbolGraphIncremental:
             )
             is sentinel
         )
+
+    def test_empty_relevant_diff_is_admitted_without_verifier(
+        self, tmp_path, monkeypatch
+    ):
+        """A docs-only transition leaves the configured graph unchanged."""
+        from codeminer.graph.code_graph import CodeGraph
+        from codeminer.graph.incremental.graph_patcher import GraphPatcher
+
+        first = _git_repo(tmp_path)
+        _commit(tmp_path, "README.md")
+        out = tmp_path / "out"
+        out.mkdir()
+
+        graph = MagicMock()
+        graph.graph.vs = []
+        monkeypatch.setattr(CodeGraph, "load_graph", lambda path: graph)
+        monkeypatch.setattr(
+            GraphPatcher,
+            "detect_changed_files",
+            lambda *args, **kwargs: {
+                "added": [],
+                "modified": [],
+                "deleted": [],
+                "renamed": [],
+            },
+        )
+
+        status = self._builder()._patch_graph(
+            "current_repo", str(tmp_path), str(out), first
+        )
+
+        assert status is not None
+        assert status.metadata["changed_files"] == 0
+        assert status.metadata["verified"] is True
+        assert status.metadata["verification_details"] == {
+            "method": "empty-relevant-diff"
+        }
+        graph.save_graph.assert_called_once_with(str(out / "graph.pkl"))

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -736,3 +736,157 @@ class TestUpdateRepo:
         calls.clear()
         compiler.update_repo(str(tmp_path))
         assert calls == [("build", None)]
+
+
+# ---------------------------------------------------------------------------
+# SymbolGraphBuilder incremental repair + admission control
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolGraphIncremental:
+    def _builder(self, **kw):
+        from codeminer.compiler.index_builders import SymbolGraphBuilder
+
+        return SymbolGraphBuilder(languages=["python"], **kw)
+
+    # -- blocker logic (pure, no LSP) ------------------------------------
+
+    def test_blocked_without_last_commit(self, tmp_path):
+        reason = self._builder()._incremental_blocker(str(tmp_path), str(tmp_path), "")
+        assert reason and "no previously indexed commit" in reason
+
+    def test_blocked_without_existing_graph(self, tmp_path):
+        _git_repo(tmp_path)
+        reason = self._builder()._incremental_blocker(
+            str(tmp_path), str(tmp_path / "out"), "abc123"
+        )
+        assert reason and "graph.pkl" in reason
+
+    def test_blocked_when_already_at_indexed_commit(self, tmp_path):
+        head = _git_repo(tmp_path)
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "graph.pkl").write_bytes(b"x")
+        reason = self._builder()._incremental_blocker(str(tmp_path), str(out), head)
+        assert reason and "already at the indexed commit" in reason
+
+    def test_blocked_when_worktree_dirty(self, tmp_path):
+        first = _git_repo(tmp_path)
+        _commit(tmp_path, "b.py")
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "graph.pkl").write_bytes(b"x")
+        # Modify a *tracked* file: its disk content no longer matches the
+        # commit, which is the case the patcher cannot reason about.
+        (tmp_path / "a.py").write_text("def a():\n    return 'changed'\n")
+        reason = self._builder()._incremental_blocker(str(tmp_path), str(out), first)
+        assert reason and "uncommitted" in reason
+
+    def test_untracked_files_do_not_block(self, tmp_path):
+        """The cache dir lives inside the repo; untracked paths must not block."""
+        first = _git_repo(tmp_path)
+        _commit(tmp_path, "b.py")
+        out = tmp_path / ".codeminer_cache" / "symbol_graph"
+        out.mkdir(parents=True)
+        (out / "graph.pkl").write_bytes(b"x")
+        assert (
+            self._builder()._incremental_blocker(str(tmp_path), str(out), first) is None
+        )
+
+    def test_not_blocked_when_clean_and_moved(self, tmp_path):
+        first = _git_repo(tmp_path)
+        _commit(tmp_path, "b.py")
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "graph.pkl").write_bytes(b"x")
+        assert (
+            self._builder()._incremental_blocker(str(tmp_path), str(out), first) is None
+        )
+
+    # -- fallback + admission -------------------------------------------
+
+    def test_falls_back_to_build_when_blocked(self, tmp_path, monkeypatch):
+        built = []
+        builder = self._builder()
+        monkeypatch.setattr(
+            builder, "build", lambda scope, **kw: built.append(kw) or "BUILT"
+        )
+        # No last_commit => blocked => build()
+        assert (
+            builder.incremental_update(
+                "current_repo", repo_path=str(tmp_path), output_dir=str(tmp_path)
+            )
+            == "BUILT"
+        )
+        assert len(built) == 1
+        # last_commit must not leak into build()'s kwargs
+        assert "last_commit" not in built[0]
+
+    def test_unverified_update_is_discarded_and_rebuilt(self, tmp_path, monkeypatch):
+        """Default NullVerifier proves nothing, so the patch must be dropped."""
+        builder = self._builder()  # require_verification=True by default
+        monkeypatch.setattr(builder, "_patch_graph", lambda *a, **k: None)
+        monkeypatch.setattr(builder, "build", lambda scope, **kw: "BUILT")
+        first = _git_repo(tmp_path)
+        _commit(tmp_path, "b.py")
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "graph.pkl").write_bytes(b"x")
+
+        result = builder.incremental_update(
+            "current_repo",
+            repo_path=str(tmp_path),
+            output_dir=str(out),
+            last_commit=first,
+        )
+        assert result == "BUILT"
+
+    def test_patch_error_falls_back_to_build(self, tmp_path, monkeypatch):
+        builder = self._builder()
+
+        def boom(*a, **k):
+            raise RuntimeError("lsp exploded")
+
+        monkeypatch.setattr(builder, "_patch_graph", boom)
+        monkeypatch.setattr(builder, "build", lambda scope, **kw: "BUILT")
+        first = _git_repo(tmp_path)
+        _commit(tmp_path, "b.py")
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "graph.pkl").write_bytes(b"x")
+
+        assert (
+            builder.incremental_update(
+                "current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(out),
+                last_commit=first,
+            )
+            == "BUILT"
+        )
+
+    def test_admitted_update_is_kept(self, tmp_path, monkeypatch):
+        """An explicitly-admitting verifier keeps the patched result."""
+        from codeminer.compiler.verification import AlwaysAdmitVerifier
+
+        builder = self._builder(verifier=AlwaysAdmitVerifier())
+        sentinel = object()
+        monkeypatch.setattr(builder, "_patch_graph", lambda *a, **k: sentinel)
+        monkeypatch.setattr(
+            builder, "build", lambda scope, **kw: pytest.fail("should not rebuild")
+        )
+        first = _git_repo(tmp_path)
+        _commit(tmp_path, "b.py")
+        out = tmp_path / "out"
+        out.mkdir()
+        (out / "graph.pkl").write_bytes(b"x")
+
+        assert (
+            builder.incremental_update(
+                "current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(out),
+                last_commit=first,
+            )
+            is sentinel
+        )

--- a/test/web/test_commit_window.py
+++ b/test/web/test_commit_window.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-side behaviour of the commit window served to the graph view."""
+
+import json
+import os
+
+from codeminer.web.commit_window import CommitWindow, window_dir
+
+
+def _write_manifest(repo_dir, commits, **extra) -> str:
+    d = window_dir(str(repo_dir))
+    os.makedirs(d, exist_ok=True)
+    path = os.path.join(d, "commit_window.json")
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump({"commits": commits, **extra}, fh)
+    return path
+
+
+def _commit(sha: str, short: str, method: str = "patched", **extra) -> dict:
+    return {
+        "sha": sha,
+        "short": short,
+        "subject": f"subject {short}",
+        "date": "2026-07-20",
+        "author": "someone",
+        "method": method,
+        "build_seconds": 1.0,
+        "node_count": 100,
+        "edge_count": 200,
+        "changed_files": 1,
+        **extra,
+    }
+
+
+class TestAvailability:
+    def test_absent_manifest_is_unavailable(self, tmp_path):
+        assert CommitWindow(str(tmp_path)).available is False
+
+    def test_unparseable_manifest_is_unavailable(self, tmp_path):
+        d = window_dir(str(tmp_path))
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "commit_window.json"), "w", encoding="utf-8") as fh:
+            fh.write("{not json")
+        assert CommitWindow(str(tmp_path)).available is False
+
+    def test_empty_commit_list_is_unavailable(self, tmp_path):
+        _write_manifest(tmp_path, [])
+        assert CommitWindow(str(tmp_path)).available is False
+
+
+class TestManifestInvalidation:
+    """A rebuilt window must take effect without restarting the server."""
+
+    def test_rebuild_is_picked_up(self, tmp_path):
+        _write_manifest(tmp_path, [_commit("a" * 40, "aaaaaaa", method="cold")])
+        window = CommitWindow(str(tmp_path))
+        assert len(window.commits()) == 1
+
+        path = _write_manifest(
+            tmp_path,
+            [
+                _commit("b" * 40, "bbbbbbb"),
+                _commit("a" * 40, "aaaaaaa", method="cold"),
+            ],
+        )
+        # Force a distinct mtime; filesystem granularity can collapse two
+        # writes in the same tick into one timestamp.
+        os.utime(path, (0, 0))
+
+        assert len(window.commits()) == 2
+
+    def test_graph_cache_cleared_on_rebuild(self, tmp_path):
+        _write_manifest(tmp_path, [_commit("a" * 40, "aaaaaaa", method="cold")])
+        window = CommitWindow(str(tmp_path))
+        window.graph_for(None)  # populates the negative cache (no pkl on disk)
+        assert window._graphs
+
+        path = _write_manifest(tmp_path, [_commit("a" * 40, "aaaaaaa", method="cold")])
+        os.utime(path, (0, 0))
+        window.commits()
+
+        assert not window._graphs, "stale graph cache survived a manifest rebuild"
+
+
+class TestResolve:
+    def _window(self, tmp_path) -> CommitWindow:
+        _write_manifest(
+            tmp_path,
+            [
+                _commit("b" * 40, "bbbbbbb"),
+                _commit("a" * 40, "aaaaaaa", method="cold"),
+            ],
+        )
+        return CommitWindow(str(tmp_path))
+
+    def test_none_selects_newest(self, tmp_path):
+        assert self._window(tmp_path).resolve(None)["sha"] == "b" * 40
+
+    def test_full_sha(self, tmp_path):
+        assert self._window(tmp_path).resolve("a" * 40)["short"] == "aaaaaaa"
+
+    def test_short_sha(self, tmp_path):
+        assert self._window(tmp_path).resolve("aaaaaaa")["sha"] == "a" * 40
+
+    def test_prefix(self, tmp_path):
+        assert self._window(tmp_path).resolve("aaaa")["sha"] == "a" * 40
+
+    def test_case_insensitive(self, tmp_path):
+        assert self._window(tmp_path).resolve("AAAAAAA")["sha"] == "a" * 40
+
+    def test_unknown_returns_none(self, tmp_path):
+        assert self._window(tmp_path).resolve("deadbeef") is None
+
+    def test_too_short_prefix_returns_none(self, tmp_path):
+        assert self._window(tmp_path).resolve("aa") is None
+
+
+class TestGraphFor:
+    def test_missing_snapshot_returns_none(self, tmp_path):
+        """An unloadable snapshot must be reported, not silently substituted."""
+        _write_manifest(
+            tmp_path,
+            [_commit("a" * 40, "aaaaaaa", method="cold", graph_path="/nope/x.pkl")],
+        )
+        assert CommitWindow(str(tmp_path)).graph_for(None) is None
+
+    def test_unknown_commit_returns_none(self, tmp_path):
+        _write_manifest(tmp_path, [_commit("a" * 40, "aaaaaaa", method="cold")])
+        assert CommitWindow(str(tmp_path)).graph_for("deadbeef") is None
+
+
+class TestSummary:
+    def test_unavailable_shape(self, tmp_path):
+        s = CommitWindow(str(tmp_path)).summary()
+        assert s == {"available": False, "commits": [], "selected": None}
+
+    def test_selected_is_newest(self, tmp_path):
+        _write_manifest(
+            tmp_path,
+            [
+                _commit("b" * 40, "bbbbbbb"),
+                _commit("a" * 40, "aaaaaaa", method="cold"),
+            ],
+            languages=["python"],
+        )
+        s = CommitWindow(str(tmp_path)).summary()
+        assert s["available"] is True
+        assert s["selected"] == "b" * 40
+        assert [c["short"] for c in s["commits"]] == ["bbbbbbb", "aaaaaaa"]
+
+    def test_legacy_manifest_language_field(self, tmp_path):
+        """Older manifests carry `language` but not `languages`."""
+        _write_manifest(
+            tmp_path,
+            [_commit("a" * 40, "aaaaaaa", method="cold")],
+            language="python",
+        )
+        assert CommitWindow(str(tmp_path)).summary()["languages"] == ["python"]

--- a/test/web/test_commit_window.py
+++ b/test/web/test_commit_window.py
@@ -117,6 +117,16 @@ class TestResolve:
     def test_too_short_prefix_returns_none(self, tmp_path):
         assert self._window(tmp_path).resolve("aa") is None
 
+    def test_ambiguous_prefix_returns_none(self, tmp_path):
+        _write_manifest(
+            tmp_path,
+            [
+                _commit("abcd" + "1" * 36, "abcd111"),
+                _commit("abcd" + "2" * 36, "abcd222"),
+            ],
+        )
+        assert CommitWindow(str(tmp_path)).resolve("abcd") is None
+
 
 class TestGraphFor:
     def test_missing_snapshot_returns_none(self, tmp_path):

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -99,19 +99,23 @@ export default function WikiPageView() {
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    let cancelled = false;
+    setCommits([]);
+    setSelectedCommit(undefined);
+
     // Deep-link support: ?p=<pageId> opens that wiki page directly.
     const p = new URLSearchParams(window.location.search).get("p");
     if (p) setActiveId(p);
     fetchRepos()
       .then((rs) => {
-        setRepo(rs.find((x) => x.id === repoId) ?? null);
+        if (!cancelled) setRepo(rs.find((x) => x.id === repoId) ?? null);
       })
       .catch(() => {});
     // Optional feature: repos without a prebuilt window just keep the static
     // commit label, so a failure here is not surfaced as a page error.
     fetchCommits(repoId)
       .then((w) => {
-        if (!w.available) return;
+        if (cancelled || !w.available) return;
         setCommits(w.commits);
         setSelectedCommit(w.selected ?? undefined);
       })
@@ -119,9 +123,18 @@ export default function WikiPageView() {
     setTocLoading(true);
     setError(null);
     fetchWikiTree(repoId)
-      .then((t) => setPages(t.pages))
-      .catch((e) => setError(String(e)))
-      .finally(() => setTocLoading(false));
+      .then((t) => {
+        if (!cancelled) setPages(t.pages);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setTocLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [repoId]);
 
   useEffect(() => {

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -8,12 +8,14 @@ import AskBar from "@/components/AskBar";
 import Codemap from "@/components/Codemap";
 import GraphView from "@/components/GraphView";
 import {
+  fetchCommits,
   fetchRepos,
   fetchWikiGraph,
   fetchWikiPage,
   fetchWikiTree,
   repoRelative,
   type CodemapResponse,
+  type CommitRef,
   type RepoInfo,
   type WikiPage,
   type WikiPageRef,
@@ -90,6 +92,10 @@ export default function WikiPageView() {
   const [pageError, setPageError] = useState<string | null>(null);
   const [tocLoading, setTocLoading] = useState(true);
   const [tocOpen, setTocOpen] = useState(false);
+  // Commit window: empty when this repo has no prebuilt snapshots, in which
+  // case the rail keeps its static "Last indexed" label.
+  const [commits, setCommits] = useState<CommitRef[]>([]);
+  const [selectedCommit, setSelectedCommit] = useState<string | undefined>(undefined);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -99,6 +105,15 @@ export default function WikiPageView() {
     fetchRepos()
       .then((rs) => {
         setRepo(rs.find((x) => x.id === repoId) ?? null);
+      })
+      .catch(() => {});
+    // Optional feature: repos without a prebuilt window just keep the static
+    // commit label, so a failure here is not surfaced as a page error.
+    fetchCommits(repoId)
+      .then((w) => {
+        if (!w.available) return;
+        setCommits(w.commits);
+        setSelectedCommit(w.selected ?? undefined);
       })
       .catch(() => {});
     setTocLoading(true);
@@ -219,8 +234,29 @@ export default function WikiPageView() {
         {tocOpen && <div className="toc-scrim" onClick={() => setTocOpen(false)} aria-hidden />}
         <aside className={`wiki-toc ${tocOpen ? "open" : ""}`} data-rail="left">
           <div className="rail-title">{repo ? repo.repo : repoId}</div>
-          {repo?.commit_short && (
-            <div className="rail-sub mono">Last indexed {repo.commit_short}</div>
+          {commits.length > 0 ? (
+            <div className="rail-sub commit-picker">
+              <label className="commit-picker-label" htmlFor="commit-select">
+                Viewing commit
+              </label>
+              <select
+                id="commit-select"
+                className="commit-select mono"
+                value={selectedCommit ?? ""}
+                onChange={(e) => setSelectedCommit(e.target.value || undefined)}
+                title="Show the symbol graph as of this commit"
+              >
+                {commits.map((c) => (
+                  <option key={c.sha} value={c.sha}>
+                    {c.short} · {c.date} · {c.subject.slice(0, 40)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : (
+            repo?.commit_short && (
+              <div className="rail-sub mono">Last indexed {repo.commit_short}</div>
+            )
           )}
           {error ? (
             <div className="muted">Failed to load wiki.</div>
@@ -360,7 +396,7 @@ export default function WikiPageView() {
               </button>
             </div>
             <div className="graph-modal-body">
-              <Codemap repoId={repoId} initialSymbol={graphSeed} />
+              <Codemap repoId={repoId} initialSymbol={graphSeed} commit={selectedCommit} />
             </div>
           </div>
         </div>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -541,6 +541,45 @@ pre {
   border-bottom: 1px solid var(--border);
 }
 
+/* Commit selector: replaces the static "Last indexed" label when the repo has
+   a prebuilt commit window (scripts/build_commit_window.py). */
+.commit-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.commit-picker-label {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.commit-select {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  font-size: 12px;
+  padding: 5px 7px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+  /* Long subjects must not widen the rail. */
+  text-overflow: ellipsis;
+}
+
+.commit-select:hover {
+  border-color: var(--accent, var(--fg));
+}
+
+.commit-select:focus-visible {
+  outline: 2px solid var(--accent, var(--fg));
+  outline-offset: 1px;
+}
+
 .toc-tree {
   list-style: none;
   margin: 0;

--- a/web/components/Codemap.tsx
+++ b/web/components/Codemap.tsx
@@ -16,9 +16,13 @@ type Depth = 1 | 2;
 export default function Codemap({
   repoId,
   initialSymbol,
+  commit,
 }: {
   repoId: string;
   initialSymbol?: string;
+  // Commit snapshot to render. Undefined = the window's newest commit (or the
+  // repo's single indexed graph when no window exists).
+  commit?: string;
 }) {
   const [symbol, setSymbol] = useState(initialSymbol ?? "");
   const [query, setQuery] = useState(initialSymbol ?? ""); // last submitted focus symbol
@@ -45,6 +49,7 @@ export default function Codemap({
       direction,
       depth,
       maxNodes: depth === 1 ? 28 : 40,
+      commit,
     })
       .then((d) => !cancelled && setData(d))
       .catch((e) => !cancelled && setErr(String(e)))
@@ -52,7 +57,7 @@ export default function Codemap({
     return () => {
       cancelled = true;
     };
-  }, [repoId, query, direction, depth]);
+  }, [repoId, query, direction, depth, commit]);
 
   function focus(label: string) {
     setSymbol(label);

--- a/web/components/Codemap.tsx
+++ b/web/components/Codemap.tsx
@@ -109,6 +109,12 @@ export default function Codemap({
             {data.root_label} · {data.nodes.length} symbols · {data.edges.length} edges
             {data.truncated ? " · truncated" : ""}
           </div>
+          {data.fell_back && (
+            <p className="muted small" role="status">
+              The selected snapshot could not be loaded. Showing the default graph
+              {data.commit ? ` at ${data.commit.slice(0, 8)}` : ""}.
+            </p>
+          )}
           {data.note && <p className="muted small">{data.note}</p>}
           <GraphView repoId={repoId} data={data} variant="explore" onFocus={focus} />
           <div className="codemap-nodes">

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -224,17 +224,61 @@ export interface CodemapResponse {
   hierarchy?: CodemapHierarchy;
   mermaid: string;
   note?: string;
+  // Which commit snapshot this payload was built from.
+  commit?: string | null;
+}
+
+// One selectable point in the repo's commit window. Snapshots are built by
+// scripts/build_commit_window.py; `method` is "cold" for the anchor build and
+// "patched" for commits reached incrementally.
+export interface CommitRef {
+  sha: string;
+  short: string;
+  subject: string;
+  date: string;
+  author: string;
+  method: "cold" | "patched";
+  build_seconds: number;
+  node_count: number;
+  edge_count: number;
+  changed_files: number;
+}
+
+export interface CommitWindowResponse {
+  available: boolean;
+  ref?: string;
+  language?: string;
+  // Every language actually built into these snapshots.
+  languages?: string[];
+  lsp_startup_seconds?: number;
+  commits: CommitRef[];
+  selected: string | null;
+}
+
+// Repos without a prebuilt window return available=false; callers should then
+// fall back to the repo's single indexed commit.
+export async function fetchCommits(repoId: string): Promise<CommitWindowResponse> {
+  const res = await fetch(`${API_BASE}/api/repos/${encodeURIComponent(repoId)}/commits`);
+  if (!res.ok) throw new Error(`Failed to load commits (${res.status})`);
+  return res.json();
 }
 
 export async function fetchCodemap(
   repoId: string,
-  opts: { symbol?: string; direction?: string; depth?: number; maxNodes?: number } = {}
+  opts: {
+    symbol?: string;
+    direction?: string;
+    depth?: number;
+    maxNodes?: number;
+    commit?: string;
+  } = {}
 ): Promise<CodemapResponse> {
   const params = new URLSearchParams();
   if (opts.symbol) params.set("symbol", opts.symbol);
   if (opts.direction) params.set("direction", opts.direction);
   if (opts.depth != null) params.set("depth", String(opts.depth));
   if (opts.maxNodes != null) params.set("max_nodes", String(opts.maxNodes));
+  if (opts.commit) params.set("commit", opts.commit);
   const qs = params.toString();
   const res = await fetch(
     `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/codemap${qs ? `?${qs}` : ""}`

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -226,6 +226,9 @@ export interface CodemapResponse {
   note?: string;
   // Which commit snapshot this payload was built from.
   commit?: string | null;
+  // True when the selected snapshot could not be loaded and the API served
+  // the repository's default graph instead.
+  fell_back?: boolean;
 }
 
 // One selectable point in the repo's commit window. Snapshots are built by


### PR DESCRIPTION
## Summary

Makes the paper's incremental view-maintenance mechanisms reachable from the
product, and surfaces one of them in the web demo.

Both mechanisms were implemented and evaluated but unreachable from the
compile/serve path: `SymbolGraphBuilder.incremental_update` discarded its
argument and rebuilt from scratch, and `IndexCompiler` only ever called
`build()`, so `VectorIndexBuilder`'s content-addressed delta never ran. The
web demo additionally skipped indexing entirely whenever a manifest already
existed, pinning indexes to the commit they were first built from.

This PR wires both paths, adds an admission-control contract so an
incremental result is only kept when something can vouch for it, and adds a
commit selector to the graph view backed by per-commit snapshots.

Measured on this repository (5-commit window, python + typescript):
cold build **96.5 s** vs mean patch **4.00 s** over 4 transitions — **24.1×**
(**13.1×** python-only). One transition correctly cost 0.00 s because it
touched no indexed source.

## Changes

- **`scripts/build_commit_window.py`** (new) — walks the last N first-parent
  commits of a ref, cold-builds only the oldest, then patches forward through
  the chain with `GraphPatcher`, writing one graph snapshot per commit plus a
  `commit_window.json` manifest. Uses a disposable detached `git worktree`, so
  a served or actively-developed checkout is never touched. `--language` takes
  a list; `paper` expands to the languages the incremental-maintenance
  experiment covers. A language that cannot be cold-built (e.g. `.go` files
  present but no `go.mod`) or whose language server will not start is dropped
  rather than failing the run.
- **`codeminer/web/commit_window.py`** (new) — read side: resolves commits by
  full/short/prefix SHA and loads snapshots lazily, cached per SHA. Kept out of
  `repo_registry.py`, which carries local uncommitted operator changes.
- **`codeminer/web/app.py`** — `GET /api/repos/{id}/commits`; `/codemap` accepts
  `?commit=`, defaulting to the window's newest.
- **`codeminer/compiler/index_compiler.py`** — new `update_repo()` compares the
  manifest's `last_indexed_commit` against HEAD and routes builders through
  `incremental_update`. `compile_repo` and `update_repo` now share one build
  loop.
- **`codeminer/compiler/index_builders.py`** — `SymbolGraphBuilder.incremental_update`
  now diffs `last_commit..HEAD` per language and repairs the graph via
  `GraphPatcher`, reusing one language server per language.
- **`codeminer/compiler/verification.py`** (new) — `UpdateVerifier` contract,
  `VerificationResult`, `NullVerifier` (default), `AlwaysAdmitVerifier`.
- **`scripts/build_qa_index.py`** — calls `update_repo()` instead of skipping
  when a manifest exists.
- **Frontend** — the rail's static `Last indexed <sha>` becomes a commit
  selector, falling back to the old label for repos without a window.
- **`.gitignore`** — ignores `.codeminer_cache/`, which held ~14 MB of graph
  pickles untracked.

### How this maps to the paper

| Paper component | Status before | Status after |
|---|---|---|
| Guarded graph maintenance (Q4, 8.67× median) | implemented for 5 languages, reachable only from the eval harness | reachable from `IndexCompiler`; demonstrated in the demo via the commit selector |
| Content-addressed vector reuse (Q4, 25.44× median) | implemented, never called | reached through `update_repo()` |
| Fresh-target admission guard (Sec. 4.2) | in the evaluation harness only | contract + default in the serving path; the exactness implementation still to be ported |
| Manifest-linked views bound to a commit (Sec. 4.1) | `commit` / `last_indexed_commit` recorded but unused | drives the patch-vs-rebuild decision |

The symbol-level classifier the paper describes (Fig. 4) is what actually runs
— manifest `patch_stats` record `classify_symbols`, `vertices_shifted`,
`remap_edges`, `lsp_incoming_refs`, `lsp_outgoing_refs` per transition.

### Effect on the demo

- The graph view gains a commit selector; picking a commit re-renders the
  symbol graph from that snapshot.
- Re-running `build_qa_index.py` now advances indexes to HEAD instead of
  skipping, so the vector index stops being pinned to its first build.
- Ask, wiki prose, and source links are **unchanged** — they still use the
  repo's single indexed commit. The selector governs the graph only.
- Default behaviour of existing callers is unchanged: with `NullVerifier` and
  `require_verification=True`, `SymbolGraphBuilder` rebuilds exactly as before.

### Correctness posture

Every incremental path falls back to a full rebuild when it cannot proceed:
no previously indexed commit, no existing `graph.pkl`, HEAD unchanged,
modified tracked files in the working tree, an unavailable language server,
any patch error, or a result that verification will not admit. The artifact is
therefore always correct; only the cost varies.

`VerificationResult` separates `verified` from `checked` so "we did not verify"
can never be reported as "we verified and it matched" — the distinction the
paper's admission guard exists to make.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/compiler/ test/web/ test/index/ test/graph/` — 444 passed,
1 skipped. 15 new tests cover `update_repo` routing (no manifest / unreadable
manifest / HEAD unchanged / HEAD moved / manifest bookkeeping), the
symbol-graph incremental blocker conditions, both rebuild-fallback paths, and
both admission outcomes. `tsc --noEmit` clean; black, isort and flake8 pass.

**Reproduce the measurement and the UI:**

```bash
# language servers (build-time only; serving needs none)
make python-lsp-tool typescript-lsp-tool CODEMINER_SCIP_TOOLS_DIR=$HOME/.codeminer-tools
export PATH="$HOME/.codeminer-tools:$PATH"

# build a 5-commit window (~2.5 min; prints the speedup)
python scripts/build_commit_window.py --repo-dir "$PWD" \
    --n 5 --ref origin/main --language paper

# serve, then open http://localhost:3001 and pick a repo
bash scripts/start_web.sh
```

Expected: `cold 96.5s vs mean patch 4.00s over 4 transitions (24.1x)`, and the
left rail shows `VIEWING COMMIT` with five entries instead of a static SHA.
Selecting the oldest vs newest commit changes the rendered graph
(10630 → 10684 nodes here).

**API check without the UI:**

```bash
curl -s localhost:8001/api/repos/<id>/commits            # 5 commits, newest first
curl -s "localhost:8001/api/repos/<id>/codemap"           # defaults to newest
curl -s "localhost:8001/api/repos/<id>/codemap?commit=<old-sha>"
curl -s "localhost:8001/api/repos/<id>/codemap?commit=deadbeef"   # 404
```

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

## Remaining work

Scoped to this line of work; tracked so nothing here is mistaken for finished.

**Blocking a correctness claim**
- [ ] **Port the exactness guard** from the evaluation harness as a third
  `UpdateVerifier`. Until then every incremental result is recorded
  `verified=false, checked=false`, and no speedup may be claimed as
  correctness-preserving. When porting: vertex identity is `unified_name`, not
  the igraph vertex key — the patcher writes keys as `{unified_name}:{start_line}`
  while the cold build does not, so comparing raw keys yields false differences
  (251 spurious vs 54 real in a 4-transition window).

**Needed for the demo to exercise this**
- [ ] `QAConfig.index_types()` returns `["bm25", "vector"]` and never
  `symbol_graph`, so the demo does not build a symbol graph at all — it reads a
  prebuilt one. Add `symbol_graph` so the new path runs there.
- [ ] The prebuilt `.codeminer_cache/symbol_graph/graph.pkl` is
  `schema_version=3` against an expected `4` and fails to load; the graph view
  works here only because commit-window snapshots bypass it. Regenerate.
- [ ] The running server never calls `update_repo()` — indexes advance when the
  build script is re-run, not automatically. Decide between a background
  refresh and an on-request check.

**Scope and correctness gaps**
- [ ] Snapshot reuse: a rebuild always cold-builds the anchor even when a usable
  snapshot for that commit already exists, so refreshing a window costs ~2.5 min
  instead of seconds. Should reuse *and* verify rather than reuse blindly.
- [ ] The commit selector governs the graph only. Making Ask commit-aware needs
  per-commit BM25 + vector (~3 s/commit).
- [ ] `hierarchy_graph` still comes from the repo's default graph, not the
  selected snapshot; adjacent commits differ little, but it is inconsistent.
- [ ] Source view and GitHub links still use `base_commit`. `/source` reads the
  live working tree rather than the indexed commit, so it can show content from
  neither — `git show <sha>:<path>` would fix both.
- [ ] Go and Rust are dropped for this repository (fixtures without `go.mod` /
  `Cargo.toml`). Matching the paper's language coverage means serving repos in
  those languages, not adding languages to this one.
- [ ] Zoekt has no incremental path; `zoekt-git-index` supports incremental
  shards natively, so this is likely wiring.

**Deliberately not doing**
- BM25 incremental. `langchain BM25Retriever` (rank_bm25) has no add/remove and
  BM25 scoring is corpus-global, while its median build is 0.81 s — engineering
  around an immutable backend to save under a second is not justified.
