### PR TITLE
docs(integrations): clarify SWE-Explore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ agent or code-Wiki framework.
 - **2026-08-04 — Native repository explorer.**
   [`RepositoryContextExplorer`](codenib/agent/runtime/explorer.py) plans BM25,
   dense, hybrid, reranked, and graph routes over manifest-backed views and
-  loads only the route selected for each query. SWE-Explore is now a thin
-  ranked-region benchmark adapter; its existing
+  loads only the route selected for each query. CodeNib runs these plans on
+  [SWE-Explore](https://github.com/Qiushao-E/SWE-Explore-Bench) through a
+  compatibility layer that preserves CodeNib's planner while producing the
+  benchmark's source-region format and official metrics. The existing
   [20-case validation](docs/evaluation/swe_explore.md) remains an explicitly
   labeled BM25 compatibility control.
 - **2026-08-03 — Native LocAgent policy.**
@@ -167,7 +169,7 @@ capabilities, loaded views, fusion, graph, and reranking trace.
 | Structural context | SCIP/LSP-backed symbol graphs with source locations and typed edges |
 | MCP and LSP-shaped tools | Serve one manifest to coding agents without tying the runtime to one agent framework |
 | External integrations | Run revision-pinned LocAgent and OrcaLoca policies over the same manifest-backed views |
-| Benchmark adapters | Project native CodeNib evidence into pinned external data and scorer contracts such as SWE-Explore |
+| Benchmark compatibility | Evaluate CodeNib's native exploration against pinned external datasets and scorers, including [SWE-Explore](https://github.com/Qiushao-E/SWE-Explore-Bench) |
 | Local inspection | Audit the same context through Wiki pages, Ask answers, citations, and the Dependency Map |
 | Evaluation harness | Measure retrieval, navigation, incremental maintenance, and context policies on the same artifacts |
 

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -57,19 +57,21 @@ indexed search, and graph traversal. This checks that the provider boundary is
 language-agnostic; it is not evidence that the pinned Python-only LocAgent or
 OrcaLoca native implementations support those languages.
 
-## Benchmark Adapters
+## Benchmark Compatibility
 
-Benchmark adapters do not define CodeNib's repository algorithm. They join
-pinned datasets, translate native evidence into an external protocol, and run
-that benchmark's scorer. Coverage retains preparation failures; quality is
-success-conditioned with its denominator stated explicitly.
+These integrations evaluate CodeNib's native repository algorithms against
+pinned external datasets and scorer contracts. They join benchmark data,
+translate source evidence at the protocol boundary, and run the corresponding
+scorer. Coverage retains preparation failures; quality is success-conditioned
+with its denominator stated explicitly.
 
-### SWE-Explore
+### [SWE-Explore](https://github.com/Qiushao-E/SWE-Explore-Bench)
 
 CodeNib's native `RepositoryContextExplorer` owns route planning, retrieval,
-graph expansion, reranking, and source validation. The SWE-Explore adapter only
-converts its 0-based evidence into the benchmark's repository-relative,
-1-based inclusive `ContextRegion` records:
+graph expansion, reranking, and source validation. The SWE-Explore
+compatibility layer preserves that execution path and converts the resulting
+0-based evidence into the benchmark's repository-relative, 1-based inclusive
+`ContextRegion` records for official evaluation:
 
 ```python
 from codenib.integrations.swe_explore import CodeNibSWEExploreExplorer

--- a/docs/evaluation/swe_explore.md
+++ b/docs/evaluation/swe_explore.md
@@ -1,15 +1,17 @@
 # SWE-Explore Compatibility Validation
 
-This validation checks whether CodeNib can participate in the official
-SWE-Explore explorer and evaluator contracts. The reported run is the explicit
-`bm25` compatibility control, not CodeNib's native multi-view `auto` policy. It
-does not measure patch generation or SWE-bench issue resolution.
+This validation runs CodeNib's native repository explorer against the
+published data and official metrics from
+[SWE-Explore](https://github.com/Qiushao-E/SWE-Explore-Bench). The reported run
+is the explicit `bm25` compatibility control, not CodeNib's native multi-view
+`auto` policy. It does not measure patch generation or SWE-bench issue
+resolution.
 
 ## Pinned Inputs
 
 | Input | Revision |
 | --- | --- |
-| SWE-Explore code | `3c12dc5a551937038afcbdb6eb6bbf19f3ddd8c1` |
+| [SWE-Explore code](https://github.com/Qiushao-E/SWE-Explore-Bench) | `3c12dc5a551937038afcbdb6eb6bbf19f3ddd8c1` |
 | SWE-Explore release | `bdb0ae45d7c337d9e1dc3ebfe2a0af6bc7c1fbd9` |
 | Public benchmark SHA-256 | `dc4f114ececd0bfb987361c26ae5e2440456e2cccb36adfccb09ea5385aec202` |
 | SWE-bench Verified | `c104f840cc67f8b6eec6f759ebc8b2693d585d4a` |


### PR DESCRIPTION
## Summary

Clarify how CodeNib integrates with SWE-Explore and link the upstream project anywhere the public documentation first introduces that support.

## Changes

- Replace the internal-sounding “thin ranked-region benchmark adapter” wording with a user-facing compatibility description.
- Explain that CodeNib retains its native repository planner while translating evidence for SWE-Explore's published region format and official metrics.
- Link the upstream SWE-Explore repository from the README, integration guide, and validation report.
- Rename the public capability label from “Benchmark adapters” to “Benchmark compatibility.”

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes
- `mkdocs build --strict`
- `python scripts/check_public_docs.py`
- `pre-commit run --files README.md docs/agent_integrations.md docs/evaluation/swe_explore.md`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
