### PR TITLE
fix(release): use production PyPI token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/codenib
     permissions:
-      id-token: write
+      contents: read
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v4
@@ -63,6 +63,8 @@ jobs:
 
       - name: Publish distributions
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   github-release:
     name: Create GitHub Release

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -51,6 +51,13 @@ def test_registry_publishers_use_separate_workflows() -> None:
         with (workflows / name).open(encoding="utf-8") as handle:
             return yaml.load(handle, Loader=yaml.BaseLoader)
 
+    def publisher_step(job: dict[str, object]) -> dict[str, object]:
+        return next(
+            step
+            for step in job["steps"]
+            if step.get("uses", "").startswith("pypa/gh-action-pypi-publish@")
+        )
+
     production = load("release.yml")
     test = load("release-test.yml")
     verification = load("release-verify.yml")
@@ -71,7 +78,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     production_publisher = production["jobs"]["publish-pypi"]
     assert production_publisher["environment"]["name"] == "pypi"
     assert production_publisher["permissions"] == {"contents": "read"}
-    assert production_publisher["steps"][-1]["with"]["password"] == (
+    assert publisher_step(production_publisher)["with"]["password"] == (
         "${{ secrets.PYPI_API_TOKEN }}"
     )
 
@@ -79,7 +86,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     test_publisher = test["jobs"]["publish-testpypi"]
     assert test_publisher["environment"]["name"] == "testpypi"
     assert (
-        test_publisher["steps"][-1]["with"]["repository-url"]
+        publisher_step(test_publisher)["with"]["repository-url"]
         == "https://test.pypi.org/legacy/"
     )
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -68,7 +68,12 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "publish-pypi",
         "github-release",
     }
-    assert production["jobs"]["publish-pypi"]["environment"]["name"] == "pypi"
+    production_publisher = production["jobs"]["publish-pypi"]
+    assert production_publisher["environment"]["name"] == "pypi"
+    assert production_publisher["permissions"] == {"contents": "read"}
+    assert production_publisher["steps"][-1]["with"]["password"] == (
+        "${{ secrets.PYPI_API_TOKEN }}"
+    )
 
     assert set(test["jobs"]) == {"verify", "publish-testpypi"}
     test_publisher = test["jobs"]["publish-testpypi"]


### PR DESCRIPTION
## Summary
Fix production releases after PyPI rejected the unconfigured Trusted Publisher claims. Tagged releases now use the environment-scoped production token already validated by the v0.1.0 bootstrap upload.

## Changes
- pass `secrets.PYPI_API_TOKEN` to the production PyPI publishing action
- reduce the publishing job permissions to `contents: read`
- assert the production credential boundary in the release workflow test

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/test_release_artifacts.py`

`pre-commit run --files .github/workflows/release.yml test/test_release_artifacts.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published