### PR TITLE
test(lsp): isolate cache preservation cases

### DIFF
--- a/test/ls_index/test_lsp_indexer.py
+++ b/test/ls_index/test_lsp_indexer.py
@@ -338,7 +338,11 @@ def test_generic_lsp_clear_cache_uses_shared_preservation_contract(
     keeps_graph,
     expected,
 ):
-    indexer = GenericLSPIndexer(tmp_path, language="java")
+    indexer = GenericLSPIndexer(
+        tmp_path,
+        output_dir=tmp_path / "index",
+        language="java",
+    )
     indexer.index_file.write_text("{}", encoding="utf-8")
     indexer.graph_file.write_bytes(b"graph")
 


### PR DESCRIPTION
## Summary

Prevent the generic LSP cache-preservation test from sharing process-global cache artifacts across pytest-xdist workers.

## Changes

- Give the parameterized cache test a pytest-owned `output_dir` under its worker-specific `tmp_path`.
- Preserve the production cache implementation and the behavior asserted by the test.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

- 20 repeated runs of `pytest -q -n 8 test/ls_index/test_lsp_indexer.py::test_generic_lsp_clear_cache_uses_shared_preservation_contract --tb=short`
- `pytest -q -n 8 test/ls_index/test_lsp_indexer.py --tb=short` (`14 passed`)
- `pre-commit run --files test/ls_index/test_lsp_indexer.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
