### PR TITLE
perf(runtime): load only required repository views

### DIFF
--- a/codenib/integrations/_repository.py
+++ b/codenib/integrations/_repository.py
@@ -156,7 +156,11 @@ class RepositoryAdapter:
 
         from ..mcp.context import ServerContext
 
-        return cls(ServerContext.load(manifest_path), require_graph=require_graph)
+        views = {"symbol_graph"} if require_graph else set()
+        return cls(
+            ServerContext.load(manifest_path, views=views),
+            require_graph=require_graph,
+        )
 
     @property
     def entities(self) -> tuple[RepositoryEntity, ...]:

--- a/codenib/integrations/locagent.py
+++ b/codenib/integrations/locagent.py
@@ -33,6 +33,7 @@ _TOOL_NAMES = (
     "get_entity_contents",
     "explore_tree_structure",
 )
+_RUNTIME_VIEWS = frozenset({"symbol_graph", "bm25"})
 
 _RELATION_TO_EDGE = {
     "contains": EDGE_TYPE_CONTAIN,
@@ -182,7 +183,7 @@ class LocAgentToolProvider:
     ) -> "LocAgentToolProvider":
         from ..mcp.context import ServerContext
 
-        return cls(ServerContext.load(manifest_path), **kwargs)
+        return cls(ServerContext.load(manifest_path, views=_RUNTIME_VIEWS), **kwargs)
 
     @property
     def context(self) -> Any:

--- a/codenib/integrations/orcaloca.py
+++ b/codenib/integrations/orcaloca.py
@@ -63,6 +63,7 @@ ORCALOCA_HISTORY_FIELDS = (
     "file_path",
     "is_skeleton",
 )
+_RUNTIME_VIEWS = frozenset({"symbol_graph"})
 
 _CALLABLE_KINDS = {
     NODE_TYPE_CLASS,
@@ -118,7 +119,7 @@ class OrcaLocaSearchProvider:
     ) -> "OrcaLocaSearchProvider":
         from ..mcp.context import ServerContext
 
-        return cls(ServerContext.load(manifest_path), **kwargs)
+        return cls(ServerContext.load(manifest_path, views=_RUNTIME_VIEWS), **kwargs)
 
     @property
     def context(self) -> Any:

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -2,31 +2,79 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""ServerContext - loads a RepoManifest and available index objects from disk.
+"""ServerContext - loads a RepoManifest and selected index objects from disk.
 
 Holds vector, symbol_graph, BM25, regex, and Zoekt indexes. Each loads
-independently; failures land in ``ctx.errors`` and the corresponding
-attribute stays ``None`` so tools can surface a clear error at call time
-rather than blocking server startup.
+independently; failures land in ``ctx.errors`` and skipped or failed views keep
+their corresponding attribute at ``None`` so tools can surface a clear error at
+call time rather than blocking server startup.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional
 
 from ..compiler.manifest import RepoManifest
-from ..index.sparse_idx import BM25CodeIndexer
 
 if TYPE_CHECKING:
     from ..graph.code_graph import CodeGraph
     from ..index.embedding.vector_store import CodeVectorStore
     from ..index.regex_idx import RegexNodeIndex
+    from ..index.sparse_idx import BM25CodeIndexer
     from ..index.trigram import ZoektSearcher
 
 logger = logging.getLogger(__name__)
+
+_VIEW_LOADERS = (
+    ("symbol_graph", "_load_symbol_graph"),
+    ("bm25", "_load_bm25"),
+    ("regex_index", "_load_regex_index"),
+    ("zoekt", "_load_zoekt"),
+    ("vector", "_load_vector"),
+)
+RUNTIME_VIEW_NAMES = frozenset(name for name, _ in _VIEW_LOADERS)
+_VIEW_DEPENDENCIES = {
+    "regex_index": frozenset({"symbol_graph"}),
+}
+
+
+def _resolve_views(views: Iterable[str] | None) -> frozenset[str]:
+    """Validate a view selection and add runtime dependencies."""
+
+    if views is None:
+        return RUNTIME_VIEW_NAMES
+    if isinstance(views, (str, bytes)):
+        raise TypeError("views must be an iterable of view names, not a string")
+
+    requested = frozenset(views)
+    invalid_types = sorted(
+        {type(view).__name__ for view in requested if not isinstance(view, str)}
+    )
+    if invalid_types:
+        raise TypeError(
+            "view names must be strings; received " + ", ".join(invalid_types)
+        )
+
+    unknown = requested - RUNTIME_VIEW_NAMES
+    if unknown:
+        supported = ", ".join(sorted(RUNTIME_VIEW_NAMES))
+        raise ValueError(
+            f"unknown runtime views {sorted(unknown)!r}; supported: {supported}"
+        )
+
+    selected = set(requested)
+    pending = list(requested)
+    while pending:
+        view = pending.pop()
+        for dependency in _VIEW_DEPENDENCIES.get(view, ()):
+            if dependency not in selected:
+                selected.add(dependency)
+                pending.append(dependency)
+    return frozenset(selected)
 
 
 @dataclass
@@ -47,26 +95,38 @@ class ServerContext:
     errors: Dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def load(cls, manifest_path: str | Path) -> ServerContext:
-        """Load a manifest and all available indexes.
+    def load(
+        cls,
+        manifest_path: str | Path,
+        *,
+        views: Iterable[str] | None = None,
+    ) -> ServerContext:
+        """Load a manifest and the selected runtime views.
 
-        Each index is loaded independently; a failure in one does not
-        block the others. Failed indexes are recorded in ``errors``.
+        ``views=None`` preserves the MCP server's load-all behavior. Explicit
+        selections avoid importing or starting unrelated view runtimes. Each
+        selected view is loaded independently; a failure in one does not block
+        the others. Failed views are recorded in ``errors``.
         """
+        selected = _resolve_views(views)
         manifest = RepoManifest.load(manifest_path)
         ctx = cls(manifest=manifest)
 
-        ctx._load_symbol_graph()
-        ctx._load_bm25()
-        ctx._load_regex_index()
-        ctx._load_zoekt()
-        ctx._load_vector()
+        for view, loader_name in _VIEW_LOADERS:
+            if view in selected:
+                getattr(ctx, loader_name)()
 
         cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
+        loaded = [
+            view for view, _ in _VIEW_LOADERS if getattr(ctx, view, None) is not None
+        ]
         logger.info(
-            "ServerContext ready  repo=%s  commit=%s  capabilities=%s  errors=%s",
+            "ServerContext ready  repo=%s  commit=%s  requested=%s  loaded=%s  "
+            "capabilities=%s  errors=%s",
             manifest.repo_path,
             manifest.commit[:8] if manifest.commit else "N/A",
+            sorted(selected),
+            loaded or "none",
             cap_summary or "none",
             list(ctx.errors) or "none",
         )
@@ -96,6 +156,8 @@ class ServerContext:
         if not entry or not self.manifest.index_is_current("bm25"):
             return
         try:
+            from ..index.sparse_idx import BM25CodeIndexer
+
             indexer = BM25CodeIndexer()
             indexer.load_index(entry.path)
             self.bm25 = indexer

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -23,6 +23,9 @@ prompt, and budget contract; it is not a general quality claim.
 Optional upstream packages are required only for policy execution. Provider
 imports and standalone provider examples remain dependency-free. Exact pinned
 revisions, fidelity limits, commands, and measured evidence follow below.
+Provider startup also selects only its declared runtime views: LocAgent loads
+the symbol graph and BM25, while OrcaLoca loads only the symbol graph. Dense and
+Zoekt runtimes are not imported or started for these contracts.
 CodeNib's graph providers can represent additional languages, but this matrix
 does not extend a Python-scoped upstream policy or native comparator beyond its
 validated domain.

--- a/test/integrations/test_locagent.py
+++ b/test/integrations/test_locagent.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -26,12 +27,28 @@ from codenib.integrations.locagent import (
     dispatch_locagent_tool_call,
     get_locagent_tool_schemas,
 )
+from codenib.mcp.context import ServerContext
 from codenib.types import EDGE_TYPE_REFERENCE, NODE_TYPE_CLASS, NODE_TYPE_FUNCTION
 
 
 @pytest.fixture()
 def provider(integration_manifest: Path) -> LocAgentToolProvider:
     return LocAgentToolProvider.from_manifest(integration_manifest)
+
+
+def test_provider_loads_only_graph_and_bm25(integration_manifest: Path) -> None:
+    with patch.object(ServerContext, "load", wraps=ServerContext.load) as load:
+        provider = LocAgentToolProvider.from_manifest(integration_manifest)
+
+    load.assert_called_once_with(
+        integration_manifest,
+        views=frozenset({"symbol_graph", "bm25"}),
+    )
+    assert provider.context.symbol_graph is not None
+    assert provider.context.bm25 is not None
+    assert provider.context.regex_index is None
+    assert provider.context.zoekt is None
+    assert provider.context.vector is None
 
 
 def _schema_contract(schemas: list[dict]) -> dict:

--- a/test/integrations/test_orcaloca.py
+++ b/test/integrations/test_orcaloca.py
@@ -8,6 +8,7 @@ import ast
 import inspect
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -22,11 +23,27 @@ from codenib.integrations.orcaloca import (
     OrcaLocaSearchProvider,
     make_orcaloca_search_manager_factory,
 )
+from codenib.mcp.context import ServerContext
 
 
 @pytest.fixture()
 def provider(integration_manifest: Path) -> OrcaLocaSearchProvider:
     return OrcaLocaSearchProvider.from_manifest(integration_manifest)
+
+
+def test_provider_loads_only_graph(integration_manifest: Path) -> None:
+    with patch.object(ServerContext, "load", wraps=ServerContext.load) as load:
+        provider = OrcaLocaSearchProvider.from_manifest(integration_manifest)
+
+    load.assert_called_once_with(
+        integration_manifest,
+        views=frozenset({"symbol_graph"}),
+    )
+    assert provider.context.symbol_graph is not None
+    assert provider.context.bm25 is None
+    assert provider.context.regex_index is None
+    assert provider.context.zoekt is None
+    assert provider.context.vector is None
 
 
 def _tool_contract(provider: OrcaLocaSearchProvider) -> dict:

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from codenib.compiler.manifest import IndexEntry, RepoManifest
-from codenib.mcp.context import ServerContext
+from codenib.mcp.context import RUNTIME_VIEW_NAMES, ServerContext
 
 
 @pytest.fixture()
@@ -53,6 +53,62 @@ def manifest_dir(tmp_path: Path) -> Path:
     manifest_path = tmp_path / "repo_manifest.json"
     manifest.save(manifest_path)
     return tmp_path
+
+
+def _record_view_loads(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    calls: list[str] = []
+    for view in ("symbol_graph", "bm25", "regex_index", "zoekt", "vector"):
+        monkeypatch.setattr(
+            ServerContext,
+            f"_load_{view}",
+            lambda _self, view=view: calls.append(view),
+        )
+    return calls
+
+
+def test_load_defaults_to_all_runtime_views(
+    manifest_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _record_view_loads(monkeypatch)
+
+    ServerContext.load(manifest_dir / "repo_manifest.json")
+
+    assert calls == ["symbol_graph", "bm25", "regex_index", "zoekt", "vector"]
+    assert RUNTIME_VIEW_NAMES == frozenset(calls)
+
+
+def test_load_selects_only_requested_views(
+    manifest_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _record_view_loads(monkeypatch)
+
+    ServerContext.load(manifest_dir / "repo_manifest.json", views={"bm25"})
+
+    assert calls == ["bm25"]
+
+
+def test_load_expands_runtime_view_dependencies(
+    manifest_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _record_view_loads(monkeypatch)
+
+    ServerContext.load(manifest_dir / "repo_manifest.json", views={"regex_index"})
+
+    assert calls == ["symbol_graph", "regex_index"]
+
+
+@pytest.mark.parametrize("views", ["bm25", {"unknown"}, {1}])
+def test_load_rejects_invalid_view_selections(
+    manifest_dir: Path,
+    views: object,
+) -> None:
+    expected = ValueError if views == {"unknown"} else TypeError
+
+    with pytest.raises(expected):
+        ServerContext.load(manifest_dir / "repo_manifest.json", views=views)
 
 
 def test_load_with_bm25_only(manifest_dir: Path) -> None:


### PR DESCRIPTION
## Summary

Make runtime view loading demand-driven for embedded agent providers while preserving the MCP server's existing load-all default.

## Changes

- Add validated `ServerContext.load(..., views=...)` selection with runtime dependency expansion.
- Keep `views=None` backward compatible and load BM25 lazily at the Python module boundary.
- Load only `symbol_graph` and `bm25` for LocAgent, and only `symbol_graph` for OrcaLoca and graph-only repository adapters.
- Document provider view requirements and test default, selective, dependency, and invalid-selection behavior.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

Commands:

- `pytest -q test/mcp_server test/integrations test/eval/test_locagent_benchmark_adapter.py test/eval/test_orcaloca_benchmark_adapter.py test/eval/test_policy_benchmark.py test/eval/test_policy_compat.py --tb=short` (`140 passed, 12 skipped`)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2381 passed, 10 skipped`)
- `pre-commit run --files ...`
- `mkdocs build --strict`
- `python scripts/check_public_docs.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
