### PR TITLE
fix(docs): use the home outline as its left rail

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -340,6 +340,31 @@ body {
     padding-left: 0.65rem;
     border-left: 1px solid var(--codenib-line);
   }
+
+  /* When a landing page hides its primary navigation, use its page outline as
+     the left rail so top-level tab changes keep the same content baseline. */
+  .md-main__inner
+    > .md-sidebar--primary[hidden]
+    + .md-sidebar--secondary:not([hidden]) {
+    order: 0;
+  }
+
+  .md-main__inner
+    > .md-sidebar--primary[hidden]
+    + .md-sidebar--secondary:not([hidden])
+    .md-sidebar__scrollwrap {
+    padding-inline: 0 0.65rem;
+    border-inline-start: 0;
+    border-inline-end: 1px solid var(--codenib-line);
+  }
+
+  .md-main__inner
+    > .md-sidebar--primary[hidden]
+    + .md-sidebar--secondary:not([hidden])
+    ~ .md-content
+    > .md-content__inner {
+    margin-inline: 1.2rem 0.8rem;
+  }
 }
 
 /* Editorial typography */
@@ -606,6 +631,14 @@ body {
 .md-footer__link:hover {
   color: var(--codenib-accent);
   opacity: 1;
+}
+
+@media screen and (min-width: 60em) and (max-width: 76.234375em) {
+  .md-main__inner
+    > .md-sidebar--primary[hidden]
+    + .md-sidebar--secondary:not([hidden]) {
+    display: none;
+  }
 }
 
 @media screen and (max-width: 76.234375em) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 hide:
-  - toc
+  - navigation
 ---
 
 <!--

--- a/test/scripts/test_check_public_docs.py
+++ b/test/scripts/test_check_public_docs.py
@@ -56,10 +56,10 @@ def test_mkdocs_navigation_tabs_contract():
     )
     assert evaluation[0] == "evaluation/index.md"
 
-    # Keep the desktop content column aligned when switching top-level tabs.
+    # Home uses its page outline as the left rail without duplicating "Home".
     home_source = (REPO_ROOT / "docs" / "index.md").read_text(encoding="utf-8")
     home_metadata = yaml.safe_load(home_source.split("---", 2)[1])
-    assert home_metadata["hide"] == ["toc"]
+    assert home_metadata["hide"] == ["navigation"]
 
 
 def _write_api_site(site_dir, routes=None):


### PR DESCRIPTION
## Summary

Replace the sparse one-item Home sidebar with the page outline while keeping top-level tab transitions geometrically stable.

## Changes

- Hide the duplicate Home primary navigation and move the Home page outline into the desktop left rail.
- Flip the rail padding and divider so it reads like the other left-side navigation.
- Preserve identical content coordinates across top-level landing pages.
- Collapse the standalone outline between 960px and the desktop tabs breakpoint; the outline remains available in the mobile drawer.
- Keep the Home layout choice covered by the navigation contract test.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] `python -m pytest test/scripts -q` (136 passed)
- [x] `python -m mkdocs build --strict`
- [x] Public docs boundary, namespace, and language capability checks
- [x] Playwright geometry at 1440px, 1220px, 1219px, 1024px, 960px, 959px, and 390px
- [x] Light/dark screenshots, mobile drawer, sticky outline, and anchor offset smoke tests
- [x] Tests pass locally
- [x] Added new tests for the changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
