### PR TITLE
feat(cli): add CodeNib command aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ IndexCompiler(
 Serve that manifest to any MCP-capable agent:
 
 ```bash
-codeminer-mcp /path/to/repo/.codeminer_cache/repo_manifest.json   # stdio MCP server
+codenib-mcp /path/to/repo/.codeminer_cache/repo_manifest.json   # stdio MCP server
 ```
+
+The compatibility alias `codeminer-mcp` reaches the same implementation.
 
 For the browser UI, start the managed backend and frontend:
 

--- a/codeminer/agent/__init__.py
+++ b/codeminer/agent/__init__.py
@@ -38,6 +38,7 @@ from .route_context import (
 from .runner import (
     AgentRunner,
     CodeMinerAgentOptions,
+    CodeNibAgentOptions,
     compile_repo,
     has_localization_contract,
     query,
@@ -59,6 +60,7 @@ __all__ = [
     "AgentRunner",
     "AGENT_TRACE_SCHEMA_VERSION",
     "AgentHarnessSpec",
+    "CodeNibAgentOptions",
     "CodeMinerAgentOptions",
     "ContextLedger",
     "ContextLedgerEntry",

--- a/codeminer/agent/runner.py
+++ b/codeminer/agent/runner.py
@@ -1472,6 +1472,11 @@ class CodeMinerAgentOptions:
     session_extras: Dict[str, Any] = field(default_factory=dict)
 
 
+# Product-facing spelling; keep the original class object for import, type, and
+# serialized-name compatibility.
+CodeNibAgentOptions = CodeMinerAgentOptions
+
+
 def query(
     prompt: str,
     *,

--- a/codeminer/mcp/server.py
+++ b/codeminer/mcp/server.py
@@ -9,7 +9,7 @@ pre-built CodeNib index via the Model Context Protocol.
 
 Usage::
 
-    codeminer-mcp --manifest /path/to/repo_manifest.json
+    codenib-mcp --manifest /path/to/repo_manifest.json
 
 Or as a module::
 
@@ -369,10 +369,23 @@ def server_status() -> str:
 # CLI entry point
 # ------------------------------------------------------------------
 
+_CLI_NAMES = frozenset({"codenib-mcp", "codeminer-mcp"})
 
-def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+
+def _cli_program_name() -> str:
+    invoked_name = Path(sys.argv[0]).name
+    if invoked_name in _CLI_NAMES:
+        return invoked_name
+    return "codenib-mcp"
+
+
+def _parse_args(
+    argv: list[str] | None = None,
+    *,
+    prog: str | None = None,
+) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        prog="codeminer-mcp",
+        prog=prog or _cli_program_name(),
         description="Start the CodeNib MCP server (stdio transport).",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -417,12 +430,14 @@ def init_server(manifest_path: str | Path) -> None:
 
 
 def main(argv: list[str] | None = None) -> None:
-    """CLI entry point: ``codeminer-mcp <manifest>``."""
+    """CLI entry point shared by ``codenib-mcp`` and ``codeminer-mcp``."""
+    program_name = _cli_program_name()
     args = _parse_args(argv)
     manifest_path = args.manifest_flag or args.manifest
     if not manifest_path:
         logger.error(
-            "No manifest provided. Use: codeminer-mcp <manifest> or --manifest <path>"
+            "No manifest provided. Use: %s <manifest> or --manifest <path>",
+            program_name,
         )
         sys.exit(1)
 

--- a/codeminer/web/app.py
+++ b/codeminer/web/app.py
@@ -11,7 +11,7 @@ Endpoints:
 
 Run with::
 
-    codeminer-web                       # uses demo_repos.yaml
+    codenib-web                         # uses demo_repos.yaml
     uvicorn codeminer.web.app:app       # for autoreload during dev
 """
 
@@ -376,7 +376,7 @@ async def chat(req: ChatRequest) -> ChatResponse:
 
 
 def main() -> None:
-    """Console-script entry point: ``codeminer-web``."""
+    """Console entry point shared by ``codenib-web`` and ``codeminer-web``."""
     import uvicorn
 
     host = os.environ.get("CODEMINER_DEMO_HOST", "127.0.0.1")

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,7 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 # MCP Server
 
 CodeNib ships a [Model Context Protocol](https://modelcontextprotocol.io/) server
-(`codeminer-mcp`) that exposes its search over a **pre-built index** to LLM agents.
+(`codenib-mcp`, with `codeminer-mcp` retained as a compatibility alias) that
+exposes its search over a **pre-built index** to LLM agents.
 It is query-only: build a repository index once, then point the server at the
 resulting manifest.
 
@@ -40,7 +41,7 @@ only that tool returns an error; the others still work.
 ## Run the server
 
 ```bash
-codeminer-mcp /path/to/repo/.codeminer_cache/repo_manifest.json
+codenib-mcp /path/to/repo/.codeminer_cache/repo_manifest.json
 ```
 
 Transport is stdio; logs go to stderr (`--log-level` to adjust).
@@ -60,6 +61,8 @@ Transport is stdio; logs go to stderr (`--log-level` to adjust).
 | `get_manifest` | — | — | repo metadata: path, commit, languages, capabilities |
 
 A `codeminer-guide` prompt returns guidance on choosing between these tools.
+The server ID, prompt ID, and tool/skill IDs retain their existing `codeminer`
+spellings so current MCP clients and recorded traces remain compatible.
 
 See [`codeminer/mcp/README.md`](https://github.com/sysevol-ai/CodeMiner/blob/main/codeminer/mcp/README.md)
 for full parameter and return-shape details.

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -70,10 +70,11 @@ From the repository root (so the relative `data_dir` resolves):
 # autoreload during dev:
 uvicorn codeminer.web.app:app --host 127.0.0.1 --port 8000
 # or the console script:
-codeminer-web                            # honors CODEMINER_DEMO_HOST/PORT
+codenib-web                              # honors CODEMINER_DEMO_HOST/PORT
 ```
 
-The `codeminer-web` console script maps to `codeminer.web.app:main`, which reads
+The `codenib-web` and compatibility `codeminer-web` console scripts both map to
+`codeminer.web.app:main`, which reads
 `CODEMINER_DEMO_HOST` (default `127.0.0.1`) and `CODEMINER_DEMO_PORT` (default
 `8000`). Index loading takes ~20s. Check it is up:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ dependencies = [
 ]
 
 [project.scripts]
+codenib-mcp = "codeminer.mcp.server:main"
+codenib-web = "codeminer.web.app:main"
 codeminer-mcp = "codeminer.mcp.server:main"
 codeminer-web = "codeminer.web.app:main"
 codeminer-lsp-provider-validate = "codeminer.eval.agent_runner.lsp_provider_cli:main"
@@ -70,7 +72,7 @@ dev = [
     "flake8-bugbear>=24.4.0",
     "mkdocs-material>=9.5.0",
 ]
-test = ["pytest>=6.0.0", "pytest-cov>=3.0.0", "pytest-xdist>=3.0.0", "pytest-timeout>=2.1.0", "filelock>=3.0.0"]
+test = ["pytest>=6.0.0", "pytest-cov>=3.0.0", "pytest-xdist>=3.0.0", "pytest-timeout>=2.1.0", "filelock>=3.0.0", "tomli>=1.1.0; python_version < '3.11'"]
 
 [tool.setuptools]
 include-package-data = true

--- a/test/test_cli_aliases.py
+++ b/test/test_cli_aliases.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from importlib.metadata import EntryPoint
+from pathlib import Path
+
+import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+from codeminer.agent import CodeMinerAgentOptions, CodeNibAgentOptions
+from codeminer.mcp.server import _parse_args
+
+
+def _console_scripts() -> dict[str, str]:
+    root = Path(__file__).resolve().parents[1]
+    with (root / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)["project"]["scripts"]
+
+
+@pytest.mark.parametrize(
+    ("legacy_name", "product_name"),
+    (
+        ("codeminer-mcp", "codenib-mcp"),
+        ("codeminer-web", "codenib-web"),
+    ),
+)
+def test_console_aliases_load_identical_implementations(
+    legacy_name: str,
+    product_name: str,
+) -> None:
+    scripts = _console_scripts()
+    legacy = EntryPoint(
+        name=legacy_name,
+        value=scripts[legacy_name],
+        group="console_scripts",
+    ).load()
+    product = EntryPoint(
+        name=product_name,
+        value=scripts[product_name],
+        group="console_scripts",
+    ).load()
+
+    assert product is legacy
+
+
+@pytest.mark.parametrize("program_name", ("codenib-mcp", "codeminer-mcp"))
+def test_mcp_help_uses_invoked_command(
+    program_name: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_args(["--help"], prog=program_name)
+
+    assert exc_info.value.code == 0
+    assert f"usage: {program_name}" in capsys.readouterr().out
+
+
+def test_agent_options_product_alias_preserves_class_identity() -> None:
+    assert CodeNibAgentOptions is CodeMinerAgentOptions


### PR DESCRIPTION
## Summary

Expose CodeNib command and Python spellings without removing or changing any existing CodeMiner compatibility surface. Stacked on #338 and part of #335.

## Changes

- Add `codenib-mcp` and `codenib-web`, both mapped to the existing implementations; retain `codeminer-mcp` and `codeminer-web`.
- Make MCP help/error usage reflect the command actually invoked.
- Export `CodeNibAgentOptions` as the identical class object as `CodeMinerAgentOptions`.
- Keep the FastMCP server ID, prompt ID, tool/skill IDs, package, environment variables, and state paths unchanged.
- Document preferred and compatibility spellings and add entry-point identity tests.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (1686 passed, 10 skipped)
- `python -m mkdocs build --strict`
- `pre-commit run --files <changed files>`
- Isolated editable-install smoke generated all four console scripts; both MCP commands returned branded help and new/old MCP and web entry points loaded identical function objects.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published