### PR TITLE
feat(web): export static wiki artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ codenib doctor --require core --require wiki
 codenib index /path/to/repository
 ```
 
+Export that indexed commit as a serverless Wiki when a live Ask backend is not
+needed:
+
+```bash
+codenib export /path/to/repository --output /tmp/repository-wiki
+```
+
+The export contains a versioned provenance manifest, precomputed Wiki pages,
+source citations, and available page-level dependency data. It contains no
+provider credential; interactive Ask and runtime graph exploration remain on
+the local or MCP serving path.
+
 See the
 [Quickstart](https://docs.codenib.ai/quickstart/)
 for ports, advanced indexing, and troubleshooting.

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -238,6 +238,35 @@ def _run_mcp(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_export(args: argparse.Namespace) -> int:
+    repo_path = resolve_repo_path(args.repo)
+    manifest_path = resolve_manifest_path(str(repo_path))
+    output_dir = (
+        Path(args.output).expanduser().resolve()
+        if args.output
+        else manifest_path.parent / "static-wiki"
+    )
+
+    from .web.static_export import export_static_wiki
+
+    try:
+        result = export_static_wiki(
+            repo_path,
+            manifest_path,
+            output_dir,
+            frontend_dir=args.frontend_dir,
+            base_path=args.base_path,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise CLIError(str(exc)) from exc
+
+    print(f"Static Wiki: {result.output_dir}")
+    print(f"Repository:  {result.repo_id}")
+    print(f"Pages:       {result.page_count}")
+    print(f"Manifest:    {result.manifest_path}")
+    return 0
+
+
 def _model_options_for_args(
     args: argparse.Namespace,
     *,
@@ -975,6 +1004,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="run the Wiki audit and print its complete JSON report",
     )
     wiki_parser.set_defaults(handler=_run_wiki)
+
+    export_parser = subparsers.add_parser(
+        "export",
+        help="export an indexed repository Wiki for static hosting",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    export_parser.add_argument("repo", nargs="?", default=".")
+    export_parser.add_argument(
+        "--output",
+        help="output directory; defaults beside the repository manifest",
+    )
+    export_parser.add_argument(
+        "--base-path",
+        default="/",
+        help="URL path where the static site will be mounted",
+    )
+    export_parser.add_argument(
+        "--frontend-dir",
+        help="path to a prebuilt CodeNib frontend or web source checkout",
+    )
+    export_parser.set_defaults(handler=_run_export)
 
     mcp_parser = subparsers.add_parser(
         "mcp",

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping
 from urllib.parse import quote, unquote, urlsplit
-from xml.sax.saxutils import quoteattr
 
 from .._version import package_version
 from ..compiler.manifest import RepoManifest
@@ -38,8 +37,11 @@ _SENSITIVE_ENV_NAMES = {
     "AWS_SESSION_TOKEN",
 }
 _SENSITIVE_ENV_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET")
-_ABSOLUTE_REFERENCE_RE = re.compile(r"(?:src|href)=(['\"])/(?!/)")
 _DOCUMENT_BASE_RE = re.compile(r"<base\s+[^>]*href=(['\"])[^'\"]*\1[^>]*>", re.I)
+_DOCUMENT_REFERENCE_RE = re.compile(
+    r"(?P<prefix>\b(?:src|href)=)(?P<quote>['\"])(?P<url>[^'\"]*)(?P=quote)",
+    re.I,
+)
 _SAFE_BASE_PATH_RE = re.compile(r"^/[A-Za-z0-9._~!$&()*+,;=:@%/-]*$")
 _SAFE_PAGE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
@@ -251,20 +253,43 @@ def _copy_frontend(source: Path, target: Path, *, base_path: str) -> None:
 
     index = target / "index.html"
     index_text = index.read_text(encoding="utf-8")
-    references = _DOCUMENT_BASE_RE.sub("", index_text)
-    if base_path != "/" and _ABSOLUTE_REFERENCE_RE.search(references):
-        raise ValueError(
-            "prebuilt frontend contains root-relative assets and cannot be "
-            "mounted below '/'; rebuild it with the current CodeNib frontend"
+    index_text = _DOCUMENT_BASE_RE.sub("", index_text)
+
+    def mount_reference(match: re.Match[str]) -> str:
+        url = match.group("url")
+        if not url or url.startswith(("#", "?")):
+            return match.group(0)
+
+        parsed = urlsplit(url)
+        if parsed.scheme or parsed.netloc:
+            return match.group(0)
+        if parsed.path.startswith("/"):
+            if base_path != "/":
+                raise ValueError(
+                    "prebuilt frontend contains root-relative assets and cannot be "
+                    "mounted below '/'; rebuild it with the current CodeNib frontend"
+                )
+            return match.group(0)
+
+        decoded = unquote(parsed.path)
+        if any(part in {".", ".."} for part in PurePosixPath(decoded).parts):
+            if not decoded.startswith("./") or any(
+                part == ".." for part in PurePosixPath(decoded).parts
+            ):
+                raise ValueError("prebuilt frontend asset path contains traversal")
+        relative = parsed.path[2:] if parsed.path.startswith("./") else parsed.path
+        mount = "" if base_path == "/" else base_path
+        mounted = f"{mount}/{relative}"
+        if parsed.query:
+            mounted += f"?{parsed.query}"
+        if parsed.fragment:
+            mounted += f"#{parsed.fragment}"
+        return (
+            f'{match.group("prefix")}{match.group("quote")}'
+            f'{mounted}{match.group("quote")}'
         )
-    document_base = f"{base_path.rstrip('/')}/" if base_path != "/" else "/"
-    base_element = f"<base href={quoteattr(document_base)}>"
-    if _DOCUMENT_BASE_RE.search(index_text):
-        index_text = _DOCUMENT_BASE_RE.sub(base_element, index_text, count=1)
-    elif "<head>" in index_text:
-        index_text = index_text.replace("<head>", f"<head>\n    {base_element}", 1)
-    else:
-        raise ValueError("prebuilt frontend index.html has no <head> element")
+
+    index_text = _DOCUMENT_REFERENCE_RE.sub(mount_reference, index_text)
     index.write_text(index_text, encoding="utf-8")
 
 
@@ -435,14 +460,31 @@ def _secret_values(environ: Mapping[str, str]) -> list[bytes]:
     return values
 
 
+def _serialized_patterns(values: Iterable[str]) -> set[bytes]:
+    patterns: set[bytes] = set()
+    for value in values:
+        if not value:
+            continue
+        patterns.add(value.encode("utf-8"))
+        escaped = json.dumps(value, ensure_ascii=True)[1:-1]
+        patterns.add(escaped.encode("utf-8"))
+    return patterns
+
+
 def _assert_publishable(
     root: Path,
     *,
     forbidden_paths: Iterable[Path],
     environ: Mapping[str, str],
 ) -> None:
-    forbidden = [str(path.resolve()).encode("utf-8") for path in forbidden_paths]
-    secrets = _secret_values(environ)
+    forbidden_values: list[str] = []
+    for path in forbidden_paths:
+        resolved = path.resolve()
+        forbidden_values.extend((str(resolved), resolved.as_posix()))
+    forbidden = _serialized_patterns(forbidden_values)
+    secrets = _serialized_patterns(
+        value.decode("utf-8") for value in _secret_values(environ)
+    )
     for path in root.rglob("*"):
         if path.is_symlink():
             raise ValueError(f"static export contains a symbolic link: {path}")

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -69,7 +69,9 @@ def normalize_base_path(value: str) -> str:
     parts = PurePosixPath(decoded).parts
     if any(part in {".", ".."} for part in parts):
         raise ValueError("base path must not contain '.' or '..' segments")
-    if not _SAFE_BASE_PATH_RE.fullmatch(parsed.path):
+    if not _SAFE_BASE_PATH_RE.fullmatch(
+        parsed.path
+    ) or not _SAFE_BASE_PATH_RE.fullmatch(decoded):
         raise ValueError("base path contains unsupported URL characters")
 
     normalized = "/" + "/".join(part for part in parts if part != "/")

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -1,0 +1,640 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export a manifest-backed repository Wiki for static hosting."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping
+from urllib.parse import quote, unquote, urlsplit
+from xml.sax.saxutils import quoteattr
+
+from .._version import package_version
+from ..compiler.manifest import RepoManifest
+from .launcher import find_frontend_dir
+from .local import prepare_local_wiki
+
+STATIC_EXPORT_SCHEMA_VERSION = "1.0"
+STATIC_EXPORT_MANIFEST = "codenib-static.json"
+
+_SENSITIVE_ENV_NAMES = {
+    "ANTHROPIC_API_KEY",
+    "AZURE_API_KEY",
+    "CODENIB_DEMO_API_KEY",
+    "GITHUB_TOKEN",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+}
+_SENSITIVE_ENV_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET")
+_ABSOLUTE_REFERENCE_RE = re.compile(r"(?:src|href)=(['\"])/(?!/)")
+_DOCUMENT_BASE_RE = re.compile(r"<base\s+[^>]*href=(['\"])[^'\"]*\1[^>]*>", re.I)
+_SAFE_BASE_PATH_RE = re.compile(r"^/[A-Za-z0-9._~!$&()*+,;=:@%/-]*$")
+_SAFE_PAGE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class StaticExportResult:
+    """Summary returned after publishing one static Wiki directory."""
+
+    output_dir: Path
+    manifest_path: Path
+    repo_id: str
+    page_count: int
+    file_count: int
+
+
+def normalize_base_path(value: str) -> str:
+    """Return a canonical URL path used as the static site's mount point."""
+
+    raw = (value or "/").strip()
+    parsed = urlsplit(raw)
+    if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment:
+        raise ValueError("base path must be a URL path without a host or query")
+    if not raw.startswith("/") or "\\" in raw:
+        raise ValueError("base path must start with '/' and use forward slashes")
+
+    decoded = unquote(parsed.path)
+    parts = PurePosixPath(decoded).parts
+    if any(part in {".", ".."} for part in parts):
+        raise ValueError("base path must not contain '.' or '..' segments")
+    if not _SAFE_BASE_PATH_RE.fullmatch(parsed.path):
+        raise ValueError("base path contains unsupported URL characters")
+
+    normalized = "/" + "/".join(part for part in parts if part != "/")
+    return "/" if normalized == "/" else normalized.rstrip("/")
+
+
+def _json_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(
+            value,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _write_bytes(root: Path, relative: str, content: bytes) -> Path:
+    target = root.joinpath(*PurePosixPath(relative).parts).resolve()
+    if root != target and root not in target.parents:
+        raise ValueError(f"export path escapes the output directory: {relative}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    return target
+
+
+def _write_json(root: Path, relative: str, value: Any) -> Path:
+    return _write_bytes(root, relative, _json_bytes(value))
+
+
+def _model_dict(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        return dict(value.model_dump(mode="json"))
+    if hasattr(value, "dict"):
+        return dict(value.dict())
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise TypeError(f"unsupported repository metadata type: {type(value).__name__}")
+
+
+def _page_ids(nodes: Iterable[Mapping[str, Any]]) -> list[str]:
+    result: list[str] = []
+    for node in nodes:
+        page_id = str(node.get("id") or "").strip()
+        if not page_id:
+            raise ValueError("Wiki page tree contains an empty page id")
+        if not _SAFE_PAGE_ID_RE.fullmatch(page_id):
+            raise ValueError(f"Wiki page id is not URL-safe: {page_id!r}")
+        result.append(page_id)
+        children = node.get("children") or ()
+        if not isinstance(children, (list, tuple)):
+            raise ValueError(f"Wiki page {page_id!r} has invalid children")
+        result.extend(_page_ids(children))
+    if len(result) != len(set(result)):
+        raise ValueError("Wiki page tree contains duplicate page ids")
+    return result
+
+
+def _source_path(value: str) -> str:
+    path = value.replace("\\", "/")
+    parts = PurePosixPath(path).parts
+    if path.startswith("/") or re.match(r"^[A-Za-z]:/", path):
+        raise ValueError(f"Wiki source path must be repository-relative: {path}")
+    if any(part == ".." for part in parts):
+        raise ValueError(f"Wiki source path contains traversal: {path}")
+    return PurePosixPath(path).as_posix() if path else ""
+
+
+def _normalize_source_fields(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            key: (
+                _source_path(str(item))
+                if key == "file" and item is not None
+                else _normalize_source_fields(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_normalize_source_fields(item) for item in value]
+    if isinstance(value, tuple):
+        return [_normalize_source_fields(item) for item in value]
+    return value
+
+
+def _normalize_page(builder: Any, page: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(page)
+    citations = []
+    for value in payload.get("citations") or ():
+        citation = dict(value)
+        file = _source_path(str(citation.get("file") or ""))
+        citation["file"] = file or None
+        if file and not citation.get("content"):
+            source = builder.source(
+                file,
+                citation.get("start_line"),
+                citation.get("end_line"),
+            )
+            if source is not None:
+                citation["content"] = source.get("content")
+        citations.append(citation)
+    payload["citations"] = citations
+
+    if "generation" not in payload:
+        payload["generation"] = {
+            "mode": "offline",
+            "model": None,
+            "repaired": False,
+        }
+    if "grounding" not in payload:
+        count = len(citations)
+        payload["grounding"] = {
+            "valid": True,
+            "citation_coverage": 1.0,
+            "cited_evidence": count,
+            "evidence_count": count,
+            "relation_count": 0,
+        }
+    return _normalize_source_fields(payload)
+
+
+def _unavailable_page_graph(note: str = "") -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "available": False,
+        "nodes": [],
+        "edges": [],
+        "mermaid": "",
+    }
+    if note:
+        payload["note"] = note
+    return payload
+
+
+def _page_graph(bundle: Any, page: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        graph = bundle.code_graph()
+        if graph is None:
+            return _unavailable_page_graph()
+        from .codemap import build_page_subgraph
+
+        return _normalize_source_fields(
+            build_page_subgraph(
+                graph,
+                page.get("citations") or (),
+                repo_dir=bundle.entry.repo_dir,
+                hierarchy_graph=bundle.hierarchical_graph(),
+            )
+        )
+    except Exception:  # noqa: BLE001 - an optional graph must not block the Wiki
+        return _unavailable_page_graph("The indexed dependency view was unavailable.")
+
+
+def _prebuilt_frontend(explicit: str | os.PathLike[str] | None) -> Path:
+    frontend = find_frontend_dir(explicit)
+    if frontend is None:
+        raise ValueError(
+            "CodeNib Wiki frontend was not found; pass --frontend-dir or install "
+            "a release wheel containing the prebuilt frontend"
+        )
+    if (frontend / "package.json").is_file():
+        frontend = frontend / "dist"
+    if not (frontend / "index.html").is_file():
+        raise ValueError(
+            f"prebuilt frontend not found under {frontend}; run "
+            "`cd web && npm ci && npm run build` first"
+        )
+    return frontend
+
+
+def _copy_frontend(source: Path, target: Path, *, base_path: str) -> None:
+    for candidate in source.rglob("*"):
+        if candidate.is_symlink():
+            raise ValueError(f"frontend contains a symbolic link: {candidate}")
+    shutil.copytree(source, target, dirs_exist_ok=True)
+
+    index = target / "index.html"
+    index_text = index.read_text(encoding="utf-8")
+    references = _DOCUMENT_BASE_RE.sub("", index_text)
+    if base_path != "/" and _ABSOLUTE_REFERENCE_RE.search(references):
+        raise ValueError(
+            "prebuilt frontend contains root-relative assets and cannot be "
+            "mounted below '/'; rebuild it with the current CodeNib frontend"
+        )
+    document_base = f"{base_path.rstrip('/')}/" if base_path != "/" else "/"
+    base_element = f"<base href={quoteattr(document_base)}>"
+    if _DOCUMENT_BASE_RE.search(index_text):
+        index_text = _DOCUMENT_BASE_RE.sub(base_element, index_text, count=1)
+    elif "<head>" in index_text:
+        index_text = index_text.replace("<head>", f"<head>\n    {base_element}", 1)
+    else:
+        raise ValueError("prebuilt frontend index.html has no <head> element")
+    index.write_text(index_text, encoding="utf-8")
+
+
+def _runtime_config(base_path: str) -> bytes:
+    data_base = f"{base_path.rstrip('/')}/data" if base_path != "/" else "/data"
+    config = {
+        "mode": "static",
+        "basePath": base_path,
+        "dataBase": data_base,
+    }
+    encoded = json.dumps(
+        config, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    )
+    return (
+        f"window.__CODENIB_RUNTIME__ = Object.freeze({encoded});\n"
+        'window.__CODENIB_API_BASE__ = "";\n'
+    ).encode("utf-8")
+
+
+def _not_found_page(base_path: str) -> bytes:
+    root = f"{base_path.rstrip('/')}/" if base_path != "/" else "/"
+    encoded_root = json.dumps(root)
+    return (
+        '<!doctype html><meta charset="utf-8"><title>CodeNib Wiki</title>'
+        "<script>"
+        f"const root={encoded_root};"
+        "const route=location.pathname+location.search+location.hash;"
+        "location.replace(root+'?__codenib_route='+encodeURIComponent(route));"
+        "</script>"
+    ).encode("utf-8")
+
+
+def _view_provenance(manifest: RepoManifest) -> dict[str, Any]:
+    result = {}
+    for name, entry in sorted(manifest.indexes.items()):
+        result[name] = {
+            "status": entry.status,
+            "current": manifest.index_is_current(name),
+            "commit": entry.commit,
+            "source_fingerprint": entry.source_fingerprint,
+        }
+    return result
+
+
+def _github_repository_url(repo_path: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "-C", str(repo_path), "remote", "get-url", "origin"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    origin = result.stdout.strip()
+    if origin.startswith("git@github.com:"):
+        path = origin.split(":", 1)[1]
+    else:
+        parsed = urlsplit(origin)
+        if (parsed.hostname or "").lower() != "github.com":
+            return None
+        path = parsed.path.lstrip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    path = path.strip("/")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", path):
+        return None
+    return f"https://github.com/{path}"
+
+
+def _load_static_bundle(local: Any, manifest_path: Path) -> Any:
+    """Load only the persisted views required to render static Wiki pages."""
+
+    from ..index.sparse_idx.bm25_index import BM25CodeIndexer
+    from .config import REGISTRY_FILENAME, load_registry
+    from .repo_registry import RepoBundle
+
+    manifest = RepoManifest.load(manifest_path)
+    bm25_entry = manifest.indexes.get("bm25")
+    if bm25_entry is None or not manifest.index_is_current("bm25"):
+        raise ValueError("static Wiki export requires a current bm25 view")
+
+    entries = load_registry(str(local.data_dir / REGISTRY_FILENAME))
+    entry = next((item for item in entries if item.instance_id == local.repo_id), None)
+    if entry is None:
+        raise ValueError(f"prepared repository {local.repo_id!r} could not be loaded")
+
+    def load_views(bundle: Any) -> None:
+        index = BM25CodeIndexer()
+        index.load_index(bm25_entry.path)
+        bundle.bm25 = index
+        bundle.vector_store = None
+
+    return RepoBundle(
+        entry=entry,
+        manifest=manifest,
+        chat_available=False,
+        view_loader=load_views,
+        runtime_loader=None,
+    )
+
+
+def _generation_summary(pages: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    page_list = list(pages)
+    modes = sorted(
+        {
+            str((page.get("generation") or {}).get("mode") or "offline")
+            for page in page_list
+        }
+    )
+    models = sorted(
+        {
+            str((page.get("generation") or {}).get("model"))
+            for page in page_list
+            if (page.get("generation") or {}).get("model")
+        }
+    )
+    policies = sorted(
+        {
+            str((page.get("generation") or {}).get("renderer") or "index-derived")
+            for page in page_list
+        }
+    )
+    prompt_versions = sorted(
+        {
+            str((page.get("generation") or {}).get("prompt_version"))
+            for page in page_list
+            if (page.get("generation") or {}).get("prompt_version")
+        }
+    )
+    grounded = sum(
+        bool((page.get("grounding") or {}).get("valid")) for page in page_list
+    )
+    return {
+        "modes": modes,
+        "models": models,
+        "policies": policies,
+        "prompt_versions": prompt_versions,
+        "page_count": len(page_list),
+        "grounding_valid_pages": grounded,
+    }
+
+
+def _file_inventory(root: Path) -> list[dict[str, Any]]:
+    files = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.name == STATIC_EXPORT_MANIFEST:
+            continue
+        data = path.read_bytes()
+        files.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "bytes": len(data),
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }
+        )
+    return files
+
+
+def _secret_values(environ: Mapping[str, str]) -> list[bytes]:
+    values = []
+    for name, value in environ.items():
+        upper = name.upper()
+        sensitive = upper in _SENSITIVE_ENV_NAMES or upper.endswith(
+            _SENSITIVE_ENV_SUFFIXES
+        )
+        if sensitive and len(value) >= 8:
+            values.append(value.encode("utf-8"))
+    return values
+
+
+def _assert_publishable(
+    root: Path,
+    *,
+    forbidden_paths: Iterable[Path],
+    environ: Mapping[str, str],
+) -> None:
+    forbidden = [str(path.resolve()).encode("utf-8") for path in forbidden_paths]
+    secrets = _secret_values(environ)
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"static export contains a symbolic link: {path}")
+        if not path.is_file():
+            continue
+        data = path.read_bytes()
+        if any(value and value in data for value in forbidden):
+            raise ValueError(
+                "static export contains an absolute build-machine path in "
+                f"{path.relative_to(root)}"
+            )
+        if any(secret in data for secret in secrets):
+            raise ValueError(
+                "static export contains a configured credential in "
+                f"{path.relative_to(root)}"
+            )
+
+
+def _validated_output(repo_path: Path, output_dir: Path) -> Path:
+    repo_path = repo_path.resolve()
+    output_dir = output_dir.expanduser().resolve()
+    if output_dir == repo_path or repo_path in output_dir.parents:
+        raise ValueError("static export output must be outside the target repository")
+    if output_dir in repo_path.parents:
+        raise ValueError("static export output must not contain the target repository")
+    if output_dir.exists() and not output_dir.is_dir():
+        raise ValueError(f"static export output is not a directory: {output_dir}")
+    if output_dir.exists() and any(output_dir.iterdir()):
+        if not (output_dir / STATIC_EXPORT_MANIFEST).is_file():
+            raise ValueError(
+                "refusing to replace a non-empty directory that is not a CodeNib "
+                f"static export: {output_dir}"
+            )
+    return output_dir
+
+
+def export_static_wiki(
+    repo_path: Path,
+    manifest_path: Path,
+    output_dir: Path,
+    *,
+    frontend_dir: str | os.PathLike[str] | None = None,
+    base_path: str = "/",
+    environ: Mapping[str, str] | None = None,
+) -> StaticExportResult:
+    """Build a deterministic static Wiki from an existing repository manifest."""
+
+    repo_path = repo_path.expanduser().resolve()
+    manifest_path = manifest_path.expanduser().resolve()
+    output_dir = _validated_output(repo_path, output_dir)
+    base_path = normalize_base_path(base_path)
+    frontend = _prebuilt_frontend(frontend_dir)
+    environment = os.environ if environ is None else environ
+
+    local = prepare_local_wiki(
+        repo_path,
+        manifest_path,
+        frontend_port=0,
+        agent_wiki=False,
+    )
+
+    from ..wiki import WikiBuilder
+
+    bundle = _load_static_bundle(local, manifest_path)
+    builder = WikiBuilder(bundle)
+
+    tree = builder.page_tree()
+    page_ids = _page_ids(tree)
+    pages = []
+    graphs: dict[str, dict[str, Any]] = {}
+    for page_id in page_ids:
+        page = builder.page(page_id)
+        if page is None:
+            raise ValueError(f"Wiki page tree references a missing page: {page_id}")
+        normalized = _normalize_page(builder, page)
+        pages.append(normalized)
+        graphs[page_id] = _page_graph(bundle, normalized)
+
+    repo_info = _model_dict(bundle.info())
+    capabilities = {name: False for name in dict(repo_info.get("capabilities") or {})}
+    capabilities.update(
+        {
+            "chat": False,
+            "codemap": False,
+            "edge_labels": False,
+            "source_citations": True,
+            "static_wiki": True,
+            "wiki_graph": any(graph.get("available") for graph in graphs.values()),
+        }
+    )
+    repo_info["capabilities"] = capabilities
+    repo_info["problem_statement"] = ""
+    repo_info["incremental"] = None
+    repo_info["source_url"] = _github_repository_url(repo_path)
+
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(
+        tempfile.mkdtemp(
+            prefix=f".{output_dir.name}.tmp-",
+            dir=str(output_dir.parent),
+        )
+    ).resolve()
+    try:
+        _copy_frontend(frontend, stage, base_path=base_path)
+        _write_bytes(stage, "runtime-config.js", _runtime_config(base_path))
+        _write_bytes(stage, "404.html", _not_found_page(base_path))
+        _write_json(stage, "data/repos.json", [repo_info])
+
+        repo_component = quote(local.repo_id, safe="")
+        repo_root = f"data/repos/{repo_component}"
+        _write_json(
+            stage,
+            f"{repo_root}/wiki.json",
+            {"repo": bundle.entry.repo, "pages": tree},
+        )
+        _write_json(
+            stage,
+            f"{repo_root}/commits.json",
+            {"available": False, "commits": [], "selected": None},
+        )
+        for page, page_id in zip(pages, page_ids, strict=True):
+            component = quote(page_id, safe="")
+            _write_json(stage, f"{repo_root}/pages/{component}.json", page)
+            _write_json(
+                stage,
+                f"{repo_root}/page-graphs/{component}.json",
+                graphs[page_id],
+            )
+
+        _assert_publishable(
+            stage,
+            forbidden_paths=(repo_path, manifest_path.parent),
+            environ=environment,
+        )
+        source_manifest = bundle.manifest
+        export_manifest = {
+            "schema_version": STATIC_EXPORT_SCHEMA_VERSION,
+            "repository": {
+                "id": local.repo_id,
+                "slug": bundle.entry.repo,
+                "url": repo_info["source_url"],
+                "commit": source_manifest.commit,
+                "source_fingerprint": source_manifest.source_fingerprint,
+                "languages": list(source_manifest.languages),
+            },
+            "builder": {
+                "codenib_version": package_version(),
+                "manifest_version": source_manifest.version,
+                "profile": sorted(
+                    name
+                    for name in source_manifest.indexes
+                    if source_manifest.index_is_current(name)
+                ),
+            },
+            "source_locations": {
+                "path": "repository-relative-posix",
+                "line_base": 1,
+                "end_line": "inclusive",
+                "commit": source_manifest.commit,
+            },
+            "views": _view_provenance(source_manifest),
+            "capabilities": capabilities,
+            "generation": _generation_summary(pages),
+            "base_path": base_path,
+            "files": _file_inventory(stage),
+        }
+        manifest_file = _write_json(stage, STATIC_EXPORT_MANIFEST, export_manifest)
+        _assert_publishable(
+            stage,
+            forbidden_paths=(repo_path, manifest_path.parent),
+            environ=environment,
+        )
+
+        if output_dir.exists():
+            shutil.rmtree(output_dir)
+        stage.rename(output_dir)
+        manifest_file = output_dir / manifest_file.relative_to(stage)
+    except Exception:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+
+    return StaticExportResult(
+        output_dir=output_dir,
+        manifest_path=manifest_file,
+        repo_id=local.repo_id,
+        page_count=len(pages),
+        file_count=len(export_manifest["files"]),
+    )
+
+
+__all__ = [
+    "STATIC_EXPORT_MANIFEST",
+    "STATIC_EXPORT_SCHEMA_VERSION",
+    "StaticExportResult",
+    "export_static_wiki",
+    "normalize_base_path",
+]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -73,6 +73,39 @@ Force a clean rebuild with:
 codenib wiki /path/to/repository --rebuild
 ```
 
+## Export A Static Wiki
+
+An existing manifest can be frozen into a serverless directory for GitHub
+Pages or another static host:
+
+```bash
+codenib index /path/to/repository
+codenib export /path/to/repository --output /tmp/repository-wiki
+```
+
+The export records the repository commit, source fingerprint, view
+capabilities, source-location convention, generation mode, and content hashes
+in `codenib-static.json`. It also embeds source slices used by page citations,
+so reading a page does not require the local FastAPI process. CodeNib rejects
+an export when the checkout no longer matches the manifest.
+
+For a GitHub project Pages site, set its mount path to the repository name:
+
+```bash
+codenib export . \
+  --output /tmp/my-project \
+  --base-path /my-project
+```
+
+The output must be outside the target checkout. CodeNib can replace a prior
+CodeNib export, but it refuses to delete an unrelated non-empty directory.
+
+Static mode publishes only capabilities with a serverless implementation:
+Wiki navigation, embedded citations, and precomputed page dependency views.
+Interactive Ask, on-demand edge labels, and arbitrary dependency queries need
+an authenticated CodeNib runtime and are not exposed by the export. No API key,
+GitHub token, endpoint credential, or build-machine absolute path is serialized.
+
 ## Select Repository Views
 
 | Preset | Required package | Views |

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -20,9 +20,28 @@ from codenib.web.local import prepare_local_wiki
 def test_parser_exposes_release_commands() -> None:
     parser = cli.build_parser()
 
-    for command in ("index", "wiki", "mcp", "doctor"):
+    for command in ("index", "wiki", "export", "mcp", "doctor"):
         args = parser.parse_args([command])
         assert args.command == command
+
+
+def test_export_parser_accepts_pages_mount_options() -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "export",
+            ".",
+            "--output",
+            "/tmp/wiki",
+            "--base-path",
+            "/project",
+            "--frontend-dir",
+            "/tmp/frontend",
+        ]
+    )
+
+    assert args.output == "/tmp/wiki"
+    assert args.base_path == "/project"
+    assert args.frontend_dir == "/tmp/frontend"
 
 
 def test_wiki_parser_accepts_headless_quality_audit() -> None:

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -1,0 +1,348 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.web.static_export import (
+    STATIC_EXPORT_MANIFEST,
+    export_static_wiki,
+    normalize_base_path,
+)
+
+
+class _Builder:
+    def __init__(self, _bundle) -> None:
+        self.pages = {
+            "overview": {
+                "id": "overview",
+                "title": "Overview",
+                "markdown": "# Overview\n\nThe runtime is source linked.",
+                "citations": [
+                    {
+                        "file": "src/runtime.py",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "node_name": "run",
+                        "type": "function",
+                        "score": None,
+                        "content": None,
+                    }
+                ],
+                "diagram": "",
+            },
+            "architecture": {
+                "id": "architecture",
+                "title": "Architecture",
+                "markdown": "# Architecture",
+                "citations": [],
+                "diagram": "",
+            },
+        }
+
+    def page_tree(self):
+        return [
+            {"id": "overview", "title": "Overview", "children": []},
+            {"id": "architecture", "title": "Architecture", "children": []},
+        ]
+
+    def page(self, page_id):
+        return self.pages.get(page_id)
+
+    def source(self, file, start, end):
+        assert (file, start, end) == ("src/runtime.py", 1, 2)
+        return {
+            "file": file,
+            "start_line": start,
+            "end_line": end,
+            "content": "def run():\n    return 'ready'\n",
+        }
+
+
+def _frontend(root: Path) -> Path:
+    frontend = root / "frontend"
+    (frontend / "assets").mkdir(parents=True)
+    (frontend / "index.html").write_text(
+        "<!doctype html><html><head><base href='/'></head><body>"
+        "<script src='./runtime-config.js'></script>"
+        "<script type='module' src='./assets/app.js'></script></body></html>",
+        encoding="utf-8",
+    )
+    (frontend / "runtime-config.js").write_text(
+        'window.__CODENIB_API_BASE__ = "";\n', encoding="utf-8"
+    )
+    (frontend / "assets" / "app.js").write_text(
+        "console.log('wiki');\n", encoding="utf-8"
+    )
+    return frontend
+
+
+def _manifest(repo: Path, artifact: Path) -> tuple[RepoManifest, Path]:
+    entry = IndexEntry(
+        index_type="bm25",
+        path=str(artifact / "bm25"),
+        built_at="2026-08-04T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        commit="abc123",
+        source_fingerprint="source-1",
+    )
+    manifest = RepoManifest(
+        repo_path=str(repo),
+        commit="abc123",
+        source_fingerprint="source-1",
+        languages=["python"],
+        file_count=1,
+        indexes={"bm25": entry},
+        capabilities={"sparse_search": True},
+    )
+    path = artifact / "repo_manifest.json"
+    manifest.save(path)
+    return manifest, path
+
+
+@pytest.fixture
+def export_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "src").mkdir()
+    (repo / "src" / "runtime.py").write_text(
+        "def run():\n    return 'ready'\n", encoding="utf-8"
+    )
+    artifact = tmp_path / "artifact"
+    manifest, manifest_path = _manifest(repo, artifact)
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            instance_id="demo",
+            repo="owner/demo",
+            repo_dir=str(repo),
+        ),
+        manifest=manifest,
+        info=lambda: {
+            "id": "demo",
+            "name": "owner/demo @ abc123",
+            "repo": "owner/demo",
+            "base_commit": "abc123",
+            "commit_short": "abc123",
+            "language": "python",
+            "description": "A demo repository.",
+            "problem_statement": "private benchmark text",
+            "languages": ["python"],
+            "file_count": 1,
+            "capabilities": {"sparse_search": True, "chat": True},
+            "graph_coverage": None,
+        },
+        code_graph=lambda: None,
+        hierarchical_graph=lambda: None,
+    )
+    local = SimpleNamespace(
+        repo_id="demo",
+        data_dir=artifact / "wiki",
+        config_path=artifact / "wiki" / "config.yaml",
+    )
+    monkeypatch.setattr(
+        "codenib.web.static_export.prepare_local_wiki",
+        lambda *_args, **_kwargs: local,
+    )
+    monkeypatch.setattr(
+        "codenib.web.static_export._load_static_bundle",
+        lambda _local, _manifest_path: bundle,
+    )
+    monkeypatch.setattr("codenib.wiki.WikiBuilder", _Builder)
+
+    return SimpleNamespace(
+        repo=repo,
+        artifact=artifact,
+        manifest_path=manifest_path,
+        frontend=_frontend(tmp_path),
+        output=tmp_path / "site",
+    )
+
+
+def _tree_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_static_export_is_deterministic_and_publishable(
+    export_setup, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    setup = export_setup
+    monkeypatch.setattr(
+        "codenib.web.static_export._github_repository_url",
+        lambda _repo: "https://github.com/owner/demo",
+    )
+    first = export_static_wiki(
+        setup.repo,
+        setup.manifest_path,
+        setup.output,
+        frontend_dir=setup.frontend,
+        base_path="/demo",
+        environ={"OPENAI_API_KEY": "not-present-in-output"},
+    )
+    first_bytes = _tree_bytes(setup.output)
+
+    second = export_static_wiki(
+        setup.repo,
+        setup.manifest_path,
+        setup.output,
+        frontend_dir=setup.frontend,
+        base_path="/demo",
+        environ={"OPENAI_API_KEY": "not-present-in-output"},
+    )
+
+    assert first.page_count == second.page_count == 2
+    assert _tree_bytes(setup.output) == first_bytes
+    manifest = json.loads((setup.output / STATIC_EXPORT_MANIFEST).read_text())
+    assert manifest["schema_version"] == "1.0"
+    assert manifest["repository"]["commit"] == "abc123"
+    assert manifest["repository"]["url"] == "https://github.com/owner/demo"
+    assert manifest["source_locations"]["line_base"] == 1
+    assert manifest["capabilities"]["static_wiki"] is True
+    assert manifest["capabilities"]["chat"] is False
+    assert manifest["capabilities"]["codemap"] is False
+    assert manifest["capabilities"]["sparse_search"] is False
+    assert manifest["views"]["bm25"]["current"] is True
+
+    repos = json.loads((setup.output / "data" / "repos.json").read_text())
+    assert repos[0]["problem_statement"] == ""
+    assert repos[0]["source_url"] == "https://github.com/owner/demo"
+    page = json.loads(
+        (
+            setup.output / "data" / "repos" / "demo" / "pages" / "overview.json"
+        ).read_text()
+    )
+    assert page["citations"][0]["content"].startswith("def run")
+    assert page["generation"]["mode"] == "offline"
+    assert b"not-present-in-output" not in b"".join(first_bytes.values())
+    assert str(setup.repo).encode() not in b"".join(first_bytes.values())
+    runtime = (setup.output / "runtime-config.js").read_text()
+    assert '"basePath":"/demo"' in runtime
+    assert '"mode":"static"' in runtime
+    assert '<base href="/demo/">' in (setup.output / "index.html").read_text()
+
+
+def test_static_export_rejects_a_configured_secret(
+    export_setup, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "provider-secret-value"
+
+    class SecretBuilder(_Builder):
+        def __init__(self, bundle) -> None:
+            super().__init__(bundle)
+            self.pages["overview"]["markdown"] = f"# Overview\n\n{secret}"
+
+    monkeypatch.setattr("codenib.wiki.WikiBuilder", SecretBuilder)
+
+    with pytest.raises(ValueError, match="configured credential"):
+        export_static_wiki(
+            export_setup.repo,
+            export_setup.manifest_path,
+            export_setup.output,
+            frontend_dir=export_setup.frontend,
+            environ={"OPENAI_API_KEY": secret},
+        )
+    assert not export_setup.output.exists()
+
+
+def test_static_export_advertises_only_precomputed_page_graphs(
+    export_setup, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "codenib.web.static_export._page_graph",
+        lambda _bundle, _page: {
+            "available": True,
+            "nodes": [{"id": "run"}],
+            "edges": [],
+            "mermaid": "",
+        },
+    )
+
+    export_static_wiki(
+        export_setup.repo,
+        export_setup.manifest_path,
+        export_setup.output,
+        frontend_dir=export_setup.frontend,
+    )
+
+    repos = json.loads((export_setup.output / "data" / "repos.json").read_text())
+    assert repos[0]["capabilities"]["wiki_graph"] is True
+    assert repos[0]["capabilities"]["codemap"] is False
+    graph = json.loads(
+        (
+            export_setup.output
+            / "data"
+            / "repos"
+            / "demo"
+            / "page-graphs"
+            / "overview.json"
+        ).read_text()
+    )
+    assert graph["available"] is True
+
+
+def test_static_export_does_not_replace_an_unrelated_directory(export_setup) -> None:
+    export_setup.output.mkdir()
+    (export_setup.output / "keep.txt").write_text("keep", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="refusing to replace"):
+        export_static_wiki(
+            export_setup.repo,
+            export_setup.manifest_path,
+            export_setup.output,
+            frontend_dir=export_setup.frontend,
+        )
+
+    assert (export_setup.output / "keep.txt").read_text() == "keep"
+
+
+def test_static_export_rejects_absolute_citation_paths(
+    export_setup, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class AbsolutePathBuilder(_Builder):
+        def __init__(self, bundle) -> None:
+            super().__init__(bundle)
+            self.pages["overview"]["citations"][0]["file"] = "/tmp/source.py"
+
+    monkeypatch.setattr("codenib.wiki.WikiBuilder", AbsolutePathBuilder)
+
+    with pytest.raises(ValueError, match="repository-relative"):
+        export_static_wiki(
+            export_setup.repo,
+            export_setup.manifest_path,
+            export_setup.output,
+            frontend_dir=export_setup.frontend,
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("/", "/"), ("/demo/", "/demo"), ("/org/demo", "/org/demo")],
+)
+def test_normalize_base_path(value: str, expected: str) -> None:
+    assert normalize_base_path(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "demo",
+        "https://example.com/demo",
+        "/demo?token=x",
+        "/demo/../other",
+        '/demo" onload="alert(1)',
+    ],
+)
+def test_normalize_base_path_rejects_unsafe_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        normalize_base_path(value)

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -340,6 +340,9 @@ def test_normalize_base_path(value: str, expected: str) -> None:
         "https://example.com/demo",
         "/demo?token=x",
         "/demo/../other",
+        "/demo%22onload",
+        "/demo%3Fquery",
+        "/demo%23fragment",
         '/demo" onload="alert(1)',
     ],
 )

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from types import SimpleNamespace
 
 import pytest
@@ -13,6 +13,7 @@ import pytest
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.web.static_export import (
     STATIC_EXPORT_MANIFEST,
+    _assert_publishable,
     export_static_wiki,
     normalize_base_path,
 )
@@ -72,7 +73,9 @@ def _frontend(root: Path) -> Path:
     (frontend / "index.html").write_text(
         "<!doctype html><html><head><base href='/'></head><body>"
         "<script src='./runtime-config.js'></script>"
-        "<script type='module' src='./assets/app.js'></script></body></html>",
+        "<script type='module' src='./assets/app.js'></script>"
+        "<a href='?p=module'>Module</a><a href='#heading'>Heading</a>"
+        "</body></html>",
         encoding="utf-8",
     )
     (frontend / "runtime-config.js").write_text(
@@ -229,7 +232,33 @@ def test_static_export_is_deterministic_and_publishable(
     runtime = (setup.output / "runtime-config.js").read_text()
     assert '"basePath":"/demo"' in runtime
     assert '"mode":"static"' in runtime
-    assert '<base href="/demo/">' in (setup.output / "index.html").read_text()
+    index = (setup.output / "index.html").read_text()
+    assert "<base" not in index
+    assert "src='/demo/runtime-config.js'" in index
+    assert "src='/demo/assets/app.js'" in index
+    assert "href='?p=module'" in index
+    assert "href='#heading'" in index
+
+
+def test_publishability_rejects_json_escaped_windows_path(tmp_path: Path) -> None:
+    root = tmp_path / "site"
+    root.mkdir()
+    windows_path = PureWindowsPath(r"C:\build\repository")
+    (root / "page.json").write_text(
+        json.dumps({"source": str(windows_path)}),
+        encoding="utf-8",
+    )
+
+    class ResolvedWindowsPath:
+        def resolve(self):
+            return windows_path
+
+    with pytest.raises(ValueError, match="absolute build-machine path"):
+        _assert_publishable(
+            root,
+            forbidden_paths=(ResolvedWindowsPath(),),
+            environ={},
+        )
 
 
 def test_static_export_rejects_a_configured_secret(

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -5,6 +5,7 @@ import Header from "@/components/Header";
 import Markdown from "@/components/Markdown";
 import AskBar from "@/components/AskBar";
 import { AppLink } from "@/lib/router";
+import { isStaticRuntime } from "@/lib/runtime";
 import {
   fetchCommits,
   fetchRepos,
@@ -54,6 +55,7 @@ function stripGeneratedDiagrams(
 // Link a repo-relative source path to the exact blob on GitHub at the indexed commit.
 function ghFileUrl(
   repo: string | undefined,
+  sourceUrl: string | null | undefined,
   commit: string | undefined,
   file: string,
   start?: number | null,
@@ -61,7 +63,8 @@ function ghFileUrl(
 ): string | null {
   if (!repo) return null;
   const lines = start ? `#L${start}${end && end !== start ? `-L${end}` : ""}` : "";
-  return `https://github.com/${repo}/blob/${commit || "HEAD"}/${file}${lines}`;
+  const root = (sourceUrl || `https://github.com/${repo}`).replace(/\/+$/, "");
+  return `${root}/blob/${commit || "HEAD"}/${file}${lines}`;
 }
 
 function TocTree({
@@ -122,6 +125,8 @@ function commitEvidence(commits: CommitRef[], selected?: string): string | null 
 }
 
 export default function WikiPageView({ repoId }: { repoId: string }) {
+
+  const staticRuntime = isStaticRuntime();
 
   const [repo, setRepo] = useState<RepoInfo | null>(null);
   const [pages, setPages] = useState<WikiPageRef[]>([]);
@@ -289,6 +294,7 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
   }, [sourceCitation]);
 
   const hasGraph = !!repo?.capabilities?.codemap;
+  const hasPageGraph = hasGraph || !!repo?.capabilities?.wiki_graph;
   const generationMode = page?.generation?.mode ?? "offline";
   // "Source checked" is the strict claim: every substantial block is cited
   // and every referenced source identifier resolves. Generated pages that only
@@ -329,36 +335,38 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
             </button>
             <span className="crumb-sep">/</span>
             <span className="crumb-repo mono">{repo ? repo.repo : repoId}</span>
-            <button
-              className={`codegraph-launch ${hasGraph ? "" : "unavailable"}`}
-              onClick={() => openGraph()}
-              title={
-                hasGraph
-                  ? "Open the interactive code dependency graph"
-                  : "Dependency graph is not indexed for this repository"
-              }
-              aria-label={
-                hasGraph
-                  ? "Open dependency map"
-                  : "Set up dependency map"
-              }
-            >
-              <svg
-                width="13"
-                height="13"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                aria-hidden
+            {(!staticRuntime || hasGraph) && (
+              <button
+                className={`codegraph-launch ${hasGraph ? "" : "unavailable"}`}
+                onClick={() => openGraph()}
+                title={
+                  hasGraph
+                    ? "Open the interactive code dependency graph"
+                    : "Dependency graph is not indexed for this repository"
+                }
+                aria-label={
+                  hasGraph
+                    ? "Open dependency map"
+                    : "Set up dependency map"
+                }
               >
-                <circle cx="5" cy="6" r="2" />
-                <circle cx="19" cy="7" r="2" />
-                <circle cx="12" cy="19" r="2" />
-                <path d="m7 6.2 10 .6M6.5 8l4.4 9.2m6.5-8.3-4.3 8.4" />
-              </svg>
-              <span>Dependency Map</span>
-            </button>
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  aria-hidden
+                >
+                  <circle cx="5" cy="6" r="2" />
+                  <circle cx="19" cy="7" r="2" />
+                  <circle cx="12" cy="19" r="2" />
+                  <path d="m7 6.2 10 .6M6.5 8l4.4 9.2m6.5-8.3-4.3 8.4" />
+                </svg>
+                <span>Dependency Map</span>
+              </button>
+            )}
             {page && <span className="crumb-sep">/</span>}
             {page && <span className="crumb-page">{page.title}</span>}
           </nav>
@@ -445,7 +453,7 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                   )}
                 </div>
               )}
-              {hasGraph && (
+              {hasPageGraph && (
                 <details
                   className="subsystem-map"
                   open={pageGraphOpen}
@@ -483,7 +491,7 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                           repoId={repoId}
                           data={pageGraph}
                           variant="wiki"
-                          onFocus={(label) => openGraph(label)}
+                          onFocus={hasGraph ? (label) => openGraph(label) : undefined}
                           repoFullName={repo?.repo}
                           commit={repo?.base_commit}
                         />
@@ -500,6 +508,7 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                     {page.evidence.items.map((item) => {
                       const url = ghFileUrl(
                         repo?.repo,
+                        repo?.source_url,
                         repo?.base_commit,
                         item.file,
                         item.start_line,
@@ -556,7 +565,12 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                         <summary>Relevant source files ({wikiFiles.length})</summary>
                         <div className="relevant-files-list">
                           {wikiFiles.map((f) => {
-                            const url = ghFileUrl(repo?.repo, repo?.base_commit, f);
+                            const url = ghFileUrl(
+                              repo?.repo,
+                              repo?.source_url,
+                              repo?.base_commit,
+                              f,
+                            );
                             return url ? (
                               <a
                                 key={f}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Header from "@/components/Header";
 import { fetchRepos, type RepoInfo } from "@/lib/api";
 import { AppLink, navigate } from "@/lib/router";
+import { isStaticRuntime } from "@/lib/runtime";
 
 function repoDescription(r: RepoInfo): string {
   if (r.description) return r.description;
@@ -66,6 +67,7 @@ const repoRetryDelays = [0, 1000, 2000, 4000, 8000];
 const sleep = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
 
 export default function Landing() {
+  const staticRuntime = isStaticRuntime();
   const [repos, setRepos] = useState<RepoInfo[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -78,8 +80,9 @@ export default function Landing() {
 
     const run = async () => {
       let lastError: unknown = null;
-      for (let attempt = 0; attempt < repoRetryDelays.length; attempt += 1) {
-        const delay = repoRetryDelays[attempt];
+      const delays = staticRuntime ? [0] : repoRetryDelays;
+      for (let attempt = 0; attempt < delays.length; attempt += 1) {
+        const delay = delays[attempt];
         if (delay > 0) {
           if (active) setError("Connecting to backend; retrying repository list...");
           await sleep(delay);
@@ -152,24 +155,30 @@ export default function Landing() {
       </section>
 
       <div className="repo-grid">
-        <AppLink
-          className="repo-card add-repo"
-          aria-label="Index your own repository"
-          href="/add-repo"
-        >
-          <span className="add-plus">+</span>
-          <span className="add-label">Add repo</span>
-          <span className="repo-card-go" aria-hidden>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M5 12h14M13 6l6 6-6 6" />
-            </svg>
-          </span>
-        </AppLink>
+        {!staticRuntime && (
+          <AppLink
+            className="repo-card add-repo"
+            aria-label="Index your own repository"
+            href="/add-repo"
+          >
+            <span className="add-plus">+</span>
+            <span className="add-label">Add repo</span>
+            <span className="repo-card-go" aria-hidden>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M5 12h14M13 6l6 6-6 6" />
+              </svg>
+            </span>
+          </AppLink>
+        )}
 
         {error && (
           <div className="empty">
             <p>
-              Backend unavailable — start it with <code>codenib-web</code> after building an index.
+              {staticRuntime ? (
+                "Static Wiki data is unavailable."
+              ) : (
+                <>Backend unavailable — start it with <code>codenib-web</code> after building an index.</>
+              )}
             </p>
             <p className="small muted">Request failed: {error}</p>
             <button type="button" className="codegraph-fit" onClick={loadRepos}>

--- a/web/components/CitationItem.tsx
+++ b/web/components/CitationItem.tsx
@@ -6,7 +6,7 @@ import { fetchSource, repoRelative, type Citation } from "@/lib/api";
 
 /** A code reference backing an answer / wiki page; expands to show the source. */
 export default function CitationItem({ repoId, c }: { repoId: string; c: Citation }) {
-  const [src, setSrc] = useState<string | null>(null);
+  const [src, setSrc] = useState<string | null>(c.content ?? null);
   const [open, setOpen] = useState(false);
   const rel = repoRelative(c.file);
   async function toggle() {

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import { AppLink } from "@/lib/router";
+import { assetUrl } from "@/lib/runtime";
 
 function ThemeToggle() {
   const [theme, setTheme] = useState<"light" | "dark">("light");
@@ -74,7 +75,7 @@ export default function Header({
   return (
     <header className="site-header">
       <AppLink href="/" className="brand">
-        <img className="brand-mark" src="/codenib-icon.svg" alt="" /> CodeNib Wiki
+        <img className="brand-mark" src={assetUrl("/codenib-icon.svg")} alt="" /> CodeNib Wiki
       </AppLink>
       {center}
       <div className="header-right">

--- a/web/index.html
+++ b/web/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en" data-theme="light">
   <head>
+    <base href="/" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta

--- a/web/index.html
+++ b/web/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en" data-theme="light">
   <head>
-    <base href="/" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,15 +1,6 @@
-declare global {
-  interface Window {
-    __CODENIB_API_BASE__?: string;
-  }
-}
+import { apiBase, isStaticRuntime, staticDataUrl } from "./runtime";
 
-function browserApiBase(): string {
-  if (typeof window === "undefined") return "";
-  return (window.__CODENIB_API_BASE__ ?? "").replace(/\/+$/, "");
-}
-
-export const API_BASE = browserApiBase();
+export const API_BASE = apiBase();
 
 /** Strip an absolute index prefix (e.g. /home/.../repo/) to a repo-relative path. */
 export function repoRelative(path: string | null | undefined): string {
@@ -24,6 +15,7 @@ export interface RepoInfo {
   id: string;
   name: string;
   repo: string;
+  source_url?: string | null;
   base_commit: string;
   commit_short: string;
   language: string;
@@ -71,7 +63,8 @@ export interface ChatResponse {
 }
 
 export async function fetchRepos(opts: { signal?: AbortSignal } = {}): Promise<RepoInfo[]> {
-  const res = await fetch(`${API_BASE}/api/repos`, { signal: opts.signal });
+  const url = isStaticRuntime() ? staticDataUrl("repos.json") : `${API_BASE}/api/repos`;
+  const res = await fetch(url, { signal: opts.signal });
   if (!res.ok) throw new Error(`Failed to load repos (${res.status})`);
   return res.json();
 }
@@ -157,15 +150,19 @@ export interface SourceSlice {
 }
 
 export async function fetchWikiTree(repoId: string): Promise<WikiTree> {
-  const res = await fetch(`${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki`);
+  const url = isStaticRuntime()
+    ? staticDataUrl("repos", repoId, "wiki.json")
+    : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki`;
+  const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to load wiki (${res.status})`);
   return res.json();
 }
 
 export async function fetchWikiPage(repoId: string, pageId: string): Promise<WikiPage> {
-  const res = await fetch(
-    `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}`
-  );
+  const url = isStaticRuntime()
+    ? staticDataUrl("repos", repoId, "pages", `${pageId}.json`)
+    : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}`;
+  const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to load page (${res.status})`);
   return res.json();
 }
@@ -177,6 +174,9 @@ export async function fetchSource(
   end?: number,
   commit?: string
 ): Promise<SourceSlice> {
+  if (isStaticRuntime()) {
+    throw new Error("Source slices are embedded in static Wiki citations");
+  }
   const params = new URLSearchParams({ file });
   if (start != null) params.set("start", String(start));
   if (end != null) params.set("end", String(end));
@@ -198,6 +198,9 @@ export async function askQuestion(
   repoId: string,
   messages: ChatMessage[]
 ): Promise<ChatResponse> {
+  if (isStaticRuntime()) {
+    throw new Error("Interactive Ask requires a CodeNib runtime");
+  }
   const res = await fetch(`${API_BASE}/api/chat`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -365,7 +368,10 @@ export interface CommitWindowResponse {
 // Repos without a prebuilt window return available=false; callers should then
 // fall back to the repo's single indexed commit.
 export async function fetchCommits(repoId: string): Promise<CommitWindowResponse> {
-  const res = await fetch(`${API_BASE}/api/repos/${encodeURIComponent(repoId)}/commits`);
+  const url = isStaticRuntime()
+    ? staticDataUrl("repos", repoId, "commits.json")
+    : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/commits`;
+  const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to load commits (${res.status})`);
   return res.json();
 }
@@ -380,6 +386,9 @@ export async function fetchCodemap(
     commit?: string;
   } = {}
 ): Promise<CodemapResponse> {
+  if (isStaticRuntime()) {
+    throw new Error("Interactive dependency exploration requires a CodeNib runtime");
+  }
   const params = new URLSearchParams();
   if (opts.symbol) params.set("symbol", opts.symbol);
   if (opts.direction) params.set("direction", opts.direction);
@@ -459,6 +468,9 @@ export async function fetchModulemap(
     commit?: string;
   } = {}
 ): Promise<ModulemapResponse> {
+  if (isStaticRuntime()) {
+    throw new Error("Interactive module exploration requires a CodeNib runtime");
+  }
   const params = new URLSearchParams();
   if (opts.focus) params.set("focus", opts.focus);
   if (opts.granularity) params.set("granularity", opts.granularity);
@@ -477,9 +489,10 @@ export async function fetchModulemap(
 // Induced dependency subgraph over a wiki page's cited symbols — lets a wiki
 // page render as a view over the graph.
 export async function fetchWikiGraph(repoId: string, pageId: string): Promise<CodemapResponse> {
-  const res = await fetch(
-    `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}/graph`
-  );
+  const url = isStaticRuntime()
+    ? staticDataUrl("repos", repoId, "page-graphs", `${pageId}.json`)
+    : `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/wiki/${encodeURIComponent(pageId)}/graph`;
+  const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to load page graph (${res.status})`);
   return res.json();
 }
@@ -512,6 +525,9 @@ export async function fetchEdgeLabel(
   },
   opts: { signal?: AbortSignal } = {}
 ): Promise<EdgeLabelResult> {
+  if (isStaticRuntime()) {
+    throw new Error("Generated edge labels require a CodeNib runtime");
+  }
   const res = await fetch(
     `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/edge-label`,
     {

--- a/web/lib/router.tsx
+++ b/web/lib/router.tsx
@@ -4,6 +4,7 @@ import {
   type AnchorHTMLAttributes,
   type MouseEvent,
 } from "react";
+import { stripBasePath, withBasePath } from "./runtime";
 
 export interface BrowserLocation {
   pathname: string;
@@ -12,13 +13,13 @@ export interface BrowserLocation {
 
 function currentLocation(): BrowserLocation {
   return {
-    pathname: window.location.pathname,
+    pathname: stripBasePath(window.location.pathname),
     search: window.location.search,
   };
 }
 
 export function navigate(href: string): void {
-  window.history.pushState(null, "", href);
+  window.history.pushState(null, "", withBasePath(href));
   window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
@@ -57,7 +58,7 @@ export function AppLink({
     navigate(href);
   }
 
-  return <a {...props} href={href} target={target} onClick={follow} />;
+  return <a {...props} href={withBasePath(href)} target={target} onClick={follow} />;
 }
 
 export function routeSegments(pathname: string): string[] {

--- a/web/lib/runtime.test.ts
+++ b/web/lib/runtime.test.ts
@@ -41,7 +41,8 @@ describe("runtime base paths", () => {
     staticWindow();
 
     expect(withBasePath("/demo")).toBe("/project/demo");
-    expect(withBasePath("/project/demo")).toBe("/project/demo");
+    // Route paths are app-relative, even when the first segment matches the mount.
+    expect(withBasePath("/project")).toBe("/project/project");
     expect(stripBasePath("/project/demo")).toBe("/demo");
     expect(staticDataUrl("repos", "demo", "pages", "overview.json")).toBe(
       "/project/data/repos/demo/pages/overview.json",

--- a/web/lib/runtime.test.ts
+++ b/web/lib/runtime.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  normalizeRuntimeBasePath,
+  restoreStaticRoute,
+  staticDataUrl,
+  stripBasePath,
+  withBasePath,
+} from "./runtime";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function staticWindow(overrides: Record<string, unknown> = {}) {
+  const replaceState = vi.fn();
+  vi.stubGlobal("window", {
+    __CODENIB_RUNTIME__: {
+      mode: "static",
+      basePath: "/project",
+      dataBase: "/project/data",
+    },
+    location: {
+      href: "https://example.test/project/",
+      origin: "https://example.test",
+    },
+    history: { replaceState },
+    ...overrides,
+  });
+  return replaceState;
+}
+
+describe("runtime base paths", () => {
+  it("normalizes trusted mount paths and rejects traversal", () => {
+    expect(normalizeRuntimeBasePath("/project/")).toBe("/project");
+    expect(normalizeRuntimeBasePath("/")).toBe("/");
+    expect(normalizeRuntimeBasePath("project")).toBe("/");
+    expect(normalizeRuntimeBasePath("/project/../other")).toBe("/");
+  });
+
+  it("adds and removes the configured Pages prefix", () => {
+    staticWindow();
+
+    expect(withBasePath("/demo")).toBe("/project/demo");
+    expect(withBasePath("/project/demo")).toBe("/project/demo");
+    expect(stripBasePath("/project/demo")).toBe("/demo");
+    expect(staticDataUrl("repos", "demo", "pages", "overview.json")).toBe(
+      "/project/data/repos/demo/pages/overview.json",
+    );
+  });
+
+  it("restores a route redirected through the static 404 page", () => {
+    const route = "/project/demo?p=architecture#runtime";
+    const replaceState = staticWindow({
+      location: {
+        href: `https://example.test/project/?__codenib_route=${encodeURIComponent(route)}`,
+        origin: "https://example.test",
+      },
+    });
+
+    restoreStaticRoute();
+
+    expect(replaceState).toHaveBeenCalledWith(null, "", route);
+  });
+});

--- a/web/lib/runtime.ts
+++ b/web/lib/runtime.ts
@@ -39,7 +39,6 @@ export function withBasePath(path: string): string {
   const base = appBasePath();
   const absolute = path.startsWith("/") ? path : `/${path}`;
   if (base === "/") return absolute;
-  if (absolute === base || absolute.startsWith(`${base}/`)) return absolute;
   return `${base}${absolute}`;
 }
 

--- a/web/lib/runtime.ts
+++ b/web/lib/runtime.ts
@@ -1,0 +1,89 @@
+declare global {
+  interface Window {
+    __CODENIB_API_BASE__?: string;
+    __CODENIB_RUNTIME__?: {
+      mode?: "api" | "static";
+      basePath?: string;
+      dataBase?: string;
+    };
+  }
+}
+
+export const STATIC_ROUTE_PARAM = "__codenib_route";
+
+export function normalizeRuntimeBasePath(value: string | undefined): string {
+  if (!value || !value.startsWith("/") || value.includes("\\")) return "/";
+  const segments = value.split("/").filter(Boolean);
+  if (segments.some((segment) => segment === "." || segment === "..")) return "/";
+  return segments.length ? `/${segments.join("/")}` : "/";
+}
+
+export function appBasePath(): string {
+  if (typeof window === "undefined") return "/";
+  return normalizeRuntimeBasePath(window.__CODENIB_RUNTIME__?.basePath);
+}
+
+export function apiBase(): string {
+  if (typeof window === "undefined") return "";
+  return (window.__CODENIB_API_BASE__ ?? "").replace(/\/+$/, "");
+}
+
+export function isStaticRuntime(): boolean {
+  return (
+    typeof window !== "undefined" && window.__CODENIB_RUNTIME__?.mode === "static"
+  );
+}
+
+export function withBasePath(path: string): string {
+  if (/^(?:[a-z][a-z\d+.-]*:|\/\/|#)/i.test(path)) return path;
+  const base = appBasePath();
+  const absolute = path.startsWith("/") ? path : `/${path}`;
+  if (base === "/") return absolute;
+  if (absolute === base || absolute.startsWith(`${base}/`)) return absolute;
+  return `${base}${absolute}`;
+}
+
+export function stripBasePath(pathname: string): string {
+  const base = appBasePath();
+  if (base === "/") return pathname || "/";
+  if (pathname === base) return "/";
+  if (pathname.startsWith(`${base}/`)) return pathname.slice(base.length) || "/";
+  return pathname || "/";
+}
+
+export function assetUrl(path: string): string {
+  return withBasePath(path);
+}
+
+export function staticDataUrl(...segments: string[]): string {
+  const configured =
+    typeof window !== "undefined" ? window.__CODENIB_RUNTIME__?.dataBase : undefined;
+  const root = (configured || withBasePath("/data")).replace(/\/+$/, "");
+  const suffix = segments.map((segment) => encodeURIComponent(segment)).join("/");
+  return suffix ? `${root}/${suffix}` : root;
+}
+
+export function restoreStaticRoute(): void {
+  if (!isStaticRuntime() || typeof window === "undefined") return;
+  const current = new URL(window.location.href);
+  const raw = current.searchParams.get(STATIC_ROUTE_PARAM);
+  if (!raw) return;
+
+  const target = new URL(raw, window.location.origin);
+  const base = appBasePath();
+  const inBase =
+    target.origin === window.location.origin &&
+    (base === "/" || target.pathname === base || target.pathname.startsWith(`${base}/`));
+  if (!inBase) {
+    current.searchParams.delete(STATIC_ROUTE_PARAM);
+    window.history.replaceState(null, "", `${current.pathname}${current.search}${current.hash}`);
+    return;
+  }
+  window.history.replaceState(
+    null,
+    "",
+    `${target.pathname}${target.search}${target.hash}`,
+  );
+}
+
+export {};

--- a/web/public/runtime-config.js
+++ b/web/public/runtime-config.js
@@ -1,1 +1,5 @@
+window.__CODENIB_RUNTIME__ = Object.freeze({
+  mode: "api",
+  basePath: "/",
+});
 window.__CODENIB_API_BASE__ = "";

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 
 import "@/app/globals.css";
 import { routeSegments, useBrowserLocation } from "@/lib/router";
+import { assetUrl, restoreStaticRoute } from "@/lib/runtime";
 
 const AskPage = lazy(() => import("@/app/[repoId]/ask/page"));
 const WikiPageView = lazy(() => import("@/app/[repoId]/page"));
@@ -12,7 +13,7 @@ const AddRepo = lazy(() => import("@/app/add-repo/page"));
 function RouteLoading() {
   return (
     <div className="route-loading" role="status">
-      <img src="/codenib-icon.svg" alt="" />
+      <img src={assetUrl("/codenib-icon.svg")} alt="" />
       <span>Loading CodeNib…</span>
     </div>
   );
@@ -38,6 +39,8 @@ function App() {
   }
   return <WikiPageView repoId={repoId} />;
 }
+
+restoreStaticRoute();
 
 const root = document.getElementById("root");
 if (!root) {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 const apiBase = process.env.CODENIB_API_BASE || "http://127.0.0.1:8000";
 
 export default defineConfig({
+  base: "./",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Add a versioned, deterministic static Wiki export for an existing manifest-backed repository.

The export targets GitHub Pages and other serverless hosts. It preserves repository and view provenance while exposing only capabilities with a real browser-side implementation. Closes #416 and advances H1 of #415.

## Changes

- Add `codenib export <repo>` with output and Pages mount-path options
- Write `codenib-static.json` with repository identity, commit, source fingerprint, source-location semantics, view provenance, generation metadata, and per-file SHA-256 digests
- Load only the views required to construct pages, without initializing an embedding provider
- Embed page citation snippets and precompute available page-level graph payloads
- Reject checkout/manifest mismatches, unsafe source paths, unrelated output directories, symlinked frontend assets, configured credentials, and raw or JSON-escaped build paths
- Add a static frontend data adapter, mount-aware routing, 404 route recovery, and honest capability gating
- Preserve query and fragment links without a global HTML base, and disambiguate repository routes whose first segment matches the Pages mount
- Document the static serving boundary and CLI flow

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- unit tier: 2546 passed, 10 skipped
- static export: 17 passed after the final restack
- frontend: 19 passed; production build completed
- strict MkDocs build
- pre-commit run --all-files
- real `pallets/itsdangerous@672971d6` export mounted at `/itsdangerous`: Playwright loaded the overview route at `/itsdangerous/itsdangerous` with no console or resource errors
- desktop and 390px mobile captures plus direct deep-link smoke

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented code where the behavior is not self-explanatory
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published