### PR TITLE
feat(web): guide users to index their own repository

### DIFF
--- a/web/app/add-repo/page.tsx
+++ b/web/app/add-repo/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import Header from "@/components/Header";
+import { AppLink } from "@/lib/router";
+
+/** Keep this path intentionally short; the linked quickstart remains the
+ *  authority for provider-specific and advanced options. */
+const STEPS: {
+  title: string;
+  body: string;
+  code: string;
+  note?: string;
+}[] = [
+  {
+    title: "Install and check the runtime",
+    body: "codenib doctor reports which language backends and optional extras are present before you index anything.",
+    code: "pip install codenib\ncodenib doctor --require core --require wiki",
+  },
+  {
+    title: "Open a wiki for your repository",
+    body: "CodeNib detects the languages, builds its views, registers the repository with a local service, and opens the wiki at localhost:3000.",
+    code: "codenib wiki /path/to/repository",
+    note: "The release wheel ships the compiled frontend, so this needs no Node.js and no source checkout. Indexes live under ~/.codenib; your repository is left unchanged.",
+  },
+  {
+    title: "Turn on agent-authored pages",
+    body: "Static pages are the default. The narrated, source-anchored pages you see in this demo come from a model you point CodeNib at — any LiteLLM-supported provider.",
+    code: 'pip install "codenib[agent]"\nexport OPENAI_API_KEY=...\ncodenib doctor --require agent \\\n  --model openai/gpt-4o-mini --api-key-env OPENAI_API_KEY --probe-model\ncodenib wiki . --generate --model openai/gpt-4o-mini',
+    note: "A hosted provider receives the source evidence needed to write each page. To keep generation local, point --api-base http://127.0.0.1:8080/v1 at a self-hosted OpenAI-compatible endpoint; add --api-key-env only when that gateway requires authentication.",
+  },
+];
+
+export default function AddRepoPage() {
+  return (
+    <div className="landing">
+      <Header />
+
+      <main className="addrepo">
+        <AppLink className="addrepo-back" href="/">
+          ← All repositories
+        </AppLink>
+
+        <h1>Index your own repository</h1>
+
+        {/* Say plainly why the hosted set is fixed. A reader who clicked "Add
+            repo" is owed the reason, not a "coming soon". */}
+        <p className="addrepo-lede">
+          This demo serves a fixed set of repositories. Writing a wiki means reading a
+          codebase through a model, so the hosted demo cannot do that on demand for
+          any repository you point it at. The same indexing pipeline runs on your own
+          machine, where the checkout and generated indexes remain local. You choose
+          the model; source evidence is sent only to that configured provider when you
+          opt into agent-authored pages.
+        </p>
+
+        <ol className="addrepo-steps">
+          {STEPS.map((step, index) => (
+            <li key={step.title}>
+              <div className="addrepo-step-head">
+                <span className="addrepo-step-n" aria-hidden="true">
+                  {index + 1}
+                </span>
+                <h2>{step.title}</h2>
+              </div>
+              <p>{step.body}</p>
+              <pre className="addrepo-code">
+                <code>{step.code}</code>
+              </pre>
+              {step.note && <p className="addrepo-note">{step.note}</p>}
+            </li>
+          ))}
+        </ol>
+
+        <p className="addrepo-foot">
+          Full options — presets, language selection, incremental reindexing, MCP —
+          are in the{" "}
+          <a href="https://docs.codenib.ai/quickstart/" target="_blank" rel="noreferrer">
+            quickstart
+          </a>
+          .
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3731,3 +3731,105 @@ a.codepanel-name:hover {
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+/* Guidance for running CodeNib on your own repository. */
+.addrepo {
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 24px 72px;
+}
+.addrepo-back {
+  border: 0;
+  background: none;
+  padding: 0;
+  margin-bottom: 20px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.addrepo-back:hover {
+  color: var(--accent);
+}
+.addrepo h1 {
+  font-size: 26px;
+  margin: 0 0 14px;
+  color: var(--text-primary);
+}
+.addrepo-lede {
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  margin: 0 0 32px;
+}
+.addrepo-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+.addrepo-step-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.addrepo-step-n {
+  flex: 0 0 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-border);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.addrepo-step-head h2 {
+  font-size: 16px;
+  margin: 0;
+  color: var(--text-primary);
+}
+.addrepo-steps p {
+  margin: 0 0 10px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+.addrepo-code {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--code-bg);
+  overflow-x: auto;
+}
+.addrepo-code code {
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+  font-size: 12.5px;
+  line-height: 1.7;
+  color: var(--text-primary);
+  white-space: pre;
+  background: none;
+  padding: 0;
+}
+.addrepo-note {
+  margin-top: 10px !important;
+  font-size: 13px !important;
+  color: var(--text-muted) !important;
+}
+.addrepo-foot {
+  margin-top: 36px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border-subtle);
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.addrepo-foot a {
+  color: var(--accent);
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -152,7 +152,11 @@ export default function Landing() {
       </section>
 
       <div className="repo-grid">
-        <div className="repo-card add-repo" role="note" aria-label="Add repo (coming soon)">
+        <AppLink
+          className="repo-card add-repo"
+          aria-label="Index your own repository"
+          href="/add-repo"
+        >
           <span className="add-plus">+</span>
           <span className="add-label">Add repo</span>
           <span className="repo-card-go" aria-hidden>
@@ -160,7 +164,7 @@ export default function Landing() {
               <path d="M5 12h14M13 6l6 6-6 6" />
             </svg>
           </span>
-        </div>
+        </AppLink>
 
         {error && (
           <div className="empty">

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import { routeSegments, useBrowserLocation } from "@/lib/router";
 const AskPage = lazy(() => import("@/app/[repoId]/ask/page"));
 const WikiPageView = lazy(() => import("@/app/[repoId]/page"));
 const Landing = lazy(() => import("@/app/page"));
+const AddRepo = lazy(() => import("@/app/add-repo/page"));
 
 function RouteLoading() {
   return (
@@ -22,6 +23,12 @@ function App() {
   const segments = routeSegments(location.pathname);
   if (segments.length === 0) {
     return <Landing />;
+  }
+
+  // Guidance for running CodeNib on your own code. Checked before the repo
+  // route because it is a page, not a repository id.
+  if (segments[0] === "add-repo") {
+    return <AddRepo />;
   }
 
   const repoId = segments[0];


### PR DESCRIPTION
## Summary

Replace the inert “Add repo” card with an honest, source-linked path for running CodeNib on a user's own repository. This is the clean replacement for #379 after the Wiki stack was squash-merged.

## Changes

- Route the Add repo card to a dedicated local-indexing guide in the Vite application.
- Reuse semantic application links for the card and return navigation.
- Keep checkout/index locality distinct from source evidence sent to a configured hosted model.
- Use the non-conflicting `127.0.0.1:8080` model endpoint example and explain when gateway credentials are required.
- Add the recommended agent-provider doctor probe before generation.
- Constrain the page at mobile widths and keep long commands inside scrollable code blocks.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes
- Frontend: 16 tests passed.
- TypeScript and Vite production build: passed.
- Playwright exercised landing-card navigation and direct `/add-repo` loading.
- Desktop 1440×1000 and mobile 390×844 visual checks passed; mobile has no page-level horizontal overflow.
- Verified privacy, provider preflight, and port guidance against the current Quickstart and CLI.
- `git diff --check origin/main...HEAD`: passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published