### PR TITLE
fix(docs): disable remote font loading

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ exclude_docs: |
 
 theme:
   name: material
+  font: false
   logo: assets/images/codenib-icon.svg
   favicon: assets/images/codenib-icon.svg
   palette:


### PR DESCRIPTION
## Summary

Stop the public documentation from requesting Google-hosted Roboto assets when the site already ships and renders self-hosted Inter and Newsreader fonts.

## Changes

- Disable MkDocs Material's default remote font injection.
- Keep the existing CodeNib typography, favicon, palette, and layout unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes
- `python -m mkdocs build --strict`: passed.
- Confirmed the generated home page contains neither `fonts.googleapis` nor `Roboto`.
- `git diff --check`: passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published