### PR TITLE
fix(ci): grant label sync checkout access [skip tests]

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -18,6 +18,7 @@ on:
         default: false
 
 permissions:
+  contents: read
   issues: write
 
 jobs:


### PR DESCRIPTION
## Summary
Restore the private-repository checkout permission required by the label synchronization workflow. This failure became visible after workflow jobs were routed to the self-hosted runner.

## Changes
- Grant `contents: read` alongside `issues: write` in `label-sync.yml`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes
- Parsed `label-sync.yml` with PyYAML
- `git diff --check`
- Manually dispatched Sync labels on this branch: run 30132249045 passed in 8 seconds

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published