### PR TITLE
fix(docs): keep tab layouts aligned

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 hide:
-  - navigation
+  - toc
 ---
 
 <!--

--- a/test/scripts/test_check_public_docs.py
+++ b/test/scripts/test_check_public_docs.py
@@ -5,6 +5,8 @@
 import json
 from pathlib import Path
 
+import yaml
+
 from scripts import check_public_docs
 
 REPO_ROOT = Path(__file__).parents[2]
@@ -53,6 +55,11 @@ def test_mkdocs_navigation_tabs_contract():
         if isinstance(item, dict) and "Benchmarks & Evaluation" in item
     )
     assert evaluation[0] == "evaluation/index.md"
+
+    # Keep the desktop content column aligned when switching top-level tabs.
+    home_source = (REPO_ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+    home_metadata = yaml.safe_load(home_source.split("---", 2)[1])
+    assert home_metadata["hide"] == ["toc"]
 
 
 def _write_api_site(site_dir, routes=None):


### PR DESCRIPTION
## Summary

Remove the horizontal layout jump when navigating from Home to another top-level documentation tab.

## Changes

- Keep the Home page on the same left-navigation layout used by the other section landing pages.
- Hide the Home table of contents instead of hiding its primary navigation.
- Add a navigation contract assertion that preserves this layout choice.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `python -m pytest test/scripts -q` (136 passed)
- [x] `python -m mkdocs build --strict`
- [x] Public docs boundary, namespace, and language capability checks
- [x] Playwright content geometry at 1440px, 1220px, 1219px, 1024px, and 390px
- [x] Mobile navigation drawer smoke test
- [x] Tests pass locally
- [x] Added new tests for the changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
