### PR TITLE
feat(web): link the demo header to docs.codenib.ai

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@
 
 site_name: CodeNib
 site_description: A multi-view data system for serving repository context to coding agents
-site_url: https://sysevol-ai.github.io/CodeNib/
+site_url: https://docs.codenib.ai/
 repo_url: https://github.com/sysevol-ai/CodeNib
 repo_name: sysevol-ai/CodeNib
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -159,6 +159,15 @@ pre {
   font-weight: 500;
   color: var(--muted);
 }
+.site-header .header-link {
+  font-size: 13.5px;
+  font-weight: 550;
+  color: var(--text-secondary);
+  transition: color 0.15s;
+}
+.site-header .header-link:hover {
+  color: var(--text);
+}
 .btn-primary {
   display: inline-flex;
   align-items: center;

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -79,6 +79,14 @@ export default function Header({
       {center}
       <div className="header-right">
         <span className="header-note">Source-linked repository docs</span>
+        <a
+          className="header-link"
+          href="https://docs.codenib.ai"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Docs
+        </a>
         {actions}
         <ShareButton />
         <ThemeToggle />


### PR DESCRIPTION
## Summary

Wires the live documentation domain into CodeNib: `docs.codenib.ai` becomes the MkDocs canonical URL and the demo header links to it directly.

## Changes

- `web/components/Header.tsx` and `web/app/globals.css`: add a `Docs` link to the demo header, styled consistently with the existing controls
- `mkdocs.yml`: set `site_url` to `https://docs.codenib.ai/` so canonical and sitemap URLs use the public documentation domain
- Keep automated demo/docs publication as a separate follow-up in #354; it is not required for this URL and navigation change

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] `python -m mkdocs build --strict`
- [x] `python scripts/check_namespace.py`
- [x] `npm --prefix web run build`
- [x] `npm --prefix web test` (4 files, 16 tests)
- [x] Verified `https://docs.codenib.ai/` returns HTTP 200
- [x] Verified the generated MkDocs canonical URL is `https://docs.codenib.ai/`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published