### PR TITLE
docs(nav): add task-oriented navigation tabs

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -85,6 +85,8 @@
   --codenib-shadow: 0 10px 34px rgba(0, 0, 0, 0.24);
 
   --md-hue: 32;
+  --md-primary-fg-color: var(--codenib-accent);
+  --md-accent-fg-color: var(--codenib-accent);
   --md-default-bg-color: var(--codenib-bg);
   --md-default-fg-color: var(--codenib-ink);
   --md-default-fg-color--light: var(--codenib-ink-soft);
@@ -126,6 +128,7 @@ body {
 .md-header,
 .md-header--shadow {
   color: var(--codenib-ink);
+  background: var(--codenib-bg);
   background: color-mix(in srgb, var(--codenib-bg) 92%, transparent);
   border-bottom: 1px solid var(--codenib-line);
   box-shadow: none;
@@ -214,6 +217,55 @@ body {
   color: var(--codenib-ink-soft);
 }
 
+/* Top-level information architecture. Keep the tabs quiet and editorial: the
+   active section gets one precise rule instead of a filled pill or shadow. */
+.md-tabs {
+  color: var(--codenib-ink-soft);
+  background: transparent;
+  border-top: 1px solid var(--codenib-line);
+  box-shadow: none;
+}
+
+.md-tabs__list {
+  gap: 0.15rem;
+}
+
+.md-tabs__item {
+  position: relative;
+  height: 2.65rem;
+  padding: 0 0.48rem;
+}
+
+.md-tabs__link {
+  margin-top: 0.78rem;
+  color: var(--codenib-ink-soft);
+  font-family: var(--codenib-sans);
+  font-size: 0.68rem;
+  font-weight: 560;
+  letter-spacing: -0.006em;
+  opacity: 0.78;
+  transition:
+    color 120ms ease,
+    opacity 120ms ease;
+}
+
+.md-tabs__link:hover,
+.md-tabs__link:focus,
+.md-tabs__item--active > .md-tabs__link {
+  color: var(--codenib-accent);
+  opacity: 1;
+}
+
+.md-tabs__item--active::after {
+  position: absolute;
+  right: 0.48rem;
+  bottom: -1px;
+  left: 0.48rem;
+  height: 2px;
+  background: var(--codenib-accent);
+  content: "";
+}
+
 /* Wider, calmer reading frame */
 .md-grid {
   max-width: 72rem;
@@ -275,6 +327,10 @@ body {
 }
 
 @media screen and (min-width: 76.25em) {
+  html {
+    scroll-padding-top: 6.2rem;
+  }
+
   .md-sidebar--primary .md-sidebar__scrollwrap {
     padding-right: 0.65rem;
     border-right: 1px solid var(--codenib-line);
@@ -358,6 +414,73 @@ body {
   padding: 0.25rem 0 0.25rem 1rem;
   color: var(--codenib-ink-soft);
   border-left: 0.15rem solid var(--codenib-accent);
+}
+
+/* Section overview pages */
+.codenib-section-lede {
+  max-width: 42rem;
+  margin-bottom: 1.5rem;
+}
+
+.codenib-section-lede p {
+  color: var(--codenib-ink-soft);
+  font-size: 1.08em;
+}
+
+.md-typeset .codenib-section-grid > ul:not([hidden]) {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin: 1.55rem 0 2.2rem;
+  padding: 0;
+}
+
+.md-typeset .codenib-section-grid > ul > li {
+  display: flex;
+  flex-direction: column;
+  min-height: 10.5rem;
+  margin: 0;
+  padding: 1.05rem 1.15rem 1.1rem;
+  color: var(--codenib-ink-soft);
+  list-style: none;
+  background: var(--codenib-surface);
+  border: 1px solid var(--codenib-line);
+  border-radius: 0.65rem;
+}
+
+.codenib-section-grid > ul > li::before {
+  display: none;
+}
+
+.codenib-section-grid strong {
+  display: block;
+  margin: 0.28rem 0 0.42rem;
+  color: var(--codenib-ink);
+  font-family: var(--codenib-serif);
+  font-size: 1.18rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.codenib-section-grid li > p {
+  margin: 0.35rem 0;
+}
+
+.codenib-section-grid li > p:last-child {
+  margin-top: auto;
+  padding-top: 0.7rem;
+  font-family: var(--codenib-sans);
+  font-size: 0.72rem;
+  font-weight: 620;
+}
+
+.codenib-card-eyebrow {
+  color: var(--codenib-muted);
+  font-family: var(--codenib-sans);
+  font-size: 0.61rem;
+  font-weight: 680;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 /* Code */
@@ -556,6 +679,14 @@ body {
 
   .md-typeset h2 {
     font-size: 1.58em;
+  }
+
+  .md-typeset .codenib-section-grid > ul:not([hidden]) {
+    grid-template-columns: 1fr;
+  }
+
+  .md-typeset .codenib-section-grid > ul > li {
+    min-height: 0;
   }
 }
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,71 @@
+---
+title: Concepts
+hide:
+  - toc
+---
+
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Concepts
+
+<div class="codenib-section-lede" markdown>
+
+CodeNib compiles one repository into several source-linked views. These pages
+explain what each view preserves, how the views align, and where their support
+boundaries differ.
+
+</div>
+
+<div class="codenib-section-grid" markdown>
+
+-   <span class="codenib-card-eyebrow">Static navigation</span>
+
+    **SCIP index**
+
+    Follow language-aware definitions and references through SCIP or LSP
+    backends and understand cache-level behavior.
+
+    [Understand SCIP indexing →](../scip_index.md)
+
+-   <span class="codenib-card-eyebrow">Structural view</span>
+
+    **CodeGraph**
+
+    Learn the typed hierarchy model and query graph nodes by source-aligned
+    symbol or line range.
+
+    [Read the hierarchy model →](../codegraph_hierarchy_model.md)
+
+-   <span class="codenib-card-eyebrow">Commit-aware updates</span>
+
+    **Incremental graph**
+
+    See how a diff updates supported graph views in place, when verification
+    admits the patch, and when CodeNib rebuilds.
+
+    [Explore incremental updates →](../incremental_graph/index.md)
+
+-   <span class="codenib-card-eyebrow">Native acceleration</span>
+
+    **Core C++ backend**
+
+    Understand decoder parity, libigraph-backed execution, fallback behavior,
+    and the boundary between Python and native code.
+
+    [Inspect the native core →](../core_cpp.md)
+
+</div>
+
+## Other index views
+
+- [Regex Index](../regex_index.md) covers structural pattern lookup.
+- [Graph Range Query](../graph_query.md) defines source-range and symbol query
+  semantics.
+- [Graph Cache](../graph_cache_usage.md) explains persisted graph reuse and
+  invalidation.
+- [Interactive Incremental Graph](../incremental_graph/interactive.md) provides
+  a visual walkthrough of commit-scoped graph changes.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,66 @@
+---
+title: Development
+hide:
+  - toc
+---
+
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Development
+
+<div class="codenib-section-lede" markdown>
+
+Extend CodeNib through its shared registries and contracts, verify the changed
+surface at the right test tier, and keep evaluation artifacts reproducible.
+
+</div>
+
+<div class="codenib-section-grid" markdown>
+
+-   <span class="codenib-card-eyebrow">Extend</span>
+
+    **Contribute a language**
+
+    Add chunking and graph capabilities through the language registry, then
+    promote each backend only after its contract checks pass.
+
+    [Follow the language workflow →](../contributing-a-language.md)
+
+-   <span class="codenib-card-eyebrow">Verify</span>
+
+    **CI/CD**
+
+    Choose among unit, integration, serial, graph-consumer, core, and slow
+    verification tiers.
+
+    [Run the right checks →](../ci_cd.md)
+
+-   <span class="codenib-card-eyebrow">Publish</span>
+
+    **Releasing**
+
+    Build and inspect distributions, run install smoke tests, and publish a
+    release without bypassing artifact checks.
+
+    [Prepare a release →](../releasing.md)
+
+-   <span class="codenib-card-eyebrow">Measure</span>
+
+    **Evaluation workflows**
+
+    Collect benchmark inputs, synthesize queries, extract ground-truth source
+    locations, and package reproducible result bundles.
+
+    [Open evaluation workflows →](../evaluation/index.md)
+
+</div>
+
+## Project contracts
+
+Use [Naming](../branding.md) for project and package terminology. Evaluation
+inputs and outputs have their own reproducibility contracts; start with the
+[Evaluation Workflows](../evaluation/index.md) overview before running them.

--- a/docs/evaluation/index.md
+++ b/docs/evaluation/index.md
@@ -1,0 +1,61 @@
+---
+title: Benchmarks & Evaluation
+hide:
+  - toc
+---
+
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Benchmarks & Evaluation
+
+<div class="codenib-section-lede" markdown>
+
+Build reproducible benchmark inputs, prepare ground truth for source-location
+retrieval evaluation, and carry the configuration and provenance needed to
+interpret every result.
+
+</div>
+
+<div class="codenib-section-grid" markdown>
+
+-   <span class="codenib-card-eyebrow">Collect</span>
+
+    **SWE-bench instances**
+
+    Sample representative tasks across repositories and languages without
+    losing their source metadata.
+
+    [Collect benchmark inputs →](../collect_swebench.md)
+
+-   <span class="codenib-card-eyebrow">Synthesize</span>
+
+    **Query datasets**
+
+    Generate traversal, behavioral, and multi-step queries with explicit
+    curation and verification stages.
+
+    [Run the synthesis pipeline →](../synthesis_pipeline.md)
+
+-   <span class="codenib-card-eyebrow">Prepare</span>
+
+    **Ground-truth locations**
+
+    Extract expected files, symbols, and one-based source ranges from benchmark
+    patches.
+
+    [Use the GT locator →](../gt_locator.md)
+
+-   <span class="codenib-card-eyebrow">Package</span>
+
+    **Artifact bundles**
+
+    Preserve manifests, metrics, diagnostics, and provenance as one verifiable
+    evaluation output.
+
+    [Build an artifact bundle →](../evaluation_artifacts.md)
+
+</div>

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -1,0 +1,67 @@
+---
+title: Get Started
+hide:
+  - toc
+---
+
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Get Started
+
+<div class="codenib-section-lede" markdown>
+
+Build the smallest useful CodeNib setup first, then add semantic, graph, or
+agent-backed capabilities only when your workflow needs them.
+
+</div>
+
+<div class="codenib-section-grid" markdown>
+
+-   <span class="codenib-card-eyebrow">01 · First run</span>
+
+    **Quickstart**
+
+    Turn a local repository into a deterministic, source-linked Wiki with no
+    API key or model download.
+
+    [Launch your first repository →](../quickstart.md)
+
+-   <span class="codenib-card-eyebrow">02 · Browser workflow</span>
+
+    **Web UI**
+
+    Configure the repository Wiki, source explorer, graph views, and optional
+    Ask experience.
+
+    [Configure the Web UI →](../web_demo.md)
+
+-   <span class="codenib-card-eyebrow">03 · Local stack</span>
+
+    **Run locally**
+
+    Keep embeddings, reranking, and page generation on infrastructure you
+    control.
+
+    [Choose a local deployment →](../running-locally.md)
+
+-   <span class="codenib-card-eyebrow">04 · Backend coverage</span>
+
+    **Language capabilities**
+
+    Check which languages support chunking, SCIP or LSP graphs, incremental
+    updates, and native decoder acceleration.
+
+    [Open the capability matrix →](../language_capabilities.md)
+
+</div>
+
+## Pick a repository profile
+
+Start with `fast` for a zero-model BM25 index. Move to `semantic`, `graph`, or
+`full` only when the query workload needs those views. The
+[Quickstart](../quickstart.md#select-repository-views) lists the package and
+toolchain requirements for each profile.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,67 @@
+---
+title: Guides
+hide:
+  - toc
+---
+
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Guides
+
+<div class="codenib-section-lede" markdown>
+
+Connect compiled repository views to coding agents, then choose the smallest
+retrieval and planning surface that answers the task.
+
+</div>
+
+<div class="codenib-section-grid" markdown>
+
+-   <span class="codenib-card-eyebrow">Serve context</span>
+
+    **MCP Server**
+
+    Build a reusable manifest and expose the full tool set, with results gated
+    by fresh, available repository views.
+
+    [Connect an MCP client →](../mcp.md)
+
+-   <span class="codenib-card-eyebrow">Compose retrieval</span>
+
+    **Agent skills**
+
+    Add bounded lexical, semantic, graph-navigation, and reranking skills to an
+    agent runtime.
+
+    [Browse the skill surface →](../agent_skills.md)
+
+-   <span class="codenib-card-eyebrow">Embed CodeNib</span>
+
+    **Agent integrations**
+
+    Use the LocAgent and OrcaLoca adapters while preserving CodeNib's manifest
+    and source-location contracts.
+
+    [Choose an integration →](../agent_integrations.md)
+
+-   <span class="codenib-card-eyebrow">Plan a query</span>
+
+    **RAG ops and planner**
+
+    Understand retrieval operators, query-aware path selection, fusion,
+    expansion, and reranking boundaries.
+
+    [Inspect the retrieval policy →](../rag_ops.md)
+
+</div>
+
+## Recommended path
+
+Use the [MCP Server](../mcp.md) for the standard agent-facing workflow. Reach
+for [Agent Skills](../agent_skills.md) when you need to compose a custom runtime,
+and use the [RAG Ops And Planner](../rag_ops.md) reference when changing query
+policy rather than wiring.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - navigation
+---
+
 <!--
 SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 
@@ -16,51 +21,15 @@ Language support varies by surface. Start with the generated
 which languages support chunking, graph indexing, incremental patching, or C++
 core decoder parity.
 
-## User Guide
+## Choose a path
 
-| Goal | Read |
-|------|------|
-| Turn a local repository into a Wiki | [Quickstart](quickstart.md) |
-| Build an index and expose it to an agent | [MCP Server](mcp.md) |
-| Configure the full browser application | [Web UI](web_demo.md) |
-| Run without cloud-hosted LLM APIs | [Running Locally](running-locally.md) |
-| Understand language support and gaps | [Language Capabilities](language_capabilities.md) |
-| Add or promote a language backend | [Contributing a Language](contributing-a-language.md) |
-
-Once an index exists, use [Agent Skills](agent_skills.md) for optional
-retrieval and reranking workflows, or [RAG Ops And Planner](rag_ops.md) for the
-query planner and graph-aware retrieval boundaries.
-
-## Concepts
-
-| Surface | Description |
-|---------|-------------|
-| [Index and MCP](mcp.md) | Build manifests with `IndexCompiler`; serve BM25, semantic, regex, Zoekt, and dependency-subgraph tools over MCP |
-| [Web UI](web_demo.md) | Source-linked Wiki and optional Ask flow over indexed repositories |
-| [Graph Range Query](graph_query.md) | LSP-aligned line-range and symbol queries with typed, source-linked results |
-| [Incremental Graph](incremental_graph/index.md) | Update a graph in place after a diff where the language backend supports it |
-| [SCIP Index](scip_index.md) | SCIP and language-server graph indexing details, cache levels, and backend behavior |
-| [Core C++ Backend](core_cpp.md) | libigraph-based decoder acceleration and parity boundaries |
-
-## Development
-
-- [Contributing a Language](contributing-a-language.md) — add a language
-  through the shared registry and verify each supported surface.
-- [CI/CD](ci_cd.md) — run local and remote test tiers, including serial,
-  graph-consumer, core, and slow jobs.
-- [Releasing](releasing.md) — prepare and verify a CodeNib release.
-- [Naming](branding.md) — use the project and package names consistently.
-
-## Evaluation
-
-- [Collecting SWE-bench Instances](collect_swebench.md) — sample
-  representative instances across languages.
-- [Synthesis Pipeline](synthesis_pipeline.md) — synthesize traversal,
-  behavior, and multi-step queries for the CodeNib Synthesis benchmark.
-- [GT Locator](gt_locator.md) — evaluate source-location retrieval against
-  ground-truth patches.
-- [Evaluation Artifact Bundles](evaluation_artifacts.md) — package
-  reproducible evaluation outputs.
+| Goal | Section | Start with |
+|------|---------|------------|
+| Install CodeNib and explore a repository | [Get Started](get-started/index.md) | [Quickstart](quickstart.md) |
+| Serve repository context to coding agents | [Guides](guides/index.md) | [MCP Server](mcp.md) |
+| Understand indexes, graphs, and incremental updates | [Concepts](concepts/index.md) | [Incremental Graph](incremental_graph/index.md) |
+| Browse source-generated Python contracts | [API Reference](api/codenib/index.md) | `codenib` public surface |
+| Extend, test, release, or evaluate CodeNib | [Development](development/index.md) | [Contributing a Language](contributing-a-language.md) |
 
 ## Quick Start
 
@@ -83,7 +52,7 @@ codenib mcp /path/to/repository
 ## Serving Docs Locally
 
 ```bash
-pip install mkdocs-material
+pip install "codenib[dev]"
 mkdocs serve
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,8 @@ theme:
         name: Switch to light mode
   features:
     - navigation.instant
+    - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
     # `prune` replaces `expand`, which the theme documents as incompatible.
     # Material inlines the generated API tree into every page, so keep the
@@ -157,32 +159,44 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - User Guide:
+  - Get Started:
+      - get-started/index.md
       - Quickstart: quickstart.md
-      - MCP Server: mcp.md
       - Web UI: web_demo.md
       - Running Locally: running-locally.md
       - Language Capabilities: language_capabilities.md
+  - Guides:
+      - guides/index.md
+      - MCP Server: mcp.md
       - Agent Skills: agent_skills.md
       - Agent Integrations: agent_integrations.md
       - RAG Ops And Planner: rag_ops.md
   - Concepts:
-      - SCIP Index: scip_index.md
-      - CodeGraph Hierarchy Model: codegraph_hierarchy_model.md
-      - Graph Range Query: graph_query.md
-      - Regex Index: regex_index.md
-      - Graph Cache: graph_cache_usage.md
-      - Incremental Graph:
-          - Overview: incremental_graph/index.md
-          - Interactive Demo: incremental_graph/interactive.md
-      - Core C++ Backend: core_cpp.md
+      - concepts/index.md
+      - Indexes:
+          - SCIP Index: scip_index.md
+          - Regex Index: regex_index.md
+      - Code Graph:
+          - Hierarchy Model: codegraph_hierarchy_model.md
+          - Range Query: graph_query.md
+          - Graph Cache: graph_cache_usage.md
+          - Incremental Graph:
+              - Overview: incremental_graph/index.md
+              - Interactive Demo: incremental_graph/interactive.md
+      - Acceleration:
+          - Core C++ Backend: core_cpp.md
+  - API Reference
   - Development:
-      - Contributing a Language: contributing-a-language.md
-      - Naming: branding.md
-      - CI/CD: ci_cd.md
-      - Releasing: releasing.md
-  - Evaluation:
-      - SWE-bench Collection: collect_swebench.md
-      - Synthesis Pipeline: synthesis_pipeline.md
-      - GT Locator: gt_locator.md
-      - Evaluation Artifact Bundles: evaluation_artifacts.md
+      - development/index.md
+      - Contributing:
+          - Contributing a Language: contributing-a-language.md
+          - CI/CD: ci_cd.md
+      - Project Maintenance:
+          - Releasing: releasing.md
+          - Naming: branding.md
+      - Benchmarks & Evaluation:
+          - evaluation/index.md
+          - SWE-bench Collection: collect_swebench.md
+          - Synthesis Pipeline: synthesis_pipeline.md
+          - GT Locator: gt_locator.md
+          - Evaluation Artifact Bundles: evaluation_artifacts.md

--- a/test/scripts/test_check_public_docs.py
+++ b/test/scripts/test_check_public_docs.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from pathlib import Path
 
 from scripts import check_public_docs
+
+REPO_ROOT = Path(__file__).parents[2]
 
 
 def _config() -> dict:
@@ -12,6 +15,44 @@ def _config() -> dict:
         "exclude_docs": "\n".join(sorted(check_public_docs.REQUIRED_EXCLUSIONS)),
         "nav": [{"Home": "index.md"}],
     }
+
+
+def test_mkdocs_navigation_tabs_contract():
+    config = check_public_docs._load_config(REPO_ROOT / "mkdocs.yml")
+    features = set(config["theme"]["features"])
+    assert {
+        "navigation.indexes",
+        "navigation.tabs",
+        "navigation.tabs.sticky",
+    } <= features
+
+    nav = config["nav"]
+    titles = [item if isinstance(item, str) else next(iter(item)) for item in nav]
+    assert titles == [
+        "Home",
+        "Get Started",
+        "Guides",
+        "Concepts",
+        "API Reference",
+        "Development",
+    ]
+
+    sections = {
+        next(iter(item)): next(iter(item.values()))
+        for item in nav
+        if isinstance(item, dict)
+    }
+    assert sections["Get Started"][0] == "get-started/index.md"
+    assert sections["Guides"][0] == "guides/index.md"
+    assert sections["Concepts"][0] == "concepts/index.md"
+    assert sections["Development"][0] == "development/index.md"
+
+    evaluation = next(
+        item["Benchmarks & Evaluation"]
+        for item in sections["Development"]
+        if isinstance(item, dict) and "Benchmarks & Evaluation" in item
+    )
+    assert evaluation[0] == "evaluation/index.md"
 
 
 def _write_api_site(site_dir, routes=None):


### PR DESCRIPTION
## Summary

Reorganize the public documentation into task-oriented top-level tabs inspired by the clearer section navigation used by mature infrastructure projects. The new structure preserves existing public URLs and the generated API tree while making the main workflows easier to scan.

## Changes

- Add six top-level tabs: Home, Get Started, Guides, Concepts, API Reference, and Development.
- Add focused landing pages for the main documentation sections and nested evaluation workflows.
- Style responsive, sticky tabs and section cards for the existing warm light and dark themes.
- Simplify the homepage path chooser and keep internal planning and experiment material outside the public site.
- Add a navigation contract test covering feature flags, ordering, landing pages, and the API autonav position.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `python -m pytest test/scripts -q` (136 passed)
- [x] `python -m mkdocs build --strict`
- [x] Public docs boundary, namespace, and language capability checks
- [x] Responsive browser smoke tests at 1440px, 1220px, 1219px, and 390px in light and dark modes
- [x] Tests pass locally
- [x] Added new tests for the changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
