### PR TITLE
ci(release): split TestPyPI publishing

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: TestPyPI Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-test-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify release artifacts
+    uses: ./.github/workflows/release-verify.yml
+    permissions:
+      contents: read
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: verify
+    runs-on: self-hosted
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/codenib
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Publish distributions
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release verification
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and inspect distributions
+    runs-on: self-hosted
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Test packaged Wiki frontend
+        working-directory: web
+        run: |
+          npm ci
+          npm test
+          npm run build
+
+      - name: Build Python distributions
+        run: |
+          BUILD_VENV="$RUNNER_TEMP/codenib-release-build-${{ github.run_id }}-${{ github.run_attempt }}"
+          python -m venv "$BUILD_VENV"
+          "$BUILD_VENV/bin/python" -m pip install \
+            --upgrade pip build twine
+          "$BUILD_VENV/bin/python" -m build
+          "$BUILD_VENV/bin/python" -m twine check dist/*
+          "$BUILD_VENV/bin/python" \
+            scripts/verify_release_artifacts.py dist
+
+      - name: Validate production release ref
+        if: github.ref_type == 'tag'
+        run: |
+          test "$(git cat-file -t "$GITHUB_REF")" = "tag"
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          python scripts/verify_release_artifacts.py dist --tag "$GITHUB_REF_NAME"
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 14
+
+  install-smoke:
+    name: Install smoke (Python ${{ matrix.python-version }})
+    needs: build
+    runs-on: self-hosted
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+    steps:
+      - name: Checkout smoke harness
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Install wheel
+        run: |
+          SMOKE_VENV="$RUNNER_TEMP/codenib-release-smoke-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          python -m venv "$SMOKE_VENV"
+          echo "$SMOKE_VENV/bin" >> "$GITHUB_PATH"
+          "$SMOKE_VENV/bin/python" -m pip install --upgrade pip
+          "$SMOKE_VENV/bin/python" -m pip install dist/*.whl
+
+      - name: Exercise installed CLI
+        working-directory: ${{ runner.temp }}
+        run: |
+          codenib --version
+          codenib doctor --require core
+          python "$GITHUB_WORKSPACE/scripts/smoke_release_install.py"
+
+  service-smoke:
+    name: Installed Wiki and MCP services
+    needs: build
+    runs-on: self-hosted
+    timeout-minutes: 20
+    steps:
+      - name: Checkout service harness
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Install wheel with MCP support
+        run: |
+          SERVICE_VENV="$RUNNER_TEMP/codenib-release-services-${{ github.run_id }}-${{ github.run_attempt }}"
+          python -m venv "$SERVICE_VENV"
+          echo "$SERVICE_VENV/bin" >> "$GITHUB_PATH"
+          "$SERVICE_VENV/bin/python" -m pip install --upgrade pip
+          WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$WHEEL"
+          "$SERVICE_VENV/bin/python" -m pip install "${WHEEL}[mcp]"
+
+      - name: Verify optional runtime boundary
+        working-directory: ${{ runner.temp }}
+        run: |
+          python - <<'PY'
+          import importlib.util
+
+          unexpected = [
+              name
+              for name in ("faiss", "igraph", "litellm", "sentence_transformers")
+              if importlib.util.find_spec(name) is not None
+          ]
+          if unexpected:
+              raise SystemExit(f"unexpected optional runtimes: {unexpected}")
+
+          import sys
+          import codenib.mcp.server
+
+          eagerly_loaded = [
+              name
+              for name in ("faiss", "igraph", "litellm", "sentence_transformers")
+              if name in sys.modules
+          ]
+          if eagerly_loaded:
+              raise SystemExit(f"optional runtimes loaded eagerly: {eagerly_loaded}")
+          PY
+
+      - name: Exercise installed services
+        working-directory: ${{ runner.temp }}
+        run: python "$GITHUB_WORKSPACE/scripts/smoke_release_services.py"

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -30,8 +30,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: npm
-          cache-dependency-path: web/package-lock.json
 
       - name: Test packaged Wiki frontend
         working-directory: web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/release.yml"
+      - ".github/workflows/release-test.yml"
+      - ".github/workflows/release-verify.yml"
       - "codenib/**"
       - "scripts/smoke_release_install.py"
       - "scripts/smoke_release_services.py"
@@ -29,15 +31,6 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Build only, or publish the verified artifacts to TestPyPI"
-        required: true
-        default: build
-        type: choice
-        options:
-          - build
-          - testpypi
 
 permissions:
   contents: read
@@ -47,205 +40,16 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: Build and inspect distributions
-    runs-on: self-hosted
-    timeout-minutes: 20
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Test packaged Wiki frontend
-        working-directory: web
-        run: |
-          npm ci
-          npm test
-          npm run build
-
-      - name: Build Python distributions
-        run: |
-          BUILD_VENV="$RUNNER_TEMP/codenib-release-build-${{ github.run_id }}-${{ github.run_attempt }}"
-          python -m venv "$BUILD_VENV"
-          "$BUILD_VENV/bin/python" -m pip install \
-            --upgrade pip build twine
-          "$BUILD_VENV/bin/python" -m build
-          "$BUILD_VENV/bin/python" -m twine check dist/*
-          "$BUILD_VENV/bin/python" \
-            scripts/verify_release_artifacts.py dist
-
-      - name: Validate production release ref
-        if: github.ref_type == 'tag'
-        run: |
-          test "$(git cat-file -t "$GITHUB_REF")" = "tag"
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
-          python scripts/verify_release_artifacts.py dist --tag "$GITHUB_REF_NAME"
-
-      - name: Upload distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: |
-            dist/*.whl
-            dist/*.tar.gz
-          if-no-files-found: error
-          retention-days: 14
-
-  install-smoke:
-    name: Install smoke (Python ${{ matrix.python-version }})
-    needs: build
-    runs-on: self-hosted
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14"
-    steps:
-      - name: Checkout smoke harness
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Download distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist
-
-      - name: Install wheel
-        run: |
-          SMOKE_VENV="$RUNNER_TEMP/codenib-release-smoke-${{ matrix.python-version }}-${{ github.run_id }}-${{ github.run_attempt }}"
-          python -m venv "$SMOKE_VENV"
-          echo "$SMOKE_VENV/bin" >> "$GITHUB_PATH"
-          "$SMOKE_VENV/bin/python" -m pip install --upgrade pip
-          "$SMOKE_VENV/bin/python" -m pip install dist/*.whl
-
-      - name: Exercise installed CLI
-        working-directory: ${{ runner.temp }}
-        run: |
-          codenib --version
-          codenib doctor --require core
-          python "$GITHUB_WORKSPACE/scripts/smoke_release_install.py"
-
-  service-smoke:
-    name: Installed Wiki and MCP services
-    needs: build
-    runs-on: self-hosted
-    timeout-minutes: 20
-    steps:
-      - name: Checkout service harness
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Download distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist
-
-      - name: Install wheel with MCP support
-        run: |
-          SERVICE_VENV="$RUNNER_TEMP/codenib-release-services-${{ github.run_id }}-${{ github.run_attempt }}"
-          python -m venv "$SERVICE_VENV"
-          echo "$SERVICE_VENV/bin" >> "$GITHUB_PATH"
-          "$SERVICE_VENV/bin/python" -m pip install --upgrade pip
-          WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          test -n "$WHEEL"
-          "$SERVICE_VENV/bin/python" -m pip install "${WHEEL}[mcp]"
-
-      - name: Verify optional runtime boundary
-        working-directory: ${{ runner.temp }}
-        run: |
-          python - <<'PY'
-          import importlib.util
-
-          unexpected = [
-              name
-              for name in ("faiss", "igraph", "litellm", "sentence_transformers")
-              if importlib.util.find_spec(name) is not None
-          ]
-          if unexpected:
-              raise SystemExit(f"unexpected optional runtimes: {unexpected}")
-
-          import sys
-          import codenib.mcp.server
-
-          eagerly_loaded = [
-              name
-              for name in ("faiss", "igraph", "litellm", "sentence_transformers")
-              if name in sys.modules
-          ]
-          if eagerly_loaded:
-              raise SystemExit(f"optional runtimes loaded eagerly: {eagerly_loaded}")
-          PY
-
-      - name: Exercise installed services
-        working-directory: ${{ runner.temp }}
-        run: python "$GITHUB_WORKSPACE/scripts/smoke_release_services.py"
-
-  publish-testpypi:
-    name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
-    needs:
-      - build
-      - install-smoke
-      - service-smoke
-    runs-on: self-hosted
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/codenib
+  verify:
+    name: Verify release artifacts
+    uses: ./.github/workflows/release-verify.yml
     permissions:
-      id-token: write
-    steps:
-      - name: Download distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist
-
-      - name: Publish distributions
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
+      contents: read
 
   publish-pypi:
     name: Publish to PyPI
     if: github.ref_type == 'tag'
-    needs:
-      - build
-      - install-smoke
-      - service-smoke
+    needs: verify
     runs-on: self-hosted
     environment:
       name: pypi

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # CI/CD
 
-GitHub Actions has five workflows:
+GitHub Actions has seven workflow files:
 
 - `.github/workflows/ci.yml` runs the Python, graph, SCIP, slow, and C++ parity
   test tiers.
@@ -21,9 +21,13 @@ GitHub Actions has five workflows:
   `main` that touch that file or the workflow file itself, or on manual
   dispatch (with an optional `delete_unused` input that removes labels absent
   from `labels.yml`).
-- `.github/workflows/release.yml` builds and verifies distributions, exercises
-  installed CLI, Wiki, and MCP surfaces on supported Python versions, and
-  publishes through trusted PyPI environments. See [Releasing](releasing.md).
+- `.github/workflows/release-verify.yml` is the reusable distribution, Python
+  compatibility, installed CLI, Wiki, and MCP verification pipeline.
+- `.github/workflows/release-test.yml` manually verifies and publishes a
+  candidate through the trusted TestPyPI environment.
+- `.github/workflows/release.yml` invokes the same verification pipeline and
+  publishes version tags through the trusted production PyPI environment
+  before creating a GitHub Release. See [Releasing](releasing.md).
 
 ## Triggers
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,36 +12,37 @@ installed distribution metadata generated from it.
 
 ## Automated Gates
 
-The Release workflow runs for packaging changes, `main`, manual dispatches, and
-version tags. It:
+The reusable Release verification workflow runs from both publishing
+workflows. It:
 
 1. Tests and production-builds the packaged Wiki frontend.
 2. Builds one sdist and one universal wheel.
 3. Runs `twine check` and validates package contents and metadata.
 4. Installs the wheel on every supported Python minor version.
 5. Builds a real BM25 index through the installed `codenib` command.
+6. Exercises the installed Wiki and MCP services end to end.
 
-A manual run with target `testpypi` publishes only to TestPyPI. Production
-publishing has no manual input: it requires a `v<version>` tag that exactly
-matches `project.version`.
+Manually dispatching the TestPyPI Release workflow from `main` runs these gates
+and then publishes to TestPyPI. Production publishing remains in the separate
+Release workflow and requires a `v<version>` tag that exactly matches
+`project.version`.
 
 ## Trusted Publisher Setup
 
 For the first release, create a pending publisher on both the
 [PyPI](https://pypi.org/manage/account/publishing/) and
 [TestPyPI](https://test.pypi.org/manage/account/publishing/) account pages.
-Use the same GitHub identity fields on both indexes:
+Register these publisher identities:
 
-| Field | Value |
-|---|---|
-| Project | `codenib` |
-| Owner | `sysevol-ai` |
-| Repository | `CodeNib` |
-| Workflow | `release.yml` |
+| Registry | Project | Owner | Repository | Workflow | Environment |
+|---|---|---|---|---|---|
+| TestPyPI | `codenib` | `sysevol-ai` | `CodeNib` | `release-test.yml` | `testpypi` |
+| PyPI | `codenib` | `sysevol-ai` | `CodeNib` | `release.yml` | `pypi` |
 
-Set the environment to `pypi` for PyPI and `testpypi` for TestPyPI. These
-values must match exactly; an unregistered or mismatched publisher fails the
-OIDC exchange with `invalid-publisher`.
+These values must match exactly; an unregistered or mismatched publisher fails
+the OIDC exchange with `invalid-publisher`. Do not register the reusable
+`release-verify.yml` workflow as a publisher: it never receives an OIDC token
+or uploads a distribution.
 
 PyPI and TestPyPI are separate registries: configuring one does not configure
 the other. A GitHub `pypi` or `testpypi` deployment environment scopes the
@@ -50,8 +51,8 @@ that each pending publisher appears on the corresponding registry account page
 before dispatching a publish workflow.
 
 The corresponding GitHub environments should restrict deployments to trusted
-maintainers. The workflow receives `id-token: write` only in publishing jobs;
-no long-lived PyPI token is stored in GitHub.
+maintainers. Each publishing workflow receives `id-token: write` only in its
+publishing job; no long-lived PyPI token or runner-local `.pypirc` is used.
 
 ## Public Surface Gate
 
@@ -76,8 +77,8 @@ on PyPI.
 2. Confirm `CITATION.cff` and `pyproject.toml` use the release version.
 3. Run `pre-commit run --all-files` and the local package smoke.
 4. Merge the release commit to `main` and confirm its package gates pass.
-5. Confirm the TestPyPI pending publisher is visible, then dispatch the Release
-   workflow from `main` with target `testpypi`.
+5. Confirm the TestPyPI pending publisher is visible, then dispatch the
+   TestPyPI Release workflow from `main`.
 6. Install and test the TestPyPI artifact in a clean environment.
 7. Complete the public-surface gate above.
 8. Confirm the PyPI pending publisher is visible.

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.verify_release_artifacts import (
     ReleaseValidationError,
@@ -28,3 +29,41 @@ def test_project_identity_and_tag_match_release_metadata() -> None:
 def test_release_tag_must_match_project_version() -> None:
     with pytest.raises(ReleaseValidationError, match="does not match"):
         validate_tag("v0.2.0", "0.1.0")
+
+
+def test_registry_publishers_use_separate_workflows() -> None:
+    workflows = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+    def load(name: str) -> dict[str, object]:
+        with (workflows / name).open(encoding="utf-8") as handle:
+            return yaml.load(handle, Loader=yaml.BaseLoader)
+
+    production = load("release.yml")
+    test = load("release-test.yml")
+    verification = load("release-verify.yml")
+
+    verification_job = {
+        "name": "Verify release artifacts",
+        "uses": "./.github/workflows/release-verify.yml",
+        "permissions": {"contents": "read"},
+    }
+    assert production["jobs"]["verify"] == verification_job
+    assert test["jobs"]["verify"] == verification_job
+
+    assert set(production["jobs"]) == {
+        "verify",
+        "publish-pypi",
+        "github-release",
+    }
+    assert production["jobs"]["publish-pypi"]["environment"]["name"] == "pypi"
+
+    assert set(test["jobs"]) == {"verify", "publish-testpypi"}
+    test_publisher = test["jobs"]["publish-testpypi"]
+    assert test_publisher["environment"]["name"] == "testpypi"
+    assert (
+        test_publisher["steps"][-1]["with"]["repository-url"]
+        == "https://test.pypi.org/legacy/"
+    )
+
+    assert set(verification["on"]) == {"workflow_call"}
+    assert not any(name.startswith("publish-") for name in verification["jobs"])


### PR DESCRIPTION
## Summary
Separate TestPyPI and production publishing identities while preserving one verified release artifact pipeline.

## Changes
- add `release-test.yml` as the TestPyPI trusted-publisher entry point
- retain `release.yml` for tag-driven PyPI and GitHub releases
- extract build, Python compatibility, Wiki, and MCP checks into `release-verify.yml`
- document exact publisher identities and remove the ineffective 43 GB setup-python cache upload
- add a contract test that prevents publishing responsibilities from drifting across workflows

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`actionlint .github/workflows/release.yml .github/workflows/release-test.yml .github/workflows/release-verify.yml`

`python -m pytest test/test_release_artifacts.py -q`

`pre-commit run --files .github/workflows/release.yml .github/workflows/release-test.yml .github/workflows/release-verify.yml docs/ci_cd.md docs/releasing.md test/test_release_artifacts.py`

`python -m mkdocs build --strict`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published