### PR TITLE
feat(wiki): generate coherent source-grounded pages

### DIFF
--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -314,16 +314,19 @@ def _run_wiki(args: argparse.Namespace) -> int:
     from .web.launcher import launch_local_wiki
     from .web.local import prepare_local_wiki
 
-    local = prepare_local_wiki(
-        repo_path,
-        manifest_path,
-        frontend_port=args.port,
-        agent_wiki=args.agent_wiki,
-        model=args.model,
-        api_base=args.api_base,
-        api_key_env=args.api_key_env,
-        model_options=_model_options_for_args(args),
-    )
+    try:
+        local = prepare_local_wiki(
+            repo_path,
+            manifest_path,
+            frontend_port=args.port,
+            agent_wiki=args.agent_wiki,
+            model=args.model,
+            api_base=args.api_base,
+            api_key_env=args.api_key_env,
+            model_options=_model_options_for_args(args),
+        )
+    except ValueError as exc:
+        raise CLIError(str(exc)) from exc
     try:
         return launch_local_wiki(
             local,

--- a/codenib/web/local.py
+++ b/codenib/web/local.py
@@ -47,6 +47,31 @@ def _origin_url(repo_path: Path) -> str | None:
     return result.stdout.strip() if result.returncode == 0 else None
 
 
+def _checkout_commit(repo_path: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _validate_checkout_identity(repo_path: Path, manifest: RepoManifest) -> None:
+    expected = (manifest.commit or "").strip()
+    actual = _checkout_commit(repo_path)
+    if not expected or not actual:
+        return
+    if actual.startswith(expected) or expected.startswith(actual):
+        return
+    raise ValueError(
+        "repository checkout does not match the indexed snapshot: "
+        f"HEAD is {actual[:12]}, manifest is {expected[:12]}. "
+        "Rebuild the index or check out the manifest commit before starting "
+        "the Wiki."
+    )
+
+
 def _repository_slug(repo_path: Path) -> str:
     origin = _origin_url(repo_path)
     if origin:
@@ -74,6 +99,7 @@ def prepare_local_wiki(
     repo_path = repo_path.expanduser().resolve()
     manifest_path = manifest_path.expanduser().resolve()
     manifest = RepoManifest.load(str(manifest_path))
+    _validate_checkout_identity(repo_path, manifest)
 
     data_dir = manifest_path.parent / "wiki"
     data_dir.mkdir(parents=True, exist_ok=True)

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -34,9 +34,14 @@ from .evidence import (
     grounding_report,
     parse_fact_plan,
     reciprocal_rank_fuse,
-    remove_promotional_sentences,
 )
-from .outline import generate_outline
+from .outline import (
+    _is_supporting_file,
+    _page_allows_supporting_files,
+    generate_outline,
+)
+from .quality import page_quality_report as _page_quality_report
+from .quality import prose_terms as _prose_terms
 
 logger = get_logger(__name__)
 
@@ -59,7 +64,10 @@ _EXT_LANG = {
     "kts": "kotlin",
 }
 _MAX_CONTEXT_CHARS = 14000
-_PROMPT_VERSION = "24"
+_OUTLINE_PROMPT_VERSION = "3"
+_PAGE_PROMPT_VERSION = "43"
+_MAX_PLAN_REPAIRS = 2
+_MAX_STYLE_REPAIRS = 2
 
 
 def _slug(text: str) -> str:
@@ -171,143 +179,6 @@ def _remove_orphan_headings(markdown: str) -> str:
     return "\n\n".join(kept)
 
 
-def _prose_terms(text: str) -> set[str]:
-    """Return stable content terms for conservative duplicate detection."""
-
-    stopwords = {
-        "a",
-        "an",
-        "and",
-        "are",
-        "as",
-        "at",
-        "be",
-        "by",
-        "for",
-        "from",
-        "in",
-        "into",
-        "is",
-        "it",
-        "of",
-        "on",
-        "or",
-        "that",
-        "the",
-        "then",
-        "this",
-        "through",
-        "to",
-        "with",
-    }
-    plain = re.sub(r"\[((?:E|R)\d+)\](?:\([^)]*\))?", " ", text)
-    plain = re.sub(r"[`*_[\]()#>/-]", " ", plain.lower())
-    return {
-        token
-        for token in re.findall(r"[a-z0-9]+", plain)
-        if len(token) > 1 and token not in stopwords
-    }
-
-
-def _duplicate_prose_blocks(markdown: str) -> List[List[int]]:
-    """Find paragraph pairs where one largely restates the other."""
-
-    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
-    terms = []
-    for raw in re.split(r"\n\s*\n", without_fences):
-        block = raw.strip()
-        if not block or block.startswith("#"):
-            continue
-        block_terms = _prose_terms(block)
-        if len(block_terms) >= 6:
-            terms.append(block_terms)
-
-    duplicates: List[List[int]] = []
-    for left in range(len(terms)):
-        for right in range(left + 1, len(terms)):
-            smaller = min(len(terms[left]), len(terms[right]))
-            overlap = len(terms[left] & terms[right]) / smaller
-            if overlap >= 0.85:
-                duplicates.append([left + 1, right + 1])
-    return duplicates
-
-
-def _page_quality_report(
-    markdown: str,
-    plan: dict[str, Any],
-    *,
-    require_dense_sections: bool = False,
-) -> dict[str, Any]:
-    """Measure whether a page represents the supported fact plan."""
-
-    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
-    rendered_sections = len(
-        re.findall(r"^#{2,6}\s+\S", without_fences, flags=re.MULTILINE)
-    )
-    substantive_blocks = 0
-    for raw in re.split(r"\n\s*\n", without_fences):
-        block = raw.strip()
-        if block and not block.startswith("#"):
-            plain = re.sub(r"[`*_[\]()#>-]", "", block).strip()
-            if len(plain) >= 40:
-                substantive_blocks += 1
-
-    sections = plan.get("sections") or []
-    claims = [
-        claim
-        for section in sections
-        for claim in section.get("claims") or []
-        if claim.get("evidence")
-    ]
-    cited = set(re.findall(r"\[((?:E|R)\d+)\]", without_fences))
-    covered_claims = sum(
-        1 for claim in claims if cited.intersection(claim.get("evidence") or [])
-    )
-    claim_coverage = covered_claims / len(claims) if claims else 0.0
-    duplicate_blocks = _duplicate_prose_blocks(markdown)
-    thin_sections = []
-    if require_dense_sections:
-        section_matches = list(
-            re.finditer(r"^##\s+(.+?)\s*$", without_fences, flags=re.MULTILINE)
-        )
-        for index, match in enumerate(section_matches):
-            end = (
-                section_matches[index + 1].start()
-                if index + 1 < len(section_matches)
-                else len(without_fences)
-            )
-            body = without_fences[match.end() : end]
-            plain = re.sub(r"\[(?:E|R)\d+\](?:\([^)]*\))?", " ", body)
-            plain = re.sub(r"[`*_[\]()#>-]", " ", plain)
-            plain = re.sub(r"\s+", " ", plain).strip()
-            sentence_count = len(re.findall(r"[.!?](?=\s|$)", plain))
-            if len(plain) < 80 or sentence_count < 2:
-                thin_sections.append(match.group(1).strip())
-    required_sections = min(3, len(sections))
-    required_blocks = 1 + required_sections
-    valid = (
-        bool(sections)
-        and rendered_sections >= required_sections
-        and substantive_blocks >= required_blocks
-        and claim_coverage >= 0.6
-        and not duplicate_blocks
-        and not thin_sections
-    )
-    return {
-        "valid": valid,
-        "planned_sections": len(sections),
-        "required_sections": required_sections,
-        "rendered_sections": rendered_sections,
-        "substantive_blocks": substantive_blocks,
-        "required_blocks": required_blocks,
-        "covered_claims": covered_claims,
-        "planned_claims": len(claims),
-        "claim_coverage": round(claim_coverage, 3),
-        "duplicate_blocks": duplicate_blocks,
-        "thin_sections": thin_sections,
-    }
-
-
 def _format_supported_literals(text: str) -> str:
     """Render quoted commands, paths, and identifiers as inline code."""
 
@@ -338,13 +209,12 @@ def _fact_plan_markdown(
     evidence: List[EvidenceItem],
     relations: List[RelationItem],
 ) -> str:
-    """Render an admitted fact plan when free-form narration is incomplete."""
+    """Render an admitted fact plan as citation-stable Markdown."""
 
     allowed = {item.id for item in evidence} | {item.id for item in relations}
     intro = _readme_intro(evidence)
     intro_terms = _prose_terms(intro[0]) if intro is not None else set()
     rendered_sections: List[tuple[str, str]] = []
-    first_claim: tuple[str, List[str], str] | None = None
     for section in plan.get("sections") or []:
         sentences = []
         for claim in section.get("claims") or []:
@@ -383,12 +253,6 @@ def _fact_plan_markdown(
                 + ". "
                 + " ".join(f"[{item}]" for item in ids)
             )
-            if first_claim is None:
-                first_claim = (
-                    rendered_statement.rstrip(".") + ".",
-                    ids,
-                    rendered_claim,
-                )
             sentences.append(rendered_claim)
         title = re.sub(r"\s+", " ", str(section.get("title") or "")).strip()
         if title and sentences:
@@ -396,20 +260,9 @@ def _fact_plan_markdown(
 
     if not rendered_sections:
         return ""
+    blocks = []
     if intro is not None:
-        intro_text = f"{intro[0]} [{intro[1]}]"
-    elif first_claim is not None:
-        statement, ids, rendered_claim = first_claim
-        intro_text = statement + " " + " ".join(f"[{item}]" for item in ids)
-        title, paragraph = rendered_sections[0]
-        if paragraph.startswith(rendered_claim):
-            remainder = paragraph[len(rendered_claim) :].lstrip()
-            prose = re.sub(r"\[(?:E|R)\d+\]", "", remainder).strip()
-            if len(prose) >= 40:
-                rendered_sections[0] = (title, remainder)
-    else:
-        return ""
-    blocks = [intro_text]
+        blocks.append(f"{intro[0]} [{intro[1]}]")
     for title, paragraph in rendered_sections:
         blocks.extend((f"## {title}", paragraph))
     return "\n\n".join(blocks)
@@ -418,12 +271,13 @@ def _fact_plan_markdown(
 def _candidate_score(
     report: dict[str, Any],
     quality: dict[str, Any],
-) -> tuple[int, int, int, int, float]:
+) -> tuple[int, int, int, int, int, float]:
     """Rank publishable page candidates with grounding as the hard boundary."""
 
     return (
         int(bool(report.get("valid"))),
         int(bool(quality.get("valid"))),
+        -len(report.get("promotional_phrases") or []),
         int(quality.get("rendered_sections") or 0),
         int(quality.get("substantive_blocks") or 0),
         float(quality.get("claim_coverage") or 0.0),
@@ -451,6 +305,33 @@ def _readme_intro(evidence: List[EvidenceItem]) -> tuple[str, str] | None:
     return None
 
 
+def _ensure_cited_intro(
+    markdown: str,
+    evidence: List[EvidenceItem],
+    *,
+    canonical_readme: bool = False,
+) -> str:
+    """Prepend the README synopsis when a model starts directly with a section."""
+
+    first_section = re.search(r"^##\s+\S", markdown, flags=re.MULTILINE)
+    intro = _readme_intro(evidence)
+    if canonical_readme and intro is not None:
+        text, evidence_id = intro
+        sections = markdown[first_section.start() :] if first_section else ""
+        return f"{text} [{evidence_id}]\n\n{sections.lstrip()}".rstrip()
+
+    intro_body = markdown[: first_section.start()] if first_section else markdown
+    intro_plain = re.sub(r"^#\s+.*$", "", intro_body, flags=re.MULTILINE)
+    intro_plain = re.sub(r"\[(?:E|R)\d+\](?:\([^)]*\))?", " ", intro_plain)
+    intro_plain = re.sub(r"[`*_[\]()#>-]", " ", intro_plain)
+    if len(re.sub(r"\s+", " ", intro_plain).strip()) >= 40:
+        return markdown
+    if intro is None:
+        return markdown
+    text, evidence_id = intro
+    return f"{text} [{evidence_id}]\n\n{markdown.lstrip()}"
+
+
 _PLAN_PROMPT = """\
 You are planning one source-grounded page of a developer wiki for the {repo}
 codebase.
@@ -458,6 +339,7 @@ codebase.
 Page title: {title}
 What it should cover: {summary}
 Planning guidance: {guidance}
+Evidence allocation: {constraints}
 
 Source evidence:
 {evidence}
@@ -487,16 +369,56 @@ def _page_planning_guidance(meta: Dict[str, Any]) -> str:
             "result, (2) the main execution or data-flow handoffs, and (3) the "
             "responsibilities of at least two major subsystems. The intro thesis "
             "already states the repository purpose, so do not repeat its channel "
-            "list. Pair README claims with implementation evidence, use at least "
+            "list. README evidence may support a distinct public command, while "
+            "implementation claims should use source evidence. Use at least "
             "four distinct evidence IDs across the plan when available, and "
             "prefer concrete actions and handoffs over generic 'provides' or "
-            "'includes' claims. Treat single-language backends, decoders, "
+            "'includes' claims. Describe the public workflow with an actual "
+            "command, route, or API from the evidence; never say that users call "
+            "a private underscore-prefixed helper. Name major components by "
+            "their class, service, or responsibility, never as a filename "
+            "subsystem. Treat single-language backends, decoders, "
             "patchers, and private helpers as implementation details unless they "
             "define the repository."
         )
     return (
-        "Explain the page's subsystem responsibility, its public entry points, "
-        "and interactions supported by the supplied evidence."
+        "Explain the page's concrete responsibility and interactions supported "
+        "by the supplied evidence. Include a public entry point only when the "
+        "evidence shows a command, route, class, or non-underscore callable that "
+        "serves that role. Otherwise describe the internal control or data flow "
+        "without relabeling private helpers as APIs. Attribute behavior only to "
+        "the function or class whose cited body implements it; a nearby field, "
+        "constructor argument, or static relation does not establish purpose."
+    )
+
+
+def _plan_evidence_constraints(
+    meta: Dict[str, Any],
+    evidence: Sequence[EvidenceItem],
+) -> str:
+    """Describe evidence allocation rules before the model writes claims."""
+
+    if meta.get("id") != "overview":
+        return "Match each claim to the source item that directly supports it."
+
+    intro = _readme_intro(list(evidence))
+    intro_id = intro[1] if intro is not None else None
+    implementation = [
+        item for item in evidence if item.id != intro_id and item.id.startswith("E")
+    ]
+    catalog = ", ".join(
+        f"{item.id}=`{item.file}`::{item.symbol}" for item in implementation
+    )
+    reserved = f"{intro_id} supplies the intro; " if intro_id else ""
+    return (
+        f"{reserved}a section may reuse an evidence item only for a different "
+        "supported fact. Use at least four source evidence IDs across the page "
+        "when four are available. The public-workflow section may reuse README "
+        "evidence; each later section must introduce at least one implementation "
+        "source not used by an earlier section. Keep the three sections "
+        "semantically distinct and assign sources by their actual responsibility. "
+        f"Implementation source catalog: "
+        f"{catalog or '(none)'}."
     )
 
 
@@ -508,11 +430,52 @@ def _plan_quality_warnings(
 ) -> List[str]:
     """Validate whether a fact plan is dense enough for its page role."""
 
-    if meta.get("id") != "overview":
-        return []
-
     sections = plan.get("sections") or []
     warnings = []
+    page_title = str(meta.get("title") or "")
+    page_is_about_helpers = bool(
+        re.search(r"\b(?:helpers?|utilit(?:y|ies))\b", page_title, re.IGNORECASE)
+    )
+    public_evidence = sum(
+        not re.search(
+            r"(?:^|[:.])_[A-Za-z]\w*(?:\(\))?$",
+            item.symbol,
+        )
+        for item in evidence
+    )
+    for section in sections:
+        title = str(section.get("title") or "untitled")
+        if (
+            not page_is_about_helpers
+            and public_evidence >= 2
+            and re.search(
+                r"\b(?:helpers?|utilit(?:y|ies))\b",
+                title,
+                re.IGNORECASE,
+            )
+        ):
+            warnings.append(
+                f"section {title!r} elevates incidental helpers over the page's "
+                "core responsibility"
+            )
+        if not re.search(r"\b(?:public|entry\s+points?)\b", title, re.IGNORECASE):
+            continue
+        for claim in section.get("claims") or []:
+            statement = str(claim.get("statement") or "")
+            if re.search(
+                r"(?:\b[A-Za-z]\w*\.)?_[A-Za-z]\w*\s*\(",
+                statement,
+            ):
+                warning = (
+                    f"section {title!r} describes a private helper as a user "
+                    "entry point"
+                )
+                if warning not in warnings:
+                    warnings.append(warning)
+
+    if meta.get("id") != "overview":
+        return warnings
+
     if len(sections) != 3:
         warnings.append("Overview must have exactly three complementary sections")
 
@@ -520,9 +483,12 @@ def _plan_quality_warnings(
     intro_terms = _prose_terms(intro[0]) if intro is not None else set()
     require_source_diversity = sum(item.id.startswith("E") for item in evidence) >= 4
     page_sources = set()
-    for section in sections:
+    prior_section_terms: List[tuple[str, set[str]]] = []
+    seen_section_sources: set[str] = set()
+    for section_index, section in enumerate(sections):
         title = str(section.get("title") or "untitled")
         useful_claims = []
+        section_sources = set()
         for claim in section.get("claims") or []:
             statement = _format_supported_literals(
                 str(claim.get("statement") or "").strip()
@@ -534,6 +500,23 @@ def _plan_quality_warnings(
                 and len(terms & intro_terms) / len(terms) >= 0.8
             )
             if redundant:
+                continue
+            if re.search(
+                r"\busers?\b[^.]{0,120}`_[A-Za-z]\w*(?:\([^`]*\))?`",
+                statement,
+                flags=re.IGNORECASE,
+            ):
+                warning = f"section {title!r} describes a private helper as a user entry point"
+                if warning not in warnings:
+                    warnings.append(warning)
+                continue
+            if re.search(
+                r"`?[\w./-]+\.(?:py|go|rs|ts|tsx|js|jsx|c|h|cc|cpp|java|rb|"
+                r"php|cs|kt|kts)`?\s+(?:file\s+)?subsystem\b",
+                statement,
+                flags=re.IGNORECASE,
+            ):
+                warnings.append(f"section {title!r} names a source file as a subsystem")
                 continue
             ids = [str(item) for item in claim.get("evidence") or []]
             candidate = f"{statement.rstrip('.')}." + "".join(
@@ -556,11 +539,39 @@ def _plan_quality_warnings(
                 for item in claim.get("evidence") or []
                 if str(item).startswith("E")
             }
+            section_sources.update(source_ids)
             page_sources.update(source_ids)
         if len(useful_claims) < 2:
             warnings.append(
                 f"section {title!r} needs two publishable, non-redundant claims"
             )
+        if (
+            section_index > 0
+            and section_sources
+            and not (section_sources - seen_section_sources)
+        ):
+            warnings.append(
+                f"section {title!r} must introduce an implementation source "
+                "not used by earlier sections"
+            )
+        seen_section_sources.update(section_sources)
+        section_terms = set().union(
+            *(
+                _prose_terms(str(claim.get("statement") or ""))
+                for claim in useful_claims
+            )
+        )
+        for prior_title, prior_terms in prior_section_terms:
+            smaller = min(len(section_terms), len(prior_terms))
+            overlap = (
+                len(section_terms & prior_terms) / smaller if smaller >= 6 else 0.0
+            )
+            if overlap >= 0.8:
+                warnings.append(
+                    f"section {title!r} substantially repeats section {prior_title!r}"
+                )
+                break
+        prior_section_terms.append((title, section_terms))
     if require_source_diversity and len(page_sources) < 4:
         warnings.append("Overview must use at least four source evidence IDs")
     return warnings
@@ -571,6 +582,7 @@ Revise the source-grounded fact plan below.
 
 Page title: {title}
 Planning guidance: {guidance}
+Evidence allocation: {constraints}
 
 Problems:
 {problems}
@@ -609,14 +621,25 @@ Static reference relations:
 {relations}
 
 Write the page as GitHub-flavored Markdown:
-- Start with a short, cited intro paragraph (no H1 title; the app adds it).
+- Start with a short, cited intro paragraph that states only the repository
+  purpose and page scope (no H1 title; the app adds it). Leave commands,
+  execution steps, and subsystem details to their planned sections.
 - Follow the approved fact plan. Explain the subsystem, its key pieces, and
   their interactions in clear prose with ## / ### subheadings.
+- Render every planned claim exactly once as one concrete sentence. Use one
+  paragraph per section and do not add transition, implication, justification,
+  or benefit sentences that are not themselves planned claims.
 - Put an evidence marker such as [E1] or [R1] in every substantive paragraph.
+- End each intro or section paragraph with its combined evidence markers; do
+  not place citations only in the middle of a paragraph.
 - Use `inline code` only for identifiers and paths present in the evidence.
 - Do not invent files, symbols, APIs, relationships, or behavior.
 - Use factual engineering language. Do not call anything powerful, efficient,
-  comprehensive, crucial, user-friendly, invaluable, or productivity-enhancing.
+  comprehensive, crucial, flexible, responsive, user-friendly, invaluable, or
+  productivity-enhancing. End a sentence after the supported mechanism instead
+  of adding a generic benefit or justification clause.
+- Name a subsystem by its concrete component or responsibility, not by appending
+  "subsystem" to a source filename. Avoid "this page/document explains" prose.
 - Do not draw a diagram; the application renders the static graph separately.
 Return only the Markdown (no JSON, no commentary)."""
 
@@ -642,14 +665,32 @@ Draft:
 Keep useful explanations, but remove unsupported names and paths. Put [E#] or
 [R#] evidence markers in every substantive paragraph, including the intro.
 Preserve the supported fact plan: write an intro and a prose section for every
-planned section instead of deleting sections to fix wording. Rephrase benefit
-claims as neutral implementation facts. Remove paragraphs that merely restate
-the intro or another section.
+planned section instead of deleting sections to fix wording. Render every
+planned claim exactly once as one concrete sentence. Remove unplanned benefit
+or justification clauses instead of paraphrasing them. Remove paragraphs that
+merely restate the intro or another section. Reusing an evidence item is valid
+when the paragraph states a different supported fact.
 The revision must contain at least {required_sections} H2 sections and
 {required_blocks} substantive evidence-cited paragraphs. End every substantive
 paragraph with its evidence marker(s); do not append unsupported sentences
 after a citation.
 Do not wrap the response in a Markdown code fence. Return only Markdown.
+"""
+
+_STYLE_REPAIR_PROMPT = """\
+Make a minimal style edit to the Markdown below.
+
+Flagged phrases:
+{phrases}
+
+Draft:
+{draft}
+
+Remove a flagged clause or sentence when it contains only a generic benefit;
+do not replace it with a synonym. Otherwise replace only the flagged wording
+and minimum surrounding grammar needed for factual prose. Preserve every
+heading, paragraph, identifier, path, concrete mechanism, and evidence marker.
+Do not merge or reorder technical claims. Return only Markdown.
 """
 
 
@@ -701,8 +742,11 @@ class AgentWiki:
                 f"{getattr(view, 'built_at_epoch', '')}:{config_hash}"
             )
         view_identity = ",".join(view_parts)
+        prompt_version = (
+            _OUTLINE_PROMPT_VERSION if suffix == "outline" else _PAGE_PROMPT_VERSION
+        )
         raw = (
-            f"{_PROMPT_VERSION}/{getattr(entry, 'instance_id', 'repo')}@{commit}/"
+            f"{prompt_version}/{getattr(entry, 'instance_id', 'repo')}@{commit}/"
             f"{self._model}/{self._api_base or ''}/{llm_identity}/"
             f"{view_identity}/{suffix}"
         )
@@ -868,6 +912,16 @@ class AgentWiki:
             routes,
             key=lambda node: candidate_key(node, self._node_attr),
         )
+        if not _page_allows_supporting_files(meta):
+            fused = [
+                item
+                for item in fused
+                if not _is_supporting_file(
+                    self._norm_hint_path(
+                        self._rel(self._node_attr(item[0], "file")) or ""
+                    )
+                )
+            ]
         by_key = {
             candidate_key(node, self._node_attr): (route_names, score)
             for node, route_names, score in fused
@@ -898,34 +952,62 @@ class AgentWiki:
         # reaches the writer even when lexical/semantic ranking favors generic
         # symbols elsewhere in the repository. This also admits README content,
         # which code-only indexes intentionally omit.
-        selected_by_file: Dict[str, List[Any]] = {}
-        for node in selected_nodes:
+        selected_by_file: Dict[str, List[tuple[Any, tuple[str, ...]]]] = {}
+        for node, route_names, _ in reranked_with_routes:
             selected_file = self._norm_hint_path(
                 self._rel(self._node_attr(node, "file")) or ""
             )
-            selected_by_file.setdefault(selected_file, []).append(node)
+            selected_by_file.setdefault(selected_file, []).append(
+                (node, tuple(route_names))
+            )
+        outline_files = {self._norm_hint_path(file) for file in files}
+        selected_keys_by_file = {
+            file: {self._source_span_key(candidate) for candidate, _ in candidates}
+            for file, candidates in selected_by_file.items()
+        }
+        try:
+            for node in self._wb._symbols():
+                selected_file = self._norm_hint_path(
+                    self._rel(self._node_attr(node, "file")) or ""
+                )
+                if selected_file not in outline_files:
+                    continue
+                key = self._source_span_key(node)
+                existing = selected_keys_by_file.setdefault(selected_file, set())
+                if key not in existing:
+                    selected_by_file.setdefault(selected_file, []).append(
+                        (node, ("outline",))
+                    )
+                    existing.add(key)
+        except Exception as exc:  # noqa: BLE001 - ranked retrieval remains usable
+            logger.debug("wiki outline symbol enumeration unavailable: %s", exc)
         anchors = []
-        promoted_node_ids = set()
+        promoted_source_keys = set()
         anchored_files = set()
-        anchor_limit = (
-            min(6, max(1, top_k - 2))
-            if meta.get("id") == "overview"
-            else min(4, max(1, top_k // 2))
-        )
+        overview = meta.get("id") == "overview"
+        anchor_limit = min(8, top_k) if overview else min(4, max(1, top_k // 2))
         for raw_file in files:
             file = self._norm_hint_path(raw_file)
             if not file or file in anchored_files:
                 continue
             matches = selected_by_file.get(file) or []
             if matches:
-                node = matches[0]
-                promoted_node_ids.add(id(node))
-                existing_routes = self._retrieval_routes.get(
-                    candidate_key(node, self._node_attr), ()
+                matches = sorted(
+                    matches,
+                    key=lambda item: self._outline_anchor_rank(meta, item[0]),
+                    reverse=True,
                 )
-                self._retrieval_routes[candidate_key(node, self._node_attr)] = tuple(
-                    dict.fromkeys(("outline", *existing_routes))
-                )
+                per_file_limit = 1 if overview else 2
+                for node, route_names in matches[:per_file_limit]:
+                    promoted_source_keys.add(self._source_span_key(node))
+                    key = candidate_key(node, self._node_attr)
+                    existing_routes = self._retrieval_routes.get(key, route_names)
+                    self._retrieval_routes[key] = tuple(
+                        dict.fromkeys(("outline", *existing_routes))
+                    )
+                    anchors.append(node)
+                    if len(anchors) >= anchor_limit:
+                        break
             else:
                 source = self._wb.source(file)
                 if not source or not source.get("content"):
@@ -941,19 +1023,76 @@ class AgentWiki:
                 self._retrieval_routes[candidate_key(node, self._node_attr)] = (
                     "outline",
                 )
-            anchors.append(node)
+                anchors.append(node)
             anchored_files.add(file)
             if len(anchors) >= anchor_limit:
                 break
         if anchors:
-            selected_nodes = anchors + [
-                node for node in selected_nodes if id(node) not in promoted_node_ids
+            remaining = [
+                node
+                for node in selected_nodes
+                if self._source_span_key(node) not in promoted_source_keys
             ]
+            remaining.sort(
+                key=lambda node: self._outline_anchor_rank(meta, node),
+                reverse=True,
+            )
+            selected_nodes = anchors + remaining
         return selected_nodes[:top_k]
 
     @staticmethod
     def _norm_hint_path(path: str) -> str:
         return path.replace("\\", "/").strip().strip("/")
+
+    def _outline_anchor_score(self, node: Any) -> int:
+        """Prefer repository-facing symbols when anchoring an outline file."""
+
+        raw_name = str(
+            self._node_attr(node, "node_name") or self._node_attr(node, "name") or ""
+        )
+        terminal = re.split(r"[:.]", raw_name)[-1].split("(", 1)[0]
+        if terminal.startswith("_") and not terminal.startswith("__"):
+            return 0
+        kind = str(self._node_attr(node, "type") or "").lower()
+        return 2 if kind in {"class", "interface", "module"} else 1
+
+    def _source_span_key(self, node: Any) -> tuple[str, Any, Any]:
+        return (
+            self._norm_hint_path(self._rel(self._node_attr(node, "file")) or ""),
+            self._node_attr(node, "start_line"),
+            self._node_attr(node, "end_line"),
+        )
+
+    def _outline_anchor_rank(
+        self,
+        meta: Dict[str, Any],
+        node: Any,
+    ) -> tuple[int, int, int, int]:
+        raw_name = str(
+            self._node_attr(node, "node_name") or self._node_attr(node, "name") or ""
+        ).lower()
+        content = str(self._node_attr(node, "content") or "").lower()
+        terms = self._keyword_terms(
+            [
+                str(meta.get("title") or ""),
+                *[str(value) for value in meta.get("keywords") or []],
+            ]
+        )
+        name_hits = sum(term in raw_name for term in terms)
+        content_hits = sum(term in content for term in terms)
+        start = self._node_attr(node, "start_line")
+        end = self._node_attr(node, "end_line")
+        span = (
+            max(1, end - start + 1)
+            if isinstance(start, int) and isinstance(end, int)
+            else 1
+        )
+        return (
+            self._outline_anchor_score(node),
+            name_hits,
+            content_hits,
+            min(span, 500),
+        )
 
     @staticmethod
     def _path_matches_hint(file: str, hint: str) -> bool:
@@ -1166,6 +1305,7 @@ class AgentWiki:
             title=meta.get("title", ""),
             summary=meta.get("summary", ""),
             guidance=_page_planning_guidance(meta),
+            constraints=_plan_evidence_constraints(meta, evidence),
             evidence=self._evidence_context(evidence),
             relations=self._relations_context(relations),
         )
@@ -1185,10 +1325,13 @@ class AgentWiki:
         if plan.get("sections"):
             quality_warnings = _plan_quality_warnings(meta, plan, evidence, relations)
             warnings = [*errors, *quality_warnings]
-            if quality_warnings:
+            repairs = 0
+            while quality_warnings and repairs < _MAX_PLAN_REPAIRS:
+                repairs += 1
                 repair_prompt = _PLAN_REPAIR_PROMPT.format(
                     title=meta.get("title", ""),
                     guidance=_page_planning_guidance(meta),
+                    constraints=_plan_evidence_constraints(meta, evidence),
                     problems=json.dumps(warnings, indent=2),
                     plan=json.dumps(plan, indent=2),
                     evidence=self._evidence_context(evidence),
@@ -1209,13 +1352,19 @@ class AgentWiki:
                             meta, repaired_plan, evidence, relations
                         ),
                     ]
-                    if repaired_plan.get("sections") and len(repaired_warnings) < len(
-                        warnings
+                    if repaired_plan.get("sections") and (
+                        len(repaired_warnings) < len(warnings)
                     ):
                         plan = repaired_plan
                         warnings = repaired_warnings
+                        quality_warnings = _plan_quality_warnings(
+                            meta, plan, evidence, relations
+                        )
+                    else:
+                        break
                 except Exception as exc:  # noqa: BLE001 - retain usable first plan
                     logger.debug("wiki fact-plan repair unavailable: %s", exc)
+                    break
             return plan, warnings
 
         claims = [
@@ -1304,7 +1453,7 @@ class AgentWiki:
                     self._client().complete(
                         [{"role": "user", "content": prompt}],
                         max_tokens=2200,
-                        temperature=0.2,
+                        temperature=0.1,
                     )
                 ),
                 False,
@@ -1346,12 +1495,34 @@ class AgentWiki:
                 self._client().complete(
                     [{"role": "user", "content": prompt}],
                     max_tokens=2200,
-                    temperature=0.1,
+                    temperature=0.0,
                 )
             )
             return repaired or draft
         except Exception as exc:  # noqa: BLE001 - retain the first usable draft
             logger.warning("wiki grounding repair failed: %s", exc)
+            return draft
+
+    def _repair_style(
+        self,
+        draft: str,
+        phrases: Sequence[str],
+    ) -> str:
+        prompt = _STYLE_REPAIR_PROMPT.format(
+            phrases=json.dumps(list(phrases), indent=2),
+            draft=draft,
+        )
+        try:
+            repaired = _clean_markdown(
+                self._client().complete(
+                    [{"role": "user", "content": prompt}],
+                    max_tokens=2200,
+                    temperature=0.0,
+                )
+            )
+            return repaired or draft
+        except Exception as exc:  # noqa: BLE001 - style is a soft constraint
+            logger.debug("wiki style repair unavailable: %s", exc)
             return draft
 
     def _generate_page(self, meta: Dict[str, Any]) -> dict:
@@ -1382,11 +1553,39 @@ class AgentWiki:
 
         relations = self._relation_items(evidence)
         plan, plan_warnings = self._fact_plan(meta, evidence, relations)
-        markdown, model_failed = self._narrate(meta, evidence, relations, plan)
-        report = grounding_report(markdown, evidence, relations)
         dense_sections = meta.get("id") == "overview"
+        structured_render = True
+        if structured_render:
+            markdown = _fact_plan_markdown(plan, evidence, relations)
+            model_failed = not bool(markdown)
+            if model_failed:
+                markdown, model_failed = self._narrate(
+                    meta,
+                    evidence,
+                    relations,
+                    plan,
+                )
+                structured_render = False
+        else:
+            markdown, model_failed = self._narrate(
+                meta,
+                evidence,
+                relations,
+                plan,
+            )
+        if dense_sections:
+            markdown = _ensure_cited_intro(
+                markdown,
+                evidence,
+                canonical_readme=True,
+            )
+        report = grounding_report(markdown, evidence, relations)
         quality = _page_quality_report(
-            markdown, plan, require_dense_sections=dense_sections
+            markdown,
+            plan,
+            require_dense_sections=dense_sections,
+            require_cited_intro=dense_sections,
+            require_narrative_novelty=dense_sections,
         )
         logger.debug(
             "wiki page candidate %s: grounding=%s quality=%s",
@@ -1396,21 +1595,48 @@ class AgentWiki:
         )
         best = (markdown, report, quality)
         repaired = False
-        if (not report["valid"] or not quality["valid"]) and not model_failed:
-            repaired_markdown = self._repair_markdown(
-                markdown,
-                {"grounding": report, "coverage": quality},
-                evidence,
-                relations,
-                plan,
+        if (
+            not report["valid"] or not quality["valid"] or report["promotional_phrases"]
+        ) and not model_failed:
+            style_only = bool(
+                report["valid"] and quality["valid"] and report["promotional_phrases"]
             )
+            if style_only:
+                repaired_markdown = markdown
+                remaining_phrases = list(report["promotional_phrases"])
+                for _ in range(_MAX_STYLE_REPAIRS):
+                    candidate = self._repair_style(
+                        repaired_markdown,
+                        remaining_phrases,
+                    )
+                    candidate_report = grounding_report(
+                        candidate,
+                        evidence,
+                        relations,
+                    )
+                    candidate_phrases = list(candidate_report["promotional_phrases"])
+                    if len(candidate_phrases) >= len(remaining_phrases):
+                        break
+                    repaired_markdown = candidate
+                    remaining_phrases = candidate_phrases
+                    if not remaining_phrases:
+                        break
+            else:
+                repaired_markdown = self._repair_markdown(
+                    markdown,
+                    {"grounding": report, "coverage": quality},
+                    evidence,
+                    relations,
+                    plan,
+                )
+            if dense_sections:
+                repaired_markdown = _ensure_cited_intro(
+                    repaired_markdown,
+                    evidence,
+                    canonical_readme=True,
+                )
             repaired = True
             repaired_report = grounding_report(repaired_markdown, evidence, relations)
-            if repaired_report["promotional_phrases"]:
-                repaired_markdown = remove_promotional_sentences(repaired_markdown)
-                repaired_report = grounding_report(
-                    repaired_markdown, evidence, relations
-                )
             if (
                 not repaired_report["valid"]
                 and repaired_report["citation_coverage"] < 1.0
@@ -1428,6 +1654,8 @@ class AgentWiki:
                 repaired_markdown,
                 plan,
                 require_dense_sections=dense_sections,
+                require_cited_intro=dense_sections,
+                require_narrative_novelty=dense_sections,
             )
             logger.debug(
                 "wiki page repaired candidate %s: grounding=%s quality=%s",
@@ -1449,6 +1677,8 @@ class AgentWiki:
                     fallback,
                     plan,
                     require_dense_sections=dense_sections,
+                    require_cited_intro=dense_sections,
+                    require_narrative_novelty=dense_sections,
                 )
                 if _candidate_score(
                     fallback_report, fallback_quality
@@ -1459,21 +1689,27 @@ class AgentWiki:
         markdown, report, quality = best
         markdown = _remove_orphan_headings(markdown)
         report = grounding_report(markdown, evidence, relations)
-        if markdown.lstrip().startswith("#"):
-            intro = _readme_intro(evidence)
-            if intro is not None:
-                text, evidence_id = intro
-                markdown = f"{text} [{evidence_id}]\n\n{markdown}"
-                report = grounding_report(markdown, evidence, relations)
+        if dense_sections:
+            markdown = _ensure_cited_intro(
+                markdown,
+                evidence,
+                canonical_readme=True,
+            )
+        report = grounding_report(markdown, evidence, relations)
         quality = _page_quality_report(
-            markdown, plan, require_dense_sections=dense_sections
+            markdown,
+            plan,
+            require_dense_sections=dense_sections,
+            require_cited_intro=dense_sections,
+            require_narrative_novelty=dense_sections,
         )
         markdown = _link_evidence_markers(markdown)
         publishable = bool(report["valid"] and quality["valid"])
-        generated = publishable and not model_failed
+        planning_failed = "model planning unavailable" in plan_warnings
+        generated = publishable and not model_failed and not planning_failed
         if generated:
             generation_reason = None
-        elif model_failed:
+        elif model_failed or planning_failed:
             generation_reason = "model_unavailable"
         else:
             generation_reason = "quality_guard"
@@ -1501,7 +1737,8 @@ class AgentWiki:
                 "mode": "generated" if generated else "degraded",
                 "model": self._model,
                 "repaired": repaired,
-                "fallback": "fact_plan" if fallback_used else None,
+                "fallback": ("fact_plan" if fallback_used or planning_failed else None),
+                "renderer": "fact_plan" if structured_render else "narrative",
                 "plan_warnings": plan_warnings,
                 "reason": generation_reason,
             },

--- a/codenib/wiki/evidence.py
+++ b/codenib/wiki/evidence.py
@@ -47,14 +47,19 @@ _COMMON_CODE_TERMS = frozenset(
     }
 )
 _PROMOTIONAL_RE = re.compile(
-    r"\b(adapt(?:s|ing)?|advanced|aids?|"
+    r"\b(adapt(?:s|ing)?|adaptable|advanced|aids?|"
     r"allows(?: for| the system| developers| users)|"
     r"allowing (?:for|developers|users)|comprehensive|crucial|dynamic(?:ally)?|"
-    r"easy to use|easier|effectively|efficient|efficiently|"
+    r"cater(?:s|ing)?|easy access|easy to use|easier|effectively|"
+    r"efficient|efficiently|"
     r"enabl(?:e|es|ing)(?: developers| users)?|"
-    r"enhanc(?:e|es|ing)(?: productivity)?|essential|"
+    r"enhanc(?:e|es|ing)(?: productivity)?|"
+    r"ensur(?:e|es|ing) (?:that )?(?:all relevant|everything|resources?)|"
+    r"essential|flexible|"
     r"facilitat(?:e|es|ing)|gain insights?|helps? users|intuitive|invaluable|"
-    r"key functionalit(?:y|ies)|making it|powerful|quickly|significantly|"
+    r"important (?:for|to)|key functionalit(?:y|ies)|making it|"
+    r"powerful|provid(?:e|es|ing) (?:easy|quick)|quickly|responsive|significantly|"
+    r"supports? (?:interactions?|management)|"
     r"optimiz(?:e|es|ing)|sophisticated|user-friendly|versatile)\b",
     re.IGNORECASE,
 )
@@ -256,11 +261,16 @@ def grounding_report(
     for identifier in _CODE_RE.findall(without_fences):
         normalized = identifier.strip()
         source_name = re.sub(r":\d+(?:-\d+)?$", "", normalized)
+        call_name_match = re.match(r"([A-Za-z_][\w.]*)\s*\(", source_name)
+        call_name = call_name_match.group(1) if call_name_match else ""
+        call_leaf = call_name.rsplit(".", 1)[-1]
         if (
             not normalized
             or normalized.lower() in _COMMON_CODE_TERMS
             or normalized.lower() in corpus
             or source_name.lower() in corpus
+            or (call_name and call_name.lower() in corpus)
+            or (call_leaf and call_leaf.lower() in corpus)
         ):
             continue
         unsupported_identifiers.append(normalized)
@@ -285,7 +295,6 @@ def grounding_report(
         and not unknown_citations
         and not unknown_files
         and not unsupported_identifiers
-        and not promotional_phrases
     )
     return {
         "valid": valid,

--- a/codenib/wiki/outline.py
+++ b/codenib/wiki/outline.py
@@ -93,6 +93,39 @@ _LOW_LEVEL_OVERVIEW_TOKENS = {
     "patcher",
     "protocol",
 }
+_SUPPORTING_PAGE_TOKENS = {
+    "benchmark",
+    "benchmarks",
+    "docs",
+    "documentation",
+    "eval",
+    "evaluation",
+    "evaluations",
+    "example",
+    "examples",
+    "fixture",
+    "fixtures",
+    "script",
+    "scripts",
+    "test",
+    "testing",
+    "tests",
+}
+
+
+def _is_supporting_file(file: str) -> bool:
+    return bool(
+        {segment.lower() for segment in Path(file).parts[:-1]} & _SUPPORTING_SEGMENTS
+    )
+
+
+def _page_allows_supporting_files(page: Dict[str, Any]) -> bool:
+    values = [
+        str(page.get("title") or ""),
+        *[str(value) for value in page.get("keywords") or []],
+    ]
+    terms = set(re.findall(r"[a-z0-9_]{4,}", " ".join(values).lower()))
+    return bool(terms & _SUPPORTING_PAGE_TOKENS)
 
 
 def _read_readme(repo_dir: str, limit: int = 3500) -> str:
@@ -227,10 +260,10 @@ _OUTLINE_PROMPT = """\
 You are documenting the {repo} codebase like a senior engineer writing a \
 developer wiki for new contributors.
 
-Propose a HIGH-LEVEL, CONCEPTUAL table of contents — organized by \
-SUBSYSTEM / CAPABILITY, never by directory or file. Think titles like \
-"Request Pipeline", "Interceptors", "Adapters & Transports", "Configuration", \
-"Error Handling" — the mental model someone needs to understand the system.
+Propose a HIGH-LEVEL, CONCEPTUAL table of contents organized by real subsystem \
+or capability, never by directory or file. Derive every concept from the \
+supplied file paths or symbol names; do not copy categories from a generic \
+software-architecture template.
 
 Repository: {repo}   (languages: {languages})
 
@@ -252,7 +285,7 @@ Central dependency communities:
 Available repository views:
 {views}
 
-Return ONLY JSON, no prose, of exactly this shape. Aim for 6-10 top-level pages \
+Return ONLY JSON, no prose, of exactly this shape. Aim for 5-8 top-level pages \
 that together cover the WHOLE system, and give the major subsystems 1-3 children \
 so the tree is genuinely TWO LEVELS deep — not a flat list. Start with "Overview".
 {{"pages":[{{"id":"kebab-case-id","title":"Concept Title","summary":"1-2 \
@@ -263,14 +296,17 @@ feature","search","terms"],"files":["likely/relevant/path.ext"],"children":[\
 
 Rules:
 - Structure it like a senior engineer's onboarding docs: top-level = major areas; \
-children = specific capabilities or flows inside them (e.g. an "I/O" page with \
-"FITS", "ASCII", "Registry" children; a "Table System" page with "Operations").
-- Cover not only domain subsystems but the cross-cutting pages a new contributor \
-needs, WHEN APPLICABLE: Getting Started / Installation, Project Structure, \
-Configuration, Testing, Extensibility / Plugins.
+children = specific capabilities or flows inside them.
+- Overview is the landing page and must have no children. Major subsystems such \
+as indexing, serving, navigation, or agent runtime belong at the top level when \
+the supplied repository evidence supports them.
+- Include a cross-cutting page only when a supplied path or symbol explicitly \
+names and implements that concern.
 - Titles are CONCEPTS, not paths (no "lib/core", no file names as titles).
 - keywords drive a code search, so make them specific symbol/feature terms.
 - Every page and child MUST name 1-4 exact files from the supplied evidence.
+- At least one named file or symbol must lexically anchor the page title. A real \
+but unrelated file does not make an invented concept valid.
 - Make Overview a product mental model: purpose, user entry points, the main
   execution/data flow, and the major subsystems. Do not elevate one language
   backend, decoder, patcher, or private helper unless it defines the repository.
@@ -278,6 +314,32 @@ Configuration, Testing, Extensibility / Plugins.
   testing, plugins, communication, or error-handling merely because most
   projects have them.
 - Cover the whole system, not just a few files; prefer depth over a flat list.
+"""
+
+_OUTLINE_REPAIR_PROMPT = """\
+{original_prompt}
+
+The previous attempt retained only {accepted} source-anchored top-level pages,
+but this repository needs at least {required}. Return a COMPLETE replacement
+outline, not a patch. Keep the accepted concepts when useful, add distinct
+major subsystems from the supplied paths and symbols, and do not attach a real
+but unrelated file to justify a generic category.
+
+Previously retained outline:
+{outline}
+"""
+
+_OUTLINE_REFINEMENT_PROMPT = """\
+{original_prompt}
+
+Produce one alternative COMPLETE outline for the same repository. The previous
+outline already passed the minimum breadth check; improve source coverage by
+representing distinct major user-facing and implementation areas from the
+supplied paths and symbols. Do not add generic categories, duplicate an
+existing responsibility under another name, or attach unrelated real files.
+
+Previous outline:
+{outline}
 """
 
 
@@ -322,7 +384,7 @@ def generate_outline(
         text = llm.complete(
             [{"role": "user", "content": prompt}],
             max_tokens=max_tokens,
-            temperature=0.2,
+            temperature=0.1,
         )
     except Exception as exc:  # noqa: BLE001 - surface a clean failure to caller
         logger.warning("outline generation failed (%s): %s", model, exc)
@@ -330,20 +392,94 @@ def generate_outline(
         fallback["error"] = str(exc)
         return fallback
 
-    data = _parse_outline(text)
+    repo_dir = getattr(bundle.entry, "repo_dir", "") or ""
     data = _validate_outline(
-        data,
-        getattr(bundle.entry, "repo_dir", "") or "",
+        _parse_outline(text),
+        repo_dir,
         symbols=symbols,
         fallback_files=files,
     )
+    required_pages = _required_top_level_pages(len(files))
+    initial_pages = len(data.get("pages") or [])
+    should_retry = initial_pages < required_pages or len(files) > 12
+    refined = False
+    if should_retry:
+        if initial_pages < required_pages:
+            retry_prompt = _OUTLINE_REPAIR_PROMPT.format(
+                original_prompt=prompt,
+                accepted=initial_pages,
+                required=required_pages,
+                outline=json.dumps(data.get("pages") or [], indent=2),
+            )
+        else:
+            retry_prompt = _OUTLINE_REFINEMENT_PROMPT.format(
+                original_prompt=prompt,
+                outline=json.dumps(data.get("pages") or [], indent=2),
+            )
+        try:
+            repaired_text = llm.complete(
+                [{"role": "user", "content": retry_prompt}],
+                max_tokens=max_tokens,
+                temperature=0.1,
+            )
+            repaired = _validate_outline(
+                _parse_outline(repaired_text),
+                repo_dir,
+                symbols=symbols,
+                fallback_files=files,
+            )
+            if _outline_score(repaired, required_pages) > _outline_score(
+                data, required_pages
+            ):
+                data = repaired
+                refined = True
+        except Exception as exc:  # noqa: BLE001 - keep the first valid outline
+            logger.debug("outline repair unavailable: %s", exc)
     if not data.get("pages"):
         fallback = _fallback_outline(files)
         fallback["error"] = data.get("error") or "model returned no usable pages"
         fallback["raw"] = data.get("raw")
         return fallback
     data["mode"] = "generated"
+    data["quality"] = {
+        "required_top_level_pages": required_pages,
+        "top_level_pages": len(data["pages"]),
+        "valid": len(data["pages"]) >= required_pages,
+        "refined": refined,
+    }
     return data
+
+
+def _required_top_level_pages(salient_file_count: int) -> int:
+    """Scale the minimum table-of-contents breadth with repository evidence."""
+
+    if salient_file_count <= 5:
+        return 2
+    if salient_file_count <= 12:
+        return 3
+    return 5
+
+
+def _outline_score(
+    data: Dict[str, Any],
+    required_pages: int,
+) -> tuple[int, int, int, int]:
+    """Prefer broad, source-diverse outlines without overriding validation."""
+
+    pages = data.get("pages") or []
+    children = sum(len(page.get("children") or []) for page in pages)
+    files = {
+        file
+        for page in pages
+        for file in page.get("files") or []
+        if isinstance(file, str)
+    }
+    return (
+        int(len(pages) >= required_pages),
+        min(len(pages), required_pages),
+        len(files),
+        children,
+    )
 
 
 def _parse_outline(text: str) -> Dict[str, Any]:
@@ -403,6 +539,45 @@ def _validate_outline(
         "system",
         "types",
     }
+
+    def tokens(value: str) -> set[str]:
+        return set(re.findall(r"[a-z0-9_]{4,}", value.lower()))
+
+    def variants(value: str) -> set[str]:
+        values = {value}
+        for suffix in ("ing", "ed", "es", "s"):
+            if value.endswith(suffix) and len(value) - len(suffix) >= 4:
+                values.add(value[: -len(suffix)])
+        return values
+
+    def matches(term: str, document_tokens: set[str]) -> bool:
+        return any(
+            left == right
+            or (
+                min(len(left), len(right)) >= 4
+                and (left.startswith(right) or right.startswith(left))
+            )
+            for left in variants(term)
+            for token in document_tokens
+            for right in variants(token)
+        )
+
+    def title_is_anchored(
+        title: str,
+        files: List[str],
+        *,
+        overview: bool = False,
+    ) -> bool:
+        if overview:
+            return True
+        title_terms = tokens(title) - generic_terms
+        if not title_terms:
+            return False
+        return any(
+            matches(term, set(searchable.get(file, "").split()))
+            for file in files
+            for term in title_terms
+        )
 
     def inferred_files(page: Dict[str, Any]) -> List[str]:
         raw_terms = [
@@ -499,31 +674,47 @@ def _validate_outline(
         *,
         child: bool = False,
         parent_files: List[str] | None = None,
+        overview: bool = False,
     ) -> Dict[str, Any] | None:
         if not isinstance(page, dict):
             return None
         title = re.sub(r"\s+", " ", str(page.get("title") or "")).strip()
         if not title:
             return None
+        if overview:
+            title = "Overview"
         summary = re.sub(r"\s+", " ", str(page.get("summary") or "")).strip()
         keywords = [
             re.sub(r"\s+", " ", str(value)).strip()
             for value in page.get("keywords") or []
             if str(value).strip()
         ]
+        allows_supporting_files = _page_allows_supporting_files(
+            {"title": title, "keywords": keywords}
+        )
         files = valid_files(page.get("files"))
-        if title.lower() == "overview":
+        if not overview and not allows_supporting_files:
+            files = [file for file in files if not _is_supporting_file(file)]
+        if overview:
             files = overview_files(files)
         if not files:
             files = inferred_files(page)
-        if not files and title.lower() == "overview":
+            if not overview and not allows_supporting_files:
+                files = [file for file in files if not _is_supporting_file(file)]
+        if not files and overview:
             files = [file for file in fallback_files if file in known_files][:8]
         if not files and child and parent_files:
             parent_matches = [
                 file for file in inferred_files(page) if file in parent_files
             ]
+            if not allows_supporting_files:
+                parent_matches = [
+                    file for file in parent_matches if not _is_supporting_file(file)
+                ]
             files = parent_matches[:4]
         if not files:
+            return None
+        if not title_is_anchored(title, files, overview=overview):
             return None
 
         children = []
@@ -541,11 +732,48 @@ def _validate_outline(
             "children": children,
         }
 
+    candidates = list((data.get("pages") or [])[:_MAX_OUTLINE_PAGES])
+    overview_index = next(
+        (
+            index
+            for index, candidate in enumerate(candidates)
+            if isinstance(candidate, dict)
+            and (
+                str(candidate.get("id") or "").strip().lower() == "overview"
+                or "overview" in str(candidate.get("title") or "").lower()
+            )
+        ),
+        None,
+    )
+    if overview_index is None:
+        overview_candidate = {
+            "id": "overview",
+            "title": "Overview",
+            "summary": "Repository purpose, public workflow, and major subsystems.",
+            "keywords": ["entry point", "runtime", "compiler"],
+            "files": fallback_files,
+            "children": [],
+        }
+        ordered = [(overview_candidate, True), *[(item, False) for item in candidates]]
+    else:
+        overview_candidate = candidates.pop(overview_index)
+        ordered = [(overview_candidate, True), *[(item, False) for item in candidates]]
+
     pages = []
-    for candidate in (data.get("pages") or [])[:_MAX_OUTLINE_PAGES]:
-        page = normalize(candidate)
+    for candidate, is_overview in ordered[:_MAX_OUTLINE_PAGES]:
+        page = normalize(candidate, overview=is_overview)
         if page is not None:
             pages.append(page)
+    if pages:
+        promoted = pages[0].get("children", [])
+        pages[0]["children"] = []
+        existing = {str(page.get("title") or "").lower() for page in pages}
+        promoted = [
+            page
+            for page in promoted
+            if str(page.get("title") or "").lower() not in existing
+        ]
+        pages[1:1] = promoted[: max(0, _MAX_OUTLINE_PAGES - len(pages))]
     return {**data, "pages": pages}
 
 

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic quality reports for generated repository Wiki pages."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable, List
+
+_EVIDENCE_MARKER = re.compile(r"\[((?:E|R)\d+)\]")
+
+
+def prose_terms(text: str) -> set[str]:
+    """Return stable content terms for conservative duplicate detection."""
+
+    stopwords = {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "into",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "that",
+        "the",
+        "then",
+        "this",
+        "through",
+        "to",
+        "with",
+    }
+    plain = re.sub(r"\[((?:E|R)\d+)\](?:\([^)]*\))?", " ", text)
+    plain = re.sub(r"[`*_[\]()#>/-]", " ", plain.lower())
+    return {
+        token
+        for token in re.findall(r"[a-z0-9]+", plain)
+        if len(token) > 1 and token not in stopwords
+    }
+
+
+def duplicate_prose_blocks(markdown: str) -> List[List[int]]:
+    """Find paragraph pairs where one largely restates the other."""
+
+    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    terms = []
+    for raw in re.split(r"\n\s*\n", without_fences):
+        block = raw.strip()
+        if not block or block.startswith("#"):
+            continue
+        block_terms = prose_terms(block)
+        if len(block_terms) >= 6:
+            terms.append(block_terms)
+
+    duplicates: List[List[int]] = []
+    for left in range(len(terms)):
+        for right in range(left + 1, len(terms)):
+            smaller = min(len(terms[left]), len(terms[right]))
+            overlap = len(terms[left] & terms[right]) / smaller
+            if overlap >= 0.85:
+                duplicates.append([left + 1, right + 1])
+    return duplicates
+
+
+def section_evidence_report(markdown: str) -> dict[str, Any]:
+    """Measure whether sections contribute evidence beyond the page intro."""
+
+    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    section_matches = list(
+        re.finditer(r"^##\s+(.+?)\s*$", without_fences, flags=re.MULTILINE)
+    )
+    intro_end = section_matches[0].start() if section_matches else len(without_fences)
+    intro_evidence = set(_EVIDENCE_MARKER.findall(without_fences[:intro_end]))
+    seen = set(intro_evidence)
+    evidence_by_section: dict[str, List[str]] = {}
+    new_evidence_by_section: dict[str, List[str]] = {}
+    sections_without_new_evidence: List[str] = []
+    intro_only_sections: List[str] = []
+
+    for index, match in enumerate(section_matches):
+        end = (
+            section_matches[index + 1].start()
+            if index + 1 < len(section_matches)
+            else len(without_fences)
+        )
+        title = match.group(1).strip()
+        evidence = set(_EVIDENCE_MARKER.findall(without_fences[match.end() : end]))
+        new_evidence = evidence - seen
+        evidence_by_section[title] = sorted(evidence)
+        new_evidence_by_section[title] = sorted(new_evidence)
+        if evidence and not new_evidence:
+            sections_without_new_evidence.append(title)
+        if intro_evidence and evidence and evidence.issubset(intro_evidence):
+            intro_only_sections.append(title)
+        seen.update(evidence)
+
+    return {
+        "intro_evidence": sorted(intro_evidence),
+        "evidence_by_section": evidence_by_section,
+        "new_evidence_by_section": new_evidence_by_section,
+        "sections_without_new_evidence": sections_without_new_evidence,
+        "intro_only_sections": intro_only_sections,
+    }
+
+
+def section_narrative_report(markdown: str) -> dict[str, Any]:
+    """Find sections that substantially restate the intro or an earlier section."""
+
+    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    section_matches = list(
+        re.finditer(r"^##\s+(.+?)\s*$", without_fences, flags=re.MULTILINE)
+    )
+    intro_end = section_matches[0].start() if section_matches else len(without_fences)
+    intro_terms = prose_terms(without_fences[:intro_end])
+    prior = [("intro", intro_terms)]
+    redundant_sections: List[str] = []
+    comparisons: dict[str, dict[str, Any]] = {}
+
+    for index, match in enumerate(section_matches):
+        end = (
+            section_matches[index + 1].start()
+            if index + 1 < len(section_matches)
+            else len(without_fences)
+        )
+        title = match.group(1).strip()
+        terms = prose_terms(without_fences[match.end() : end])
+        best_against = ""
+        best_overlap = 0.0
+        for prior_title, prior_terms in prior:
+            smaller = min(len(terms), len(prior_terms))
+            overlap = len(terms & prior_terms) / smaller if smaller >= 6 else 0.0
+            if overlap > best_overlap:
+                best_against = prior_title
+                best_overlap = overlap
+        comparisons[title] = {
+            "against": best_against or None,
+            "overlap": round(best_overlap, 3),
+        }
+        if best_overlap >= 0.8:
+            redundant_sections.append(title)
+        prior.append((title, terms))
+
+    return {
+        "redundant_sections": redundant_sections,
+        "section_similarity": comparisons,
+    }
+
+
+def page_quality_report(
+    markdown: str,
+    plan: dict[str, Any],
+    *,
+    require_dense_sections: bool = False,
+    require_cited_intro: bool = False,
+    require_narrative_novelty: bool = False,
+) -> dict[str, Any]:
+    """Measure whether a page represents its supported fact plan."""
+
+    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    rendered_sections = len(
+        re.findall(r"^#{2,6}\s+\S", without_fences, flags=re.MULTILINE)
+    )
+    substantive_blocks = 0
+    for raw in re.split(r"\n\s*\n", without_fences):
+        block = raw.strip()
+        if block and not block.startswith("#"):
+            plain = re.sub(r"[`*_[\]()#>-]", "", block).strip()
+            if len(plain) >= 40:
+                substantive_blocks += 1
+
+    sections = plan.get("sections") or []
+    claims = [
+        claim
+        for section in sections
+        for claim in section.get("claims") or []
+        if claim.get("evidence")
+    ]
+    cited = set(_EVIDENCE_MARKER.findall(without_fences))
+    covered_claims = sum(
+        1 for claim in claims if cited.intersection(claim.get("evidence") or [])
+    )
+    claim_coverage = covered_claims / len(claims) if claims else 0.0
+    duplicate_blocks = duplicate_prose_blocks(markdown)
+    evidence_report = section_evidence_report(markdown)
+    narrative_report = section_narrative_report(markdown)
+    first_section = re.search(r"^##\s+\S", without_fences, flags=re.MULTILINE)
+    intro_body = without_fences[: first_section.start()] if first_section else ""
+    intro_plain = re.sub(r"^#\s+.*$", "", intro_body, flags=re.MULTILINE)
+    intro_plain = re.sub(r"\[(?:E|R)\d+\](?:\([^)]*\))?", " ", intro_plain)
+    intro_plain = re.sub(r"[`*_[\]()#>-]", " ", intro_plain)
+    intro_plain = re.sub(r"\s+", " ", intro_plain).strip()
+    cited_intro = bool(evidence_report["intro_evidence"]) and len(intro_plain) >= 40
+    thin_sections = []
+    if require_dense_sections:
+        section_matches = list(
+            re.finditer(r"^##\s+(.+?)\s*$", without_fences, flags=re.MULTILINE)
+        )
+        for index, match in enumerate(section_matches):
+            end = (
+                section_matches[index + 1].start()
+                if index + 1 < len(section_matches)
+                else len(without_fences)
+            )
+            body = without_fences[match.end() : end]
+            plain = re.sub(r"\[(?:E|R)\d+\](?:\([^)]*\))?", " ", body)
+            plain = re.sub(r"[`*_[\]()#>-]", " ", plain)
+            plain = re.sub(r"\s+", " ", plain).strip()
+            sentence_count = len(re.findall(r"[.!?](?=\s|$)", plain))
+            if len(plain) < 80 or sentence_count < 2:
+                thin_sections.append(match.group(1).strip())
+    required_sections = min(3, len(sections))
+    required_blocks = required_sections + int(require_cited_intro)
+    valid = (
+        bool(sections)
+        and rendered_sections >= required_sections
+        and substantive_blocks >= required_blocks
+        and claim_coverage >= 0.6
+        and not duplicate_blocks
+        and not thin_sections
+        and (not require_cited_intro or cited_intro)
+        and (
+            not require_narrative_novelty or not narrative_report["redundant_sections"]
+        )
+    )
+    return {
+        "valid": valid,
+        "planned_sections": len(sections),
+        "required_sections": required_sections,
+        "rendered_sections": rendered_sections,
+        "substantive_blocks": substantive_blocks,
+        "required_blocks": required_blocks,
+        "covered_claims": covered_claims,
+        "planned_claims": len(claims),
+        "claim_coverage": round(claim_coverage, 3),
+        "duplicate_blocks": duplicate_blocks,
+        "thin_sections": thin_sections,
+        "cited_intro": cited_intro,
+        "require_cited_intro": require_cited_intro,
+        "require_narrative_novelty": require_narrative_novelty,
+        **evidence_report,
+        **narrative_report,
+    }
+
+
+def audit_page(page: dict[str, Any]) -> dict[str, Any]:
+    """Audit one serialized page, including pages produced by older prompts."""
+
+    markdown = str(page.get("markdown") or "")
+    grounding = page.get("grounding") or {}
+    quality = page.get("quality") or {}
+    generation = page.get("generation") or {}
+    evidence = section_evidence_report(markdown)
+    narrative = section_narrative_report(markdown)
+    duplicate_blocks = duplicate_prose_blocks(markdown)
+    grounding_valid = bool(grounding.get("valid"))
+    structural_valid = bool(quality.get("valid")) or (
+        int(quality.get("rendered_sections") or 0)
+        >= int(quality.get("required_sections") or 1)
+        and int(quality.get("substantive_blocks") or 0)
+        >= int(quality.get("required_blocks") or 1)
+        and float(quality.get("claim_coverage") or 0.0) >= 0.6
+        and not quality.get("thin_sections")
+        and not duplicate_blocks
+    )
+    require_novelty = page.get("id") == "overview"
+    narrative_valid = not require_novelty or (
+        bool(evidence["intro_evidence"])
+        and not narrative["redundant_sections"]
+        and not duplicate_blocks
+    )
+    return {
+        "id": page.get("id"),
+        "title": page.get("title"),
+        "publishable": grounding_valid and structural_valid and narrative_valid,
+        "grounding_valid": grounding_valid,
+        "structural_valid": structural_valid,
+        "narrative_valid": narrative_valid,
+        "citation_coverage": float(grounding.get("citation_coverage") or 0.0),
+        "claim_coverage": float(quality.get("claim_coverage") or 0.0),
+        "repaired": bool(generation.get("repaired")),
+        "fallback": generation.get("fallback"),
+        "generation_mode": generation.get("mode"),
+        "markdown_chars": len(markdown),
+        "duplicate_blocks": duplicate_blocks,
+        **evidence,
+        **narrative,
+    }
+
+
+def summarize_page_audits(pages: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate deterministic quality gates over serialized Wiki pages."""
+
+    details = [audit_page(page) for page in pages]
+    count = len(details)
+    return {
+        "pages": count,
+        "publishable": sum(bool(item["publishable"]) for item in details),
+        "grounding_valid": sum(bool(item["grounding_valid"]) for item in details),
+        "structural_valid": sum(bool(item["structural_valid"]) for item in details),
+        "narrative_valid": sum(bool(item["narrative_valid"]) for item in details),
+        "repaired": sum(bool(item["repaired"]) for item in details),
+        "fallbacks": sum(bool(item["fallback"]) for item in details),
+        "details": details,
+    }
+
+
+def audit_cache(cache_dir: str | Path) -> dict[str, Any]:
+    """Load and summarize generated page records from an AgentWiki cache."""
+
+    pages = []
+    for path in sorted(Path(cache_dir).glob("agentwiki_*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if isinstance(data, dict) and data.get("id") and data.get("markdown"):
+            pages.append(data)
+    return summarize_page_audits(pages)
+
+
+__all__ = [
+    "audit_cache",
+    "audit_page",
+    "duplicate_prose_blocks",
+    "page_quality_report",
+    "prose_terms",
+    "section_evidence_report",
+    "section_narrative_report",
+    "summarize_page_audits",
+]

--- a/scripts/smoke_release_services.py
+++ b/scripts/smoke_release_services.py
@@ -372,6 +372,53 @@ def _assert_mcp(
     asyncio.run(_assert_mcp_async(root, repo, executable=executable, env=env))
 
 
+def _assert_stale_snapshot_rejected(
+    root: Path,
+    repo: Path,
+    *,
+    executable: str,
+    env: dict[str, str],
+) -> None:
+    """Advance the checkout and prove that the installed Wiki rejects the index."""
+
+    source_path = repo / "calculator.py"
+    source_path.write_text(
+        source_path.read_text(encoding="utf-8") + "\ndef release_marker() -> str:\n"
+        '    return "new checkout"\n',
+        encoding="utf-8",
+    )
+    _run(["git", "add", "calculator.py"], cwd=repo, env=env)
+    _run(["git", "commit", "--quiet", "-m", "advance fixture"], cwd=repo, env=env)
+
+    missing_frontend = root / "intentionally-missing-frontend"
+    command = [
+        executable,
+        "wiki",
+        str(repo),
+        "--no-index",
+        "--no-open",
+        "--frontend-dir",
+        str(missing_frontend),
+        "--no-install-frontend",
+    ]
+    print("+", " ".join(command), flush=True)
+    result = subprocess.run(
+        command,
+        cwd=root,
+        env=env,
+        check=False,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+    expected = "repository checkout does not match the indexed snapshot"
+    if result.returncode != 2 or expected not in result.stderr:
+        raise RuntimeError(
+            "installed Wiki accepted a stale repository snapshot "
+            f"(status {result.returncode}, stderr={result.stderr!r})"
+        )
+
+
 def smoke(root: Path, *, executable: str = "codenib") -> None:
     root.mkdir(parents=True, exist_ok=True)
     repo = _fixture_repository(root)
@@ -398,6 +445,12 @@ def smoke(root: Path, *, executable: str = "codenib") -> None:
         raise RuntimeError(f"indexing modified the target repository: {status!r}")
     _assert_wiki(root, repo, executable=executable, env=env)
     _assert_mcp(root, repo, executable=executable, env=env)
+    _assert_stale_snapshot_rejected(
+        root,
+        repo,
+        executable=executable,
+        env=env,
+    )
     print("Installed Wiki and MCP service smoke passed")
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -366,6 +366,35 @@ def test_prepare_local_wiki_writes_single_repo_registry(
     assert local.repo_id == tmp_path.name.lower()
 
 
+def test_prepare_local_wiki_rejects_mismatched_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codenib.compiler.manifest import RepoManifest
+
+    manifest_path = tmp_path / ".codenib_cache" / "repo_manifest.json"
+    manifest_path.parent.mkdir()
+    RepoManifest(
+        repo_path=str(tmp_path),
+        commit="a" * 40,
+        languages=["python"],
+    ).save(str(manifest_path))
+    monkeypatch.setattr(
+        "codenib.web.local._checkout_commit",
+        lambda _repo_path: "b" * 40,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="repository checkout does not match the indexed snapshot",
+    ):
+        prepare_local_wiki(
+            tmp_path,
+            manifest_path,
+            frontend_port=3000,
+        )
+
+
 def test_prepare_local_wiki_uses_github_origin_identity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -8,7 +8,9 @@ from types import SimpleNamespace
 
 from codenib.wiki.agent_wiki import (
     AgentWiki,
+    _candidate_score,
     _clean_markdown,
+    _ensure_cited_intro,
     _fact_plan_markdown,
     _format_supported_literals,
     _page_quality_report,
@@ -18,6 +20,7 @@ from codenib.wiki.agent_wiki import (
     _readme_intro,
     _remove_orphan_headings,
 )
+from codenib.wiki.builder import Symbol
 from codenib.wiki.evidence import EvidenceItem, candidate_key
 
 
@@ -47,6 +50,54 @@ def test_markdown_cleanup_removes_outer_fence_and_uncited_prose():
     assert "Unsupported introductory" not in pruned
     assert "## Flow" in pruned
     assert "[E1]" in pruned
+
+
+def test_style_repair_is_a_bounded_zero_temperature_edit():
+    class LLM:
+        cache_identity = "fake"
+
+        def __init__(self):
+            self.calls = []
+
+        def complete(self, messages, **kwargs):
+            self.calls.append((messages, kwargs))
+            return "The runtime loads the generated page. [E1]"
+
+    llm = LLM()
+    wiki = AgentWiki(
+        SimpleNamespace(
+            entry=SimpleNamespace(
+                repo="owner/repo",
+                language="python",
+                repo_dir="",
+            )
+        ),
+        model="fake-model",
+        llm=llm,
+    )
+
+    rendered = wiki._repair_style(
+        "The runtime efficiently loads the generated page. [E1]",
+        ["efficiently"],
+    )
+
+    assert rendered == "The runtime loads the generated page. [E1]"
+    assert llm.calls[0][1]["temperature"] == 0.0
+    prompt = " ".join(llm.calls[0][0][0]["content"].split())
+    assert "do not replace it with a synonym" in prompt
+
+
+def test_candidate_score_prefers_fewer_style_warnings():
+    quality = {
+        "valid": True,
+        "rendered_sections": 3,
+        "substantive_blocks": 4,
+        "claim_coverage": 1.0,
+    }
+    noisy = {"valid": True, "promotional_phrases": ["dynamic", "efficient"]}
+    cleaner = {"valid": True, "promotional_phrases": ["dynamic"]}
+
+    assert _candidate_score(cleaner, quality) > _candidate_score(noisy, quality)
 
 
 def test_markdown_cleanup_removes_empty_sections_but_keeps_parent_sections():
@@ -168,6 +219,102 @@ def test_overview_quality_rejects_thin_sections():
 
     assert report["valid"] is False
     assert report["thin_sections"] == ["Subsystems"]
+
+
+def test_overview_quality_allows_distinct_fact_from_intro_evidence():
+    plan = {
+        "sections": [
+            {"title": "Workflow", "claims": [{"evidence": ["E1"]}]},
+            {"title": "Execution", "claims": [{"evidence": ["E2"]}]},
+            {"title": "Subsystems", "claims": [{"evidence": ["E3"]}]},
+        ]
+    }
+    markdown = (
+        "The repository assembles source-backed context for coding agents and "
+        "serves it through local interfaces. [E1]\n\n"
+        "## Workflow\n\n"
+        "A user supplies a checkout to the command-line entry point. The command "
+        "then opens a local repository workspace for inspection. [E1]\n\n"
+        "## Execution\n\n"
+        "The compiler materializes searchable repository records. The runtime "
+        "loads those records when a request arrives. [E2]\n\n"
+        "## Subsystems\n\n"
+        "The manifest records view provenance and status. The server uses that "
+        "state to expose available repository capabilities. [E3]"
+    )
+
+    report = _page_quality_report(
+        markdown,
+        plan,
+        require_dense_sections=True,
+        require_narrative_novelty=True,
+    )
+
+    assert report["valid"] is True
+    assert report["intro_only_sections"] == ["Workflow"]
+    assert report["new_evidence_by_section"]["Workflow"] == []
+    assert report["redundant_sections"] == []
+
+
+def test_overview_quality_rejects_semantic_intro_repetition():
+    plan = {
+        "sections": [
+            {"title": "Purpose Again", "claims": [{"evidence": ["E1"]}]},
+            {"title": "Execution", "claims": [{"evidence": ["E2"]}]},
+            {"title": "Runtime", "claims": [{"evidence": ["E3"]}]},
+        ]
+    }
+    markdown = (
+        "The repository compiles source into reusable indexed context and serves "
+        "that context through a local Wiki. [E1]\n\n"
+        "## Purpose Again\n\n"
+        "The repository compiles source into reusable indexed context, then "
+        "serves that context through its local Wiki. [E1]\n\n"
+        "## Execution\n\n"
+        "The compiler writes searchable repository views. It also records their "
+        "state in a manifest. [E2]\n\n"
+        "## Runtime\n\n"
+        "The server loads repository views. It returns source-linked pages for "
+        "incoming requests. [E3]"
+    )
+
+    report = _page_quality_report(
+        markdown,
+        plan,
+        require_dense_sections=True,
+        require_narrative_novelty=True,
+    )
+
+    assert report["valid"] is False
+    assert report["redundant_sections"] == ["Purpose Again"]
+
+
+def test_overview_quality_requires_cited_intro():
+    plan = {
+        "sections": [
+            {"title": "Workflow", "claims": [{"evidence": ["E1"]}]},
+            {"title": "Execution", "claims": [{"evidence": ["E2"]}]},
+            {"title": "Runtime", "claims": [{"evidence": ["E3"]}]},
+        ]
+    }
+    markdown = (
+        "## Workflow\n\n"
+        "The command accepts a repository path and prepares a local Wiki. [E1]\n\n"
+        "## Execution\n\n"
+        "The compiler writes searchable repository views and a manifest. [E2]\n\n"
+        "## Runtime\n\n"
+        "The server loads the views and returns source-linked pages. [E3]"
+    )
+
+    report = _page_quality_report(
+        markdown,
+        plan,
+        require_dense_sections=True,
+        require_cited_intro=True,
+    )
+
+    assert report["valid"] is False
+    assert report["cited_intro"] is False
 
 
 def test_fact_plan_renderer_drops_unsupported_claims():
@@ -408,7 +555,10 @@ def test_overview_plan_requires_dense_page_wide_evidence():
                         "statement": "The compiler creates repository indexes",
                         "evidence": ["E3"],
                     },
-                    {"statement": "The server loads those indexes", "evidence": ["E4"]},
+                    {
+                        "statement": "The compiler records repository indexes",
+                        "evidence": ["E3"],
+                    },
                 ],
             },
             {
@@ -492,6 +642,333 @@ def test_overview_plan_allows_one_source_for_a_cohesive_section():
     assert _plan_quality_warnings({"id": "overview"}, plan, evidence) == []
 
 
+def test_overview_plan_allows_distinct_readme_facts():
+    evidence = [
+        EvidenceItem(
+            id=f"E{index}",
+            file=file,
+            start_line=None,
+            end_line=None,
+            symbol=file,
+            kind="file",
+            content=content,
+        )
+        for index, file, content in [
+            (
+                1,
+                "README.md",
+                "The project builds a source-linked repository Wiki from local "
+                "source code for coding agents.",
+            ),
+            (2, "src/cli.py", "The CLI accepts a repository path."),
+            (3, "src/compiler.py", "The compiler writes an index manifest."),
+            (4, "src/server.py", "The server returns Wiki pages."),
+        ]
+    ]
+    plan = {
+        "sections": [
+            {
+                "title": "Workflow",
+                "claims": [
+                    {"statement": "The project builds a Wiki", "evidence": ["E1"]},
+                    {
+                        "statement": "The Wiki contains source links",
+                        "evidence": ["E1"],
+                    },
+                ],
+            },
+            {
+                "title": "Execution",
+                "claims": [
+                    {"statement": "The CLI accepts a path", "evidence": ["E2"]},
+                    {
+                        "statement": "The compiler writes a manifest",
+                        "evidence": ["E3"],
+                    },
+                ],
+            },
+            {
+                "title": "Runtime",
+                "claims": [
+                    {"statement": "The server returns pages", "evidence": ["E4"]},
+                    {
+                        "statement": "The CLI starts compilation",
+                        "evidence": ["E2", "E3"],
+                    },
+                ],
+            },
+        ]
+    }
+
+    warnings = _plan_quality_warnings({"id": "overview"}, plan, evidence)
+
+    assert warnings == []
+
+
+def test_overview_plan_requires_new_sources_after_public_workflow():
+    evidence = [
+        EvidenceItem(
+            id=f"E{index}",
+            file=file,
+            start_line=None,
+            end_line=None,
+            symbol=file,
+            kind="file",
+            content=content,
+        )
+        for index, file, content in [
+            (1, "docs/workflow.md", "The Wiki accepts and indexes a repository."),
+            (2, "src/cli.py", "The CLI starts the compiler."),
+            (3, "src/compiler.py", "The compiler writes a manifest."),
+            (4, "src/server.py", "The server returns Wiki pages."),
+        ]
+    ]
+    plan = {
+        "sections": [
+            {
+                "title": "Workflow",
+                "claims": [
+                    {
+                        "statement": "The Wiki accepts a repository",
+                        "evidence": ["E1"],
+                    },
+                    {
+                        "statement": "The Wiki indexes the repository",
+                        "evidence": ["E1"],
+                    },
+                ],
+            },
+            {
+                "title": "Execution",
+                "claims": [
+                    {"statement": "The CLI starts the compiler", "evidence": ["E2"]},
+                    {
+                        "statement": "The compiler writes a manifest",
+                        "evidence": ["E3"],
+                    },
+                ],
+            },
+            {
+                "title": "Subsystems",
+                "claims": [
+                    {"statement": "The CLI owns the entry point", "evidence": ["E2"]},
+                    {
+                        "statement": "The compiler owns the manifest",
+                        "evidence": ["E3"],
+                    },
+                ],
+            },
+        ]
+    }
+
+    warnings = _plan_quality_warnings({"id": "overview"}, plan, evidence)
+
+    assert (
+        "section 'Subsystems' must introduce an implementation source not used "
+        "by earlier sections" in warnings
+    )
+
+
+def test_overview_plan_rejects_private_helper_as_user_entrypoint():
+    evidence = [
+        EvidenceItem(
+            id=f"E{index}",
+            file=file,
+            start_line=None,
+            end_line=None,
+            symbol=file,
+            kind="file",
+            content=content,
+        )
+        for index, file, content in [
+            (1, "src/cli.py", "def _run_wiki(): pass"),
+            (2, "src/compiler.py", "class Compiler: pass"),
+            (3, "src/server.py", "class Server: pass"),
+            (4, "src/runtime.py", "class Runtime: pass"),
+        ]
+    ]
+    plan = {
+        "sections": [
+            {
+                "title": "Workflow",
+                "claims": [
+                    {
+                        "statement": "Users execute `_run_wiki()` to build a Wiki",
+                        "evidence": ["E1"],
+                    },
+                    {
+                        "statement": "The CLI starts repository processing",
+                        "evidence": ["E1"],
+                    },
+                ],
+            },
+            {
+                "title": "Build",
+                "claims": [
+                    {"statement": "The compiler writes views", "evidence": ["E2"]},
+                    {"statement": "The compiler writes state", "evidence": ["E2"]},
+                ],
+            },
+            {
+                "title": "Serve",
+                "claims": [
+                    {"statement": "The server returns pages", "evidence": ["E3"]},
+                    {"statement": "The runtime loads views", "evidence": ["E4"]},
+                ],
+            },
+        ]
+    }
+
+    warnings = _plan_quality_warnings({"id": "overview"}, plan, evidence)
+
+    assert (
+        "section 'Workflow' describes a private helper as a user entry point"
+        in warnings
+    )
+
+
+def test_page_plan_rejects_private_helper_as_public_entrypoint():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/wiki.py",
+            start_line=10,
+            end_line=20,
+            symbol="AgentWiki._retrieve",
+            kind="method",
+            content="def _retrieve(self): pass",
+        )
+    ]
+    plan = {
+        "sections": [
+            {
+                "title": "Public Entry Points",
+                "claims": [
+                    {
+                        "statement": "`AgentWiki._retrieve()` obtains candidates",
+                        "evidence": ["E1"],
+                    }
+                ],
+            }
+        ]
+    }
+
+    warnings = _plan_quality_warnings(
+        {"id": "wiki-serving"},
+        plan,
+        evidence,
+    )
+
+    assert warnings == [
+        "section 'Public Entry Points' describes a private helper as a user "
+        "entry point"
+    ]
+
+
+def test_page_plan_rejects_incidental_helper_section():
+    evidence = [
+        EvidenceItem(
+            id=f"E{index}",
+            file="src/runtime.py",
+            start_line=0,
+            end_line=10,
+            symbol=symbol,
+            kind="method",
+            content="def method(): pass",
+        )
+        for index, symbol in [
+            (1, "AgentRunner.run"),
+            (2, "AgentRunner.configure"),
+            (3, "AgentRunner._serialize"),
+        ]
+    ]
+    plan = {
+        "sections": [
+            {
+                "title": "Agent Execution",
+                "claims": [
+                    {
+                        "statement": "`AgentRunner.run()` executes the loop",
+                        "evidence": ["E1"],
+                    }
+                ],
+            },
+            {
+                "title": "Internal Helpers",
+                "claims": [
+                    {
+                        "statement": "`AgentRunner._serialize()` formats state",
+                        "evidence": ["E3"],
+                    }
+                ],
+            },
+        ]
+    }
+
+    warnings = _plan_quality_warnings(
+        {"id": "agent-runtime", "title": "Agent Runtime"},
+        plan,
+        evidence,
+    )
+
+    assert warnings == [
+        "section 'Internal Helpers' elevates incidental helpers over the page's "
+        "core responsibility"
+    ]
+
+
+def test_overview_plan_rejects_filename_as_subsystem_name():
+    evidence = [
+        EvidenceItem(
+            id=f"E{index}",
+            file=file,
+            start_line=None,
+            end_line=None,
+            symbol=file,
+            kind="file",
+            content=content,
+        )
+        for index, file, content in [
+            (1, "src/cli.py", "def main(): pass"),
+            (2, "src/compiler.py", "class Compiler: pass"),
+            (3, "src/server.py", "class Server: pass"),
+            (4, "src/runtime.py", "class Runtime: pass"),
+        ]
+    ]
+    plan = {
+        "sections": [
+            {
+                "title": "Workflow",
+                "claims": [
+                    {"statement": "The CLI accepts a path", "evidence": ["E1"]},
+                    {"statement": "The CLI starts processing", "evidence": ["E1"]},
+                ],
+            },
+            {
+                "title": "Build",
+                "claims": [
+                    {"statement": "The compiler writes views", "evidence": ["E2"]},
+                    {"statement": "The compiler writes state", "evidence": ["E2"]},
+                ],
+            },
+            {
+                "title": "Subsystems",
+                "claims": [
+                    {
+                        "statement": "The `server.py` subsystem returns pages",
+                        "evidence": ["E3"],
+                    },
+                    {"statement": "The runtime loads views", "evidence": ["E4"]},
+                ],
+            },
+        ]
+    }
+
+    warnings = _plan_quality_warnings({"id": "overview"}, plan, evidence)
+
+    assert "section 'Subsystems' names a source file as a subsystem" in warnings
+
+
 def test_overview_fact_plan_repairs_sparse_plan():
     sparse = (
         '{"thesis":"indexed source","sections":['
@@ -509,7 +986,7 @@ def test_overview_fact_plan_repairs_sparse_plan():
         '{"statement":"The Wiki exposes indexed source","evidence":["E1"]}]},'
         '{"title":"Flow","claims":['
         '{"statement":"The compiler creates repository indexes","evidence":["E3"]},'
-        '{"statement":"The server loads those indexes","evidence":["E4"]}]},'
+        '{"statement":"The compiler records repository indexes","evidence":["E3"]}]},'
         '{"title":"Subsystems","claims":['
         '{"statement":"The server returns Wiki pages","evidence":["E4"]},'
         '{"statement":"The CLI invokes the compiler","evidence":["E2","E3"]}]}]}'
@@ -589,6 +1066,37 @@ def test_readme_intro_skips_logo_markup():
         "through a local Wiki and tools.",
         "E1",
     )
+
+
+def test_overview_uses_canonical_readme_intro():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="README.md",
+            start_line=1,
+            end_line=20,
+            symbol="README.md",
+            kind="file",
+            content=(
+                "The repository compiles source into reusable views and serves "
+                "them through a local developer Wiki."
+            ),
+        )
+    ]
+    draft = (
+        "This document provides a comprehensive overview of the system. [E1]\n\n"
+        "## Workflow\n\n"
+        "The command builds a repository Wiki. [E1]"
+    )
+
+    rendered = _ensure_cited_intro(draft, evidence, canonical_readme=True)
+
+    assert rendered.startswith(
+        "The repository compiles source into reusable views and serves them "
+        "through a local developer Wiki. [E1]"
+    )
+    assert "This document provides" not in rendered
+    assert "## Workflow" in rendered
 
 
 def test_readme_evidence_drops_chrome_and_keeps_complete_paragraphs():
@@ -742,6 +1250,234 @@ def test_agent_wiki_fuses_dense_and_bm25_routes(tmp_path):
     assert bm25.calls[0][2]["return_code_content"] is True
 
 
+def test_page_retrieval_promotes_two_symbols_per_outline_file(tmp_path):
+    target_nodes = [
+        {
+            "file": "src/runtime.py",
+            "node_name": "AgentRunner",
+            "start_line": 0,
+            "end_line": 20,
+            "content": "class AgentRunner: pass",
+        },
+        {
+            "file": "src/runtime.py",
+            "node_name": "run",
+            "start_line": 22,
+            "end_line": 40,
+            "content": "def run(): pass",
+        },
+    ]
+    unrelated = [
+        {
+            "file": f"src/helper_{index}.py",
+            "node_name": f"helper_{index}",
+            "start_line": 0,
+            "end_line": 4,
+            "content": "agent runtime helper",
+        }
+        for index in range(4)
+    ]
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir=str(tmp_path), language="python"),
+        vector_store=None,
+        bm25=_FakeBM25([target_nodes[0], *unrelated, target_nodes[1]]),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    result = wiki._retrieve(
+        {
+            "id": "agent-runtime",
+            "title": "Agent Runtime",
+            "summary": "Agent execution and context handling",
+            "keywords": ["AgentRunner", "run"],
+            "files": ["src/runtime.py"],
+        },
+        top_k=4,
+    )
+
+    assert [node["node_name"] for node in result[:2]] == ["AgentRunner", "run"]
+    assert all(
+        wiki._retrieval_routes[candidate_key(node, wiki._node_attr)][0] == "outline"
+        for node in target_nodes
+    )
+
+
+def test_page_retrieval_prefers_public_outline_symbols(tmp_path):
+    private = {
+        "file": "src/wiki.py",
+        "node_name": "AgentWiki._retrieve",
+        "start_line": 0,
+        "end_line": 10,
+        "type": "method",
+        "content": "def _retrieve(): pass",
+    }
+    public = {
+        "file": "src/wiki.py",
+        "node_name": "AgentWiki.page",
+        "start_line": 12,
+        "end_line": 22,
+        "type": "method",
+        "content": "def page(): pass",
+    }
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir=str(tmp_path), language="python"),
+        vector_store=None,
+        bm25=_FakeBM25([private, public]),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    result = wiki._retrieve(
+        {
+            "id": "wiki-serving",
+            "title": "Wiki Serving",
+            "summary": "Wiki page serving",
+            "keywords": ["wiki", "page"],
+            "files": ["src/wiki.py"],
+        },
+        top_k=4,
+    )
+
+    assert [node["node_name"] for node in result[:2]] == [
+        "AgentWiki.page",
+        "AgentWiki._retrieve",
+    ]
+
+
+def test_page_retrieval_excludes_eval_candidates_from_runtime_page(tmp_path):
+    runtime = {
+        "file": "src/agent/runner.py",
+        "node_name": "AgentRunner.run",
+        "start_line": 0,
+        "end_line": 20,
+        "type": "method",
+        "content": "def run(): pass",
+    }
+    evaluation = {
+        "file": "src/eval/agent_study.py",
+        "node_name": "run_agent_study",
+        "start_line": 0,
+        "end_line": 20,
+        "type": "function",
+        "content": "def run_agent_study(): pass",
+    }
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir=str(tmp_path), language="python"),
+        vector_store=None,
+        bm25=_FakeBM25([evaluation, runtime]),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    result = wiki._retrieve(
+        {
+            "id": "agent-runtime",
+            "title": "Agent Runtime",
+            "summary": "Agent execution",
+            "keywords": ["agent", "run"],
+            "files": ["src/agent/runner.py"],
+        },
+        top_k=4,
+    )
+
+    assert [node["node_name"] for node in result] == ["AgentRunner.run"]
+
+
+def test_page_retrieval_adds_representative_symbols_from_outline_files(tmp_path):
+    private = {
+        "file": "src/agent/runner.py",
+        "node_name": "AgentRunner._serialize",
+        "start_line": 0,
+        "end_line": 20,
+        "type": "method",
+        "content": "def _serialize(): pass",
+    }
+    public = Symbol(
+        file="src/agent/runner.py",
+        name="AgentRunner.run",
+        type="method",
+        start_line=30,
+        end_line=120,
+        content="def run(): execute_agent_loop()",
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir=str(tmp_path), language="python"),
+        vector_store=None,
+        bm25=_FakeBM25([private]),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+    wiki._wb._symbols = lambda: (public,)
+
+    result = wiki._retrieve(
+        {
+            "id": "agent-runtime",
+            "title": "Agent Runtime",
+            "summary": "Agent execution",
+            "keywords": ["agent", "run"],
+            "files": ["src/agent/runner.py"],
+        },
+        top_k=4,
+    )
+
+    assert wiki._node_attr(result[0], "name") == "AgentRunner.run"
+    assert wiki._retrieval_routes[candidate_key(public, wiki._node_attr)] == (
+        "outline",
+    )
+
+
+def test_page_retrieval_prefers_public_remaining_candidates(tmp_path):
+    anchor = {
+        "file": "src/runtime.py",
+        "node_name": "AgentRunner.run",
+        "start_line": 0,
+        "end_line": 20,
+        "type": "method",
+        "content": "def run(): pass",
+    }
+    private = {
+        "file": "src/internal.py",
+        "node_name": "_serialize",
+        "start_line": 0,
+        "end_line": 20,
+        "type": "function",
+        "content": "def _serialize(): return agent_context",
+    }
+    public = {
+        "file": "src/context.py",
+        "node_name": "ContextLedger",
+        "start_line": 0,
+        "end_line": 20,
+        "type": "class",
+        "content": "class ContextLedger: pass",
+    }
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir=str(tmp_path), language="python"),
+        vector_store=None,
+        bm25=_FakeBM25([anchor, private, public]),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    result = wiki._retrieve(
+        {
+            "id": "agent-runtime",
+            "title": "Agent Runtime",
+            "summary": "Agent execution and context",
+            "keywords": ["agent", "context"],
+            "files": ["src/runtime.py"],
+        },
+        top_k=4,
+    )
+
+    assert [node["node_name"] for node in result[:3]] == [
+        "AgentRunner.run",
+        "ContextLedger",
+        "_serialize",
+    ]
+
+
 def test_overview_retrieval_reserves_space_for_architecture_anchors(tmp_path):
     files = [
         "README.md",
@@ -798,6 +1534,84 @@ def test_overview_retrieval_reserves_space_for_architecture_anchors(tmp_path):
     )
 
 
+def test_overview_uses_validated_fact_plan_without_narration(tmp_path):
+    source = {
+        "README.md": (
+            "The repository compiles local source into lexical, semantic, and "
+            "structural views for a source-linked developer Wiki and repository "
+            "tools. It stores reusable artifacts for later requests.\n\n"
+            "Users run codenib wiki with a repository path. The command detects "
+            "languages and starts the local Wiki."
+        ),
+        "src/cli.py": "def main():\n    return compile_repository()",
+        "src/compiler.py": "class Compiler:\n    def build(self): pass",
+        "src/server.py": "class Server:\n    def page(self): pass",
+    }
+    for file, content in source.items():
+        path = tmp_path / file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    plan = (
+        '{"thesis":"repository context","sections":['
+        '{"title":"Workflow","claims":['
+        '{"statement":"Users run `codenib wiki` with a repository path",'
+        '"evidence":["E1"]},'
+        '{"statement":"The command detects repository languages","evidence":["E1"]}]},'
+        '{"title":"Execution","claims":['
+        '{"statement":"The CLI starts repository compilation from parsed command arguments",'
+        '"evidence":["E2"]},'
+        '{"statement":"The `Compiler` builds repository views for later requests",'
+        '"evidence":["E3"]}]},'
+        '{"title":"Subsystems","claims":['
+        '{"statement":"The `Server` returns source-linked Wiki pages to callers",'
+        '"evidence":["E4"]},'
+        '{"statement":"The CLI owns the public command and dispatches compilation",'
+        '"evidence":["E2"]}]}]}'
+    )
+
+    class LLM:
+        cache_identity = "fake"
+
+        def __init__(self):
+            self.calls = 0
+
+        def complete(self, _messages, **_kwargs):
+            self.calls += 1
+            return plan
+
+    llm = LLM()
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=None,
+        bm25=_FakeBM25([]),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        code_graph=lambda: None,
+    )
+    page = AgentWiki(bundle, model="fake-model", llm=llm)._generate_page(
+        {
+            "id": "overview",
+            "title": "Overview",
+            "summary": "Repository purpose and architecture",
+            "keywords": ["workflow", "compiler", "server"],
+            "files": list(source),
+        }
+    )
+
+    assert llm.calls == 1
+    assert page["generation"]["renderer"] == "fact_plan"
+    assert page["generation"]["fallback"] is None
+    assert page["generation"]["mode"] == "generated"
+    assert page["quality"]["valid"] is True
+    assert "## Workflow" in page["markdown"]
+
+
 def test_generated_page_uses_fact_plan_and_reports_grounding(tmp_path):
     class LLM:
         cache_identity = "fake"
@@ -807,18 +1621,10 @@ def test_generated_page_uses_fact_plan_and_reports_grounding(tmp_path):
 
         def complete(self, messages, **kwargs):
             self.calls.append((messages, kwargs))
-            if len(self.calls) == 1:
-                return (
-                    '{"thesis":"request routing","sections":[{"title":"Flow",'
-                    '"claims":[{"statement":"Router dispatches requests",'
-                    '"evidence":["E1"]}]}]}'
-                )
             return (
-                "The `Router` owns request dispatch and coordinates the "
-                "source-backed request path. [E1]\n\n"
-                "## Flow\n\n"
-                "The implementation in `src/core.py` provides the concrete "
-                "dispatch entry point used by this subsystem. [E1]"
+                '{"thesis":"request routing","sections":[{"title":"Flow",'
+                '"claims":[{"statement":"The `Router` dispatches source-backed '
+                'repository requests through `dispatch`","evidence":["E1"]}]}]}'
             )
 
     node = {
@@ -855,15 +1661,16 @@ def test_generated_page_uses_fact_plan_and_reports_grounding(tmp_path):
         }
     )
 
-    assert len(llm.calls) == 2
+    assert len(llm.calls) == 1
     assert page["grounding"]["valid"] is True
     assert page["quality"]["valid"] is True
     assert page["generation"]["mode"] == "generated"
+    assert page["generation"]["renderer"] == "fact_plan"
     assert page["citations"][0]["start_line"] == 1
     assert page["evidence"]["items"][0]["routes"] == ("outline", "dense")
 
 
-def test_page_reports_model_unavailable_when_narration_falls_back(tmp_path):
+def test_page_reports_model_unavailable_when_fact_planning_falls_back(tmp_path):
     class LLM:
         cache_identity = "fake"
 
@@ -872,12 +1679,6 @@ def test_page_reports_model_unavailable_when_narration_falls_back(tmp_path):
 
         def complete(self, _messages, **_kwargs):
             self.calls += 1
-            if self.calls == 1:
-                return (
-                    '{"thesis":"request routing","sections":[{"title":"Flow",'
-                    '"claims":[{"statement":"Router dispatches requests",'
-                    '"evidence":["E1"]}]}]}'
-                )
             raise RuntimeError("provider unavailable")
 
     node = {
@@ -902,7 +1703,8 @@ def test_page_reports_model_unavailable_when_narration_falls_back(tmp_path):
         code_graph=lambda: None,
     )
 
-    page = AgentWiki(bundle, model="fake-model", llm=LLM())._generate_page(
+    llm = LLM()
+    page = AgentWiki(bundle, model="fake-model", llm=llm)._generate_page(
         {
             "id": "routing",
             "title": "Request Routing",
@@ -914,7 +1716,10 @@ def test_page_reports_model_unavailable_when_narration_falls_back(tmp_path):
 
     assert page["generation"]["mode"] == "degraded"
     assert page["generation"]["reason"] == "model_unavailable"
+    assert page["generation"]["renderer"] == "fact_plan"
+    assert page["generation"]["fallback"] == "fact_plan"
     assert page["grounding"]["valid"] is True
+    assert llm.calls == 1
 
 
 def test_agent_wiki_cache_key_tracks_view_rebuild_identity(tmp_path):

--- a/test/wiki/test_evidence.py
+++ b/test/wiki/test_evidence.py
@@ -170,7 +170,33 @@ def test_grounding_report_accepts_path_like_terms_present_in_evidence():
     assert report["unknown_files"] == []
 
 
-def test_grounding_report_rejects_promotional_prose():
+def test_grounding_report_accepts_call_without_source_type_annotations():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/server.py",
+            start_line=1,
+            end_line=8,
+            symbol="src/server.py:wiki_page()",
+            kind="function",
+            content=(
+                "async def wiki_page(repo_id: str, page_id: str) -> dict:\n"
+                "    return await load_page(repo_id, page_id)"
+            ),
+        )
+    ]
+
+    report = grounding_report(
+        "The server dispatches `wiki_page(repo_id, page_id)` for a page request. [E1]",
+        evidence,
+        [],
+    )
+
+    assert report["valid"] is True
+    assert report["unsupported_identifiers"] == []
+
+
+def test_grounding_report_reports_promotional_prose_without_conflating_sources():
     evidence = [
         EvidenceItem(
             id="E1",
@@ -191,13 +217,42 @@ def test_grounding_report_rejects_promotional_prose():
         [],
     )
 
-    assert report["valid"] is False
+    assert report["valid"] is True
     assert report["promotional_phrases"] == [
         "allowing for",
         "enhances productivity",
         "optimizing",
         "powerful",
         "significantly",
+    ]
+
+
+def test_grounding_report_finds_generic_benefit_synonyms():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/core.py",
+            start_line=1,
+            end_line=8,
+            symbol="Router",
+            kind="class",
+            content="class Router: pass",
+        )
+    ]
+
+    report = grounding_report(
+        "The responsive and adaptable `Router` provides easy access while "
+        "ensuring that all relevant state is retained. [E1]",
+        evidence,
+        [],
+    )
+
+    assert report["valid"] is True
+    assert report["promotional_phrases"] == [
+        "adaptable",
+        "ensuring that all relevant",
+        "provides easy",
+        "responsive",
     ]
 
 

--- a/test/wiki/test_outline.py
+++ b/test/wiki/test_outline.py
@@ -5,7 +5,23 @@
 from __future__ import annotations
 
 from codenib.wiki.builder import Symbol
-from codenib.wiki.outline import _fallback_outline, _validate_outline
+from codenib.wiki.outline import (
+    _fallback_outline,
+    _outline_score,
+    _required_top_level_pages,
+    _validate_outline,
+)
+
+
+def test_outline_breadth_scales_with_available_repository_evidence():
+    assert _required_top_level_pages(4) == 2
+    assert _required_top_level_pages(8) == 3
+    assert _required_top_level_pages(40) == 5
+
+    sparse = {"pages": [{"files": ["src/a.py"], "children": []}] * 3}
+    broad = {"pages": [{"files": [f"src/{i}.py"], "children": []} for i in range(5)]}
+
+    assert _outline_score(broad, 5) > _outline_score(sparse, 5)
 
 
 def test_outline_requires_real_source_anchors(tmp_path):
@@ -87,6 +103,86 @@ def test_outline_requires_real_source_anchors(tmp_path):
     assert result["pages"][1]["children"] == []
 
 
+def test_non_evaluation_page_drops_supporting_eval_files(tmp_path):
+    files = [
+        "src/agent/runner.py",
+        "src/eval/agent_study_runner.py",
+    ]
+    for file in files:
+        path = tmp_path / file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# source\n")
+    symbols = [
+        Symbol(
+            file="src/agent/runner.py",
+            name="AgentRunner",
+            type="class",
+            start_line=0,
+            end_line=0,
+            content="class AgentRunner: pass",
+        )
+    ]
+
+    result = _validate_outline(
+        {
+            "pages": [
+                {
+                    "id": "agent-runtime",
+                    "title": "Agent Runtime",
+                    "summary": "Agent execution and context handling.",
+                    "keywords": ["AgentRunner", "runtime"],
+                    "files": files,
+                    "children": [],
+                }
+            ]
+        },
+        str(tmp_path),
+        symbols=symbols,
+        fallback_files=files,
+    )
+
+    runtime = next(page for page in result["pages"] if page["id"] == "agent-runtime")
+    assert runtime["files"] == ["src/agent/runner.py"]
+
+
+def test_evaluation_page_retains_explicit_eval_files(tmp_path):
+    file = "src/eval/agent_study_runner.py"
+    path = tmp_path / file
+    path.parent.mkdir(parents=True)
+    path.write_text("class EvaluationRunner: pass\n")
+    symbols = [
+        Symbol(
+            file=file,
+            name="EvaluationRunner",
+            type="class",
+            start_line=0,
+            end_line=0,
+            content="class EvaluationRunner: pass",
+        )
+    ]
+
+    result = _validate_outline(
+        {
+            "pages": [
+                {
+                    "id": "evaluation",
+                    "title": "Evaluation Framework",
+                    "summary": "Evaluation studies and measurements.",
+                    "keywords": ["evaluation", "EvaluationRunner"],
+                    "files": [file],
+                    "children": [],
+                }
+            ]
+        },
+        str(tmp_path),
+        symbols=symbols,
+        fallback_files=[file],
+    )
+
+    evaluation = next(page for page in result["pages"] if page["id"] == "evaluation")
+    assert evaluation["files"] == [file]
+
+
 def test_fallback_outline_remains_navigable_without_model():
     result = _fallback_outline(
         [
@@ -134,6 +230,79 @@ def test_overview_prefers_repository_root_readme(tmp_path):
     assert result["pages"][0]["files"][0] == "README.md"
 
 
+def test_first_outline_page_is_canonical_overview(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "README.md").write_text("Repository overview.\n")
+    (tmp_path / "src" / "cli.py").write_text("def main(): pass\n")
+
+    result = _validate_outline(
+        {
+            "pages": [
+                {
+                    "id": "codenib-overview",
+                    "title": "CodeNib Overview",
+                    "summary": "Repository purpose and workflow",
+                    "keywords": ["workflow"],
+                    "files": ["src/cli.py"],
+                    "children": [],
+                }
+            ]
+        },
+        str(tmp_path),
+        symbols=[],
+        fallback_files=["src/cli.py"],
+    )
+
+    assert result["pages"][0]["title"] == "Overview"
+    assert result["pages"][0]["files"][0] == "README.md"
+
+
+def test_overview_children_are_promoted_to_top_level(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "README.md").write_text("Repository overview.\n")
+    (tmp_path / "src" / "compiler.py").write_text("class IndexCompiler: pass\n")
+    symbols = [
+        Symbol(
+            file="src/compiler.py",
+            name="IndexCompiler",
+            type="class",
+            start_line=0,
+            end_line=0,
+            content="class IndexCompiler: pass",
+        )
+    ]
+
+    result = _validate_outline(
+        {
+            "pages": [
+                {
+                    "id": "overview",
+                    "title": "Overview",
+                    "summary": "Repository purpose",
+                    "keywords": ["architecture"],
+                    "files": ["README.md", "src/compiler.py"],
+                    "children": [
+                        {
+                            "id": "indexing",
+                            "title": "Indexing",
+                            "summary": "Repository index construction",
+                            "keywords": ["index", "compiler"],
+                            "files": ["src/compiler.py"],
+                            "children": [],
+                        }
+                    ],
+                }
+            ]
+        },
+        str(tmp_path),
+        symbols=symbols,
+        fallback_files=["src/compiler.py"],
+    )
+
+    assert [page["id"] for page in result["pages"]] == ["overview", "indexing"]
+    assert result["pages"][0]["children"] == []
+
+
 def test_overview_prioritizes_product_entrypoints_over_backend_details(tmp_path):
     files = [
         "README.md",
@@ -178,3 +347,70 @@ def test_overview_prioritizes_product_entrypoints_over_backend_details(tmp_path)
         "src/languages/decoder.py"
     )
     assert "tests/test_cli.py" not in selected
+
+
+def test_outline_rejects_generic_concepts_with_unrelated_real_files(tmp_path):
+    files = [
+        "src/agent/runner.py",
+        "src/index/compiler.py",
+        "src/graph/code_graph.py",
+    ]
+    symbols = [
+        Symbol(
+            file=file,
+            name=name,
+            type="class",
+            start_line=0,
+            end_line=0,
+            content=f"class {name}: pass",
+        )
+        for file, name in [
+            ("src/agent/runner.py", "AgentRunner"),
+            ("src/index/compiler.py", "IndexCompiler"),
+            ("src/graph/code_graph.py", "CodeGraph"),
+        ]
+    ]
+    for file in files:
+        path = tmp_path / file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# source\n")
+
+    result = _validate_outline(
+        {
+            "pages": [
+                {
+                    "id": "interceptors",
+                    "title": "Interceptors",
+                    "summary": "Generic middleware around requests.",
+                    "keywords": ["middleware", "request"],
+                    "files": ["src/agent/runner.py"],
+                    "children": [],
+                },
+                {
+                    "id": "indexing",
+                    "title": "Indexing",
+                    "summary": "Repository index construction.",
+                    "keywords": ["index", "compiler"],
+                    "files": ["src/index/compiler.py"],
+                    "children": [],
+                },
+                {
+                    "id": "graph",
+                    "title": "Graph Structure",
+                    "summary": "Repository dependency graph.",
+                    "keywords": ["graph", "dependencies"],
+                    "files": ["src/graph/code_graph.py"],
+                    "children": [],
+                },
+            ]
+        },
+        str(tmp_path),
+        symbols=symbols,
+        fallback_files=files,
+    )
+
+    assert [page["id"] for page in result["pages"]] == [
+        "overview",
+        "indexing",
+        "graph",
+    ]

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from codenib.wiki.quality import (
+    audit_cache,
+    audit_page,
+    section_evidence_report,
+    section_narrative_report,
+    summarize_page_audits,
+)
+
+
+def _page(*, repeated_prose: bool) -> dict:
+    workflow = (
+        "The repository compiles source into reusable indexed context, then "
+        "serves that context through its local Wiki. [E1]"
+        if repeated_prose
+        else "The command accepts a checkout and prepares a local Wiki. [E1]"
+    )
+    return {
+        "id": "overview",
+        "title": "Overview",
+        "markdown": (
+            "# Overview\n\n"
+            "The repository compiles source into reusable indexed context and "
+            "serves that context through a local Wiki. [E1]\n\n"
+            "## Workflow\n\n"
+            f"{workflow}\n\n"
+            "## Runtime\n\n"
+            "The runtime serves source-linked requests. [E3]"
+        ),
+        "generation": {
+            "mode": "generated",
+            "repaired": False,
+            "fallback": None,
+        },
+        "grounding": {"valid": True, "citation_coverage": 1.0},
+        "quality": {"valid": True, "claim_coverage": 1.0},
+    }
+
+
+def test_section_evidence_report_detects_semantic_intro_reuse():
+    report = section_evidence_report(_page(repeated_prose=True)["markdown"])
+
+    assert report["intro_evidence"] == ["E1"]
+    assert report["intro_only_sections"] == ["Workflow"]
+    assert report["new_evidence_by_section"]["Workflow"] == []
+
+
+def test_section_narrative_report_detects_repeated_prose():
+    repeated = section_narrative_report(_page(repeated_prose=True)["markdown"])
+    distinct = section_narrative_report(_page(repeated_prose=False)["markdown"])
+
+    assert repeated["redundant_sections"] == ["Workflow"]
+    assert distinct["redundant_sections"] == []
+
+
+def test_section_evidence_report_detects_section_source_reuse():
+    markdown = (
+        "# Overview\n\n"
+        "The repository serves indexed source context. [E1]\n\n"
+        "## Build\n\n"
+        "The compiler writes a repository index. [E2]\n\n"
+        "## Load\n\n"
+        "The runtime loads the repository index. [E3]\n\n"
+        "## Serve\n\n"
+        "The server exposes the loaded repository index. [E2] [E3]"
+    )
+
+    report = section_evidence_report(markdown)
+
+    assert report["intro_only_sections"] == []
+    assert report["sections_without_new_evidence"] == ["Serve"]
+
+
+def test_page_audit_adds_narrative_validity_to_legacy_quality():
+    old_gate = audit_page(_page(repeated_prose=True))
+    improved = audit_page(_page(repeated_prose=False))
+
+    assert old_gate["grounding_valid"] is True
+    assert old_gate["structural_valid"] is True
+    assert old_gate["narrative_valid"] is False
+    assert old_gate["publishable"] is False
+    assert improved["publishable"] is True
+
+
+def test_cache_audit_ignores_outline_records_and_summarizes_pages(tmp_path):
+    pages = [_page(repeated_prose=True), _page(repeated_prose=False)]
+    for index, page in enumerate(pages):
+        (tmp_path / f"agentwiki_page_{index}.json").write_text(
+            json.dumps({"model": "test", "data": page})
+        )
+    (tmp_path / "agentwiki_outline.json").write_text(
+        json.dumps({"model": "test", "data": {"pages": []}})
+    )
+    (tmp_path / "agentwiki_broken.json").write_text("{")
+
+    report = audit_cache(tmp_path)
+
+    assert report == summarize_page_audits(pages)
+    assert report["pages"] == 2
+    assert report["publishable"] == 1
+    assert report["narrative_valid"] == 1

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -102,6 +102,7 @@ export interface WikiPage {
     model: string | null;
     repaired?: boolean;
     fallback?: "fact_plan" | null;
+    renderer?: "fact_plan" | "narrative";
     reason?: string;
     plan_warnings?: string[];
   };


### PR DESCRIPTION
## Summary

Makes the generated repository Wiki coherent enough to use as an engineering entry point: outlines must be source-anchored, page evidence prioritizes representative symbols from planned files, and publication is governed by deterministic grounding and narrative-quality reports. It also refuses to serve a Wiki when the checkout revision differs from the indexed manifest.

## Changes

- validate conceptual outlines against real files and symbols, with bounded breadth refinement
- keep test, evaluation, example, and script code scoped to pages that explicitly cover those areas
- fuse dense and BM25 retrieval while promoting representative public symbols from each planned file
- generate deterministic Markdown from validated fact plans and repair sparse, repetitive, or misleading plans
- separate source grounding from style diagnostics and expose reusable cache/page quality audits
- version outline and page caches independently so page-only changes do not regenerate the table of contents
- reject local Wiki startup when checkout HEAD and manifest commit differ
- expose the fact-plan renderer in the web API contract

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- full unit tier: 1851 passed, 10 skipped, 170 deselected
- focused Wiki/CLI tier after rebase: 102 passed
- frontend: 15 tests passed
- frontend production build passed
- changed-file pre-commit hooks passed
- real CodeNib snapshot: 6/6 top-level pages publishable, 100% citation and claim coverage, 0 repairs, 0 fallbacks

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published