### PR TITLE
feat(integrations): serve LocAgent from repository views

### DIFF
--- a/codenib/integrations/__init__.py
+++ b/codenib/integrations/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility providers for external coding-agent runtimes."""
+
+from ._repository import (
+    IntegrationCapabilityError,
+    RepositoryAdapter,
+    RepositoryEntity,
+    RepositoryPathError,
+)
+
+__all__ = [
+    "IntegrationCapabilityError",
+    "RepositoryAdapter",
+    "RepositoryEntity",
+    "RepositoryPathError",
+]

--- a/codenib/integrations/_repository.py
+++ b/codenib/integrations/_repository.py
@@ -585,12 +585,14 @@ class RepositoryAdapter:
                 node = node.setdefault(part, {})
 
         limit = (
-            100 if max_depth is None or int(max_depth) == -1 else max(0, int(max_depth))
+            None
+            if max_depth is None or int(max_depth) == -1
+            else max(0, int(max_depth))
         )
         lines = [prefix or "/"]
 
         def render(tree: Mapping[str, Any], indent: str, level: int) -> None:
-            if level >= limit:
+            if limit is not None and level >= limit:
                 return
             items = sorted(tree.items(), key=lambda item: (bool(item[1]), item[0]))
             for index, (label, children) in enumerate(items):
@@ -608,11 +610,7 @@ class RepositoryAdapter:
     def skeleton(self, entity: RepositoryEntity) -> str:
         """Render a language-neutral signature skeleton from graph ranges."""
 
-        if entity.kind == NODE_TYPE_FILE:
-            children = self.children(entity)
-        else:
-            children = self.children(entity)
-
+        children = self.children(entity)
         records = [entity] if entity.kind != NODE_TYPE_FILE else []
         records.extend(children)
         signatures: list[str] = []

--- a/codenib/integrations/_repository.py
+++ b/codenib/integrations/_repository.py
@@ -1,0 +1,788 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only adapter over manifest-backed repository views.
+
+External agent integrations need different names and output formats, but they
+must not acquire their own repository state.  This module centralizes the
+small shared boundary: safe source reads, deterministic symbol resolution,
+containment queries, and bounded graph traversal over one ``ServerContext``.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import math
+import re
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Iterator, Mapping
+
+from ..types import (
+    EDGE_TYPE_CONTAIN,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_DIRECTORY,
+    NODE_TYPE_FILE,
+    NODE_TYPE_METHOD,
+    is_symbol_node,
+)
+
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:")
+_EMPTY_QUALIFIED_NAMES = frozenset({"", ".", "/"})
+
+
+class IntegrationCapabilityError(RuntimeError):
+    """A required manifest view is missing, stale, or failed to load."""
+
+
+class RepositoryPathError(ValueError):
+    """A requested path is invalid or escapes the manifest repository."""
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryEntity:
+    """A stable adapter-local view of one graph vertex.
+
+    Lines remain 0-based internally.  Integrations convert them exactly once
+    while formatting results for their external agent contract.
+    """
+
+    vertex_id: int
+    canonical_name: str
+    display_name: str
+    kind: str
+    file_path: str
+    qualified_name: str
+    simple_name: str
+    start_line: int | None
+    end_line: int | None
+    parent_name: str | None = None
+    class_name: str | None = None
+
+    @property
+    def line_count(self) -> int | None:
+        if self.start_line is None or self.end_line is None:
+            return None
+        return self.end_line - self.start_line + 1
+
+    @property
+    def locagent_id(self) -> str:
+        if self.kind in {NODE_TYPE_FILE, NODE_TYPE_DIRECTORY}:
+            return self.file_path or self.canonical_name
+        if self.file_path and self.qualified_name:
+            return f"{self.file_path}:{self.qualified_name}"
+        return self.display_name or self.canonical_name
+
+    @property
+    def orcaloca_id(self) -> str:
+        if self.kind in {NODE_TYPE_FILE, NODE_TYPE_DIRECTORY}:
+            return self.file_path or self.canonical_name
+        parts = [self.file_path]
+        if self.class_name:
+            parts.append(self.class_name)
+        parts.append(self.simple_name or self.qualified_name)
+        return "::".join(part for part in parts if part)
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryRelation:
+    """One typed, directed graph relation."""
+
+    source: RepositoryEntity
+    target: RepositoryEntity
+    edge_type: str
+
+
+def _valid_line(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
+def _strip_call_suffix(value: str) -> str:
+    """Normalize display-only ``()`` markers without changing identities."""
+
+    return re.sub(r"\(\)(?=\.|$)", "", value.strip())
+
+
+def _simple_name(value: str) -> str:
+    normalized = _strip_call_suffix(value)
+    return normalized.replace("::", ".").rsplit(".", 1)[-1]
+
+
+def _looks_like_file_prefix(value: str) -> bool:
+    return "/" in value or "\\" in value or "." in value.rsplit("/", 1)[-1]
+
+
+class RepositoryAdapter:
+    """Read-only repository facts backed by one ``ServerContext``."""
+
+    def __init__(self, context: Any, *, require_graph: bool = True) -> None:
+        self.context = context
+        manifest = getattr(context, "manifest", None)
+        if manifest is None:
+            raise IntegrationCapabilityError("ServerContext has no manifest")
+
+        raw_root = str(getattr(manifest, "repo_path", "") or "").strip()
+        if not raw_root:
+            raise IntegrationCapabilityError("manifest has no repository path")
+        self.repo_root = Path(raw_root).expanduser().resolve()
+        if not self.repo_root.is_dir():
+            raise IntegrationCapabilityError(
+                f"manifest repository is not available: {self.repo_root}"
+            )
+
+        self.graph = getattr(context, "symbol_graph", None)
+        if require_graph and self.graph is None:
+            self.require_view("symbol_graph", "symbol_graph")
+
+        self._entities: tuple[RepositoryEntity, ...] = ()
+        self._entity_by_vertex: dict[int, RepositoryEntity] = {}
+        self._entity_by_canonical: dict[str, RepositoryEntity] = {}
+        self._aliases: dict[str, list[RepositoryEntity]] = {}
+        self._aliases_lower: dict[str, list[RepositoryEntity]] = {}
+        self._files: tuple[str, ...] = ()
+        if self.graph is not None:
+            self._build_entity_index()
+
+    @classmethod
+    def from_manifest(
+        cls, manifest_path: str | Path, *, require_graph: bool = True
+    ) -> "RepositoryAdapter":
+        """Load one ``ServerContext`` and bind an adapter to it."""
+
+        from ..mcp.context import ServerContext
+
+        return cls(ServerContext.load(manifest_path), require_graph=require_graph)
+
+    @property
+    def entities(self) -> tuple[RepositoryEntity, ...]:
+        return self._entities
+
+    @property
+    def symbols(self) -> tuple[RepositoryEntity, ...]:
+        return tuple(entity for entity in self._entities if is_symbol_node(entity.kind))
+
+    @property
+    def files(self) -> tuple[str, ...]:
+        return self._files
+
+    def require_view(self, index_name: str, attribute: str) -> Any:
+        """Return a loaded view or raise with manifest-aware diagnostics."""
+
+        view = getattr(self.context, attribute, None)
+        if view is not None:
+            return view
+
+        manifest = self.context.manifest
+        entry = getattr(manifest, "indexes", {}).get(index_name)
+        errors = getattr(self.context, "errors", {})
+        if index_name in errors:
+            detail = f"failed to load: {errors[index_name]}"
+        elif entry is None:
+            detail = "no manifest entry"
+        elif not manifest.index_is_current(index_name):
+            detail = f"manifest status is {entry.status!r} or source identity is stale"
+        else:
+            detail = "manifest entry did not produce a runtime view"
+        raise IntegrationCapabilityError(
+            f"required {index_name!r} view is unavailable ({detail})"
+        )
+
+    # ------------------------------------------------------------------
+    # Source paths and reads
+    # ------------------------------------------------------------------
+
+    def normalize_path(self, value: str) -> str:
+        """Return a safe repository-relative POSIX path."""
+
+        raw = str(value or "").strip().replace("\\", "/")
+        while raw.startswith("./"):
+            raw = raw[2:]
+        if not raw or raw in {".", "/"}:
+            return "."
+        if raw.startswith("/") or _WINDOWS_DRIVE.match(raw):
+            raise RepositoryPathError(
+                f"absolute repository path is not allowed: {value}"
+            )
+
+        pure = PurePosixPath(raw)
+        if ".." in pure.parts:
+            raise RepositoryPathError(
+                f"repository path traversal is not allowed: {value}"
+            )
+
+        normalized = pure.as_posix()
+        candidate = (self.repo_root / normalized).resolve()
+        if not candidate.is_relative_to(self.repo_root):
+            raise RepositoryPathError(f"repository path escapes the root: {value}")
+        return normalized
+
+    def source_path(self, value: str, *, require_file: bool = True) -> Path:
+        normalized = self.normalize_path(value)
+        if normalized == ".":
+            path = self.repo_root
+        else:
+            path = (self.repo_root / normalized).resolve()
+        if not path.is_relative_to(self.repo_root):
+            raise RepositoryPathError(f"repository path escapes the root: {value}")
+        if require_file and not path.is_file():
+            raise RepositoryPathError(f"repository file does not exist: {normalized}")
+        return path
+
+    def source_lines(self, file_path: str) -> list[str]:
+        path = self.source_path(file_path)
+        return path.read_text(encoding="utf-8", errors="replace").splitlines()
+
+    def read_range(
+        self,
+        file_path: str,
+        start_line: int | None = None,
+        end_line: int | None = None,
+    ) -> tuple[str, int, int]:
+        """Read an inclusive 0-based range and return its actual bounds."""
+
+        lines = self.source_lines(file_path)
+        if not lines:
+            return "", 0, 0
+        start = 0 if start_line is None else max(0, int(start_line))
+        end = len(lines) - 1 if end_line is None else min(len(lines) - 1, int(end_line))
+        if end < start:
+            return "", start, start
+        return "\n".join(lines[start : end + 1]), start, end
+
+    def read_entity(self, entity: RepositoryEntity) -> tuple[str, int, int]:
+        if not entity.file_path:
+            raise RepositoryPathError(
+                f"entity has no repository source path: {entity.locagent_id}"
+            )
+        if entity.kind == NODE_TYPE_FILE:
+            return self.read_range(entity.file_path)
+        if entity.start_line is None or entity.end_line is None:
+            raise RepositoryPathError(
+                f"entity has no source range: {entity.locagent_id}"
+            )
+        return self.read_range(
+            entity.file_path,
+            start_line=entity.start_line,
+            end_line=entity.end_line,
+        )
+
+    @staticmethod
+    def numbered_source(content: str, start_line: int = 0) -> str:
+        lines = content.splitlines()
+        if not lines:
+            return "```\n```"
+        last = start_line + len(lines)
+        width = len(str(last))
+        body = "\n".join(
+            f"{str(start_line + offset + 1).rjust(width)} | {line}"
+            for offset, line in enumerate(lines)
+        )
+        return f"```\n{body}\n```"
+
+    # ------------------------------------------------------------------
+    # File and entity resolution
+    # ------------------------------------------------------------------
+
+    def match_files(self, pattern: str | None) -> list[str]:
+        if not pattern:
+            return list(self._files)
+        raw = str(pattern).strip().replace("\\", "/")
+        if not any(char in raw for char in "*?[]"):
+            try:
+                normalized = self.normalize_path(raw)
+            except RepositoryPathError:
+                return []
+            return [normalized] if normalized in self._files else []
+
+        patterns = [raw]
+        if raw.startswith("**/"):
+            patterns.append(raw[3:])
+        matches = [
+            file_path
+            for file_path in self._files
+            if any(
+                fnmatch.fnmatchcase(file_path, candidate)
+                or PurePosixPath(file_path).match(candidate)
+                for candidate in patterns
+            )
+        ]
+        return sorted(dict.fromkeys(matches))
+
+    def find_files(self, query: str) -> list[str]:
+        raw = str(query or "").strip().replace("\\", "/").strip("/")
+        if not raw:
+            return []
+        try:
+            normalized = self.normalize_path(raw)
+        except RepositoryPathError:
+            return []
+        exact = [path for path in self._files if path == normalized]
+        if exact:
+            return exact
+        return sorted(
+            path
+            for path in self._files
+            if PurePosixPath(path).name == PurePosixPath(normalized).name
+            or path.endswith("/" + normalized)
+        )
+
+    def entity_for_file(self, file_path: str) -> RepositoryEntity | None:
+        candidates = self.find_entities(file_path, kinds={NODE_TYPE_FILE})
+        return candidates[0] if len(candidates) == 1 else None
+
+    def find_entities(
+        self,
+        query: str,
+        *,
+        file_path: str | None = None,
+        kinds: Iterable[str] | None = None,
+        class_name: str | None = None,
+        fuzzy: bool = False,
+    ) -> list[RepositoryEntity]:
+        raw = str(query or "").strip().strip("`'\"").strip()
+        if not raw:
+            return []
+
+        requested_file = file_path
+        query_key = self._normalize_alias(raw)
+        candidates = list(self._aliases.get(query_key, ()))
+
+        if not candidates and "::" in raw:
+            parts = [part for part in raw.split("::") if part]
+            if parts and self.find_files(parts[0]):
+                requested_file = requested_file or parts[0]
+                query_key = self._normalize_alias(".".join(parts[1:]))
+                candidates = list(self._aliases.get(query_key, ()))
+
+        if not candidates and ":" in raw:
+            prefix, suffix = raw.split(":", 1)
+            if _looks_like_file_prefix(prefix):
+                requested_file = requested_file or prefix
+                candidates = list(self._aliases.get(self._normalize_alias(suffix), ()))
+
+        if not candidates and fuzzy:
+            lowered = self._normalize_alias(raw).lower()
+            for alias, values in self._aliases_lower.items():
+                if lowered and lowered in alias:
+                    candidates.extend(values)
+
+        allowed_kinds = set(kinds or ())
+        normalized_file: str | None = None
+        if requested_file:
+            files = self.find_files(requested_file)
+            if len(files) == 1:
+                normalized_file = files[0]
+            else:
+                normalized_file = str(requested_file).replace("\\", "/").strip("/")
+
+        filtered: list[RepositoryEntity] = []
+        seen: set[int] = set()
+        for entity in candidates:
+            if entity.vertex_id in seen:
+                continue
+            if allowed_kinds and entity.kind not in allowed_kinds:
+                continue
+            if normalized_file and entity.file_path != normalized_file:
+                continue
+            if class_name and (entity.class_name or "") != class_name:
+                continue
+            seen.add(entity.vertex_id)
+            filtered.append(entity)
+        return sorted(filtered, key=self._entity_sort_key)
+
+    def containing_entity(self, file_path: str, line: int) -> RepositoryEntity | None:
+        """Return the narrowest symbol containing a 0-based source line."""
+
+        files = self.find_files(file_path)
+        if len(files) != 1:
+            return None
+        matches = [
+            entity
+            for entity in self.symbols
+            if entity.file_path == files[0]
+            and entity.start_line is not None
+            and entity.end_line is not None
+            and entity.start_line <= line <= entity.end_line
+        ]
+        if not matches:
+            return None
+        return min(
+            matches,
+            key=lambda entity: (
+                (entity.end_line or 0) - (entity.start_line or 0),
+                -(entity.start_line or 0),
+                entity.locagent_id,
+            ),
+        )
+
+    def children(
+        self,
+        entity: RepositoryEntity,
+        *,
+        kinds: Iterable[str] | None = None,
+    ) -> list[RepositoryEntity]:
+        allowed = set(kinds or ())
+        relations = self.adjacent(
+            entity, direction="downstream", edge_types={EDGE_TYPE_CONTAIN}
+        )
+        children = [relation.target for relation in relations]
+        if allowed:
+            children = [child for child in children if child.kind in allowed]
+        return sorted(children, key=self._entity_sort_key)
+
+    # ------------------------------------------------------------------
+    # Graph operations
+    # ------------------------------------------------------------------
+
+    def adjacent(
+        self,
+        entity: RepositoryEntity,
+        *,
+        direction: str,
+        edge_types: Iterable[str] | None = None,
+    ) -> list[RepositoryRelation]:
+        if self.graph is None:
+            self.require_view("symbol_graph", "symbol_graph")
+        selected = set(edge_types or ())
+        modes: tuple[str, ...]
+        if direction == "downstream":
+            modes = ("out",)
+        elif direction == "upstream":
+            modes = ("in",)
+        elif direction == "both":
+            modes = ("out", "in")
+        else:
+            raise ValueError(
+                "direction must be one of 'downstream', 'upstream', or 'both'"
+            )
+
+        relations: list[RepositoryRelation] = []
+        seen: set[tuple[int, int, str]] = set()
+        for mode in modes:
+            for edge_id in self.graph.graph.incident(entity.vertex_id, mode=mode):
+                edge = self.graph.graph.es[edge_id]
+                edge_type = str(edge.attributes().get("type") or "")
+                if selected and edge_type not in selected:
+                    continue
+                source = self._entity_by_vertex.get(edge.source)
+                target = self._entity_by_vertex.get(edge.target)
+                if source is None or target is None:
+                    continue
+                key = (source.vertex_id, target.vertex_id, edge_type)
+                if key in seen:
+                    continue
+                seen.add(key)
+                relations.append(
+                    RepositoryRelation(
+                        source=source,
+                        target=target,
+                        edge_type=edge_type,
+                    )
+                )
+        return sorted(
+            relations,
+            key=lambda relation: (
+                relation.edge_type,
+                relation.source.locagent_id,
+                relation.target.locagent_id,
+            ),
+        )
+
+    def traverse(
+        self,
+        start: RepositoryEntity,
+        *,
+        direction: str = "downstream",
+        depth: int = 2,
+        edge_types: Iterable[str] | None = None,
+        entity_kinds: Iterable[str] | None = None,
+        max_nodes: int = 80,
+    ) -> list[tuple[int, RepositoryRelation, RepositoryEntity]]:
+        if depth < -1:
+            raise ValueError("depth must be -1 or a non-negative integer")
+        depth_limit = 20 if depth == -1 else depth
+        if depth_limit == 0 or max_nodes <= 1:
+            return []
+
+        allowed_kinds = set(entity_kinds or ())
+        queue: deque[tuple[RepositoryEntity, int]] = deque([(start, 0)])
+        expanded = {start.vertex_id}
+        output: list[tuple[int, RepositoryRelation, RepositoryEntity]] = []
+
+        while queue and len(expanded) < max_nodes:
+            current, level = queue.popleft()
+            if level >= depth_limit:
+                continue
+            for relation in self.adjacent(
+                current, direction=direction, edge_types=edge_types
+            ):
+                neighbor = (
+                    relation.target
+                    if relation.source.vertex_id == current.vertex_id
+                    else relation.source
+                )
+                if allowed_kinds and neighbor.kind not in allowed_kinds:
+                    continue
+                if neighbor.vertex_id in expanded:
+                    continue
+                output.append((level + 1, relation, neighbor))
+                expanded.add(neighbor.vertex_id)
+                queue.append((neighbor, level + 1))
+                if len(expanded) >= max_nodes:
+                    break
+        return output
+
+    def distance(self, first: str, second: str) -> int:
+        """Return an undirected graph hop distance, or ``-1`` if unresolved."""
+
+        left = self.find_entities(first)
+        right = self.find_entities(second)
+        if len(left) != 1 or len(right) != 1:
+            return -1
+        distance = self.graph.graph.distances(
+            [left[0].vertex_id], [right[0].vertex_id], mode="all"
+        )[0][0]
+        if isinstance(distance, float) and math.isinf(distance):
+            return -1
+        return int(distance)
+
+    def file_tree(self, name: str | None = None, max_depth: int | None = None) -> str:
+        """Render a deterministic tree from files represented in the graph."""
+
+        prefix = str(name or "").strip().replace("\\", "/").strip("/")
+        files = list(self._files)
+        if prefix:
+            exact_files = self.find_files(prefix)
+            if exact_files:
+                files = exact_files
+                prefix = str(PurePosixPath(exact_files[0]).parent)
+                if prefix == ".":
+                    prefix = ""
+            else:
+                files = [
+                    file_path
+                    for file_path in files
+                    if file_path == prefix or file_path.startswith(prefix + "/")
+                ]
+        if not files:
+            return f"Cannot find the file tree rooted at {name}"
+
+        root: dict[str, Any] = {}
+        for file_path in files:
+            parts = PurePosixPath(file_path).parts
+            if prefix:
+                prefix_parts = PurePosixPath(prefix).parts
+                if tuple(parts[: len(prefix_parts)]) == prefix_parts:
+                    parts = parts[len(prefix_parts) :]
+            node = root
+            for part in parts:
+                node = node.setdefault(part, {})
+
+        limit = (
+            100 if max_depth is None or int(max_depth) == -1 else max(0, int(max_depth))
+        )
+        lines = [prefix or "/"]
+
+        def render(tree: Mapping[str, Any], indent: str, level: int) -> None:
+            if level >= limit:
+                return
+            items = sorted(tree.items(), key=lambda item: (bool(item[1]), item[0]))
+            for index, (label, children) in enumerate(items):
+                last = index == len(items) - 1
+                lines.append(f"{indent}{'`-- ' if last else '|-- '}{label}")
+                render(
+                    children,
+                    indent + ("    " if last else "|   "),
+                    level + 1,
+                )
+
+        render(root, "", 0)
+        return "\n".join(lines)
+
+    def skeleton(self, entity: RepositoryEntity) -> str:
+        """Render a language-neutral signature skeleton from graph ranges."""
+
+        if entity.kind == NODE_TYPE_FILE:
+            children = self.children(entity)
+        else:
+            children = self.children(entity)
+
+        records = [entity] if entity.kind != NODE_TYPE_FILE else []
+        records.extend(children)
+        signatures: list[str] = []
+        for record in records:
+            if not record.file_path or record.start_line is None:
+                continue
+            content, _, _ = self.read_range(
+                record.file_path, record.start_line, record.start_line
+            )
+            signature = content.strip()
+            if not signature:
+                signature = record.qualified_name or record.simple_name
+            if record is not entity:
+                signature = "    " + signature
+            signatures.append(signature)
+        return "\n".join(signatures)
+
+    # ------------------------------------------------------------------
+    # Index construction
+    # ------------------------------------------------------------------
+
+    def _build_entity_index(self) -> None:
+        raw: dict[int, dict[str, Any]] = {}
+        parent_by_vertex: dict[int, int] = {}
+        graph = self.graph.graph
+
+        for vertex_id in range(graph.vcount()):
+            attrs = graph.vs[vertex_id].attributes()
+            canonical = str(attrs.get("name") or "")
+            kind = str(attrs.get("type") or "")
+            file_path = self._graph_file_path(canonical, kind, attrs.get("file"))
+            display = str(attrs.get("unified_name") or canonical)
+            qualified = self._qualified_name(display, canonical, file_path, kind)
+            raw[vertex_id] = {
+                "canonical": canonical,
+                "kind": kind,
+                "file_path": file_path,
+                "display": display,
+                "qualified": qualified,
+                "start_line": _valid_line(attrs.get("start_line")),
+                "end_line": _valid_line(attrs.get("end_line")),
+            }
+
+        for edge in graph.es:
+            if edge.attributes().get("type") == EDGE_TYPE_CONTAIN:
+                parent_by_vertex.setdefault(edge.target, edge.source)
+
+        entities: list[RepositoryEntity] = []
+        for vertex_id, item in raw.items():
+            parent_id = parent_by_vertex.get(vertex_id)
+            parent = raw.get(parent_id) if parent_id is not None else None
+            class_name: str | None = None
+            if parent and parent["kind"] == NODE_TYPE_CLASS:
+                class_name = _simple_name(parent["qualified"])
+            elif item["kind"] == NODE_TYPE_METHOD:
+                parts = _strip_call_suffix(item["qualified"]).split(".")
+                if len(parts) > 1:
+                    class_name = parts[-2]
+
+            entity = RepositoryEntity(
+                vertex_id=vertex_id,
+                canonical_name=item["canonical"],
+                display_name=item["display"],
+                kind=item["kind"],
+                file_path=item["file_path"],
+                qualified_name=item["qualified"],
+                simple_name=_simple_name(item["qualified"] or item["canonical"]),
+                start_line=item["start_line"],
+                end_line=item["end_line"],
+                parent_name=parent["canonical"] if parent else None,
+                class_name=class_name,
+            )
+            entities.append(entity)
+
+        self._entities = tuple(sorted(entities, key=self._entity_sort_key))
+        self._entity_by_vertex = {entity.vertex_id: entity for entity in self._entities}
+        self._entity_by_canonical = {
+            entity.canonical_name: entity for entity in self._entities
+        }
+
+        aliases: dict[str, list[RepositoryEntity]] = defaultdict(list)
+        aliases_lower: dict[str, list[RepositoryEntity]] = defaultdict(list)
+        files: set[str] = set()
+        for entity in self._entities:
+            if entity.file_path:
+                files.add(entity.file_path)
+            for alias in self._entity_aliases(entity):
+                key = self._normalize_alias(alias)
+                if not key:
+                    continue
+                aliases[key].append(entity)
+                aliases_lower[key.lower()].append(entity)
+        self._aliases = dict(aliases)
+        self._aliases_lower = dict(aliases_lower)
+        self._files = tuple(sorted(files))
+
+    def _graph_file_path(self, canonical: str, kind: str, value: Any) -> str:
+        raw = str(value or "")
+        if kind == NODE_TYPE_FILE:
+            raw = canonical
+        if not raw and ":" in canonical:
+            prefix = canonical.split(":", 1)[0]
+            if _looks_like_file_prefix(prefix):
+                raw = prefix
+        raw = raw.replace("\\", "/").strip()
+        if not raw:
+            return ""
+        path = Path(raw)
+        if path.is_absolute():
+            try:
+                raw = path.resolve().relative_to(self.repo_root).as_posix()
+            except ValueError:
+                return ""
+        while raw.startswith("./"):
+            raw = raw[2:]
+        if raw.startswith("/") or ".." in PurePosixPath(raw).parts:
+            return ""
+        return PurePosixPath(raw).as_posix()
+
+    @staticmethod
+    def _qualified_name(display: str, canonical: str, file_path: str, kind: str) -> str:
+        if kind in {NODE_TYPE_FILE, NODE_TYPE_DIRECTORY}:
+            return ""
+        for candidate in (display, canonical):
+            value = str(candidate or "").strip()
+            if not value:
+                continue
+            if file_path and value.startswith(file_path + ":"):
+                value = value[len(file_path) + 1 :]
+            elif ":" in value:
+                prefix, suffix = value.split(":", 1)
+                if _looks_like_file_prefix(prefix):
+                    value = suffix
+            value = _strip_call_suffix(value).strip(".:")
+            if value not in _EMPTY_QUALIFIED_NAMES:
+                return value
+        return ""
+
+    @staticmethod
+    def _normalize_alias(value: str) -> str:
+        normalized = str(value or "").strip().strip("`'\"")
+        normalized = normalized.replace("\\", "/").strip()
+        return _strip_call_suffix(normalized).rstrip(".")
+
+    @staticmethod
+    def _entity_sort_key(entity: RepositoryEntity) -> tuple[Any, ...]:
+        return (
+            entity.file_path,
+            entity.start_line if entity.start_line is not None else 1 << 30,
+            entity.end_line if entity.end_line is not None else 1 << 30,
+            entity.locagent_id,
+        )
+
+    @staticmethod
+    def _entity_aliases(entity: RepositoryEntity) -> Iterator[str]:
+        yield entity.canonical_name
+        yield entity.display_name
+        yield entity.locagent_id
+        yield entity.orcaloca_id
+        yield entity.qualified_name
+        yield entity.simple_name
+        if entity.file_path:
+            yield entity.file_path
+        if entity.file_path and entity.qualified_name:
+            yield f"{entity.file_path}::{entity.qualified_name.replace('.', '::')}"
+            yield f"{entity.file_path}::{entity.simple_name}"
+
+
+__all__ = [
+    "IntegrationCapabilityError",
+    "RepositoryAdapter",
+    "RepositoryEntity",
+    "RepositoryPathError",
+    "RepositoryRelation",
+]

--- a/codenib/integrations/_repository.py
+++ b/codenib/integrations/_repository.py
@@ -504,7 +504,7 @@ class RepositoryAdapter:
     ) -> list[tuple[int, RepositoryRelation, RepositoryEntity]]:
         if depth < -1:
             raise ValueError("depth must be -1 or a non-negative integer")
-        depth_limit = 20 if depth == -1 else depth
+        depth_limit = None if depth == -1 else depth
         if depth_limit == 0 or max_nodes <= 1:
             return []
 
@@ -515,7 +515,7 @@ class RepositoryAdapter:
 
         while queue and len(expanded) < max_nodes:
             current, level = queue.popleft()
-            if level >= depth_limit:
+            if depth_limit is not None and level >= depth_limit:
                 continue
             for relation in self.adjacent(
                 current, direction=direction, edge_types=edge_types
@@ -539,6 +539,8 @@ class RepositoryAdapter:
     def distance(self, first: str, second: str) -> int:
         """Return an undirected graph hop distance, or ``-1`` if unresolved."""
 
+        if self.graph is None:
+            self.require_view("symbol_graph", "symbol_graph")
         left = self.find_entities(first)
         right = self.find_entities(second)
         if len(left) != 1 or len(right) != 1:

--- a/codenib/integrations/locagent.py
+++ b/codenib/integrations/locagent.py
@@ -370,10 +370,23 @@ class LocAgentToolProvider:
             return "No start entities were provided."
         return self._bounded("\n\n".join(sections))
 
-    def explore_graph_structure(self, *args: Any, **kwargs: Any) -> str:
-        """Compatibility alias for LocAgent's non-function-calling path."""
+    def explore_graph_structure(
+        self,
+        start_entities: Sequence[str],
+        direction: str = "downstream",
+        traversal_depth: int = 1,
+        entity_type_filter: Sequence[str] | None = None,
+        dependency_type_filter: Sequence[str] | None = None,
+    ) -> str:
+        """Compatibility wrapper for LocAgent's non-function-calling path."""
 
-        return self.explore_tree_structure(*args, **kwargs)
+        return self.explore_tree_structure(
+            start_entities=start_entities,
+            direction=direction,
+            traversal_depth=traversal_depth,
+            entity_type_filter=entity_type_filter,
+            dependency_type_filter=dependency_type_filter,
+        )
 
     # ------------------------------------------------------------------
     # Formatting and search helpers

--- a/codenib/integrations/locagent.py
+++ b/codenib/integrations/locagent.py
@@ -1,0 +1,600 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""LocAgent/OpenHands-compatible tools over CodeNib repository views."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from ..types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_IMPORT,
+    EDGE_TYPE_REFERENCE,
+    EDGE_TYPE_TYPE_USE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_DIRECTORY,
+    NODE_TYPE_FILE,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NODE_TYPE_SYMBOL,
+)
+from ._repository import RepositoryAdapter, RepositoryEntity, RepositoryPathError
+
+LOCAGENT_REVISION = "ef170542a5cca88a1bd8463335ec43de222ed5f9"
+OPENHANDS_LOCAGENT_REVISION = "efe287ce3402706a171b3a5fb40f15914e98ef20"
+
+_TOOL_NAMES = (
+    "search_code_snippets",
+    "get_entity_contents",
+    "explore_tree_structure",
+)
+
+_RELATION_TO_EDGE = {
+    "contains": EDGE_TYPE_CONTAIN,
+    "imports": EDGE_TYPE_IMPORT,
+    "invokes": EDGE_TYPE_REFERENCE,
+    "inherits": EDGE_TYPE_TYPE_USE,
+}
+_EDGE_TO_RELATION = {value: key for key, value in _RELATION_TO_EDGE.items()}
+_BROADER_RELATIONS = {
+    "invokes": "CodeNib reference edges are a conservative superset of calls",
+    "inherits": "CodeNib type-use edges are a conservative superset of inheritance",
+}
+_ENTITY_TYPES = {
+    "directory": {NODE_TYPE_DIRECTORY},
+    "file": {NODE_TYPE_FILE},
+    "class": {NODE_TYPE_CLASS},
+    "function": {NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_SYMBOL},
+}
+
+_SEARCH_DESCRIPTION = """Search repository code by entity name, keyword, file
+pattern, or 1-based line number. Entity names use
+`file_path:QualifiedName`; files use repository-relative paths."""
+
+_ENTITY_DESCRIPTION = """Return source for repository entities. Functions and
+classes use `file_path:QualifiedName`; files use repository-relative paths."""
+
+_TREE_DESCRIPTION = """Traverse a pre-built repository graph upstream,
+downstream, or in both directions. Traversal can be filtered by entity and
+dependency types."""
+
+_LOCAGENT_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
+    {
+        "type": "function",
+        "function": {
+            "name": "search_code_snippets",
+            "description": _SEARCH_DESCRIPTION,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "search_terms": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Names, keywords, or code fragments to search.",
+                    },
+                    "line_nums": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "description": "1-based source lines in one concrete file.",
+                    },
+                    "file_path_or_pattern": {
+                        "type": "string",
+                        "description": "Repository-relative file path or glob.",
+                        "default": "**/*.py",
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_entity_contents",
+            "description": _ENTITY_DESCRIPTION,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "entity_names": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Repository-relative file or entity identifiers.",
+                    }
+                },
+                "required": ["entity_names"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "explore_tree_structure",
+            "description": _TREE_DESCRIPTION,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "start_entities": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Repository entities from which traversal starts.",
+                    },
+                    "direction": {
+                        "type": "string",
+                        "enum": ["upstream", "downstream", "both"],
+                        "default": "downstream",
+                    },
+                    "traversal_depth": {
+                        "type": "integer",
+                        "default": 2,
+                    },
+                    "entity_type_filter": {
+                        "type": ["array", "null"],
+                        "items": {"type": "string"},
+                        "default": None,
+                    },
+                    "dependency_type_filter": {
+                        "type": ["array", "null"],
+                        "items": {"type": "string"},
+                        "default": None,
+                    },
+                },
+                "required": ["start_entities"],
+            },
+        },
+    },
+)
+
+
+def get_locagent_tool_schemas() -> list[dict[str, Any]]:
+    """Return dependency-free OpenAI schemas for the pinned LocAgent tools."""
+
+    return copy.deepcopy(list(_LOCAGENT_TOOL_SCHEMAS))
+
+
+class LocAgentToolProvider:
+    """Serve LocAgent's three repository tools from one ``ServerContext``."""
+
+    def __init__(
+        self,
+        context: Any,
+        *,
+        max_results: int = 5,
+        context_lines: int = 20,
+        max_source_lines: int = 220,
+        max_output_chars: int = 48_000,
+        traversal_max_nodes: int = 80,
+    ) -> None:
+        self.repository = RepositoryAdapter(context, require_graph=True)
+        self.max_results = max(1, int(max_results))
+        self.context_lines = max(0, int(context_lines))
+        self.max_source_lines = max(20, int(max_source_lines))
+        self.max_output_chars = max(2_000, int(max_output_chars))
+        self.traversal_max_nodes = max(2, int(traversal_max_nodes))
+
+    @classmethod
+    def from_manifest(
+        cls, manifest_path: str | Path, **kwargs: Any
+    ) -> "LocAgentToolProvider":
+        from ..mcp.context import ServerContext
+
+        return cls(ServerContext.load(manifest_path), **kwargs)
+
+    @property
+    def context(self) -> Any:
+        return self.repository.context
+
+    def bindings(self) -> dict[str, Callable[..., str]]:
+        """Return functions suitable for an OpenHands-style runtime export."""
+
+        return {
+            "search_code_snippets": self.search_code_snippets,
+            "get_entity_contents": self.get_entity_contents,
+            "explore_tree_structure": self.explore_tree_structure,
+        }
+
+    def dispatch(
+        self, name: str, arguments: Mapping[str, Any] | str | None = None
+    ) -> str:
+        """Execute a function call directly, without IPython string evaluation."""
+
+        if isinstance(arguments, str):
+            parsed = json.loads(arguments)
+        else:
+            parsed = dict(arguments or {})
+        function = self.bindings().get(name)
+        if function is None:
+            supported = ", ".join(_TOOL_NAMES)
+            raise KeyError(f"unknown LocAgent tool {name!r}; supported: {supported}")
+        return function(**parsed)
+
+    def search_code_snippets(
+        self,
+        search_terms: Sequence[str] | None = None,
+        line_nums: Sequence[int] | int | None = None,
+        file_path_or_pattern: str | None = "**/*.py",
+    ) -> str:
+        """Search entities, indexed code, or 1-based lines."""
+
+        terms = self._coerce_strings(search_terms)
+        lines = [line_nums] if isinstance(line_nums, int) else list(line_nums or ())
+        if not terms and not lines:
+            return (
+                "No search requested. Provide at least one search term or 1-based "
+                "line number."
+            )
+
+        matched_files = self.repository.match_files(file_path_or_pattern)
+        prefix = ""
+        if file_path_or_pattern and not matched_files:
+            matched_files = list(self.repository.files)
+            prefix = (
+                f"No files matched pattern {file_path_or_pattern!r}; "
+                "searching all indexed files.\n\n"
+            )
+        file_filter = set(matched_files)
+
+        sections: list[str] = []
+        for term in terms:
+            sections.append(self._search_term(term, file_filter))
+        if lines:
+            sections.append(
+                self._search_lines(lines, file_path_or_pattern, matched_files)
+            )
+        return self._bounded(
+            prefix + "\n\n".join(section for section in sections if section)
+        )
+
+    def get_entity_contents(self, entity_names: Sequence[str]) -> str:
+        """Return deterministic source for exact or disambiguated entities."""
+
+        sections: list[str] = []
+        for raw_name in self._coerce_strings(entity_names):
+            heading = (
+                f"## Searching for entity `{raw_name}`...\n" "### Search Result:\n"
+            )
+            files = self.repository.find_files(raw_name)
+            entities = self.repository.find_entities(raw_name)
+            if len(files) == 1:
+                file_entity = self.repository.entity_for_file(files[0])
+                if file_entity is not None:
+                    sections.append(
+                        heading + self._format_entity(file_entity, complete=True)
+                    )
+                    continue
+            if len(entities) == 1:
+                sections.append(
+                    heading + self._format_entity(entities[0], complete=True)
+                )
+            elif len(entities) > 1:
+                sections.append(
+                    heading + self._format_disambiguation(raw_name, entities)
+                )
+            else:
+                sections.append(
+                    heading
+                    + "Invalid name.\n"
+                    + 'Hint: use "file_path:QualifiedName" or a repository-relative file.'
+                )
+        if not sections:
+            return "No entity names were provided."
+        return self._bounded("\n\n".join(sections))
+
+    def explore_tree_structure(
+        self,
+        start_entities: Sequence[str],
+        direction: str = "downstream",
+        traversal_depth: int = 2,
+        entity_type_filter: Sequence[str] | None = None,
+        dependency_type_filter: Sequence[str] | None = None,
+    ) -> str:
+        """Traverse CodeNib graph facts under LocAgent relation names."""
+
+        if direction not in {"upstream", "downstream", "both"}:
+            raise ValueError(
+                "direction must be one of 'upstream', 'downstream', or 'both'"
+            )
+        depth = int(traversal_depth)
+        if depth < -1:
+            raise ValueError("traversal_depth must be -1 or non-negative")
+
+        entity_kinds: set[str] = set()
+        for entity_type in entity_type_filter or ():
+            if entity_type not in _ENTITY_TYPES:
+                supported = ", ".join(sorted(_ENTITY_TYPES))
+                raise ValueError(
+                    f"unknown entity type {entity_type!r}; supported: {supported}"
+                )
+            entity_kinds.update(_ENTITY_TYPES[entity_type])
+
+        requested_relations = list(dependency_type_filter or _RELATION_TO_EDGE)
+        invalid_relations = sorted(set(requested_relations) - set(_RELATION_TO_EDGE))
+        if invalid_relations:
+            supported = ", ".join(sorted(_RELATION_TO_EDGE))
+            raise ValueError(
+                f"unknown dependency types {invalid_relations}; supported: {supported}"
+            )
+        edge_types = {_RELATION_TO_EDGE[name] for name in requested_relations}
+
+        sections: list[str] = []
+        broader_used: set[str] = set()
+        for raw_start in self._coerce_strings(start_entities):
+            if raw_start == "/":
+                sections.append(self.repository.file_tree(max_depth=depth))
+                continue
+            candidates = self.repository.find_entities(raw_start)
+            if len(candidates) != 1:
+                if candidates:
+                    sections.append(self._format_disambiguation(raw_start, candidates))
+                else:
+                    sections.append(f"Invalid start entity `{raw_start}`.")
+                continue
+            start = candidates[0]
+            rows = self.repository.traverse(
+                start,
+                direction=direction,
+                depth=depth,
+                edge_types=edge_types,
+                entity_kinds=entity_kinds,
+                max_nodes=self.traversal_max_nodes,
+            )
+            rendered = [f"{start.locagent_id} [{self._external_kind(start.kind)}]"]
+            for level, relation, neighbor in rows:
+                relation_name = _EDGE_TO_RELATION.get(
+                    relation.edge_type, relation.edge_type
+                )
+                if relation_name in _BROADER_RELATIONS:
+                    broader_used.add(relation_name)
+                if relation.source.vertex_id == neighbor.vertex_id:
+                    relation_text = f"<- {relation_name} -"
+                else:
+                    relation_text = f"{relation_name} ->"
+                rendered.append(
+                    f"{'  ' * level}- {relation_text} "
+                    f"{neighbor.locagent_id} [{self._external_kind(neighbor.kind)}]"
+                )
+            if not rows:
+                rendered.append("  (no matching relations)")
+            sections.append("\n".join(rendered))
+
+        if broader_used:
+            notes = "; ".join(
+                f"{name}: {_BROADER_RELATIONS[name]}" for name in sorted(broader_used)
+            )
+            sections.append(f"Relation fidelity: {notes}.")
+        if not sections:
+            return "No start entities were provided."
+        return self._bounded("\n\n".join(sections))
+
+    def explore_graph_structure(self, *args: Any, **kwargs: Any) -> str:
+        """Compatibility alias for LocAgent's non-function-calling path."""
+
+        return self.explore_tree_structure(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Formatting and search helpers
+    # ------------------------------------------------------------------
+
+    def _search_term(self, term: str, file_filter: set[str]) -> str:
+        heading = f"## Searching for term {term!r}...\n### Search Result:\n"
+        files = [
+            path for path in self.repository.find_files(term) if path in file_filter
+        ]
+        if len(files) == 1:
+            entity = self.repository.entity_for_file(files[0])
+            if entity:
+                return heading + self._format_entity(entity, complete=False)
+
+        candidates = [
+            entity
+            for entity in self.repository.find_entities(term)
+            if not entity.file_path or entity.file_path in file_filter
+        ]
+        if candidates:
+            rendered = [
+                self._format_entity(entity, complete=len(candidates) == 1)
+                for entity in candidates[: self.max_results]
+            ]
+            if len(candidates) > self.max_results:
+                rendered.append(
+                    f"... {len(candidates) - self.max_results} additional matches omitted."
+                )
+            return heading + "\n\n".join(rendered)
+
+        bm25 = self.repository.require_view("bm25", "bm25")
+        nodes = bm25.search(
+            query=term,
+            top_k=max(self.max_results * 4, self.max_results),
+            return_code_content=True,
+            wrap_with_ln=False,
+            filter_test=False,
+        )
+        selected: list[RepositoryEntity] = []
+        seen: set[int] = set()
+        for node in nodes:
+            node_file = str(getattr(node, "file", "") or "")
+            if file_filter and node_file not in file_filter:
+                continue
+            entity_matches = self.repository.find_entities(
+                str(getattr(node, "node_name", "") or ""),
+                file_path=node_file or None,
+            )
+            if not entity_matches and node_file:
+                line = getattr(node, "start_line", None)
+                if isinstance(line, int) and not isinstance(line, bool):
+                    containing = self.repository.containing_entity(node_file, line)
+                    entity_matches = [containing] if containing else []
+            for entity in entity_matches:
+                if entity and entity.vertex_id not in seen:
+                    seen.add(entity.vertex_id)
+                    selected.append(entity)
+                    break
+            if len(selected) >= self.max_results:
+                break
+        if not selected:
+            return heading + "No locations found."
+        return heading + "\n\n".join(
+            self._format_entity(entity, complete=False) for entity in selected
+        )
+
+    def _search_lines(
+        self,
+        line_nums: Sequence[int],
+        file_path_or_pattern: str | None,
+        matched_files: Sequence[str],
+    ) -> str:
+        if not file_path_or_pattern or any(
+            char in file_path_or_pattern for char in "*?[]"
+        ):
+            return (
+                "## Searching by line...\n### Search Result:\n"
+                "Line lookup requires one concrete repository-relative file path."
+            )
+        files = self.repository.find_files(file_path_or_pattern)
+        if len(files) != 1:
+            return (
+                "## Searching by line...\n### Search Result:\n"
+                f"Cannot resolve one file from {file_path_or_pattern!r}."
+            )
+        file_path = files[0]
+        if matched_files and file_path not in set(matched_files):
+            return (
+                "## Searching by line...\n### Search Result:\n"
+                f"File {file_path!r} is outside the requested filter."
+            )
+
+        entities: list[RepositoryEntity] = []
+        uncovered: list[int] = []
+        seen: set[int] = set()
+        for value in line_nums:
+            if isinstance(value, bool) or int(value) < 1:
+                raise ValueError("line numbers must be positive 1-based integers")
+            line = int(value) - 1
+            entity = self.repository.containing_entity(file_path, line)
+            if entity is None:
+                uncovered.append(line)
+            elif entity.vertex_id not in seen:
+                seen.add(entity.vertex_id)
+                entities.append(entity)
+
+        rendered = [
+            "## Searching by line...\n### Search Result:",
+            *[self._format_entity(entity, complete=True) for entity in entities],
+        ]
+        for line in self._merge_line_windows(uncovered):
+            content, start, end = self.repository.read_range(
+                file_path, line[0], line[1]
+            )
+            rendered.append(
+                f"Found code snippet in file `{file_path}` (lines {start + 1}-{end + 1}).\n"
+                + self.repository.numbered_source(content, start)
+            )
+        if len(rendered) == 1:
+            rendered.append("No locations found.")
+        return "\n\n".join(rendered)
+
+    def _merge_line_windows(self, lines: Sequence[int]) -> list[tuple[int, int]]:
+        intervals = sorted(
+            (
+                max(0, line - self.context_lines),
+                line + self.context_lines,
+            )
+            for line in lines
+        )
+        merged: list[list[int]] = []
+        for start, end in intervals:
+            if not merged or start > merged[-1][1] + 1:
+                merged.append([start, end])
+            else:
+                merged[-1][1] = max(merged[-1][1], end)
+        return [(start, end) for start, end in merged]
+
+    def _format_entity(self, entity: RepositoryEntity, *, complete: bool) -> str:
+        try:
+            content, start, end = self.repository.read_entity(entity)
+        except RepositoryPathError as exc:
+            return (
+                f"Found {self._external_kind(entity.kind)} "
+                f"`{entity.locagent_id}`, but source is unavailable: {exc}."
+            )
+        line_count = end - start + 1
+        kind = self._external_kind(entity.kind)
+        header = (
+            f"Found {kind} `{entity.locagent_id}` " f"(lines {start + 1}-{end + 1})."
+        )
+        if line_count > self.max_source_lines and not complete:
+            skeleton = self.repository.skeleton(entity)
+            return (
+                f"{header}\n"
+                f"Showing a graph-derived structure because the source has "
+                f"{line_count} lines:\n```\n{skeleton}\n```\n"
+                f"Hint: request `{entity.locagent_id}` directly for full source."
+            )
+        return f"{header}\n{self.repository.numbered_source(content, start)}"
+
+    @staticmethod
+    def _format_disambiguation(
+        query: str, candidates: Sequence[RepositoryEntity]
+    ) -> str:
+        lines = [f"Multiple entities match `{query}`:"]
+        for index, entity in enumerate(candidates, start=1):
+            location = ""
+            if entity.start_line is not None:
+                location = f" at line {entity.start_line + 1}"
+            lines.append(f"{index}. `{entity.locagent_id}`{location}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _external_kind(kind: str) -> str:
+        if kind in {NODE_TYPE_METHOD, NODE_TYPE_SYMBOL}:
+            return "function"
+        return kind or "entity"
+
+    @staticmethod
+    def _coerce_strings(values: Sequence[str] | str | None) -> list[str]:
+        if values is None:
+            return []
+        if isinstance(values, str):
+            values = [values]
+        return [str(value).strip().strip(".") for value in values if str(value).strip()]
+
+    def _bounded(self, value: str) -> str:
+        if len(value) <= self.max_output_chars:
+            return value.strip()
+        marker = "\n\n[Output truncated by CodeNib's LocAgent adapter budget.]"
+        prefix = value[: self.max_output_chars - len(marker)].rstrip()
+        if prefix.count("```") % 2:
+            prefix += "\n```"
+        return prefix + marker
+
+
+def bind_locagent_tools(
+    provider: LocAgentToolProvider,
+) -> dict[str, Callable[..., str]]:
+    """Return the three functions expected by an OpenHands runtime plugin."""
+
+    return provider.bindings()
+
+
+def dispatch_locagent_tool_call(
+    provider: LocAgentToolProvider,
+    name: str,
+    arguments: Mapping[str, Any] | str | None = None,
+) -> str:
+    """Dispatch a pinned LocAgent/OpenHands tool call without code evaluation."""
+
+    return provider.dispatch(name, arguments)
+
+
+__all__ = [
+    "LOCAGENT_REVISION",
+    "OPENHANDS_LOCAGENT_REVISION",
+    "LocAgentToolProvider",
+    "bind_locagent_tools",
+    "dispatch_locagent_tool_call",
+    "get_locagent_tool_schemas",
+]

--- a/codenib/integrations/locagent.py
+++ b/codenib/integrations/locagent.py
@@ -560,7 +560,8 @@ class LocAgentToolProvider:
             return []
         if isinstance(values, str):
             values = [values]
-        return [str(value).strip().strip(".") for value in values if str(value).strip()]
+        normalized = [str(value).strip().rstrip(".") for value in values]
+        return [value for value in normalized if value]
 
     def _bounded(self, value: str) -> str:
         if len(value) <= self.max_output_chars:

--- a/codenib/integrations/locagent.py
+++ b/codenib/integrations/locagent.py
@@ -203,7 +203,15 @@ class LocAgentToolProvider:
         """Execute a function call directly, without IPython string evaluation."""
 
         if isinstance(arguments, str):
-            parsed = json.loads(arguments)
+            try:
+                decoded = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    "LocAgent tool arguments must be a valid JSON object"
+                ) from exc
+            if not isinstance(decoded, Mapping):
+                raise ValueError("LocAgent tool arguments must decode to a JSON object")
+            parsed = dict(decoded)
         else:
             parsed = dict(arguments or {})
         function = self.bindings().get(name)

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -1,0 +1,101 @@
+# Agent Integrations
+
+CodeNib can supply repository search and graph-navigation tools to an external
+agent without importing that agent or rebuilding its indexes. Integrations bind
+to one existing `repo_manifest.json` through `ServerContext`; they never create
+an agent-specific graph, BM25 index, or cache directory.
+
+## LocAgent And OpenHands
+
+The LocAgent provider implements the three repository functions used by
+LocAgent and the historical OpenHands integration:
+
+- `search_code_snippets`
+- `get_entity_contents`
+- `explore_tree_structure`
+
+Build a graph-enabled repository index, then bind the provider:
+
+```bash
+codenib index /path/to/repository --preset graph
+```
+
+```python
+from codenib.integrations.locagent import (
+    LocAgentToolProvider,
+    get_locagent_tool_schemas,
+)
+
+provider = LocAgentToolProvider.from_manifest(
+    "/path/to/repo_manifest.json",
+)
+
+tools = get_locagent_tool_schemas()
+result = provider.dispatch(
+    "get_entity_contents",
+    {"entity_names": ["src/service.py:BillingService.calculate_tax"]},
+)
+```
+
+`provider.bindings()` returns the same-named Python callables for a runtime
+plugin. This follows the separation in
+[OpenHands PR #7371](https://github.com/OpenHands/OpenHands/pull/7371): the
+agent owns function schemas and action conversion, while the runtime supplies
+the repository functions. CodeNib dispatches calls directly and does not copy
+the historical IPython string-evaluation bridge.
+
+For the historical OpenHands runtime plugin, the complete provider-binding
+change is:
+
+```python
+import os
+
+from codenib.integrations.locagent import LocAgentToolProvider
+
+_provider = LocAgentToolProvider.from_manifest(os.environ["CODENIB_MANIFEST"])
+get_entity_contents = _provider.get_entity_contents
+search_code_snippets = _provider.search_code_snippets
+explore_tree_structure = _provider.explore_tree_structure
+```
+
+The agent-side schemas and action loop remain unchanged. Modern runtimes can
+use `provider.dispatch(name, arguments)` directly instead of constructing
+Python source from model-supplied arguments.
+
+Compatibility is revision-scoped:
+
+| Contract | Pinned revision |
+| --- | --- |
+| LocAgent behavior | `ef170542a5cca88a1bd8463335ec43de222ed5f9` |
+| OpenHands integration | `efe287ce3402706a171b3a5fb40f15914e98ef20` |
+
+Current OpenHands CLI does not contain that historical LocAgent module. The pin
+describes the supported tool contract; it is not a claim that every OpenHands
+CLI revision exposes LocAgent.
+
+### Relation Semantics
+
+LocAgent and CodeNib use different graph relation vocabularies. The provider
+maps them at the integration boundary:
+
+| LocAgent relation | CodeNib relation | Fidelity |
+| --- | --- | --- |
+| `contains` | `contain` | Exact |
+| `imports` | `import` | Exact when emitted by the graph backend |
+| `invokes` | `reference` | Conservative superset |
+| `inherits` | `type-use` | Conservative superset |
+
+Traversal output states when a broader relation was used. It does not present
+reference or type-use edges as exact call or inheritance facts.
+
+### Runtime Guarantees
+
+- Source paths are repository-relative and cannot escape the manifest root.
+- External line numbers are 1-based; CodeNib graph ranges remain 0-based.
+- Missing, stale, or failed graph and BM25 views produce explicit errors.
+- Tool output is deterministic and bounded by provider-level result, traversal,
+  source-line, and character budgets.
+- Loading the provider never invokes LocAgent, OpenHands ACI, NetworkX,
+  LlamaIndex, or an index builder.
+
+The base `codenib` package therefore gains no LocAgent or OpenHands dependency.

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -73,6 +73,19 @@ Current OpenHands CLI does not contain that historical LocAgent module. The pin
 describes the supported tool contract; it is not a claim that every OpenHands
 CLI revision exposes LocAgent.
 
+Run the optional source-level probe against local upstream checkouts with:
+
+```bash
+LOCAGENT_CHECKOUT=/path/to/LocAgent \
+OPENHANDS_CHECKOUT=/path/to/OpenHands \
+  pytest -q test/integrations/test_locagent_upstream.py
+```
+
+The probe reads files directly from the pinned Git objects and does not import
+either project. To advance compatibility, update the two revision constants,
+refresh the YAML fixture from the reviewed upstream schemas, and run both this
+probe and `test/integrations/test_locagent.py` in the same change.
+
 ### Relation Semantics
 
 LocAgent and CodeNib use different graph relation vocabularies. The provider

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
       - Running Locally: running-locally.md
       - Language Capabilities: language_capabilities.md
       - Agent Skills: agent_skills.md
+      - Agent Integrations: agent_integrations.md
       - RAG Ops And Planner: rag_ops.md
   - Concepts:
       - SCIP Index: scip_index.md

--- a/test/integrations/conftest.py
+++ b/test/integrations/conftest.py
@@ -39,6 +39,7 @@ REPOSITORY_FILES = {
         "def helper(amount):\n" '    """Fallback tax helper."""\n' "    return amount\n"
     ),
     "src/model.py": ("class TaxRule:\n" "    rate = 0.08\n"),
+    ".github/workflows/ci.yml": "name: CI\n",
     "README.md": "# Billing fixture\n",
 }
 
@@ -74,6 +75,8 @@ def build_integration_graph(repo_root: Path) -> CodeGraph:
     graph = CodeGraph(project_root=str(repo_root))
     _add_vertex(graph, ROOT_NODE, kind=NODE_TYPE_DIRECTORY)
     _add_vertex(graph, "src", kind=NODE_TYPE_DIRECTORY)
+    _add_vertex(graph, ".github", kind=NODE_TYPE_DIRECTORY)
+    _add_vertex(graph, ".github/workflows", kind=NODE_TYPE_DIRECTORY)
     for relative in REPOSITORY_FILES:
         _add_vertex(graph, relative, kind=NODE_TYPE_FILE)
 
@@ -124,6 +127,13 @@ def build_integration_graph(repo_root: Path) -> CodeGraph:
     )
 
     graph._add_edge(ROOT_NODE, "src", EDGE_TYPE_CONTAIN)
+    graph._add_edge(ROOT_NODE, ".github", EDGE_TYPE_CONTAIN)
+    graph._add_edge(".github", ".github/workflows", EDGE_TYPE_CONTAIN)
+    graph._add_edge(
+        ".github/workflows",
+        ".github/workflows/ci.yml",
+        EDGE_TYPE_CONTAIN,
+    )
     graph._add_edge(ROOT_NODE, "README.md", EDGE_TYPE_CONTAIN)
     for relative in ("src/service.py", "src/other.py", "src/model.py"):
         graph._add_edge("src", relative, EDGE_TYPE_CONTAIN)

--- a/test/integrations/conftest.py
+++ b/test/integrations/conftest.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.graph.code_graph import CodeGraph
+from codenib.index.sparse_idx import BM25CodeIndexer
+from codenib.types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_IMPORT,
+    EDGE_TYPE_REFERENCE,
+    EDGE_TYPE_TYPE_USE,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_DIRECTORY,
+    NODE_TYPE_FILE,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    ROOT_NODE,
+)
+
+REPOSITORY_FILES = {
+    "src/service.py": (
+        "class BillingService:\n"
+        "    def calculate_tax(self, amount):\n"
+        '        """Compute sales tax for an invoice."""\n'
+        "        return helper(amount)\n"
+        "\n"
+        "def helper(amount):\n"
+        "    return amount * 0.08\n"
+    ),
+    "src/other.py": (
+        "def helper(amount):\n" '    """Fallback tax helper."""\n' "    return amount\n"
+    ),
+    "src/model.py": ("class TaxRule:\n" "    rate = 0.08\n"),
+    "README.md": "# Billing fixture\n",
+}
+
+
+def _add_vertex(
+    graph: CodeGraph,
+    name: str,
+    *,
+    kind: str,
+    file_path: str = "",
+    unified_name: str = "",
+    start_line: int | None = None,
+    end_line: int | None = None,
+) -> None:
+    attrs: dict[str, Any] = {"type": kind}
+    if file_path:
+        attrs["file"] = file_path
+    if unified_name:
+        attrs["unified_name"] = unified_name
+    if start_line is not None:
+        attrs["start_line"] = start_line
+    if end_line is not None:
+        attrs["end_line"] = end_line
+    graph._add_vertex(name, attrs)
+
+
+def build_integration_graph(repo_root: Path) -> CodeGraph:
+    for relative, content in REPOSITORY_FILES.items():
+        path = repo_root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    graph = CodeGraph(project_root=str(repo_root))
+    _add_vertex(graph, ROOT_NODE, kind=NODE_TYPE_DIRECTORY)
+    _add_vertex(graph, "src", kind=NODE_TYPE_DIRECTORY)
+    for relative in REPOSITORY_FILES:
+        _add_vertex(graph, relative, kind=NODE_TYPE_FILE)
+
+    _add_vertex(
+        graph,
+        "scip:service:BillingService",
+        kind=NODE_TYPE_CLASS,
+        file_path="src/service.py",
+        unified_name="src/service.py:BillingService",
+        start_line=0,
+        end_line=3,
+    )
+    _add_vertex(
+        graph,
+        "scip:service:BillingService.calculate_tax",
+        kind=NODE_TYPE_METHOD,
+        file_path="src/service.py",
+        unified_name="src/service.py:BillingService.calculate_tax()",
+        start_line=1,
+        end_line=3,
+    )
+    _add_vertex(
+        graph,
+        "scip:service:helper",
+        kind=NODE_TYPE_FUNCTION,
+        file_path="src/service.py",
+        unified_name="src/service.py:helper()",
+        start_line=5,
+        end_line=6,
+    )
+    _add_vertex(
+        graph,
+        "scip:other:helper",
+        kind=NODE_TYPE_FUNCTION,
+        file_path="src/other.py",
+        unified_name="src/other.py:helper()",
+        start_line=0,
+        end_line=2,
+    )
+    _add_vertex(
+        graph,
+        "scip:model:TaxRule",
+        kind=NODE_TYPE_CLASS,
+        file_path="src/model.py",
+        unified_name="src/model.py:TaxRule",
+        start_line=0,
+        end_line=1,
+    )
+
+    graph._add_edge(ROOT_NODE, "src", EDGE_TYPE_CONTAIN)
+    graph._add_edge(ROOT_NODE, "README.md", EDGE_TYPE_CONTAIN)
+    for relative in ("src/service.py", "src/other.py", "src/model.py"):
+        graph._add_edge("src", relative, EDGE_TYPE_CONTAIN)
+    graph._add_edge("src/service.py", "scip:service:BillingService", EDGE_TYPE_CONTAIN)
+    graph._add_edge(
+        "scip:service:BillingService",
+        "scip:service:BillingService.calculate_tax",
+        EDGE_TYPE_CONTAIN,
+    )
+    graph._add_edge("src/service.py", "scip:service:helper", EDGE_TYPE_CONTAIN)
+    graph._add_edge("src/other.py", "scip:other:helper", EDGE_TYPE_CONTAIN)
+    graph._add_edge("src/model.py", "scip:model:TaxRule", EDGE_TYPE_CONTAIN)
+    graph._add_edge(
+        "scip:service:BillingService.calculate_tax",
+        "scip:service:helper",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="src/service.py",
+        anchor_line=3,
+    )
+    graph._add_edge("src/service.py", "src/model.py", EDGE_TYPE_IMPORT)
+    graph._add_edge(
+        "scip:service:BillingService",
+        "scip:model:TaxRule",
+        EDGE_TYPE_TYPE_USE,
+    )
+    graph.build_range_indexes()
+    return graph
+
+
+@pytest.fixture()
+def integration_manifest(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    graph = build_integration_graph(repo_root)
+
+    graph_dir = tmp_path / "symbol_graph"
+    graph_dir.mkdir()
+    graph_path = graph_dir / "graph.pkl"
+    graph.save_graph(str(graph_path))
+
+    bm25_dir = tmp_path / "bm25"
+    bm25_dir.mkdir()
+    bm25 = BM25CodeIndexer()
+    bm25.build_index_from_graph(graph)
+    bm25.save_index(str(bm25_dir))
+
+    manifest = RepoManifest(
+        repo_path=str(repo_root),
+        commit="integration-fixture",
+        languages=["python"],
+        indexes={
+            "symbol_graph": IndexEntry(
+                index_type="symbol_graph",
+                path=str(graph_path),
+                built_at="2026-07-30T00:00:00Z",
+                built_at_epoch=1_785_369_600.0,
+                status="fresh",
+            ),
+            "bm25": IndexEntry(
+                index_type="bm25",
+                path=str(bm25_dir),
+                built_at="2026-07-30T00:00:00Z",
+                built_at_epoch=1_785_369_600.0,
+                status="fresh",
+            ),
+        },
+    )
+    manifest.derive_capabilities()
+    manifest_path = tmp_path / "repo_manifest.json"
+    manifest.save(manifest_path)
+    return manifest_path

--- a/test/integrations/contracts/locagent_openhands_efe287c.yaml
+++ b/test/integrations/contracts/locagent_openhands_efe287c.yaml
@@ -1,0 +1,27 @@
+behavior_revision: ef170542a5cca88a1bd8463335ec43de222ed5f9
+integration_revision: efe287ce3402706a171b3a5fb40f15914e98ef20
+tools:
+  explore_tree_structure:
+    required:
+      - start_entities
+    properties:
+      start_entities: array
+      direction: string
+      traversal_depth: integer
+      entity_type_filter:
+        - array
+        - "null"
+      dependency_type_filter:
+        - array
+        - "null"
+  get_entity_contents:
+    required:
+      - entity_names
+    properties:
+      entity_names: array
+  search_code_snippets:
+    required: []
+    properties:
+      search_terms: array
+      line_nums: array
+      file_path_or_pattern: string

--- a/test/integrations/test_locagent.py
+++ b/test/integrations/test_locagent.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.integrations import (
+    IntegrationCapabilityError,
+    RepositoryAdapter,
+    RepositoryPathError,
+)
+from codenib.integrations.locagent import (
+    LOCAGENT_REVISION,
+    OPENHANDS_LOCAGENT_REVISION,
+    LocAgentToolProvider,
+    bind_locagent_tools,
+    dispatch_locagent_tool_call,
+    get_locagent_tool_schemas,
+)
+
+
+@pytest.fixture()
+def provider(integration_manifest: Path) -> LocAgentToolProvider:
+    return LocAgentToolProvider.from_manifest(integration_manifest)
+
+
+def _schema_contract(schemas: list[dict]) -> dict:
+    tools = {}
+    for schema in schemas:
+        function = schema["function"]
+        parameters = function["parameters"]
+        tools[function["name"]] = {
+            "required": parameters.get("required", []),
+            "properties": {
+                name: value["type"] for name, value in parameters["properties"].items()
+            },
+        }
+    return {
+        "behavior_revision": LOCAGENT_REVISION,
+        "integration_revision": OPENHANDS_LOCAGENT_REVISION,
+        "tools": dict(sorted(tools.items())),
+    }
+
+
+def test_pinned_openhands_tool_contract() -> None:
+    contract_path = (
+        Path(__file__).parent / "contracts" / "locagent_openhands_efe287c.yaml"
+    )
+    expected = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+
+    assert _schema_contract(get_locagent_tool_schemas()) == expected
+
+
+def test_tool_schema_results_are_independent() -> None:
+    first = get_locagent_tool_schemas()
+    first[0]["function"]["name"] = "mutated"
+
+    assert get_locagent_tool_schemas()[0]["function"]["name"] == (
+        "search_code_snippets"
+    )
+
+
+def test_exact_entity_returns_one_based_numbered_source(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.get_entity_contents(
+        ["src/service.py:BillingService.calculate_tax"]
+    )
+
+    assert "Found function `src/service.py:BillingService.calculate_tax`" in result
+    assert "(lines 2-4)" in result
+    assert "2 |     def calculate_tax" in result
+    assert "4 |         return helper(amount)" in result
+
+
+def test_ambiguous_symbol_lists_repository_relative_candidates(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.get_entity_contents(["helper"])
+
+    assert "Multiple entities match `helper`" in result
+    assert "`src/other.py:helper`" in result
+    assert "`src/service.py:helper`" in result
+    assert "/tmp/" not in result
+
+
+def test_keyword_search_uses_prebuilt_bm25(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.search_code_snippets(
+        search_terms=["invoice sales computation"],
+        file_path_or_pattern="src/*.py",
+    )
+
+    assert "src/service.py:BillingService.calculate_tax" in result
+    assert "Compute sales tax for an invoice" in result
+
+
+def test_file_glob_restricts_symbol_matches(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.search_code_snippets(
+        search_terms=["helper"],
+        file_path_or_pattern="src/service.py",
+    )
+
+    assert "src/service.py:helper" in result
+    assert "src/other.py:helper" not in result
+
+
+def test_line_lookup_returns_narrowest_containing_symbol(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.search_code_snippets(
+        line_nums=[3],
+        file_path_or_pattern="src/service.py",
+    )
+
+    assert "src/service.py:BillingService.calculate_tax" in result
+    assert "(lines 2-4)" in result
+
+
+def test_uncovered_line_uses_bounded_source_window(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.search_code_snippets(
+        line_nums=[5],
+        file_path_or_pattern="src/service.py",
+    )
+
+    assert "Found code snippet in file `src/service.py`" in result
+    assert "5 | " in result
+
+
+def test_reference_traversal_discloses_broader_relation(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.explore_tree_structure(
+        ["src/service.py:BillingService.calculate_tax"],
+        dependency_type_filter=["invokes"],
+        traversal_depth=1,
+    )
+
+    assert "invokes -> src/service.py:helper" in result
+    assert "conservative superset of calls" in result
+
+
+def test_upstream_traversal_marks_incoming_direction(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.explore_tree_structure(
+        ["src/service.py:helper"],
+        direction="upstream",
+        dependency_type_filter=["invokes"],
+        traversal_depth=1,
+    )
+
+    assert "<- invokes - src/service.py:BillingService.calculate_tax" in result
+
+
+def test_exact_containment_traversal_has_no_fidelity_warning(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.explore_tree_structure(
+        ["src/service.py:BillingService"],
+        dependency_type_filter=["contains"],
+        traversal_depth=1,
+    )
+
+    assert "contains -> src/service.py:BillingService.calculate_tax" in result
+    assert "Relation fidelity:" not in result
+
+
+def test_root_tree_uses_graph_files(provider: LocAgentToolProvider) -> None:
+    result = provider.explore_tree_structure(
+        ["/"],
+        dependency_type_filter=["contains"],
+        traversal_depth=3,
+    )
+
+    assert "src" in result
+    assert "service.py" in result
+    assert "README.md" in result
+
+
+def test_unlimited_root_tree_is_not_collapsed(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.explore_tree_structure(
+        ["/"],
+        dependency_type_filter=["contains"],
+        traversal_depth=-1,
+    )
+
+    assert "service.py" in result
+
+
+def test_openhands_style_bindings_and_json_dispatch(
+    provider: LocAgentToolProvider,
+) -> None:
+    bindings = bind_locagent_tools(provider)
+
+    assert set(bindings) == {
+        "search_code_snippets",
+        "get_entity_contents",
+        "explore_tree_structure",
+    }
+    result = dispatch_locagent_tool_call(
+        provider,
+        "get_entity_contents",
+        '{"entity_names":["src/model.py:TaxRule"]}',
+    )
+    assert "src/model.py:TaxRule" in result
+
+    with pytest.raises(KeyError, match="unknown LocAgent tool"):
+        dispatch_locagent_tool_call(provider, "bash", {})
+
+
+def test_repository_path_escape_is_rejected(
+    provider: LocAgentToolProvider,
+) -> None:
+    with pytest.raises(RepositoryPathError, match="traversal"):
+        provider.repository.source_path("../outside.py")
+
+    with pytest.raises(RepositoryPathError, match="absolute"):
+        provider.repository.source_path("/etc/passwd")
+
+
+def test_missing_graph_fails_explicitly(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = RepoManifest(repo_path=str(repo), commit="current")
+    context = SimpleNamespace(
+        manifest=manifest,
+        symbol_graph=None,
+        errors={},
+    )
+
+    with pytest.raises(
+        IntegrationCapabilityError, match="required 'symbol_graph' view"
+    ):
+        LocAgentToolProvider(context)
+
+
+def test_stale_graph_fails_explicitly(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        commit="new",
+        indexes={
+            "symbol_graph": IndexEntry(
+                index_type="symbol_graph",
+                path=str(tmp_path / "graph.pkl"),
+                built_at="2026-07-30T00:00:00Z",
+                built_at_epoch=1_785_369_600.0,
+                status="fresh",
+                commit="old",
+            )
+        },
+    )
+    context = SimpleNamespace(
+        manifest=manifest,
+        symbol_graph=None,
+        errors={},
+    )
+
+    with pytest.raises(IntegrationCapabilityError, match="source identity is stale"):
+        RepositoryAdapter(context)
+
+
+def test_keyword_search_without_bm25_fails_at_operation_boundary(
+    integration_manifest: Path,
+) -> None:
+    provider = LocAgentToolProvider.from_manifest(integration_manifest)
+    provider.context.bm25 = None
+    provider.context.manifest.indexes.pop("bm25")
+
+    assert "TaxRule" in provider.get_entity_contents(["src/model.py:TaxRule"])
+    with pytest.raises(IntegrationCapabilityError, match="required 'bm25' view"):
+        provider.search_code_snippets(search_terms=["unindexed prose"])
+
+
+def test_loading_provider_creates_no_foreign_index_directory(
+    integration_manifest: Path,
+) -> None:
+    repo_root = Path(RepoManifest.load(integration_manifest).repo_path)
+    before = sorted(path.relative_to(repo_root) for path in repo_root.rglob("*"))
+
+    LocAgentToolProvider.from_manifest(integration_manifest)
+
+    after = sorted(path.relative_to(repo_root) for path in repo_root.rglob("*"))
+    assert after == before
+    assert not (repo_root / "_index_data").exists()

--- a/test/integrations/test_locagent.py
+++ b/test/integrations/test_locagent.py
@@ -16,6 +16,7 @@ from codenib.integrations import (
     RepositoryAdapter,
     RepositoryPathError,
 )
+from codenib.integrations._repository import RepositoryEntity, RepositoryRelation
 from codenib.integrations.locagent import (
     LOCAGENT_REVISION,
     OPENHANDS_LOCAGENT_REVISION,
@@ -24,6 +25,7 @@ from codenib.integrations.locagent import (
     dispatch_locagent_tool_call,
     get_locagent_tool_schemas,
 )
+from codenib.types import EDGE_TYPE_REFERENCE, NODE_TYPE_FUNCTION
 
 
 @pytest.fixture()
@@ -89,6 +91,15 @@ def test_ambiguous_symbol_lists_repository_relative_candidates(
     assert "`src/other.py:helper`" in result
     assert "`src/service.py:helper`" in result
     assert "/tmp/" not in result
+
+
+def test_dotfile_path_keeps_its_leading_period(
+    provider: LocAgentToolProvider,
+) -> None:
+    result = provider.get_entity_contents([".github/workflows/ci.yml."])
+
+    assert "`.github/workflows/ci.yml`" in result
+    assert "name: CI" in result
 
 
 def test_keyword_search_uses_prebuilt_bm25(
@@ -202,6 +213,47 @@ def test_unlimited_root_tree_is_not_collapsed(
     assert "service.py" in result
 
 
+def test_unlimited_traversal_uses_node_budget_not_hidden_depth_cap(
+    provider: LocAgentToolProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nodes = [
+        RepositoryEntity(
+            vertex_id=index,
+            canonical_name=f"node-{index}",
+            display_name=f"node-{index}",
+            kind=NODE_TYPE_FUNCTION,
+            file_path="src/service.py",
+            qualified_name=f"node_{index}",
+            simple_name=f"node_{index}",
+            start_line=0,
+            end_line=0,
+        )
+        for index in range(26)
+    ]
+
+    def adjacent(entity, **_kwargs):
+        if entity.vertex_id + 1 >= len(nodes):
+            return []
+        return [
+            RepositoryRelation(
+                source=entity,
+                target=nodes[entity.vertex_id + 1],
+                edge_type=EDGE_TYPE_REFERENCE,
+            )
+        ]
+
+    monkeypatch.setattr(provider.repository, "adjacent", adjacent)
+    traversed = provider.repository.traverse(
+        nodes[0],
+        depth=-1,
+        max_nodes=len(nodes),
+    )
+
+    assert len(traversed) == 25
+    assert traversed[-1][0] == 25
+
+
 def test_openhands_style_bindings_and_json_dispatch(
     provider: LocAgentToolProvider,
 ) -> None:
@@ -247,6 +299,25 @@ def test_missing_graph_fails_explicitly(tmp_path: Path) -> None:
         IntegrationCapabilityError, match="required 'symbol_graph' view"
     ):
         LocAgentToolProvider(context)
+
+
+def test_optional_adapter_distance_fails_explicitly_without_graph(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    context = SimpleNamespace(
+        manifest=RepoManifest(repo_path=str(repo), commit="current"),
+        symbol_graph=None,
+        errors={},
+    )
+    adapter = RepositoryAdapter(context, require_graph=False)
+
+    with pytest.raises(
+        IntegrationCapabilityError,
+        match="required 'symbol_graph' view",
+    ):
+        adapter.distance("first", "second")
 
 
 def test_stale_graph_fails_explicitly(tmp_path: Path) -> None:

--- a/test/integrations/test_locagent.py
+++ b/test/integrations/test_locagent.py
@@ -203,14 +203,20 @@ def test_root_tree_uses_graph_files(provider: LocAgentToolProvider) -> None:
 
 def test_unlimited_root_tree_is_not_collapsed(
     provider: LocAgentToolProvider,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    deep_file = "/".join(
+        [f"directory_{index}" for index in range(101)] + ["terminal.py"]
+    )
+    monkeypatch.setattr(provider.repository, "_files", (deep_file,))
+
     result = provider.explore_tree_structure(
         ["/"],
         dependency_type_filter=["contains"],
         traversal_depth=-1,
     )
 
-    assert "service.py" in result
+    assert "terminal.py" in result
 
 
 def test_unlimited_traversal_uses_node_budget_not_hidden_depth_cap(
@@ -293,6 +299,10 @@ def test_openhands_style_bindings_and_json_dispatch(
 
     with pytest.raises(KeyError, match="unknown LocAgent tool"):
         dispatch_locagent_tool_call(provider, "bash", {})
+    with pytest.raises(ValueError, match="valid JSON object"):
+        dispatch_locagent_tool_call(provider, "get_entity_contents", "{")
+    with pytest.raises(ValueError, match="decode to a JSON object"):
+        dispatch_locagent_tool_call(provider, "get_entity_contents", "[]")
 
 
 def test_repository_path_escape_is_rejected(

--- a/test/integrations/test_locagent.py
+++ b/test/integrations/test_locagent.py
@@ -269,7 +269,27 @@ def test_openhands_style_bindings_and_json_dispatch(
         "get_entity_contents",
         '{"entity_names":["src/model.py:TaxRule"]}',
     )
+    search_result = dispatch_locagent_tool_call(
+        provider,
+        "search_code_snippets",
+        {
+            "search_terms": ["invoice sales computation"],
+            "file_path_or_pattern": "src/*.py",
+        },
+    )
+    graph_result = dispatch_locagent_tool_call(
+        provider,
+        "explore_tree_structure",
+        {
+            "start_entities": ["src/service.py:BillingService.calculate_tax"],
+            "dependency_type_filter": ["invokes"],
+            "traversal_depth": 1,
+        },
+    )
+
     assert "src/model.py:TaxRule" in result
+    assert "src/service.py:BillingService.calculate_tax" in search_result
+    assert "invokes -> src/service.py:helper" in graph_result
 
     with pytest.raises(KeyError, match="unknown LocAgent tool"):
         dispatch_locagent_tool_call(provider, "bash", {})

--- a/test/integrations/test_locagent_upstream.py
+++ b/test/integrations/test_locagent_upstream.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional source-level probe for the pinned LocAgent/OpenHands contracts."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import yaml
+
+from codenib.integrations.locagent import (
+    LOCAGENT_REVISION,
+    OPENHANDS_LOCAGENT_REVISION,
+    LocAgentToolProvider,
+    get_locagent_tool_schemas,
+)
+
+pytestmark = pytest.mark.integration
+
+_LOCAGENT_REPO_OPS = "plugins/location_tools/repo_ops/repo_ops.py"
+_OPENHANDS_TOOL_FILES = (
+    "openhands/agenthub/loc_agent/tools/search_content.py",
+    "openhands/agenthub/loc_agent/tools/explore_structure.py",
+)
+_LOCAGENT_FUNCTIONS = (
+    "search_code_snippets",
+    "get_entity_contents",
+    "explore_graph_structure",
+    "explore_tree_structure",
+)
+
+
+def _git_show(checkout: Path, revision: str, path: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "show", f"{revision}:{path}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"{checkout} does not contain {path} at pinned revision {revision}")
+    return result.stdout
+
+
+@pytest.fixture(scope="module")
+def upstream_sources() -> SimpleNamespace:
+    raw_locagent = os.environ.get("LOCAGENT_CHECKOUT")
+    raw_openhands = os.environ.get("OPENHANDS_CHECKOUT")
+    if not raw_locagent or not raw_openhands:
+        pytest.skip(
+            "set LOCAGENT_CHECKOUT and OPENHANDS_CHECKOUT for the upstream probe"
+        )
+    locagent = Path(raw_locagent).expanduser().resolve()
+    openhands = Path(raw_openhands).expanduser().resolve()
+    if not (locagent / ".git").exists() or not (openhands / ".git").exists():
+        pytest.fail("upstream probe paths must be Git checkouts")
+
+    return SimpleNamespace(
+        locagent_repo_ops=_git_show(
+            locagent,
+            LOCAGENT_REVISION,
+            _LOCAGENT_REPO_OPS,
+        ),
+        openhands_tools=[
+            _git_show(openhands, OPENHANDS_LOCAGENT_REVISION, path)
+            for path in _OPENHANDS_TOOL_FILES
+        ],
+    )
+
+
+def _function_signatures(source: str) -> dict[str, dict[str, Any]]:
+    tree = ast.parse(source)
+    signatures = {}
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name not in _LOCAGENT_FUNCTIONS:
+            continue
+        parameters = [argument.arg for argument in node.args.args]
+        defaults = {}
+        offset = len(parameters) - len(node.args.defaults)
+        for parameter, default in zip(
+            parameters[offset:],
+            node.args.defaults,
+            strict=True,
+        ):
+            defaults[parameter] = ast.literal_eval(default)
+        signatures[node.name] = {
+            "parameters": parameters,
+            "defaults": defaults,
+        }
+    return signatures
+
+
+def _provider_signatures(provider: LocAgentToolProvider) -> dict[str, dict[str, Any]]:
+    signatures = {}
+    for name in _LOCAGENT_FUNCTIONS:
+        signature = inspect.signature(getattr(provider, name))
+        signatures[name] = {
+            "parameters": list(signature.parameters),
+            "defaults": {
+                parameter.name: parameter.default
+                for parameter in signature.parameters.values()
+                if parameter.default is not inspect.Parameter.empty
+            },
+        }
+    return signatures
+
+
+def _dict_items(node: ast.AST) -> dict[str, ast.AST]:
+    if not isinstance(node, ast.Dict):
+        raise AssertionError(f"expected dictionary, found {ast.dump(node)}")
+    return {
+        str(ast.literal_eval(key)): value
+        for key, value in zip(node.keys, node.values, strict=True)
+        if key is not None
+    }
+
+
+def _parameter_shape(
+    node: ast.AST,
+    assignments: dict[str, ast.AST],
+) -> dict[str, Any]:
+    if isinstance(node, ast.Name):
+        node = assignments[node.id]
+    parameters = _dict_items(node)
+    properties = _dict_items(parameters["properties"])
+    return {
+        "required": ast.literal_eval(parameters["required"]),
+        "properties": {
+            name: ast.literal_eval(_dict_items(specification)["type"])
+            for name, specification in properties.items()
+        },
+    }
+
+
+def _openhands_tool_contract(sources: list[str]) -> dict[str, dict[str, Any]]:
+    tools = {}
+    for source in sources:
+        tree = ast.parse(source)
+        assignments = {
+            target.id: node.value
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        }
+        for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+            function_name = (
+                call.func.id
+                if isinstance(call.func, ast.Name)
+                else getattr(call.func, "attr", "")
+            )
+            if function_name != "ChatCompletionToolParamFunctionChunk":
+                continue
+            keywords = {
+                keyword.arg: keyword.value
+                for keyword in call.keywords
+                if keyword.arg is not None
+            }
+            name_node = keywords.get("name")
+            parameters_node = keywords.get("parameters")
+            if not isinstance(name_node, ast.Constant) or parameters_node is None:
+                continue
+            name = str(name_node.value)
+            if name in {
+                "search_code_snippets",
+                "get_entity_contents",
+                "explore_tree_structure",
+            }:
+                tools[name] = _parameter_shape(parameters_node, assignments)
+    return dict(sorted(tools.items()))
+
+
+def test_original_locagent_function_signatures(
+    upstream_sources: SimpleNamespace,
+    integration_manifest: Path,
+) -> None:
+    provider = LocAgentToolProvider.from_manifest(integration_manifest)
+
+    assert _provider_signatures(provider) == _function_signatures(
+        upstream_sources.locagent_repo_ops
+    )
+
+
+def test_openhands_function_schemas_match_frozen_contract(
+    upstream_sources: SimpleNamespace,
+) -> None:
+    contract_path = (
+        Path(__file__).parent / "contracts" / "locagent_openhands_efe287c.yaml"
+    )
+    expected = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+    current = {
+        schema["function"]["name"]: {
+            "required": schema["function"]["parameters"].get("required", []),
+            "properties": {
+                name: specification["type"]
+                for name, specification in schema["function"]["parameters"][
+                    "properties"
+                ].items()
+            },
+        }
+        for schema in get_locagent_tool_schemas()
+    }
+
+    assert (
+        _openhands_tool_contract(upstream_sources.openhands_tools) == expected["tools"]
+    )
+    assert dict(sorted(current.items())) == expected["tools"]


### PR DESCRIPTION
## Summary

Add a manifest-backed LocAgent/OpenHands compatibility provider over CodeNib's existing repository views. The provider preserves the pinned tool contracts while keeping CodeNib's `ServerContext` as the only owner of source, BM25, and graph state.

Closes #386.

## Changes
- Add a read-only integration boundary for safe source reads, symbol translation, deterministic disambiguation, unlimited or bounded graph traversal, and graph-derived skeletons.
- Implement `search_code_snippets`, `get_entity_contents`, `explore_tree_structure`, the graph alias, dependency-free OpenAI schemas, and direct OpenHands-style bindings.
- Pin behavioral compatibility to LocAgent `ef17054` and integration compatibility to OpenHands `efe287c`; disclose broader `reference -> invokes` and `type-use -> inherits` mappings in output.
- Add public integration documentation, a pinned schema fixture, real manifest/BM25/CodeGraph smoke coverage, stale-view checks, path isolation, no-hidden-build assertions, and source-level upstream probes.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/integrations/test_locagent.py --tb=short` (`22 passed`)

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2145 passed, 10 skipped, 170 deselected`)

`LOCAGENT_CHECKOUT=/tmp/codenib-compat-locagent-20260730 OPENHANDS_CHECKOUT=/tmp/codenib-compat-openhands-20260730 pytest -q test/integrations/test_locagent_upstream.py --tb=short` (`2 passed`)

`mkdocs build --strict --site-dir /tmp/codenib-docs-locagent`

`python -m build --wheel --outdir /tmp/codenib-locagent-wheel`

Pre-commit passed over every changed file.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published