### PR TITLE
test(agent): stabilize ripgrep syntax coverage

### DIFF
--- a/test/agent/test_default_tools.py
+++ b/test/agent/test_default_tools.py
@@ -237,7 +237,12 @@ class TestGrep:
 
     @pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep is unavailable")
     def test_ripgrep_syntax_is_not_rejected_by_python(self, sample_dir):
-        result = _grep(r"\p{L}+", path=str(sample_dir), head_limit=1)
+        result = _grep(
+            r"\p{L}+",
+            path=str(sample_dir),
+            glob="*.py",
+            head_limit=1,
+        )
 
         assert not result.startswith("Error:")
         assert ".py:" in result


### PR DESCRIPTION
## Summary

Stabilize the ripgrep-specific regex unit test that failed on the post-merge `main` run for #338. The test previously combined `head_limit=1` with an assertion that the first traversal result had a `.py` suffix, even though its fixture also contains a matching Markdown file.

## Changes

- Restrict the ripgrep Unicode-property query to `*.py`.
- Preserve the intended assertion that ripgrep syntax is accepted rather than rejected by Python regex parsing.
- Remove filesystem traversal order from the expected result.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes
- `pytest -q -n auto test/agent/test_default_tools.py::TestGrep::test_ripgrep_syntax_is_not_rejected_by_python --tb=short`
- Commit hooks, including black, isort, flake8, and the branding guard

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published