### PR TITLE
refactor(integrations): make LocAgent delivery CodeNib-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ agent or code-Wiki framework.
 
 ## News
 
+- **2026-08-03 — LocAgent policy integration.** CodeNib now runs LocAgent's
+  revision-pinned prompts and function-calling loop over manifest-backed BM25
+  and symbol-graph views. The paired harness swaps the native and CodeNib data
+  planes under one policy and applies strict case, provenance, and denominator
+  checks with common ranked localization metrics.
 - **2026-08-02 — OrcaLoca SearchAgent integration.** CodeNib can now serve a
   revision-pinned OrcaLoca `SearchAgent` through its manifest-backed symbol
   graph, preserving the upstream six-tool and private-hook contract without

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ agent or code-Wiki framework.
 
 ## News
 
-- **2026-08-03 — LocAgent policy integration.** CodeNib now runs LocAgent's
-  revision-pinned prompts and function-calling loop over manifest-backed BM25
-  and symbol-graph views. The paired harness swaps the native and CodeNib data
-  planes under one policy and applies strict case, provenance, and denominator
-  checks with common ranked localization metrics.
+- **2026-08-03 — Native LocAgent policy integration.** CodeNib now runs
+  revision-pinned LocAgent prompts and its function-calling loop directly over
+  manifest-backed BM25 and symbol-graph views without importing LocAgent,
+  LiteLLM, or LlamaIndex. The paired harness applies strict case,
+  provenance, denominator, and ranked-localization checks.
 - **2026-08-02 — OrcaLoca SearchAgent integration.** CodeNib can now serve a
   revision-pinned OrcaLoca `SearchAgent` through its manifest-backed symbol
   graph, preserving the upstream six-tool and private-hook contract without

--- a/codenib/clients/locagent_agent.py
+++ b/codenib/clients/locagent_agent.py
@@ -8,16 +8,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import subprocess
-import sys
 import time
 from dataclasses import dataclass
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence
 
 from codenib.clients._manifest import ManifestResolver, select_checkout_manifest
+from codenib.clients.locagent_protocol import LocAgentProtocol, build_locagent_protocol
 from codenib.eval.baseline import BaselineLocation, BaselineRunResult
 from codenib.eval.benchmarks.locagent import LocAgentLocation, parse_locagent_locations
 from codenib.integrations._repository import RepositoryAdapter, RepositoryEntity
@@ -28,38 +25,6 @@ from codenib.types import (
     NODE_TYPE_METHOD,
     NODE_TYPE_SYMBOL,
 )
-
-_READ_ONLY_WARNING = (
-    "IMPORTANT: You should only use the provided read-only tools, never ask "
-    "for human help, and never modify files.\n"
-)
-_PROTOCOL_EXTRACT_TIMEOUT_SECONDS = 60
-_PROTOCOL_EXTRACT_SCRIPT = r"""
-import contextlib
-import io
-import json
-
-captured = io.StringIO()
-with contextlib.redirect_stdout(captured):
-    from util.prompts import general_prompt
-    from util.prompts.pipelines import auto_search_prompt
-    from util.runtime import function_calling
-
-    tools = function_calling.get_tools(
-        codeact_enable_search_keyword=True,
-        codeact_enable_search_entity=True,
-        codeact_enable_tree_structure_traverser=True,
-        simple_desc=False,
-    )
-
-print(json.dumps({
-    "system_prompt": function_calling.SYSTEM_PROMPT,
-    "task_template": auto_search_prompt.TASK_INSTRUECTION,
-    "pr_template": general_prompt.PR_TEMPLATE,
-    "followup": auto_search_prompt.FAKE_USER_MSG_FOR_LOC,
-    "tools": tools,
-}))
-"""
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,16 +37,6 @@ class LocAgentExecution:
     iterations: Optional[int] = None
     tool_trace: Sequence[Mapping[str, Any]] = ()
     trajectory: Sequence[Mapping[str, Any]] = ()
-
-
-@dataclass(frozen=True, slots=True)
-class LocAgentProtocol:
-    """Pinned upstream prompts and OpenAI-compatible function schemas."""
-
-    system_prompt: str
-    instruction: str
-    followup: str
-    tools: tuple[Mapping[str, Any], ...]
 
 
 LocAgentPolicyRunner = Callable[
@@ -251,104 +206,24 @@ def locagent_locations_to_baseline(
     return tuple(output)
 
 
-@lru_cache(maxsize=8)
-def _load_upstream_assets(
-    checkout_value: str,
-    python_value: str,
-) -> tuple[str, str, str, str, tuple[Mapping[str, Any], ...]]:
-    checkout = Path(checkout_value).expanduser().resolve()
-    if not (checkout / "util" / "runtime" / "function_calling.py").is_file():
-        raise FileNotFoundError(f"Not a LocAgent checkout: {checkout}")
-    python = Path(python_value).expanduser().resolve()
-    if not python.is_file():
-        raise FileNotFoundError(f"LocAgent Python executable not found: {python}")
-
-    env = os.environ.copy()
-    current_pythonpath = env.get("PYTHONPATH")
-    env["PYTHONPATH"] = (
-        str(checkout)
-        if not current_pythonpath
-        else os.pathsep.join((str(checkout), current_pythonpath))
-    )
-    try:
-        completed = subprocess.run(
-            [str(python), "-c", _PROTOCOL_EXTRACT_SCRIPT],
-            cwd=checkout,
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=_PROTOCOL_EXTRACT_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(
-            "LocAgent protocol extraction timed out after "
-            f"{_PROTOCOL_EXTRACT_TIMEOUT_SECONDS}s"
-        ) from exc
-    if completed.returncode != 0:
-        detail = completed.stderr.strip() or completed.stdout.strip()
-        raise RuntimeError(f"LocAgent protocol extraction failed: {detail}")
-    try:
-        payload = json.loads(completed.stdout)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(
-            "LocAgent protocol extraction returned invalid JSON"
-        ) from exc
-    if not isinstance(payload, Mapping):
-        raise RuntimeError("LocAgent protocol extraction returned a non-object")
-    required = {
-        "system_prompt",
-        "task_template",
-        "pr_template",
-        "followup",
-        "tools",
-    }
-    missing = required - set(payload)
-    if missing:
-        raise RuntimeError(
-            "LocAgent protocol extraction omitted " + ", ".join(sorted(missing))
-        )
-    tools = payload.get("tools")
-    if not isinstance(tools, Sequence) or isinstance(tools, (str, bytes)):
-        raise RuntimeError("LocAgent protocol extraction returned invalid tools")
-    return (
-        str(payload["system_prompt"]),
-        str(payload["task_template"]),
-        str(payload["pr_template"]),
-        str(payload["followup"]),
-        tuple(json.loads(json.dumps(tools))),
-    )
-
-
 def load_locagent_protocol(
-    checkout: str | Path,
+    checkout: str | Path | None = None,
     *,
     problem_statement: str,
     package_name: str,
     python_executable: str | Path | None = None,
 ) -> LocAgentProtocol:
-    """Extract pinned LocAgent prompts and schemas in an isolated process."""
+    """Build the vendored protocol; legacy path arguments are ignored."""
 
-    system_prompt, task_template, pr_template, followup, tools = _load_upstream_assets(
-        str(Path(checkout).expanduser().resolve()),
-        str(Path(python_executable or sys.executable).expanduser().resolve()),
-    )
-    lines = problem_statement.strip().splitlines()
-    instruction = task_template.format(package_name=package_name)
-    instruction += pr_template.format(
-        title=lines[0] if lines else "",
-        description="\n".join(lines[1:]).strip(),
-    )
-    instruction += _READ_ONLY_WARNING
-    return LocAgentProtocol(
-        system_prompt=system_prompt,
-        instruction=instruction,
-        followup=followup,
-        tools=tuple(json.loads(json.dumps(tools))),
+    del checkout, python_executable
+    return build_locagent_protocol(
+        problem_statement=problem_statement,
+        package_name=package_name,
     )
 
 
 class LocAgentAgent:
-    """Run LocAgent's upstream policy over manifest-backed CodeNib tools."""
+    """Run CodeNib's pinned LocAgent policy over manifest-backed tools."""
 
     def __init__(
         self,
@@ -378,19 +253,10 @@ class LocAgentAgent:
         if max_completion_tokens < 1:
             raise ValueError("max_completion_tokens must be positive")
 
-        checkout_value = locagent_checkout or os.environ.get("LOCAGENT_CHECKOUT")
-        if policy_runner is None and not checkout_value:
-            raise ValueError("LocAgent requires locagent_checkout or LOCAGENT_CHECKOUT")
-
         self.model = str(model)
-        self.locagent_checkout = (
-            Path(checkout_value).expanduser().resolve() if checkout_value else None
-        )
-        self.locagent_python = (
-            Path(locagent_python).expanduser().resolve()
-            if locagent_python is not None
-            else None
-        )
+        # Retain these arguments for callers migrating from the checkout-backed
+        # adapter. The pinned production protocol no longer reads either path.
+        del locagent_checkout, locagent_python
         self.max_iterations = int(max_iterations)
         self.max_completion_tokens = int(max_completion_tokens)
         self.reasoning_effort = reasoning_effort
@@ -402,7 +268,7 @@ class LocAgentAgent:
             else None
         )
         self._manifest_resolver = manifest_resolver
-        self._policy_runner = policy_runner or self._run_upstream_policy
+        self._policy_runner = policy_runner or self._run_pinned_policy
         self._provider_factory = provider_factory or LocAgentToolProvider.from_manifest
         self._client_factory = client_factory
 
@@ -491,7 +357,7 @@ class LocAgentAgent:
             kwargs["api_key"] = self.api_key
         return OpenAI(**kwargs)
 
-    def _run_upstream_policy(
+    def _run_pinned_policy(
         self,
         problem_statement: str,
         repo_path: str,
@@ -499,19 +365,15 @@ class LocAgentAgent:
         context: Mapping[str, Any],
     ) -> LocAgentExecution:
         del repo_path
-        if self.locagent_checkout is None:
-            raise RuntimeError("LocAgent checkout is not configured")
         package_name = str(
             context.get("package_name")
             or context.get("repo_name")
             or provider.repository.repo_root.name
         ).replace("\\", "/")
         package_name = package_name.rsplit("/", 1)[-1]
-        protocol = load_locagent_protocol(
-            self.locagent_checkout,
+        protocol = build_locagent_protocol(
             problem_statement=problem_statement,
             package_name=package_name,
-            python_executable=self.locagent_python,
         )
         return run_locagent_policy(
             protocol=protocol,

--- a/codenib/clients/locagent_protocol.py
+++ b/codenib/clients/locagent_protocol.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-free LocAgent policy assets pinned by CodeNib."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from codenib.integrations.locagent import LOCAGENT_REVISION, get_locagent_tool_schemas
+
+LOCAGENT_PROTOCOL_REVISION = LOCAGENT_REVISION
+
+_READ_ONLY_WARNING = (
+    "IMPORTANT: You should only use the provided read-only tools, never ask "
+    "for human help, and never modify files.\n"
+)
+
+_SYSTEM_PROMPT = """You are a helpful assistant that can interact with a computer to solve tasks.
+<IMPORTANT>
+* If user provides a path, you should NOT assume it's relative to the current working directory. Instead, you should explore the file system to find the file before working on it.
+</IMPORTANT>
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_TASK_INSTRUCTION_TEMPLATE = """
+Given the following GitHub problem description, your objective is to localize the specific files, classes or functions, and lines of code that need modification or contain key information to resolve the issue.
+
+Follow these steps to localize the issue:
+## Step 1: Categorize and Extract Key Problem Information
+ - Classify the problem statement into the following categories:
+    Problem description, error trace, code to reproduce the bug, and additional context.
+ - Identify modules in the '{package_name}' package mentioned in each category.
+ - Use extracted keywords and line numbers to search for relevant code references for additional context.
+
+## Step 2: Locate Referenced Modules
+- Accurately determine specific modules
+    - Explore the repo to familiarize yourself with its structure.
+    - Analyze the described execution flow to identify specific modules or components being referenced.
+- Pay special attention to distinguishing between modules with similar names using context and described execution flow.
+- Output Format for collected relevant modules:
+    - Use the format: 'file_path:QualifiedName'
+    - E.g., for a function `calculate_sum` in the `MathUtils` class located in `src/helpers/math_helpers.py`, represent it as: 'src/helpers/math_helpers.py:MathUtils.calculate_sum'.
+
+## Step 3: Analyze and Reproducing the Problem
+- Clarify the Purpose of the Issue
+    - If expanding capabilities: Identify where and how to incorporate new behavior, fields, or modules.
+    - If addressing unexpected behavior: Focus on localizing modules containing potential bugs.
+- Reconstruct the execution flow
+    - Identify main entry points triggering the issue.
+    - Trace function calls, class interactions, and sequences of events.
+    - Identify potential breakpoints causing the issue.
+    Important: Keep the reconstructed flow focused on the problem, avoiding irrelevant details.
+
+## Step 4: Locate Areas for Modification
+- Locate specific files, functions, or lines of code requiring changes or containing critical information for resolving the issue.
+- Consider upstream and downstream dependencies that may affect or be affected by the issue.
+- If applicable, identify where to introduce new fields, functions, or variables.
+- Think Thoroughly: List multiple potential solutions and consider edge cases that could impact the resolution.
+
+## Output Format for Final Results:
+Your final output should list the locations requiring modification, wrapped with triple backticks ```
+Each location should include the file path, class name (if applicable), function name, or line numbers, ordered by importance.
+Your answer would better include about 5 files.
+
+### Examples:
+```
+full_path1/file1.py
+line: 10
+class: MyClass1
+function: my_function1
+
+full_path2/file2.py
+line: 76
+function: MyClass2.my_function2
+
+full_path3/file3.py
+line: 24
+line: 156
+function: my_function3
+```
+
+Return just the location(s)
+
+Note: Your thinking should be thorough and so it's fine if it's very long.
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_PROBLEM_TEMPLATE = """
+--- BEGIN PROBLEM STATEMENT ---
+Title: {title}
+
+{description}
+--- END PROBLEM STATEMENT ---
+
+"""
+
+_FOLLOWUP = (
+    "Verify if the found locations contain all the necessary information to "
+    "address the issue, and check for any relevant references in other parts "
+    "of the codebase that may not have appeared in the search results. If not, "
+    "continue searching for additional locations related to the issue.\n"
+    "Verify that you have carefully analyzed the impact of the found locations "
+    "on the repository, especially their dependencies. If you think you have "
+    "solved the task, please send your final answer (including the former "
+    "answer and reranking) to user through message and then call `finish` to "
+    "finish.\n"
+    "IMPORTANT: YOU SHOULD NEVER ASK FOR HUMAN HELP.\n"
+)
+
+_FINISH_TOOL: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "finish",
+        "description": (
+            "Finish the interaction when the task is complete OR if the "
+            "assistant cannot proceed further with the task."
+        ),
+    },
+}
+
+
+def _protocol_asset_sha256() -> str:
+    payload = {
+        "revision": LOCAGENT_PROTOCOL_REVISION,
+        "system_prompt": _SYSTEM_PROMPT,
+        "task_template": _TASK_INSTRUCTION_TEMPLATE,
+        "problem_template": _PROBLEM_TEMPLATE,
+        "followup": _FOLLOWUP,
+        "tools": [_FINISH_TOOL, *get_locagent_tool_schemas()],
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+LOCAGENT_PROTOCOL_SHA256 = _protocol_asset_sha256()
+
+
+@dataclass(frozen=True, slots=True)
+class LocAgentProtocol:
+    """Pinned LocAgent prompts and OpenAI-compatible function schemas."""
+
+    system_prompt: str
+    instruction: str
+    followup: str
+    tools: tuple[Mapping[str, Any], ...]
+
+
+def build_locagent_protocol(
+    *,
+    problem_statement: str,
+    package_name: str,
+) -> LocAgentProtocol:
+    """Build the pinned LocAgent protocol without an upstream runtime."""
+
+    lines = str(problem_statement or "").strip().splitlines()
+    instruction = _TASK_INSTRUCTION_TEMPLATE.format(package_name=package_name)
+    instruction += _PROBLEM_TEMPLATE.format(
+        title=lines[0] if lines else "",
+        description="\n".join(lines[1:]).strip(),
+    )
+    instruction += _READ_ONLY_WARNING
+    tools = [copy.deepcopy(_FINISH_TOOL), *get_locagent_tool_schemas()]
+    return LocAgentProtocol(
+        system_prompt=_SYSTEM_PROMPT,
+        instruction=instruction,
+        followup=_FOLLOWUP,
+        tools=tuple(tools),
+    )
+
+
+__all__ = [
+    "LOCAGENT_PROTOCOL_REVISION",
+    "LOCAGENT_PROTOCOL_SHA256",
+    "LocAgentProtocol",
+    "build_locagent_protocol",
+]

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -755,6 +755,8 @@ class SymbolGraphBuilder:
         self, repo_path: str, output_dir: str, last_commit: str
     ) -> Optional[str]:
         """Return why the incremental path cannot run, or None if it can."""
+        if self.source_coverage_fallback:
+            return "source coverage fallback requires a provenance-complete rebuild"
         if not last_commit:
             return "no previously indexed commit"
         if not os.path.isfile(os.path.join(output_dir, "graph.pkl")):

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -542,6 +542,8 @@ class SymbolGraphBuilder:
     graph_route: str = "active"
     exclude_patterns: List[str] = field(default_factory=default_exclude_patterns)
     allow_partial_languages: bool = False
+    allow_partial_index: bool = False
+    source_coverage_fallback: bool = False
     # Admission control for incremental updates. The default proves nothing and
     # says so, which combined with require_verification=True means the builder
     # behaves exactly like a full rebuild until a real verifier is configured.
@@ -555,23 +557,28 @@ class SymbolGraphBuilder:
     def artifact_identity(self) -> Dict[str, Any]:
         graph_languages = self.languages or [self.language]
         return {
-            "builder_schema": 2,
+            "builder_schema": 3,
             "languages": list(graph_languages),
             "graph_route": self.graph_route,
             "exclude_patterns": sorted(self.exclude_patterns),
             "allow_partial_languages": self.allow_partial_languages,
+            "allow_partial_index": self.allow_partial_index,
+            "source_coverage_fallback": self.source_coverage_fallback,
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
+
+    def __post_init__(self) -> None:
+        if self.allow_partial_index and not self.source_coverage_fallback:
+            raise ValueError(
+                "allow_partial_index requires source_coverage_fallback so a "
+                "partial compiler artifact cannot be published as complete"
+            )
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
 
-        from ..ls_router import (
-            GraphBuildResult,
-            build_graph_for_languages,
-            build_graph_for_languages_with_report,
-        )
+        from ..ls_router import build_graph_for_languages_with_report
 
         os.makedirs(output_dir, exist_ok=True)
         graph_languages = self.languages or [self.language]
@@ -582,37 +589,99 @@ class SymbolGraphBuilder:
             "exclude_patterns": self.exclude_patterns,
             "graph_route": self.graph_route,
         }
-        if self.allow_partial_languages:
-            result = build_graph_for_languages_with_report(
-                repo_path,
-                output_dir,
-                allow_partial=True,
-                **build_kwargs,
-            )
-        else:
-            graph = build_graph_for_languages(
-                repo_path,
-                output_dir,
-                **build_kwargs,
-            )
-            result = GraphBuildResult(
-                graph=graph,
-                requested_languages=list(graph_languages),
-                available_languages=list(graph_languages) if graph is not None else [],
-                failed_languages={},
-            )
+        if self.allow_partial_index:
+            build_kwargs["allow_partial_index"] = True
+        result = build_graph_for_languages_with_report(
+            repo_path,
+            output_dir,
+            allow_partial=self.allow_partial_languages,
+            **build_kwargs,
+        )
 
         graph = result.graph
-        if graph is None or not hasattr(graph, "graph"):
+        compiler_graph_available = graph is not None and hasattr(graph, "graph")
+        compiler_node_count = len(graph.graph.vs) if compiler_graph_available else 0
+        compiler_edge_count = len(graph.graph.es) if compiler_graph_available else 0
+        if not compiler_graph_available and not self.source_coverage_fallback:
             detail = "; ".join(
                 f"{language}: {error}"
                 for language, error in result.failed_languages.items()
             )
             suffix = f" ({detail})" if detail else ""
             raise RuntimeError(f"symbol graph builder returned no graph{suffix}")
+        if not compiler_graph_available:
+            from ..graph.code_graph import CodeGraph
+            from ..types import ROOT_NODE
+
+            graph = CodeGraph(repo_path)
+            graph.add_root_node(ROOT_NODE)
+
+        compiler_partial_languages = sorted(
+            language
+            for language, report in result.index_generation_reports.items()
+            if report.get("partial") is True
+        )
+        compiler_index_complete = (
+            False
+            if not compiler_graph_available
+            else (
+                all(
+                    result.index_generation_reports.get(language, {}).get("complete")
+                    is True
+                    for language in result.available_languages
+                )
+                if result.available_languages
+                and all(
+                    language in result.index_generation_reports
+                    for language in result.available_languages
+                )
+                else None
+            )
+        )
+        fallback_report = None
+        if self.source_coverage_fallback:
+            from ..git_snapshot import GitSourceSurface
+            from ..graph.source_coverage import supplement_graph_source_coverage
+            from ..languages import extensions_for_language
+            from .artifact_quality import graph_file_paths
+
+            surface = GitSourceSurface.load(repo_path)
+            extensions = {
+                extension
+                for language in graph_languages
+                for extension in extensions_for_language(language, "graph")
+            }
+            coverage_report = supplement_graph_source_coverage(
+                graph,
+                repo_root=repo_path,
+                surface=surface,
+                extensions=extensions,
+                represented_paths=graph_file_paths(graph),
+                exclude_patterns=self.exclude_patterns,
+            )
+            if coverage_report.get("coverage_after") != 1.0:
+                raise RuntimeError(
+                    "source coverage fallback did not cover the requested "
+                    "repository surface"
+                )
+            fallback_report = {
+                "compiler_graph_available": compiler_graph_available,
+                "compiler_index_complete": compiler_index_complete,
+                "compiler_partial_languages": compiler_partial_languages,
+                "compiler_nodes": compiler_node_count,
+                "compiler_edges": compiler_edge_count,
+                **coverage_report,
+            }
+            graph.save_graph(os.path.join(output_dir, "graph.pkl"))
+
         node_count = len(graph.graph.vs)
         if node_count == 0:
             raise RuntimeError("symbol graph builder returned an empty graph")
+        available_languages = (
+            list(graph_languages)
+            if fallback_report is not None
+            else result.available_languages
+        )
 
         return IndexStatus(
             index_type="symbol_graph",
@@ -624,10 +693,18 @@ class SymbolGraphBuilder:
             metadata={
                 **self.artifact_identity(),
                 "node_count": node_count,
-                "language": result.available_languages[0],
-                "available_languages": result.available_languages,
+                "language": available_languages[0],
+                "available_languages": available_languages,
+                "compiler_available_languages": result.available_languages,
+                "index_generation_reports": result.index_generation_reports,
+                "partial_index": bool(compiler_partial_languages),
                 "failed_languages": result.failed_languages,
                 "partial": result.partial,
+                **(
+                    {"source_coverage_report": fallback_report}
+                    if fallback_report is not None
+                    else {}
+                ),
             },
         )
 
@@ -823,6 +900,8 @@ def register_default_builders(
     embedding_max_seq_length: Optional[int] = None,
     exclude_patterns: Optional[List[str]] = None,
     allow_partial_graph_languages: bool = False,
+    allow_partial_graph_index: bool = False,
+    graph_source_coverage_fallback: bool = False,
 ) -> None:
     """Register all standard index builders with sensible defaults."""
     langs = languages or ["python"]
@@ -859,6 +938,8 @@ def register_default_builders(
             languages=list(langs),
             graph_route=graph_route,
             allow_partial_languages=allow_partial_graph_languages,
+            allow_partial_index=allow_partial_graph_index,
+            source_coverage_fallback=graph_source_coverage_fallback,
             exclude_patterns=(
                 list(exclude_patterns)
                 if exclude_patterns is not None

--- a/codenib/eval/benchmarks/locagent.py
+++ b/codenib/eval/benchmarks/locagent.py
@@ -66,6 +66,23 @@ def _match_valid_path(candidate: str, valid_files: Sequence[str]) -> str:
 
 
 def _extract_path(line: str, valid_files: Sequence[str]) -> tuple[bool, str, str]:
+    if valid_files:
+        candidate_line = line.strip().strip("`").strip()
+        if candidate_line.startswith(("- ", "* ")):
+            candidate_line = candidate_line[2:].strip()
+        candidate_line = candidate_line.strip("`'\" ")
+        normalized_line = candidate_line.replace("\\", "/")
+        for valid_path in sorted(valid_files, key=len, reverse=True):
+            start = normalized_line.find(valid_path)
+            while start >= 0:
+                prefix_ok = start == 0 or normalized_line[start - 1] == "/"
+                remainder = normalized_line[start + len(valid_path) :].strip()
+                suffix_ok = not remainder or remainder.startswith(":")
+                if prefix_ok and suffix_ok:
+                    tail = remainder[1:].strip() if remainder.startswith(":") else ""
+                    return True, valid_path, tail
+                start = normalized_line.find(valid_path, start + 1)
+
     for match in _PATH_TOKEN.finditer(line):
         candidate = _normalize_path(match.group(0))
         extension = candidate.rsplit(".", 1)[-1].lower()

--- a/codenib/eval/benchmarks/policy_benchmark.py
+++ b/codenib/eval/benchmarks/policy_benchmark.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
 from codenib.clients.locagent_agent import load_locagent_protocol, run_locagent_policy
-from codenib.eval.benchmarks.locagent import locagent_regions
+from codenib.eval.benchmarks.locagent import locagent_regions, parse_locagent_locations
 from codenib.eval.benchmarks.orcaloca import (
     OrcaLocaGroundTruth,
     OrcaLocaScore,
@@ -55,6 +55,7 @@ from codenib.eval.benchmarks.policy_compat import (
     source_files,
     write_json_atomic,
 )
+from codenib.eval.retrieval_eval import compute_metrics, normalize_file_path
 from codenib.integrations.locagent import LOCAGENT_REVISION, OPENHANDS_LOCAGENT_REVISION
 from codenib.integrations.orcaloca import ORCALOCA_REVISION
 
@@ -522,6 +523,331 @@ def _mean(rows: Sequence[Mapping[str, Any]], key: str) -> float | None:
     return sum(values) / len(values) if values else None
 
 
+def _locagent_symbol_id(
+    file_path: str,
+    *,
+    class_name: str = "",
+    function_name: str = "",
+) -> str:
+    """Return the ranked ``file:qualified-name`` form used by LocAgent."""
+
+    normalized_path = normalize_file_path(file_path)
+    if not normalized_path:
+        return ""
+    normalized_class = str(class_name or "").strip().replace("::", ".").lstrip(".:")
+    normalized_function = (
+        str(function_name or "")
+        .strip()
+        .strip("`'\" ")
+        .replace("::", ".")
+        .split("(", 1)[0]
+        .strip()
+        .lstrip(".:")
+    )
+    if normalized_function:
+        if normalized_class and not normalized_function.startswith(
+            normalized_class + "."
+        ):
+            normalized_function = f"{normalized_class}.{normalized_function}"
+        if normalized_function.endswith(".__init__"):
+            normalized_function = normalized_function[: -len(".__init__")]
+        symbol = normalized_function
+    else:
+        symbol = normalized_class
+    return f"{normalized_path}:{symbol}" if symbol else ""
+
+
+def _normalize_locagent_target(value: object) -> str:
+    raw = str(value or "").strip()
+    if ":" not in raw:
+        return raw
+    file_path, symbol = raw.split(":", 1)
+    return _locagent_symbol_id(file_path, function_name=symbol)
+
+
+def _locagent_predictions(
+    case: PolicyBenchmarkCase,
+    result: Mapping[str, Any],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    raw_output = str(result.get("final_output") or result.get("raw_output") or "")
+    locations = parse_locagent_locations(
+        raw_output,
+        valid_files=source_files(case.repo_path),
+    )
+    files: list[str] = []
+    functions: list[str] = []
+    seen_files: set[str] = set()
+    seen_functions: set[str] = set()
+    for location in locations:
+        file_path = normalize_file_path(location.file_path)
+        if file_path and file_path not in seen_files:
+            seen_files.add(file_path)
+            files.append(file_path)
+        function_id = _locagent_symbol_id(
+            location.file_path,
+            class_name=location.class_name,
+            function_name=location.function_name,
+        )
+        if function_id and function_id not in seen_functions:
+            seen_functions.add(function_id)
+            functions.append(function_id)
+
+    # Older cells may retain source regions but not the final textual answer.
+    if not files:
+        for region in result.get("regions") or ():
+            if not isinstance(region, Mapping):
+                continue
+            file_path = normalize_file_path(str(region.get("path") or ""))
+            if file_path and file_path not in seen_files:
+                seen_files.add(file_path)
+                files.append(file_path)
+    return tuple(files), tuple(functions)
+
+
+def _score_locagent_result(
+    case: PolicyBenchmarkCase,
+    result: Mapping[str, Any],
+    *,
+    ks: Sequence[int],
+) -> dict[str, Any]:
+    ground_truth = OrcaLocaGroundTruth.from_mapping(case.ground_truth)
+    gold_files = tuple(
+        path
+        for path in (normalize_file_path(value) for value in ground_truth.files)
+        if path
+    )
+    gold_functions = tuple(
+        value
+        for value in (
+            _normalize_locagent_target(target) for target in ground_truth.functions
+        )
+        if value
+    )
+    failed = bool(result.get("error") or result.get("success") is False)
+    predicted_files, predicted_functions = (
+        ((), ()) if failed else _locagent_predictions(case, result)
+    )
+    metrics = {
+        "files": {
+            str(k): (
+                compute_metrics(predicted_files[:k], gold_files) if gold_files else None
+            )
+            for k in ks
+        },
+        "functions": {
+            str(k): (
+                compute_metrics(predicted_functions[:k], gold_functions)
+                if gold_functions
+                else None
+            )
+            for k in ks
+        },
+    }
+    usage = result.get("usage") or {}
+    total_tokens = usage.get("total_tokens")
+    if total_tokens is None:
+        total_tokens = usage.get("total_tokens_estimated")
+    return {
+        "instance_id": case.instance_id,
+        "provider": result.get("provider"),
+        "error": result.get("error"),
+        "failed": failed,
+        "missing": bool(result.get("missing", False)),
+        "gold_files": list(gold_files),
+        "predicted_files": list(predicted_files),
+        "gold_functions": list(gold_functions),
+        "predicted_functions": list(predicted_functions),
+        "metrics": metrics,
+        "elapsed_seconds": result.get("elapsed_seconds"),
+        "provider_load_seconds": result.get("provider_load_seconds"),
+        "tool_calls": result.get("tool_calls"),
+        "total_tokens": total_tokens,
+    }
+
+
+def _summarize_locagent_rows(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    provider: str,
+    ks: Sequence[int],
+) -> dict[str, Any]:
+    provider_rows = [row for row in rows if row["provider"] == provider]
+
+    def summarize_scope(scope: str, label_key: str) -> tuple[int, dict[str, Any]]:
+        labeled = [row for row in provider_rows if row[label_key]]
+        per_k: dict[str, Any] = {}
+        for k in ks:
+            values = [row["metrics"][scope][str(k)] for row in labeled]
+            per_k[str(k)] = (
+                {
+                    metric: statistics.fmean(value[metric] for value in values)
+                    for metric in ("accuracy", "precision", "recall", "hits")
+                }
+                if values
+                else None
+            )
+        return len(labeled), per_k
+
+    file_labeled_n, file_metrics = summarize_scope("files", "gold_files")
+    function_labeled_n, function_metrics = summarize_scope(
+        "functions", "gold_functions"
+    )
+    return {
+        "provider": provider,
+        "n": len(provider_rows),
+        "failed_count": sum(bool(row["failed"]) for row in provider_rows),
+        "file_labeled_n": file_labeled_n,
+        "function_labeled_n": function_labeled_n,
+        "file_metrics": file_metrics,
+        "function_metrics": function_metrics,
+        "elapsed_seconds_mean": _mean(provider_rows, "elapsed_seconds"),
+        "total_tokens_mean": _mean(provider_rows, "total_tokens"),
+    }
+
+
+def _run_score_locagent(args: argparse.Namespace) -> int:
+    ks = tuple(sorted(set(int(value) for value in args.k)))
+    if not ks or any(value < 1 for value in ks):
+        raise ValueError("--k values must be positive")
+    case_set = PolicyCaseSet.load(args.cases)
+    cases = case_set.select(args.instance_id)
+    providers = POLICY_PROVIDERS if args.provider == "both" else (args.provider,)
+    results = load_policy_results(
+        args.results_dir,
+        agent="locagent",
+        cases=cases,
+        providers=providers,
+    )
+    coverage = assess_policy_coverage(cases, results, providers=providers)
+    selection_sha256 = case_set.selection_sha256(cases)
+    provenance_audit = audit_policy_provenance(
+        results,
+        source_sha256=case_set.source_sha256,
+        selection_sha256=selection_sha256,
+        instance_ids=[case.instance_id for case in cases],
+    )
+    results_by_key = {
+        (str(result["instance_id"]), str(result["provider"])): result
+        for result in results
+    }
+    rows = []
+    for case in cases:
+        for provider in providers:
+            result = results_by_key.get((case.instance_id, provider))
+            if result is None:
+                result = {
+                    "agent": "locagent",
+                    "provider": provider,
+                    "instance_id": case.instance_id,
+                    "error": "missing result cell",
+                    "missing": True,
+                }
+            rows.append(_score_locagent_result(case, result, ks=ks))
+
+    models = {str(result.get("model") or "") for result in results}
+    models.discard("")
+    if args.model is not None and models - {args.model}:
+        raise ValueError(
+            f"result model mismatch: found {sorted(models)}, expected {args.model}"
+        )
+    if len(models) > 1:
+        raise ValueError(f"cannot aggregate mixed models: {sorted(models)}")
+    model = args.model or (next(iter(models)) if models else None)
+
+    summary = [
+        _summarize_locagent_rows(rows, provider=provider, ks=ks)
+        for provider in providers
+    ]
+    rows_by_key = {(str(row["instance_id"]), str(row["provider"])): row for row in rows}
+    paired = []
+    for case in cases:
+        native = rows_by_key.get((case.instance_id, "native"))
+        codenib = rows_by_key.get((case.instance_id, "codenib"))
+        if native is None or codenib is None:
+            continue
+        if native["failed"] or codenib["failed"]:
+            continue
+        native_tokens = native.get("total_tokens")
+        codenib_tokens = codenib.get("total_tokens")
+        paired.append(
+            {
+                "instance_id": case.instance_id,
+                "same_predicted_files": (
+                    native["predicted_files"] == codenib["predicted_files"]
+                ),
+                "same_predicted_functions": (
+                    native["predicted_functions"] == codenib["predicted_functions"]
+                ),
+                "native_to_codenib_total_tokens_ratio": (
+                    float(native_tokens) / float(codenib_tokens)
+                    if native_tokens is not None
+                    and codenib_tokens is not None
+                    and float(codenib_tokens) > 0
+                    else None
+                ),
+            }
+        )
+    token_ratios = [
+        float(row["native_to_codenib_total_tokens_ratio"])
+        for row in paired
+        if row["native_to_codenib_total_tokens_ratio"] is not None
+    ]
+    payload = {
+        "metric": "Common ranked golden-patch localization",
+        "model": model,
+        "k": list(ks),
+        "comparison_scope": {
+            "provider_compatibility": "ranked golden-patch localization outcomes",
+            "token_and_time_statistics": "single-trajectory descriptive statistics",
+            "performance_inference_supported": False,
+            "reason": (
+                "The runner preserves the upstream policy but does not collect "
+                "repeated trials. Provider semantics require contract tests or "
+                "deterministic tool-output replay."
+            ),
+        },
+        "case_set": {
+            "source_sha256": case_set.source_sha256,
+            "selection_sha256": selection_sha256,
+        },
+        "coverage": coverage.to_record(),
+        "provenance": provenance_audit.to_record(),
+        "rows": rows,
+        "summary": summary,
+        "paired": paired,
+        "paired_summary": {
+            "n": len(paired),
+            "same_predicted_files_count": sum(
+                row["same_predicted_files"] for row in paired
+            ),
+            "same_predicted_functions_count": sum(
+                row["same_predicted_functions"] for row in paired
+            ),
+            "native_to_codenib_total_tokens_ratio_median": (
+                statistics.median(token_ratios) if token_ratios else None
+            ),
+        },
+        "missing": [
+            str(
+                policy_result_path(
+                    args.results_dir,
+                    instance_id=key.instance_id,
+                    agent="locagent",
+                    provider=key.provider,
+                )
+            )
+            for key in coverage.missing
+        ],
+    }
+    if args.output is not None:
+        write_json_atomic(args.output, payload)
+        print(args.output)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    incomplete = bool(coverage.missing or coverage.failed or provenance_audit.invalid)
+    return 1 if incomplete and args.require_complete else 0
+
+
 def _run_score_orcaloca(args: argparse.Namespace) -> int:
     case_set = PolicyCaseSet.load(args.cases)
     cases = case_set.select(args.instance_id)
@@ -924,6 +1250,34 @@ def _build_parser() -> argparse.ArgumentParser:
     worker.add_argument("--instance-id", required=True)
     worker.add_argument("--base-commit", required=True)
     worker.set_defaults(handler=_run_locagent_worker)
+
+    score_locagent = subparsers.add_parser("score-locagent")
+    score_locagent.add_argument("--cases", type=Path, required=True)
+    score_locagent.add_argument("--instance-id", action="append")
+    score_locagent.add_argument("--results-dir", type=Path, required=True)
+    score_locagent.add_argument(
+        "--provider", choices=("native", "codenib", "both"), default="both"
+    )
+    score_locagent.add_argument("--model")
+    score_locagent.add_argument("--k", type=int, nargs="+", default=(1, 3, 5))
+    score_locagent.add_argument("--output", type=Path)
+    locagent_completeness = score_locagent.add_mutually_exclusive_group()
+    locagent_completeness.add_argument(
+        "--require-complete",
+        action="store_true",
+        dest="require_complete",
+        help="Fail when any requested provider cell is missing or failed (default).",
+    )
+    locagent_completeness.add_argument(
+        "--allow-incomplete",
+        action="store_false",
+        dest="require_complete",
+        help="Allow missing or failed cells after writing the coverage audit.",
+    )
+    score_locagent.set_defaults(
+        handler=_run_score_locagent,
+        require_complete=True,
+    )
 
     orcaloca = subparsers.add_parser("orcaloca")
     orcaloca.add_argument("--cases", type=Path, required=True)

--- a/codenib/eval/benchmarks/policy_benchmark.py
+++ b/codenib/eval/benchmarks/policy_benchmark.py
@@ -30,7 +30,12 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
-from codenib.clients.locagent_agent import load_locagent_protocol, run_locagent_policy
+from codenib.clients.locagent_agent import run_locagent_policy
+from codenib.clients.locagent_protocol import (
+    LOCAGENT_PROTOCOL_REVISION,
+    LOCAGENT_PROTOCOL_SHA256,
+    build_locagent_protocol,
+)
 from codenib.eval.benchmarks.locagent import locagent_regions, parse_locagent_locations
 from codenib.eval.benchmarks.orcaloca import (
     OrcaLocaGroundTruth,
@@ -62,7 +67,7 @@ from codenib.integrations.orcaloca import ORCALOCA_REVISION
 _CODE_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _locagent_revision_sources(checkout: Path) -> tuple[RevisionSource, ...]:
+def _locagent_revision_sources(checkout: Path | None) -> tuple[RevisionSource, ...]:
     return (
         RevisionSource(
             name="locagent",
@@ -243,20 +248,16 @@ def _close_provider(provider: Any | None) -> str | None:
 def _run_locagent_loop(
     *,
     case: PolicyBenchmarkCase,
-    checkout: Path,
     dispatch: Callable[[str, Mapping[str, Any]], str],
     model: str,
     base_url: str | None,
     max_iterations: int,
-    locagent_python: Path | None = None,
 ) -> dict[str, Any]:
     from openai import OpenAI
 
-    protocol = load_locagent_protocol(
-        checkout,
+    protocol = build_locagent_protocol(
         problem_statement=case.problem_statement,
         package_name=case.instance_id.split("_")[0],
-        python_executable=locagent_python,
     )
     client_options = {"base_url": base_url} if base_url else {}
     execution = run_locagent_policy(
@@ -303,6 +304,8 @@ def _run_locagent(args: argparse.Namespace) -> int:
         raise ValueError("--locagent-python is required for the native provider")
     if "native" in order and args.native_index_dir is None:
         raise ValueError("--native-index-dir is required for the native provider")
+    if "native" in order and args.locagent_checkout is None:
+        raise ValueError("--locagent-checkout is required for the native provider")
     revision_sources = _locagent_revision_sources(args.locagent_checkout)
     preflight = inspect_policy_run_preflight(
         cases,
@@ -329,6 +332,9 @@ def _run_locagent(args: argparse.Namespace) -> int:
             "max_completion_tokens": 4096,
             "reasoning_effort": "none",
             "custom_base_url": bool(args.base_url),
+            "protocol_revision": LOCAGENT_PROTOCOL_REVISION,
+            "protocol_sha256": LOCAGENT_PROTOCOL_SHA256,
+            "policy_runtime": "codenib-native-v1",
         },
     )
     failed = False
@@ -377,12 +383,10 @@ def _run_locagent(args: argparse.Namespace) -> int:
                     dispatch = provider.dispatch
                 result = _run_locagent_loop(
                     case=case,
-                    checkout=args.locagent_checkout,
                     dispatch=dispatch,
                     model=args.model,
                     base_url=args.base_url,
                     max_iterations=args.max_iterations,
-                    locagent_python=args.locagent_python,
                 )
                 result.update(
                     {
@@ -1235,7 +1239,11 @@ def _build_parser() -> argparse.ArgumentParser:
     locagent.add_argument(
         "--provider", choices=("native", "codenib", "both"), default="both"
     )
-    locagent.add_argument("--locagent-checkout", type=Path, required=True)
+    locagent.add_argument(
+        "--locagent-checkout",
+        type=Path,
+        help="Pinned checkout required only by the optional native provider.",
+    )
     locagent.add_argument("--locagent-python", type=Path)
     locagent.add_argument("--native-index-dir", type=Path)
     locagent.add_argument("--model", required=True)

--- a/codenib/eval/benchmarks/policy_benchmark.py
+++ b/codenib/eval/benchmarks/policy_benchmark.py
@@ -57,7 +57,7 @@ from codenib.eval.benchmarks.policy_compat import (
     inspect_policy_run_preflight,
     load_policy_results,
     policy_result_path,
-    source_files,
+    repository_files,
     write_json_atomic,
 )
 from codenib.eval.retrieval_eval import compute_metrics, normalize_file_path
@@ -287,7 +287,7 @@ def _run_locagent_loop(
         "regions": list(
             locagent_regions(
                 execution.final_output,
-                valid_files=source_files(case.repo_path),
+                valid_files=repository_files(case.repo_path),
             )
         ),
         "tool_trace": list(execution.tool_trace),
@@ -576,7 +576,7 @@ def _locagent_predictions(
     raw_output = str(result.get("final_output") or result.get("raw_output") or "")
     locations = parse_locagent_locations(
         raw_output,
-        valid_files=source_files(case.repo_path),
+        valid_files=repository_files(case.repo_path),
     )
     files: list[str] = []
     functions: list[str] = []
@@ -587,11 +587,13 @@ def _locagent_predictions(
         if file_path and file_path not in seen_files:
             seen_files.add(file_path)
             files.append(file_path)
-        function_id = _locagent_symbol_id(
-            location.file_path,
-            class_name=location.class_name,
-            function_name=location.function_name,
-        )
+        function_id = ""
+        if location.function_name.strip():
+            function_id = _locagent_symbol_id(
+                location.file_path,
+                class_name=location.class_name,
+                function_name=location.function_name,
+            )
         if function_id and function_id not in seen_functions:
             seen_functions.add(function_id)
             functions.append(function_id)

--- a/codenib/eval/benchmarks/policy_compat.py
+++ b/codenib/eval/benchmarks/policy_compat.py
@@ -43,6 +43,7 @@ _REQUIRED_CASE_FIELDS = {
     "manifest_path",
 }
 _COMMIT_RE = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+_INSTANCE_ID_RE = re.compile(r"[A-Za-z0-9_.-]+\Z")
 _NAME_RE = re.compile(r"[a-z0-9][a-z0-9_-]*\Z")
 _SOURCE_SUFFIXES = frozenset(extension_to_language_map("chunker"))
 
@@ -92,11 +93,9 @@ class PolicyBenchmarkCase:
             identifier = value.get("instance_id", "<unknown>")
             raise ValueError(f"case {identifier} is missing {sorted(missing)}")
 
-        instance_id = str(value["instance_id"]).strip()
+        instance_id = validate_policy_instance_id(value["instance_id"])
         problem_statement = str(value["problem_statement"]).strip()
         base_commit = str(value["base_commit"]).strip().lower()
-        if not instance_id:
-            raise ValueError("policy benchmark instance_id must not be empty")
         if not problem_statement:
             raise ValueError(f"case {instance_id} has an empty problem_statement")
         if not _COMMIT_RE.fullmatch(base_commit):
@@ -824,6 +823,15 @@ def validate_provider(provider: str) -> str:
     return normalized
 
 
+def validate_policy_instance_id(value: object) -> str:
+    """Return a path-safe benchmark instance identifier."""
+
+    normalized = str(value).strip()
+    if normalized in {".", ".."} or not _INSTANCE_ID_RE.fullmatch(normalized):
+        raise ValueError(f"invalid instance_id for policy benchmark: {value!r}")
+    return normalized
+
+
 def policy_result_path(
     output_dir: str | Path,
     *,
@@ -835,9 +843,8 @@ def policy_result_path(
 
     agent_name = validate_policy_name(agent, field_name="agent")
     provider_name = validate_provider(provider)
-    if not re.fullmatch(r"[A-Za-z0-9_.-]+", instance_id):
-        raise ValueError(f"invalid instance_id for result path: {instance_id!r}")
-    return Path(output_dir) / f"{instance_id}.{agent_name}.{provider_name}.json"
+    safe_instance_id = validate_policy_instance_id(instance_id)
+    return Path(output_dir) / (f"{safe_instance_id}.{agent_name}.{provider_name}.json")
 
 
 def load_policy_results(
@@ -881,16 +888,40 @@ def load_policy_results(
     return tuple(results)
 
 
-def source_files(repo_path: str | Path) -> tuple[str, ...]:
-    """List source files deterministically for free-form output validation."""
+def repository_files(repo_path: str | Path) -> tuple[str, ...]:
+    """List tracked files accepted by localization scoring.
+
+    Non-Git fixtures fall back to the shared repository traversal policy.
+    """
 
     root = Path(repo_path).expanduser().resolve()
-    files = [
-        path.relative_to(root).as_posix()
-        for path in walk_repository_files(root)
-        if path.suffix.lower() in _SOURCE_SUFFIXES
-    ]
-    return tuple(sorted(files))
+    try:
+        tracked = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        tracked = None
+    if tracked is not None and tracked.returncode == 0:
+        return tuple(sorted(path for path in tracked.stdout.split("\0") if path))
+    return tuple(
+        sorted(
+            path.relative_to(root).as_posix() for path in walk_repository_files(root)
+        )
+    )
+
+
+def source_files(repo_path: str | Path) -> tuple[str, ...]:
+    """List source files deterministically for source-only consumers."""
+
+    return tuple(
+        path
+        for path in repository_files(repo_path)
+        if Path(path).suffix.lower() in _SOURCE_SUFFIXES
+    )
 
 
 def write_json_atomic(path: str | Path, payload: Mapping[str, Any]) -> None:
@@ -927,7 +958,9 @@ __all__ = [
     "inspect_git_revision",
     "load_policy_results",
     "policy_result_path",
+    "repository_files",
     "source_files",
+    "validate_policy_instance_id",
     "validate_policy_name",
     "validate_provider",
     "write_json_atomic",

--- a/codenib/eval/benchmarks/swebench_policy_cases.py
+++ b/codenib/eval/benchmarks/swebench_policy_cases.py
@@ -468,6 +468,48 @@ def _scip_producer(index_path: Path) -> dict[str, Any]:
     }
 
 
+def _graph_producer(
+    index_path: Path,
+    graph_metadata: Mapping[str, Any],
+) -> dict[str, Any]:
+    if index_path.is_file():
+        return _scip_producer(index_path)
+    coverage = graph_metadata.get("source_coverage_report")
+    if (
+        isinstance(coverage, Mapping)
+        and coverage.get("compiler_graph_available") is False
+    ):
+        return {
+            "name": "codenib-syntax-fallback",
+            "version": "1",
+            "arguments": [],
+        }
+    raise RuntimeError(f"symbol graph has no compiler provenance: {index_path}")
+
+
+def _graph_coverage_mode(
+    index_path: Path,
+    graph_metadata: Mapping[str, Any],
+) -> str:
+    """Describe which source supplied the published graph surface."""
+
+    coverage = graph_metadata.get("source_coverage_report")
+    if not index_path.is_file():
+        if (
+            isinstance(coverage, Mapping)
+            and coverage.get("compiler_graph_available") is False
+        ):
+            return "syntax"
+        raise RuntimeError(f"symbol graph has no compiler provenance: {index_path}")
+    if not isinstance(coverage, Mapping):
+        return "compiler"
+    if coverage.get("supplemented_files"):
+        return "compiler-prefix+syntax"
+    if coverage.get("compiler_index_complete") is False:
+        return "compiler-prefix"
+    return "compiler"
+
+
 def assess_policy_graph(
     manifest_path: Path,
     checkout: Path,
@@ -493,8 +535,15 @@ def assess_policy_graph(
         represented,
         outside_commit=outside_commit,
     )
-    report["producer"] = _scip_producer(
-        Path(manifest.indexes["symbol_graph"].path) / "index.scip"
+    graph_entry = manifest.indexes["symbol_graph"]
+    index_path = Path(graph_entry.path) / "index.scip"
+    report["producer"] = _graph_producer(
+        index_path,
+        graph_entry.metadata,
+    )
+    report["coverage_mode"] = _graph_coverage_mode(
+        index_path,
+        graph_entry.metadata,
     )
     if not report["passed"]:
         raise RuntimeError(
@@ -517,11 +566,31 @@ def build_policy_manifest(
     root = Path(checkout).expanduser().resolve()
     output = Path(artifact_dir).expanduser().resolve() / "indexes"
     manifest_path = output / MANIFEST_FILENAME
+    started = time.perf_counter()
+
+    if manifest_path.is_file():
+        errors = _manifest_errors(manifest_path, root, commit)
+        if not errors:
+            try:
+                graph_quality = assess_policy_graph(manifest_path, root, commit)
+            except (OSError, RuntimeError, ValueError):
+                pass
+            else:
+                manifest = RepoManifest.load(manifest_path)
+                return manifest_path, _policy_build_report(
+                    manifest,
+                    graph_quality,
+                    duration_seconds=time.perf_counter() - started,
+                    reused_existing=True,
+                )
+
     registry = IndexBuilderRegistry()
     register_default_builders(
         registry,
         languages=["python"],
         allow_partial_graph_languages=False,
+        allow_partial_graph_index=True,
+        graph_source_coverage_fallback=True,
     )
     compiler = IndexCompiler(
         registry,
@@ -530,7 +599,6 @@ def build_policy_manifest(
             languages=["python"],
         ),
     )
-    started = time.perf_counter()
     if manifest_path.is_file():
         manifest = compiler.update_repo(
             str(root),
@@ -547,11 +615,29 @@ def build_policy_manifest(
     if errors:
         raise RuntimeError("; ".join(errors))
     graph_quality = assess_policy_graph(manifest_path, root, commit)
-    return manifest_path, {
-        "duration_seconds": time.perf_counter() - started,
+    return manifest_path, _policy_build_report(
+        manifest,
+        graph_quality,
+        duration_seconds=time.perf_counter() - started,
+        reused_existing=False,
+    )
+
+
+def _policy_build_report(
+    manifest: RepoManifest,
+    graph_quality: Mapping[str, Any],
+    *,
+    duration_seconds: float,
+    reused_existing: bool,
+) -> dict[str, Any]:
+    graph_metadata = manifest.indexes["symbol_graph"].metadata
+    return {
+        "duration_seconds": duration_seconds,
+        "reused_existing": reused_existing,
         "file_count": manifest.file_count,
         "capabilities": dict(manifest.capabilities),
-        "graph_quality": graph_quality,
+        "graph_quality": dict(graph_quality),
+        "source_coverage_report": graph_metadata.get("source_coverage_report"),
         "views": {
             name: {
                 "status": manifest.indexes[name].status,

--- a/codenib/eval/benchmarks/swebench_policy_cases.py
+++ b/codenib/eval/benchmarks/swebench_policy_cases.py
@@ -37,6 +37,7 @@ from codenib.dataset.gt_locate import GTLocator, language_for_file
 from codenib.eval.benchmarks.policy_compat import (
     PolicyCaseSet,
     inspect_policy_run_preflight,
+    validate_policy_instance_id,
     write_json_atomic,
 )
 from codenib.eval.retrieval_eval import collect_targets
@@ -133,11 +134,13 @@ def load_dataset_records(path: str | Path) -> tuple[list[dict[str, Any]], str]:
         missing = _DATASET_FIELDS - set(record)
         if missing:
             raise ValueError(f"dataset record {position} is missing {sorted(missing)}")
-        instance_id = str(record["instance_id"]).strip()
-        if not instance_id or instance_id in seen:
-            raise ValueError(f"invalid or duplicate instance_id: {instance_id!r}")
+        instance_id = validate_policy_instance_id(record["instance_id"])
+        if instance_id in seen:
+            raise ValueError(f"duplicate instance_id: {instance_id!r}")
         seen.add(instance_id)
-        normalized.append(dict(record))
+        normalized_record = dict(record)
+        normalized_record["instance_id"] = instance_id
+        normalized.append(normalized_record)
     return normalized, _file_sha256(source)
 
 
@@ -161,9 +164,10 @@ def select_balanced_repository_cases(
     for raw in records:
         record = dict(raw)
         repo = str(record.get("repo") or "").strip()
-        instance_id = str(record.get("instance_id") or "").strip()
-        if not repo or not instance_id:
+        instance_id = validate_policy_instance_id(record.get("instance_id") or "")
+        if not repo:
             raise ValueError("selection records require repo and instance_id")
+        record["instance_id"] = instance_id
         grouped[repo].append(record)
     if count > sum(len(values) for values in grouped.values()):
         raise ValueError("selection count exceeds the dataset population")
@@ -428,6 +432,24 @@ def _manifest_errors(manifest_path: Path, checkout: Path, commit: str) -> list[s
     return errors
 
 
+def _invalidate_manifest_view(
+    manifest_path: Path,
+    view: str,
+    *,
+    reason: str,
+) -> None:
+    """Make a current-but-invalid artifact eligible for a forced rebuild."""
+
+    manifest = RepoManifest.load(manifest_path)
+    entry = manifest.indexes.get(view)
+    if entry is None:
+        return
+    entry.status = "stale"
+    entry.metadata["stale_reason"] = reason
+    manifest.derive_capabilities()
+    manifest.save(manifest_path)
+
+
 def _graph_source_coverage_report(
     expected: Iterable[str],
     represented: Iterable[str],
@@ -573,8 +595,15 @@ def build_policy_manifest(
         if not errors:
             try:
                 graph_quality = assess_policy_graph(manifest_path, root, commit)
-            except (OSError, RuntimeError, ValueError):
-                pass
+            except Exception as exc:  # noqa: BLE001 - failed audit forces rebuild
+                _invalidate_manifest_view(
+                    manifest_path,
+                    "symbol_graph",
+                    reason=(
+                        "policy graph quality validation failed: "
+                        f"{type(exc).__name__}: {exc}"
+                    ),
+                )
             else:
                 manifest = RepoManifest.load(manifest_path)
                 return manifest_path, _policy_build_report(
@@ -662,7 +691,7 @@ def prepare_policy_case(
     """Prepare one already-created source snapshot and return its case record."""
 
     root = Path(output_dir).expanduser().resolve()
-    instance_id = str(record["instance_id"])
+    instance_id = validate_policy_instance_id(record["instance_id"])
     case_dir = root / "prepared" / instance_id
     checkout = root / "snapshots" / instance_id / "repo"
     case_path = case_dir / "case.json"

--- a/codenib/eval/benchmarks/swebench_policy_cases.py
+++ b/codenib/eval/benchmarks/swebench_policy_cases.py
@@ -1,0 +1,836 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare fixed SWE-bench Lite cases for policy compatibility studies.
+
+The preparation stage is intentionally separate from the model runner. It
+freezes a label-independent repository-stratified sample, creates one detached
+checkout per case, derives localization labels from the golden patch, builds
+the CodeNib views required by the policy, and validates every manifest before
+any model request is sent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from codenib.compiler.artifact_quality import graph_file_paths
+from codenib.compiler.index_builders import (
+    IndexBuilderRegistry,
+    register_default_builders,
+)
+from codenib.compiler.index_compiler import IndexCompiler, IndexCompilerConfig
+from codenib.compiler.manifest import MANIFEST_FILENAME, RepoManifest
+from codenib.dataset.gt_locate import GTLocator, language_for_file
+from codenib.eval.benchmarks.policy_compat import (
+    PolicyCaseSet,
+    inspect_policy_run_preflight,
+    write_json_atomic,
+)
+from codenib.eval.retrieval_eval import collect_targets
+from codenib.git_snapshot import GitSourceSurface
+from codenib.graph.code_graph import CodeGraph
+from codenib.languages import get_language_spec
+from codenib.repository_filters import repository_path_is_visible
+from codenib.scip_interface.scip_pb2 import Index as SCIPIndex
+
+SWE_BENCH_LITE_DATASET = "princeton-nlp/SWE-bench_Lite"
+SWE_BENCH_LITE_REVISION = "6ec7bb89b9342f664a54a6e0a6ea6501d3437cc2"
+DEFAULT_SELECTION_SEED = "codenib-locagent-swebench-lite-50-v1"
+SELECTION_ALGORITHM = "balanced-repository-stratified-v1"
+PREPARATION_SCHEMA_VERSION = 1
+MIN_GRAPH_SOURCE_COVERAGE = 0.95
+
+_DATASET_FIELDS = frozenset(
+    {"repo", "instance_id", "base_commit", "patch", "problem_statement"}
+)
+
+
+def _canonical_sha256(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _stable_rank(seed: str, *parts: str) -> str:
+    value = "\0".join((seed, *parts)).encode("utf-8")
+    return hashlib.sha256(value).hexdigest()
+
+
+def _scip_python_provenance() -> dict[str, Any]:
+    path = shutil.which("scip-python")
+    if path is None:
+        raise RuntimeError(
+            "SWE-bench policy preparation requires scip-python on PATH; "
+            "run `make scip-python-tool` and prepend CODENIB_SCIP_TOOLS_DIR"
+        )
+    result = subprocess.run(
+        [path, "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    version = (result.stdout or result.stderr).strip().splitlines()
+    if result.returncode != 0 or not version:
+        raise RuntimeError(f"could not resolve scip-python version from {path}")
+    return {
+        "path": str(Path(path).resolve()),
+        "version": version[0],
+        "index_timeout_seconds": os.environ.get(
+            "CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS",
+            "default",
+        ),
+    }
+
+
+def load_dataset_records(path: str | Path) -> tuple[list[dict[str, Any]], str]:
+    """Load a JSON array or JSONL dataset and return its byte-level digest."""
+
+    source = Path(path).expanduser().resolve()
+    raw = source.read_text(encoding="utf-8")
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError:
+        decoded = [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+    if isinstance(decoded, Mapping):
+        records = decoded.get("data") or decoded.get("cases")
+    else:
+        records = decoded
+    if not isinstance(records, list) or not records:
+        raise ValueError(f"{source} does not contain dataset records")
+
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for position, record in enumerate(records):
+        if not isinstance(record, Mapping):
+            raise ValueError(f"dataset record {position} is not an object")
+        missing = _DATASET_FIELDS - set(record)
+        if missing:
+            raise ValueError(f"dataset record {position} is missing {sorted(missing)}")
+        instance_id = str(record["instance_id"]).strip()
+        if not instance_id or instance_id in seen:
+            raise ValueError(f"invalid or duplicate instance_id: {instance_id!r}")
+        seen.add(instance_id)
+        normalized.append(dict(record))
+    return normalized, _file_sha256(source)
+
+
+def select_balanced_repository_cases(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    count: int,
+    seed: str,
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Select a deterministic, broad sample without consulting gold labels.
+
+    Each repository first receives an equal quota capped by its population.
+    Remaining slots are distributed one per round to strata with the greatest
+    residual capacity. Cases within a repository are ordered by a seeded hash,
+    and the final sample is emitted round-robin across repositories.
+    """
+
+    if count < 1:
+        raise ValueError("selection count must be positive")
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for raw in records:
+        record = dict(raw)
+        repo = str(record.get("repo") or "").strip()
+        instance_id = str(record.get("instance_id") or "").strip()
+        if not repo or not instance_id:
+            raise ValueError("selection records require repo and instance_id")
+        grouped[repo].append(record)
+    if count > sum(len(values) for values in grouped.values()):
+        raise ValueError("selection count exceeds the dataset population")
+    if count < len(grouped):
+        raise ValueError("selection count is smaller than the repository stratum count")
+
+    repos = sorted(grouped)
+    for _repo, values in grouped.items():
+        values.sort(
+            key=lambda row: (
+                _stable_rank(seed, str(row["instance_id"])),
+                str(row["instance_id"]),
+            )
+        )
+
+    equal_quota = count // len(repos)
+    quotas = {repo: min(equal_quota, len(grouped[repo])) for repo in repos}
+    remaining = count - sum(quotas.values())
+    while remaining:
+        eligible = [repo for repo in repos if quotas[repo] < len(grouped[repo])]
+        if not eligible:
+            raise RuntimeError("selection quota allocation exhausted all strata")
+        eligible.sort(
+            key=lambda repo: (
+                -(len(grouped[repo]) - quotas[repo]),
+                _stable_rank(seed, repo),
+                repo,
+            )
+        )
+        for repo in eligible:
+            if not remaining:
+                break
+            quotas[repo] += 1
+            remaining -= 1
+
+    selected: list[dict[str, Any]] = []
+    for rank in range(max(quotas.values(), default=0)):
+        for repo in repos:
+            if rank < quotas[repo]:
+                selected.append(grouped[repo][rank])
+    if len(selected) != count:
+        raise RuntimeError(f"selected {len(selected)} cases, expected {count}")
+    return selected, quotas
+
+
+def _run_git(
+    repo: Path,
+    *args: str,
+    input_text: str | None = None,
+    check: bool = True,
+    timeout: int = 600,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-c", f"safe.directory={repo}", "-C", str(repo), *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def _source_path(source_root: Path, repository: str) -> Path:
+    return source_root / repository.replace("/", "__")
+
+
+def ensure_source_repository(
+    source_root: Path,
+    *,
+    repository: str,
+    commits: Sequence[str],
+) -> Path:
+    """Create one object-sharing source clone and ensure all commits exist."""
+
+    source = _source_path(source_root, repository)
+    source_root.mkdir(parents=True, exist_ok=True)
+    if not (source / ".git").is_dir():
+        if source.exists():
+            raise RuntimeError(f"source path exists but is not a Git clone: {source}")
+        print(f"clone {repository} -> {source}", flush=True)
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--quiet",
+                "--filter=blob:none",
+                "--no-checkout",
+                f"https://github.com/{repository}.git",
+                str(source),
+            ],
+            check=True,
+            timeout=1800,
+        )
+
+    for commit in sorted(set(commits)):
+        probe = _run_git(
+            source,
+            "cat-file",
+            "-e",
+            f"{commit}^{{commit}}",
+            check=False,
+        )
+        if probe.returncode == 0:
+            continue
+        print(f"fetch {repository}@{commit[:12]}", flush=True)
+        _run_git(source, "fetch", "origin", commit, timeout=1800)
+    return source
+
+
+def ensure_snapshot_worktree(source: Path, snapshot: Path, commit: str) -> Path:
+    """Create or verify an experiment-owned detached worktree."""
+
+    if snapshot.is_dir():
+        head = _run_git(snapshot, "rev-parse", "HEAD", check=False)
+        status = _run_git(snapshot, "status", "--porcelain", check=False)
+        if (
+            head.returncode == 0
+            and head.stdout.strip() == commit
+            and status.returncode == 0
+            and not status.stdout.strip()
+        ):
+            return snapshot
+        _run_git(source, "worktree", "remove", "--force", str(snapshot), check=False)
+        if snapshot.exists():
+            shutil.rmtree(snapshot)
+        _run_git(source, "worktree", "prune", check=False)
+
+    snapshot.parent.mkdir(parents=True, exist_ok=True)
+    _run_git(source, "worktree", "add", "--detach", str(snapshot), commit)
+    return snapshot
+
+
+def _extract_symbols(locator: GTLocator, checkout: Path, files: Sequence[str]):
+    symbols = {}
+    for relative_path in files:
+        source = checkout / relative_path
+        if source.is_file():
+            symbols.update(
+                locator.extract_symbols_from_file(str(source), relative_path)
+            )
+    return symbols
+
+
+def extract_golden_patch_labels(
+    checkout: str | Path,
+    record: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Derive file and existing-function labels, restoring the checkout exactly."""
+
+    root = Path(checkout).expanduser().resolve()
+    expected_commit = str(record["base_commit"])
+    actual_commit = _run_git(root, "rev-parse", "HEAD").stdout.strip()
+    if actual_commit != expected_commit:
+        raise RuntimeError(
+            f"snapshot commit mismatch: {actual_commit} != {expected_commit}"
+        )
+    if _run_git(root, "status", "--porcelain").stdout.strip():
+        raise RuntimeError(f"snapshot is dirty before label extraction: {root}")
+
+    patch = str(record["patch"])
+    patch_input = patch if patch.endswith("\n") else patch + "\n"
+    locator = GTLocator(work_dir=str(root.parent))
+    target_files = locator.get_target_files(patch)
+    supported_files = [path for path in target_files if language_for_file(path)]
+    symbols_before = _extract_symbols(locator, root, supported_files)
+    changed_ranges = locator.get_changed_line_ranges(patch)
+
+    applied = False
+    try:
+        apply_result = _run_git(
+            root,
+            "apply",
+            "-",
+            input_text=patch_input,
+            check=False,
+            timeout=60,
+        )
+        if apply_result.returncode != 0:
+            raise RuntimeError(
+                "gold patch did not apply: " + apply_result.stderr.strip()
+            )
+        applied = True
+        symbols_after = _extract_symbols(locator, root, supported_files)
+        modified, added, deleted = locator.compare_symbols(
+            symbols_before,
+            symbols_after,
+            changed_ranges,
+        )
+        analysis = {
+            "target_files": target_files,
+            "symbols_modified": [name for name, _chunk in modified],
+            "symbols_added": [name for name, _chunk in added],
+            "symbols_deleted": [name for name, _chunk in deleted],
+        }
+        gold_files, gold_functions = collect_targets(
+            analysis,
+            simplified_symbols=True,
+        )
+        result = {
+            "gold_files": list(dict.fromkeys(gold_files)),
+            "gold_functions": list(dict.fromkeys(gold_functions)),
+            "method": "gold-patch-tree-sitter-existing-functions-v1",
+            "patch_sha256": hashlib.sha256(patch.encode("utf-8")).hexdigest(),
+            "supported_target_files": supported_files,
+            "symbols_added": analysis["symbols_added"],
+        }
+    finally:
+        if applied:
+            reverse = _run_git(
+                root,
+                "apply",
+                "--reverse",
+                "-",
+                input_text=patch_input,
+                check=False,
+                timeout=60,
+            )
+            if reverse.returncode != 0:
+                raise RuntimeError(
+                    "failed to restore snapshot after label extraction: "
+                    + reverse.stderr.strip()
+                )
+
+    final_commit = _run_git(root, "rev-parse", "HEAD").stdout.strip()
+    final_status = _run_git(root, "status", "--porcelain").stdout.strip()
+    if final_commit != expected_commit or final_status:
+        raise RuntimeError("gold-label extraction did not restore the source snapshot")
+    return result
+
+
+def _snapshot_errors(checkout: Path, commit: str) -> list[str]:
+    errors: list[str] = []
+    head = _run_git(checkout, "rev-parse", "HEAD", check=False)
+    if head.returncode != 0:
+        errors.append("snapshot HEAD cannot be resolved")
+    elif head.stdout.strip() != commit:
+        errors.append(f"snapshot commit mismatch: {head.stdout.strip()} != {commit}")
+    status = _run_git(checkout, "status", "--porcelain", check=False)
+    if status.returncode != 0:
+        errors.append("snapshot status cannot be resolved")
+    elif status.stdout.strip():
+        errors.append("snapshot is dirty after index construction")
+    return errors
+
+
+def _manifest_errors(manifest_path: Path, checkout: Path, commit: str) -> list[str]:
+    errors = _snapshot_errors(checkout, commit)
+    try:
+        manifest = RepoManifest.load(manifest_path)
+    except Exception as exc:  # noqa: BLE001 - preparation audit records exact error
+        return [f"manifest cannot be loaded: {type(exc).__name__}: {exc}"]
+    if Path(manifest.repo_path).resolve() != checkout.resolve():
+        errors.append("manifest repository path does not match the snapshot")
+    if manifest.commit != commit:
+        errors.append(f"manifest commit mismatch: {manifest.commit} != {commit}")
+    for view in ("bm25", "symbol_graph"):
+        if not manifest.index_is_current(view):
+            errors.append(f"manifest view is not current: {view}")
+    for capability in ("sparse_search", "symbol_navigation"):
+        if not manifest.capabilities.get(capability, False):
+            errors.append(f"manifest lacks capability: {capability}")
+    return errors
+
+
+def _graph_source_coverage_report(
+    expected: Iterable[str],
+    represented: Iterable[str],
+    *,
+    outside_commit: Iterable[str] = (),
+    minimum: float = MIN_GRAPH_SOURCE_COVERAGE,
+) -> dict[str, Any]:
+    expected_paths = frozenset(expected)
+    represented_paths = frozenset(represented)
+    covered = expected_paths & represented_paths
+    missing = sorted(expected_paths - represented_paths)
+    extra = sorted(represented_paths - expected_paths)
+    outside = sorted(set(outside_commit))
+    coverage = len(covered) / len(expected_paths) if expected_paths else 1.0
+    return {
+        "minimum": minimum,
+        "expected_source_files": len(expected_paths),
+        "represented_source_files": len(covered),
+        "graph_file_nodes": len(represented_paths),
+        "coverage": coverage,
+        "missing_source_files": missing,
+        "extra_graph_files": extra,
+        "outside_commit_files": outside,
+        "passed": bool(expected_paths and coverage >= minimum and not outside),
+    }
+
+
+def _scip_producer(index_path: Path) -> dict[str, Any]:
+    index = SCIPIndex()
+    index.ParseFromString(index_path.read_bytes())
+    tool = index.metadata.tool_info
+    if not tool.name or not tool.version:
+        raise RuntimeError(f"SCIP index does not declare its producer: {index_path}")
+    return {
+        "name": tool.name,
+        "version": tool.version,
+        "arguments": list(tool.arguments),
+    }
+
+
+def assess_policy_graph(
+    manifest_path: Path,
+    checkout: Path,
+    commit: str,
+) -> dict[str, Any]:
+    """Audit graph file nodes against the label-independent Git surface."""
+
+    manifest = RepoManifest.load(manifest_path)
+    graph = CodeGraph.load_graph(
+        Path(manifest.indexes["symbol_graph"].path) / "graph.pkl"
+    )
+    surface = GitSourceSurface.load(checkout, commit)
+    suffixes = frozenset(get_language_spec("python").graph_extensions)
+    expected = {
+        path
+        for path in surface.tracked_files
+        if Path(path).suffix in suffixes and repository_path_is_visible(path)
+    }
+    represented = set(graph_file_paths(graph))
+    outside_commit = {path for path in represented if not surface.contains(path)}
+    report = _graph_source_coverage_report(
+        expected,
+        represented,
+        outside_commit=outside_commit,
+    )
+    report["producer"] = _scip_producer(
+        Path(manifest.indexes["symbol_graph"].path) / "index.scip"
+    )
+    if not report["passed"]:
+        raise RuntimeError(
+            "symbol graph source coverage failed: "
+            f"coverage={report['coverage']:.3f}, "
+            f"minimum={report['minimum']:.3f}, "
+            f"outside={len(report['outside_commit_files'])}"
+        )
+    return report
+
+
+def build_policy_manifest(
+    checkout: str | Path,
+    artifact_dir: str | Path,
+    *,
+    commit: str,
+) -> tuple[Path, dict[str, Any]]:
+    """Build or resume the BM25 and symbol-graph views for one snapshot."""
+
+    root = Path(checkout).expanduser().resolve()
+    output = Path(artifact_dir).expanduser().resolve() / "indexes"
+    manifest_path = output / MANIFEST_FILENAME
+    registry = IndexBuilderRegistry()
+    register_default_builders(
+        registry,
+        languages=["python"],
+        allow_partial_graph_languages=False,
+    )
+    compiler = IndexCompiler(
+        registry,
+        IndexCompilerConfig(
+            index_types=["bm25", "symbol_graph"],
+            languages=["python"],
+        ),
+    )
+    started = time.perf_counter()
+    if manifest_path.is_file():
+        manifest = compiler.update_repo(
+            str(root),
+            index_types=["bm25", "symbol_graph"],
+            cache_dir=str(output),
+        )
+    else:
+        manifest = compiler.compile_repo(
+            str(root),
+            index_types=["bm25", "symbol_graph"],
+            cache_dir=str(output),
+        )
+    errors = _manifest_errors(manifest_path, root, commit)
+    if errors:
+        raise RuntimeError("; ".join(errors))
+    graph_quality = assess_policy_graph(manifest_path, root, commit)
+    return manifest_path, {
+        "duration_seconds": time.perf_counter() - started,
+        "file_count": manifest.file_count,
+        "capabilities": dict(manifest.capabilities),
+        "graph_quality": graph_quality,
+        "views": {
+            name: {
+                "status": manifest.indexes[name].status,
+                "build_duration_seconds": manifest.indexes[name].metadata.get(
+                    "build_duration_seconds"
+                ),
+                "item_count": manifest.indexes[name].metadata.get(
+                    "chunk_count",
+                    manifest.indexes[name].metadata.get("node_count"),
+                ),
+            }
+            for name in ("bm25", "symbol_graph")
+        },
+    }
+
+
+def prepare_policy_case(
+    record: Mapping[str, Any],
+    *,
+    output_dir: str | Path,
+) -> dict[str, Any]:
+    """Prepare one already-created source snapshot and return its case record."""
+
+    root = Path(output_dir).expanduser().resolve()
+    instance_id = str(record["instance_id"])
+    case_dir = root / "prepared" / instance_id
+    checkout = root / "snapshots" / instance_id / "repo"
+    case_path = case_dir / "case.json"
+    labels_path = case_dir / "ground_truth.json"
+    report_path = case_dir / "build_report.json"
+    failure_path = case_dir / "build_failure.json"
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    patch_sha256 = hashlib.sha256(str(record["patch"]).encode("utf-8")).hexdigest()
+    labels: dict[str, Any]
+    if labels_path.is_file():
+        labels = json.loads(labels_path.read_text(encoding="utf-8"))
+        if labels.get("patch_sha256") != patch_sha256:
+            raise RuntimeError("cached ground truth belongs to a different patch")
+    else:
+        labels = extract_golden_patch_labels(checkout, record)
+        write_json_atomic(labels_path, labels)
+
+    manifest_path, build_report = build_policy_manifest(
+        checkout,
+        case_dir,
+        commit=str(record["base_commit"]),
+    )
+    case = {
+        "instance_id": instance_id,
+        "repo": str(record["repo"]),
+        "base_commit": str(record["base_commit"]),
+        "problem_statement": str(record["problem_statement"]),
+        "repo_path": str(checkout),
+        "manifest_path": str(manifest_path),
+        "ground_truth": {
+            "gold_files": labels["gold_files"],
+            "gold_functions": labels["gold_functions"],
+        },
+        "ground_truth_method": labels["method"],
+        "gold_patch_sha256": labels["patch_sha256"],
+    }
+    write_json_atomic(case_path, case)
+    write_json_atomic(
+        report_path,
+        {
+            "instance_id": instance_id,
+            "status": "ready",
+            "labels": {
+                "file_count": len(labels["gold_files"]),
+                "function_count": len(labels["gold_functions"]),
+                "supported_target_file_count": len(labels["supported_target_files"]),
+                "added_symbol_count": len(labels["symbols_added"]),
+            },
+            "index": build_report,
+        },
+    )
+    failure_path.unlink(missing_ok=True)
+    return case
+
+
+def _selection_record(
+    selected: Sequence[Mapping[str, Any]],
+    *,
+    source_path: Path,
+    source_sha256: str,
+    dataset_revision: str,
+    seed: str,
+    quotas: Mapping[str, int],
+) -> dict[str, Any]:
+    semantic = [
+        {
+            "instance_id": str(row["instance_id"]),
+            "repo": str(row["repo"]),
+            "base_commit": str(row["base_commit"]),
+            "patch_sha256": hashlib.sha256(
+                str(row["patch"]).encode("utf-8")
+            ).hexdigest(),
+        }
+        for row in selected
+    ]
+    return {
+        "schema_version": PREPARATION_SCHEMA_VERSION,
+        "dataset": SWE_BENCH_LITE_DATASET,
+        "split": "test",
+        "dataset_revision": dataset_revision,
+        "dataset_source": str(source_path),
+        "dataset_source_sha256": source_sha256,
+        "selection_algorithm": SELECTION_ALGORITHM,
+        "selection_seed": seed,
+        "selection_count": len(selected),
+        "selection_sha256": _canonical_sha256(semantic),
+        "per_repository_count": dict(sorted(quotas.items())),
+        "instances": semantic,
+    }
+
+
+def _case_failure(instance_id: str, exc: BaseException) -> dict[str, Any]:
+    return {
+        "instance_id": instance_id,
+        "status": "failed",
+        "error": f"{type(exc).__name__}: {exc}",
+    }
+
+
+def prepare_cases(args: argparse.Namespace) -> int:
+    dataset_path = args.dataset_json.expanduser().resolve()
+    output = args.output_dir.expanduser().resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    environment = {
+        "schema_version": PREPARATION_SCHEMA_VERSION,
+        "python": sys.version.split()[0],
+        "parallel_workers": args.jobs,
+        "scip_python": _scip_python_provenance(),
+    }
+    write_json_atomic(output / "preparation_environment.json", environment)
+    print(
+        "toolchain: "
+        f"scip-python={environment['scip_python']['version']} "
+        f"path={environment['scip_python']['path']} "
+        f"timeout={environment['scip_python']['index_timeout_seconds']}",
+        flush=True,
+    )
+    records, source_sha256 = load_dataset_records(dataset_path)
+    selected, quotas = select_balanced_repository_cases(
+        records,
+        count=args.count,
+        seed=args.seed,
+    )
+    selection = _selection_record(
+        selected,
+        source_path=dataset_path,
+        source_sha256=source_sha256,
+        dataset_revision=args.dataset_revision,
+        seed=args.seed,
+        quotas=quotas,
+    )
+    selection_path = output / "selection.json"
+    if selection_path.is_file():
+        existing = json.loads(selection_path.read_text(encoding="utf-8"))
+        if existing != selection:
+            raise RuntimeError(
+                "existing selection does not match the requested dataset/configuration"
+            )
+    else:
+        write_json_atomic(selection_path, selection)
+
+    by_repo: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in selected:
+        by_repo[str(row["repo"])].append(row)
+    source_root = output / "sources"
+    for repo in sorted(by_repo):
+        rows = by_repo[repo]
+        source = ensure_source_repository(
+            source_root,
+            repository=repo,
+            commits=[str(row["base_commit"]) for row in rows],
+        )
+        for row in rows:
+            instance_id = str(row["instance_id"])
+            snapshot = output / "snapshots" / instance_id / "repo"
+            ensure_snapshot_worktree(
+                source,
+                snapshot,
+                str(row["base_commit"]),
+            )
+            print(f"snapshot ready {instance_id}", flush=True)
+
+    prepared: dict[str, dict[str, Any]] = {}
+    failures: list[dict[str, Any]] = []
+    with ProcessPoolExecutor(max_workers=args.jobs) as executor:
+        futures = {
+            executor.submit(prepare_policy_case, row, output_dir=output): str(
+                row["instance_id"]
+            )
+            for row in selected
+        }
+        for future in as_completed(futures):
+            instance_id = futures[future]
+            try:
+                prepared[instance_id] = future.result()
+                print(f"prepared {instance_id}", flush=True)
+            except Exception as exc:  # noqa: BLE001 - preserve every failed case
+                failure = _case_failure(instance_id, exc)
+                failures.append(failure)
+                failure_path = output / "prepared" / instance_id / "build_failure.json"
+                failure_path.parent.mkdir(parents=True, exist_ok=True)
+                write_json_atomic(failure_path, failure)
+                print(f"FAILED {instance_id}: {failure['error']}", flush=True)
+
+    ordered_cases = [
+        prepared[str(row["instance_id"])]
+        for row in selected
+        if str(row["instance_id"]) in prepared
+    ]
+    report = {
+        "schema_version": PREPARATION_SCHEMA_VERSION,
+        "selection_sha256": selection["selection_sha256"],
+        "requested_count": len(selected),
+        "prepared_count": len(ordered_cases),
+        "failed_count": len(failures),
+        "failures": failures,
+    }
+    write_json_atomic(output / "prepare_report.json", report)
+    if failures or len(ordered_cases) != len(selected):
+        return 1
+
+    cases_payload = {
+        "schema_version": PREPARATION_SCHEMA_VERSION,
+        "dataset": SWE_BENCH_LITE_DATASET,
+        "split": "test",
+        "dataset_revision": args.dataset_revision,
+        "dataset_source_sha256": source_sha256,
+        "selection_algorithm": SELECTION_ALGORITHM,
+        "selection_seed": args.seed,
+        "selection_sha256": selection["selection_sha256"],
+        "per_repository_count": selection["per_repository_count"],
+        "cases": ordered_cases,
+    }
+    cases_path = output / "cases.json"
+    write_json_atomic(cases_path, cases_payload)
+    case_set = PolicyCaseSet.load(cases_path)
+    preflight = inspect_policy_run_preflight(
+        case_set.cases,
+        agent="locagent",
+        providers=("codenib",),
+        required_capabilities={"codenib": ("sparse_search", "symbol_navigation")},
+    )
+    write_json_atomic(output / "preflight.json", preflight.to_record())
+    preflight.require_eligible()
+    print(
+        f"ready: {len(case_set.cases)} cases, selection={selection['selection_sha256']}",
+        flush=True,
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-json", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--count", type=int, default=50)
+    parser.add_argument("--seed", default=DEFAULT_SELECTION_SEED)
+    parser.add_argument("--dataset-revision", default=SWE_BENCH_LITE_REVISION)
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=min(4, os.cpu_count() or 1),
+        help="parallel label/index workers",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.jobs < 1:
+        raise ValueError("--jobs must be positive")
+    return prepare_cases(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codenib/integrations/locagent.py
+++ b/codenib/integrations/locagent.py
@@ -53,16 +53,109 @@ _ENTITY_TYPES = {
     "function": {NODE_TYPE_FUNCTION, NODE_TYPE_METHOD, NODE_TYPE_SYMBOL},
 }
 
-_SEARCH_DESCRIPTION = """Search repository code by entity name, keyword, file
-pattern, or 1-based line number. Entity names use
-`file_path:QualifiedName`; files use repository-relative paths."""
+_SEARCH_DESCRIPTION = """Searches the codebase to retrieve relevant code snippets based on given queries(terms or line numbers).
+** Note:
+- Either `search_terms` or `line_nums` must be provided to perform a search.
+- If `search_terms` are provided, it searches for code snippets based on each term:
+- If `line_nums` is provided, it searches for code snippets around the specified lines within the file defined by `file_path_or_pattern`.
 
-_ENTITY_DESCRIPTION = """Return source for repository entities. Functions and
-classes use `file_path:QualifiedName`; files use repository-relative paths."""
+** Example Usage:
+# Search for code content contain keyword `order`, `bill`
+search_code_snippets(search_terms=["order", "bill"])
 
-_TREE_DESCRIPTION = """Traverse a pre-built repository graph upstream,
-downstream, or in both directions. Traversal can be filtered by entity and
-dependency types."""
+# Search for a class
+search_code_snippets(search_terms=["MyClass"])
+
+# Search for context around specific lines (10 and 15) within a file
+search_code_snippets(line_nums=[10, 15], file_path_or_pattern='src/example.py')
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_ENTITY_DESCRIPTION = (
+    "\n"
+    "Searches the codebase to retrieve the complete implementations of specified "
+    "entities based on the provided entity names. \n"
+    "The tool can handle specific entity queries such as function names, class "
+    "names, or file paths.\n"
+    """
+**Usage Example:**
+# Search for a specific function implementation
+get_entity_contents(['src/my_file.py:MyClass.func_name'])
+
+# Search for a file's complete content
+get_entity_contents(['src/my_file.py'])
+
+**Entity Name Format:**
+- To specify a function or class, use the format: `file_path:QualifiedName`
+  (e.g., 'src/helpers/math_helpers.py:MathUtils.calculate_sum').
+- To search for a file's content, use only the file path (e.g., 'src/my_file.py').
+"""
+)  # noqa: B950 - exact text from the pinned upstream policy
+
+_TREE_DESCRIPTION = """
+Unified repository exploring tool that traverses a pre-built code graph to retrieve dependency structure around specified entities.
+The search can be controlled to traverse upstream (exploring dependencies that entities rely on) or downstream (exploring how entities impact others), with optional limits on traversal depth and filters for entity and dependency types.
+
+Code Graph Definition:
+* Entity Types: 'directory', 'file', 'class', 'function'.
+* Dependency Types: 'contains', 'imports', 'invokes', 'inherits'.
+* Hierarchy:
+    - Directories contain files and subdirectories.
+    - Files contain classes and functions.
+    - Classes contain inner classes and methods.
+    - Functions can contain inner functions.
+* Interactions:
+    - Files/classes/functions can import classes and functions.
+    - Classes can inherit from other classes.
+    - Classes and functions can invoke others (invocations in a class's `__init__` are attributed to the class).
+Entity ID:
+* Unique identifier including file path and module path.
+* Here's an example of an Entity ID: `"interface/C.py:C.method_a.inner_func"` identifies function `inner_func` within `method_a` of class `C` in `"interface/C.py"`.
+
+Notes:
+* Traversal Control: The `traversal_depth` parameter specifies how deep the function should explore the graph starting from the input entities.
+* Filtering: Use `entity_type_filter` and `dependency_type_filter` to narrow down the scope of the search, focusing on specific entity types and relationships.
+
+
+Example Usage:
+1. Exploring Outward Dependencies:
+    ```
+    explore_tree_structure(
+        start_entities=['src/module_a.py:ClassA'],
+        direction='downstream',
+        traversal_depth=2,
+        dependency_type_filter=['invokes', 'imports']
+    )
+    ```
+    This retrieves the dependencies of `ClassA` up to 2 levels deep, focusing only on classes and functions with 'invokes' and 'imports' relationships.
+
+2. Exploring Inward Dependencies:
+    ```
+    explore_tree_structure(
+        start_entities=['src/module_b.py:FunctionY'],
+        direction='upstream',
+        traversal_depth=-1
+    )
+    ```
+    This finds all entities that depend on `FunctionY` without restricting the traversal depth.
+3. Exploring Repository Structure:
+    ```
+    explore_tree_structure(
+      start_entities=['/'],
+      traversal_depth=2,
+      dependency_type_filter=['contains']
+    )
+    ```
+    This retrieves the tree repository structure from the root directory (/), traversing up to two levels deep and focusing only on 'contains' relationship.
+4. Generate Class Diagrams:
+    ```
+    explore_tree_structure(
+        start_entities=selected_entity_ids,
+        direction='both',
+        traverse_depth=-1,
+        dependency_type_filter=['inherits']
+    )
+    ```
+"""  # noqa: B950 - exact text from the pinned upstream policy
 
 _LOCAGENT_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
     {
@@ -76,16 +169,33 @@ _LOCAGENT_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
                     "search_terms": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Names, keywords, or code fragments to search.",
+                        "description": (
+                            "A list of names, keywords, or code snippets to search "
+                            "for within the codebase. This can include potential "
+                            "function names, class names, or general code fragments. "
+                            "Either `search_terms` or `line_nums` must be provided "
+                            "to perform a search."
+                        ),
                     },
                     "line_nums": {
                         "type": "array",
                         "items": {"type": "integer"},
-                        "description": "1-based source lines in one concrete file.",
+                        "description": (
+                            "Specific line numbers to locate code snippets within "
+                            "a specified file. Must be used alongside a valid "
+                            "`file_path_or_pattern`. Either `line_nums` or "
+                            "`search_terms` must be provided to perform a search."
+                        ),
                     },
                     "file_path_or_pattern": {
                         "type": "string",
-                        "description": "Repository-relative file path or glob.",
+                        "description": (
+                            "A glob pattern or specific file path used to filter "
+                            "search results to particular files or directories. "
+                            'Defaults to "**/*.py", meaning all Python files are '
+                            "searched by default. If `line_nums` are provided, "
+                            "this must specify a specific file path."
+                        ),
                         "default": "**/*.py",
                     },
                 },
@@ -104,7 +214,15 @@ _LOCAGENT_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
                     "entity_names": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Repository-relative file or entity identifiers.",
+                        "description": (
+                            "A list of entity names to query. Each entity name can "
+                            "represent a function, class, or file. For functions or "
+                            "classes, the format should be "
+                            "'file_path:QualifiedName' (e.g., "
+                            "'src/helpers/math_helpers.py:MathUtils.calculate_sum'). "
+                            "For files, use just the file path (e.g., "
+                            "'src/my_file.py')."
+                        ),
                     }
                 },
                 "required": ["entity_names"],
@@ -122,26 +240,60 @@ _LOCAGENT_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
                     "start_entities": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Repository entities from which traversal starts.",
+                        "description": (
+                            "List of entities (e.g., class, function, file, or "
+                            "directory paths) to begin the search from.\n"
+                            "Entities representing classes or functions must be "
+                            'formatted as "file_path:QualifiedName" (e.g., '
+                            "`interface/C.py:C.method_a.inner_func`).\n"
+                            "For files or directories, provide only the file or "
+                            "directory path (e.g., `src/module_a.py` or `src/`)."
+                        ),
                     },
                     "direction": {
                         "type": "string",
                         "enum": ["upstream", "downstream", "both"],
                         "default": "downstream",
+                        "description": (
+                            "Direction of traversal in the code graph; allowed "
+                            "options are: `upstream`, `downstream`, `both`.\n"
+                            "- 'upstream': Traversal to explore dependencies that "
+                            "the specified entities rely on (how they depend on "
+                            "others).\n"
+                            "- 'downstream': Traversal to explore the effects or "
+                            "interactions of the specified entities on others (how "
+                            "others depend on them).\n"
+                            "- 'both': Traversal on both direction."
+                        ),
                     },
                     "traversal_depth": {
                         "type": "integer",
                         "default": 2,
+                        "description": (
+                            "Maximum depth of traversal. A value of -1 indicates "
+                            "unlimited depth (subject to a maximum limit).Must be "
+                            "either `-1` or a non-negative integer (\u2265 0)."
+                        ),
                     },
                     "entity_type_filter": {
                         "type": ["array", "null"],
                         "items": {"type": "string"},
                         "default": None,
+                        "description": (
+                            "List of entity types (e.g., 'class', 'function', "
+                            "'file', 'directory') to include in the traversal. If "
+                            "None, all entity types are included."
+                        ),
                     },
                     "dependency_type_filter": {
                         "type": ["array", "null"],
                         "items": {"type": "string"},
                         "default": None,
+                        "description": (
+                            "List of dependency types (e.g., 'contains', 'imports', "
+                            "'invokes', 'inherits') to include in the traversal. If "
+                            "None, all dependency types are included."
+                        ),
                     },
                 },
                 "required": ["start_entities"],

--- a/codenib/ls_router.py
+++ b/codenib/ls_router.py
@@ -271,6 +271,12 @@ class LSIndexer:
 
         return getattr(self._delegate, "index_generation_report", None)
 
+    @property
+    def supports_partial_index(self) -> bool:
+        """Whether this backend can identify partial output from this run."""
+
+        return bool(getattr(self._delegate, "supports_partial_index", False))
+
     def graph_patch(
         self,
         graph: "CodeGraph",
@@ -336,8 +342,8 @@ def build_graph_for_languages_with_report(
     opt-in for evaluating candidate SCIP cold-start backends without promoting
     them. With ``allow_partial=True``, a failed language does not discard graphs
     already built for other languages. ``allow_partial_index=True`` lets a
-    backend retain a parseable compiler prefix and reports that state separately
-    from per-language availability.
+    supporting backend retain a parseable compiler prefix and reports that
+    state separately from per-language availability.
     """
     normalized = _normalize_language_sequence(languages, graph_route=graph_route)
     base_output = Path(output_dir)
@@ -353,8 +359,6 @@ def build_graph_for_languages_with_report(
         pipeline_kwargs["target_dir"] = target_dir
     if include_references:
         pipeline_kwargs["include_references"] = True
-    if allow_partial_index:
-        pipeline_kwargs["allow_partial_index"] = True
 
     def run_language(language: str, language_output: Path, language_project: str):
         indexer = LSIndexer(
@@ -366,10 +370,13 @@ def build_graph_for_languages_with_report(
             graph_route=graph_route,
             **indexer_kwargs,
         )
+        language_pipeline_kwargs = dict(pipeline_kwargs)
+        if allow_partial_index and getattr(indexer, "supports_partial_index", False):
+            language_pipeline_kwargs["allow_partial_index"] = True
         graph = indexer.run_pipeline(
             project_name=language_project,
             skip_level=skip_level,
-            **pipeline_kwargs,
+            **language_pipeline_kwargs,
         )
         report = getattr(indexer, "index_generation_report", None)
         return graph, dict(report) if isinstance(report, dict) else None

--- a/codenib/ls_router.py
+++ b/codenib/ls_router.py
@@ -24,10 +24,10 @@ Example:
     graph = decoder.decode()
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib import import_module
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
 from .graph.code_graph import CodeGraph
 from .languages import (
@@ -61,6 +61,7 @@ class GraphBuildResult:
     requested_languages: List[str]
     available_languages: List[str]
     failed_languages: Dict[str, str]
+    index_generation_reports: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
     @property
     def partial(self) -> bool:
@@ -264,6 +265,12 @@ class LSIndexer:
 
         return getattr(self._delegate, "index_quality_report", None)
 
+    @property
+    def index_generation_report(self):
+        """Latest backend generation report, when the indexer provides one."""
+
+        return getattr(self._delegate, "index_generation_report", None)
+
     def graph_patch(
         self,
         graph: "CodeGraph",
@@ -315,6 +322,7 @@ def build_graph_for_languages_with_report(
     decoder_backend: Optional[str] = None,
     graph_route: str = ACTIVE_GRAPH_ROUTE,
     allow_partial: bool = False,
+    allow_partial_index: bool = False,
 ) -> GraphBuildResult:
     """Build a graph and report per-language availability.
 
@@ -327,7 +335,9 @@ def build_graph_for_languages_with_report(
     for backend comparison; ``graph_route="scip-candidate"`` is an explicit
     opt-in for evaluating candidate SCIP cold-start backends without promoting
     them. With ``allow_partial=True``, a failed language does not discard graphs
-    already built for other languages.
+    already built for other languages. ``allow_partial_index=True`` lets a
+    backend retain a parseable compiler prefix and reports that state separately
+    from per-language availability.
     """
     normalized = _normalize_language_sequence(languages, graph_route=graph_route)
     base_output = Path(output_dir)
@@ -343,6 +353,8 @@ def build_graph_for_languages_with_report(
         pipeline_kwargs["target_dir"] = target_dir
     if include_references:
         pipeline_kwargs["include_references"] = True
+    if allow_partial_index:
+        pipeline_kwargs["allow_partial_index"] = True
 
     def run_language(language: str, language_output: Path, language_project: str):
         indexer = LSIndexer(
@@ -354,16 +366,19 @@ def build_graph_for_languages_with_report(
             graph_route=graph_route,
             **indexer_kwargs,
         )
-        return indexer.run_pipeline(
+        graph = indexer.run_pipeline(
             project_name=language_project,
             skip_level=skip_level,
             **pipeline_kwargs,
         )
+        report = getattr(indexer, "index_generation_report", None)
+        return graph, dict(report) if isinstance(report, dict) else None
 
     if len(normalized) == 1:
         language = normalized[0]
+        generation_report = None
         try:
-            graph = run_language(language, base_output, pname)
+            graph, generation_report = run_language(language, base_output, pname)
         except Exception as exc:
             if not allow_partial:
                 raise
@@ -377,21 +392,29 @@ def build_graph_for_languages_with_report(
             requested_languages=normalized,
             available_languages=[language] if graph is not None else [],
             failed_languages=failures,
+            index_generation_reports=(
+                {language: generation_report} if generation_report is not None else {}
+            ),
         )
 
     combined = CodeGraph(str(Path(project_root).absolute()))
     available: List[str] = []
+    generation_reports: Dict[str, Dict[str, Any]] = {}
     for language in normalized:
         language_output = base_output / "graphs" / language
         language_project = f"{pname}-{language}"
         try:
-            graph = run_language(language, language_output, language_project)
+            graph, generation_report = run_language(
+                language, language_output, language_project
+            )
         except Exception as exc:
             if not allow_partial:
                 raise
             failures[language] = str(exc)
             logger.warning("Graph build unavailable for %s: %s", language, exc)
             continue
+        if generation_report is not None:
+            generation_reports[language] = generation_report
         if graph is None:
             message = (
                 f"Failed to build code graph for language {language!r} "
@@ -411,6 +434,7 @@ def build_graph_for_languages_with_report(
             requested_languages=normalized,
             available_languages=[],
             failed_languages=failures,
+            index_generation_reports=generation_reports,
         )
 
     base_output.mkdir(parents=True, exist_ok=True)
@@ -425,6 +449,7 @@ def build_graph_for_languages_with_report(
         requested_languages=normalized,
         available_languages=available,
         failed_languages=failures,
+        index_generation_reports=generation_reports,
     )
 
 
@@ -441,6 +466,7 @@ def build_graph_for_languages(
     profiler: Optional[Profiler] = None,
     decoder_backend: Optional[str] = None,
     graph_route: str = ACTIVE_GRAPH_ROUTE,
+    allow_partial_index: bool = False,
 ) -> Union[CodeGraph, None]:
     """Build a strict CodeGraph for one or more graph languages."""
 
@@ -456,6 +482,7 @@ def build_graph_for_languages(
         profiler=profiler,
         decoder_backend=decoder_backend,
         graph_route=graph_route,
+        allow_partial_index=allow_partial_index,
     ).graph
 
 

--- a/codenib/scip_interface/scip_indexer_python.py
+++ b/codenib/scip_interface/scip_indexer_python.py
@@ -55,7 +55,7 @@ def _scip_python_index_timeout() -> float:
 
 def _run_checked_with_timeout(cmd, *, timeout, **popen_kwargs):
     """Like ``subprocess.run(cmd, check=True, timeout=...)`` but kills the whole
-    process group on timeout.
+    process group on timeout or caller cancellation.
 
     ``subprocess.run``'s own timeout only SIGKILLs the immediate child. conda
     (libmamba solver) and scip-python (Node) spawn grandchildren that survive
@@ -73,6 +73,19 @@ def _run_checked_with_timeout(cmd, *, timeout, **popen_kwargs):
                 # The process group may already have exited between timeout and kill.
                 # In that race, there is nothing left to terminate.
                 logger.debug("Process group %s already exited before SIGKILL", proc.pid)
+            proc.communicate()
+            raise
+        except BaseException:
+            # A benchmark cancellation must not orphan the Node indexer. The
+            # next run could otherwise race the old process for the same
+            # output and temporary repository configuration.
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                logger.debug(
+                    "Process group %s already exited during cancellation",
+                    proc.pid,
+                )
             proc.communicate()
             raise
         retcode = proc.poll()

--- a/codenib/scip_interface/scip_indexer_python.py
+++ b/codenib/scip_interface/scip_indexer_python.py
@@ -105,6 +105,8 @@ class SCIPPythonIndexer(SCIPIndexerBase):
     development and CI environments that do not expose the tool directly.
     """
 
+    supports_partial_index = True
+
     def __init__(
         self,
         project_root: Union[str, Path],
@@ -297,6 +299,9 @@ class SCIPPythonIndexer(SCIPIndexerBase):
             bool: True if index generation was successful, False otherwise
         """
         self.index_generation_report = None
+        if self.index_file.exists():
+            self.index_file.unlink()
+            logger.info("Removed pre-existing SCIP index before generation")
         if not self._check_indexer_available():
             self.index_generation_report = {
                 "backend": "scip-python",

--- a/codenib/scip_interface/scip_indexer_python.py
+++ b/codenib/scip_interface/scip_indexer_python.py
@@ -136,6 +136,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
         self.conda_env_name = "scip-env"
         self.env_file = self.module_dir / "scip-environment.yml"
         self._direct_indexer_path: Optional[str] = None
+        self.index_generation_report: Optional[dict] = None
 
     def _check_indexer_available(self) -> bool:
         """
@@ -275,6 +276,7 @@ class SCIPPythonIndexer(SCIPIndexerBase):
         cwd: Optional[str] = None,
         project_name: Optional[str] = None,
         target_dir: Optional[str] = None,
+        allow_partial_index: bool = False,
         **kwargs,
     ) -> bool:
         """
@@ -287,12 +289,22 @@ class SCIPPythonIndexer(SCIPIndexerBase):
             cwd: Working directory (defaults to project_root)
             project_name: Project name to use in the index
             target_dir: Optional subdirectory to target for indexing
+            allow_partial_index: Preserve a parseable compiler prefix for
+                downstream source-coverage repair.
             **kwargs: Additional arguments (ignored)
 
         Returns:
             bool: True if index generation was successful, False otherwise
         """
+        self.index_generation_report = None
         if not self._check_indexer_available():
+            self.index_generation_report = {
+                "backend": "scip-python",
+                "status": "unavailable",
+                "complete": False,
+                "partial": False,
+                "document_count": 0,
+            }
             return False
 
         cmd = self._build_index_command(
@@ -312,16 +324,62 @@ class SCIPPythonIndexer(SCIPIndexerBase):
         duration = section.duration
 
         if success:
+            document_count = self._usable_index_document_count()
+            self.index_generation_report = {
+                "backend": "scip-python",
+                "status": "complete",
+                "complete": True,
+                "partial": False,
+                "document_count": document_count,
+            }
             logger.info(f"Successfully generated SCIP index at {self.index_file}")
             logger.info(f"Index generation took: {duration:.2f} seconds")
             return True
         else:
             logger.error(f"Index generation failed after {duration:.2f} seconds")
-            # Remove partial index file so pipeline does not continue with broken data
+            document_count = self._usable_index_document_count()
+            if allow_partial_index and document_count > 0:
+                self.index_generation_report = {
+                    "backend": "scip-python",
+                    "status": "partial",
+                    "complete": False,
+                    "partial": True,
+                    "document_count": document_count,
+                }
+                logger.warning(
+                    "Preserving parseable partial SCIP index with %d documents",
+                    document_count,
+                )
+                return False
+            # Never let the generic pipeline mistake an unvalidated partial file
+            # for a complete graph unless the caller explicitly opted into repair.
             if self.index_file.exists():
                 self.index_file.unlink()
                 logger.info("Removed partial index file")
+            self.index_generation_report = {
+                "backend": "scip-python",
+                "status": "failed",
+                "complete": False,
+                "partial": False,
+                "document_count": document_count,
+            }
             return False
+
+    def _usable_index_document_count(self) -> int:
+        """Count path-addressable documents in a parseable SCIP artifact."""
+
+        if not self.index_file.is_file():
+            return 0
+        try:
+            from google.protobuf.message import DecodeError
+
+            from .scip_pb2 import Index
+
+            index = Index()
+            index.ParseFromString(self.index_file.read_bytes())
+        except (OSError, DecodeError, ValueError):
+            return 0
+        return sum(bool(document.relative_path) for document in index.documents)
 
     def run_pipeline(
         self,

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -447,7 +447,7 @@ policy:
 ```bash
 make scip-python-tool
 export PATH="${CODENIB_SCIP_TOOLS_DIR:-/tmp/codenib/scip-tools}:$PATH"
-export CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS=3600
+export CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS=900
 
 python scripts/analysis/prepare_swebench_policy_cases.py \
   --dataset-json ~/.codenib/princeton-nlp__SWE-bench_Lite_test.json \
@@ -486,6 +486,18 @@ valid artifacts but rejects a changed dataset or selection configuration.
 Preparation performs no model requests.
 The sample is deliberately repository-balanced coverage, not a
 population-weighted estimate over all SWE-bench Lite tasks.
+
+When `scip-python` times out after emitting parseable, path-addressable protobuf
+documents, preparation retains that compiler-derived prefix and applies the
+same label-independent tree-sitter fallback to every missing tracked Python
+file. If no usable compiler document exists, the malformed or metadata-only
+artifact is rejected and the same fallback covers the full tracked surface.
+The report distinguishes compiler availability and coverage from supplemented
+files, symbols, and final Git-surface coverage. The manifest also records
+whether generation completed or retained a partial compiler prefix. The
+fallback adds definitions and containment only; it does not synthesize
+compiler reference edges. Graph audits label the resulting surface as
+`compiler`, `compiler-prefix`, `compiler-prefix+syntax`, or `syntax`.
 
 File metrics retain all 50 selected cases in the denominator, including failed
 model cells. Function metrics use the declared subset whose golden patch

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -8,14 +8,14 @@ an agent-specific graph, BM25 index, or cache directory.
 ## Support Matrix
 
 The support levels below are intentionally separate. **Provider** means CodeNib
-implements the repository-call contract. **Policy** means a pinned upstream
+implements the repository-call contract. **Policy** means a revision-pinned
 agent loop executes with that provider. **Paired evaluation** means the native
 and CodeNib providers can be swapped under one fixed case, model, prompt, and
 budget contract. None of these labels alone claims end-to-end task quality.
 
 | Integration | Status | Required views | Provider contract | Policy and evaluation | Boundary |
 | --- | --- | --- | --- | --- | --- |
-| LocAgent | Revision-pinned supported | Symbol graph + BM25 | Pinned three-tool contract | Pinned prompts and function-calling loop; paired runner with strict common file/function@k scoring | Python SWE-bench repositories; reference and type-use are disclosed as conservative relation mappings |
+| LocAgent | CodeNib-native, revision-pinned | Symbol graph + BM25 | Pinned three-tool contract | Vendored prompts and function-calling loop; paired runner with strict common file/function@k scoring | Python SWE-bench repositories; reference and type-use are disclosed as conservative relation mappings |
 | Historical OpenHands LocAgent plugin | Contract-only | Symbol graph + BM25 | Python bindings for the pinned plugin revision | Covered through the LocAgent contract; policy is absent from current OpenHands CLI | No compatibility claim for other OpenHands revisions |
 | OrcaLoca SearchAgent | Revision-pinned supported | Symbol graph | Pinned six-tool and private-hook contract | Upstream `SearchAgent`; fixed-case paired runner and native File/Function Match scorer | Python SWE-bench repositories; empty `TraceAnalysisOutput`; upstream trace generation is not included |
 | SWE-Explore | Reference-only | N/A | No adapter | No policy runner or paired evaluation | Used only to distinguish trajectory-read labels from golden-patch localization metrics |
@@ -177,12 +177,15 @@ reasoning loop while replacing its repository data plane with
 `BaselineTask -> locate_code() -> BaselineRunResult` contract as the other
 localization baselines:
 
+```bash
+pip install "codenib[agent,graph]"
+```
+
 ```python
 from codenib.clients.locagent_agent import LocAgentAgent
 
 agent = LocAgentAgent(
     model="openai-compatible-model",
-    locagent_checkout="/path/to/LocAgent",
 )
 result = await agent.locate_code(
     query_text=issue,
@@ -191,11 +194,14 @@ result = await agent.locate_code(
 )
 ```
 
-The adapter extracts the upstream protocol lazily in an isolated subprocess
-and resolves final file, class, function, and 1-based line records through
-CodeNib's language-neutral graph. The main process never imports LocAgent or
-LiteLLM; `--locagent-python` can select a dedicated upstream environment.
-OpenAI is loaded only when the policy executes, and `--base-url` accepts an
+The adapter vendors the prompts and function schemas from the pinned revision,
+runs the policy loop in CodeNib, and resolves final file, class, function, and
+1-based line records through CodeNib's language-neutral graph. Delivery does
+not require a LocAgent checkout or a second Python environment, and it does
+not import LocAgent, LiteLLM, or LlamaIndex. The optional source-level probe
+above checks the vendored contract against pinned Git objects without importing
+upstream packages. OpenAI is loaded only when the policy executes, and
+`--base-url` accepts an
 OpenAI-compatible endpoint such as a LiteLLM proxy.
 
 The common runner reports the same ranked file/symbol accuracy, precision, and
@@ -207,7 +213,6 @@ contract.
 python examples/locagent_loc_agent.py \
   --dataset codenib_base \
   --model "$LOCAGENT_MODEL" \
-  --locagent-checkout /path/to/LocAgent \
   --result-path results/locagent.jsonl
 ```
 
@@ -429,6 +434,10 @@ python scripts/analysis/compare_agent_integrations.py score-orcaloca \
   --results-dir results/orcaloca-paired \
   --output results/orcaloca-summary.json
 ```
+
+The LocAgent checkout, Python, and native-index flags belong only to the
+optional upstream-native comparison cell. A CodeNib-only run uses
+`--provider codenib`, omits all three, and has no LlamaIndex dependency.
 
 Before any model call, the driver checks every requested checkout commit,
 tracked-file state, manifest commit, required capability, and actual loading of

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -15,7 +15,7 @@ budget contract. None of these labels alone claims end-to-end task quality.
 
 | Integration | Status | Required views | Provider contract | Policy and evaluation | Boundary |
 | --- | --- | --- | --- | --- | --- |
-| LocAgent | Revision-pinned supported | Symbol graph + BM25 | Pinned three-tool contract | Pinned prompts and function-calling loop; fixed-case paired runner | Python SWE-bench repositories; reference and type-use are disclosed as conservative relation mappings |
+| LocAgent | Revision-pinned supported | Symbol graph + BM25 | Pinned three-tool contract | Pinned prompts and function-calling loop; paired runner with strict common file/function@k scoring | Python SWE-bench repositories; reference and type-use are disclosed as conservative relation mappings |
 | Historical OpenHands LocAgent plugin | Contract-only | Symbol graph + BM25 | Python bindings for the pinned plugin revision | Covered through the LocAgent contract; policy is absent from current OpenHands CLI | No compatibility claim for other OpenHands revisions |
 | OrcaLoca SearchAgent | Revision-pinned supported | Symbol graph | Pinned six-tool and private-hook contract | Upstream `SearchAgent`; fixed-case paired runner and native File/Function Match scorer | Python SWE-bench repositories; empty `TraceAnalysisOutput`; upstream trace generation is not included |
 | SWE-Explore | Reference-only | N/A | No adapter | No policy runner or paired evaluation | Used only to distinguish trajectory-read labels from golden-patch localization metrics |
@@ -412,6 +412,11 @@ python scripts/analysis/compare_agent_integrations.py locagent \
   --native-index-dir /path/to/locagent-index \
   --model "$LOCAGENT_MODEL"
 
+python scripts/analysis/compare_agent_integrations.py score-locagent \
+  --cases /path/to/cases.json \
+  --results-dir results/locagent-paired \
+  --output results/locagent-summary.json
+
 python scripts/analysis/compare_agent_integrations.py orcaloca \
   --cases /path/to/cases.json \
   --output-dir results/orcaloca-paired \
@@ -433,6 +438,14 @@ missing and failed cells in the requested denominator, verifies recorded case
 digests against the active case set, and rejects mixed-model aggregation.
 `--allow-incomplete` writes an explicit partial audit; it does not turn a
 partial matrix into a complete one.
+
+Both scorers require explicit golden-patch `gold_files` and `gold_functions`
+in each case. `score-locagent` reports the common ranked accuracy, precision,
+and recall contract at configurable cutoffs; `score-orcaloca` reports
+OrcaLoca's unranked File Match and Function Match contract. They intentionally
+do not compare the two policies under one metric. A manifest whose persisted
+graph predates the current graph schema fails preflight and must be rebuilt;
+historical successful cells do not count as current delivery evidence.
 
 The OrcaLoca comparison follows the
 [trace-analysis boundary](#trace-analysis-boundary). File Match and Function

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -439,6 +439,59 @@ The LocAgent checkout, Python, and native-index flags belong only to the
 optional upstream-native comparison cell. A CodeNib-only run uses
 `--provider codenib`, omits all three, and has no LlamaIndex dependency.
 
+### Fixed SWE-bench Lite coverage
+
+Prepare a broad, reproducible CodeNib-only coverage set before running the
+policy:
+
+```bash
+make scip-python-tool
+export PATH="${CODENIB_SCIP_TOOLS_DIR:-/tmp/codenib/scip-tools}:$PATH"
+export CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS=3600
+
+python scripts/analysis/prepare_swebench_policy_cases.py \
+  --dataset-json ~/.codenib/princeton-nlp__SWE-bench_Lite_test.json \
+  --output-dir results/locagent-swebench-lite-50 \
+  --count 50 \
+  --jobs 4
+
+python scripts/analysis/compare_agent_integrations.py locagent \
+  --cases results/locagent-swebench-lite-50/cases.json \
+  --output-dir results/locagent-swebench-lite-50/results \
+  --provider codenib \
+  --model "$LOCAGENT_MODEL" \
+  --max-iterations 10
+
+python scripts/analysis/compare_agent_integrations.py score-locagent \
+  --cases results/locagent-swebench-lite-50/cases.json \
+  --results-dir results/locagent-swebench-lite-50/results \
+  --provider codenib \
+  --model "$LOCAGENT_MODEL" \
+  --output results/locagent-swebench-lite-50/summary.json
+```
+
+The preparation command pins the official SWE-bench Lite dataset revision and
+the local dataset-file digest. Its label-independent, seeded selection covers
+every repository stratum, creates an isolated checkout for every base commit,
+derives labels from the golden patch, and builds the required BM25 and symbol
+graph views. A label-independent guard requires the graph to represent at
+least 95% of the commit's visible Python source files and rejects paths outside
+that commit. The final audit also requires the checkout to remain clean at its
+declared base commit. Each case report reads the actual SCIP producer and
+version from the persisted index; a failed build leaves a resumable
+`build_failure.json` sidecar. The run writes `selection.json`, `prepare_report.json`,
+`preparation_environment.json`, and `preflight.json`; `cases.json` is published
+only after every selected case is eligible. Re-running the command resumes
+valid artifacts but rejects a changed dataset or selection configuration.
+Preparation performs no model requests.
+The sample is deliberately repository-balanced coverage, not a
+population-weighted estimate over all SWE-bench Lite tasks.
+
+File metrics retain all 50 selected cases in the denominator, including failed
+model cells. Function metrics use the declared subset whose golden patch
+modifies or deletes a function present in the base snapshot; pure additions
+and non-function changes are not silently scored as function misses.
+
 Before any model call, the driver checks every requested checkout commit,
 tracked-file state, manifest commit, required capability, and actual loading of
 the required runtime views. Result files bind the selected-case digest, CodeNib

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -492,6 +492,10 @@ documents, preparation retains that compiler-derived prefix and applies the
 same label-independent tree-sitter fallback to every missing tracked Python
 file. If no usable compiler document exists, the malformed or metadata-only
 artifact is rejected and the same fallback covers the full tracked surface.
+Each compiler attempt removes any earlier `index.scip` first, so retained
+documents can only come from that attempt. A graph built with source-coverage
+fallback is fully rebuilt on a later commit instead of entering the incremental
+patch path, which keeps its compiler/fallback provenance complete.
 The report distinguishes compiler availability and coverage from supplemented
 files, symbols, and final Git-surface coverage. The manifest also records
 whether generation completed or retained a partial compiler prefix. The
@@ -499,10 +503,13 @@ fallback adds definitions and containment only; it does not synthesize
 compiler reference edges. Graph audits label the resulting surface as
 `compiler`, `compiler-prefix`, `compiler-prefix+syntax`, or `syntax`.
 
-File metrics retain all 50 selected cases in the denominator, including failed
-model cells. Function metrics use the declared subset whose golden patch
-modifies or deletes a function present in the base snapshot; pure additions
-and non-function changes are not silently scored as function misses.
+File metrics validate predictions against every tracked repository file and
+retain all 50 selected cases in the denominator, including failed model cells.
+Function rankings include only locations that explicitly name a function;
+class-only locations remain file predictions. Function metrics use the declared
+subset whose golden patch modifies or deletes a function present in the base
+snapshot; pure additions and non-function changes are not silently scored as
+function misses.
 
 Before any model call, the driver checks every requested checkout commit,
 tracked-file state, manifest commit, required capability, and actual loading of

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -16,7 +16,6 @@ budget contract. None of these labels alone claims end-to-end task quality.
 | Integration | Status | Required views | Provider contract | Policy and evaluation | Boundary |
 | --- | --- | --- | --- | --- | --- |
 | LocAgent | CodeNib-native, revision-pinned | Symbol graph + BM25 | Pinned three-tool contract | Vendored prompts and function-calling loop; paired runner with strict common file/function@k scoring | Python SWE-bench repositories; reference and type-use are disclosed as conservative relation mappings |
-| Historical OpenHands LocAgent plugin | Contract-only | Symbol graph + BM25 | Python bindings for the pinned plugin revision | Covered through the LocAgent contract; policy is absent from current OpenHands CLI | No compatibility claim for other OpenHands revisions |
 | OrcaLoca SearchAgent | Revision-pinned supported | Symbol graph | Pinned six-tool and private-hook contract | Upstream `SearchAgent`; fixed-case paired runner and native File/Function Match scorer | Python SWE-bench repositories; empty `TraceAnalysisOutput`; upstream trace generation is not included |
 | SWE-Explore | Reference-only | N/A | No adapter | No policy runner or paired evaluation | Used only to distinguish trajectory-read labels from golden-patch localization metrics |
 
@@ -55,10 +54,9 @@ indexed search, and graph traversal. This checks that the provider boundary is
 language-agnostic; it is not evidence that the pinned Python-only LocAgent or
 OrcaLoca native implementations support those languages.
 
-## LocAgent And OpenHands
+## LocAgent
 
-The LocAgent provider implements the three repository functions used by
-LocAgent and the historical OpenHands integration:
+The LocAgent provider implements the policy's three repository functions:
 
 - `search_code_snippets`
 - `get_entity_contents`
@@ -96,53 +94,9 @@ python examples/integrations/locagent.py \
 ```
 
 `provider.bindings()` returns the same-named Python callables for a runtime
-plugin. This follows the separation in
-[OpenHands PR #7371](https://github.com/OpenHands/OpenHands/pull/7371): the
-agent owns function schemas and action conversion, while the runtime supplies
-the repository functions. CodeNib dispatches calls directly and does not copy
-the historical IPython string-evaluation bridge.
-
-For the historical OpenHands runtime plugin, the complete provider-binding
-change is:
-
-```python
-import os
-
-from codenib.integrations.locagent import LocAgentToolProvider
-
-_provider = LocAgentToolProvider.from_manifest(os.environ["CODENIB_MANIFEST"])
-get_entity_contents = _provider.get_entity_contents
-search_code_snippets = _provider.search_code_snippets
-explore_tree_structure = _provider.explore_tree_structure
-```
-
-The agent-side schemas and action loop remain unchanged. Modern runtimes can
-use `provider.dispatch(name, arguments)` directly instead of constructing
-Python source from model-supplied arguments.
-
-Compatibility is revision-scoped:
-
-| Contract | Pinned revision |
-| --- | --- |
-| LocAgent behavior | `ef170542a5cca88a1bd8463335ec43de222ed5f9` |
-| OpenHands integration | `efe287ce3402706a171b3a5fb40f15914e98ef20` |
-
-Current OpenHands CLI does not contain that historical LocAgent module. The pin
-describes the supported tool contract; it is not a claim that every OpenHands
-CLI revision exposes LocAgent.
-
-Run the optional source-level probe against local upstream checkouts with:
-
-```bash
-LOCAGENT_CHECKOUT=/path/to/LocAgent \
-OPENHANDS_CHECKOUT=/path/to/OpenHands \
-  pytest -q test/integrations/test_locagent_upstream.py
-```
-
-The probe reads files directly from the pinned Git objects and does not import
-either project. To advance compatibility, update the two revision constants,
-refresh the YAML fixture from the reviewed upstream schemas, and run both this
-probe and `test/integrations/test_locagent.py` in the same change.
+plugin. Modern runtimes can use `provider.dispatch(name, arguments)` directly.
+The supported behavior is pinned to LocAgent revision
+`ef170542a5cca88a1bd8463335ec43de222ed5f9`.
 
 ### Relation Semantics
 
@@ -166,8 +120,8 @@ reference or type-use edges as exact call or inheritance facts.
 - Missing, stale, or failed graph and BM25 views produce explicit errors.
 - Tool output is deterministic and bounded by provider-level result, traversal,
   source-line, and character budgets.
-- Loading the provider never invokes LocAgent, OpenHands ACI, NetworkX,
-  LlamaIndex, or an index builder.
+- Loading the provider never invokes LocAgent, NetworkX, LlamaIndex, or an
+  index builder.
 
 ### Shared Benchmark Interface
 
@@ -397,8 +351,8 @@ ORCALOCA_CHECKOUT=/path/to/OrcaLoca \
 The upstream probe is optional and marked `integration`; without
 `ORCALOCA_CHECKOUT`, it skips before importing OrcaLoca.
 
-The base `codenib` package therefore gains no LocAgent, OpenHands, OrcaLoca,
-LlamaIndex, pandas, or NetworkX dependency.
+The base `codenib` package therefore gains no LocAgent, OrcaLoca, LlamaIndex,
+pandas, or NetworkX dependency.
 
 ## Paired Provider Compatibility
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -117,7 +117,7 @@ evaluated.
 |--------|-------|---------------|
 | [`claude_loc_agent.py`](claude_loc_agent.py) | `ClaudeLocAgent` over `claude_agent_sdk` | `pip install claude-agent-sdk` |
 | [`codex_loc_agent.py`](codex_loc_agent.py) | `CodexLocAgent` over OpenAI's `openai_codex` | see the script's header (GitHub, not PyPI) |
-| [`locagent_loc_agent.py`](locagent_loc_agent.py) | LocAgent policy over CodeNib's manifest-backed tools | pinned LocAgent checkout and its policy dependencies |
+| [`locagent_loc_agent.py`](locagent_loc_agent.py) | Pinned LocAgent policy over CodeNib's manifest-backed tools | `pip install "codenib[agent,graph]"` |
 | [`orcaloca_loc_agent.py`](orcaloca_loc_agent.py) | OrcaLoca policy over CodeNib's manifest-backed graph | pinned OrcaLoca checkout and its LlamaIndex dependencies |
 
 The Claude and Codex wrappers lock down writes (read-only sandbox +
@@ -138,7 +138,6 @@ each checkout with the graph preset, then run either policy:
 ```bash
 python examples/locagent_loc_agent.py \
     --dataset codenib_base --model "$LOCAGENT_MODEL" \
-    --locagent-checkout /path/to/LocAgent \
     --result-path results/locagent_loc.jsonl --resume
 
 python examples/orcaloca_loc_agent.py \

--- a/examples/locagent_loc_agent.py
+++ b/examples/locagent_loc_agent.py
@@ -4,11 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run LocAgent's policy over CodeNib views with the common benchmark runner.
-
-The pinned LocAgent checkout supplies the prompts and function schemas.
-CodeNib supplies all repository tools from an existing graph-enabled manifest.
-"""
+"""Run CodeNib's pinned LocAgent policy with the common benchmark runner."""
 
 from __future__ import annotations
 
@@ -33,18 +29,6 @@ def parse_args() -> argparse.Namespace:
         "--model",
         required=True,
         help="OpenAI-compatible model name used by the LocAgent policy.",
-    )
-    parser.add_argument(
-        "--locagent-checkout",
-        type=Path,
-        default=None,
-        help="Pinned LocAgent checkout (or set LOCAGENT_CHECKOUT).",
-    )
-    parser.add_argument(
-        "--locagent-python",
-        type=Path,
-        default=None,
-        help="Python executable with the pinned LocAgent policy dependencies.",
     )
     parser.add_argument(
         "--manifest",
@@ -82,8 +66,6 @@ def main() -> None:
     def factory() -> LocAgentAgent:
         return LocAgentAgent(
             model=args.model,
-            locagent_checkout=args.locagent_checkout,
-            locagent_python=args.locagent_python,
             manifest_path=args.manifest,
             max_iterations=args.max_iterations,
             max_completion_tokens=args.max_completion_tokens,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ codenib-artifact-bundle = "codenib.eval.artifact_bundle:main"
 [project.optional-dependencies]
 agent = [
     "litellm>=1.40.0",
+    "openai>=1.0.0",
 ]
 datasets = [
     "datasets>=4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ codenib-artifact-bundle = "codenib.eval.artifact_bundle:main"
 
 [project.optional-dependencies]
 agent = [
-    "litellm>=1.40.0",
+    "litellm>=1.93.0",
     "openai>=1.0.0",
 ]
 datasets = [
@@ -131,7 +131,7 @@ test = [
     "faiss-cpu>=1.7.0",
     "filelock>=3.0.0",
     "igraph>=0.11.6",
-    "litellm>=1.40.0",
+    "litellm>=1.93.0",
     "matplotlib>=3.4.0",
     "mcp>=2.0.0,<3",
     "numpy>=1.24.0",

--- a/scripts/analysis/prepare_swebench_policy_cases.py
+++ b/scripts/analysis/prepare_swebench_policy_cases.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare a fixed SWE-bench Lite case set for policy evaluation."""
+
+from codenib.eval.benchmarks.swebench_policy_cases import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -1483,6 +1483,31 @@ class TestSymbolGraphIncremental:
         # last_commit must not leak into build()'s kwargs
         assert "last_commit" not in built[0]
 
+    def test_source_coverage_fallback_rebuilds_instead_of_patching(
+        self, tmp_path, monkeypatch
+    ):
+        built = []
+        builder = self._builder(source_coverage_fallback=True)
+        monkeypatch.setattr(
+            builder, "build", lambda scope, **kw: built.append(kw) or "BUILT"
+        )
+        monkeypatch.setattr(
+            builder,
+            "_patch_graph",
+            lambda *_args, **_kwargs: pytest.fail("fallback graph must not be patched"),
+        )
+
+        result = builder.incremental_update(
+            "current_repo",
+            repo_path=str(tmp_path),
+            output_dir=str(tmp_path / "out"),
+            last_commit="a" * 40,
+        )
+
+        assert result == "BUILT"
+        assert len(built) == 1
+        assert "last_commit" not in built[0]
+
     def test_unverified_update_is_discarded_and_rebuilt(self, tmp_path, monkeypatch):
         """Default NullVerifier proves nothing, so the patch must be dropped."""
         builder = self._builder()  # require_verification=True by default

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -37,6 +37,7 @@ from codenib.compiler.resources import (
     ResourceResolver,
 )
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
+from codenib.ls_router import GraphBuildResult
 from codenib.repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
     default_exclude_patterns,
@@ -212,11 +213,16 @@ class TestSymbolGraphBuilder:
 
         def fake_build_graph_for_languages(*args, **kwargs):
             calls.append((args, kwargs))
-            return mock_graph
+            return GraphBuildResult(
+                graph=mock_graph,
+                requested_languages=["python"],
+                available_languages=["python"],
+                failed_languages={},
+            )
 
         monkeypatch.setattr(
             ls_router,
-            "build_graph_for_languages",
+            "build_graph_for_languages_with_report",
             fake_build_graph_for_languages,
         )
 
@@ -237,6 +243,7 @@ class TestSymbolGraphBuilder:
             (
                 ("/fake/repo", output),
                 {
+                    "allow_partial": False,
                     "languages": ["python"],
                     "project_name": "repo",
                     "skip_level": None,
@@ -251,8 +258,13 @@ class TestSymbolGraphBuilder:
 
         monkeypatch.setattr(
             ls_router,
-            "build_graph_for_languages",
-            lambda *args, **kwargs: None,
+            "build_graph_for_languages_with_report",
+            lambda *args, **kwargs: GraphBuildResult(
+                graph=None,
+                requested_languages=["python"],
+                available_languages=[],
+                failed_languages={"python": "indexer returned no graph"},
+            ),
         )
 
         builder = SymbolGraphBuilder()
@@ -264,20 +276,129 @@ class TestSymbolGraphBuilder:
                 output_dir=output,
             )
 
+    def test_build_can_fall_back_when_compiler_returns_no_graph(
+        self, monkeypatch, tmp_path
+    ):
+        from codenib import ls_router
+
+        monkeypatch.setattr(
+            ls_router,
+            "build_graph_for_languages_with_report",
+            lambda *args, **kwargs: GraphBuildResult(
+                graph=None,
+                requested_languages=["python"],
+                available_languages=[],
+                failed_languages={"python": "indexer returned no graph"},
+                index_generation_reports={
+                    "python": {
+                        "status": "failed",
+                        "complete": False,
+                        "partial": False,
+                        "document_count": 0,
+                    }
+                },
+            ),
+        )
+        monkeypatch.setattr(
+            "codenib.git_snapshot.GitSourceSurface.load",
+            lambda _repo_path: object(),
+        )
+        monkeypatch.setattr(
+            "codenib.languages.extensions_for_language",
+            lambda _language, _capability: {".py"},
+        )
+
+        def fake_supplement(graph, **_kwargs):
+            assert graph.graph.vs[0]["type"] == "root"
+            graph.add_file_node("fallback.py")
+            graph.build_range_indexes()
+            return {
+                "coverage_before": 0.0,
+                "coverage_after": 1.0,
+                "supplemented_files": 1,
+            }
+
+        monkeypatch.setattr(
+            "codenib.graph.source_coverage.supplement_graph_source_coverage",
+            fake_supplement,
+        )
+
+        output = tmp_path / "graph"
+        status = SymbolGraphBuilder(
+            allow_partial_index=True,
+            source_coverage_fallback=True,
+        ).build(
+            scope="current_repo",
+            repo_path="/fake/repo",
+            output_dir=str(output),
+        )
+
+        report = status.metadata["source_coverage_report"]
+        assert status.state == IndexState.FRESH
+        assert status.metadata["available_languages"] == ["python"]
+        assert status.metadata["compiler_available_languages"] == []
+        assert report["compiler_graph_available"] is False
+        assert report["compiler_index_complete"] is False
+        assert report["compiler_nodes"] == 0
+        assert report["compiler_edges"] == 0
+        assert report["coverage_after"] == 1.0
+        assert (output / "graph.pkl").is_file()
+
+    def test_build_rejects_incomplete_source_coverage_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        from codenib import ls_router
+
+        monkeypatch.setattr(
+            ls_router,
+            "build_graph_for_languages_with_report",
+            lambda *args, **kwargs: GraphBuildResult(
+                graph=None,
+                requested_languages=["python"],
+                available_languages=[],
+                failed_languages={"python": "indexer returned no graph"},
+            ),
+        )
+        monkeypatch.setattr(
+            "codenib.git_snapshot.GitSourceSurface.load",
+            lambda _repo_path: object(),
+        )
+        monkeypatch.setattr(
+            "codenib.languages.extensions_for_language",
+            lambda _language, _capability: {".py"},
+        )
+        monkeypatch.setattr(
+            "codenib.graph.source_coverage.supplement_graph_source_coverage",
+            lambda *_args, **_kwargs: {"coverage_after": 0.5},
+        )
+
+        with pytest.raises(RuntimeError, match="did not cover"):
+            SymbolGraphBuilder(source_coverage_fallback=True).build(
+                scope="current_repo",
+                repo_path="/fake/repo",
+                output_dir=str(tmp_path / "graph"),
+            )
+
     def test_build_forwards_multiple_languages(self, monkeypatch, tmp_path):
         from codenib import ls_router
 
         mock_graph = MagicMock()
         mock_graph.graph.vs = [MagicMock()]
+        mock_graph.graph.es = []
         calls = []
 
         def fake_build_graph_for_languages(*args, **kwargs):
             calls.append((args, kwargs))
-            return mock_graph
+            return GraphBuildResult(
+                graph=mock_graph,
+                requested_languages=["python", "go"],
+                available_languages=["python", "go"],
+                failed_languages={},
+            )
 
         monkeypatch.setattr(
             ls_router,
-            "build_graph_for_languages",
+            "build_graph_for_languages_with_report",
             fake_build_graph_for_languages,
         )
 
@@ -303,11 +424,16 @@ class TestSymbolGraphBuilder:
 
         def fake_build_graph_for_languages(*args, **kwargs):
             calls.append((args, kwargs))
-            return mock_graph
+            return GraphBuildResult(
+                graph=mock_graph,
+                requested_languages=["java"],
+                available_languages=["java"],
+                failed_languages={},
+            )
 
         monkeypatch.setattr(
             ls_router,
-            "build_graph_for_languages",
+            "build_graph_for_languages_with_report",
             fake_build_graph_for_languages,
         )
 
@@ -321,6 +447,82 @@ class TestSymbolGraphBuilder:
 
         assert status.metadata["graph_route"] == "scip-candidate"
         assert calls[0][1]["graph_route"] == "scip-candidate"
+
+    def test_build_records_source_coverage_fallback_report(self, monkeypatch, tmp_path):
+        from codenib import ls_router
+
+        mock_graph = MagicMock()
+        mock_graph.graph.vs = [MagicMock()]
+        mock_graph.graph.es = []
+        calls = []
+        report = {
+            "coverage_before": 0.5,
+            "coverage_after": 1.0,
+            "supplemented_files": ["missing.py"],
+        }
+
+        def fake_build_graph_for_languages(*args, **kwargs):
+            calls.append((args, kwargs))
+            return GraphBuildResult(
+                graph=mock_graph,
+                requested_languages=["python"],
+                available_languages=["python"],
+                failed_languages={},
+                index_generation_reports={
+                    "python": {
+                        "status": "partial",
+                        "complete": False,
+                        "partial": True,
+                        "document_count": 10,
+                    }
+                },
+            )
+
+        monkeypatch.setattr(
+            ls_router,
+            "build_graph_for_languages_with_report",
+            fake_build_graph_for_languages,
+        )
+        monkeypatch.setattr(
+            "codenib.compiler.artifact_quality.graph_file_paths",
+            lambda _graph: {"covered.py"},
+        )
+        monkeypatch.setattr(
+            "codenib.git_snapshot.GitSourceSurface.load",
+            lambda _repo_path: object(),
+        )
+        monkeypatch.setattr(
+            "codenib.languages.extensions_for_language",
+            lambda _language, _capability: {".py"},
+        )
+        monkeypatch.setattr(
+            "codenib.graph.source_coverage.supplement_graph_source_coverage",
+            lambda *_args, **_kwargs: report,
+        )
+
+        builder = SymbolGraphBuilder(
+            languages=["python"],
+            allow_partial_index=True,
+            source_coverage_fallback=True,
+        )
+        status = builder.build(
+            scope="current_repo",
+            repo_path="/fake/repo",
+            output_dir=str(tmp_path / "graph"),
+        )
+
+        assert calls[0][1]["allow_partial_index"] is True
+        assert status.metadata["source_coverage_fallback"] is True
+        assert status.metadata["source_coverage_report"] == {
+            "compiler_graph_available": True,
+            "compiler_index_complete": False,
+            "compiler_partial_languages": ["python"],
+            "compiler_nodes": 1,
+            "compiler_edges": 0,
+            **report,
+        }
+        assert status.metadata["partial_index"] is True
+        mock_graph.save_graph.assert_called_once()
 
     def test_build_records_partial_language_coverage(self, monkeypatch, tmp_path):
         from codenib import ls_router
@@ -419,6 +621,8 @@ class TestRegisterDefaultBuilders:
         assert symbol_graph.languages == ["rust", "python"]
         assert symbol_graph.graph_route == "scip-candidate"
         assert symbol_graph.allow_partial_languages is False
+        assert symbol_graph.allow_partial_index is False
+        assert symbol_graph.source_coverage_fallback is False
 
     def test_can_register_partial_multi_language_graph_builder(self):
         registry = IndexBuilderRegistry()
@@ -431,6 +635,24 @@ class TestRegisterDefaultBuilders:
         symbol_graph = registry.get("symbol_graph")
         assert isinstance(symbol_graph, SymbolGraphBuilder)
         assert symbol_graph.allow_partial_languages is True
+
+    def test_can_register_partial_index_graph_builder(self):
+        registry = IndexBuilderRegistry()
+        register_default_builders(
+            registry,
+            languages=["python"],
+            allow_partial_graph_index=True,
+            graph_source_coverage_fallback=True,
+        )
+
+        symbol_graph = registry.get("symbol_graph")
+        assert isinstance(symbol_graph, SymbolGraphBuilder)
+        assert symbol_graph.allow_partial_index is True
+        assert symbol_graph.source_coverage_fallback is True
+
+    def test_partial_index_requires_source_coverage_fallback(self):
+        with pytest.raises(ValueError, match="requires source_coverage_fallback"):
+            SymbolGraphBuilder(allow_partial_index=True)
 
 
 # ---------------------------------------------------------------------------

--- a/test/eval/test_locagent_benchmark_adapter.py
+++ b/test/eval/test_locagent_benchmark_adapter.py
@@ -102,10 +102,16 @@ def test_adapter_import_does_not_require_locagent_litellm_or_openai() -> None:
     script = """
 import sys
 sys.modules["litellm"] = None
+sys.modules["llama_index"] = None
 sys.modules["openai"] = None
 sys.modules["util"] = None
-from codenib.clients.locagent_agent import LocAgentAgent
+from codenib.clients.locagent_agent import LocAgentAgent, load_locagent_protocol
 assert LocAgentAgent.__name__ == "LocAgentAgent"
+protocol = load_locagent_protocol(
+    problem_statement="Fix parser",
+    package_name="demo",
+)
+assert protocol.tools[0]["function"]["name"] == "finish"
 """
 
     result = subprocess.run(
@@ -182,57 +188,27 @@ def test_parser_does_not_treat_qualified_symbol_as_file() -> None:
     assert locations[0].function_name == "BillingService.calculate_tax"
 
 
-def test_protocol_is_extracted_in_an_isolated_python_process(
-    monkeypatch,
+def test_protocol_is_vendored_and_does_not_require_upstream_paths(
     tmp_path: Path,
 ) -> None:
-    checkout = tmp_path / "LocAgent"
-    runtime = checkout / "util" / "runtime"
-    runtime.mkdir(parents=True)
-    (runtime / "function_calling.py").write_text("", encoding="utf-8")
-    python = tmp_path / "locagent-python"
-    python.write_text("", encoding="utf-8")
-    calls = []
-    payload = {
-        "system_prompt": "system",
-        "task_template": "Inspect {package_name}.\n",
-        "pr_template": "Title: {title}\n{description}\n",
-        "followup": "verify",
-        "tools": [
-            {
-                "type": "function",
-                "function": {"name": "finish", "parameters": {}},
-            }
-        ],
-    }
-
-    def run(command, **kwargs):
-        calls.append((command, kwargs))
-        return SimpleNamespace(
-            returncode=0,
-            stdout=json.dumps(payload),
-            stderr="",
-        )
-
-    locagent_client._load_upstream_assets.cache_clear()
-    monkeypatch.setattr(locagent_client.subprocess, "run", run)
     protocol = locagent_client.load_locagent_protocol(
-        checkout,
+        tmp_path / "missing-locagent-checkout",
         problem_statement="Fix parser\nPreserve ranges.",
         package_name="demo",
-        python_executable=python,
+        python_executable=tmp_path / "missing-locagent-python",
     )
-    locagent_client._load_upstream_assets.cache_clear()
 
-    assert protocol.system_prompt == "system"
-    assert protocol.followup == "verify"
-    assert "Inspect demo." in protocol.instruction
+    assert protocol.system_prompt.startswith("You are a helpful assistant")
+    assert "modules in the 'demo' package" in protocol.instruction
     assert "Title: Fix parser" in protocol.instruction
     assert "Preserve ranges." in protocol.instruction
+    assert "never modify files" in protocol.instruction
     assert protocol.tools[0]["function"]["name"] == "finish"
-    assert calls[0][0][0] == str(python.resolve())
-    assert calls[0][1]["cwd"] == checkout.resolve()
-    assert calls[0][1]["timeout"] == 60
+    assert [tool["function"]["name"] for tool in protocol.tools[1:]] == [
+        "search_code_snippets",
+        "get_entity_contents",
+        "explore_tree_structure",
+    ]
 
 
 def test_agent_resolves_locagent_output_to_generic_symbols(
@@ -343,7 +319,7 @@ def test_default_policy_loop_dispatches_tools_and_finishes(
     )
     monkeypatch.setattr(
         locagent_client,
-        "load_locagent_protocol",
+        "build_locagent_protocol",
         lambda *_args, **_kwargs: protocol,
     )
 
@@ -425,7 +401,6 @@ def test_default_policy_loop_dispatches_tools_and_finishes(
     )
     agent = LocAgentAgent(
         model="test-model",
-        locagent_checkout=tmp_path / "LocAgent",
         manifest_path=manifest,
         provider_factory=lambda _manifest: provider,
         client_factory=lambda: client,

--- a/test/eval/test_policy_benchmark.py
+++ b/test/eval/test_policy_benchmark.py
@@ -365,15 +365,9 @@ def test_failed_orcaloca_cell_is_an_all_miss_with_empty_function_labels(
     assert summary["paired_summary"]["n"] == 0
 
 
-def test_locagent_loop_uses_the_configured_protocol_python(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_locagent_loop_uses_the_vendored_protocol(monkeypatch, tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
-    python = tmp_path / "locagent-python"
-    python.write_text("", encoding="utf-8")
-    checkout = tmp_path / "LocAgent"
-    checkout.mkdir()
     case = PolicyBenchmarkCase.from_mapping(
         {
             "instance_id": "demo__repo-1",
@@ -385,11 +379,11 @@ def test_locagent_loop_uses_the_configured_protocol_python(
     )
     captured = {}
 
-    def load_protocol(_checkout, **kwargs):
+    def build_protocol(**kwargs):
         captured.update(kwargs)
         return object()
 
-    monkeypatch.setattr(policy_benchmark, "load_locagent_protocol", load_protocol)
+    monkeypatch.setattr(policy_benchmark, "build_locagent_protocol", build_protocol)
     monkeypatch.setattr(
         policy_benchmark,
         "run_locagent_policy",
@@ -408,16 +402,86 @@ def test_locagent_loop_uses_the_configured_protocol_python(
 
     result = _run_locagent_loop(
         case=case,
-        checkout=checkout,
         dispatch=lambda _name, _arguments: "",
         model="test-model",
         base_url=None,
         max_iterations=2,
-        locagent_python=python,
     )
 
-    assert captured["python_executable"] == python
+    assert captured == {
+        "problem_statement": "Locate the parser",
+        "package_name": "demo",
+    }
     assert result["iterations"] == 1
+
+
+def test_codenib_locagent_run_needs_no_upstream_checkout_or_python(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from codenib.integrations.locagent import LocAgentToolProvider
+
+    cases = tmp_path / "cases.json"
+    output_dir = tmp_path / "results"
+    _write_cases(cases)
+
+    class Provider:
+        load_seconds = 0.01
+
+        def dispatch(self, _name, _arguments):
+            return ""
+
+    monkeypatch.setattr(
+        policy_benchmark,
+        "inspect_policy_run_preflight",
+        lambda *_args, **_kwargs: SimpleNamespace(require_eligible=lambda: None),
+    )
+    monkeypatch.setattr(
+        policy_benchmark,
+        "_policy_provenance_by_provider",
+        lambda **_kwargs: {"codenib": {"fixture": True}},
+    )
+    monkeypatch.setattr(
+        LocAgentToolProvider,
+        "from_manifest",
+        lambda _manifest: Provider(),
+    )
+    monkeypatch.setattr(
+        policy_benchmark,
+        "_run_locagent_loop",
+        lambda **_kwargs: {
+            "model": "test-model",
+            "elapsed_seconds": 0.1,
+            "regions": [],
+            "usage": {},
+        },
+    )
+
+    assert (
+        main(
+            [
+                "locagent",
+                "--cases",
+                str(cases),
+                "--output-dir",
+                str(output_dir),
+                "--provider",
+                "codenib",
+                "--model",
+                "test-model",
+            ]
+        )
+        == 0
+    )
+    result = json.loads(
+        policy_result_path(
+            output_dir,
+            instance_id="demo__repo-1",
+            agent="locagent",
+            provider="codenib",
+        ).read_text(encoding="utf-8")
+    )
+    assert result["provider"] == "codenib"
+    assert "error" not in result
 
 
 def test_provider_cleanup_failure_is_recordable() -> None:

--- a/test/eval/test_policy_benchmark.py
+++ b/test/eval/test_policy_benchmark.py
@@ -18,6 +18,7 @@ import codenib.eval.benchmarks.policy_benchmark as policy_benchmark
 from codenib.eval.benchmarks.policy_benchmark import (
     _activate_orcaloca_checkout,
     _close_provider,
+    _locagent_predictions,
     _run_locagent_loop,
     main,
 )
@@ -143,6 +144,44 @@ def test_score_locagent_uses_common_ranked_metrics_and_strict_denominator(
     assert complete["paired_summary"][
         "native_to_codenib_total_tokens_ratio_median"
     ] == pytest.approx(1.25)
+
+
+def test_locagent_predictions_score_repository_files_but_only_named_functions(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "Dockerfile").write_text("FROM python:3.12\n", encoding="utf-8")
+    (repo / "setup.cfg").write_text("[metadata]\n", encoding="utf-8")
+    (repo / "src" / "model.py").write_text(
+        "class Widget:\n    def save(self):\n        pass\n",
+        encoding="utf-8",
+    )
+    case = PolicyBenchmarkCase(
+        instance_id="demo__repo-1",
+        problem_statement="Locate the configuration and save method",
+        repo_path=repo,
+        base_commit="a" * 40,
+        manifest_path=tmp_path / "manifest.json",
+    )
+
+    files, functions = _locagent_predictions(
+        case,
+        {
+            "final_output": (
+                "Dockerfile\n"
+                "setup.cfg\n"
+                "src/model.py\n"
+                "Class: Widget\n"
+                "src/model.py\n"
+                "Class: Widget\n"
+                "Functions: save\n"
+            )
+        },
+    )
+
+    assert files == ("Dockerfile", "setup.cfg", "src/model.py")
+    assert functions == ("src/model.py:Widget.save",)
 
 
 def test_score_command_enforces_the_requested_cell_denominator(tmp_path: Path) -> None:

--- a/test/eval/test_policy_benchmark.py
+++ b/test/eval/test_policy_benchmark.py
@@ -77,6 +77,74 @@ def _write_result(results: Path, *, provider: str, model: str = "test-model") ->
     )
 
 
+def _write_locagent_result(
+    results: Path,
+    *,
+    provider: str,
+    model: str = "test-model",
+) -> None:
+    write_json_atomic(
+        policy_result_path(
+            results,
+            instance_id="demo__repo-1",
+            agent="locagent",
+            provider=provider,
+        ),
+        {
+            "agent": "locagent",
+            "provider": provider,
+            "instance_id": "demo__repo-1",
+            "model": model,
+            "usage": {"total_tokens": 100 if provider == "native" else 80},
+            "final_output": "src/parser.py\nFunctions: parse\n",
+        },
+    )
+
+
+def test_score_locagent_uses_common_ranked_metrics_and_strict_denominator(
+    tmp_path: Path,
+) -> None:
+    cases = tmp_path / "cases.json"
+    results = tmp_path / "results"
+    output = tmp_path / "summary.json"
+    repo = tmp_path / "repo" / "src"
+    repo.mkdir(parents=True)
+    (repo / "parser.py").write_text("def parse():\n    pass\n", encoding="utf-8")
+    _write_cases(cases)
+    payload = json.loads(cases.read_text(encoding="utf-8"))
+    payload["cases"][0]["repo_path"] = "repo"
+    cases.write_text(json.dumps(payload), encoding="utf-8")
+    _write_locagent_result(results, provider="native")
+    base_args = [
+        "score-locagent",
+        "--cases",
+        str(cases),
+        "--results-dir",
+        str(results),
+        "--output",
+        str(output),
+    ]
+
+    assert main(base_args) == 1
+    assert main([*base_args, "--allow-incomplete"]) == 0
+    partial = json.loads(output.read_text(encoding="utf-8"))
+    assert partial["coverage"]["expected_cell_count"] == 2
+    by_provider = {row["provider"]: row for row in partial["summary"]}
+    assert by_provider["native"]["file_metrics"]["1"]["accuracy"] == 1.0
+    assert by_provider["native"]["function_metrics"]["1"]["accuracy"] == 1.0
+    assert by_provider["codenib"]["failed_count"] == 1
+    assert by_provider["codenib"]["file_metrics"]["1"]["accuracy"] == 0.0
+
+    _write_locagent_result(results, provider="codenib")
+    assert main(base_args) == 0
+    complete = json.loads(output.read_text(encoding="utf-8"))
+    assert complete["coverage"]["paired_successful_count"] == 1
+    assert complete["paired_summary"]["n"] == 1
+    assert complete["paired_summary"][
+        "native_to_codenib_total_tokens_ratio_median"
+    ] == pytest.approx(1.25)
+
+
 def test_score_command_enforces_the_requested_cell_denominator(tmp_path: Path) -> None:
     cases = tmp_path / "cases.json"
     results = tmp_path / "results"

--- a/test/eval/test_policy_compat.py
+++ b/test/eval/test_policy_compat.py
@@ -24,6 +24,7 @@ from codenib.eval.benchmarks.policy_compat import (
     inspect_policy_run_preflight,
     load_policy_results,
     policy_result_path,
+    repository_files,
     source_files,
     write_json_atomic,
 )
@@ -63,6 +64,20 @@ def _init_repo(path: Path) -> str:
         capture_output=True,
         text=True,
     ).stdout.strip()
+
+
+def test_repository_files_uses_the_complete_tracked_surface(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    ignored_by_traversal = repo / "node_modules" / "pinned.cfg"
+    ignored_by_traversal.parent.mkdir()
+    ignored_by_traversal.write_text("pinned=true\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "-f", "node_modules/pinned.cfg"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "commit", "-qm", "track config"], cwd=repo, check=True)
+
+    assert repository_files(repo) == ("node_modules/pinned.cfg", "source.py")
 
 
 def test_case_set_loads_metadata_selects_stably_and_hashes_semantics(
@@ -366,6 +381,15 @@ def test_result_loading_validates_identity_and_source_listing(tmp_path: Path) ->
     assert len(loaded) == 1
     assert source_files(repo) == tuple(
         sorted(["src/code.py", *(f"src/extra{suffix}" for suffix in registry_suffixes)])
+    )
+    assert repository_files(repo) == tuple(
+        sorted(
+            [
+                "README.md",
+                "src/code.py",
+                *(f"src/extra{suffix}" for suffix in registry_suffixes),
+            ]
+        )
     )
 
     write_json_atomic(

--- a/test/eval/test_swebench_policy_cases.py
+++ b/test/eval/test_swebench_policy_cases.py
@@ -10,8 +10,12 @@ from collections import Counter
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from codenib.eval.benchmarks import swebench_policy_cases
 from codenib.eval.benchmarks.swebench_policy_cases import (
+    _graph_coverage_mode,
+    _graph_producer,
     _graph_source_coverage_report,
     _scip_producer,
     _snapshot_errors,
@@ -81,6 +85,51 @@ def test_scip_producer_reads_artifact_metadata(tmp_path: Path) -> None:
         "version": "0.6.6",
         "arguments": ["index", "--cwd", "/repo"],
     }
+
+
+def test_graph_producer_requires_explicit_syntax_fallback(tmp_path: Path) -> None:
+    missing_index = tmp_path / "index.scip"
+
+    assert _graph_producer(
+        missing_index,
+        {"source_coverage_report": {"compiler_graph_available": False}},
+    ) == {
+        "name": "codenib-syntax-fallback",
+        "version": "1",
+        "arguments": [],
+    }
+    with pytest.raises(RuntimeError, match="no compiler provenance"):
+        _graph_producer(missing_index, {})
+
+
+def test_graph_coverage_mode_distinguishes_compiler_and_fallbacks(
+    tmp_path: Path,
+) -> None:
+    index_path = tmp_path / "index.scip"
+    assert (
+        _graph_coverage_mode(
+            index_path,
+            {"source_coverage_report": {"compiler_graph_available": False}},
+        )
+        == "syntax"
+    )
+
+    index_path.touch()
+    assert _graph_coverage_mode(index_path, {}) == "compiler"
+    assert (
+        _graph_coverage_mode(
+            index_path,
+            {"source_coverage_report": {"compiler_index_complete": False}},
+        )
+        == "compiler-prefix"
+    )
+    assert (
+        _graph_coverage_mode(
+            index_path,
+            {"source_coverage_report": {"supplemented_files": 2}},
+        )
+        == "compiler-prefix+syntax"
+    )
 
 
 def _record(repo: str, index: int) -> dict[str, str]:

--- a/test/eval/test_swebench_policy_cases.py
+++ b/test/eval/test_swebench_policy_cases.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+
+from codenib.eval.benchmarks import swebench_policy_cases
+from codenib.eval.benchmarks.swebench_policy_cases import (
+    _graph_source_coverage_report,
+    _scip_producer,
+    _snapshot_errors,
+    extract_golden_patch_labels,
+    load_dataset_records,
+    select_balanced_repository_cases,
+)
+from codenib.scip_interface.scip_pb2 import Index as SCIPIndex
+
+
+def test_scip_provenance_records_resolved_tool_and_timeout(monkeypatch) -> None:
+    monkeypatch.setattr(
+        swebench_policy_cases.shutil,
+        "which",
+        lambda command: "/tools/scip-python" if command == "scip-python" else None,
+    )
+    monkeypatch.setattr(
+        swebench_policy_cases.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="0.6.6\n",
+            stderr="",
+        ),
+    )
+    monkeypatch.setenv("CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS", "1800")
+
+    assert swebench_policy_cases._scip_python_provenance() == {
+        "path": "/tools/scip-python",
+        "version": "0.6.6",
+        "index_timeout_seconds": "1800",
+    }
+
+
+def test_graph_source_coverage_rejects_missing_or_outside_files() -> None:
+    accepted = _graph_source_coverage_report(
+        {"a.py", "b.py"},
+        {"a.py", "b.py"},
+    )
+    low_coverage = _graph_source_coverage_report(
+        {"a.py", "b.py"},
+        {"a.py"},
+    )
+    outside = _graph_source_coverage_report(
+        {"a.py"},
+        {"a.py", "generated.py"},
+        outside_commit={"generated.py"},
+    )
+
+    assert accepted["passed"] is True
+    assert low_coverage["passed"] is False
+    assert low_coverage["coverage"] == 0.5
+    assert outside["passed"] is False
+    assert outside["outside_commit_files"] == ["generated.py"]
+
+
+def test_scip_producer_reads_artifact_metadata(tmp_path: Path) -> None:
+    index = SCIPIndex()
+    index.metadata.tool_info.name = "scip-python"
+    index.metadata.tool_info.version = "0.6.6"
+    index.metadata.tool_info.arguments.extend(("index", "--cwd", "/repo"))
+    index_path = tmp_path / "index.scip"
+    index_path.write_bytes(index.SerializeToString())
+
+    assert _scip_producer(index_path) == {
+        "name": "scip-python",
+        "version": "0.6.6",
+        "arguments": ["index", "--cwd", "/repo"],
+    }
+
+
+def _record(repo: str, index: int) -> dict[str, str]:
+    return {
+        "repo": repo,
+        "instance_id": f"{repo.replace('/', '__')}-{index}",
+        "base_commit": f"{index:040x}",
+        "patch": f"patch-{index}",
+        "problem_statement": f"problem-{index}",
+    }
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> str:
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "parser.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "parser.py")
+    _git(repo, "commit", "-m", "base")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def test_snapshot_errors_rejects_commit_drift_and_dirty_checkout(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    base_commit = _init_repo(repo)
+
+    assert _snapshot_errors(repo, base_commit) == []
+
+    (repo / "parser.py").write_text("value = 2\n", encoding="utf-8")
+    assert _snapshot_errors(repo, base_commit) == [
+        "snapshot is dirty after index construction"
+    ]
+
+    _git(repo, "add", "parser.py")
+    _git(repo, "commit", "-m", "change")
+    assert _snapshot_errors(repo, base_commit) == [
+        f"snapshot commit mismatch: {_git(repo, 'rev-parse', 'HEAD')} != {base_commit}"
+    ]
+
+
+def test_load_dataset_records_accepts_jsonl_and_hashes_source(tmp_path: Path) -> None:
+    source = tmp_path / "dataset.jsonl"
+    records = [_record("org/a", 1), _record("org/b", 2)]
+    source.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+    loaded, digest = load_dataset_records(source)
+
+    assert loaded == records
+    assert len(digest) == 64
+
+
+def test_balanced_selection_is_deterministic_and_covers_every_repo() -> None:
+    records = [
+        *(_record("org/small", index) for index in range(2)),
+        *(_record("org/medium", index + 10) for index in range(5)),
+        *(_record("org/large", index + 20) for index in range(20)),
+    ]
+
+    first, quotas = select_balanced_repository_cases(
+        records,
+        count=10,
+        seed="fixed",
+    )
+    second, second_quotas = select_balanced_repository_cases(
+        reversed(records),
+        count=10,
+        seed="fixed",
+    )
+
+    assert [row["instance_id"] for row in first] == [
+        row["instance_id"] for row in second
+    ]
+    assert quotas == second_quotas
+    assert quotas == {"org/large": 4, "org/medium": 4, "org/small": 2}
+    assert Counter(row["repo"] for row in first) == Counter(quotas)
+
+
+def test_extract_golden_patch_labels_restores_snapshot(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    source = repo / "parser.py"
+    source.write_text(
+        "def parse(value):\n    return value.strip()\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "parser.py")
+    _git(repo, "commit", "-m", "base")
+    base_commit = _git(repo, "rev-parse", "HEAD")
+    source.write_text(
+        "def parse(value):\n    return value.strip().lower()\n",
+        encoding="utf-8",
+    )
+    patch = _git(repo, "diff", "--", "parser.py")
+    _git(repo, "restore", "parser.py")
+
+    labels = extract_golden_patch_labels(
+        repo,
+        {
+            "base_commit": base_commit,
+            "patch": patch,
+        },
+    )
+
+    assert labels["gold_files"] == ["parser.py"]
+    assert labels["gold_functions"] == ["parser.py:parse()"]
+    assert _git(repo, "status", "--porcelain") == ""
+    assert _git(repo, "rev-parse", "HEAD") == base_commit

--- a/test/eval/test_swebench_policy_cases.py
+++ b/test/eval/test_swebench_policy_cases.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.eval.benchmarks import swebench_policy_cases
 from codenib.eval.benchmarks.swebench_policy_cases import (
     _graph_coverage_mode,
@@ -19,6 +20,7 @@ from codenib.eval.benchmarks.swebench_policy_cases import (
     _graph_source_coverage_report,
     _scip_producer,
     _snapshot_errors,
+    build_policy_manifest,
     extract_golden_patch_labels,
     load_dataset_records,
     select_balanced_repository_cases,
@@ -113,7 +115,6 @@ def test_graph_coverage_mode_distinguishes_compiler_and_fallbacks(
         )
         == "syntax"
     )
-
     index_path.touch()
     assert _graph_coverage_mode(index_path, {}) == "compiler"
     assert (
@@ -130,6 +131,81 @@ def test_graph_coverage_mode_distinguishes_compiler_and_fallbacks(
         )
         == "compiler-prefix+syntax"
     )
+
+
+def test_build_policy_manifest_rebuilds_a_current_graph_that_fails_audit(
+    monkeypatch, tmp_path: Path
+) -> None:
+    checkout = tmp_path / "repo"
+    checkout.mkdir()
+    artifact_dir = tmp_path / "artifact"
+    indexes = artifact_dir / "indexes"
+    commit = "a" * 40
+    source_fingerprint = "sha256:fixture"
+    now = 1.0
+    manifest = RepoManifest(
+        repo_path=str(checkout),
+        commit=commit,
+        last_indexed_commit=commit,
+        source_fingerprint=source_fingerprint,
+        last_indexed_source_fingerprint=source_fingerprint,
+        languages=["python"],
+        file_count=1,
+        indexes={
+            name: IndexEntry(
+                index_type=name,
+                path=str(indexes / name),
+                built_at="1970-01-01T00:00:01+00:00",
+                built_at_epoch=now,
+                status="fresh",
+                metadata={"node_count": 1},
+                commit=commit,
+                source_fingerprint=source_fingerprint,
+            )
+            for name in ("bm25", "symbol_graph")
+        },
+        capabilities={"sparse_search": True, "symbol_navigation": True},
+    )
+    manifest_path = indexes / "repo_manifest.json"
+    manifest.save(manifest_path)
+    audit_calls = 0
+
+    def fake_assess(*_args, **_kwargs):
+        nonlocal audit_calls
+        audit_calls += 1
+        if audit_calls == 1:
+            raise EOFError("truncated graph.pkl")
+        return {"passed": True, "coverage": 1.0}
+
+    def fake_update(_self, *_args, **_kwargs):
+        persisted = RepoManifest.load(manifest_path)
+        graph_entry = persisted.indexes["symbol_graph"]
+        assert graph_entry.status == "stale"
+        assert "truncated graph.pkl" in graph_entry.metadata["stale_reason"]
+        assert persisted.capabilities["symbol_navigation"] is False
+        graph_entry.status = "fresh"
+        persisted.derive_capabilities()
+        persisted.save(manifest_path)
+        return persisted
+
+    monkeypatch.setattr(swebench_policy_cases, "_manifest_errors", lambda *_: [])
+    monkeypatch.setattr(swebench_policy_cases, "assess_policy_graph", fake_assess)
+    monkeypatch.setattr(
+        swebench_policy_cases,
+        "register_default_builders",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(swebench_policy_cases.IndexCompiler, "update_repo", fake_update)
+
+    returned_path, report = build_policy_manifest(
+        checkout,
+        artifact_dir,
+        commit=commit,
+    )
+
+    assert returned_path == manifest_path
+    assert report["reused_existing"] is False
+    assert audit_calls == 2
 
 
 def _record(repo: str, index: int) -> dict[str, str]:
@@ -195,6 +271,23 @@ def test_load_dataset_records_accepts_jsonl_and_hashes_source(tmp_path: Path) ->
 
     assert loaded == records
     assert len(digest) == 64
+
+
+@pytest.mark.parametrize(
+    "instance_id",
+    ["../../victim", "/tmp/victim", "a/b", ".", ".."],
+)
+def test_load_dataset_records_rejects_path_escaping_instance_ids(
+    tmp_path: Path,
+    instance_id: str,
+) -> None:
+    source = tmp_path / "dataset.json"
+    record = _record("org/a", 1)
+    record["instance_id"] = instance_id
+    source.write_text(json.dumps([record]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid instance_id"):
+        load_dataset_records(source)
 
 
 def test_balanced_selection_is_deterministic_and_covers_every_repo() -> None:

--- a/test/integrations/test_locagent_upstream.py
+++ b/test/integrations/test_locagent_upstream.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 import yaml
 
+from codenib.clients import locagent_protocol
 from codenib.integrations.locagent import (
     LOCAGENT_REVISION,
     OPENHANDS_LOCAGENT_REVISION,
@@ -27,6 +28,14 @@ from codenib.integrations.locagent import (
 pytestmark = pytest.mark.integration
 
 _LOCAGENT_REPO_OPS = "plugins/location_tools/repo_ops/repo_ops.py"
+_LOCAGENT_PROTOCOL_FILES = {
+    "function_calling": "util/runtime/function_calling.py",
+    "finish": "util/runtime/finish.py",
+    "content_tools": "util/runtime/content_tools.py",
+    "structure_tools": "util/runtime/structure_tools.py",
+    "auto_search_prompt": "util/prompts/pipelines/auto_search_prompt.py",
+    "general_prompt": "util/prompts/general_prompt.py",
+}
 _OPENHANDS_TOOL_FILES = (
     "openhands/agenthub/loc_agent/tools/search_content.py",
     "openhands/agenthub/loc_agent/tools/explore_structure.py",
@@ -70,6 +79,10 @@ def upstream_sources() -> SimpleNamespace:
             LOCAGENT_REVISION,
             _LOCAGENT_REPO_OPS,
         ),
+        locagent_protocol={
+            name: _git_show(locagent, LOCAGENT_REVISION, path)
+            for name, path in _LOCAGENT_PROTOCOL_FILES.items()
+        },
         openhands_tools=[
             _git_show(openhands, OPENHANDS_LOCAGENT_REVISION, path)
             for path in _OPENHANDS_TOOL_FILES
@@ -124,6 +137,68 @@ def _dict_items(node: ast.AST) -> dict[str, ast.AST]:
         for key, value in zip(node.keys, node.values, strict=True)
         if key is not None
     }
+
+
+def _static_value(node: ast.AST, values: dict[str, Any]) -> Any:
+    if isinstance(node, ast.Name):
+        return values[node.id]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _static_value(node.left, values) + _static_value(node.right, values)
+    if isinstance(node, ast.Dict):
+        return {
+            _static_value(key, values): _static_value(value, values)
+            for key, value in zip(node.keys, node.values, strict=True)
+            if key is not None
+        }
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [_static_value(item, values) for item in node.elts]
+    return ast.literal_eval(node)
+
+
+def _static_assignments(source: str) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for node in ast.parse(source).body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        try:
+            values[target.id] = _static_value(node.value, values)
+        except (KeyError, ValueError, TypeError):
+            continue
+    return values
+
+
+def _function_tool_schemas(source: str) -> dict[str, dict[str, Any]]:
+    values = _static_assignments(source)
+    schemas: dict[str, dict[str, Any]] = {}
+    for call in (
+        node for node in ast.walk(ast.parse(source)) if isinstance(node, ast.Call)
+    ):
+        function_name = (
+            call.func.id
+            if isinstance(call.func, ast.Name)
+            else getattr(call.func, "attr", "")
+        )
+        if function_name != "ChatCompletionToolParamFunctionChunk":
+            continue
+        keywords = {
+            keyword.arg: keyword.value
+            for keyword in call.keywords
+            if keyword.arg is not None
+        }
+        if "name" not in keywords or "description" not in keywords:
+            continue
+        name = str(_static_value(keywords["name"], values))
+        function: dict[str, Any] = {
+            "name": name,
+            "description": _static_value(keywords["description"], values),
+        }
+        if "parameters" in keywords:
+            function["parameters"] = _static_value(keywords["parameters"], values)
+        schemas[name] = {"type": "function", "function": function}
+    return schemas
 
 
 def _parameter_shape(
@@ -216,3 +291,48 @@ def test_openhands_function_schemas_match_frozen_contract(
         _openhands_tool_contract(upstream_sources.openhands_tools) == expected["tools"]
     )
     assert dict(sorted(current.items())) == expected["tools"]
+
+
+def test_vendored_policy_assets_match_pinned_locagent_source(
+    upstream_sources: SimpleNamespace,
+) -> None:
+    sources = upstream_sources.locagent_protocol
+    function_calling = _static_assignments(sources["function_calling"])
+    auto_search = _static_assignments(sources["auto_search_prompt"])
+    general = _static_assignments(sources["general_prompt"])
+    structure = _static_assignments(sources["structure_tools"])
+
+    assert locagent_protocol.LOCAGENT_PROTOCOL_REVISION == LOCAGENT_REVISION
+    assert locagent_protocol._SYSTEM_PROMPT == function_calling["SYSTEM_PROMPT"]
+    assert (
+        locagent_protocol._TASK_INSTRUCTION_TEMPLATE == auto_search["TASK_INSTRUECTION"]
+    )
+    assert locagent_protocol._PROBLEM_TEMPLATE == general["PR_TEMPLATE"]
+    assert locagent_protocol._FOLLOWUP == auto_search["FAKE_USER_MSG_FOR_LOC"]
+
+    upstream_tools: dict[str, dict[str, Any]] = {}
+    for name in ("finish", "content_tools"):
+        upstream_tools.update(_function_tool_schemas(sources[name]))
+    upstream_tools["explore_tree_structure"] = {
+        "type": "function",
+        "function": {
+            "name": "explore_tree_structure",
+            "description": (
+                structure["_STRUCTURE_EXPLORER_DESCRIPTION"]
+                + structure["_TREE_EXAMPLE"]
+            ),
+            "parameters": structure["_STRUCTURE_EXPLORER_PARAMETERS"],
+        },
+    }
+    ordered_names = (
+        "finish",
+        "search_code_snippets",
+        "get_entity_contents",
+        "explore_tree_structure",
+    )
+    expected_tools = [upstream_tools[name] for name in ordered_names]
+    actual_tools = [
+        locagent_protocol._FINISH_TOOL,
+        *get_locagent_tool_schemas(),
+    ]
+    assert actual_tools == expected_tools

--- a/test/scip/test_scip_python_runtime.py
+++ b/test/scip/test_scip_python_runtime.py
@@ -223,3 +223,75 @@ def test_scip_python_preserves_project_owned_pyright_config(tmp_path):
         assert config_path.read_text() == original
 
     assert config_path.read_text() == original
+
+
+@pytest.mark.parametrize("allow_partial", [False, True])
+def test_scip_python_only_preserves_partial_index_when_opted_in(
+    monkeypatch, tmp_path, allow_partial
+):
+    indexer = SCIPPythonIndexer(tmp_path, output_dir=tmp_path / "out")
+    indexer._direct_indexer_path = "/tools/scip-python"
+    monkeypatch.setattr(indexer, "_check_indexer_available", lambda: True)
+
+    def failed_run(*_args, **_kwargs):
+        payload = Index()
+        payload.metadata.tool_info.name = "scip-python"
+        payload.metadata.tool_info.version = "0.6.6"
+        payload.documents.add().relative_path = "partial.py"
+        indexer.index_file.write_bytes(payload.SerializeToString())
+        return False
+
+    monkeypatch.setattr(indexer, "_run_direct", failed_run)
+
+    assert indexer.generate_index(allow_partial_index=allow_partial) is False
+    assert indexer.index_file.exists() is allow_partial
+    assert indexer.index_generation_report == {
+        "backend": "scip-python",
+        "status": "partial" if allow_partial else "failed",
+        "complete": False,
+        "partial": allow_partial,
+        "document_count": 1,
+    }
+
+
+def test_scip_python_rejects_metadata_only_partial_index(monkeypatch, tmp_path):
+    indexer = SCIPPythonIndexer(tmp_path, output_dir=tmp_path / "out")
+    indexer._direct_indexer_path = "/tools/scip-python"
+    monkeypatch.setattr(indexer, "_check_indexer_available", lambda: True)
+
+    def failed_run(*_args, **_kwargs):
+        payload = Index()
+        payload.metadata.tool_info.name = "scip-python"
+        payload.metadata.tool_info.version = "0.6.6"
+        indexer.index_file.write_bytes(payload.SerializeToString())
+        return False
+
+    monkeypatch.setattr(indexer, "_run_direct", failed_run)
+
+    assert indexer.generate_index(allow_partial_index=True) is False
+    assert not indexer.index_file.exists()
+    assert indexer.index_generation_report == {
+        "backend": "scip-python",
+        "status": "failed",
+        "complete": False,
+        "partial": False,
+        "document_count": 0,
+    }
+
+
+def test_scip_python_rejects_pathless_partial_document(monkeypatch, tmp_path):
+    indexer = SCIPPythonIndexer(tmp_path, output_dir=tmp_path / "out")
+    indexer._direct_indexer_path = "/tools/scip-python"
+    monkeypatch.setattr(indexer, "_check_indexer_available", lambda: True)
+
+    def failed_run(*_args, **_kwargs):
+        payload = Index()
+        payload.documents.add()
+        indexer.index_file.write_bytes(payload.SerializeToString())
+        return False
+
+    monkeypatch.setattr(indexer, "_run_direct", failed_run)
+
+    assert indexer.generate_index(allow_partial_index=True) is False
+    assert not indexer.index_file.exists()
+    assert indexer.index_generation_report["status"] == "failed"

--- a/test/scip/test_scip_python_runtime.py
+++ b/test/scip/test_scip_python_runtime.py
@@ -295,3 +295,25 @@ def test_scip_python_rejects_pathless_partial_document(monkeypatch, tmp_path):
     assert indexer.generate_index(allow_partial_index=True) is False
     assert not indexer.index_file.exists()
     assert indexer.index_generation_report["status"] == "failed"
+
+
+def test_scip_python_does_not_preserve_an_index_from_an_earlier_run(
+    monkeypatch, tmp_path
+):
+    indexer = SCIPPythonIndexer(tmp_path, output_dir=tmp_path / "out")
+    indexer._direct_indexer_path = "/tools/scip-python"
+    monkeypatch.setattr(indexer, "_check_indexer_available", lambda: True)
+    stale = Index()
+    stale.documents.add().relative_path = "stale.py"
+    indexer.index_file.write_bytes(stale.SerializeToString())
+    monkeypatch.setattr(indexer, "_run_direct", lambda *_args, **_kwargs: False)
+
+    assert indexer.generate_index(allow_partial_index=True) is False
+    assert not indexer.index_file.exists()
+    assert indexer.index_generation_report == {
+        "backend": "scip-python",
+        "status": "failed",
+        "complete": False,
+        "partial": False,
+        "document_count": 0,
+    }

--- a/test/scip/test_scip_python_runtime.py
+++ b/test/scip/test_scip_python_runtime.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import signal
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,53 @@ import pytest
 from codenib.scip_interface import scip_indexer_base, scip_indexer_python
 from codenib.scip_interface.scip_indexer_python import SCIPPythonIndexer
 from codenib.scip_interface.scip_pb2 import Index
+
+
+def test_checked_run_kills_process_group_when_caller_cancels(monkeypatch):
+    class InterruptedProcess:
+        pid = 1234
+        args = ["scip-python", "index"]
+
+        def __init__(self):
+            self.communicate_calls = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def communicate(self, timeout=None):
+            self.communicate_calls += 1
+            if timeout is not None:
+                raise KeyboardInterrupt
+            return "", ""
+
+        def poll(self):
+            return None
+
+    process = InterruptedProcess()
+    killed = []
+    monkeypatch.setattr(
+        scip_indexer_python.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: process,
+    )
+    monkeypatch.setattr(scip_indexer_python.os, "getpgid", lambda pid: pid + 1)
+    monkeypatch.setattr(
+        scip_indexer_python.os,
+        "killpg",
+        lambda pgid, sig: killed.append((pgid, sig)),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        scip_indexer_python._run_checked_with_timeout(
+            process.args,
+            timeout=30,
+        )
+
+    assert killed == [(1235, signal.SIGKILL)]
+    assert process.communicate_calls == 2
 
 
 def _captured_subprocess_env(monkeypatch, tmp_path, node_options=None):

--- a/test/test_ls_router_registry.py
+++ b/test/test_ls_router_registry.py
@@ -529,12 +529,13 @@ def test_build_graph_for_languages_passes_route_filter_options(tmp_path, monkeyp
     assert call.pipeline_kwargs == {
         "target_dir": "lib",
         "include_references": True,
-        "allow_partial_index": True,
     }
 
 
 def test_build_graph_for_languages_reports_index_generation(tmp_path, monkeypatch):
     class FakeIndexer:
+        supports_partial_index = True
+
         def __init__(self, project_root, **_kwargs):
             self.project_root = project_root
             self.index_generation_report = {
@@ -544,7 +545,8 @@ def test_build_graph_for_languages_reports_index_generation(tmp_path, monkeypatc
                 "document_count": 3,
             }
 
-        def run_pipeline(self, **_kwargs):
+        def run_pipeline(self, **kwargs):
+            assert kwargs["allow_partial_index"] is True
             graph = CodeGraph(str(self.project_root))
             graph.add_file_node("partial.py")
             graph.build_range_indexes()

--- a/test/test_ls_router_registry.py
+++ b/test/test_ls_router_registry.py
@@ -518,6 +518,7 @@ def test_build_graph_for_languages_passes_route_filter_options(tmp_path, monkeyp
         include_references=True,
         exclude_patterns=["vendor/**"],
         graph_route="lsp",
+        allow_partial_index=True,
     )
 
     assert graph is not None
@@ -525,4 +526,46 @@ def test_build_graph_for_languages_passes_route_filter_options(tmp_path, monkeyp
     assert call.language == "ruby"
     assert call.graph_route == "lsp"
     assert call.exclude_patterns == ["vendor/**"]
-    assert call.pipeline_kwargs == {"target_dir": "lib", "include_references": True}
+    assert call.pipeline_kwargs == {
+        "target_dir": "lib",
+        "include_references": True,
+        "allow_partial_index": True,
+    }
+
+
+def test_build_graph_for_languages_reports_index_generation(tmp_path, monkeypatch):
+    class FakeIndexer:
+        def __init__(self, project_root, **_kwargs):
+            self.project_root = project_root
+            self.index_generation_report = {
+                "status": "partial",
+                "complete": False,
+                "partial": True,
+                "document_count": 3,
+            }
+
+        def run_pipeline(self, **_kwargs):
+            graph = CodeGraph(str(self.project_root))
+            graph.add_file_node("partial.py")
+            graph.build_range_indexes()
+            return graph
+
+    monkeypatch.setattr(ls_router, "LSIndexer", FakeIndexer)
+
+    result = ls_router.build_graph_for_languages_with_report(
+        tmp_path / "repo",
+        tmp_path / "out",
+        languages=["python"],
+        skip_level=None,
+        allow_partial_index=True,
+    )
+
+    assert result.graph is not None
+    assert result.index_generation_reports == {
+        "python": {
+            "status": "partial",
+            "complete": False,
+            "partial": True,
+            "document_count": 3,
+        }
+    }

--- a/test/test_release_metadata.py
+++ b/test/test_release_metadata.py
@@ -78,8 +78,11 @@ def test_optional_capabilities_have_named_extras() -> None:
 
 def test_vertex_capability_uses_litellm_provider_constraints() -> None:
     extras = _project()["optional-dependencies"]
+    runtime_requirement = "litellm>=1.93.0"
     provider_requirement = "litellm[google]>=1.93.0"
 
+    assert runtime_requirement in extras["agent"]
+    assert runtime_requirement in extras["test"]
     # The provider-specific preset must install both LiteLLM and the Google SDK
     # versions LiteLLM declares compatible. The full preset promises every
     # supported backend, so it must carry the identical coupled requirement.

--- a/uv.lock
+++ b/uv.lock
@@ -696,8 +696,8 @@ requires-dist = [
     { name = "igraph", marker = "extra == 'graph'", specifier = ">=0.11.6" },
     { name = "igraph", marker = "extra == 'test'", specifier = ">=0.11.6" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.10.1" },
-    { name = "litellm", marker = "extra == 'agent'", specifier = ">=1.40.0" },
-    { name = "litellm", marker = "extra == 'test'", specifier = ">=1.40.0" },
+    { name = "litellm", marker = "extra == 'agent'", specifier = ">=1.93.0" },
+    { name = "litellm", marker = "extra == 'test'", specifier = ">=1.93.0" },
     { name = "litellm", extras = ["google"], marker = "extra == 'full'", specifier = ">=1.93.0" },
     { name = "litellm", extras = ["google"], marker = "extra == 'vertex'", specifier = ">=1.93.0" },
     { name = "matplotlib", marker = "extra == 'test'", specifier = ">=3.4.0" },
@@ -2454,7 +2454,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.94.1"
+version = "1.95.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2470,23 +2470,23 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d6/6995fbc8cc4a22c9a1346981dd62348cf563e9285e17587703ad235f1fc0/litellm-1.94.1.tar.gz", hash = "sha256:e9effe4c1e9206740b4bb4c98142ea1f71bae57e49df007cd25ef24b0ce4563f", size = 16264730, upload-time = "2026-07-30T23:14:22.682Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/96/8cdfb9aaf584b57af35a0423c111a1c1264a78b548cebbb5ed96defacdab/litellm-1.95.0.tar.gz", hash = "sha256:0ef126d52c7a559f8353e50d60fd0d5e7e6c8767ad54df25ddaf79b9edca1afc", size = 17513577, upload-time = "2026-08-02T02:52:49.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/ac/f06bf996adfa848e0e5f248002f16ccc7e054b56a95c803778dc2c0b9ba7/litellm-1.94.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2103e9b155d6545b48936d2ac2e614661613adb9e3d081c58c7303ca5dd6c656", size = 20686660, upload-time = "2026-07-30T23:13:32.99Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/67/0a03ffa4074da77a95c41bb614b92e18984998148d6199ceb1e7ebb3d584/litellm-1.94.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:156c62022320bccab7c3507b6b13400b26e55b74c799e5a4a2d5bf904a77368f", size = 20673547, upload-time = "2026-07-30T23:13:36.299Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/8d/ed2b04ccac44ed854e3086fd67e4b7c29307ec20b46c25af4d056bceefc3/litellm-1.94.1-cp310-cp310-win_amd64.whl", hash = "sha256:e9b6d92e305d96bdadb8a5ccd343b1ac188de142fbd6c91f72c75416b8c25c48", size = 20274367, upload-time = "2026-07-30T23:13:39.385Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/7b/131fb487fbe6a7f4e255c217750c6e85e552b7e220efd5f59a14aac0caa5/litellm-1.94.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:001be1cde7950f2ae484e450ab2f8e93ab8791e5e8d4da560d21f2fb456b0b47", size = 20686025, upload-time = "2026-07-30T23:13:42.319Z" },
-    { url = "https://files.pythonhosted.org/packages/25/91/1b79a585c836eb6eb6db5c2b3524cb285d4de2439002757c7e3f8b7f04b5/litellm-1.94.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b0145d6b9fb718d12b7242ce5c975123f4dbfecd7b8ed1eb6a6939b0e506c946", size = 20673362, upload-time = "2026-07-30T23:13:45.506Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/bf/7cde618559d00c94945f92d21b4e1b44aca2efcbc08b00cb904e18631e46/litellm-1.94.1-cp311-cp311-win_amd64.whl", hash = "sha256:07c1771315d7d26e242ef90b9336bcbc49a52158ff72ee640b4f8160cc963147", size = 20273833, upload-time = "2026-07-30T23:13:48.443Z" },
-    { url = "https://files.pythonhosted.org/packages/31/42/77f98b30e99327971a9c27d1f1f2a92a9578b068d4833f42fda8ae9278fa/litellm-1.94.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:af37356cf5b325a2887c40ff772b39e1e0865b988297c544b29123ffb13fd1b9", size = 20681910, upload-time = "2026-07-30T23:13:51.535Z" },
-    { url = "https://files.pythonhosted.org/packages/03/3c/f75a840c3a1b6466e138f5833e1623fcbf32a63bae8a56efc31a4265f8b6/litellm-1.94.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:66bc95498af3ab687ce7570704cb274bcf1d78049afa87a9f5f64db45b72847d", size = 20664250, upload-time = "2026-07-30T23:13:55.007Z" },
-    { url = "https://files.pythonhosted.org/packages/89/cd/ab61853dc3699a96997dd731bd005f2c511235f695cb32c11209d55201c6/litellm-1.94.1-cp312-cp312-win_amd64.whl", hash = "sha256:44e55a55270dee8bb85e063940c368d32040e6db66765c55db4b884fc002d4ef", size = 20268551, upload-time = "2026-07-30T23:13:58.222Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c0/c00d40bc9a62c397601e23dd7be1905f52f5981413e78fef1184116a1036/litellm-1.94.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:cfef0468bda9c1ba8f554bebc2966f08436f1ead98017e7ed2d7663ece77f1c2", size = 20682610, upload-time = "2026-07-30T23:14:01.361Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/51/6923345e9584e6855cbc182af99efcd4de5d5aea75330dfcb53eaa2e3131/litellm-1.94.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1b0bc4a2373e54f2bd4c13f8ef9fda3839bfb2e1173fb4bcea3150b07d4c59bc", size = 20665189, upload-time = "2026-07-30T23:14:04.562Z" },
-    { url = "https://files.pythonhosted.org/packages/28/b6/bc53595152faad2275fcbd4106a9d9bfe6133b704b2be3b4fdae31090598/litellm-1.94.1-cp313-cp313-win_amd64.whl", hash = "sha256:d14e5812b5f36af2ab45461ee0c925251bc07daf65c33b8f2ce3fd3ec1235eae", size = 20266790, upload-time = "2026-07-30T23:14:08.139Z" },
-    { url = "https://files.pythonhosted.org/packages/61/3c/e141bf70dd1d93b234ef52e7ae18b1e77c7fe4b83dc262984dbd000fd8b9/litellm-1.94.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c5c9247d9fea8fe7cda851f7b15db560ee547a8325a0af86048967edf3ccfa15", size = 20681030, upload-time = "2026-07-30T23:14:12.575Z" },
-    { url = "https://files.pythonhosted.org/packages/25/85/36265d4a7ad51636b0e18aded355ef5a2b1e4a38368f0e1068393ed13ddb/litellm-1.94.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:a6f5274876f20dd5c9e53ba3da502e94f5b3c681c5027a0398231d0caae4aacd", size = 20671012, upload-time = "2026-07-30T23:14:16.235Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/9d/533802021f7654deced4ed05d2b73e6206170d6a0ae5000993aa4955e246/litellm-1.94.1-cp314-cp314-win_amd64.whl", hash = "sha256:ffa9a6cd9b6205d60b02ffc0b7f077a03693d835b06d2a34bfeaabb4f073c08a", size = 20269681, upload-time = "2026-07-30T23:14:19.5Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/4ba824200c235c56bc87759f05bde5c53223f8036282026b2c731af7eb9a/litellm-1.95.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:0106b3564b60d00cb5b2810824ebf5071f59c9f9262318884d9c6f040aa2c435", size = 26426637, upload-time = "2026-08-02T02:51:53.675Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/38d6a4a53be2cca1e4efa05a4233b791efe82ba92a10088630235132933f/litellm-1.95.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:053cea1a584bf92d5d44b422f99fa03715bf7c346c8fe080c29bf0c6bd71eddc", size = 26304372, upload-time = "2026-08-02T02:51:58.15Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/dc/3c4c46343188fda4aa6b7294aff9969beb58dae400130a0f09c774d23f61/litellm-1.95.0-cp310-cp310-win_amd64.whl", hash = "sha256:667cc7cc58e05a9f9c4bf4588cd4ff5c785fd265060acdfb9147332b75b73ce9", size = 24920517, upload-time = "2026-08-02T02:52:01.547Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c1/470070205a3b36c4d99d95046102468165a55bfd675f32c552566085e746/litellm-1.95.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4bafa3494d503a3c6c1f2eeb785a2af364d85463c71a92cabaaa761c9227d62a", size = 26425608, upload-time = "2026-08-02T02:52:05.277Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c1/54c79849f4b60aab55772d69099557e49c86c6a43a863d65c1bc985246b3/litellm-1.95.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:4c2a06d2263a07a29228cd3af2b594cf86cd3a4182a7324c517cba88a9415969", size = 26303794, upload-time = "2026-08-02T02:52:08.675Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/52/31f2f50063e619b782c74df3ea8835270cce40f94dadaed350cf2f499aa0/litellm-1.95.0-cp311-cp311-win_amd64.whl", hash = "sha256:aac37bb6d2be191bafc0ce590ed06d21dd7e5a37599ffc1af1071899f6c74b73", size = 24921269, upload-time = "2026-08-02T02:52:12.281Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d0/ad0272853cc450f8bb4a40a93d206e767e18ac2ff3f91870374e1d9fc090/litellm-1.95.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:cb667f84f08520f32b076e03c7a3fa51bf3f7e8b641dade34ab046bf00314d6b", size = 26421359, upload-time = "2026-08-02T02:52:16.048Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c1/4301aa8ef6d2fb0e4a2b8dec973d7c4499f680b26d2e1b77643864235a4b/litellm-1.95.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1bdf7153557cc0851fa9477b137fde476c56d5de92a5778ecfc6c3a75439a4e1", size = 26300401, upload-time = "2026-08-02T02:52:19.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6cd087bd541f18d924f17bd8e1bb68a7f9d73d03274c5339f9de563bc992/litellm-1.95.0-cp312-cp312-win_amd64.whl", hash = "sha256:62cc5d834e8223dbd16c9ad0b46c73354b6d67cc7fa0eba2764ce65b3b8c474f", size = 24917446, upload-time = "2026-08-02T02:52:23.119Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/47/719785f65b01779cf7568c329430c93b2e7832498deb3deec53bdd106f8d/litellm-1.95.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9d80a9adc506bfce48145621d6649e3fd428407811eb00211bcce33344054701", size = 26422310, upload-time = "2026-08-02T02:52:26.626Z" },
+    { url = "https://files.pythonhosted.org/packages/55/48/06447e1125d7ae31bd24d34d2af2833b15aed79dc5f7e8b45862c1d06af8/litellm-1.95.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cf014ff515825ad49937b4cdf95616270789311db7841d16702e0a5b1ac5b067", size = 26300935, upload-time = "2026-08-02T02:52:30.032Z" },
+    { url = "https://files.pythonhosted.org/packages/45/6f/388f85ebcb4e239dc738cab99307051d5a8a69d907023b0dbb200ee95226/litellm-1.95.0-cp313-cp313-win_amd64.whl", hash = "sha256:c73df441153e585832d4e90e3717d17ae888b269daa71d723336369e81ef884b", size = 24917355, upload-time = "2026-08-02T02:52:33.593Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f6/5b2e944d5c8cea5164e10a28220d9af598792a9c3f25605bcf14946323ef/litellm-1.95.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c8e712f95764a9a730f3aec9dff8be916973423411ca12a79a35c8bea3f7d5a4", size = 26423318, upload-time = "2026-08-02T02:52:37.629Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f7/d7450f5d3d7b566900067a21bdfafb5cee62bc0bc73b190e8598df1f2e67/litellm-1.95.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:071a63c0e1d949bf7ed5e5c73843cb042a6e00324d3f214b13f8c6b90da6822d", size = 26299965, upload-time = "2026-08-02T02:52:41.577Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/c2b7d8b239021c7737a228ab5ffe4f40e4a596ce4629ff3c8899bfd40904/litellm-1.95.0-cp314-cp314-win_amd64.whl", hash = "sha256:c3684dcf16aefe98bd6f11586d60a9a92bb1bf7e85468a6a4ac28a65532fab3e", size = 24920863, upload-time = "2026-08-02T02:52:45.663Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -588,6 +588,7 @@ dependencies = [
 [package.optional-dependencies]
 agent = [
     { name = "litellm" },
+    { name = "openai" },
 ]
 datasets = [
     { name = "datasets" },
@@ -711,6 +712,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'full'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'semantic'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'test'", specifier = ">=1.24.0" },
+    { name = "openai", marker = "extra == 'agent'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'full'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'semantic'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'test'", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
Migrate the revision-pinned LocAgent policy onto CodeNib's manifest-backed runtime and validate the complete delivery path on a fixed 50-case SWE-bench Lite sample without adding LocAgent or LlamaIndex dependencies.

## Changes
- Vendor the pinned LocAgent prompts, follow-up, finish schema, and three tool schemas, with a source-level parity probe against the pinned Git revision.
- Run the LocAgent function-calling loop directly over CodeNib BM25 and symbol-graph views; checkout, secondary Python, and native index flags are required only for the optional upstream-native comparison.
- Add strict ranked File Match and Function Match scoring that retains missing, failed, and empty-output cells in the denominator and audits case, model, and run provenance.
- Add a deterministic, repository-balanced 50-case SWE-bench Lite preparation gate with isolated base-commit snapshots, golden-patch labels, source-coverage checks, and resumable artifacts.
- Repair stalled Python SCIP builds conservatively: preserve only parseable path-addressable compiler prefixes, fill missing tracked files with label-independent syntax definitions and containment, expose generation completeness, and reject incomplete fallback surfaces. Syntax fallback does not synthesize compiler reference edges.
- Harden replay correctness: score the complete tracked file surface, exclude class-only locations from function ranks, reject unsafe instance IDs, bind partial SCIP output to the current attempt, and force invalid or fallback graphs through full rebuilds.
- Record protocol and dataset provenance, update the support matrix and reproducible commands, declare the OpenAI-compatible SDK explicitly, and raise the LiteLLM compatibility floor.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Unit tier: `2441 passed, 10 skipped, 178 deselected`
- Focused graph, SCIP, router, preparation, and evaluation suite: `186 passed`
- `pre-commit` passed for all changed files
- Scorer-only replay preserved File and Function Accuracy@1/3/5; Function@5 hit/recall was corrected to `89.6% / 81.6%` without rerunning model cells
- `mkdocs build --strict` and `uv lock --check` passed
- Existing wheel/install and pinned-source contract probes remain covered by the earlier commits in this PR
- Fixed sample: official SWE-bench Lite revision `6ec7bb89...`, selection `4fcdd3be...`, 50 unique instance/commit pairs across all 12 repositories
- Preparation: 50/50 eligible, 100% final tracked-Python source coverage, 46 compiler graphs, 2 compiler-prefix + syntax repairs, and 2 explicit syntax-only fallbacks
- `gpt-5.6-luna` delivery run: 50/50 observed, 0 missing, 0 runtime failures; five empty localization outputs remain in the denominator
- File Match@1/3/5: `78% / 88% / 88%`; Function Match@1/3/5 over the 48 declared function-label cases: `54.2% / 75.0% / 79.2%`
- The model run is a single-trajectory compatibility/coverage check, not a native-provider performance comparison. Its provenance records a mutable model alias and a dirty graph-repair worktree at `ba88679`; the committed implementation was re-tested and all 50 artifacts were re-audited without rewriting model outputs.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
