### PR TITLE
feat(integrations): add classic Agentless localization

### DIFF
--- a/codenib/clients/agentless_agent.py
+++ b/codenib/clients/agentless_agent.py
@@ -234,12 +234,14 @@ class AgentlessAgent:
                 valid_files=provider.files,
                 root_name=provider.project_root_name,
             )
+            parsed = _valid_locations(parsed, provider)
             if not parsed and execution.symbol_output:
                 parsed = parse_agentless_locations(
                     execution.symbol_output,
                     valid_files=provider.files,
                     root_name=provider.project_root_name,
                 )
+                parsed = _valid_locations(parsed, provider)
             if not parsed and execution.file_output:
                 parsed = tuple(
                     AgentlessLocation(file_path=file_path)
@@ -318,24 +320,37 @@ def run_agentless_policy(
     trajectory: list[dict[str, Any]] = []
     started = time.perf_counter()
     temperature_supported = True
+    max_completion_tokens_supported = True
 
     def complete(stage: str, prompt: str, temperature: float) -> str:
-        nonlocal temperature_supported
+        nonlocal max_completion_tokens_supported, temperature_supported
         request: dict[str, Any] = {
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
-            "max_completion_tokens": max_completion_tokens,
         }
+        token_parameter = (
+            "max_completion_tokens" if max_completion_tokens_supported else "max_tokens"
+        )
+        request[token_parameter] = max_completion_tokens
         if temperature_supported:
             request["temperature"] = temperature
-        try:
-            response = client.chat.completions.create(**request)
-        except Exception as exc:
-            if not temperature_supported or not _unsupported_temperature(exc):
+        while True:
+            try:
+                response = client.chat.completions.create(**request)
+                break
+            except Exception as exc:
+                if temperature_supported and _unsupported_temperature(exc):
+                    temperature_supported = False
+                    request.pop("temperature", None)
+                    continue
+                if max_completion_tokens_supported and (
+                    _unsupported_max_completion_tokens(exc)
+                ):
+                    max_completion_tokens_supported = False
+                    request.pop("max_completion_tokens", None)
+                    request["max_tokens"] = max_completion_tokens
+                    continue
                 raise
-            temperature_supported = False
-            request.pop("temperature", None)
-            response = client.chat.completions.create(**request)
         prompt_tokens, completion_tokens, cached_tokens = _response_usage(response)
         usage["prompt_tokens"] += prompt_tokens
         usage["completion_tokens"] += completion_tokens
@@ -440,17 +455,26 @@ def _contains_valid_location(
     locations: Sequence[AgentlessLocation],
     provider: AgentlessRepositoryProvider,
 ) -> bool:
+    return bool(_valid_locations(locations, provider))
+
+
+def _valid_locations(
+    locations: Sequence[AgentlessLocation],
+    provider: AgentlessRepositoryProvider,
+) -> tuple[AgentlessLocation, ...]:
+    valid: list[AgentlessLocation] = []
     for location in locations:
         files = provider.resolve_files([location.file_path], limit=1)
         if not files:
             continue
         if location.kind == "line" and location.line_start is not None:
             line_count = len(provider.repository.source_lines(files[0]))
-            if 1 <= location.line_start <= line_count:
-                return True
+            line_end = location.line_end or location.line_start
+            if 1 <= location.line_start <= line_end <= line_count:
+                valid.append(location)
         elif provider.resolve_entity(files[0], location.kind, location.name):
-            return True
-    return False
+            valid.append(location)
+    return tuple(valid)
 
 
 def _response_text(response: Any) -> str:
@@ -505,6 +529,25 @@ def _unsupported_temperature(exc: Exception) -> bool:
                 return True
     message = str(exc).lower()
     return "temperature" in message and "unsupported value" in message
+
+
+def _unsupported_max_completion_tokens(exc: Exception) -> bool:
+    body = getattr(exc, "body", None)
+    if isinstance(body, Mapping):
+        detail = body.get("error", body)
+        if isinstance(detail, Mapping):
+            param = str(detail.get("param") or "").lower()
+            message = str(detail.get("message") or "").lower()
+            if param == "max_completion_tokens" and any(
+                marker in message
+                for marker in ("unsupported", "unrecognized", "unknown")
+            ):
+                return True
+    message = str(exc).lower()
+    return "max_completion_tokens" in message and any(
+        marker in message
+        for marker in ("unexpected keyword", "unsupported", "unrecognized", "unknown")
+    )
 
 
 __all__ = [

--- a/codenib/clients/agentless_agent.py
+++ b/codenib/clients/agentless_agent.py
@@ -236,16 +236,23 @@ class AgentlessAgent:
                 if isinstance(raw_execution, AgentlessExecution)
                 else AgentlessExecution(line_output=str(raw_execution))
             )
+            selected_files = parse_agentless_files(
+                execution.file_output,
+                valid_files=provider.files,
+                root_name=provider.project_root_name,
+                limit=self.top_n_files,
+            )
+            stage_files = selected_files if execution.file_output else provider.files
             parsed = parse_agentless_locations(
                 execution.final_output,
-                valid_files=provider.files,
+                valid_files=stage_files,
                 root_name=provider.project_root_name,
             )
             parsed = _valid_locations(parsed, provider)
             if not parsed and execution.symbol_output:
                 parsed = parse_agentless_locations(
                     execution.symbol_output,
-                    valid_files=provider.files,
+                    valid_files=stage_files,
                     root_name=provider.project_root_name,
                 )
                 parsed = _valid_locations(parsed, provider)

--- a/codenib/clients/agentless_agent.py
+++ b/codenib/clients/agentless_agent.py
@@ -317,14 +317,25 @@ def run_agentless_policy(
     usage = {"prompt_tokens": 0, "completion_tokens": 0, "cached_tokens": 0}
     trajectory: list[dict[str, Any]] = []
     started = time.perf_counter()
+    temperature_supported = True
 
     def complete(stage: str, prompt: str, temperature: float) -> str:
-        response = client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}],
-            max_completion_tokens=max_completion_tokens,
-            temperature=temperature,
-        )
+        nonlocal temperature_supported
+        request: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_completion_tokens": max_completion_tokens,
+        }
+        if temperature_supported:
+            request["temperature"] = temperature
+        try:
+            response = client.chat.completions.create(**request)
+        except Exception as exc:
+            if not temperature_supported or not _unsupported_temperature(exc):
+                raise
+            temperature_supported = False
+            request.pop("temperature", None)
+            response = client.chat.completions.create(**request)
         prompt_tokens, completion_tokens, cached_tokens = _response_usage(response)
         usage["prompt_tokens"] += prompt_tokens
         usage["completion_tokens"] += completion_tokens
@@ -333,7 +344,7 @@ def run_agentless_policy(
         trajectory.append(
             {
                 "stage": stage,
-                "temperature": temperature,
+                "temperature": temperature if temperature_supported else None,
                 "prompt": prompt,
                 "response": content,
             }
@@ -479,6 +490,22 @@ def _response_usage(response: Any) -> tuple[int, int, int]:
     details = getattr(usage, "prompt_tokens_details", None)
     cached = int(getattr(details, "cached_tokens", 0) or 0)
     return prompt, completion, cached
+
+
+def _unsupported_temperature(exc: Exception) -> bool:
+    body = getattr(exc, "body", None)
+    if isinstance(body, Mapping):
+        detail = body.get("error", body)
+        if isinstance(detail, Mapping):
+            param = str(detail.get("param") or "").lower()
+            code = str(detail.get("code") or "").lower()
+            message = str(detail.get("message") or "").lower()
+            if param == "temperature" and (
+                code == "unsupported_value" or "unsupported" in message
+            ):
+                return True
+    message = str(exc).lower()
+    return "temperature" in message and "unsupported value" in message
 
 
 __all__ = [

--- a/codenib/clients/agentless_agent.py
+++ b/codenib/clients/agentless_agent.py
@@ -96,10 +96,17 @@ def agentless_locations_to_baseline(
         file_path = files[0]
         entity: RepositoryEntity | None = None
         if parsed.kind == "line" and parsed.line_start is not None:
-            entity = provider.repository.containing_entity(
+            candidate = provider.repository.containing_entity(
                 file_path,
                 max(0, parsed.line_start - 1),
             )
+            endpoint = parsed.line_end or parsed.line_start
+            if (
+                candidate is not None
+                and candidate.end_line is not None
+                and endpoint - 1 <= candidate.end_line
+            ):
+                entity = candidate
         elif parsed.name:
             entity = provider.resolve_entity(file_path, parsed.kind, parsed.name)
 

--- a/codenib/clients/agentless_agent.py
+++ b/codenib/clients/agentless_agent.py
@@ -365,6 +365,7 @@ def run_agentless_policy(
     if not files:
         usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
         usage["elapsed_seconds"] = time.perf_counter() - started
+        usage["model_calls"] = len(trajectory)
         return AgentlessExecution(
             file_output=file_output,
             usage=usage,
@@ -443,8 +444,6 @@ def _contains_valid_location(
         files = provider.resolve_files([location.file_path], limit=1)
         if not files:
             continue
-        if location.kind == "file":
-            return True
         if location.kind == "line" and location.line_start is not None:
             line_count = len(provider.repository.source_lines(files[0]))
             if 1 <= location.line_start <= line_count:

--- a/codenib/clients/agentless_agent.py
+++ b/codenib/clients/agentless_agent.py
@@ -1,0 +1,492 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classic Agentless localization over CodeNib manifest views."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from codenib.clients._manifest import ManifestResolver, select_checkout_manifest
+from codenib.clients.agentless_protocol import (
+    AgentlessProtocol,
+    build_agentless_protocol,
+)
+from codenib.eval.baseline import BaselineLocation, BaselineRunResult
+from codenib.eval.benchmarks.agentless import (
+    AgentlessLocation,
+    parse_agentless_files,
+    parse_agentless_locations,
+)
+from codenib.integrations._repository import RepositoryEntity
+from codenib.integrations.agentless import AgentlessRepositoryProvider
+from codenib.types import NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD
+
+
+@dataclass(frozen=True, slots=True)
+class AgentlessExecution:
+    """Outputs and accounting from the three localization stages."""
+
+    file_output: str = ""
+    symbol_output: str = ""
+    line_output: str = ""
+    usage: Optional[Mapping[str, Any]] = None
+    trajectory: Sequence[Mapping[str, Any]] = ()
+
+    @property
+    def final_output(self) -> str:
+        return self.line_output or self.symbol_output or self.file_output
+
+
+AgentlessPolicyRunner = Callable[
+    [str, str, AgentlessRepositoryProvider, Mapping[str, Any]],
+    AgentlessExecution | str,
+]
+AgentlessProviderFactory = Callable[[Path], AgentlessRepositoryProvider]
+AgentlessManifestResolver = ManifestResolver
+
+
+def _entity_location(
+    entity: RepositoryEntity,
+    parsed: AgentlessLocation,
+) -> BaselineLocation:
+    qualified = entity.qualified_name or entity.simple_name
+    if entity.kind in {NODE_TYPE_FUNCTION, NODE_TYPE_METHOD}:
+        name = qualified.split("(", 1)[0].strip()
+        name = f"{name}()" if name else ""
+        location_type = "method" if entity.kind == NODE_TYPE_METHOD else "function"
+    elif entity.kind == NODE_TYPE_CLASS:
+        name = qualified
+        location_type = "class"
+    else:
+        name = qualified
+        location_type = parsed.kind if parsed.kind != "line" else "symbol"
+    return BaselineLocation(
+        name=name,
+        type=location_type,
+        file_path=entity.file_path,
+        line_start=(
+            entity.start_line + 1
+            if entity.start_line is not None
+            else parsed.line_start
+        ),
+        line_end=(
+            entity.end_line + 1 if entity.end_line is not None else parsed.line_end
+        ),
+    )
+
+
+def agentless_locations_to_baseline(
+    locations: Sequence[AgentlessLocation],
+    provider: AgentlessRepositoryProvider,
+) -> tuple[BaselineLocation, ...]:
+    """Resolve parsed Agentless records against CodeNib source identities."""
+
+    output: list[BaselineLocation] = []
+    seen: set[tuple[object, ...]] = set()
+    for parsed in locations:
+        files = provider.resolve_files([parsed.file_path], limit=1)
+        if not files:
+            continue
+        file_path = files[0]
+        entity: RepositoryEntity | None = None
+        if parsed.kind == "line" and parsed.line_start is not None:
+            entity = provider.repository.containing_entity(
+                file_path,
+                max(0, parsed.line_start - 1),
+            )
+        elif parsed.name:
+            entity = provider.resolve_entity(file_path, parsed.kind, parsed.name)
+
+        if entity is not None:
+            location = _entity_location(entity, parsed)
+        else:
+            name = parsed.name.split("(", 1)[0].strip()
+            if parsed.kind in {"function", "method"} and name:
+                name += "()"
+            location = BaselineLocation(
+                name=name,
+                type=parsed.kind,
+                file_path=file_path,
+                line_start=parsed.line_start,
+                line_end=parsed.line_end,
+            )
+        key = (
+            location.file_path,
+            location.name,
+            location.type,
+            location.line_start,
+            location.line_end,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        output.append(location)
+    return tuple(output)
+
+
+class AgentlessAgent:
+    """Run the pinned Agentless v1.5.0 localization policy on CodeNib views."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        manifest_path: str | Path | None = None,
+        manifest_resolver: AgentlessManifestResolver | None = None,
+        top_n_files: int = 3,
+        context_window: int = 10,
+        max_retries: int = 5,
+        max_completion_tokens: int = 300,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        policy_runner: AgentlessPolicyRunner | None = None,
+        provider_factory: AgentlessProviderFactory | None = None,
+        client_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        if not str(model).strip():
+            raise ValueError("Agentless model must not be empty")
+        if manifest_path is not None and manifest_resolver is not None:
+            raise ValueError(
+                "Specify either manifest_path or manifest_resolver, not both"
+            )
+        if top_n_files < 1 or top_n_files > 5:
+            raise ValueError("top_n_files must be between 1 and 5")
+        if context_window < 0:
+            raise ValueError("context_window must be non-negative")
+        if max_retries < 1:
+            raise ValueError("max_retries must be at least 1")
+        if max_completion_tokens < 1:
+            raise ValueError("max_completion_tokens must be positive")
+
+        self.model = str(model)
+        self.top_n_files = int(top_n_files)
+        self.context_window = int(context_window)
+        self.max_retries = int(max_retries)
+        self.max_completion_tokens = int(max_completion_tokens)
+        self.base_url = base_url
+        self.api_key = api_key
+        self._manifest_path = (
+            Path(manifest_path).expanduser().resolve()
+            if manifest_path is not None
+            else None
+        )
+        self._manifest_resolver = manifest_resolver
+        self._policy_runner = policy_runner or self._run_pinned_policy
+        self._provider_factory = (
+            provider_factory or AgentlessRepositoryProvider.from_manifest
+        )
+        self._client_factory = client_factory
+
+    async def locate_code(
+        self,
+        query_text: str,
+        repo_path: str,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> BaselineRunResult:
+        """Localize one issue through the shared baseline interface."""
+
+        repo = Path(repo_path).expanduser().resolve()
+        if not repo.is_dir():
+            return BaselineRunResult(
+                success=False,
+                repo_path=str(repo),
+                error_message=f"Repository path does not exist: {repo}",
+            )
+        problem = str(query_text or "").strip()
+        runtime_context = dict(context or {})
+        if not problem:
+            problem = str(runtime_context.get("issue_body") or "").strip()
+        if not problem:
+            return BaselineRunResult(
+                success=False,
+                repo_path=str(repo),
+                error_message="Agentless requires a non-empty problem statement",
+            )
+
+        try:
+            manifest_path = select_checkout_manifest(
+                repo,
+                integration_name="Agentless",
+                manifest_path=self._manifest_path,
+                manifest_resolver=self._manifest_resolver,
+            )
+            provider = self._provider_factory(manifest_path)
+            raw_execution = await asyncio.to_thread(
+                self._policy_runner,
+                problem,
+                str(repo),
+                provider,
+                runtime_context,
+            )
+            execution = (
+                raw_execution
+                if isinstance(raw_execution, AgentlessExecution)
+                else AgentlessExecution(line_output=str(raw_execution))
+            )
+            parsed = parse_agentless_locations(
+                execution.final_output,
+                valid_files=provider.files,
+                root_name=provider.project_root_name,
+            )
+            if not parsed and execution.symbol_output:
+                parsed = parse_agentless_locations(
+                    execution.symbol_output,
+                    valid_files=provider.files,
+                    root_name=provider.project_root_name,
+                )
+            if not parsed and execution.file_output:
+                parsed = tuple(
+                    AgentlessLocation(file_path=file_path)
+                    for file_path in parse_agentless_files(
+                        execution.file_output,
+                        valid_files=provider.files,
+                        root_name=provider.project_root_name,
+                        limit=self.top_n_files,
+                    )
+                )
+            return BaselineRunResult(
+                success=True,
+                repo_path=str(repo),
+                locations=agentless_locations_to_baseline(parsed, provider),
+                usage=dict(execution.usage or {}) or None,
+                raw_output={
+                    "file": execution.file_output,
+                    "symbol": execution.symbol_output,
+                    "line": execution.line_output,
+                    "trajectory": list(execution.trajectory),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - external baseline boundary
+            return BaselineRunResult(
+                success=False,
+                repo_path=str(repo),
+                error_message=f"Agentless localization failed: {exc}",
+            )
+
+    def _openai_client(self) -> Any:
+        if self._client_factory is not None:
+            return self._client_factory()
+        from openai import OpenAI
+
+        kwargs: dict[str, Any] = {}
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        return OpenAI(**kwargs)
+
+    def _run_pinned_policy(
+        self,
+        problem_statement: str,
+        repo_path: str,
+        provider: AgentlessRepositoryProvider,
+        context: Mapping[str, Any],
+    ) -> AgentlessExecution:
+        del repo_path, context
+        return run_agentless_policy(
+            protocol=build_agentless_protocol(problem_statement),
+            provider=provider,
+            model=self.model,
+            client=self._openai_client(),
+            top_n_files=self.top_n_files,
+            context_window=self.context_window,
+            max_retries=self.max_retries,
+            max_completion_tokens=self.max_completion_tokens,
+        )
+
+
+def run_agentless_policy(
+    *,
+    protocol: AgentlessProtocol,
+    provider: AgentlessRepositoryProvider,
+    model: str,
+    client: Any,
+    top_n_files: int = 3,
+    context_window: int = 10,
+    max_retries: int = 5,
+    max_completion_tokens: int = 300,
+) -> AgentlessExecution:
+    """Run file, symbol, and line localization with classic retry semantics."""
+
+    usage = {"prompt_tokens": 0, "completion_tokens": 0, "cached_tokens": 0}
+    trajectory: list[dict[str, Any]] = []
+    started = time.perf_counter()
+
+    def complete(stage: str, prompt: str, temperature: float) -> str:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_completion_tokens=max_completion_tokens,
+            temperature=temperature,
+        )
+        prompt_tokens, completion_tokens, cached_tokens = _response_usage(response)
+        usage["prompt_tokens"] += prompt_tokens
+        usage["completion_tokens"] += completion_tokens
+        usage["cached_tokens"] += cached_tokens
+        content = _response_text(response)
+        trajectory.append(
+            {
+                "stage": stage,
+                "temperature": temperature,
+                "prompt": prompt,
+                "response": content,
+            }
+        )
+        return content
+
+    file_output = complete(
+        "file",
+        protocol.file_prompt(provider.project_structure()),
+        0.0,
+    )
+    files = parse_agentless_files(
+        file_output,
+        valid_files=provider.files,
+        root_name=provider.project_root_name,
+        limit=top_n_files,
+    )
+    if not files:
+        usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+        usage["elapsed_seconds"] = time.perf_counter() - started
+        return AgentlessExecution(
+            file_output=file_output,
+            usage=usage,
+            trajectory=tuple(trajectory),
+        )
+
+    symbol_prompt = protocol.symbol_prompt(provider.skeleton_context(files))
+    symbol_output = ""
+    coarse: tuple[AgentlessLocation, ...] = ()
+    coarse_is_valid = False
+    for attempt in range(max_retries):
+        symbol_output = complete(
+            "symbol",
+            symbol_prompt,
+            0.0 if attempt == 0 else 1.0,
+        )
+        coarse = parse_agentless_locations(
+            symbol_output,
+            valid_files=files,
+            root_name=provider.project_root_name,
+        )
+        coarse_is_valid = _contains_valid_location(coarse, provider)
+        if coarse_is_valid:
+            break
+
+    if not coarse_is_valid:
+        usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+        usage["elapsed_seconds"] = time.perf_counter() - started
+        usage["model_calls"] = len(trajectory)
+        return AgentlessExecution(
+            file_output=file_output,
+            symbol_output=symbol_output,
+            usage=usage,
+            trajectory=tuple(trajectory),
+        )
+
+    line_prompt = protocol.line_prompt(
+        provider.line_context(
+            files,
+            coarse,
+            context_window=context_window,
+        )
+    )
+    line_output = ""
+    for attempt in range(max_retries):
+        line_output = complete(
+            "line",
+            line_prompt,
+            0.0 if attempt == 0 else 1.0,
+        )
+        fine = parse_agentless_locations(
+            line_output,
+            valid_files=files,
+            root_name=provider.project_root_name,
+        )
+        if _contains_valid_location(fine, provider):
+            break
+
+    usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+    usage["elapsed_seconds"] = time.perf_counter() - started
+    usage["model_calls"] = len(trajectory)
+    return AgentlessExecution(
+        file_output=file_output,
+        symbol_output=symbol_output,
+        line_output=line_output,
+        usage=usage,
+        trajectory=tuple(trajectory),
+    )
+
+
+def _contains_valid_location(
+    locations: Sequence[AgentlessLocation],
+    provider: AgentlessRepositoryProvider,
+) -> bool:
+    for location in locations:
+        files = provider.resolve_files([location.file_path], limit=1)
+        if not files:
+            continue
+        if location.kind == "file":
+            return True
+        if location.kind == "line" and location.line_start is not None:
+            line_count = len(provider.repository.source_lines(files[0]))
+            if 1 <= location.line_start <= line_count:
+                return True
+        elif provider.resolve_entity(files[0], location.kind, location.name):
+            return True
+    return False
+
+
+def _response_text(response: Any) -> str:
+    content = getattr(response.choices[0].message, "content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Sequence) and not isinstance(content, (str, bytes)):
+        return "\n".join(
+            str(
+                item.get("text")
+                if isinstance(item, Mapping)
+                else getattr(item, "text", "")
+            )
+            for item in content
+            if (
+                item.get("text")
+                if isinstance(item, Mapping)
+                else getattr(item, "text", "")
+            )
+        )
+    return ""
+
+
+def _response_usage(response: Any) -> tuple[int, int, int]:
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return 0, 0, 0
+    prompt = int(
+        getattr(usage, "prompt_tokens", None) or getattr(usage, "input_tokens", 0) or 0
+    )
+    completion = int(
+        getattr(usage, "completion_tokens", None)
+        or getattr(usage, "output_tokens", 0)
+        or 0
+    )
+    details = getattr(usage, "prompt_tokens_details", None)
+    cached = int(getattr(details, "cached_tokens", 0) or 0)
+    return prompt, completion, cached
+
+
+__all__ = [
+    "AgentlessAgent",
+    "AgentlessExecution",
+    "AgentlessManifestResolver",
+    "AgentlessPolicyRunner",
+    "AgentlessProviderFactory",
+    "agentless_locations_to_baseline",
+    "run_agentless_policy",
+]

--- a/codenib/clients/agentless_protocol.py
+++ b/codenib/clients/agentless_protocol.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frozen prompt contract for classic Agentless localization.
+
+The prompt wording follows Agentless v1.5.0 (MIT), pinned by
+``AGENTLESS_PROTOCOL_REVISION``. Keeping it in a dependency-free module lets
+CodeNib validate drift against an optional upstream checkout without importing
+Agentless at runtime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from codenib.integrations.agentless import AGENTLESS_REVISION
+
+AGENTLESS_PROTOCOL_REVISION = AGENTLESS_REVISION
+
+_FILE_PROMPT = """
+Please look through the following GitHub problem description and Repository structure and provide a list of files that one would need to edit to fix the problem.
+
+### GitHub Problem Description ###
+{problem_statement}
+
+###
+
+### Repository Structure ###
+{structure}
+
+###
+
+Please only provide the full path and return at most 5 files.
+The returned files should be separated by new lines ordered by most to least important and wrapped with ```
+For example:
+```
+file1.py
+file2.py
+```
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_SYMBOL_PROMPT = """
+Please look through the following GitHub Problem Description and the Skeleton of Relevant Files.
+Identify all locations that need inspection or editing to fix the problem, including directly related areas as well as any potentially related global variables, functions, and classes.
+For each location you provide, either give the name of the class, the name of a method in a class, the name of a function, or the name of a global variable.
+
+### GitHub Problem Description ###
+{problem_statement}
+
+### Skeleton of Relevant Files ###
+{file_contents}
+
+###
+
+Please provide the complete set of locations as either a class name, a function name, or a variable name.
+Note that if you include a class, you do not need to list its specific methods.
+You can include either the entire class or don't include the class name and instead include specific methods in the class.
+### Examples:
+```
+full_path1/file1.py
+function: my_function_1
+class: MyClass1
+function: MyClass2.my_method
+
+full_path2/file2.py
+variable: my_var
+function: MyClass3.my_method
+
+full_path3/file3.py
+function: my_function_2
+function: my_function_3
+function: MyClass4.my_method_1
+class: MyClass5
+```
+
+Return just the locations.
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_LINE_PROMPT = """
+Please review the following GitHub problem description and relevant files, and provide a set of locations that need to be edited to fix the issue.
+The locations can be specified as class names, function or method names, or exact line numbers that require modification.
+
+### GitHub Problem Description ###
+{problem_statement}
+
+###
+{file_contents}
+
+###
+
+Please provide the class name, function or method name, or the exact line numbers that need to be edited.
+### Examples:
+```
+full_path1/file1.py
+line: 10
+class: MyClass1
+line: 51
+
+full_path2/file2.py
+function: MyClass2.my_method
+line: 12
+
+full_path3/file3.py
+function: my_function
+line: 24
+line: 156
+```
+
+Return just the location(s)
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+
+@dataclass(frozen=True, slots=True)
+class AgentlessProtocol:
+    """Three prompt stages used by classic Agentless localization."""
+
+    problem_statement: str
+
+    def file_prompt(self, structure: str) -> str:
+        return _FILE_PROMPT.format(
+            problem_statement=self.problem_statement,
+            structure=structure,
+        ).strip()
+
+    def symbol_prompt(self, file_contents: str) -> str:
+        return _SYMBOL_PROMPT.format(
+            problem_statement=self.problem_statement,
+            file_contents=file_contents,
+        ).strip()
+
+    def line_prompt(self, file_contents: str) -> str:
+        return _LINE_PROMPT.format(
+            problem_statement=self.problem_statement,
+            file_contents=file_contents,
+        ).strip()
+
+
+def build_agentless_protocol(problem_statement: str) -> AgentlessProtocol:
+    """Build the pinned protocol for one non-empty issue statement."""
+
+    problem = str(problem_statement or "").strip()
+    if not problem:
+        raise ValueError("Agentless requires a non-empty problem statement")
+    return AgentlessProtocol(problem_statement=problem)
+
+
+__all__ = [
+    "AGENTLESS_PROTOCOL_REVISION",
+    "AgentlessProtocol",
+    "build_agentless_protocol",
+]

--- a/codenib/eval/benchmarks/__init__.py
+++ b/codenib/eval/benchmarks/__init__.py
@@ -4,6 +4,11 @@
 
 """Benchmark-specific schemas and scorers built on CodeNib outputs."""
 
+from .agentless import (
+    AgentlessLocation,
+    parse_agentless_files,
+    parse_agentless_locations,
+)
 from .locagent import LocAgentLocation, locagent_regions, parse_locagent_locations
 from .orcaloca import (
     OrcaLocaGroundTruth,
@@ -59,6 +64,7 @@ from .swe_explore import (
 )
 
 __all__ = [
+    "AgentlessLocation",
     "LocAgentLocation",
     "locagent_regions",
     "CaseEligibility",
@@ -96,6 +102,8 @@ __all__ = [
     "load_swe_explore_cases",
     "load_swe_explore_sources",
     "normalize_swe_explore_instance_id",
+    "parse_agentless_files",
+    "parse_agentless_locations",
     "parse_orcaloca_locations",
     "resolve_orcaloca_locations",
     "parse_locagent_locations",

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -20,8 +20,8 @@ _LIST_PREFIX = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 
 
 def _normalize(value: object) -> str:
-    text = str(value or "").strip().strip("`'\"()[]{} ").rstrip(",;")
-    text = _LIST_PREFIX.sub("", text).replace("\\", "/")
+    text = _LIST_PREFIX.sub("", str(value or "").strip())
+    text = text.strip("`'\"()[]{} ").rstrip(",;").replace("\\", "/")
     while text.startswith("./"):
         text = text[2:]
     return text.lstrip("/")

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -17,6 +17,7 @@ _FIELD = re.compile(
 )
 _LINE_RANGE = re.compile(r"(-?\d+)(?:\s*(?:-|:|to)\s*(-?\d+))?", re.IGNORECASE)
 _LIST_PREFIX = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
+_FILE_HEADING = re.compile(r"^(?:[^/\s]+/)*[^/\s]+\.[A-Za-z0-9_+-]+(?::.*)?$")
 
 
 def _normalize(value: object) -> str:
@@ -27,10 +28,15 @@ def _normalize(value: object) -> str:
     return text.lstrip("/")
 
 
-def _match_file(line: str, valid_files: Sequence[str], root_name: str) -> str:
+def _file_candidate(line: str) -> str:
     candidate = _normalize(line).strip("# ")
     if candidate.lower().startswith("file:"):
         candidate = _normalize(candidate.split(":", 1)[1]).strip("# ")
+    return candidate
+
+
+def _match_file(line: str, valid_files: Sequence[str], root_name: str) -> str:
+    candidate = _file_candidate(line)
     roots = tuple(filter(None, (root_name.strip("/"),)))
     for file_path in sorted(valid_files, key=len, reverse=True):
         accepted = {file_path}
@@ -45,6 +51,10 @@ def _match_file(line: str, valid_files: Sequence[str], root_name: str) -> str:
     if len(suffix_matches) == 1:
         return suffix_matches[0]
     return ""
+
+
+def _looks_like_file_heading(line: str) -> bool:
+    return bool(_FILE_HEADING.fullmatch(_file_candidate(line)))
 
 
 def _symbols(value: str) -> list[str]:
@@ -126,6 +136,10 @@ def parse_agentless_locations(
         if file_path:
             flush_file()
             current_file = file_path
+            continue
+        if _looks_like_file_heading(line):
+            flush_file()
+            current_file = ""
             continue
         if not current_file:
             continue

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -119,7 +119,7 @@ def parse_agentless_locations(
         current_has_detail = False
 
     for raw_line in str(raw_output or "").splitlines():
-        line = raw_line.strip().strip("`").strip()
+        line = _LIST_PREFIX.sub("", raw_line.strip()).strip("`").strip()
         if not line:
             continue
         file_path = _match_file(line, files, root_name)

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-free parsing for classic Agentless localization output."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+_FIELD = re.compile(
+    r"^(?:[-*]\s*)?"
+    r"(lines?|class(?:es)?|functions?|methods?|variables?)\s*:\s*(.+?)\s*$",
+    re.IGNORECASE,
+)
+_LINE_RANGE = re.compile(r"(\d+)(?:\s*(?:-|:|to)\s*(\d+))?", re.IGNORECASE)
+_LIST_PREFIX = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
+
+
+def _normalize(value: object) -> str:
+    text = str(value or "").strip().strip("`'\".,;()[]{} ")
+    text = _LIST_PREFIX.sub("", text).replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    return text.lstrip("/")
+
+
+def _match_file(line: str, valid_files: Sequence[str], root_name: str) -> str:
+    candidate = _normalize(line)
+    if candidate.lower().startswith("file:"):
+        candidate = _normalize(candidate.split(":", 1)[1])
+    candidate = candidate.strip("# ")
+    roots = tuple(filter(None, (root_name.strip("/"),)))
+    for file_path in sorted(valid_files, key=len, reverse=True):
+        accepted = {file_path}
+        accepted.update(f"{root}/{file_path}" for root in roots)
+        if candidate in accepted:
+            return file_path
+        if any(candidate.startswith(value + ":") for value in accepted):
+            return file_path
+    return ""
+
+
+def _symbols(value: str) -> list[str]:
+    output: list[str] = []
+    for raw in re.split(r"\s*[,;]\s*", value):
+        symbol = raw.strip().strip("`'\" ")
+        if symbol:
+            output.append(symbol)
+    return output
+
+
+@dataclass(frozen=True, slots=True)
+class AgentlessLocation:
+    """One file, symbol, variable, or line emitted by Agentless."""
+
+    file_path: str
+    kind: str = "file"
+    name: str = ""
+    line_start: int | None = None
+    line_end: int | None = None
+
+    def to_record(self) -> dict[str, str | int | None]:
+        return {
+            "file_path": self.file_path,
+            "kind": self.kind,
+            "name": self.name,
+            "line_start": self.line_start,
+            "line_end": self.line_end,
+        }
+
+
+def parse_agentless_files(
+    raw_output: str,
+    *,
+    valid_files: Iterable[str],
+    root_name: str = "",
+    limit: int | None = None,
+) -> tuple[str, ...]:
+    """Parse the ranked file-only response used by Agentless stage one."""
+
+    files = tuple(dict.fromkeys(_normalize(path) for path in valid_files if path))
+    output: list[str] = []
+    seen: set[str] = set()
+    for line in str(raw_output or "").splitlines():
+        file_path = _match_file(line, files, root_name)
+        if not file_path or file_path in seen:
+            continue
+        seen.add(file_path)
+        output.append(file_path)
+        if limit is not None and len(output) >= limit:
+            break
+    return tuple(output)
+
+
+def parse_agentless_locations(
+    raw_output: str,
+    *,
+    valid_files: Iterable[str],
+    root_name: str = "",
+) -> tuple[AgentlessLocation, ...]:
+    """Parse Agentless's fenced file/class/function/variable/line blocks."""
+
+    files = tuple(dict.fromkeys(_normalize(path) for path in valid_files if path))
+    output: list[AgentlessLocation] = []
+    current_file = ""
+    current_has_detail = False
+
+    def flush_file() -> None:
+        nonlocal current_has_detail
+        if current_file and not current_has_detail:
+            output.append(AgentlessLocation(file_path=current_file))
+        current_has_detail = False
+
+    for raw_line in str(raw_output or "").splitlines():
+        line = raw_line.strip().strip("`").strip()
+        if not line:
+            continue
+        file_path = _match_file(line, files, root_name)
+        if file_path:
+            flush_file()
+            current_file = file_path
+            continue
+        if not current_file:
+            continue
+        match = _FIELD.match(line)
+        if match is None:
+            continue
+        field = match.group(1).lower()
+        value = match.group(2)
+        current_has_detail = True
+        if field.startswith("line"):
+            for line_match in _LINE_RANGE.finditer(value):
+                start = max(1, int(line_match.group(1)))
+                end = max(start, int(line_match.group(2) or start))
+                output.append(
+                    AgentlessLocation(
+                        file_path=current_file,
+                        kind="line",
+                        line_start=start,
+                        line_end=end,
+                    )
+                )
+            continue
+        if field.startswith("class"):
+            kind = "class"
+        elif field.startswith("variable"):
+            kind = "variable"
+        elif field.startswith("method"):
+            kind = "method"
+        else:
+            kind = "function"
+        output.extend(
+            AgentlessLocation(file_path=current_file, kind=kind, name=symbol)
+            for symbol in _symbols(value)
+        )
+    flush_file()
+
+    deduplicated: list[AgentlessLocation] = []
+    seen: set[tuple[object, ...]] = set()
+    for location in output:
+        key = (
+            location.file_path,
+            location.kind,
+            location.name,
+            location.line_start,
+            location.line_end,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduplicated.append(location)
+    return tuple(deduplicated)
+
+
+__all__ = [
+    "AgentlessLocation",
+    "parse_agentless_files",
+    "parse_agentless_locations",
+]

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -15,12 +15,12 @@ _FIELD = re.compile(
     r"(lines?|class(?:es)?|functions?|methods?|variables?)\s*:\s*(.+?)\s*$",
     re.IGNORECASE,
 )
-_LINE_RANGE = re.compile(r"(\d+)(?:\s*(?:-|:|to)\s*(\d+))?", re.IGNORECASE)
+_LINE_RANGE = re.compile(r"(-?\d+)(?:\s*(?:-|:|to)\s*(-?\d+))?", re.IGNORECASE)
 _LIST_PREFIX = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 
 
 def _normalize(value: object) -> str:
-    text = str(value or "").strip().strip("`'\".,;()[]{} ")
+    text = str(value or "").strip().strip("`'\"()[]{} ").rstrip(",;")
     text = _LIST_PREFIX.sub("", text).replace("\\", "/")
     while text.startswith("./"):
         text = text[2:]
@@ -132,8 +132,10 @@ def parse_agentless_locations(
         current_has_detail = True
         if field.startswith("line"):
             for line_match in _LINE_RANGE.finditer(value):
-                start = max(1, int(line_match.group(1)))
-                end = max(start, int(line_match.group(2) or start))
+                start = int(line_match.group(1))
+                end = int(line_match.group(2) or start)
+                if start < 1 or end < start:
+                    continue
                 output.append(
                     AgentlessLocation(
                         file_path=current_file,

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -153,9 +153,12 @@ def parse_agentless_locations(
             kind = "method"
         else:
             kind = "function"
+        symbols = _symbols(value)
+        if kind == "variable":
+            symbols = [name for symbol in symbols for name in symbol.split()]
         output.extend(
             AgentlessLocation(file_path=current_file, kind=kind, name=symbol)
-            for symbol in _symbols(value)
+            for symbol in symbols
         )
     flush_file()
 

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -37,6 +37,7 @@ def _file_candidate(line: str) -> str:
 
 def _match_file(line: str, valid_files: Sequence[str], root_name: str) -> str:
     candidate = _file_candidate(line)
+    path_candidate = candidate.split(":", 1)[0]
     roots = tuple(filter(None, (root_name.strip("/"),)))
     for file_path in sorted(valid_files, key=len, reverse=True):
         accepted = {file_path}
@@ -46,10 +47,27 @@ def _match_file(line: str, valid_files: Sequence[str], root_name: str) -> str:
         if any(candidate.startswith(value + ":") for value in accepted):
             return file_path
     suffix_matches = tuple(
-        file_path for file_path in valid_files if file_path.endswith("/" + candidate)
+        file_path
+        for file_path in valid_files
+        if file_path.endswith("/" + path_candidate)
     )
     if len(suffix_matches) == 1:
         return suffix_matches[0]
+    return ""
+
+
+def _file_suffix(line: str, file_path: str, root_name: str) -> str:
+    candidate = _file_candidate(line)
+    path_candidate, separator, suffix = candidate.partition(":")
+    accepted = {file_path}
+    root = root_name.strip("/")
+    if root:
+        accepted.add(f"{root}/{file_path}")
+    for value in sorted(accepted, key=len, reverse=True):
+        if candidate.startswith(value + ":"):
+            return candidate[len(value) + 1 :].strip()
+    if separator and file_path.endswith("/" + path_candidate):
+        return suffix.strip()
     return ""
 
 
@@ -136,8 +154,14 @@ def parse_agentless_locations(
         if file_path:
             flush_file()
             current_file = file_path
-            continue
-        if _looks_like_file_heading(line):
+            suffix = _file_suffix(line, file_path, root_name)
+            if not suffix:
+                continue
+            if re.fullmatch(r"-?\d+(?:\s*(?:-|:|to)\s*-?\d+)?", suffix):
+                line = f"line: {suffix}"
+            else:
+                line = re.sub(r"^(lines?)\s+", r"\1: ", suffix, flags=re.IGNORECASE)
+        elif _looks_like_file_heading(line):
             flush_file()
             current_file = ""
             continue

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -28,10 +28,9 @@ def _normalize(value: object) -> str:
 
 
 def _match_file(line: str, valid_files: Sequence[str], root_name: str) -> str:
-    candidate = _normalize(line)
+    candidate = _normalize(line).strip("# ")
     if candidate.lower().startswith("file:"):
-        candidate = _normalize(candidate.split(":", 1)[1])
-    candidate = candidate.strip("# ")
+        candidate = _normalize(candidate.split(":", 1)[1]).strip("# ")
     roots = tuple(filter(None, (root_name.strip("/"),)))
     for file_path in sorted(valid_files, key=len, reverse=True):
         accepted = {file_path}

--- a/codenib/eval/benchmarks/agentless.py
+++ b/codenib/eval/benchmarks/agentless.py
@@ -39,6 +39,11 @@ def _match_file(line: str, valid_files: Sequence[str], root_name: str) -> str:
             return file_path
         if any(candidate.startswith(value + ":") for value in accepted):
             return file_path
+    suffix_matches = tuple(
+        file_path for file_path in valid_files if file_path.endswith("/" + candidate)
+    )
+    if len(suffix_matches) == 1:
+        return suffix_matches[0]
     return ""
 
 

--- a/codenib/integrations/agentless.py
+++ b/codenib/integrations/agentless.py
@@ -214,22 +214,15 @@ class AgentlessRepositoryProvider:
             kinds = {NODE_TYPE_CLASS, NODE_TYPE_FIELD, NODE_TYPE_SYMBOL}
         else:
             kinds = set(_SYMBOL_KINDS)
+        requested = name.strip().removesuffix("()")
         matches = self.repository.find_entities(
-            name,
+            requested,
             file_path=resolved[0],
             kinds=kinds,
         )
         if len(matches) == 1:
             return matches[0]
-        if "." in name:
-            matches = self.repository.find_entities(
-                name.rsplit(".", 1)[-1],
-                file_path=resolved[0],
-                kinds=kinds,
-            )
-        if len(matches) == 1:
-            return matches[0]
-        return self._resolve_source_entity(resolved[0], name, kinds)
+        return self._resolve_source_entity(resolved[0], requested, kinds)
 
     def _resolve_source_entity(
         self,
@@ -250,6 +243,8 @@ class AgentlessRepositoryProvider:
         )
         if len(exact) == 1:
             return exact[0]
+        if "." in requested:
+            return None
         simple = requested.rsplit(".", 1)[-1]
         matches = tuple(entity for entity in entities if entity.simple_name == simple)
         return matches[0] if len(matches) == 1 else None

--- a/codenib/integrations/agentless.py
+++ b/codenib/integrations/agentless.py
@@ -56,6 +56,7 @@ class AgentlessRepositoryProvider:
 
     def __init__(self, context: Any) -> None:
         self.repository = RepositoryAdapter(context, require_graph=True)
+        self._source_entity_cache: dict[str, tuple[RepositoryEntity, ...]] = {}
         self._files = tuple(
             file_path
             for file_path in self.repository.files
@@ -226,7 +227,118 @@ class AgentlessRepositoryProvider:
                 file_path=resolved[0],
                 kinds=kinds,
             )
+        if len(matches) == 1:
+            return matches[0]
+        return self._resolve_source_entity(resolved[0], name, kinds)
+
+    def _resolve_source_entity(
+        self,
+        file_path: str,
+        name: str,
+        kinds: set[str],
+    ) -> RepositoryEntity | None:
+        requested = name.strip().removesuffix("()")
+        entities = tuple(
+            entity
+            for entity in self._source_entities(file_path)
+            if entity.kind in kinds
+        )
+        exact = tuple(
+            entity
+            for entity in entities
+            if entity.qualified_name == requested or entity.display_name == requested
+        )
+        if len(exact) == 1:
+            return exact[0]
+        simple = requested.rsplit(".", 1)[-1]
+        matches = tuple(entity for entity in entities if entity.simple_name == simple)
         return matches[0] if len(matches) == 1 else None
+
+    def _source_entities(self, file_path: str) -> tuple[RepositoryEntity, ...]:
+        cached = self._source_entity_cache.get(file_path)
+        if cached is not None:
+            return cached
+        content, _, _ = self.repository.read_range(file_path)
+        try:
+            module = ast.parse(content)
+        except SyntaxError:
+            self._source_entity_cache[file_path] = ()
+            return ()
+
+        entities: list[RepositoryEntity] = []
+
+        def add_entity(
+            node: ast.AST,
+            *,
+            simple_name: str,
+            kind: str,
+            parents: tuple[str, ...],
+        ) -> None:
+            qualified_name = ".".join((*parents, simple_name))
+            start = max(0, int(getattr(node, "lineno", 1)) - 1)
+            end = max(start, int(getattr(node, "end_lineno", start + 1)) - 1)
+            entities.append(
+                RepositoryEntity(
+                    vertex_id=-1,
+                    canonical_name=f"source:{file_path}:{qualified_name}",
+                    display_name=qualified_name,
+                    kind=kind,
+                    file_path=file_path,
+                    qualified_name=qualified_name,
+                    simple_name=simple_name,
+                    start_line=start,
+                    end_line=end,
+                    parent_name=".".join(parents) or None,
+                    class_name=parents[-1] if parents else None,
+                )
+            )
+
+        def visit(nodes: Sequence[ast.stmt], parents: tuple[str, ...] = ()) -> None:
+            for node in nodes:
+                if isinstance(node, ast.ClassDef):
+                    add_entity(
+                        node,
+                        simple_name=node.name,
+                        kind=NODE_TYPE_CLASS,
+                        parents=parents,
+                    )
+                    visit(node.body, (*parents, node.name))
+                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    add_entity(
+                        node,
+                        simple_name=node.name,
+                        kind=NODE_TYPE_METHOD if parents else NODE_TYPE_FUNCTION,
+                        parents=parents,
+                    )
+                elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+                    for target_name in self._assignment_names(node):
+                        add_entity(
+                            node,
+                            simple_name=target_name,
+                            kind=NODE_TYPE_FIELD if parents else NODE_TYPE_SYMBOL,
+                            parents=parents,
+                        )
+
+        visit(module.body)
+        result = tuple(entities)
+        self._source_entity_cache[file_path] = result
+        return result
+
+    @staticmethod
+    def _assignment_names(node: ast.Assign | ast.AnnAssign) -> tuple[str, ...]:
+        targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+        names: list[str] = []
+
+        def collect(target: ast.AST) -> None:
+            if isinstance(target, ast.Name):
+                names.append(target.id)
+            elif isinstance(target, (ast.Tuple, ast.List)):
+                for element in target.elts:
+                    collect(element)
+
+        for target in targets:
+            collect(target)
+        return tuple(names)
 
     def _location_interval(
         self, file_path: str, location: Any

--- a/codenib/integrations/agentless.py
+++ b/codenib/integrations/agentless.py
@@ -214,7 +214,11 @@ class AgentlessRepositoryProvider:
             kinds = {NODE_TYPE_CLASS, NODE_TYPE_FIELD, NODE_TYPE_SYMBOL}
         else:
             kinds = set(_SYMBOL_KINDS)
-        requested = name.strip().removesuffix("()")
+        requested = name.strip()
+        if kind in {"function", "method"}:
+            requested = requested.split("(", 1)[0].strip()
+        else:
+            requested = requested.removesuffix("()")
         matches = self.repository.find_entities(
             requested,
             file_path=resolved[0],

--- a/codenib/integrations/agentless.py
+++ b/codenib/integrations/agentless.py
@@ -1,0 +1,344 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classic Agentless repository context over manifest-backed views.
+
+The compatibility boundary is the localization phase from Agentless v1.5.0:
+Python project structure, compressed symbol context, and bounded line context.
+Repair generation and patch validation remain outside this adapter.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping, Sequence
+
+from ..types import (
+    NODE_TYPE_CLASS,
+    NODE_TYPE_FIELD,
+    NODE_TYPE_FUNCTION,
+    NODE_TYPE_METHOD,
+    NODE_TYPE_SYMBOL,
+)
+from ._repository import RepositoryAdapter, RepositoryEntity
+
+AGENTLESS_REVISION = "b150f28465a77a81a7f4776384957a4271f5bd69"
+AGENTLESS_VERSION = "v1.5.0"
+
+_RUNTIME_VIEWS = frozenset({"symbol_graph"})
+_SYMBOL_KINDS = frozenset(
+    {
+        NODE_TYPE_CLASS,
+        NODE_TYPE_FIELD,
+        NODE_TYPE_FUNCTION,
+        NODE_TYPE_METHOD,
+        NODE_TYPE_SYMBOL,
+    }
+)
+_LIST_PREFIX = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
+
+
+def _is_agentless_python_path(file_path: str) -> bool:
+    """Match Agentless's Python-only and ``test*`` subtree filters."""
+
+    path = PurePosixPath(file_path)
+    return path.suffix == ".py" and not any(
+        part.startswith("test") for part in path.parts
+    )
+
+
+class AgentlessRepositoryProvider:
+    """Serve classic Agentless localization context from one manifest graph."""
+
+    def __init__(self, context: Any) -> None:
+        self.repository = RepositoryAdapter(context, require_graph=True)
+        self._files = tuple(
+            file_path
+            for file_path in self.repository.files
+            if _is_agentless_python_path(file_path)
+        )
+
+    @classmethod
+    def from_manifest(
+        cls, manifest_path: str | Path, **_kwargs: Any
+    ) -> "AgentlessRepositoryProvider":
+        from ..mcp.context import ServerContext
+
+        return cls(ServerContext.load(manifest_path, views=_RUNTIME_VIEWS))
+
+    @property
+    def context(self) -> Any:
+        return self.repository.context
+
+    @property
+    def files(self) -> tuple[str, ...]:
+        return self._files
+
+    @property
+    def project_root_name(self) -> str:
+        return self.repository.repo_root.name
+
+    def project_structure(self) -> str:
+        """Render the Python tree in Agentless's four-space layout."""
+
+        tree: dict[str, Any] = {}
+        for file_path in self._files:
+            node = tree
+            for part in PurePosixPath(file_path).parts:
+                node = node.setdefault(part, {})
+
+        lines = [f"{self.project_root_name}/"]
+
+        def render(current: Mapping[str, Any], depth: int) -> None:
+            for name, children in current.items():
+                suffix = "/" if children else ""
+                lines.append(f"{' ' * (depth * 4)}{name}{suffix}")
+                if children:
+                    render(children, depth + 1)
+
+        render(tree, 1)
+        return "\n".join(lines)
+
+    def resolve_files(
+        self,
+        values: str | Sequence[str],
+        *,
+        limit: int | None = None,
+    ) -> tuple[str, ...]:
+        """Resolve an Agentless file response to ranked repository paths."""
+
+        lines = values.splitlines() if isinstance(values, str) else values
+        selected: list[str] = []
+        seen: set[str] = set()
+        root_prefix = self.project_root_name + "/"
+
+        for raw in lines:
+            value = _LIST_PREFIX.sub("", str(raw).strip().strip("`'\" "))
+            if not value:
+                continue
+            value = value.replace("\\", "/")
+            while value.startswith("./"):
+                value = value[2:]
+            if value.startswith(root_prefix):
+                value = value[len(root_prefix) :]
+            matches = self.repository.find_files(value)
+            for match in matches:
+                if match not in self._files or match in seen:
+                    continue
+                seen.add(match)
+                selected.append(match)
+                break
+            if limit is not None and len(selected) >= limit:
+                break
+        return tuple(selected)
+
+    def skeleton_context(self, file_paths: Sequence[str]) -> str:
+        """Format graph-selected Python skeletons for Agentless stage two."""
+
+        sections: list[str] = []
+        for file_path in self.resolve_files(file_paths):
+            content, _, _ = self.repository.read_range(file_path)
+            skeleton = self._python_skeleton(content)
+            sections.append(
+                f"\n### File: {file_path} ###\n```python\n{skeleton}\n```\n"
+            )
+        return "".join(sections)
+
+    def line_context(
+        self,
+        file_paths: Sequence[str],
+        locations: Sequence[Any],
+        *,
+        context_window: int = 10,
+    ) -> str:
+        """Build numbered source windows around coarse Agentless locations."""
+
+        window = max(0, int(context_window))
+        allowed_files = self.resolve_files(file_paths)
+        by_file: dict[str, list[tuple[int, int]]] = defaultdict(list)
+        for location in locations:
+            file_path = str(getattr(location, "file_path", "") or "")
+            resolved = self.resolve_files([file_path], limit=1)
+            if not resolved or resolved[0] not in allowed_files:
+                continue
+            file_path = resolved[0]
+            interval = self._location_interval(file_path, location)
+            if interval is not None:
+                by_file[file_path].append(
+                    (max(0, interval[0] - window), interval[1] + window)
+                )
+
+        sections: list[str] = []
+        for file_path in allowed_files:
+            lines = self.repository.source_lines(file_path)
+            if not lines:
+                continue
+            intervals = by_file.get(file_path)
+            if not intervals:
+                continue
+            intervals = self._merge_intervals(
+                (start, min(end, len(lines) - 1)) for start, end in intervals
+            )
+            rendered: list[str] = []
+            previous_end: int | None = None
+            for start, end in intervals:
+                if previous_end is not None and start > previous_end + 1:
+                    rendered.append("...")
+                rendered.extend(
+                    f"{line_number + 1}|{lines[line_number]}"
+                    for line_number in range(start, end + 1)
+                )
+                previous_end = end
+            sections.append(f"### File: {file_path} ###\n" + "\n".join(rendered))
+        return "\n\n".join(sections)
+
+    def resolve_entity(
+        self, file_path: str, kind: str, name: str
+    ) -> RepositoryEntity | None:
+        """Resolve one parsed Agentless class/function/variable location."""
+
+        resolved = self.resolve_files([file_path], limit=1)
+        if not resolved or not name:
+            return None
+        kinds: set[str]
+        if kind == "class":
+            kinds = {NODE_TYPE_CLASS}
+        elif kind in {"function", "method"}:
+            kinds = {NODE_TYPE_FUNCTION, NODE_TYPE_METHOD}
+        elif kind == "variable":
+            kinds = {NODE_TYPE_CLASS, NODE_TYPE_FIELD, NODE_TYPE_SYMBOL}
+        else:
+            kinds = set(_SYMBOL_KINDS)
+        matches = self.repository.find_entities(
+            name,
+            file_path=resolved[0],
+            kinds=kinds,
+        )
+        if len(matches) == 1:
+            return matches[0]
+        if "." in name:
+            matches = self.repository.find_entities(
+                name.rsplit(".", 1)[-1],
+                file_path=resolved[0],
+                kinds=kinds,
+            )
+        return matches[0] if len(matches) == 1 else None
+
+    def _location_interval(
+        self, file_path: str, location: Any
+    ) -> tuple[int, int] | None:
+        line_start = getattr(location, "line_start", None)
+        line_end = getattr(location, "line_end", None)
+        if isinstance(line_start, int) and not isinstance(line_start, bool):
+            start = max(0, line_start - 1)
+            end = max(start, (line_end or line_start) - 1)
+            return start, end
+
+        entity = self.resolve_entity(
+            file_path,
+            str(getattr(location, "kind", "") or ""),
+            str(getattr(location, "name", "") or ""),
+        )
+        if entity and entity.start_line is not None and entity.end_line is not None:
+            return entity.start_line, entity.end_line
+        return None
+
+    @staticmethod
+    def _merge_intervals(
+        intervals: Iterable[tuple[int, int]],
+    ) -> list[tuple[int, int]]:
+        merged: list[list[int]] = []
+        for start, end in sorted(intervals):
+            if not merged or start > merged[-1][1] + 1:
+                merged.append([start, end])
+            else:
+                merged[-1][1] = max(merged[-1][1], end)
+        return [(start, end) for start, end in merged]
+
+    @classmethod
+    def _python_skeleton(cls, content: str) -> str:
+        """Approximate Agentless's libcst skeleton with the Python stdlib AST."""
+
+        try:
+            module = ast.parse(content)
+        except SyntaxError:
+            return content
+        lines = content.splitlines()
+        rendered: list[str] = []
+        for node in module.body:
+            rendered.extend(cls._render_python_node(node, lines, indent=0))
+        return "\n".join(rendered).rstrip()
+
+    @classmethod
+    def _render_python_node(
+        cls,
+        node: ast.AST,
+        lines: Sequence[str],
+        *,
+        indent: int,
+    ) -> list[str]:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            start = max(0, int(getattr(node, "lineno", 1)) - 1)
+            end = max(start, int(getattr(node, "end_lineno", start + 1)) - 1)
+            return [" " * indent + line.lstrip() for line in lines[start : end + 1]]
+
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            header = cls._definition_header(node, lines, indent)
+            return [*header, " " * (indent + 4) + "..."]
+
+        if isinstance(node, ast.ClassDef):
+            output = cls._definition_header(node, lines, indent)
+            body: list[str] = []
+            for child in node.body:
+                if isinstance(child, ast.Expr) and isinstance(
+                    getattr(child, "value", None), (ast.Constant, ast.Str)
+                ):
+                    continue
+                body.extend(cls._render_python_node(child, lines, indent=indent + 4))
+            output.extend(body or [" " * (indent + 4) + "..."])
+            return output
+        return []
+
+    @staticmethod
+    def _definition_header(
+        node: ast.AST,
+        lines: Sequence[str],
+        indent: int,
+    ) -> list[str]:
+        decorators = list(getattr(node, "decorator_list", ()) or ())
+        output = [" " * indent + "@" + ast.unparse(item) for item in decorators]
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+            signature = f"{prefix} {node.name}({ast.unparse(node.args)})"
+            if node.returns is not None:
+                signature += f" -> {ast.unparse(node.returns)}"
+            output.append(" " * indent + signature + ":")
+            return output
+        if isinstance(node, ast.ClassDef):
+            arguments = [ast.unparse(base) for base in node.bases]
+            arguments.extend(
+                (
+                    f"{keyword.arg}={ast.unparse(keyword.value)}"
+                    if keyword.arg is not None
+                    else f"**{ast.unparse(keyword.value)}"
+                )
+                for keyword in node.keywords
+            )
+            suffix = f"({', '.join(arguments)})" if arguments else ""
+            output.append(" " * indent + f"class {node.name}{suffix}:")
+            return output
+        line_number = max(1, int(getattr(node, "lineno", 1)))
+        fallback = lines[line_number - 1].lstrip() if lines else "symbol"
+        output.append(" " * indent + fallback)
+        return output
+
+
+__all__ = [
+    "AGENTLESS_REVISION",
+    "AGENTLESS_VERSION",
+    "AgentlessRepositoryProvider",
+]

--- a/codenib/integrations/agentless.py
+++ b/codenib/integrations/agentless.py
@@ -124,7 +124,7 @@ class AgentlessRepositoryProvider:
             value = value.replace("\\", "/")
             while value.startswith("./"):
                 value = value[2:]
-            if value.startswith(root_prefix):
+            if value not in self._files and value.startswith(root_prefix):
                 value = value[len(root_prefix) :]
             matches = self.repository.find_files(value)
             for match in matches:

--- a/codenib/model/agentless_pipeline.py
+++ b/codenib/model/agentless_pipeline.py
@@ -331,7 +331,7 @@ class AgentlessPipeline:
             if not node_data_list:
                 raise ValueError(f"No code data returned for {symbol_node_id}")
 
-            code_content = node_data_list[0].get("code", "")
+            code_content = node_data_list[0].get("code_content", "")
             code_segments.append(
                 f"### {symbol_node_id} ###\n```\n{code_content}\n```\n"
             )

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -16,6 +16,7 @@ budget contract. None of these labels alone claims end-to-end task quality.
 | Integration | Status | Required views | Provider contract | Policy and evaluation | Boundary |
 | --- | --- | --- | --- | --- | --- |
 | LocAgent | CodeNib-native, revision-pinned | Symbol graph + BM25 | Pinned three-tool contract | Vendored prompts and function-calling loop; paired runner with strict common file/function@k scoring | Python SWE-bench repositories; reference and type-use are disclosed as conservative relation mappings |
+| Agentless v1.5.0 | CodeNib-native, revision-pinned | Symbol graph | Python tree, symbol skeleton, and line-window context | Vendored three-stage localization prompts; shared ranked file/symbol scoring | Localization only; repair and patch validation are excluded |
 | OrcaLoca SearchAgent | Revision-pinned supported | Symbol graph | Pinned six-tool and private-hook contract | Upstream `SearchAgent`; fixed-case paired runner and native File/Function Match scorer | Python SWE-bench repositories; empty `TraceAnalysisOutput`; upstream trace generation is not included |
 | SWE-Explore | Official explorer-compatible, revision-pinned | BM25 | Ranked `ContextRegion` explorer protocol | Official runner adapter, pinned scorer contract, and strict seven-language compatibility run | Trajectory-read localization only; no patch-generation or issue-resolution claim |
 
@@ -44,12 +45,13 @@ against the pinned official scorer. Coverage retains preparation failures;
 quality is success-conditioned with its denominator stated explicitly. It does
 not reinterpret trajectory labels as golden-patch labels.
 
-Optional upstream packages are required only for policy execution. Provider
-imports and standalone provider examples remain dependency-free. Exact pinned
+Optional upstream packages are required only where the policy still executes
+inside the upstream runtime. Provider imports and standalone provider examples
+remain dependency-free. Exact pinned
 revisions, fidelity limits, commands, and measured evidence follow below.
 Provider startup also selects only its declared runtime views: LocAgent loads
-the symbol graph and BM25, while OrcaLoca loads only the symbol graph. Dense and
-Zoekt runtimes are not imported or started for these contracts.
+the symbol graph and BM25, while Agentless and OrcaLoca load only the symbol
+graph. Dense and Zoekt runtimes are not imported or started for these contracts.
 CodeNib's graph providers can represent additional languages, but this matrix
 does not extend a Python-scoped upstream policy or native comparator beyond its
 validated domain.
@@ -250,6 +252,68 @@ Run the provider and common-runner tests with:
 ```bash
 pytest -q test/integrations/test_locagent.py \
   test/eval/test_locagent_benchmark_adapter.py
+```
+
+## Agentless
+
+`AgentlessAgent` preserves the classic Agentless v1.5.0 localization sequence:
+
+1. rank files from the filtered Python project tree;
+2. identify classes, functions, methods, and variables from compressed files;
+3. refine them to source-linked edit locations in numbered context windows.
+
+CodeNib supplies all three inputs from one manifest-backed symbol graph and its
+bound checkout. It does not build Agentless's per-case AST artifact, import
+Agentless or LibCST, or run the downstream repair and patch-validation phases.
+The output is normalized to `BaselineRunResult`, so file and symbol ranking use
+the same denominator and metrics as other localization policies.
+
+```python
+from codenib.clients.agentless_agent import AgentlessAgent
+
+agent = AgentlessAgent(model="openai-compatible-model")
+result = await agent.locate_code(
+    query_text=issue,
+    repo_path=checkout,
+)
+```
+
+The standalone provider can inspect the exact context delivered to each stage:
+
+```bash
+python examples/integrations/agentless.py \
+  --manifest /path/to/repo_manifest.json \
+  --file src/service.py
+```
+
+Run the policy through the shared benchmark harness with:
+
+```bash
+python examples/agentless_loc_agent.py \
+  --dataset codenib_base \
+  --model "$AGENTLESS_MODEL" \
+  --result-path results/agentless.jsonl
+```
+
+Compatibility is pinned to Agentless `v1.5.0`, revision
+`b150f28465a77a81a7f4776384957a4271f5bd69`. The optional upstream probe reads
+that Git object and checks the three vendored prompts byte-for-byte. The
+provider intentionally keeps Agentless's Python-only and `test*` subtree
+filters. Its stdlib-AST skeleton preserves the policy's classes, callables, and
+module assignments, but formatting can differ from Agentless's LibCST output;
+that distinction is treated as provider fidelity, not exact artifact equality.
+
+The older `codenib.model.AgentlessPipeline` remains available for compatibility
+with existing callers. It uses CodeNib-specific structured prompts and is not
+the revision-pinned Agentless policy described in this matrix.
+
+```bash
+pytest -q test/integrations/test_agentless.py \
+  test/integrations/test_agentless_policy.py \
+  test/model/test_agentless_pipeline.py
+
+AGENTLESS_CHECKOUT=/path/to/Agentless \
+pytest -q test/integrations/test_agentless_upstream.py
 ```
 
 ## OrcaLoca

--- a/examples/agentless_loc_agent.py
+++ b/examples/agentless_loc_agent.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run classic Agentless localization with the common benchmark runner."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from codenib.clients.agentless_agent import AgentlessAgent
+from codenib.eval.agent_runner.loc_baseline import add_common_args, run_agent_baseline
+from codenib.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Agentless over CodeNib views on a benchmark dataset",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    add_common_args(parser)
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="OpenAI-compatible model name used by the Agentless policy.",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help=(
+            "Fixed manifest for a single-snapshot run. Multi-repository runs "
+            "resolve each manifest from CODENIB_HOME."
+        ),
+    )
+    parser.add_argument("--top-n-files", type=int, default=3)
+    parser.add_argument("--context-window", type=int, default=10)
+    parser.add_argument("--max-retries", type=int, default=5)
+    parser.add_argument("--max-completion-tokens", type=int, default=300)
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Optional OpenAI-compatible endpoint, including a LiteLLM proxy.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logger.info(
+        "Agentless baseline | dataset=%s model=%s top_n_files=%d",
+        args.dataset,
+        args.model,
+        args.top_n_files,
+    )
+
+    def factory() -> AgentlessAgent:
+        return AgentlessAgent(
+            model=args.model,
+            manifest_path=args.manifest,
+            top_n_files=args.top_n_files,
+            context_window=args.context_window,
+            max_retries=args.max_retries,
+            max_completion_tokens=args.max_completion_tokens,
+            base_url=args.base_url,
+        )
+
+    rc = asyncio.run(
+        run_agent_baseline(
+            args,
+            agent_factory=factory,
+            agent_name="agentless-codenib",
+            model_label=args.model,
+        )
+    )
+    raise SystemExit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/integrations/agentless.py
+++ b/examples/integrations/agentless.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inspect classic Agentless context without installing Agentless."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from codenib.integrations.agentless import AgentlessRepositoryProvider
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        required=True,
+        help="Graph-enabled CodeNib repo_manifest.json",
+    )
+    parser.add_argument(
+        "--file",
+        action="append",
+        default=[],
+        help="Repository-relative Python file to render as a skeleton.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    provider = AgentlessRepositoryProvider.from_manifest(args.manifest)
+    if args.file:
+        print(provider.skeleton_context(args.file))
+    else:
+        print(provider.project_structure())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/integrations/test_agentless.py
+++ b/test/integrations/test_agentless.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from codenib.eval.benchmarks.agentless import AgentlessLocation
+from codenib.integrations.agentless import AgentlessRepositoryProvider
+from codenib.mcp.context import ServerContext
+
+
+def test_provider_loads_only_symbol_graph(integration_manifest: Path) -> None:
+    with patch.object(ServerContext, "load", wraps=ServerContext.load) as load:
+        provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    load.assert_called_once_with(
+        integration_manifest,
+        views=frozenset({"symbol_graph"}),
+    )
+    assert provider.context.symbol_graph is not None
+    assert provider.context.bm25 is None
+    assert provider.context.vector is None
+
+
+def test_project_structure_matches_classic_python_boundary(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    assert provider.files == (
+        "src/model.py",
+        "src/other.py",
+        "src/service.py",
+    )
+    assert provider.project_structure() == (
+        "repo/\n"
+        "    src/\n"
+        "        model.py\n"
+        "        other.py\n"
+        "        service.py"
+    )
+
+
+def test_root_prefixed_file_response_resolves_to_repository_path(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    assert provider.resolve_files(
+        "```\nrepo/src/service.py\nsrc/model.py\n```",
+        limit=2,
+    ) == ("src/service.py", "src/model.py")
+
+
+def test_skeleton_uses_source_signatures_without_function_bodies(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    result = provider.skeleton_context(["src/service.py"])
+
+    assert "class BillingService:" in result
+    assert "def calculate_tax(self, amount):" in result
+    assert "def helper(amount):" in result
+    assert "return helper(amount)" not in result
+    assert result.count("...") == 2
+
+
+def test_line_context_uses_graph_symbol_range_and_one_based_lines(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    result = provider.line_context(
+        ["src/service.py"],
+        [
+            AgentlessLocation(
+                file_path="src/service.py",
+                kind="function",
+                name="BillingService.calculate_tax",
+            )
+        ],
+        context_window=0,
+    )
+
+    assert "### File: src/service.py ###" in result
+    assert "2|    def calculate_tax" in result
+    assert "4|        return helper(amount)" in result
+    assert "6|def helper" not in result
+
+
+def test_unknown_coarse_location_does_not_expand_to_whole_file(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    result = provider.line_context(
+        ["src/model.py"],
+        [
+            AgentlessLocation(
+                file_path="src/model.py",
+                kind="function",
+                name="missing",
+            )
+        ],
+        context_window=0,
+    )
+
+    assert result == ""

--- a/test/integrations/test_agentless.py
+++ b/test/integrations/test_agentless.py
@@ -127,6 +127,21 @@ def test_unknown_coarse_location_does_not_expand_to_whole_file(
     assert result == ""
 
 
+def test_qualified_method_does_not_resolve_another_class(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    assert (
+        provider.resolve_entity(
+            "src/service.py",
+            "method",
+            "Missing.calculate_tax",
+        )
+        is None
+    )
+
+
 def test_source_ast_resolves_assignment_exposed_by_skeleton(
     integration_manifest: Path,
 ) -> None:

--- a/test/integrations/test_agentless.py
+++ b/test/integrations/test_agentless.py
@@ -142,6 +142,21 @@ def test_qualified_method_does_not_resolve_another_class(
     )
 
 
+def test_function_signature_resolves_to_skeleton_symbol(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    entity = provider.resolve_entity(
+        "src/service.py",
+        "method",
+        "BillingService.calculate_tax(self, amount)",
+    )
+
+    assert entity is not None
+    assert entity.qualified_name == "BillingService.calculate_tax"
+
+
 def test_source_ast_resolves_assignment_exposed_by_skeleton(
     integration_manifest: Path,
 ) -> None:

--- a/test/integrations/test_agentless.py
+++ b/test/integrations/test_agentless.py
@@ -55,6 +55,21 @@ def test_root_prefixed_file_response_resolves_to_repository_path(
     ) == ("src/service.py", "src/model.py")
 
 
+def test_valid_file_named_after_repository_is_not_stripped(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+    provider._files = ("repo/module.py",)
+    monkeypatch.setattr(
+        provider.repository,
+        "find_files",
+        lambda value: [value] if value == "repo/module.py" else [],
+    )
+
+    assert provider.resolve_files("repo/module.py") == ("repo/module.py",)
+
+
 def test_skeleton_uses_source_signatures_without_function_bodies(
     integration_manifest: Path,
 ) -> None:

--- a/test/integrations/test_agentless.py
+++ b/test/integrations/test_agentless.py
@@ -110,3 +110,27 @@ def test_unknown_coarse_location_does_not_expand_to_whole_file(
     )
 
     assert result == ""
+
+
+def test_source_ast_resolves_assignment_exposed_by_skeleton(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    entity = provider.resolve_entity("src/model.py", "variable", "TaxRule.rate")
+    context = provider.line_context(
+        ["src/model.py"],
+        [
+            AgentlessLocation(
+                file_path="src/model.py",
+                kind="variable",
+                name="TaxRule.rate",
+            )
+        ],
+        context_window=0,
+    )
+
+    assert entity is not None
+    assert entity.qualified_name == "TaxRule.rate"
+    assert (entity.start_line, entity.end_line) == (1, 1)
+    assert "2|    rate = 0.08" in context

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -64,6 +64,21 @@ class _TemperatureRejectingCompletions(_Completions):
         return super().create(**request)
 
 
+class _MaxCompletionTokensRejectingCompletions(_Completions):
+    def __init__(self, responses: list[str]) -> None:
+        super().__init__(responses)
+        self.attempts: list[dict] = []
+
+    def create(self, **request):
+        self.attempts.append(request)
+        if "max_completion_tokens" in request:
+            raise TypeError(
+                "Completions.create() got an unexpected keyword argument "
+                "'max_completion_tokens'"
+            )
+        return super().create(**request)
+
+
 def test_file_parser_accepts_root_prefixed_ranked_output() -> None:
     result = parse_agentless_files(
         "```\nrepo/src/service.py\n- src/model.py\nmissing.py\n```",
@@ -72,6 +87,16 @@ def test_file_parser_accepts_root_prefixed_ranked_output() -> None:
     )
 
     assert result == ("src/service.py", "src/model.py")
+
+
+def test_file_parser_preserves_dot_prefixed_repository_paths() -> None:
+    result = parse_agentless_files(
+        ".github/scripts/tool.py\n.config.py",
+        valid_files=(".github/scripts/tool.py", ".config.py"),
+        root_name="repo",
+    )
+
+    assert result == (".github/scripts/tool.py", ".config.py")
 
 
 def test_location_parser_accepts_rendered_markdown_heading() -> None:
@@ -130,6 +155,16 @@ def test_location_parser_preserves_agentless_location_types() -> None:
             name="TaxRule",
         ),
     )
+
+
+def test_location_parser_rejects_nonpositive_and_reversed_ranges() -> None:
+    result = parse_agentless_locations(
+        "src/service.py\nline: 0, -2, 10-5",
+        valid_files=("src/service.py",),
+        root_name="repo",
+    )
+
+    assert result == ()
 
 
 def test_native_policy_runs_three_stages_over_manifest(
@@ -228,6 +263,36 @@ def test_policy_retries_without_unsupported_temperature(
     assert all("temperature" not in item for item in completions.attempts[1:])
 
 
+def test_policy_falls_back_to_legacy_max_tokens(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    completions = _MaxCompletionTokensRejectingCompletions(
+        [
+            "src/service.py",
+            "src/service.py\nfunction: helper",
+            "src/service.py\nline: 6",
+        ]
+    )
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    agent = AgentlessAgent(
+        model="legacy-sdk-model",
+        manifest_path=integration_manifest,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix helper", manifest.repo_path))
+
+    assert result.success is True
+    assert "max_completion_tokens" in completions.attempts[0]
+    assert all("max_tokens" in item for item in completions.attempts[1:])
+
+
 def test_policy_retries_file_only_symbol_and_line_outputs(
     integration_manifest: Path,
     monkeypatch,
@@ -317,6 +382,35 @@ def test_invalid_line_stage_falls_back_to_valid_symbol_stage(
     assert result.success is True
     assert [location.name for location in result.locations] == ["helper()"]
     assert len(client.chat.completions.requests) == 3
+
+
+def test_invalid_parsed_line_stage_falls_back_to_valid_symbol_stage(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            "repo/src/service.py",
+            "src/service.py\nfunction: helper",
+            "src/service.py\nfunction: missing_symbol",
+        ]
+    )
+    agent = AgentlessAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_retries=1,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix helper", manifest.repo_path))
+
+    assert result.success is True
+    assert [location.name for location in result.locations] == ["helper()"]
 
 
 def test_invalid_symbol_stage_stops_before_line_context(

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -148,6 +148,29 @@ def test_location_parser_resets_block_on_unselected_file_heading() -> None:
     assert result == (AgentlessLocation(file_path="src/service.py"),)
 
 
+def test_location_parser_accepts_inline_path_line_locations() -> None:
+    result = parse_agentless_locations(
+        "service.py:4\nrepo/src/model.py: line 2",
+        valid_files=("src/service.py", "src/model.py"),
+        root_name="repo",
+    )
+
+    assert result == (
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="line",
+            line_start=4,
+            line_end=4,
+        ),
+        AgentlessLocation(
+            file_path="src/model.py",
+            kind="line",
+            line_start=2,
+            line_end=2,
+        ),
+    )
+
+
 def test_location_parser_splits_whitespace_separated_variables() -> None:
     result = parse_agentless_locations(
         "src/service.py\nvariables: TAX_RATE DEFAULT_RATE",

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -74,6 +74,22 @@ def test_file_parser_accepts_root_prefixed_ranked_output() -> None:
     assert result == ("src/service.py", "src/model.py")
 
 
+def test_location_parser_accepts_rendered_markdown_heading() -> None:
+    result = parse_agentless_locations(
+        "### File: src/service.py ###\nfunction: helper",
+        valid_files=("src/service.py",),
+        root_name="repo",
+    )
+
+    assert result == (
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="function",
+            name="helper",
+        ),
+    )
+
+
 def test_location_parser_preserves_agentless_location_types() -> None:
     result = parse_agentless_locations(
         """
@@ -210,6 +226,67 @@ def test_policy_retries_without_unsupported_temperature(
     assert result.success is True
     assert "temperature" in completions.attempts[0]
     assert all("temperature" not in item for item in completions.attempts[1:])
+
+
+def test_policy_retries_file_only_symbol_and_line_outputs(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            "src/service.py",
+            "src/service.py",
+            "src/service.py\nfunction: helper",
+            "src/service.py",
+            "src/service.py\nline: 6",
+        ]
+    )
+    agent = AgentlessAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_retries=2,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix helper", manifest.repo_path))
+
+    assert result.success is True
+    assert result.usage["model_calls"] == 5
+    assert [item["stage"] for item in result.raw_output["trajectory"]] == [
+        "file",
+        "symbol",
+        "symbol",
+        "line",
+        "line",
+    ]
+
+
+def test_empty_file_stage_records_model_call(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(["missing.py"])
+    agent = AgentlessAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix missing code", manifest.repo_path))
+
+    assert result.success is True
+    assert result.locations == ()
+    assert result.usage["model_calls"] == 1
 
 
 def test_invalid_line_stage_falls_back_to_valid_symbol_stage(

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -113,6 +113,16 @@ def test_file_parser_preserves_dot_prefixed_repository_paths() -> None:
     assert result == (".github/scripts/tool.py", ".config.py")
 
 
+def test_file_parser_accepts_only_unique_path_suffixes() -> None:
+    result = parse_agentless_files(
+        "service.py\nmodel.py",
+        valid_files=("src/service.py", "src/model.py", "vendor/model.py"),
+        root_name="repo",
+    )
+
+    assert result == ("src/service.py",)
+
+
 def test_location_parser_accepts_rendered_markdown_heading() -> None:
     result = parse_agentless_locations(
         "### File: src/service.py ###\nfunction: helper",
@@ -468,6 +478,37 @@ def test_invalid_parsed_line_stage_falls_back_to_valid_symbol_stage(
 
     assert result.success is True
     assert [location.name for location in result.locations] == ["helper()"]
+
+
+def test_unselected_line_stage_file_falls_back_to_selected_symbol(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            "repo/src/service.py",
+            "src/service.py\nfunction: helper",
+            "src/other.py\nfunction: helper",
+        ]
+    )
+    agent = AgentlessAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_retries=1,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix helper", manifest.repo_path))
+
+    assert result.success is True
+    assert [(location.file_path, location.name) for location in result.locations] == [
+        ("src/service.py", "helper()")
+    ]
 
 
 def test_invalid_symbol_stage_stops_before_line_context(

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -40,6 +40,30 @@ class _Client:
         self.chat = SimpleNamespace(completions=_Completions(responses))
 
 
+class _UnsupportedTemperatureError(Exception):
+    body = {
+        "error": {
+            "message": "Unsupported value for temperature",
+            "param": "temperature",
+            "code": "unsupported_value",
+        }
+    }
+
+
+class _TemperatureRejectingCompletions(_Completions):
+    def __init__(self, responses: list[str]) -> None:
+        super().__init__(responses)
+        self.attempts: list[dict] = []
+        self.rejected = False
+
+    def create(self, **request):
+        self.attempts.append(request)
+        if "temperature" in request and not self.rejected:
+            self.rejected = True
+            raise _UnsupportedTemperatureError
+        return super().create(**request)
+
+
 def test_file_parser_accepts_root_prefixed_ranked_output() -> None:
     result = parse_agentless_files(
         "```\nrepo/src/service.py\n- src/model.py\nmissing.py\n```",
@@ -156,6 +180,36 @@ def test_empty_issue_returns_explicit_failure(integration_manifest: Path) -> Non
 
     assert result.success is False
     assert result.error_message == "Agentless requires a non-empty problem statement"
+
+
+def test_policy_retries_without_unsupported_temperature(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    completions = _TemperatureRejectingCompletions(
+        [
+            "```\nsrc/service.py\n```",
+            "```\nsrc/service.py\nfunction: helper\n```",
+            "```\nsrc/service.py\nline: 6\n```",
+        ]
+    )
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    agent = AgentlessAgent(
+        model="reasoning-model",
+        manifest_path=integration_manifest,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix helper", manifest.repo_path))
+
+    assert result.success is True
+    assert "temperature" in completions.attempts[0]
+    assert all("temperature" not in item for item in completions.attempts[1:])
 
 
 def test_invalid_line_stage_falls_back_to_valid_symbol_stage(

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -129,6 +129,26 @@ def test_location_parser_accepts_rendered_markdown_heading() -> None:
     )
 
 
+def test_location_parser_splits_whitespace_separated_variables() -> None:
+    result = parse_agentless_locations(
+        "src/service.py\nvariables: TAX_RATE DEFAULT_RATE",
+        valid_files=("src/service.py",),
+    )
+
+    assert result == (
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="variable",
+            name="TAX_RATE",
+        ),
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="variable",
+            name="DEFAULT_RATE",
+        ),
+    )
+
+
 def test_location_parser_preserves_agentless_location_types() -> None:
     result = parse_agentless_locations(
         """

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -139,6 +139,15 @@ def test_location_parser_accepts_rendered_markdown_heading() -> None:
     )
 
 
+def test_location_parser_resets_block_on_unselected_file_heading() -> None:
+    result = parse_agentless_locations(
+        "src/service.py\n### File: src/unselected.py ###\nfunction: helper",
+        valid_files=("src/service.py",),
+    )
+
+    assert result == (AgentlessLocation(file_path="src/service.py"),)
+
+
 def test_location_parser_splits_whitespace_separated_variables() -> None:
     result = parse_agentless_locations(
         "src/service.py\nvariables: TAX_RATE DEFAULT_RATE",

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -159,6 +159,27 @@ def test_location_parser_splits_whitespace_separated_variables() -> None:
     )
 
 
+def test_location_parser_accepts_numbered_field_prefixes() -> None:
+    result = parse_agentless_locations(
+        "src/service.py\n1. `function: helper`\n2) line: 4",
+        valid_files=("src/service.py",),
+    )
+
+    assert result == (
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="function",
+            name="helper",
+        ),
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="line",
+            line_start=4,
+            line_end=4,
+        ),
+    )
+
+
 def test_location_parser_preserves_agentless_location_types() -> None:
     result = parse_agentless_locations(
         """

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from codenib.clients.agentless_agent import AgentlessAgent
+from codenib.compiler.manifest import RepoManifest
+from codenib.eval.benchmarks.agentless import (
+    AgentlessLocation,
+    parse_agentless_files,
+    parse_agentless_locations,
+)
+
+
+class _Completions:
+    def __init__(self, responses: list[str]) -> None:
+        self.responses = responses
+        self.requests: list[dict] = []
+
+    def create(self, **request):
+        self.requests.append(request)
+        content = self.responses.pop(0)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=2,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=1),
+            ),
+        )
+
+
+class _Client:
+    def __init__(self, responses: list[str]) -> None:
+        self.chat = SimpleNamespace(completions=_Completions(responses))
+
+
+def test_file_parser_accepts_root_prefixed_ranked_output() -> None:
+    result = parse_agentless_files(
+        "```\nrepo/src/service.py\n- src/model.py\nmissing.py\n```",
+        valid_files=("src/service.py", "src/model.py"),
+        root_name="repo",
+    )
+
+    assert result == ("src/service.py", "src/model.py")
+
+
+def test_location_parser_preserves_agentless_location_types() -> None:
+    result = parse_agentless_locations(
+        """
+        ```
+        repo/src/service.py
+        function: BillingService.calculate_tax
+        variable: TAX_RATE
+        line: 4-5
+
+        src/model.py
+        class: TaxRule
+        ```
+        """,
+        valid_files=("src/service.py", "src/model.py"),
+        root_name="repo",
+    )
+
+    assert result == (
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="function",
+            name="BillingService.calculate_tax",
+        ),
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="variable",
+            name="TAX_RATE",
+        ),
+        AgentlessLocation(
+            file_path="src/service.py",
+            kind="line",
+            line_start=4,
+            line_end=5,
+        ),
+        AgentlessLocation(
+            file_path="src/model.py",
+            kind="class",
+            name="TaxRule",
+        ),
+    )
+
+
+def test_native_policy_runs_three_stages_over_manifest(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            "```\nrepo/src/service.py\n```",
+            "```\nsrc/service.py\nfunction: BillingService.calculate_tax\n```",
+            "```\nsrc/service.py\nline: 4\n```",
+        ]
+    )
+    agent = AgentlessAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(
+        agent.locate_code(
+            "Tax calculations are wrong",
+            manifest.repo_path,
+        )
+    )
+
+    assert result.success is True
+    assert len(result.locations) == 1
+    location = result.locations[0]
+    assert location.file_path == "src/service.py"
+    assert location.name == "BillingService.calculate_tax()"
+    assert location.type == "method"
+    assert location.line_start == 2
+    assert location.line_end == 4
+    assert result.usage == {
+        "prompt_tokens": 30,
+        "completion_tokens": 6,
+        "cached_tokens": 3,
+        "total_tokens": 36,
+        "elapsed_seconds": result.usage["elapsed_seconds"],
+        "model_calls": 3,
+    }
+    requests = client.chat.completions.requests
+    assert len(requests) == 3
+    assert "Repository Structure" in requests[0]["messages"][0]["content"]
+    assert "Skeleton of Relevant Files" in requests[1]["messages"][0]["content"]
+    assert "4|        return helper(amount)" in requests[2]["messages"][0]["content"]
+
+
+def test_empty_issue_returns_explicit_failure(integration_manifest: Path) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    agent = AgentlessAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        client_factory=lambda: _Client([]),
+    )
+
+    result = asyncio.run(agent.locate_code("", manifest.repo_path))
+
+    assert result.success is False
+    assert result.error_message == "Agentless requires a non-empty problem statement"
+
+
+def test_invalid_line_stage_falls_back_to_valid_symbol_stage(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            "repo/src/service.py",
+            "src/service.py\nfunction: helper",
+            "No usable locations",
+        ]
+    )
+    agent = AgentlessAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_retries=1,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix helper", manifest.repo_path))
+
+    assert result.success is True
+    assert [location.name for location in result.locations] == ["helper()"]
+    assert len(client.chat.completions.requests) == 3
+
+
+def test_invalid_symbol_stage_stops_before_line_context(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.agentless_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            "repo/src/service.py",
+            "src/service.py\nfunction: missing_symbol",
+        ]
+    )
+    agent = AgentlessAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_retries=1,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix unknown code", manifest.repo_path))
+
+    assert result.success is True
+    assert [location.file_path for location in result.locations] == ["src/service.py"]
+    assert len(client.chat.completions.requests) == 2

--- a/test/integrations/test_agentless_policy.py
+++ b/test/integrations/test_agentless_policy.py
@@ -8,13 +8,17 @@ import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
-from codenib.clients.agentless_agent import AgentlessAgent
+from codenib.clients.agentless_agent import (
+    AgentlessAgent,
+    agentless_locations_to_baseline,
+)
 from codenib.compiler.manifest import RepoManifest
 from codenib.eval.benchmarks.agentless import (
     AgentlessLocation,
     parse_agentless_files,
     parse_agentless_locations,
 )
+from codenib.integrations.agentless import AgentlessRepositoryProvider
 
 
 class _Completions:
@@ -82,6 +86,16 @@ class _MaxCompletionTokensRejectingCompletions(_Completions):
 def test_file_parser_accepts_root_prefixed_ranked_output() -> None:
     result = parse_agentless_files(
         "```\nrepo/src/service.py\n- src/model.py\nmissing.py\n```",
+        valid_files=("src/service.py", "src/model.py"),
+        root_name="repo",
+    )
+
+    assert result == ("src/service.py", "src/model.py")
+
+
+def test_file_parser_strips_list_markers_before_markdown_delimiters() -> None:
+    result = parse_agentless_files(
+        "- `src/service.py`\n1. `src/model.py`",
         valid_files=("src/service.py", "src/model.py"),
         root_name="repo",
     )
@@ -165,6 +179,29 @@ def test_location_parser_rejects_nonpositive_and_reversed_ranges() -> None:
     )
 
     assert result == ()
+
+
+def test_cross_symbol_line_range_preserves_exact_bounds(
+    integration_manifest: Path,
+) -> None:
+    provider = AgentlessRepositoryProvider.from_manifest(integration_manifest)
+
+    result = agentless_locations_to_baseline(
+        (
+            AgentlessLocation(
+                file_path="src/service.py",
+                kind="line",
+                line_start=4,
+                line_end=6,
+            ),
+        ),
+        provider,
+    )
+
+    assert len(result) == 1
+    assert result[0].name == ""
+    assert result[0].type == "line"
+    assert (result[0].line_start, result[0].line_end) == (4, 6)
 
 
 def test_native_policy_runs_three_stages_over_manifest(

--- a/test/integrations/test_agentless_upstream.py
+++ b/test/integrations/test_agentless_upstream.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional source-level probe for the pinned Agentless v1.5.0 contract."""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codenib.clients import agentless_protocol
+from codenib.integrations.agentless import AGENTLESS_REVISION, AGENTLESS_VERSION
+
+pytestmark = pytest.mark.integration
+
+_FL_SOURCE = "agentless/fl/FL.py"
+
+
+def _git_show(checkout: Path, revision: str, path: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "show", f"{revision}:{path}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"{checkout} does not contain {path} at {revision}")
+    return result.stdout
+
+
+def _class_string_assignments(source: str, class_name: str) -> dict[str, str]:
+    tree = ast.parse(source)
+    target = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    values: dict[str, str] = {}
+    for node in target.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        name = node.targets[0]
+        if not isinstance(name, ast.Name):
+            continue
+        try:
+            value = ast.literal_eval(node.value)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(value, str):
+            values[name.id] = value
+    return values
+
+
+@pytest.fixture(scope="module")
+def upstream_agentless() -> tuple[Path, str]:
+    raw_checkout = os.environ.get("AGENTLESS_CHECKOUT")
+    if not raw_checkout:
+        pytest.skip("set AGENTLESS_CHECKOUT for the upstream Agentless probe")
+    checkout = Path(raw_checkout).expanduser().resolve()
+    if not (checkout / ".git").exists():
+        pytest.fail("AGENTLESS_CHECKOUT must point to a Git checkout")
+    return checkout, _git_show(checkout, AGENTLESS_REVISION, _FL_SOURCE)
+
+
+def test_pinned_revision_is_classic_release(
+    upstream_agentless: tuple[Path, str],
+) -> None:
+    checkout, _source = upstream_agentless
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "tag", "--points-at", AGENTLESS_REVISION],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert AGENTLESS_VERSION in result.stdout.splitlines()
+
+
+def test_vendored_prompts_match_pinned_agentless_source(
+    upstream_agentless: tuple[Path, str],
+) -> None:
+    _checkout, source = upstream_agentless
+    values = _class_string_assignments(source, "LLMFL")
+
+    assert agentless_protocol.AGENTLESS_PROTOCOL_REVISION == AGENTLESS_REVISION
+    assert agentless_protocol._FILE_PROMPT == values["obtain_relevant_files_prompt"]
+    assert (
+        agentless_protocol._SYMBOL_PROMPT
+        == values[
+            "obtain_relevant_functions_and_vars_from_compressed_files_prompt_more"
+        ]
+    )
+    assert (
+        agentless_protocol._LINE_PROMPT
+        == values["obtain_relevant_code_combine_top_n_prompt"]
+    )

--- a/test/model/test_agentless_pipeline.py
+++ b/test/model/test_agentless_pipeline.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from codenib.model.agentless_pipeline import AgentlessPipeline
+
+
+def test_stage_three_uses_extracted_code_content(monkeypatch) -> None:
+    pipeline = AgentlessPipeline.__new__(AgentlessPipeline)
+    pipeline.stage3_prompt = "{problem_statement}\n{code_segments}"
+    pipeline.structured_llm_stage3 = SimpleNamespace(
+        invoke=lambda _messages: SimpleNamespace(refined_nodes=["symbol"])
+    )
+    pipeline._has_node = lambda _node_id: True
+
+    def get_node_data(_node_ids, return_code_content=False, **_kwargs):
+        if return_code_content:
+            return [{"code_content": "12 | def target():\n13 |     pass"}]
+        return [
+            {
+                "type": "function",
+                "file": "target.py",
+                "start_line": 11,
+                "end_line": 12,
+            }
+        ]
+
+    pipeline._get_node_data = get_node_data
+    monkeypatch.setattr(
+        "codenib.model.agentless_pipeline.human_message",
+        lambda value: value,
+    )
+
+    result = pipeline._stage_3("fix target", ["symbol"])
+
+    assert result[0].content == "12 | def target():\n13 |     pass"


### PR DESCRIPTION
## Summary
Add a revision-pinned, dependency-free implementation of the classic Agentless v1.5.0 localization policy over CodeNib manifest views. The supported boundary is Python file, symbol, and line localization; repair and patch validation remain out of scope.

## Changes
- Serve the Agentless project tree, Python skeletons, and numbered line windows from one selectively loaded symbol graph.
- Run the pinned three-stage policy through an OpenAI-compatible client and normalize outputs to the shared localization benchmark contract.
- Validate stage outputs against exact repository paths, source ranges, and graph/AST symbol identities before accepting them.
- Retry unsupported OpenAI parameters conservatively while preserving pinned temperature and token settings where supported.
- Add prompt-drift probes against the v1.5.0 Git revision, provider/policy tests, benchmark and inspection examples, and support-matrix documentation.
- Fix the legacy AgentlessPipeline stage-three code-content field lookup while documenting that it is not the pinned compatibility path.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2498 passed, 10 skipped`)
- `AGENTLESS_CHECKOUT=/mnt/data/codeminer/upstreams/Agentless pytest -q test/integrations/test_agentless.py test/integrations/test_agentless_policy.py test/integrations/test_agentless_upstream.py --tb=short` (`34 passed`)
- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `mkdocs build --strict`
- Static graph coverage over three Astropy SWE-bench snapshots: `1399/1399` files and `22125/22628` upstream symbols represented.
- Live `gpt-5.6-luna` smoke on `psf__requests-1963`: completed the three-stage path in about 21 seconds using 8,559 tokens and returned only the gold method `SessionRedirectMixin.resolve_redirects`. This is an execution smoke, not a localization benchmark.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published