### PR TITLE
fix(graph): reject incomplete LSP symbol snapshots

### DIFF
--- a/codenib/graph/incremental/patcher_base.py
+++ b/codenib/graph/incremental/patcher_base.py
@@ -11,6 +11,7 @@ behavior to patcher_lang subclasses.
 
 from __future__ import annotations
 
+import time
 from abc import abstractmethod
 from typing import Optional
 
@@ -67,6 +68,8 @@ class PatcherBase(SubgraphMgr):
         }
     )
     REGISTRY_LANGUAGE: str | None = None
+    DOCUMENT_SYMBOL_ATTEMPTS = 10
+    DOCUMENT_SYMBOL_RETRY_DELAY_S = 1.0
 
     def __init__(
         self,
@@ -559,10 +562,14 @@ class PatcherBase(SubgraphMgr):
             return None
 
         abs_file = str(self.project_root / file_path)
-        with self.profiler.section("lsp_document_symbol"):
-            raw_symbols = self.lsp_client.document_symbol(abs_file)
-            new_symbols = self.flatten_symbols(file_path, raw_symbols)
         old_symbols = self.get_old_symbols(file_path)
+        with self.profiler.section("lsp_document_symbol"):
+            new_symbols = self._read_incremental_symbols(
+                file_path=file_path,
+                abs_file=abs_file,
+                old_symbols=old_symbols,
+                hunks=hunks,
+            )
 
         if not old_symbols:
             # No old symbols (SCIP didn't index this file) — fall back to
@@ -655,6 +662,53 @@ class PatcherBase(SubgraphMgr):
             "added_vnames": added_vnames,
             "hunks": hunks,
         }
+
+    def _read_incremental_symbols(
+        self,
+        *,
+        file_path: str,
+        abs_file: str,
+        old_symbols: dict[str, dict],
+        hunks: list[tuple[int, int, int, int]],
+    ) -> dict[str, dict]:
+        """Read a coherent post-change ``documentSymbol`` snapshot.
+
+        Large language servers can briefly return an empty list after a
+        checkout even though unchanged indexed definitions remain in the
+        file. Treating that transient response as authoritative deletes every
+        old symbol touched by the diff. Retry that one inconsistent state and
+        fail closed so the compiler can fall back to a fresh graph build.
+        """
+
+        has_untouched_old_symbol = any(
+            not any(
+                old["start_line"] <= old_end
+                and old.get("end_line", old["start_line"]) >= old_start
+                for old_start, old_end, _new_start, _new_end in hunks
+            )
+            for old in old_symbols.values()
+        )
+
+        for attempt in range(1, self.DOCUMENT_SYMBOL_ATTEMPTS + 1):
+            raw_symbols = self.lsp_client.document_symbol(abs_file)
+            new_symbols = self.flatten_symbols(file_path, raw_symbols)
+            if new_symbols or not has_untouched_old_symbol:
+                return new_symbols
+
+            if attempt < self.DOCUMENT_SYMBOL_ATTEMPTS:
+                logger.warning(
+                    "documentSymbol returned no symbols for %s while unchanged "
+                    "indexed definitions remain; retrying (%d/%d)",
+                    file_path,
+                    attempt,
+                    self.DOCUMENT_SYMBOL_ATTEMPTS,
+                )
+                time.sleep(self.DOCUMENT_SYMBOL_RETRY_DELAY_S)
+
+        raise RuntimeError(
+            f"documentSymbol remained empty for {file_path} while unchanged "
+            "indexed definitions remain"
+        )
 
     def _incremental_connect_edges(self, file_path: str, ctx: dict) -> dict:
         """Round 2: connect reference edges using LSP queries.

--- a/test/graph/incremental/test_document_symbol_readiness.py
+++ b/test/graph/incremental/test_document_symbol_readiness.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for coherent incremental document-symbol reads."""
+
+from __future__ import annotations
+
+import pytest
+
+from codenib.graph.code_graph import CodeGraph
+from codenib.graph.incremental.patcher_rust import PatcherRust
+
+
+class _DocumentSymbolClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def document_symbol(self, _file_path):
+        response_index = min(self.calls, len(self._responses) - 1)
+        self.calls += 1
+        return self._responses[response_index]
+
+
+def _function_symbol(name: str, start_line: int, end_line: int) -> dict:
+    location = {
+        "start": {"line": start_line, "character": 0},
+        "end": {"line": end_line, "character": 1},
+    }
+    return {
+        "name": name,
+        "kind": 12,
+        "range": location,
+        "selectionRange": location,
+    }
+
+
+def _patcher(tmp_path, responses) -> tuple[PatcherRust, _DocumentSymbolClient]:
+    patcher = PatcherRust(str(tmp_path), CodeGraph(str(tmp_path)))
+    client = _DocumentSymbolClient(responses)
+    patcher.lsp_client = client
+    patcher.DOCUMENT_SYMBOL_ATTEMPTS = 3
+    patcher.DOCUMENT_SYMBOL_RETRY_DELAY_S = 0
+    return patcher, client
+
+
+def test_incremental_symbols_retry_transient_empty_snapshot(tmp_path):
+    symbol = _function_symbol("kept", 2, 5)
+    patcher, client = _patcher(tmp_path, [[], [symbol]])
+
+    result = patcher._read_incremental_symbols(
+        file_path="src/lib.rs",
+        abs_file=str(tmp_path / "src/lib.rs"),
+        old_symbols={
+            "src/lib.rs:kept()": {
+                "start_line": 2,
+                "end_line": 5,
+            }
+        },
+        hunks=[(10, 10, 10, 10)],
+    )
+
+    assert list(result) == ["src/lib.rs:kept()"]
+    assert client.calls == 2
+
+
+def test_incremental_symbols_reject_persistently_empty_snapshot(tmp_path):
+    patcher, client = _patcher(tmp_path, [[]])
+
+    with pytest.raises(RuntimeError, match="unchanged indexed definitions remain"):
+        patcher._read_incremental_symbols(
+            file_path="src/lib.rs",
+            abs_file=str(tmp_path / "src/lib.rs"),
+            old_symbols={
+                "src/lib.rs:kept()": {
+                    "start_line": 2,
+                    "end_line": 5,
+                }
+            },
+            hunks=[(10, 10, 10, 10)],
+        )
+
+    assert client.calls == 3
+
+
+def test_incremental_symbols_allow_empty_file_after_complete_deletion(tmp_path):
+    patcher, client = _patcher(tmp_path, [[]])
+
+    result = patcher._read_incremental_symbols(
+        file_path="src/lib.rs",
+        abs_file=str(tmp_path / "src/lib.rs"),
+        old_symbols={
+            "src/lib.rs:removed()": {
+                "start_line": 2,
+                "end_line": 5,
+            }
+        },
+        hunks=[(2, 5, 2, 2)],
+    )
+
+    assert result == {}
+    assert client.calls == 1

--- a/test/graph/incremental/test_graph_patcher.py
+++ b/test/graph/incremental/test_graph_patcher.py
@@ -112,9 +112,11 @@ def _build_graph_with_scip(
 ) -> CodeGraph:
     """Build a CodeGraph via SCIP cold-start (LSIndexer.run_pipeline).
 
-    Uses skip_level="graph" to reuse cached graph.pkl if available,
-    falling back to full pipeline if not.
+    Reuses a cached graph only for the same language and source commit,
+    falling back to a full pipeline when that exact cache is absent.
     """
+    source_commit = _git("rev-parse", "HEAD", cwd=project_root)
+    output_dir = output_dir / language / source_commit
     indexer = LSIndexer(
         project_root=project_root,
         output_dir=output_dir,


### PR DESCRIPTION
## Summary

Keep incremental graph tests tied to the exact source commit and prevent transient empty LSP symbol responses from deleting valid graph definitions.

## Changes
- Namespace serial SCIP graph caches by language and source commit.
- Retry an empty `documentSymbol` result when unchanged indexed definitions must still exist.
- Fail closed after bounded retries so `SymbolGraphBuilder` uses its existing fresh-rebuild fallback.
- Cover transient recovery, persistent inconsistency, and legitimate complete deletion with unit tests.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/graph/incremental -m "not integration and not integration_serial and not integration_serial_consumer and not slow" --tb=short` (100 passed)

`pytest -q test/graph/incremental/test_graph_patcher.py::TestSWEBenchRust::test_graph_patch -v --tb=short` (1 passed)

`pre-commit run --files codenib/graph/incremental/patcher_base.py test/graph/incremental/test_document_symbol_readiness.py test/graph/incremental/test_graph_patcher.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published