### PR TITLE
fix(index): harden artifact reuse and policy preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 - Graph schema 5 records semantic symbol kinds, explicit definition
   provenance, and anchored TypeScript/TSX import and re-export edges.
+- Revision-pinned LocAgent and OrcaLoca SearchAgent adapters can reuse
+  manifest-backed repository views without introducing upstream agent
+  dependencies into the base package.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ SPDX-License-Identifier: Apache-2.0
     &nbsp;&middot;&nbsp;
     <a href="https://docs.codenib.ai/mcp/">MCP</a>
     &nbsp;&middot;&nbsp;
+    <a href="https://docs.codenib.ai/agent_integrations/">Agent Integrations</a>
+    &nbsp;&middot;&nbsp;
     <a href="https://docs.codenib.ai/language_capabilities/">Languages</a>
   </p>
   <p>
@@ -45,6 +47,16 @@ The Wiki, Ask view, and Dependency Map are inspection clients of that same
 runtime, not the system boundary. The core implementation lives in CodeNib;
 optional model endpoints and language servers are providers rather than a host
 agent or code-Wiki framework.
+
+## News
+
+- **2026-08-02 — OrcaLoca SearchAgent integration.** CodeNib can now serve a
+  revision-pinned OrcaLoca `SearchAgent` through its manifest-backed symbol
+  graph, preserving the upstream six-tool and private-hook contract without
+  building an OrcaLoca-specific graph. The supported boundary starts at
+  `SearchAgent` with an empty `TraceAnalysisOutput`; see the
+  [agent integration support matrix](https://docs.codenib.ai/agent_integrations/)
+  for validation evidence and scope.
 
 ## System Architecture
 
@@ -128,6 +140,7 @@ for client configuration and tool contracts.
 | Retrieval | BM25, dense-vector, regex/trigram, Zoekt, fusion, and reranking paths |
 | Structural context | SCIP/LSP-backed symbol graphs with source locations and typed edges |
 | MCP and LSP-shaped tools | Serve one manifest to coding agents without tying the runtime to one agent framework |
+| External policy adapters | Run revision-pinned LocAgent and OrcaLoca SearchAgent policies over the same manifest-backed views |
 | Local inspection | Audit the same context through Wiki pages, Ask answers, citations, and the Dependency Map |
 | Evaluation harness | Measure retrieval, navigation, incremental maintenance, and context policies on the same artifacts |
 
@@ -139,6 +152,7 @@ records chunking, graph, incremental, and C++ decoder support.
 
 - [Quickstart](https://docs.codenib.ai/quickstart/)
 - [MCP Server](https://docs.codenib.ai/mcp/)
+- [Agent Integrations](https://docs.codenib.ai/agent_integrations/)
 - [Web UI](https://docs.codenib.ai/web_demo/)
 - [Language Capabilities](https://docs.codenib.ai/language_capabilities/)
 - [Concepts and development guides](https://docs.codenib.ai/)

--- a/codenib/clients/orcaloca_agent.py
+++ b/codenib/clients/orcaloca_agent.py
@@ -2,7 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""OrcaLoca adapter for CodeNib's generic localization benchmark contract."""
+"""OrcaLoca SearchAgent adapter for the generic localization contract.
+
+The supported boundary starts at SearchAgent. The default runner intentionally
+uses an empty TraceAnalysisOutput and does not execute OrcaLoca's upstream
+trace-analysis stage.
+"""
 
 from __future__ import annotations
 
@@ -83,11 +88,15 @@ def orcaloca_locations_to_baseline(
 
 
 class OrcaLocaAgent:
-    """Run OrcaLoca policy over CodeNib views through ``locate_code``.
+    """Run OrcaLoca SearchAgent over CodeNib views through ``locate_code``.
 
     The class imports OrcaLoca, LlamaIndex, and tiktoken only when the default
     search runner executes. Tests and alternative runtimes can inject a
     dependency-free ``search_runner`` with the same raw-output contract.
+
+    Trace-analysis generation is outside this adapter. The default runner
+    supplies an empty ``TraceAnalysisOutput`` so repository-provider behavior
+    can be evaluated without changing an upstream issue-analysis input.
     """
 
     def __init__(
@@ -215,6 +224,8 @@ class OrcaLocaAgent:
 
         from codenib.integrations.orcaloca import make_orcaloca_search_manager_factory
 
+        # Trace analysis is a distinct upstream stage. Keep its output empty so
+        # this adapter changes only the repository provider used by SearchAgent.
         search_input = SearchInput(
             problem_statement=problem_statement,
             trace_analysis_output=TraceAnalysisOutput(),

--- a/codenib/code_chunking/README.md
+++ b/codenib/code_chunking/README.md
@@ -15,7 +15,7 @@ Controlled by the `chunk_depth` parameter in `BaseCodeChunker`:
 
 | Depth | Name | Description |
 |-------|------|-------------|
-| 0 | **L0 — File** | Entire file as a single chunk. With `skeleton_mode=True`, emits a signature-only skeleton of the file. |
+| 0 | **L0 — File** | Entire file as a single chunk. With `skeleton_mode=True`, emits a signature-only skeleton and falls back to full source when no signature can be extracted. |
 | 1 | **L1 — Top-level** | Top-level definitions only: classes, standalone functions, and language-specific constructs (vars, consts, macros, etc.). Methods/members inside containers are **not** emitted. |
 | 2 | **L2 — Member** | Method/member level (default). Emits methods and members inside classes/structs/impls. When `l2_level_exclusive=True` (default), the L1 container chunks are excluded, keeping only their L2 members. |
 

--- a/codenib/code_chunking/__init__.py
+++ b/codenib/code_chunking/__init__.py
@@ -55,7 +55,7 @@ def create_chunker(
     Args:
         language: Programming language ('python', 'cpp', 'java', etc.)
         max_lines_per_chunk: Maximum number of lines per emitted chunk. Default:
-            None (no splitting)
+            None (no general splitting; raw L0 fallbacks retain a safe bound)
         chunk_depth: Granularity level
             0 = Entire file as a chunk
             1 = Top-level declarations only

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -175,8 +175,17 @@ class BaseCodeChunker(ABC):
                 if not skeleton_content:
                     # L0 is the file view. Declaration-only files and language
                     # constructs not recognized by the skeleton extractor must
-                    # remain addressable rather than disappearing from the index.
-                    skeleton_content = code_content
+                    # remain addressable, while still honoring the configured
+                    # payload bound for a raw-source fallback.
+                    return self._split_by_max_lines(
+                        lines=lines,
+                        start_line=0,
+                        end_line=len(lines) - 1,
+                        chunk_type="file",
+                        name=Path(file_path).name,
+                        file_path=file_path,
+                        node_id=path_for_node_id,
+                    )
                 return [
                     CodeChunk(
                         skeleton_content,

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -24,6 +24,8 @@ from ..log_utils import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_L0_RAW_FALLBACK_MAX_LINES = 300
+
 # Define structures for code chunks
 CodeChunk = namedtuple(
     "CodeChunk",
@@ -56,7 +58,9 @@ class BaseCodeChunker(ABC):
                 large logical chunks (function/class) will be split into
                 multiple sequential chunks of at most this many lines. node_id and name
                 remain the same across the split pieces. Default: None (no splitting).
-                Set to a number to enable.
+                Set to a number to enable. An L0 skeleton that cannot extract
+                any declarations falls back to raw source capped at
+                ``DEFAULT_L0_RAW_FALLBACK_MAX_LINES`` when this is None.
             chunk_depth: Depth of AST traversal for chunking:
                 0 = Treat entire file as a single chunk
                 1 = Top-level only (classes and top-level functions, no methods)
@@ -185,6 +189,11 @@ class BaseCodeChunker(ABC):
                         name=Path(file_path).name,
                         file_path=file_path,
                         node_id=path_for_node_id,
+                        line_limit=(
+                            self.max_lines_per_chunk
+                            if self.max_lines_per_chunk is not None
+                            else DEFAULT_L0_RAW_FALLBACK_MAX_LINES
+                        ),
                     )
                 return [
                     CodeChunk(
@@ -312,22 +321,22 @@ class BaseCodeChunker(ABC):
         name: str,
         file_path: str,
         node_id: str,
+        line_limit: Optional[int] = None,
     ) -> List[CodeChunk]:
         """
-        Split a logical chunk into multiple CodeChunk pieces if it exceeds max_lines_per_chunk.
+        Split a logical chunk into pieces if it exceeds the effective line limit.
         Keeps node_id and name unchanged across pieces.
         Uses balanced splitting to distribute lines evenly across chunks.
         """
         prefix = self._build_chunk_prefix(node_id, chunk_type, name)
         total_lines = end_line - start_line + 1
+        effective_limit = self.max_lines_per_chunk if line_limit is None else line_limit
 
         # Calculate number of chunks needed
-        if not self.max_lines_per_chunk or self.max_lines_per_chunk <= 0:
+        if not effective_limit or effective_limit <= 0:
             num_chunks = 1
         else:
-            num_chunks = (
-                total_lines + self.max_lines_per_chunk - 1
-            ) // self.max_lines_per_chunk
+            num_chunks = (total_lines + effective_limit - 1) // effective_limit
 
         # 1. Single chunk: no splitting needed
         if num_chunks == 1:

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -173,7 +173,10 @@ class BaseCodeChunker(ABC):
                     top_level_nodes, code_content
                 )
                 if not skeleton_content:
-                    return []
+                    # L0 is the file view. Declaration-only files and language
+                    # constructs not recognized by the skeleton extractor must
+                    # remain addressable rather than disappearing from the index.
+                    skeleton_content = code_content
                 return [
                     CodeChunk(
                         skeleton_content,

--- a/codenib/compiler/artifact_quality.py
+++ b/codenib/compiler/artifact_quality.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Commit-surface and completeness gates for reusable benchmark artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from .. import compat_pickle
+from ..git_snapshot import GitSourceSurface, normalize_repository_path
+from ..graph.code_graph import CodeGraph
+from ..types import NODE_TYPE_DIRECTORY, NODE_TYPE_FILE, ROOT_NODE, is_symbol_node
+
+ARTIFACT_QUALITY_SCHEMA_VERSION = 1
+
+
+def required_source_files(
+    instance: Mapping[str, Any],
+    extensions: Iterable[str],
+) -> tuple[str, ...]:
+    """Return GT target files within one backend's source-language surface."""
+
+    accepted = frozenset(extensions)
+    required = set()
+    for raw_path in instance.get("gt_target_files") or ():
+        path = normalize_repository_path(str(raw_path))
+        if Path(path).suffix in accepted:
+            required.add(path)
+    return tuple(sorted(required))
+
+
+def _path_or_none(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return normalize_repository_path(value)
+    except ValueError:
+        return None
+
+
+def graph_source_paths(graph: CodeGraph) -> tuple[str, ...]:
+    """Collect every repository path represented by a graph artifact."""
+
+    paths: set[str] = set()
+    for vertex in graph.graph.vs:
+        attrs = vertex.attributes()
+        node_type = attrs.get("type")
+        candidate = (
+            attrs.get("name") if node_type == NODE_TYPE_FILE else attrs.get("file")
+        )
+        path = _path_or_none(candidate)
+        if path:
+            paths.add(path)
+    for edge in graph.graph.es:
+        path = _path_or_none(edge.attributes().get("anchor_file"))
+        if path:
+            paths.add(path)
+    occurrence_index = getattr(graph, "lsp_occurrence_index", None)
+    if occurrence_index is not None:
+        for occurrence in occurrence_index.occurrences:
+            path = _path_or_none(occurrence.file_path)
+            if path:
+                paths.add(path)
+    return tuple(sorted(paths))
+
+
+def graph_file_paths(graph: CodeGraph) -> tuple[str, ...]:
+    """Collect repository files materialized as graph file-view nodes."""
+
+    paths = {
+        path
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("type") == NODE_TYPE_FILE
+        and (path := _path_or_none(vertex.attributes().get("name"))) is not None
+    }
+    return tuple(sorted(paths))
+
+
+def _keep_graph_vertex(attrs: Mapping[str, Any], surface: GitSourceSurface) -> bool:
+    node_type = attrs.get("type")
+    name = attrs.get("name")
+    if node_type == "root" or name == ROOT_NODE:
+        return True
+    if node_type == NODE_TYPE_DIRECTORY:
+        path = _path_or_none(name)
+        return bool(path and surface.has_descendant(path))
+    if node_type == NODE_TYPE_FILE:
+        path = _path_or_none(name)
+        return bool(path and surface.contains(path))
+    if is_symbol_node(node_type):
+        raw_path = attrs.get("file")
+        path = _path_or_none(raw_path)
+        # External/reference-only symbols may not have a repository definition.
+        if path is None:
+            return raw_path is None or raw_path == ""
+        return surface.contains(path)
+    raw_path = attrs.get("file")
+    path = _path_or_none(raw_path)
+    if path is None:
+        return raw_path is None or raw_path == ""
+    return surface.contains(path)
+
+
+def constrain_graph_to_source_surface(
+    graph: CodeGraph,
+    surface: GitSourceSurface,
+) -> dict[str, Any]:
+    """Remove graph records not addressable by *surface* and rebuild indexes."""
+
+    before_nodes = graph.graph.vcount()
+    before_edges = graph.graph.ecount()
+    before_paths = graph_source_paths(graph)
+    before_classes = surface.classify(before_paths)
+
+    keep_vertices = [
+        vertex.index
+        for vertex in graph.graph.vs
+        if _keep_graph_vertex(vertex.attributes(), surface)
+    ]
+    if len(keep_vertices) != before_nodes:
+        graph.graph = graph.graph.subgraph(keep_vertices)
+
+    remove_edges = []
+    for edge in graph.graph.es:
+        raw_anchor = edge.attributes().get("anchor_file")
+        anchor = _path_or_none(raw_anchor)
+        if (raw_anchor is not None and raw_anchor != "" and anchor is None) or (
+            anchor is not None and not surface.contains(anchor)
+        ):
+            remove_edges.append(edge.index)
+    if remove_edges:
+        graph.graph.delete_edges(remove_edges)
+
+    graph.name_to_vertex = {
+        vertex["name"]: vertex.index
+        for vertex in graph.graph.vs
+        if "name" in vertex.attributes()
+    }
+    graph.symbol_ranges = {
+        name: value
+        for name, value in graph.symbol_ranges.items()
+        if name in graph.name_to_vertex
+    }
+    graph._invalidate_edge_index()
+
+    occurrence_index = getattr(graph, "lsp_occurrence_index", None)
+    if occurrence_index is not None:
+        from ..scip_interface.lsp_occurrence_index import SCIPOccurrenceIndex
+
+        graph.lsp_occurrence_index = SCIPOccurrenceIndex(
+            (
+                occurrence
+                for occurrence in occurrence_index.occurrences
+                if (path := _path_or_none(occurrence.file_path)) is not None
+                and surface.contains(path)
+            ),
+            position_encoding=occurrence_index.position_encoding,
+        )
+    graph.build_range_indexes()
+
+    after_paths = graph_source_paths(graph)
+    after_classes = surface.classify(after_paths)
+    return {
+        "nodes_before": before_nodes,
+        "nodes_after": graph.graph.vcount(),
+        "edges_before": before_edges,
+        "edges_after": graph.graph.ecount(),
+        "paths_before": len(before_paths),
+        "paths_after": len(after_paths),
+        "tracked_paths": len(after_classes["tracked"]),
+        "submodule_paths": len(after_classes["submodule"]),
+        "removed_outside_paths": list(before_classes["outside"]),
+        "outside_paths_after": list(after_classes["outside"]),
+    }
+
+
+def assess_graph_artifact(
+    graph: CodeGraph,
+    surface: GitSourceSurface,
+    *,
+    required_files: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Constrain a graph and report commit identity plus required-file coverage."""
+
+    surface_report = constrain_graph_to_source_surface(graph, surface)
+    represented = set(graph_file_paths(graph))
+    required = tuple(sorted(normalize_repository_path(path) for path in required_files))
+    missing = tuple(path for path in required if path not in represented)
+    failures = []
+    if surface_report["outside_paths_after"]:
+        failures.append("outside_commit_paths")
+    if missing:
+        failures.append("missing_required_source_files")
+    if graph.graph.vcount() <= 1:
+        failures.append("empty_graph")
+    return {
+        "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+        "kind": "graph",
+        "commit": surface.commit,
+        "tree": surface.tree,
+        "required_source_files": list(required),
+        "missing_required_source_files": list(missing),
+        "surface": surface_report,
+        "failure_names": failures,
+        "passed": not failures,
+    }
+
+
+def _load_vector_level(
+    root: Path,
+    level: str,
+    model_suffix: str,
+) -> tuple[list[Any], int, list[str]]:
+    failures = []
+    level_root = root / level
+    config_path = level_root / f"config_{model_suffix}.json"
+    index_path = level_root / f"index_{model_suffix}.faiss"
+    documents_path = level_root / f"documents_{model_suffix}.pkl"
+    for path in (config_path, index_path, documents_path):
+        if not path.is_file():
+            failures.append(f"missing:{path.name}")
+    if failures:
+        return [], 0, failures
+
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        with documents_path.open("rb") as handle:
+            documents = list(compat_pickle.load(handle))
+        import faiss
+
+        index = faiss.read_index(str(index_path))
+    except Exception as exc:
+        return [], 0, [f"unreadable_level:{type(exc).__name__}"]
+    expected = int(config.get("num_documents", -1))
+    if expected != len(documents):
+        failures.append("document_config_count_mismatch")
+    if int(index.ntotal) != len(documents):
+        failures.append("faiss_document_count_mismatch")
+    return documents, int(index.ntotal), failures
+
+
+def assess_vector_artifact(
+    root: str | Path,
+    *,
+    embedding_model: str,
+    build_levels: Sequence[str],
+    surface: GitSourceSurface,
+    expected_artifact: Mapping[str, Any],
+    required_l0_files: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Validate vector files, provenance, commit paths, and L0 GT coverage."""
+
+    artifact_root = Path(root)
+    model_suffix = embedding_model.replace("/", "__")
+    top_config_path = artifact_root / f"config_{model_suffix}.json"
+    failures: list[str] = []
+    top_config: Mapping[str, Any] = {}
+    if not top_config_path.is_file():
+        failures.append("missing_top_config")
+    else:
+        try:
+            top_config = json.loads(top_config_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            failures.append(f"unreadable_top_config:{type(exc).__name__}")
+        else:
+            if top_config.get("embedding_model") != embedding_model:
+                failures.append("embedding_model_mismatch")
+            if top_config.get("artifact") != dict(expected_artifact):
+                failures.append("artifact_identity_mismatch")
+
+    levels: dict[str, Any] = {}
+    all_paths: set[str] = set()
+    l0_paths: set[str] = set()
+    invalid_document_paths: set[str] = set()
+    for raw_level in build_levels:
+        level = raw_level.lower()
+        documents, vector_count, level_failures = _load_vector_level(
+            artifact_root, level, model_suffix
+        )
+        paths = set()
+        for document in documents:
+            metadata = getattr(document, "metadata", {})
+            raw_path = metadata.get("file")
+            path = _path_or_none(raw_path)
+            if path:
+                paths.add(path)
+            elif raw_path is not None and raw_path != "":
+                invalid_document_paths.add(str(raw_path))
+        all_paths.update(paths)
+        if level == "l0":
+            l0_paths.update(paths)
+        if not documents:
+            level_failures.append("empty_level")
+        levels[level] = {
+            "documents": len(documents),
+            "vectors": vector_count,
+            "paths": len(paths),
+            "failures": level_failures,
+        }
+        failures.extend(f"{level}:{failure}" for failure in level_failures)
+
+    classified = surface.classify(all_paths)
+    if classified["outside"]:
+        failures.append("outside_commit_paths")
+    if invalid_document_paths:
+        failures.append("invalid_document_paths")
+    required = tuple(
+        sorted(normalize_repository_path(path) for path in required_l0_files)
+    )
+    missing = tuple(path for path in required if path not in l0_paths)
+    if missing:
+        failures.append("missing_required_l0_files")
+    return {
+        "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+        "kind": "vector",
+        "artifact": dict(expected_artifact),
+        "commit": surface.commit,
+        "tree": surface.tree,
+        "levels": levels,
+        "paths": {
+            "tracked": len(classified["tracked"]),
+            "submodule": len(classified["submodule"]),
+            "outside": list(classified["outside"]),
+            "invalid": sorted(invalid_document_paths),
+        },
+        "required_l0_files": list(required),
+        "missing_required_l0_files": list(missing),
+        "failure_names": sorted(set(failures)),
+        "passed": not failures,
+    }
+
+
+def write_artifact_quality(path: str | Path, report: Mapping[str, Any]) -> None:
+    """Atomically publish a human-readable artifact quality report."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.tmp")
+    temporary.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(output)
+
+
+__all__ = [
+    "ARTIFACT_QUALITY_SCHEMA_VERSION",
+    "assess_graph_artifact",
+    "assess_vector_artifact",
+    "constrain_graph_to_source_surface",
+    "graph_file_paths",
+    "graph_source_paths",
+    "required_source_files",
+    "write_artifact_quality",
+]

--- a/codenib/compiler/artifact_quality.py
+++ b/codenib/compiler/artifact_quality.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
@@ -277,6 +278,78 @@ def _load_vector_level(
     return documents, int(index.ntotal), failures, True
 
 
+def _vector_artifact_relative_paths(
+    model_suffix: str,
+    build_levels: Sequence[str],
+) -> tuple[Path, ...]:
+    paths = [Path(f"config_{model_suffix}.json")]
+    for level in sorted({raw_level.lower() for raw_level in build_levels}):
+        level_root = Path(level)
+        paths.extend(
+            (
+                level_root / f"config_{model_suffix}.json",
+                level_root / f"index_{model_suffix}.faiss",
+                level_root / f"documents_{model_suffix}.pkl",
+            )
+        )
+    return tuple(paths)
+
+
+def _file_fingerprint(path: Path) -> dict[str, Any]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        while block := handle.read(1024 * 1024):
+            digest.update(block)
+            size += len(block)
+    return {"size": size, "sha256": digest.hexdigest()}
+
+
+def vector_artifact_file_fingerprints(
+    root: str | Path,
+    *,
+    embedding_model: str,
+    build_levels: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    """Fingerprint every file covered by a vector quality assessment."""
+
+    artifact_root = Path(root)
+    model_suffix = embedding_model.replace("/", "__")
+    fingerprints: dict[str, dict[str, Any]] = {}
+    for relative in _vector_artifact_relative_paths(model_suffix, build_levels):
+        path = artifact_root / relative
+        try:
+            fingerprints[relative.as_posix()] = _file_fingerprint(path)
+        except OSError:
+            continue
+    return fingerprints
+
+
+def vector_artifact_files_match(
+    root: str | Path,
+    *,
+    embedding_model: str,
+    build_levels: Sequence[str],
+    expected_fingerprints: object,
+) -> bool:
+    """Return whether all assessed vector files still match their report."""
+
+    if not isinstance(expected_fingerprints, Mapping):
+        return False
+    model_suffix = embedding_model.replace("/", "__")
+    expected_paths = {
+        path.as_posix()
+        for path in _vector_artifact_relative_paths(model_suffix, build_levels)
+    }
+    if set(expected_fingerprints) != expected_paths:
+        return False
+    return vector_artifact_file_fingerprints(
+        root,
+        embedding_model=embedding_model,
+        build_levels=build_levels,
+    ) == dict(expected_fingerprints)
+
+
 def assess_vector_artifact(
     root: str | Path,
     *,
@@ -315,13 +388,27 @@ def assess_vector_artifact(
     l0_paths: set[str] = set()
     invalid_document_paths: set[str] = set()
     invalid_document_metadata = 0
-    for raw_level in build_levels:
-        level = raw_level.lower()
+    normalized_levels = tuple(dict.fromkeys(level.lower() for level in build_levels))
+    unexpected_levels = []
+    for level in sorted({"l0", "l2"} - set(normalized_levels)):
+        level_root = artifact_root / level
+        if any(
+            (level_root / name).exists()
+            for name in (
+                f"config_{model_suffix}.json",
+                f"index_{model_suffix}.faiss",
+                f"documents_{model_suffix}.pkl",
+                f"index_{model_suffix}.pkl",
+            )
+        ):
+            unexpected_levels.append(level)
+            failures.append(f"unexpected_level:{level}")
+    for level in normalized_levels:
         documents, vector_count, level_failures, loaded = _load_vector_level(
             artifact_root, level, model_suffix
         )
         paths = set()
-        for document in documents:
+        for document_index, document in enumerate(documents):
             metadata = getattr(document, "metadata", {})
             if not isinstance(metadata, Mapping):
                 invalid_document_metadata += 1
@@ -330,8 +417,10 @@ def assess_vector_artifact(
             path = _path_or_none(raw_path)
             if path:
                 paths.add(path)
-            elif raw_path is not None and raw_path != "":
-                invalid_document_paths.add(str(raw_path))
+            else:
+                invalid_document_paths.add(
+                    f"{level}[{document_index}].file={raw_path!r}"
+                )
         all_paths.update(paths)
         if level == "l0":
             l0_paths.update(paths)
@@ -358,6 +447,16 @@ def assess_vector_artifact(
     missing = tuple(path for path in required if path not in l0_paths)
     if missing:
         failures.append("missing_required_l0_files")
+    file_fingerprints = vector_artifact_file_fingerprints(
+        artifact_root,
+        embedding_model=embedding_model,
+        build_levels=normalized_levels,
+    )
+    expected_file_count = len(
+        _vector_artifact_relative_paths(model_suffix, normalized_levels)
+    )
+    if len(file_fingerprints) != expected_file_count:
+        failures.append("incomplete_file_fingerprints")
     return {
         "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
         "kind": "vector",
@@ -365,6 +464,7 @@ def assess_vector_artifact(
         "commit": surface.commit,
         "tree": surface.tree,
         "levels": levels,
+        "unexpected_levels": unexpected_levels,
         "paths": {
             "tracked": len(classified["tracked"]),
             "submodule": len(classified["submodule"]),
@@ -373,7 +473,9 @@ def assess_vector_artifact(
             "invalid_metadata": invalid_document_metadata,
         },
         "required_l0_files": list(required),
+        "l0_files": sorted(l0_paths),
         "missing_required_l0_files": list(missing),
+        "file_fingerprints": file_fingerprints,
         "failure_names": sorted(set(failures)),
         "passed": not failures,
     }
@@ -397,5 +499,7 @@ __all__ = [
     "graph_file_paths",
     "graph_source_paths",
     "required_source_files",
+    "vector_artifact_file_fingerprints",
+    "vector_artifact_files_match",
     "write_artifact_quality",
 ]

--- a/codenib/compiler/artifact_quality.py
+++ b/codenib/compiler/artifact_quality.py
@@ -42,30 +42,56 @@ def _path_or_none(value: object) -> str | None:
         return None
 
 
-def graph_source_paths(graph: CodeGraph) -> tuple[str, ...]:
-    """Collect every repository path represented by a graph artifact."""
-
+def _graph_paths_and_invalid(
+    graph: CodeGraph,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
     paths: set[str] = set()
+    invalid: set[str] = set()
+
+    def collect(value: object, owner: str, *, required: bool = False) -> None:
+        if value is None or value == "":
+            if required:
+                invalid.add(f"{owner}={value!r}")
+            return
+        path = _path_or_none(value)
+        if path is None:
+            invalid.add(f"{owner}={value!r}")
+        else:
+            paths.add(path)
+
     for vertex in graph.graph.vs:
         attrs = vertex.attributes()
         node_type = attrs.get("type")
-        candidate = (
-            attrs.get("name") if node_type == NODE_TYPE_FILE else attrs.get("file")
-        )
-        path = _path_or_none(candidate)
-        if path:
-            paths.add(path)
+        if node_type == NODE_TYPE_DIRECTORY:
+            value = attrs.get("name")
+            if _path_or_none(value) is None:
+                invalid.add(f"vertex[{vertex.index}].name={value!r}")
+        elif node_type == NODE_TYPE_FILE:
+            collect(
+                attrs.get("name"),
+                f"vertex[{vertex.index}].name",
+                required=True,
+            )
+        else:
+            collect(attrs.get("file"), f"vertex[{vertex.index}].file")
     for edge in graph.graph.es:
-        path = _path_or_none(edge.attributes().get("anchor_file"))
-        if path:
-            paths.add(path)
+        collect(edge.attributes().get("anchor_file"), f"edge[{edge.index}].anchor_file")
     occurrence_index = getattr(graph, "lsp_occurrence_index", None)
     if occurrence_index is not None:
-        for occurrence in occurrence_index.occurrences:
-            path = _path_or_none(occurrence.file_path)
-            if path:
-                paths.add(path)
-    return tuple(sorted(paths))
+        for index, occurrence in enumerate(occurrence_index.occurrences):
+            collect(
+                occurrence.file_path,
+                f"occurrence[{index}].file_path",
+                required=True,
+            )
+    return tuple(sorted(paths)), tuple(sorted(invalid))
+
+
+def graph_source_paths(graph: CodeGraph) -> tuple[str, ...]:
+    """Collect every repository path represented by a graph artifact."""
+
+    paths, _invalid = _graph_paths_and_invalid(graph)
+    return paths
 
 
 def graph_file_paths(graph: CodeGraph) -> tuple[str, ...]:
@@ -113,7 +139,7 @@ def constrain_graph_to_source_surface(
 
     before_nodes = graph.graph.vcount()
     before_edges = graph.graph.ecount()
-    before_paths = graph_source_paths(graph)
+    before_paths, invalid_paths_before = _graph_paths_and_invalid(graph)
     before_classes = surface.classify(before_paths)
 
     keep_vertices = [
@@ -136,16 +162,16 @@ def constrain_graph_to_source_surface(
         graph.graph.delete_edges(remove_edges)
 
     graph.name_to_vertex = {
-        vertex["name"]: vertex.index
+        name: vertex.index
         for vertex in graph.graph.vs
-        if "name" in vertex.attributes()
+        if isinstance((name := vertex.attributes().get("name")), str) and name
     }
     graph.symbol_ranges = {
         name: value
         for name, value in graph.symbol_ranges.items()
         if name in graph.name_to_vertex
     }
-    graph._invalidate_edge_index()
+    graph.invalidate_caches()
 
     occurrence_index = getattr(graph, "lsp_occurrence_index", None)
     if occurrence_index is not None:
@@ -162,7 +188,7 @@ def constrain_graph_to_source_surface(
         )
     graph.build_range_indexes()
 
-    after_paths = graph_source_paths(graph)
+    after_paths, invalid_paths_after = _graph_paths_and_invalid(graph)
     after_classes = surface.classify(after_paths)
     return {
         "nodes_before": before_nodes,
@@ -175,10 +201,12 @@ def constrain_graph_to_source_surface(
         "submodule_paths": len(after_classes["submodule"]),
         "removed_outside_paths": list(before_classes["outside"]),
         "outside_paths_after": list(after_classes["outside"]),
+        "invalid_paths_before": list(invalid_paths_before),
+        "invalid_paths_after": list(invalid_paths_after),
     }
 
 
-def assess_graph_artifact(
+def constrain_and_assess_graph_artifact(
     graph: CodeGraph,
     surface: GitSourceSurface,
     *,
@@ -191,6 +219,8 @@ def assess_graph_artifact(
     required = tuple(sorted(normalize_repository_path(path) for path in required_files))
     missing = tuple(path for path in required if path not in represented)
     failures = []
+    if surface_report["invalid_paths_before"]:
+        failures.append("invalid_graph_paths")
     if surface_report["outside_paths_after"]:
         failures.append("outside_commit_paths")
     if missing:
@@ -214,7 +244,9 @@ def _load_vector_level(
     root: Path,
     level: str,
     model_suffix: str,
-) -> tuple[list[Any], int, list[str]]:
+) -> tuple[list[Any], int, list[str], bool]:
+    import faiss
+
     failures = []
     level_root = root / level
     config_path = level_root / f"config_{model_suffix}.json"
@@ -224,23 +256,25 @@ def _load_vector_level(
         if not path.is_file():
             failures.append(f"missing:{path.name}")
     if failures:
-        return [], 0, failures
+        return [], 0, failures, False
 
     try:
         config = json.loads(config_path.read_text(encoding="utf-8"))
         with documents_path.open("rb") as handle:
             documents = list(compat_pickle.load(handle))
-        import faiss
-
         index = faiss.read_index(str(index_path))
     except Exception as exc:
-        return [], 0, [f"unreadable_level:{type(exc).__name__}"]
-    expected = int(config.get("num_documents", -1))
-    if expected != len(documents):
+        return [], 0, [f"unreadable_level:{type(exc).__name__}"], False
+    if not isinstance(config, Mapping):
+        return [], 0, ["invalid_level_config"], False
+    expected = config.get("num_documents")
+    if not isinstance(expected, int) or isinstance(expected, bool) or expected < 0:
+        failures.append("invalid_document_config_count")
+    elif expected != len(documents):
         failures.append("document_config_count_mismatch")
     if int(index.ntotal) != len(documents):
         failures.append("faiss_document_count_mismatch")
-    return documents, int(index.ntotal), failures
+    return documents, int(index.ntotal), failures, True
 
 
 def assess_vector_artifact(
@@ -267,23 +301,31 @@ def assess_vector_artifact(
         except Exception as exc:
             failures.append(f"unreadable_top_config:{type(exc).__name__}")
         else:
-            if top_config.get("embedding_model") != embedding_model:
-                failures.append("embedding_model_mismatch")
-            if top_config.get("artifact") != dict(expected_artifact):
-                failures.append("artifact_identity_mismatch")
+            if not isinstance(top_config, Mapping):
+                failures.append("invalid_top_config")
+                top_config = {}
+            else:
+                if top_config.get("embedding_model") != embedding_model:
+                    failures.append("embedding_model_mismatch")
+                if top_config.get("artifact") != dict(expected_artifact):
+                    failures.append("artifact_identity_mismatch")
 
     levels: dict[str, Any] = {}
     all_paths: set[str] = set()
     l0_paths: set[str] = set()
     invalid_document_paths: set[str] = set()
+    invalid_document_metadata = 0
     for raw_level in build_levels:
         level = raw_level.lower()
-        documents, vector_count, level_failures = _load_vector_level(
+        documents, vector_count, level_failures, loaded = _load_vector_level(
             artifact_root, level, model_suffix
         )
         paths = set()
         for document in documents:
             metadata = getattr(document, "metadata", {})
+            if not isinstance(metadata, Mapping):
+                invalid_document_metadata += 1
+                continue
             raw_path = metadata.get("file")
             path = _path_or_none(raw_path)
             if path:
@@ -293,7 +335,7 @@ def assess_vector_artifact(
         all_paths.update(paths)
         if level == "l0":
             l0_paths.update(paths)
-        if not documents:
+        if loaded and not documents:
             level_failures.append("empty_level")
         levels[level] = {
             "documents": len(documents),
@@ -308,6 +350,8 @@ def assess_vector_artifact(
         failures.append("outside_commit_paths")
     if invalid_document_paths:
         failures.append("invalid_document_paths")
+    if invalid_document_metadata:
+        failures.append("invalid_document_metadata")
     required = tuple(
         sorted(normalize_repository_path(path) for path in required_l0_files)
     )
@@ -326,6 +370,7 @@ def assess_vector_artifact(
             "submodule": len(classified["submodule"]),
             "outside": list(classified["outside"]),
             "invalid": sorted(invalid_document_paths),
+            "invalid_metadata": invalid_document_metadata,
         },
         "required_l0_files": list(required),
         "missing_required_l0_files": list(missing),
@@ -346,8 +391,8 @@ def write_artifact_quality(path: str | Path, report: Mapping[str, Any]) -> None:
 
 __all__ = [
     "ARTIFACT_QUALITY_SCHEMA_VERSION",
-    "assess_graph_artifact",
     "assess_vector_artifact",
+    "constrain_and_assess_graph_artifact",
     "constrain_graph_to_source_surface",
     "graph_file_paths",
     "graph_source_paths",

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -395,6 +395,7 @@ class VectorIndexBuilder:
             l0_chunker = CodeChunker(
                 language=primary,
                 repo_config=repo_cfg,
+                max_lines_per_chunk=self.max_lines_per_chunk,
                 chunk_depth=0,
                 skeleton_mode=True,
             )

--- a/codenib/compiler/snapshot_store.py
+++ b/codenib/compiler/snapshot_store.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 from urllib.parse import urlparse
 
+from ..git_snapshot import restore_git_worktree
 from ..languages import normalize_language
 
 SNAPSHOT_STORE_VERSION = "1"
@@ -203,6 +204,7 @@ class SnapshotArtifactStore:
                 raise ValueError(
                     f"snapshot worktree mismatch: expected {expected}, found {actual}"
                 )
+            restore_git_worktree(target, expected)
             return target
 
         expected = self._git_output(source_repo, "rev-parse", f"{commit}^{{commit}}")
@@ -224,6 +226,7 @@ class SnapshotArtifactStore:
             stderr=subprocess.PIPE,
             text=True,
         )
+        restore_git_worktree(target, expected)
         return target
 
     def resolve(self, instance_id: str) -> Path:

--- a/codenib/dataset/codenib_base.py
+++ b/codenib/dataset/codenib_base.py
@@ -23,6 +23,15 @@ from .base import DatasetBase
 logger = get_logger(__name__)
 
 
+def _command_error_detail(exc: subprocess.CalledProcessError | RuntimeError) -> str:
+    stderr = getattr(exc, "stderr", None)
+    if isinstance(stderr, bytes):
+        return stderr.decode("utf-8", errors="replace").strip()
+    if isinstance(stderr, str) and stderr.strip():
+        return stderr.strip()
+    return str(exc)
+
+
 class CodeNibBaseDataset(DatasetBase):
     """Dataset wrapper for CodeNib base dataset.
 
@@ -243,13 +252,12 @@ class CodeNibBaseDataset(DatasetBase):
                         "Removed %d source-visible generated path(s)",
                         len(restore.removed_ignored_paths),
                     )
-            except subprocess.CalledProcessError as e:
-                stderr = e.stderr.decode("utf-8")
+            except (subprocess.CalledProcessError, RuntimeError) as e:
                 logger.warning(
                     "Initial checkout failed for %s at %s: %s",
                     repo_name,
                     base_commit,
-                    stderr.strip(),
+                    _command_error_detail(e),
                 )
 
                 # Reused repo caches may be shallow clones from sampling.
@@ -289,9 +297,9 @@ class CodeNibBaseDataset(DatasetBase):
 
                 try:
                     restore_git_worktree(repo_path, base_commit)
-                except subprocess.CalledProcessError as e2:
+                except (subprocess.CalledProcessError, RuntimeError) as e2:
                     logger.error(f"Failed to checkout commit {base_commit}: {e2}")
-                    logger.error(f"STDERR: {e2.stderr.decode('utf-8')}")
+                    logger.error("DETAIL: %s", _command_error_detail(e2))
                     raise RuntimeError(
                         f"Failed to checkout commit {base_commit} for repo {repo_name}"
                     ) from e2

--- a/codenib/dataset/codenib_base.py
+++ b/codenib/dataset/codenib_base.py
@@ -16,6 +16,7 @@ from datasets import Features
 from datasets import Sequence as Seq
 from datasets import Value
 
+from ..git_snapshot import restore_git_worktree
 from ..log_utils import get_logger
 from .base import DatasetBase
 
@@ -236,24 +237,12 @@ class CodeNibBaseDataset(DatasetBase):
 
             logger.info(f"Checking out commit {base_commit}")
             try:
-                subprocess.run(
-                    ["git", "reset", "--hard"],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-                subprocess.run(
-                    ["git", "clean", "-fd"],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-                subprocess.run(
-                    ["git", "checkout", "-f", base_commit],
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
+                restore = restore_git_worktree(repo_path, base_commit)
+                if restore.removed_ignored_paths:
+                    logger.info(
+                        "Removed %d source-visible generated path(s)",
+                        len(restore.removed_ignored_paths),
+                    )
             except subprocess.CalledProcessError as e:
                 stderr = e.stderr.decode("utf-8")
                 logger.warning(
@@ -299,12 +288,7 @@ class CodeNibBaseDataset(DatasetBase):
                 )
 
                 try:
-                    subprocess.run(
-                        ["git", "checkout", "-f", base_commit],
-                        check=True,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                    )
+                    restore_git_worktree(repo_path, base_commit)
                 except subprocess.CalledProcessError as e2:
                     logger.error(f"Failed to checkout commit {base_commit}: {e2}")
                     logger.error(f"STDERR: {e2.stderr.decode('utf-8')}")

--- a/codenib/eval/benchmarks/policy_benchmark.py
+++ b/codenib/eval/benchmarks/policy_benchmark.py
@@ -10,7 +10,9 @@ upstream agent's prompt and policy fixed while swapping only its repository
 provider between the pinned native implementation and CodeNib.
 
 The OrcaLoca scorer follows its published golden-patch file/function subset
-metric.  SWE-Explore trajectory read sets are a different target.
+metric. Its runner starts at SearchAgent with an empty TraceAnalysisOutput;
+upstream trace generation is intentionally outside this provider comparison.
+SWE-Explore trajectory read sets are a different target.
 """
 
 from __future__ import annotations
@@ -794,6 +796,8 @@ def _run_orcaloca(args: argparse.Namespace) -> int:
                 print(f"skip existing {output_path}", flush=True)
                 continue
 
+            # Freeze the upstream trace-analysis input so the paired arm changes
+            # only the repository provider used by SearchAgent.
             search_input = SearchInput(
                 problem_statement=case.problem_statement,
                 trace_analysis_output=TraceAnalysisOutput(),

--- a/codenib/eval/benchmarks/policy_compat.py
+++ b/codenib/eval/benchmarks/policy_compat.py
@@ -460,27 +460,33 @@ def inspect_case_eligibility(
                 if runtime_views and not reasons:
                     from codenib.mcp.context import ServerContext
 
-                    context = ServerContext.load(
-                        case.manifest_path,
-                        views=runtime_views,
-                    )
-                    for capability in required_capabilities:
-                        required_views = _CAPABILITY_RUNTIME_VIEWS.get(capability, ())
-                        unavailable = sorted(
-                            view
-                            for view in required_views
-                            if getattr(context, view, None) is None
+                    try:
+                        view_errors = ServerContext.validate_views(
+                            manifest,
+                            views=runtime_views,
                         )
-                        if not unavailable:
-                            continue
-                        details = "; ".join(
-                            f"{view}: {context.errors.get(view, 'view did not load')}"
-                            for view in unavailable
-                        )
+                    except Exception as exc:
                         reasons.append(
-                            f"manifest capability is unusable at runtime: "
-                            f"{capability} ({details})"
+                            "runtime view validation failed: "
+                            f"{type(exc).__name__}: {exc}"
                         )
+                    else:
+                        for capability in required_capabilities:
+                            required_views = _CAPABILITY_RUNTIME_VIEWS.get(
+                                capability, ()
+                            )
+                            unavailable = sorted(
+                                view for view in required_views if view in view_errors
+                            )
+                            if not unavailable:
+                                continue
+                            details = "; ".join(
+                                f"{view}: {view_errors[view]}" for view in unavailable
+                            )
+                            reasons.append(
+                                f"manifest capability is unusable at runtime: "
+                                f"{capability} ({details})"
+                            )
 
     return CaseEligibility(
         instance_id=case.instance_id,

--- a/codenib/eval/benchmarks/policy_compat.py
+++ b/codenib/eval/benchmarks/policy_compat.py
@@ -28,6 +28,13 @@ from codenib.repository_filters import walk_repository_files
 POLICY_RESULT_SCHEMA_VERSION = 1
 POLICY_PROVIDERS = ("native", "codenib")
 
+_CAPABILITY_RUNTIME_VIEWS = {
+    "sparse_search": frozenset({"bm25"}),
+    "dense_search": frozenset({"vector"}),
+    "hybrid_search": frozenset({"bm25", "vector"}),
+    "symbol_navigation": frozenset({"symbol_graph"}),
+}
+
 _REQUIRED_CASE_FIELDS = {
     "instance_id",
     "problem_statement",
@@ -444,6 +451,36 @@ def inspect_case_eligibility(
                 for capability in required_capabilities:
                     if not manifest.capabilities.get(capability, False):
                         reasons.append(f"manifest lacks capability: {capability}")
+
+                runtime_views = frozenset(
+                    view
+                    for capability in required_capabilities
+                    for view in _CAPABILITY_RUNTIME_VIEWS.get(capability, ())
+                )
+                if runtime_views and not reasons:
+                    from codenib.mcp.context import ServerContext
+
+                    context = ServerContext.load(
+                        case.manifest_path,
+                        views=runtime_views,
+                    )
+                    for capability in required_capabilities:
+                        required_views = _CAPABILITY_RUNTIME_VIEWS.get(capability, ())
+                        unavailable = sorted(
+                            view
+                            for view in required_views
+                            if getattr(context, view, None) is None
+                        )
+                        if not unavailable:
+                            continue
+                        details = "; ".join(
+                            f"{view}: {context.errors.get(view, 'view did not load')}"
+                            for view in unavailable
+                        )
+                        reasons.append(
+                            f"manifest capability is unusable at runtime: "
+                            f"{capability} ({details})"
+                        )
 
     return CaseEligibility(
         instance_id=case.instance_id,

--- a/codenib/git_snapshot.py
+++ b/codenib/git_snapshot.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Git-backed source boundaries for reproducible repository artifacts."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+from .repository_filters import repository_path_is_visible
+
+
+def normalize_repository_path(path: str | Path) -> str:
+    """Return a validated POSIX repository-relative path."""
+
+    value = os.fspath(path).replace("\\", "/")
+    if value.startswith("./"):
+        value = value[2:]
+    normalized = PurePosixPath(value)
+    if not normalized.parts or normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError(f"path must stay repository-relative: {path!r}")
+    return normalized.as_posix()
+
+
+def _git(
+    repo: str | Path, *args: str, check: bool = True
+) -> subprocess.CompletedProcess:
+    root = Path(repo).expanduser().resolve()
+    return subprocess.run(
+        [
+            "git",
+            "-c",
+            f"safe.directory={root}",
+            "-C",
+            str(root),
+            *args,
+        ],
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def resolve_git_commit(repo: str | Path, commit: str = "HEAD") -> str:
+    """Resolve *commit* to its full immutable commit object ID."""
+
+    result = _git(repo, "rev-parse", f"{commit}^{{commit}}")
+    return result.stdout.decode("ascii").strip().lower()
+
+
+@dataclass(frozen=True, slots=True)
+class GitSourceSurface:
+    """Paths addressable by one Git commit, including gitlink subtrees."""
+
+    commit: str
+    tree: str
+    tracked_files: frozenset[str]
+    submodules: tuple[tuple[str, str], ...]
+
+    @classmethod
+    def load(cls, repo: str | Path, commit: str = "HEAD") -> "GitSourceSurface":
+        resolved = resolve_git_commit(repo, commit)
+        tree = (
+            _git(repo, "rev-parse", f"{resolved}^{{tree}}")
+            .stdout.decode("ascii")
+            .strip()
+            .lower()
+        )
+        records = _git(repo, "ls-tree", "-r", "-z", "--full-tree", resolved).stdout
+        tracked_files: set[str] = set()
+        submodules: list[tuple[str, str]] = []
+        for record in records.split(b"\0"):
+            if not record:
+                continue
+            metadata, separator, encoded_path = record.partition(b"\t")
+            if not separator:
+                raise ValueError("invalid git ls-tree record")
+            mode, object_type, object_id = metadata.decode("ascii").split()
+            path = normalize_repository_path(os.fsdecode(encoded_path))
+            if mode == "160000" or object_type == "commit":
+                submodules.append((path, object_id.lower()))
+            elif object_type == "blob":
+                tracked_files.add(path)
+        return cls(
+            commit=resolved,
+            tree=tree,
+            tracked_files=frozenset(tracked_files),
+            submodules=tuple(sorted(submodules)),
+        )
+
+    @property
+    def submodule_roots(self) -> tuple[str, ...]:
+        return tuple(path for path, _commit in self.submodules)
+
+    def contains(self, path: str | Path) -> bool:
+        """Whether *path* belongs to this commit's source address space."""
+
+        normalized = normalize_repository_path(path)
+        if normalized in self.tracked_files:
+            return True
+        return any(
+            normalized == root or normalized.startswith(f"{root}/")
+            for root, _commit in self.submodules
+        )
+
+    def has_descendant(self, path: str | Path) -> bool:
+        """Whether *path* is an ancestor of an addressable commit path."""
+
+        normalized = normalize_repository_path(path)
+        prefix = f"{normalized}/"
+        return any(item.startswith(prefix) for item in self.tracked_files) or any(
+            root == normalized
+            or root.startswith(prefix)
+            or normalized.startswith(f"{root}/")
+            for root, _commit in self.submodules
+        )
+
+    def classify(self, paths: Iterable[str | Path]) -> dict[str, tuple[str, ...]]:
+        """Classify paths as tracked, submodule-owned, or outside the commit."""
+
+        tracked: set[str] = set()
+        submodule: set[str] = set()
+        outside: set[str] = set()
+        for path in paths:
+            normalized = normalize_repository_path(path)
+            if normalized in self.tracked_files:
+                tracked.add(normalized)
+            elif any(
+                normalized == root or normalized.startswith(f"{root}/")
+                for root, _commit in self.submodules
+            ):
+                submodule.add(normalized)
+            else:
+                outside.add(normalized)
+        return {
+            "tracked": tuple(sorted(tracked)),
+            "submodule": tuple(sorted(submodule)),
+            "outside": tuple(sorted(outside)),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeRestoreResult:
+    """Outcome of restoring one checkout to an immutable source boundary."""
+
+    commit: str
+    removed_ignored_paths: tuple[str, ...]
+
+
+def _ignored_visible_paths(repo: Path) -> tuple[str, ...]:
+    result = _git(
+        repo,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignored=matching",
+    )
+    paths: set[str] = set()
+    for record in result.stdout.split(b"\0"):
+        if len(record) < 4 or record[:2] != b"!!":
+            continue
+        path = normalize_repository_path(os.fsdecode(record[3:]))
+        if repository_path_is_visible(path):
+            paths.add(path)
+
+    # Removing an ignored directory also removes any nested status records.
+    selected: list[str] = []
+    for path in sorted(paths, key=lambda value: (value.count("/"), value)):
+        if any(path.startswith(f"{parent}/") for parent in selected):
+            continue
+        selected.append(path)
+    return tuple(selected)
+
+
+def _remove_relative_path(repo: Path, relative: str) -> None:
+    target = repo.joinpath(*PurePosixPath(relative).parts)
+    try:
+        target.relative_to(repo)
+    except ValueError as exc:
+        raise ValueError(
+            f"refusing to remove path outside repository: {relative}"
+        ) from exc
+    if target.is_symlink() or target.is_file():
+        target.unlink(missing_ok=True)
+    elif target.is_dir():
+        shutil.rmtree(target)
+
+
+def restore_git_worktree(
+    repo: str | Path,
+    commit: str,
+) -> WorktreeRestoreResult:
+    """Restore tracked source and remove source-visible generated files.
+
+    Ignored dependency/tool caches excluded by the shared repository traversal
+    policy are retained. Ignored paths that an index builder would otherwise
+    observe are removed so artifacts cannot silently include build products
+    left by another benchmark instance.
+    """
+
+    root = Path(repo).expanduser().resolve()
+    expected = resolve_git_commit(root, commit)
+    _git(root, "checkout", "--detach", "--force", expected)
+    _git(root, "reset", "--hard", expected)
+    _git(root, "clean", "-fd")
+
+    ignored = _ignored_visible_paths(root)
+    for relative in ignored:
+        _remove_relative_path(root, relative)
+
+    actual = resolve_git_commit(root)
+    if actual != expected:
+        raise RuntimeError(
+            f"worktree commit mismatch after restore: expected {expected}, found {actual}"
+        )
+    remaining = _ignored_visible_paths(root)
+    if remaining:
+        raise RuntimeError(
+            "source-visible ignored paths remain after restore: " + ", ".join(remaining)
+        )
+    return WorktreeRestoreResult(
+        commit=expected,
+        removed_ignored_paths=ignored,
+    )
+
+
+__all__ = [
+    "GitSourceSurface",
+    "WorktreeRestoreResult",
+    "normalize_repository_path",
+    "resolve_git_commit",
+    "restore_git_worktree",
+]

--- a/codenib/git_snapshot.py
+++ b/codenib/git_snapshot.py
@@ -7,25 +7,33 @@
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import Iterable
 
+from .languages import extension_to_language_map
 from .repository_filters import repository_path_is_visible
+
+_SOURCE_SUFFIXES = frozenset(extension_to_language_map("chunker"))
+
+
+@lru_cache(maxsize=32768)
+def _normalize_repository_path(value: str) -> str:
+    value = value.replace("\\", "/")
+    if value.startswith("./"):
+        value = value[2:]
+    normalized = PurePosixPath(value)
+    if not normalized.parts or normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError(f"path must stay repository-relative: {value!r}")
+    return normalized.as_posix()
 
 
 def normalize_repository_path(path: str | Path) -> str:
     """Return a validated POSIX repository-relative path."""
 
-    value = os.fspath(path).replace("\\", "/")
-    if value.startswith("./"):
-        value = value[2:]
-    normalized = PurePosixPath(value)
-    if not normalized.parts or normalized.is_absolute() or ".." in normalized.parts:
-        raise ValueError(f"path must stay repository-relative: {path!r}")
-    return normalized.as_posix()
+    return _normalize_repository_path(os.fspath(path))
 
 
 def _git(
@@ -153,7 +161,34 @@ class WorktreeRestoreResult:
     removed_ignored_paths: tuple[str, ...]
 
 
-def _ignored_visible_paths(repo: Path) -> tuple[str, ...]:
+def _visible_source_files(repo: Path, relative: str) -> tuple[str, ...]:
+    """Expand one ignored status path to source files visible to indexers."""
+
+    target = repo.joinpath(*PurePosixPath(relative).parts)
+    if target.is_symlink() or target.is_file():
+        return (relative,) if Path(relative).suffix in _SOURCE_SUFFIXES else ()
+    if not target.is_dir():
+        return ()
+
+    files: list[str] = []
+    for current_root, dirs, names in os.walk(target, followlinks=False):
+        current = Path(current_root)
+        dirs[:] = sorted(
+            name
+            for name in dirs
+            if repository_path_is_visible((current / name).relative_to(repo))
+        )
+        for name in sorted(names):
+            path = current / name
+            source_path = path.relative_to(repo).as_posix()
+            if Path(name).suffix in _SOURCE_SUFFIXES and repository_path_is_visible(
+                source_path
+            ):
+                files.append(source_path)
+    return tuple(files)
+
+
+def _ignored_visible_source_paths(repo: Path) -> tuple[str, ...]:
     result = _git(
         repo,
         "status",
@@ -168,15 +203,8 @@ def _ignored_visible_paths(repo: Path) -> tuple[str, ...]:
             continue
         path = normalize_repository_path(os.fsdecode(record[3:]))
         if repository_path_is_visible(path):
-            paths.add(path)
-
-    # Removing an ignored directory also removes any nested status records.
-    selected: list[str] = []
-    for path in sorted(paths, key=lambda value: (value.count("/"), value)):
-        if any(path.startswith(f"{parent}/") for parent in selected):
-            continue
-        selected.append(path)
-    return tuple(selected)
+            paths.update(_visible_source_files(repo, path))
+    return tuple(sorted(paths))
 
 
 def _remove_relative_path(repo: Path, relative: str) -> None:
@@ -190,7 +218,15 @@ def _remove_relative_path(repo: Path, relative: str) -> None:
     if target.is_symlink() or target.is_file():
         target.unlink(missing_ok=True)
     elif target.is_dir():
-        shutil.rmtree(target)
+        raise RuntimeError(f"refusing to recursively remove source path: {relative}")
+
+    parent = target.parent
+    while parent != repo:
+        try:
+            parent.rmdir()
+        except OSError:
+            break
+        parent = parent.parent
 
 
 def restore_git_worktree(
@@ -199,10 +235,10 @@ def restore_git_worktree(
 ) -> WorktreeRestoreResult:
     """Restore tracked source and remove source-visible generated files.
 
-    Ignored dependency/tool caches excluded by the shared repository traversal
-    policy are retained. Ignored paths that an index builder would otherwise
-    observe are removed so artifacts cannot silently include build products
-    left by another benchmark instance.
+    Ignored dependency/tool caches and non-source build inputs are retained.
+    Ignored source files that an index builder would otherwise observe are
+    removed so artifacts cannot silently include generated code left by another
+    benchmark instance.
     """
 
     root = Path(repo).expanduser().resolve()
@@ -211,7 +247,7 @@ def restore_git_worktree(
     _git(root, "reset", "--hard", expected)
     _git(root, "clean", "-fd")
 
-    ignored = _ignored_visible_paths(root)
+    ignored = _ignored_visible_source_paths(root)
     for relative in ignored:
         _remove_relative_path(root, relative)
 
@@ -220,7 +256,12 @@ def restore_git_worktree(
         raise RuntimeError(
             f"worktree commit mismatch after restore: expected {expected}, found {actual}"
         )
-    remaining = _ignored_visible_paths(root)
+    remaining = tuple(
+        relative
+        for relative in ignored
+        if (target := root.joinpath(*PurePosixPath(relative).parts)).exists()
+        or target.is_symlink()
+    )
     if remaining:
         raise RuntimeError(
             "source-visible ignored paths remain after restore: " + ", ".join(remaining)

--- a/codenib/git_snapshot.py
+++ b/codenib/git_snapshot.py
@@ -229,16 +229,46 @@ def _remove_relative_path(repo: Path, relative: str) -> None:
         parent = parent.parent
 
 
+def _restore_git_submodules(root: Path, surface: GitSourceSurface) -> None:
+    if not surface.submodules:
+        return
+
+    _git(root, "submodule", "sync", "--recursive")
+    _git(root, "submodule", "update", "--init", "--recursive", "--force")
+    _git(
+        root,
+        "submodule",
+        "foreach",
+        "--quiet",
+        "--recursive",
+        "git reset --hard && git clean -fd",
+    )
+    mismatches = []
+    for relative, expected in surface.submodules:
+        submodule_root = root.joinpath(*PurePosixPath(relative).parts)
+        try:
+            actual = resolve_git_commit(submodule_root)
+        except (OSError, subprocess.CalledProcessError):
+            actual = "missing"
+        if actual != expected:
+            mismatches.append(f"{relative}: expected {expected}, found {actual}")
+    if mismatches:
+        raise RuntimeError(
+            "submodule commit mismatch after restore: " + "; ".join(mismatches)
+        )
+
+
 def restore_git_worktree(
     repo: str | Path,
     commit: str,
 ) -> WorktreeRestoreResult:
-    """Restore tracked source and remove source-visible generated files.
+    """Restore tracked source, gitlinks, and source-visible generated files.
 
     Ignored dependency/tool caches and non-source build inputs are retained.
     Ignored source files that an index builder would otherwise observe are
     removed so artifacts cannot silently include generated code left by another
-    benchmark instance.
+    benchmark instance. Recorded submodules are initialized recursively and
+    reset to the commits referenced by the restored superproject.
     """
 
     root = Path(repo).expanduser().resolve()
@@ -246,6 +276,8 @@ def restore_git_worktree(
     _git(root, "checkout", "--detach", "--force", expected)
     _git(root, "reset", "--hard", expected)
     _git(root, "clean", "-fd")
+    surface = GitSourceSurface.load(root, expected)
+    _restore_git_submodules(root, surface)
 
     ignored = _ignored_visible_source_paths(root)
     for relative in ignored:

--- a/codenib/graph/code_graph.py
+++ b/codenib/graph/code_graph.py
@@ -507,6 +507,10 @@ class CodeGraph:
         """Mark the edge index stale. Next _add_edge will rebuild it.
         Call after any igraph delete_edges/delete_vertices — eids shift on
         delete and cached values would point at wrong edges."""
+        self.invalidate_caches()
+
+    def invalidate_caches(self) -> None:
+        """Invalidate derived indexes after direct graph mutation."""
         self._edge_index = None
 
     # ------------------------------------------------------------------

--- a/codenib/graph/source_coverage.py
+++ b/codenib/graph/source_coverage.py
@@ -153,6 +153,7 @@ def supplement_graph_source_coverage(
     supplemented_files = []
     supplemented_symbols = 0
     unreadable_files = []
+    unreadable_errors = {}
 
     for file_path in missing:
         absolute = root.joinpath(*PurePosixPath(file_path).parts)
@@ -160,19 +161,22 @@ def supplement_graph_source_coverage(
         if language is None or not absolute.is_file():
             unreadable_files.append(file_path)
             continue
-        chunker = chunkers.get(language)
-        if chunker is None:
-            chunker = create_chunker(
-                language,
-                chunk_depth=2,
-                l2_level_exclusive=False,
-                skeleton_mode=False,
-            )
-            chunkers[language] = chunker
         try:
+            chunker = chunkers.get(language)
+            if chunker is None:
+                chunker = create_chunker(
+                    language,
+                    chunk_depth=2,
+                    l2_level_exclusive=False,
+                    skeleton_mode=False,
+                )
+                chunkers[language] = chunker
             chunks = chunker.chunk_file(str(absolute), relative_path=file_path)
-        except (OSError, UnicodeError):
+        # The syntax path supplements a compiler graph. One parser or plugin
+        # failure should remain a quality diagnostic, not discard that graph.
+        except Exception as exc:
             unreadable_files.append(file_path)
+            unreadable_errors[file_path] = f"{type(exc).__name__}: {exc}"
             continue
 
         _ensure_file_hierarchy(graph, file_path)
@@ -207,7 +211,7 @@ def supplement_graph_source_coverage(
             supplemented_symbols += 1
         supplemented_files.append(file_path)
 
-    graph._invalidate_edge_index()
+    graph.invalidate_caches()
     graph.build_range_indexes()
     represented_after = represented.union(supplemented_files)
     expected_count = len(expected_files)
@@ -228,6 +232,7 @@ def supplement_graph_source_coverage(
         "supplemented_symbols": supplemented_symbols,
         "files": supplemented_files,
         "unreadable_files": unreadable_files,
+        "unreadable_errors": unreadable_errors,
     }
 
 

--- a/codenib/graph/source_coverage.py
+++ b/codenib/graph/source_coverage.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Syntax fallback for source files omitted by compiler-backed graph indexes."""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Sequence
+
+from ..code_chunking import create_chunker
+from ..git_snapshot import GitSourceSurface, normalize_repository_path
+from ..languages import extension_to_language_map
+from ..repository_filters import repository_path_is_visible
+from ..types import (
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FIELD,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NODE_TYPE_SYMBOL,
+)
+from .code_graph import CodeGraph
+
+_CONTAINER_TYPES = frozenset(
+    {
+        "class",
+        "enum",
+        "extension",
+        "impl",
+        "interface",
+        "module",
+        "namespace",
+        "protocol",
+        "record",
+        "struct",
+        "trait",
+    }
+)
+_FIELD_TYPES = frozenset(
+    {
+        "constant",
+        "field",
+        "property",
+        "type_alias",
+        "variable",
+    }
+)
+
+
+def _matches_any(path: str, patterns: Sequence[str]) -> bool:
+    for pattern in patterns:
+        normalized = str(pattern).strip().replace("\\", "/").strip("/")
+        if not normalized:
+            continue
+        if fnmatch.fnmatch(path, normalized):
+            return True
+        if normalized.endswith("/**"):
+            prefix = normalized[:-3]
+            if path == prefix or path.startswith(f"{prefix}/"):
+                return True
+    return False
+
+
+def _node_type(chunk_type: str) -> str:
+    normalized = chunk_type.lower()
+    if normalized in _CONTAINER_TYPES:
+        return NODE_TYPE_CLASS
+    if normalized in {"function", "constructor"}:
+        return NODE_TYPE_FUNCTION
+    if normalized in {"method", "getter", "setter"}:
+        return NODE_TYPE_METHOD
+    if normalized in _FIELD_TYPES:
+        return NODE_TYPE_FIELD
+    return NODE_TYPE_SYMBOL
+
+
+def _root_name(graph: CodeGraph) -> str | None:
+    for vertex in graph.graph.vs:
+        if vertex.attributes().get("type") == "root":
+            return vertex.attributes().get("name")
+    return None
+
+
+def _ensure_file_hierarchy(graph: CodeGraph, file_path: str) -> None:
+    path = PurePosixPath(file_path)
+    parent = _root_name(graph)
+    current_parts: list[str] = []
+    for part in path.parent.parts:
+        if part == ".":
+            continue
+        current_parts.append(part)
+        directory = PurePosixPath(*current_parts).as_posix()
+        graph.add_directory_node(directory)
+        if parent is not None:
+            graph.current_scope = parent
+            graph.add_containment_edge(directory)
+        parent = directory
+
+    graph.add_file_node(file_path)
+    if parent is not None:
+        graph.current_scope = parent
+        graph.add_containment_edge(file_path)
+    graph.current_scope = file_path
+
+
+def _containing_parent(
+    chunk: Any,
+    containers: Sequence[tuple[int, int, str]],
+    file_path: str,
+) -> str:
+    candidates = [
+        (end - start, identity)
+        for start, end, identity in containers
+        if start <= chunk.start_line
+        and end >= chunk.end_line
+        and (start, end) != (chunk.start_line, chunk.end_line)
+    ]
+    return min(candidates)[1] if candidates else file_path
+
+
+def supplement_graph_source_coverage(
+    graph: CodeGraph,
+    *,
+    repo_root: str | Path,
+    surface: GitSourceSurface,
+    extensions: Iterable[str],
+    represented_paths: Iterable[str],
+    exclude_patterns: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Add syntax definitions for tracked source files absent from *graph*.
+
+    The fallback is independent of benchmark labels: it covers every tracked
+    source file in the requested language surface. It adds file, definition,
+    and containment records only; compiler-derived reference edges remain
+    authoritative when available.
+    """
+
+    root = Path(repo_root).expanduser().resolve()
+    accepted = frozenset(extensions)
+    represented = {normalize_repository_path(path) for path in represented_paths}
+    expected_files = [
+        path
+        for path in sorted(surface.tracked_files)
+        if Path(path).suffix in accepted
+        and repository_path_is_visible(path)
+        and not _matches_any(path, exclude_patterns)
+    ]
+    missing = [path for path in expected_files if path not in represented]
+    chunker_languages = extension_to_language_map("chunker")
+    chunkers: dict[str, Any] = {}
+    supplemented_files = []
+    supplemented_symbols = 0
+    unreadable_files = []
+
+    for file_path in missing:
+        absolute = root.joinpath(*PurePosixPath(file_path).parts)
+        language = chunker_languages.get(Path(file_path).suffix)
+        if language is None or not absolute.is_file():
+            unreadable_files.append(file_path)
+            continue
+        chunker = chunkers.get(language)
+        if chunker is None:
+            chunker = create_chunker(
+                language,
+                chunk_depth=2,
+                l2_level_exclusive=False,
+                skeleton_mode=False,
+            )
+            chunkers[language] = chunker
+        try:
+            chunks = chunker.chunk_file(str(absolute), relative_path=file_path)
+        except (OSError, UnicodeError):
+            unreadable_files.append(file_path)
+            continue
+
+        _ensure_file_hierarchy(graph, file_path)
+        containers: list[tuple[int, int, str]] = []
+        seen_symbols: set[str] = set()
+        for chunk in sorted(
+            chunks,
+            key=lambda item: (
+                item.start_line,
+                -(item.end_line - item.start_line),
+                item.node_id,
+            ),
+        ):
+            identity = str(chunk.node_id)
+            if identity in seen_symbols:
+                continue
+            seen_symbols.add(identity)
+            parent = _containing_parent(chunk, containers, file_path)
+            graph.add_symbol_node(
+                identity,
+                chunk.start_line,
+                chunk.start_line,
+                chunk.end_line,
+                _node_type(chunk.chunk_type),
+            )
+            vertex = graph.graph.vs[graph.name_to_vertex[identity]]
+            vertex["unified_name"] = chunk.name
+            graph.current_scope = parent
+            graph.add_containment_edge(identity)
+            if chunk.chunk_type.lower() in _CONTAINER_TYPES:
+                containers.append((chunk.start_line, chunk.end_line, identity))
+            supplemented_symbols += 1
+        supplemented_files.append(file_path)
+
+    graph._invalidate_edge_index()
+    graph.build_range_indexes()
+    represented_after = represented.union(supplemented_files)
+    expected_count = len(expected_files)
+    return {
+        "tracked_source_files": expected_count,
+        "represented_before": expected_count - len(missing),
+        "represented_after": len(set(expected_files).intersection(represented_after)),
+        "coverage_before": (
+            (expected_count - len(missing)) / expected_count if expected_count else 1.0
+        ),
+        "coverage_after": (
+            len(set(expected_files).intersection(represented_after)) / expected_count
+            if expected_count
+            else 1.0
+        ),
+        "candidate_files": len(missing),
+        "supplemented_files": len(supplemented_files),
+        "supplemented_symbols": supplemented_symbols,
+        "files": supplemented_files,
+        "unreadable_files": unreadable_files,
+    }
+
+
+__all__ = ["supplement_graph_source_coverage"]

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -18,6 +18,30 @@ from .vector_store import CodeVectorStore
 logger = get_logger(__name__)
 
 
+def _remove_unrequested_model_levels(
+    store_path: Path,
+    embedding_model: str,
+    build_levels: List[str],
+) -> None:
+    model_suffix = embedding_model.replace("/", "__")
+    requested = frozenset(build_levels)
+    for level in ("l0", "l2"):
+        if level in requested:
+            continue
+        level_path = store_path / level
+        for name in (
+            f"config_{model_suffix}.json",
+            f"index_{model_suffix}.faiss",
+            f"documents_{model_suffix}.pkl",
+            f"index_{model_suffix}.pkl",
+        ):
+            (level_path / name).unlink(missing_ok=True)
+        try:
+            level_path.rmdir()
+        except OSError:
+            pass
+
+
 def _profiler_section(profiler, label, metadata=None):
     """Return an active profiler section context if profiling is enabled."""
     if profiler is None:
@@ -57,6 +81,14 @@ def build_hierarchical_vector_store(
     if plan_name:
         store_path = store_path / plan_name
 
+    normalized_levels = [level.lower() for level in (build_levels or ["l0", "l2"])]
+    if force_rebuild:
+        _remove_unrequested_model_levels(
+            store_path,
+            embedding_model,
+            normalized_levels,
+        )
+
     if not force_rebuild:
         model_suffix = embedding_model.replace("/", "__")
         config_path = store_path / f"config_{model_suffix}.json"
@@ -84,7 +116,7 @@ def build_hierarchical_vector_store(
             return vector_store
 
     languages = languages or ["python"]
-    build_levels = [level.lower() for level in (build_levels or ["l0", "l2"])]
+    build_levels = normalized_levels
     repo_cfg = RepoChunkingConfig(languages=languages)
 
     chunks_by_level = {}

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -8,7 +8,7 @@
 
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from ...code_chunker import CodeChunker, RepoChunkingConfig
 from ...log_utils import get_logger
@@ -44,6 +44,7 @@ def build_hierarchical_vector_store(
     ivf_nprobe: int = 8,
     profiler: Optional[Profiler] = None,
     force_rebuild: bool = False,
+    artifact_metadata: Optional[Dict[str, Any]] = None,
 ) -> CodeVectorStore:
     """Build (or load) a hierarchical vector store (L0/L2) for a repository.
 
@@ -76,6 +77,7 @@ def build_hierarchical_vector_store(
                 store_path=str(store_path),
                 profiler=profiler,
                 embedding=embedding,
+                artifact_metadata=artifact_metadata,
                 **(embedding_kwargs or {}),
             )
             vector_store.load(str(store_path))
@@ -163,6 +165,7 @@ def build_hierarchical_vector_store(
         store_path=str(store_path),
         profiler=profiler,
         embedding=embedding,
+        artifact_metadata=artifact_metadata,
         **(embedding_kwargs or {}),
     )
 

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -93,7 +93,7 @@ def build_hierarchical_vector_store(
             chunker_kwargs=dict(
                 language=languages[0],
                 repo_config=repo_cfg,
-                max_lines_per_chunk=None,
+                max_lines_per_chunk=max_lines_per_chunk,
                 chunk_depth=0,
                 skeleton_mode=True,
             )

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -1034,10 +1034,11 @@ class CodeVectorStore:
             with open(config_path, "r") as f:
                 config = json.load(f)
 
-            if config.get("dimension") != self.dimension:
-                logger.warning(
-                    f"Dimension mismatch: expected {self.dimension}, "
-                    f"got {config.get('dimension')}"
+            saved_dimension = config.get("dimension")
+            if saved_dimension is not None and saved_dimension != self.dimension:
+                raise ValueError(
+                    f"Vector config dimension mismatch: expected {self.dimension}, "
+                    f"found {saved_dimension}"
                 )
             saved_metric = config.get("index_metric")
             if saved_metric and saved_metric != self.index_metric:
@@ -1093,6 +1094,11 @@ class CodeVectorStore:
         except Exception as e:
             logger.warning(f"Could not load FAISS index from {faiss_path}: {e}")
             return None
+        if int(index.d) != self.dimension:
+            raise ValueError(
+                f"FAISS dimension mismatch at {faiss_path}: "
+                f"expected {self.dimension}, found {int(index.d)}"
+            )
 
         # Try loading documents pickle (works for both new _Document and
         # legacy LangChain Document objects via duck-typing conversion).

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -242,6 +242,7 @@ class CodeVectorStore:
         store_path: Optional[str] = None,
         profiler: Optional[Profiler] = None,
         embedding: Optional[Any] = None,
+        artifact_metadata: Optional[Dict[str, Any]] = None,
         **embedding_kwargs,
     ):
         """
@@ -265,6 +266,8 @@ class CodeVectorStore:
             embedding: A pre-built embedding wrapper to reuse. When several
                 stores share one model (e.g. one per repo), pass the same
                 instance so the model is loaded onto the GPU only once.
+            artifact_metadata: Optional immutable source/build identity persisted
+                with the top-level configuration.
             **embedding_kwargs: Additional arguments for embedding model
         """
         self.embedding_model = embedding_model
@@ -284,6 +287,7 @@ class CodeVectorStore:
         self.ivf_nprobe = max(1, int(ivf_nprobe))
         self.store_path = Path(store_path) if store_path else None
         self.profiler = profiler
+        self.artifact_metadata = dict(artifact_metadata or {})
 
         # Initialize the embedding model — or reuse a shared one so the same
         # model isn't loaded onto the GPU once per store.
@@ -963,6 +967,8 @@ class CodeVectorStore:
             "l0_documents": len(self.l0_documents),
             "l2_documents": len(self.l2_documents),
         }
+        if self.artifact_metadata:
+            config["artifact"] = self.artifact_metadata
         with open(config_path, "w") as f:
             json.dump(config, f, indent=2)
 
@@ -1041,6 +1047,9 @@ class CodeVectorStore:
                     saved_metric,
                 )
                 self.index_metric = saved_metric
+            saved_artifact = config.get("artifact")
+            if isinstance(saved_artifact, dict):
+                self.artifact_metadata = dict(saved_artifact)
 
         # Load L0
         l0_path = load_path / "l0"

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -42,6 +42,26 @@ _VIEW_DEPENDENCIES = {
 }
 
 
+class _DimensionProbeEmbedding:
+    """Avoid model/API initialization while validating saved vector files."""
+
+    def __init__(self, dimension: int) -> None:
+        self.dimension = dimension
+
+    def embed_query(self, _text: str) -> list[float]:
+        return [0.0] * self.dimension
+
+    def embed_documents(self, _texts: list[str]) -> list[list[float]]:
+        raise RuntimeError("validation probe cannot embed documents")
+
+
+def _close_vector(vector: CodeVectorStore) -> None:
+    try:
+        vector.close()
+    except Exception as exc:
+        logger.warning("Failed to release vector resources: %s", exc)
+
+
 def _resolve_views(views: Iterable[str] | None) -> frozenset[str]:
     """Validate a view selection and add runtime dependencies."""
 
@@ -97,7 +117,7 @@ class ServerContext:
     @classmethod
     def load(
         cls,
-        manifest_path: str | Path,
+        manifest_path: RepoManifest | str | Path,
         *,
         views: Iterable[str] | None = None,
     ) -> ServerContext:
@@ -109,7 +129,11 @@ class ServerContext:
         the others. Failed views are recorded in ``errors``.
         """
         selected = _resolve_views(views)
-        manifest = RepoManifest.load(manifest_path)
+        manifest = (
+            manifest_path
+            if isinstance(manifest_path, RepoManifest)
+            else RepoManifest.load(manifest_path)
+        )
         ctx = cls(manifest=manifest)
 
         for view, loader_name in _VIEW_LOADERS:
@@ -131,6 +155,49 @@ class ServerContext:
             list(ctx.errors) or "none",
         )
         return ctx
+
+    @classmethod
+    def validate_views(
+        cls,
+        manifest: RepoManifest | str | Path,
+        *,
+        views: Iterable[str],
+    ) -> Dict[str, str]:
+        """Open selected artifacts without initializing a vector query model.
+
+        The returned mapping contains only unavailable views. Vector indexes
+        follow the normal FAISS/document load path with a fixed-dimension
+        embedding probe, then release their resources before returning.
+        """
+
+        selected = _resolve_views(views)
+        resolved_manifest = (
+            manifest
+            if isinstance(manifest, RepoManifest)
+            else RepoManifest.load(manifest)
+        )
+        ctx = cls(manifest=resolved_manifest)
+        available: set[str] = set()
+        try:
+            for view, loader_name in _VIEW_LOADERS:
+                if view not in selected:
+                    continue
+                loader = getattr(ctx, loader_name)
+                if view == "vector":
+                    loader(probe=True)
+                else:
+                    loader()
+                if getattr(ctx, view, None) is not None:
+                    available.add(view)
+            return {
+                view: ctx.errors.get(view, "view did not load")
+                for view in selected
+                if view not in available
+            }
+        finally:
+            if ctx.vector is not None:
+                _close_vector(ctx.vector)
+                ctx.vector = None
 
     # ------------------------------------------------------------------
     # Private loaders
@@ -213,12 +280,13 @@ class ServerContext:
             self.errors["zoekt"] = str(exc)
             logger.warning("Failed to start zoekt-webserver: %s", exc)
 
-    def _load_vector(self) -> None:
+    def _load_vector(self, *, probe: bool = False) -> None:
         """Load vector embedding index if available."""
         entry = self.manifest.indexes.get("vector")
         if not entry or not self.manifest.index_is_current("vector"):
             return
 
+        vector = None
         try:
             from ..index.embedding.vector_store import CodeVectorStore
 
@@ -237,21 +305,25 @@ class ServerContext:
             ):
                 raise ValueError("vector manifest has incomplete embedding identity")
 
+            kwargs = dict(embedding_kwargs)
+            if probe:
+                kwargs["embedding"] = _DimensionProbeEmbedding(dimension)
+
             # Create CodeVectorStore with embedding model from manifest
-            self.vector = CodeVectorStore(
+            vector = CodeVectorStore(
                 embedding_model=embedding_model,
                 embedding_provider=embedding_provider,
                 dimension=dimension,
                 index_metric=cfg.get("index_metric", "ip"),
                 store_path=entry.path,
-                **embedding_kwargs,
+                **kwargs,
             )
 
             # Load FAISS index from disk
-            self.vector.load()
+            vector.load()
 
             # Validate model consistency
-            loaded_model = self.vector.embedding_model
+            loaded_model = vector.embedding_model
             manifest_model = embedding_model
             if loaded_model != manifest_model:
                 raise RuntimeError(
@@ -260,7 +332,8 @@ class ServerContext:
                     f"Re-run indexing with the correct model."
                 )
 
-            stats = self.vector.get_stats()
+            stats = vector.get_stats()
+            self.vector = vector
             logger.info(
                 "Loaded vector index from %s (%d docs, model=%s)",
                 entry.path,
@@ -268,6 +341,8 @@ class ServerContext:
                 embedding_model,
             )
         except Exception as exc:
+            if vector is not None:
+                _close_vector(vector)
             self.vector = None
             self.errors["vector"] = str(exc)
             logger.warning("Failed to load vector index: %s", exc)

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -62,6 +62,13 @@ def _close_vector(vector: CodeVectorStore) -> None:
         logger.warning("Failed to release vector resources: %s", exc)
 
 
+def _stop_zoekt(searcher: ZoektSearcher) -> None:
+    try:
+        searcher.stop()
+    except Exception as exc:
+        logger.warning("Failed to stop Zoekt runtime: %s", exc)
+
+
 def _resolve_views(views: Iterable[str] | None) -> frozenset[str]:
     """Validate a view selection and add runtime dependencies."""
 
@@ -167,7 +174,8 @@ class ServerContext:
 
         The returned mapping contains only unavailable views. Vector indexes
         follow the normal FAISS/document load path with a fixed-dimension
-        embedding probe, then release their resources before returning.
+        embedding probe. Temporary vector and Zoekt resources are released
+        before returning.
         """
 
         selected = _resolve_views(views)
@@ -195,6 +203,9 @@ class ServerContext:
                 if view not in available
             }
         finally:
+            if ctx.zoekt is not None:
+                _stop_zoekt(ctx.zoekt)
+                ctx.zoekt = None
             if ctx.vector is not None:
                 _close_vector(ctx.vector)
                 ctx.vector = None
@@ -264,6 +275,7 @@ class ServerContext:
             logger.warning("Failed to load Zoekt runtime: %s", exc)
             return
 
+        searcher = None
         try:
             searcher = ZoektSearcher(index_dir=entry.path)
             searcher.start()
@@ -274,9 +286,13 @@ class ServerContext:
                 searcher.port,
             )
         except ZoektUnavailableError as exc:
+            if searcher is not None:
+                _stop_zoekt(searcher)
             self.errors["zoekt"] = str(exc)
             logger.warning("Zoekt unavailable: %s", exc)
         except Exception as exc:
+            if searcher is not None:
+                _stop_zoekt(searcher)
             self.errors["zoekt"] = str(exc)
             logger.warning("Failed to start zoekt-webserver: %s", exc)
 
@@ -333,6 +349,8 @@ class ServerContext:
                 )
 
             stats = vector.get_stats()
+            if stats["total_documents"] <= 0:
+                raise RuntimeError("vector index contains no documents")
             self.vector = vector
             logger.info(
                 "Loaded vector index from %s (%d docs, model=%s)",

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -7,18 +7,37 @@ an agent-specific graph, BM25 index, or cache directory.
 
 ## Support Matrix
 
-The three support levels below are intentionally separate. **Provider** means
-CodeNib implements the repository-call contract. **Policy** means the pinned
-agent loop can execute with that provider. **Paired** means the repository
-provider can be swapped between native and CodeNib under one fixed case, model,
-prompt, and budget contract; it is not a general quality claim.
+The support levels below are intentionally separate. **Provider** means CodeNib
+implements the repository-call contract. **Policy** means a pinned upstream
+agent loop executes with that provider. **Paired evaluation** means the native
+and CodeNib providers can be swapped under one fixed case, model, prompt, and
+budget contract. None of these labels alone claims end-to-end task quality.
 
-| Integration | Provider | Policy | Paired evaluation | Upstream domain | Boundary |
+| Integration | Status | Required views | Provider contract | Policy and evaluation | Boundary |
 | --- | --- | --- | --- | --- | --- |
-| LocAgent | Pinned three-tool contract | Pinned prompts and function-calling loop | Fixed-case runner | Python SWE-bench repositories; symbol graph + BM25 | Reference and type-use are disclosed as conservative relation mappings |
-| Historical OpenHands LocAgent plugin | Python bindings for the pinned plugin revision | Not present in current OpenHands CLI | Covered through the LocAgent contract | Same Python contract as LocAgent | No claim of compatibility with every OpenHands revision |
-| OrcaLoca | Pinned six-tool and private-hook contract | Upstream `SearchAgent` with an injected manager | Fixed-case runner + native File/Function Match scorer | Python SWE-bench repositories; symbol graph | Empty `TraceAnalysisOutput`; TraceAnalysis generation is out of scope |
-| SWE-Explore | No adapter | No | No | N/A | Referenced only to distinguish its trajectory-read labels from golden-patch localization metrics |
+| LocAgent | Revision-pinned supported | Symbol graph + BM25 | Pinned three-tool contract | Pinned prompts and function-calling loop; fixed-case paired runner | Python SWE-bench repositories; reference and type-use are disclosed as conservative relation mappings |
+| Historical OpenHands LocAgent plugin | Contract-only | Symbol graph + BM25 | Python bindings for the pinned plugin revision | Covered through the LocAgent contract; policy is absent from current OpenHands CLI | No compatibility claim for other OpenHands revisions |
+| OrcaLoca SearchAgent | Revision-pinned supported | Symbol graph | Pinned six-tool and private-hook contract | Upstream `SearchAgent`; fixed-case paired runner and native File/Function Match scorer | Python SWE-bench repositories; empty `TraceAnalysisOutput`; upstream trace generation is not included |
+| SWE-Explore | Reference-only | N/A | No adapter | No policy runner or paired evaluation | Used only to distinguish trajectory-read labels from golden-patch localization metrics |
+
+### What Supported Means
+
+A revision-pinned integration must pass four separate gates:
+
+1. Dependency-free provider tests exercise its public tools, source identities,
+   ranges, budgets, and failure behavior.
+2. An upstream probe checks the pinned tool signatures and the private hooks
+   that the policy actually invokes.
+3. Benchmark preflight verifies clean checkout commits, manifest identity,
+   declared capabilities, and successful loading of every required runtime
+   view before a model call.
+4. The paired runner records every requested cell, keeps failures in the
+   denominator, and binds the case-set, CodeNib, upstream, model, and run-option
+   identities into result provenance.
+
+Passing these gates supports the stated provider and policy boundary. It does
+not imply compatibility with an arbitrary upstream revision or with stages
+explicitly excluded by the matrix.
 
 Optional upstream packages are required only for policy execution. Provider
 imports and standalone provider examples remain dependency-free. Exact pinned
@@ -267,6 +286,26 @@ ranges. Python symbols that the pinned visitor does not recognize are not
 exposed merely because CodeNib's graph is richer. Prose and ambiguous-result
 tie ordering may differ outside this semantic output boundary.
 
+### Trace-Analysis Boundary
+
+The supported OrcaLoca integration begins at `SearchAgent`, after the optional
+upstream trace-analysis stage:
+
+```text
+issue -> [trace analysis: out of scope] -> SearchInput -> SearchAgent -> repository provider
+```
+
+Both the generic adapter and paired runner construct `SearchInput` with an
+empty `TraceAnalysisOutput`. This is a valid upstream input and is also
+OrcaLoca's fallback when its trace-analysis stage raises an exception. Holding
+that input fixed isolates the repository provider: native and CodeNib runs
+receive the same absence of trace-derived hints, while only the search manager
+changes. Consequently, the integration supports OrcaLoca SearchAgent execution
+and provider compatibility; it does not claim to reproduce OrcaLoca's complete
+trace-analysis pipeline or its published end-to-end score. A future
+trace-enabled experiment should supply one fixed, recorded trace to both
+providers rather than regenerate traces independently.
+
 ### Evaluation Metrics
 
 The dependency-free scorer under `codenib.eval.benchmarks.orcaloca` implements
@@ -387,23 +426,24 @@ python scripts/analysis/compare_agent_integrations.py score-orcaloca \
 ```
 
 Before any model call, the driver checks every requested checkout commit,
-tracked-file state, manifest commit, and required capability. Result files bind
-the selected-case digest, CodeNib revision, pinned upstream revisions, model,
-and run options. The scorer retains missing and failed cells in the requested
-denominator, verifies recorded case digests against the active case set, and
-rejects mixed-model aggregation. `--allow-incomplete` writes an explicit
-partial audit; it does not turn a partial matrix into a complete one.
+tracked-file state, manifest commit, required capability, and actual loading of
+the required runtime views. Result files bind the selected-case digest, CodeNib
+revision, pinned upstream revisions, model, and run options. The scorer retains
+missing and failed cells in the requested denominator, verifies recorded case
+digests against the active case set, and rejects mixed-model aggregation.
+`--allow-incomplete` writes an explicit partial audit; it does not turn a
+partial matrix into a complete one.
 
-The OrcaLoca comparison covers its search policy with an empty
-`TraceAnalysisOutput`; TraceAnalysis generation is outside this compatibility
-experiment. File Match and Function Match use golden-patch labels and remain
-separate from the common ranked file/symbol metrics. Legacy result cells may be
-reused, but the summary reports their missing provenance explicitly.
+The OrcaLoca comparison follows the
+[trace-analysis boundary](#trace-analysis-boundary). File Match and Function
+Match use golden-patch labels and remain separate from the common ranked
+file/symbol metrics. Legacy result cells may be reused, but the summary reports
+their missing provenance explicitly.
 
-Provider semantics and model-run cost are separate gates. The pinned upstream
-probe and exact tool-output replay establish deterministic provider
-compatibility. The paired model runner preserves upstream sampling defaults
-(including OrcaLoca's `temperature=1.0`) and records one trajectory per cell, so
-its token and wall-time ratios are descriptive smoke data, not evidence of a
-performance improvement. A performance comparison requires repeated paired
-trials or an endpoint with a documented deterministic sampling contract.
+Provider semantics and model-run cost are separate gates. Provider fixtures and
+the pinned upstream probe check the declared tool and helper semantics. The
+paired model runner preserves upstream sampling defaults (including OrcaLoca's
+`temperature=1.0`) and records one trajectory per cell, so its token and
+wall-time ratios are descriptive smoke data, not evidence of a performance
+improvement. A performance comparison requires repeated paired trials or an
+endpoint with a documented deterministic sampling contract.

--- a/scripts/embeddings/build_codenib_base_embeddings.sh
+++ b/scripts/embeddings/build_codenib_base_embeddings.sh
@@ -31,6 +31,7 @@ DATASET="${DATASET:-fishmingyu/codeminer-base-dataset}"
 SPLIT="${SPLIT:-test}"
 FILTER="${FILTER:-.*}"
 PROFILE_TAG="${PROFILE_TAG:-codenib_base_${SPLIT}}"
+ARTIFACT_LAYOUT="${ARTIFACT_LAYOUT:-instance}"
 
 # model:dimension:batch_size:fallback_batch_size:max_seq_length
 # Batch sizes and max_seq_length tuned for H100 80GB without flash-attn.
@@ -54,6 +55,7 @@ MODELS=(
 )
 
 mkdir -p "${STORAGE_DIR}"
+FAILED_MODELS=()
 
 for entry in "${MODELS[@]}"; do
   IFS=':' read -r MODEL DIM BATCH FALLBACK_BATCH MAX_SEQ <<< "${entry}"
@@ -68,12 +70,14 @@ for entry in "${MODELS[@]}"; do
   echo "Building embeddings: ${MODEL} (dim=${DIM}, batch=${BATCH}, max_seq=${MAX_SEQ})"
   echo "  dataset=${DATASET}  split=${SPLIT}  filter=${FILTER}"
   echo "================================================================"
+  PRIMARY_STATUS=0
   python scripts/embeddings/build_embeddings.py \
     --dataset-class codenib_base \
     --dataset "${DATASET}" \
     --split "${SPLIT}" \
     --filter-instance "${FILTER}" \
     --storage-dir "${STORAGE_DIR}" \
+    --artifact-layout "${ARTIFACT_LAYOUT}" \
     --enable-profiler \
     --profile-tag "${PROFILE_TAG}" \
     --embedding-model "${MODEL}" \
@@ -83,7 +87,7 @@ for entry in "${MODELS[@]}"; do
     --trust-remote-code \
     --isolate-instances \
     ${SEQ_FLAG} \
-    "$@" || true
+    "$@" || PRIMARY_STATUS=$?
 
   # Retry failed instances with a smaller batch size.
   # Do NOT forward --force-rebuild here: we only want to retry instances
@@ -98,12 +102,14 @@ for entry in "${MODELS[@]}"; do
     echo "----------------------------------------------------------------"
     echo "Retrying with fallback batch=${FALLBACK_BATCH} for any failures"
     echo "----------------------------------------------------------------"
+    RETRY_STATUS=0
     python scripts/embeddings/build_embeddings.py \
       --dataset-class codenib_base \
       --dataset "${DATASET}" \
       --split "${SPLIT}" \
       --filter-instance "${FILTER}" \
       --storage-dir "${STORAGE_DIR}" \
+      --artifact-layout "${ARTIFACT_LAYOUT}" \
       --enable-profiler \
       --profile-tag "${PROFILE_TAG}" \
       --embedding-model "${MODEL}" \
@@ -113,10 +119,19 @@ for entry in "${MODELS[@]}"; do
       --trust-remote-code \
       --isolate-instances \
       ${SEQ_FLAG} \
-      "${RETRY_ARGS[@]}" || true
+      "${RETRY_ARGS[@]}" || RETRY_STATUS=$?
+    if [ "${RETRY_STATUS}" -ne 0 ]; then
+      FAILED_MODELS+=("${MODEL}")
+    fi
+  elif [ "${PRIMARY_STATUS}" -ne 0 ]; then
+    FAILED_MODELS+=("${MODEL}")
   fi
 done
 
 echo ""
 echo "Done. Embeddings stored under ${STORAGE_DIR}"
 echo "Profile logs stored under ${STORAGE_DIR}/profile_log"
+if [ "${#FAILED_MODELS[@]}" -ne 0 ]; then
+  printf 'Failed models: %s\n' "${FAILED_MODELS[*]}" >&2
+  exit 1
+fi

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -27,18 +27,27 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 project_root = Path(__file__).resolve().parents[2]
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
+from codenib.compiler.artifact_quality import (  # noqa: E402
+    ARTIFACT_QUALITY_SCHEMA_VERSION,
+    assess_vector_artifact,
+    required_source_files,
+    write_artifact_quality,
+)
 from codenib.compiler.snapshot_store import ArtifactProfile  # noqa: E402
 from codenib.compiler.snapshot_store import SnapshotArtifactStore, SourceSnapshot
+from codenib.git_snapshot import GitSourceSurface  # noqa: E402
 from codenib.index.embedding import build_hierarchical_vector_store  # noqa: E402
+from codenib.languages import extensions_for_language  # noqa: E402
 from codenib.log_utils import get_logger  # noqa: E402
 from codenib.paths import prebuilt_data_dir  # noqa: E402
 from codenib.profiler import Profiler  # noqa: E402
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION  # noqa: E402
 
 logger = get_logger(__name__)
 
@@ -377,6 +386,112 @@ def _load_dataset(args):
     )
 
 
+def _vector_artifact_root(root: Path, plan_name: Optional[str]) -> Path:
+    return root / plan_name if plan_name else root
+
+
+def _vector_quality_path(root: Path, embedding_model: str) -> Path:
+    model_suffix = embedding_model.replace("/", "__")
+    return root / f"artifact_quality_{model_suffix}.json"
+
+
+def _artifact_metadata(
+    *,
+    instance: dict[str, Any],
+    languages: List[str],
+    build_levels: List[str],
+    surface: GitSourceSurface,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    return {
+        "repo": instance["repo"],
+        "commit": surface.commit,
+        "tree": surface.tree,
+        **_artifact_configuration(
+            languages=languages,
+            build_levels=build_levels,
+            args=args,
+        ),
+    }
+
+
+def _artifact_configuration(
+    *,
+    languages: List[str],
+    build_levels: List[str],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    return {
+        "languages": sorted(languages),
+        "build_levels": sorted(build_levels),
+        "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
+        "chunking": {
+            "l0_skeleton": True,
+            "max_lines_per_chunk": args.max_lines_per_chunk,
+        },
+        "embedding": {
+            "provider": args.embedding_provider,
+            "dimension": args.embedding_dimension,
+            "index_type": args.index_type,
+            "index_metric": args.index_metric,
+            "ivf_nlist": args.ivf_nlist,
+            "ivf_nprobe": args.ivf_nprobe,
+            "max_seq_length": args.max_seq_length,
+        },
+    }
+
+
+def _required_l0_files(
+    instance: dict[str, Any], languages: List[str]
+) -> tuple[str, ...]:
+    extensions = set()
+    for language in languages:
+        extensions.update(extensions_for_language(language, "chunker"))
+    return required_source_files(instance, extensions)
+
+
+def _quality_report_is_reusable(
+    root: Path,
+    *,
+    embedding_model: str,
+    instance: dict[str, Any],
+    expected_configuration: Optional[dict[str, Any]] = None,
+) -> bool:
+    """Fast parent-process check; the child repeats the complete gate."""
+
+    quality_path = _vector_quality_path(root, embedding_model)
+    config_path = root / f"config_{embedding_model.replace('/', '__')}.json"
+    try:
+        quality = json.loads(quality_path.read_text(encoding="utf-8"))
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    artifact = config.get("artifact") or {}
+    expected_commit = str(instance.get("base_commit") or "").lower()
+    actual_commit = str(artifact.get("commit") or "").lower()
+    commit_matches = bool(
+        expected_commit
+        and actual_commit
+        and (
+            expected_commit == actual_commit
+            or actual_commit.startswith(expected_commit)
+            or expected_commit.startswith(actual_commit)
+        )
+    )
+    configuration_matches = all(
+        artifact.get(key) == value
+        for key, value in (expected_configuration or {}).items()
+    )
+    return bool(
+        quality.get("schema_version") == ARTIFACT_QUALITY_SCHEMA_VERSION
+        and quality.get("passed")
+        and quality.get("artifact") == artifact
+        and artifact.get("repo") == instance.get("repo")
+        and commit_matches
+        and configuration_matches
+    )
+
+
 def build_embeddings(args):
     """Build hierarchical embedding indices for dataset instances."""
 
@@ -385,7 +500,6 @@ def build_embeddings(args):
     # Load dataset
     dataset_obj = _load_dataset(args)
     dataset_instances = dataset_obj.load()
-
     if len(dataset_instances) == 0:
         raise ValueError(
             f"No instances found in {args.dataset or _DATASET_DEFAULTS[args.dataset_class]}"
@@ -410,6 +524,10 @@ def build_embeddings(args):
     profile_output_dir.mkdir(parents=True, exist_ok=True)
     if args.profile_dir:
         logger.info(f"Profiler summaries will be stored in: {profile_output_dir}")
+
+    failures: list[str] = []
+    succeeded = 0
+    skipped = 0
 
     # Process each instance
     for idx, instance in enumerate(dataset_instances):
@@ -480,17 +598,51 @@ def build_embeddings(args):
             logger.info(f"Target directory: {instance_final_dir}")
             logger.info(f"Languages: {instance_languages}")
 
-            # Check if embedding already exists (model-specific config)
+            surface = GitSourceSurface.load(repo_path, instance["base_commit"])
+            artifact_metadata = _artifact_metadata(
+                instance=instance,
+                languages=instance_languages,
+                build_levels=build_levels,
+                surface=surface,
+                args=args,
+            )
+            required_l0 = (
+                _required_l0_files(instance, instance_languages)
+                if "l0" in build_levels
+                else ()
+            )
+            artifact_root = _vector_artifact_root(instance_final_dir, args.plan_name)
+
+            # Reuse only artifacts that pass identity, file, and coverage checks.
             model_suffix = args.embedding_model.replace("/", "__")
-            config_file = instance_final_dir / f"config_{model_suffix}.json"
-            if config_file.exists() and not args.force_rebuild:
+            config_file = artifact_root / f"config_{model_suffix}.json"
+            existing_quality = assess_vector_artifact(
+                artifact_root,
+                embedding_model=args.embedding_model,
+                build_levels=build_levels,
+                surface=surface,
+                expected_artifact=artifact_metadata,
+                required_l0_files=required_l0,
+            )
+            if existing_quality["passed"] and not args.force_rebuild:
                 logger.info(
-                    f"Embedding already exists at {instance_final_dir}, skipping..."
+                    "Embedding already exists and passed quality gates at %s; skipping",
+                    artifact_root,
                 )
+                write_artifact_quality(
+                    _vector_quality_path(artifact_root, args.embedding_model),
+                    existing_quality,
+                )
+                skipped += 1
                 continue
             elif config_file.exists() and args.force_rebuild:
                 logger.info(
                     "Embedding already exists but force-rebuild is enabled, rebuilding..."
+                )
+            elif config_file.exists():
+                logger.warning(
+                    "Existing embedding failed quality gates (%s); rebuilding",
+                    ", ".join(existing_quality["failure_names"]),
                 )
 
             embedding_kwargs = {}
@@ -520,7 +672,24 @@ def build_embeddings(args):
                     ivf_nlist=args.ivf_nlist,
                     ivf_nprobe=args.ivf_nprobe,
                     profiler=instance_profiler,
-                    force_rebuild=args.force_rebuild,
+                    force_rebuild=args.force_rebuild or config_file.exists(),
+                    artifact_metadata=artifact_metadata,
+                )
+
+            artifact_quality = assess_vector_artifact(
+                artifact_root,
+                embedding_model=args.embedding_model,
+                build_levels=build_levels,
+                surface=surface,
+                expected_artifact=artifact_metadata,
+                required_l0_files=required_l0,
+            )
+            quality_path = _vector_quality_path(artifact_root, args.embedding_model)
+            write_artifact_quality(quality_path, artifact_quality)
+            if not artifact_quality["passed"]:
+                raise RuntimeError(
+                    "vector artifact quality failed: "
+                    + ", ".join(artifact_quality["failure_names"])
                 )
 
             # Save profiler report
@@ -579,12 +748,14 @@ def build_embeddings(args):
                 f"✓ Successfully built hierarchical embedding for {instance_id}"
             )
             logger.info(f"  - Saved to: {instance_final_dir}")
+            succeeded += 1
 
         except Exception as e:
             logger.error(f"✗ Failed to process {instance_id}: {e}")
             import traceback
 
             logger.error(traceback.format_exc())
+            failures.append(instance_id)
         finally:
             if vector_store is not None:
                 vector_store.close()
@@ -599,10 +770,21 @@ def build_embeddings(args):
                 pass
     logger.info(f"\n{'='*80}")
     logger.info("Hierarchical embedding build complete!")
-    logger.info(f"Processed {len(dataset_instances)} instance(s)")
+    logger.info(
+        "Processed %d instance(s): %d built, %d reused, %d failed",
+        len(dataset_instances),
+        succeeded,
+        skipped,
+        len(failures),
+    )
     if args.enable_profiler or args.profile_dir:
         logger.info(f"Profile logs stored in: {profile_output_dir}")
     logger.info(f"{'='*80}")
+    if failures:
+        raise RuntimeError(
+            "Embedding build failed for "
+            f"{len(failures)} instance(s): {', '.join(failures)}"
+        )
 
 
 def build_embeddings_isolated(args):
@@ -619,6 +801,7 @@ def build_embeddings_isolated(args):
 
     dataset_obj = _load_dataset(args)
     dataset_instances = dataset_obj.load()
+    repo_languages = _load_repo_language_map(args.multilingual_repo_language_csv)
 
     if len(dataset_instances) == 0:
         raise ValueError(
@@ -658,13 +841,29 @@ def build_embeddings_isolated(args):
             f"{'='*80}"
         )
 
-        # Check if already built (mirrors the skip logic in build_embeddings)
+        # Trust only artifacts carrying a passing model-specific quality report.
         instance_dir_name = instance_id.replace("/", "__")
         instance_final_dir = Path(args.storage_dir) / instance_dir_name
-        model_suffix = args.embedding_model.replace("/", "__")
-        config_file = instance_final_dir / f"config_{model_suffix}.json"
-        if config_file.exists() and not args.force_rebuild:
-            logger.info(f"  Already exists, skipping: {config_file}")
+        artifact_root = _vector_artifact_root(instance_final_dir, args.plan_name)
+        instance_languages = _resolve_languages(
+            dict(instance),
+            args.languages,
+            repo_languages,
+        )
+        expected_configuration = _artifact_configuration(
+            languages=instance_languages,
+            build_levels=[level.lower() for level in args.build_levels],
+            args=args,
+        )
+        if not args.force_rebuild and _quality_report_is_reusable(
+            artifact_root,
+            embedding_model=args.embedding_model,
+            instance=dict(instance),
+            expected_configuration=expected_configuration,
+        ):
+            logger.info(
+                "  Existing artifact passed quality gates; skipping: %s", artifact_root
+            )
             skipped += 1
             continue
 

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -27,7 +27,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional
 
 project_root = Path(__file__).resolve().parents[2]
 if str(project_root) not in sys.path:
@@ -193,8 +193,8 @@ def parse_args():
         type=int,
         default=None,
         help=(
-            "Maximum lines per L2 code chunk (default: None, no splitting to "
-            "preserve function integrity)"
+            "Maximum lines per L2 code chunk and raw-source L0 fallback "
+            "(default: None, no splitting)"
         ),
     )
     parser.add_argument(
@@ -466,18 +466,14 @@ def _quality_report_is_reusable(
         config = json.loads(config_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return False
+    if not isinstance(quality, Mapping) or not isinstance(config, Mapping):
+        return False
     artifact = config.get("artifact") or {}
+    if not isinstance(artifact, Mapping):
+        return False
     expected_commit = str(instance.get("base_commit") or "").lower()
     actual_commit = str(artifact.get("commit") or "").lower()
-    commit_matches = bool(
-        expected_commit
-        and actual_commit
-        and (
-            expected_commit == actual_commit
-            or actual_commit.startswith(expected_commit)
-            or expected_commit.startswith(actual_commit)
-        )
-    )
+    commit_matches = bool(expected_commit and expected_commit == actual_commit)
     configuration_matches = all(
         artifact.get(key) == value
         for key, value in (expected_configuration or {}).items()

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -27,16 +27,18 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional, Sequence
 
 project_root = Path(__file__).resolve().parents[2]
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
+from codenib.code_chunking.base import DEFAULT_L0_RAW_FALLBACK_MAX_LINES  # noqa: E402
 from codenib.compiler.artifact_quality import (  # noqa: E402
     ARTIFACT_QUALITY_SCHEMA_VERSION,
     assess_vector_artifact,
     required_source_files,
+    vector_artifact_files_match,
     write_artifact_quality,
 )
 from codenib.compiler.snapshot_store import ArtifactProfile  # noqa: E402
@@ -193,8 +195,9 @@ def parse_args():
         type=int,
         default=None,
         help=(
-            "Maximum lines per L2 code chunk and raw-source L0 fallback "
-            "(default: None, no splitting)"
+            "Maximum lines per L2 code chunk and raw-source L0 fallback. "
+            "By default L2 is unsplit and raw L0 fallback uses the safe limit "
+            f"{DEFAULT_L0_RAW_FALLBACK_MAX_LINES}."
         ),
     )
     parser.add_argument(
@@ -428,6 +431,11 @@ def _artifact_configuration(
         "chunking": {
             "l0_skeleton": True,
             "max_lines_per_chunk": args.max_lines_per_chunk,
+            "l0_raw_fallback_max_lines": (
+                args.max_lines_per_chunk
+                if args.max_lines_per_chunk is not None
+                else DEFAULT_L0_RAW_FALLBACK_MAX_LINES
+            ),
         },
         "embedding": {
             "provider": args.embedding_provider,
@@ -455,9 +463,11 @@ def _quality_report_is_reusable(
     *,
     embedding_model: str,
     instance: dict[str, Any],
-    expected_configuration: Optional[dict[str, Any]] = None,
+    expected_configuration: Mapping[str, Any],
+    build_levels: Sequence[str],
+    required_l0_files: Sequence[str] = (),
 ) -> bool:
-    """Fast parent-process check; the child repeats the complete gate."""
+    """Revalidate an assessed artifact before skipping its isolated child."""
 
     quality_path = _vector_quality_path(root, embedding_model)
     config_path = root / f"config_{embedding_model.replace('/', '__')}.json"
@@ -475,8 +485,17 @@ def _quality_report_is_reusable(
     actual_commit = str(artifact.get("commit") or "").lower()
     commit_matches = bool(expected_commit and expected_commit == actual_commit)
     configuration_matches = all(
-        artifact.get(key) == value
-        for key, value in (expected_configuration or {}).items()
+        artifact.get(key) == value for key, value in expected_configuration.items()
+    )
+    reported_l0_files = quality.get("l0_files")
+    required_matches = isinstance(reported_l0_files, list) and set(
+        required_l0_files
+    ).issubset(reported_l0_files)
+    files_match = vector_artifact_files_match(
+        root,
+        embedding_model=embedding_model,
+        build_levels=build_levels,
+        expected_fingerprints=quality.get("file_fingerprints"),
     )
     return bool(
         quality.get("schema_version") == ARTIFACT_QUALITY_SCHEMA_VERSION
@@ -485,6 +504,8 @@ def _quality_report_is_reusable(
         and artifact.get("repo") == instance.get("repo")
         and commit_matches
         and configuration_matches
+        and required_matches
+        and files_match
     )
 
 
@@ -851,11 +872,19 @@ def build_embeddings_isolated(args):
             build_levels=[level.lower() for level in args.build_levels],
             args=args,
         )
+        build_levels = [level.lower() for level in args.build_levels]
+        required_l0 = (
+            _required_l0_files(dict(instance), instance_languages)
+            if "l0" in build_levels
+            else ()
+        )
         if not args.force_rebuild and _quality_report_is_reusable(
             artifact_root,
             embedding_model=args.embedding_model,
             instance=dict(instance),
             expected_configuration=expected_configuration,
+            build_levels=build_levels,
+            required_l0_files=required_l0,
         ):
             logger.info(
                 "  Existing artifact passed quality gates; skipping: %s", artifact_root

--- a/scripts/swebench_graph_index.py
+++ b/scripts/swebench_graph_index.py
@@ -555,6 +555,7 @@ def _graph_artifact_metadata(
         "commit": surface.commit,
         "tree": surface.tree,
         "language": language,
+        "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         "exclude_patterns": sorted(exclude_patterns),
         "enforce_commit_surface": enforce_commit_surface,
         "source_coverage_fallback": source_coverage_fallback,

--- a/scripts/swebench_graph_index.py
+++ b/scripts/swebench_graph_index.py
@@ -8,6 +8,7 @@ Build SCIP graph indexes for multiple benchmark sources.
 Supported sources:
 - swebench
 - swebench_multilingual
+- codenib_base
 - locbench
 - sampled_csv (for sampled instance lists like selected.csv/selected_instances.csv)
 """
@@ -28,18 +29,30 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from codenib.compiler.artifact_quality import (  # noqa: E402
+    ARTIFACT_QUALITY_SCHEMA_VERSION,
+    assess_graph_artifact,
+    graph_file_paths,
+    required_source_files,
+    write_artifact_quality,
+)
 from codenib.compiler.snapshot_store import ArtifactProfile  # noqa: E402
 from codenib.compiler.snapshot_store import SnapshotArtifactStore, SourceSnapshot
+from codenib.dataset.codenib_base import CodeNibBaseDataset  # noqa: E402
 from codenib.dataset.locbench import LocbenchDataset  # noqa: E402
 from codenib.dataset.swebench import SwebenchDataset  # noqa: E402
 from codenib.dataset.swebench_multilingual import (  # noqa: E402
     SwebenchMultilingualDataset,
 )
-from codenib.languages import language_capability_rows  # noqa: E402
+from codenib.git_snapshot import GitSourceSurface  # noqa: E402
+from codenib.graph.source_coverage import supplement_graph_source_coverage  # noqa: E402
+from codenib.languages import extensions_for_language  # noqa: E402
+from codenib.languages import language_capability_rows
 from codenib.log_utils import get_logger  # noqa: E402
 from codenib.ls_router import LSIndexer  # noqa: E402
 from codenib.paths import user_state_dir  # noqa: E402
 from codenib.profiler import Profiler  # noqa: E402
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION  # noqa: E402
 
 logger = get_logger(__name__)
 
@@ -73,7 +86,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--source",
         type=str,
-        choices=["swebench", "swebench_multilingual", "locbench", "sampled_csv"],
+        choices=[
+            "swebench",
+            "swebench_multilingual",
+            "codenib_base",
+            "locbench",
+            "sampled_csv",
+        ],
         default="swebench",
         help="Source type for instances to index.",
     )
@@ -88,6 +107,12 @@ def parse_args() -> argparse.Namespace:
         type=str,
         default="SWE-bench/SWE-bench_Multilingual",
         help="Dataset name used when source is swebench_multilingual.",
+    )
+    parser.add_argument(
+        "--codenib-base-dataset",
+        type=str,
+        default="fishmingyu/codeminer-base-dataset",
+        help="Dataset name used when source is codenib_base.",
     )
     parser.add_argument(
         "--locbench-dataset",
@@ -200,6 +225,24 @@ def parse_args() -> argparse.Namespace:
         help="Compatibility profile name used by snapshot-addressed artifacts.",
     )
     parser.add_argument(
+        "--enforce-commit-surface",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Constrain graph paths to the declared base commit and reject "
+            "missing source-language ground-truth files."
+        ),
+    )
+    parser.add_argument(
+        "--source-coverage-fallback",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Use tree-sitter definitions to cover tracked source files omitted "
+            "by the compiler-backed graph; reference edges remain compiler-derived."
+        ),
+    )
+    parser.add_argument(
         "--multilingual-repo-language-csv",
         type=str,
         default=str(DEFAULT_MULTILINGUAL_REPO_LANG_CSV),
@@ -277,6 +320,8 @@ def _build_dataset(source: str, args: argparse.Namespace):
         return SwebenchDataset(dataset=args.dataset, **kwargs)
     if source == "swebench_multilingual":
         return SwebenchMultilingualDataset(dataset=args.multilingual_dataset, **kwargs)
+    if source == "codenib_base":
+        return CodeNibBaseDataset(dataset=args.codenib_base_dataset, **kwargs)
     if source == "locbench":
         return LocbenchDataset(dataset=args.locbench_dataset, **kwargs)
     raise ValueError(f"Unsupported source: {source}")
@@ -484,6 +529,7 @@ def _write_profile(
         "base_commit": instance.get("base_commit"),
         "source": source_kind,
         "language": language,
+        "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         "total_duration": sum(section["total"] for section in sections_payload),
         "sections": sections_payload,
     }
@@ -493,6 +539,44 @@ def _write_profile(
     )
     profile_file.write_text(json.dumps(profile_payload, indent=2), encoding="utf-8")
     logger.info("Saved profiler results to %s", profile_file)
+
+
+def _graph_artifact_metadata(
+    *,
+    repo: str,
+    surface: GitSourceSurface,
+    language: str,
+    exclude_patterns: Iterable[str],
+    enforce_commit_surface: bool,
+    source_coverage_fallback: bool,
+) -> Dict[str, Any]:
+    return {
+        "repo": repo,
+        "commit": surface.commit,
+        "tree": surface.tree,
+        "language": language,
+        "exclude_patterns": sorted(exclude_patterns),
+        "enforce_commit_surface": enforce_commit_surface,
+        "source_coverage_fallback": source_coverage_fallback,
+    }
+
+
+def _graph_quality_is_reusable(
+    output_dir: Path,
+    *,
+    expected_artifact: Mapping[str, Any],
+) -> bool:
+    try:
+        quality = json.loads(
+            (output_dir / "artifact_quality.json").read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(
+        quality.get("schema_version") == ARTIFACT_QUALITY_SCHEMA_VERSION
+        and quality.get("passed")
+        and quality.get("artifact") == expected_artifact
+    )
 
 
 def main() -> None:
@@ -586,6 +670,29 @@ def main() -> None:
                 instance_output_dir = output_path / instance_id.replace("/", "__")
                 instance_output_dir.mkdir(parents=True, exist_ok=True)
 
+            surface = None
+            artifact_metadata = None
+            instance_skip_level = effective_skip_level
+            if args.enforce_commit_surface:
+                surface = GitSourceSurface.load(repo_path, base_commit)
+                artifact_metadata = _graph_artifact_metadata(
+                    repo=repo,
+                    surface=surface,
+                    language=task.language,
+                    exclude_patterns=args.exclude_patterns,
+                    enforce_commit_surface=args.enforce_commit_surface,
+                    source_coverage_fallback=args.source_coverage_fallback,
+                )
+                if instance_skip_level is not None and not _graph_quality_is_reusable(
+                    instance_output_dir,
+                    expected_artifact=artifact_metadata,
+                ):
+                    logger.warning(
+                        "Cached graph lacks matching provenance and quality gates; "
+                        "running a full rebuild"
+                    )
+                    instance_skip_level = None
+
             profiler = Profiler(
                 name=f"scip_indexer[{instance_id}]",
                 logger=logger,
@@ -602,7 +709,7 @@ def main() -> None:
 
             logger.info("Starting graph indexing for %s", instance_id)
             graph = indexer.run_pipeline(
-                skip_level=effective_skip_level,
+                skip_level=instance_skip_level,
                 report_profile=False,
             )
             logger.info("Profiler summary for %s:", instance_id)
@@ -616,6 +723,53 @@ def main() -> None:
             )
 
             if graph:
+                artifact_quality = None
+                if args.enforce_commit_surface:
+                    assert surface is not None
+                    assert artifact_metadata is not None
+                    graph_extensions = extensions_for_language(task.language, "graph")
+                    fallback_report = None
+                    if args.source_coverage_fallback:
+                        fallback_report = supplement_graph_source_coverage(
+                            graph,
+                            repo_root=repo_path,
+                            surface=surface,
+                            extensions=graph_extensions,
+                            represented_paths=graph_file_paths(graph),
+                            exclude_patterns=args.exclude_patterns,
+                        )
+                    required_files = required_source_files(
+                        instance,
+                        graph_extensions,
+                    )
+                    artifact_quality = assess_graph_artifact(
+                        graph,
+                        surface,
+                        required_files=required_files,
+                    )
+                    artifact_quality["artifact"] = artifact_metadata
+                    if fallback_report is not None:
+                        artifact_quality["source_coverage_fallback"] = fallback_report
+                        if fallback_report["unreadable_files"]:
+                            artifact_quality["failure_names"].append(
+                                "source_coverage_fallback_incomplete"
+                            )
+                            artifact_quality["passed"] = False
+                    graph.project_root = repo_path
+                    graph.save_graph(indexer.graph_file)
+                    occurrence_index = getattr(graph, "lsp_occurrence_index", None)
+                    if occurrence_index is not None:
+                        occurrence_index.save(
+                            Path(indexer.graph_file).with_name("lsp_index.pkl")
+                        )
+                    quality_path = instance_output_dir / "artifact_quality.json"
+                    write_artifact_quality(quality_path, artifact_quality)
+                    logger.info(
+                        "Artifact quality: %s (%s)",
+                        "passed" if artifact_quality["passed"] else "failed",
+                        quality_path,
+                    )
+
                 logger.info("Successfully created graph index for %s", instance_id)
                 logger.info("Graph saved to: %s", indexer.graph_file)
                 logger.info(
@@ -630,6 +784,11 @@ def main() -> None:
                         "passed" if quality["passed"] else "failed",
                         instance_output_dir / "index_quality.json",
                     )
+                if (quality is not None and not quality["passed"]) or (
+                    artifact_quality is not None and not artifact_quality["passed"]
+                ):
+                    logger.error("Quality gate failed for %s", instance_id)
+                    failures.append(instance_id)
             else:
                 logger.error("Failed to create graph index for %s", instance_id)
                 failures.append(instance_id)

--- a/scripts/swebench_graph_index.py
+++ b/scripts/swebench_graph_index.py
@@ -31,7 +31,7 @@ if str(ROOT) not in sys.path:
 
 from codenib.compiler.artifact_quality import (  # noqa: E402
     ARTIFACT_QUALITY_SCHEMA_VERSION,
-    assess_graph_artifact,
+    constrain_and_assess_graph_artifact,
     graph_file_paths,
     required_source_files,
     write_artifact_quality,
@@ -742,7 +742,7 @@ def main() -> None:
                         instance,
                         graph_extensions,
                     )
-                    artifact_quality = assess_graph_artifact(
+                    artifact_quality = constrain_and_assess_graph_artifact(
                         graph,
                         surface,
                         required_files=required_files,
@@ -750,18 +750,11 @@ def main() -> None:
                     artifact_quality["artifact"] = artifact_metadata
                     if fallback_report is not None:
                         artifact_quality["source_coverage_fallback"] = fallback_report
-                        if fallback_report["unreadable_files"]:
-                            artifact_quality["failure_names"].append(
-                                "source_coverage_fallback_incomplete"
-                            )
-                            artifact_quality["passed"] = False
                     graph.project_root = repo_path
                     graph.save_graph(indexer.graph_file)
                     occurrence_index = getattr(graph, "lsp_occurrence_index", None)
                     if occurrence_index is not None:
-                        occurrence_index.save(
-                            Path(indexer.graph_file).with_name("lsp_index.pkl")
-                        )
+                        occurrence_index.save(indexer.lsp_index_file)
                     quality_path = instance_output_dir / "artifact_quality.json"
                     write_artifact_quality(quality_path, artifact_quality)
                     logger.info(

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -91,5 +91,35 @@ def test_l0_empty_skeleton_falls_back_to_full_file(monkeypatch, tmp_path):
 
     assert len(chunks) == 1
     assert chunks[0].chunk_type == "file"
-    assert chunks[0].content == content
+    assert chunks[0].content == f"include/declarations.h\n{content}"
     assert chunks[0].node_id == "include/declarations.h"
+
+
+def test_l0_empty_skeleton_fallback_honors_max_lines(monkeypatch, tmp_path):
+    source = tmp_path / "generated.h"
+    source.write_text(
+        "".join(f"#define VALUE_{line} {line}\n" for line in range(5000)),
+        encoding="utf-8",
+    )
+
+    parser = SimpleNamespace(parse=lambda _code: SimpleNamespace(root_node=object()))
+    monkeypatch.setattr(
+        "codenib.code_chunking.base.get_language", lambda _lang: object()
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_create_parser",
+        staticmethod(lambda _language: parser),
+    )
+
+    chunker = StubCodeChunker(
+        "cpp",
+        max_lines_per_chunk=100,
+        chunk_depth=0,
+        skeleton_mode=True,
+    )
+    chunks = chunker.chunk_file(str(source), relative_path="include/generated.h")
+
+    assert len(chunks) == 51
+    assert all(chunk.end_line - chunk.start_line + 1 <= 100 for chunk in chunks)
+    assert all(chunk.node_id == "include/generated.h" for chunk in chunks)

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -11,7 +11,10 @@ from typing import List, Optional, Tuple
 
 import pytest
 
-from codenib.code_chunking.base import BaseCodeChunker
+from codenib.code_chunking.base import (
+    DEFAULT_L0_RAW_FALLBACK_MAX_LINES,
+    BaseCodeChunker,
+)
 
 
 class StubCodeChunker(BaseCodeChunker):
@@ -95,7 +98,13 @@ def test_l0_empty_skeleton_falls_back_to_full_file(monkeypatch, tmp_path):
     assert chunks[0].node_id == "include/declarations.h"
 
 
-def test_l0_empty_skeleton_fallback_honors_max_lines(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("configured_limit", "expected_limit"),
+    [(None, DEFAULT_L0_RAW_FALLBACK_MAX_LINES), (100, 100)],
+)
+def test_l0_empty_skeleton_fallback_is_bounded(
+    monkeypatch, tmp_path, configured_limit, expected_limit
+):
     source = tmp_path / "generated.h"
     source.write_text(
         "".join(f"#define VALUE_{line} {line}\n" for line in range(5000)),
@@ -114,12 +123,14 @@ def test_l0_empty_skeleton_fallback_honors_max_lines(monkeypatch, tmp_path):
 
     chunker = StubCodeChunker(
         "cpp",
-        max_lines_per_chunk=100,
+        max_lines_per_chunk=configured_limit,
         chunk_depth=0,
         skeleton_mode=True,
     )
     chunks = chunker.chunk_file(str(source), relative_path="include/generated.h")
 
-    assert len(chunks) == 51
-    assert all(chunk.end_line - chunk.start_line + 1 <= 100 for chunk in chunks)
+    assert len(chunks) == (5001 + expected_limit - 1) // expected_limit
+    assert all(
+        chunk.end_line - chunk.start_line + 1 <= expected_limit for chunk in chunks
+    )
     assert all(chunk.node_id == "include/generated.h" for chunk in chunks)

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -6,6 +6,7 @@
 
 """Tests for shared code chunker behavior."""
 
+from types import SimpleNamespace
 from typing import List, Optional, Tuple
 
 import pytest
@@ -68,3 +69,27 @@ def test_tree_sitter_language_load_is_cached_per_language(monkeypatch):
     assert calls == ["python", "go"]
     assert first.tree_sitter_language is second.tree_sitter_language
     assert third.tree_sitter_language is languages["go"]
+
+
+def test_l0_empty_skeleton_falls_back_to_full_file(monkeypatch, tmp_path):
+    source = tmp_path / "declarations.h"
+    content = "#define VALUE 1\n"
+    source.write_text(content, encoding="utf-8")
+
+    parser = SimpleNamespace(parse=lambda _code: SimpleNamespace(root_node=object()))
+    monkeypatch.setattr(
+        "codenib.code_chunking.base.get_language", lambda _lang: object()
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_create_parser",
+        staticmethod(lambda _language: parser),
+    )
+
+    chunker = StubCodeChunker("cpp", chunk_depth=0, skeleton_mode=True)
+    chunks = chunker.chunk_file(str(source), relative_path="include/declarations.h")
+
+    assert len(chunks) == 1
+    assert chunks[0].chunk_type == "file"
+    assert chunks[0].content == content
+    assert chunks[0].node_id == "include/declarations.h"

--- a/test/compiler/test_artifact_quality.py
+++ b/test/compiler/test_artifact_quality.py
@@ -15,6 +15,7 @@ import numpy as np
 from codenib.compiler.artifact_quality import (
     assess_vector_artifact,
     constrain_and_assess_graph_artifact,
+    vector_artifact_files_match,
 )
 from codenib.git_snapshot import GitSourceSurface
 from codenib.graph.code_graph import CodeGraph
@@ -148,9 +149,42 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
     assert report["passed"] is True
     assert report["artifact"] == identity
     assert report["levels"]["l0"]["documents"] == 1
+    assert report["l0_files"] == ["src/main.py"]
+    assert vector_artifact_files_match(
+        root,
+        embedding_model=model,
+        build_levels=["l0"],
+        expected_fingerprints=report["file_fingerprints"],
+    )
+
+    documents_path = level / f"documents_{suffix}.pkl"
+    original_documents = documents_path.read_bytes()
+    documents_path.write_bytes(original_documents + b"stale")
+    assert not vector_artifact_files_match(
+        root,
+        embedding_model=model,
+        build_levels=["l0"],
+        expected_fingerprints=report["file_fingerprints"],
+    )
+
+    stale_level = root / "l2"
+    stale_level.mkdir()
+    stale_index = stale_level / f"index_{suffix}.faiss"
+    stale_index.write_bytes(b"stale")
+    unexpected = assess_vector_artifact(
+        root,
+        embedding_model=model,
+        build_levels=["l0"],
+        surface=surface,
+        expected_artifact=identity,
+    )
+    assert unexpected["unexpected_levels"] == ["l2"]
+    assert "unexpected_level:l2" in unexpected["failure_names"]
+    stale_index.unlink()
+    stale_level.rmdir()
 
     documents[0].metadata = []
-    with (level / f"documents_{suffix}.pkl").open("wb") as handle:
+    with documents_path.open("wb") as handle:
         pickle.dump(documents, handle)
     invalid = assess_vector_artifact(
         root,
@@ -164,6 +198,20 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
     assert invalid["passed"] is False
     assert "invalid_document_metadata" in invalid["failure_names"]
     assert invalid["paths"]["invalid_metadata"] == 1
+
+    for metadata in ({}, {"file": ""}):
+        documents[0].metadata = metadata
+        with documents_path.open("wb") as handle:
+            pickle.dump(documents, handle)
+        invalid_path = assess_vector_artifact(
+            root,
+            embedding_model=model,
+            build_levels=["l0"],
+            surface=surface,
+            expected_artifact=identity,
+        )
+        assert "invalid_document_paths" in invalid_path["failure_names"]
+        assert invalid_path["paths"]["invalid"]
 
 
 def test_vector_quality_does_not_report_missing_level_as_empty(tmp_path):

--- a/test/compiler/test_artifact_quality.py
+++ b/test/compiler/test_artifact_quality.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import pickle
+import subprocess
+from types import SimpleNamespace
+
+import faiss
+import numpy as np
+
+from codenib.compiler.artifact_quality import (
+    assess_graph_artifact,
+    assess_vector_artifact,
+)
+from codenib.git_snapshot import GitSourceSurface
+from codenib.graph.code_graph import CodeGraph
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def _source_surface(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "src").mkdir()
+    (repo / "src" / "main.py").write_text("def main(): pass\n", encoding="utf-8")
+    _git(repo, "add", "src/main.py")
+    _git(repo, "commit", "-m", "initial")
+    return repo, GitSourceSurface.load(repo)
+
+
+def test_graph_quality_removes_paths_outside_commit(tmp_path):
+    repo, surface = _source_surface(tmp_path)
+    graph = CodeGraph(str(repo))
+    graph.add_root_node(str(repo))
+    graph.add_directory_node("src")
+    graph.add_file_node("src/main.py")
+    graph.add_symbol_node("main", 0, 0, 0, "function")
+    graph.add_directory_node("lib")
+    graph.add_file_node("lib/generated.py")
+    graph.add_symbol_node("generated", 0, 0, 0, "function")
+
+    report = assess_graph_artifact(
+        graph,
+        surface,
+        required_files=["src/main.py"],
+    )
+
+    assert report["passed"] is True
+    assert report["surface"]["removed_outside_paths"] == ["lib/generated.py"]
+    assert "lib/generated.py" not in graph.name_to_vertex
+    assert "generated" not in graph.name_to_vertex
+    assert "src/main.py" in graph.name_to_vertex
+
+
+def test_graph_quality_rejects_missing_required_source_file(tmp_path):
+    repo, surface = _source_surface(tmp_path)
+    graph = CodeGraph(str(repo))
+    graph.add_root_node(str(repo))
+    graph.current_file = "src/main.py"
+    graph.add_symbol_node("reference_only", 0, 0, 0, "symbol")
+
+    report = assess_graph_artifact(
+        graph,
+        surface,
+        required_files=["src/main.py"],
+    )
+
+    assert report["passed"] is False
+    assert "missing_required_source_files" in report["failure_names"]
+
+
+def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
+    _repo, surface = _source_surface(tmp_path)
+    model = "test/model"
+    suffix = "test__model"
+    identity = {
+        "repo": "org/repo",
+        "commit": surface.commit,
+        "tree": surface.tree,
+        "languages": ["python"],
+    }
+    root = tmp_path / "vectors"
+    level = root / "l0"
+    level.mkdir(parents=True)
+    documents = [
+        SimpleNamespace(
+            page_content="def main(): pass\n",
+            metadata={"file": "src/main.py"},
+        )
+    ]
+    with (level / f"documents_{suffix}.pkl").open("wb") as handle:
+        pickle.dump(documents, handle)
+    index = faiss.IndexFlatIP(2)
+    index.add(np.asarray([[1.0, 0.0]], dtype=np.float32))
+    faiss.write_index(index, str(level / f"index_{suffix}.faiss"))
+    (level / f"config_{suffix}.json").write_text(
+        json.dumps({"num_documents": 1}), encoding="utf-8"
+    )
+    (root / f"config_{suffix}.json").write_text(
+        json.dumps({"embedding_model": model, "artifact": identity}),
+        encoding="utf-8",
+    )
+
+    report = assess_vector_artifact(
+        root,
+        embedding_model=model,
+        build_levels=["l0"],
+        surface=surface,
+        expected_artifact=identity,
+        required_l0_files=["src/main.py"],
+    )
+
+    assert report["passed"] is True
+    assert report["artifact"] == identity
+    assert report["levels"]["l0"]["documents"] == 1

--- a/test/compiler/test_artifact_quality.py
+++ b/test/compiler/test_artifact_quality.py
@@ -13,8 +13,8 @@ import faiss
 import numpy as np
 
 from codenib.compiler.artifact_quality import (
-    assess_graph_artifact,
     assess_vector_artifact,
+    constrain_and_assess_graph_artifact,
 )
 from codenib.git_snapshot import GitSourceSurface
 from codenib.graph.code_graph import CodeGraph
@@ -54,7 +54,7 @@ def test_graph_quality_removes_paths_outside_commit(tmp_path):
     graph.add_file_node("lib/generated.py")
     graph.add_symbol_node("generated", 0, 0, 0, "function")
 
-    report = assess_graph_artifact(
+    report = constrain_and_assess_graph_artifact(
         graph,
         surface,
         required_files=["src/main.py"],
@@ -74,7 +74,7 @@ def test_graph_quality_rejects_missing_required_source_file(tmp_path):
     graph.current_file = "src/main.py"
     graph.add_symbol_node("reference_only", 0, 0, 0, "symbol")
 
-    report = assess_graph_artifact(
+    report = constrain_and_assess_graph_artifact(
         graph,
         surface,
         required_files=["src/main.py"],
@@ -82,6 +82,26 @@ def test_graph_quality_rejects_missing_required_source_file(tmp_path):
 
     assert report["passed"] is False
     assert "missing_required_source_files" in report["failure_names"]
+
+
+def test_graph_quality_reports_malformed_paths_before_constraining(tmp_path):
+    repo, surface = _source_surface(tmp_path)
+    graph = CodeGraph(str(repo))
+    graph.add_root_node(str(repo))
+    graph.add_file_node("src/main.py")
+    graph.add_file_node("../generated.py")
+
+    report = constrain_and_assess_graph_artifact(
+        graph,
+        surface,
+        required_files=["src/main.py"],
+    )
+
+    assert report["passed"] is False
+    assert "invalid_graph_paths" in report["failure_names"]
+    assert report["surface"]["invalid_paths_before"]
+    assert report["surface"]["invalid_paths_after"] == []
+    assert "../generated.py" not in graph.name_to_vertex
 
 
 def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
@@ -128,3 +148,43 @@ def test_vector_quality_checks_identity_counts_paths_and_l0_coverage(tmp_path):
     assert report["passed"] is True
     assert report["artifact"] == identity
     assert report["levels"]["l0"]["documents"] == 1
+
+    documents[0].metadata = []
+    with (level / f"documents_{suffix}.pkl").open("wb") as handle:
+        pickle.dump(documents, handle)
+    invalid = assess_vector_artifact(
+        root,
+        embedding_model=model,
+        build_levels=["l0"],
+        surface=surface,
+        expected_artifact=identity,
+        required_l0_files=["src/main.py"],
+    )
+
+    assert invalid["passed"] is False
+    assert "invalid_document_metadata" in invalid["failure_names"]
+    assert invalid["paths"]["invalid_metadata"] == 1
+
+
+def test_vector_quality_does_not_report_missing_level_as_empty(tmp_path):
+    _repo, surface = _source_surface(tmp_path)
+    model = "test/model"
+    root = tmp_path / "vectors"
+    root.mkdir()
+    identity = {"repo": "org/repo", "commit": surface.commit}
+    (root / "config_test__model.json").write_text(
+        json.dumps({"embedding_model": model, "artifact": identity}),
+        encoding="utf-8",
+    )
+
+    report = assess_vector_artifact(
+        root,
+        embedding_model=model,
+        build_levels=["l0"],
+        surface=surface,
+        expected_artifact=identity,
+    )
+
+    failures = report["levels"]["l0"]["failures"]
+    assert any(failure.startswith("missing:") for failure in failures)
+    assert "empty_level" not in failures

--- a/test/compiler/test_snapshot_store.py
+++ b/test/compiler/test_snapshot_store.py
@@ -32,7 +32,10 @@ def _make_repo(path):
     _git(path, "config", "user.email", "test@example.com")
     _git(path, "config", "user.name", "Test User")
     (path / "main.py").write_text("VALUE = 1\n", encoding="utf-8")
-    (path / ".gitignore").write_text("lib/\nnode_modules/\n", encoding="utf-8")
+    (path / ".gitignore").write_text(
+        "lib/\nnode_modules/\ncompile_commands.json\n*.so\n",
+        encoding="utf-8",
+    )
     _git(path, "add", "main.py", ".gitignore")
     _git(path, "commit", "-m", "initial")
     return _git(path, "rev-parse", "HEAD")
@@ -125,6 +128,10 @@ def test_ensure_worktree_removes_visible_generated_files_but_keeps_tool_cache(
     (worktree / "scratch.py").write_text("temporary\n", encoding="utf-8")
     (worktree / "lib").mkdir()
     (worktree / "lib" / "generated.py").write_text("generated\n", encoding="utf-8")
+    compile_commands = worktree / "compile_commands.json"
+    compile_commands.write_text("[]\n", encoding="utf-8")
+    extension = worktree / "codenib_core.so"
+    extension.write_bytes(b"compiled-extension")
     (worktree / "node_modules" / "pkg").mkdir(parents=True)
     cached = worktree / "node_modules" / "pkg" / "index.js"
     cached.write_text("cached\n", encoding="utf-8")
@@ -134,4 +141,6 @@ def test_ensure_worktree_removes_visible_generated_files_but_keeps_tool_cache(
     assert (worktree / "main.py").read_text(encoding="utf-8") == "VALUE = 1\n"
     assert not (worktree / "scratch.py").exists()
     assert not (worktree / "lib").exists()
+    assert compile_commands.read_text(encoding="utf-8") == "[]\n"
+    assert extension.read_bytes() == b"compiled-extension"
     assert cached.read_text(encoding="utf-8") == "cached\n"

--- a/test/compiler/test_snapshot_store.py
+++ b/test/compiler/test_snapshot_store.py
@@ -32,7 +32,8 @@ def _make_repo(path):
     _git(path, "config", "user.email", "test@example.com")
     _git(path, "config", "user.name", "Test User")
     (path / "main.py").write_text("VALUE = 1\n", encoding="utf-8")
-    _git(path, "add", "main.py")
+    (path / ".gitignore").write_text("lib/\nnode_modules/\n", encoding="utf-8")
+    _git(path, "add", "main.py", ".gitignore")
     _git(path, "commit", "-m", "initial")
     return _git(path, "rev-parse", "HEAD")
 
@@ -105,3 +106,32 @@ def test_ensure_worktree_is_durable_and_idempotent(tmp_path):
     assert (worktree / "main.py").read_text(encoding="utf-8") == "VALUE = 1\n"
     assert _git(worktree, "rev-parse", "HEAD") == commit
     assert (binding.profile_dir / "repo").resolve() == worktree
+
+
+def test_ensure_worktree_removes_visible_generated_files_but_keeps_tool_cache(
+    tmp_path,
+):
+    source = tmp_path / "source"
+    commit = _make_repo(source)
+    store = SnapshotArtifactStore(tmp_path / "artifacts")
+    binding = store.bind(
+        "org__repo-1",
+        SourceSnapshot("org/repo", commit),
+        ArtifactProfile.create(["python"]),
+    )
+    worktree = store.ensure_worktree(binding, source_repo=source, commit=commit)
+
+    (worktree / "main.py").write_text("VALUE = 2\n", encoding="utf-8")
+    (worktree / "scratch.py").write_text("temporary\n", encoding="utf-8")
+    (worktree / "lib").mkdir()
+    (worktree / "lib" / "generated.py").write_text("generated\n", encoding="utf-8")
+    (worktree / "node_modules" / "pkg").mkdir(parents=True)
+    cached = worktree / "node_modules" / "pkg" / "index.js"
+    cached.write_text("cached\n", encoding="utf-8")
+
+    store.ensure_worktree(binding, source_repo=source, commit=commit)
+
+    assert (worktree / "main.py").read_text(encoding="utf-8") == "VALUE = 1\n"
+    assert not (worktree / "scratch.py").exists()
+    assert not (worktree / "lib").exists()
+    assert cached.read_text(encoding="utf-8") == "cached\n"

--- a/test/eval/test_orcaloca_benchmark_adapter.py
+++ b/test/eval/test_orcaloca_benchmark_adapter.py
@@ -290,6 +290,9 @@ def test_default_runner_forwards_openai_compatible_base_url(
 
     assert captured["llm"]["api_base"] == "https://gateway.example/v1"
     assert captured["agent"]["llm"].__class__ is FakeOpenAI
+    trace_analysis = captured["agent"]["search_input"].trace_analysis_output
+    assert isinstance(trace_analysis, FakeTraceAnalysisOutput)
+    assert vars(trace_analysis) == {}
     assert captured["content"] == "Locate the parser"
     assert execution.tool_calls == 0
 

--- a/test/eval/test_policy_compat.py
+++ b/test/eval/test_policy_compat.py
@@ -5,12 +5,13 @@
 from __future__ import annotations
 
 import json
+import pickle
 import subprocess
 from pathlib import Path
 
 import pytest
 
-from codenib.compiler.manifest import RepoManifest
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.eval.benchmarks.policy_compat import (
     PolicyBenchmarkCase,
     PolicyCaseSet,
@@ -25,6 +26,7 @@ from codenib.eval.benchmarks.policy_compat import (
     source_files,
     write_json_atomic,
 )
+from codenib.graph.code_graph import CodeGraph
 
 COMMIT = "a" * 40
 
@@ -109,10 +111,24 @@ def test_eligibility_checks_checkout_manifest_commit_and_capabilities(
     record = _case_record(tmp_path)
     record["base_commit"] = commit
     record["orcaloca_native_repo_path"] = str(repo)
+    graph_dir = tmp_path / "symbol_graph"
+    graph_dir.mkdir()
+    graph_path = graph_dir / "graph.pkl"
+    CodeGraph(project_root=str(repo)).save_graph(graph_path)
     manifest = RepoManifest(
         repo_path=str(repo),
         commit=commit,
         last_indexed_commit=commit,
+        indexes={
+            "symbol_graph": IndexEntry(
+                index_type="symbol_graph",
+                path=str(graph_dir),
+                built_at="2026-08-02T00:00:00Z",
+                built_at_epoch=0.0,
+                status="fresh",
+                commit=commit,
+            )
+        },
         capabilities={"symbol_navigation": True},
     )
     manifest.save(record["manifest_path"])
@@ -127,6 +143,24 @@ def test_eligibility_checks_checkout_manifest_commit_and_capabilities(
     assert eligible.eligible
     assert eligible.repo_commit == commit
     assert eligible.manifest_commit == commit
+
+    with graph_path.open("rb") as handle:
+        stale_graph = pickle.load(handle)
+    stale_graph["schema_version"] = 4
+    with graph_path.open("wb") as handle:
+        pickle.dump(stale_graph, handle)
+    stale = inspect_case_eligibility(
+        case,
+        agent="orcaloca",
+        provider="codenib",
+        required_capabilities=("symbol_navigation",),
+    )
+    assert not stale.eligible
+    assert any(
+        "manifest capability is unusable at runtime" in reason
+        and "schema_version=4" in reason
+        for reason in stale.reasons
+    )
 
     manifest.capabilities.clear()
     manifest.commit = "b" * 40

--- a/test/eval/test_policy_compat.py
+++ b/test/eval/test_policy_compat.py
@@ -8,6 +8,7 @@ import json
 import pickle
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -143,6 +144,21 @@ def test_eligibility_checks_checkout_manifest_commit_and_capabilities(
     assert eligible.eligible
     assert eligible.repo_commit == commit
     assert eligible.manifest_commit == commit
+
+    with patch(
+        "codenib.mcp.context.ServerContext.validate_views",
+        side_effect=RuntimeError("probe failed"),
+    ):
+        failed_probe = inspect_case_eligibility(
+            case,
+            agent="orcaloca",
+            provider="codenib",
+            required_capabilities=("symbol_navigation",),
+        )
+    assert not failed_probe.eligible
+    assert any(
+        "runtime view validation failed" in reason for reason in failed_probe.reasons
+    )
 
     with graph_path.open("rb") as handle:
         stale_graph = pickle.load(handle)

--- a/test/graph/test_source_coverage.py
+++ b/test/graph/test_source_coverage.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+
+from codenib.git_snapshot import GitSourceSurface
+from codenib.graph.code_graph import CodeGraph
+from codenib.graph.source_coverage import supplement_graph_source_coverage
+from codenib.types import EDGE_TYPE_CONTAIN
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def test_source_coverage_supplements_all_missing_tracked_files(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "src").mkdir()
+    (repo / "src" / "main.py").write_text(
+        "class Service:\n    def run(self):\n        return 1\n",
+        encoding="utf-8",
+    )
+    (repo / "src" / "other.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", "src/main.py", "src/other.py")
+    _git(repo, "commit", "-m", "initial")
+
+    graph = CodeGraph(str(repo))
+    graph.add_root_node(str(repo))
+    report = supplement_graph_source_coverage(
+        graph,
+        repo_root=repo,
+        surface=GitSourceSurface.load(repo),
+        extensions={".py"},
+        represented_paths=(),
+    )
+
+    assert report["supplemented_files"] == 2
+    assert "src/main.py:Service" in graph.name_to_vertex
+    assert "src/main.py:Service.run()" in graph.name_to_vertex
+    contain_edges = [
+        edge
+        for edge in graph.graph.es
+        if edge.attributes().get("type") == EDGE_TYPE_CONTAIN
+    ]
+    assert contain_edges
+
+
+def test_source_coverage_does_not_use_required_file_labels(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "kept.py").write_text("def kept(): pass\n", encoding="utf-8")
+    (repo / "excluded.py").write_text("def excluded(): pass\n", encoding="utf-8")
+    _git(repo, "add", "kept.py", "excluded.py")
+    _git(repo, "commit", "-m", "initial")
+    graph = CodeGraph(str(repo))
+    graph.add_root_node(str(repo))
+
+    report = supplement_graph_source_coverage(
+        graph,
+        repo_root=repo,
+        surface=GitSourceSurface.load(repo),
+        extensions={".py"},
+        represented_paths={"kept.py"},
+        exclude_patterns=["excluded.py"],
+    )
+
+    assert report["candidate_files"] == 0
+    assert report["files"] == []

--- a/test/graph/test_source_coverage.py
+++ b/test/graph/test_source_coverage.py
@@ -82,3 +82,37 @@ def test_source_coverage_does_not_use_required_file_labels(tmp_path):
 
     assert report["candidate_files"] == 0
     assert report["files"] == []
+
+
+def test_source_coverage_records_parser_failure_without_aborting(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "broken.py").write_text("def broken(:\n", encoding="utf-8")
+    _git(repo, "add", "broken.py")
+    _git(repo, "commit", "-m", "initial")
+
+    class BrokenChunker:
+        def chunk_file(self, *_args, **_kwargs):
+            raise ValueError("parser failed")
+
+    monkeypatch.setattr(
+        "codenib.graph.source_coverage.create_chunker",
+        lambda *_args, **_kwargs: BrokenChunker(),
+    )
+    graph = CodeGraph(str(repo))
+    graph.add_root_node(str(repo))
+
+    report = supplement_graph_source_coverage(
+        graph,
+        repo_root=repo,
+        surface=GitSourceSurface.load(repo),
+        extensions={".py"},
+        represented_paths=(),
+    )
+
+    assert report["unreadable_files"] == ["broken.py"]
+    assert report["unreadable_errors"] == {"broken.py": "ValueError: parser failed"}
+    assert report["coverage_after"] == 0.0

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -52,8 +52,10 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
         embedding_provider="huggingface",
         embedding_dimension=2,
         embedding=embedding,
+        artifact_metadata={"commit": "a" * 40},
         force_rebuild=True,
     )
 
     assert captured["embedding"] is embedding
+    assert captured["artifact_metadata"] == {"commit": "a" * 40}
     assert result.l2_documents

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -42,6 +42,19 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
     monkeypatch.setattr(builders, "CodeChunker", FakeChunker)
     monkeypatch.setattr(builders, "CodeVectorStore", FakeStore)
     embedding = object()
+    stale_level = tmp_path / "index" / "l0"
+    stale_level.mkdir(parents=True)
+    model_suffix = "test-model"
+    stale_files = [
+        stale_level / f"config_{model_suffix}.json",
+        stale_level / f"index_{model_suffix}.faiss",
+        stale_level / f"documents_{model_suffix}.pkl",
+        stale_level / f"index_{model_suffix}.pkl",
+    ]
+    for path in stale_files:
+        path.write_bytes(b"stale")
+    unrelated = stale_level / "index_other-model.faiss"
+    unrelated.write_bytes(b"other")
 
     result = builders.build_hierarchical_vector_store(
         repo_path=str(tmp_path),
@@ -59,3 +72,5 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
     assert captured["embedding"] is embedding
     assert captured["artifact_metadata"] == {"commit": "a" * 40}
     assert result.l2_documents
+    assert all(not path.exists() for path in stale_files)
+    assert unrelated.read_bytes() == b"other"

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -14,6 +14,7 @@ found even at ``nprobe=1``.
 from __future__ import annotations
 
 import hashlib
+import json
 from unittest.mock import patch
 
 import faiss
@@ -166,3 +167,30 @@ def test_ivf_save_load_roundtrip(tmp_path):
     assert loaded.l2_index.ntotal == 5
     res = loaded.search(chunks[1]["content"], top_k=3)
     assert res and res[0].node_name == chunks[1]["name"]
+
+
+def test_load_rejects_faiss_dimension_mismatch(tmp_path):
+    path = tmp_path / "vs"
+    model = "test/model"
+    store = _make_store(embedding_model=model)
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+
+    config_path = path / "config_test__model.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["dimension"] = 8
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with patch.object(
+        CodeVectorStore,
+        "_initialize_embedding_model",
+        return_value=_FakeEmbedding(8),
+    ):
+        loaded = CodeVectorStore(
+            embedding_model=model,
+            dimension=8,
+            store_path=str(path),
+        )
+
+    with pytest.raises(ValueError, match="FAISS dimension mismatch"):
+        loaded.load()

--- a/test/integrations/test_orcaloca_upstream.py
+++ b/test/integrations/test_orcaloca_upstream.py
@@ -320,3 +320,17 @@ def test_search_agent_injects_provider_without_upstream_build(
     assert isinstance(agent._search_manager, OrcaLocaSearchProvider)
     assert agent._search_manager.repo_path == str(Path(manifest.repo_path).resolve())
     assert not (Path(manifest.repo_path) / "_index_data").exists()
+
+
+def test_empty_trace_analysis_is_a_valid_upstream_input(
+    upstream_modules: SimpleNamespace,
+) -> None:
+    trace = upstream_modules.types.TraceAnalysisOutput()
+
+    assert trace.summary == ""
+    assert trace.suspicious_code == []
+    assert trace.suspicious_code_from_tracer == []
+    assert trace.related_source_code == ""
+    assert trace.is_reproduce_pass is False
+    assert trace.reproduce_code == ""
+    assert trace.env_reproduce_path == ""

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -251,6 +251,40 @@ def test_validate_views_probes_vector_without_loading_embedding_model(
     vector.close.assert_called_once_with()
 
 
+def test_validate_views_rejects_empty_vector_artifact(tmp_path: Path) -> None:
+    vector_dir = tmp_path / "vector"
+    vector_dir.mkdir()
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path=str(vector_dir),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=0.0,
+                status="fresh",
+                config={
+                    "embedding_model": "test-model",
+                    "embedding_provider": "huggingface",
+                    "embedding_dimension": 384,
+                },
+            ),
+        },
+    )
+    vector = MagicMock()
+    vector.embedding_model = "test-model"
+    vector.get_stats.return_value = {"total_documents": 0}
+
+    with patch(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        return_value=vector,
+    ):
+        errors = ServerContext.validate_views(manifest, views={"vector"})
+
+    assert errors == {"vector": "vector index contains no documents"}
+    vector.close.assert_called_once_with()
+
+
 def test_regex_index_built_when_graph_available(manifest_dir: Path) -> None:
     """RegexNodeIndex is built when symbol_graph loads successfully."""
     graph_dir = manifest_dir / "symbol_graph"
@@ -325,6 +359,25 @@ def test_zoekt_started_when_entry_fresh(manifest_dir: Path) -> None:
     fake_searcher.start.assert_called_once()
     assert ctx.zoekt is fake_searcher
     assert "zoekt" not in ctx.errors
+
+
+def test_validate_views_stops_zoekt_probe(manifest_dir: Path) -> None:
+    shard_dir = manifest_dir / "zoekt"
+    shard_dir.mkdir()
+    manifest_path = manifest_dir / "repo_manifest.json"
+    _add_zoekt_entry(manifest_path, shard_dir)
+    fake_searcher = MagicMock()
+    fake_searcher.port = 9999
+
+    with patch(
+        "codenib.index.trigram.ZoektSearcher",
+        return_value=fake_searcher,
+    ):
+        errors = ServerContext.validate_views(manifest_path, views={"zoekt"})
+
+    assert errors == {}
+    fake_searcher.start.assert_called_once_with()
+    fake_searcher.stop.assert_called_once_with()
 
 
 def test_zoekt_unavailable_recorded_in_errors(manifest_dir: Path) -> None:

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -213,6 +213,44 @@ def test_load_vector_accepts_compiler_manifest_identity(tmp_path: Path) -> None:
     assert "vector" not in ctx.errors
 
 
+def test_validate_views_probes_vector_without_loading_embedding_model(
+    tmp_path: Path,
+) -> None:
+    vector_dir = tmp_path / "vector"
+    vector_dir.mkdir()
+    manifest = RepoManifest(
+        repo_path=str(tmp_path),
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path=str(vector_dir),
+                built_at="2026-01-01T00:00:00",
+                built_at_epoch=0.0,
+                status="fresh",
+                config={
+                    "embedding_model": "test-model",
+                    "embedding_provider": "huggingface",
+                    "embedding_dimension": 384,
+                },
+            ),
+        },
+    )
+    vector = MagicMock()
+    vector.embedding_model = "test-model"
+    vector.get_stats.return_value = {"total_documents": 3}
+
+    with patch(
+        "codenib.index.embedding.vector_store.CodeVectorStore",
+        return_value=vector,
+    ) as cls:
+        errors = ServerContext.validate_views(manifest, views={"vector"})
+
+    assert errors == {}
+    assert cls.call_args.kwargs["embedding"].dimension == 384
+    vector.load.assert_called_once_with()
+    vector.close.assert_called_once_with()
+
+
 def test_regex_index_built_when_graph_available(manifest_dir: Path) -> None:
     """RegexNodeIndex is built when symbol_graph loads successfully."""
     graph_dir = manifest_dir / "symbol_graph"

--- a/test/scripts/test_snapshot_artifact_builders.py
+++ b/test/scripts/test_snapshot_artifact_builders.py
@@ -9,8 +9,12 @@ from types import SimpleNamespace
 
 import pytest
 
-from codenib.compiler.artifact_quality import ARTIFACT_QUALITY_SCHEMA_VERSION
+from codenib.compiler.artifact_quality import (
+    ARTIFACT_QUALITY_SCHEMA_VERSION,
+    vector_artifact_file_fingerprints,
+)
 from codenib.compiler.snapshot_store import ArtifactProfile
+from codenib.repository_filters import REPOSITORY_FILTER_POLICY_VERSION
 from scripts import swebench_graph_index
 from scripts.embeddings import build_embeddings
 
@@ -50,6 +54,41 @@ def test_embedding_resolves_language_from_multilingual_repo_map():
     ) == ["java"]
 
 
+@pytest.mark.parametrize(("configured", "effective"), [(None, 300), (128, 128)])
+def test_embedding_artifact_records_effective_l0_fallback_limit(configured, effective):
+    args = SimpleNamespace(
+        max_lines_per_chunk=configured,
+        embedding_provider="huggingface",
+        embedding_dimension=384,
+        index_type="flat",
+        index_metric="ip",
+        ivf_nlist=100,
+        ivf_nprobe=8,
+        max_seq_length=8192,
+    )
+
+    configuration = build_embeddings._artifact_configuration(
+        languages=["cpp"],
+        build_levels=["l0", "l2"],
+        args=args,
+    )
+
+    assert configuration["chunking"]["l0_raw_fallback_max_lines"] == effective
+
+
+def test_graph_artifact_identity_tracks_repository_filter_policy():
+    metadata = swebench_graph_index._graph_artifact_metadata(
+        repo="org/repo",
+        surface=SimpleNamespace(commit="a" * 40, tree="b" * 40),
+        language="python",
+        exclude_patterns=(),
+        enforce_commit_surface=True,
+        source_coverage_fallback=True,
+    )
+
+    assert metadata["repository_filter_policy"] == REPOSITORY_FILTER_POLICY_VERSION
+
+
 def test_graph_builder_supports_codenib_base_source(monkeypatch, tmp_path):
     captured = {}
 
@@ -73,7 +112,9 @@ def test_graph_builder_supports_codenib_base_source(monkeypatch, tmp_path):
     assert captured["repo_root"] == str(tmp_path / "repos")
 
 
-def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
+def test_isolated_embedding_reuse_requires_passing_quality_report(
+    monkeypatch, tmp_path
+):
     root = tmp_path / "artifact"
     root.mkdir()
     model = "test/model"
@@ -82,6 +123,23 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
         "repo": "org/repo",
         "base_commit": "a" * 40,
     }
+    files_match = True
+    monkeypatch.setattr(
+        build_embeddings,
+        "vector_artifact_files_match",
+        lambda *_args, **_kwargs: files_match,
+    )
+
+    def is_reusable(expected_configuration=None, required_l0_files=()):
+        return build_embeddings._quality_report_is_reusable(
+            root,
+            embedding_model=model,
+            instance=instance,
+            expected_configuration=expected_configuration or {},
+            build_levels=["l0"],
+            required_l0_files=required_l0_files,
+        )
+
     (root / f"config_{suffix}.json").write_text(
         json.dumps(
             {
@@ -104,11 +162,7 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
         encoding="utf-8",
     )
 
-    assert not build_embeddings._quality_report_is_reusable(
-        root,
-        embedding_model=model,
-        instance=instance,
-    )
+    assert not is_reusable()
 
     artifact = {
         "repo": "org/repo",
@@ -118,11 +172,7 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
         json.dumps({"passed": True, "artifact": artifact}),
         encoding="utf-8",
     )
-    assert not build_embeddings._quality_report_is_reusable(
-        root,
-        embedding_model=model,
-        instance=instance,
-    )
+    assert not is_reusable()
 
     quality_path.write_text(
         json.dumps(
@@ -134,11 +184,7 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
         ),
         encoding="utf-8",
     )
-    assert not build_embeddings._quality_report_is_reusable(
-        root,
-        embedding_model=model,
-        instance=instance,
-    )
+    assert not is_reusable()
 
     quality_path.write_text(
         json.dumps(
@@ -146,16 +192,17 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
                 "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
                 "passed": True,
                 "artifact": artifact,
+                "l0_files": [],
             }
         ),
         encoding="utf-8",
     )
-    assert build_embeddings._quality_report_is_reusable(
-        root,
-        embedding_model=model,
-        instance=instance,
-        expected_configuration={},
-    )
+    assert is_reusable()
+    assert not is_reusable(required_l0_files=("src/required.py",))
+
+    files_match = False
+    assert not is_reusable()
+    files_match = True
 
     short_artifact = {**artifact, "commit": "a"}
     (root / f"config_{suffix}.json").write_text(
@@ -172,12 +219,7 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
         ),
         encoding="utf-8",
     )
-    assert not build_embeddings._quality_report_is_reusable(
-        root,
-        embedding_model=model,
-        instance=instance,
-        expected_configuration={},
-    )
+    assert not is_reusable()
 
     (root / f"config_{suffix}.json").write_text(
         json.dumps({"artifact": artifact}),
@@ -194,12 +236,58 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
         encoding="utf-8",
     )
 
-    assert not build_embeddings._quality_report_is_reusable(
-        root,
-        embedding_model=model,
-        instance=instance,
-        expected_configuration={"build_levels": ["l0", "l2"]},
+    assert not is_reusable(expected_configuration={"build_levels": ["l0", "l2"]})
+
+
+def test_isolated_embedding_reuse_revalidates_assessed_files(tmp_path):
+    root = tmp_path / "artifact"
+    level = root / "l0"
+    level.mkdir(parents=True)
+    model = "test/model"
+    suffix = "test__model"
+    artifact = {"repo": "org/repo", "commit": "a" * 40}
+    (root / f"config_{suffix}.json").write_text(
+        json.dumps({"artifact": artifact}), encoding="utf-8"
     )
+    for name in (
+        f"config_{suffix}.json",
+        f"index_{suffix}.faiss",
+        f"documents_{suffix}.pkl",
+    ):
+        (level / name).write_bytes(name.encode("utf-8"))
+    quality_path = root / f"artifact_quality_{suffix}.json"
+    quality_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+                "passed": True,
+                "artifact": artifact,
+                "l0_files": ["src/main.py"],
+                "file_fingerprints": vector_artifact_file_fingerprints(
+                    root,
+                    embedding_model=model,
+                    build_levels=["l0"],
+                ),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    kwargs = {
+        "embedding_model": model,
+        "instance": {
+            "repo": "org/repo",
+            "base_commit": "a" * 40,
+        },
+        "expected_configuration": {},
+        "build_levels": ["l0"],
+        "required_l0_files": ["src/main.py"],
+    }
+    assert build_embeddings._quality_report_is_reusable(root, **kwargs)
+
+    (level / f"index_{suffix}.faiss").write_bytes(b"corrupt")
+
+    assert not build_embeddings._quality_report_is_reusable(root, **kwargs)
 
 
 def test_graph_reuse_requires_matching_artifact_provenance(tmp_path):

--- a/test/scripts/test_snapshot_artifact_builders.py
+++ b/test/scripts/test_snapshot_artifact_builders.py
@@ -157,6 +157,43 @@ def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
         expected_configuration={},
     )
 
+    short_artifact = {**artifact, "commit": "a"}
+    (root / f"config_{suffix}.json").write_text(
+        json.dumps({"artifact": short_artifact}),
+        encoding="utf-8",
+    )
+    quality_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+                "passed": True,
+                "artifact": short_artifact,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert not build_embeddings._quality_report_is_reusable(
+        root,
+        embedding_model=model,
+        instance=instance,
+        expected_configuration={},
+    )
+
+    (root / f"config_{suffix}.json").write_text(
+        json.dumps({"artifact": artifact}),
+        encoding="utf-8",
+    )
+    quality_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+                "passed": True,
+                "artifact": artifact,
+            }
+        ),
+        encoding="utf-8",
+    )
+
     assert not build_embeddings._quality_report_is_reusable(
         root,
         embedding_model=model,

--- a/test/scripts/test_snapshot_artifact_builders.py
+++ b/test/scripts/test_snapshot_artifact_builders.py
@@ -4,8 +4,12 @@
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+
 import pytest
 
+from codenib.compiler.artifact_quality import ARTIFACT_QUALITY_SCHEMA_VERSION
 from codenib.compiler.snapshot_store import ArtifactProfile
 from scripts import swebench_graph_index
 from scripts.embeddings import build_embeddings
@@ -44,3 +48,169 @@ def test_embedding_resolves_language_from_multilingual_repo_map():
         ["python"],
         {"google/gson": "Java"},
     ) == ["java"]
+
+
+def test_graph_builder_supports_codenib_base_source(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeDataset:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(swebench_graph_index, "CodeNibBaseDataset", FakeDataset)
+    args = SimpleNamespace(
+        split="test",
+        filter_instance=".*",
+        cache_dir=str(tmp_path / "cache"),
+        repo_cache_dir=str(tmp_path / "repos"),
+        codenib_base_dataset="org/codenib-base",
+    )
+
+    dataset = swebench_graph_index._build_dataset("codenib_base", args)
+
+    assert isinstance(dataset, FakeDataset)
+    assert captured["dataset"] == "org/codenib-base"
+    assert captured["repo_root"] == str(tmp_path / "repos")
+
+
+def test_isolated_embedding_reuse_requires_passing_quality_report(tmp_path):
+    root = tmp_path / "artifact"
+    root.mkdir()
+    model = "test/model"
+    suffix = "test__model"
+    instance = {
+        "repo": "org/repo",
+        "base_commit": "a" * 40,
+    }
+    (root / f"config_{suffix}.json").write_text(
+        json.dumps(
+            {
+                "artifact": {
+                    "repo": "org/repo",
+                    "commit": "a" * 40,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    quality_path = root / f"artifact_quality_{suffix}.json"
+    quality_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+                "passed": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert not build_embeddings._quality_report_is_reusable(
+        root,
+        embedding_model=model,
+        instance=instance,
+    )
+
+    artifact = {
+        "repo": "org/repo",
+        "commit": "a" * 40,
+    }
+    quality_path.write_text(
+        json.dumps({"passed": True, "artifact": artifact}),
+        encoding="utf-8",
+    )
+    assert not build_embeddings._quality_report_is_reusable(
+        root,
+        embedding_model=model,
+        instance=instance,
+    )
+
+    quality_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+                "passed": True,
+                "artifact": {**artifact, "repo": "org/other"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert not build_embeddings._quality_report_is_reusable(
+        root,
+        embedding_model=model,
+        instance=instance,
+    )
+
+    quality_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+                "passed": True,
+                "artifact": artifact,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert build_embeddings._quality_report_is_reusable(
+        root,
+        embedding_model=model,
+        instance=instance,
+        expected_configuration={},
+    )
+
+    assert not build_embeddings._quality_report_is_reusable(
+        root,
+        embedding_model=model,
+        instance=instance,
+        expected_configuration={"build_levels": ["l0", "l2"]},
+    )
+
+
+def test_graph_reuse_requires_matching_artifact_provenance(tmp_path):
+    expected = {
+        "repo": "org/repo",
+        "commit": "a" * 40,
+        "tree": "b" * 40,
+        "language": "python",
+    }
+
+    assert not swebench_graph_index._graph_quality_is_reusable(
+        tmp_path,
+        expected_artifact=expected,
+    )
+
+    quality_path = tmp_path / "artifact_quality.json"
+    quality_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+                "passed": False,
+                "artifact": expected,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert not swebench_graph_index._graph_quality_is_reusable(
+        tmp_path,
+        expected_artifact=expected,
+    )
+
+    quality_path.write_text(
+        json.dumps(
+            {
+                "schema_version": ARTIFACT_QUALITY_SCHEMA_VERSION,
+                "passed": True,
+                "artifact": expected,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert swebench_graph_index._graph_quality_is_reusable(
+        tmp_path,
+        expected_artifact=expected,
+    )
+
+    changed = {**expected, "language": "go"}
+    assert not swebench_graph_index._graph_quality_is_reusable(
+        tmp_path,
+        expected_artifact=changed,
+    )

--- a/test/test_git_snapshot.py
+++ b/test/test_git_snapshot.py
@@ -8,7 +8,11 @@ import subprocess
 
 import pytest
 
-from codenib.git_snapshot import GitSourceSurface, normalize_repository_path
+from codenib.git_snapshot import (
+    GitSourceSurface,
+    normalize_repository_path,
+    restore_git_worktree,
+)
 
 
 def _git(repo, *args):
@@ -48,3 +52,54 @@ def test_git_source_surface_classifies_commit_paths(tmp_path):
 def test_normalize_repository_path_rejects_escape(path):
     with pytest.raises(ValueError):
         normalize_repository_path(path)
+
+
+def test_restore_git_worktree_hydrates_recorded_submodule_commit(tmp_path):
+    dependency = tmp_path / "dependency"
+    dependency.mkdir()
+    _git(dependency, "init")
+    _git(dependency, "config", "user.email", "test@example.com")
+    _git(dependency, "config", "user.name", "Test User")
+    (dependency / "value.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(dependency, "add", "value.py")
+    _git(dependency, "commit", "-m", "first")
+    first = _git(dependency, "rev-parse", "HEAD")
+    (dependency / "value.py").write_text("VALUE = 2\n", encoding="utf-8")
+    _git(dependency, "commit", "-am", "second")
+    second = _git(dependency, "rev-parse", "HEAD")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    _git(
+        repo,
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        str(dependency),
+        "vendor/dependency",
+    )
+    submodule = repo / "vendor" / "dependency"
+    _git(submodule, "checkout", "--detach", first)
+    _git(repo, "add", ".gitmodules", "vendor/dependency")
+    _git(repo, "commit", "-m", "pin dependency")
+    parent_commit = _git(repo, "rev-parse", "HEAD")
+
+    _git(submodule, "checkout", "--detach", second)
+    assert (submodule / "value.py").read_text(encoding="utf-8") == "VALUE = 2\n"
+
+    restore_git_worktree(repo, parent_commit)
+
+    assert _git(submodule, "rev-parse", "HEAD") == first
+    assert (submodule / "value.py").read_text(encoding="utf-8") == "VALUE = 1\n"
+
+    _git(repo, "submodule", "deinit", "--force", "vendor/dependency")
+    assert not (submodule / "value.py").exists()
+
+    restore_git_worktree(repo, parent_commit)
+
+    assert _git(submodule, "rev-parse", "HEAD") == first
+    assert (submodule / "value.py").read_text(encoding="utf-8") == "VALUE = 1\n"

--- a/test/test_git_snapshot.py
+++ b/test/test_git_snapshot.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from codenib.git_snapshot import GitSourceSurface, normalize_repository_path
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+
+def test_git_source_surface_classifies_commit_paths(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "src").mkdir()
+    (repo / "src" / "main.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", "src/main.py")
+    _git(repo, "commit", "-m", "initial")
+
+    surface = GitSourceSurface.load(repo)
+
+    assert surface.contains("src/main.py")
+    assert surface.contains("./src/main.py")
+    assert not surface.contains("lib/generated.py")
+    assert surface.classify(["src/main.py", "lib/generated.py"]) == {
+        "tracked": ("src/main.py",),
+        "submodule": (),
+        "outside": ("lib/generated.py",),
+    }
+
+
+@pytest.mark.parametrize("path", ["../escape.py", "/tmp/escape.py", ""])
+def test_normalize_repository_path_rejects_escape(path):
+    with pytest.raises(ValueError):
+        normalize_repository_path(path)


### PR DESCRIPTION
## Summary

Harden repository benchmark artifacts and external-policy evaluation so stale, dirty, incomplete, or unloadable views fail before model calls. The shared indexing fixes also keep raw L0 fallbacks bounded and make persisted vector contracts enforceable at load time.

## Changes

- Prepare benchmark cases from clean, exact-commit Git snapshots and restore recursive submodules to their recorded gitlink commits.
- Remove only ignored source files visible to index builders while preserving compile databases, compiled extensions, dependency caches, and other non-source build inputs.
- Bound empty-skeleton raw L0 fallbacks by default while preserving the existing unsplit L2 default and explicit overrides.
- Add reusable graph and vector artifact-quality checks for source coverage, graph-size ratios, persisted metadata, compile-database coverage, malformed source paths, and missing document paths.
- Bind reusable vector quality reports to SHA-256 fingerprints of every validated config, FAISS, and document file plus the represented L0 file set.
- Reject unrequested stale vector levels, remove current-model leftovers during forced rebuilds, and reject saved FAISS/config dimensions that disagree with the runtime contract.
- Include repository filter policy in graph artifact identity.
- Reject incomplete C/C++ and embedding artifacts in indexing scripts and record durable snapshot identity.
- Validate required policy views before model calls; vector preflight opens saved FAISS/document data with a fixed-dimension probe, and temporary vector/Zoekt resources are released.
- Clarify OrcaLoca SearchAgent support, empty `TraceAnalysisOutput` semantics, provider provenance, and supported integration levels in README and docs.
- Add unit and pinned-upstream contract coverage for the guardrails.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Focused artifact/runtime regression suite: `146 passed`
- Unit tier: `2409 passed`, `10 skipped`
- Integration tier: `36 passed`, `8 skipped`
- Serial integration tier: `37 passed`, `8 skipped`
- Serial graph-consumer tier: `48 passed`, `13 skipped`
- Pinned OrcaLoca upstream probe: `4 passed`
- `mkdocs build --strict`
- `pre-commit run --files ...`
- Paired model smoke: all 20 Python cases from codenib-base plus a four-case SWE-bench Lite slice; all requested cells retained in the scorer denominator.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

