### PR TITLE
feat(integrations): back OrcaLoca with repository views

### DIFF
--- a/codenib/integrations/_repository.py
+++ b/codenib/integrations/_repository.py
@@ -334,6 +334,30 @@ class RepositoryAdapter:
         candidates = self.find_entities(file_path, kinds={NODE_TYPE_FILE})
         return candidates[0] if len(candidates) == 1 else None
 
+    def entity_by_canonical(self, canonical_name: str) -> RepositoryEntity | None:
+        return self._entity_by_canonical.get(canonical_name)
+
+    def parent(self, entity: RepositoryEntity) -> RepositoryEntity | None:
+        if entity.parent_name is None:
+            return None
+        return self._entity_by_canonical.get(entity.parent_name)
+
+    def entities_in_file(
+        self,
+        file_path: str,
+        *,
+        kinds: Iterable[str] | None = None,
+    ) -> list[RepositoryEntity]:
+        files = self.find_files(file_path)
+        if len(files) != 1:
+            return []
+        allowed = set(kinds or ())
+        return [
+            entity
+            for entity in self._entities
+            if entity.file_path == files[0] and (not allowed or entity.kind in allowed)
+        ]
+
     def find_entities(
         self,
         query: str,
@@ -537,7 +561,7 @@ class RepositoryAdapter:
         return output
 
     def distance(self, first: str, second: str) -> int:
-        """Return an undirected graph hop distance, or ``-1`` if unresolved."""
+        """Return the shorter directed distance, or ``-1`` if unresolved."""
 
         if self.graph is None:
             self.require_view("symbol_graph", "symbol_graph")
@@ -545,12 +569,20 @@ class RepositoryAdapter:
         right = self.find_entities(second)
         if len(left) != 1 or len(right) != 1:
             return -1
-        distance = self.graph.graph.distances(
-            [left[0].vertex_id], [right[0].vertex_id], mode="all"
+        forward = self.graph.graph.distances(
+            [left[0].vertex_id], [right[0].vertex_id], mode="out"
         )[0][0]
-        if isinstance(distance, float) and math.isinf(distance):
+        backward = self.graph.graph.distances(
+            [right[0].vertex_id], [left[0].vertex_id], mode="out"
+        )[0][0]
+        finite = [
+            distance
+            for distance in (forward, backward)
+            if not (isinstance(distance, float) and math.isinf(distance))
+        ]
+        if not finite:
             return -1
-        return int(distance)
+        return int(min(finite))
 
     def file_tree(self, name: str | None = None, max_depth: int | None = None) -> str:
         """Render a deterministic tree from files represented in the graph."""
@@ -771,6 +803,7 @@ class RepositoryAdapter:
         yield entity.locagent_id
         yield entity.orcaloca_id
         yield entity.qualified_name
+        yield entity.qualified_name.replace(".", "::")
         yield entity.simple_name
         if entity.file_path:
             yield entity.file_path

--- a/codenib/integrations/orcaloca.py
+++ b/codenib/integrations/orcaloca.py
@@ -1,0 +1,829 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""OrcaLoca search-manager compatibility over CodeNib repository views.
+
+The upstream search policy is coupled to several private ``SearchManager``
+helpers in addition to its six tools.  This provider implements that pinned
+duck-typed surface while keeping OrcaLoca's policy, LlamaIndex wrappers, and
+queue/scoring types outside CodeNib.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, NamedTuple, Sequence
+
+from ..types import (
+    DEPENDENCY_EDGE_TYPES,
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FIELD,
+    NODE_TYPE_FILE,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NODE_TYPE_SYMBOL,
+)
+from ._repository import RepositoryAdapter, RepositoryEntity, RepositoryPathError
+
+ORCALOCA_REVISION = "37db289be2dc3b7432183fe08b3f06becce87c27"
+
+ORCALOCA_TOOL_NAMES = (
+    "search_file_contents",
+    "search_source_code",
+    "search_class",
+    "search_method_in_class",
+    "search_callable",
+    "search_file_tree",
+)
+
+ORCALOCA_MANAGER_HOOKS = (
+    "_get_class_methods",
+    "_get_disambiguous_classes",
+    "_get_disambiguous_files",
+    "_get_disambiguous_methods",
+    "_get_exact_loc",
+    "_get_file_functions",
+    "check_and_add_query",
+    "get_distance_between_queries",
+    "get_frame_from_history",
+    "get_node_existence",
+    "get_query_from_history",
+)
+
+ORCALOCA_HISTORY_FIELDS = (
+    "search_action",
+    "search_input",
+    "search_query",
+    "search_content",
+    "query_type",
+    "file_path",
+    "is_skeleton",
+)
+
+_CALLABLE_KINDS = {
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NODE_TYPE_SYMBOL,
+    NODE_TYPE_FIELD,
+}
+_METHOD_KINDS = {NODE_TYPE_METHOD, NODE_TYPE_FUNCTION, NODE_TYPE_SYMBOL}
+_NO_PATH = 999_999
+
+
+class OrcaLocation(NamedTuple):
+    """Dependency-free equivalent of OrcaLoca's ``Loc`` named tuple."""
+
+    file_name: str
+    node_name: str
+    start_line: int
+    end_line: int
+
+
+@dataclass(frozen=True, slots=True)
+class OrcaLocationInfo:
+    """Dependency-free equivalent of OrcaLoca's ``LocInfo`` wrapper."""
+
+    loc: OrcaLocation
+    type: str
+
+
+class OrcaLocaSearchProvider:
+    """Duck-typed replacement for OrcaLoca's pinned ``SearchManager``."""
+
+    def __init__(
+        self,
+        context: Any,
+        *,
+        file_skeleton_threshold: int = 200,
+        class_skeleton_threshold: int = 100,
+        max_output_chars: int = 48_000,
+    ) -> None:
+        self.repository = RepositoryAdapter(context, require_graph=True)
+        self.repo_path = str(self.repository.repo_root)
+        self.file_skeleton_threshold = max(1, int(file_skeleton_threshold))
+        self.class_skeleton_threshold = max(1, int(class_skeleton_threshold))
+        self.max_output_chars = max(2_000, int(max_output_chars))
+        self.history: list[dict[str, Any]] = []
+        self.history_query_set: set[str] = set()
+
+    @classmethod
+    def from_manifest(
+        cls, manifest_path: str | Path, **kwargs: Any
+    ) -> "OrcaLocaSearchProvider":
+        from ..mcp.context import ServerContext
+
+        return cls(ServerContext.load(manifest_path), **kwargs)
+
+    @property
+    def context(self) -> Any:
+        return self.repository.context
+
+    # ------------------------------------------------------------------
+    # Upstream manager state and policy hooks
+    # ------------------------------------------------------------------
+
+    def add_result_to_history(self, new_row: Mapping[str, Any]) -> None:
+        row = {field: new_row.get(field) for field in ORCALOCA_HISTORY_FIELDS}
+        row["is_skeleton"] = bool(row["is_skeleton"])
+        self.history.append(row)
+
+    def get_frame_from_history(self, action: str, input: str) -> dict[str, Any] | None:
+        for row in self.history:
+            if row["search_action"] == action and row["search_input"] == input:
+                return dict(row)
+        return None
+
+    def get_query_from_history(self, action: str, input: str) -> str | None:
+        row = self.get_frame_from_history(action, input)
+        if row is None:
+            return None
+        query = row.get("search_query")
+        return str(query) if query is not None else None
+
+    def check_and_add_query(self, query: str) -> bool:
+        if query in self.history_query_set:
+            return True
+        if self.get_node_existence(query):
+            self.history_query_set.add(query)
+        return False
+
+    def get_node_existence(self, query: str | None) -> bool:
+        if not query:
+            return False
+        if len(self.repository.find_files(query)) == 1:
+            return True
+        return len(self.repository.find_entities(query)) == 1
+
+    def get_distance_between_queries(
+        self, query1: str | None, query2: str | None
+    ) -> int:
+        if query1 is None or query2 is None:
+            return -1
+        if not self.get_node_existence(query1) or not self.get_node_existence(query2):
+            return _NO_PATH
+        distance = self.repository.distance(query1, query2)
+        return distance if distance >= 0 else _NO_PATH
+
+    def _get_exact_loc(self, query: str) -> OrcaLocationInfo | None:
+        files = self.repository.find_files(query)
+        if len(files) == 1 and query.replace("\\", "/").strip("/") == files[0]:
+            entity = self.repository.entity_for_file(files[0])
+            return self._location_info(entity) if entity else None
+        entities = self.repository.find_entities(query)
+        source_backed = [entity for entity in entities if self._has_source(entity)]
+        if len(source_backed) != 1:
+            return None
+        return self._location_info(source_backed[0])
+
+    def _get_dependency(self, query: str) -> list[OrcaLocation] | None:
+        entities = self.repository.find_entities(query)
+        if len(entities) != 1:
+            return None
+        entity = entities[0]
+        locations: list[OrcaLocation] = []
+        seen: set[str] = set()
+        for relation in self.repository.adjacent(
+            entity,
+            direction="downstream",
+            edge_types=DEPENDENCY_EDGE_TYPES,
+        ):
+            target = relation.target
+            if target.canonical_name in seen or not self._has_source(target):
+                continue
+            seen.add(target.canonical_name)
+            locations.append(self._location(target))
+        parent = self.repository.parent(entity)
+        if (
+            parent is not None
+            and parent.kind == NODE_TYPE_CLASS
+            and parent.canonical_name not in seen
+            and self._has_source(parent)
+        ):
+            locations.append(self._location(parent))
+        return locations
+
+    def _get_query_in_file(self, file_path: str, query: str) -> OrcaLocationInfo | None:
+        entities = self.repository.find_entities(query, file_path=file_path)
+        source_backed = [entity for entity in entities if self._has_source(entity)]
+        if len(source_backed) != 1:
+            return None
+        return self._location_info(source_backed[0])
+
+    def _search_file_tree(
+        self, name: str | None = None, max_depth: int | None = None
+    ) -> str:
+        return self.repository.file_tree(name=name, max_depth=max_depth)
+
+    def _search_source_code(self, file_path: str, source_code: str) -> str:
+        files = self.repository.find_files(file_path)
+        if len(files) != 1:
+            return f"Cannot find the context of {source_code} in {file_path}"
+        normalized_query = self._normalize_code(source_code)
+        if not normalized_query:
+            return f"Cannot find the context of {source_code} in {files[0]}"
+
+        candidates: list[tuple[int, RepositoryEntity, str]] = []
+        for entity in self.repository.entities_in_file(files[0], kinds=_CALLABLE_KINDS):
+            if not self._has_source(entity):
+                continue
+            content = self._source(entity)
+            if normalized_query in self._normalize_code(content):
+                candidates.append((entity.line_count or _NO_PATH, entity, content))
+        if not candidates:
+            return f"Cannot find the context of {source_code} in {files[0]}"
+        _, _, content = min(
+            candidates,
+            key=lambda item: (
+                item[0],
+                item[1].start_line or 0,
+                item[1].orcaloca_id,
+            ),
+        )
+        return content
+
+    def _dfs_get_file_skeleton(self, file_name: str) -> tuple[OrcaLocation, str] | None:
+        files = self.repository.find_files(file_name)
+        if len(files) != 1:
+            return None
+        entity = self.repository.entity_for_file(files[0])
+        if entity is None:
+            return None
+        return self._location(entity), self._file_skeleton(entity)
+
+    def _direct_get_file_skeleton(self, file_node_name: str) -> str | None:
+        files = self.repository.find_files(file_node_name)
+        if len(files) != 1:
+            return None
+        entity = self.repository.entity_for_file(files[0])
+        return self._file_skeleton(entity) if entity else None
+
+    def _search_callable_kg(self, callable: str) -> OrcaLocationInfo | None:
+        entities = self.repository.find_entities(callable, kinds=_CALLABLE_KINDS)
+        source_backed = [entity for entity in entities if self._has_source(entity)]
+        if len(source_backed) != 1:
+            return None
+        return self._location_info(source_backed[0])
+
+    def _dfs_get_class(self, class_name: str) -> tuple[OrcaLocation, str] | None:
+        classes = self.repository.find_entities(class_name, kinds={NODE_TYPE_CLASS})
+        source_backed = [entity for entity in classes if self._has_source(entity)]
+        if len(source_backed) != 1:
+            return None
+        entity = source_backed[0]
+        return self._location(entity), self._class_skeleton(entity)
+
+    def _direct_get_class(self, class_node_name: str) -> str | None:
+        classes = self.repository.find_entities(
+            class_node_name, kinds={NODE_TYPE_CLASS}
+        )
+        if len(classes) != 1:
+            return None
+        return self._class_skeleton(classes[0])
+
+    def _get_class_methods(self, class_node_name: str) -> tuple[list[str], list[str]]:
+        classes = self.repository.find_entities(
+            class_node_name, kinds={NODE_TYPE_CLASS}
+        )
+        if len(classes) != 1:
+            return [], []
+        methods = [
+            child
+            for child in self.repository.children(classes[0])
+            if child.kind in _METHOD_KINDS and self._has_source(child)
+        ]
+        return (
+            [method.orcaloca_id for method in methods],
+            [self._source(method) for method in methods],
+        )
+
+    def _get_file_functions(self, file_node_name: str) -> tuple[list[str], list[str]]:
+        files = self.repository.find_files(file_node_name)
+        if len(files) != 1:
+            return [], []
+        file_entity = self.repository.entity_for_file(files[0])
+        if file_entity is None:
+            return [], []
+        functions = []
+        for child in self.repository.children(file_entity):
+            if child.kind in _METHOD_KINDS and self._has_source(child):
+                functions.append(child)
+            elif (
+                child.kind == NODE_TYPE_CLASS
+                and self._has_source(child)
+                and self._line_span(child) <= self.class_skeleton_threshold
+            ):
+                functions.append(child)
+        return (
+            [function.orcaloca_id for function in functions],
+            [self._source(function) for function in functions],
+        )
+
+    def _get_disambiguous_classes(self, class_name: str) -> list[str]:
+        return sorted(
+            {
+                entity.file_path
+                for entity in self.repository.find_entities(
+                    class_name, kinds={NODE_TYPE_CLASS}
+                )
+                if entity.file_path
+            }
+        )
+
+    def _get_disambiguous_files(self, file_name: str) -> list[str]:
+        return self.repository.find_files(file_name)
+
+    def _get_disambiguous_query_type(self, query: str) -> str | None:
+        entities = self.repository.find_entities(query, kinds=_CALLABLE_KINDS)
+        if not entities:
+            return None
+        return self._query_type(entities[0])
+
+    def _get_disambiguous_methods(
+        self,
+        method_name: str,
+        class_name: str | None = None,
+        file_path: str | None = None,
+    ) -> tuple[list[str], list[str]]:
+        methods = self.repository.find_entities(
+            method_name,
+            file_path=file_path,
+            kinds=_METHOD_KINDS,
+            class_name=class_name,
+        )
+        methods = [method for method in methods if self._has_source(method)]
+        return (
+            [method.orcaloca_id for method in methods],
+            [self._source(method) for method in methods],
+        )
+
+    def _get_bug_location(
+        self, query: str, file_path: str | None = None
+    ) -> dict[str, list[dict[str, str]]]:
+        entities = self.repository.find_entities(
+            query, file_path=file_path, kinds=_CALLABLE_KINDS
+        )
+        locations = []
+        for entity in entities:
+            query_type = self._query_type(entity)
+            locations.append(
+                {
+                    "file_path": entity.file_path,
+                    "class_name": (
+                        entity.simple_name
+                        if query_type == "class"
+                        else entity.class_name or ""
+                    ),
+                    "method_name": (
+                        entity.simple_name
+                        if query_type in {"method", "function"}
+                        else ""
+                    ),
+                }
+            )
+        return {"bug_locations": locations}
+
+    # ------------------------------------------------------------------
+    # Six functions exposed to OrcaLoca's agent
+    # ------------------------------------------------------------------
+
+    def get_search_functions(self) -> list[Callable[..., str]]:
+        return [
+            self.search_file_contents,
+            self.search_source_code,
+            self.search_class,
+            self.search_method_in_class,
+            self.search_callable,
+            self.search_file_tree,
+        ]
+
+    def search_file_tree(
+        self, name: str | None = None, max_depth: int | None = None
+    ) -> str:
+        """Return the repository file tree, optionally rooted at a directory."""
+
+        content = self._search_file_tree(name, max_depth)
+        self._record(
+            action="search_file_tree",
+            search_input=name,
+            query=name,
+            content=content,
+            query_type="file_tree",
+        )
+        return self._bounded(content)
+
+    def search_file_contents(
+        self, file_name: str, directory_path: str | None = None
+    ) -> str:
+        """Return one file's content or a graph-derived large-file skeleton."""
+
+        search_input = (
+            f"{directory_path.rstrip('/')}/{file_name}" if directory_path else file_name
+        )
+        files = self.repository.find_files(search_input)
+        if not directory_path:
+            files = self.repository.find_files(file_name)
+        if not files:
+            return f"Cannot find the file {file_name}"
+        if len(files) > 1:
+            content = self._disambiguation(
+                f"Multiple matches found for file {file_name}.", files=files
+            )
+            self._record(
+                action="search_file_contents",
+                search_input=search_input,
+                query=file_name,
+                content=content,
+                query_type="disambiguation",
+            )
+            return content
+
+        file_path = files[0]
+        entity = self.repository.entity_for_file(file_path)
+        if entity is None:
+            return f"Cannot find the file {file_name}"
+        source = self._source(entity)
+        line_count = len(source.splitlines())
+        is_skeleton = max(0, line_count - 1) > self.file_skeleton_threshold
+        content = self._file_skeleton(entity) if is_skeleton else source
+        self._record(
+            action="search_file_contents",
+            search_input=search_input,
+            query=entity.orcaloca_id,
+            content=content,
+            query_type="file",
+            file_path=file_path,
+            is_skeleton=is_skeleton,
+        )
+        marker = "File Skeleton" if is_skeleton else "File Content"
+        return self._bounded(f"File Path: {file_path} \n{marker}: \n{content}")
+
+    def search_source_code(self, file_path: str, source_code: str) -> str:
+        """Find the narrowest graph symbol containing a source fragment."""
+
+        content = self._search_source_code(file_path, source_code)
+        self._record(
+            action="search_source_code",
+            search_input=source_code,
+            query=source_code,
+            content=content,
+            query_type="source_code",
+            file_path=file_path,
+        )
+        return self._bounded(f"File Path: {file_path} \nCode Snippet: \n{content}")
+
+    def search_class(self, class_name: str, file_path: str | None = None) -> str:
+        """Return one class or ask the agent to disambiguate its file."""
+
+        search_input = f"{file_path}::{class_name}" if file_path else class_name
+        classes = self.repository.find_entities(
+            class_name, file_path=file_path, kinds={NODE_TYPE_CLASS}
+        )
+        classes = [entity for entity in classes if self._has_source(entity)]
+        if not classes:
+            suffix = f" in {file_path}" if file_path else ""
+            return f"Cannot find the class {class_name}{suffix}"
+        if len(classes) > 1:
+            content = self._disambiguation(
+                f"Multiple matched classes found about class: {class_name}.",
+                entities=classes,
+            )
+            self._record(
+                action="search_class",
+                search_input=search_input,
+                query=class_name,
+                content=content,
+                query_type="disambiguation",
+            )
+            return content
+
+        entity = classes[0]
+        is_skeleton = self._line_span(entity) > self.class_skeleton_threshold
+        content = self._class_skeleton(entity) if is_skeleton else self._source(entity)
+        self._record(
+            action="search_class",
+            search_input=search_input,
+            query=entity.orcaloca_id,
+            content=content,
+            query_type="class",
+            file_path=entity.file_path,
+            is_skeleton=is_skeleton,
+        )
+        marker = "Class Skeleton" if is_skeleton else "Class Content"
+        return self._bounded(f"File Path: {entity.file_path} \n{marker}: \n{content}")
+
+    def search_method_in_class(
+        self,
+        class_name: str,
+        method_name: str,
+        file_path: str | None = None,
+    ) -> str:
+        """Return a method constrained by class and optional file."""
+
+        search_input = (
+            f"{file_path}::{class_name}::{method_name}"
+            if file_path
+            else f"{class_name}::{method_name}"
+        )
+        methods = self.repository.find_entities(
+            method_name,
+            file_path=file_path,
+            kinds=_METHOD_KINDS,
+            class_name=class_name,
+        )
+        methods = [entity for entity in methods if self._has_source(entity)]
+        if not methods:
+            suffix = f" in {file_path}" if file_path else ""
+            return f"Cannot find the method {method_name} in {class_name}{suffix}"
+        if len(methods) > 1:
+            content = self._disambiguation(
+                f"Multiple matched methods found about method: {method_name} "
+                f"in class: {class_name}.",
+                entities=methods,
+            )
+            self._record(
+                action="search_method_in_class",
+                search_input=search_input,
+                query=method_name,
+                content=content,
+                query_type="disambiguation",
+            )
+            return content
+
+        entity = methods[0]
+        content = self._source(entity)
+        self._record(
+            action="search_method_in_class",
+            search_input=search_input,
+            query=entity.orcaloca_id,
+            content=content,
+            query_type="method",
+            file_path=entity.file_path,
+        )
+        return self._bounded(
+            f"File Path: {entity.file_path} \nMethod Content: \n{content}"
+        )
+
+    def search_callable(self, query_name: str, file_path: str | None = None) -> str:
+        """Return a class, function, method, or symbol definition."""
+
+        search_input = f"{file_path}::{query_name}" if file_path else query_name
+        entities = self.repository.find_entities(
+            query_name, file_path=file_path, kinds=_CALLABLE_KINDS
+        )
+        entities = [entity for entity in entities if self._has_source(entity)]
+        if not entities:
+            suffix = f" in {file_path}" if file_path else ""
+            return f"Cannot find the definition of {query_name}{suffix}"
+        if len(entities) > 1:
+            content = self._disambiguation(
+                f"Multiple matched callables found about query {query_name}.",
+                entities=entities,
+            )
+            self._record(
+                action="search_callable",
+                search_input=search_input,
+                query=query_name,
+                content=content,
+                query_type="disambiguation",
+                file_path=file_path or "",
+            )
+            return content
+
+        entity = entities[0]
+        query_type = self._query_type(entity)
+        is_skeleton = (
+            query_type == "class"
+            and self._line_span(entity) > self.class_skeleton_threshold
+        )
+        content = self._class_skeleton(entity) if is_skeleton else self._source(entity)
+        self._record(
+            action="search_callable",
+            search_input=search_input,
+            query=entity.orcaloca_id,
+            content=content,
+            query_type=query_type,
+            file_path=entity.file_path,
+            is_skeleton=is_skeleton,
+        )
+        marker = "Class Skeleton" if is_skeleton else "Code Snippet"
+        return self._bounded(
+            f"File Path: {entity.file_path} \n"
+            f"Query Type: {query_type} \n{marker}: \n{content}"
+        )
+
+    # ------------------------------------------------------------------
+    # Adapter-local helpers
+    # ------------------------------------------------------------------
+
+    def _record(
+        self,
+        *,
+        action: str,
+        search_input: Any,
+        query: Any,
+        content: str,
+        query_type: str,
+        file_path: str = "",
+        is_skeleton: bool = False,
+    ) -> None:
+        self.add_result_to_history(
+            {
+                "search_action": action,
+                "search_input": search_input,
+                "search_query": query,
+                "search_content": content,
+                "query_type": query_type,
+                "file_path": file_path,
+                "is_skeleton": is_skeleton,
+            }
+        )
+
+    def _location_info(self, entity: RepositoryEntity) -> OrcaLocationInfo:
+        return OrcaLocationInfo(
+            loc=self._location(entity),
+            type=self._query_type(entity),
+        )
+
+    def _location(self, entity: RepositoryEntity) -> OrcaLocation:
+        if entity.kind == NODE_TYPE_FILE:
+            line_count = max(1, len(self.repository.source_lines(entity.file_path)))
+            start_line, end_line = 1, line_count
+        elif entity.start_line is not None and entity.end_line is not None:
+            start_line, end_line = entity.start_line + 1, entity.end_line + 1
+        else:
+            raise RepositoryPathError(
+                f"entity has no source range: {entity.orcaloca_id}"
+            )
+        return OrcaLocation(
+            file_name=entity.file_path,
+            node_name=entity.orcaloca_id,
+            start_line=start_line,
+            end_line=end_line,
+        )
+
+    @staticmethod
+    def _query_type(entity: RepositoryEntity) -> str:
+        if entity.kind == NODE_TYPE_FILE:
+            return "file"
+        if entity.kind == NODE_TYPE_CLASS:
+            return "class"
+        if entity.kind == NODE_TYPE_METHOD or entity.class_name:
+            return "method"
+        return "function"
+
+    @staticmethod
+    def _has_source(entity: RepositoryEntity) -> bool:
+        return bool(
+            entity.file_path
+            and (
+                entity.kind == NODE_TYPE_FILE
+                or (entity.start_line is not None and entity.end_line is not None)
+            )
+        )
+
+    @staticmethod
+    def _line_span(entity: RepositoryEntity) -> int:
+        if entity.start_line is None or entity.end_line is None:
+            return _NO_PATH
+        return entity.end_line - entity.start_line
+
+    def _source(self, entity: RepositoryEntity) -> str:
+        content, _, _ = self.repository.read_entity(entity)
+        return content
+
+    def _signature(self, entity: RepositoryEntity) -> str:
+        if not self._has_source(entity):
+            return entity.simple_name
+        content, _, _ = self.repository.read_range(
+            entity.file_path, entity.start_line, entity.start_line
+        )
+        return content.strip() or entity.simple_name
+
+    def _class_skeleton(self, entity: RepositoryEntity) -> str:
+        lines = [f"Class Signature: {self._signature(entity)}"]
+        methods = [
+            child
+            for child in self.repository.children(entity)
+            if child.kind in _METHOD_KINDS
+        ]
+        for method in methods:
+            lines.extend(
+                [
+                    "",
+                    f"Method: {method.simple_name}",
+                    f"Method Signature: {self._signature(method)}",
+                ]
+            )
+        return "\n".join(lines)
+
+    def _file_skeleton(self, entity: RepositoryEntity) -> str:
+        lines: list[str] = []
+        for child in self.repository.children(entity):
+            query_type = self._query_type(child)
+            if query_type not in {"class", "function"}:
+                continue
+            lines.extend(
+                [
+                    f"{query_type.capitalize()}: {child.simple_name}",
+                    f"Signature: {self._signature(child)}",
+                    "",
+                ]
+            )
+        return "\n".join(lines).rstrip()
+
+    @staticmethod
+    def _normalize_code(value: str) -> str:
+        return re.sub(r"\s+", " ", str(value or "").strip())
+
+    @staticmethod
+    def _disambiguation(
+        heading: str,
+        *,
+        entities: Sequence[RepositoryEntity] = (),
+        files: Sequence[str] = (),
+    ) -> str:
+        lines = [heading]
+        if entities:
+            for index, entity in enumerate(entities, start=1):
+                lines.extend(
+                    [
+                        f"Possible Location {index}:",
+                        f"File Path: {entity.file_path}",
+                    ]
+                )
+                if entity.class_name:
+                    lines.append(f"Containing Class: {entity.class_name}")
+                lines.append("")
+        else:
+            for index, file_path in enumerate(files, start=1):
+                lines.extend(
+                    [
+                        f"Possible Location {index}:",
+                        f"File Path: {file_path}",
+                        "",
+                    ]
+                )
+        return "<Disambiguation>\n" + "\n".join(lines).rstrip() + "\n</Disambiguation>"
+
+    def _bounded(self, value: str) -> str:
+        if len(value) <= self.max_output_chars:
+            return value
+        marker = "\n\n[Output truncated by CodeNib's OrcaLoca adapter budget.]"
+        return value[: self.max_output_chars - len(marker)].rstrip() + marker
+
+
+def make_orcaloca_search_manager_factory(
+    manifest_path: str | Path,
+    **provider_options: Any,
+) -> Callable[[str], OrcaLocaSearchProvider]:
+    """Build the factory accepted by the proposed upstream injection seam."""
+
+    resolved_manifest = Path(manifest_path).expanduser().resolve()
+
+    def factory(repo_path: str) -> OrcaLocaSearchProvider:
+        provider = OrcaLocaSearchProvider.from_manifest(
+            resolved_manifest, **provider_options
+        )
+        requested = Path(repo_path).expanduser().resolve()
+        if requested != provider.repository.repo_root:
+            raise ValueError(
+                "OrcaLoca repo_path does not match the CodeNib manifest: "
+                f"{requested} != {provider.repository.repo_root}"
+            )
+        return provider
+
+    return factory
+
+
+def orcaloca_bug_location(
+    entity: RepositoryEntity,
+) -> dict[str, str]:
+    """Translate one CodeNib entity to OrcaLoca's final location schema."""
+
+    query_type = OrcaLocaSearchProvider._query_type(entity)
+    return {
+        "file_path": entity.file_path,
+        "class_name": (
+            entity.simple_name if query_type == "class" else entity.class_name or ""
+        ),
+        "method_name": (
+            entity.simple_name if query_type in {"method", "function"} else ""
+        ),
+    }
+
+
+__all__ = [
+    "ORCALOCA_HISTORY_FIELDS",
+    "ORCALOCA_MANAGER_HOOKS",
+    "ORCALOCA_REVISION",
+    "ORCALOCA_TOOL_NAMES",
+    "OrcaLocaSearchProvider",
+    "OrcaLocation",
+    "OrcaLocationInfo",
+    "make_orcaloca_search_manager_factory",
+    "orcaloca_bug_location",
+]

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -111,4 +111,79 @@ reference or type-use edges as exact call or inheritance facts.
 - Loading the provider never invokes LocAgent, OpenHands ACI, NetworkX,
   LlamaIndex, or an index builder.
 
-The base `codenib` package therefore gains no LocAgent or OpenHands dependency.
+## OrcaLoca
+
+The OrcaLoca provider replaces its repository data plane while retaining the
+upstream search policy. It implements the six functions exposed to the model:
+
+- `search_file_contents`
+- `search_source_code`
+- `search_class`
+- `search_method_in_class`
+- `search_callable`
+- `search_file_tree`
+
+It also implements the history, distance, exact-location, decomposition, and
+disambiguation hooks that OrcaLoca's `SearchWorker` calls directly. Those
+private hooks are a revision-scoped compatibility surface, not new CodeNib core
+APIs.
+
+Build a graph-enabled manifest and create the factory:
+
+```python
+from codenib.integrations.orcaloca import (
+    make_orcaloca_search_manager_factory,
+)
+
+search_manager_factory = make_orcaloca_search_manager_factory(
+    "/path/to/repo_manifest.json",
+)
+```
+
+With the small injection seam from
+[OrcaLoca PR #140](https://github.com/fishmingyu/OrcaLoca/pull/140), pass that
+factory to the unchanged search agent:
+
+```python
+from Orcar.search_agent import SearchAgent
+
+agent = SearchAgent(
+    llm=llm,
+    search_input=search_input,
+    repo_path="/path/to/repository",
+    search_manager_factory=search_manager_factory,
+)
+```
+
+The factory verifies that `repo_path` is the repository bound by the manifest.
+It loads no OrcaLoca graph and creates no `_index_data` directory. Each agent
+gets isolated lightweight query history, while source, symbol identity,
+containment, dependency distance, and ranges all come from the same
+manifest-backed `ServerContext`.
+
+Compatibility is pinned to OrcaLoca revision
+`37db289be2dc3b7432183fe08b3f06becce87c27`. The adapter preserves its
+repository-relative `file::Class::method` identities, 1-based locations, and
+prompt-visible markers. Prose and ambiguous-result tie ordering may differ;
+semantic file, class, method, and source ranges are the compatibility
+boundary.
+
+Run the local contract and provider tests with:
+
+```bash
+pytest -q test/integrations/test_orcaloca.py
+```
+
+To compare against a pinned upstream checkout and exercise OrcaLoca's actual
+decomposition, priority queue, and final-location decoder:
+
+```bash
+ORCALOCA_CHECKOUT=/path/to/OrcaLoca \
+  pytest -q test/integrations/test_orcaloca_upstream.py
+```
+
+The upstream probe is optional and marked `integration`; without
+`ORCALOCA_CHECKOUT`, it skips before importing OrcaLoca.
+
+The base `codenib` package therefore gains no LocAgent, OpenHands, OrcaLoca,
+LlamaIndex, pandas, or NetworkX dependency.

--- a/test/integrations/contracts/orcaloca_37db289.yaml
+++ b/test/integrations/contracts/orcaloca_37db289.yaml
@@ -1,0 +1,59 @@
+revision: 37db289be2dc3b7432183fe08b3f06becce87c27
+tools:
+  search_file_contents:
+    parameters:
+      - file_name
+      - directory_path
+    defaults:
+      directory_path: null
+  search_source_code:
+    parameters:
+      - file_path
+      - source_code
+    defaults: {}
+  search_class:
+    parameters:
+      - class_name
+      - file_path
+    defaults:
+      file_path: null
+  search_method_in_class:
+    parameters:
+      - class_name
+      - method_name
+      - file_path
+    defaults:
+      file_path: null
+  search_callable:
+    parameters:
+      - query_name
+      - file_path
+    defaults:
+      file_path: null
+  search_file_tree:
+    parameters:
+      - name
+      - max_depth
+    defaults:
+      name: null
+      max_depth: null
+manager_hooks:
+  - _get_class_methods
+  - _get_disambiguous_classes
+  - _get_disambiguous_files
+  - _get_disambiguous_methods
+  - _get_exact_loc
+  - _get_file_functions
+  - check_and_add_query
+  - get_distance_between_queries
+  - get_frame_from_history
+  - get_node_existence
+  - get_query_from_history
+history_fields:
+  - search_action
+  - search_input
+  - search_query
+  - search_content
+  - query_type
+  - file_path
+  - is_skeleton

--- a/test/integrations/test_orcaloca.py
+++ b/test/integrations/test_orcaloca.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from codenib.compiler.manifest import RepoManifest
+from codenib.integrations import IntegrationCapabilityError
+from codenib.integrations.orcaloca import (
+    ORCALOCA_HISTORY_FIELDS,
+    ORCALOCA_MANAGER_HOOKS,
+    ORCALOCA_REVISION,
+    ORCALOCA_TOOL_NAMES,
+    OrcaLocaSearchProvider,
+    make_orcaloca_search_manager_factory,
+)
+
+
+@pytest.fixture()
+def provider(integration_manifest: Path) -> OrcaLocaSearchProvider:
+    return OrcaLocaSearchProvider.from_manifest(integration_manifest)
+
+
+def _tool_contract(provider: OrcaLocaSearchProvider) -> dict:
+    tools = {}
+    for name in ORCALOCA_TOOL_NAMES:
+        signature = inspect.signature(getattr(provider, name))
+        defaults = {
+            parameter.name: (None if parameter.default is None else parameter.default)
+            for parameter in signature.parameters.values()
+            if parameter.default is not inspect.Parameter.empty
+        }
+        tools[name] = {
+            "parameters": list(signature.parameters),
+            "defaults": defaults,
+        }
+    return {
+        "revision": ORCALOCA_REVISION,
+        "tools": tools,
+        "manager_hooks": list(ORCALOCA_MANAGER_HOOKS),
+        "history_fields": list(ORCALOCA_HISTORY_FIELDS),
+    }
+
+
+def test_pinned_orcaloca_contract(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    contract_path = Path(__file__).parent / "contracts" / "orcaloca_37db289.yaml"
+    expected = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+
+    assert _tool_contract(provider) == expected
+    assert [function.__name__ for function in provider.get_search_functions()] == list(
+        ORCALOCA_TOOL_NAMES
+    )
+    for hook in ORCALOCA_MANAGER_HOOKS:
+        assert callable(getattr(provider, hook))
+
+
+def test_file_tree_and_contents_use_manifest_source(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    tree = provider.search_file_tree()
+    content = provider.search_file_contents("service.py", "src")
+
+    assert "service.py" in tree
+    assert "model.py" in tree
+    assert "File Path: src/service.py" in content
+    assert "class BillingService" in content
+    assert (
+        provider.get_query_from_history("search_file_contents", "src/service.py")
+        == "src/service.py"
+    )
+
+
+def test_class_decomposition_matches_search_worker_hooks(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    result = provider.search_class("BillingService")
+    frame = provider.get_frame_from_history("search_class", "BillingService")
+
+    assert "File Path: src/service.py" in result
+    assert frame is not None
+    assert set(frame) == set(ORCALOCA_HISTORY_FIELDS)
+    assert frame["query_type"] == "class"
+    assert frame["search_query"] == "src/service.py::BillingService"
+
+    method_names, method_sources = provider._get_class_methods(frame["search_query"])
+    assert method_names == ["src/service.py::BillingService::calculate_tax"]
+    assert "def calculate_tax" in method_sources[0]
+
+
+def test_method_lookup_produces_one_based_location_and_history(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    result = provider.search_method_in_class(
+        "BillingService",
+        "calculate_tax",
+        "src/service.py",
+    )
+    query = "src/service.py::BillingService::calculate_tax"
+    location = provider._get_exact_loc(query)
+
+    assert "Method Content" in result
+    assert "return helper(amount)" in result
+    assert location is not None
+    assert location.type == "method"
+    assert location.loc.file_name == "src/service.py"
+    assert location.loc.node_name == query
+    assert (location.loc.start_line, location.loc.end_line) == (2, 4)
+    assert provider.get_query_from_history("search_method_in_class", query) == query
+
+
+def test_callable_disambiguation_preserves_upstream_markers(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    result = provider.search_callable("helper")
+
+    assert result.startswith("<Disambiguation>")
+    assert result.endswith("</Disambiguation>")
+    assert "File Path: src/other.py" in result
+    assert "File Path: src/service.py" in result
+    frame = provider.get_frame_from_history("search_callable", "helper")
+    assert frame is not None
+    assert frame["query_type"] == "disambiguation"
+
+
+def test_source_fragment_returns_narrowest_graph_range(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    result = provider.search_source_code("src/service.py", "return helper(amount)")
+
+    assert "def calculate_tax" in result
+    assert "return helper(amount)" in result
+    assert "class BillingService" not in result
+
+
+def test_skeleton_thresholds_use_upstream_line_span(
+    integration_manifest: Path,
+) -> None:
+    at_boundary = OrcaLocaSearchProvider.from_manifest(
+        integration_manifest,
+        file_skeleton_threshold=6,
+        class_skeleton_threshold=3,
+    )
+    above_boundary = OrcaLocaSearchProvider.from_manifest(
+        integration_manifest,
+        file_skeleton_threshold=5,
+        class_skeleton_threshold=2,
+    )
+
+    assert "File Content:" in at_boundary.search_file_contents("service.py", "src")
+    assert "Class Content:" in at_boundary.search_class("BillingService")
+    assert "File Skeleton:" in above_boundary.search_file_contents("service.py", "src")
+    assert "Class Skeleton:" in above_boundary.search_class("BillingService")
+
+
+def test_file_and_method_decomposition_hooks(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    functions, sources = provider._get_file_functions("src/service.py")
+    methods, method_sources = provider._get_disambiguous_methods(
+        "calculate_tax",
+        class_name="BillingService",
+        file_path="src/service.py",
+    )
+
+    assert functions == [
+        "src/service.py::BillingService",
+        "src/service.py::helper",
+    ]
+    assert any("class BillingService" in source for source in sources)
+    assert methods == ["src/service.py::BillingService::calculate_tax"]
+    assert "def calculate_tax" in method_sources[0]
+    assert provider._get_disambiguous_classes("TaxRule") == ["src/model.py"]
+    assert provider._get_disambiguous_files("service.py") == ["src/service.py"]
+
+
+def test_graph_identity_distance_and_duplicate_tracking(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    method = "src/service.py::BillingService::calculate_tax"
+    helper = "src/service.py::helper"
+    other_file = "src/other.py::helper"
+
+    assert provider.get_node_existence(method)
+    assert provider.get_distance_between_queries(method, helper) == 1
+    assert provider.get_distance_between_queries(method, other_file) == 999_999
+    assert provider.get_distance_between_queries(method, "missing") == 999_999
+    assert provider.get_distance_between_queries(None, helper) == -1
+    assert provider.check_and_add_query(method) is False
+    assert provider.check_and_add_query(method) is True
+
+
+def test_bug_location_schema_is_policy_consumable(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    result = provider._get_bug_location("calculate_tax", file_path="src/service.py")
+
+    assert result == {
+        "bug_locations": [
+            {
+                "file_path": "src/service.py",
+                "class_name": "BillingService",
+                "method_name": "calculate_tax",
+            }
+        ]
+    }
+
+
+def test_policy_smoke_sequence_uses_one_provider(
+    provider: OrcaLocaSearchProvider,
+) -> None:
+    provider.search_class("BillingService")
+    class_frame = provider.get_frame_from_history("search_class", "BillingService")
+    assert class_frame is not None
+
+    method_names, _ = provider._get_class_methods(class_frame["search_query"])
+    method_name = method_names[0]
+    provider.search_method_in_class(
+        "BillingService",
+        method_name.split("::")[-1],
+        class_frame["file_path"],
+    )
+
+    assert provider.get_node_existence(method_name)
+    assert (
+        provider.get_query_from_history("search_method_in_class", method_name)
+        == method_name
+    )
+    assert provider._get_bug_location("calculate_tax", class_frame["file_path"])[
+        "bug_locations"
+    ]
+
+
+def test_factory_reuses_manifest_and_rejects_repo_mismatch(
+    integration_manifest: Path,
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(RepoManifest.load(integration_manifest).repo_path)
+    before = sorted(path.relative_to(repo_root) for path in repo_root.rglob("*"))
+    factory = make_orcaloca_search_manager_factory(integration_manifest)
+
+    provider = factory(str(repo_root))
+    after = sorted(path.relative_to(repo_root) for path in repo_root.rglob("*"))
+
+    assert provider.repository.repo_root == repo_root.resolve()
+    assert before == after
+    assert not (repo_root / "_index_data").exists()
+    with pytest.raises(ValueError, match="does not match"):
+        factory(str(tmp_path))
+
+
+def test_missing_graph_fails_without_upstream_fallback(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    context = SimpleNamespace(
+        manifest=RepoManifest(repo_path=str(repo), commit="current"),
+        symbol_graph=None,
+        errors={},
+    )
+
+    with pytest.raises(
+        IntegrationCapabilityError,
+        match="required 'symbol_graph' view",
+    ):
+        OrcaLocaSearchProvider(context)
+
+
+def test_adapter_has_no_orcaloca_runtime_dependencies() -> None:
+    source_path = Path(__file__).parents[2] / "codenib" / "integrations" / "orcaloca.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imported_roots = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported_roots.add(node.module.split(".", 1)[0])
+
+    assert imported_roots.isdisjoint({"Orcar", "llama_index", "networkx", "pandas"})

--- a/test/integrations/test_orcaloca_upstream.py
+++ b/test/integrations/test_orcaloca_upstream.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional compatibility probe against a pinned OrcaLoca checkout."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from codenib.compiler.manifest import RepoManifest
+from codenib.integrations.orcaloca import (
+    ORCALOCA_MANAGER_HOOKS,
+    ORCALOCA_REVISION,
+    ORCALOCA_TOOL_NAMES,
+    OrcaLocaSearchProvider,
+    make_orcaloca_search_manager_factory,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def upstream_modules() -> SimpleNamespace:
+    raw_checkout = os.environ.get("ORCALOCA_CHECKOUT")
+    if not raw_checkout:
+        pytest.skip("set ORCALOCA_CHECKOUT to run the pinned upstream probe")
+    checkout = Path(raw_checkout).expanduser().resolve()
+    if not (checkout / "Orcar" / "search_agent.py").is_file():
+        pytest.fail(f"not an OrcaLoca checkout: {checkout}")
+
+    ancestor = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(checkout),
+            "merge-base",
+            "--is-ancestor",
+            ORCALOCA_REVISION,
+            "HEAD",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if ancestor.returncode != 0:
+        pytest.fail(
+            "OrcaLoca checkout does not contain pinned revision " f"{ORCALOCA_REVISION}"
+        )
+
+    pinned_manager = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(checkout),
+            "show",
+            f"{ORCALOCA_REVISION}:Orcar/search/search_tool.py",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    current_manager = (checkout / "Orcar" / "search" / "search_tool.py").read_text(
+        encoding="utf-8"
+    )
+    if current_manager != pinned_manager:
+        pytest.fail(
+            "OrcaLoca SearchManager drifted from the supported revision "
+            f"{ORCALOCA_REVISION}"
+        )
+
+    sys.path.insert(0, str(checkout))
+    search = importlib.import_module("Orcar.search")
+    search_agent = importlib.import_module("Orcar.search_agent")
+    types = importlib.import_module("Orcar.types")
+    loaded_path = Path(inspect.getfile(search_agent)).resolve()
+    if not loaded_path.is_relative_to(checkout):
+        pytest.fail(f"loaded OrcaLoca from {loaded_path}, not {checkout}")
+    return SimpleNamespace(
+        checkout=checkout,
+        SearchManager=search.SearchManager,
+        search_agent=search_agent,
+        types=types,
+    )
+
+
+def _location_tuple(location_info) -> tuple[str, str, int, int, str]:
+    location = location_info.loc
+    return (
+        location.file_name,
+        location.node_name,
+        location.start_line,
+        location.end_line,
+        location_info.type,
+    )
+
+
+def test_upstream_contract_and_semantic_locations(
+    upstream_modules: SimpleNamespace,
+    integration_manifest: Path,
+) -> None:
+    provider = OrcaLocaSearchProvider.from_manifest(integration_manifest)
+    upstream_type = upstream_modules.SearchManager
+
+    for name in ORCALOCA_TOOL_NAMES:
+        upstream_parameters = list(
+            inspect.signature(getattr(upstream_type, name)).parameters
+        )
+        provider_parameters = list(
+            inspect.signature(getattr(provider, name)).parameters
+        )
+        assert upstream_parameters[1:] == provider_parameters
+    for name in ORCALOCA_MANAGER_HOOKS:
+        assert hasattr(upstream_type, name)
+
+    upstream = upstream_type(repo_path=provider.repo_path)
+    queries = (
+        "src/service.py",
+        "src/service.py::BillingService",
+        "src/service.py::BillingService::calculate_tax",
+        "src/service.py::helper",
+        "src/model.py::TaxRule",
+    )
+    for query in queries:
+        expected = upstream._get_exact_loc(query)
+        actual = provider._get_exact_loc(query)
+        assert expected is not None
+        assert actual is not None
+        assert _location_tuple(actual) == _location_tuple(expected)
+
+    distance_pairs = (
+        (
+            "src/service.py::BillingService::calculate_tax",
+            "src/service.py::helper",
+        ),
+        (
+            "src/service.py::BillingService::calculate_tax",
+            "src/other.py::helper",
+        ),
+    )
+    for first, second in distance_pairs:
+        assert provider.get_distance_between_queries(
+            first, second
+        ) == upstream.get_distance_between_queries(first, second)
+
+    upstream_results = {
+        "tree": upstream.search_file_tree(),
+        "file": upstream.search_file_contents("service.py", "src"),
+        "source": upstream.search_source_code(
+            "src/service.py", "return helper(amount)"
+        ),
+        "class": upstream.search_class("BillingService"),
+        "method": upstream.search_method_in_class(
+            "BillingService", "calculate_tax", "src/service.py"
+        ),
+        "callable": upstream.search_callable("helper", "src/service.py"),
+    }
+    provider_results = {
+        "tree": provider.search_file_tree(),
+        "file": provider.search_file_contents("service.py", "src"),
+        "source": provider.search_source_code(
+            "src/service.py", "return helper(amount)"
+        ),
+        "class": provider.search_class("BillingService"),
+        "method": provider.search_method_in_class(
+            "BillingService", "calculate_tax", "src/service.py"
+        ),
+        "callable": provider.search_callable("helper", "src/service.py"),
+    }
+    markers = {
+        "tree": "service.py",
+        "file": "File Path: src/service.py",
+        "source": "File Path: src/service.py",
+        "class": "File Path: src/service.py",
+        "method": "File Path: src/service.py",
+        "callable": "File Path: src/service.py",
+    }
+    for result_name, marker in markers.items():
+        assert marker in upstream_results[result_name]
+        assert marker in provider_results[result_name]
+
+    history_keys = (
+        ("search_file_contents", "src/service.py"),
+        ("search_source_code", "return helper(amount)"),
+        ("search_class", "BillingService"),
+        (
+            "search_method_in_class",
+            "src/service.py::BillingService::calculate_tax",
+        ),
+        ("search_callable", "src/service.py::helper"),
+    )
+    for action, search_input in history_keys:
+        expected = upstream.get_frame_from_history(action, search_input)
+        actual = provider.get_frame_from_history(action, search_input)
+        assert expected is not None
+        assert actual is not None
+        assert actual["file_path"] == expected["file_path"]
+        assert actual["query_type"] == expected["query_type"]
+        assert actual["search_query"] == expected["search_query"]
+
+
+def test_search_worker_decomposition_and_final_location(
+    upstream_modules: SimpleNamespace,
+    integration_manifest: Path,
+) -> None:
+    provider = OrcaLocaSearchProvider.from_manifest(integration_manifest)
+    class_content = provider.search_class("BillingService")
+    SearchResult = upstream_modules.types.SearchResult
+    SearchQueue = upstream_modules.types.SearchQueue
+    SearchWorker = upstream_modules.search_agent.SearchWorker
+
+    class_result = SearchResult(
+        search_action="search_class",
+        search_action_input={"class_name": "BillingService"},
+        search_content=class_content,
+    )
+    worker = object.__new__(SearchWorker)
+    worker._search_manager = provider
+    worker._llm = object()
+    worker._problem_statement = "Tax calculation is wrong."
+    worker._config_dict = {"score_threshold": 0.0, "top_k_methods": 2}
+    task = SimpleNamespace(extra_state={"token_cnts": []})
+
+    scorer = SimpleNamespace(
+        score_batch=lambda messages: [1.0 for _ in messages],
+        get_sum_cnt=lambda: SimpleNamespace(in_token_cnt=0, out_token_cnt=0),
+    )
+
+    def scorer_factory(**_kwargs):
+        return scorer
+
+    with patch.object(
+        upstream_modules.search_agent,
+        "CodeScorer",
+        scorer_factory,
+    ):
+        steps = worker._class_methods_ranking(class_result, task)
+
+    assert len(steps) == 1
+    assert steps[0].search_action == "search_method_in_class"
+    assert steps[0].search_action_input == {
+        "class_name": "BillingService",
+        "method_name": "calculate_tax",
+        "file_path": "src/service.py",
+    }
+
+    queue = SearchQueue({"enable": True, "basic": 1})
+    queue.append_with_priority(steps[0], 2)
+    assert queue.pop() == steps[0]
+
+    method_content = provider.search_method_in_class(
+        "BillingService",
+        "calculate_tax",
+        "src/service.py",
+    )
+    method_result = SearchResult(
+        search_action="search_method_in_class",
+        search_action_input=steps[0].search_action_input,
+        search_content=method_content,
+    )
+    assert worker._decode_bug_location(method_result) == {
+        "file_path": "src/service.py",
+        "class_name": "BillingService",
+        "method_name": "calculate_tax",
+    }
+
+
+def test_search_agent_injects_provider_without_upstream_build(
+    upstream_modules: SimpleNamespace,
+    integration_manifest: Path,
+) -> None:
+    module = upstream_modules.search_agent
+    manifest = RepoManifest.load(integration_manifest)
+    factory = make_orcaloca_search_manager_factory(integration_manifest)
+    llm = SimpleNamespace(callback_manager=None)
+
+    with (
+        patch.object(module, "SearchManager", side_effect=AssertionError),
+        patch.object(module.SearchAgent, "_setup_tools", return_value=[]),
+        patch.object(module.SearchWorker, "from_tools", return_value=object()),
+        patch.object(module.AgentRunner, "__init__", return_value=None),
+    ):
+        agent = module.SearchAgent(
+            llm=llm,
+            repo_path=manifest.repo_path,
+            search_manager_factory=factory,
+        )
+
+    assert isinstance(agent._search_manager, OrcaLocaSearchProvider)
+    assert agent._search_manager.repo_path == str(Path(manifest.repo_path).resolve())
+    assert not (Path(manifest.repo_path) / "_index_data").exists()


### PR DESCRIPTION
## Summary

Serve OrcaLoca's pinned localization policy from a pre-built CodeNib manifest without importing its runtime or rebuilding its Python graph.

The shared repository integration boundary landed in #388. The minimal upstream injection seam landed in [fishmingyu/OrcaLoca#140](https://github.com/fishmingyu/OrcaLoca/pull/140) as `f6b47dd`.

Closes #387.

## Changes

- add a revision-pinned, duck-typed OrcaLoca `SearchManager` provider over `ServerContext`
- preserve all six tools plus the history, distance, decomposition, disambiguation, and location hooks consumed by `SearchWorker`
- translate CodeNib symbols to repository-relative `file::Class::method` identities and 1-based source locations
- add a frozen contract fixture, deterministic provider tests, and an optional probe against the actual pinned OrcaLoca `SearchManager`, `SearchWorker`, and injected `SearchAgent`
- document factory injection, supported semantics, and the dependency-free runtime boundary

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/integrations --tb=short -m 'not integration'`

Result: 36 passed, 5 deselected.

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`

Result: 2159 passed, 10 skipped, 175 deselected.

`ORCALOCA_CHECKOUT=/tmp/codenib-compat-orcaloca-20260730 pytest -q test/integrations/test_orcaloca_upstream.py --tb=short`

Result: 3 passed against the pinned upstream manager and unchanged `SearchWorker` and `SearchAgent` policy paths.

Also verified with `mkdocs build --strict`, `python -m build --wheel`, and pre-commit over every changed file.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published