### PR TITLE
feat(agent): add native repository explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ agent or code-Wiki framework.
 
 ## News
 
-- **2026-08-03 — SWE-Explore benchmark compatibility.**
-  [`CodeNibSWEExploreExplorer`](codenib/integrations/swe_explore.py) serves the
-  official ranked-region contract from a manifest-backed BM25 view. A strict
-  [20-case, seven-language validation](docs/evaluation/swe_explore.md)
-  completed every case and matched all 1,020 real-output metric values from the
-  pinned official evaluator.
+- **2026-08-04 — Native repository explorer.**
+  [`RepositoryContextExplorer`](codenib/agent/runtime/explorer.py) plans BM25,
+  dense, hybrid, reranked, and graph routes over manifest-backed views and
+  loads only the route selected for each query. SWE-Explore is now a thin
+  ranked-region benchmark adapter; its existing
+  [20-case validation](docs/evaluation/swe_explore.md) remains an explicitly
+  labeled BM25 compatibility control.
 - **2026-08-03 — Native LocAgent policy.**
   [`LocAgentAgent`](codenib/clients/locagent_agent.py) runs pinned prompts and
   function calls over [`LocAgentToolProvider`](codenib/integrations/locagent.py),
@@ -142,6 +143,20 @@ locations for follow-up reads and citations. See
 [MCP Server](https://docs.codenib.ai/mcp/)
 for client configuration and tool contracts.
 
+The same planner is available directly to Python agents:
+
+```python
+from codenib.agent import RepositoryContextExplorer
+
+with RepositoryContextExplorer.from_repository(
+    "/path/to/repository", policy="auto"
+) as explorer:
+    result = explorer.explore("where is request retry behavior implemented?", top_k=10)
+```
+
+Each result includes source-validated evidence plus the selected plan,
+capabilities, loaded views, fusion, graph, and reranking trace.
+
 ## What CodeNib Provides
 
 | Surface | Purpose |
@@ -151,7 +166,8 @@ for client configuration and tool contracts.
 | Retrieval | BM25, dense-vector, regex/trigram, Zoekt, fusion, and reranking paths |
 | Structural context | SCIP/LSP-backed symbol graphs with source locations and typed edges |
 | MCP and LSP-shaped tools | Serve one manifest to coding agents without tying the runtime to one agent framework |
-| External integrations | Run revision-pinned LocAgent and OrcaLoca policies and serve SWE-Explore's explorer contract over the same manifest-backed views |
+| External integrations | Run revision-pinned LocAgent and OrcaLoca policies over the same manifest-backed views |
+| Benchmark adapters | Project native CodeNib evidence into pinned external data and scorer contracts such as SWE-Explore |
 | Local inspection | Audit the same context through Wiki pages, Ask answers, citations, and the Dependency Map |
 | Evaluation harness | Measure retrieval, navigation, incremental maintenance, and context policies on the same artifacts |
 

--- a/codenib/agent/__init__.py
+++ b/codenib/agent/__init__.py
@@ -59,10 +59,19 @@ if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
     )
     from codenib.agent.runtime import (
         AGENT_TRACE_SCHEMA_VERSION,
+        REPOSITORY_EXPLORER_POLICIES,
         AgentRunTrace,
         AgentTraceEvent,
         ContextLedger,
         ContextLedgerEntry,
+        RepositoryContextExplorer,
+        RepositoryEvidence,
+        RepositoryExplorePreparation,
+        RepositoryExplorerCapabilityError,
+        RepositoryExploreResult,
+        RepositoryExploreTrace,
+        normalize_repository_explorer_policy,
+        repository_explorer_build_views,
     )
     from codenib.agent.tool_schema import registry_to_tools, skill_to_tool_schema
 
@@ -156,6 +165,39 @@ _EXPORTS = {
     "AgentTraceEvent": ("codenib.agent.runtime", "AgentTraceEvent"),
     "ContextLedger": ("codenib.agent.runtime", "ContextLedger"),
     "ContextLedgerEntry": ("codenib.agent.runtime", "ContextLedgerEntry"),
+    "REPOSITORY_EXPLORER_POLICIES": (
+        "codenib.agent.runtime",
+        "REPOSITORY_EXPLORER_POLICIES",
+    ),
+    "RepositoryContextExplorer": (
+        "codenib.agent.runtime",
+        "RepositoryContextExplorer",
+    ),
+    "RepositoryEvidence": ("codenib.agent.runtime", "RepositoryEvidence"),
+    "RepositoryExplorePreparation": (
+        "codenib.agent.runtime",
+        "RepositoryExplorePreparation",
+    ),
+    "RepositoryExploreResult": (
+        "codenib.agent.runtime",
+        "RepositoryExploreResult",
+    ),
+    "RepositoryExploreTrace": (
+        "codenib.agent.runtime",
+        "RepositoryExploreTrace",
+    ),
+    "RepositoryExplorerCapabilityError": (
+        "codenib.agent.runtime",
+        "RepositoryExplorerCapabilityError",
+    ),
+    "normalize_repository_explorer_policy": (
+        "codenib.agent.runtime",
+        "normalize_repository_explorer_policy",
+    ),
+    "repository_explorer_build_views": (
+        "codenib.agent.runtime",
+        "repository_explorer_build_views",
+    ),
     "registry_to_tools": ("codenib.agent.tool_schema", "registry_to_tools"),
     "skill_to_tool_schema": (
         "codenib.agent.tool_schema",
@@ -182,6 +224,13 @@ __all__ = [
     "PlainChatHistory",
     "RerankAgent",
     "RerankResult",
+    "REPOSITORY_EXPLORER_POLICIES",
+    "RepositoryContextExplorer",
+    "RepositoryEvidence",
+    "RepositoryExplorePreparation",
+    "RepositoryExploreResult",
+    "RepositoryExploreTrace",
+    "RepositoryExplorerCapabilityError",
     "TokenBudgetedChatHistory",
     "ToolCallRecord",
     "StaticLSPProvider",
@@ -198,11 +247,13 @@ __all__ = [
     "is_specific_lsp_symbol_seed",
     "lsp_result_metadata",
     "normalize_lsp_route_seed_policy",
+    "normalize_repository_explorer_policy",
     "query",
     "rerank_nodes_with_query",
     "render_lsp_route_context",
     "registry_to_tools",
     "run_agent_in_directory",
+    "repository_explorer_build_views",
     "skill_to_tool_schema",
 ]
 

--- a/codenib/agent/runtime/__init__.py
+++ b/codenib/agent/runtime/__init__.py
@@ -4,13 +4,87 @@
 
 """Runtime support types for agent execution."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ..._lazy import exported_dir, load_export
 from .context import ContextLedger, ContextLedgerEntry
 from .trace import AGENT_TRACE_SCHEMA_VERSION, AgentRunTrace, AgentTraceEvent
 
+if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
+    from .explorer import (
+        REPOSITORY_EXPLORER_POLICIES,
+        RepositoryContextExplorer,
+        RepositoryEvidence,
+        RepositoryExplorePreparation,
+        RepositoryExplorerCapabilityError,
+        RepositoryExploreResult,
+        RepositoryExploreTrace,
+        normalize_repository_explorer_policy,
+        repository_explorer_build_views,
+    )
+
+_EXPORTS = {
+    "REPOSITORY_EXPLORER_POLICIES": (
+        "codenib.agent.runtime.explorer",
+        "REPOSITORY_EXPLORER_POLICIES",
+    ),
+    "RepositoryContextExplorer": (
+        "codenib.agent.runtime.explorer",
+        "RepositoryContextExplorer",
+    ),
+    "RepositoryEvidence": (
+        "codenib.agent.runtime.explorer",
+        "RepositoryEvidence",
+    ),
+    "RepositoryExplorePreparation": (
+        "codenib.agent.runtime.explorer",
+        "RepositoryExplorePreparation",
+    ),
+    "RepositoryExploreResult": (
+        "codenib.agent.runtime.explorer",
+        "RepositoryExploreResult",
+    ),
+    "RepositoryExploreTrace": (
+        "codenib.agent.runtime.explorer",
+        "RepositoryExploreTrace",
+    ),
+    "RepositoryExplorerCapabilityError": (
+        "codenib.agent.runtime.explorer",
+        "RepositoryExplorerCapabilityError",
+    ),
+    "normalize_repository_explorer_policy": (
+        "codenib.agent.runtime.explorer",
+        "normalize_repository_explorer_policy",
+    ),
+    "repository_explorer_build_views": (
+        "codenib.agent.runtime.explorer",
+        "repository_explorer_build_views",
+    ),
+}
+
 __all__ = [
     "AGENT_TRACE_SCHEMA_VERSION",
-    "ContextLedger",
     "AgentRunTrace",
     "AgentTraceEvent",
+    "ContextLedger",
     "ContextLedgerEntry",
+    "REPOSITORY_EXPLORER_POLICIES",
+    "RepositoryContextExplorer",
+    "RepositoryEvidence",
+    "RepositoryExplorePreparation",
+    "RepositoryExploreResult",
+    "RepositoryExploreTrace",
+    "RepositoryExplorerCapabilityError",
+    "normalize_repository_explorer_policy",
+    "repository_explorer_build_views",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    return load_export(globals(), _EXPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return exported_dir(globals(), _EXPORTS)

--- a/codenib/agent/runtime/explorer.py
+++ b/codenib/agent/runtime/explorer.py
@@ -1,0 +1,729 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Manifest-backed repository exploration for agent and benchmark clients."""
+
+from __future__ import annotations
+
+import math
+from contextlib import nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import Any, Mapping, Sequence
+
+from ...git_snapshot import normalize_repository_path
+from ...model.retrieval_planner import (
+    BudgetInput,
+    GraphExpansionPlan,
+    QuerySignals,
+    RetrievalBudget,
+    RetrievalCapabilities,
+    RetrievalPathPlan,
+    RetrievalPlanner,
+    RetrievalStagePlan,
+)
+from ...types import QueriedNode
+
+REPOSITORY_EXPLORER_POLICIES = frozenset(
+    {"auto", "bm25", "dense", "hybrid", "hybrid_rerank", "graph"}
+)
+_NATIVE_VIEWS = ("bm25", "vector", "symbol_graph")
+_POLICY_VIEWS = {
+    "bm25": ("bm25",),
+    "dense": ("vector",),
+    "hybrid": ("bm25", "vector"),
+    "hybrid_rerank": ("bm25", "vector"),
+    "graph": ("bm25", "symbol_graph"),
+}
+
+
+class RepositoryExplorerCapabilityError(RuntimeError):
+    """The selected exploration policy cannot run over the manifest."""
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryEvidence:
+    """One ranked source span in CodeNib's 0-based coordinate system."""
+
+    path: str
+    start_line: int
+    end_line: int
+    score: float
+    node_name: str = ""
+    node_type: str = ""
+    node_id: str | None = None
+    content: str | None = None
+
+    def to_record(self) -> dict[str, str | int | float | None]:
+        return {
+            "path": self.path,
+            "start_line": self.start_line,
+            "end_line": self.end_line,
+            "score": self.score,
+            "node_name": self.node_name,
+            "node_type": self.node_type,
+            "node_id": self.node_id,
+            "content": self.content,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryExploreTrace:
+    """Planner and execution provenance for one exploration request."""
+
+    policy: str
+    plan: RetrievalPathPlan
+    signals: QuerySignals
+    budget: RetrievalBudget
+    capabilities: RetrievalCapabilities
+    advertised_views: tuple[str, ...]
+    loaded_views: tuple[str, ...]
+    stage_candidate_counts: tuple[tuple[str, int], ...]
+    retrieved_candidates: int
+    returned_evidence: int
+
+    def to_record(self) -> dict[str, Any]:
+        graph = self.plan.graph
+        return {
+            "policy": self.policy,
+            "plan": {
+                "name": self.plan.name,
+                "intent": self.plan.intent,
+                "stages": [stage.engine for stage in self.plan.stages],
+                "fusion": self.plan.fusion,
+                "rerank_strategy": self.plan.rerank_strategy,
+                "graph": (
+                    {
+                        "seed_top_k": graph.seed_top_k,
+                        "expand_top_k": graph.expand_top_k,
+                        "hops": graph.hops,
+                        "direction": graph.direction,
+                        "use_ppr": graph.use_ppr,
+                    }
+                    if graph is not None
+                    else None
+                ),
+                "rationale": self.plan.rationale,
+            },
+            "signals": {
+                "lexical": self.signals.lexical,
+                "semantic": self.signals.semantic,
+                "structural": self.signals.structural,
+                "mixed": self.signals.mixed,
+            },
+            "budget": {
+                "tier": self.budget.tier,
+                "retrieve_top_k": self.budget.retrieve_top_k,
+                "rerank_candidate_top_k": self.budget.rerank_candidate_top_k,
+            },
+            "capabilities": {
+                "dense": self.capabilities.has_dense,
+                "sparse": self.capabilities.has_sparse,
+                "graph": self.capabilities.has_graph,
+                "embedding_rerank": self.capabilities.has_embedding_rerank,
+            },
+            "advertised_views": list(self.advertised_views),
+            "loaded_views": list(self.loaded_views),
+            "stage_candidate_counts": dict(self.stage_candidate_counts),
+            "retrieved_candidates": self.retrieved_candidates,
+            "returned_evidence": self.returned_evidence,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryExplorePreparation:
+    """A deterministic query plan with all selected views loaded."""
+
+    query: str
+    plan: RetrievalPathPlan
+    signals: QuerySignals
+    budget: RetrievalBudget
+    capabilities: RetrievalCapabilities
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryExploreResult:
+    """Ranked repository evidence and the plan that produced it."""
+
+    evidence: tuple[RepositoryEvidence, ...]
+    trace: RepositoryExploreTrace | None
+
+    def to_record(self) -> dict[str, Any]:
+        return {
+            "evidence": [item.to_record() for item in self.evidence],
+            "trace": self.trace.to_record() if self.trace is not None else None,
+        }
+
+
+def normalize_repository_explorer_policy(value: str) -> str:
+    """Return the canonical repository-explorer policy name."""
+
+    normalized = str(value or "auto").strip().lower().replace("-", "_")
+    aliases = {"sparse": "bm25", "semantic": "dense", "rrf": "hybrid"}
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in REPOSITORY_EXPLORER_POLICIES:
+        supported = ", ".join(sorted(REPOSITORY_EXPLORER_POLICIES))
+        raise ValueError(
+            f"unknown repository explorer policy; choose from: {supported}"
+        )
+    return normalized
+
+
+def repository_explorer_build_views(policy: str) -> tuple[str, ...]:
+    """Return the deterministic materialization set for a benchmark policy."""
+
+    normalized = normalize_repository_explorer_policy(policy)
+    if normalized == "auto":
+        return _NATIVE_VIEWS
+    return _POLICY_VIEWS[normalized]
+
+
+class RepositoryContextExplorer:
+    """Plan and execute repository search over manifest-backed CodeNib views.
+
+    ``auto`` plans against manifest-advertised capabilities and loads only the
+    selected query path. Explicit policies provide stable ablation arms. The
+    class never materializes indexes; callers build views separately.
+    """
+
+    def __init__(
+        self,
+        context: Any,
+        *,
+        policy: str = "auto",
+        budget: BudgetInput = "balanced",
+        level: str = "l2",
+        _owns_context: bool = False,
+    ) -> None:
+        manifest = getattr(context, "manifest", None)
+        if manifest is None:
+            raise RepositoryExplorerCapabilityError("context has no manifest")
+        raw_root = str(getattr(manifest, "repo_path", "") or "").strip()
+        if not raw_root:
+            raise RepositoryExplorerCapabilityError("manifest has no repository path")
+        repo_root = Path(raw_root).expanduser().resolve()
+        if not repo_root.is_dir():
+            raise RepositoryExplorerCapabilityError(
+                f"manifest repository is not available: {repo_root}"
+            )
+        normalized_level = str(level or "l2").strip().lower()
+        if normalized_level not in {"l0", "l2"}:
+            raise ValueError("repository explorer level must be 'l0' or 'l2'")
+
+        self.context = context
+        self.repo_root = repo_root
+        self.policy = normalize_repository_explorer_policy(policy)
+        self.planner = RetrievalPlanner()
+        self.budget = self.planner.normalize_budget(budget)
+        self.level = normalized_level
+        self._owns_context = _owns_context
+        self._source_lines: dict[str, tuple[str, ...]] = {}
+        self._lock = RLock()
+        self._validate_advertised_policy()
+
+    @classmethod
+    def from_manifest(
+        cls,
+        manifest_path: str | Path,
+        *,
+        policy: str = "auto",
+        budget: BudgetInput = "balanced",
+        level: str = "l2",
+    ) -> RepositoryContextExplorer:
+        """Bind to a manifest without eagerly loading retrieval views."""
+
+        from ...mcp.context import ServerContext
+
+        context = ServerContext.load(manifest_path, views=())
+        return cls(
+            context,
+            policy=policy,
+            budget=budget,
+            level=level,
+            _owns_context=True,
+        )
+
+    @classmethod
+    def from_repository(
+        cls,
+        repo_path: str | Path,
+        *,
+        manifest_path: str | Path | None = None,
+        policy: str = "auto",
+        budget: BudgetInput = "balanced",
+        level: str = "l2",
+    ) -> RepositoryContextExplorer:
+        """Resolve the manifest bound to one checkout and create an explorer."""
+
+        from ...clients._manifest import select_checkout_manifest
+
+        selected = select_checkout_manifest(
+            repo_path,
+            integration_name="repository explorer",
+            manifest_path=manifest_path,
+        )
+        return cls.from_manifest(
+            selected,
+            policy=policy,
+            budget=budget,
+            level=level,
+        )
+
+    def close(self) -> None:
+        """Release resources loaded by a manifest-constructed explorer."""
+
+        if self._owns_context:
+            close = getattr(self.context, "close", None)
+            if callable(close):
+                close()
+
+    def __enter__(self) -> RepositoryContextExplorer:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def explore(
+        self,
+        query: str,
+        *,
+        top_k: int = 10,
+        include_content: bool = False,
+        budget: BudgetInput | None = None,
+    ) -> RepositoryExploreResult:
+        """Return bounded, source-validated evidence for one context request."""
+
+        _validate_top_k(top_k)
+        text = str(query or "").strip()
+        if top_k == 0 or not text:
+            return RepositoryExploreResult(evidence=(), trace=None)
+
+        with self._lock:
+            prepared = self.prepare(text, budget=budget)
+            active_budget = prepared.budget
+            signals = prepared.signals
+            plan = prepared.plan
+            capabilities = prepared.capabilities
+            vector = getattr(self.context, "vector", None)
+            reuse_query = getattr(vector, "reuse_query_embedding", None)
+            scope = reuse_query() if callable(reuse_query) else nullcontext()
+            with scope:
+                candidates, stage_counts = self._execute_plan(
+                    text,
+                    plan,
+                    top_k=top_k,
+                )
+            evidence = self._source_evidence(
+                candidates,
+                top_k=top_k,
+                include_content=include_content,
+            )
+            trace = RepositoryExploreTrace(
+                policy=self.policy,
+                plan=plan,
+                signals=signals,
+                budget=active_budget,
+                capabilities=capabilities,
+                advertised_views=tuple(sorted(self._advertised_views())),
+                loaded_views=tuple(sorted(self._loaded_views())),
+                stage_candidate_counts=tuple(stage_counts),
+                retrieved_candidates=len(candidates),
+                returned_evidence=len(evidence),
+            )
+            return RepositoryExploreResult(evidence=tuple(evidence), trace=trace)
+
+    def prepare(
+        self,
+        query: str,
+        *,
+        budget: BudgetInput | None = None,
+    ) -> RepositoryExplorePreparation:
+        """Plan a query and load only the views selected for that plan."""
+
+        text = str(query or "").strip()
+        if not text:
+            raise ValueError("repository explorer query must not be empty")
+        with self._lock:
+            active_budget = self.planner.normalize_budget(budget or self.budget)
+            plan, capabilities = self._select_and_load_plan(text, active_budget)
+            return RepositoryExplorePreparation(
+                query=text,
+                plan=plan,
+                signals=self.planner.classify_query(text),
+                budget=active_budget,
+                capabilities=capabilities,
+            )
+
+    def _validate_advertised_policy(self) -> None:
+        advertised = self._advertised_views()
+        if self.policy == "auto":
+            if not advertised.intersection({"bm25", "vector"}):
+                raise RepositoryExplorerCapabilityError(
+                    "auto exploration requires a current BM25 or vector view"
+                )
+            return
+        missing = set(_POLICY_VIEWS[self.policy]) - advertised
+        if missing:
+            raise RepositoryExplorerCapabilityError(
+                f"policy {self.policy!r} requires unavailable manifest views: "
+                + ", ".join(sorted(missing))
+            )
+
+    def _select_and_load_plan(
+        self,
+        query: str,
+        budget: RetrievalBudget,
+    ) -> tuple[RetrievalPathPlan, RetrievalCapabilities]:
+        if self.policy != "auto":
+            required = set(_POLICY_VIEWS[self.policy])
+            self._load_views(required)
+            missing = required - self._loaded_views()
+            if missing:
+                raise self._capability_error(missing)
+            capabilities = self._runtime_capabilities()
+            return _explicit_plan(self.policy, budget), capabilities
+
+        advertised = self._advertised_capabilities()
+        initial = self.planner.select(query, budget=budget, capabilities=advertised)
+        requested = _plan_views(initial)
+        self._load_views(requested)
+
+        capabilities = self._runtime_capabilities()
+        if not capabilities.has_dense and not capabilities.has_sparse:
+            alternatives = self._advertised_views().intersection({"bm25", "vector"})
+            self._load_views(alternatives - requested - self._loaded_views())
+            capabilities = self._runtime_capabilities()
+        if not capabilities.has_dense and not capabilities.has_sparse:
+            raise self._capability_error(requested)
+
+        plan = self.planner.select(query, budget=budget, capabilities=capabilities)
+        return plan, capabilities
+
+    def _execute_plan(
+        self,
+        query: str,
+        plan: RetrievalPathPlan,
+        *,
+        top_k: int,
+    ) -> tuple[list[QueriedNode], list[tuple[str, int]]]:
+        from ...ops.retrieve import merge_hybrid, to_queried_nodes
+
+        branches: list[list[QueriedNode]] = []
+        counts: list[tuple[str, int]] = []
+        for stage in plan.stages:
+            stage_top_k = max(top_k, stage.top_k or plan.retrieval_top_k)
+            if stage.engine == "sparse":
+                bm25 = getattr(self.context, "bm25", None)
+                if bm25 is None:
+                    raise RepositoryExplorerCapabilityError("BM25 view is not loaded")
+                max_k = getattr(bm25, "max_k", stage_top_k)
+                if isinstance(max_k, int) and max_k > 0:
+                    stage_top_k = min(stage_top_k, max_k)
+                raw = bm25.search(
+                    query=query,
+                    top_k=stage_top_k,
+                    return_code_content=False,
+                )
+            elif stage.engine == "dense":
+                vector = getattr(self.context, "vector", None)
+                if vector is None:
+                    raise RepositoryExplorerCapabilityError("vector view is not loaded")
+                raw = vector.search(query, top_k=stage_top_k, level=self.level)
+            else:
+                raise ValueError(f"unsupported retrieval engine: {stage.engine!r}")
+            branch = to_queried_nodes(raw)
+            branches.append(branch)
+            counts.append((stage.engine, len(branch)))
+
+        if len(branches) == 1:
+            candidates = branches[0]
+        else:
+            candidates = merge_hybrid(
+                branches,
+                weights=[stage.weight for stage in plan.stages],
+                top_k=plan.retrieval_top_k,
+                fusion=plan.fusion,
+            )
+
+        if plan.graph is not None:
+            candidates = self._expand_graph(plan.graph, candidates)
+            counts.append(("graph", len(candidates)))
+
+        if plan.enable_rerank and plan.rerank_strategy == "embedding":
+            from ...ops.rerank import rerank_by_indexed_embedding
+
+            candidate_top_k = plan.rerank_candidate_top_k or len(candidates)
+            candidates = rerank_by_indexed_embedding(
+                query,
+                candidates[: max(top_k, candidate_top_k)],
+                self.context.vector,
+                top_k=max(top_k, candidate_top_k),
+                level=self.level,
+            )
+            counts.append(("embedding_rerank", len(candidates)))
+        return candidates, counts
+
+    def _expand_graph(
+        self,
+        graph_plan: GraphExpansionPlan,
+        candidates: Sequence[QueriedNode],
+    ) -> list[QueriedNode]:
+        from ...ops.expand import ExpandContext, expand_graph_region
+        from ...ops.retrieve import dedup_queried_nodes
+
+        seeds = list(candidates[: graph_plan.seed_top_k])
+        expanded = expand_graph_region(
+            ExpandContext(code_graph=self.context.symbol_graph),
+            seeds,
+            top_k=graph_plan.expand_top_k,
+            hops=graph_plan.hops,
+            direction=graph_plan.direction,
+            use_ppr=graph_plan.use_ppr,
+            repo_path=str(self.repo_root),
+            include_content=False,
+        )
+        return dedup_queried_nodes([*seeds, *expanded])[: graph_plan.expand_top_k]
+
+    def _source_evidence(
+        self,
+        candidates: Sequence[QueriedNode],
+        *,
+        top_k: int,
+        include_content: bool,
+    ) -> list[RepositoryEvidence]:
+        evidence: list[RepositoryEvidence] = []
+        seen: set[tuple[str, int, int]] = set()
+        for candidate in candidates:
+            item = self._candidate_evidence(candidate, include_content=include_content)
+            if item is None:
+                continue
+            key = (item.path, item.start_line, item.end_line)
+            if key in seen:
+                continue
+            seen.add(key)
+            evidence.append(item)
+            if len(evidence) >= top_k:
+                break
+        return evidence
+
+    def _candidate_evidence(
+        self,
+        candidate: QueriedNode,
+        *,
+        include_content: bool,
+    ) -> RepositoryEvidence | None:
+        path = self._candidate_path(candidate.file)
+        if path is None:
+            return None
+        lines = self._lines(path)
+        if not lines:
+            return None
+        start = _line_number(candidate.start_line)
+        end = _line_number(candidate.end_line)
+        if start is None or end is None or end < start or start >= len(lines):
+            return None
+        end = min(end, len(lines) - 1)
+        content = "\n".join(lines[start : end + 1]) if include_content else None
+        return RepositoryEvidence(
+            path=path,
+            start_line=start,
+            end_line=end,
+            score=_finite_score(candidate.score),
+            node_name=str(candidate.node_name or ""),
+            node_type=str(candidate.type or ""),
+            node_id=str(candidate.node_id) if candidate.node_id else None,
+            content=content,
+        )
+
+    def _candidate_path(self, value: str | None) -> str | None:
+        raw_value = str(value or "").strip()
+        if not raw_value:
+            return None
+        try:
+            raw = Path(raw_value).expanduser()
+            if raw.is_absolute():
+                relative = raw.resolve().relative_to(self.repo_root).as_posix()
+            else:
+                relative = normalize_repository_path(raw_value)
+            resolved = (self.repo_root / relative).resolve()
+            resolved.relative_to(self.repo_root)
+            if not resolved.is_file():
+                return None
+            return normalize_repository_path(relative)
+        except (OSError, ValueError):
+            return None
+
+    def _lines(self, path: str) -> tuple[str, ...]:
+        lines = self._source_lines.get(path)
+        if lines is None:
+            try:
+                lines = tuple(
+                    (self.repo_root / path)
+                    .read_text(encoding="utf-8", errors="replace")
+                    .splitlines()
+                )
+            except OSError:
+                lines = ()
+            self._source_lines[path] = lines
+        return lines
+
+    def _advertised_views(self) -> set[str]:
+        loaded = self._loaded_views()
+        manifest = self.context.manifest
+        indexes: Mapping[str, Any] = getattr(manifest, "indexes", {})
+        advertised = set(loaded)
+        for view in _NATIVE_VIEWS:
+            if view not in indexes:
+                continue
+            try:
+                current = bool(manifest.index_is_current(view))
+            except (AttributeError, TypeError, ValueError):
+                current = getattr(indexes[view], "status", None) == "fresh"
+            if current:
+                advertised.add(view)
+        return advertised
+
+    def _loaded_views(self) -> set[str]:
+        loaded = getattr(self.context, "loaded_views", None)
+        if loaded is not None:
+            return set(loaded)
+        return {
+            view
+            for view in _NATIVE_VIEWS
+            if getattr(self.context, view, None) is not None
+        }
+
+    def _load_views(self, views: set[str]) -> None:
+        if not views:
+            return
+        load_views = getattr(self.context, "load_views", None)
+        if callable(load_views):
+            load_views(views)
+
+    def _advertised_capabilities(self) -> RetrievalCapabilities:
+        advertised = self._advertised_views()
+        return _capabilities(advertised)
+
+    def _runtime_capabilities(self) -> RetrievalCapabilities:
+        return _capabilities(self._loaded_views())
+
+    def _capability_error(self, missing: set[str]) -> RepositoryExplorerCapabilityError:
+        errors = getattr(self.context, "errors", {})
+        details = "; ".join(
+            f"{view}: {errors.get(view, 'not loaded')}" for view in sorted(missing)
+        )
+        return RepositoryExplorerCapabilityError(
+            f"repository explorer cannot load required views ({details})"
+        )
+
+
+def _capabilities(views: set[str]) -> RetrievalCapabilities:
+    has_vector = "vector" in views
+    return RetrievalCapabilities(
+        has_dense=has_vector,
+        has_sparse="bm25" in views,
+        has_graph="symbol_graph" in views,
+        has_embedding_rerank=has_vector,
+        has_llm_rerank=False,
+    )
+
+
+def _plan_views(plan: RetrievalPathPlan) -> set[str]:
+    views: set[str] = set()
+    if plan.uses_sparse:
+        views.add("bm25")
+    if plan.uses_dense or plan.rerank_strategy == "embedding":
+        views.add("vector")
+    if plan.uses_graph:
+        views.add("symbol_graph")
+    return views
+
+
+def _explicit_plan(policy: str, budget: RetrievalBudget) -> RetrievalPathPlan:
+    if policy == "bm25":
+        return RetrievalPathPlan(
+            name="bm25_control",
+            intent="lexical",
+            stages=(RetrievalStagePlan("sparse", top_k=budget.retrieve_top_k),),
+            retrieval_top_k=budget.retrieve_top_k,
+            fusion="none",
+            rationale="explicit BM25 compatibility control",
+        )
+    if policy == "dense":
+        return RetrievalPathPlan(
+            name="dense",
+            intent="semantic",
+            stages=(RetrievalStagePlan("dense", top_k=budget.retrieve_top_k),),
+            retrieval_top_k=budget.retrieve_top_k,
+            fusion="none",
+            rationale="explicit dense retrieval policy",
+        )
+    if policy in {"hybrid", "hybrid_rerank"}:
+        rerank = policy == "hybrid_rerank"
+        return RetrievalPathPlan(
+            name=policy,
+            intent="hybrid",
+            stages=(
+                RetrievalStagePlan("dense", weight=0.6, top_k=budget.retrieve_top_k),
+                RetrievalStagePlan("sparse", weight=0.4, top_k=budget.retrieve_top_k),
+            ),
+            retrieval_top_k=budget.retrieve_top_k,
+            fusion="rrf",
+            enable_rerank=rerank,
+            rerank_strategy="embedding" if rerank else None,
+            rerank_candidate_top_k=budget.rerank_candidate_top_k if rerank else None,
+            rationale="explicit dense and BM25 reciprocal-rank fusion policy",
+        )
+    if policy == "graph":
+        graph = GraphExpansionPlan(
+            seed_top_k=min(12, max(5, budget.retrieve_top_k // 12)),
+            expand_top_k=budget.retrieve_top_k,
+            hops=2 if budget.tier != "fast" else 1,
+            use_ppr=budget.tier == "thorough",
+        )
+        return RetrievalPathPlan(
+            name="graph",
+            intent="structural",
+            stages=(RetrievalStagePlan("sparse", top_k=graph.seed_top_k),),
+            retrieval_top_k=budget.retrieve_top_k,
+            fusion="none",
+            graph=graph,
+            rationale="explicit BM25-seeded graph expansion policy",
+        )
+    raise ValueError(f"unsupported explicit policy: {policy!r}")
+
+
+def _validate_top_k(value: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("top_k must be an integer")
+    if value < 0:
+        raise ValueError("top_k must be non-negative")
+
+
+def _line_number(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
+def _finite_score(value: Any) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return score if math.isfinite(score) else 0.0
+
+
+__all__ = [
+    "REPOSITORY_EXPLORER_POLICIES",
+    "RepositoryContextExplorer",
+    "RepositoryEvidence",
+    "RepositoryExplorePreparation",
+    "RepositoryExploreResult",
+    "RepositoryExploreTrace",
+    "RepositoryExplorerCapabilityError",
+    "normalize_repository_explorer_policy",
+    "repository_explorer_build_views",
+]

--- a/codenib/eval/benchmarks/swe_explore_runner.py
+++ b/codenib/eval/benchmarks/swe_explore_runner.py
@@ -20,6 +20,11 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from codenib._version import package_version
+from codenib.agent.runtime.explorer import (
+    REPOSITORY_EXPLORER_POLICIES,
+    normalize_repository_explorer_policy,
+    repository_explorer_build_views,
+)
 from codenib.cli import detect_languages, index_repository
 from codenib.compiler.artifact_fingerprints import (
     bm25_artifact_file_fingerprints,
@@ -55,10 +60,21 @@ def run_swe_explore_benchmark(
     top_ks: Sequence[int],
     build_indexes: bool = True,
     rebuild: bool = False,
+    policy: str = "auto",
+    planning_budget: str = "balanced",
+    retrieval_level: str = "l2",
     expected_bench_sha256: str | None = SWE_EXPLORE_BENCHMARK_SHA256,
 ) -> dict[str, Any]:
     """Run a fixed case set without dropping preparation or query failures."""
 
+    normalized_policy = normalize_repository_explorer_policy(policy)
+    build_views = repository_explorer_build_views(normalized_policy)
+    planning_budget = str(planning_budget).strip().lower()
+    retrieval_level = str(retrieval_level).strip().lower()
+    if planning_budget not in {"fast", "balanced", "thorough"}:
+        raise ValueError("planning_budget must be fast, balanced, or thorough")
+    if retrieval_level not in {"l0", "l2"}:
+        raise ValueError("retrieval_level must be l0 or l2")
     normalized_ks = tuple(sorted(set(int(value) for value in top_ks)))
     if not normalized_ks or normalized_ks[0] <= 0:
         raise ValueError("SWE-Explore top-k values must be positive")
@@ -97,6 +113,10 @@ def run_swe_explore_benchmark(
                     top_ks=normalized_ks,
                     build_indexes=build_indexes,
                     rebuild=rebuild,
+                    policy=normalized_policy,
+                    planning_budget=planning_budget,
+                    retrieval_level=retrieval_level,
+                    build_views=build_views,
                 )
             )
         except Exception as exc:
@@ -112,7 +132,7 @@ def run_swe_explore_benchmark(
             )
 
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "provenance": {
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "codenib": _code_provenance(),
@@ -128,6 +148,10 @@ def run_swe_explore_benchmark(
             "top_ks": list(normalized_ks),
             "build_indexes": build_indexes,
             "rebuild": rebuild,
+            "explorer_policy": normalized_policy,
+            "planning_budget": planning_budget,
+            "retrieval_level": retrieval_level,
+            "materialized_views": list(build_views),
         },
         "summary": _summarize(rows, normalized_ks),
         "cases": rows,
@@ -142,6 +166,10 @@ def _run_case(
     top_ks: Sequence[int],
     build_indexes: bool,
     rebuild: bool,
+    policy: str,
+    planning_budget: str,
+    retrieval_level: str,
+    build_views: Sequence[str],
 ) -> dict[str, Any]:
     snapshot = audit_swe_explore_snapshot(case, repos_root)
     if not snapshot.valid:
@@ -162,31 +190,43 @@ def _run_case(
         _manifest, failed = index_repository(
             repo,
             languages=detected_languages,
-            views=("bm25",),
+            views=build_views,
             rebuild=rebuild,
         )
         build_seconds = time.perf_counter() - started
         if failed:
-            raise RuntimeError("BM25 build failed")
+            raise RuntimeError("required view builds failed: " + ", ".join(failed))
 
     manifest_path = repo_index_dir(repo) / MANIFEST_FILENAME
-    bm25_profile = _validated_bm25_profile(
+    view_profiles = _validated_view_profiles(
         manifest_path,
+        views=build_views,
         languages=detected_languages,
         required_top_k=max(top_ks),
     )
     load_started = time.perf_counter()
     explorer = CodeNibSWEExploreExplorer.from_repository(
-        repo, manifest_path=manifest_path
+        repo,
+        manifest_path=manifest_path,
+        policy=policy,
+        budget=planning_budget,
+        level=retrieval_level,
     )
-    load_seconds = time.perf_counter() - load_started
-    query_started = time.perf_counter()
-    results = explorer.explore(
-        instance_id=case.instance_id,
-        query=case.query,
-        top_k=max(top_ks),
-    )
-    query_seconds = time.perf_counter() - query_started
+    try:
+        preparation = explorer.prepare(case.query)
+        load_seconds = time.perf_counter() - load_started
+        query_started = time.perf_counter()
+        results = explorer.explore(
+            instance_id=case.instance_id,
+            query=case.query,
+            top_k=max(top_ks),
+        )
+        query_seconds = time.perf_counter() - query_started
+        query_trace = (
+            explorer.last_trace.to_record() if explorer.last_trace is not None else None
+        )
+    finally:
+        explorer.close()
     all_regions = flatten_swe_explore_results(results)
 
     evaluations: dict[str, Any] = {}
@@ -200,7 +240,7 @@ def _run_case(
         evaluations[str(top_k)] = swe_explore_prediction_record(
             instance_id=case.instance_id,
             regions=regions,
-            explorer="codenib",
+            explorer=f"codenib-{policy.replace('_', '-')}",
             metrics=metrics,
         )
 
@@ -212,7 +252,10 @@ def _run_case(
         "snapshot": snapshot.to_record(),
         "detected_languages": detected_languages,
         "manifest_path": str(manifest_path),
-        "bm25_profile": bm25_profile,
+        "policy": policy,
+        "view_profiles": view_profiles,
+        "selected_plan": preparation.plan.name,
+        "query_trace": query_trace,
         "timing_seconds": {
             "build": build_seconds,
             "load": load_seconds,
@@ -220,6 +263,40 @@ def _run_case(
         },
         "evaluations": evaluations,
     }
+
+
+def _validated_view_profiles(
+    manifest_path: str | Path,
+    *,
+    views: Sequence[str],
+    languages: Sequence[str],
+    required_top_k: int,
+) -> dict[str, Any]:
+    """Validate and record every view required by one explorer policy."""
+
+    manifest = RepoManifest.load(manifest_path)
+    profiles: dict[str, Any] = {}
+    for view in views:
+        if view == "bm25":
+            profiles[view] = _validated_bm25_profile(
+                manifest_path,
+                languages=languages,
+                required_top_k=required_top_k,
+            )
+            continue
+        entry = manifest.indexes.get(view)
+        if entry is None or not manifest.index_is_current(view):
+            raise ValueError(f"SWE-Explore requires a fresh {view} manifest entry")
+        artifact_path = Path(entry.path).expanduser()
+        if not artifact_path.exists():
+            raise ValueError(f"SWE-Explore {view} artifact is missing: {artifact_path}")
+        profiles[view] = {
+            "config": dict(entry.config),
+            "commit": entry.commit,
+            "source_fingerprint": entry.source_fingerprint,
+            "artifact_path": entry.path,
+        }
+    return profiles
 
 
 def _validated_bm25_profile(
@@ -420,6 +497,18 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--no-build", action="store_true")
     parser.add_argument("--rebuild", action="store_true")
+    parser.add_argument(
+        "--policy",
+        choices=tuple(sorted(REPOSITORY_EXPLORER_POLICIES)),
+        default="auto",
+        help="native CodeNib exploration policy (bm25 is the compatibility control)",
+    )
+    parser.add_argument(
+        "--planning-budget",
+        choices=("fast", "balanced", "thorough"),
+        default="balanced",
+    )
+    parser.add_argument("--retrieval-level", choices=("l0", "l2"), default="l2")
     return parser
 
 
@@ -432,6 +521,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         top_ks=args.top_k,
         build_indexes=not args.no_build,
         rebuild=args.rebuild,
+        policy=args.policy,
+        planning_budget=args.planning_budget,
+        retrieval_level=args.retrieval_level,
         expected_bench_sha256=args.bench_sha256,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/codenib/integrations/swe_explore.py
+++ b/codenib/integrations/swe_explore.py
@@ -2,24 +2,27 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""SWE-Explore's ranked-region contract over CodeNib repository views.
+"""SWE-Explore's ranked-region contract over CodeNib repository exploration.
 
 The official benchmark asks an explorer for ranked, repository-relative,
 1-based inclusive source regions.  CodeNib stores chunk ranges as 0-based
-inclusive locations.  This module owns that conversion and keeps benchmark
-serving separate from index construction.
+inclusive locations. This module owns only that protocol conversion; planning,
+retrieval, graph expansion, reranking, and source validation stay in CodeNib's
+native repository-context runtime.
 """
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from ._repository import RepositoryAdapter, RepositoryPathError
-
-_RUNTIME_VIEWS = frozenset({"bm25"})
+from ..agent.runtime.explorer import (
+    RepositoryContextExplorer,
+    RepositoryExplorePreparation,
+    RepositoryExploreTrace,
+)
+from ..model.retrieval_planner import BudgetInput
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,18 +64,17 @@ class SWEExploreResult:
 
 
 class CodeNibSWEExploreExplorer:
-    """Serve ranked CodeNib BM25 chunks under SWE-Explore's protocol.
+    """Adapt CodeNib's native explorer to SWE-Explore's region protocol."""
 
-    The explorer loads only the BM25 view declared by the manifest.  It does
-    not build or update indexes; callers must materialize the view explicitly
-    before constructing the explorer.
-    """
-
-    def __init__(self, context: Any, *, include_snippets: bool = False) -> None:
-        self.repository = RepositoryAdapter(context, require_graph=False)
-        self.bm25 = self.repository.require_view("bm25", "bm25")
+    def __init__(
+        self,
+        explorer: RepositoryContextExplorer,
+        *,
+        include_snippets: bool = False,
+    ) -> None:
+        self.runtime = explorer
         self.include_snippets = bool(include_snippets)
-        self._source_lines: dict[str, list[str]] = {}
+        self.last_trace: RepositoryExploreTrace | None = None
 
     @classmethod
     def from_manifest(
@@ -80,13 +82,19 @@ class CodeNibSWEExploreExplorer:
         manifest_path: str | Path,
         *,
         include_snippets: bool = False,
+        policy: str = "auto",
+        budget: BudgetInput = "balanced",
+        level: str = "l2",
     ) -> "CodeNibSWEExploreExplorer":
-        """Load only the BM25 artifact from an existing CodeNib manifest."""
+        """Bind the protocol adapter to an existing CodeNib manifest."""
 
-        from ..mcp.context import ServerContext
-
-        context = ServerContext.load(manifest_path, views=_RUNTIME_VIEWS)
-        return cls(context, include_snippets=include_snippets)
+        runtime = RepositoryContextExplorer.from_manifest(
+            manifest_path,
+            policy=policy,
+            budget=budget,
+            level=level,
+        )
+        return cls(runtime, include_snippets=include_snippets)
 
     @classmethod
     def from_repository(
@@ -95,21 +103,41 @@ class CodeNibSWEExploreExplorer:
         *,
         manifest_path: str | Path | None = None,
         include_snippets: bool = False,
+        policy: str = "auto",
+        budget: BudgetInput = "balanced",
+        level: str = "l2",
     ) -> "CodeNibSWEExploreExplorer":
         """Resolve and validate the manifest bound to one checkout."""
 
-        from ..clients._manifest import select_checkout_manifest
-
-        selected = select_checkout_manifest(
+        runtime = RepositoryContextExplorer.from_repository(
             repo_path,
-            integration_name="SWE-Explore",
             manifest_path=manifest_path,
+            policy=policy,
+            budget=budget,
+            level=level,
         )
-        return cls.from_manifest(selected, include_snippets=include_snippets)
+        return cls(
+            runtime,
+            include_snippets=include_snippets,
+        )
 
     @property
     def context(self) -> Any:
-        return self.repository.context
+        return self.runtime.context
+
+    def close(self) -> None:
+        self.runtime.close()
+
+    def prepare(self, query: str) -> RepositoryExplorePreparation:
+        """Load the native views selected for a benchmark query."""
+
+        return self.runtime.prepare(query)
+
+    def __enter__(self) -> "CodeNibSWEExploreExplorer":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
     def explore(
         self,
@@ -124,100 +152,27 @@ class CodeNibSWEExploreExplorer:
         metrics apply a separate cumulative-line budget in the scorer.
         """
 
-        if isinstance(top_k, bool) or not isinstance(top_k, int):
-            raise TypeError("top_k must be an integer")
-        if top_k < 0:
-            raise ValueError("top_k must be non-negative")
-        if top_k == 0 or not str(query or "").strip():
-            return []
-
-        max_candidates = max(top_k, top_k * 4)
-        index_limit = getattr(self.bm25, "max_k", max_candidates)
-        if isinstance(index_limit, int) and index_limit > 0:
-            max_candidates = min(max_candidates, index_limit)
-        candidates = self.bm25.search(
-            query=str(query),
-            top_k=max_candidates,
-            return_code_content=False,
+        result = self.runtime.explore(
+            str(query or ""),
+            top_k=top_k,
+            include_content=self.include_snippets,
         )
-
-        results: list[SWEExploreResult] = []
-        seen: set[tuple[str, int, int]] = set()
-        for candidate in candidates:
-            region = self._region_from_candidate(candidate)
-            if region is None:
-                continue
-            key = (region.path, region.start, region.end)
-            if key in seen:
-                continue
-            seen.add(key)
-            results.append(
-                SWEExploreResult(
-                    instance_id=str(instance_id),
-                    score=_finite_score(getattr(candidate, "score", 0.0)),
-                    regions=(region,),
-                )
+        self.last_trace = result.trace
+        return [
+            SWEExploreResult(
+                instance_id=str(instance_id),
+                score=item.score,
+                regions=(
+                    SWEExploreContextRegion(
+                        path=item.path,
+                        start=item.start_line + 1,
+                        end=item.end_line + 1,
+                        snippet=item.content,
+                    ),
+                ),
             )
-            if len(results) >= top_k:
-                break
-        return results
-
-    def _region_from_candidate(self, candidate: Any) -> SWEExploreContextRegion | None:
-        raw_path = str(getattr(candidate, "file", "") or "").strip()
-        if not raw_path:
-            return None
-        try:
-            path = self._relative_path(raw_path)
-            lines = self._lines(path)
-        except (OSError, RepositoryPathError, UnicodeError):
-            return None
-        if not lines:
-            return None
-
-        start = _line_number(getattr(candidate, "start_line", None))
-        end = _line_number(getattr(candidate, "end_line", None))
-        if start is None or end is None or end < start or start >= len(lines):
-            return None
-        end = min(end, len(lines) - 1)
-        snippet = "\n".join(lines[start : end + 1]) if self.include_snippets else None
-        return SWEExploreContextRegion(
-            path=path,
-            start=start + 1,
-            end=end + 1,
-            snippet=snippet,
-        )
-
-    def _relative_path(self, value: str) -> str:
-        raw = Path(value).expanduser()
-        if raw.is_absolute():
-            try:
-                value = raw.resolve().relative_to(self.repository.repo_root).as_posix()
-            except ValueError as exc:
-                raise RepositoryPathError(
-                    f"retrieval result is outside the manifest repository: {raw}"
-                ) from exc
-        return self.repository.normalize_path(value)
-
-    def _lines(self, path: str) -> list[str]:
-        lines = self._source_lines.get(path)
-        if lines is None:
-            lines = self.repository.source_lines(path)
-            self._source_lines[path] = lines
-        return lines
-
-
-def _line_number(value: Any) -> int | None:
-    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-        return value
-    return None
-
-
-def _finite_score(value: Any) -> float:
-    try:
-        score = float(value)
-    except (TypeError, ValueError):
-        return 0.0
-    return score if math.isfinite(score) else 0.0
+            for item in result.evidence
+        ]
 
 
 __all__ = [

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -16,6 +16,7 @@ import logging
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
+from threading import RLock
 from typing import TYPE_CHECKING, Dict, Optional
 
 from ..compiler.manifest import RepoManifest
@@ -120,6 +121,7 @@ class ServerContext:
     zoekt: Optional[ZoektSearcher] = None
     vector: Optional[CodeVectorStore] = None
     errors: Dict[str, str] = field(default_factory=dict)
+    _view_lock: RLock = field(default_factory=RLock, init=False, repr=False)
 
     @classmethod
     def load(
@@ -143,9 +145,7 @@ class ServerContext:
         )
         ctx = cls(manifest=manifest)
 
-        for view, loader_name in _VIEW_LOADERS:
-            if view in selected:
-                getattr(ctx, loader_name)()
+        ctx.load_views(selected)
 
         cap_summary = {k: v for k, v in manifest.capabilities.items() if v}
         loaded = [
@@ -162,6 +162,50 @@ class ServerContext:
             list(ctx.errors) or "none",
         )
         return ctx
+
+    @property
+    def loaded_views(self) -> frozenset[str]:
+        """Return the runtime views currently available in this context."""
+
+        return frozenset(
+            view
+            for view, _loader_name in _VIEW_LOADERS
+            if getattr(self, view, None) is not None
+        )
+
+    def load_views(self, views: Iterable[str]) -> Dict[str, str]:
+        """Load additional manifest views without disturbing loaded resources.
+
+        View dependencies are resolved in the same way as :meth:`load`. The
+        operation is idempotent and serialized so query-time planners can
+        safely request only the backends selected for a query. The returned
+        mapping contains requested views that remain unavailable.
+        """
+
+        selected = _resolve_views(views)
+        with self._view_lock:
+            for view, loader_name in _VIEW_LOADERS:
+                if view not in selected or getattr(self, view, None) is not None:
+                    continue
+                getattr(self, loader_name)()
+                if getattr(self, view, None) is not None:
+                    self.errors.pop(view, None)
+            return {
+                view: self.errors.get(view, "view did not load")
+                for view in selected
+                if getattr(self, view, None) is None
+            }
+
+    def close(self) -> None:
+        """Release runtime resources owned by this context."""
+
+        with self._view_lock:
+            if self.zoekt is not None:
+                _stop_zoekt(self.zoekt)
+                self.zoekt = None
+            if self.vector is not None:
+                _close_vector(self.vector)
+                self.vector = None
 
     @classmethod
     def validate_views(

--- a/codenib/model/__init__.py
+++ b/codenib/model/__init__.py
@@ -2,31 +2,100 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Model module for CodeNib."""
+"""Model pipelines and planners exposed without eager optional imports."""
 
-from .agentless_pipeline import AgentlessPipeline
-from .bm25_retrieve_pipeline import BM25RetrievePipeline
-from .dense_graph_expand_rerank_pipeline import DenseGraphExpandRerankPipeline
-from .embedding_retrieve_pipeline import EmbeddingRetrievePipeline
-from .graph_augmented_rerank_pipeline import GraphAugmentedRerankPipeline
-from .graph_retrieve_pipeline import (
-    GraphRetrievePipeline,
-    SparseSeededGraphRetrievePipeline,
-)
-from .hybrid_retrieve_pipeline import HybridRetrievePipeline
-from .retrieval_planner import (
-    GraphExpansionPlan,
-    RetrievalBudget,
-    RetrievalCapabilities,
-    RetrievalPathPlan,
-    RetrievalPlanner,
-    RetrievalStagePlan,
-)
-from .retrieve_rerank_pipeline import (
-    RetrieveRerankPipeline,
-    RetrieveStageConfig,
-    build_retrieve_plan,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .._lazy import exported_dir, load_export
+
+if TYPE_CHECKING:  # pragma: no cover - imported only by static analyzers
+    from .agentless_pipeline import AgentlessPipeline
+    from .bm25_retrieve_pipeline import BM25RetrievePipeline
+    from .dense_graph_expand_rerank_pipeline import DenseGraphExpandRerankPipeline
+    from .embedding_retrieve_pipeline import EmbeddingRetrievePipeline
+    from .graph_augmented_rerank_pipeline import GraphAugmentedRerankPipeline
+    from .graph_retrieve_pipeline import (
+        GraphRetrievePipeline,
+        SparseSeededGraphRetrievePipeline,
+    )
+    from .hybrid_retrieve_pipeline import HybridRetrievePipeline
+    from .retrieval_planner import (
+        GraphExpansionPlan,
+        RetrievalBudget,
+        RetrievalCapabilities,
+        RetrievalPathPlan,
+        RetrievalPlanner,
+        RetrievalStagePlan,
+    )
+    from .retrieve_rerank_pipeline import (
+        RetrieveRerankPipeline,
+        RetrieveStageConfig,
+        build_retrieve_plan,
+    )
+
+_EXPORTS = {
+    "AgentlessPipeline": ("codenib.model.agentless_pipeline", "AgentlessPipeline"),
+    "BM25RetrievePipeline": (
+        "codenib.model.bm25_retrieve_pipeline",
+        "BM25RetrievePipeline",
+    ),
+    "DenseGraphExpandRerankPipeline": (
+        "codenib.model.dense_graph_expand_rerank_pipeline",
+        "DenseGraphExpandRerankPipeline",
+    ),
+    "EmbeddingRetrievePipeline": (
+        "codenib.model.embedding_retrieve_pipeline",
+        "EmbeddingRetrievePipeline",
+    ),
+    "GraphAugmentedRerankPipeline": (
+        "codenib.model.graph_augmented_rerank_pipeline",
+        "GraphAugmentedRerankPipeline",
+    ),
+    "GraphRetrievePipeline": (
+        "codenib.model.graph_retrieve_pipeline",
+        "GraphRetrievePipeline",
+    ),
+    "SparseSeededGraphRetrievePipeline": (
+        "codenib.model.graph_retrieve_pipeline",
+        "SparseSeededGraphRetrievePipeline",
+    ),
+    "HybridRetrievePipeline": (
+        "codenib.model.hybrid_retrieve_pipeline",
+        "HybridRetrievePipeline",
+    ),
+    "GraphExpansionPlan": (
+        "codenib.model.retrieval_planner",
+        "GraphExpansionPlan",
+    ),
+    "RetrievalBudget": ("codenib.model.retrieval_planner", "RetrievalBudget"),
+    "RetrievalCapabilities": (
+        "codenib.model.retrieval_planner",
+        "RetrievalCapabilities",
+    ),
+    "RetrievalPathPlan": (
+        "codenib.model.retrieval_planner",
+        "RetrievalPathPlan",
+    ),
+    "RetrievalPlanner": ("codenib.model.retrieval_planner", "RetrievalPlanner"),
+    "RetrievalStagePlan": (
+        "codenib.model.retrieval_planner",
+        "RetrievalStagePlan",
+    ),
+    "RetrieveRerankPipeline": (
+        "codenib.model.retrieve_rerank_pipeline",
+        "RetrieveRerankPipeline",
+    ),
+    "RetrieveStageConfig": (
+        "codenib.model.retrieve_rerank_pipeline",
+        "RetrieveStageConfig",
+    ),
+    "build_retrieve_plan": (
+        "codenib.model.retrieve_rerank_pipeline",
+        "build_retrieve_plan",
+    ),
+}
 
 __all__ = [
     "AgentlessPipeline",
@@ -34,16 +103,24 @@ __all__ = [
     "DenseGraphExpandRerankPipeline",
     "EmbeddingRetrievePipeline",
     "GraphAugmentedRerankPipeline",
+    "GraphExpansionPlan",
     "GraphRetrievePipeline",
     "HybridRetrievePipeline",
-    "RetrieveRerankPipeline",
     "RetrievalBudget",
     "RetrievalCapabilities",
     "RetrievalPathPlan",
     "RetrievalPlanner",
     "RetrievalStagePlan",
+    "RetrieveRerankPipeline",
     "RetrieveStageConfig",
-    "GraphExpansionPlan",
     "SparseSeededGraphRetrievePipeline",
     "build_retrieve_plan",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    return load_export(globals(), _EXPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return exported_dir(globals(), _EXPORTS)

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -11,13 +11,12 @@ from typing import Dict, List, Optional, Sequence, Set
 
 from ..code_chunker import CodeChunker, RepoChunkingConfig
 from ..graph.code_graph import CodeGraph
-from ..graph.roi_subgraph import ROISubgraph
 from ..index.embedding import CodeVectorStore, build_hierarchical_vector_store
 from ..index.rerank.cross_encoder import build_reranker
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..llm.litellm_chat import LiteLLMChat
 from ..log_utils import get_logger
-from ..ops.expand import ExpandContext, expand_graph_neighbors, nodeinfo_to_queried
+from ..ops.expand import ExpandContext, expand_graph_region
 from ..ops.rerank import RerankContext, rerank_by_embedding
 from ..ops.retrieve import (
     RetrieveContext,
@@ -583,62 +582,19 @@ class RetrieveRerankPipeline:
         if not graph_seeds:
             return []
 
-        if graph_plan.use_ppr or graph_plan.hops > 1:
-            expanded = self._expand_graph_roi(graph_seeds, graph_plan)
-        else:
-            expanded = []
-
-        if not expanded:
-            expanded = self._expand_graph_neighbors(graph_seeds, graph_plan)
+        expanded = expand_graph_region(
+            self.expand_context,
+            graph_seeds,
+            top_k=graph_plan.expand_top_k,
+            hops=graph_plan.hops,
+            direction=graph_plan.direction,
+            use_ppr=graph_plan.use_ppr,
+            repo_path=self.repo_path,
+            include_content=True,
+        )
 
         candidates = dedup_queried_nodes([*graph_seeds, *expanded])
         return candidates[: graph_plan.expand_top_k]
-
-    def _expand_graph_roi(
-        self, seeds: List[QueriedNode], graph_plan
-    ) -> List[QueriedNode]:
-        graph = self.expand_context.code_graph
-        if graph is None or not hasattr(graph, "name_to_vertex"):
-            return []
-
-        seed_names = _resolve_graph_seed_names(graph, seeds)
-        if not seed_names:
-            return []
-
-        roi = ROISubgraph(graph)
-        if graph_plan.use_ppr:
-            nodes = roi.expand_ppr(
-                seed_names,
-                top_k=graph_plan.expand_top_k,
-                damping=self.expand_context.default_damping,
-                filter_tests=self.expand_context.filter_tests,
-            )
-        else:
-            subgraph = roi.extract_subgraph(
-                seed_names,
-                k_hop=graph_plan.hops,
-                direction=_roi_direction(graph_plan.direction),
-            )
-            nodes = roi.get_filtered_subgraph_nodes(
-                subgraph,
-                filter_tests=self.expand_context.filter_tests,
-            )[: graph_plan.expand_top_k]
-        return nodeinfo_to_queried(nodes)
-
-    def _expand_graph_neighbors(
-        self, seeds: List[QueriedNode], graph_plan
-    ) -> List[QueriedNode]:
-        per_seed = max(1, graph_plan.expand_top_k // max(1, len(seeds)))
-        return expand_graph_neighbors(
-            self.expand_context,
-            seeds,
-            per_seed=per_seed,
-            direction=_neighbor_direction(graph_plan.direction),
-            repo_path=self.repo_path,
-            include_content=True,
-            symbol_only=True,
-            require_span=True,
-        )
 
     @staticmethod
     def _merge_hybrid(
@@ -1010,41 +966,3 @@ def _planner_trace(
             "rationale": plan.rationale,
         },
     }
-
-
-def _resolve_graph_seed_names(
-    graph: CodeGraph, seeds: Sequence[QueriedNode]
-) -> List[str]:
-    name_to_vertex = getattr(graph, "name_to_vertex", {})
-    out: List[str] = []
-    seen: Set[str] = set()
-    for seed in seeds:
-        candidates = [seed.node_id, seed.node_name]
-        if seed.file and seed.node_name:
-            candidates.append(f"{seed.file}:{seed.node_name}")
-        for candidate in candidates:
-            if candidate and candidate in name_to_vertex and candidate not in seen:
-                seen.add(candidate)
-                out.append(candidate)
-                break
-    return out
-
-
-def _roi_direction(direction: str) -> str:
-    normalized = (direction or "both").strip().lower()
-    if normalized in {"callees", "successors", "forward", "out"}:
-        return "forward"
-    if normalized in {"callers", "predecessors", "backward", "in"}:
-        return "backward"
-    return "both"
-
-
-def _neighbor_direction(direction: str) -> str:
-    normalized = (direction or "both").strip().lower()
-    if normalized in {"forward", "out"}:
-        return "successors"
-    if normalized in {"backward", "in"}:
-        return "predecessors"
-    if normalized in {"callees", "successors", "callers", "predecessors", "both"}:
-        return normalized
-    return "both"

--- a/codenib/ops/expand.py
+++ b/codenib/ops/expand.py
@@ -175,6 +175,121 @@ def expand_graph_neighbors(
     return out
 
 
+def expand_graph_region(
+    context: ExpandContext,
+    seeds: Sequence[QueriedNode],
+    *,
+    top_k: int = 50,
+    hops: int = 2,
+    direction: str = "both",
+    use_ppr: bool = False,
+    repo_path: Optional[str] = None,
+    include_content: bool = False,
+) -> List[QueriedNode]:
+    """Expand ranked seeds through a bounded graph region.
+
+    Multi-hop and PPR expansion share this operator so manifest-backed
+    runtimes and the standalone retrieval pipeline execute the same graph
+    semantics. If no region can be resolved, the function falls back to the
+    one-hop neighbor operator.
+    """
+
+    graph = context.code_graph
+    if graph is None or not seeds or top_k <= 0:
+        return []
+
+    seed_names: List[str] = []
+    for seed in seeds:
+        canonical = _resolve_seed(graph, seed)
+        if canonical is not None and canonical not in seed_names:
+            seed_names.append(canonical)
+    if not seed_names:
+        return []
+    if not hasattr(graph, "get_graph") or not hasattr(graph, "name_to_vertex"):
+        return _expand_neighbor_fallback(
+            context,
+            seeds,
+            top_k=top_k,
+            direction=direction,
+            repo_path=repo_path,
+            include_content=include_content,
+        )
+
+    from ..graph.roi_subgraph import ROISubgraph
+
+    roi = ROISubgraph(graph)
+    if use_ppr:
+        nodes = roi.expand_ppr(
+            seed_names,
+            top_k=top_k,
+            damping=context.default_damping,
+            filter_tests=context.filter_tests,
+        )
+    else:
+        subgraph = roi.extract_subgraph(
+            seed_names,
+            k_hop=max(1, int(hops)),
+            direction=_roi_direction(direction),
+        )
+        nodes = roi.get_filtered_subgraph_nodes(
+            subgraph,
+            filter_tests=context.filter_tests,
+        )[:top_k]
+
+    expanded = nodeinfo_to_queried(nodes)
+    if include_content:
+        expanded = hydrate_candidate_contents(expanded, repo_path=repo_path)
+    if expanded:
+        return expanded[:top_k]
+
+    return _expand_neighbor_fallback(
+        context,
+        seeds,
+        top_k=top_k,
+        direction=direction,
+        repo_path=repo_path,
+        include_content=include_content,
+    )
+
+
+def _expand_neighbor_fallback(
+    context: ExpandContext,
+    seeds: Sequence[QueriedNode],
+    *,
+    top_k: int,
+    direction: str,
+    repo_path: Optional[str],
+    include_content: bool,
+) -> List[QueriedNode]:
+    per_seed = max(1, top_k // max(1, len(seeds)))
+    return expand_graph_neighbors(
+        context,
+        seeds,
+        per_seed=per_seed,
+        direction=_neighbor_direction(direction),
+        repo_path=repo_path,
+        include_content=include_content,
+    )[:top_k]
+
+
+def _roi_direction(direction: str) -> str:
+    normalized = (direction or "both").strip().lower()
+    if normalized in {"callees", "successors", "forward", "out"}:
+        return "forward"
+    if normalized in {"callers", "predecessors", "backward", "in"}:
+        return "backward"
+    return "both"
+
+
+def _neighbor_direction(direction: str) -> str:
+    normalized = (direction or "both").strip().lower()
+    if normalized in {"forward", "out"}:
+        return "successors"
+    if normalized in {"backward", "in"}:
+        return "predecessors"
+    return normalized
+
+
 def _resolve_seed(graph: CodeGraph, seed: QueriedNode) -> Optional[str]:
     for value in (seed.node_id, seed.node_name):
         if not value:

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -19,7 +19,6 @@ budget contract. None of these labels alone claims end-to-end task quality.
 | Agentless v1.5.0 | CodeNib-native, revision-pinned | Symbol graph | Python tree, symbol skeleton, and line-window context | Vendored three-stage localization prompts; shared ranked file/symbol scoring | Localization only; repair and patch validation are excluded |
 | CoSIL | CodeNib-native, revision-pinned | Symbol graph | Pinned four-tool contract | Vendored file reflection, function tool loop, prune policy, and shared localization scoring | RQ1 file/function localization only; line localization and patch generation are excluded |
 | OrcaLoca SearchAgent | Revision-pinned supported | Symbol graph | Pinned six-tool and private-hook contract | Upstream `SearchAgent`; fixed-case paired runner and native File/Function Match scorer | Python SWE-bench repositories; empty `TraceAnalysisOutput`; upstream trace generation is not included |
-| SWE-Explore | Official explorer-compatible, revision-pinned | BM25 | Ranked `ContextRegion` explorer protocol | Official runner adapter, pinned scorer contract, and strict seven-language compatibility run | Trajectory-read localization only; no patch-generation or issue-resolution claim |
 
 ### What Supported Means
 
@@ -40,12 +39,6 @@ Passing these gates supports the stated provider and policy boundary. It does
 not imply compatibility with an arbitrary upstream revision or with stages
 explicitly excluded by the matrix.
 
-For a benchmark integration such as SWE-Explore, the policy gate is replaced
-by its public explorer protocol and evaluator. CodeNib checks every metric
-against the pinned official scorer. Coverage retains preparation failures;
-quality is success-conditioned with its denominator stated explicitly. It does
-not reinterpret trajectory labels as golden-patch labels.
-
 Optional upstream packages are required only where the policy still executes
 inside the upstream runtime. Provider imports and standalone provider examples
 remain dependency-free. Exact pinned
@@ -64,15 +57,27 @@ indexed search, and graph traversal. This checks that the provider boundary is
 language-agnostic; it is not evidence that the pinned Python-only LocAgent or
 OrcaLoca native implementations support those languages.
 
-## SWE-Explore
+## Benchmark Adapters
 
-CodeNib implements SWE-Explore's ranked-region explorer protocol without
-importing the benchmark at runtime:
+Benchmark adapters do not define CodeNib's repository algorithm. They join
+pinned datasets, translate native evidence into an external protocol, and run
+that benchmark's scorer. Coverage retains preparation failures; quality is
+success-conditioned with its denominator stated explicitly.
+
+### SWE-Explore
+
+CodeNib's native `RepositoryContextExplorer` owns route planning, retrieval,
+graph expansion, reranking, and source validation. The SWE-Explore adapter only
+converts its 0-based evidence into the benchmark's repository-relative,
+1-based inclusive `ContextRegion` records:
 
 ```python
 from codenib.integrations.swe_explore import CodeNibSWEExploreExplorer
 
-explorer = CodeNibSWEExploreExplorer.from_repository("/path/to/checkout")
+explorer = CodeNibSWEExploreExplorer.from_repository(
+    "/path/to/checkout",
+    policy="auto",
+)
 results = explorer.explore(
     instance_id="org__repo-123",
     query="issue text",
@@ -80,10 +85,11 @@ results = explorer.explore(
 )
 ```
 
-The adapter loads only the manifest's BM25 view. It emits repository-relative,
-1-based inclusive regions, clips ranges to source files, rejects escaping
-paths, removes exact duplicate regions, and preserves retrieval order. Index
-construction remains a separate operation.
+`auto` plans against manifest-advertised BM25, vector, and symbol-graph
+capabilities and loads only the selected query route. Stable ablation policies
+are `bm25`, `dense`, `hybrid`, `hybrid_rerank`, and `graph`. Index construction
+remains a separate operation; the strict runner materializes and records the
+exact views required by the selected policy.
 
 Compatibility is pinned to SWE-Explore revision
 `3c12dc5a551937038afcbdb6eb6bbf19f3ddd8c1` and released dataset revision
@@ -106,7 +112,8 @@ preserves malformed optional trajectory ranges under upstream semantics: the
 released data contains 455 reversed optional ranges and 8 with `end=0`.
 Silently repairing them would make CodeNib's scores incomparable.
 
-The fixed compatibility subset contains 20 base-commit checkouts across
+The released compatibility result is the explicit `bm25` control on 20
+base-commit checkouts across
 Python, Go, Rust, TypeScript, JavaScript, C, and C++. All 20 passed checkout,
 benchmark-digest, BM25-profile, build, load, and query gates. Snapshot checks
 include index-visible untracked and gitignored source files. On the validation machine, median
@@ -125,8 +132,14 @@ codenib-swe-explore-benchmark \
   --case-set docs/assets/swe_explore_cases.json \
   --repos-root /path/to/repos \
   --output results/codenib-swe-explore.json \
+  --policy auto \
   --top-k 5,10,20
 ```
+
+Use `--policy bm25` to reproduce the published compatibility control. The
+runner records the policy, materialized view set, selected per-query plan, and
+runtime trace; no native `auto` quality number is claimed until that arm is
+executed on the pinned case set.
 
 The upstream SWE-Explore runner can also select `--explorers codenib`. Its
 native BM25 control has a Python/document-oriented extension allowlist, so the

--- a/docs/evaluation/swe_explore.md
+++ b/docs/evaluation/swe_explore.md
@@ -1,8 +1,9 @@
 # SWE-Explore Compatibility Validation
 
 This validation checks whether CodeNib can participate in the official
-SWE-Explore explorer and evaluator contracts. It does not measure patch
-generation or SWE-bench issue resolution.
+SWE-Explore explorer and evaluator contracts. The reported run is the explicit
+`bm25` compatibility control, not CodeNib's native multi-view `auto` policy. It
+does not measure patch generation or SWE-bench issue resolution.
 
 ## Pinned Inputs
 
@@ -26,7 +27,9 @@ execution: two Python cases and three each for Go, Rust, TypeScript,
 JavaScript, C, and C++. Every repository is a clean detached checkout at the
 joined `base_commit`. The audit rejects tracked changes plus untracked or
 gitignored source files that CodeNib's chunker would index. The runner also
-requires the default BM25 artifact profile and records it per case.
+requires the default BM25 artifact profile and records it per case. The current
+runner can separately execute `dense`, `hybrid`, `hybrid_rerank`, `graph`, or
+`auto`; those arms require new measurements and are not backfilled here.
 
 Coverage always uses all requested cases. Quality metrics are conditioned on
 successful cases because zero-imputation would make lower-is-better noise
@@ -39,7 +42,7 @@ lists every failed case separately.
 | --- | ---: |
 | Snapshot revision and cleanliness | 20/20 |
 | BM25 view construction | 20/20 |
-| Selective BM25-only loading | 20/20 |
+| Selective BM25-only loading (`--policy bm25`) | 20/20 |
 | Ranked region query | 20/20 |
 | Official runner completion | 20/20 |
 | Generated differential metric cells | 4,250/4,250 |
@@ -62,7 +65,7 @@ query serving.
 
 ## Localization Summary
 
-The table reports the CodeNib arm only. Values are means over the fixed 20
+The table reports the CodeNib BM25 control only. Values are means over the fixed 20
 cases and characterize this compatibility subset rather than a repository
 population.
 

--- a/test/eval/test_swe_explore_runner.py
+++ b/test/eval/test_swe_explore_runner.py
@@ -42,7 +42,10 @@ def test_runner_reports_failures_separately_from_quality_metrics(
         swe_explore_runner, "load_swe_explore_cases", lambda *_a, **_kw: cases
     )
 
+    observed_kwargs = []
+
     def run_case(case, **kwargs):
+        observed_kwargs.append(kwargs)
         if case.instance_id == "failed":
             raise RuntimeError("index unavailable")
         metrics = {metric: 1.0 for metric in SWE_EXPLORE_METRICS}
@@ -78,6 +81,18 @@ def test_runner_reports_failures_separately_from_quality_metrics(
     }
     assert report["summary"]["metrics_by_top_k"]["5"]["recall"] == 1.0
     assert report["cases"][1]["error_type"] == "RuntimeError"
+    assert report["schema_version"] == 3
+    assert report["provenance"]["explorer_policy"] == "auto"
+    assert report["provenance"]["materialized_views"] == [
+        "bm25",
+        "vector",
+        "symbol_graph",
+    ]
+    assert all(kwargs["policy"] == "auto" for kwargs in observed_kwargs)
+    assert all(
+        kwargs["build_views"] == ("bm25", "vector", "symbol_graph")
+        for kwargs in observed_kwargs
+    )
 
 
 def test_runner_rejects_unpinned_benchmark_bytes(tmp_path) -> None:
@@ -169,6 +184,94 @@ def test_bm25_profile_validation_records_exact_artifact(tmp_path) -> None:
             languages=("python", "go"),
             required_top_k=20,
         )
+
+
+def test_view_profile_validation_records_native_policy_artifacts(tmp_path) -> None:
+    manifest_path = tmp_path / "repo_manifest.json"
+    vector_path = tmp_path / "vector"
+    graph_path = tmp_path / "graph.pkl"
+    vector_path.mkdir()
+    graph_path.write_bytes(b"graph")
+    manifest = RepoManifest(
+        commit="abc123",
+        indexes={
+            "vector": IndexEntry(
+                index_type="vector",
+                path=str(vector_path),
+                built_at="2026-08-04T00:00:00+00:00",
+                built_at_epoch=0.0,
+                status="fresh",
+                config={"embedding_model": "fixture"},
+                commit="abc123",
+                source_fingerprint="sha256:source",
+            ),
+            "symbol_graph": IndexEntry(
+                index_type="symbol_graph",
+                path=str(graph_path),
+                built_at="2026-08-04T00:00:00+00:00",
+                built_at_epoch=0.0,
+                status="fresh",
+                config={"builder_schema": 3},
+                commit="abc123",
+                source_fingerprint="sha256:source",
+            ),
+        },
+    )
+    manifest.save(manifest_path)
+
+    profiles = swe_explore_runner._validated_view_profiles(
+        manifest_path,
+        views=("vector", "symbol_graph"),
+        languages=("python",),
+        required_top_k=20,
+    )
+
+    assert profiles["vector"]["config"] == {"embedding_model": "fixture"}
+    assert profiles["symbol_graph"]["artifact_path"] == str(graph_path)
+
+
+def test_runner_normalizes_explicit_bm25_control(monkeypatch, tmp_path) -> None:
+    case_set = tmp_path / "cases.json"
+    case_set.write_text(
+        json.dumps({"cases": [{"instance_id": "case", "language": "python"}]}),
+        encoding="utf-8",
+    )
+    bench = tmp_path / "bench.jsonl"
+    bench.write_text("fixture\n", encoding="utf-8")
+    case = SimpleNamespace(instance_id="case", dataset="verified")
+    monkeypatch.setattr(swe_explore_runner, "_load_pinned_source_rows", lambda: {})
+    monkeypatch.setattr(swe_explore_runner, "load_swe_explore_sources", lambda _x: {})
+    monkeypatch.setattr(
+        swe_explore_runner, "load_swe_explore_cases", lambda *_a, **_kw: (case,)
+    )
+    observed = {}
+
+    def run_case(_case, **kwargs):
+        observed.update(kwargs)
+        metrics = {metric: 0.0 for metric in SWE_EXPLORE_METRICS}
+        return {
+            "instance_id": "case",
+            "dataset": "verified",
+            "language": "python",
+            "success": True,
+            "timing_seconds": {"build": 0.0, "load": 0.0, "query": 0.0},
+            "evaluations": {"5": {"metrics": metrics}},
+        }
+
+    monkeypatch.setattr(swe_explore_runner, "_run_case", run_case)
+
+    report = swe_explore_runner.run_swe_explore_benchmark(
+        bench_path=bench,
+        case_set_path=case_set,
+        repos_root=tmp_path / "repos",
+        top_ks=(5,),
+        policy="BM25",
+        expected_bench_sha256=hashlib.sha256(bench.read_bytes()).hexdigest(),
+    )
+
+    assert observed["policy"] == "bm25"
+    assert observed["build_views"] == ("bm25",)
+    assert report["provenance"]["explorer_policy"] == "bm25"
 
 
 def test_runner_rejects_duplicate_case_ids(tmp_path) -> None:

--- a/test/integrations/test_swe_explore.py
+++ b/test/integrations/test_swe_explore.py
@@ -9,18 +9,53 @@ from unittest.mock import patch
 
 import pytest
 
+from codenib.agent.runtime.explorer import (
+    RepositoryContextExplorer,
+    RepositoryEvidence,
+    RepositoryExploreResult,
+)
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.integrations.swe_explore import CodeNibSWEExploreExplorer
 from codenib.mcp.context import ServerContext
+from codenib.types import NodeInfo
 
 
-def test_explorer_loads_only_bm25(integration_manifest) -> None:
+def test_explorer_defers_view_loading_until_query_planning(
+    integration_manifest,
+) -> None:
     with patch.object(ServerContext, "load", wraps=ServerContext.load) as load:
         explorer = CodeNibSWEExploreExplorer.from_manifest(integration_manifest)
 
+    assert explorer.context.bm25 is None
+    assert explorer.context.symbol_graph is None
+    assert explorer.context.vector is None
+    assert load.call_args.kwargs["views"] == ()
+
+    preparation = explorer.prepare("calculate_tax")
+
+    assert preparation.plan.name == "fast_lexical"
     assert explorer.context.bm25 is not None
     assert explorer.context.symbol_graph is None
     assert explorer.context.vector is None
-    assert load.call_args.kwargs["views"] == frozenset({"bm25"})
+
+
+def test_auto_structural_query_loads_graph_route(integration_manifest) -> None:
+    explorer = CodeNibSWEExploreExplorer.from_manifest(integration_manifest)
+
+    preparation = explorer.prepare("who calls `calculate_tax`?")
+    results = explorer.explore(
+        instance_id="iid",
+        query="who calls `calculate_tax`?",
+        top_k=5,
+    )
+
+    assert preparation.plan.name == "structural_graph"
+    assert explorer.context.bm25 is not None
+    assert explorer.context.symbol_graph is not None
+    assert explorer.context.vector is None
+    assert results
+    assert explorer.last_trace is not None
+    assert explorer.last_trace.plan.uses_graph is True
 
 
 def test_explorer_returns_official_one_based_regions(integration_manifest) -> None:
@@ -48,18 +83,19 @@ def test_explorer_returns_official_one_based_regions(integration_manifest) -> No
 def test_explorer_filters_invalid_and_duplicate_candidates(
     integration_manifest,
 ) -> None:
-    explorer = CodeNibSWEExploreExplorer.from_manifest(integration_manifest)
-    repo = explorer.repository.repo_root
-    valid = SimpleNamespace(
-        file="src/service.py", start_line=1, end_line=999, score=0.7
+    explorer = CodeNibSWEExploreExplorer.from_manifest(
+        integration_manifest, policy="bm25"
     )
-    explorer.bm25 = SimpleNamespace(
+    explorer.prepare("tax")
+    repo = explorer.runtime.repo_root
+    valid = NodeInfo(file="src/service.py", start_line=1, end_line=999, score=0.7)
+    explorer.context.bm25 = SimpleNamespace(
         max_k=20,
         search=lambda **_kwargs: [
-            SimpleNamespace(file="../outside.py", start_line=0, end_line=1, score=1.0),
+            NodeInfo(file="../outside.py", start_line=0, end_line=1, score=1.0),
             valid,
             valid,
-            SimpleNamespace(
+            NodeInfo(
                 file=str(repo / "src/other.py"),
                 start_line=0,
                 end_line=1,
@@ -77,6 +113,190 @@ def test_explorer_filters_invalid_and_duplicate_candidates(
         ("src/other.py", 1, 2),
     ]
     assert [result.score for result in results] == [0.7, 0.0]
+
+
+def test_adapter_only_converts_native_evidence_to_official_regions() -> None:
+    evidence = RepositoryEvidence(
+        path="src/service.py",
+        start_line=2,
+        end_line=4,
+        score=0.75,
+        content="three lines",
+    )
+    runtime = SimpleNamespace(
+        context=SimpleNamespace(),
+        explore=lambda *_args, **_kwargs: RepositoryExploreResult(
+            evidence=(evidence,), trace=None
+        ),
+        close=lambda: None,
+    )
+    explorer = CodeNibSWEExploreExplorer(runtime, include_snippets=True)
+
+    results = explorer.explore(instance_id="iid", query="ignored", top_k=1)
+
+    assert results[0].regions[0].to_record() == {
+        "path": "src/service.py",
+        "start": 3,
+        "end": 5,
+        "snippet": "three lines",
+    }
+
+
+def test_auto_mixed_query_loads_and_fuses_sparse_and_dense_views(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "src" / "service.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("def calculate_tax():\n    return 1\n", encoding="utf-8")
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        indexes={
+            view: IndexEntry(
+                index_type=view,
+                path=str(tmp_path / view),
+                built_at="2026-08-04T00:00:00Z",
+                built_at_epoch=0.0,
+                status="fresh",
+            )
+            for view in ("bm25", "vector")
+        },
+    )
+    sparse = SimpleNamespace(
+        max_k=100,
+        search=lambda **_kwargs: [
+            NodeInfo(
+                node_name="calculate_tax",
+                type="function",
+                file="src/service.py",
+                node_id="tax",
+                start_line=0,
+                end_line=1,
+                score=2.0,
+            )
+        ],
+    )
+
+    class Vector:
+        def search(self, *_args, **_kwargs):
+            return [
+                NodeInfo(
+                    node_name="calculate_tax",
+                    type="function",
+                    file="src/service.py",
+                    node_id="tax",
+                    start_line=0,
+                    end_line=1,
+                    score=0.8,
+                )
+            ]
+
+        def search_within_ids(self, *_args, **_kwargs):
+            return self.search()
+
+    vector = Vector()
+
+    class LazyContext:
+        def __init__(self):
+            self.manifest = manifest
+            self.bm25 = None
+            self.vector = None
+            self.symbol_graph = None
+            self.errors = {}
+            self.requests = []
+
+        @property
+        def loaded_views(self):
+            return frozenset(
+                view
+                for view in ("bm25", "vector", "symbol_graph")
+                if getattr(self, view) is not None
+            )
+
+        def load_views(self, views):
+            self.requests.append(frozenset(views))
+            if "bm25" in views:
+                self.bm25 = sparse
+            if "vector" in views:
+                self.vector = vector
+            return {}
+
+    context = LazyContext()
+    explorer = RepositoryContextExplorer(context)
+
+    result = explorer.explore(
+        "Explain `calculate_tax` behavior",
+        top_k=5,
+        include_content=True,
+    )
+
+    assert context.requests == [frozenset({"bm25", "vector"})]
+    assert result.trace is not None
+    assert result.trace.plan.name == "hybrid_fusion"
+    assert result.trace.stage_candidate_counts[:2] == (("dense", 1), ("sparse", 1))
+    assert result.trace.stage_candidate_counts[2] == ("embedding_rerank", 1)
+    assert result.evidence[0].content == "def calculate_tax():\n    return 1"
+
+
+def test_auto_falls_back_to_an_available_view_after_load_failure(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "service.py").write_text("def price():\n    return 1\n", encoding="utf-8")
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        indexes={
+            view: IndexEntry(
+                index_type=view,
+                path=str(tmp_path / view),
+                built_at="2026-08-04T00:00:00Z",
+                built_at_epoch=0.0,
+                status="fresh",
+            )
+            for view in ("bm25", "vector")
+        },
+    )
+    sparse = SimpleNamespace(
+        max_k=100,
+        search=lambda **_kwargs: [
+            NodeInfo(
+                node_name="price",
+                type="function",
+                file="service.py",
+                start_line=0,
+                end_line=1,
+                score=1.0,
+            )
+        ],
+    )
+
+    class FailingVectorContext:
+        def __init__(self):
+            self.manifest = manifest
+            self.bm25 = None
+            self.vector = None
+            self.symbol_graph = None
+            self.errors = {}
+            self.requests = []
+
+        @property
+        def loaded_views(self):
+            return frozenset({"bm25"}) if self.bm25 is not None else frozenset()
+
+        def load_views(self, views):
+            self.requests.append(frozenset(views))
+            if "vector" in views:
+                self.errors["vector"] = "embedding backend unavailable"
+            if "bm25" in views:
+                self.bm25 = sparse
+            return {view: self.errors[view] for view in views if view in self.errors}
+
+    context = FailingVectorContext()
+    explorer = RepositoryContextExplorer(context)
+
+    result = explorer.explore("How does invoice pricing work?", top_k=5)
+
+    assert context.requests == [frozenset({"vector"}), frozenset({"bm25"})]
+    assert result.trace is not None
+    assert result.trace.plan.name == "fast_lexical"
+    assert result.trace.loaded_views == ("bm25",)
 
 
 @pytest.mark.parametrize("top_k", [0])

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -89,6 +89,42 @@ def test_load_selects_only_requested_views(
     assert calls == ["bm25"]
 
 
+def test_load_views_adds_resources_idempotently(
+    manifest_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = ServerContext.load(manifest_dir / "repo_manifest.json", views=())
+    loaded_bm25 = object()
+    calls = []
+
+    def load_bm25(self):
+        calls.append("bm25")
+        self.bm25 = loaded_bm25
+
+    monkeypatch.setattr(ServerContext, "_load_bm25", load_bm25)
+
+    assert ctx.load_views({"bm25"}) == {}
+    assert ctx.load_views({"bm25"}) == {}
+
+    assert calls == ["bm25"]
+    assert ctx.loaded_views == frozenset({"bm25"})
+
+
+def test_close_releases_live_runtime_resources(manifest_dir: Path) -> None:
+    ctx = ServerContext.load(manifest_dir / "repo_manifest.json", views=())
+    vector = MagicMock()
+    zoekt = MagicMock()
+    ctx.vector = vector
+    ctx.zoekt = zoekt
+
+    ctx.close()
+
+    assert ctx.vector is None
+    assert ctx.zoekt is None
+    vector.close.assert_called_once_with()
+    zoekt.stop.assert_called_once_with()
+
+
 def test_load_expands_runtime_view_dependencies(
     manifest_dir: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/test/test_lazy_imports.py
+++ b/test/test_lazy_imports.py
@@ -96,3 +96,29 @@ if bundle.runner is None:
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_retrieval_planner_export_does_not_import_pipeline_extras() -> None:
+    root = Path(__file__).resolve().parents[1]
+    script = """
+import sys
+
+for name in ("faiss", "igraph", "litellm", "sentence_transformers"):
+    sys.modules[name] = None
+
+from codenib.model import RetrievalPlanner
+from codenib.agent.runtime import RepositoryContextExplorer
+
+if RetrievalPlanner.__name__ != "RetrievalPlanner":
+    raise SystemExit("planner export did not resolve")
+if RepositoryContextExplorer.__name__ != "RepositoryContextExplorer":
+    raise SystemExit("explorer export did not resolve")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Add a CodeNib-native, manifest-backed repository explorer so repository exploration is a core runtime capability rather than behavior owned by a benchmark integration. Keep SWE-Explore as a thin protocol adapter and retain BM25-only execution as an explicit compatibility control.

## Changes

- Add native `RepositoryContextExplorer` policies for automatic planning, BM25, dense, hybrid, reranked hybrid, and graph retrieval.
- Select and load only the manifest-backed views required by each query, with bounded source validation and recorded execution traces.
- Reuse the public graph-expansion operator across native exploration and rerank pipelines.
- Reduce the SWE-Explore integration to coordinate conversion and benchmark protocol mapping.
- Record policy, materialized views, selected plan, timing, and query provenance in the SWE-Explore runner.
- Make model and explorer package exports lazy so lexical-only installs do not require graph or semantic extras.
- Document the native capability boundary and identify the existing 20-case SWE-Explore result as the BM25 control.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (2532 passed, 10 skipped)
- `pytest -m integration --tb=short` (36 passed, 14 skipped)
- `mkdocs build --strict`
- All pre-commit hooks passed on every changed file and again during commit.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published