### PR TITLE
docs(readme): add paper recognition badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ SPDX-License-Identifier: Apache-2.0
     Incremental compilation, explicit per-view manifests, and agent-native context serving.
   </p>
   <p>
+    <a href="https://arxiv.org/abs/2607.25431"><img src="https://img.shields.io/badge/arXiv-2607.25431-b31b1b.svg?logo=arxiv&amp;logoColor=white" alt="arXiv 2607.25431"></a>
+    <a href="https://huggingface.co/papers/2607.25431"><img src="https://img.shields.io/badge/Hugging_Face-%232_Paper_of_the_Day-FFD21E.svg?logo=huggingface&amp;logoColor=black" alt="Hugging Face: #2 Paper of the Day"></a>
+  </p>
+  <p>
     <a href="#quickstart">Quickstart</a>
     &nbsp;&middot;&nbsp;
     <a href="https://codenib.ai">Website</a>


### PR DESCRIPTION
## Summary

Add concise publication badges to the repository header so visitors can reach the CodeNib paper and its Hugging Face Daily Papers recognition directly from the README.

## Changes

- Add an arXiv badge linking to paper 2607.25431.
- Add a Hugging Face badge linking to the paper's #2 Paper of the Day page.
- Keep the existing project navigation and status badges unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

Validated the README through GitHub's GFM renderer. Both Shields badge endpoints and both destination links return HTTP 200.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published