### PR TITLE
fix(mcp): migrate to SDK v2

### DIFF
--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -25,7 +25,7 @@ import sys
 from pathlib import Path
 from typing import Any, Optional
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from .context import ServerContext
 from .prompts import CODENIB_GUIDE
@@ -48,7 +48,7 @@ def get_context() -> ServerContext:
     return _ctx
 
 
-mcp = FastMCP(
+mcp = MCPServer(
     "codenib",
     instructions=(
         "CodeNib provides code search over pre-built indexes. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ graph = [
     "protobuf>=3.20.0",
 ]
 mcp = [
-    "mcp>=1.0.0",
+    "mcp>=2.0.0,<3",
 ]
 semantic = [
     "einops>=0.8.0",
@@ -96,7 +96,7 @@ full = [
     "faiss-cpu>=1.7.0",
     "igraph>=0.11.6",
     "litellm>=1.40.0",
-    "mcp>=1.0.0",
+    "mcp>=2.0.0,<3",
     "numpy>=1.24.0",
     "openai>=1.0.0",
     "protobuf>=3.20.0",
@@ -120,7 +120,7 @@ test = [
     "igraph>=0.11.6",
     "litellm>=1.40.0",
     "matplotlib>=3.4.0",
-    "mcp>=1.0.0",
+    "mcp>=2.0.0,<3",
     "numpy>=1.24.0",
     "openai>=1.0.0",
     "protobuf>=3.20.0",

--- a/scripts/smoke_release_services.py
+++ b/scripts/smoke_release_services.py
@@ -267,9 +267,9 @@ class _ProtocolErrorHandler(logging.Handler):
 
 
 def _structured_result(result: Any) -> dict[str, Any]:
-    if getattr(result, "isError", False):
+    if getattr(result, "is_error", False):
         raise RuntimeError(f"MCP tool returned a protocol error: {result!r}")
-    payload = getattr(result, "structuredContent", None)
+    payload = getattr(result, "structured_content", None)
     if not isinstance(payload, dict):
         raise RuntimeError(f"MCP tool did not return structured content: {result!r}")
     return payload
@@ -282,7 +282,7 @@ async def _assert_mcp_async(
     executable: str,
     env: dict[str, str],
 ) -> None:
-    from mcp import ClientSession, StdioServerParameters
+    from mcp import Client, StdioServerParameters
     from mcp.client.stdio import stdio_client
 
     protocol_errors = _ProtocolErrorHandler()
@@ -299,18 +299,22 @@ async def _assert_mcp_async(
     try:
         try:
             with stderr_path.open("w+", encoding="utf-8") as server_stderr:
-                async with stdio_client(parameters, errlog=server_stderr) as streams:
-                    async with ClientSession(*streams) as session:
-                        await session.initialize()
-                        tools = await session.list_tools()
+                for mode in ("auto", "legacy"):
+                    transport = stdio_client(parameters, errlog=server_stderr)
+                    async with Client(transport, mode=mode, cache=None) as client:
+                        tools = await client.list_tools()
                         names = {tool.name for tool in tools.tools}
                         required = {"get_manifest", "search_bm25", "search_semantic"}
                         if not required.issubset(names):
                             raise RuntimeError(
-                                f"MCP tools are missing: {sorted(required - names)}"
+                                f"MCP tools are missing in {mode} mode: "
+                                f"{sorted(required - names)}"
                             )
 
-                        result = await session.call_tool(
+                        if mode == "legacy":
+                            continue
+
+                        result = await client.call_tool(
                             "search_bm25",
                             arguments={"query": "release_signature", "top_k": 5},
                         )
@@ -325,7 +329,7 @@ async def _assert_mcp_async(
                                 f"MCP BM25 hit was unexpected: {hits[0]!r}"
                             )
 
-                        unavailable = await session.call_tool(
+                        unavailable = await client.call_tool(
                             "search_semantic",
                             arguments={"query": "release signature", "top_k": 5},
                         )

--- a/test/mcp/test_mcp_e2e.py
+++ b/test/mcp/test_mcp_e2e.py
@@ -72,9 +72,9 @@ class TestMCPServerE2E:
 
     def test_mcp_server_initialization(self, test_manifest_path):
         """Test MCP server can initialize with real index."""
-        # Mock FastMCP to avoid dependency
+        # Mock MCPServer to avoid dependency
         mock_mcp = MagicMock()
-        with patch.object(server_module, "FastMCP", return_value=mock_mcp):
+        with patch.object(server_module, "MCPServer", return_value=mock_mcp):
             with patch.object(server_module, "mcp", mock_mcp):
                 server_module.init_server(test_manifest_path)
 
@@ -94,7 +94,7 @@ class TestMCPServerE2E:
         """Test MCP semantic_search tool with real query."""
         # Initialize server
         mock_mcp = MagicMock()
-        with patch.object(server_module, "FastMCP", return_value=mock_mcp):
+        with patch.object(server_module, "MCPServer", return_value=mock_mcp):
             with patch.object(server_module, "mcp", mock_mcp):
                 server_module.init_server(test_manifest_path)
 
@@ -167,7 +167,7 @@ class TestMCPServerE2E:
 
         # MCP server call
         mock_mcp = MagicMock()
-        with patch.object(server_module, "FastMCP", return_value=mock_mcp):
+        with patch.object(server_module, "MCPServer", return_value=mock_mcp):
             with patch.object(server_module, "mcp", mock_mcp):
                 server_module.init_server(test_manifest_path)
 
@@ -196,7 +196,7 @@ class TestMCPServerE2E:
     def test_mcp_server_status(self, test_manifest_path):
         """Test server_status resource returns correct info."""
         mock_mcp = MagicMock()
-        with patch.object(server_module, "FastMCP", return_value=mock_mcp):
+        with patch.object(server_module, "MCPServer", return_value=mock_mcp):
             with patch.object(server_module, "mcp", mock_mcp):
                 server_module.init_server(test_manifest_path)
 

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -15,9 +15,12 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Literal
 from unittest.mock import MagicMock, patch
 
 import pytest
+from mcp import Client
+from mcp.types import LATEST_PROTOCOL_VERSION
 
 # Import server module components
 import codenib.mcp.server as server_module
@@ -38,6 +41,21 @@ if loaded:
 """
 
     subprocess.run([sys.executable, "-c", script], check=True)
+
+
+def test_server_negotiates_modern_and_legacy_protocols() -> None:
+    async def negotiate(mode: Literal["auto", "legacy"]) -> tuple[str, set[str]]:
+        async with Client(server_module.mcp, mode=mode, cache=None) as client:
+            tools = await client.list_tools()
+            return client.protocol_version, {tool.name for tool in tools.tools}
+
+    modern_version, modern_tools = asyncio.run(negotiate("auto"))
+    legacy_version, legacy_tools = asyncio.run(negotiate("legacy"))
+
+    assert modern_version == LATEST_PROTOCOL_VERSION
+    assert legacy_version != modern_version
+    assert modern_tools == legacy_tools
+    assert {"get_manifest", "search_bm25", "search_semantic"} <= modern_tools
 
 
 @pytest.fixture
@@ -76,8 +94,8 @@ def mock_manifest(tmp_path: Path) -> Path:
 
 def test_init_server_missing_manifest():
     """Test that init_server raises FileNotFoundError for missing manifest."""
-    # Mock FastMCP availability
-    with patch.object(server_module, "FastMCP", MagicMock()):
+    # Mock MCPServer availability
+    with patch.object(server_module, "MCPServer", MagicMock()):
         with pytest.raises(FileNotFoundError, match="Manifest not found"):
             server_module.init_server("/nonexistent/manifest.json")
 
@@ -85,7 +103,7 @@ def test_init_server_missing_manifest():
 def test_init_server_success(mock_manifest: Path):
     """Test successful server initialization."""
     mock_mcp = MagicMock()
-    with patch.object(server_module, "FastMCP", return_value=mock_mcp):
+    with patch.object(server_module, "MCPServer", return_value=mock_mcp):
         with patch.object(server_module, "mcp", mock_mcp):
             with patch.object(CodeVectorStore, "load"):
                 with patch.object(CodeVectorStore, "__init__", return_value=None):
@@ -110,7 +128,7 @@ def test_semantic_search_tool_no_vector_index(mock_manifest: Path):
     """Test semantic_search tool returns error when vector index not loaded."""
     # Initialize server with mock that fails vector loading
     mock_mcp = MagicMock()
-    with patch.object(server_module, "FastMCP", return_value=mock_mcp):
+    with patch.object(server_module, "MCPServer", return_value=mock_mcp):
         with patch.object(server_module, "mcp", mock_mcp):
             with patch.object(
                 CodeVectorStore, "load", side_effect=Exception("Load failed")
@@ -141,7 +159,7 @@ def test_semantic_search_tool_with_vector_index(mock_manifest: Path):
     mock_vector.search_with_content.return_value = [mock_node]
 
     mock_mcp = MagicMock()
-    with patch.object(server_module, "FastMCP", return_value=mock_mcp):
+    with patch.object(server_module, "MCPServer", return_value=mock_mcp):
         with patch.object(server_module, "mcp", mock_mcp):
             with patch.object(CodeVectorStore, "load"):
                 with patch.object(CodeVectorStore, "__init__", return_value=None):
@@ -237,7 +255,7 @@ def test_server_status_resource(mock_manifest: Path):
     mock_vector.get_stats.return_value = {"total_documents": 150}
 
     mock_mcp = MagicMock()
-    with patch.object(server_module, "FastMCP", return_value=mock_mcp):
+    with patch.object(server_module, "MCPServer", return_value=mock_mcp):
         with patch.object(server_module, "mcp", mock_mcp):
             with patch.object(CodeVectorStore, "load"):
                 with patch.object(CodeVectorStore, "__init__", return_value=None):


### PR DESCRIPTION
## Summary

Migrate CodeNib directly to MCP Python SDK 2.x. The stable 2.0 release removed the v1 `FastMCP` import and camelCase result fields, which caused fresh installs and release-service CI to fail.

## Changes

- Require `mcp>=2.0.0,<3` for MCP-enabled installs.
- Replace `FastMCP` with the SDK 2 `MCPServer` API.
- Update release smoke coverage to use the SDK 2 `Client` and snake_case result fields.
- Verify both the current protocol and SDK 2's legacy-client compatibility mode.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- [x] `pre-commit run --files pyproject.toml codenib/mcp/server.py scripts/smoke_release_services.py test/mcp/test_mcp_e2e.py test/mcp/test_mcp_server.py`
- [x] `pytest test/mcp test/test_namespace_contract.py -q --tb=short` (20 passed, 7 skipped)
- [x] Full unit tier (2063 passed, 10 skipped, 170 deselected)
- [x] Fresh wheel install with `mcp==2.0.0` and release-service smoke

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published