### PR TITLE
feat(llm): configure LiteLLM backends explicitly

### DIFF
--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -240,12 +240,50 @@ def _run_mcp(args: argparse.Namespace) -> int:
     return 0
 
 
+def _model_options_for_args(
+    args: argparse.Namespace,
+    *,
+    include_wiki_environment: bool = False,
+) -> dict[str, object]:
+    """Resolve provider options from environment and repeatable CLI flags."""
+
+    from .llm.options import (
+        merge_model_options,
+        parse_model_option_assignments,
+        parse_model_options_json,
+    )
+
+    try:
+        environment = parse_model_options_json(
+            os.environ.get("CODENIB_DEMO_MODEL_OPTIONS"),
+            source="CODENIB_DEMO_MODEL_OPTIONS",
+        )
+        wiki_environment = {}
+        if include_wiki_environment:
+            wiki_environment = parse_model_options_json(
+                os.environ.get("CODENIB_DEMO_WIKI_MODEL_OPTIONS"),
+                source="CODENIB_DEMO_WIKI_MODEL_OPTIONS",
+            )
+        command_line = parse_model_option_assignments(
+            getattr(args, "model_option", None)
+        )
+        return merge_model_options(environment, wiki_environment, command_line)
+    except ValueError as exc:
+        raise CLIError(str(exc)) from exc
+
+
 def _run_wiki(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
     languages = _selected_languages(repo_path, args.language)
     views = _selected_views(args.preset, args.view)
     _check_view_dependencies(views)
-    if args.agent_wiki or args.model or args.api_base or args.api_key_env:
+    if (
+        args.agent_wiki
+        or args.model
+        or args.api_base
+        or args.api_key_env
+        or args.model_option
+    ):
         _require_modules(
             ("litellm",),
             extra="agent",
@@ -284,6 +322,7 @@ def _run_wiki(args: argparse.Namespace) -> int:
         model=args.model,
         api_base=args.api_base,
         api_key_env=args.api_key_env,
+        model_options=_model_options_for_args(args),
     )
     try:
         return launch_local_wiki(
@@ -368,6 +407,13 @@ def _doctor_model_config(
         )
     if not _check_module("litellm"):
         return ("Model configuration", False, f"{model}; LiteLLM is missing")
+    options = _model_options_for_args(
+        args,
+        include_wiki_environment=(
+            not getattr(args, "model", None)
+            and bool(os.environ.get("CODENIB_DEMO_WIKI_MODEL"))
+        ),
+    )
     try:
         from .llm import litellm_chat
 
@@ -383,6 +429,19 @@ def _doctor_model_config(
     ok = bool(result.get("keys_in_environment")) and not missing
     endpoint = f"; endpoint={api_base}" if api_base else ""
     detail = f"{model}{endpoint}"
+    try:
+        _resolved_model, provider, _dynamic_key, _dynamic_base = (
+            litellm_chat.litellm.get_llm_provider(
+                model=model,
+                api_base=api_base,
+                api_key=api_key,
+            )
+        )
+        detail += f"; provider={provider}"
+    except Exception:  # provider discovery is advisory for custom gateways
+        detail += "; provider=unresolved"
+    if options:
+        detail += "; options=" + ",".join(sorted(options))
     if missing:
         detail += "; missing " + ", ".join(str(key) for key in missing)
     return ("Model configuration", ok, detail)
@@ -539,6 +598,13 @@ def _probe_doctor_model(args: argparse.Namespace) -> tuple[bool, str]:
         else os.environ.get("CODENIB_DEMO_WIKI_API_KEY")
         or os.environ.get("CODENIB_DEMO_API_KEY")
     )
+    options = _model_options_for_args(
+        args,
+        include_wiki_environment=(
+            not getattr(args, "model", None)
+            and bool(os.environ.get("CODENIB_DEMO_WIKI_MODEL"))
+        ),
+    )
     try:
         from .llm.litellm_chat import LiteLLMChat, RetryConfig
 
@@ -548,6 +614,7 @@ def _probe_doctor_model(args: argparse.Namespace) -> tuple[bool, str]:
             max_tokens=8,
             api_base=api_base,
             api_key=api_key,
+            extra_kwargs=options,
             retry=RetryConfig(max_retries=0),
         ).complete(
             [{"role": "user", "content": "Reply with OK."}],
@@ -649,6 +716,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--api-key-env",
         help="name of the environment variable containing the model API key",
     )
+    wiki_parser.add_argument(
+        "--model-option",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "provider-specific LiteLLM option; repeat as needed and use dotted "
+            "keys for nested values"
+        ),
+    )
     wiki_parser.add_argument("--host", default="127.0.0.1")
     wiki_parser.add_argument("--port", type=int, default=3000)
     wiki_parser.add_argument("--api-host", default="127.0.0.1")
@@ -705,6 +782,15 @@ def build_parser() -> argparse.ArgumentParser:
     doctor_parser.add_argument(
         "--api-key-env",
         help="name of the environment variable containing the model API key",
+    )
+    doctor_parser.add_argument(
+        "--model-option",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "provider-specific LiteLLM option to validate or probe; repeat as " "needed"
+        ),
     )
     doctor_parser.add_argument(
         "--probe-model",

--- a/codenib/llm/__init__.py
+++ b/codenib/llm/__init__.py
@@ -4,14 +4,12 @@
 
 """LLM module for CodeNib."""
 
-from .litellm_chat import (
-    ChatMessage,
-    LiteLLMChat,
-    RetryConfig,
-    human_message,
-    is_transient_error,
-    system_message,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .litellm_chat import ChatMessage, LiteLLMChat, RetryConfig
 
 __all__ = [
     "ChatMessage",
@@ -21,3 +19,15 @@ __all__ = [
     "is_transient_error",
     "system_message",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Load the optional LiteLLM runtime only when an LLM symbol is requested."""
+
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from . import litellm_chat
+
+    value = getattr(litellm_chat, name)
+    globals()[name] = value
+    return value

--- a/codenib/llm/litellm_chat.py
+++ b/codenib/llm/litellm_chat.py
@@ -43,6 +43,7 @@ with warnings.catch_warnings():
 from pydantic import BaseModel
 
 from ..log_utils import get_logger
+from .options import validate_model_options
 
 logger = get_logger(__name__)
 
@@ -247,6 +248,12 @@ class LiteLLMChat:
     extra_kwargs: Dict[str, Any] = field(default_factory=dict)
     retry: RetryConfig = field(default_factory=RetryConfig)
 
+    def __post_init__(self) -> None:
+        self.extra_kwargs = validate_model_options(
+            self.extra_kwargs,
+            source="LiteLLMChat.extra_kwargs",
+        )
+
     def invoke(self, messages: List[ChatMessage]) -> str:
         """Send messages and return the assistant content string."""
         response = self._call(messages)
@@ -269,9 +276,9 @@ class LiteLLMChat:
         payload = {
             "model": self.model,
             "api_base": self.api_base or "",
-            "extra_keys": sorted(self.extra_kwargs),
+            "extra_kwargs": self.extra_kwargs,
         }
-        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
         return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:20]
 
     def with_structured_output(self, schema: Type[BaseModel]) -> _StructuredLLM:

--- a/codenib/llm/options.py
+++ b/codenib/llm/options.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validated LiteLLM request options shared by CLI and web runtimes."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+_RESERVED_OPTIONS = frozenset(
+    {
+        "api_base",
+        "api_key",
+        "max_tokens",
+        "messages",
+        "model",
+        "stream",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "usage_tracker",
+        "usage_turn",
+    }
+)
+
+
+def _copy_mapping(value: Mapping[str, Any], *, source: str) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError(f"{source} must use non-empty string keys")
+        result[key.strip()] = (
+            _copy_mapping(item, source=source) if isinstance(item, Mapping) else item
+        )
+    return result
+
+
+def validate_model_options(
+    value: Mapping[str, Any] | None,
+    *,
+    source: str = "model options",
+) -> dict[str, Any]:
+    """Copy and validate provider-specific LiteLLM completion options."""
+
+    if value is not None and not isinstance(value, Mapping):
+        raise ValueError(f"{source} must be a mapping")
+    options = _copy_mapping(value or {}, source=source)
+    reserved = sorted(_RESERVED_OPTIONS.intersection(options))
+    if reserved:
+        raise ValueError(
+            f"{source} cannot override managed option(s): {', '.join(reserved)}"
+        )
+    try:
+        json.dumps(options, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{source} must contain JSON-compatible values") from exc
+    return options
+
+
+def parse_model_options_json(
+    value: str | None,
+    *,
+    source: str,
+) -> dict[str, Any]:
+    """Parse one JSON object containing provider-specific LiteLLM options."""
+
+    if not value:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{source} must be a JSON object: {exc.msg}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{source} must be a JSON object")
+    return validate_model_options(parsed, source=source)
+
+
+def merge_model_options(*values: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Deep-merge validated option mappings from lowest to highest precedence."""
+
+    def merge_nested(
+        base: dict[str, Any],
+        overlay: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        for key, item in overlay.items():
+            if isinstance(item, Mapping) and isinstance(base.get(key), dict):
+                merge_nested(base[key], item)
+            else:
+                base[key] = (
+                    _copy_mapping(item, source="model options")
+                    if isinstance(item, Mapping)
+                    else item
+                )
+        return base
+
+    merged: dict[str, Any] = {}
+    for value in values:
+        merge_nested(merged, validate_model_options(value))
+    return validate_model_options(merged)
+
+
+def parse_model_option_assignments(values: Iterable[str] | None) -> dict[str, Any]:
+    """Parse repeatable ``KEY=JSON`` CLI values, including dotted nested keys."""
+
+    result: dict[str, Any] = {}
+    for assignment in values or ():
+        key, separator, raw = assignment.partition("=")
+        path = [part.strip() for part in key.split(".") if part.strip()]
+        if not separator or not path:
+            raise ValueError(f"model option must use KEY=VALUE syntax: {assignment!r}")
+        try:
+            parsed: Any = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = raw
+
+        cursor = result
+        for part in path[:-1]:
+            existing = cursor.get(part)
+            if existing is None:
+                existing = {}
+                cursor[part] = existing
+            if not isinstance(existing, dict):
+                raise ValueError(
+                    f"model option path conflicts with an existing value: {key!r}"
+                )
+            cursor = existing
+        cursor[path[-1]] = parsed
+    return validate_model_options(result, source="--model-option")
+
+
+__all__ = [
+    "merge_model_options",
+    "parse_model_option_assignments",
+    "parse_model_options_json",
+    "validate_model_options",
+]

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -51,6 +51,7 @@ def _wiki_llm(config, *, model=None, max_tokens=4096):
         max_tokens=max_tokens,
         api_base=getattr(config, "wiki_generation_api_base", None),
         api_key=getattr(config, "wiki_generation_api_key", None),
+        extra_kwargs=getattr(config, "wiki_generation_options", {}),
     )
 
 
@@ -62,6 +63,7 @@ def _wiki_narrator(config):
         enabled=None if config.wiki_agent else False,
         api_base=getattr(config, "wiki_generation_api_base", None),
         api_key=getattr(config, "wiki_generation_api_key", None),
+        model_options=getattr(config, "wiki_generation_options", {}),
     )
 
 

--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -17,10 +17,15 @@ import json
 import os
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 
+from ..llm.options import (
+    merge_model_options,
+    parse_model_options_json,
+    validate_model_options,
+)
 from ..paths import QA_DATA_DIRNAME, REPO_INDEX_DIRNAME
 
 DEFAULT_CONFIG_PATH = "qa_config.yaml"
@@ -60,6 +65,12 @@ class QAConfig:
     # models (for example Vertex or Anthropic) normally leave these unset.
     model_api_base: Optional[str] = None
     model_api_key: Optional[str] = field(default=None, repr=False)
+    # Provider-specific LiteLLM completion options. Core fields such as model,
+    # endpoint, credentials, token budget, and tools remain managed separately.
+    model_options: Dict[str, Any] = field(default_factory=dict)
+    # Wiki generation inherits ``model_options`` and may override individual
+    # values (including nested ``extra_body`` fields).
+    wiki_model_options: Dict[str, Any] = field(default_factory=dict)
     # "sparse" (BM25 only) or "hybrid" (BM25 + vector embeddings).
     mode: str = "sparse"
     embedding_model: str = "BAAI/bge-small-en-v1.5"
@@ -114,6 +125,16 @@ class QAConfig:
     )
     per_language: int = 1
 
+    def __post_init__(self) -> None:
+        self.model_options = validate_model_options(
+            self.model_options,
+            source="model_options",
+        )
+        self.wiki_model_options = validate_model_options(
+            self.wiki_model_options,
+            source="wiki_model_options",
+        )
+
     def index_types(self) -> List[str]:
         return ["bm25", "vector"] if self.mode == "hybrid" else ["bm25"]
 
@@ -141,6 +162,12 @@ class QAConfig:
 
         return self.wiki_api_key or self.model_api_key
 
+    @property
+    def wiki_generation_options(self) -> Dict[str, Any]:
+        """Provider options for Wiki calls, layered over the Ask defaults."""
+
+        return merge_model_options(self.model_options, self.wiki_model_options)
+
 
 def load_config(path: Optional[str] = None) -> QAConfig:
     """Load demo config from YAML, applying env overrides."""
@@ -158,6 +185,14 @@ def load_config(path: Optional[str] = None) -> QAConfig:
         wiki_api_key=data.get("wiki_api_key"),
         model_api_base=data.get("model_api_base"),
         model_api_key=data.get("model_api_key"),
+        model_options=validate_model_options(
+            data.get("model_options"),
+            source="model_options",
+        ),
+        wiki_model_options=validate_model_options(
+            data.get("wiki_model_options"),
+            source="wiki_model_options",
+        ),
         mode=data.get("mode", defaults.mode),
         embedding_model=data.get("embedding_model", defaults.embedding_model),
         embedding_dimension=data.get(
@@ -204,6 +239,22 @@ def load_config(path: Optional[str] = None) -> QAConfig:
         cfg.model_api_base = os.environ["CODENIB_DEMO_API_BASE"]
     if os.environ.get("CODENIB_DEMO_API_KEY"):
         cfg.model_api_key = os.environ["CODENIB_DEMO_API_KEY"]
+    if os.environ.get("CODENIB_DEMO_MODEL_OPTIONS"):
+        cfg.model_options = merge_model_options(
+            cfg.model_options,
+            parse_model_options_json(
+                os.environ["CODENIB_DEMO_MODEL_OPTIONS"],
+                source="CODENIB_DEMO_MODEL_OPTIONS",
+            ),
+        )
+    if os.environ.get("CODENIB_DEMO_WIKI_MODEL_OPTIONS"):
+        cfg.wiki_model_options = merge_model_options(
+            cfg.wiki_model_options,
+            parse_model_options_json(
+                os.environ["CODENIB_DEMO_WIKI_MODEL_OPTIONS"],
+                source="CODENIB_DEMO_WIKI_MODEL_OPTIONS",
+            ),
+        )
     if os.environ.get("CODENIB_DEMO_DATA_DIR"):
         cfg.data_dir = os.environ["CODENIB_DEMO_DATA_DIR"]
     if os.environ.get("CODENIB_DEMO_PREBUILT_DIR"):

--- a/codenib/web/local.py
+++ b/codenib/web/local.py
@@ -6,16 +6,19 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Mapping
 
 import yaml
 
 from ..compiler.manifest import RepoManifest
 from ..compiler.snapshot_store import normalize_repo
+from ..llm.options import validate_model_options
 from .config import RepoEntry, save_registry
 
 
@@ -65,6 +68,7 @@ def prepare_local_wiki(
     model: str | None = None,
     api_base: str | None = None,
     api_key_env: str | None = None,
+    model_options: Mapping[str, Any] | None = None,
 ) -> LocalWiki:
     """Write the registry and config consumed by the existing Wiki service."""
     repo_path = repo_path.expanduser().resolve()
@@ -110,10 +114,23 @@ def prepare_local_wiki(
         config["model"] = model
     if api_base:
         config["model_api_base"] = api_base
+    options = validate_model_options(model_options)
+    if options:
+        config["model_options"] = options
     with config_path.open("w", encoding="utf-8") as handle:
         yaml.safe_dump(config, handle, sort_keys=True)
 
     runtime_env: dict[str, str] = {}
+    if model:
+        runtime_env["CODENIB_DEMO_MODEL"] = model
+    if api_base:
+        runtime_env["CODENIB_DEMO_API_BASE"] = api_base
+    if options:
+        runtime_env["CODENIB_DEMO_MODEL_OPTIONS"] = json.dumps(
+            options,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
     if api_key_env:
         api_key = os.environ.get(api_key_env)
         if not api_key:

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -385,6 +385,7 @@ class RepoRegistry:
             max_tokens=self._config.max_tokens,
             api_base=self._config.model_api_base,
             api_key=self._config.model_api_key,
+            extra_kwargs=self._config.model_options,
         )
 
     def _load_repo_views(self, bundle: RepoBundle) -> None:

--- a/codenib/wiki/narrator.py
+++ b/codenib/wiki/narrator.py
@@ -21,6 +21,8 @@ import logging
 import os
 from typing import Any, List, Optional
 
+from ..llm.options import validate_model_options
+
 logger = logging.getLogger(__name__)
 
 # Keep prose terse and on-brand; the structural facts come from the builder.
@@ -35,21 +37,6 @@ _SYSTEM = (
 _PROMPT_VERSION = "2"
 
 
-def _no_thinking_kwargs(model: str) -> dict:
-    """litellm kwargs that disable hidden reasoning for thinking models.
-
-    Gemini 2.5 models spend the ``max_tokens`` budget on hidden reasoning
-    tokens first; with the small prose budgets here that leaves ``content``
-    empty (``finish_reason="length"``). LiteLLM maps Anthropic-style
-    ``thinking`` to Gemini's ``thinkingConfig``; a zero budget turns thinking off
-    so the budget goes to the answer. No-op for other providers.
-    """
-    m = model.lower()
-    if "gemini-2.5" in m or "gemini-2-5" in m:
-        return {"thinking": {"type": "disabled", "budget_tokens": 0}}
-    return {}
-
-
 class Narrator:
     """Cached, fail-soft LLM prose generator."""
 
@@ -61,6 +48,7 @@ class Narrator:
         llm: Optional[Any] = None,
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
+        model_options: Optional[dict[str, Any]] = None,
     ) -> None:
         self.model = (
             model
@@ -71,6 +59,10 @@ class Narrator:
         self._llm = llm
         self.api_base = api_base
         self.api_key = api_key
+        self.model_options = validate_model_options(
+            model_options,
+            source="Narrator.model_options",
+        )
         self.cache_dir = cache_dir
         if cache_dir:
             os.makedirs(cache_dir, exist_ok=True)
@@ -104,6 +96,7 @@ class Narrator:
         llm_identity = getattr(self._llm, "cache_identity", "")
         identity = (
             f"{_PROMPT_VERSION}\0{self.model}\0{self.api_base or ''}\0"
+            f"{json.dumps(self.model_options, sort_keys=True)}\0"
             f"{llm_identity}\0{key}"
         )
         h = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:20]
@@ -142,6 +135,7 @@ class Narrator:
                 max_tokens=500,
                 api_base=self.api_base,
                 api_key=self.api_key,
+                extra_kwargs=self.model_options,
             )
         return self._llm
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -121,6 +121,35 @@ codenib wiki . --generate \
   --api-key-env LOCAL_LLM_KEY
 ```
 
+Provider-native LiteLLM routes use their normal model prefix and credentials:
+
+```bash
+export ANTHROPIC_API_KEY=...
+codenib wiki . --generate --model anthropic/claude-sonnet-4-5
+
+gcloud auth application-default login
+codenib wiki . --generate \
+  --model vertex_ai/gemini-2.5-flash \
+  --model-option vertex_project=my-project \
+  --model-option vertex_location=us-central1
+```
+
+Repeat `--model-option KEY=VALUE` for provider-specific LiteLLM parameters.
+Values are JSON-decoded and dotted keys create nested payloads:
+
+```bash
+codenib wiki . --generate \
+  --model openai/qwen3 \
+  --api-base http://127.0.0.1:8000/v1 \
+  --model-option extra_body.chat_template_kwargs.enable_thinking=false
+```
+
+CodeNib manages `model`, credentials, token budgets, messages, and tools;
+those fields cannot be overridden through `--model-option`. Keep secrets in
+provider environment variables or `--api-key-env`, not option values. Run the
+same model arguments through `codenib doctor --probe-model` before generating
+pages.
+
 Provider and model configuration is documented in
 [Web UI](web_demo.md). Search, source links, and deterministic pages remain
 available without this extra.

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -107,12 +107,47 @@ environment variables beat the YAML (`load_config()` in
 | `model` | `CODENIB_DEMO_MODEL` | LiteLLM model for the Ask agent (default `gpt-4o`) |
 | `wiki_model` | `CODENIB_DEMO_WIKI_MODEL` | Separate model for wiki prose and edge labels; unset → uses `model` |
 | `model_api_base` / `model_api_key` | `CODENIB_DEMO_API_BASE` / `CODENIB_DEMO_API_KEY` | OpenAI-compatible endpoint for the Ask model; provider-native models (Vertex, Anthropic) leave these unset |
+| `model_options` | `CODENIB_DEMO_MODEL_OPTIONS` | Provider-specific LiteLLM options for Ask; the environment value is a JSON object and overrides matching YAML fields |
+| `wiki_model_options` | `CODENIB_DEMO_WIKI_MODEL_OPTIONS` | Nested overrides applied only to Wiki, narration, and edge-label calls |
 | `data_dir` | `CODENIB_DEMO_DATA_DIR` | Where checked-out repos, indexes, and the registry live (default `.codenib_qa/`) |
 | `prebuilt_dir` | `CODENIB_DEMO_PREBUILT_DIR` | Read-only tree of pre-built per-instance artifacts (see above) |
 | `embedding_provider` | `CODENIB_EMBEDDING_PROVIDER` | `huggingface` (in-process, default) or `openai` (OpenAI-compatible endpoint) |
 | `embedding_model` / `embedding_base_url` / `embedding_api_key` | `CODENIB_EMBEDDING_MODEL` / `CODENIB_EMBEDDING_BASE_URL` / `CODENIB_EMBEDDING_API_KEY` | Embedding model plus the endpoint and credential for the remote provider |
 | `edge_labels` | `CODENIB_EDGE_LABELS` | Opt-in LLM-written edge phrases in the graph view (off by default; each first-seen edge costs one small LLM call, then cached) |
 | `edge_label_model` | `CODENIB_EDGE_MODEL` | Optional cheaper model for the short edge-label calls |
+
+LiteLLM provider selection comes from the model prefix, for example
+`anthropic/...`, `vertex_ai/...`, `ollama/...`, or `openrouter/...`. CodeNib
+does not infer request parameters from a model name. Put non-secret
+provider-specific parameters in the option mappings:
+
+```yaml
+model: vertex_ai/gemini-2.5-flash
+model_options:
+  vertex_project: my-project
+  vertex_location: us-central1
+
+wiki_model_options:
+  timeout: 60
+```
+
+For an OpenAI-compatible Qwen endpoint whose chat template supports the
+setting:
+
+```yaml
+model: openai/qwen3
+model_api_base: http://127.0.0.1:8000/v1
+model_options:
+  extra_body:
+    chat_template_kwargs:
+      enable_thinking: false
+```
+
+The CLI equivalent is repeatable
+`--model-option extra_body.chat_template_kwargs.enable_thinking=false`.
+CodeNib rejects options that attempt to replace managed fields such as
+`model`, `messages`, `tools`, or `api_key`. Keep credentials in the provider's
+standard environment variables or the dedicated API-key setting.
 
 ### Managed local dev servers
 

--- a/test/llm/test_litellm_retry.py
+++ b/test/llm/test_litellm_retry.py
@@ -110,11 +110,22 @@ class TestIsTransientError:
 
 
 class TestCompletionWithRetry:
+    def test_chat_rejects_extra_kwargs_that_replace_managed_fields(self):
+        with pytest.raises(ValueError, match="cannot override.*model"):
+            LiteLLMChat(
+                model="openai/local",
+                extra_kwargs={"model": "anthropic/other"},
+            )
+
     def test_complete_returns_stripped_text_and_forwards_endpoint(self):
         chat = LiteLLMChat(
             model="openai/local",
             api_base="http://localhost:4000/v1",
             api_key="secret",
+            extra_kwargs={
+                "api_version": "2025-01-01",
+                "extra_body": {"reasoning": {"enabled": False}},
+            },
             retry=RetryConfig(max_retries=0),
         )
         with patch(
@@ -128,6 +139,8 @@ class TestCompletionWithRetry:
         assert kwargs["api_base"] == "http://localhost:4000/v1"
         assert kwargs["api_key"] == "secret"
         assert kwargs["max_tokens"] == 12
+        assert kwargs["api_version"] == "2025-01-01"
+        assert kwargs["extra_body"] == {"reasoning": {"enabled": False}}
 
     def test_cache_identity_excludes_secret_but_tracks_endpoint(self):
         first = LiteLLMChat(
@@ -145,9 +158,20 @@ class TestCompletionWithRetry:
             api_base="http://two/v1",
             api_key="first-secret",
         )
+        configured = LiteLLMChat(
+            model="openai/local",
+            api_base="http://one/v1",
+            extra_kwargs={"api_version": "2025-01-01"},
+        )
+        reconfigured = LiteLLMChat(
+            model="openai/local",
+            api_base="http://one/v1",
+            extra_kwargs={"api_version": "2026-01-01"},
+        )
 
         assert first.cache_identity == rotated.cache_identity
         assert first.cache_identity != moved.cache_identity
+        assert configured.cache_identity != reconfigured.cache_identity
         assert "secret" not in first.cache_identity
 
     def test_transient_then_success_is_retried(self):

--- a/test/llm/test_options.py
+++ b/test/llm/test_options.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from codenib.llm.options import (
+    merge_model_options,
+    parse_model_option_assignments,
+    parse_model_options_json,
+    validate_model_options,
+)
+
+
+def test_cli_assignments_support_nested_json_values():
+    options = parse_model_option_assignments(
+        [
+            "api_version=2025-01-01",
+            "timeout=30",
+            "extra_body.chat_template_kwargs.enable_thinking=false",
+        ]
+    )
+
+    assert options == {
+        "api_version": "2025-01-01",
+        "timeout": 30,
+        "extra_body": {
+            "chat_template_kwargs": {
+                "enable_thinking": False,
+            }
+        },
+    }
+
+
+def test_model_options_deep_merge_provider_payloads():
+    assert merge_model_options(
+        {
+            "timeout": 20,
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "enable_thinking": True,
+                    "reasoning_budget": 100,
+                }
+            },
+        },
+        {
+            "timeout": 45,
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "enable_thinking": False,
+                }
+            },
+        },
+    ) == {
+        "timeout": 45,
+        "extra_body": {
+            "chat_template_kwargs": {
+                "enable_thinking": False,
+                "reasoning_budget": 100,
+            }
+        },
+    }
+
+
+@pytest.mark.parametrize("key", ["model", "messages", "tools", "api_key"])
+def test_model_options_reject_managed_fields(key):
+    with pytest.raises(ValueError, match="cannot override"):
+        validate_model_options({key: "unexpected"})
+
+
+def test_model_options_json_requires_an_object():
+    with pytest.raises(ValueError, match="JSON object"):
+        parse_model_options_json("[1, 2]", source="MODEL_OPTIONS")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -37,6 +37,10 @@ def test_doctor_parser_accepts_model_backend_options() -> None:
             "http://localhost:4000/v1",
             "--api-key-env",
             "LOCAL_LLM_KEY",
+            "--model-option",
+            "api_version=2025-01-01",
+            "--model-option",
+            "extra_body.reasoning.enabled=false",
             "--probe-model",
         ]
     )
@@ -44,6 +48,10 @@ def test_doctor_parser_accepts_model_backend_options() -> None:
     assert args.model == "openai/local-model"
     assert args.api_base == "http://localhost:4000/v1"
     assert args.api_key_env == "LOCAL_LLM_KEY"
+    assert args.model_option == [
+        "api_version=2025-01-01",
+        "extra_body.reasoning.enabled=false",
+    ]
     assert args.probe_model is True
 
 
@@ -92,6 +100,41 @@ def test_doctor_model_config_uses_litellm_validation(
         "model": "openai/local-model",
         "api_base": "http://localhost:4000/v1",
         "api_key": "secret",
+    }
+
+
+def test_cli_model_options_layer_environment_and_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "CODENIB_DEMO_MODEL_OPTIONS",
+        '{"timeout":20,"extra_body":{"reasoning":{"enabled":true}}}',
+    )
+    monkeypatch.setenv(
+        "CODENIB_DEMO_WIKI_MODEL_OPTIONS",
+        '{"timeout":90,"extra_body":{"wiki_only":true}}',
+    )
+    args = SimpleNamespace(
+        model="openai/local-model",
+        model_option=[
+            "timeout=45",
+            "extra_body.reasoning.enabled=false",
+        ],
+    )
+
+    assert cli._model_options_for_args(args) == {
+        "timeout": 45,
+        "extra_body": {"reasoning": {"enabled": False}},
+    }
+    assert cli._model_options_for_args(
+        args,
+        include_wiki_environment=True,
+    ) == {
+        "timeout": 45,
+        "extra_body": {
+            "reasoning": {"enabled": False},
+            "wiki_only": True,
+        },
     }
 
 
@@ -384,14 +427,30 @@ def test_prepare_generated_wiki_keeps_secret_out_of_config(
         model="openai/local-model",
         api_base="http://localhost:4000/v1",
         api_key_env="LOCAL_LLM_KEY",
+        model_options={
+            "api_version": "2025-01-01",
+            "extra_body": {"reasoning": {"enabled": False}},
+        },
     )
 
     config = yaml.safe_load(local.config_path.read_text())
     assert config["wiki_agent"] is True
     assert config["model"] == "openai/local-model"
     assert config["model_api_base"] == "http://localhost:4000/v1"
+    assert config["model_options"] == {
+        "api_version": "2025-01-01",
+        "extra_body": {"reasoning": {"enabled": False}},
+    }
     assert "key" not in local.config_path.read_text().lower()
-    assert local.runtime_env == {"CODENIB_DEMO_API_KEY": "super-secret"}
+    assert local.runtime_env == {
+        "CODENIB_DEMO_MODEL": "openai/local-model",
+        "CODENIB_DEMO_API_BASE": "http://localhost:4000/v1",
+        "CODENIB_DEMO_MODEL_OPTIONS": (
+            '{"api_version":"2025-01-01","extra_body":'
+            '{"reasoning":{"enabled":false}}}'
+        ),
+        "CODENIB_DEMO_API_KEY": "super-secret",
+    }
 
 
 def test_installed_package_frontend_is_prebuilt(

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -85,6 +85,10 @@ def test_wiki_llm_receives_provider_configuration(monkeypatch):
         wiki_generation_model="openai/local-model",
         wiki_generation_api_base="http://localhost:4000/v1",
         wiki_generation_api_key="secret",
+        wiki_generation_options={
+            "api_version": "2025-01-01",
+            "extra_body": {"reasoning": {"enabled": False}},
+        },
     )
 
     web_app._wiki_llm(config, max_tokens=123)
@@ -95,4 +99,8 @@ def test_wiki_llm_receives_provider_configuration(monkeypatch):
         "max_tokens": 123,
         "api_base": "http://localhost:4000/v1",
         "api_key": "secret",
+        "extra_kwargs": {
+            "api_version": "2025-01-01",
+            "extra_body": {"reasoning": {"enabled": False}},
+        },
     }

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -174,6 +174,16 @@ def test_load_config_from_yaml(tmp_path):
         "wiki_model: wiki-model\n"
         "wiki_api_base: http://wiki.example/v1\n"
         "model_api_base: http://ask.example/v1\n"
+        "model_options:\n"
+        "  timeout: 20\n"
+        "  extra_body:\n"
+        "    reasoning:\n"
+        "      enabled: true\n"
+        "wiki_model_options:\n"
+        "  timeout: 45\n"
+        "  extra_body:\n"
+        "    reasoning:\n"
+        "      enabled: false\n"
         "mode: hybrid\n"
         "embedding_provider: openai\n"
         "embedding_base_url: http://embed.example/v1\n"
@@ -187,6 +197,11 @@ def test_load_config_from_yaml(tmp_path):
     assert cfg.wiki_generation_model == "wiki-model"
     assert cfg.wiki_generation_api_base == "http://wiki.example/v1"
     assert cfg.model_api_base == "http://ask.example/v1"
+    assert cfg.model_options["timeout"] == 20
+    assert cfg.wiki_generation_options == {
+        "timeout": 45,
+        "extra_body": {"reasoning": {"enabled": False}},
+    }
     assert cfg.mode == "hybrid"
     assert cfg.embedding_provider == "openai"
     assert cfg.embedding_base_url == "http://embed.example/v1"
@@ -208,6 +223,14 @@ def test_backend_environment_overrides_yaml(tmp_path, monkeypatch):
     monkeypatch.setenv("CODENIB_DEMO_WIKI_API_BASE", "http://wiki.local/v1")
     monkeypatch.setenv("CODENIB_DEMO_WIKI_API_KEY", "wiki-secret")
     monkeypatch.setenv("CODENIB_DEMO_API_BASE", "http://ask.local/v1")
+    monkeypatch.setenv(
+        "CODENIB_DEMO_MODEL_OPTIONS",
+        '{"timeout":30,"extra_body":{"reasoning":{"enabled":true}}}',
+    )
+    monkeypatch.setenv(
+        "CODENIB_DEMO_WIKI_MODEL_OPTIONS",
+        '{"extra_body":{"reasoning":{"enabled":false}}}',
+    )
     monkeypatch.setenv("CODENIB_EMBEDDING_PROVIDER", "OPENAI")
     monkeypatch.setenv("CODENIB_EMBEDDING_BASE_URL", "http://embed.local/v1")
 
@@ -218,6 +241,14 @@ def test_backend_environment_overrides_yaml(tmp_path, monkeypatch):
     assert cfg.wiki_generation_api_base == "http://wiki.local/v1"
     assert cfg.wiki_generation_api_key == "wiki-secret"
     assert cfg.model_api_base == "http://ask.local/v1"
+    assert cfg.model_options == {
+        "timeout": 30,
+        "extra_body": {"reasoning": {"enabled": True}},
+    }
+    assert cfg.wiki_generation_options == {
+        "timeout": 30,
+        "extra_body": {"reasoning": {"enabled": False}},
+    }
     assert cfg.embedding_provider == "openai"
     assert cfg.embedding_base_url == "http://embed.local/v1"
 
@@ -293,6 +324,7 @@ def test_ask_model_receives_its_own_endpoint(monkeypatch):
             model_api_base="http://ask.local/v1",
             model_api_key="ask-secret",
             max_tokens=2048,
+            model_options={"api_version": "2025-01-01"},
         )
     )
 
@@ -304,7 +336,51 @@ def test_ask_model_receives_its_own_endpoint(monkeypatch):
         "max_tokens": 2048,
         "api_base": "http://ask.local/v1",
         "api_key": "ask-secret",
+        "extra_kwargs": {"api_version": "2025-01-01"},
     }
+
+
+@pytest.mark.parametrize(
+    ("model", "api_base", "options"),
+    [
+        ("anthropic/claude-sonnet-4-5", None, {"timeout": 60}),
+        (
+            "vertex_ai/gemini-2.5-flash",
+            None,
+            {"vertex_project": "project", "vertex_location": "us-central1"},
+        ),
+        ("ollama/qwen3", "http://localhost:11434", {}),
+        (
+            "openrouter/qwen/qwen3-coder",
+            None,
+            {"extra_headers": {"HTTP-Referer": "https://codenib.ai"}},
+        ),
+    ],
+)
+def test_ask_model_preserves_litellm_provider_configuration(
+    monkeypatch,
+    model,
+    api_base,
+    options,
+):
+    captured = {}
+
+    def fake_chat(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("codenib.web.repo_registry._ask_llm_type", lambda: fake_chat)
+    RepoRegistry(
+        QAConfig(
+            model=model,
+            model_api_base=api_base,
+            model_options=options,
+        )
+    )._create_ask_llm()
+
+    assert captured["model"] == model
+    assert captured["api_base"] == api_base
+    assert captured["extra_kwargs"] == options
 
 
 def test_registry_round_trip(tmp_path):

--- a/test/wiki/test_builder.py
+++ b/test/wiki/test_builder.py
@@ -228,10 +228,11 @@ def test_architecture_reports_area_facts_and_source_citations(repo_dir):
 
 # -- Critique #8: LLM-authored content layer ---------------------------------
 
-from codenib.wiki.narrator import Narrator, _no_thinking_kwargs  # noqa: E402
+from codenib.llm.litellm_chat import _no_thinking_kwargs  # noqa: E402
+from codenib.wiki.narrator import Narrator  # noqa: E402
 
 
-def test_narrator_gemini_25_uses_litellm_thinking_zero_budget():
+def test_shared_litellm_adapter_disables_gemini_25_thinking():
     assert _no_thinking_kwargs("vertex_ai/gemini-2.5-flash") == {
         "thinking": {"type": "disabled", "budget_tokens": 0}
     }


### PR DESCRIPTION
## Summary

Makes CodeNib's Ask and generated Wiki paths work with LiteLLM backends through explicit, validated configuration rather than model-name heuristics. Users can keep the simple model/base/key path or add provider-specific options through CLI, YAML, or JSON environment overrides.

## Changes

- add validated, deeply merged LiteLLM provider options with managed-field protection
- expose repeatable `--model-option KEY=VALUE` flags, including dotted nested values
- support `model_options` and `wiki_model_options` in YAML and environment configuration
- pass the same configuration into Ask, page generation, narration, and edge labels
- preserve CLI-over-environment precedence for locally launched services without writing credentials to config
- include provider options in generation cache identity
- report the resolved provider and non-secret option keys in `codenib doctor`
- keep `codenib.llm` exports lazy so static Wiki startup does not import optional LiteLLM dependencies
- document OpenAI-compatible, Anthropic, Vertex, Ollama, OpenRouter, and Qwen endpoint configuration

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- unit tier: 1819 passed, 10 skipped, 170 deselected
- provider/configuration surface after rebase: 99 passed
- `mkdocs build --strict`
- changed-file pre-commit hooks
- local `codenib doctor` configuration probes for OpenAI-compatible, Anthropic, Vertex, and Ollama shapes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published