### PR TITLE
fix(agent): keep sparse Ask free of heavy runtimes

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -169,3 +169,54 @@ jobs:
       - name: Exercise installed services
         working-directory: ${{ runner.temp }}
         run: python "$GITHUB_WORKSPACE/scripts/smoke_release_services.py"
+
+  agent-smoke:
+    name: Installed sparse Ask service
+    needs: build
+    runs-on: self-hosted
+    timeout-minutes: 20
+    steps:
+      - name: Checkout agent harness
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Install wheel with agent support
+        run: |
+          AGENT_VENV="$RUNNER_TEMP/codenib-release-agent-${{ github.run_id }}-${{ github.run_attempt }}"
+          python -m venv "$AGENT_VENV"
+          echo "$AGENT_VENV/bin" >> "$GITHUB_PATH"
+          "$AGENT_VENV/bin/python" -m pip install --upgrade pip
+          WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$WHEEL"
+          "$AGENT_VENV/bin/python" -m pip install "${WHEEL}[agent]"
+
+      - name: Verify sparse agent dependency boundary
+        working-directory: ${{ runner.temp }}
+        run: |
+          python - <<'PY'
+          import importlib.util
+
+          unexpected = [
+              name
+              for name in ("faiss", "igraph", "sentence_transformers")
+              if importlib.util.find_spec(name) is not None
+          ]
+          if unexpected:
+              raise SystemExit(f"unexpected retrieval runtimes: {unexpected}")
+          if importlib.util.find_spec("litellm") is None:
+              raise SystemExit("LiteLLM is missing from the agent extra")
+          PY
+
+      - name: Exercise installed Ask service
+        working-directory: ${{ runner.temp }}
+        run: python "$GITHUB_WORKSPACE/scripts/smoke_release_agent.py"

--- a/codenib/ops/retrieve.py
+++ b/codenib/ops/retrieve.py
@@ -5,13 +5,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
-from ..index.embedding.vector_store import CodeVectorStore
-from ..index.regex_idx.regex_idx import RegexNodeIndex
-from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..log_utils import get_logger
 from ..types import NodeInfo, QueriedNode
+
+if TYPE_CHECKING:
+    from ..index.embedding.vector_store import CodeVectorStore
+    from ..index.regex_idx.regex_idx import RegexNodeIndex
+    from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
 logger = get_logger(__name__)
 

--- a/codenib/scip_interface/__init__.py
+++ b/codenib/scip_interface/__init__.py
@@ -2,57 +2,119 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Language-specific SCIP indexing and decoding.
+
+The public classes stay lazy so importing an LSP-shaped provider does not load
+the optional igraph runtime or every language backend.
 """
-SCIP Interface Module
 
-Language-specific SCIP indexing and decoding for active and candidate
-cold-start routes.
-"""
+from __future__ import annotations
 
-from .lsp_occurrence_index import (
-    LSP_OCCURRENCE_INDEX_SCHEMA_VERSION,
-    SCIPLocation,
-    SCIPOccurrence,
-    SCIPOccurrenceIndex,
-)
-from .scip_decode_csharp import SCIPCSharpGraphDecoder
-from .scip_decode_java import SCIPJavaGraphDecoder
-from .scip_decode_php import SCIPPHPGraphDecoder
-from .scip_decode_python import SCIPPythonGraphDecoder
-from .scip_decode_ruby import SCIPRubyGraphDecoder
-from .scip_decode_rust import SCIPRustGraphDecoder
-from .scip_decode_ts import SCIPTypeScriptGraphDecoder
-from .scip_indexer_base import SCIPIndexerBase
-from .scip_indexer_csharp import SCIPCSharpIndexer
-from .scip_indexer_java import SCIPJavaIndexer, SCIPKotlinIndexer, SCIPScalaIndexer
-from .scip_indexer_php import PHPHybridIndexer, SCIPPHPIndexer
-from .scip_indexer_python import SCIPPythonIndexer
-from .scip_indexer_ruby import RubyHybridIndexer, SCIPRubyIndexer
-from .scip_indexer_rust import SCIPRustIndexer
-from .scip_indexer_ts import SCIPTypeScriptIndexer
+from typing import Any
 
-__all__ = [
-    "SCIPIndexerBase",
-    "SCIPPythonIndexer",
-    "SCIPRustIndexer",
-    "SCIPTypeScriptIndexer",
-    "SCIPCSharpIndexer",
-    "SCIPJavaIndexer",
-    "SCIPKotlinIndexer",
-    "SCIPScalaIndexer",
-    "RubyHybridIndexer",
-    "SCIPRubyIndexer",
-    "SCIPPHPIndexer",
-    "PHPHybridIndexer",
-    "SCIPJavaGraphDecoder",
-    "SCIPCSharpGraphDecoder",
-    "SCIPRubyGraphDecoder",
-    "SCIPPHPGraphDecoder",
-    "SCIPPythonGraphDecoder",
-    "SCIPRustGraphDecoder",
-    "SCIPTypeScriptGraphDecoder",
-    "LSP_OCCURRENCE_INDEX_SCHEMA_VERSION",
-    "SCIPLocation",
-    "SCIPOccurrence",
-    "SCIPOccurrenceIndex",
-]
+from .._lazy import exported_dir, load_export
+
+_EXPORTS = {
+    "SCIPIndexerBase": (
+        "codenib.scip_interface.scip_indexer_base",
+        "SCIPIndexerBase",
+    ),
+    "SCIPPythonIndexer": (
+        "codenib.scip_interface.scip_indexer_python",
+        "SCIPPythonIndexer",
+    ),
+    "SCIPRustIndexer": (
+        "codenib.scip_interface.scip_indexer_rust",
+        "SCIPRustIndexer",
+    ),
+    "SCIPTypeScriptIndexer": (
+        "codenib.scip_interface.scip_indexer_ts",
+        "SCIPTypeScriptIndexer",
+    ),
+    "SCIPCSharpIndexer": (
+        "codenib.scip_interface.scip_indexer_csharp",
+        "SCIPCSharpIndexer",
+    ),
+    "SCIPJavaIndexer": (
+        "codenib.scip_interface.scip_indexer_java",
+        "SCIPJavaIndexer",
+    ),
+    "SCIPKotlinIndexer": (
+        "codenib.scip_interface.scip_indexer_java",
+        "SCIPKotlinIndexer",
+    ),
+    "SCIPScalaIndexer": (
+        "codenib.scip_interface.scip_indexer_java",
+        "SCIPScalaIndexer",
+    ),
+    "RubyHybridIndexer": (
+        "codenib.scip_interface.scip_indexer_ruby",
+        "RubyHybridIndexer",
+    ),
+    "SCIPRubyIndexer": (
+        "codenib.scip_interface.scip_indexer_ruby",
+        "SCIPRubyIndexer",
+    ),
+    "SCIPPHPIndexer": (
+        "codenib.scip_interface.scip_indexer_php",
+        "SCIPPHPIndexer",
+    ),
+    "PHPHybridIndexer": (
+        "codenib.scip_interface.scip_indexer_php",
+        "PHPHybridIndexer",
+    ),
+    "SCIPJavaGraphDecoder": (
+        "codenib.scip_interface.scip_decode_java",
+        "SCIPJavaGraphDecoder",
+    ),
+    "SCIPCSharpGraphDecoder": (
+        "codenib.scip_interface.scip_decode_csharp",
+        "SCIPCSharpGraphDecoder",
+    ),
+    "SCIPRubyGraphDecoder": (
+        "codenib.scip_interface.scip_decode_ruby",
+        "SCIPRubyGraphDecoder",
+    ),
+    "SCIPPHPGraphDecoder": (
+        "codenib.scip_interface.scip_decode_php",
+        "SCIPPHPGraphDecoder",
+    ),
+    "SCIPPythonGraphDecoder": (
+        "codenib.scip_interface.scip_decode_python",
+        "SCIPPythonGraphDecoder",
+    ),
+    "SCIPRustGraphDecoder": (
+        "codenib.scip_interface.scip_decode_rust",
+        "SCIPRustGraphDecoder",
+    ),
+    "SCIPTypeScriptGraphDecoder": (
+        "codenib.scip_interface.scip_decode_ts",
+        "SCIPTypeScriptGraphDecoder",
+    ),
+    "LSP_OCCURRENCE_INDEX_SCHEMA_VERSION": (
+        "codenib.scip_interface.lsp_occurrence_index",
+        "LSP_OCCURRENCE_INDEX_SCHEMA_VERSION",
+    ),
+    "SCIPLocation": (
+        "codenib.scip_interface.lsp_occurrence_index",
+        "SCIPLocation",
+    ),
+    "SCIPOccurrence": (
+        "codenib.scip_interface.lsp_occurrence_index",
+        "SCIPOccurrence",
+    ),
+    "SCIPOccurrenceIndex": (
+        "codenib.scip_interface.lsp_occurrence_index",
+        "SCIPOccurrenceIndex",
+    ),
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name: str) -> Any:
+    return load_export(globals(), _EXPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return exported_dir(globals(), _EXPORTS)

--- a/codenib/scip_interface/scip_indexer_base.py
+++ b/codenib/scip_interface/scip_indexer_base.py
@@ -7,18 +7,22 @@
 """
 Base class for SCIP indexers across different languages.
 """
+from __future__ import annotations
+
 import fnmatch
 import os
 import subprocess
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
-from ..graph.code_graph import CodeGraph
 from ..log_utils import get_logger
 from ..paths import temp_state_dir
 from ..profiler import Profiler
 from ..types import NODE_TYPE_DIRECTORY, NODE_TYPE_FILE, ROOT_NODE, is_symbol_node
+
+if TYPE_CHECKING:
+    from ..graph.code_graph import CodeGraph
 
 logger = get_logger("scip_indexer_base")
 
@@ -496,6 +500,8 @@ class SCIPIndexerBase(ABC):
         if skip_level == "graph" and self.graph_file.exists():
             logger.info(f"Loading cached graph from {self.graph_file}")
             try:
+                from ..graph.code_graph import CodeGraph
+
                 graph = CodeGraph.load_graph(str(self.graph_file))
                 if self.lsp_index_file.is_file():
                     from .lsp_occurrence_index import SCIPOccurrenceIndex

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -413,7 +413,6 @@ class RepoRegistry:
         from ..agent.runner import AgentRunner
         from ..agent.skills.loader import SkillLoader
         from ..compiler.params import SessionContext
-        from ..ops.rerank import RerankContext
         from ..ops.retrieve import RetrieveContext
 
         entry = bundle.entry
@@ -429,6 +428,8 @@ class RepoRegistry:
         )
         contexts: Dict[str, object] = {"retrieve": retrieve_ctx}
         if vector_store is not None:
+            from ..ops.rerank import RerankContext
+
             contexts["rerank"] = RerankContext(embedding_store=vector_store)
 
         registry = _fresh_registry()

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,6 +21,9 @@ workflows. It:
 4. Installs the wheel on every supported Python minor version.
 5. Builds a real BM25 index through the installed `codenib` command.
 6. Exercises the installed Wiki and MCP services end to end.
+7. Runs sparse Ask through a local OpenAI-compatible endpoint, including a
+   real BM25 tool call, final answer, and source citation, without installing
+   semantic or graph extras.
 
 Manually dispatching the TestPyPI Release workflow from `main` runs these gates
 and then publishes to TestPyPI. Production publishing remains in the separate

--- a/scripts/smoke_release_agent.py
+++ b/scripts/smoke_release_agent.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise installed sparse Ask through an OpenAI-compatible endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import traceback
+import urllib.error
+import urllib.request
+from contextlib import nullcontext
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Sequence
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    print("+", " ".join(command), flush=True)
+    return subprocess.run(
+        list(command),
+        cwd=cwd,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _fixture_repository(root: Path) -> Path:
+    repo = root / "agent-smoke-repository"
+    repo.mkdir()
+    (repo / "calculator.py").write_text(
+        "def release_signature(left: int, right: int) -> int:\n"
+        '    """Return the release verification sum."""\n'
+        "    return left + right\n",
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text(
+        "# Agent smoke repository\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    _run(["git", "init", "--quiet"], cwd=repo, env=env)
+    _run(
+        ["git", "config", "user.email", "release-smoke@example.invalid"],
+        cwd=repo,
+        env=env,
+    )
+    _run(
+        ["git", "config", "user.name", "CodeNib Release Smoke"],
+        cwd=repo,
+        env=env,
+    )
+    _run(["git", "add", "."], cwd=repo, env=env)
+    _run(["git", "commit", "--quiet", "-m", "initial fixture"], cwd=repo, env=env)
+    return repo
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _request_json(
+    url: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 5.0,
+) -> Any:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json"} if body is not None else {},
+        method="POST" if body is not None else "GET",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read())
+
+
+def _wait_for_json(
+    url: str,
+    *,
+    process: subprocess.Popen[Any],
+    timeout: float,
+) -> Any:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"Wiki exited before {url} became ready "
+                f"(status {process.returncode})"
+            )
+        try:
+            return _request_json(url)
+        except (OSError, ValueError, urllib.error.URLError) as exc:
+            last_error = exc
+        time.sleep(0.25)
+    raise RuntimeError(f"timed out waiting for {url}: {last_error}")
+
+
+def _stop_process_group(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "posix":
+        os.killpg(process.pid, signal.SIGINT)
+    else:  # pragma: no cover - release CI currently runs on Linux
+        process.terminate()
+    try:
+        process.wait(timeout=15)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+
+    if os.name == "posix":
+        os.killpg(process.pid, signal.SIGTERM)
+    else:  # pragma: no cover
+        process.terminate()
+    process.wait(timeout=5)
+
+
+class _FakeOpenAIHandler(BaseHTTPRequestHandler):
+    """Two-turn endpoint: request BM25 once, then answer from its result."""
+
+    requests: list[dict[str, Any]] = []
+
+    def do_POST(self) -> None:
+        if self.path != "/v1/chat/completions":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        request = json.loads(self.rfile.read(length))
+        self.requests.append(request)
+        messages = request.get("messages") or []
+        has_tool_result = any(message.get("role") == "tool" for message in messages)
+
+        if has_tool_result:
+            message = {
+                "role": "assistant",
+                "content": (
+                    "The repository defines `release_signature` in "
+                    "`calculator.py`; it returns the sum of its two inputs."
+                ),
+            }
+            finish_reason = "stop"
+        else:
+            names = {
+                tool.get("function", {}).get("name")
+                for tool in request.get("tools") or []
+                if isinstance(tool, dict)
+            }
+            if "bm25_search" not in names:
+                self.send_error(400, f"bm25_search missing from tools: {sorted(names)}")
+                return
+            message = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_release_search",
+                        "type": "function",
+                        "function": {
+                            "name": "bm25_search",
+                            "arguments": json.dumps(
+                                {"query": "release_signature", "top_k": 5}
+                            ),
+                        },
+                    }
+                ],
+            }
+            finish_reason = "tool_calls"
+
+        payload = {
+            "id": f"chatcmpl-{len(self.requests)}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": request.get("model", "fake-model"),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": message,
+                    "finish_reason": finish_reason,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        }
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def _assert_chat_response(response: Any) -> None:
+    if not isinstance(response, dict):
+        raise RuntimeError(f"Ask returned a non-object response: {response!r}")
+    if "returns the sum" not in response.get("answer", ""):
+        raise RuntimeError(f"Ask returned an unexpected answer: {response!r}")
+    if response.get("total_turns") != 2:
+        raise RuntimeError(f"Ask did not complete in two turns: {response!r}")
+
+    calls = response.get("tool_calls") or []
+    if (
+        len(calls) != 1
+        or calls[0].get("skill_id") != "bm25_search"
+        or calls[0].get("result_count", 0) < 1
+        or calls[0].get("error") is not None
+    ):
+        raise RuntimeError(f"Ask did not execute grounded BM25 retrieval: {calls!r}")
+
+    citations = response.get("citations") or []
+    if (
+        not citations
+        or citations[0].get("file") != "calculator.py"
+        or citations[0].get("start_line") != 1
+    ):
+        raise RuntimeError(f"Ask returned invalid source citations: {citations!r}")
+
+
+def smoke(root: Path, *, executable: str = "codenib") -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    repo = _fixture_repository(root)
+    env = os.environ.copy()
+    env["CODENIB_HOME"] = str(root / "user-state")
+    env["CODENIB_RELEASE_SMOKE_KEY"] = "local-release-smoke"
+
+    _FakeOpenAIHandler.requests = []
+    model_server = ThreadingHTTPServer(
+        ("127.0.0.1", _free_port()),
+        _FakeOpenAIHandler,
+    )
+    model_thread = threading.Thread(target=model_server.serve_forever, daemon=True)
+    model_thread.start()
+    model_base = f"http://127.0.0.1:{model_server.server_port}/v1"
+
+    try:
+        _run(
+            [
+                executable,
+                "doctor",
+                "--require",
+                "core",
+                "--require",
+                "wiki",
+                "--require",
+                "agent",
+                "--model",
+                "openai/fake-model",
+                "--api-base",
+                model_base,
+                "--api-key-env",
+                "CODENIB_RELEASE_SMOKE_KEY",
+            ],
+            cwd=root,
+            env=env,
+        )
+        _run([executable, "index", str(repo)], cwd=root, env=env)
+        status = _run(["git", "status", "--porcelain"], cwd=repo, env=env).stdout
+        if status:
+            raise RuntimeError(f"indexing modified the target repository: {status!r}")
+
+        frontend_port = _free_port()
+        api_port = _free_port()
+        log_path = root / "agent-wiki.log"
+        command = [
+            executable,
+            "wiki",
+            str(repo),
+            "--no-index",
+            "--no-open",
+            "--model",
+            "openai/fake-model",
+            "--api-base",
+            model_base,
+            "--api-key-env",
+            "CODENIB_RELEASE_SMOKE_KEY",
+            "--port",
+            str(frontend_port),
+            "--api-port",
+            str(api_port),
+        ]
+        print("+", " ".join(command), flush=True)
+        with log_path.open("w", encoding="utf-8") as service_log:
+            process = subprocess.Popen(
+                command,
+                cwd=root,
+                env=env,
+                stdout=service_log,
+                stderr=subprocess.STDOUT,
+                text=True,
+                start_new_session=True,
+            )
+            try:
+                api_base = f"http://127.0.0.1:{api_port}"
+                repos = _wait_for_json(
+                    f"{api_base}/api/repos",
+                    process=process,
+                    timeout=120,
+                )
+                if len(repos) != 1 or not repos[0].get("capabilities", {}).get("chat"):
+                    raise RuntimeError(f"installed Wiki did not expose Ask: {repos!r}")
+                response = _request_json(
+                    f"{api_base}/api/chat",
+                    payload={
+                        "repo_id": repos[0]["id"],
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": "What does release_signature do?",
+                            }
+                        ],
+                    },
+                    timeout=60,
+                )
+                _assert_chat_response(response)
+                if len(_FakeOpenAIHandler.requests) != 2:
+                    raise RuntimeError(
+                        "Ask did not make exactly one tool-selection and one "
+                        f"final-answer request: {len(_FakeOpenAIHandler.requests)}"
+                    )
+            except Exception:
+                service_log.flush()
+                details = log_path.read_text(encoding="utf-8", errors="replace")
+                print(f"\n--- Agent Wiki log ---\n{details}", file=sys.stderr)
+                print(
+                    "\n--- Model requests ---\n"
+                    + json.dumps(_FakeOpenAIHandler.requests, indent=2),
+                    file=sys.stderr,
+                )
+                raise
+            finally:
+                _stop_process_group(process)
+    finally:
+        model_server.shutdown()
+        model_server.server_close()
+        model_thread.join(timeout=5)
+
+    print("Installed sparse Ask service smoke passed")
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path)
+    parser.add_argument("--executable", default="codenib")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    executable = shutil.which(args.executable)
+    if executable is None:
+        print(
+            f"release agent smoke failed: command not found: {args.executable}",
+            file=sys.stderr,
+        )
+        return 1
+
+    context = (
+        nullcontext(args.root.expanduser().resolve())
+        if args.root is not None
+        else tempfile.TemporaryDirectory(prefix="codenib-release-agent-")
+    )
+    try:
+        with context as value:
+            smoke(Path(value), executable=executable)
+    except Exception as exc:
+        print(f"release agent smoke failed: {exc}", file=sys.stderr)
+        traceback.print_exception(exc)
+        if isinstance(exc, subprocess.CalledProcessError):
+            if exc.stdout:
+                print(exc.stdout, file=sys.stderr)
+            if exc.stderr:
+                print(exc.stderr, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_lazy_imports.py
+++ b/test/test_lazy_imports.py
@@ -28,10 +28,70 @@ if loaded:
     raise SystemExit(f"optional runtimes imported eagerly: {loaded}")
 """
 
-    subprocess.run(
+    result = subprocess.run(
         [sys.executable, "-c", script],
         cwd=root,
-        check=True,
         capture_output=True,
         text=True,
     )
+    assert result.returncode == 0, result.stderr
+
+
+def test_sparse_ask_runtime_does_not_require_semantic_or_graph_extras() -> None:
+    root = Path(__file__).resolve().parents[1]
+    script = """
+import sys
+import time
+
+for name in ("faiss", "igraph", "sentence_transformers"):
+    sys.modules[name] = None
+sys.modules["codenib.ops.rerank"] = None
+
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.web.config import QAConfig, RepoEntry
+from codenib.web.repo_registry import RepoBundle, RepoRegistry
+
+entry = RepoEntry(
+    instance_id="sparse-repo",
+    repo="sparse-repo",
+    base_commit="abc123",
+    language="python",
+    repo_dir="/tmp/sparse-repo",
+    manifest_path="/tmp/sparse-repo/repo_manifest.json",
+)
+manifest = RepoManifest(
+    repo_path=entry.repo_dir,
+    commit=entry.base_commit,
+    languages=["python"],
+    file_count=1,
+    indexes={
+        "bm25": IndexEntry(
+            index_type="bm25",
+            path="/tmp/sparse-repo/bm25",
+            built_at="now",
+            built_at_epoch=time.time(),
+            status="fresh",
+            commit=entry.base_commit,
+        )
+    },
+)
+bundle = RepoBundle(
+    entry=entry,
+    manifest=manifest,
+    bm25=object(),
+)
+RepoRegistry(
+    QAConfig(model="openai/fake-model", model_api_key="fake-key")
+)._load_repo_runtime(bundle)
+
+if bundle.runner is None:
+    raise SystemExit("sparse Ask runtime was not created")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
Fix the installed `[agent]` experience so BM25-only Ask does not require semantic or graph runtimes. The release workflow now proves the sparse product path end to end through a local OpenAI-compatible model endpoint.

## Changes
- Lazily load vector reranking, graph types, and language-specific SCIP backends only when those capabilities are requested.
- Add a regression test that constructs a BM25-only Ask runtime while blocking FAISS, igraph, sentence-transformers, and reranking imports.
- Add an installed-wheel smoke that indexes a real Git fixture, launches Wiki, executes a BM25 tool call, returns a final answer, and verifies a source citation.
- Document the sparse Ask release gate.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1820 passed, 10 skipped`)

`pytest -q test/test_lazy_imports.py test/web/test_repo_registry.py test/scip/test_lsp_occurrence_index.py test/agent/test_lsp_provider.py test/scip/test_scip_python_runtime.py test/test_ls_router_registry.py` (`96 passed`)

`/tmp/codenib-agent-e2e2/bin/python scripts/smoke_release_agent.py --executable /tmp/codenib-agent-e2e2/bin/codenib`

`pre-commit run --files .github/workflows/release-verify.yml codenib/ops/retrieve.py codenib/scip_interface/__init__.py codenib/scip_interface/scip_indexer_base.py codenib/web/repo_registry.py docs/releasing.md scripts/smoke_release_agent.py test/test_lazy_imports.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published