### PR TITLE
feat(integrations): add native CoSIL localization

### DIFF
--- a/codenib/clients/cosil_agent.py
+++ b/codenib/clients/cosil_agent.py
@@ -28,6 +28,7 @@ _FALSE_OBSERVATION = (
     "I have already checked this function/class and it is not related to the bug. "
     "Don't check the functions it calls."
 )
+_TRUNCATION_MARKER = "\n...[truncated]"
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,6 +105,7 @@ class CoSILAgent:
         prune_tool_results: bool = True,
         max_prune_rounds: int = 3,
         max_completion_tokens: int = 4096,
+        max_tool_context_chars: int = 32_000,
         base_url: str | None = None,
         api_key: str | None = None,
         policy_runner: CoSILPolicyRunner | None = None,
@@ -124,6 +126,8 @@ class CoSILAgent:
             raise ValueError("tool and prune round limits must be positive")
         if max_completion_tokens < 1:
             raise ValueError("max_completion_tokens must be positive")
+        if max_tool_context_chars < 1:
+            raise ValueError("max_tool_context_chars must be positive")
 
         self.model = str(model)
         self.top_n_files = int(top_n_files)
@@ -132,6 +136,7 @@ class CoSILAgent:
         self.prune_tool_results = bool(prune_tool_results)
         self.max_prune_rounds = int(max_prune_rounds)
         self.max_completion_tokens = int(max_completion_tokens)
+        self.max_tool_context_chars = int(max_tool_context_chars)
         self.base_url = base_url
         self.api_key = api_key
         self._manifest_path = (
@@ -259,6 +264,7 @@ class CoSILAgent:
             prune_tool_results=self.prune_tool_results,
             max_prune_rounds=self.max_prune_rounds,
             max_completion_tokens=self.max_completion_tokens,
+            max_tool_context_chars=self.max_tool_context_chars,
         )
 
 
@@ -274,8 +280,12 @@ def run_cosil_policy(
     prune_tool_results: bool = True,
     max_prune_rounds: int = 3,
     max_completion_tokens: int = 4096,
+    max_tool_context_chars: int = 32_000,
 ) -> CoSILExecution:
     """Run CoSIL's file reflection, tool loop, pruning, and XML summary."""
+
+    if max_tool_context_chars < 1:
+        raise ValueError("max_tool_context_chars must be positive")
 
     usage = {"prompt_tokens": 0, "completion_tokens": 0, "cached_tokens": 0}
     trajectory: list[dict[str, Any]] = []
@@ -284,6 +294,16 @@ def run_cosil_policy(
     temperature_supported = True
     max_completion_tokens_supported = True
     tool_reasoning_disabled = False
+    remaining_tool_context_chars = int(max_tool_context_chars)
+
+    def deliver_tool_result(value: str) -> tuple[str, bool]:
+        nonlocal remaining_tool_context_chars
+        delivered, truncated = _truncate_tool_result(
+            value,
+            remaining_tool_context_chars,
+        )
+        remaining_tool_context_chars -= len(delivered)
+        return delivered, truncated
 
     def complete(
         *,
@@ -435,19 +455,22 @@ def run_cosil_policy(
             arguments = _tool_arguments(function.get("arguments"))
             tool_started = time.perf_counter()
             try:
-                result = provider.dispatch(name, arguments)
+                raw_result = provider.dispatch(name, arguments)
                 error = None
             except Exception as exc:  # noqa: BLE001 - policy observation
-                result = f"Tool call failed: {exc}"
-                error = result
-            kept = name != "exit"
+                raw_result = f"Tool call failed: {exc}"
+                error = raw_result
+            result, truncated = deliver_tool_result(raw_result)
+            kept = name != "exit" and bool(result)
             trace_entry: dict[str, Any] = {
                 "phase": "location",
                 "round": round_index + 1,
                 "name": name,
                 "arguments": arguments,
                 "seconds": time.perf_counter() - tool_started,
-                "output_chars": len(result),
+                "output_chars": len(raw_result),
+                "delivered_chars": len(result),
+                "truncated": truncated,
                 "kept": kept,
                 "error": error,
             }
@@ -463,6 +486,7 @@ def run_cosil_policy(
                     tool_result=result,
                     max_rounds=max_prune_rounds,
                     tool_trace=tool_trace,
+                    deliver_tool_result=deliver_tool_result,
                 )
                 if not kept:
                     result = _FALSE_OBSERVATION
@@ -512,6 +536,7 @@ def _prune_tool_result(
     tool_result: str,
     max_rounds: int,
     tool_trace: list[dict[str, Any]],
+    deliver_tool_result: Callable[[str], tuple[str, bool]],
 ) -> bool:
     messages: list[dict[str, Any]] = protocol.prune_messages(
         tool_name=tool_name,
@@ -536,11 +561,12 @@ def _prune_tool_result(
             arguments = _tool_arguments(function.get("arguments"))
             tool_started = time.perf_counter()
             try:
-                result = provider.dispatch(name, arguments)
+                raw_result = provider.dispatch(name, arguments)
                 error = None
             except Exception as exc:  # noqa: BLE001 - policy observation
-                result = f"Tool call failed: {exc}"
-                error = result
+                raw_result = f"Tool call failed: {exc}"
+                error = raw_result
+            result, truncated = deliver_tool_result(raw_result)
             tool_trace.append(
                 {
                     "phase": "prune",
@@ -548,8 +574,10 @@ def _prune_tool_result(
                     "name": name,
                     "arguments": arguments,
                     "seconds": time.perf_counter() - tool_started,
-                    "output_chars": len(result),
-                    "kept": name != "exit" and error is None,
+                    "output_chars": len(raw_result),
+                    "delivered_chars": len(result),
+                    "truncated": truncated,
+                    "kept": name != "exit" and error is None and bool(result),
                     "error": error,
                 }
             )
@@ -601,6 +629,16 @@ def _finish_execution(
         tool_trace=tuple(tool_trace),
         trajectory=tuple(trajectory),
     )
+
+
+def _truncate_tool_result(value: str, limit: int) -> tuple[str, bool]:
+    text = str(value)
+    if len(text) <= limit:
+        return text, False
+    if limit <= len(_TRUNCATION_MARKER):
+        return _TRUNCATION_MARKER[:limit], True
+    prefix_length = limit - len(_TRUNCATION_MARKER)
+    return text[:prefix_length] + _TRUNCATION_MARKER, True
 
 
 def _tool_arguments(value: Any) -> dict[str, Any]:

--- a/codenib/clients/cosil_agent.py
+++ b/codenib/clients/cosil_agent.py
@@ -1,0 +1,665 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CoSIL RQ1 localization over CodeNib manifest-backed repository views."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from codenib.clients._manifest import ManifestResolver, select_checkout_manifest
+from codenib.clients.cosil_protocol import CoSILProtocol, build_cosil_protocol
+from codenib.eval.baseline import BaselineLocation, BaselineRunResult
+from codenib.eval.benchmarks.cosil import (
+    CoSILLocation,
+    parse_cosil_files,
+    parse_cosil_locations,
+)
+from codenib.integrations.cosil import CoSILRepositoryProvider, get_cosil_tool_schemas
+
+_FALSE_OBSERVATION = (
+    "I have already checked this function/class and it is not related to the bug. "
+    "Don't check the functions it calls."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CoSILExecution:
+    """File, reflection, function, and accounting outputs from one run."""
+
+    file_output: str = ""
+    reflection_output: str = ""
+    location_output: str = ""
+    candidate_files: Sequence[str] = ()
+    usage: Optional[Mapping[str, Any]] = None
+    tool_trace: Sequence[Mapping[str, Any]] = ()
+    trajectory: Sequence[Mapping[str, Any]] = ()
+
+
+CoSILPolicyRunner = Callable[
+    [str, str, CoSILRepositoryProvider, Mapping[str, Any]],
+    CoSILExecution | str,
+]
+CoSILProviderFactory = Callable[[Path], CoSILRepositoryProvider]
+CoSILManifestResolver = ManifestResolver
+
+
+def cosil_locations_to_baseline(
+    locations: Sequence[CoSILLocation],
+    provider: CoSILRepositoryProvider,
+) -> tuple[BaselineLocation, ...]:
+    """Resolve CoSIL XML identities against its manifest-bound AST view."""
+
+    output: list[BaselineLocation] = []
+    seen: set[tuple[object, ...]] = set()
+    for parsed in locations:
+        files = provider.resolve_files([parsed.file_path], limit=1)
+        if not files:
+            continue
+        file_path = files[0]
+        resolved = provider.resolve_location(file_path, parsed.kind, parsed.name)
+        if resolved is None:
+            location = BaselineLocation(
+                name=(f"{parsed.name}()" if parsed.kind == "function" else parsed.name),
+                type=parsed.kind,
+                file_path=file_path,
+            )
+        else:
+            kind, name, start, end = resolved
+            location = BaselineLocation(
+                name=f"{name}()" if kind in {"function", "method"} else name,
+                type=kind,
+                file_path=file_path,
+                line_start=start,
+                line_end=end,
+            )
+        key = (
+            location.file_path,
+            location.name,
+            location.type,
+            location.line_start,
+            location.line_end,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        output.append(location)
+    return tuple(output)
+
+
+class CoSILAgent:
+    """Run CoSIL file reflection and function localization on CodeNib views."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        manifest_path: str | Path | None = None,
+        manifest_resolver: CoSILManifestResolver | None = None,
+        top_n_files: int = 5,
+        file_max_retry: int = 10,
+        max_tool_rounds: int = 10,
+        prune_tool_results: bool = True,
+        max_prune_rounds: int = 3,
+        max_completion_tokens: int = 4096,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        policy_runner: CoSILPolicyRunner | None = None,
+        provider_factory: CoSILProviderFactory | None = None,
+        client_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        if not str(model).strip():
+            raise ValueError("CoSIL model must not be empty")
+        if manifest_path is not None and manifest_resolver is not None:
+            raise ValueError(
+                "Specify either manifest_path or manifest_resolver, not both"
+            )
+        if not 1 <= top_n_files <= 5:
+            raise ValueError("top_n_files must be between 1 and 5")
+        if file_max_retry < 2:
+            raise ValueError("file_max_retry must be at least 2")
+        if max_tool_rounds < 1 or max_prune_rounds < 1:
+            raise ValueError("tool and prune round limits must be positive")
+        if max_completion_tokens < 1:
+            raise ValueError("max_completion_tokens must be positive")
+
+        self.model = str(model)
+        self.top_n_files = int(top_n_files)
+        self.file_max_retry = int(file_max_retry)
+        self.max_tool_rounds = int(max_tool_rounds)
+        self.prune_tool_results = bool(prune_tool_results)
+        self.max_prune_rounds = int(max_prune_rounds)
+        self.max_completion_tokens = int(max_completion_tokens)
+        self.base_url = base_url
+        self.api_key = api_key
+        self._manifest_path = (
+            Path(manifest_path).expanduser().resolve()
+            if manifest_path is not None
+            else None
+        )
+        self._manifest_resolver = manifest_resolver
+        self._policy_runner = policy_runner or self._run_pinned_policy
+        self._provider_factory = (
+            provider_factory or CoSILRepositoryProvider.from_manifest
+        )
+        self._client_factory = client_factory
+
+    async def locate_code(
+        self,
+        query_text: str,
+        repo_path: str,
+        context: Optional[Mapping[str, Any]] = None,
+    ) -> BaselineRunResult:
+        repo = Path(repo_path).expanduser().resolve()
+        if not repo.is_dir():
+            return BaselineRunResult(
+                success=False,
+                repo_path=str(repo),
+                error_message=f"Repository path does not exist: {repo}",
+            )
+        problem = str(query_text or "").strip()
+        runtime_context = dict(context or {})
+        if not problem:
+            problem = str(runtime_context.get("issue_body") or "").strip()
+        if not problem:
+            return BaselineRunResult(
+                success=False,
+                repo_path=str(repo),
+                error_message="CoSIL requires a non-empty problem statement",
+            )
+
+        try:
+            manifest_path = select_checkout_manifest(
+                repo,
+                integration_name="CoSIL",
+                manifest_path=self._manifest_path,
+                manifest_resolver=self._manifest_resolver,
+            )
+            provider = self._provider_factory(manifest_path)
+            raw_execution = await asyncio.to_thread(
+                self._policy_runner,
+                problem,
+                str(repo),
+                provider,
+                runtime_context,
+            )
+            execution = (
+                raw_execution
+                if isinstance(raw_execution, CoSILExecution)
+                else CoSILExecution(location_output=str(raw_execution))
+            )
+            parsed = parse_cosil_locations(
+                execution.location_output,
+                valid_files=execution.candidate_files or provider.files,
+                root_name=provider.project_root_name,
+            )
+            locations = cosil_locations_to_baseline(parsed, provider)
+            if not locations:
+                files = tuple(execution.candidate_files) or parse_cosil_files(
+                    execution.reflection_output or execution.file_output,
+                    valid_files=provider.files,
+                    root_name=provider.project_root_name,
+                    limit=self.top_n_files,
+                )
+                locations = tuple(
+                    BaselineLocation(name="", type="file", file_path=file_path)
+                    for file_path in files
+                )
+            return BaselineRunResult(
+                success=True,
+                repo_path=str(repo),
+                locations=locations,
+                usage=dict(execution.usage or {}) or None,
+                raw_output={
+                    "file": execution.file_output,
+                    "reflection": execution.reflection_output,
+                    "locations": execution.location_output,
+                    "candidate_files": list(execution.candidate_files),
+                    "tool_trace": list(execution.tool_trace),
+                    "trajectory": list(execution.trajectory),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 - external baseline boundary
+            return BaselineRunResult(
+                success=False,
+                repo_path=str(repo),
+                error_message=f"CoSIL localization failed: {exc}",
+            )
+
+    def _openai_client(self) -> Any:
+        if self._client_factory is not None:
+            return self._client_factory()
+        from openai import OpenAI
+
+        kwargs: dict[str, Any] = {}
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        return OpenAI(**kwargs)
+
+    def _run_pinned_policy(
+        self,
+        problem_statement: str,
+        repo_path: str,
+        provider: CoSILRepositoryProvider,
+        context: Mapping[str, Any],
+    ) -> CoSILExecution:
+        del repo_path, context
+        return run_cosil_policy(
+            protocol=build_cosil_protocol(problem_statement),
+            provider=provider,
+            model=self.model,
+            client=self._openai_client(),
+            top_n_files=self.top_n_files,
+            file_max_retry=self.file_max_retry,
+            max_tool_rounds=self.max_tool_rounds,
+            prune_tool_results=self.prune_tool_results,
+            max_prune_rounds=self.max_prune_rounds,
+            max_completion_tokens=self.max_completion_tokens,
+        )
+
+
+def run_cosil_policy(
+    *,
+    protocol: CoSILProtocol,
+    provider: CoSILRepositoryProvider,
+    model: str,
+    client: Any,
+    top_n_files: int = 5,
+    file_max_retry: int = 10,
+    max_tool_rounds: int = 10,
+    prune_tool_results: bool = True,
+    max_prune_rounds: int = 3,
+    max_completion_tokens: int = 4096,
+) -> CoSILExecution:
+    """Run CoSIL's file reflection, tool loop, pruning, and XML summary."""
+
+    usage = {"prompt_tokens": 0, "completion_tokens": 0, "cached_tokens": 0}
+    trajectory: list[dict[str, Any]] = []
+    tool_trace: list[dict[str, Any]] = []
+    started = time.perf_counter()
+    temperature_supported = True
+    tool_reasoning_disabled = False
+
+    def complete(
+        *,
+        stage: str,
+        messages: Sequence[Mapping[str, Any]],
+        temperature: float = 0.0,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        nonlocal temperature_supported, tool_reasoning_disabled
+        request: dict[str, Any] = {
+            "model": model,
+            "messages": list(messages),
+            "max_completion_tokens": max_completion_tokens,
+        }
+        if temperature_supported:
+            request["temperature"] = temperature
+        if tools is not None:
+            request["tools"] = list(tools)
+            if tool_reasoning_disabled:
+                request["reasoning_effort"] = "none"
+        if tool_choice is not None:
+            request["tool_choice"] = tool_choice
+        while True:
+            try:
+                response = client.chat.completions.create(**request)
+                break
+            except Exception as exc:
+                if temperature_supported and _unsupported_temperature(exc):
+                    temperature_supported = False
+                    request.pop("temperature", None)
+                    continue
+                if tools is not None and _requires_no_reasoning_with_tools(exc):
+                    tool_reasoning_disabled = True
+                    request["reasoning_effort"] = "none"
+                    continue
+                raise
+        prompt_tokens, completion_tokens, cached_tokens = _response_usage(response)
+        usage["prompt_tokens"] += prompt_tokens
+        usage["completion_tokens"] += completion_tokens
+        usage["cached_tokens"] += cached_tokens
+        message = _assistant_message(response.choices[0].message)
+        content = str(message.get("content") or "")
+        trajectory.append(
+            {
+                "stage": stage,
+                "temperature": temperature if temperature_supported else None,
+                "reasoning_effort": request.get("reasoning_effort"),
+                "response": content,
+                "tool_calls": message.get("tool_calls", []),
+            }
+        )
+        return content, message
+
+    structure = provider.project_structure()
+    file_output, _ = complete(
+        stage="file",
+        messages=protocol.file_messages(
+            structure=structure,
+            max_retry=file_max_retry,
+        ),
+    )
+    files = parse_cosil_files(
+        file_output,
+        valid_files=provider.files,
+        root_name=provider.project_root_name,
+        limit=top_n_files,
+    )
+    if not files:
+        corrected, _ = complete(
+            stage="file_format_correction",
+            messages=[
+                {"role": "user", "content": protocol.correction_prompt(file_output)}
+            ],
+        )
+        files = parse_cosil_files(
+            corrected,
+            valid_files=provider.files,
+            root_name=provider.project_root_name,
+            limit=top_n_files,
+        )
+    if not files:
+        return _finish_execution(
+            started=started,
+            usage=usage,
+            trajectory=trajectory,
+            tool_trace=tool_trace,
+            file_output=file_output,
+        )
+
+    reflection_output, _ = complete(
+        stage="file_reflection",
+        messages=[
+            {
+                "role": "user",
+                "content": protocol.reflection_prompt(
+                    structure=structure,
+                    pre_files=list(files),
+                    import_content=provider.import_context(files),
+                ),
+            }
+        ],
+    )
+    reflected = parse_cosil_files(
+        reflection_output,
+        valid_files=provider.files,
+        root_name=provider.project_root_name,
+        limit=top_n_files,
+    )
+    candidate_files = reflected or files
+    candidate_structure = provider.candidate_structure(candidate_files)
+    messages: list[dict[str, Any]] = protocol.location_messages(
+        candidate_structure=candidate_structure,
+        max_rounds=max_tool_rounds,
+    )
+    tools = get_cosil_tool_schemas()
+    collected_code: list[tuple[str, str]] = []
+
+    for round_index in range(max_tool_rounds):
+        _content, assistant = complete(
+            stage="location_tool",
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+        )
+        messages.append(assistant)
+        calls = list(assistant.get("tool_calls") or ())
+        if not calls:
+            break
+        should_exit = False
+        for call in calls:
+            function = dict(call.get("function") or {})
+            name = str(function.get("name") or "")
+            arguments = _tool_arguments(function.get("arguments"))
+            tool_started = time.perf_counter()
+            try:
+                result = provider.dispatch(name, arguments)
+                error = None
+            except Exception as exc:  # noqa: BLE001 - policy observation
+                result = f"Tool call failed: {exc}"
+                error = result
+            kept = name != "exit"
+            if kept and prune_tool_results and error is None:
+                kept = _prune_tool_result(
+                    protocol=protocol,
+                    provider=provider,
+                    complete=complete,
+                    tools=tools,
+                    tool_name=name,
+                    arguments=arguments,
+                    tool_result=result,
+                    max_rounds=max_prune_rounds,
+                )
+                if not kept:
+                    result = _FALSE_OBSERVATION
+            elapsed = time.perf_counter() - tool_started
+            tool_trace.append(
+                {
+                    "round": round_index + 1,
+                    "name": name,
+                    "arguments": arguments,
+                    "seconds": elapsed,
+                    "output_chars": len(result),
+                    "kept": kept,
+                    "error": error,
+                }
+            )
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": str(call.get("id") or ""),
+                    "name": name,
+                    "content": result,
+                }
+            )
+            if kept and error is None:
+                collected_code.append((name, result))
+            if name == "exit":
+                should_exit = True
+        if should_exit:
+            break
+
+    location_output, _ = complete(
+        stage="location_summary",
+        messages=protocol.summary_messages(
+            candidate_structure=candidate_structure,
+            collected_code=collected_code,
+        ),
+    )
+    return _finish_execution(
+        started=started,
+        usage=usage,
+        trajectory=trajectory,
+        tool_trace=tool_trace,
+        file_output=file_output,
+        reflection_output=reflection_output,
+        location_output=location_output,
+        candidate_files=candidate_files,
+    )
+
+
+def _prune_tool_result(
+    *,
+    protocol: CoSILProtocol,
+    provider: CoSILRepositoryProvider,
+    complete: Callable[..., tuple[str, dict[str, Any]]],
+    tools: Sequence[Mapping[str, Any]],
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    tool_result: str,
+    max_rounds: int,
+) -> bool:
+    messages: list[dict[str, Any]] = protocol.prune_messages(
+        tool_name=tool_name,
+        arguments=arguments,
+        tool_result=tool_result,
+    )
+    for _round_index in range(max_rounds):
+        _content, assistant = complete(
+            stage="prune_explore",
+            messages=messages,
+            tools=tools,
+            tool_choice="auto",
+        )
+        messages.append(assistant)
+        calls = list(assistant.get("tool_calls") or ())
+        if not calls:
+            break
+        should_exit = False
+        for call in calls:
+            function = dict(call.get("function") or {})
+            name = str(function.get("name") or "")
+            arguments = _tool_arguments(function.get("arguments"))
+            try:
+                result = provider.dispatch(name, arguments)
+            except Exception as exc:  # noqa: BLE001 - policy observation
+                result = f"Tool call failed: {exc}"
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": str(call.get("id") or ""),
+                    "name": name,
+                    "content": result,
+                }
+            )
+            should_exit = should_exit or name == "exit"
+        if should_exit:
+            break
+    messages.append({"role": "user", "content": protocol.prune_decision_prompt})
+    decision, _assistant = complete(
+        stage="prune_decision",
+        messages=messages,
+        tools=tools,
+        tool_choice="none",
+    )
+    fenced = re.search(r"```(?:[^\n]*\n)?\s*(True|False)\s*```", decision)
+    value = fenced.group(1) if fenced is not None else decision.strip()
+    return value == "True"
+
+
+def _finish_execution(
+    *,
+    started: float,
+    usage: dict[str, Any],
+    trajectory: Sequence[Mapping[str, Any]],
+    tool_trace: Sequence[Mapping[str, Any]],
+    file_output: str,
+    reflection_output: str = "",
+    location_output: str = "",
+    candidate_files: Sequence[str] = (),
+) -> CoSILExecution:
+    usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+    usage["model_calls"] = len(trajectory)
+    usage["tool_calls"] = len(tool_trace)
+    usage["tool_seconds"] = sum(float(item["seconds"]) for item in tool_trace)
+    usage["elapsed_seconds"] = time.perf_counter() - started
+    return CoSILExecution(
+        file_output=file_output,
+        reflection_output=reflection_output,
+        location_output=location_output,
+        candidate_files=tuple(candidate_files),
+        usage=usage,
+        tool_trace=tuple(tool_trace),
+        trajectory=tuple(trajectory),
+    )
+
+
+def _tool_arguments(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    try:
+        decoded = json.loads(str(value or "{}"))
+    except json.JSONDecodeError:
+        return {}
+    return dict(decoded) if isinstance(decoded, Mapping) else {}
+
+
+def _unsupported_temperature(exc: Exception) -> bool:
+    body = getattr(exc, "body", None)
+    if isinstance(body, Mapping):
+        detail = body.get("error", body)
+        if isinstance(detail, Mapping):
+            param = str(detail.get("param") or "").lower()
+            code = str(detail.get("code") or "").lower()
+            message = str(detail.get("message") or "").lower()
+            if param == "temperature" and (
+                code == "unsupported_value" or "unsupported" in message
+            ):
+                return True
+    message = str(exc).lower()
+    return "temperature" in message and "unsupported value" in message
+
+
+def _requires_no_reasoning_with_tools(exc: Exception) -> bool:
+    body = getattr(exc, "body", None)
+    if isinstance(body, Mapping):
+        detail = body.get("error", body)
+        if isinstance(detail, Mapping):
+            param = str(detail.get("param") or "").lower()
+            message = str(detail.get("message") or "").lower()
+            if param == "reasoning_effort" and "function tools" in message:
+                return True
+    message = str(exc).lower()
+    return "function tools" in message and "reasoning_effort" in message
+
+
+def _assistant_message(message: Any) -> dict[str, Any]:
+    calls = []
+    for call in list(getattr(message, "tool_calls", None) or ()):
+        function = getattr(call, "function", None)
+        calls.append(
+            {
+                "id": str(getattr(call, "id", "")),
+                "type": str(getattr(call, "type", "function") or "function"),
+                "function": {
+                    "name": str(getattr(function, "name", "")),
+                    "arguments": getattr(function, "arguments", "{}"),
+                },
+            }
+        )
+    output: dict[str, Any] = {
+        "role": str(getattr(message, "role", "assistant") or "assistant"),
+        "content": getattr(message, "content", None),
+    }
+    if calls:
+        output["tool_calls"] = calls
+    return output
+
+
+def _response_usage(response: Any) -> tuple[int, int, int]:
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return 0, 0, 0
+    prompt = int(
+        getattr(usage, "prompt_tokens", None) or getattr(usage, "input_tokens", 0) or 0
+    )
+    completion = int(
+        getattr(usage, "completion_tokens", None)
+        or getattr(usage, "output_tokens", 0)
+        or 0
+    )
+    details = getattr(usage, "prompt_tokens_details", None)
+    cached = int(getattr(details, "cached_tokens", 0) or 0)
+    return prompt, completion, cached
+
+
+__all__ = [
+    "CoSILAgent",
+    "CoSILExecution",
+    "CoSILManifestResolver",
+    "CoSILPolicyRunner",
+    "CoSILProviderFactory",
+    "cosil_locations_to_baseline",
+    "run_cosil_policy",
+]

--- a/codenib/clients/cosil_agent.py
+++ b/codenib/clients/cosil_agent.py
@@ -66,20 +66,15 @@ def cosil_locations_to_baseline(
         file_path = files[0]
         resolved = provider.resolve_location(file_path, parsed.kind, parsed.name)
         if resolved is None:
-            location = BaselineLocation(
-                name=(f"{parsed.name}()" if parsed.kind == "function" else parsed.name),
-                type=parsed.kind,
-                file_path=file_path,
-            )
-        else:
-            kind, name, start, end = resolved
-            location = BaselineLocation(
-                name=f"{name}()" if kind in {"function", "method"} else name,
-                type=kind,
-                file_path=file_path,
-                line_start=start,
-                line_end=end,
-            )
+            continue
+        kind, name, start, end = resolved
+        location = BaselineLocation(
+            name=f"{name}()" if kind in {"function", "method"} else name,
+            type=kind,
+            file_path=file_path,
+            line_start=start,
+            line_end=end,
+        )
         key = (
             location.file_path,
             location.name,

--- a/codenib/clients/cosil_agent.py
+++ b/codenib/clients/cosil_agent.py
@@ -287,6 +287,7 @@ def run_cosil_policy(
     tool_trace: list[dict[str, Any]] = []
     started = time.perf_counter()
     temperature_supported = True
+    max_completion_tokens_supported = True
     tool_reasoning_disabled = False
 
     def complete(
@@ -297,12 +298,16 @@ def run_cosil_policy(
         tools: Sequence[Mapping[str, Any]] | None = None,
         tool_choice: str | None = None,
     ) -> tuple[str, dict[str, Any]]:
-        nonlocal temperature_supported, tool_reasoning_disabled
+        nonlocal max_completion_tokens_supported, temperature_supported
+        nonlocal tool_reasoning_disabled
         request: dict[str, Any] = {
             "model": model,
             "messages": list(messages),
-            "max_completion_tokens": max_completion_tokens,
         }
+        token_parameter = (
+            "max_completion_tokens" if max_completion_tokens_supported else "max_tokens"
+        )
+        request[token_parameter] = max_completion_tokens
         if temperature_supported:
             request["temperature"] = temperature
         if tools is not None:
@@ -319,6 +324,13 @@ def run_cosil_policy(
                 if temperature_supported and _unsupported_temperature(exc):
                     temperature_supported = False
                     request.pop("temperature", None)
+                    continue
+                if max_completion_tokens_supported and (
+                    _unsupported_max_completion_tokens(exc)
+                ):
+                    max_completion_tokens_supported = False
+                    request.pop("max_completion_tokens", None)
+                    request["max_tokens"] = max_completion_tokens
                     continue
                 if (
                     tools is not None
@@ -620,6 +632,25 @@ def _unsupported_temperature(exc: Exception) -> bool:
                 return True
     message = str(exc).lower()
     return "temperature" in message and "unsupported value" in message
+
+
+def _unsupported_max_completion_tokens(exc: Exception) -> bool:
+    body = getattr(exc, "body", None)
+    if isinstance(body, Mapping):
+        detail = body.get("error", body)
+        if isinstance(detail, Mapping):
+            param = str(detail.get("param") or "").lower()
+            message = str(detail.get("message") or "").lower()
+            if param == "max_completion_tokens" and any(
+                marker in message
+                for marker in ("unsupported", "unrecognized", "unknown")
+            ):
+                return True
+    message = str(exc).lower()
+    return "max_completion_tokens" in message and any(
+        marker in message
+        for marker in ("unexpected keyword", "unsupported", "unrecognized", "unknown")
+    )
 
 
 def _requires_no_reasoning_with_tools(exc: Exception) -> bool:

--- a/codenib/clients/cosil_agent.py
+++ b/codenib/clients/cosil_agent.py
@@ -320,7 +320,11 @@ def run_cosil_policy(
                     temperature_supported = False
                     request.pop("temperature", None)
                     continue
-                if tools is not None and _requires_no_reasoning_with_tools(exc):
+                if (
+                    tools is not None
+                    and not tool_reasoning_disabled
+                    and _requires_no_reasoning_with_tools(exc)
+                ):
                     tool_reasoning_disabled = True
                     request["reasoning_effort"] = "none"
                     continue
@@ -404,7 +408,7 @@ def run_cosil_policy(
         max_rounds=max_tool_rounds,
     )
     tools = get_cosil_tool_schemas()
-    collected_code: list[tuple[str, str]] = []
+    collected_code: list[tuple[str, Mapping[str, Any], str]] = []
 
     for round_index in range(max_tool_rounds):
         _content, assistant = complete(
@@ -430,6 +434,17 @@ def run_cosil_policy(
                 result = f"Tool call failed: {exc}"
                 error = result
             kept = name != "exit"
+            trace_entry: dict[str, Any] = {
+                "phase": "location",
+                "round": round_index + 1,
+                "name": name,
+                "arguments": arguments,
+                "seconds": time.perf_counter() - tool_started,
+                "output_chars": len(result),
+                "kept": kept,
+                "error": error,
+            }
+            tool_trace.append(trace_entry)
             if kept and prune_tool_results and error is None:
                 kept = _prune_tool_result(
                     protocol=protocol,
@@ -440,21 +455,11 @@ def run_cosil_policy(
                     arguments=arguments,
                     tool_result=result,
                     max_rounds=max_prune_rounds,
+                    tool_trace=tool_trace,
                 )
                 if not kept:
                     result = _FALSE_OBSERVATION
-            elapsed = time.perf_counter() - tool_started
-            tool_trace.append(
-                {
-                    "round": round_index + 1,
-                    "name": name,
-                    "arguments": arguments,
-                    "seconds": elapsed,
-                    "output_chars": len(result),
-                    "kept": kept,
-                    "error": error,
-                }
-            )
+            trace_entry["kept"] = kept
             messages.append(
                 {
                     "role": "tool",
@@ -464,7 +469,7 @@ def run_cosil_policy(
                 }
             )
             if kept and error is None:
-                collected_code.append((name, result))
+                collected_code.append((name, arguments, result))
             if name == "exit":
                 should_exit = True
         if should_exit:
@@ -499,6 +504,7 @@ def _prune_tool_result(
     arguments: Mapping[str, Any],
     tool_result: str,
     max_rounds: int,
+    tool_trace: list[dict[str, Any]],
 ) -> bool:
     messages: list[dict[str, Any]] = protocol.prune_messages(
         tool_name=tool_name,
@@ -521,10 +527,25 @@ def _prune_tool_result(
             function = dict(call.get("function") or {})
             name = str(function.get("name") or "")
             arguments = _tool_arguments(function.get("arguments"))
+            tool_started = time.perf_counter()
             try:
                 result = provider.dispatch(name, arguments)
+                error = None
             except Exception as exc:  # noqa: BLE001 - policy observation
                 result = f"Tool call failed: {exc}"
+                error = result
+            tool_trace.append(
+                {
+                    "phase": "prune",
+                    "round": _round_index + 1,
+                    "name": name,
+                    "arguments": arguments,
+                    "seconds": time.perf_counter() - tool_started,
+                    "output_chars": len(result),
+                    "kept": name != "exit" and error is None,
+                    "error": error,
+                }
+            )
             messages.append(
                 {
                     "role": "tool",

--- a/codenib/clients/cosil_protocol.py
+++ b/codenib/clients/cosil_protocol.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
@@ -301,7 +302,7 @@ class CoSILProtocol:
         self,
         *,
         candidate_structure: str,
-        collected_code: Sequence[tuple[str, str]],
+        collected_code: Sequence[tuple[str, Mapping[str, Any], str]],
     ) -> list[dict[str, str]]:
         bug_report = _BUG_REPORT_NO_STRUCTURE.format(
             problem_statement=self.problem_statement
@@ -309,8 +310,12 @@ class CoSILProtocol:
         retrieved = ""
         if collected_code:
             blocks = "\n\n".join(
-                f'<code from="{name}">\n{content}\n</code>'  # noqa: B907
-                for name, content in collected_code
+                (
+                    f"Tool: {name}\n"
+                    f"Arguments: {json.dumps(dict(arguments), sort_keys=True)}\n"
+                    f"<code>\n{content}\n</code>"
+                )
+                for name, arguments, content in collected_code
             )
             retrieved = f"Relevant code retrieved during analysis:\n\n{blocks}\n\n"
         summary = _LOCATION_SUMMARY.format(bug_file_list=candidate_structure)

--- a/codenib/clients/cosil_protocol.py
+++ b/codenib/clients/cosil_protocol.py
@@ -1,0 +1,371 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frozen prompt assets for the pinned CoSIL localization policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from codenib.integrations.cosil import COSIL_REVISION
+
+COSIL_PROTOCOL_REVISION = COSIL_REVISION
+
+_BUG_REPORT = """
+The bug report is as follows:
+```
+### GitHub Problem Description ###
+{problem_statement}
+
+###
+
+### Candidate Files ###
+{structure}
+
+###
+```
+"""
+
+_BUG_REPORT_NO_STRUCTURE = """
+The bug report is as follows:
+```
+### GitHub Problem Description ###
+{problem_statement}
+
+###
+"""
+
+_FILE_SYSTEM = """
+You will be presented with a bug report with repository structure to access the source code of the system under test (SUT).
+Your task is to locate the top-5 most likely culprit files based on the bug report.
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_FILE_GUIDANCE = """
+Let's locate the faulty file step by step using reasoning.\x20
+In order to locate accurately, you can pre-select {pre_select_num} files, then check them through function calls, and finally confirm {top_n} file names.
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_FILE_SUMMARY = """
+Based on the available information, reconfirm and provide complete name of the top-5 most likely culprit files for the bug.\x20
+Since your answer will be processed automatically, please give your answer in the format as follows.
+The returned files should be separated by new lines ordered by most to least important and wrapped with ```.
+```
+file1.py
+file2.py
+file3.py
+file4.py
+file5.py
+```
+Replace the 'file1.py' with the actual file path.
+For example,\x20
+```
+sklearn/linear_model/__init__.py
+sklearn/base.py
+```
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_FORMAT_CORRECT = """
+Here is a localization result, but it seems not in the correct format. Please correct it.
+The returned files should be separated by new lines ordered by most to least important and wrapped with ```
+This is an example of expected output:
+```
+sklearn/linear_model/__init__.py
+sklearn/base.py
+```
+
+Please help me corrct the following result.
+{res}
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_FILE_REFLECTION = """
+Please look through the following GitHub problem description and Repository structure and provide a list of files that one would need to edit to fix the problem.
+I have already find 5 relevent files. Accrording to the import relations, construct the call graph first.
+Then, Rank them again and reflect the result.
+
+### GitHub Problem Description ###
+{problem_statement}
+
+###
+
+### Repository Structure ###
+{structure}
+
+###
+
+### Files To Be Ranked ###
+{pre_files}
+
+###
+
+### Import Relations ###
+{import_content}
+###
+
+
+Please only provide the full path and return top 5 files.
+The returned files should be separated by new lines ordered by most to least important and wrapped with ```
+For example:
+```
+file1.py
+file2.py
+file3.py
+file4.py
+file5.py
+```
+Note: file1.py indicates the top-1 file, file2.py indicates the top-2 file, and so on. Do not include test files.
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_LOCATION_SYSTEM = """
+You will be presented with a bug report and tools to access the source code of the system under test (SUT).
+Since the modification is based on the code repository, the modified locations may include files, classes, and functions, and the modifications may be in the form of addition, deletion, or update.
+Your task is to locate the top-5 most likely culprit locations based on the bug report and the information you retrieve using the provided tools.
+
+The tools available to you are:
+* get_code_of_class(file_name, class_name) -> source code of a class.
+* get_code_of_class_function(file_name, class_name, func_name) -> source code of a method defined in a class.
+* get_code_of_file_function(file_name, func_name) -> source code of a top-level (static) function in a file.
+* exit() -> stop calling tools and proceed to your final answer.
+
+Working rules:
+- Do NOT guess the culprit from the file structure alone. You MUST first retrieve and read the actual
+  source code with the tools before deciding a location is relevant.
+- Inspect candidates one or a few at a time, reason over the returned code, then continue.
+- Avoid repeating an identical tool call.
+- You have at most {max_try} tool-call rounds. As soon as you are confident, call exit() to finish early.
+- Do NOT produce the final top-5 answer while you are still calling tools; you will be explicitly asked
+  for the final answer after the tool phase ends.
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_LOCATION_GUIDANCE = """
+Let's locate the faulty location (class / function) step by step using reasoning and tool calls.
+I have pre-identified top-5 files that may contain bugs. Their structures are as follows:
+{bug_file_list}
+The tool parameter 'file_name' takes the value in "file:".
+The tool parameter 'class_name' takes the value in "class:".
+The tool parameter 'func_name' takes the value in "static functions:" and "class functions:".
+Use the tools as follows:
+* For a class, use 'get_code_of_class(file_name, class_name)'.
+* For a class method (in "class functions:"), use 'get_code_of_class_function(file_name, class_name, func_name)'.
+* For a static/top-level function (in "static functions:"), use 'get_code_of_file_function(file_name, func_name)'.
+* When you are confident about the culprit locations, call 'exit()' to finish.
+Avoid making multiple identical tool calls to save overhead.
+In order to locate accurately, pre-select {pre_select_num} locations, inspect their code through tool calls, and finally confirm {top_n} locations.
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_LOCATION_SUMMARY = """
+Based on the available information, reconfirm and provide the complete names of the top-5 most likely culprit locations for the bug.
+Before making the final decision, please check whether the function name is correct or not. For static (top-level) functions, do NOT add a class name.
+{bug_file_list}
+
+Since your answer will be processed automatically, return ONLY an XML document in the exact structure below,
+ordered from most to least likely. Do not add any text outside the <locations> element.
+For each location:
+- <file> is the full file path.
+- <type> is either "function" or "class".
+- <name> is "ClassName.MethodName" for a class method, "FunctionName" for a static/top-level function,
+  or "ClassName" for a whole class.
+
+<locations>
+  <location>
+    <file>top1_file_fullpath.py</file>
+    <type>function</type>
+    <name>Class1.Function1</name>
+  </location>
+  <location>
+    <file>top2_file_fullpath.py</file>
+    <type>function</type>
+    <name>Function2</name>
+  </location>
+  <location>
+    <file>top3_file_fullpath.py</file>
+    <type>class</type>
+    <name>Class3</name>
+  </location>
+  <location>
+    <file>top4_file_fullpath.py</file>
+    <type>function</type>
+    <name>Class4.Function4</name>
+  </location>
+  <location>
+    <file>top5_file_fullpath.py</file>
+    <type>function</type>
+    <name>Function5</name>
+  </location>
+</locations>
+
+For example:
+<locations>
+  <location>
+    <file>sklearn/linear_model/__init__.py</file>
+    <type>function</type>
+    <name>LinearRegression.fit</name>
+  </location>
+</locations>
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+_SUMMARY_SYSTEM = (
+    "You are a debugging assistant.  Based on the bug report and the code "
+    "retrieved above, output ONLY the XML locations summary as instructed.  "
+    "Do NOT make any tool calls; you are in the final summary phase."
+)
+
+_PRUNE_SYSTEM = (
+    "You are a debugging assistant that judges code relevance to a bug report."
+)
+
+_PRUNE_DECISION = """
+Based on everything you have inspected, decide whether the original retrieved code is
+related to the bug and should be added into context.
+Since your answer will be processed automatically, please give your answer in the format as follows.
+The returned content should be wrapped with ```.
+```
+True
+```
+or
+```
+False
+```
+"""  # noqa: B950 - exact text from the pinned upstream policy
+
+
+@dataclass(frozen=True, slots=True)
+class CoSILProtocol:
+    """Prompts and message builders for CoSIL's RQ1 localization path."""
+
+    problem_statement: str
+
+    def file_messages(
+        self,
+        *,
+        structure: str,
+        max_retry: int,
+    ) -> list[dict[str, str]]:
+        bug_report = _BUG_REPORT.format(
+            problem_statement=self.problem_statement,
+            structure=structure,
+        )
+        guidance = _FILE_GUIDANCE.format(
+            pre_select_num=int(max_retry * 0.75),
+            top_n=int(max_retry / 2),
+        )
+        return [
+            {"role": "system", "content": _FILE_SYSTEM},
+            {
+                "role": "user",
+                "content": f"\n{bug_report}\n{guidance}\n{_FILE_SUMMARY}\n",
+            },
+        ]
+
+    def correction_prompt(self, result: str) -> str:
+        return _FORMAT_CORRECT.format(res=result)
+
+    def reflection_prompt(
+        self,
+        *,
+        structure: str,
+        pre_files: list[str],
+        import_content: str,
+    ) -> str:
+        return _FILE_REFLECTION.format(
+            problem_statement=self.problem_statement,
+            structure=structure,
+            pre_files=pre_files,
+            import_content=import_content,
+        )
+
+    def location_messages(
+        self,
+        *,
+        candidate_structure: str,
+        max_rounds: int,
+    ) -> list[dict[str, str]]:
+        bug_report = _BUG_REPORT_NO_STRUCTURE.format(
+            problem_statement=self.problem_statement
+        ).strip()
+        guidance = _LOCATION_GUIDANCE.format(
+            bug_file_list=candidate_structure,
+            pre_select_num=7,
+            top_n=5,
+        )
+        return [
+            {
+                "role": "system",
+                "content": _LOCATION_SYSTEM.format(max_try=max_rounds),
+            },
+            {"role": "user", "content": f"\n{bug_report}\n{guidance}\n"},
+        ]
+
+    def summary_messages(
+        self,
+        *,
+        candidate_structure: str,
+        collected_code: Sequence[tuple[str, str]],
+    ) -> list[dict[str, str]]:
+        bug_report = _BUG_REPORT_NO_STRUCTURE.format(
+            problem_statement=self.problem_statement
+        ).strip()
+        retrieved = ""
+        if collected_code:
+            blocks = "\n\n".join(
+                f'<code from="{name}">\n{content}\n</code>'  # noqa: B907
+                for name, content in collected_code
+            )
+            retrieved = f"Relevant code retrieved during analysis:\n\n{blocks}\n\n"
+        summary = _LOCATION_SUMMARY.format(bug_file_list=candidate_structure)
+        return [
+            {"role": "system", "content": _SUMMARY_SYSTEM},
+            {
+                "role": "user",
+                "content": (
+                    f"{bug_report}\n\n{candidate_structure}\n\n" f"{retrieved}{summary}"
+                ),
+            },
+        ]
+
+    def prune_messages(
+        self,
+        *,
+        tool_name: str,
+        arguments: Mapping[str, Any],
+        tool_result: str,
+    ) -> list[dict[str, str]]:
+        quoted_tool_name = f"'{tool_name}'"  # noqa: B907 - pinned prompt text
+        prompt = f"""
+You will be presented with a bug report with repository structure to access the source code of the system under test (SUT).
+Your task is to decide whether a retrieved function/class is related to the bug and should be kept in context.
+<bug report>
+{self.problem_statement}
+</bug report>
+
+Here is a result of a function/class code retrieved by {quoted_tool_name} with arguments {arguments}.
+<code>
+{tool_result}
+</code>
+
+You may call the provided tools to inspect related code (e.g. functions it calls or the
+class it belongs to) before making your decision. Investigate first; do not answer yet.
+"""  # noqa: B950 - exact text from the pinned upstream policy
+        return [
+            {"role": "system", "content": _PRUNE_SYSTEM},
+            {"role": "user", "content": prompt},
+        ]
+
+    @property
+    def prune_decision_prompt(self) -> str:
+        return _PRUNE_DECISION
+
+
+def build_cosil_protocol(problem_statement: str) -> CoSILProtocol:
+    problem = str(problem_statement or "").strip()
+    if not problem:
+        raise ValueError("CoSIL requires a non-empty problem statement")
+    return CoSILProtocol(problem_statement=problem)
+
+
+__all__ = [
+    "COSIL_PROTOCOL_REVISION",
+    "CoSILProtocol",
+    "build_cosil_protocol",
+]

--- a/codenib/eval/benchmarks/__init__.py
+++ b/codenib/eval/benchmarks/__init__.py
@@ -9,6 +9,7 @@ from .agentless import (
     parse_agentless_files,
     parse_agentless_locations,
 )
+from .cosil import CoSILLocation, parse_cosil_files, parse_cosil_locations
 from .locagent import LocAgentLocation, locagent_regions, parse_locagent_locations
 from .orcaloca import (
     OrcaLocaGroundTruth,
@@ -65,6 +66,7 @@ from .swe_explore import (
 
 __all__ = [
     "AgentlessLocation",
+    "CoSILLocation",
     "LocAgentLocation",
     "locagent_regions",
     "CaseEligibility",
@@ -104,6 +106,8 @@ __all__ = [
     "normalize_swe_explore_instance_id",
     "parse_agentless_files",
     "parse_agentless_locations",
+    "parse_cosil_files",
+    "parse_cosil_locations",
     "parse_orcaloca_locations",
     "resolve_orcaloca_locations",
     "parse_locagent_locations",

--- a/codenib/eval/benchmarks/cosil.py
+++ b/codenib/eval/benchmarks/cosil.py
@@ -16,7 +16,7 @@ _LOCATIONS_XML = re.compile(r"<locations\b[^>]*>.*?</locations>", re.DOTALL)
 
 
 def _normalize(value: object) -> str:
-    text = str(value or "").strip().strip("`'\".,;()[]{} ")
+    text = str(value or "").strip().strip("`'\"()[]{} ").rstrip(",;")
     text = text.replace("\\", "/")
     while text.startswith("./"):
         text = text[2:]

--- a/codenib/eval/benchmarks/cosil.py
+++ b/codenib/eval/benchmarks/cosil.py
@@ -25,6 +25,8 @@ def _normalize(value: object) -> str:
 
 def _match_file(value: object, valid_files: Sequence[str], root_name: str) -> str:
     candidate = _normalize(value)
+    if candidate in valid_files:
+        return candidate
     prefix = root_name.strip("/") + "/" if root_name.strip("/") else ""
     if prefix and candidate.startswith(prefix):
         candidate = candidate[len(prefix) :]
@@ -78,6 +80,7 @@ def parse_cosil_locations(
     *,
     valid_files: Iterable[str],
     root_name: str = "",
+    limit: int = 5,
 ) -> tuple[CoSILLocation, ...]:
     """Parse a well-formed ``<locations>`` document and reject unknown files."""
 
@@ -103,6 +106,8 @@ def parse_cosil_locations(
             continue
         seen.add(key)
         output.append(CoSILLocation(file_path=file_path, kind=kind, name=name))
+        if len(output) >= max(1, int(limit)):
+            break
     return tuple(output)
 
 

--- a/codenib/eval/benchmarks/cosil.py
+++ b/codenib/eval/benchmarks/cosil.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-free parsers for CoSIL file and XML location output."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+_FENCED_BLOCK = re.compile(r"```(?:[^\n]*\n)?(.*?)```", re.DOTALL)
+_LOCATIONS_XML = re.compile(r"<locations\b[^>]*>.*?</locations>", re.DOTALL)
+
+
+def _normalize(value: object) -> str:
+    text = str(value or "").strip().strip("`'\".,;()[]{} ")
+    text = text.replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    return text.lstrip("/")
+
+
+def _match_file(value: object, valid_files: Sequence[str], root_name: str) -> str:
+    candidate = _normalize(value)
+    prefix = root_name.strip("/") + "/" if root_name.strip("/") else ""
+    if prefix and candidate.startswith(prefix):
+        candidate = candidate[len(prefix) :]
+    return candidate if candidate in valid_files else ""
+
+
+def parse_cosil_files(
+    raw_output: str,
+    *,
+    valid_files: Iterable[str],
+    root_name: str = "",
+    limit: int = 5,
+) -> tuple[str, ...]:
+    """Parse CoSIL's fenced ranked-file response."""
+
+    files = tuple(dict.fromkeys(_normalize(path) for path in valid_files if path))
+    if str(raw_output or "").count("```") % 2:
+        return ()
+    output: list[str] = []
+    seen: set[str] = set()
+    for block in _FENCED_BLOCK.findall(str(raw_output or "")):
+        for line in block.splitlines():
+            file_path = _match_file(line.strip(), files, root_name)
+            if not file_path or file_path in seen:
+                continue
+            seen.add(file_path)
+            output.append(file_path)
+            if len(output) >= max(1, int(limit)):
+                return tuple(output)
+    return tuple(output)
+
+
+@dataclass(frozen=True, slots=True)
+class CoSILLocation:
+    """One source-linked location from CoSIL's final XML summary."""
+
+    file_path: str
+    kind: str
+    name: str
+
+    def to_record(self) -> dict[str, str]:
+        return {
+            "file_path": self.file_path,
+            "kind": self.kind,
+            "name": self.name,
+        }
+
+
+def parse_cosil_locations(
+    raw_output: str,
+    *,
+    valid_files: Iterable[str],
+    root_name: str = "",
+) -> tuple[CoSILLocation, ...]:
+    """Parse a well-formed ``<locations>`` document and reject unknown files."""
+
+    files = tuple(dict.fromkeys(_normalize(path) for path in valid_files if path))
+    match = _LOCATIONS_XML.search(str(raw_output or ""))
+    if match is None:
+        return ()
+    try:
+        root = ET.fromstring(match.group(0))
+    except ET.ParseError:
+        return ()
+
+    output: list[CoSILLocation] = []
+    seen: set[tuple[str, str, str]] = set()
+    for node in root.findall("./location"):
+        file_path = _match_file(node.findtext("file") or "", files, root_name)
+        name = str(node.findtext("name") or "").strip()
+        kind = str(node.findtext("type") or "function").strip().lower()
+        if kind not in {"function", "class", "variable"}:
+            kind = "function"
+        key = (file_path, kind, name)
+        if not file_path or not name or key in seen:
+            continue
+        seen.add(key)
+        output.append(CoSILLocation(file_path=file_path, kind=kind, name=name))
+    return tuple(output)
+
+
+__all__ = [
+    "CoSILLocation",
+    "parse_cosil_files",
+    "parse_cosil_locations",
+]

--- a/codenib/eval/benchmarks/cosil.py
+++ b/codenib/eval/benchmarks/cosil.py
@@ -99,8 +99,8 @@ def parse_cosil_locations(
         file_path = _match_file(node.findtext("file") or "", files, root_name)
         name = str(node.findtext("name") or "").strip()
         kind = str(node.findtext("type") or "function").strip().lower()
-        if kind not in {"function", "class", "variable"}:
-            kind = "function"
+        if kind not in {"function", "class"}:
+            continue
         key = (file_path, kind, name)
         if not file_path or not name or key in seen:
             continue

--- a/codenib/integrations/cosil.py
+++ b/codenib/integrations/cosil.py
@@ -275,7 +275,7 @@ class CoSILRepositoryProvider:
             value = value.replace("\\", "/")
             while value.startswith("./"):
                 value = value[2:]
-            if value.startswith(root_prefix):
+            if value not in self._files and value.startswith(root_prefix):
                 value = value[len(root_prefix) :]
             matches = self.repository.find_files(value)
             for match in matches:

--- a/codenib/integrations/cosil.py
+++ b/codenib/integrations/cosil.py
@@ -455,7 +455,6 @@ class CoSILRepositoryProvider:
         lines = source.splitlines()
         classes: list[CoSILClass] = []
         functions: list[CoSILFunction] = []
-        class_method_names: set[str] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
                 methods: list[CoSILMethod] = []
@@ -472,7 +471,6 @@ class CoSILRepositoryProvider:
                             source="\n".join(lines[start - 1 : end]),
                         )
                     )
-                    class_method_names.add(child.name)
                 start = int(node.lineno)
                 end = int(node.end_lineno or start)
                 classes.append(
@@ -484,9 +482,8 @@ class CoSILRepositoryProvider:
                         methods=tuple(methods),
                     )
                 )
-            elif isinstance(node, ast.FunctionDef):
-                if node.name in class_method_names:
-                    continue
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef):
                 start = int(node.lineno)
                 end = int(node.end_lineno or start)
                 functions.append(

--- a/codenib/integrations/cosil.py
+++ b/codenib/integrations/cosil.py
@@ -277,12 +277,9 @@ class CoSILRepositoryProvider:
                 value = value[2:]
             if value not in self._files and value.startswith(root_prefix):
                 value = value[len(root_prefix) :]
-            matches = self.repository.find_files(value)
-            for match in matches:
-                if match in self._files and match not in seen:
-                    seen.add(match)
-                    output.append(match)
-                    break
+            if value in self._files and value not in seen:
+                seen.add(value)
+                output.append(value)
             if limit is not None and len(output) >= limit:
                 break
         return tuple(output)

--- a/codenib/integrations/cosil.py
+++ b/codenib/integrations/cosil.py
@@ -1,0 +1,504 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CoSIL localization tools over CodeNib manifest-backed source views."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable, Mapping, Sequence
+
+from ._repository import RepositoryAdapter
+
+COSIL_REVISION = "0568e423735b399d5b089996961fea9ae142e4c7"
+
+_RUNTIME_VIEWS = frozenset({"symbol_graph"})
+_TOOL_NAMES = (
+    "get_code_of_class",
+    "get_code_of_class_function",
+    "get_code_of_file_function",
+    "exit",
+)
+_LIST_PREFIX = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
+
+_COSIL_TOOL_SCHEMAS: tuple[dict[str, Any], ...] = (
+    {
+        "type": "function",
+        "function": {
+            "name": "get_code_of_class",
+            "description": "Get the source code of a class in a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_name": {
+                        "type": "string",
+                        "description": (
+                            "Full file path exactly as shown after 'file:' in the "
+                            "candidate file structure."
+                        ),
+                    },
+                    "class_name": {
+                        "type": "string",
+                        "description": (
+                            "Class name exactly as shown in the candidate file "
+                            "structure."
+                        ),
+                    },
+                },
+                "required": ["file_name", "class_name"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_code_of_class_function",
+            "description": "Get the source code of a method defined in a class.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_name": {
+                        "type": "string",
+                        "description": (
+                            "Full file path exactly as shown after 'file:' in the "
+                            "candidate file structure."
+                        ),
+                    },
+                    "class_name": {
+                        "type": "string",
+                        "description": (
+                            "Class name exactly as shown in the candidate file "
+                            "structure."
+                        ),
+                    },
+                    "func_name": {
+                        "type": "string",
+                        "description": (
+                            "Method name exactly as shown in the class functions list."
+                        ),
+                    },
+                },
+                "required": ["file_name", "class_name", "func_name"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_code_of_file_function",
+            "description": (
+                "Get the source code of a top-level function defined in a file."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_name": {
+                        "type": "string",
+                        "description": (
+                            "Full file path exactly as shown after 'file:' in the "
+                            "candidate file structure."
+                        ),
+                    },
+                    "func_name": {
+                        "type": "string",
+                        "description": (
+                            "Top-level function name exactly as shown in the static "
+                            "functions list."
+                        ),
+                    },
+                },
+                "required": ["file_name", "func_name"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "exit",
+            "description": (
+                "Exit tool calling and proceed to give the final answer once you are "
+                "confident about the culprit locations. Call this instead of making "
+                "further retrieval calls."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+        },
+    },
+)
+
+
+def get_cosil_tool_schemas() -> list[dict[str, Any]]:
+    """Return independent OpenAI schemas for the pinned CoSIL tools."""
+
+    return copy.deepcopy(list(_COSIL_TOOL_SCHEMAS))
+
+
+@dataclass(frozen=True, slots=True)
+class CoSILMethod:
+    name: str
+    start_line: int
+    end_line: int
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class CoSILClass:
+    name: str
+    start_line: int
+    end_line: int
+    source: str
+    methods: tuple[CoSILMethod, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CoSILFunction:
+    name: str
+    start_line: int
+    end_line: int
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class CoSILOutline:
+    file_path: str
+    source: str
+    classes: tuple[CoSILClass, ...]
+    functions: tuple[CoSILFunction, ...]
+
+
+class CoSILRepositoryProvider:
+    """Serve CoSIL's four tools without its per-instance AST artifact."""
+
+    def __init__(self, context: Any, *, include_tests: bool = False) -> None:
+        self.repository = RepositoryAdapter(context, require_graph=True)
+        self.include_tests = bool(include_tests)
+        self._files = tuple(
+            file_path
+            for file_path in self.repository.files
+            if self._accept_file(file_path)
+        )
+        self._outlines: dict[str, CoSILOutline | None] = {}
+
+    @classmethod
+    def from_manifest(
+        cls,
+        manifest_path: str | Path,
+        **kwargs: Any,
+    ) -> "CoSILRepositoryProvider":
+        from ..mcp.context import ServerContext
+
+        return cls(ServerContext.load(manifest_path, views=_RUNTIME_VIEWS), **kwargs)
+
+    @property
+    def context(self) -> Any:
+        return self.repository.context
+
+    @property
+    def files(self) -> tuple[str, ...]:
+        return self._files
+
+    @property
+    def project_root_name(self) -> str:
+        return self.repository.repo_root.name
+
+    def bindings(self) -> dict[str, Callable[..., str]]:
+        return {
+            "get_code_of_class": self.get_code_of_class,
+            "get_code_of_class_function": self.get_code_of_class_function,
+            "get_code_of_file_function": self.get_code_of_file_function,
+            "exit": self.exit,
+        }
+
+    def dispatch(
+        self,
+        name: str,
+        arguments: Mapping[str, Any] | str | None = None,
+    ) -> str:
+        if isinstance(arguments, str):
+            try:
+                decoded = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                raise ValueError("CoSIL tool arguments must be valid JSON") from exc
+            if not isinstance(decoded, Mapping):
+                raise ValueError("CoSIL tool arguments must decode to an object")
+            parsed = dict(decoded)
+        else:
+            parsed = dict(arguments or {})
+        function = self.bindings().get(name)
+        if function is None:
+            raise KeyError(
+                f"unknown CoSIL tool {name!r}; supported: {', '.join(_TOOL_NAMES)}"
+            )
+        return function(**parsed)
+
+    def project_structure(self) -> str:
+        tree: dict[str, Any] = {}
+        for file_path in self._files:
+            node = tree
+            for part in PurePosixPath(file_path).parts:
+                node = node.setdefault(part, {})
+        lines = [f"{self.project_root_name}/"]
+
+        def render(current: Mapping[str, Any], depth: int) -> None:
+            for name, children in current.items():
+                lines.append(f"{' ' * (depth * 4)}{name}{'/' if children else ''}")
+                if children:
+                    render(children, depth + 1)
+
+        render(tree, 1)
+        return "\n".join(lines)
+
+    def resolve_files(
+        self,
+        values: str | Sequence[str],
+        *,
+        limit: int | None = None,
+    ) -> tuple[str, ...]:
+        lines = values.splitlines() if isinstance(values, str) else values
+        root_prefix = self.project_root_name + "/"
+        output: list[str] = []
+        seen: set[str] = set()
+        for raw in lines:
+            value = _LIST_PREFIX.sub("", str(raw).strip().strip("`'\" "))
+            value = value.replace("\\", "/")
+            while value.startswith("./"):
+                value = value[2:]
+            if value.startswith(root_prefix):
+                value = value[len(root_prefix) :]
+            matches = self.repository.find_files(value)
+            for match in matches:
+                if match in self._files and match not in seen:
+                    seen.add(match)
+                    output.append(match)
+                    break
+            if limit is not None and len(output) >= limit:
+                break
+        return tuple(output)
+
+    def candidate_structure(self, file_names: Sequence[str]) -> str:
+        sections: list[str] = []
+        for file_path in self.resolve_files(file_names):
+            outline = self._outline(file_path)
+            if outline is None:
+                continue
+            classes = [item.name for item in outline.classes]
+            functions = [item.name for item in outline.functions]
+            class_functions = "[\n"
+            for item in outline.classes:
+                class_functions += (
+                    f"{item.name}: {[method.name for method in item.methods]} \n"
+                )
+            class_functions += "]"
+            sections.append(
+                f"file: {file_path} \n"
+                f"\t class: {classes} \n"
+                f"\t static functions:  {functions} \n"
+                f"\t class fucntions: {class_functions}\n"
+            )
+        return "".join(sections)
+
+    def import_context(self, file_names: Sequence[str]) -> str:
+        sections: list[str] = []
+        for file_path in self.resolve_files(file_names):
+            outline = self._outline(file_path)
+            if outline is None:
+                continue
+            imports = [
+                line
+                for line in outline.source.splitlines()
+                if line.startswith("import")
+                or (line.startswith("from") and "import" in line)
+            ]
+            sections.append(f"file: {file_path}\n {imports}\n")
+        return "".join(sections)
+
+    def get_code_of_class(self, file_name: str, class_name: str) -> str:
+        outline = self._resolved_outline(file_name)
+        if outline is not None:
+            match = next(
+                (item for item in outline.classes if item.name == class_name),
+                None,
+            )
+            if match is not None:
+                return match.source
+        return (
+            "You provide a wrong file name or class name. Please try another file "
+            "name again."
+        )
+
+    def get_code_of_class_function(
+        self,
+        file_name: str,
+        class_name: str,
+        func_name: str,
+    ) -> str:
+        outline = self._resolved_outline(file_name)
+        if outline is not None:
+            class_match = next(
+                (item for item in outline.classes if item.name == class_name),
+                None,
+            )
+            if class_match is not None:
+                method = next(
+                    (item for item in class_match.methods if item.name == func_name),
+                    None,
+                )
+                if method is not None:
+                    return method.source
+        return (
+            "You provide a wrong file name or class name or function name. Please "
+            "try another file name again. It may be a file function."
+        )
+
+    def get_code_of_file_function(self, file_name: str, func_name: str) -> str:
+        outline = self._resolved_outline(file_name)
+        if outline is not None:
+            match = next(
+                (item for item in outline.functions if item.name == func_name),
+                None,
+            )
+            if match is not None:
+                return match.source
+        return (
+            "You provide a wrong file name or function name. Please try another "
+            "file name again. It may be a class function."
+        )
+
+    def resolve_location(
+        self,
+        file_name: str,
+        kind: str,
+        name: str,
+    ) -> tuple[str, str, int, int] | None:
+        """Resolve CoSIL's XML identity to kind, name, and 1-based range."""
+
+        outline = self._resolved_outline(file_name)
+        if outline is None:
+            return None
+        if kind == "class":
+            item = next((item for item in outline.classes if item.name == name), None)
+            if item is not None:
+                return "class", item.name, item.start_line, item.end_line
+            return None
+        if kind == "function" and "." in name:
+            class_name, method_name = name.rsplit(".", 1)
+            class_item = next(
+                (item for item in outline.classes if item.name == class_name),
+                None,
+            )
+            if class_item is not None:
+                method = next(
+                    (item for item in class_item.methods if item.name == method_name),
+                    None,
+                )
+                if method is not None:
+                    return "method", name, method.start_line, method.end_line
+        if kind == "function":
+            item = next(
+                (item for item in outline.functions if item.name == name),
+                None,
+            )
+            if item is not None:
+                return "function", item.name, item.start_line, item.end_line
+        return None
+
+    @staticmethod
+    def exit() -> str:
+        return "Exiting tool calls. Now provide your final answer."
+
+    def _accept_file(self, file_path: str) -> bool:
+        path = PurePosixPath(file_path)
+        if path.suffix != ".py":
+            return False
+        return self.include_tests or not any(
+            part.startswith("test") for part in path.parts
+        )
+
+    def _resolved_outline(self, file_name: str) -> CoSILOutline | None:
+        files = self.resolve_files([file_name], limit=1)
+        return self._outline(files[0]) if files else None
+
+    def _outline(self, file_path: str) -> CoSILOutline | None:
+        if file_path in self._outlines:
+            return self._outlines[file_path]
+        source, _, _ = self.repository.read_range(file_path)
+        outline = self._parse_outline(file_path, source)
+        self._outlines[file_path] = outline
+        return outline
+
+    @staticmethod
+    def _parse_outline(file_path: str, source: str) -> CoSILOutline | None:
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            return None
+        lines = source.splitlines()
+        classes: list[CoSILClass] = []
+        functions: list[CoSILFunction] = []
+        class_method_names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                methods: list[CoSILMethod] = []
+                for child in node.body:
+                    if not isinstance(child, ast.FunctionDef):
+                        continue
+                    start = int(child.lineno)
+                    end = int(child.end_lineno or start)
+                    methods.append(
+                        CoSILMethod(
+                            name=child.name,
+                            start_line=start,
+                            end_line=end,
+                            source="\n".join(lines[start - 1 : end]),
+                        )
+                    )
+                    class_method_names.add(child.name)
+                start = int(node.lineno)
+                end = int(node.end_lineno or start)
+                classes.append(
+                    CoSILClass(
+                        name=node.name,
+                        start_line=start,
+                        end_line=end,
+                        source="\n".join(lines[start - 1 : end]),
+                        methods=tuple(methods),
+                    )
+                )
+            elif isinstance(node, ast.FunctionDef):
+                if node.name in class_method_names:
+                    continue
+                start = int(node.lineno)
+                end = int(node.end_lineno or start)
+                functions.append(
+                    CoSILFunction(
+                        name=node.name,
+                        start_line=start,
+                        end_line=end,
+                        source="\n".join(lines[start - 1 : end]),
+                    )
+                )
+        return CoSILOutline(
+            file_path=file_path,
+            source=source,
+            classes=tuple(classes),
+            functions=tuple(functions),
+        )
+
+
+__all__ = [
+    "COSIL_REVISION",
+    "CoSILRepositoryProvider",
+    "get_cosil_tool_schemas",
+]

--- a/codenib/integrations/cosil.py
+++ b/codenib/integrations/cosil.py
@@ -419,8 +419,19 @@ class CoSILRepositoryProvider:
         path = PurePosixPath(file_path)
         if path.suffix != ".py":
             return False
-        return self.include_tests or not any(
-            part.startswith("test") for part in path.parts
+        if self.include_tests:
+            return True
+
+        file_name = path.name.lower()
+        directories = tuple(part.lower() for part in path.parts[:-1])
+        if directories and directories[0] in {"test", "tests"}:
+            return False
+        if any(part in {"tests", "__tests__", "spec", "specs"} for part in directories):
+            return False
+        return not (
+            file_name == "test.py"
+            or file_name.startswith("test_")
+            or file_name.endswith(("_test.py", "_spec.py"))
         )
 
     def _resolved_outline(self, file_name: str) -> CoSILOutline | None:

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -17,6 +17,7 @@ budget contract. None of these labels alone claims end-to-end task quality.
 | --- | --- | --- | --- | --- | --- |
 | LocAgent | CodeNib-native, revision-pinned | Symbol graph + BM25 | Pinned three-tool contract | Vendored prompts and function-calling loop; paired runner with strict common file/function@k scoring | Python SWE-bench repositories; reference and type-use are disclosed as conservative relation mappings |
 | Agentless v1.5.0 | CodeNib-native, revision-pinned | Symbol graph | Python tree, symbol skeleton, and line-window context | Vendored three-stage localization prompts; shared ranked file/symbol scoring | Localization only; repair and patch validation are excluded |
+| CoSIL | CodeNib-native, revision-pinned | Symbol graph | Pinned four-tool contract | Vendored file reflection, function tool loop, prune policy, and shared localization scoring | RQ1 file/function localization only; line localization and patch generation are excluded |
 | OrcaLoca SearchAgent | Revision-pinned supported | Symbol graph | Pinned six-tool and private-hook contract | Upstream `SearchAgent`; fixed-case paired runner and native File/Function Match scorer | Python SWE-bench repositories; empty `TraceAnalysisOutput`; upstream trace generation is not included |
 | SWE-Explore | Official explorer-compatible, revision-pinned | BM25 | Ranked `ContextRegion` explorer protocol | Official runner adapter, pinned scorer contract, and strict seven-language compatibility run | Trajectory-read localization only; no patch-generation or issue-resolution claim |
 
@@ -50,8 +51,9 @@ inside the upstream runtime. Provider imports and standalone provider examples
 remain dependency-free. Exact pinned
 revisions, fidelity limits, commands, and measured evidence follow below.
 Provider startup also selects only its declared runtime views: LocAgent loads
-the symbol graph and BM25, while Agentless and OrcaLoca load only the symbol
-graph. Dense and Zoekt runtimes are not imported or started for these contracts.
+the symbol graph and BM25, while Agentless, CoSIL, and OrcaLoca load only the
+symbol graph. Dense and Zoekt runtimes are not imported or started for these
+contracts.
 CodeNib's graph providers can represent additional languages, but this matrix
 does not extend a Python-scoped upstream policy or native comparator beyond its
 validated domain.
@@ -314,6 +316,84 @@ pytest -q test/integrations/test_agentless.py \
 
 AGENTLESS_CHECKOUT=/path/to/Agentless \
 pytest -q test/integrations/test_agentless_upstream.py
+```
+
+## CoSIL
+
+The CoSIL integration follows the two scripts used by the
+[pinned public RQ1 path](https://github.com/ZhonghaoJiang/CoSIL/tree/0568e423735b399d5b089996961fea9ae142e4c7/CoSIL/fl):
+
+1. rank files and reflect that ranking against their import statements;
+2. inspect candidate classes and functions through four tools, optionally prune
+   irrelevant observations, and emit a final XML location summary.
+
+`CoSILRepositoryProvider` implements the pinned tools:
+
+- `get_code_of_class`
+- `get_code_of_class_function`
+- `get_code_of_file_function`
+- `exit`
+
+The provider loads only CodeNib's symbol graph. File identity comes from that
+manifest view, while a lazy Python AST parse of requested candidate files
+restores CoSIL's exact class/function classification and source ranges. It does
+not load CoSIL's `repo_structures/<instance>.json` or build another graph.
+
+```python
+from codenib.integrations.cosil import CoSILRepositoryProvider
+
+provider = CoSILRepositoryProvider.from_manifest(
+    "/path/to/repo_manifest.json",
+)
+source = provider.dispatch(
+    "get_code_of_class_function",
+    {
+        "file_name": "src/service.py",
+        "class_name": "Service",
+        "func_name": "run",
+    },
+)
+```
+
+Inspect the candidate contract without CoSIL installed:
+
+```bash
+python examples/integrations/cosil.py \
+  --manifest /path/to/repo_manifest.json \
+  --file src/service.py
+```
+
+`CoSILAgent` vendors the file/reflection prompts, four-tool loop, optional
+per-result prune loop, and XML summary prompt from revision
+`0568e423735b399d5b089996961fea9ae142e4c7`. The optional upstream probe compares
+those prompt and schema objects directly with the pinned Git tree. The runtime
+does not import CoSIL, Agentless, LiteLLM, or a second index implementation.
+
+```bash
+python examples/cosil_loc_agent.py \
+  --dataset codenib_base \
+  --model "$COSIL_MODEL" \
+  --result-path results/cosil.jsonl
+```
+
+This boundary matches CoSIL's file and function localization experiment. It
+does not claim compatibility with its line-localization, patch-generation, or
+test-validation stages. If import reflection is malformed, CodeNib retains the
+validated initial file ranking rather than turning an empty reflection into an
+empty candidate set.
+
+The AST compatibility check compared all 1,791 eligible Python files from five
+SWE-bench Lite repository snapshots (Requests, Flask, Django, SymPy, and
+Pylint) against CoSIL's pinned `parse_python_file`; class, function, method,
+range, and source records matched for every file. This validates the provider
+contract, not CoSIL's model-dependent localization score.
+
+```bash
+pytest -q test/integrations/test_cosil.py \
+  test/integrations/test_cosil_policy.py
+
+COSIL_CHECKOUT=/path/to/CoSIL \
+pytest -q test/integrations/test_cosil_upstream.py
 ```
 
 ## OrcaLoca

--- a/examples/cosil_loc_agent.py
+++ b/examples/cosil_loc_agent.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run pinned CoSIL localization with the common benchmark runner."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from codenib.clients.cosil_agent import CoSILAgent
+from codenib.eval.agent_runner.loc_baseline import add_common_args, run_agent_baseline
+from codenib.log_utils import get_logger
+
+logger = get_logger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run CoSIL over CodeNib views on a benchmark dataset",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    add_common_args(parser)
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="OpenAI-compatible model name used by the CoSIL policy.",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help=(
+            "Fixed manifest for a single-snapshot run. Multi-repository runs "
+            "resolve each manifest from CODENIB_HOME."
+        ),
+    )
+    parser.add_argument("--top-n-files", type=int, default=5)
+    parser.add_argument("--file-max-retry", type=int, default=10)
+    parser.add_argument("--max-tool-rounds", type=int, default=10)
+    parser.add_argument("--max-prune-rounds", type=int, default=3)
+    parser.add_argument("--max-completion-tokens", type=int, default=4096)
+    parser.add_argument(
+        "--no-prune",
+        action="store_true",
+        help="Disable CoSIL's per-result relevance-pruning ablation.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Optional OpenAI-compatible endpoint, including a LiteLLM proxy.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logger.info(
+        "CoSIL baseline | dataset=%s model=%s rounds=%d prune=%s",
+        args.dataset,
+        args.model,
+        args.max_tool_rounds,
+        not args.no_prune,
+    )
+
+    def factory() -> CoSILAgent:
+        return CoSILAgent(
+            model=args.model,
+            manifest_path=args.manifest,
+            top_n_files=args.top_n_files,
+            file_max_retry=args.file_max_retry,
+            max_tool_rounds=args.max_tool_rounds,
+            prune_tool_results=not args.no_prune,
+            max_prune_rounds=args.max_prune_rounds,
+            max_completion_tokens=args.max_completion_tokens,
+            base_url=args.base_url,
+        )
+
+    rc = asyncio.run(
+        run_agent_baseline(
+            args,
+            agent_factory=factory,
+            agent_name="cosil-codenib",
+            model_label=args.model,
+        )
+    )
+    raise SystemExit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cosil_loc_agent.py
+++ b/examples/cosil_loc_agent.py
@@ -44,6 +44,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-tool-rounds", type=int, default=10)
     parser.add_argument("--max-prune-rounds", type=int, default=3)
     parser.add_argument("--max-completion-tokens", type=int, default=4096)
+    parser.add_argument("--max-tool-context-chars", type=int, default=32_000)
     parser.add_argument(
         "--no-prune",
         action="store_true",
@@ -77,6 +78,7 @@ def main() -> None:
             prune_tool_results=not args.no_prune,
             max_prune_rounds=args.max_prune_rounds,
             max_completion_tokens=args.max_completion_tokens,
+            max_tool_context_chars=args.max_tool_context_chars,
             base_url=args.base_url,
         )
 

--- a/examples/integrations/cosil.py
+++ b/examples/integrations/cosil.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inspect CoSIL-compatible repository context without installing CoSIL."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from codenib.integrations.cosil import CoSILRepositoryProvider
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        required=True,
+        help="Graph-enabled CodeNib repo_manifest.json",
+    )
+    parser.add_argument(
+        "--file",
+        action="append",
+        default=[],
+        help="Candidate Python file whose CoSIL structure should be shown.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    provider = CoSILRepositoryProvider.from_manifest(args.manifest)
+    if args.file:
+        print(provider.candidate_structure(args.file))
+    else:
+        print(provider.project_structure())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/integrations/test_cosil.py
+++ b/test/integrations/test_cosil.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from codenib.integrations.cosil import (
+    COSIL_REVISION,
+    CoSILRepositoryProvider,
+    get_cosil_tool_schemas,
+)
+from codenib.mcp.context import ServerContext
+
+
+@pytest.fixture()
+def provider(integration_manifest: Path) -> CoSILRepositoryProvider:
+    return CoSILRepositoryProvider.from_manifest(integration_manifest)
+
+
+def test_provider_loads_only_symbol_graph(integration_manifest: Path) -> None:
+    with patch.object(ServerContext, "load", wraps=ServerContext.load) as load:
+        provider = CoSILRepositoryProvider.from_manifest(integration_manifest)
+
+    load.assert_called_once_with(
+        integration_manifest,
+        views=frozenset({"symbol_graph"}),
+    )
+    assert provider.context.symbol_graph is not None
+    assert provider.context.bm25 is None
+    assert provider.context.vector is None
+
+
+def test_tool_contract_is_pinned_and_independent() -> None:
+    schemas = get_cosil_tool_schemas()
+    assert COSIL_REVISION == "0568e423735b399d5b089996961fea9ae142e4c7"
+    assert [item["function"]["name"] for item in schemas] == [
+        "get_code_of_class",
+        "get_code_of_class_function",
+        "get_code_of_file_function",
+        "exit",
+    ]
+    assert schemas[0]["function"]["parameters"]["required"] == [
+        "file_name",
+        "class_name",
+    ]
+
+    schemas[0]["function"]["name"] = "changed"
+    assert get_cosil_tool_schemas()[0]["function"]["name"] == "get_code_of_class"
+
+
+def test_project_structure_keeps_cosil_python_boundary(
+    provider: CoSILRepositoryProvider,
+) -> None:
+    assert provider.files == (
+        "src/model.py",
+        "src/other.py",
+        "src/service.py",
+    )
+    assert provider.project_structure() == (
+        "repo/\n"
+        "    src/\n"
+        "        model.py\n"
+        "        other.py\n"
+        "        service.py"
+    )
+
+
+def test_candidate_structure_matches_upstream_fields(
+    provider: CoSILRepositoryProvider,
+) -> None:
+    result = provider.candidate_structure(["src/service.py"])
+
+    assert "file: src/service.py" in result
+    assert "class: ['BillingService']" in result
+    assert "static functions:  ['helper']" in result
+    assert "BillingService: ['calculate_tax']" in result
+    assert "class fucntions:" in result
+
+
+def test_four_tool_provider_returns_exact_source(
+    provider: CoSILRepositoryProvider,
+) -> None:
+    class_source = provider.get_code_of_class("src/service.py", "BillingService")
+    method_source = provider.get_code_of_class_function(
+        "src/service.py",
+        "BillingService",
+        "calculate_tax",
+    )
+    function_source = provider.get_code_of_file_function(
+        "src/service.py",
+        "helper",
+    )
+
+    assert class_source.startswith("class BillingService:")
+    assert class_source.endswith("return helper(amount)")
+    assert method_source.startswith("    def calculate_tax")
+    assert method_source.endswith("return helper(amount)")
+    assert function_source == "def helper(amount):\n    return amount * 0.08"
+    assert provider.exit() == "Exiting tool calls. Now provide your final answer."
+
+
+def test_json_dispatch_does_not_evaluate_tool_calls(
+    provider: CoSILRepositoryProvider,
+) -> None:
+    result = provider.dispatch(
+        "get_code_of_class_function",
+        '{"file_name":"src/service.py","class_name":"BillingService",'
+        '"func_name":"calculate_tax"}',
+    )
+
+    assert "def calculate_tax" in result
+    with pytest.raises(KeyError, match="unknown CoSIL tool"):
+        provider.dispatch("bash", {})
+    with pytest.raises(ValueError, match="valid JSON"):
+        provider.dispatch("get_code_of_class", "{")
+    with pytest.raises(ValueError, match="decode to an object"):
+        provider.dispatch("get_code_of_class", "[]")
+
+
+def test_invalid_symbol_preserves_upstream_observation(
+    provider: CoSILRepositoryProvider,
+) -> None:
+    assert provider.get_code_of_class("src/service.py", "Missing") == (
+        "You provide a wrong file name or class name. Please try another file "
+        "name again."
+    )
+    assert provider.get_code_of_file_function("src/service.py", "Missing") == (
+        "You provide a wrong file name or function name. Please try another "
+        "file name again. It may be a class function."
+    )
+
+
+def test_outline_preserves_cosil_function_classification() -> None:
+    outline = CoSILRepositoryProvider._parse_outline(
+        "module.py",
+        """
+class Service:
+    def run(self):
+        return helper()
+
+def helper():
+    return 1
+
+async def ignored_by_upstream():
+    return 2
+""".strip(),
+    )
+
+    assert outline is not None
+    assert [item.name for item in outline.classes] == ["Service"]
+    assert [item.name for item in outline.classes[0].methods] == ["run"]
+    assert [item.name for item in outline.functions] == ["helper"]
+
+
+def test_outline_preserves_upstream_traversal_order() -> None:
+    outline = CoSILRepositoryProvider._parse_outline(
+        "module.py",
+        """
+def shared():
+    return 1
+
+class Service:
+    def shared(self):
+        return 2
+""".strip(),
+    )
+
+    assert outline is not None
+    assert [item.name for item in outline.classes[0].methods] == ["shared"]
+    assert [item.name for item in outline.functions] == ["shared"]

--- a/test/integrations/test_cosil.py
+++ b/test/integrations/test_cosil.py
@@ -70,6 +70,20 @@ def test_project_structure_keeps_cosil_python_boundary(
     )
 
 
+def test_resolve_files_prefers_valid_path_before_root_prefix(
+    provider: CoSILRepositoryProvider,
+    monkeypatch,
+) -> None:
+    provider._files = ("repo/module.py",)
+    monkeypatch.setattr(
+        provider.repository,
+        "find_files",
+        lambda value: [value] if value == "repo/module.py" else [],
+    )
+
+    assert provider.resolve_files(["repo/module.py"]) == ("repo/module.py",)
+
+
 def test_candidate_structure_matches_upstream_fields(
     provider: CoSILRepositoryProvider,
 ) -> None:

--- a/test/integrations/test_cosil.py
+++ b/test/integrations/test_cosil.py
@@ -201,3 +201,26 @@ class Service:
     assert outline is not None
     assert [item.name for item in outline.classes[0].methods] == ["shared"]
     assert [item.name for item in outline.functions] == ["shared"]
+
+
+def test_outline_limits_static_functions_to_module_scope() -> None:
+    outline = CoSILRepositoryProvider._parse_outline(
+        "module.py",
+        """
+class Service:
+    def shared(self):
+        return 1
+
+def shared():
+    return 2
+
+def outer():
+    def nested():
+        return 3
+    return nested()
+""".strip(),
+    )
+
+    assert outline is not None
+    assert [item.name for item in outline.classes[0].methods] == ["shared"]
+    assert [item.name for item in outline.functions] == ["shared", "outer"]

--- a/test/integrations/test_cosil.py
+++ b/test/integrations/test_cosil.py
@@ -72,16 +72,21 @@ def test_project_structure_keeps_cosil_python_boundary(
 
 def test_resolve_files_prefers_valid_path_before_root_prefix(
     provider: CoSILRepositoryProvider,
-    monkeypatch,
 ) -> None:
     provider._files = ("repo/module.py",)
-    monkeypatch.setattr(
-        provider.repository,
-        "find_files",
-        lambda value: [value] if value == "repo/module.py" else [],
-    )
 
     assert provider.resolve_files(["repo/module.py"]) == ("repo/module.py",)
+    assert provider.resolve_files(["repo/repo/module.py"]) == ("repo/module.py",)
+
+
+def test_resolve_files_rejects_inexact_directories(
+    provider: CoSILRepositoryProvider,
+) -> None:
+    assert provider.resolve_files(["wrong/service.py"]) == ()
+    assert provider.get_code_of_file_function("wrong/service.py", "helper") == (
+        "You provide a wrong file name or function name. Please try another "
+        "file name again. It may be a class function."
+    )
 
 
 def test_candidate_structure_matches_upstream_fields(

--- a/test/integrations/test_cosil.py
+++ b/test/integrations/test_cosil.py
@@ -70,6 +70,15 @@ def test_project_structure_keeps_cosil_python_boundary(
     )
 
 
+def test_default_filter_keeps_production_test_packages(
+    provider: CoSILRepositoryProvider,
+) -> None:
+    assert provider._accept_file("django/test/client.py")
+    assert not provider._accept_file("tests/client.py")
+    assert not provider._accept_file("django/tests/client.py")
+    assert not provider._accept_file("django/test_client.py")
+
+
 def test_resolve_files_prefers_valid_path_before_root_prefix(
     provider: CoSILRepositoryProvider,
 ) -> None:

--- a/test/integrations/test_cosil_policy.py
+++ b/test/integrations/test_cosil_policy.py
@@ -103,6 +103,18 @@ class _ToolReasoningRejectingCompletions(_Completions):
         return super().create(**request)
 
 
+class _AlwaysToolReasoningRejectingCompletions(_Completions):
+    def __init__(self, responses: list[dict]) -> None:
+        super().__init__(responses)
+        self.attempts: list[dict] = []
+
+    def create(self, **request):
+        self.attempts.append(request)
+        if request.get("tools"):
+            raise _ToolReasoningError
+        return super().create(**request)
+
+
 def test_file_parser_requires_balanced_fences_and_known_paths() -> None:
     valid = ("src/service.py", "src/model.py")
 
@@ -122,6 +134,11 @@ def test_file_parser_requires_balanced_fences_and_known_paths() -> None:
         )
         == ()
     )
+    assert parse_cosil_files(
+        "```\ndjango/db/models.py\n```",
+        valid_files=("django/db/models.py",),
+        root_name="django",
+    ) == ("django/db/models.py",)
 
 
 def test_xml_parser_is_structured_and_candidate_bounded() -> None:
@@ -158,6 +175,23 @@ def test_xml_parser_is_structured_and_candidate_bounded() -> None:
         )
         == ()
     )
+
+
+def test_xml_parser_preserves_same_named_root_and_limits_to_five() -> None:
+    locations = "".join(
+        "<location><file>django/db/models.py</file><type>function</type>"
+        f"<name>candidate_{index}</name></location>"
+        for index in range(6)
+    )
+
+    result = parse_cosil_locations(
+        f"<locations>{locations}</locations>",
+        valid_files=("django/db/models.py",),
+        root_name="django",
+    )
+
+    assert len(result) == 5
+    assert all(item.file_path == "django/db/models.py" for item in result)
 
 
 def test_native_policy_runs_reflection_tools_and_xml_summary(
@@ -229,6 +263,7 @@ def test_native_policy_runs_reflection_tools_and_xml_summary(
     ]
     assert "def calculate_tax" in requests[3]["messages"][-1]["content"]
     assert "Relevant code retrieved" in requests[4]["messages"][1]["content"]
+    assert '"file_name": "src/service.py"' in requests[4]["messages"][1]["content"]
 
 
 def test_failed_reflection_keeps_initial_file_candidates(
@@ -330,6 +365,39 @@ def test_policy_disables_reasoning_when_tools_require_it(
     assert tool_attempts[1]["reasoning_effort"] == "none"
 
 
+def test_policy_bounds_reasoning_fallback_retry(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.cosil_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    completions = _AlwaysToolReasoningRejectingCompletions(
+        [
+            {"content": "```\nsrc/model.py\n```"},
+            {"content": "```\nsrc/model.py\n```"},
+        ]
+    )
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    agent = CoSILAgent(
+        model="reasoning-model",
+        manifest_path=integration_manifest,
+        max_tool_rounds=1,
+        prune_tool_results=False,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix tax model", manifest.repo_path))
+
+    assert result.success is False
+    tool_attempts = [item for item in completions.attempts if item.get("tools")]
+    assert len(tool_attempts) == 2
+    assert "reasoning_effort" not in tool_attempts[0]
+    assert tool_attempts[1]["reasoning_effort"] == "none"
+
+
 def test_prune_false_masks_code_before_next_main_round(
     integration_manifest: Path,
     monkeypatch,
@@ -352,7 +420,16 @@ def test_prune_false_masks_code_before_next_main_round(
                     )
                 ]
             },
-            {"content": "I inspected the function"},
+            {
+                "tool_calls": [
+                    _tool_call(
+                        "prune-1",
+                        "get_code_of_class",
+                        '{"file_name":"src/service.py",'
+                        '"class_name":"BillingService"}',
+                    )
+                ]
+            },
             {"content": "```\nFalse\n```"},
             {"tool_calls": [_tool_call("main-2", "exit")]},
             {"content": "<locations></locations>"},
@@ -370,6 +447,12 @@ def test_prune_false_masks_code_before_next_main_round(
     result = asyncio.run(agent.locate_code("Fix tax helper", manifest.repo_path))
 
     assert result.success is True
+    assert result.usage["tool_calls"] == 3
+    assert [item["phase"] for item in result.raw_output["tool_trace"]] == [
+        "location",
+        "prune",
+        "location",
+    ]
     requests = client.chat.completions.requests
     next_main_messages = requests[5]["messages"]
     assert "not related to the bug" in next_main_messages[-1]["content"]

--- a/test/integrations/test_cosil_policy.py
+++ b/test/integrations/test_cosil_policy.py
@@ -8,13 +8,14 @@ import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
-from codenib.clients.cosil_agent import CoSILAgent
+from codenib.clients.cosil_agent import CoSILAgent, cosil_locations_to_baseline
 from codenib.compiler.manifest import RepoManifest
 from codenib.eval.benchmarks.cosil import (
     CoSILLocation,
     parse_cosil_files,
     parse_cosil_locations,
 )
+from codenib.integrations.cosil import CoSILRepositoryProvider
 
 
 def _tool_call(call_id: str, name: str, arguments: str = "{}") -> SimpleNamespace:
@@ -221,6 +222,37 @@ def test_xml_parser_preserves_same_named_root_and_limits_to_five() -> None:
 
     assert len(result) == 5
     assert all(item.file_path == "django/db/models.py" for item in result)
+
+
+def test_baseline_conversion_rejects_unresolved_xml_symbols(
+    integration_manifest: Path,
+) -> None:
+    provider = CoSILRepositoryProvider.from_manifest(integration_manifest)
+
+    result = cosil_locations_to_baseline(
+        (
+            CoSILLocation(
+                file_path="src/service.py",
+                kind="function",
+                name="BillingService.calculate_tax",
+            ),
+            CoSILLocation(
+                file_path="src/service.py",
+                kind="function",
+                name="calculate_tax",
+            ),
+            CoSILLocation(
+                file_path="src/service.py",
+                kind="class",
+                name="MissingService",
+            ),
+        ),
+        provider,
+    )
+
+    assert len(result) == 1
+    assert result[0].name == "BillingService.calculate_tax()"
+    assert result[0].type == "method"
 
 
 def test_native_policy_runs_reflection_tools_and_xml_summary(

--- a/test/integrations/test_cosil_policy.py
+++ b/test/integrations/test_cosil_policy.py
@@ -327,6 +327,54 @@ def test_native_policy_runs_reflection_tools_and_xml_summary(
     assert '"file_name": "src/service.py"' in requests[4]["messages"][1]["content"]
 
 
+def test_tool_context_budget_bounds_history_and_summary(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.cosil_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            {"content": "```\nsrc/service.py\n```"},
+            {"content": "```\nsrc/service.py\n```"},
+            {
+                "tool_calls": [
+                    _tool_call(
+                        "call-1",
+                        "get_code_of_file_function",
+                        '{"file_name":"src/service.py","func_name":"helper"}',
+                    )
+                ]
+            },
+            {"content": "No further tool calls"},
+            {"content": "<locations></locations>"},
+        ]
+    )
+    agent = CoSILAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_tool_rounds=2,
+        prune_tool_results=False,
+        max_tool_context_chars=24,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix helper", manifest.repo_path))
+
+    assert result.success is True
+    delivered = client.chat.completions.requests[3]["messages"][-1]["content"]
+    assert len(delivered) == 24
+    assert delivered.endswith("...[truncated]")
+    summary = client.chat.completions.requests[4]["messages"][1]["content"]
+    assert delivered in summary
+    trace = result.raw_output["tool_trace"][0]
+    assert trace["output_chars"] > trace["delivered_chars"] == 24
+    assert trace["truncated"] is True
+
+
 def test_failed_reflection_keeps_initial_file_candidates(
     integration_manifest: Path,
     monkeypatch,

--- a/test/integrations/test_cosil_policy.py
+++ b/test/integrations/test_cosil_policy.py
@@ -180,6 +180,11 @@ def test_xml_parser_is_structured_and_candidate_bounded() -> None:
             <type>function</type>
             <name>hallucinated</name>
           </location>
+          <location>
+            <file>src/service.py</file>
+            <type>variable</type>
+            <name>unsupported</name>
+          </location>
         </locations>
         """,
         valid_files=("src/service.py",),

--- a/test/integrations/test_cosil_policy.py
+++ b/test/integrations/test_cosil_policy.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from codenib.clients.cosil_agent import CoSILAgent
+from codenib.compiler.manifest import RepoManifest
+from codenib.eval.benchmarks.cosil import (
+    CoSILLocation,
+    parse_cosil_files,
+    parse_cosil_locations,
+)
+
+
+def _tool_call(call_id: str, name: str, arguments: str = "{}") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+class _Completions:
+    def __init__(self, responses: list[dict]) -> None:
+        self.responses = responses
+        self.requests: list[dict] = []
+
+    def create(self, **request):
+        self.requests.append(request)
+        response = self.responses.pop(0)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        role="assistant",
+                        content=response.get("content", ""),
+                        tool_calls=response.get("tool_calls"),
+                    )
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=2,
+                prompt_tokens_details=SimpleNamespace(cached_tokens=1),
+            ),
+        )
+
+
+class _Client:
+    def __init__(self, responses: list[dict]) -> None:
+        self.chat = SimpleNamespace(completions=_Completions(responses))
+
+
+class _UnsupportedTemperatureError(Exception):
+    body = {
+        "error": {
+            "message": "Unsupported value for temperature",
+            "param": "temperature",
+            "code": "unsupported_value",
+        }
+    }
+
+
+class _TemperatureRejectingCompletions(_Completions):
+    def __init__(self, responses: list[dict]) -> None:
+        super().__init__(responses)
+        self.attempts: list[dict] = []
+        self.rejected = False
+
+    def create(self, **request):
+        self.attempts.append(request)
+        if "temperature" in request and not self.rejected:
+            self.rejected = True
+            raise _UnsupportedTemperatureError
+        return super().create(**request)
+
+
+class _ToolReasoningError(Exception):
+    body = {
+        "error": {
+            "message": "Function tools with reasoning_effort are not supported",
+            "param": "reasoning_effort",
+        }
+    }
+
+
+class _ToolReasoningRejectingCompletions(_Completions):
+    def __init__(self, responses: list[dict]) -> None:
+        super().__init__(responses)
+        self.attempts: list[dict] = []
+        self.rejected = False
+
+    def create(self, **request):
+        self.attempts.append(request)
+        if request.get("tools") and not self.rejected:
+            self.rejected = True
+            raise _ToolReasoningError
+        return super().create(**request)
+
+
+def test_file_parser_requires_balanced_fences_and_known_paths() -> None:
+    valid = ("src/service.py", "src/model.py")
+
+    assert (
+        parse_cosil_files(
+            "```\nrepo/src/service.py\nsrc/model.py\nmissing.py\n```",
+            valid_files=valid,
+            root_name="repo",
+        )
+        == valid
+    )
+    assert (
+        parse_cosil_files(
+            "```\nsrc/service.py",
+            valid_files=valid,
+            root_name="repo",
+        )
+        == ()
+    )
+
+
+def test_xml_parser_is_structured_and_candidate_bounded() -> None:
+    result = parse_cosil_locations(
+        """
+        analysis before XML
+        <locations>
+          <location>
+            <file>src/service.py</file>
+            <type>function</type>
+            <name>BillingService.calculate_tax</name>
+          </location>
+          <location>
+            <file>outside.py</file>
+            <type>function</type>
+            <name>hallucinated</name>
+          </location>
+        </locations>
+        """,
+        valid_files=("src/service.py",),
+    )
+
+    assert result == (
+        CoSILLocation(
+            file_path="src/service.py",
+            kind="function",
+            name="BillingService.calculate_tax",
+        ),
+    )
+    assert (
+        parse_cosil_locations(
+            "<locations><location></locations>",
+            valid_files=("src/service.py",),
+        )
+        == ()
+    )
+
+
+def test_native_policy_runs_reflection_tools_and_xml_summary(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.cosil_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            {"content": "```\nrepo/src/service.py\n```"},
+            {"content": "```\nsrc/service.py\n```"},
+            {
+                "tool_calls": [
+                    _tool_call(
+                        "call-1",
+                        "get_code_of_class_function",
+                        '{"file_name":"src/service.py",'
+                        '"class_name":"BillingService",'
+                        '"func_name":"calculate_tax"}',
+                    )
+                ]
+            },
+            {"tool_calls": [_tool_call("call-2", "exit")]},
+            {
+                "content": (
+                    "<locations><location><file>src/service.py</file>"
+                    "<type>function</type>"
+                    "<name>BillingService.calculate_tax</name>"
+                    "</location></locations>"
+                )
+            },
+        ]
+    )
+    agent = CoSILAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_tool_rounds=2,
+        prune_tool_results=False,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(
+        agent.locate_code("Tax calculations are wrong", manifest.repo_path)
+    )
+
+    assert result.success is True
+    assert len(result.locations) == 1
+    location = result.locations[0]
+    assert location.file_path == "src/service.py"
+    assert location.name == "BillingService.calculate_tax()"
+    assert location.type == "method"
+    assert (location.line_start, location.line_end) == (2, 4)
+    assert result.usage["model_calls"] == 5
+    assert result.usage["tool_calls"] == 2
+    assert result.usage["total_tokens"] == 60
+
+    requests = client.chat.completions.requests
+    assert "Import Relations" in requests[1]["messages"][0]["content"]
+    assert "BillingService: ['calculate_tax']" in requests[2]["messages"][1]["content"]
+    assert [item["function"]["name"] for item in requests[2]["tools"]] == [
+        "get_code_of_class",
+        "get_code_of_class_function",
+        "get_code_of_file_function",
+        "exit",
+    ]
+    assert "def calculate_tax" in requests[3]["messages"][-1]["content"]
+    assert "Relevant code retrieved" in requests[4]["messages"][1]["content"]
+
+
+def test_failed_reflection_keeps_initial_file_candidates(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.cosil_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            {"content": "```\nsrc/model.py\n```"},
+            {"content": "Unable to format a reflection"},
+            {"content": "No tool call"},
+            {"content": "Malformed summary"},
+        ]
+    )
+    agent = CoSILAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_tool_rounds=1,
+        prune_tool_results=False,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix tax model", manifest.repo_path))
+
+    assert result.success is True
+    assert [location.file_path for location in result.locations] == ["src/model.py"]
+    assert result.raw_output["candidate_files"] == ["src/model.py"]
+
+
+def test_policy_retries_without_unsupported_temperature(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.cosil_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    completions = _TemperatureRejectingCompletions(
+        [
+            {"content": "```\nsrc/model.py\n```"},
+            {"content": "```\nsrc/model.py\n```"},
+            {"content": "No tool call"},
+            {"content": "<locations></locations>"},
+        ]
+    )
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    agent = CoSILAgent(
+        model="reasoning-model",
+        manifest_path=integration_manifest,
+        max_tool_rounds=1,
+        prune_tool_results=False,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix tax model", manifest.repo_path))
+
+    assert result.success is True
+    assert "temperature" in completions.attempts[0]
+    assert all("temperature" not in item for item in completions.attempts[1:])
+
+
+def test_policy_disables_reasoning_when_tools_require_it(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.cosil_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    completions = _ToolReasoningRejectingCompletions(
+        [
+            {"content": "```\nsrc/model.py\n```"},
+            {"content": "```\nsrc/model.py\n```"},
+            {"content": "No tool call"},
+            {"content": "<locations></locations>"},
+        ]
+    )
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    agent = CoSILAgent(
+        model="reasoning-model",
+        manifest_path=integration_manifest,
+        max_tool_rounds=1,
+        prune_tool_results=False,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix tax model", manifest.repo_path))
+
+    assert result.success is True
+    tool_attempts = [item for item in completions.attempts if item.get("tools")]
+    assert "reasoning_effort" not in tool_attempts[0]
+    assert tool_attempts[1]["reasoning_effort"] == "none"
+
+
+def test_prune_false_masks_code_before_next_main_round(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.cosil_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    client = _Client(
+        [
+            {"content": "```\nsrc/service.py\n```"},
+            {"content": "```\nsrc/service.py\n```"},
+            {
+                "tool_calls": [
+                    _tool_call(
+                        "main-1",
+                        "get_code_of_file_function",
+                        '{"file_name":"src/service.py","func_name":"helper"}',
+                    )
+                ]
+            },
+            {"content": "I inspected the function"},
+            {"content": "```\nFalse\n```"},
+            {"tool_calls": [_tool_call("main-2", "exit")]},
+            {"content": "<locations></locations>"},
+        ]
+    )
+    agent = CoSILAgent(
+        model="test-model",
+        manifest_path=integration_manifest,
+        max_tool_rounds=2,
+        prune_tool_results=True,
+        max_prune_rounds=1,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix tax helper", manifest.repo_path))
+
+    assert result.success is True
+    requests = client.chat.completions.requests
+    next_main_messages = requests[5]["messages"]
+    assert "not related to the bug" in next_main_messages[-1]["content"]
+    summary = requests[6]["messages"][1]["content"]
+    assert "Relevant code retrieved" not in summary

--- a/test/integrations/test_cosil_policy.py
+++ b/test/integrations/test_cosil_policy.py
@@ -66,6 +66,10 @@ class _UnsupportedTemperatureError(Exception):
     }
 
 
+class _UnsupportedMaxCompletionTokensError(TypeError):
+    pass
+
+
 class _TemperatureRejectingCompletions(_Completions):
     def __init__(self, responses: list[dict]) -> None:
         super().__init__(responses)
@@ -77,6 +81,22 @@ class _TemperatureRejectingCompletions(_Completions):
         if "temperature" in request and not self.rejected:
             self.rejected = True
             raise _UnsupportedTemperatureError
+        return super().create(**request)
+
+
+class _MaxCompletionTokensRejectingCompletions(_Completions):
+    def __init__(self, responses: list[dict]) -> None:
+        super().__init__(responses)
+        self.attempts: list[dict] = []
+        self.rejected = False
+
+    def create(self, **request):
+        self.attempts.append(request)
+        if "max_completion_tokens" in request and not self.rejected:
+            self.rejected = True
+            raise _UnsupportedMaxCompletionTokensError(
+                "create() got an unexpected keyword argument 'max_completion_tokens'"
+            )
         return super().create(**request)
 
 
@@ -139,6 +159,10 @@ def test_file_parser_requires_balanced_fences_and_known_paths() -> None:
         valid_files=("django/db/models.py",),
         root_name="django",
     ) == ("django/db/models.py",)
+    assert parse_cosil_files(
+        "```\n.github/scripts/check.py\n```",
+        valid_files=(".github/scripts/check.py",),
+    ) == (".github/scripts/check.py",)
 
 
 def test_xml_parser_is_structured_and_candidate_bounded() -> None:
@@ -329,6 +353,40 @@ def test_policy_retries_without_unsupported_temperature(
     assert result.success is True
     assert "temperature" in completions.attempts[0]
     assert all("temperature" not in item for item in completions.attempts[1:])
+
+
+def test_policy_retries_with_legacy_max_tokens(
+    integration_manifest: Path,
+    monkeypatch,
+) -> None:
+    manifest = RepoManifest.load(integration_manifest)
+    monkeypatch.setattr(
+        "codenib.clients.cosil_agent.select_checkout_manifest",
+        lambda *_args, **_kwargs: integration_manifest,
+    )
+    completions = _MaxCompletionTokensRejectingCompletions(
+        [
+            {"content": "```\nsrc/model.py\n```"},
+            {"content": "```\nsrc/model.py\n```"},
+            {"content": "No tool call"},
+            {"content": "<locations></locations>"},
+        ]
+    )
+    client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+    agent = CoSILAgent(
+        model="legacy-sdk-model",
+        manifest_path=integration_manifest,
+        max_tool_rounds=1,
+        prune_tool_results=False,
+        client_factory=lambda: client,
+    )
+
+    result = asyncio.run(agent.locate_code("Fix tax model", manifest.repo_path))
+
+    assert result.success is True
+    assert "max_completion_tokens" in completions.attempts[0]
+    assert "max_tokens" in completions.attempts[1]
+    assert all("max_completion_tokens" not in item for item in completions.attempts[1:])
 
 
 def test_policy_disables_reasoning_when_tools_require_it(

--- a/test/integrations/test_cosil_upstream.py
+++ b/test/integrations/test_cosil_upstream.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional source-level probes for the pinned CoSIL policy contract."""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codenib.clients import cosil_protocol
+from codenib.integrations.cosil import COSIL_REVISION, get_cosil_tool_schemas
+
+pytestmark = pytest.mark.integration
+
+
+def _git_show(checkout: Path, path: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(checkout), "show", f"{COSIL_REVISION}:{path}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"{checkout} does not contain {path} at {COSIL_REVISION}")
+    return result.stdout
+
+
+def _static_assignments(source: str) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for node in ast.parse(source).body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        try:
+            values[target.id] = ast.literal_eval(node.value)
+        except (ValueError, TypeError):
+            continue
+    return values
+
+
+@pytest.fixture(scope="module")
+def upstream_sources() -> dict[str, str]:
+    raw_checkout = os.environ.get("COSIL_CHECKOUT")
+    if not raw_checkout:
+        pytest.skip("set COSIL_CHECKOUT for the upstream CoSIL probe")
+    checkout = Path(raw_checkout).expanduser().resolve()
+    if not (checkout / ".git").exists():
+        pytest.fail("COSIL_CHECKOUT must point to a Git checkout")
+    return {
+        "prompts": _git_show(checkout, "CoSIL/fl/FL_prompt.py"),
+        "tools": _git_show(checkout, "CoSIL/fl/FL_tools.py"),
+        "file_runner": _git_show(checkout, "CoSIL/fl/CoSIL_localize_file.py"),
+        "function_runner": _git_show(
+            checkout,
+            "CoSIL/fl/CoSIL_localize_func.py",
+        ),
+    }
+
+
+def test_vendored_tool_schemas_match_pinned_source(
+    upstream_sources: dict[str, str],
+) -> None:
+    values = _static_assignments(upstream_sources["tools"])
+
+    assert get_cosil_tool_schemas() == values["CoSIL_LOCATION_TOOL_SCHEMAS"]
+
+
+def test_vendored_prompts_match_pinned_source(
+    upstream_sources: dict[str, str],
+) -> None:
+    values = _static_assignments(upstream_sources["prompts"])
+    expected = {
+        "_BUG_REPORT": "bug_report_template",
+        "_BUG_REPORT_NO_STRUCTURE": "bug_report_template_wo_repo_struct",
+        "_FILE_SYSTEM": "file_system_prompt_without_tool",
+        "_FILE_GUIDANCE": "file_guidence_prmpt_without_tool",
+        "_FILE_SUMMARY": "file_summary",
+        "_FORMAT_CORRECT": "format_correct_prompt",
+        "_FILE_REFLECTION": "file_reflection_prompt",
+        "_LOCATION_SYSTEM": "location_system_prompt",
+        "_LOCATION_GUIDANCE": "location_guidence_prmpt",
+        "_LOCATION_SUMMARY": "location_summary",
+    }
+
+    assert cosil_protocol.COSIL_PROTOCOL_REVISION == COSIL_REVISION
+    for local_name, upstream_name in expected.items():
+        assert getattr(cosil_protocol, local_name) == values[upstream_name]
+
+
+def test_supported_boundary_matches_upstream_rq1_scripts(
+    upstream_sources: dict[str, str],
+) -> None:
+    assert "file_localize_with_g" in upstream_sources["file_runner"]
+    assert "localize_with_p" in upstream_sources["function_runner"]


### PR DESCRIPTION
## Summary
Add a revision-pinned, CodeNib-native implementation of CoSIL's public RQ1 file/function localization path. It reuses the manifest-backed symbol graph and source checkout, without importing CoSIL or building its per-instance `repo_structures` artifact.

## Changes
- Add the pinned four-tool repository provider with selective symbol-graph loading and lazy Python AST outlines.
- Vendor CoSIL's file ranking, import reflection, function-tool, prune, and XML-summary protocol at revision `0568e423735b399d5b089996961fea9ae142e4c7`.
- Add OpenAI-compatible model capability fallback for unsupported temperature and reasoning-with-tools parameters.
- Bound retrieved source with a shared execution budget and expose truncation in the tool trace.
- Normalize CoSIL locations into the shared baseline result contract and add a common-runner CLI.
- Document the supported RQ1 boundary; line localization, patch generation, and test validation remain out of scope.
- Add provider, policy, parser, and pinned-source drift tests.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2523 passed, 10 skipped, 183 deselected`)
- `COSIL_CHECKOUT=/mnt/data/codeminer/upstreams/CoSIL pytest -q test/integrations/test_cosil.py test/integrations/test_cosil_policy.py test/integrations/test_cosil_upstream.py --tb=short` (`28 passed`)
- `pre-commit run --files codenib/clients/cosil_agent.py codenib/integrations/cosil.py examples/cosil_loc_agent.py test/integrations/test_cosil.py test/integrations/test_cosil_policy.py`
- `mkdocs build --strict`
- Differential check against pinned `parse_python_file`: `1791/1791` exact files across Requests, Flask, Django, SymPy, and Pylint SWE-bench Lite snapshots.
- Live `gpt-5.6-luna` smoke on `psf__requests-1963`: completed the default prune/tool/summary path and ranked the gold function `SessionRedirectMixin.resolve_redirects` first. This is an execution smoke, not a localization benchmark.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published