### PR TITLE
feat(sandbox): add isolated agent execution

### DIFF
--- a/codenib/agent/runner.py
+++ b/codenib/agent/runner.py
@@ -16,7 +16,17 @@ import re
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
 
 from ..compiler.manifest import RepoManifest
 from ..index.embedding.model_policy import (
@@ -53,6 +63,9 @@ from .tools.defaults import (
     ensure_default_tools_registered,
 )
 from .tools.spec import ToolRegistry
+
+if TYPE_CHECKING:
+    from ..sandbox.protocol import SandboxSession
 
 logger = get_logger(__name__)
 
@@ -178,6 +191,7 @@ class AgentRunner:
         compile_table: Optional[Any] = None,
         include_default_tools: bool = True,
         default_tool_ids: Optional[Set[str]] = None,
+        sandbox: Optional["SandboxSession"] = None,
         retry: Optional[RetryConfig] = None,
         force_localization_contract: bool = False,
         force_final_answer: bool = False,
@@ -210,6 +224,38 @@ class AgentRunner:
         # long tool-calling loop can't overflow the model context.
         self.max_context_tokens = max_context_tokens
         self.registry = registry or SkillRegistry()
+        self._sandbox = sandbox
+        if sandbox is not None and manifest is None and self.registry.list_skills():
+            raise ValueError(
+                "sandbox execution without a manifest cannot expose retrieval "
+                "skills because their source snapshot is unbound"
+            )
+        if sandbox is not None and manifest is not None:
+            manifest_revision = str(getattr(manifest, "commit", "") or "")
+            sandbox_revision = str(sandbox.metadata.source_revision or "")
+            if not manifest_revision:
+                raise ValueError(
+                    "sandbox execution requires a revision-bearing RepoManifest"
+                )
+            if manifest_revision != sandbox_revision:
+                raise ValueError(
+                    "sandbox source revision does not match RepoManifest.commit: "
+                    f"{sandbox_revision!r} != {manifest_revision!r}"
+                )
+            manifest_fingerprint = str(
+                getattr(manifest, "source_fingerprint", "") or ""
+            )
+            sandbox_fingerprint = str(sandbox.metadata.source_fingerprint or "")
+            if not manifest_fingerprint or not sandbox_fingerprint:
+                raise ValueError(
+                    "sandbox execution requires matching source fingerprints in "
+                    "the manifest and sandbox metadata"
+                )
+            if manifest_fingerprint != sandbox_fingerprint:
+                raise ValueError(
+                    "sandbox source fingerprint does not match RepoManifest: "
+                    f"{sandbox_fingerprint!r} != {manifest_fingerprint!r}"
+                )
         # Default tools (read + grep + glob + bash) are a SEPARATE type from
         # retrieval skills: they live in their own ``ToolRegistry`` and never
         # pass through the skill allow/exclude/compile_table funnel. Registered
@@ -221,7 +267,14 @@ class AgentRunner:
         self._include_defaults = include_default_tools
         self._default_ids: Set[str] = set()
         if include_default_tools:
-            ensure_default_tools_registered(self.tool_registry)
+            if sandbox is None:
+                ensure_default_tools_registered(self.tool_registry)
+            else:
+                # Import only for the explicit isolated path. Ordinary local
+                # queries do not import a container backend or contact Docker.
+                from .tools.sandbox import ensure_sandbox_tools_registered
+
+                ensure_sandbox_tools_registered(self.tool_registry, sandbox)
             # Which of the registered defaults to actually expose. Defaults to
             # ALL (read + grep + glob + bash). Restricting to a subset — e.g.
             # ``{"read"}`` — yields a graph-primary / LocAgent-style harness
@@ -322,7 +375,9 @@ class AgentRunner:
         # table can narrow that list per query, so run() renders it again after
         # resolving the query-specific subset.
         self._custom_system_prompt = system_prompt or None
-        self._environment_prompt_block = self._build_environment_block(self.session_ctx)
+        self._environment_prompt_block = self._build_environment_block(
+            self.session_ctx, sandbox=self._sandbox
+        )
         self._resource_warnings = list(resource_warnings)
         self.system_prompt = self._render_system_prompt(self.tools)
 
@@ -420,7 +475,9 @@ limited tool budget, so converge once the implementing location is confirmed.
         return ""
 
     @staticmethod
-    def _build_environment_block(session_ctx: Optional[Any]) -> str:
+    def _build_environment_block(
+        session_ctx: Optional[Any], *, sandbox: Optional["SandboxSession"] = None
+    ) -> str:
         """Render an <environment> block giving the agent a starting point.
 
         Mirrors OpenCode's environment-info layer: the agent sees the repo
@@ -428,6 +485,25 @@ limited tool budget, so converge once the implementing location is confirmed.
         before searching. Returns "" when no repo_path is available (keeps
         prompt-free tests unchanged).
         """
+        if sandbox is not None:
+            lines = [
+                "<environment>",
+                "repo_path: .",
+                "workspace_root: /workspace",
+                f"source_revision: {sandbox.metadata.source_revision or 'unversioned'}",
+                "git_metadata: unavailable; the caller collects the workspace diff",
+                "retrieval_snapshot: immutable baseline; indexes may become stale "
+                "after workspace edits",
+            ]
+            lang = getattr(session_ctx, "primary_language", None)
+            if lang:
+                lines.append(f"primary_language: {lang}")
+            size = getattr(session_ctx, "repo_size", None)
+            if size:
+                lines.append(f"repo_size: {size} files")
+            lines.append("</environment>")
+            return "\n".join(lines)
+
         repo_path = getattr(session_ctx, "repo_path", None) if session_ctx else None
         if not repo_path:
             return ""
@@ -555,6 +631,9 @@ limited tool budget, so converge once the implementing location is confirmed.
             query_chars=len(query or ""),
             max_turns=max_turns,
             tool_count=len(tools or []),
+            sandbox=(
+                self._sandbox.metadata.to_dict() if self._sandbox is not None else None
+            ),
         )
         user_query = query
         if self._enable_lsp_route_context:
@@ -1575,6 +1654,10 @@ class CodeNibAgentOptions:
     lsp_route_top_k: int = 12
     lsp_route_include_neighbors: bool = True
     retry: Optional[RetryConfig] = None
+    # Explicit isolation for the four default filesystem/shell tools. The
+    # session lifecycle remains owned by the caller so it can collect a diff
+    # and artifacts after the model turn.
+    sandbox: Optional["SandboxSession"] = None
 
     # --- extras for SessionContext.extras ---
     session_extras: Dict[str, Any] = field(default_factory=dict)
@@ -1600,6 +1683,12 @@ def query(
     opts = options or CodeNibAgentOptions()
 
     _check_exactly_one_mode(opts)
+    if opts.sandbox is not None and opts.manifest is None:
+        raise ValueError(
+            "query() sandbox execution requires a trusted, revision-matched "
+            "manifest; repo_path can run repository-selected toolchains on the "
+            "host and contexts have no source provenance"
+        )
 
     if opts.llm is None and opts.model is None:
         model_for_llm: Optional[str] = _DEFAULT_MODEL
@@ -1614,6 +1703,30 @@ def query(
     # ``load_contexts_from_manifest`` (loading) and ``AgentRunner`` (for
     # ``ResourceGuard`` freshness checks).
     manifest = _load_manifest_if_path(opts.manifest)
+    if opts.sandbox is not None and manifest is not None:
+        manifest_revision = str(manifest.commit or "")
+        sandbox_revision = str(opts.sandbox.metadata.source_revision or "")
+        if not manifest_revision:
+            raise ValueError(
+                "sandbox execution requires a revision-bearing RepoManifest"
+            )
+        if manifest_revision != sandbox_revision:
+            raise ValueError(
+                "sandbox source revision does not match RepoManifest.commit: "
+                f"{sandbox_revision!r} != {manifest_revision!r}"
+            )
+        manifest_fingerprint = str(manifest.source_fingerprint or "")
+        sandbox_fingerprint = str(opts.sandbox.metadata.source_fingerprint or "")
+        if not manifest_fingerprint or not sandbox_fingerprint:
+            raise ValueError(
+                "sandbox execution requires matching source fingerprints in the "
+                "manifest and sandbox metadata"
+            )
+        if manifest_fingerprint != sandbox_fingerprint:
+            raise ValueError(
+                "sandbox source fingerprint does not match RepoManifest: "
+                f"{sandbox_fingerprint!r} != {manifest_fingerprint!r}"
+            )
 
     # --- 1c. Surface allowed_skills ↔ compile_table mismatches before any
     # work happens. Two failure modes the caller almost certainly didn't
@@ -1723,6 +1836,7 @@ def query(
         manifest=manifest,
         session_ctx=session_ctx,
         compile_table=table,
+        sandbox=opts.sandbox,
     )
     return runner.run(prompt)
 

--- a/codenib/agent/tools/defaults.py
+++ b/codenib/agent/tools/defaults.py
@@ -104,7 +104,7 @@ _SKIP_DIR_PREFIXES = frozenset(
 # `grep` file-type filter: maps a language token to the extensions it covers.
 # Mirrors the reference Grep's ``type`` parameter (ripgrep types) for the
 # languages CodeNib indexes, plus a few common siblings.
-_TYPE_EXTENSIONS: Dict[str, Tuple[str, ...]] = {
+TYPE_EXTENSIONS: Dict[str, Tuple[str, ...]] = {
     "py": (".py", ".pyi"),
     "python": (".py", ".pyi"),
     "js": (".js", ".jsx", ".mjs", ".cjs"),
@@ -119,6 +119,7 @@ _TYPE_EXTENSIONS: Dict[str, Tuple[str, ...]] = {
     "ruby": (".rb",),
     "md": (".md", ".markdown"),
 }
+_TYPE_EXTENSIONS = TYPE_EXTENSIONS
 
 _GREP_OUTPUT_MODES = ("content", "files_with_matches", "count")
 

--- a/codenib/agent/tools/sandbox.py
+++ b/codenib/agent/tools/sandbox.py
@@ -1,0 +1,552 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Default ``read``/``grep``/``glob``/``bash`` tools bound to a sandbox."""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+from collections.abc import Mapping
+from pathlib import PurePosixPath
+from typing import List, Optional
+
+from ...sandbox import ExecRequest, SandboxSession
+from ...sandbox.types import normalize_workspace_path
+from .defaults import TYPE_EXTENSIONS
+from .spec import ToolInputSpec, ToolRegistry, ToolSpec
+
+_READ_MAX_FILE_BYTES = 4 * 1024**2
+_READ_LINES_DEFAULT = 200
+_GREP_RESULTS_DEFAULT = 50
+_GLOB_RESULTS_MAX = 100
+_BASH_TIMEOUT_MS_DEFAULT = 30_000
+_BASH_MAX_OUTPUT_CHARS = 16_000
+_SEARCH_CAPTURE_BYTES = 40 * 1024
+_SKIP_GLOBS = (
+    "!.git/**",
+    "!.hg/**",
+    "!.svn/**",
+    "!**/__pycache__/**",
+    "!**/.mypy_cache/**",
+    "!**/.pytest_cache/**",
+    "!**/.ruff_cache/**",
+    "!**/.tox/**",
+    "!**/.venv/**",
+    "!**/venv/**",
+    "!**/node_modules/**",
+    "!**/.cache/**",
+    "!**/dist/**",
+    "!**/build/**",
+)
+
+_BOUNDED_LINES_HELPER = r"""
+import base64, json, pathlib, subprocess, sys
+
+row_limit = int(sys.argv[1])
+byte_limit = int(sys.argv[2])
+workspace = pathlib.Path(sys.argv[3])
+relative = pathlib.PurePosixPath(sys.argv[4])
+target = workspace
+for part in relative.parts:
+    target = target / part
+    if target.is_symlink():
+        raise SystemExit('search paths cannot contain symlinks')
+target = target.resolve(strict=True)
+if target != workspace and workspace not in target.parents:
+    raise SystemExit('search path escaped workspace')
+command = list(sys.argv[5:])
+root_is_file = target.is_file()
+if root_is_file:
+    cwd = target.parent
+    command[-1] = target.name
+elif target.is_dir():
+    cwd = target
+    command[-1] = '.'
+else:
+    raise SystemExit('search path must be a regular file or directory')
+process = subprocess.Popen(command, cwd=cwd, stdout=subprocess.PIPE)
+rows = []
+used = 0
+truncated = False
+assert process.stdout is not None
+while len(rows) <= row_limit:
+    row = process.stdout.readline(65537)
+    if not row:
+        break
+    if len(row) > 65536 and not row.endswith(b'\n'):
+        truncated = True
+        break
+    if used + len(row) > byte_limit:
+        truncated = True
+        break
+    rows.append(row)
+    used += len(row)
+if len(rows) > row_limit:
+    rows = rows[:row_limit]
+    truncated = True
+if truncated:
+    process.terminate()
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
+else:
+    process.wait()
+process.stdout.close()
+payload = {
+    'data': base64.b64encode(b''.join(rows)).decode('ascii'),
+    'returncode': process.returncode,
+    'root_is_file': root_is_file,
+    'truncated': truncated,
+}
+print(json.dumps(payload, sort_keys=True, separators=(',', ':')))
+""".strip()
+
+
+def get_sandboxed_tool_specs(session: SandboxSession) -> List[ToolSpec]:
+    """Return the four default tool shapes backed only by *session*."""
+
+    return [
+        _build_read_tool(session),
+        _build_grep_tool(session),
+        _build_glob_tool(session),
+        _build_bash_tool(session),
+    ]
+
+
+def ensure_sandbox_tools_registered(
+    registry: ToolRegistry,
+    session: SandboxSession,
+) -> None:
+    """Idempotently register sandbox-backed default tools."""
+
+    for spec in get_sandboxed_tool_specs(session):
+        if not registry.has(spec.tool_id):
+            registry.register(spec)
+
+
+def _build_read_tool(session: SandboxSession) -> ToolSpec:
+    def read(file_path: str, offset: int = 1, limit: int = _READ_LINES_DEFAULT) -> str:
+        try:
+            start = max(1, int(offset))
+            line_limit = max(1, int(limit))
+        except (TypeError, ValueError):
+            return "Error: offset and limit must be integers"
+        try:
+            data = session.read_file(
+                file_path,
+                max_bytes=min(
+                    _READ_MAX_FILE_BYTES,
+                    int(
+                        _session_limit(session, "artifact_bytes", _READ_MAX_FILE_BYTES)
+                    ),
+                ),
+            )
+        except Exception as exc:
+            return f"Error reading {file_path!r} in sandbox: {exc}"
+        text = data.decode("utf-8", errors="replace")
+        lines = text.splitlines()
+        if not lines and not text:
+            return f"(empty file: {file_path})"
+        if start > len(lines):
+            return (
+                f"Error: offset {start} exceeds file length {len(lines)} "
+                f"in {file_path!r}"
+            )
+        selected = lines[start - 1 : start - 1 + line_limit]
+        result = "\n".join(
+            f"{number:6d} | {line}" for number, line in enumerate(selected, start=start)
+        )
+        extra = len(lines) - (start - 1 + len(selected))
+        if extra > 0:
+            result += (
+                f"\n... ({extra} more lines; "
+                f"use offset={start + line_limit} to continue)"
+            )
+        return result
+
+    return ToolSpec(
+        tool_id="read",
+        inputs=[
+            ToolInputSpec("file_path", "str", description="Repo-relative file path."),
+            ToolInputSpec(
+                "offset",
+                "int",
+                required=False,
+                default=1,
+                description="First 1-based line to read.",
+            ),
+            ToolInputSpec(
+                "limit",
+                "int",
+                required=False,
+                default=_READ_LINES_DEFAULT,
+                description="Maximum lines to return.",
+            ),
+        ],
+        executor_fn=read,
+        defaults={"offset": 1, "limit": _READ_LINES_DEFAULT},
+        tool_doc=(
+            "Read a repository-relative file from the isolated sandbox. "
+            "Absolute paths, traversal, symlinks, and special files are rejected."
+        ),
+        description="Read bounded source lines from the isolated workspace.",
+    )
+
+
+def _build_grep_tool(session: SandboxSession) -> ToolSpec:
+    def grep(
+        pattern: str,
+        path: str = ".",
+        glob: Optional[str] = None,
+        type: Optional[str] = None,
+        output_mode: str = "content",
+        case_insensitive: bool = True,
+        multiline: bool = False,
+        head_limit: int = _GREP_RESULTS_DEFAULT,
+    ) -> str:
+        try:
+            relative = normalize_workspace_path(path)
+            limit = max(1, min(1000, int(head_limit)))
+        except (TypeError, ValueError) as exc:
+            return f"Error: {exc}"
+        if output_mode not in {"content", "files_with_matches", "count"}:
+            return f"Error: unsupported output_mode: {output_mode!r}"
+        # Ripgrep emits one physical output row for every line touched by a
+        # multiline match.  The public grep contract, however, emits one row
+        # per regex match.  Do not silently return a different shape from the
+        # isolated backend; a bounded, provider-neutral multiline scanner can
+        # be added later without weakening the command/output limits here.
+        if multiline:
+            return "Error: multiline grep is not supported in sandbox mode"
+        output_limit = int(_session_limit(session, "output_bytes", 64 * 1024))
+        if output_limit < 512:
+            return "Error: sandbox output limit is too small for grep helper metadata"
+        capture_bytes = min(
+            _SEARCH_CAPTURE_BYTES,
+            max(1, ((output_limit - 256) * 3) // 4),
+        )
+
+        argv = [
+            "rg",
+            "--no-heading",
+            "--color",
+            "never",
+            "--hidden",
+            "--no-ignore",
+            "--text",
+            "--with-filename",
+        ]
+        if case_insensitive:
+            argv.append("--ignore-case")
+        if output_mode == "content":
+            argv.extend(["--line-number", "--null"])
+        elif output_mode == "files_with_matches":
+            argv.extend(["--files-with-matches", "--sort", "path"])
+        else:
+            argv.append("--count")
+        if glob:
+            argv.extend(["--glob", glob])
+        normalized_type = (type or "").lower()
+        if normalized_type in TYPE_EXTENSIONS:
+            for extension in TYPE_EXTENSIONS[normalized_type]:
+                argv.extend(["--type-add", f"codenib:*{extension}"])
+            argv.extend(["--type", "codenib"])
+        for skipped in _SKIP_GLOBS:
+            argv.extend(["--glob", skipped])
+        argv.extend(["--", pattern, str(relative)])
+
+        try:
+            result = session.execute(
+                ExecRequest(
+                    argv=(
+                        "python3",
+                        "-I",
+                        "-S",
+                        "-c",
+                        _BOUNDED_LINES_HELPER,
+                        str(limit),
+                        str(capture_bytes),
+                        "/workspace",
+                        str(relative),
+                        *argv,
+                    )
+                )
+            )
+        except Exception as exc:
+            return f"Error executing sandbox grep: {exc}"
+        if result.timed_out:
+            return "Error: sandbox grep timed out"
+        if result.output_limited:
+            return "Error: sandbox grep exceeded the audit output limit"
+        if result.exit_code != 0:
+            return f"Error: {result.stderr.strip() or 'sandbox grep failed'}"
+        try:
+            payload = json.loads(result.stdout)
+            raw = base64.b64decode(payload["data"], validate=True)
+            search_returncode = int(payload["returncode"])
+            root_is_file = bool(payload["root_is_file"])
+            helper_truncated = bool(payload["truncated"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            return f"Error: sandbox grep helper returned invalid output: {exc}"
+        if not helper_truncated and search_returncode == 1:
+            return f"No matches found for {pattern!r}"
+        if not helper_truncated and search_returncode != 0:
+            return f"Error: {result.stderr.strip() or 'sandbox grep failed'}"
+
+        rows = raw.decode("utf-8", errors="replace").splitlines()
+        if output_mode == "content":
+            normalized_rows = []
+            for row in rows:
+                path_field, path_separator, match = row.partition("\0")
+                line_number, line_separator, content = match.partition(":")
+                if path_separator and line_separator and line_number.isdigit():
+                    normalized_rows.append(
+                        f"{_normalize_rg_path(path_field)}:{line_number}: {content}"
+                    )
+                else:
+                    normalized_rows.append(
+                        re.sub(
+                            r"^(.+?:\d+:)(\S)",
+                            r"\1 \2",
+                            _normalize_rg_path(row.replace("\0", ":", 1)),
+                        )
+                    )
+            rows = normalized_rows
+        else:
+            rows = [_normalize_rg_path(row) for row in rows]
+        if root_is_file:
+            basename = relative.name
+            root_display = str(relative)
+            rows = [
+                (
+                    root_display + row[len(basename) :]
+                    if row == basename or row.startswith(f"{basename}:")
+                    else row
+                )
+                for row in rows
+            ]
+        truncated = helper_truncated or result.stdout_truncated
+        text = "\n".join(rows)
+        if truncated:
+            text += f"\n... (results truncated at head_limit={limit})"
+        return text or f"No matches found for {pattern!r}"
+
+    return ToolSpec(
+        tool_id="grep",
+        inputs=[
+            ToolInputSpec("pattern", "str", description="Ripgrep pattern."),
+            ToolInputSpec("path", "str", required=False, default="."),
+            ToolInputSpec("glob", "str", required=False, default=None),
+            ToolInputSpec("type", "str", required=False, default=None),
+            ToolInputSpec(
+                "output_mode",
+                "str",
+                required=False,
+                default="content",
+                enum=["content", "files_with_matches", "count"],
+            ),
+            ToolInputSpec("case_insensitive", "bool", required=False, default=True),
+            ToolInputSpec(
+                "multiline",
+                "bool",
+                required=False,
+                default=False,
+                description="Unavailable in sandbox mode; keep false.",
+            ),
+            ToolInputSpec(
+                "head_limit",
+                "int",
+                required=False,
+                default=_GREP_RESULTS_DEFAULT,
+            ),
+        ],
+        executor_fn=grep,
+        defaults={
+            "path": ".",
+            "output_mode": "content",
+            "case_insensitive": True,
+            "multiline": False,
+            "head_limit": _GREP_RESULTS_DEFAULT,
+        },
+        tool_doc=(
+            "Search repository content with ripgrep inside the isolated sandbox. "
+            "The pinned sandbox image must provide `rg`. Multiline matching is "
+            "rejected because ripgrep's row shape differs from the local tool "
+            "contract."
+        ),
+        description="Search source content inside the isolated workspace.",
+    )
+
+
+def _build_glob_tool(session: SandboxSession) -> ToolSpec:
+    def glob(pattern: str, path: str = ".") -> str:
+        if not pattern:
+            return "Error: pattern must be non-empty"
+        try:
+            relative = normalize_workspace_path(path)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        output_limit = int(_session_limit(session, "output_bytes", 64 * 1024))
+        if output_limit < 512:
+            return "Error: sandbox output limit is too small for glob helper metadata"
+        capture_bytes = min(
+            _SEARCH_CAPTURE_BYTES,
+            max(1, ((output_limit - 256) * 3) // 4),
+        )
+        argv = ["rg", "--files", "--hidden", "--no-ignore", "--glob", pattern]
+        for skipped in _SKIP_GLOBS:
+            argv.extend(["--glob", skipped])
+        argv.extend(["--", str(relative)])
+        try:
+            result = session.execute(
+                ExecRequest(
+                    argv=(
+                        "python3",
+                        "-I",
+                        "-S",
+                        "-c",
+                        _BOUNDED_LINES_HELPER,
+                        str(_GLOB_RESULTS_MAX),
+                        str(capture_bytes),
+                        "/workspace",
+                        str(relative),
+                        *argv,
+                    )
+                )
+            )
+        except Exception as exc:
+            return f"Error executing sandbox glob: {exc}"
+        if result.timed_out:
+            return "Error: sandbox glob timed out"
+        if result.output_limited:
+            return "Error: sandbox glob exceeded the audit output limit"
+        if result.exit_code != 0:
+            return f"Error: {result.stderr.strip() or 'sandbox glob failed'}"
+        try:
+            payload = json.loads(result.stdout)
+            raw = base64.b64decode(payload["data"], validate=True)
+            search_returncode = int(payload["returncode"])
+            root_is_file = bool(payload["root_is_file"])
+            helper_truncated = bool(payload["truncated"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            return f"Error: sandbox glob helper returned invalid output: {exc}"
+        if not helper_truncated and search_returncode not in {0, 1}:
+            return f"Error: {result.stderr.strip() or 'sandbox glob failed'}"
+        rows = sorted(
+            {
+                _normalize_rg_path(row)
+                for row in raw.decode("utf-8", errors="replace").splitlines()
+                if row
+            }
+        )
+        if root_is_file:
+            rows = [str(relative) if row == relative.name else row for row in rows]
+        truncated = helper_truncated or result.stdout_truncated
+        text = "\n".join(rows)
+        if truncated:
+            text += f"\n... (results truncated at {_GLOB_RESULTS_MAX})"
+        return text or f"No files matched {pattern!r}"
+
+    return ToolSpec(
+        tool_id="glob",
+        inputs=[
+            ToolInputSpec("pattern", "str", description="File glob pattern."),
+            ToolInputSpec("path", "str", required=False, default="."),
+        ],
+        executor_fn=glob,
+        defaults={"path": "."},
+        tool_doc=(
+            "List matching repository files inside the isolated sandbox. "
+            "The pinned sandbox image must provide `rg`."
+        ),
+        description="Enumerate files inside the isolated workspace.",
+    )
+
+
+def _build_bash_tool(session: SandboxSession) -> ToolSpec:
+    def bash(
+        command: str,
+        timeout: int = _BASH_TIMEOUT_MS_DEFAULT,
+        description: Optional[str] = None,  # noqa: ARG001
+        cwd: Optional[str] = None,
+    ) -> str:
+        try:
+            timeout_ms = int(timeout)
+        except (TypeError, ValueError):
+            return "Error: timeout must be an integer (milliseconds)"
+        timeout_seconds = min(
+            max(0.001, timeout_ms / 1000),
+            float(_session_limit(session, "command_timeout_seconds", 300.0)),
+        )
+        try:
+            request = ExecRequest(
+                argv=("/bin/sh", "-lc", command),
+                cwd=cwd or PurePosixPath("."),
+                timeout_seconds=timeout_seconds,
+            )
+            result = session.execute(request)
+        except Exception as exc:
+            return f"Error executing sandbox command {command!r}: {exc}"
+        if result.timed_out:
+            return f"Error: command timed out after {timeout_seconds}s: {command!r}"
+        if result.output_limited:
+            return f"Error: command exceeded the sandbox output limit: {command!r}"
+
+        parts = [f"$ {command}", f"(exit code: {result.exit_code})"]
+        if result.stdout:
+            parts.append(f"--- stdout ---\n{result.stdout.rstrip()}")
+        if result.stderr:
+            parts.append(f"--- stderr ---\n{result.stderr.rstrip()}")
+        text = "\n".join(parts)
+        if result.stdout_truncated or result.stderr_truncated:
+            text += (
+                "\n... (output truncated; full bounded logs are in the audit record)"
+            )
+        if len(text) > _BASH_MAX_OUTPUT_CHARS:
+            text = text[:_BASH_MAX_OUTPUT_CHARS] + "\n... (output truncated)"
+        return text
+
+    return ToolSpec(
+        tool_id="bash",
+        inputs=[
+            ToolInputSpec("command", "str", description="Shell command line."),
+            ToolInputSpec(
+                "timeout",
+                "int",
+                required=False,
+                default=_BASH_TIMEOUT_MS_DEFAULT,
+            ),
+            ToolInputSpec("description", "str", required=False, default=None),
+            ToolInputSpec("cwd", "str", required=False, default=None),
+        ],
+        executor_fn=bash,
+        defaults={"timeout": _BASH_TIMEOUT_MS_DEFAULT},
+        tool_doc=(
+            "Execute a shell command inside the isolated sandbox. The host "
+            "never interprets the command and no host environment is forwarded."
+        ),
+        description="Execute a bounded command inside the isolated workspace.",
+    )
+
+
+def _normalize_rg_path(row: str) -> str:
+    return row[2:] if row.startswith("./") else row
+
+
+def _session_limit(
+    session: SandboxSession, name: str, default: float | int
+) -> float | int:
+    policy = session.metadata.policy
+    limits = policy.get("limits") if isinstance(policy, Mapping) else None
+    value = limits.get(name) if isinstance(limits, Mapping) else None
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        return value
+    return default
+
+
+__all__ = ["ensure_sandbox_tools_registered", "get_sandboxed_tool_specs"]

--- a/codenib/sandbox/__init__.py
+++ b/codenib/sandbox/__init__.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider-neutral isolation for repository execution.
+
+Sandboxing is opt-in. Importing this package never contacts a container
+runtime; construct :class:`DockerSandboxProvider` explicitly on a dedicated
+worker when untrusted code execution is required.
+"""
+
+from .docker import DockerSandboxProvider, DockerSandboxSession
+from .protocol import (
+    SandboxClosedError,
+    SandboxError,
+    SandboxPolicyError,
+    SandboxProvider,
+    SandboxSession,
+    SandboxUnavailableError,
+)
+from .types import (
+    ArtifactBundle,
+    ArtifactMember,
+    DiffResult,
+    ExecRequest,
+    ExecResult,
+    NetworkMode,
+    SandboxCapabilities,
+    SandboxLimits,
+    SandboxMetadata,
+    SandboxPolicy,
+    SandboxSpec,
+)
+
+__all__ = [
+    "ArtifactBundle",
+    "ArtifactMember",
+    "DiffResult",
+    "DockerSandboxProvider",
+    "DockerSandboxSession",
+    "ExecRequest",
+    "ExecResult",
+    "NetworkMode",
+    "SandboxCapabilities",
+    "SandboxClosedError",
+    "SandboxError",
+    "SandboxLimits",
+    "SandboxMetadata",
+    "SandboxPolicy",
+    "SandboxPolicyError",
+    "SandboxProvider",
+    "SandboxSession",
+    "SandboxSpec",
+    "SandboxUnavailableError",
+]

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -33,10 +33,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Collection, Dict, Mapping, Sequence, TypedDict
 
-from ..repository_filters import (
-    DEFAULT_IGNORED_DIRS,
-    REPOSITORY_FILTER_POLICY_VERSION,
-)
+from ..repository_filters import DEFAULT_IGNORED_DIRS, REPOSITORY_FILTER_POLICY_VERSION
 from ..source_fingerprint import SOURCE_FINGERPRINT_VERSION
 from .protocol import (
     SandboxClosedError,
@@ -70,7 +67,7 @@ _SECRET_IMAGE_ENV_RE = re.compile(
 _COPY_TRUSTED_SOURCE_SCRIPT = r"""
 set -eu
 tar -C /source --exclude=.git --exclude='*/.git' -cf - . \
-  | tar -C /workspace -xf -
+  | tar -C /workspace --no-same-owner -xf -
 chown -R 65532:65532 /workspace
 """.strip()
 
@@ -87,13 +84,13 @@ export GIT_ALLOW_PROTOCOL=
 git --git-dir=/repository.git -c core.hooksPath=/dev/null \
   -c core.attributesFile=/dev/null \
   archive --format=tar --output=/tmp/source.tar "$1"
-tar -C /workspace -xf /tmp/source.tar
+tar -C /workspace --no-same-owner -xf /tmp/source.tar
 chown -R 65532:65532 /workspace
 """.strip()
 
 _COPY_VOLUME_SCRIPT = r"""
 set -eu
-tar -C /baseline -cf - . | tar -C /workspace -xf -
+tar -C /baseline -cf - . | tar -C /workspace --no-same-owner -xf -
 chown -R 65532:65532 /workspace
 """.strip()
 

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -1,0 +1,2083 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rootless-Docker sandbox backend for untrusted repository commands.
+
+The backend deliberately uses one ``docker run --rm`` container per command.
+Only a server-created named volume survives between commands. This makes a
+timeout or output-limit kill remove the entire process tree instead of leaving
+background children in a persistent container.
+
+The repository baseline is held in a second volume that is never mounted into
+model-controlled commands. Diff and file helpers are fixed provider calls; they
+do not trust a workspace ``.git`` directory or run host-side repository code.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import stat
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+import zipfile
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Collection, Dict, Mapping, Sequence, TypedDict
+
+from ..repository_filters import (
+    DEFAULT_IGNORED_DIRS,
+    REPOSITORY_FILTER_POLICY_VERSION,
+)
+from ..source_fingerprint import SOURCE_FINGERPRINT_VERSION
+from .protocol import (
+    SandboxClosedError,
+    SandboxError,
+    SandboxPolicyError,
+    SandboxUnavailableError,
+)
+from .types import (
+    ArtifactBundle,
+    ArtifactMember,
+    DiffResult,
+    ExecRequest,
+    ExecResult,
+    NetworkMode,
+    SandboxCapabilities,
+    SandboxMetadata,
+    SandboxSpec,
+    normalize_workspace_path,
+)
+
+_CONTAINER_USER = "65532:65532"
+_CONTROL_USER = "0:0"
+_MAX_ARTIFACT_FILES = 1000
+_SECRET_IMAGE_ENV_RE = re.compile(
+    r"(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|PRIVATE_KEY|API_KEY|AUTH|COOKIE|"
+    r"AWS_|AZURE_|GOOGLE_APPLICATION_CREDENTIALS|GITHUB_|OPENAI_|ANTHROPIC_|"
+    r"SSH_|KUBE|DOCKER_)",
+    re.IGNORECASE,
+)
+
+_COPY_TRUSTED_SOURCE_SCRIPT = r"""
+set -eu
+tar -C /source --exclude=.git --exclude='*/.git' -cf - . \
+  | tar -C /workspace -xf -
+chown -R 65532:65532 /workspace
+""".strip()
+
+_ARCHIVE_COMMIT_SCRIPT = r"""
+set -eu
+export GIT_NO_REPLACE_OBJECTS=1
+export GIT_NO_LAZY_FETCH=1
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/bin/false
+export SSH_ASKPASS=/bin/false
+export GIT_ALLOW_PROTOCOL=
+git --git-dir=/repository.git -c core.hooksPath=/dev/null \
+  -c core.attributesFile=/dev/null \
+  archive --format=tar --output=/tmp/source.tar "$1"
+tar -C /workspace -xf /tmp/source.tar
+chown -R 65532:65532 /workspace
+""".strip()
+
+_COPY_VOLUME_SCRIPT = r"""
+set -eu
+tar -C /baseline -cf - . | tar -C /workspace -xf -
+chown -R 65532:65532 /workspace
+""".strip()
+
+_CGROUP_PROBE_SCRIPT = r"""
+set -eu
+printf 'memory='; cat /sys/fs/cgroup/memory.max
+printf 'pids='; cat /sys/fs/cgroup/pids.max
+printf 'cpu='; cat /sys/fs/cgroup/cpu.max
+""".strip()
+
+_FINGERPRINT_SOURCE_SCRIPT = r"""
+import hashlib, json, os, pathlib, stat, sys
+
+root = pathlib.Path('/workspace')
+ignored = set(json.loads(sys.argv[1]))
+fingerprint_version = int(sys.argv[2])
+filter_version = int(sys.argv[3])
+hasher = hashlib.sha256()
+hasher.update(
+    (
+        f'codenib-source-fingerprint:{fingerprint_version}:'
+        f'{filter_version}\0'
+    ).encode('ascii')
+)
+file_count = 0
+for current_root, directories, files in os.walk(root):
+    directories[:] = sorted(
+        name for name in directories
+        if name not in ignored and not name.startswith('.codenib')
+    )
+    current = pathlib.Path(current_root)
+    for filename in sorted(files):
+        path = current / filename
+        mode = path.lstat().st_mode
+        if stat.S_ISLNK(mode):
+            raise SystemExit('source fingerprint does not permit symlinks')
+        if not stat.S_ISREG(mode):
+            continue
+        relative = path.relative_to(root).as_posix().encode(
+            'utf-8', errors='surrogateescape'
+        )
+        hasher.update(b'F\0')
+        hasher.update(relative)
+        hasher.update(b'\0')
+        with path.open('rb') as handle:
+            while True:
+                block = handle.read(1024 * 1024)
+                if not block:
+                    break
+                hasher.update(block)
+        hasher.update(b'\0')
+        file_count += 1
+print(json.dumps({
+    'file_count': file_count,
+    'source_fingerprint': 'sha256:' + hasher.hexdigest(),
+}, sort_keys=True, separators=(',', ':')))
+""".strip()
+
+_READ_FILE_HELPER = r"""
+import os, pathlib, stat, sys
+root = pathlib.Path('/workspace')
+relative = pathlib.PurePosixPath(sys.argv[1])
+limit = int(sys.argv[2])
+current = root
+for part in relative.parts:
+    current = current / part
+    if current.is_symlink():
+        raise SystemExit('symlink paths are not allowed')
+resolved = current.resolve(strict=True)
+if resolved != root and root not in resolved.parents:
+    raise SystemExit('path escaped workspace')
+mode = resolved.stat().st_mode
+if not stat.S_ISREG(mode):
+    raise SystemExit('path is not a regular file')
+with resolved.open('rb') as handle:
+    data = handle.read(limit + 1)
+if len(data) > limit:
+    raise SystemExit('file exceeds byte limit')
+sys.stdout.buffer.write(data)
+""".strip()
+
+_WRITE_FILE_HELPER = r"""
+import os, pathlib, stat, sys, tempfile
+root = pathlib.Path('/workspace')
+relative = pathlib.PurePosixPath(sys.argv[1])
+create_parents = sys.argv[2] == '1'
+current = root
+parts = relative.parts
+for part in parts[:-1]:
+    current = current / part
+    if current.exists() and current.is_symlink():
+        raise SystemExit('symlink paths are not allowed')
+    if not current.exists():
+        if not create_parents:
+            raise SystemExit('parent directory does not exist')
+        current.mkdir(mode=0o755)
+parent = current.resolve(strict=True)
+if parent != root and root not in parent.parents:
+    raise SystemExit('path escaped workspace')
+target = parent / parts[-1]
+if target.exists() and (target.is_symlink() or not target.is_file()):
+    raise SystemExit('target must be a regular file')
+data = sys.stdin.buffer.read()
+fd, temporary = tempfile.mkstemp(prefix='.codenib-write-', dir=parent)
+try:
+    with os.fdopen(fd, 'wb') as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(temporary, 0o644)
+    os.replace(temporary, target)
+finally:
+    try:
+        os.unlink(temporary)
+    except FileNotFoundError:
+        pass
+""".strip()
+
+_LIST_ARTIFACTS_HELPER = r"""
+import json, os, pathlib, stat, sys
+root = pathlib.Path('/workspace')
+limit = int(sys.argv[1])
+seen = set()
+rows = []
+
+def add_path(path):
+    relative = path.relative_to(root).as_posix()
+    if relative in seen:
+        return
+    info = path.lstat()
+    if stat.S_ISLNK(info.st_mode):
+        raise SystemExit('artifact symlinks are not allowed')
+    if stat.S_ISREG(info.st_mode):
+        if info.st_nlink != 1:
+            raise SystemExit('artifact hardlinks are not allowed')
+        seen.add(relative)
+        rows.append({'path': relative, 'size': info.st_size})
+        if len(rows) > limit:
+            raise SystemExit('artifact file-count limit exceeded')
+        return
+    if not stat.S_ISDIR(info.st_mode):
+        raise SystemExit('artifact contains a special file')
+    for entry in sorted(os.scandir(path), key=lambda item: item.name):
+        if entry.is_symlink():
+            raise SystemExit('artifact symlinks are not allowed')
+        add_path(pathlib.Path(entry.path))
+
+for raw in sys.argv[2:]:
+    current = root
+    for part in pathlib.PurePosixPath(raw).parts:
+        current = current / part
+        if current.is_symlink():
+            raise SystemExit('artifact symlinks are not allowed')
+    resolved = current.resolve(strict=True)
+    if resolved != root and root not in resolved.parents:
+        raise SystemExit('artifact path escaped workspace')
+    add_path(resolved)
+print(json.dumps(rows, sort_keys=True, separators=(',', ':')))
+""".strip()
+
+
+RunCLI = Callable[..., subprocess.CompletedProcess[str]]
+PopenFactory = Callable[..., subprocess.Popen[bytes]]
+
+
+@dataclass
+class _StreamState:
+    """Shared byte budget for stdout and stderr drain threads."""
+
+    remaining: int
+
+    def __post_init__(self) -> None:
+        self.lock = threading.Lock()
+        self.exhausted = threading.Event()
+        self.failed = threading.Event()
+        self.errors: list[str] = []
+
+    def reserve(self, size: int) -> int:
+        with self.lock:
+            allowed = min(size, self.remaining)
+            self.remaining -= allowed
+            if allowed < size:
+                self.exhausted.set()
+            return allowed
+
+    def record_failure(self, exc: BaseException) -> None:
+        with self.lock:
+            self.errors.append(f"{type(exc).__name__}: {exc}")
+            self.failed.set()
+
+
+@dataclass(frozen=True)
+class _StreamRecord:
+    path: Path
+    sha256: str
+    bytes: int
+
+
+@dataclass(frozen=True)
+class _RunCapture:
+    result: ExecResult
+    stdout_record: _StreamRecord
+    stderr_record: _StreamRecord
+
+
+class _SourceIdentity(TypedDict):
+    source_fingerprint: str
+    file_count: int
+
+
+class DockerSandboxProvider:
+    """Create digest-pinned, rootless-Docker sandbox sessions.
+
+    Args:
+        allowed_images: Exact digest-pinned image references approved by the
+            service control plane. The model never selects an arbitrary image.
+        docker_binary: Docker-compatible client binary. This backend validates
+            Docker semantics and must not be pointed at Podman.
+        work_root: Controller-only directory for bounded audit logs.
+        retain_audit_logs: Keep audit logs after session close. Production bot
+            workers should set this and apply their own retention policy.
+    """
+
+    def __init__(
+        self,
+        *,
+        allowed_images: Collection[str],
+        docker_binary: str = "docker",
+        docker_host: str | None = None,
+        git_binary: str = "git",
+        work_root: Path | None = None,
+        retain_audit_logs: bool = False,
+        run_cli: RunCLI = subprocess.run,
+        popen_factory: PopenFactory = subprocess.Popen,
+        clock: Callable[[], float] = time.monotonic,
+        id_factory: Callable[[], uuid.UUID] = uuid.uuid4,
+    ) -> None:
+        images = frozenset(allowed_images)
+        if not images:
+            raise ValueError("allowed_images must contain at least one pinned image")
+        self._allowed_images = images
+        self._docker_binary_request = docker_binary
+        self._docker_binary: str | None = None
+        self._git_binary_request = git_binary
+        self._git_binary: str | None = None
+        self._docker_host = docker_host or f"unix:///run/user/{os.getuid()}/docker.sock"
+        self._validate_docker_host(self._docker_host)
+        # Every client call uses the same explicit endpoint, absolute binary,
+        # and minimal environment. Host Docker contexts/config and credentials
+        # cannot redirect a preflighted call or reach a registry helper.
+        self._docker_env = {
+            "DOCKER_CONFIG": "/nonexistent/codenib-docker-config",
+            "DOCKER_CONTEXT": "",
+            "DOCKER_HOST": self._docker_host,
+            "HOME": "/nonexistent",
+            "LANG": "C.UTF-8",
+            "PATH": "/usr/bin:/bin",
+        }
+        self._work_root = Path(work_root) if work_root is not None else None
+        self._retain_audit_logs = retain_audit_logs
+        self._run_cli = run_cli
+        self._popen_factory = popen_factory
+        self._clock = clock
+        self._id_factory = id_factory
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            provider="docker",
+            isolation="container",
+            non_root_user=True,
+            network_isolation=True,
+            read_only_rootfs=True,
+            resource_limits=True,
+            process_tree_cleanup=True,
+            disk_quota=False,
+            rootless_runtime=None,
+        )
+
+    def create(self, spec: SandboxSpec) -> "DockerSandboxSession":
+        """Preflight runtime/image policy, copy the source, and return a session."""
+
+        if spec.image not in self._allowed_images:
+            raise SandboxPolicyError("image is not in the provider allowlist")
+        if spec.source_revision is not None:
+            self._resolve_git_binary()
+        source_request = (
+            spec.source_dir
+            if spec.source_dir.is_absolute()
+            else Path.cwd() / spec.source_dir
+        )
+        self._validate_host_mount_path(source_request)
+        if not source_request.is_dir():
+            raise SandboxPolicyError(
+                f"source directory does not exist: {spec.source_dir}"
+            )
+        source = source_request.resolve(strict=True)
+        if source == Path(source.anchor):
+            raise SandboxPolicyError("filesystem root cannot be a sandbox source")
+        if self._work_root is not None:
+            audit_root = self._work_root.expanduser().resolve()
+            if audit_root == source or source in audit_root.parents:
+                raise SandboxPolicyError(
+                    "controller audit root must be outside the repository source"
+                )
+        git_common_dir = self._verify_source_revision(source, spec.source_revision)
+
+        runtime = self._inspect_runtime(spec)
+        image = self._inspect_image(spec)
+        sandbox_token = self._id_factory().hex
+        sandbox_id = f"sbx-{sandbox_token}"
+        self._verify_runtime_limits(spec, sandbox_id)
+        task_id = spec.task_id or sandbox_id
+        baseline_volume = f"codenib-{sandbox_token}-base"
+        workspace_volume = f"codenib-{sandbox_token}-work"
+        audit_dir = self._create_audit_dir(sandbox_token)
+        created_volumes: list[str] = []
+
+        try:
+            created_volumes.append(baseline_volume)
+            self._create_volume(baseline_volume, sandbox_id, "baseline")
+            created_volumes.append(workspace_volume)
+            self._create_volume(workspace_volume, sandbox_id, "workspace")
+            self._populate_baseline(
+                spec,
+                sandbox_id=sandbox_id,
+                source=source,
+                git_common_dir=git_common_dir,
+                baseline_volume=baseline_volume,
+            )
+            source_identity: _SourceIdentity = (
+                self._fingerprint_baseline(
+                    spec,
+                    sandbox_id=sandbox_id,
+                    baseline_volume=baseline_volume,
+                )
+                if spec.source_revision is not None
+                else {"source_fingerprint": "", "file_count": 0}
+            )
+            # Detect a controller checkout changing during the snapshot.
+            self._verify_source_revision(source, spec.source_revision)
+            self._populate_workspace(
+                spec,
+                sandbox_id=sandbox_id,
+                baseline_volume=baseline_volume,
+                workspace_volume=workspace_volume,
+            )
+
+            metadata = SandboxMetadata(
+                sandbox_id=sandbox_id,
+                task_id=task_id,
+                provider="docker",
+                image=spec.image,
+                image_id=str(image["Id"]),
+                platform=spec.platform,
+                source_revision=spec.source_revision,
+                network=spec.policy.network.value,
+                rootless_runtime=runtime["rootless"],
+                source_fingerprint=source_identity["source_fingerprint"],
+                policy=_policy_summary(spec),
+            )
+            session = DockerSandboxSession(
+                provider=self,
+                spec=spec,
+                metadata=metadata,
+                baseline_volume=baseline_volume,
+                workspace_volume=workspace_volume,
+                audit_dir=audit_dir,
+            )
+            session._record_audit(
+                "sandbox_created",
+                image_id=metadata.image_id,
+                source_revision=metadata.source_revision,
+                source_fingerprint=metadata.source_fingerprint,
+                source_file_count=source_identity["file_count"],
+                platform=metadata.platform,
+                network=metadata.network,
+                rootless_runtime=metadata.rootless_runtime,
+                policy=metadata.policy,
+                capabilities=asdict(session.capabilities),
+            )
+        except Exception as exc:
+            failed_cleanup = [
+                volume
+                for volume in reversed(created_volumes)
+                if not self._remove_volume(volume)
+            ]
+            if failed_cleanup:
+                _write_emergency_audit(
+                    audit_dir,
+                    event="bootstrap_cleanup_failed",
+                    sandbox_id=sandbox_id,
+                    volumes=failed_cleanup,
+                )
+                raise SandboxUnavailableError(
+                    "sandbox bootstrap cleanup failed; quarantine and reap the "
+                    "worker before accepting another job"
+                ) from exc
+            self._remove_audit_dir(audit_dir)
+            raise
+        return session
+
+    def _inspect_runtime(self, spec: SandboxSpec) -> Dict[str, Any]:
+        binary = shutil.which(self._docker_binary_request)
+        if binary is None:
+            raise SandboxUnavailableError(
+                f"Docker client is unavailable: {self._docker_binary_request}"
+            )
+        try:
+            resolved_binary = Path(binary).resolve(strict=True)
+        except OSError as exc:
+            raise SandboxUnavailableError(
+                f"Docker client cannot be resolved safely: {binary}"
+            ) from exc
+        if not resolved_binary.is_file() or not os.access(resolved_binary, os.X_OK):
+            raise SandboxUnavailableError(
+                f"Docker client is not an executable file: {resolved_binary}"
+            )
+        self._docker_binary = str(resolved_binary)
+
+        completed = self._call_cli(["info", "--format", "{{json .}}"])
+        try:
+            info = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise SandboxUnavailableError("Docker info returned invalid JSON") from exc
+        options_text = json.dumps(info.get("SecurityOptions") or []).lower()
+        rootless = "rootless" in options_text
+        seccomp = "seccomp" in options_text
+        if spec.policy.require_rootless_runtime and not rootless:
+            raise SandboxPolicyError("Docker daemon is not running in rootless mode")
+        if not seccomp:
+            raise SandboxPolicyError("Docker daemon does not report seccomp support")
+        if rootless and (
+            str(info.get("CgroupVersion")) != "2"
+            or str(info.get("CgroupDriver")) != "systemd"
+        ):
+            raise SandboxPolicyError(
+                "rootless Docker needs cgroup v2 + systemd for enforced limits"
+            )
+        return {"rootless": rootless, "info": info}
+
+    def _inspect_image(self, spec: SandboxSpec) -> Mapping[str, Any]:
+        completed = self._call_cli(["image", "inspect", spec.image])
+        try:
+            images = json.loads(completed.stdout)
+            image = images[0]
+        except (json.JSONDecodeError, IndexError, KeyError, TypeError) as exc:
+            raise SandboxUnavailableError(
+                "Docker image inspect returned invalid JSON"
+            ) from exc
+
+        expected_os, expected_arch, *expected_variant = spec.platform.split("/")
+        actual_variant = str(image.get("Variant") or "")
+        if (
+            str(image.get("Os")) != expected_os
+            or str(image.get("Architecture")) != expected_arch
+        ):
+            raise SandboxPolicyError(
+                "image platform does not match SandboxSpec.platform"
+            )
+        if expected_variant and actual_variant != expected_variant[0]:
+            raise SandboxPolicyError(
+                "image variant does not match SandboxSpec.platform"
+            )
+
+        requested_digest = spec.image.rsplit("@", 1)[-1] if "@" in spec.image else None
+        repo_digests = image.get("RepoDigests") or []
+        if requested_digest and not any(
+            str(value).endswith(f"@{requested_digest}") for value in repo_digests
+        ):
+            raise SandboxPolicyError("local image does not match the requested digest")
+
+        config = image.get("Config") or {}
+        if config.get("Volumes"):
+            raise SandboxPolicyError(
+                "sandbox images must not declare Docker VOLUME paths"
+            )
+        for item in config.get("Env") or []:
+            name = str(item).partition("=")[0]
+            if _SECRET_IMAGE_ENV_RE.search(name):
+                raise SandboxPolicyError(
+                    f"sandbox image embeds a sensitive environment name: {name}"
+                )
+        if not image.get("Id"):
+            raise SandboxUnavailableError("Docker image inspect omitted image Id")
+        return image
+
+    def _verify_runtime_limits(self, spec: SandboxSpec, sandbox_id: str) -> None:
+        """Run a fixed probe and verify cgroup limits were not silently ignored."""
+
+        name = f"{sandbox_id}-limit-probe"
+        args = self._base_run_args(
+            spec,
+            container_name=name,
+            user=_CONTAINER_USER,
+            network=NetworkMode.NONE,
+        )
+        args.extend(
+            [
+                "--workdir",
+                "/",
+                spec.image,
+                "/bin/sh",
+                "-c",
+                _CGROUP_PROBE_SCRIPT,
+            ]
+        )
+        completed = self._run_control_container(name, args)
+        values: Dict[str, str] = {}
+        for line in completed.stdout.splitlines():
+            key, separator, value = line.partition("=")
+            if separator:
+                values[key] = value.strip()
+        limits = spec.policy.limits
+        if values.get("memory") != str(limits.memory_bytes):
+            raise SandboxPolicyError(
+                "Docker did not enforce the requested memory limit"
+            )
+        if values.get("pids") != str(limits.pids):
+            raise SandboxPolicyError("Docker did not enforce the requested PID limit")
+        cpu_parts = values.get("cpu", "").split()
+        try:
+            quota, period = (float(value) for value in cpu_parts)
+        except (TypeError, ValueError) as exc:
+            raise SandboxPolicyError(
+                "Docker did not expose a finite CPU limit"
+            ) from exc
+        if period <= 0 or abs((quota / period) - limits.cpus) > 0.001:
+            raise SandboxPolicyError("Docker did not enforce the requested CPU limit")
+
+    def _verify_source_revision(
+        self, source: Path, revision: str | None
+    ) -> Path | None:
+        if revision is None:
+            return None
+        completed = subprocess.run(
+            self._git_command(
+                [
+                    "-c",
+                    "core.fsmonitor=false",
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "-C",
+                    str(source),
+                    "rev-parse",
+                    "--verify",
+                    "HEAD^{commit}",
+                ]
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=_safe_git_environment(),
+        )
+        actual = completed.stdout.strip()
+        if completed.returncode != 0 or actual != revision:
+            raise SandboxPolicyError(
+                f"source checkout is not at requested revision {revision}"
+            )
+        top_level_result = subprocess.run(
+            self._git_command(["-C", str(source), "rev-parse", "--show-toplevel"]),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=_safe_git_environment(),
+        )
+        try:
+            top_level = Path(top_level_result.stdout.strip()).resolve(strict=True)
+        except OSError as exc:
+            raise SandboxPolicyError("source Git top-level is unavailable") from exc
+        if top_level_result.returncode != 0 or top_level != source:
+            raise SandboxPolicyError(
+                "sandbox source_dir must be the repository top-level directory"
+            )
+        common_dir_result = subprocess.run(
+            self._git_command(
+                [
+                    "-c",
+                    "core.fsmonitor=false",
+                    "-C",
+                    str(source),
+                    "rev-parse",
+                    "--path-format=absolute",
+                    "--git-common-dir",
+                ]
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_safe_git_environment(),
+        )
+        common_dir_request = Path(common_dir_result.stdout.strip())
+        try:
+            self._validate_host_mount_path(common_dir_request)
+            common_dir = common_dir_request.resolve(strict=True)
+        except OSError as exc:
+            raise SandboxPolicyError(
+                "source Git object directory is unavailable"
+            ) from exc
+        if common_dir_result.returncode != 0 or not common_dir.is_dir():
+            raise SandboxPolicyError(
+                "source checkout does not expose a valid Git object directory"
+            )
+        tree_modes = subprocess.run(
+            self._git_command(
+                [
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "-C",
+                    str(source),
+                    "ls-tree",
+                    "-r",
+                    "--full-tree",
+                    "--format=%(objectmode)",
+                    revision,
+                ]
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_safe_git_environment(),
+        )
+        if tree_modes.returncode != 0:
+            raise SandboxPolicyError("source Git tree cannot be inspected safely")
+        if "160000" in tree_modes.stdout.splitlines():
+            raise SandboxPolicyError(
+                "Git submodules are unsupported in revision-pinned sandboxes"
+            )
+        if "120000" in tree_modes.stdout.splitlines():
+            raise SandboxPolicyError(
+                "Git symlinks are unsupported in revision-pinned sandboxes"
+            )
+        archive_attributes = subprocess.run(
+            self._git_command(
+                [
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "-C",
+                    str(source),
+                    "grep",
+                    "--quiet",
+                    "--extended-regexp",
+                    r"export-(ignore|subst)",
+                    revision,
+                    "--",
+                    ".gitattributes",
+                    ":(glob)**/.gitattributes",
+                ]
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_safe_git_environment(),
+        )
+        if archive_attributes.returncode == 0:
+            raise SandboxPolicyError(
+                "export-ignore/export-subst attributes are unsupported in exact "
+                "revision snapshots"
+            )
+        if archive_attributes.returncode != 1:
+            raise SandboxPolicyError("source archive attributes cannot be inspected")
+        info_attributes = common_dir / "info" / "attributes"
+        try:
+            info_attributes_stat = info_attributes.lstat()
+        except FileNotFoundError:
+            info_attributes_stat = None
+        except OSError as exc:
+            raise SandboxPolicyError(
+                "Git info attributes file cannot be inspected"
+            ) from exc
+        if info_attributes_stat is not None:
+            if not stat.S_ISREG(info_attributes_stat.st_mode):
+                raise SandboxPolicyError(
+                    "Git info attributes must be a regular, non-symlink file"
+                )
+            try:
+                if info_attributes_stat.st_size > 1024**2:
+                    raise SandboxPolicyError("Git info attributes file is too large")
+                info_text = info_attributes.read_text(
+                    encoding="utf-8", errors="replace"
+                )
+            except OSError as exc:
+                raise SandboxPolicyError(
+                    "Git info attributes file cannot be inspected"
+                ) from exc
+            if re.search(r"export-(?:ignore|subst)", info_text):
+                raise SandboxPolicyError(
+                    "Git info export attributes are unsupported in exact snapshots"
+                )
+        self._validate_host_mount_path(common_dir)
+        return common_dir
+
+    def _create_volume(self, name: str, sandbox_id: str, kind: str) -> None:
+        self._call_cli(
+            [
+                "volume",
+                "create",
+                "--label",
+                f"ai.codenib.sandbox={sandbox_id}",
+                "--label",
+                f"ai.codenib.kind={kind}",
+                name,
+            ]
+        )
+
+    def _populate_baseline(
+        self,
+        spec: SandboxSpec,
+        *,
+        sandbox_id: str,
+        source: Path,
+        git_common_dir: Path | None,
+        baseline_volume: str,
+    ) -> None:
+        name = f"{sandbox_id}-init-base"
+        args = self._base_run_args(
+            spec,
+            container_name=name,
+            user=_CONTROL_USER,
+            network=NetworkMode.NONE,
+        )
+        args.extend(["--cap-add", "CHOWN"])
+        if spec.source_revision is not None:
+            if git_common_dir is None:
+                raise SandboxPolicyError("verified Git source has no object directory")
+            args.extend(
+                [
+                    "--mount",
+                    f"type=bind,src={git_common_dir},dst=/repository.git,readonly",
+                ]
+            )
+        else:
+            # Explicitly trusted generated fixtures may opt out of Git revision
+            # verification. Public automation must never use this path.
+            args.extend(
+                [
+                    "--mount",
+                    f"type=bind,src={source},dst=/source,readonly",
+                ]
+            )
+        args.extend(
+            [
+                "--mount",
+                f"type=volume,src={baseline_volume},dst=/workspace,volume-nocopy",
+                "--workdir",
+                "/",
+                spec.image,
+                "/bin/sh",
+                "-c",
+                (
+                    _ARCHIVE_COMMIT_SCRIPT
+                    if spec.source_revision is not None
+                    else _COPY_TRUSTED_SOURCE_SCRIPT
+                ),
+            ]
+        )
+        if spec.source_revision is not None:
+            args.extend(["codenib-archive", spec.source_revision])
+        self._run_control_container(name, args)
+
+    def _populate_workspace(
+        self,
+        spec: SandboxSpec,
+        *,
+        sandbox_id: str,
+        baseline_volume: str,
+        workspace_volume: str,
+    ) -> None:
+        name = f"{sandbox_id}-init-work"
+        args = self._base_run_args(
+            spec,
+            container_name=name,
+            user=_CONTROL_USER,
+            network=NetworkMode.NONE,
+        )
+        args.extend(
+            [
+                "--cap-add",
+                "CHOWN",
+                "--mount",
+                f"type=volume,src={baseline_volume},dst=/baseline,readonly,volume-nocopy",
+                "--mount",
+                f"type=volume,src={workspace_volume},dst=/workspace,volume-nocopy",
+                "--workdir",
+                "/",
+                spec.image,
+                "/bin/sh",
+                "-c",
+                _COPY_VOLUME_SCRIPT,
+            ]
+        )
+        self._run_control_container(name, args)
+
+    def _fingerprint_baseline(
+        self,
+        spec: SandboxSpec,
+        *,
+        sandbox_id: str,
+        baseline_volume: str,
+    ) -> _SourceIdentity:
+        name = f"{sandbox_id}-fingerprint"
+        args = self._base_run_args(
+            spec,
+            container_name=name,
+            user=_CONTAINER_USER,
+            network=NetworkMode.NONE,
+        )
+        args.extend(
+            [
+                "--mount",
+                f"type=volume,src={baseline_volume},dst=/workspace,readonly,volume-nocopy",
+                "--workdir",
+                "/",
+                spec.image,
+                "python3",
+                "-I",
+                "-S",
+                "-c",
+                _FINGERPRINT_SOURCE_SCRIPT,
+                json.dumps(sorted(DEFAULT_IGNORED_DIRS), separators=(",", ":")),
+                str(SOURCE_FINGERPRINT_VERSION),
+                str(REPOSITORY_FILTER_POLICY_VERSION),
+            ]
+        )
+        completed = self._run_control_container(name, args)
+        try:
+            identity = json.loads(completed.stdout)
+            fingerprint = str(identity["source_fingerprint"])
+            file_count = int(identity["file_count"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise SandboxUnavailableError(
+                "sandbox source fingerprint helper returned invalid output"
+            ) from exc
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", fingerprint) or file_count < 0:
+            raise SandboxUnavailableError(
+                "sandbox source fingerprint helper returned invalid identity"
+            )
+        return {"source_fingerprint": fingerprint, "file_count": file_count}
+
+    def _run_control_container(
+        self, name: str, args: Sequence[str]
+    ) -> subprocess.CompletedProcess[str]:
+        failed = False
+        try:
+            completed = self._run_cli(
+                self._docker_command(args),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                shell=False,
+                env=self._docker_env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            failed = True
+            raise SandboxUnavailableError("sandbox bootstrap timed out") from exc
+        except OSError as exc:
+            failed = True
+            raise SandboxUnavailableError(f"sandbox bootstrap failed: {exc}") from exc
+        finally:
+            cleanup_ok = self._remove_container(name)
+            if failed and not cleanup_ok:
+                raise SandboxUnavailableError(
+                    "sandbox bootstrap cleanup failed; quarantine and reap the worker"
+                )
+        if not cleanup_ok:
+            raise SandboxUnavailableError(
+                "sandbox bootstrap cleanup failed; quarantine and reap the worker"
+            )
+        if completed.returncode != 0:
+            message = (completed.stderr or completed.stdout or "unknown error").strip()
+            raise SandboxUnavailableError(f"sandbox bootstrap failed: {message[:500]}")
+        return completed
+
+    def _base_run_args(
+        self,
+        spec: SandboxSpec,
+        *,
+        container_name: str,
+        user: str,
+        network: NetworkMode,
+    ) -> list[str]:
+        limits = spec.policy.limits
+        args = [
+            "run",
+            "--rm",
+            "--name",
+            container_name,
+            "--label",
+            f"ai.codenib.sandbox={container_name.split('-cmd-')[0]}",
+            "--pull",
+            "never",
+            "--platform",
+            spec.platform,
+            "--network",
+            network.value,
+            "--cap-drop",
+            "ALL",
+            "--security-opt",
+            "no-new-privileges=true",
+            "--security-opt",
+            (
+                f"seccomp={spec.policy.seccomp_profile}"
+                if spec.policy.seccomp_profile
+                else "seccomp=builtin"
+            ),
+            "--user",
+            user,
+            "--pids-limit",
+            str(limits.pids),
+            "--memory",
+            str(limits.memory_bytes),
+            "--memory-swap",
+            str(limits.memory_bytes),
+            "--cpus",
+            str(limits.cpus),
+            "--ulimit",
+            "nofile=1024:1024",
+            "--ulimit",
+            "core=0:0",
+            "--ipc",
+            "private",
+            "--cgroupns",
+            "private",
+            "--init",
+            "--stop-timeout",
+            "2",
+            "--no-healthcheck",
+            "--log-driver",
+            "none",
+            "--hostname",
+            "codenib-sandbox",
+            "--tmpfs",
+            ("/tmp:rw,nosuid,nodev,noexec,mode=1777,size=" f"{limits.tmpfs_bytes}"),
+            "--tmpfs",
+            "/run:rw,nosuid,nodev,noexec,size=16777216",
+            "--env",
+            "HOME=/tmp/codenib-home",
+            "--env",
+            "TMPDIR=/tmp",
+            "--env",
+            "CI=1",
+            "--env",
+            "LANG=C.UTF-8",
+            "--env",
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "--env",
+            "HTTP_PROXY=",
+            "--env",
+            "HTTPS_PROXY=",
+            "--env",
+            "ALL_PROXY=",
+            "--env",
+            "NO_PROXY=",
+            "--env",
+            "http_proxy=",
+            "--env",
+            "https_proxy=",
+            "--env",
+            "all_proxy=",
+            "--env",
+            "no_proxy=",
+            "--entrypoint",
+            "",
+        ]
+        if spec.policy.read_only_rootfs:
+            args.append("--read-only")
+        if spec.policy.runtime:
+            args.extend(["--runtime", spec.policy.runtime])
+        return args
+
+    def _run_session_container(
+        self,
+        session: "DockerSandboxSession",
+        request: ExecRequest,
+        *,
+        mounts: Sequence[str] | None = None,
+        workdir: str | None = None,
+        audit_limit: int | None = None,
+        preview_limit: int | None = None,
+    ) -> _RunCapture:
+        timeout = (
+            request.timeout_seconds
+            or session._spec.policy.limits.command_timeout_seconds
+        )
+        if timeout > session._spec.policy.limits.command_timeout_seconds:
+            raise SandboxPolicyError("command timeout exceeds the session policy")
+        if (
+            request.stdin is not None
+            and len(request.stdin) > session._spec.policy.limits.stdin_bytes
+        ):
+            raise SandboxPolicyError("command stdin exceeds the session policy")
+
+        command_id = self._id_factory().hex
+        name = f"{session.sandbox_id}-cmd-{command_id[:12]}"
+        args = self._base_run_args(
+            session._spec,
+            container_name=name,
+            user=_CONTAINER_USER,
+            network=session._spec.policy.network,
+        )
+        if request.stdin is not None:
+            args.append("--interactive")
+        effective_mounts = list(mounts or [])
+        if not effective_mounts:
+            effective_mounts.append(
+                f"type=volume,src={session._workspace_volume},"
+                "dst=/workspace,volume-nocopy"
+            )
+        for mount in effective_mounts:
+            args.extend(["--mount", mount])
+        cwd = workdir or _container_workspace_path(
+            normalize_workspace_path(request.cwd)
+        )
+        args.extend(["--workdir", cwd])
+        for key, value in sorted(request.environment.items()):
+            args.extend(["--env", f"{key}={value}"])
+        args.extend([session._spec.image, *request.argv])
+
+        audit_limit = audit_limit or session._spec.policy.limits.audit_log_bytes
+        preview_limit = preview_limit or session._spec.policy.limits.output_bytes
+        capture = self._spawn_bounded(
+            session,
+            command_id=command_id,
+            container_name=name,
+            docker_args=args,
+            request=request,
+            timeout=timeout,
+            audit_limit=audit_limit,
+            preview_limit=preview_limit,
+        )
+        return capture
+
+    def _spawn_bounded(
+        self,
+        session: "DockerSandboxSession",
+        *,
+        command_id: str,
+        container_name: str,
+        docker_args: Sequence[str],
+        request: ExecRequest,
+        timeout: float,
+        audit_limit: int,
+        preview_limit: int,
+    ) -> _RunCapture:
+        stdout_path = session._audit_dir / f"{command_id}.stdout"
+        stderr_path = session._audit_dir / f"{command_id}.stderr"
+        started = self._clock()
+        stream_state = _StreamState(audit_limit)
+        try:
+            session._record_audit(
+                "command_started",
+                command_id=command_id,
+                argv=list(request.argv),
+                cwd=str(request.cwd),
+                environment_names=sorted(request.environment),
+                timeout_seconds=timeout,
+            )
+        except OSError as exc:
+            session._poison("audit_event_failed", phase="command_started")
+            raise SandboxUnavailableError(
+                "sandbox audit event write failed; quarantine the worker"
+            ) from exc
+
+        try:
+            process = self._popen_factory(
+                self._docker_command(docker_args),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
+                start_new_session=True,
+                env=self._docker_env,
+            )
+        except OSError as exc:
+            if not self._remove_container(container_name):
+                session._poison(
+                    "container_cleanup_failed", container_name=container_name
+                )
+            raise SandboxUnavailableError(f"failed to start Docker: {exc}") from exc
+
+        stdout_holder: list[_StreamRecord] = []
+        stderr_holder: list[_StreamRecord] = []
+        stdout_thread = threading.Thread(
+            target=_drain_stream,
+            args=(process.stdout, stdout_path, stream_state, stdout_holder),
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            target=_drain_stream,
+            args=(process.stderr, stderr_path, stream_state, stderr_holder),
+            daemon=True,
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+
+        writer = threading.Thread(
+            target=_write_stdin,
+            args=(process.stdin, request.stdin or b""),
+            daemon=True,
+        )
+        writer.start()
+        deadline = started + timeout
+        timed_out = False
+        output_limited = False
+        cleanup_failed = False
+        audit_failed = False
+
+        try:
+            while process.poll() is None:
+                if stream_state.failed.is_set():
+                    audit_failed = True
+                    cleanup_failed = not self._remove_container(container_name)
+                    _kill_process_group(process)
+                    break
+                if stream_state.exhausted.is_set():
+                    output_limited = True
+                    cleanup_failed = not self._remove_container(container_name)
+                    _kill_process_group(process)
+                    break
+                if self._clock() >= deadline:
+                    timed_out = True
+                    cleanup_failed = not self._remove_container(container_name)
+                    _kill_process_group(process)
+                    break
+                time.sleep(0.02)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                _kill_process_group(process)
+                process.wait(timeout=5)
+        finally:
+            # ``--rm`` handles the normal path; this covers client crashes and
+            # timeout races without trusting it to have removed the container.
+            cleanup_failed = (
+                not self._remove_container(container_name) or cleanup_failed
+            )
+            writer.join(timeout=1)
+            stdout_thread.join(timeout=5)
+            stderr_thread.join(timeout=5)
+
+        if cleanup_failed:
+            session._poison("container_cleanup_failed", container_name=container_name)
+            raise SandboxUnavailableError(
+                "sandbox container cleanup failed; quarantine and reap the worker"
+            )
+        audit_failed = audit_failed or stream_state.failed.is_set()
+        if audit_failed:
+            session._poison("audit_stream_failed", errors=stream_state.errors[:2])
+            raise SandboxUnavailableError(
+                "sandbox audit output capture failed; quarantine the worker"
+            )
+
+        # A short-lived command can exit before the reader threads observe the
+        # final buffered chunk. Honour the shared cap even on that race.
+        output_limited = output_limited or stream_state.exhausted.is_set()
+
+        stdout_record = (
+            stdout_holder[0] if stdout_holder else _empty_stream(stdout_path)
+        )
+        stderr_record = (
+            stderr_holder[0] if stderr_holder else _empty_stream(stderr_path)
+        )
+        stdout_preview = _read_preview(stdout_record.path, preview_limit)
+        stderr_preview = _read_preview(
+            stderr_record.path, max(0, preview_limit - len(stdout_preview))
+        )
+        duration_ms = (self._clock() - started) * 1000
+        result = ExecResult(
+            command_id=command_id,
+            argv=tuple(request.argv),
+            exit_code=None if (timed_out or output_limited) else process.returncode,
+            stdout=stdout_preview.decode("utf-8", errors="replace"),
+            stderr=stderr_preview.decode("utf-8", errors="replace"),
+            duration_ms=duration_ms,
+            timed_out=timed_out,
+            output_limited=output_limited,
+            stdout_truncated=(
+                output_limited or stdout_record.bytes > len(stdout_preview)
+            ),
+            stderr_truncated=(
+                output_limited or stderr_record.bytes > len(stderr_preview)
+            ),
+            stdout_sha256=stdout_record.sha256,
+            stderr_sha256=stderr_record.sha256,
+            stdout_bytes=stdout_record.bytes,
+            stderr_bytes=stderr_record.bytes,
+        )
+        try:
+            session._record_audit(
+                "command_finished",
+                **{
+                    key: value
+                    for key, value in result.to_dict().items()
+                    if key not in {"stdout", "stderr"}
+                },
+            )
+        except OSError as exc:
+            session._poison("audit_event_failed", phase="command_finished")
+            raise SandboxUnavailableError(
+                "sandbox audit event write failed; quarantine the worker"
+            ) from exc
+        return _RunCapture(result, stdout_record, stderr_record)
+
+    def _call_cli(self, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        try:
+            completed = self._run_cli(
+                self._docker_command(args),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                shell=False,
+                env=self._docker_env,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SandboxUnavailableError(f"Docker CLI failed: {exc}") from exc
+        if completed.returncode != 0:
+            message = (completed.stderr or completed.stdout or "unknown error").strip()
+            raise SandboxUnavailableError(f"Docker CLI failed: {message[:500]}")
+        return completed
+
+    def _remove_container(self, name: str) -> bool:
+        removed = False
+        for action in (("kill", name), ("rm", "-f", name)):
+            try:
+                completed = self._run_cli(
+                    self._docker_command(action),
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    shell=False,
+                    env=self._docker_env,
+                )
+            except (OSError, subprocess.SubprocessError):
+                continue
+            if action[0] == "rm" and completed.returncode == 0:
+                removed = True
+        if removed:
+            return True
+        try:
+            inspected = self._run_cli(
+                self._docker_command(("container", "inspect", name)),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                shell=False,
+                env=self._docker_env,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        message = f"{inspected.stdout}\n{inspected.stderr}".lower()
+        return inspected.returncode != 0 and (
+            "no such container" in message or "no such object" in message
+        )
+
+    def _remove_volume(self, name: str) -> bool:
+        try:
+            completed = self._run_cli(
+                self._docker_command(("volume", "rm", "-f", name)),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                shell=False,
+                env=self._docker_env,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return completed.returncode == 0
+
+    def _create_audit_dir(self, token: str) -> Path:
+        parent = self._work_root
+        if parent is not None:
+            parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            parent = parent.resolve(strict=True)
+        path = Path(
+            tempfile.mkdtemp(prefix=f"codenib-sandbox-{token[:12]}-", dir=parent)
+        )
+        path.chmod(0o700)
+        return path
+
+    def _remove_audit_dir(self, path: Path) -> None:
+        if path.name.startswith("codenib-sandbox-") and path.is_dir():
+            shutil.rmtree(path)
+
+    @staticmethod
+    def _validate_host_mount_path(path: Path) -> None:
+        if not path.is_absolute():
+            raise SandboxPolicyError("host mount paths must be absolute")
+        if any(character in str(path) for character in (",", "\n", "\r", "\x00")):
+            raise SandboxPolicyError(
+                "source path cannot be represented as a Docker mount"
+            )
+        current = Path(path.anchor)
+        for part in path.parts[1:]:
+            if part == "..":
+                raise SandboxPolicyError("host mount paths cannot contain '..'")
+            current /= part
+            try:
+                mode = current.lstat().st_mode
+            except FileNotFoundError:
+                # The caller emits the more useful missing-source error. No
+                # later component can exist beneath a missing ancestor.
+                break
+            except OSError as exc:
+                raise SandboxPolicyError(
+                    f"host mount path cannot be inspected: {current}"
+                ) from exc
+            if stat.S_ISLNK(mode):
+                raise SandboxPolicyError("source path ancestors must not be symlinks")
+
+    @staticmethod
+    def _validate_docker_host(host: str) -> None:
+        if not isinstance(host, str) or not host.startswith("unix:///"):
+            raise ValueError("docker_host must be an absolute Unix-socket endpoint")
+        if any(character in host for character in ("\n", "\r", "\x00")):
+            raise ValueError("docker_host contains unsupported characters")
+
+    def _docker_command(self, args: Sequence[str]) -> list[str]:
+        if self._docker_binary is None:
+            raise SandboxUnavailableError("Docker client has not passed preflight")
+        return [self._docker_binary, "--host", self._docker_host, *args]
+
+    def _resolve_git_binary(self) -> None:
+        requested = Path(self._git_binary_request)
+        binary = (
+            str(requested)
+            if requested.is_absolute()
+            else shutil.which(self._git_binary_request)
+        )
+        if binary is None:
+            raise SandboxUnavailableError(
+                f"Git client is unavailable: {self._git_binary_request}"
+            )
+        try:
+            resolved = Path(binary).resolve(strict=True)
+        except OSError as exc:
+            raise SandboxUnavailableError(
+                f"Git client cannot be resolved safely: {binary}"
+            ) from exc
+        if not resolved.is_file() or not os.access(resolved, os.X_OK):
+            raise SandboxUnavailableError(
+                f"Git client is not an executable file: {resolved}"
+            )
+        self._git_binary = str(resolved)
+
+    def _git_command(self, args: Sequence[str]) -> list[str]:
+        if self._git_binary is None:
+            raise SandboxUnavailableError("Git client has not passed preflight")
+        return [self._git_binary, *args]
+
+
+class DockerSandboxSession:
+    """A copied repository backed by private baseline/workspace volumes."""
+
+    def __init__(
+        self,
+        *,
+        provider: DockerSandboxProvider,
+        spec: SandboxSpec,
+        metadata: SandboxMetadata,
+        baseline_volume: str,
+        workspace_volume: str,
+        audit_dir: Path,
+    ) -> None:
+        self._provider = provider
+        self._spec = spec
+        self._metadata = metadata
+        self._baseline_volume = baseline_volume
+        self._workspace_volume = workspace_volume
+        self._audit_dir = audit_dir
+        self._closed = False
+        self._poisoned = False
+        self._lock = threading.RLock()
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._metadata.sandbox_id
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            provider="docker",
+            isolation=(
+                "rootless-container"
+                if self._metadata.rootless_runtime
+                else "rootful-container"
+            ),
+            non_root_user=True,
+            network_isolation=self._spec.policy.network is NetworkMode.NONE,
+            read_only_rootfs=self._spec.policy.read_only_rootfs,
+            resource_limits=True,
+            process_tree_cleanup=True,
+            disk_quota=False,
+            rootless_runtime=self._metadata.rootless_runtime,
+        )
+
+    @property
+    def metadata(self) -> SandboxMetadata:
+        return self._metadata
+
+    @property
+    def audit_dir(self) -> Path:
+        """Controller-only audit directory; never mounted into the sandbox."""
+
+        return self._audit_dir
+
+    def execute(self, request: ExecRequest) -> ExecResult:
+        with self._lock:
+            self._ensure_open()
+            return self._provider._run_session_container(self, request).result
+
+    def read_file(
+        self,
+        path: str | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> bytes:
+        with self._lock:
+            self._ensure_open()
+            relative = normalize_workspace_path(path)
+            limit = _bounded_byte_limit(
+                max_bytes,
+                default=self._spec.policy.limits.artifact_bytes,
+                maximum=self._spec.policy.limits.artifact_bytes,
+                label="file",
+            )
+            capture = self._provider._run_session_container(
+                self,
+                ExecRequest(
+                    argv=(
+                        "python3",
+                        "-I",
+                        "-S",
+                        "-c",
+                        _READ_FILE_HELPER,
+                        str(relative),
+                        str(limit),
+                    ),
+                    timeout_seconds=min(
+                        30.0, self._spec.policy.limits.command_timeout_seconds
+                    ),
+                ),
+                mounts=(
+                    f"type=volume,src={self._workspace_volume},"
+                    "dst=/workspace,readonly,volume-nocopy",
+                ),
+                workdir="/",
+                audit_limit=limit + 1,
+                preview_limit=1,
+            )
+            result = capture.result
+            if result.output_limited:
+                raise SandboxPolicyError("file exceeds requested byte limit")
+            if result.exit_code != 0:
+                raise SandboxError(result.stderr.strip() or "sandbox file read failed")
+            return capture.stdout_record.path.read_bytes()
+
+    def write_file(
+        self,
+        path: str | PurePosixPath,
+        data: bytes,
+        *,
+        create_parents: bool = False,
+    ) -> None:
+        with self._lock:
+            self._ensure_open()
+            relative = normalize_workspace_path(path)
+            if not isinstance(data, bytes):
+                raise TypeError("data must be bytes")
+            if len(data) > self._spec.policy.limits.stdin_bytes:
+                raise SandboxPolicyError("file content exceeds session stdin policy")
+            result = self._provider._run_session_container(
+                self,
+                ExecRequest(
+                    argv=(
+                        "python3",
+                        "-I",
+                        "-S",
+                        "-c",
+                        _WRITE_FILE_HELPER,
+                        str(relative),
+                        "1" if create_parents else "0",
+                    ),
+                    stdin=data,
+                    timeout_seconds=min(
+                        30.0, self._spec.policy.limits.command_timeout_seconds
+                    ),
+                ),
+                workdir="/",
+            ).result
+            if not result.succeeded:
+                raise SandboxError(result.stderr.strip() or "sandbox file write failed")
+
+    def get_diff(self, *, max_bytes: int | None = None) -> DiffResult:
+        with self._lock:
+            self._ensure_open()
+            limit = _bounded_byte_limit(
+                max_bytes,
+                default=self._spec.policy.limits.audit_log_bytes,
+                maximum=self._spec.policy.limits.audit_log_bytes,
+                label="diff",
+            )
+            mounts = [
+                f"type=volume,src={self._baseline_volume},dst=/baseline,readonly,volume-nocopy",
+                f"type=volume,src={self._workspace_volume},dst=/workspace,readonly,volume-nocopy",
+            ]
+            capture = self._provider._run_session_container(
+                self,
+                ExecRequest(
+                    argv=(
+                        "git",
+                        "diff",
+                        "--no-index",
+                        "--no-ext-diff",
+                        "--no-textconv",
+                        "--no-color",
+                        "--binary",
+                        "--no-renames",
+                        "--src-prefix=a/",
+                        "--dst-prefix=b/",
+                        "--",
+                        "/baseline",
+                        "/workspace",
+                    ),
+                    timeout_seconds=min(
+                        120.0, self._spec.policy.limits.command_timeout_seconds
+                    ),
+                ),
+                mounts=mounts,
+                workdir="/",
+                audit_limit=limit,
+                preview_limit=limit,
+            )
+            result = capture.result
+            if result.output_limited:
+                raise SandboxPolicyError(
+                    "diff exceeds requested byte limit; partial patches are not returned"
+                )
+            if result.exit_code not in {0, 1}:
+                raise SandboxError(result.stderr.strip() or "sandbox diff failed")
+            try:
+                raw_patch = capture.stdout_record.path.read_text(encoding="utf-8")
+            except UnicodeDecodeError as exc:
+                raise SandboxError(
+                    "sandbox diff is not valid UTF-8; export the changed files as "
+                    "artifacts instead"
+                ) from exc
+            patch = _normalize_no_index_patch(raw_patch)
+            encoded = patch.encode("utf-8")
+            return DiffResult(
+                patch=patch,
+                sha256=hashlib.sha256(encoded).hexdigest(),
+                bytes=len(encoded),
+                truncated=False,
+            )
+
+    def collect_artifacts(
+        self,
+        paths: Sequence[str | PurePosixPath],
+        destination: Path,
+        *,
+        max_bytes: int | None = None,
+    ) -> ArtifactBundle:
+        with self._lock:
+            self._ensure_open()
+            if not paths:
+                raise ValueError("at least one artifact path is required")
+            normalized = [str(normalize_workspace_path(path)) for path in paths]
+            limit = _bounded_byte_limit(
+                max_bytes,
+                default=self._spec.policy.limits.artifact_bytes,
+                maximum=self._spec.policy.limits.artifact_bytes,
+                label="artifact",
+            )
+            listing = self._provider._run_session_container(
+                self,
+                ExecRequest(
+                    argv=(
+                        "python3",
+                        "-I",
+                        "-S",
+                        "-c",
+                        _LIST_ARTIFACTS_HELPER,
+                        str(_MAX_ARTIFACT_FILES),
+                        *normalized,
+                    ),
+                    timeout_seconds=min(
+                        30.0, self._spec.policy.limits.command_timeout_seconds
+                    ),
+                ),
+                mounts=(
+                    f"type=volume,src={self._workspace_volume},"
+                    "dst=/workspace,readonly,volume-nocopy",
+                ),
+                workdir="/",
+                audit_limit=1024**2,
+                preview_limit=1024**2,
+            ).result
+            if not listing.succeeded:
+                raise SandboxError(listing.stderr.strip() or "artifact listing failed")
+            try:
+                rows = json.loads(listing.stdout)
+            except json.JSONDecodeError as exc:
+                raise SandboxError("artifact helper returned invalid JSON") from exc
+            total = sum(int(row["size"]) for row in rows)
+            if total > limit:
+                raise SandboxPolicyError("artifact files exceed requested byte limit")
+
+            destination = Path(destination)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            members: list[ArtifactMember] = []
+            try:
+                with destination.open("xb") as raw_output:
+                    os.fchmod(raw_output.fileno(), 0o600)
+                    with zipfile.ZipFile(
+                        raw_output, mode="w", compression=zipfile.ZIP_DEFLATED
+                    ) as archive:
+                        for row in rows:
+                            relative = str(normalize_workspace_path(row["path"]))
+                            expected_size = int(row["size"])
+                            data = self.read_file(
+                                relative,
+                                max_bytes=max(1, expected_size),
+                            )
+                            if len(data) != expected_size:
+                                raise SandboxError(
+                                    "artifact changed while it was being collected"
+                                )
+                            digest = hashlib.sha256(data).hexdigest()
+                            archive.writestr(relative, data)
+                            if raw_output.tell() > limit:
+                                raise SandboxPolicyError(
+                                    "artifact bundle exceeds requested byte limit"
+                                )
+                            members.append(
+                                ArtifactMember(
+                                    path=relative,
+                                    size=len(data),
+                                    sha256=digest,
+                                )
+                            )
+                    if raw_output.tell() > limit:
+                        raise SandboxPolicyError(
+                            "artifact bundle exceeds requested byte limit"
+                        )
+            except Exception:
+                try:
+                    destination.unlink()
+                except FileNotFoundError:
+                    pass
+                raise
+
+            bundle_size = destination.stat().st_size
+            if bundle_size > limit:
+                destination.unlink()
+                raise SandboxPolicyError("artifact bundle exceeds requested byte limit")
+            bundle = ArtifactBundle(
+                path=destination,
+                size=bundle_size,
+                sha256=_sha256_file(destination),
+                members=tuple(members),
+            )
+            self._record_audit(
+                "artifacts_collected",
+                bundle_sha256=bundle.sha256,
+                bundle_bytes=bundle.size,
+                members=[asdict(member) for member in bundle.members],
+            )
+            return bundle
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            # Poison the session before cleanup starts. Even if Docker or audit
+            # I/O fails, callers can never reuse a deleted/stale volume name.
+            self._closed = True
+            workspace_removed = self._provider._remove_volume(self._workspace_volume)
+            baseline_removed = self._provider._remove_volume(self._baseline_volume)
+            cleanup_ok = workspace_removed and baseline_removed
+            audit_error: OSError | None = None
+            try:
+                self._record_audit("sandbox_closed", cleanup_ok=cleanup_ok)
+            except OSError as exc:
+                audit_error = exc
+            finally:
+                if (
+                    cleanup_ok
+                    and audit_error is None
+                    and not self._provider._retain_audit_logs
+                ):
+                    self._provider._remove_audit_dir(self._audit_dir)
+            if not cleanup_ok:
+                raise SandboxError(
+                    "sandbox closed, but one or more labeled volumes require reaping"
+                )
+            if audit_error is not None:
+                raise SandboxError(
+                    "sandbox closed, but its final audit event could not be written"
+                ) from audit_error
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise SandboxClosedError(f"sandbox is closed: {self.sandbox_id}")
+        if self._poisoned:
+            raise SandboxUnavailableError(
+                f"sandbox worker requires quarantine/reaping: {self.sandbox_id}"
+            )
+
+    def _poison(self, event: str, **data: object) -> None:
+        self._poisoned = True
+        try:
+            self._record_audit(event, **data)
+        except OSError:
+            pass
+
+    def _record_audit(self, event: str, **data: object) -> None:
+        payload = {
+            "event": event,
+            "sandbox_id": self.sandbox_id,
+            "task_id": self._metadata.task_id,
+            "timestamp_ns": time.time_ns(),
+            **data,
+        }
+        with (self._audit_dir / "events.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+
+    def __enter__(self) -> "DockerSandboxSession":
+        self._ensure_open()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+
+def _container_workspace_path(path: PurePosixPath) -> str:
+    if path == PurePosixPath("."):
+        return "/workspace"
+    return f"/workspace/{path.as_posix()}"
+
+
+def _bounded_byte_limit(
+    value: int | None, *, default: int, maximum: int, label: str
+) -> int:
+    limit = default if value is None else value
+    if (
+        isinstance(limit, bool)
+        or not isinstance(limit, int)
+        or not 0 < limit <= maximum
+    ):
+        raise SandboxPolicyError(f"{label} byte limit exceeds session policy")
+    return limit
+
+
+def _drain_stream(
+    stream: Any,
+    destination: Path,
+    state: _StreamState,
+    holder: list[_StreamRecord],
+) -> None:
+    digest = hashlib.sha256()
+    total = 0
+    try:
+        with destination.open("wb") as output:
+            if stream is not None:
+                while True:
+                    chunk = stream.read(64 * 1024)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+                    total += len(chunk)
+                    allowed = state.reserve(len(chunk))
+                    if allowed:
+                        output.write(chunk[:allowed])
+        holder.append(
+            _StreamRecord(path=destination, sha256=digest.hexdigest(), bytes=total)
+        )
+    except Exception as exc:  # noqa: BLE001 - cross-thread failure propagation
+        state.record_failure(exc)
+
+
+def _write_stdin(stream: Any, data: bytes) -> None:
+    if stream is None:
+        return
+    try:
+        if data:
+            stream.write(data)
+            stream.flush()
+    except (OSError, ValueError):
+        pass
+    finally:
+        try:
+            stream.close()
+        except (OSError, ValueError):
+            pass
+
+
+def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
+    try:
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+    except OSError:
+        try:
+            process.kill()
+        except OSError:
+            pass
+
+
+def _empty_stream(path: Path) -> _StreamRecord:
+    if not path.exists():
+        path.touch(mode=0o600)
+    return _StreamRecord(path=path, sha256=hashlib.sha256(b"").hexdigest(), bytes=0)
+
+
+def _read_preview(path: Path, limit: int) -> bytes:
+    with path.open("rb") as handle:
+        return handle.read(limit)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024**2), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _policy_summary(spec: SandboxSpec) -> Dict[str, object]:
+    seccomp: Dict[str, str]
+    if spec.policy.seccomp_profile is None:
+        seccomp = {"kind": "builtin"}
+    else:
+        seccomp = {
+            "kind": "custom",
+            "sha256": _sha256_file(Path(spec.policy.seccomp_profile)),
+        }
+    return {
+        "network": spec.policy.network.value,
+        "allow_unpinned_image": spec.policy.allow_unpinned_image,
+        "read_only_rootfs": spec.policy.read_only_rootfs,
+        "require_rootless_runtime": spec.policy.require_rootless_runtime,
+        "require_source_revision": spec.policy.require_source_revision,
+        "runtime": spec.policy.runtime,
+        "seccomp": seccomp,
+        "limits": asdict(spec.policy.limits),
+    }
+
+
+def _write_emergency_audit(path: Path, **payload: object) -> None:
+    """Best-effort lifecycle record retained when normal cleanup is unsafe."""
+
+    payload.setdefault("timestamp_ns", time.time_ns())
+    try:
+        with (path / "events.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+    except OSError:
+        pass
+
+
+def _normalize_no_index_patch(patch: str) -> str:
+    """Remove only the outer helper directory from Git-controlled headers."""
+
+    lines: list[str] = []
+    in_file = False
+    saw_old_header = False
+    headers_done = False
+    for line in patch.splitlines(keepends=True):
+        if line.startswith("diff --git "):
+            in_file = True
+            saw_old_header = False
+            headers_done = False
+            line = _normalize_diff_git_header(line)
+        elif in_file and not headers_done and line.startswith("--- "):
+            saw_old_header = True
+            line = _normalize_single_path_header(line, "--- ")
+        elif (
+            in_file and not headers_done and saw_old_header and line.startswith("+++ ")
+        ):
+            headers_done = True
+            line = _normalize_single_path_header(line, "+++ ")
+        elif in_file and not headers_done and line.startswith("Binary files "):
+            headers_done = True
+            line = _normalize_binary_files_header(line)
+        elif in_file and line.startswith(("@@ ", "GIT binary patch")):
+            headers_done = True
+
+        lines.append(line)
+    return "".join(lines)
+
+
+def _normalize_diff_git_header(line: str) -> str:
+    prefix = "diff --git "
+    first, remainder = _take_git_path_token(line[len(prefix) :])
+    whitespace = remainder[: len(remainder) - len(remainder.lstrip(" \t"))]
+    second, tail = _take_git_path_token(remainder[len(whitespace) :])
+    if not first or not whitespace or not second:
+        return line
+    return (
+        prefix
+        + _strip_diff_mount_token(first)
+        + whitespace
+        + _strip_diff_mount_token(second)
+        + tail
+    )
+
+
+def _normalize_single_path_header(line: str, prefix: str) -> str:
+    token, tail = _take_git_path_token(line[len(prefix) :])
+    if not token:
+        return line
+    return prefix + _strip_diff_mount_token(token) + tail
+
+
+def _normalize_binary_files_header(line: str) -> str:
+    prefix = "Binary files "
+    first, remainder = _take_git_path_token(line[len(prefix) :])
+    if not first or not remainder.startswith(" and "):
+        return line
+    second, tail = _take_git_path_token(remainder[len(" and ") :])
+    if not second:
+        return line
+    return (
+        prefix
+        + _strip_diff_mount_token(first)
+        + " and "
+        + _strip_diff_mount_token(second)
+        + tail
+    )
+
+
+def _take_git_path_token(value: str) -> tuple[str, str]:
+    if not value:
+        return "", value
+    if value[0] != '"':
+        match = re.match(r"[^\t\r\n ]+", value)
+        if match is None:
+            return "", value
+        return match.group(0), value[match.end() :]
+    escaped = False
+    for index, character in enumerate(value[1:], start=1):
+        if escaped:
+            escaped = False
+        elif character == "\\":
+            escaped = True
+        elif character == '"':
+            return value[: index + 1], value[index + 1 :]
+    return "", value
+
+
+def _strip_diff_mount_token(token: str) -> str:
+    quote = '"' if token.startswith('"') else ""
+    offset = len(quote)
+    for side in ("a", "b"):
+        for mount in ("baseline", "workspace"):
+            prefix = f"{side}/{mount}/"
+            if token.startswith(prefix, offset):
+                return token[:offset] + f"{side}/" + token[offset + len(prefix) :]
+    return token
+
+
+def _safe_git_environment() -> Dict[str, str]:
+    """Minimal controller environment for read-only Git provenance checks."""
+
+    return {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_NO_LAZY_FETCH": "1",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ASKPASS": "/bin/false",
+        "SSH_ASKPASS": "/bin/false",
+        "GIT_ALLOW_PROTOCOL": "",
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PATH": "/usr/bin:/bin",
+    }
+
+
+__all__ = ["DockerSandboxProvider", "DockerSandboxSession"]

--- a/codenib/sandbox/protocol.py
+++ b/codenib/sandbox/protocol.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-neutral sandbox provider and session protocols."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import Protocol, Sequence, runtime_checkable
+
+from .types import (
+    ArtifactBundle,
+    DiffResult,
+    ExecRequest,
+    ExecResult,
+    SandboxCapabilities,
+    SandboxMetadata,
+    SandboxSpec,
+)
+
+
+class SandboxError(RuntimeError):
+    """Base error for sandbox infrastructure or policy failures."""
+
+
+class SandboxUnavailableError(SandboxError):
+    """Raised when the configured runtime or image is unavailable."""
+
+
+class SandboxPolicyError(SandboxError):
+    """Raised when a request would weaken an enforced policy."""
+
+
+class SandboxClosedError(SandboxError):
+    """Raised when an operation targets a closed session."""
+
+
+@runtime_checkable
+class SandboxSession(Protocol):
+    """One isolated, copied repository workspace."""
+
+    @property
+    def sandbox_id(self) -> str: ...
+
+    @property
+    def capabilities(self) -> SandboxCapabilities: ...
+
+    @property
+    def metadata(self) -> SandboxMetadata: ...
+
+    def execute(self, request: ExecRequest) -> ExecResult: ...
+
+    def read_file(
+        self,
+        path: str | PurePosixPath,
+        *,
+        max_bytes: int | None = None,
+    ) -> bytes: ...
+
+    def write_file(
+        self,
+        path: str | PurePosixPath,
+        data: bytes,
+        *,
+        create_parents: bool = False,
+    ) -> None: ...
+
+    def get_diff(self, *, max_bytes: int | None = None) -> DiffResult: ...
+
+    def collect_artifacts(
+        self,
+        paths: Sequence[str | PurePosixPath],
+        destination: Path,
+        *,
+        max_bytes: int | None = None,
+    ) -> ArtifactBundle: ...
+
+    def close(self) -> None: ...
+
+    def __enter__(self) -> "SandboxSession": ...
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None: ...
+
+
+@runtime_checkable
+class SandboxProvider(Protocol):
+    """Factory for backend-specific sandbox sessions."""
+
+    @property
+    def capabilities(self) -> SandboxCapabilities: ...
+
+    def create(self, spec: SandboxSpec) -> SandboxSession: ...
+
+
+__all__ = [
+    "SandboxClosedError",
+    "SandboxError",
+    "SandboxPolicyError",
+    "SandboxProvider",
+    "SandboxSession",
+    "SandboxUnavailableError",
+]

--- a/codenib/sandbox/types.py
+++ b/codenib/sandbox/types.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable value types for isolated repository execution."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import Dict, Mapping, Sequence, Tuple
+
+_IMAGE_DIGEST_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+_IMAGE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/:@-]*$")
+_PLATFORM_RE = re.compile(r"^[a-z0-9]+/[a-z0-9_]+(?:/[a-z0-9_]+)?$")
+_REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+_TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SECRET_ENV_RE = re.compile(
+    r"(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|PRIVATE_KEY|API_KEY|AUTH|COOKIE)",
+    re.IGNORECASE,
+)
+_BLOCKED_ENV_NAMES = frozenset(
+    {
+        "DOCKER_CONFIG",
+        "DOCKER_CONTEXT",
+        "DOCKER_HOST",
+        "GIT_ASKPASS",
+        "ALL_PROXY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "LD_LIBRARY_PATH",
+        "LD_PRELOAD",
+        "SSH_AUTH_SOCK",
+        "all_proxy",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+)
+
+
+class NetworkMode(str, Enum):
+    """Container egress policy.
+
+    ``BRIDGE`` is intentionally explicit. Docker cannot implement a reliable
+    hostname allowlist by itself, so public issue-bot jobs should remain on
+    ``NONE`` and use a separate, policy-enforcing bootstrap service when they
+    need dependencies.
+    """
+
+    NONE = "none"
+    BRIDGE = "bridge"
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxLimits:
+    """Hard resource and output bounds applied to every command."""
+
+    cpus: float = 2.0
+    memory_bytes: int = 2 * 1024**3
+    pids: int = 256
+    command_timeout_seconds: float = 300.0
+    output_bytes: int = 64 * 1024
+    audit_log_bytes: int = 8 * 1024**2
+    stdin_bytes: int = 1024**2
+    tmpfs_bytes: int = 256 * 1024**2
+    artifact_bytes: int = 64 * 1024**2
+
+    def __post_init__(self) -> None:
+        finite_numbers = {
+            "cpus": self.cpus,
+            "command_timeout_seconds": self.command_timeout_seconds,
+        }
+        invalid_numbers = [
+            name
+            for name, value in finite_numbers.items()
+            if isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or value <= 0
+        ]
+        integer_limits = {
+            "memory_bytes": self.memory_bytes,
+            "pids": self.pids,
+            "output_bytes": self.output_bytes,
+            "audit_log_bytes": self.audit_log_bytes,
+            "stdin_bytes": self.stdin_bytes,
+            "tmpfs_bytes": self.tmpfs_bytes,
+            "artifact_bytes": self.artifact_bytes,
+        }
+        invalid_integers = [
+            name
+            for name, value in integer_limits.items()
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0
+        ]
+        invalid = sorted(invalid_numbers + invalid_integers)
+        if invalid:
+            raise ValueError(
+                "sandbox limits must be finite positive numbers with byte, PID, "
+                f"and count limits expressed as integers: {invalid}"
+            )
+        if self.output_bytes > self.audit_log_bytes:
+            raise ValueError("output_bytes cannot exceed audit_log_bytes")
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxPolicy:
+    """Security policy for one sandbox session.
+
+    The safe defaults are fail-closed: no network, a read-only container root,
+    no Linux capabilities, no privilege escalation, and a rootless daemon
+    requirement. ``require_rootless_runtime=False`` is intended only for
+    explicitly trusted repositories or a separately isolated worker VM.
+    """
+
+    network: NetworkMode = NetworkMode.NONE
+    read_only_rootfs: bool = True
+    require_rootless_runtime: bool = True
+    require_source_revision: bool = True
+    allow_unpinned_image: bool = False
+    seccomp_profile: str | None = None
+    runtime: str | None = None
+    limits: SandboxLimits = field(default_factory=SandboxLimits)
+
+    def __post_init__(self) -> None:
+        boolean_fields = {
+            "read_only_rootfs": self.read_only_rootfs,
+            "require_rootless_runtime": self.require_rootless_runtime,
+            "require_source_revision": self.require_source_revision,
+            "allow_unpinned_image": self.allow_unpinned_image,
+        }
+        invalid_booleans = [
+            name for name, value in boolean_fields.items() if type(value) is not bool
+        ]
+        if invalid_booleans:
+            raise TypeError(
+                f"sandbox policy flags must be booleans: {sorted(invalid_booleans)}"
+            )
+        try:
+            object.__setattr__(self, "network", NetworkMode(self.network))
+        except ValueError as exc:
+            raise ValueError(
+                f"unsupported sandbox network mode: {self.network}"
+            ) from exc
+        if self.seccomp_profile is not None:
+            profile = Path(self.seccomp_profile)
+            if not profile.is_absolute():
+                raise ValueError("seccomp_profile must be an absolute path")
+            if not profile.is_file():
+                raise ValueError(f"seccomp_profile does not exist: {profile}")
+        if self.runtime is not None and not re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9_.-]*", self.runtime
+        ):
+            raise ValueError("runtime contains unsupported characters")
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxSpec:
+    """Immutable request for a repository sandbox.
+
+    ``source_revision`` is optional at the library boundary for generated or
+    non-Git fixtures. GitHub automation should always provide the exact
+    40-character commit and let the provider verify it before copying files.
+    """
+
+    source_dir: Path
+    image: str
+    platform: str
+    source_revision: str | None = None
+    task_id: str | None = None
+    policy: SandboxPolicy = field(default_factory=SandboxPolicy)
+
+    def __post_init__(self) -> None:
+        source_dir = Path(self.source_dir).expanduser()
+        object.__setattr__(self, "source_dir", source_dir)
+        if not self.image or not _IMAGE_REF_RE.fullmatch(self.image):
+            raise ValueError("image must be a non-empty Docker image reference")
+        if not self.policy.allow_unpinned_image and not _IMAGE_DIGEST_RE.search(
+            self.image
+        ):
+            raise ValueError(
+                "image must be pinned by sha256 digest; set "
+                "allow_unpinned_image only for trusted development"
+            )
+        if not _PLATFORM_RE.fullmatch(self.platform):
+            raise ValueError("platform must look like 'linux/amd64'")
+        if self.source_revision is not None and not _REVISION_RE.fullmatch(
+            self.source_revision
+        ):
+            raise ValueError("source_revision must be a full lowercase Git SHA")
+        if self.policy.require_source_revision and self.source_revision is None:
+            raise ValueError(
+                "source_revision is required by the sandbox policy; disable the "
+                "requirement only for trusted generated fixtures"
+            )
+        if self.task_id is not None and not _TASK_ID_RE.fullmatch(self.task_id):
+            raise ValueError("task_id contains unsupported characters")
+
+
+def normalize_workspace_path(path: str | PurePosixPath) -> PurePosixPath:
+    """Return a safe, repository-relative POSIX path.
+
+    The value is validated lexically here and resolved against the copied
+    workspace by the provider before any host-side file access.
+    """
+
+    raw = str(path)
+    if not raw or "\x00" in raw or "\\" in raw:
+        raise ValueError("workspace path must be a non-empty POSIX path")
+    value = PurePosixPath(raw)
+    if value.is_absolute() or any(part in {"", ".."} for part in value.parts):
+        raise ValueError("workspace path must stay below the repository root")
+    if value == PurePosixPath("."):
+        return value
+    return PurePosixPath(*[part for part in value.parts if part != "."])
+
+
+def validate_environment(environment: Mapping[str, str]) -> Dict[str, str]:
+    """Validate non-sensitive environment values for a container command."""
+
+    clean: Dict[str, str] = {}
+    for name, value in environment.items():
+        if not isinstance(name, str) or not _ENV_NAME_RE.fullmatch(name):
+            raise ValueError(f"invalid environment variable name: {name!r}")
+        if name in _BLOCKED_ENV_NAMES or _SECRET_ENV_RE.search(name):
+            raise ValueError(f"sensitive environment variable is not allowed: {name}")
+        if not isinstance(value, str) or "\x00" in value:
+            raise ValueError(f"invalid value for environment variable: {name}")
+        clean[name] = value
+    return clean
+
+
+@dataclass(frozen=True, slots=True)
+class ExecRequest:
+    """One argv-based command request.
+
+    No host shell is involved. Callers that deliberately need shell syntax can
+    request ``('/bin/sh', '-lc', command)``; those three argv elements are
+    still passed after the pinned container image.
+    """
+
+    argv: Tuple[str, ...] | Sequence[str]
+    cwd: PurePosixPath | str = PurePosixPath(".")
+    stdin: bytes | None = None
+    environment: Mapping[str, str] = field(default_factory=dict)
+    timeout_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.argv, (str, bytes)):
+            raise TypeError("argv must be a sequence of argument strings")
+        argv = tuple(self.argv)
+        if not argv or any(not isinstance(arg, str) or "\x00" in arg for arg in argv):
+            raise ValueError("argv must contain non-empty, NUL-free strings")
+        if not argv[0]:
+            raise ValueError("argv[0] must be non-empty")
+        object.__setattr__(self, "argv", argv)
+        object.__setattr__(self, "cwd", normalize_workspace_path(self.cwd))
+        object.__setattr__(
+            self,
+            "environment",
+            MappingProxyType(validate_environment(self.environment)),
+        )
+        if self.stdin is not None and not isinstance(self.stdin, bytes):
+            raise TypeError("stdin must be bytes when provided")
+        if self.timeout_seconds is not None:
+            timeout = self.timeout_seconds
+            if (
+                isinstance(timeout, bool)
+                or not isinstance(timeout, (int, float))
+                or not math.isfinite(float(timeout))
+                or timeout <= 0
+            ):
+                raise ValueError(
+                    "timeout_seconds must be a finite positive number when provided"
+                )
+
+
+@dataclass(frozen=True, slots=True)
+class ExecResult:
+    """Bounded model-facing output plus audit hashes for one command."""
+
+    command_id: str
+    argv: Tuple[str, ...]
+    exit_code: int | None
+    stdout: str
+    stderr: str
+    duration_ms: float
+    timed_out: bool = False
+    output_limited: bool = False
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+    stdout_sha256: str = ""
+    stderr_sha256: str = ""
+    stdout_bytes: int = 0
+    stderr_bytes: int = 0
+
+    @property
+    def succeeded(self) -> bool:
+        return not self.timed_out and not self.output_limited and self.exit_code == 0
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "command_id": self.command_id,
+            "argv": list(self.argv),
+            "exit_code": self.exit_code,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "duration_ms": self.duration_ms,
+            "timed_out": self.timed_out,
+            "output_limited": self.output_limited,
+            "stdout_truncated": self.stdout_truncated,
+            "stderr_truncated": self.stderr_truncated,
+            "stdout_sha256": self.stdout_sha256,
+            "stderr_sha256": self.stderr_sha256,
+            "stdout_bytes": self.stdout_bytes,
+            "stderr_bytes": self.stderr_bytes,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DiffResult:
+    """Canonical Git patch produced from the immutable source snapshot."""
+
+    patch: str
+    sha256: str
+    bytes: int
+    truncated: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactMember:
+    """One regular file included in an exported artifact bundle."""
+
+    path: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactBundle:
+    """Controller-owned ZIP export of selected workspace files."""
+
+    path: Path
+    size: int
+    sha256: str
+    members: Tuple[ArtifactMember, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxCapabilities:
+    """Auditable guarantees a provider can truthfully claim."""
+
+    provider: str
+    isolation: str
+    non_root_user: bool
+    network_isolation: bool
+    read_only_rootfs: bool
+    resource_limits: bool
+    process_tree_cleanup: bool
+    disk_quota: bool
+    rootless_runtime: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxMetadata:
+    """Non-secret identity recorded in agent traces and job artifacts."""
+
+    sandbox_id: str
+    task_id: str
+    provider: str
+    image: str
+    image_id: str
+    platform: str
+    source_revision: str | None
+    network: str
+    rootless_runtime: bool | None
+    source_fingerprint: str = ""
+    policy: Mapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "sandbox_id": self.sandbox_id,
+            "task_id": self.task_id,
+            "provider": self.provider,
+            "image": self.image,
+            "image_id": self.image_id,
+            "platform": self.platform,
+            "source_revision": self.source_revision,
+            "network": self.network,
+            "rootless_runtime": self.rootless_runtime,
+            "source_fingerprint": self.source_fingerprint,
+            "policy": dict(self.policy),
+        }
+
+
+__all__ = [
+    "ArtifactBundle",
+    "ArtifactMember",
+    "DiffResult",
+    "ExecRequest",
+    "ExecResult",
+    "NetworkMode",
+    "SandboxCapabilities",
+    "SandboxLimits",
+    "SandboxMetadata",
+    "SandboxPolicy",
+    "SandboxSpec",
+    "normalize_workspace_path",
+    "validate_environment",
+]

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -48,6 +48,15 @@ retrieval and planning surface that answers the task.
 
     [Choose an integration →](../agent_integrations.md)
 
+-   <span class="codenib-card-eyebrow">Execute safely</span>
+
+    **Isolated agent execution**
+
+    Run issue reproduction, edits, and tests through a provider-neutral,
+    resource-bounded sandbox instead of the CodeNib service host.
+
+    [Design an isolated worker →](../sandbox.md)
+
 -   <span class="codenib-card-eyebrow">Plan a query</span>
 
     **RAG ops and planner**
@@ -63,5 +72,6 @@ retrieval and planning surface that answers the task.
 
 Use the [MCP Server](../mcp.md) for the standard agent-facing workflow. Reach
 for [Agent Skills](../agent_skills.md) when you need to compose a custom runtime,
+use [Isolated Agent Execution](../sandbox.md) before running repository code,
 and use the [RAG Ops And Planner](../rag_ops.md) reference when changing query
 policy rather than wiring.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -1,0 +1,196 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Isolated Agent Execution
+
+CodeNib's pure parsing and retrieval paths do not execute repository code, but
+some SCIP/LSP view builders invoke repository-selected package managers and
+toolchains. Those can execute lifecycle or build scripts. For a public issue
+bot, the repository, indexing job, issue text, build scripts, dependencies, and
+generated commands must all be treated as untrusted.
+
+The `codenib.sandbox` package provides the execution boundary for CodeNib's four
+default agent tools; it does not automatically isolate indexing, retrieval, the
+LLM client, or application control-plane code. A `SandboxProvider` creates an isolated
+`SandboxSession`; the session owns command execution, bounded file operations,
+diff generation, artifact export, and cleanup. GitHub webhooks, queues, tokens,
+and pull-request publication remain application-layer responsibilities.
+
+## GitHub Issue Bot Flow
+
+1. The control plane validates a webhook and materializes an exact commit
+   without exposing the GitHub installation token to repository-controlled
+   processes.
+2. One disposable VM/microVM (or an equivalently strong per-job sandbox) builds
+   CodeNib views and runs the query. It has a job-exclusive runtime socket and
+   storage, no other tenants, and no control-plane secrets. A plain OS process
+   is not an isolation boundary. Never run SCIP/LSP view construction for an
+   untrusted repository on the service host. Current graph/vector artifacts can
+   contain pickle data, so the control plane must not deserialize artifacts
+   produced by an untrusted indexing worker; keep indexing and retrieval in the
+   same isolated worker.
+3. It creates an execution sandbox from a service-approved, digest-pinned image.
+4. `AgentRunner(..., sandbox=session)` replaces all four default tools—`read`,
+   `grep`, `glob`, and `bash`—with sandbox-backed executors.
+5. The agent edits and tests only the copied workspace. The immutable baseline
+   is never mounted into model-controlled commands.
+6. The control plane collects the patch and selected data-only artifacts,
+   verifies size and digests, runs `git apply --check` against a fresh checkout
+   of the same commit, and creates a pull request after policy or human approval.
+
+Never call `agent_working_directory()` for concurrent bot jobs. It changes the
+process-wide current directory and is intended only for trusted local harnesses.
+`SkillRegistry` is also process-global today, so run exactly one issue job per
+worker process; do not construct or run two `query()` jobs concurrently.
+`SandboxLimits.command_timeout_seconds` is a per-command cap, not a job lease.
+The worker/control plane must also enforce a total wall-clock deadline, command
+and LLM-call budgets, and cancellation tied to the external lease reaper.
+
+## Docker Backend
+
+The initial backend uses rootless Docker and one short-lived container per
+command. Workspace state persists in a private named volume; process state does
+not. On timeout or output exhaustion, CodeNib kills and removes the uniquely
+named container, which also removes its descendant processes.
+
+The provider pins every Docker CLI call to one configured local Unix socket,
+an absolute client binary, and a minimal environment; host contexts, Docker
+config, and credential helpers are not inherited. It fails closed unless:
+
+- the configured Docker endpoint is an absolute local Unix socket;
+- rootless mode, seccomp, cgroup v2, and the systemd cgroup driver are active;
+- a fixed preflight container observes the requested CPU, memory, and PID
+  limits in its own cgroup;
+- the image is on the control-plane allowlist and pinned by SHA-256 digest;
+- the image OS and architecture match the requested platform;
+- the image does not declare volumes or secret-like environment variables; and
+- the source checkout HEAD matches the requested full Git commit.
+
+For revision-pinned jobs, the baseline is exported from that commit's Git
+objects inside the fixed bootstrap container. Ignored files, untracked files,
+and working-tree modifications are never copied. The provider rejects commits
+containing Git submodules, tracked symlinks, or `export-ignore`/`export-subst`
+attributes, then fingerprints the sealed baseline with CodeNib's repository
+filter policy. `query(..., sandbox=...)` requires both that fingerprint and the
+commit to match its trusted manifest. Git LFS pointer files remain pointers;
+bot jobs that require symlink, submodule, or LFS contents are unsupported by
+this MVP and must be skipped.
+
+Every agent command gets a read-only root filesystem, a non-root user, all Linux
+capabilities dropped, `no-new-privileges`, the built-in seccomp profile, private
+IPC/cgroup namespaces, CPU/memory/PID limits, bounded tmpfs, and no network by
+default. The host Docker socket, host home directory, SSH agent, cloud
+credentials, and GitHub token are never mounted or forwarded.
+
+The approved image must provide `/bin/sh`, `python3`, `git`, `rg`, and `tar`.
+Pre-build project toolchains into the image; ordinary agent commands should not
+install system packages.
+
+```python
+import os
+from pathlib import Path
+
+from codenib.agent import AgentRunner
+from codenib.sandbox import DockerSandboxProvider, SandboxSpec
+
+image = os.environ["CODENIB_SANDBOX_IMAGE"]  # full name@sha256:... reference
+revision = os.environ["GITHUB_SHA"]          # full 40-character commit
+
+provider = DockerSandboxProvider(
+    allowed_images={image},
+    docker_host=f"unix:///run/user/{os.getuid()}/docker.sock",
+    work_root=Path("/var/lib/codenib/sandbox-audit"),
+    retain_audit_logs=True,
+)
+
+spec = SandboxSpec(
+    source_dir=Path("/srv/codenib/checkouts/issue-123"),
+    source_revision=revision,
+    image=image,
+    platform="linux/amd64",
+    task_id="issue-123",
+)
+
+with provider.create(spec) as session:
+    runner = AgentRunner(llm=my_llm, sandbox=session)
+    result = runner.run("Reproduce and fix issue #123, then run targeted tests.")
+    patch = session.get_diff()
+    bundle = session.collect_artifacts(
+        ["test-results.xml"],
+        Path("/srv/codenib/artifacts/issue-123.zip"),
+    )
+```
+
+The caller owns the session lifecycle so it can retrieve the diff and artifacts
+after the model finishes. `close()` is idempotent and removes both private
+volumes. This minimal example demonstrates isolated default tools; a retrieval
+job must additionally use a trusted manifest whose commit matches the sandbox
+revision and fingerprint. `AgentRunner` rejects a non-empty skill registry when
+a sandbox is used without such a manifest, preventing stale process-global
+contexts from leaking into this default-tools-only path.
+
+The copied workspace intentionally contains no `.git` metadata. Commands such
+as `git status`, version derivation through `setuptools-scm`/`hatch-vcs`, and
+tests that require repository history will not work in this MVP. CodeNib
+produces the baseline diff through the provider instead.
+
+## Network And Secrets
+
+`NetworkMode.NONE` is the production default. Docker's normal bridge network
+cannot enforce a hostname allowlist, block DNS rebinding, or reliably exclude
+cloud metadata and private address ranges. `NetworkMode.BRIDGE` therefore means
+full container egress and should be restricted to trusted development.
+
+If dependencies must be fetched, use a separate provisioning stage behind a
+policy-enforcing egress proxy. This MVP has no sealed-snapshot or dependency
+volume import API, so production jobs currently need toolchains/dependencies
+prebuilt into the approved image or available offline in the tracked tree. Do
+not pass registry, GitHub, package-manager, or cloud credentials into general
+agent commands.
+
+## Deployment Gates
+
+This package is the sandbox foundation, not a claim that a public GitHub bot is
+ready to expose. Before accepting arbitrary repositories:
+
+- run checkout, dependency provisioning, SCIP/LSP indexing, retrieval, and the
+  agent in a disposable VM/microVM with job-exclusive runtime/storage and no
+  GitHub installation token or other control-plane secret;
+- never load an untrusted worker's current manifest, graph pickle, vector
+  docstore, or other executable serialization in the control plane;
+- define a strictly data-only, path-confined, size-bounded, digest-verified
+  artifact format before moving indexes across a trust boundary;
+- use a narrow authenticated LLM proxy rather than placing model credentials in
+  the worker; and
+- validate every complete patch on a fresh, revision-matched checkout before
+  publication. Diff output that reaches its byte limit fails instead of
+  returning a partial patch.
+
+## Security Boundary
+
+Rootless Docker is a practical initial backend, not a strong hostile
+multi-tenant boundary. Before accepting arbitrary public repositories at scale,
+run workers on dedicated hosts or VMs and add a stronger provider backed by
+gVisor or microVM isolation. Keep the same provider/session API so this does not
+change CodeNib's agent or indexing layers.
+
+Named volumes also do not enforce workspace disk quotas. Before accepting jobs,
+production workers must place Docker storage on a quota-limited task filesystem
+and run an external lease reaper for containers and volumes bearing the
+`ai.codenib.sandbox` label. A cleanup verification failure must quarantine the
+worker until that reaper confirms the container is gone. Output, stdin,
+artifacts, time, memory, CPU, and PID counts are bounded by the library; disk is
+an infrastructure responsibility.
+
+Audit events contain full command argv, and bounded stdout/stderr or selected
+artifacts can contain source, issue text, and repository secrets. Keep
+`work_root` controller-only with encryption, access control, a total storage
+quota, and an explicit retention/deletion policy.
+
+For the runtime prerequisites, see Docker's documentation for
+[rootless mode](https://docs.docker.com/engine/security/rootless/),
+[UID/GID mapping](https://docs.docker.com/engine/security/rootless/uid-gid-mapping/),
+and the [default seccomp profile](https://docs.docker.com/engine/security/seccomp/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ plugins:
               | model
               | ops
               | ops\.(?:expand|filter|rerank|retrieve|transform)
+              | sandbox
               | scip_interface
               | search
               | types
@@ -172,6 +173,7 @@ nav:
       - MCP Server: mcp.md
       - Agent Skills: agent_skills.md
       - Agent Integrations: agent_integrations.md
+      - Isolated Agent Execution: sandbox.md
       - RAG Ops And Planner: rag_ops.md
   - Concepts:
       - concepts/index.md

--- a/scripts/check_public_docs.py
+++ b/scripts/check_public_docs.py
@@ -81,6 +81,7 @@ PUBLIC_API_MODULES = frozenset(
         "codenib.ops.rerank",
         "codenib.ops.retrieve",
         "codenib.ops.transform",
+        "codenib.sandbox",
         "codenib.scip_interface",
         "codenib.search",
         "codenib.types",

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -71,7 +71,12 @@ def _validate_wheel(wheel: Path, name: str, version: str) -> None:
     required = {
         "codenib/__init__.py",
         "codenib/__main__.py",
+        "codenib/agent/tools/sandbox.py",
         "codenib/cli.py",
+        "codenib/sandbox/__init__.py",
+        "codenib/sandbox/docker.py",
+        "codenib/sandbox/protocol.py",
+        "codenib/sandbox/types.py",
         "codenib/web/frontend/index.html",
         "codenib/web/frontend/codenib-icon.svg",
         "codenib/web/frontend/runtime-config.js",

--- a/test/agent/test_runner_sandbox.py
+++ b/test/agent/test_runner_sandbox.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import MappingProxyType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from codenib.agent import CodeNibAgentOptions, query
+from codenib.agent.runner import AgentRunner
+from codenib.agent.skills.registry import SkillRegistry
+from codenib.agent.tools.defaults import DEFAULT_TOOL_IDS
+from codenib.agent.tools.sandbox import _BOUNDED_LINES_HELPER
+from codenib.compiler.manifest import RepoManifest
+from codenib.compiler.params import SessionContext
+from codenib.llm.litellm_chat import LiteLLMChat
+from codenib.sandbox import ExecResult, SandboxCapabilities, SandboxMetadata
+
+
+class FakeSandbox:
+    def __init__(self):
+        self.requests = []
+        self.read_paths = []
+        self.sandbox_id = "sbx-test"
+        self.capabilities = SandboxCapabilities(
+            provider="fake",
+            isolation="test",
+            non_root_user=True,
+            network_isolation=True,
+            read_only_rootfs=True,
+            resource_limits=True,
+            process_tree_cleanup=True,
+            disk_quota=False,
+        )
+        self.metadata = SandboxMetadata(
+            sandbox_id=self.sandbox_id,
+            task_id="issue-1",
+            provider="fake",
+            image="test@sha256:" + "a" * 64,
+            image_id="sha256:" + "b" * 64,
+            platform="linux/amd64",
+            source_revision="c" * 40,
+            network="none",
+            rootless_runtime=True,
+            source_fingerprint="sha256:" + "e" * 64,
+        )
+
+    def execute(self, request):
+        self.requests.append(request)
+        if "rg" in request.argv and "--files" in request.argv:
+            data = b"src/app.py\n"
+            stdout = json.dumps(
+                {
+                    "data": base64.b64encode(data).decode("ascii"),
+                    "returncode": 0,
+                    "root_is_file": False,
+                    "truncated": False,
+                }
+            )
+        elif "rg" in request.argv:
+            data = b"src/app.py:1:def app():\n"
+            stdout = json.dumps(
+                {
+                    "data": base64.b64encode(data).decode("ascii"),
+                    "returncode": 0,
+                    "root_is_file": False,
+                    "truncated": False,
+                }
+            )
+        else:
+            stdout = "sandbox-only\n"
+        return ExecResult(
+            command_id=f"cmd-{len(self.requests)}",
+            argv=request.argv,
+            exit_code=0,
+            stdout=stdout,
+            stderr="",
+            duration_ms=1,
+        )
+
+    def read_file(self, path, *, max_bytes=None):
+        self.read_paths.append((str(path), max_bytes))
+        return b"def app():\n    return 1\n"
+
+    def write_file(self, *args, **kwargs):
+        raise AssertionError("not used")
+
+    def get_diff(self, *args, **kwargs):
+        raise AssertionError("not used")
+
+    def collect_artifacts(self, *args, **kwargs):
+        raise AssertionError("not used")
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    SkillRegistry.reset()
+    yield
+    SkillRegistry.reset()
+
+
+def _llm_with_tool_call(name, arguments):
+    llm = MagicMock(spec=LiteLLMChat)
+    call = SimpleNamespace(
+        id="call-1",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=json.dumps(arguments)),
+    )
+    llm._call_raw.side_effect = [
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        role="assistant", content=None, tool_calls=[call]
+                    )
+                )
+            ]
+        ),
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        role="assistant", content="done", tool_calls=None
+                    )
+                )
+            ]
+        ),
+    ]
+    return llm
+
+
+def test_sandbox_mode_replaces_all_default_tool_executors():
+    sandbox = FakeSandbox()
+    runner = AgentRunner(
+        MagicMock(spec=LiteLLMChat),
+        SkillRegistry(),
+        sandbox=sandbox,
+    )
+
+    assert set(runner.tool_registry.list_tools()) == set(DEFAULT_TOOL_IDS)
+    assert "isolated sandbox" in runner.tool_registry.get("bash").tool_doc
+    assert "isolated sandbox" in runner.tool_registry.get("read").tool_doc
+
+
+def test_runner_bash_has_no_host_executor_bypass(monkeypatch):
+    sandbox = FakeSandbox()
+    monkeypatch.setattr(
+        "codenib.agent.tools.defaults._bash",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("host bash must not run")
+        ),
+    )
+    runner = AgentRunner(
+        _llm_with_tool_call("bash", {"command": "echo hello"}),
+        SkillRegistry(),
+        sandbox=sandbox,
+    )
+    result = runner.run("run command")
+
+    assert result.tool_calls[0].error is None
+    assert "sandbox-only" in result.tool_calls[0].result
+    assert sandbox.requests[0].argv == ("/bin/sh", "-lc", "echo hello")
+    run_start = result.trace.events[0].to_dict()
+    assert run_start["data"]["sandbox"]["sandbox_id"] == "sbx-test"
+
+
+def test_sandbox_read_grep_and_glob_are_session_backed():
+    sandbox = FakeSandbox()
+    runner = AgentRunner(
+        MagicMock(spec=LiteLLMChat),
+        SkillRegistry(),
+        sandbox=sandbox,
+    )
+
+    read = runner.tool_registry.get("read").executor_fn("src/app.py")
+    grep = runner.tool_registry.get("grep").executor_fn("def app", path=".")
+    glob = runner.tool_registry.get("glob").executor_fn("*.py", path=".")
+
+    assert "def app" in read
+    assert sandbox.read_paths[0][0] == "src/app.py"
+    assert "src/app.py:1: def app" in grep
+    assert glob == "src/app.py"
+    assert [request.argv[0] for request in sandbox.requests] == [
+        "python3",
+        "python3",
+    ]
+    assert all("rg" in request.argv for request in sandbox.requests)
+
+
+def test_sandbox_grep_uses_bounded_parity_flags_and_type_alias():
+    sandbox = FakeSandbox()
+    runner = AgentRunner(
+        MagicMock(spec=LiteLLMChat),
+        SkillRegistry(),
+        sandbox=sandbox,
+    )
+
+    runner.tool_registry.get("grep").executor_fn(
+        "needle", type="python", output_mode="count"
+    )
+    argv = sandbox.requests[0].argv
+
+    assert argv[:4] == ("python3", "-I", "-S", "-c")
+    assert "--hidden" in argv
+    assert "--no-ignore" in argv
+    assert "--text" in argv
+    assert "--count" in argv
+    assert "--count-matches" not in argv
+    assert "codenib:*.py" in argv
+    assert "codenib:*.pyi" in argv
+
+
+def test_sandbox_grep_rejects_multiline_without_running_command():
+    sandbox = FakeSandbox()
+    runner = AgentRunner(
+        MagicMock(spec=LiteLLMChat),
+        SkillRegistry(),
+        sandbox=sandbox,
+    )
+
+    result = runner.tool_registry.get("grep").executor_fn("start.*end", multiline=True)
+
+    assert result == "Error: multiline grep is not supported in sandbox mode"
+    assert sandbox.requests == []
+
+
+def test_search_helper_stops_at_row_limit():
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            _BOUNDED_LINES_HELPER,
+            "3",
+            "40960",
+            str(Path.cwd()),
+            ".",
+            sys.executable,
+            "-c",
+            "for i in range(100): print(i)",
+            ".",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(completed.stdout)
+
+    assert base64.b64decode(payload["data"]).splitlines() == [b"0", b"1", b"2"]
+    assert payload["truncated"] is True
+
+
+def test_sandbox_tools_negotiate_tighter_session_limits():
+    sandbox = FakeSandbox()
+    object.__setattr__(
+        sandbox.metadata,
+        "policy",
+        MappingProxyType(
+            {
+                "limits": MappingProxyType(
+                    {
+                        "artifact_bytes": 128,
+                        "command_timeout_seconds": 0.5,
+                        "output_bytes": 1024,
+                    }
+                )
+            }
+        ),
+    )
+    runner = AgentRunner(
+        MagicMock(spec=LiteLLMChat),
+        SkillRegistry(),
+        sandbox=sandbox,
+    )
+
+    runner.tool_registry.get("read").executor_fn("src/app.py")
+    runner.tool_registry.get("grep").executor_fn("needle")
+    runner.tool_registry.get("bash").executor_fn("true")
+
+    assert sandbox.read_paths[0][1] == 128
+    assert int(sandbox.requests[0].argv[6]) <= 576
+    assert sandbox.requests[1].timeout_seconds == 0.5
+
+
+def test_without_sandbox_keeps_existing_local_default_tools():
+    runner = AgentRunner(MagicMock(spec=LiteLLMChat), SkillRegistry())
+    assert "no path jail" in runner.tool_registry.get("bash").tool_doc
+
+
+def test_sandbox_can_be_combined_with_default_tool_off_switch():
+    runner = AgentRunner(
+        MagicMock(spec=LiteLLMChat),
+        SkillRegistry(),
+        sandbox=FakeSandbox(),
+        include_default_tools=False,
+    )
+    assert runner.tool_registry.list_tools() == {}
+
+
+def test_sandbox_prompt_hides_host_path_and_uses_workspace_root(tmp_path):
+    host_path = str(tmp_path / "secret-worker-layout" / "repo")
+    runner = AgentRunner(
+        MagicMock(spec=LiteLLMChat),
+        SkillRegistry(),
+        sandbox=FakeSandbox(),
+        session_ctx=SessionContext(repo_path=host_path, primary_language="python"),
+    )
+
+    assert host_path not in runner.system_prompt
+    assert "repo_path: ." in runner.system_prompt
+    assert "workspace_root: /workspace" in runner.system_prompt
+    assert "git_metadata: unavailable" in runner.system_prompt
+    assert "indexes may become stale" in runner.system_prompt
+
+
+def test_sandbox_manifest_revision_must_match():
+    manifest = RepoManifest(commit="d" * 40, source_fingerprint="sha256:" + "e" * 64)
+    with pytest.raises(ValueError, match="does not match"):
+        AgentRunner(
+            MagicMock(spec=LiteLLMChat),
+            SkillRegistry(),
+            sandbox=FakeSandbox(),
+            manifest=manifest,
+        )
+
+
+def test_sandbox_manifest_requires_revision():
+    with pytest.raises(ValueError, match="revision-bearing"):
+        AgentRunner(
+            MagicMock(spec=LiteLLMChat),
+            SkillRegistry(),
+            sandbox=FakeSandbox(),
+            manifest=RepoManifest(),
+        )
+
+
+def test_sandbox_manifest_fingerprint_must_match():
+    manifest = RepoManifest(commit="c" * 40, source_fingerprint="sha256:" + "f" * 64)
+    with pytest.raises(ValueError, match="fingerprint does not match"):
+        AgentRunner(
+            MagicMock(spec=LiteLLMChat),
+            SkillRegistry(),
+            sandbox=FakeSandbox(),
+            manifest=manifest,
+        )
+
+
+def test_sandbox_without_manifest_rejects_unbound_skills():
+    registry = MagicMock(spec=SkillRegistry)
+    registry.list_skills.return_value = {"bm25_search": object()}
+
+    with pytest.raises(ValueError, match="source snapshot is unbound"):
+        AgentRunner(
+            MagicMock(spec=LiteLLMChat),
+            registry,
+            sandbox=FakeSandbox(),
+        )
+
+
+def test_query_rejects_host_inline_index_build_with_sandbox(tmp_path):
+    with pytest.raises(ValueError, match=r"query\(\) sandbox.*requires"):
+        query(
+            "noop",
+            options=CodeNibAgentOptions(
+                repo_path=str(tmp_path),
+                llm=MagicMock(spec=LiteLLMChat),
+                sandbox=FakeSandbox(),
+            ),
+        )
+
+
+def test_query_rejects_unversioned_contexts_with_sandbox():
+    with pytest.raises(ValueError, match="contexts have no source provenance"):
+        query(
+            "noop",
+            options=CodeNibAgentOptions(
+                contexts={},
+                llm=MagicMock(spec=LiteLLMChat),
+                sandbox=FakeSandbox(),
+            ),
+        )

--- a/test/sandbox/test_contract.py
+++ b/test/sandbox/test_contract.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from codenib.sandbox import (
+    ExecRequest,
+    ExecResult,
+    NetworkMode,
+    SandboxLimits,
+    SandboxPolicy,
+    SandboxProvider,
+    SandboxSpec,
+)
+from codenib.sandbox.types import normalize_workspace_path
+
+PINNED_IMAGE = "registry.example/codenib-agent@sha256:" + "a" * 64
+
+
+def test_sandbox_limits_are_safe_and_positive_by_default():
+    limits = SandboxLimits()
+
+    assert limits.cpus > 0
+    assert limits.memory_bytes > 0
+    assert limits.pids > 0
+    assert limits.output_bytes <= limits.audit_log_bytes
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"cpus": 0},
+        {"cpus": float("nan")},
+        {"cpus": float("inf")},
+        {"memory_bytes": 0},
+        {"memory_bytes": 1.5},
+        {"memory_bytes": True},
+        {"pids": -1},
+        {"command_timeout_seconds": 0},
+        {"command_timeout_seconds": float("nan")},
+        {"command_timeout_seconds": float("inf")},
+        {"output_bytes": 2, "audit_log_bytes": 1},
+    ],
+)
+def test_sandbox_limits_reject_invalid_values(overrides):
+    with pytest.raises(ValueError):
+        SandboxLimits(**overrides)
+
+
+def test_policy_defaults_fail_closed():
+    policy = SandboxPolicy()
+
+    assert policy.network is NetworkMode.NONE
+    assert policy.read_only_rootfs is True
+    assert policy.require_rootless_runtime is True
+    assert policy.require_source_revision is True
+    assert policy.allow_unpinned_image is False
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("read_only_rootfs", 0),
+        ("require_rootless_runtime", "false"),
+        ("require_source_revision", 1),
+        ("allow_unpinned_image", "true"),
+    ],
+)
+def test_policy_rejects_non_boolean_security_flags(field, value):
+    with pytest.raises(TypeError, match="must be booleans"):
+        SandboxPolicy(**{field: value})
+
+
+def test_spec_requires_digest_pin_by_default(tmp_path):
+    with pytest.raises(ValueError, match="pinned"):
+        SandboxSpec(
+            source_dir=tmp_path,
+            image="python:3.12-slim",
+            platform="linux/amd64",
+        )
+
+
+def test_spec_requires_exact_source_revision_by_default(tmp_path):
+    with pytest.raises(ValueError, match="source_revision"):
+        SandboxSpec(
+            source_dir=tmp_path,
+            image=PINNED_IMAGE,
+            platform="linux/amd64",
+        )
+
+
+def test_spec_accepts_exact_revision_and_digest(tmp_path):
+    spec = SandboxSpec(
+        source_dir=tmp_path,
+        image=PINNED_IMAGE,
+        platform="linux/amd64",
+        source_revision="b" * 40,
+        task_id="issue-123",
+    )
+
+    assert spec.source_dir == tmp_path
+    assert spec.source_revision == "b" * 40
+
+
+def test_trusted_fixture_can_explicitly_disable_revision_requirement(tmp_path):
+    spec = SandboxSpec(
+        source_dir=tmp_path,
+        image=PINNED_IMAGE,
+        platform="linux/amd64",
+        policy=SandboxPolicy(require_source_revision=False),
+    )
+
+    assert spec.source_revision is None
+
+
+@pytest.mark.parametrize("path", ["/etc/passwd", "../secret", "a/../../b", "C:\\x"])
+def test_workspace_paths_reject_escape(path):
+    with pytest.raises(ValueError):
+        normalize_workspace_path(path)
+
+
+def test_exec_request_is_argv_based_and_rejects_sensitive_environment():
+    request = ExecRequest(argv=("/bin/sh", "-lc", "echo hi"), cwd="src")
+    assert request.argv == ("/bin/sh", "-lc", "echo hi")
+    assert str(request.cwd) == "src"
+
+    with pytest.raises(ValueError, match="sensitive"):
+        ExecRequest(argv=("env",), environment={"GITHUB_TOKEN": "secret"})
+    with pytest.raises(ValueError, match="sensitive"):
+        ExecRequest(argv=("env",), environment={"SSH_AUTH_SOCK": "/tmp/agent"})
+
+    immutable = ExecRequest(argv=("env",), environment={"SAFE": "value"})
+    with pytest.raises(TypeError):
+        immutable.environment["GITHUB_TOKEN"] = "bypass"  # type: ignore[index]
+
+
+@pytest.mark.parametrize("timeout", [float("nan"), float("inf"), True, 0])
+def test_exec_request_rejects_nonfinite_or_invalid_timeout(timeout):
+    with pytest.raises(ValueError, match="finite positive"):
+        ExecRequest(argv=("true",), timeout_seconds=timeout)
+
+
+def test_exec_result_separates_exit_timeout_and_output_limit():
+    ok = ExecResult(
+        command_id="cmd",
+        argv=("true",),
+        exit_code=0,
+        stdout="",
+        stderr="",
+        duration_ms=1,
+    )
+    timed_out = ExecResult(
+        command_id="cmd",
+        argv=("sleep", "10"),
+        exit_code=None,
+        stdout="",
+        stderr="",
+        duration_ms=10,
+        timed_out=True,
+    )
+    limited = ExecResult(
+        command_id="cmd",
+        argv=("yes",),
+        exit_code=None,
+        stdout="x",
+        stderr="",
+        duration_ms=2,
+        output_limited=True,
+    )
+
+    assert ok.succeeded is True
+    assert timed_out.succeeded is False
+    assert limited.succeeded is False
+    assert limited.to_dict()["output_limited"] is True
+
+
+def test_provider_protocol_accepts_structural_fake():
+    class FakeProvider:
+        capabilities = object()
+
+        def create(self, spec):
+            return spec
+
+    assert isinstance(FakeProvider(), SandboxProvider)

--- a/test/sandbox/test_docker.py
+++ b/test/sandbox/test_docker.py
@@ -1,0 +1,899 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codenib.sandbox import (
+    DockerSandboxProvider,
+    ExecRequest,
+    ExecResult,
+    SandboxClosedError,
+    SandboxError,
+    SandboxLimits,
+    SandboxPolicy,
+    SandboxPolicyError,
+    SandboxSpec,
+    SandboxUnavailableError,
+)
+from codenib.sandbox.docker import _normalize_no_index_patch
+
+DIGEST = "sha256:" + "a" * 64
+IMAGE = f"registry.example/codenib-agent@{DIGEST}"
+
+
+class RecordingCLI:
+    def __init__(self, *, rootless: bool = True, image_overrides=None):
+        self.calls = []
+        self.rootless = rootless
+        self.image_overrides = dict(image_overrides or {})
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append((list(argv), dict(kwargs)))
+        command = argv[3:] if argv[1:2] == ["--host"] else argv[1:]
+        if command[:1] == ["info"]:
+            options = ["name=seccomp,profile=builtin"]
+            if self.rootless:
+                options.append("name=rootless")
+            stdout = json.dumps(
+                {
+                    "SecurityOptions": options,
+                    "CgroupVersion": "2",
+                    "CgroupDriver": "systemd",
+                }
+            )
+        elif command[:2] == ["image", "inspect"]:
+            image = {
+                "Id": "sha256:" + "b" * 64,
+                "RepoDigests": [IMAGE],
+                "Os": "linux",
+                "Architecture": "amd64",
+                "Variant": "",
+                "Config": {"Env": ["PATH=/usr/bin:/bin"], "Volumes": None},
+            }
+            image.update(self.image_overrides)
+            stdout = json.dumps([image])
+        elif command[:2] == ["volume", "create"]:
+            stdout = command[-1]
+        elif command[:1] == ["run"] and "memory.max" in " ".join(command):
+            stdout = "memory=2147483648\npids=256\ncpu=200000 100000\n"
+        elif command[:1] == ["run"] and "codenib-source-fingerprint" in " ".join(
+            command
+        ):
+            stdout = json.dumps(
+                {
+                    "file_count": 2,
+                    "source_fingerprint": "sha256:" + "e" * 64,
+                }
+            )
+        else:
+            stdout = ""
+        return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr="")
+
+
+class CapturingBytesIO(io.BytesIO):
+    captured = b""
+
+    def close(self):
+        self.captured = self.getvalue()
+        super().close()
+
+
+class FinishedProcess:
+    def __init__(
+        self,
+        argv,
+        *,
+        stdout_data=b"ok\n",
+        stderr_data=b"",
+        returncode=0,
+        **kwargs,
+    ):
+        self.argv = argv
+        self.stdout = io.BytesIO(stdout_data)
+        self.stderr = io.BytesIO(stderr_data)
+        self.stdin = CapturingBytesIO()
+        self.returncode = returncode
+        self.pid = 99999999
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def kill(self):
+        self.returncode = -9
+
+
+class HangingProcess(FinishedProcess):
+    def __init__(self, argv, **kwargs):
+        super().__init__(
+            argv,
+            stdout_data=b"",
+            stderr_data=b"",
+            returncode=None,
+            **kwargs,
+        )
+
+
+def _spec(tmp_path: Path, *, limits=None):
+    source = tmp_path / "repo"
+    source.mkdir(exist_ok=True)
+    return SandboxSpec(
+        source_dir=source,
+        image=IMAGE,
+        platform="linux/amd64",
+        task_id="issue-1",
+        policy=SandboxPolicy(
+            require_source_revision=False,
+            limits=limits or SandboxLimits(),
+        ),
+    )
+
+
+def _provider(tmp_path, cli, *, popen_factory=FinishedProcess, retain=True):
+    return DockerSandboxProvider(
+        allowed_images={IMAGE},
+        git_binary="/usr/bin/git",
+        work_root=tmp_path / "audit",
+        retain_audit_logs=retain,
+        run_cli=cli,
+        popen_factory=popen_factory,
+    )
+
+
+def _docker_subcommand(argv):
+    return argv[3:] if argv[1:2] == ["--host"] else argv[1:]
+
+
+def _git_repo(tmp_path: Path) -> tuple[Path, str]:
+    source = tmp_path / "versioned-repo"
+    source.mkdir()
+    subprocess.run(["git", "init", "-q", str(source)], check=True)
+    (source / ".gitignore").write_text(".env\n", encoding="utf-8")
+    (source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+    (source / ".env").write_text("IGNORED_SECRET=never-copy\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(source), "add", ".gitignore", "tracked.txt"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CodeNib Test",
+            "-c",
+            "user.email=test@example.com",
+            "-C",
+            str(source),
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        check=True,
+    )
+    revision = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return source, revision
+
+
+def test_create_replays_default_security_flags(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI()
+    session = _provider(tmp_path, cli).create(_spec(tmp_path))
+
+    run_calls = [
+        argv for argv, _ in cli.calls if _docker_subcommand(argv)[:1] == ["run"]
+    ]
+    assert len(run_calls) == 3  # cgroup probe + baseline/workspace init
+    for argv in run_calls:
+        joined = " ".join(argv)
+        assert "--network none" in joined
+        assert "--read-only" in argv
+        assert "--cap-drop" in argv and "ALL" in argv
+        assert "no-new-privileges=true" in argv
+        assert "seccomp=builtin" in argv
+        assert "--pids-limit" in argv
+        assert "--memory" in argv
+        assert "--memory-swap" in argv
+        assert "--cpus" in argv
+        assert "--pull" in argv and "never" in argv
+        assert "--privileged" not in argv
+        assert "/var/run/docker.sock" not in joined
+        assert all(kwargs.get("shell") is False for _, kwargs in cli.calls)
+
+    session.close()
+
+
+def test_create_rejects_symlinked_source_path(tmp_path):
+    real_source = tmp_path / "real-repo"
+    real_source.mkdir()
+    linked_source = tmp_path / "linked-repo"
+    linked_source.symlink_to(real_source, target_is_directory=True)
+    spec = SandboxSpec(
+        source_dir=linked_source,
+        image=IMAGE,
+        platform="linux/amd64",
+        policy=SandboxPolicy(require_source_revision=False),
+    )
+    provider = _provider(tmp_path, RecordingCLI())
+
+    with pytest.raises(SandboxPolicyError, match="must not be symlinks"):
+        provider.create(spec)
+
+
+def test_agent_command_is_after_image_and_uses_non_root_user(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI()
+    processes = []
+
+    def popen(argv, **kwargs):
+        process = FinishedProcess(argv, **kwargs)
+        processes.append((process, kwargs))
+        return process
+
+    session = _provider(tmp_path, cli, popen_factory=popen).create(_spec(tmp_path))
+    result = session.execute(
+        ExecRequest(argv=("/bin/sh", "-lc", "echo hi; --privileged"))
+    )
+
+    argv = processes[0][0].argv
+    image_index = argv.index(IMAGE)
+    assert argv[argv.index("--user") + 1] == "65532:65532"
+    assert argv[image_index + 1 :] == [
+        "/bin/sh",
+        "-lc",
+        "echo hi; --privileged",
+    ]
+    assert processes[0][1]["shell"] is False
+    assert result.exit_code == 0
+    session.close()
+
+
+def test_write_file_enables_interactive_stdin_and_isolates_helper(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI()
+    processes = []
+
+    def popen(argv, **kwargs):
+        process = FinishedProcess(argv, **kwargs)
+        processes.append(process)
+        return process
+
+    session = _provider(tmp_path, cli, popen_factory=popen).create(_spec(tmp_path))
+    session.write_file("src/new.py", b"print('written')\n", create_parents=True)
+
+    argv = processes[0].argv
+    assert "--interactive" in argv
+    image_index = argv.index(IMAGE)
+    assert argv[image_index + 1 : image_index + 5] == [
+        "python3",
+        "-I",
+        "-S",
+        "-c",
+    ]
+    assert argv[argv.index("--workdir") + 1] == "/"
+    assert processes[0].stdin.captured == b"print('written')\n"
+    session.close()
+
+
+def test_read_file_uses_isolated_python_and_read_only_mount(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI()
+    processes = []
+
+    def popen(argv, **kwargs):
+        process = FinishedProcess(argv, stdout_data=b"contents", **kwargs)
+        processes.append(process)
+        return process
+
+    session = _provider(tmp_path, cli, popen_factory=popen).create(_spec(tmp_path))
+    assert session.read_file("tracked.txt") == b"contents"
+
+    argv = processes[0].argv
+    image_index = argv.index(IMAGE)
+    assert argv[image_index + 1 : image_index + 5] == [
+        "python3",
+        "-I",
+        "-S",
+        "-c",
+    ]
+    assert "dst=/workspace,readonly,volume-nocopy" in " ".join(argv)
+    assert "--interactive" not in argv
+    session.close()
+
+
+def test_file_byte_limit_zero_fails_instead_of_using_default(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
+
+    with pytest.raises(SandboxPolicyError, match="file byte limit"):
+        session.read_file("tracked.txt", max_bytes=0)
+
+    session.close()
+
+
+def test_host_secrets_are_not_forwarded(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "do-not-forward")
+    monkeypatch.setenv("OPENAI_API_KEY", "do-not-forward")
+    cli = RecordingCLI()
+    processes = []
+
+    def popen(argv, **kwargs):
+        processes.append((argv, kwargs))
+        return FinishedProcess(argv, **kwargs)
+
+    session = _provider(tmp_path, cli, popen_factory=popen).create(_spec(tmp_path))
+    session.execute(ExecRequest(argv=("env",)))
+    rendered = " ".join(processes[0][0])
+
+    assert "GITHUB_TOKEN" not in rendered
+    assert "OPENAI_API_KEY" not in rendered
+    assert "do-not-forward" not in rendered
+    assert processes[0][1]["env"] == {
+        "DOCKER_CONFIG": "/nonexistent/codenib-docker-config",
+        "DOCKER_CONTEXT": "",
+        "DOCKER_HOST": f"unix:///run/user/{os.getuid()}/docker.sock",
+        "HOME": "/nonexistent",
+        "LANG": "C.UTF-8",
+        "PATH": "/usr/bin:/bin",
+    }
+    assert processes[0][0][:3] == [
+        "/usr/bin/docker",
+        "--host",
+        f"unix:///run/user/{os.getuid()}/docker.sock",
+    ]
+    session.close()
+
+
+def test_revision_snapshot_archives_git_objects_not_worktree(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, revision = _git_repo(tmp_path)
+    spec = SandboxSpec(
+        source_dir=source,
+        source_revision=revision,
+        image=IMAGE,
+        platform="linux/amd64",
+    )
+    cli = RecordingCLI()
+
+    session = _provider(tmp_path, cli).create(spec)
+
+    run_calls = [
+        _docker_subcommand(argv)
+        for argv, _ in cli.calls
+        if _docker_subcommand(argv)[:1] == ["run"]
+    ]
+    archive_call = next(
+        call for call in run_calls if "archive --format=tar" in " ".join(call)
+    )
+    rendered = " ".join(archive_call)
+    assert "dst=/repository.git,readonly" in rendered
+    assert f"type=bind,src={source},dst=/source" not in rendered
+    assert revision in archive_call
+    assert session.metadata.source_fingerprint == "sha256:" + "e" * 64
+    created = json.loads(
+        (session.audit_dir / "events.jsonl").read_text().splitlines()[0]
+    )
+    assert created["source_fingerprint"] == session.metadata.source_fingerprint
+    assert created["policy"]["limits"]["memory_bytes"] == 2 * 1024**3
+    assert created["capabilities"]["process_tree_cleanup"] is True
+    session.close()
+
+
+def test_revision_snapshot_rejects_submodules(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, first_revision = _git_repo(tmp_path)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(source),
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            f"160000,{first_revision},vendor/dependency",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CodeNib Test",
+            "-c",
+            "user.email=test@example.com",
+            "-C",
+            str(source),
+            "commit",
+            "-qm",
+            "add gitlink",
+        ],
+        check=True,
+    )
+    revision = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    spec = SandboxSpec(
+        source_dir=source,
+        source_revision=revision,
+        image=IMAGE,
+        platform="linux/amd64",
+    )
+
+    with pytest.raises(SandboxPolicyError, match="submodules"):
+        _provider(tmp_path, RecordingCLI()).create(spec)
+
+
+def test_revision_snapshot_rejects_tracked_symlinks(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, _ = _git_repo(tmp_path)
+    os.symlink("tracked.txt", source / "tracked-link")
+    subprocess.run(["git", "-C", str(source), "add", "tracked-link"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CodeNib Test",
+            "-c",
+            "user.email=test@example.com",
+            "-C",
+            str(source),
+            "commit",
+            "-qm",
+            "add symlink",
+        ],
+        check=True,
+    )
+    revision = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    with pytest.raises(SandboxPolicyError, match="symlinks"):
+        _provider(tmp_path, RecordingCLI()).create(
+            SandboxSpec(
+                source_dir=source,
+                source_revision=revision,
+                image=IMAGE,
+                platform="linux/amd64",
+            )
+        )
+
+
+def test_revision_snapshot_rejects_archive_mutating_attributes(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, _ = _git_repo(tmp_path)
+    (source / ".gitattributes").write_text(
+        "tracked.txt export-ignore\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", str(source), "add", ".gitattributes"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CodeNib Test",
+            "-c",
+            "user.email=test@example.com",
+            "-C",
+            str(source),
+            "commit",
+            "-qm",
+            "add archive attributes",
+        ],
+        check=True,
+    )
+    revision = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    with pytest.raises(SandboxPolicyError, match="export-ignore"):
+        _provider(tmp_path, RecordingCLI()).create(
+            SandboxSpec(
+                source_dir=source,
+                source_revision=revision,
+                image=IMAGE,
+                platform="linux/amd64",
+            )
+        )
+
+
+def test_revision_snapshot_requires_repository_top_level(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, revision = _git_repo(tmp_path)
+    subdirectory = source / "nested"
+    subdirectory.mkdir()
+
+    with pytest.raises(SandboxPolicyError, match="top-level"):
+        _provider(tmp_path, RecordingCLI()).create(
+            SandboxSpec(
+                source_dir=subdirectory,
+                source_revision=revision,
+                image=IMAGE,
+                platform="linux/amd64",
+            )
+        )
+
+
+def test_non_rootless_daemon_fails_before_volume_creation(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI(rootless=False)
+
+    with pytest.raises(SandboxPolicyError, match="rootless"):
+        _provider(tmp_path, cli).create(_spec(tmp_path))
+
+    assert not any(
+        _docker_subcommand(argv)[:2] == ["volume", "create"] for argv, _ in cli.calls
+    )
+
+
+def test_image_declared_volume_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI(
+        image_overrides={"Config": {"Env": [], "Volumes": {"/data": {}}}}
+    )
+
+    with pytest.raises(SandboxPolicyError, match="VOLUME"):
+        _provider(tmp_path, cli).create(_spec(tmp_path))
+
+
+def test_timeout_kills_and_removes_container(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI()
+    process = None
+
+    def popen(argv, **kwargs):
+        nonlocal process
+        process = HangingProcess(argv, **kwargs)
+        return process
+
+    limits = SandboxLimits(command_timeout_seconds=0.01)
+    session = _provider(tmp_path, cli, popen_factory=popen).create(
+        _spec(tmp_path, limits=limits)
+    )
+    result = session.execute(ExecRequest(argv=("sleep", "100")))
+
+    assert result.timed_out is True
+    assert result.exit_code is None
+    command_name = process.argv[process.argv.index("--name") + 1]
+    assert any(
+        _docker_subcommand(argv)[:2] == ["kill", command_name] for argv, _ in cli.calls
+    )
+    assert any(
+        _docker_subcommand(argv)[:3] == ["rm", "-f", command_name]
+        for argv, _ in cli.calls
+    )
+    session.close()
+
+
+def test_output_limit_is_hard_and_audited(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI()
+
+    def popen(argv, **kwargs):
+        return FinishedProcess(argv, stdout_data=b"x" * 1024, **kwargs)
+
+    limits = SandboxLimits(output_bytes=64, audit_log_bytes=128)
+    session = _provider(tmp_path, cli, popen_factory=popen).create(
+        _spec(tmp_path, limits=limits)
+    )
+    result = session.execute(ExecRequest(argv=("yes",)))
+
+    assert result.output_limited is True
+    assert result.stdout_truncated is True
+    assert len(result.stdout.encode()) <= 64
+    session.close()
+
+
+def test_model_preview_budget_is_shared_across_stdout_and_stderr(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+
+    def popen(argv, **kwargs):
+        return FinishedProcess(
+            argv,
+            stdout_data=b"a" * 50,
+            stderr_data=b"b" * 50,
+            **kwargs,
+        )
+
+    limits = SandboxLimits(output_bytes=64, audit_log_bytes=128)
+    session = _provider(tmp_path, RecordingCLI(), popen_factory=popen).create(
+        _spec(tmp_path, limits=limits)
+    )
+    result = session.execute(ExecRequest(argv=("emit",)))
+
+    assert len(result.stdout.encode()) + len(result.stderr.encode()) <= 64
+    assert result.stdout_truncated is False
+    assert result.stderr_truncated is True
+    session.close()
+
+
+def test_diff_output_limit_fails_without_returning_partial_patch(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+
+    def popen(argv, **kwargs):
+        return FinishedProcess(argv, stdout_data=b"x" * 256, **kwargs)
+
+    limits = SandboxLimits(output_bytes=32, audit_log_bytes=64)
+    session = _provider(tmp_path, RecordingCLI(), popen_factory=popen).create(
+        _spec(tmp_path, limits=limits)
+    )
+
+    with pytest.raises(SandboxPolicyError, match="partial patches"):
+        session.get_diff()
+
+    session.close()
+
+
+def test_timeout_cleanup_failure_poisons_session(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+
+    class FailingCleanupCLI(RecordingCLI):
+        fail_container_cleanup = False
+
+        def __call__(self, argv, **kwargs):
+            command = _docker_subcommand(argv)
+            if self.fail_container_cleanup and tuple(command[:1]) in {
+                ("kill",),
+                ("rm",),
+                ("container",),
+            }:
+                self.calls.append((list(argv), dict(kwargs)))
+                return subprocess.CompletedProcess(
+                    argv, 1, stdout="", stderr="daemon unavailable"
+                )
+            return super().__call__(argv, **kwargs)
+
+    cli = FailingCleanupCLI()
+    limits = SandboxLimits(command_timeout_seconds=0.01)
+    session = _provider(tmp_path, cli, popen_factory=HangingProcess).create(
+        _spec(tmp_path, limits=limits)
+    )
+    cli.fail_container_cleanup = True
+
+    with pytest.raises(SandboxUnavailableError, match="quarantine"):
+        session.execute(ExecRequest(argv=("sleep", "100")))
+    with pytest.raises(SandboxUnavailableError, match="quarantine"):
+        session.execute(ExecRequest(argv=("true",)))
+
+    cli.fail_container_cleanup = False
+    session.close()
+
+
+def test_close_is_idempotent_and_removes_both_volumes(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    cli = RecordingCLI()
+    session = _provider(tmp_path, cli).create(_spec(tmp_path))
+
+    session.close()
+    session.close()
+
+    volume_removes = [
+        argv
+        for argv, _ in cli.calls
+        if _docker_subcommand(argv)[:3] == ["volume", "rm", "-f"]
+    ]
+    assert len(volume_removes) == 2
+
+
+def test_close_remains_closed_when_final_audit_write_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
+    original_record = session._record_audit
+
+    def fail_close_event(event, **data):
+        if event == "sandbox_closed":
+            raise OSError("audit disk unavailable")
+        return original_record(event, **data)
+
+    monkeypatch.setattr(session, "_record_audit", fail_close_event)
+    with pytest.raises(SandboxError, match="final audit"):
+        session.close()
+    with pytest.raises(SandboxClosedError):
+        session.execute(ExecRequest(argv=("true",)))
+
+
+@pytest.mark.parametrize("failed_phase", ["command_started", "command_finished"])
+def test_command_audit_failure_poisons_session(monkeypatch, tmp_path, failed_phase):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    session = _provider(tmp_path, RecordingCLI()).create(_spec(tmp_path))
+    original_record = session._record_audit
+
+    def fail_selected_event(event, **data):
+        if event == failed_phase:
+            raise OSError("audit disk unavailable")
+        return original_record(event, **data)
+
+    monkeypatch.setattr(session, "_record_audit", fail_selected_event)
+    with pytest.raises(SandboxUnavailableError, match="audit event"):
+        session.execute(ExecRequest(argv=("true",)))
+    with pytest.raises(SandboxUnavailableError, match="quarantine"):
+        session.execute(ExecRequest(argv=("true",)))
+    session.close()
+
+
+def test_artifact_bundle_size_is_bounded_and_partial_file_removed(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    provider = _provider(tmp_path, RecordingCLI())
+    session = provider.create(_spec(tmp_path))
+    listing = json.dumps([{"path": "x" * 200, "size": 0}])
+    monkeypatch.setattr(
+        provider,
+        "_run_session_container",
+        lambda *args, **kwargs: SimpleNamespace(
+            result=ExecResult(
+                command_id="listing",
+                argv=("python3",),
+                exit_code=0,
+                stdout=listing,
+                stderr="",
+                duration_ms=1,
+            )
+        ),
+    )
+    monkeypatch.setattr(session, "read_file", lambda *args, **kwargs: b"")
+    destination = tmp_path / "artifacts.zip"
+
+    with pytest.raises(SandboxPolicyError, match="bundle exceeds"):
+        session.collect_artifacts(["result"], destination, max_bytes=64)
+
+    assert not destination.exists()
+    session.close()
+
+
+def test_artifact_bundle_is_controller_private(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    provider = _provider(tmp_path, RecordingCLI())
+    session = provider.create(_spec(tmp_path))
+    listing = json.dumps([{"path": "result.txt", "size": 0}])
+    monkeypatch.setattr(
+        provider,
+        "_run_session_container",
+        lambda *args, **kwargs: SimpleNamespace(
+            result=ExecResult(
+                command_id="listing",
+                argv=("python3",),
+                exit_code=0,
+                stdout=listing,
+                stderr="",
+                duration_ms=1,
+            )
+        ),
+    )
+    monkeypatch.setattr(session, "read_file", lambda *args, **kwargs: b"")
+    destination = tmp_path / "private.zip"
+
+    bundle = session.collect_artifacts(["result.txt"], destination, max_bytes=4096)
+
+    assert bundle.path == destination
+    assert destination.stat().st_mode & 0o777 == 0o600
+    session.close()
+
+
+def test_diff_path_normalization_does_not_rewrite_source_content():
+    raw = (
+        "diff --git a/baseline/src/a.py b/workspace/src/a.py\n"
+        "--- a/baseline/src/a.py\n"
+        "+++ b/workspace/src/a.py\n"
+        "@@ -1 +1 @@\n"
+        "-literal a/baseline/value\n"
+        "+literal b/workspace/value\n"
+    )
+
+    normalized = _normalize_no_index_patch(raw)
+
+    assert "diff --git a/src/a.py b/src/a.py" in normalized
+    assert "--- a/src/a.py" in normalized
+    assert "+++ b/src/a.py" in normalized
+    assert "-literal a/baseline/value" in normalized
+    assert "+literal b/workspace/value" in normalized
+
+
+def test_diff_normalization_strips_one_outer_component_and_not_hunk_content():
+    raw = (
+        "diff --git a/baseline/baseline_secret.py b/workspace/workspace_secret.py\n"
+        "--- a/baseline/baseline_secret.py\n"
+        "+++ b/workspace/workspace_secret.py\n"
+        "@@ -1 +1 @@\n"
+        "--- a/baseline/content-must-not-change\n"
+        "+++ b/workspace/content-must-not-change\n"
+        "diff --git a/workspace/added.py b/workspace/added.py\n"
+        "--- /dev/null\n"
+        "+++ b/workspace/added.py\n"
+        "diff --git a/baseline/deleted.py b/baseline/deleted.py\n"
+        "--- a/baseline/deleted.py\n"
+        "+++ /dev/null\n"
+        "diff --git a/baseline/workspace/secret.py "
+        "b/workspace/workspace/secret.py\n"
+        "--- a/baseline/workspace/secret.py\n"
+        "+++ b/workspace/workspace/secret.py\n"
+        "diff --git a/workspace/baseline/added.py "
+        "b/workspace/baseline/added.py\n"
+        "--- /dev/null\n"
+        "+++ b/workspace/baseline/added.py\n"
+    )
+
+    normalized = _normalize_no_index_patch(raw)
+
+    assert "a/baseline_secret.py b/workspace_secret.py" in normalized
+    assert "--- a/baseline_secret.py" in normalized
+    assert "+++ b/workspace_secret.py" in normalized
+    assert "--- a/baseline/content-must-not-change" in normalized
+    assert "+++ b/workspace/content-must-not-change" in normalized
+    assert "diff --git a/added.py b/added.py" in normalized
+    assert "diff --git a/deleted.py b/deleted.py" in normalized
+    assert "diff --git a/workspace/secret.py b/workspace/secret.py" in normalized
+    assert "diff --git a/baseline/added.py b/baseline/added.py" in normalized

--- a/test/sandbox/test_docker.py
+++ b/test/sandbox/test_docker.py
@@ -218,6 +218,10 @@ def test_create_replays_default_security_flags(monkeypatch, tmp_path):
         assert "/var/run/docker.sock" not in joined
         assert all(kwargs.get("shell") is False for _, kwargs in cli.calls)
 
+    copy_calls = [call for call in run_calls if "tar -C /workspace" in " ".join(call)]
+    assert len(copy_calls) == 2
+    assert all("--no-same-owner" in " ".join(call) for call in copy_calls)
+
     session.close()
 
 

--- a/test/sandbox/test_docker_integration.py
+++ b/test/sandbox/test_docker_integration.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codenib.sandbox import (
+    DockerSandboxProvider,
+    ExecRequest,
+    SandboxError,
+    SandboxSpec,
+)
+from codenib.source_fingerprint import fingerprint_repository
+
+pytestmark = pytest.mark.integration
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def test_rootless_docker_session_end_to_end(tmp_path):
+    image = os.environ.get("CODENIB_TEST_DOCKER_IMAGE")
+    if not image:
+        pytest.skip("CODENIB_TEST_DOCKER_IMAGE is not configured")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "CodeNib Test")
+    _git(repo, "config", "user.email", "test@codenib.invalid")
+    (repo / ".gitignore").write_text(".env/\n", encoding="utf-8")
+    (repo / "hello.txt").write_text("before\n", encoding="utf-8")
+    (repo / ".env").mkdir()
+    (repo / ".env" / "ignored-secret.txt").write_text(
+        "must-not-enter-snapshot\n", encoding="utf-8"
+    )
+    (repo / "scripts").mkdir()
+    executable = repo / "scripts" / "run.sh"
+    executable.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+    executable.chmod(0o755)
+    _git(repo, "add", ".gitignore", "hello.txt", "scripts/run.sh")
+    _git(repo, "commit", "-qm", "fixture")
+    revision = _git(repo, "rev-parse", "HEAD")
+
+    provider = DockerSandboxProvider(
+        allowed_images={image},
+        work_root=tmp_path / "audit",
+        retain_audit_logs=True,
+    )
+    spec = SandboxSpec(
+        source_dir=repo,
+        source_revision=revision,
+        image=image,
+        platform=os.environ.get("CODENIB_TEST_DOCKER_PLATFORM", "linux/amd64"),
+        task_id="integration-smoke",
+    )
+
+    with provider.create(spec) as session:
+        assert session.metadata.source_fingerprint == fingerprint_repository(repo).value
+        result = session.execute(
+            ExecRequest(argv=("/bin/sh", "-lc", "printf 'after\\n' > hello.txt"))
+        )
+        assert result.succeeded
+        assert session.read_file("hello.txt") == b"after\n"
+        with pytest.raises(SandboxError):
+            session.read_file(".env/ignored-secret.txt")
+
+        session.write_file("nested/result.txt", b"ok\n", create_parents=True)
+        diff = session.get_diff()
+        assert diff.truncated is False
+        assert "hello.txt" in diff.patch
+        assert "nested/result.txt" in diff.patch
+        patch_path = tmp_path / "workspace.patch"
+        patch_path.write_text(diff.patch, encoding="utf-8")
+        _git(repo, "apply", "--check", str(patch_path))
+
+        bundle = session.collect_artifacts(
+            ["nested/result.txt"], tmp_path / "artifacts.zip"
+        )
+        assert bundle.members[0].path == "nested/result.txt"
+        assert bundle.members[0].sha256

--- a/test/sandbox/test_docker_integration.py
+++ b/test/sandbox/test_docker_integration.py
@@ -35,6 +35,7 @@ def test_rootless_docker_session_end_to_end(tmp_path):
     image = os.environ.get("CODENIB_TEST_DOCKER_IMAGE")
     if not image:
         pytest.skip("CODENIB_TEST_DOCKER_IMAGE is not configured")
+    docker_host = os.environ.get("CODENIB_TEST_DOCKER_HOST")
 
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -57,6 +58,7 @@ def test_rootless_docker_session_end_to_end(tmp_path):
 
     provider = DockerSandboxProvider(
         allowed_images={image},
+        docker_host=docker_host,
         work_root=tmp_path / "audit",
         retain_audit_logs=True,
     )
@@ -74,6 +76,10 @@ def test_rootless_docker_session_end_to_end(tmp_path):
             ExecRequest(argv=("/bin/sh", "-lc", "printf 'after\\n' > hello.txt"))
         )
         assert result.succeeded
+        executable_result = session.execute(
+            ExecRequest(argv=("/bin/sh", "-lc", "test -x scripts/run.sh"))
+        )
+        assert executable_result.succeeded
         assert session.read_file("hello.txt") == b"after\n"
         with pytest.raises(SandboxError):
             session.read_file(".env/ignored-secret.txt")


### PR DESCRIPTION
## Summary

Add a provider-neutral sandbox execution foundation for CodeNib agents and the future GitHub issue-bot workflow. The initial backend uses fail-closed rootless Docker sessions over revision-pinned repository snapshots, while keeping public-bot deployment boundaries explicit.

## Changes

- Add stable sandbox provider/session contracts, value types, resource policies, audit metadata, diff export, and bounded artifact collection.
- Add a rootless Docker backend with digest-pinned images, no-network defaults, non-root execution, capability dropping, seccomp, cgroup resource checks, isolated volumes, and verified cleanup.
- Bind AgentRunner read, grep, glob, and bash tools to an optional sandbox session without changing the existing local path.
- Require sandbox revision and source-fingerprint parity before exposing manifest-backed retrieval.
- Normalize archive ownership during rootless volume initialization while preserving executable modes.
- Add unit, security, lifecycle, tool-integration, and real rootless Docker end-to-end coverage.
- Require the public sandbox modules in release artifacts.
- Document the GitHub issue-bot flow and the remaining VM/microVM, quota/reaper, LLM proxy, artifact, and patch-validation deployment gates.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Full unit tier after rebasing onto `main@1b14611`: 2373 passed, 10 skipped, 176 deselected.
- Focused sandbox, AgentRunner, and external-integration tier: 114 passed, 6 skipped.
- Real rootless Docker E2E: 1 passed against Docker 28.0.4 with rootless, seccomp, cgroup v2, and systemd cgroup driver.
- E2E image: `localhost:5000/codenib-sandbox-e2e@sha256:e6f30f8e446fa9bc29b6c9005b9eb588d3cab1111724fc14535d61628cb9b310`.
- The E2E covers revision snapshotting, ignored-secret exclusion, enforced resource limits, executable-mode preservation, workspace mutation, applicable diff export, and bounded artifact collection.
- `pre-commit run --all-files`, `mkdocs build --strict`, and `scripts/check_public_docs.py` pass.
- Wiki frontend: 16 passed; production build succeeds.
- Wheel and sdist build, release-artifact verification, and isolated wheel imports for the sandbox provider and agent tools pass.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
