### PR TITLE
docs(release): finalize v0.1.0 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-26
+
 ### Added
 
 - A unified `codenib` CLI with `index`, `wiki`, `mcp`, and `doctor` commands.
@@ -36,4 +38,5 @@ All notable user-facing changes are recorded here. CodeNib follows
 - Prepared secretless PyPI publishing through a dedicated GitHub Actions OIDC
   workflow.
 
-[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/main...HEAD
+[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/sysevol-ai/CodeNib/releases/tag/v0.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,7 @@ message: "If you use CodeNib in research, please cite this software."
 title: "CodeNib"
 type: software
 version: 0.1.0
+date-released: 2026-07-26
 abstract: >-
   CodeNib compiles repositories into reusable lexical, semantic, and
   structural views and serves source-linked context to coding agents and


### PR DESCRIPTION
## Summary

Finalize the release metadata for the CodeNib v0.1.0 Developer Preview before creating the production tag. This is the final repository-side metadata gate tracked by #346.

## Changes
- Move the accumulated release notes from `Unreleased` into a dated `0.1.0` section.
- Add stable comparison and release links for `v0.1.0`.
- Record the same release date in `CITATION.cff`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

`python -m pytest test/test_release_artifacts.py -q`

`pre-commit run --files CHANGELOG.md CITATION.cff`

`python scripts/check_namespace.py`

A fresh `0.1.0` wheel and sdist also pass `twine check` and `scripts/verify_release_artifacts.py`; clean-wheel CLI/index and installed Wiki/MCP service smokes pass on the parent `main` tree.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
