### PR TITLE
ci: deploy the demo from main

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy the live demo (demo.codenib.ai + codenib.ai landing) whenever main
+# changes something it serves. The SSH key is command-restricted on the
+# serving box: it can only run scripts/serve/deploy_demo.sh, and the command
+# sent here merely selects the deploy mode.
+name: Deploy demo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "codenib/**"
+      - "web/**"
+      - "landing/**"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "qa_config.yaml"
+      - "scripts/serve/**"
+      - ".github/workflows/deploy-demo.yml"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Deploy mode
+        type: choice
+        options: [normal, force, dry]
+        default: normal
+
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Deploy over SSH
+        env:
+          SSH_KEY: ${{ secrets.DEMO_DEPLOY_SSH_KEY }}
+          SSH_HOST: ${{ secrets.DEMO_DEPLOY_SSH_HOST }}
+          SSH_USER: ${{ secrets.DEMO_DEPLOY_SSH_USER }}
+          MODE: ${{ inputs.mode || 'normal' }}
+        run: |
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes \
+            "$SSH_USER@$SSH_HOST" "$MODE"

--- a/scripts/serve/deploy_demo.sh
+++ b/scripts/serve/deploy_demo.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy the newest main to the CodeNib demo box (backend, frontend, landing).
+#
+# Run ON the serving box:   bash "$HOME/CodeNib/scripts/serve/deploy_demo.sh" [mode]
+# CI runs it through a command-restricted SSH key; the mode arrives as the
+# SSH command. Server-local settings come from ~/.codenib-demo.env.
+#
+# Modes:
+#   normal (default)  fast-forward to origin/main, rebuild + restart what changed
+#   force             rebuild + restart everything regardless of the diff
+#   dry               fetch and report what a normal run would do; change nothing
+set -euo pipefail
+
+MODE="${1:-normal}"
+case "$MODE" in
+  normal|force|dry) ;;
+  *) echo "usage: deploy_demo.sh [normal|force|dry]" >&2; exit 2 ;;
+esac
+
+source "$HOME/.codenib-demo.env"
+cd "$CODENIB_REPO"
+
+# Tracked modifications block a deploy (they would conflict with the pull);
+# untracked files are fine — the box keeps a few local artifacts around.
+if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+  echo "deploy aborted: working tree has local changes:" >&2
+  git status --short --untracked-files=no >&2
+  echo "land them upstream or discard them, then rerun." >&2
+  exit 1
+fi
+
+BEFORE=$(git rev-parse HEAD)
+git fetch -q origin main
+AFTER=$(git rev-parse origin/main)
+CHANGED=$(git diff --name-only "$BEFORE" "$AFTER")
+
+if [[ "$BEFORE" == "$AFTER" && "$MODE" == "normal" ]]; then
+  echo "already up to date (main @ ${BEFORE:0:9})"
+  exit 0
+fi
+
+need() {
+  [[ "$MODE" == "force" ]] && return 0
+  grep -qE "$1" <<<"$CHANGED"
+}
+
+echo "deploying ${BEFORE:0:9} -> ${AFTER:0:9} (mode: $MODE)"
+if [[ "$MODE" == "dry" ]]; then
+  need '^landing/' && echo "would sync: landing"
+  need '^(docs/|mkdocs\.yml)' && echo "would rebuild: docs site"
+  need '^pyproject\.toml' && echo "would reinstall: python package"
+  need '^web/' && echo "would rebuild + restart: frontend"
+  need '^(codenib/|qa_config\.yaml|scripts/serve/run_backend\.sh)' \
+    && echo "would restart: backend"
+  exit 0
+fi
+
+git merge -q --ff-only "$AFTER"
+
+if need '^landing/'; then
+  rsync -a --delete "$CODENIB_REPO/landing/" "$CODENIB_LANDING_DIR/"
+  echo "landing synced to $CODENIB_LANDING_DIR"
+fi
+
+if need '^(docs/|mkdocs\.yml)'; then
+  "$CODENIB_MKDOCS_VENV/bin/python" -m mkdocs build --strict \
+    -d "$CODENIB_DOCS_SITE_DIR"
+  echo "docs site rebuilt at $CODENIB_DOCS_SITE_DIR"
+fi
+
+if need '^pyproject\.toml'; then
+  "$CODENIB_VENV/bin/pip" install -q -e .
+  echo "python package reinstalled"
+fi
+
+FRONTEND=0
+if need '^web/'; then
+  FRONTEND=1
+  export NVM_DIR="$HOME/.nvm"
+  . "$NVM_DIR/nvm.sh"
+  nvm use --lts >/dev/null
+  cd web
+  if need '^web/package(-lock)?\.json'; then
+    npm ci --no-audit --no-fund
+  fi
+  npm run build
+  cd ..
+fi
+
+# Kill whatever still listens on a port (covers sessions from older setups).
+free_port() {
+  local pid
+  pid=$(ss -tlnp 2>/dev/null | awk -v p=":$1\$" '$4 ~ p' \
+    | grep -oE 'pid=[0-9]+' | head -1 | cut -d= -f2)
+  if [[ -n "${pid:-}" ]]; then
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+  fi
+}
+
+restart() { # restart <tmux-session> <run-script> <port>
+  tmux kill-session -t "$1" 2>/dev/null || true
+  free_port "$3"
+  tmux new-session -d -s "$1" "bash $CODENIB_REPO/scripts/serve/$2"
+}
+
+if need '^(codenib/|qa_config\.yaml|scripts/serve/run_backend\.sh)'; then
+  restart nib-backend run_backend.sh 8000
+  echo -n "waiting for backend (index load takes a while)"
+  ok=0
+  for _ in $(seq 1 120); do
+    if curl -sf http://127.0.0.1:8000/api/health >/dev/null 2>&1; then
+      ok=1
+      break
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo
+  if [[ $ok -ne 1 ]]; then
+    echo "backend failed to become healthy; see ~/nib-backend.log" >&2
+    exit 1
+  fi
+fi
+
+if [[ $FRONTEND -eq 1 ]]; then
+  restart nib-frontend run_frontend.sh 3000
+  sleep 6
+fi
+
+fail=0
+check() { # check <name> <url>
+  local code
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "$2" || echo 000)
+  echo "$1: $code"
+  [[ "$code" == "200" ]] || fail=1
+}
+check backend http://127.0.0.1:8000/api/health
+check frontend http://127.0.0.1:3000/
+check docs http://127.0.0.1:7880/
+check demo https://demo.codenib.ai/
+check landing https://codenib.ai/
+exit $fail

--- a/scripts/serve/run_backend.sh
+++ b/scripts/serve/run_backend.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run the CodeNib demo backend (FastAPI) on the serving box. Server-local
+# settings (paths, project ids, config file) come from ~/.codenib-demo.env,
+# which is never committed. Normally started inside tmux by deploy_demo.sh.
+set -euo pipefail
+
+source "$HOME/.codenib-demo.env"
+source "$CODENIB_VENV/bin/activate"
+cd "$CODENIB_REPO"
+python -m codenib.web.app 2>&1 | tee "$HOME/nib-backend.log"

--- a/scripts/serve/run_frontend.sh
+++ b/scripts/serve/run_frontend.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run the CodeNib demo frontend (Next.js production server) on the serving
+# box. Assumes deploy_demo.sh already ran `npm run build`. Server-local
+# settings come from ~/.codenib-demo.env. Normally started inside tmux.
+set -euo pipefail
+
+source "$HOME/.codenib-demo.env"
+export NVM_DIR="$HOME/.nvm"
+. "$NVM_DIR/nvm.sh"
+nvm use --lts >/dev/null
+cd "$CODENIB_REPO/web"
+npm run start -- -H 127.0.0.1 -p 3000 2>&1 | tee "$HOME/nib-frontend.log"


### PR DESCRIPTION
## Summary
GitHub Action that deploys the live demo (demo.codenib.ai and the codenib.ai landing) whenever `main` changes something it serves. Companion to #353; together they let the demo track `main` instead of a hand-patched serving branch.

## Changes
- `.github/workflows/deploy-demo.yml`: on push to `main` touching `codenib/**`, `web/**`, `landing/**`, `qa_config.yaml`, or `scripts/serve/**` (plus `workflow_dispatch` with normal/force/dry modes), SSH to the serving box with a command-restricted key and run the deploy script; single-flight via a concurrency group
- `scripts/serve/deploy_demo.sh`: fast-forwards the box to `origin/main`, then acts only on what the diff touches — syncs `landing/` to the static site, reinstalls the package on `pyproject.toml` changes, `npm ci`/`next build` on `web/` changes, restarts the tmux services (freeing ports held by older sessions), waits for backend health, and exits nonzero unless local ports and both public hostnames return 200 (so the Action goes red on a bad deploy)
- `scripts/serve/run_backend.sh` / `run_frontend.sh`: the service entrypoints tmux runs; all host-specific paths and credentials live in `~/.codenib-demo.env` on the box, never in the repo
- Repo secrets used: `DEMO_DEPLOY_SSH_KEY` / `DEMO_DEPLOY_SSH_HOST` / `DEMO_DEPLOY_SSH_USER`; the key's `authorized_keys` entry forces `deploy_demo.sh`, so it cannot run anything else

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [ ] Tests pass locally
- [ ] Added new tests for the changes
- Static assets / ops scripts only; no library code paths
- The full SSH path was exercised against the serving box exactly as the Action will run it (command-restricted key, dry and force modes); results in the PR discussion

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published