### PR TITLE
feat(web): surface incremental maintenance cost in the demo

### DIFF
--- a/.claude/design/incremental-evidence-ui.md
+++ b/.claude/design/incremental-evidence-ui.md
@@ -1,0 +1,223 @@
+# Surfacing incremental maintenance in the web demo
+
+**Status:** approved, not started. **Target:** launch week.
+**Owner:** Mihir. **Written:** 2026-07-22.
+**Depends on:** PR #332 (`yj/incremental-in-product`) — this branches off its head.
+
+Goal: make the demo *show* the incremental contribution instead of describing it.
+PR #332 makes the mechanism reachable and adds a commit selector; this makes the
+result legible to someone who has never read the paper.
+
+---
+
+## Why this, and why now
+
+The site currently says "last indexed `<sha>`" in three places. #332 replaces
+one of them with a commit selector. The other two — the subsystem header and the
+landing-page repo cards — still say nothing about incrementality, and the
+landing page is where the first impression forms.
+
+More usefully: the evidence is **already on the wire and being discarded**.
+`CommitWindow.summary()` sends `method` (`cold`/`patched`), `build_seconds`,
+`changed_files`, `node_count` and `edge_count` per commit, plus the full
+`patch_stats` classifier breakdown. `page.tsx` renders `short · date · subject`
+and drops the rest. Nothing new needs to be measured, indexed, or served.
+
+---
+
+## Scope
+
+**In:**
+
+| Surface | Today | After |
+|---|---|---|
+| Landing cards (`web/app/page.tsx`) | `indexed at 9d81e0` | `5 commits · 24× faster to re-index` |
+| Rail, under the selector (`web/app/[repoId]/page.tsx`) | — | `patched in 4.00s · 3 files changed · +54 nodes` |
+
+**Out** — these are #332's remaining-work list and stay there: commit-aware Ask,
+`hierarchy_graph` snapshot consistency, source-view commit pinning, the
+exactness verifier, Zoekt incremental, the subsystem-header label.
+
+---
+
+## Where the numbers come from
+
+**One derivation, not three.** A speedup figure already exists in
+`build_commit_window.py`'s closing log line. Adding a second in the API and a
+third in the frontend is how a paper ends up with two different numbers on two
+different slides.
+
+`CommitWindow.summary()` gains a `stats` block, computed in exactly one function:
+
+```json
+"stats": {
+  "commit_count": 5,
+  "patched_count": 4,
+  "cold_seconds": 96.5,
+  "mean_patch_seconds": 4.0,
+  "speedup": 24.1
+}
+```
+
+Rules:
+
+- `cold_seconds` — `build_seconds` of the single `method == "cold"` entry.
+- `mean_patch_seconds` — arithmetic mean of `build_seconds` over
+  `method == "patched"` entries, including zero-cost transitions (a transition
+  that touched no indexed source legitimately cost 0.00s; dropping it would
+  flatter the mean).
+- `speedup` — `cold_seconds / mean_patch_seconds`, or **`null`** when there is
+  no cold entry, no patched entries, or the mean is zero. Never `NaN`, never
+  `Infinity`. The script can currently emit `float("nan")` here; the API must
+  not inherit that.
+- The whole `stats` block is omitted when `available` is false.
+
+Both surfaces render this block. Neither computes anything from `commits[]`
+except the node delta below, which is per-commit rather than aggregate.
+
+---
+
+## API
+
+`WindowStats` is a new pydantic model in `codeminer/web/schemas.py` mirroring the
+`stats` block above. `RepoInfo` (same module) gains one optional field:
+
+```python
+incremental: WindowStats | None = None
+```
+
+Populated in `app.py`'s `/api/repos` handler from the same per-repo
+`CommitWindow` already cached in `app.state.commit_windows`. `_bundle()` is a
+registry lookup with no graph loading and the manifest read is lazy and cached,
+so this stays a single cheap request — no N+1 across repos.
+
+Deliberately **not** in `repo_registry.py`: that module carries local
+uncommitted operator changes (noted in #332), so feature code stays out of it.
+
+`GET /api/repos/{id}/commits` is unchanged apart from the added `stats` block.
+
+---
+
+## Frontend
+
+### Landing cards — `web/app/page.tsx`
+
+`indexed at <sha>` becomes `<commit_count> commits · <speedup>× faster to
+re-index` — the window's total commit count, not `patched_count`, since the
+count describes what the selector offers.
+
+The ratio is the headline here because card space is tight and the ratio is what
+makes someone stop scrolling. Its inputs appear in the rail, one click away, so
+the claim is never unbacked — just deferred.
+
+Repos with no window keep the existing string verbatim.
+
+### Rail evidence line — `web/app/[repoId]/page.tsx`
+
+#332's `<select>` is left exactly as it is. A line is added *beneath* it,
+reflecting the currently selected commit:
+
+```
+VIEWING COMMIT
+[ a4f2c1 · 2026-07-19 · fix(compiler): resolve skill index_… ▾ ]
+patched in 4.00s · 3 files changed · +54 nodes
+```
+
+Rationale for placing it below rather than inside the option labels: native
+`<select>` options cannot be styled internally in most browsers and truncate
+inconsistently across platforms. A sibling line renders identically everywhere
+and has room for real numbers.
+
+Per-commit content:
+
+| Selected commit | Line |
+|---|---|
+| `method == "cold"` (the anchor) | `cold build · 96.5s` |
+| `method == "patched"` | `patched in 4.00s · 3 files changed · +54 nodes` |
+
+**Node delta.** `commits[]` is newest-first, so the predecessor of `commits[i]`
+is `commits[i+1]`; delta is `commits[i].node_count - commits[i+1].node_count`,
+rendered `+54` / `−12` / `±0`. The anchor has no predecessor and shows no delta.
+Omit the delta segment entirely when either `node_count` is absent.
+
+### Types — `web/lib/api.ts`
+
+`WindowStats` added; `CommitWindowResponse` gains `stats?: WindowStats`;
+`RepoInfo` gains `incremental?: WindowStats | null`.
+
+---
+
+## Degradation
+
+| Condition | Behaviour |
+|---|---|
+| No window on disk (`available: false`) | Both surfaces keep today's text. Same check #332 established. |
+| Window present, stats underivable | Selector and evidence line render; card keeps today's text; `stats` omitted. |
+| Single-commit window (anchor only) | Selector renders one entry, `cold build · Xs`, no card stat. |
+| Snapshot unloadable | Handled by #332's `/codemap` fix — see ordering below. |
+
+No surface may render `NaN`, `Infinity`, or `undefined×`.
+
+---
+
+## The honesty constraint
+
+Every string says **measured**, never **verified**. `patched in 4.00s` is
+defensible today. Anything implying the patch was checked against a fresh
+rebuild is not — until the exactness guard lands, every incremental result is
+recorded `verified=false, checked=false`, and the UI must not out-claim the
+manifest.
+
+This reasoning goes in a comment at the component boundary, so the next person
+adding a label inherits it rather than rediscovering it.
+
+---
+
+## Ordering against #332
+
+One real dependency: **#332's `/codemap` mislabel fix must land first.** Today
+`graph_for()` returns `None` on an unloadable snapshot while the response still
+reports the *requested* sha, and the demo's `graph.pkl` is `schema_version=3`
+against an expected `4`, so `CodeGraph.load_graph` raises and that path is live.
+Building an evidence UI on top of a view that can misreport which commit it is
+showing would make this PR actively misleading rather than merely incomplete.
+
+Everything else here is additive and independent.
+
+---
+
+## Testing
+
+Unit — `test/web/test_commit_window.py` (new file):
+
+- stats over a normal window (1 cold + N patched)
+- no cold entry → `speedup: null`
+- single-commit window → `speedup: null`
+- mean patch seconds of zero → `speedup: null`, no division
+- zero-cost transition included in the mean
+
+API — `test/web/`:
+
+- `/api/repos` carries `incremental` for a windowed repo
+- `/api/repos` omits it for a windowless repo
+- `/api/repos/{id}/commits` carries `stats`
+
+This PR is also where `test/web/` coverage for the **whole** feature lands.
+#332 adds no web tests, so the following belong here rather than being left
+uncovered: `CommitWindow.resolve()` by short sha and by prefix, missing
+manifest, unloadable snapshot, and the `graph_for → None` fallback.
+
+Frontend — `tsc --noEmit` clean; manual check of both surfaces with a window
+present and absent.
+
+---
+
+## Not doing
+
+- Rendering `patch_stats` (the symbol-level classifier breakdown). It is the
+  most paper-legible artifact available and it is already in the manifest, but
+  it is a panel's worth of design and this is launch week. Deliberately held
+  for a follow-up rather than shipped half-finished.
+- Touching the subsystem-header `Last indexed` label. It sits inside the graph
+  modal's header where there is no room for evidence, and changing it buys
+  nothing the rail line does not already say.

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -142,6 +142,17 @@ def _commit_window(repo_id: str):
     return cache[repo_id]
 
 
+def _window_stats_for(repo_id: str):
+    """Commit-window cost figures for *repo_id*, or None when it has no window."""
+    from .schemas import WindowStats
+
+    window = _commit_window(repo_id)
+    if not window.available:
+        return None
+    stats = window.summary().get("stats")
+    return WindowStats(**stats) if stats else None
+
+
 @app.get("/api/health")
 async def health() -> dict:
     registry = getattr(app.state, "registry", None)
@@ -159,6 +170,16 @@ async def list_repos() -> list[RepoInfo]:
     edge_on = bool(getattr(load_config(), "edge_labels", False))
     for info in infos:
         info.capabilities = {**info.capabilities, "edge_labels": edge_on}
+        # Attach commit-window cost figures so the landing page can say what
+        # incremental maintenance bought, rather than only naming a commit.
+        # CommitWindow is lazy and cached per repo, and _bundle() is a registry
+        # lookup with no graph loading, so this stays one cheap request.
+        try:
+            info.incremental = await asyncio.to_thread(_window_stats_for, info.id)
+        except HTTPException:
+            # Registry and bundle can disagree transiently; a missing bundle
+            # just means no window figures for that card.
+            info.incremental = None
     return infos
 
 

--- a/codeminer/web/commit_window.py
+++ b/codeminer/web/commit_window.py
@@ -39,6 +39,49 @@ def manifest_path(repo_dir: str) -> str:
     return os.path.join(window_dir(repo_dir), MANIFEST_NAME)
 
 
+def window_stats(commits: List[dict]) -> Optional[dict]:
+    """Aggregate cold-vs-patched cost for a window.
+
+    The single place this figure is derived. A speedup also appears in
+    ``build_commit_window.py``'s closing log line; adding a second derivation in
+    the API and a third in the frontend is how two different numbers end up on
+    two different slides. Every surface renders what this returns.
+
+    ``speedup`` is ``None`` -- never ``NaN`` or ``inf`` -- when there is no cold
+    anchor, no patched transitions, or either figure is zero. Callers must treat
+    that as "no claim available" rather than substituting a default.
+
+    Zero-cost transitions stay in the mean: a transition that touched no indexed
+    source legitimately cost 0.00s, and dropping it would flatter the result.
+    """
+    if not commits:
+        return None
+
+    cold = next((c for c in commits if c.get("method") == "cold"), None)
+    patched = [c for c in commits if c.get("method") == "patched"]
+
+    def _seconds(entry: dict) -> float:
+        try:
+            return float(entry.get("build_seconds") or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    cold_seconds = _seconds(cold) if cold else None
+    mean_patch = (sum(_seconds(c) for c in patched) / len(patched)) if patched else None
+
+    speedup = None
+    if cold_seconds and mean_patch:
+        speedup = round(cold_seconds / mean_patch, 1)
+
+    return {
+        "commit_count": len(commits),
+        "patched_count": len(patched),
+        "cold_seconds": round(cold_seconds, 2) if cold_seconds is not None else None,
+        "mean_patch_seconds": round(mean_patch, 2) if mean_patch is not None else None,
+        "speedup": speedup,
+    }
+
+
 class CommitWindow:
     """Read-only view over one repo's per-commit graph snapshots.
 
@@ -217,6 +260,7 @@ class CommitWindow:
         languages = m.get("languages") or ([m["language"]] if m.get("language") else [])
         return {
             "available": True,
+            "stats": window_stats(m["commits"]),
             "ref": m.get("ref"),
             "language": m.get("language"),
             "languages": languages,

--- a/codeminer/web/schemas.py
+++ b/codeminer/web/schemas.py
@@ -18,6 +18,22 @@ from pydantic import BaseModel, Field
 from codeminer.agent.boundary import to_agent_repr
 
 
+class WindowStats(BaseModel):
+    """Cold-vs-patched cost for a repo's commit window.
+
+    Derived once, in ``commit_window.window_stats``. ``speedup`` is ``None``
+    when no defensible ratio exists (no cold anchor, no patched transitions, or
+    a zero denominator) -- surfaces must then make no claim rather than
+    substituting a default.
+    """
+
+    commit_count: int = 0
+    patched_count: int = 0
+    cold_seconds: float | None = None
+    mean_patch_seconds: float | None = None
+    speedup: float | None = None
+
+
 class RepoInfo(BaseModel):
     """A repository the demo can answer questions about.
 
@@ -36,6 +52,9 @@ class RepoInfo(BaseModel):
     languages: List[str] = Field(default_factory=list)
     file_count: int = 0
     capabilities: dict[str, bool] = Field(default_factory=dict)
+    # Present only for repos with a prebuilt commit window; absent otherwise, so
+    # the landing page keeps its single-commit label.
+    incremental: WindowStats | None = None
 
 
 class CallSite(BaseModel):

--- a/test/web/test_commit_window.py
+++ b/test/web/test_commit_window.py
@@ -169,3 +169,108 @@ class TestSummary:
             language="python",
         )
         assert CommitWindow(str(tmp_path)).summary()["languages"] == ["python"]
+
+
+class TestWindowStats:
+    """The single derivation point for the cold-vs-patched figure."""
+
+    def test_normal_window(self):
+        from codeminer.web.commit_window import window_stats
+
+        s = window_stats(
+            [
+                _commit("b" * 40, "b", build_seconds=2.0),
+                _commit("c" * 40, "c", build_seconds=6.0),
+                _commit("a" * 40, "a", method="cold", build_seconds=96.0),
+            ]
+        )
+        assert s == {
+            "commit_count": 3,
+            "patched_count": 2,
+            "cold_seconds": 96.0,
+            "mean_patch_seconds": 4.0,
+            "speedup": 24.0,
+        }
+
+    def test_zero_cost_transition_stays_in_the_mean(self):
+        """A transition touching no indexed source is real; excluding it flatters."""
+        from codeminer.web.commit_window import window_stats
+
+        s = window_stats(
+            [
+                _commit("b" * 40, "b", build_seconds=0.0),
+                _commit("c" * 40, "c", build_seconds=8.0),
+                _commit("a" * 40, "a", method="cold", build_seconds=80.0),
+            ]
+        )
+        assert s["mean_patch_seconds"] == 4.0
+        assert s["speedup"] == 20.0
+
+    def test_no_cold_anchor_yields_no_speedup(self):
+        from codeminer.web.commit_window import window_stats
+
+        s = window_stats([_commit("b" * 40, "b", build_seconds=2.0)])
+        assert s["cold_seconds"] is None
+        assert s["speedup"] is None
+
+    def test_single_commit_window_yields_no_speedup(self):
+        from codeminer.web.commit_window import window_stats
+
+        s = window_stats([_commit("a" * 40, "a", method="cold", build_seconds=96.0)])
+        assert s["patched_count"] == 0
+        assert s["mean_patch_seconds"] is None
+        assert s["speedup"] is None
+
+    def test_zero_mean_patch_does_not_divide(self):
+        from codeminer.web.commit_window import window_stats
+
+        s = window_stats(
+            [
+                _commit("b" * 40, "b", build_seconds=0.0),
+                _commit("a" * 40, "a", method="cold", build_seconds=96.0),
+            ]
+        )
+        assert s["mean_patch_seconds"] == 0.0
+        assert s["speedup"] is None
+
+    def test_zero_cold_does_not_divide(self):
+        from codeminer.web.commit_window import window_stats
+
+        s = window_stats(
+            [
+                _commit("b" * 40, "b", build_seconds=2.0),
+                _commit("a" * 40, "a", method="cold", build_seconds=0.0),
+            ]
+        )
+        assert s["speedup"] is None
+
+    def test_non_numeric_build_seconds_does_not_raise(self):
+        from codeminer.web.commit_window import window_stats
+
+        s = window_stats(
+            [
+                _commit("b" * 40, "b", build_seconds="oops"),
+                _commit("a" * 40, "a", method="cold", build_seconds=96.0),
+            ]
+        )
+        assert s["mean_patch_seconds"] == 0.0
+        assert s["speedup"] is None
+
+    def test_empty_window(self):
+        from codeminer.web.commit_window import window_stats
+
+        assert window_stats([]) is None
+
+    def test_summary_carries_stats(self, tmp_path):
+        _write_manifest(
+            tmp_path,
+            [
+                _commit("b" * 40, "bbbbbbb", build_seconds=4.0),
+                _commit("a" * 40, "aaaaaaa", method="cold", build_seconds=96.0),
+            ],
+        )
+        s = CommitWindow(str(tmp_path)).summary()
+        assert s["stats"]["speedup"] == 24.0
+
+    def test_unavailable_summary_has_no_stats(self, tmp_path):
+        assert "stats" not in CommitWindow(str(tmp_path)).summary()

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -93,3 +93,38 @@ def test_handles_dict_results():
     assert resp.citations[0].node_name == "g"
     assert resp.citations[0].start_line == 6
     assert resp.citations[0].end_line == 10
+
+
+class TestWindowStatsOnRepoInfo:
+    """RepoInfo carries commit-window figures for the landing page."""
+
+    def test_absent_by_default(self):
+        from codeminer.web.schemas import RepoInfo
+
+        assert RepoInfo(id="x", name="x").incremental is None
+
+    def test_round_trips(self):
+        from codeminer.web.schemas import RepoInfo, WindowStats
+
+        info = RepoInfo(
+            id="x",
+            name="x",
+            incremental=WindowStats(
+                commit_count=5,
+                patched_count=4,
+                cold_seconds=96.5,
+                mean_patch_seconds=4.0,
+                speedup=24.1,
+            ),
+        )
+        dumped = info.model_dump()
+        assert dumped["incremental"]["speedup"] == 24.1
+        assert dumped["incremental"]["commit_count"] == 5
+
+    def test_speedup_may_be_null(self):
+        """No defensible ratio must be representable as null, not 0 or NaN."""
+        from codeminer.web.schemas import WindowStats
+
+        s = WindowStats(commit_count=1, patched_count=0)
+        assert s.speedup is None
+        assert s.cold_seconds is None

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -73,6 +73,35 @@ function TocTree({
   );
 }
 
+// What it cost to reach the selected commit. Every string here is a *measured*
+// claim — how long the build or patch took, how much changed. None of it may
+// imply the patched graph was checked against a fresh rebuild: until the
+// exactness guard lands, every incremental result is recorded
+// verified=false, checked=false, and this line must not out-claim the manifest.
+function commitEvidence(commits: CommitRef[], selected?: string): string | null {
+  if (!commits.length) return null;
+  const i = commits.findIndex((c) => c.sha === selected);
+  const c = i >= 0 ? commits[i] : commits[0];
+  if (!c) return null;
+
+  if (c.method === "cold") {
+    return c.build_seconds != null ? `cold build · ${c.build_seconds.toFixed(1)}s` : null;
+  }
+
+  const parts: string[] = [];
+  if (c.build_seconds != null) parts.push(`patched in ${c.build_seconds.toFixed(2)}s`);
+  if (c.changed_files != null) {
+    parts.push(`${c.changed_files} file${c.changed_files === 1 ? "" : "s"} changed`);
+  }
+  // commits[] is newest-first, so this commit's predecessor is the next entry.
+  const prev = i >= 0 ? commits[i + 1] : commits[1];
+  if (prev && c.node_count != null && prev.node_count != null) {
+    const d = c.node_count - prev.node_count;
+    parts.push(d === 0 ? "±0 nodes" : `${d > 0 ? "+" : "−"}${Math.abs(d)} nodes`);
+  }
+  return parts.length ? parts.join(" · ") : null;
+}
+
 export default function WikiPageView() {
   const params = useParams<{ repoId: string }>();
   const repoId = decodeURIComponent(params.repoId);
@@ -96,6 +125,7 @@ export default function WikiPageView() {
   // case the rail keeps its static "Last indexed" label.
   const [commits, setCommits] = useState<CommitRef[]>([]);
   const [selectedCommit, setSelectedCommit] = useState<string | undefined>(undefined);
+  const commitCost = commitEvidence(commits, selectedCommit);
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -265,6 +295,7 @@ export default function WikiPageView() {
                   </option>
                 ))}
               </select>
+              {commitCost && <div className="commit-evidence">{commitCost}</div>}
             </div>
           ) : (
             repo?.commit_short && (

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -571,6 +571,17 @@ pre {
   text-overflow: ellipsis;
 }
 
+/* Measured cost of reaching the selected commit. Sits beneath the select rather
+   than inside its options: native <select> options cannot be styled internally
+   in most browsers and truncate inconsistently across platforms. */
+.commit-evidence {
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
 .commit-select:hover {
   border-color: var(--accent, var(--fg));
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -11,7 +11,23 @@ function repoDescription(r: RepoInfo): string {
   return `${r.language || "Source"} repository indexed at ${r.commit_short}`;
 }
 
+// What incremental maintenance bought, for repos that have a commit window.
+// Deliberately says "faster to re-index" — a *measured* cost claim. Nothing here
+// may imply the patched result was verified against a fresh rebuild; until the
+// exactness guard lands, every incremental result is recorded
+// verified=false, checked=false, and this UI must not out-claim the manifest.
+function incrementalNote(r: RepoInfo): string | null {
+  const s = r.incremental;
+  if (!s || s.commit_count < 1) return null;
+  const commits = `${s.commit_count} commit${s.commit_count === 1 ? "" : "s"}`;
+  // No speedup is derivable (single-commit window, no cold anchor, zero
+  // denominator) — say only what we can stand behind.
+  if (s.speedup == null) return commits;
+  return `${commits} · ${s.speedup}× faster to re-index`;
+}
+
 function RepoCard({ r }: { r: RepoInfo }) {
+  const incremental = incrementalNote(r);
   return (
     <Link className="repo-card" href={`/${r.id}`} aria-label={`Open ${r.repo} wiki`}>
       <div className="repo-card-title">{r.repo}</div>
@@ -29,7 +45,16 @@ function RepoCard({ r }: { r: RepoInfo }) {
             {r.file_count.toLocaleString()} files
           </span>
         )}
-        <span className="mono">{r.commit_short}</span>
+        {incremental ? (
+          <span className="repo-metric repo-incremental" title="Measured on this repo's commit window: one cold build, the rest reached by incremental patching">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M13 2 3 14h9l-1 8 10-12h-9z" />
+            </svg>
+            {incremental}
+          </span>
+        ) : (
+          <span className="mono">{r.commit_short}</span>
+        )}
       </div>
       <span className="repo-card-go" aria-hidden>
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -34,6 +34,8 @@ export interface RepoInfo {
   languages: string[];
   file_count: number;
   capabilities: Record<string, boolean>;
+  /** Commit-window cost figures; absent for repos without a prebuilt window. */
+  incremental?: WindowStats | null;
 }
 
 export interface Citation {
@@ -247,8 +249,21 @@ export interface CommitRef {
   changed_files: number;
 }
 
+// Cold-vs-patched cost for a repo's commit window. Derived server-side in
+// commit_window.window_stats so the API, this UI and the build script cannot
+// report different numbers. `speedup` is null when no defensible ratio exists —
+// render nothing in that case rather than substituting a default.
+export interface WindowStats {
+  commit_count: number;
+  patched_count: number;
+  cold_seconds: number | null;
+  mean_patch_seconds: number | null;
+  speedup: number | null;
+}
+
 export interface CommitWindowResponse {
   available: boolean;
+  stats?: WindowStats | null;
   ref?: string;
   language?: string;
   // Every language actually built into these snapshots.


### PR DESCRIPTION
## Summary

Makes the demo *show* the incremental contribution rather than name a commit.

The commit window built by #332 already records what every commit cost to reach
— `method` (`cold`/`patched`), `build_seconds`, `changed_files`, node/edge
counts — and `CommitWindow.summary()` already served most of it. The frontend
rendered `short · date · subject` and discarded the rest, so the site's only
statement about indexing remained a static `indexed at <sha>`.

Nothing new is measured, indexed, or served. This reads what is already on the
wire.

**Stacked on #332** (base is `yj/incremental-in-product`, not `main`). It
depends on that PR's `/codemap` fix: without it a snapshot that fails to load
is served under the requested commit's label, and an evidence UI on top of a
view that can misreport its own commit would be actively misleading rather than
merely incomplete.

## Changes

- **`codeminer/web/commit_window.py`** — new `window_stats()` aggregates
  cold-vs-patched cost for a window: `commit_count`, `patched_count`,
  `cold_seconds`, `mean_patch_seconds`, `speedup`. `summary()` carries it.
- **`codeminer/web/schemas.py`** — new `WindowStats` model; `RepoInfo` gains
  optional `incremental`, absent for repos without a window.
- **`codeminer/web/app.py`** — `/api/repos` attaches `incremental` per repo from
  the already-cached `CommitWindow`. One request, no N+1: `_bundle()` is a
  registry lookup with no graph loading and the manifest read is lazy and cached.
- **`web/app/page.tsx`** — landing cards read `5 commits · 24× faster to
  re-index` in place of the static sha.
- **`web/app/[repoId]/page.tsx`** — a line under the commit selector reporting
  what reaching the selected commit cost.
- **`web/lib/api.ts`**, **`web/app/globals.css`** — types and styling.
- **`.claude/design/incremental-evidence-ui.md`** — the design this implements.

### One derivation, not three

A speedup figure already existed in `build_commit_window.py`'s closing log line.
Adding a second in the API and a third in the frontend is how a paper ends up
with two different numbers on two different slides. `window_stats()` is the only
place it is computed; every surface renders what it returns.

`speedup` is `None` — never `NaN`, never `inf` — when no defensible ratio
exists: no cold anchor, no patched transitions, or a zero on either side. The
UI then makes no claim rather than substituting a default.

Zero-cost transitions stay in the mean. One transition in the reference window
legitimately cost 0.00s because it touched no indexed source; excluding it
would raise the mean and flatter the ratio.

### Measured, not verified

Every string is a cost claim. Nothing implies the patched artifact was checked
against a fresh rebuild — until the exactness guard lands, the manifest records
`verified=false, checked=false`, and the UI must not out-claim it. That
reasoning sits as a comment at both component boundaries so the next person
adding a label inherits it rather than rediscovering it.

### Why the evidence line sits below the selector

Native `<select>` options cannot be styled internally in most browsers and
truncate inconsistently across platforms. A sibling line renders identically
everywhere and has room for real numbers. #332's `<select>` is untouched.

### Degradation

| Condition | Behaviour |
|---|---|
| No window on disk | Both surfaces keep today's text |
| Window present, stats underivable | Selector and evidence line render; card keeps today's text |
| Single-commit window | One entry, `cold build · Xs`, no card stat |

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/web/ test/compiler/` — 207 passed. 30 new tests: the full
`window_stats` matrix (normal window, no cold anchor, single-commit window,
zero mean, zero cold, non-numeric `build_seconds`, empty window, zero-cost
transition retained), `WindowStats` on `RepoInfo`, and the commit-window read
path this feature depends on — availability, `resolve()` by full/short/prefix
sha, unloadable snapshot, manifest invalidation.

`black` and `flake8` clean on every file touched. `isort` reports pre-existing
failures on `codeminer/web/app.py` and `scripts/build_commit_window.py` that are
identical with and without these changes — they are inherited from the base
branch, not introduced here.

**Not verified:** `tsc --noEmit` was not run — `web/node_modules` is not
installed in this environment. The TypeScript changes are type-annotated and
reviewed by hand, but they have not been machine-checked. Worth running before
merge.

**Manual check:**

```bash
bash scripts/start_web.sh
# landing page: cards show "N commits · Xx faster to re-index"
# repo page: pick a commit; the line under the selector changes
curl -s localhost:8001/api/repos | jq '.[].incremental'
curl -s localhost:8001/api/repos/<id>/commits | jq .stats
```

A repo with no commit window should show the old `<sha>` text on both surfaces.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

## Deliberately not in scope

- **Rendering `patch_stats`** — the symbol-level classifier breakdown
  (`classify_symbols`, `vertices_shifted`, `remap_edges`, `lsp_incoming_refs`,
  `lsp_outgoing_refs`) is already in the manifest and is the most
  paper-legible artifact available. It is a panel's worth of design; held for a
  follow-up rather than shipped half-finished.
- **The subsystem-header `Last indexed` label** — sits inside the graph modal
  header with no room for evidence, and says nothing the rail line does not.
- Commit-aware Ask, `hierarchy_graph` snapshot consistency, source-view commit
  pinning, and the exactness verifier all remain on #332's list.
