### PR TITLE
docs(readme): clarify the architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ runtime, not the system boundary. The core implementation lives in CodeNib;
 optional model endpoints and language servers are providers rather than a host
 agent or code-Wiki framework.
 
-## Runtime Model
+## System Architecture
 
-| Layer | Native responsibility |
+| Layer | Responsibility |
 |---|---|
 | Incremental compiler | Chunk source and materialize BM25, dense, graph, and navigation views; reuse or repair supported artifacts and rebuild when an update cannot be admitted |
 | View manifest | Record repository identity, source fingerprint, builder profile, capabilities, status, and artifact location independently for each view |


### PR DESCRIPTION
## Summary

Name the README's system-layer overview according to what it actually describes.

## Changes
- Rename `Runtime Model` to `System Architecture`.
- Simplify the table heading from `Native responsibility` to `Responsibility`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Validated with `pre-commit run --files README.md` and `git diff --check`.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published