### PR TITLE
feat(agent): force a final answer for interactive Ask

### DIFF
--- a/codenib/agent/runner.py
+++ b/codenib/agent/runner.py
@@ -154,6 +154,7 @@ class AgentRunner:
         default_tool_ids: Optional[Set[str]] = None,
         retry: Optional[RetryConfig] = None,
         force_localization_contract: bool = False,
+        force_final_answer: bool = False,
         first_turn_tool_choice: Optional[str] = None,
         force_first_turn_only: bool = False,
         compact_after_read: bool = False,
@@ -224,6 +225,12 @@ class AgentRunner:
         # Locations: contract; QA callers (web demo) keep prose, so they turn
         # this off and skip the schema-forcing final turn entirely.
         self._force_contract = force_localization_contract
+        # Chat callers (the web demo) want a usable prose answer even when the
+        # exploration budget runs out: one extra tool-free turn asks the model
+        # to commit to an answer from what it already read. Opt-in so eval
+        # behaviour is untouched; an empty forced answer raises instead of
+        # silently returning mid-exploration chatter.
+        self._final_answer = force_final_answer
         self.first_turn_tool_choice = first_turn_tool_choice
         # When True, only turn 0 is forced (legacy single-turn behaviour);
         # default False = force until the agent reads a file.
@@ -842,6 +849,21 @@ limited tool budget, so converge once the implementing location is confirmed.
                 or last_content
             )
             answer_source = "forced_schema"
+        elif self._final_answer:
+            trace.add(
+                "final_answer_forced",
+                max_turns,
+                reason="max_turns_exhausted",
+            )
+            last_content = self._force_final_answer(
+                history, usage_tracker, max_turns + 1
+            )
+            if not last_content.strip():
+                raise RuntimeError(
+                    f"agent exhausted max_turns={max_turns} without producing "
+                    "a final answer"
+                )
+            answer_source = "forced_answer"
 
         return _finish_result(
             answer=last_content,
@@ -1028,6 +1050,38 @@ limited tool budget, so converge once the implementing location is confirmed.
             ):
                 break
         return out
+
+    def _force_final_answer(self, history, usage_tracker, usage_turn: int) -> str:
+        """One tool-free turn that turns an exhausted exploration into an answer.
+
+        The chat path has no schema to force; the model just needs to stop
+        searching and commit to prose grounded in what it already read.
+        Anthropic rejects a tool-history conversation unless ``tools=`` is
+        passed, so pass it with ``tool_choice="none"`` to forbid further
+        calls. Errors propagate to the caller — the serving layer surfaces
+        them instead of shipping a truncated answer.
+        """
+        history.add_message(
+            {
+                "role": "user",
+                "content": (
+                    "Stop searching. Using what you have already read, give "
+                    "your complete final answer now, citing the relevant "
+                    "files and symbols."
+                ),
+            }
+        )
+        overrides: Dict[str, Any] = {
+            "usage_tracker": usage_tracker,
+            "usage_turn": usage_turn,
+        }
+        if self.tools:
+            overrides["tools"] = self.tools
+            overrides["tool_choice"] = "none"
+        final = self.llm._call_raw(history.get_messages(), **overrides)
+        forced_msg = final.choices[0].message
+        history.add_message(_message_to_dict(forced_msg))
+        return getattr(forced_msg, "content", None) or ""
 
     def _new_history(self):
         """Build the chat-history container for one ``run()``.

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -458,6 +458,9 @@ class RepoRegistry:
             # Keep prose answers: the Files:/Symbols:/Locations: schema turn is
             # for the localization eval and would replace the explanation.
             force_localization_contract=False,
+            # A capped exploration should still end in a usable answer (one
+            # extra tool-free turn) instead of mid-search chatter.
+            force_final_answer=True,
         )
         bundle.runner = runner
 

--- a/test/agent/test_runner.py
+++ b/test/agent/test_runner.py
@@ -231,6 +231,54 @@ class TestAgentRunner:
         # 3 loop turns + 1 forced summary turn.
         assert llm._call_raw.call_count == 4
 
+    def test_force_final_answer_on_max_turns(self, echo_registry):
+        """Chat opt-in: exhausted budget ends in one tool-free prose turn."""
+        llm = _make_llm()
+        tc = _make_tool_call("call_x", "echo", '{"text": "loop"}')
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(tool_calls=[tc]),
+            _make_response(content="Grounded final answer."),
+        ]
+
+        runner = AgentRunner(llm, echo_registry, max_turns=2, force_final_answer=True)
+        result = runner.run("loop forever")
+
+        assert result.answer == "Grounded final answer."
+        assert llm._call_raw.call_count == 3
+        forced_kwargs = llm._call_raw.call_args.kwargs
+        assert forced_kwargs.get("tool_choice") == "none"
+        assert forced_kwargs.get("usage_turn") == 3
+
+    def test_force_final_answer_empty_result_raises(self, echo_registry):
+        """An empty forced answer is an error, not a silent fallback."""
+        llm = _make_llm()
+        tc = _make_tool_call("call_x", "echo", '{"text": "loop"}')
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(tool_calls=[tc]),
+            _make_response(content=None),
+        ]
+
+        runner = AgentRunner(llm, echo_registry, max_turns=2, force_final_answer=True)
+        with pytest.raises(RuntimeError, match="max_turns"):
+            runner.run("loop forever")
+
+    def test_force_final_answer_leaves_normal_termination_alone(self, echo_registry):
+        """A run that ends in prose on its own never gets an extra turn."""
+        llm = _make_llm()
+        tc = _make_tool_call("call_1", "echo", '{"text": "hello"}')
+        llm._call_raw.side_effect = [
+            _make_response(tool_calls=[tc]),
+            _make_response(content="Done."),
+        ]
+
+        runner = AgentRunner(llm, echo_registry, max_turns=5, force_final_answer=True)
+        result = runner.run("test")
+
+        assert result.answer == "Done."
+        assert llm._call_raw.call_count == 2
+
     def test_unknown_skill_returns_error(self):
         """Tool call for unregistered skill records an error."""
         llm = _make_llm()


### PR DESCRIPTION
## Summary

Ensures the interactive Ask path returns a usable prose answer when its bounded exploration budget is exhausted. The behavior is opt-in, so localization evaluation and other agent callers retain their current termination semantics.

## Changes

- `codenib/agent/runner.py`: add an opt-in `force_final_answer` policy that performs one tool-free answer turn after `max_turns` exhaustion, records the extra usage turn, and rejects an empty result
- `codenib/web/repo_registry.py`: enable the policy for the repository Ask runner
- `test/agent/test_runner.py`: cover exhausted exploration, empty forced output, and normal termination
- keep provider-specific request options out of this PR; backend capabilities will be configured explicitly rather than inferred from model-name substrings

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest test/agent/test_runner.py test/web/test_repo_registry.py -q --tb=short` - 40 passed
- unit tier - 1806 passed, 10 skipped, 170 deselected
- changed-file pre-commit hooks passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published