### PR TITLE
ci: route workflow entry jobs to local runner

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/labeler@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
   # Preflight — evaluate skip condition once for all jobs
   # =============================================================
   preflight:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     # paths-filter fetches the PR's changed-file list via the GitHub API
     # (base is empty for pull_request events), which needs pull-requests:read.
     # Job-level permissions replace the top-level block, so contents:read is

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: Checkout repository

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
Route every remaining GitHub-hosted workflow entry job to the online repository self-hosted runner. The CI preflight previously failed at hosted-runner scheduling because of the account billing state, which skipped all dependent local test jobs.

## Changes
- Run the CI preflight on `self-hosted` so unit and integration jobs can be scheduled
- Run docs build, PR labeling, and label synchronization on `self-hosted`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes
- Parsed all workflow YAML files with PyYAML
- `git diff --check`
- Commit pre-hooks, including YAML syntax validation

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published