### PR TITLE
docs: remove obsolete license transition note

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,5 +165,3 @@ package, import namespace, commands, and repository use `CodeNib`. See
 
 CodeNib is licensed under the
 [Apache License, Version 2.0](https://github.com/sysevol-ai/CodeNib/blob/main/LICENSE).
-Contributions previously made under the MIT License are retained under the
-terms of Section 4 of Apache 2.0.


### PR DESCRIPTION
## Summary

Remove the obsolete MIT-to-Apache transition note from the public README so the license section states only the repository's current Apache-2.0 terms.

## Changes

- Delete the two-line historical license transition statement.
- Leave the canonical Apache-2.0 license link unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

Validated with `pre-commit run --files README.md`, `git diff --check`, and a repository-wide scan for stale MIT transition wording.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published