### PR TITLE
fix(llm): support DeepSeek structured output

### DIFF
--- a/codenib/llm/litellm_chat.py
+++ b/codenib/llm/litellm_chat.py
@@ -160,6 +160,23 @@ def _no_thinking_kwargs(model: str) -> Dict[str, Any]:
     return {}
 
 
+_JSON_OBJECT_STRUCTURED_OUTPUT_PROVIDERS = frozenset({"deepseek"})
+
+
+def _uses_json_object_for_structured_output(model: str) -> bool:
+    """Return whether *model* needs JSON mode instead of JSON Schema mode.
+
+    DeepSeek's OpenAI-compatible API currently accepts ``text`` and
+    ``json_object`` response formats, but not OpenAI's ``json_schema`` format.
+    CodeNib requires provider-prefixed LiteLLM model names, so the native
+    ``deepseek/...`` route can select the compatible format without first
+    sending a request that is guaranteed to fail.
+    """
+
+    provider, separator, _ = (model or "").lower().partition("/")
+    return bool(separator and provider in _JSON_OBJECT_STRUCTURED_OUTPUT_PROVIDERS)
+
+
 # ---------------------------------------------------------------------------
 # Anthropic prompt caching
 # ---------------------------------------------------------------------------
@@ -399,9 +416,9 @@ class LiteLLMChat:
 class _StructuredLLM:
     """Wraps a :class:`LiteLLMChat` to parse responses into a Pydantic model.
 
-    Uses LiteLLM's ``response_format`` parameter which translates to
-    provider-native structured output (OpenAI JSON mode, Anthropic tool_use,
-    Vertex function calling, etc.).
+    Most providers receive the Pydantic model directly through LiteLLM's
+    ``response_format`` translation. Providers limited to JSON Object mode
+    receive the schema in the prompt and are validated locally in the same way.
     """
 
     chat: LiteLLMChat
@@ -409,7 +426,8 @@ class _StructuredLLM:
 
     def invoke(self, messages: List[ChatMessage]) -> BaseModel:
         """Call the LLM and return a validated Pydantic instance."""
-        response = self.chat._call(messages, response_format=self.schema)
+        messages, response_format = self._prepare_request(messages)
+        response = self.chat._call(messages, response_format=response_format)
         content = response.choices[0].message.content
 
         try:
@@ -420,3 +438,42 @@ class _StructuredLLM:
             if match:
                 return self.schema.model_validate_json(match.group(1).strip())
             raise
+
+    def _prepare_request(
+        self,
+        messages: List[ChatMessage],
+    ) -> Tuple[List[ChatMessage], Any]:
+        """Select the provider's structured-output protocol."""
+
+        if not _uses_json_object_for_structured_output(self.chat.model):
+            return messages, self.schema
+        return self._with_schema_instruction(messages), {"type": "json_object"}
+
+    def _with_schema_instruction(
+        self,
+        messages: List[ChatMessage],
+    ) -> List[ChatMessage]:
+        """Add the schema instruction required by JSON Object mode."""
+
+        schema_json = json.dumps(
+            self.schema.model_json_schema(),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        instruction = (
+            "Return only a JSON object that validates against the JSON Schema "
+            "below. Do not add markdown fences or explanatory text.\n"
+            f"JSON Schema:\n{schema_json}"
+        )
+        prompted = list(messages)
+        for index, message in enumerate(prompted):
+            if message.role == "system":
+                prompted[index] = ChatMessage(
+                    role="system",
+                    content=f"{message.content}\n\n{instruction}",
+                )
+                break
+        else:
+            prompted.insert(0, system_message(instruction))
+        return prompted

--- a/test/llm/test_structured_output.py
+++ b/test/llm/test_structured_output.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for provider-compatible structured LLM output."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from codenib.llm.litellm_chat import LiteLLMChat, human_message, system_message
+
+
+class _ProbeResponse(BaseModel):
+    status: str
+
+
+def _response(content: str) -> SimpleNamespace:
+    message = SimpleNamespace(role="assistant", content=content, tool_calls=None)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)], usage=None)
+
+
+def _chat(model: str) -> LiteLLMChat:
+    return LiteLLMChat(model=model)
+
+
+def test_deepseek_uses_json_object_with_schema_prompt() -> None:
+    chat = _chat("deepseek/deepseek-v4-flash")
+
+    with patch(
+        "codenib.llm.litellm_chat.litellm.completion",
+        return_value=_response('{"status":"ok"}'),
+    ) as mock_completion:
+        result = chat.with_structured_output(_ProbeResponse).invoke(
+            [human_message("Return status ok.")]
+        )
+
+    assert result == _ProbeResponse(status="ok")
+    kwargs = mock_completion.call_args.kwargs
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert kwargs["messages"][0]["role"] == "system"
+    assert "JSON Schema" in kwargs["messages"][0]["content"]
+    assert '"status"' in kwargs["messages"][0]["content"]
+    assert kwargs["messages"][1] == {
+        "role": "user",
+        "content": "Return status ok.",
+    }
+
+
+def test_json_object_instruction_extends_existing_system_prompt() -> None:
+    chat = _chat("deepseek/deepseek-v4-pro")
+
+    with patch(
+        "codenib.llm.litellm_chat.litellm.completion",
+        return_value=_response('{"status":"ok"}'),
+    ) as mock_completion:
+        chat.with_structured_output(_ProbeResponse).invoke(
+            [system_message("Keep the original policy."), human_message("Answer.")]
+        )
+
+    messages = mock_completion.call_args.kwargs["messages"]
+    assert len(messages) == 2
+    assert messages[0]["content"].startswith("Keep the original policy.\n\n")
+    assert "JSON Schema" in messages[0]["content"]
+
+
+def test_other_providers_keep_pydantic_response_format() -> None:
+    chat = _chat("openai/gpt-4o-mini")
+
+    with patch(
+        "codenib.llm.litellm_chat.litellm.completion",
+        return_value=_response('{"status":"ok"}'),
+    ) as mock_completion:
+        result = chat.with_structured_output(_ProbeResponse).invoke(
+            [human_message("Return status ok.")]
+        )
+
+    assert result.status == "ok"
+    assert mock_completion.call_args.kwargs["response_format"] is _ProbeResponse
+
+
+def test_json_object_is_still_validated_against_schema() -> None:
+    chat = _chat("deepseek/deepseek-v4-flash")
+
+    with patch(
+        "codenib.llm.litellm_chat.litellm.completion",
+        return_value=_response('{"unexpected":"value"}'),
+    ):
+        with pytest.raises(ValidationError):
+            chat.with_structured_output(_ProbeResponse).invoke(
+                [human_message("Return status ok.")]
+            )


### PR DESCRIPTION
## Summary
Enable DeepSeek V4 Pro and Flash structured output through LiteLLM's native `deepseek/...` route. DeepSeek accepts JSON Object mode rather than the Pydantic-derived JSON Schema response format used by default.

## Changes
- Use DeepSeek JSON Object mode and add the Pydantic schema to the system prompt.
- Preserve local Pydantic validation and the existing structured-output path for other providers.
- Add focused unit coverage for request shaping, prompt preservation, provider isolation, and validation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `70 passed`: `pytest -q test/llm/test_structured_output.py test/llm/test_litellm_retry.py test/llm/test_prompt_caching.py test/test_cli.py -x --tb=short`
- Live `codenib doctor --probe-model`: DeepSeek V4 Flash and V4 Pro passed text, tool-calling, and structured-output probes with thinking disabled.
- Live sparse Ask smoke: DeepSeek V4 Flash completed three turns, called `repository_search`, and returned a source citation from a BM25-only fixture.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published