### PR TITLE
fix(product): close installed Wiki acceptance gaps

### DIFF
--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -88,7 +88,7 @@ class BM25IndexBuilder:
 
     def artifact_identity(self) -> Dict[str, Any]:
         return {
-            "builder_schema": 2,
+            "builder_schema": 3,
             "languages": list(self.languages),
             "max_k": self.max_k,
             "max_lines_per_chunk": self.max_lines_per_chunk,
@@ -127,6 +127,11 @@ class BM25IndexBuilder:
             path=output_dir,
             metadata={
                 **self.artifact_identity(),
+                "chunk_count": len(chunks),
+                "source_file_count": len(
+                    {chunk.file for chunk in chunks if getattr(chunk, "file", "")}
+                ),
+                # Retain the legacy field for existing manifest consumers.
                 "file_count": len(chunks),
             },
         )

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -47,8 +47,16 @@ _DEMO_SYSTEM_PROMPT = (
     "Use the search tools (hybrid_search / embedding_search / bm25_search) to "
     "find the relevant code, then write a clear, well-structured explanation. "
     "Ground every claim in the retrieved code and name the key files and symbols "
-    "you found so the reader can open them. If a search returns nothing useful, "
-    "try a different query or tool before concluding."
+    "you found so the reader can open them. Follow identifiers discovered in a "
+    "call site with a targeted search when the question asks for a definition, "
+    "owner, implementation, or control flow; do not claim that a symbol is "
+    "missing while an unresolved candidate identifier remains in the evidence. "
+    "When a call site names several candidates, distinguish registries and "
+    "configuration objects from the component whose method performs the "
+    "requested operation, then resolve that component's definition. "
+    "Answer definition questions with the exact identifier and defining file, "
+    "and use call sites only to explain how it is reached. If a search returns "
+    "nothing useful, try a different query or tool before concluding."
 )
 
 
@@ -286,7 +294,12 @@ class RepoBundle:
         cached = getattr(self, "_file_count_cache", None)
         if cached is not None:
             return cached
-        n = self.manifest.file_count or 0
+        indexes = getattr(self.manifest, "indexes", {}) or {}
+        bm25 = indexes.get("bm25")
+        metadata = getattr(bm25, "metadata", {}) or {}
+        n = int(metadata.get("source_file_count") or 0)
+        if not n:
+            n = self.manifest.file_count or 0
         vs = self.vector_store
         if vs is not None:
             docs = getattr(vs, "l0_documents", None)

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -11,6 +11,7 @@ flat, UI-friendly ``ChatResponse`` the Wiki frontend renders.
 from __future__ import annotations
 
 import os
+import re
 from typing import Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field
@@ -206,6 +207,69 @@ def _node_to_citation(node: Any, repo_path: str = "") -> Optional[Citation]:
     )
 
 
+def _answer_citations(
+    answer: str,
+    citations: List[Citation],
+    *,
+    limit: int = 8,
+) -> List[Citation]:
+    """Prefer retrieved locations that the final answer actually names."""
+
+    normalized_answer = (answer or "").replace("\\", "/").lower()
+    ranked: list[tuple[int, int, Citation]] = []
+    generic_symbols = {
+        "build",
+        "class",
+        "function",
+        "index",
+        "main",
+        "method",
+        "query",
+        "run",
+        "search",
+    }
+    for position, citation in enumerate(citations):
+        score = 0
+        file = (citation.file or "").replace("\\", "/").lower()
+        if file and file in normalized_answer:
+            score += 8
+        elif file:
+            basename = file.rsplit("/", 1)[-1]
+            if basename and basename in normalized_answer:
+                score += 2
+
+        raw_symbol = (citation.node_name or "").rsplit(":", 1)[-1]
+        symbol = re.sub(r"\([^)]*\)$", "", raw_symbol).strip()
+        if symbol and symbol.lower() in normalized_answer:
+            score += 6
+        for part in symbol.split("."):
+            candidate = part.strip()
+            if len(candidate) < 4 or candidate.lower() in generic_symbols:
+                continue
+            if re.search(
+                rf"(?<![\w]){re.escape(candidate.lower())}(?![\w])",
+                normalized_answer,
+            ):
+                score += 4
+        if score:
+            ranked.append((-score, position, citation))
+
+    if not ranked:
+        return citations[: min(5, limit)]
+
+    selected: List[Citation] = []
+    per_file: dict[str, int] = {}
+    for _, _, citation in sorted(ranked):
+        file_key = citation.file or ""
+        if per_file.get(file_key, 0) >= 3:
+            continue
+        selected.append(citation)
+        per_file[file_key] = per_file.get(file_key, 0) + 1
+        if len(selected) >= limit:
+            break
+    return selected
+
+
 def agent_result_to_response(result: Any, repo_path: str = "") -> ChatResponse:
     """Flatten an ``AgentResult`` into the API response.
 
@@ -240,7 +304,7 @@ def agent_result_to_response(result: Any, repo_path: str = "") -> ChatResponse:
 
     return ChatResponse(
         answer=result.answer or "",
-        citations=citations,
+        citations=_answer_citations(result.answer or "", citations),
         tool_calls=tool_calls,
         total_turns=result.total_turns,
         total_duration_ms=result.total_duration_ms,

--- a/codenib/web/static_server.py
+++ b/codenib/web/static_server.py
@@ -65,6 +65,10 @@ class WikiStaticHandler(SimpleHTTPRequestHandler):
         if request_path == "/api" or request_path.startswith("/api/"):
             self._proxy_api_request()
             return
+        relative = request_path.lstrip("/")
+        candidate = Path(self.directory, relative)
+        if request_path != "/" and not candidate.is_file():
+            self.path = "/index.html"
         super().do_HEAD()
 
     def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract

--- a/codenib/wiki/builder.py
+++ b/codenib/wiki/builder.py
@@ -360,10 +360,16 @@ class WikiBuilder:
 
     def _indexed_file_count(self) -> int:
         symbol_files = len({symbol.file for symbol in self._symbols()})
-        manifest_count = int(
-            getattr(getattr(self._bundle, "manifest", None), "file_count", 0) or 0
-        )
-        return max(symbol_files, manifest_count)
+        manifest = getattr(self._bundle, "manifest", None)
+        indexes = getattr(manifest, "indexes", {}) or {}
+        bm25 = indexes.get("bm25")
+        metadata = getattr(bm25, "metadata", {}) or {}
+        source_files = int(metadata.get("source_file_count") or 0)
+        if source_files:
+            return source_files
+        if symbol_files:
+            return symbol_files
+        return int(getattr(manifest, "file_count", 0) or 0)
 
     def _project_summary(self) -> str:
         if self._project_summary_cache is not None:

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -10,6 +10,7 @@ import json
 import os
 import subprocess
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -92,9 +93,9 @@ class TestBM25IndexBuilder:
         # Mock chunker returns fake chunks
         mock_chunker_instance = MagicMock()
         mock_chunker_instance.chunk_repository.return_value = [
-            "chunk1",
-            "chunk2",
-            "chunk3",
+            SimpleNamespace(file="src/a.py"),
+            SimpleNamespace(file="src/a.py"),
+            SimpleNamespace(file="src/b.py"),
         ]
         MockChunker.return_value = mock_chunker_instance
 
@@ -114,6 +115,9 @@ class TestBM25IndexBuilder:
         assert status.index_type == "bm25"
         assert status.state == IndexState.FRESH
         assert status.metadata["file_count"] == 3
+        assert status.metadata["chunk_count"] == 3
+        assert status.metadata["source_file_count"] == 2
+        assert status.metadata["builder_schema"] == 3
         assert status.metadata["max_k"] == 64
         assert status.path == output
         mock_indexer_instance.save_index.assert_called_once_with(output)

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -16,7 +16,12 @@ from codenib.web.config import (
     load_registry,
     save_registry,
 )
-from codenib.web.repo_registry import RepoBundle, RepoRegistry, _fresh_registry
+from codenib.web.repo_registry import (
+    _DEMO_SYSTEM_PROMPT,
+    RepoBundle,
+    RepoRegistry,
+    _fresh_registry,
+)
 
 
 def test_fresh_registry_is_isolated_from_singleton():
@@ -29,6 +34,12 @@ def test_fresh_registry_is_isolated_from_singleton():
     assert reg_a is not reg_b
     assert reg_a._skills is not reg_b._skills
     assert reg_a._skills is not singleton._skills
+
+
+def test_ask_prompt_requires_resolving_discovered_identifiers():
+    assert "targeted search" in _DEMO_SYSTEM_PROMPT
+    assert "exact identifier and defining file" in _DEMO_SYSTEM_PROMPT
+    assert "unresolved candidate identifier" in _DEMO_SYSTEM_PROMPT
 
 
 def test_bundle_loads_views_without_constructing_agent_runtime():
@@ -50,6 +61,20 @@ def test_bundle_loads_views_without_constructing_agent_runtime():
     bundle.ensure_runtime()
 
     assert calls == [("views", bundle), ("runtime", bundle)]
+
+
+def test_bundle_reports_indexed_source_files_instead_of_repository_files():
+    bundle = RepoBundle(
+        entry=SimpleNamespace(),
+        manifest=SimpleNamespace(
+            file_count=99,
+            indexes={
+                "bm25": SimpleNamespace(metadata={"source_file_count": 3}),
+            },
+        ),
+    )
+
+    assert bundle._file_count() == 3
 
 
 def test_bundle_reports_partial_graph_language_coverage():

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -64,6 +64,49 @@ def test_citations_are_deduplicated_across_tool_calls():
     assert len(resp.tool_calls) == 2
 
 
+def test_citations_prefer_files_and_symbols_named_in_the_answer():
+    result = AgentResult(
+        answer=("`AuthService` is defined in `src/auth.py` and owns authentication."),
+        tool_calls=[
+            ToolCallRecord(
+                "1",
+                "bm25_search",
+                {},
+                result=[
+                    _node("src/bootstrap.py", 0, 9, "bootstrap"),
+                    _node("src/auth.py", 10, 30, "AuthService.login"),
+                    _node("src/config.py", 0, 9, "Config"),
+                ],
+            )
+        ],
+    )
+
+    response = agent_result_to_response(result)
+
+    assert [citation.file for citation in response.citations] == ["src/auth.py"]
+
+
+def test_citations_bound_unnamed_retrieval_candidates():
+    result = AgentResult(
+        answer="The repository has several relevant components.",
+        tool_calls=[
+            ToolCallRecord(
+                "1",
+                "bm25_search",
+                {},
+                result=[_node(f"src/{index}.py", 0, 9) for index in range(10)],
+            )
+        ],
+    )
+
+    response = agent_result_to_response(result)
+
+    assert len(response.citations) == 5
+    assert [citation.file for citation in response.citations] == [
+        f"src/{index}.py" for index in range(5)
+    ]
+
+
 def test_error_tool_call_has_no_citations():
     result = AgentResult(
         answer="ans",

--- a/test/web/test_static_server.py
+++ b/test/web/test_static_server.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import http.client
 import json
 import threading
 import urllib.request
@@ -31,6 +32,12 @@ def test_static_server_uses_same_origin_api_and_falls_back_to_spa(tmp_path):
             assert response.headers["Cache-Control"] == "no-store"
         with urllib.request.urlopen(f"{base}/owner/repo") as response:
             page = response.read().decode()
+        connection = http.client.HTTPConnection("127.0.0.1", server.server_port)
+        connection.request("HEAD", "/owner/repo")
+        head_response = connection.getresponse()
+        head_status = head_response.status
+        head_length = int(head_response.headers["Content-Length"])
+        connection.close()
         with urllib.request.urlopen(f"{base}/assets/app.js") as response:
             asset = response.read().decode()
             assert "immutable" in response.headers["Cache-Control"]
@@ -41,6 +48,8 @@ def test_static_server_uses_same_origin_api_and_falls_back_to_spa(tmp_path):
 
     assert config == 'window.__CODENIB_API_BASE__ = "";\n'
     assert "CodeNib Wiki" in page
+    assert head_status == 200
+    assert head_length == len("<title>CodeNib Wiki</title>")
     assert "ready" in asset
 
 

--- a/test/wiki/test_builder.py
+++ b/test/wiki/test_builder.py
@@ -195,6 +195,22 @@ def test_overview_links_modules(repo_dir):
     assert "```mermaid" not in page["markdown"]
 
 
+def test_overview_uses_indexed_source_file_count(repo_dir):
+    bundle = _make_bundle(repo_dir)
+    bundle.manifest = SimpleNamespace(
+        languages=["python"],
+        file_count=99,
+        indexes={
+            "bm25": SimpleNamespace(metadata={"source_file_count": 3}),
+        },
+    )
+
+    markdown = WikiBuilder(bundle).page("overview")["markdown"]
+
+    assert "| python | 3 | 4 |" in markdown
+    assert "| python | 99 |" not in markdown
+
+
 def test_overview_uses_readme_purpose_without_a_model(repo_dir):
     with open(f"{repo_dir}/README.md", "w", encoding="utf-8") as handle:
         handle.write(

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -933,6 +933,9 @@ pre {
   margin: 12px 0;
   overflow-x: auto;
 }
+.markdown .table-cards {
+  display: none;
+}
 .markdown table {
   border-collapse: collapse;
   margin: 0;
@@ -944,8 +947,38 @@ pre {
   padding: 6px 12px;
 }
 @media (max-width: 680px) {
-  .markdown .table-scroll table {
-    min-width: 620px;
+  .markdown .table-scroll {
+    display: none;
+  }
+  .markdown .table-cards {
+    display: grid;
+    gap: 10px;
+    margin: 12px 0;
+  }
+  .markdown .table-card {
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface-2);
+  }
+  .markdown .table-card-field {
+    display: grid;
+    grid-template-columns: minmax(92px, 0.42fr) minmax(0, 1fr);
+    gap: 12px;
+    align-items: start;
+    padding: 8px 10px;
+  }
+  .markdown .table-card-field + .table-card-field {
+    border-top: 1px solid var(--border);
+  }
+  .markdown .table-card-label {
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .markdown .table-card-value {
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 }
 

--- a/web/components/Markdown.test.tsx
+++ b/web/components/Markdown.test.tsx
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import Markdown from "./Markdown";
+
+describe("Markdown tables", () => {
+  it("renders both a semantic table and labeled mobile rows", () => {
+    const html = renderToStaticMarkup(
+      <Markdown>
+        {
+          "| Area | Files | Definition |\n" +
+          "|---|---:|---|\n" +
+          "| Runtime | 3 | `serve` |"
+        }
+      </Markdown>,
+    );
+
+    expect(html).toContain('class="table-scroll"');
+    expect(html).toContain('class="table-cards"');
+    expect(html).toContain('class="table-card-label">Definition</div>');
+    expect(html).toContain('class="table-card-value"><code>serve</code>');
+  });
+});

--- a/web/components/Markdown.tsx
+++ b/web/components/Markdown.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import {
+  Children,
+  isValidElement,
   lazy,
   Suspense,
   type ReactElement,
@@ -17,6 +19,15 @@ import type { Citation } from "@/lib/api";
 const Mermaid = lazy(() => import("./Mermaid"));
 const HighlightedBlock = lazy(() => import("./HighlightedBlock"));
 
+type ChildElement = ReactElement<{ children?: ReactNode }>;
+
+function childElements(children: ReactNode): ChildElement[] {
+  return Children.toArray(children).filter(
+    (child): child is ChildElement =>
+      isValidElement<{ children?: ReactNode }>(child),
+  );
+}
+
 // Recursively collect plain text from React children (to recover raw code).
 function nodeText(n: ReactNode): string {
   if (n == null || n === false) return "";
@@ -25,6 +36,49 @@ function nodeText(n: ReactNode): string {
   // @ts-expect-error - runtime prop access on element
   if (n.props?.children) return nodeText(n.props.children);
   return "";
+}
+
+function ResponsiveTable({ children }: { children: ReactNode }) {
+  const sections = childElements(children);
+  const head = sections.find((section) => section.type === "thead");
+  const body = sections.find((section) => section.type === "tbody");
+  const headerRow = head
+    ? childElements(head.props.children).find((row) => row.type === "tr")
+    : undefined;
+  const headers = headerRow
+    ? childElements(headerRow.props.children).map((cell) =>
+        nodeText(cell.props.children),
+      )
+    : [];
+  const rows = body
+    ? childElements(body.props.children)
+        .filter((row) => row.type === "tr")
+        .map((row) => childElements(row.props.children))
+    : [];
+
+  return (
+    <>
+      <div className="table-scroll">
+        <table>{children}</table>
+      </div>
+      {headers.length > 0 && rows.length > 0 && (
+        <div className="table-cards" role="list">
+          {rows.map((cells, rowIndex) => (
+            <div className="table-card" role="listitem" key={rowIndex}>
+              {cells.map((cell, cellIndex) => (
+                <div className="table-card-field" key={cellIndex}>
+                  <div className="table-card-label">
+                    {headers[cellIndex] || `Column ${cellIndex + 1}`}
+                  </div>
+                  <div className="table-card-value">{cell.props.children}</div>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
 }
 
 /** Inline `code` span that names a cited symbol/file: click to jump the code pane. */
@@ -75,11 +129,7 @@ export default function Markdown({
         rehypePlugins={[rehypeSlug]}
         components={{
           table({ children }) {
-            return (
-              <div className="table-scroll">
-                <table>{children}</table>
-              </div>
-            );
+            return <ResponsiveTable>{children}</ResponsiveTable>;
           },
           pre({ children }) {
             const codeEl = (Array.isArray(children) ? children[0] : children) as


### PR DESCRIPTION
## Summary

Close the concrete product gaps found during a clean-wheel acceptance run against the CodeNib repository. The installed Wiki now reports an accurate indexed-source count, renders generated Markdown tables readably on mobile, handles deep-route `HEAD` requests consistently, and keeps Ask citations focused on evidence named by the final answer.

## Changes

- Persist separate BM25 chunk and indexed-source-file counts, with a schema bump that refreshes stale metadata once.
- Use the indexed-source count consistently in the repository list and generated Overview.
- Render Markdown tables as semantic tables on desktop and labeled field cards on narrow screens.
- Apply the SPA fallback to `HEAD` as well as `GET` for deep Wiki routes.
- Guide Ask to resolve identifiers discovered at call sites before answering definition and ownership questions.
- Rank and bound answer citations by the files and symbols actually named in the final response.
- Add focused Python and frontend regression tests for every behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`1856 passed`, `10 skipped`)
- `npm test` (`16 passed`)
- `npm run build`
- `pre-commit run --all-files`
- Built and installed `codenib-0.1.0-py3-none-any.whl` in a fresh virtual environment.
- Ran `codenib doctor --require core --require wiki` from outside the checkout.
- Built a fresh fast index for the real CodeNib repository (`401/401` files processed, `3,670` chunks, `347` indexed source files), then verified a second launch reused the unchanged manifest.
- Verified `/api/repos` and the Overview both report `347`, deep-route `HEAD /codenib` returns `200`, and the packaged mobile Wiki has no page overflow, console errors, or hidden table columns.
- Exercised three real Ask definition/flow/metric questions; all returned useful source-grounded answers, with the ownership query resolving `IndexCompiler` and citations restricted to its defining file.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published