### PR TITLE
docs(readme): link policy integration sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,18 @@ agent or code-Wiki framework.
 
 ## News
 
-- **2026-08-03 — Native LocAgent policy integration.** CodeNib now runs
-  revision-pinned LocAgent prompts and its function-calling loop directly over
-  manifest-backed BM25 and symbol-graph views without importing LocAgent,
-  LiteLLM, or LlamaIndex. The paired harness applies strict case,
-  provenance, denominator, and ranked-localization checks.
-- **2026-08-02 — OrcaLoca SearchAgent integration.** CodeNib can now serve a
-  revision-pinned OrcaLoca `SearchAgent` through its manifest-backed symbol
-  graph, preserving the upstream six-tool and private-hook contract without
-  building an OrcaLoca-specific graph. The supported boundary starts at
-  `SearchAgent` with an empty `TraceAnalysisOutput`; see the
-  [agent integration support matrix](https://docs.codenib.ai/agent_integrations/)
-  for validation evidence and scope.
+- **2026-08-03 — Native LocAgent policy.**
+  [`LocAgentAgent`](codenib/clients/locagent_agent.py) runs pinned prompts and
+  function calls over [`LocAgentToolProvider`](codenib/integrations/locagent.py),
+  with no LocAgent, LiteLLM, or LlamaIndex dependency. Its
+  [paired harness](codenib/eval/benchmarks/policy_benchmark.py) validates
+  provenance and ranked localization.
+- **2026-08-02 — OrcaLoca SearchAgent.**
+  [`OrcaLocaAgent`](codenib/clients/orcaloca_agent.py) binds upstream
+  `SearchAgent` to
+  [`OrcaLocaSearchProvider`](codenib/integrations/orcaloca.py), preserving its
+  six-tool contract without a second graph. Scope: empty `TraceAnalysisOutput`;
+  see the [validation matrix](https://docs.codenib.ai/agent_integrations/).
 
 ## System Architecture
 


### PR DESCRIPTION
## Summary
Link the LocAgent and OrcaLoca News entries directly to their CodeNib implementation entry points while making both announcements shorter.

## Changes
- Link the LocAgent policy runner, provider, and paired benchmark harness.
- Link the OrcaLoca SearchAgent adapter, provider, and validation matrix.
- Remove repeated architecture and validation wording from the News section.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

`pre-commit run --files README.md`

`git diff --check`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published