### PR TITLE
perf(scip): make Python index timeout configurable

### DIFF
--- a/codenib/scip_interface/scip_indexer_python.py
+++ b/codenib/scip_interface/scip_indexer_python.py
@@ -6,6 +6,7 @@
 
 """SCIP indexer for Python projects using scip-python."""
 import json
+import math
 import os
 import shutil
 import signal
@@ -41,7 +42,7 @@ def _scip_python_index_timeout() -> float:
         timeout = float(raw)
     except ValueError:
         timeout = 0.0
-    if timeout <= 0:
+    if not math.isfinite(timeout) or timeout <= 0:
         logger.warning(
             "Ignoring invalid %s=%r; using %ss",
             _SCIP_PYTHON_INDEX_TIMEOUT_ENV,

--- a/codenib/scip_interface/scip_indexer_python.py
+++ b/codenib/scip_interface/scip_indexer_python.py
@@ -28,8 +28,28 @@ logger = get_logger("scip_python_indexer")
 # so a too-high bound (e.g. 20 min) can never fire before the 45-min job cap
 # kills the whole job — defeating the point of the timeout.
 _SCIP_PYTHON_INDEX_TIMEOUT_S = 600  # scip-python (Node) index run
+_SCIP_PYTHON_INDEX_TIMEOUT_ENV = "CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS"
 _CONDA_ENV_CREATE_TIMEOUT_S = 600  # fallback `conda env create`
 _SCIP_PYTHON_MAX_OLD_SPACE_MB = 16384
+
+
+def _scip_python_index_timeout() -> float:
+    raw = os.environ.get(_SCIP_PYTHON_INDEX_TIMEOUT_ENV)
+    if raw is None:
+        return float(_SCIP_PYTHON_INDEX_TIMEOUT_S)
+    try:
+        timeout = float(raw)
+    except ValueError:
+        timeout = 0.0
+    if timeout <= 0:
+        logger.warning(
+            "Ignoring invalid %s=%r; using %ss",
+            _SCIP_PYTHON_INDEX_TIMEOUT_ENV,
+            raw,
+            _SCIP_PYTHON_INDEX_TIMEOUT_S,
+        )
+        return float(_SCIP_PYTHON_INDEX_TIMEOUT_S)
+    return timeout
 
 
 def _run_checked_with_timeout(cmd, *, timeout, **popen_kwargs):
@@ -340,7 +360,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                 cmd,
                 cwd=work_dir,
                 env=self._subprocess_env(),
-                timeout=_SCIP_PYTHON_INDEX_TIMEOUT_S,
+                timeout=_scip_python_index_timeout(),
             )
             return True
         except subprocess.TimeoutExpired as exc:
@@ -477,7 +497,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                     cmd,
                     cwd=work_dir,
                     env=env,
-                    timeout=_SCIP_PYTHON_INDEX_TIMEOUT_S,
+                    timeout=_scip_python_index_timeout(),
                 )
             else:
                 # Fallback: use conda run (may have PATH issues)
@@ -486,7 +506,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
                 _run_checked_with_timeout(
                     conda_cmd,
                     cwd=work_dir,
-                    timeout=_SCIP_PYTHON_INDEX_TIMEOUT_S,
+                    timeout=_scip_python_index_timeout(),
                 )
             return True
         except subprocess.TimeoutExpired as e:

--- a/test/scip/test_scip_python_runtime.py
+++ b/test/scip/test_scip_python_runtime.py
@@ -86,6 +86,36 @@ def test_scip_python_direct_run_preserves_node_heap(monkeypatch, tmp_path):
     assert captured["env"]["NODE_OPTIONS"] == "--max-old-space-size=16384"
 
 
+def test_scip_python_index_timeout_can_be_extended_for_large_repos(
+    monkeypatch, tmp_path
+):
+    indexer = SCIPPythonIndexer(tmp_path, output_dir=tmp_path / "out")
+    captured = {}
+
+    def fake_run(_cmd, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(scip_indexer_python, "_run_checked_with_timeout", fake_run)
+    monkeypatch.setenv("CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS", "1800")
+
+    assert indexer._run_direct(["/tools/scip-python", "index"], tmp_path)
+    assert captured["timeout"] == 1800.0
+
+
+def test_scip_python_invalid_index_timeout_uses_the_ci_default(monkeypatch, tmp_path):
+    indexer = SCIPPythonIndexer(tmp_path, output_dir=tmp_path / "out")
+    captured = {}
+
+    def fake_run(_cmd, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(scip_indexer_python, "_run_checked_with_timeout", fake_run)
+    monkeypatch.setenv("CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS", "invalid")
+
+    assert indexer._run_direct(["/tools/scip-python", "index"], tmp_path)
+    assert captured["timeout"] == 600.0
+
+
 def test_scip_binary_decode_uses_packaged_protobuf_descriptor(monkeypatch, tmp_path):
     indexer = SCIPPythonIndexer(tmp_path, output_dir=tmp_path / "out")
     monkeypatch.setattr(

--- a/test/scip/test_scip_python_runtime.py
+++ b/test/scip/test_scip_python_runtime.py
@@ -5,6 +5,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from codenib.scip_interface import scip_indexer_base, scip_indexer_python
 from codenib.scip_interface.scip_indexer_python import SCIPPythonIndexer
 from codenib.scip_interface.scip_pb2 import Index
@@ -102,7 +104,10 @@ def test_scip_python_index_timeout_can_be_extended_for_large_repos(
     assert captured["timeout"] == 1800.0
 
 
-def test_scip_python_invalid_index_timeout_uses_the_ci_default(monkeypatch, tmp_path):
+@pytest.mark.parametrize("value", ["invalid", "0", "-1", "nan", "inf"])
+def test_scip_python_invalid_index_timeout_uses_the_ci_default(
+    monkeypatch, tmp_path, value
+):
     indexer = SCIPPythonIndexer(tmp_path, output_dir=tmp_path / "out")
     captured = {}
 
@@ -110,7 +115,7 @@ def test_scip_python_invalid_index_timeout_uses_the_ci_default(monkeypatch, tmp_
         captured.update(kwargs)
 
     monkeypatch.setattr(scip_indexer_python, "_run_checked_with_timeout", fake_run)
-    monkeypatch.setenv("CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS", "invalid")
+    monkeypatch.setenv("CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS", value)
 
     assert indexer._run_direct(["/tools/scip-python", "index"], tmp_path)
     assert captured["timeout"] == 600.0


### PR DESCRIPTION
## Summary

Make the Python SCIP child-process timeout configurable for large repositories while preserving the existing 600-second CI default.

## Changes

- Read `CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS` through one validated helper.
- Apply the override consistently to direct, activated-Conda, and `conda run` execution paths.
- Fall back to 600 seconds for missing, non-numeric, non-finite, zero, or negative values.
- Add focused tests for an extended timeout and every invalid-value class.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/scip/test_scip_python_runtime.py --tb=short` (13 passed)
- `pre-commit run --files codenib/scip_interface/scip_indexer_python.py test/scip/test_scip_python_runtime.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published