### PR TITLE
docs(brand): align product and paper positioning

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,9 +5,10 @@ type: software
 version: 0.1.0
 date-released: 2026-07-26
 abstract: >-
-  CodeNib compiles repositories into reusable lexical, semantic, and
-  structural views and serves source-linked context to coding agents and
-  developers.
+  CodeNib is a multi-view data system for serving repository context to
+  coding agents. It compiles repositories into reusable lexical, semantic,
+  structural, and static-navigation views and serves source-linked evidence
+  through agent-native interfaces.
 authors:
   - family-names: Yu
     given-names: Zhongming
@@ -70,7 +71,7 @@ authors:
     email: jzhao@ucsd.edu
     affiliation: University of California San Diego
 repository-code: "https://github.com/sysevol-ai/CodeNib"
-url: "https://github.com/sysevol-ai/CodeNib"
+url: "https://codenib.ai"
 license: Apache-2.0
 keywords:
   - coding agents

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ SPDX-License-Identifier: Apache-2.0
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/sysevol-ai/CodeNib/main/assets/codenib_logo.svg" alt="CodeNib" width="560">
-  <h1>Incremental repository context for coding agents</h1>
+  <h1>A Multi-View Data System for Serving Repository Context to Coding Agents</h1>
   <p>
-    Compile once. Update what changed. Serve source-linked context through agent-native tools.
+    Incremental compilation, explicit per-view manifests, and agent-native context serving.
   </p>
   <p>
     <a href="#quickstart">Quickstart</a>
+    &nbsp;&middot;&nbsp;
+    <a href="https://codenib.ai">Website</a>
     &nbsp;&middot;&nbsp;
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/docs/index.md">Documentation</a>
     &nbsp;&middot;&nbsp;
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/docs/mcp.md">MCP</a>
     &nbsp;&middot;&nbsp;
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/docs/language_capabilities.md">Languages</a>
-    &nbsp;&middot;&nbsp;
-    <a href="https://github.com/sysevol-ai/CodeNib">GitHub</a>
   </p>
   <p>
     <a href="https://github.com/sysevol-ai/CodeNib/actions/workflows/ci.yml"><img src="https://github.com/sysevol-ai/CodeNib/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -29,11 +29,11 @@ SPDX-License-Identifier: Apache-2.0
   </p>
 </div>
 
-CodeNib is a native repository-context compiler and serving runtime for coding
-agents. It turns a checkout into manifest-linked lexical, semantic, structural,
-and static-navigation views, updates supported views as the repository evolves,
-and serves bounded source evidence through MCP, LSP-shaped providers, Python,
-and HTTP APIs.
+CodeNib is a multi-view data system for serving repository context to coding
+agents. Its native runtime compiles a checkout into manifest-linked lexical,
+semantic, structural, and static-navigation views, incrementally maintains
+supported transitions, and serves bounded source evidence through MCP,
+LSP-shaped providers, Python, and HTTP APIs.
 
 The Wiki, Ask view, and Dependency Map are inspection clients of that same
 runtime, not the system boundary. The core implementation lives in CodeNib;
@@ -193,6 +193,8 @@ package, import namespace, commands, and repository use `CodeNib`. See
 
 ## Project
 
+[Website](https://codenib.ai)
+&nbsp;&middot;&nbsp;
 [Changelog](https://github.com/sysevol-ai/CodeNib/blob/main/CHANGELOG.md)
 &nbsp;&middot;&nbsp;
 [Contributing](https://github.com/sysevol-ai/CodeNib/blob/main/CONTRIBUTING.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 # CodeNib
 
-CodeNib compiles repositories into reusable, source-linked context for coding
-agents and developers. Start with a local Wiki, then reuse the same manifest
-through MCP, Python APIs, and evaluation harnesses.
+CodeNib is a multi-view data system for serving repository context to coding
+agents. It compiles repositories into reusable, source-linked lexical, semantic,
+structural, and static-navigation views, then serves the same manifest through
+MCP, Python APIs, the local Wiki, and evaluation harnesses.
 
 Language support varies by surface. Start with the generated
 [Language Capabilities](language_capabilities.md) matrix when you need to know

--- a/landing/index.html
+++ b/landing/index.html
@@ -7,10 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>CodeNib: Understand any codebase in minutes</title>
-<meta name="description" content="CodeNib compiles a repository into a precise symbol graph, then writes its wiki and answers questions with line-level citations.">
-<meta property="og:title" content="CodeNib">
-<meta property="og:description" content="Understand any codebase in minutes. Wikis, dependency maps, and cited answers, compiled from a symbol graph.">
+<title>CodeNib: Multi-View Repository Context for Coding Agents</title>
+<meta name="description" content="CodeNib is a multi-view data system for serving repository context to coding agents through incremental, source-linked indexes.">
+<meta property="og:title" content="CodeNib: Multi-View Repository Context for Coding Agents">
+<meta property="og:description" content="Incremental lexical, semantic, structural, and navigation views served through agent-native interfaces.">
 <meta property="og:image" content="https://codenib.ai/assets/shots/wiki-light.png">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://codenib.ai/">
@@ -247,7 +247,7 @@ footer { border-top: 1px solid var(--line); }
     <div class="wrap hero-grid">
       <div>
         <h1 class="rise">Understand any codebase in minutes.</h1>
-        <p class="sub rise d1">CodeNib is a multi-view data system that serves codebase context to coding agents.</p>
+        <p class="sub rise d1">CodeNib is a multi-view data system for serving repository context to coding agents.</p>
         <div class="ctas rise d2">
           <a class="btn btn-primary btn-lg" href="https://demo.codenib.ai">Open the demo</a>
           <a class="btn btn-ghost btn-lg" href="https://github.com/sysevol-ai/CodeNib#readme">Read the docs</a>
@@ -265,7 +265,7 @@ footer { border-top: 1px solid var(--line); }
           <span class="t-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 5 20 19H4Z"/></svg></span>
           <div>
             <div class="k">incremental</div>
-            <div class="v">Commit diffs update only the views that changed.</div>
+            <div class="v">Supported changes repair affected views; other transitions rebuild safely.</div>
           </div>
         </div>
         <div>
@@ -293,8 +293,8 @@ footer { border-top: 1px solid var(--line); }
 
   <section>
     <div class="wrap">
-      <h2 class="reveal">One graph, three views</h2>
-      <p class="section-sub reveal">The wiki, the dependency map, and the chat are projections of the same compiled index.</p>
+      <h2 class="reveal">One repository, coordinated views</h2>
+      <p class="section-sub reveal">The Wiki, Dependency Map, and Ask consume manifest-linked lexical, semantic, and structural views from one incremental compiler.</p>
       <div class="bento">
         <div class="cell cell-ask reveal">
           <h3>Ask, with receipts</h3>
@@ -319,7 +319,7 @@ footer { border-top: 1px solid var(--line); }
         <div class="cell cell-wide reveal">
           <div class="cw-text">
             <h3>Five languages in the live demo</h3>
-            <p>Tree-sitter parses everything into the same graph. Browse the repositories already indexed in the demo.</p>
+            <p>Language backends preserve shared source locations and capability metadata across each compiled view.</p>
             <div class="chips">
               <span>python</span><span>c/c++</span><span>go</span><span>rust</span><span>typescript</span>
             </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 site_name: CodeNib
-site_description: Source-linked repository context for coding agents and developers
+site_description: A multi-view data system for serving repository context to coding agents
 site_url: https://sysevol-ai.github.io/CodeNib/
 repo_url: https://github.com/sysevol-ai/CodeNib
 repo_name: sysevol-ai/CodeNib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "codenib"
 version = "0.1.0"
-description = "Multi-view repository context serving for coding agents"
+description = "A multi-view data system for serving repository context to coding agents"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -48,7 +48,7 @@ dependencies = [
 
 [project.urls]
 Documentation = "https://sysevol-ai.github.io/CodeNib/"
-Homepage = "https://github.com/sysevol-ai/CodeNib"
+Homepage = "https://codenib.ai"
 Issues = "https://github.com/sysevol-ai/CodeNib/issues"
 Repository = "https://github.com/sysevol-ai/CodeNib.git"
 


### PR DESCRIPTION
## Summary

Align CodeNib's repository and product identity with the paper title: **CodeNib: A Multi-View Data System for Serving Repository Context to Coding Agents**. Make `codenib.ai` the canonical public homepage while retaining GitHub as the source repository and GitHub Pages as the current documentation host.

## Changes
- Use the paper subtitle as the README hero and define CodeNib consistently as a multi-view data system.
- Point README, package, and citation homepage metadata to `https://codenib.ai`.
- Align MkDocs and documentation-home descriptions with the same system boundary.
- Correct the landing page's graph-only framing: lexical, semantic, structural, and navigation views are coordinated by one incremental compiler rather than projections of one graph.
- Preserve the user-facing “Understand any codebase in minutes” value proposition.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

- `pre-commit run --files README.md pyproject.toml mkdocs.yml docs/index.md CITATION.cff landing/index.html`
- `python -m mkdocs build --strict`
- `python scripts/check_namespace.py`
- Playwright desktop and 390px mobile screenshots of the canonical landing page

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published