### PR TITLE
ci(release): gate full verification off pull requests

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -6,6 +6,11 @@ name: Release verification
 
 on:
   workflow_call:
+    inputs:
+      full:
+        description: Run the cross-version and installed-service matrix.
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -79,6 +84,7 @@ jobs:
 
   install-smoke:
     name: Install smoke (Python ${{ matrix.python-version }})
+    if: inputs.full
     needs: build
     runs-on: self-hosted
     timeout-minutes: 15
@@ -123,6 +129,7 @@ jobs:
 
   service-smoke:
     name: Installed Wiki and MCP services
+    if: inputs.full
     needs: build
     runs-on: self-hosted
     timeout-minutes: 20
@@ -183,6 +190,7 @@ jobs:
 
   agent-smoke:
     name: Installed sparse Ask service
+    if: inputs.full
     needs: build
     runs-on: self-hosted
     timeout-minutes: 20
@@ -234,6 +242,7 @@ jobs:
 
   graph-smoke:
     name: Installed graph and Dependency Map
+    if: inputs.full
     needs: build
     runs-on: self-hosted
     timeout-minutes: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,14 @@ permissions:
 
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
   verify:
     name: Verify release artifacts
     uses: ./.github/workflows/release-verify.yml
+    with:
+      full: ${{ github.event_name != 'pull_request' }}
     permissions:
       contents: read
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -62,13 +62,22 @@ def test_registry_publishers_use_separate_workflows() -> None:
     test = load("release-test.yml")
     verification = load("release-verify.yml")
 
-    verification_job = {
+    production_verification_job = {
+        "name": "Verify release artifacts",
+        "uses": "./.github/workflows/release-verify.yml",
+        "with": {"full": "${{ github.event_name != 'pull_request' }}"},
+        "permissions": {"contents": "read"},
+    }
+    test_verification_job = {
         "name": "Verify release artifacts",
         "uses": "./.github/workflows/release-verify.yml",
         "permissions": {"contents": "read"},
     }
-    assert production["jobs"]["verify"] == verification_job
-    assert test["jobs"]["verify"] == verification_job
+    assert production["jobs"]["verify"] == production_verification_job
+    assert test["jobs"]["verify"] == test_verification_job
+    assert production["concurrency"]["cancel-in-progress"] == (
+        "${{ github.ref_type != 'tag' }}"
+    )
 
     assert set(production["jobs"]) == {
         "verify",
@@ -91,4 +100,16 @@ def test_registry_publishers_use_separate_workflows() -> None:
     )
 
     assert set(verification["on"]) == {"workflow_call"}
+    assert verification["on"]["workflow_call"]["inputs"]["full"] == {
+        "description": "Run the cross-version and installed-service matrix.",
+        "type": "boolean",
+        "default": "true",
+    }
+    for job_name in (
+        "install-smoke",
+        "service-smoke",
+        "agent-smoke",
+        "graph-smoke",
+    ):
+        assert verification["jobs"][job_name]["if"] == "inputs.full"
     assert not any(name.startswith("publish-") for name in verification["jobs"])


### PR DESCRIPTION
## Summary

Keep pull-request feedback focused while preserving a complete release gate on `main` and immutable version tags. Pull requests now build and inspect the wheel/sdist once; cross-version installs and installed-service smoke jobs run after merge, on release tags, and in explicitly invoked release-test workflows.

## Changes

- add a typed `full` input to the reusable release-verification workflow
- skip the five-version install matrix and Wiki/MCP, agent, and graph service smokes when `full` is false
- pass `full: false` only for pull-request runs of the production release workflow
- let a newer branch/main run supersede an older run while keeping tag releases non-cancellable
- extend workflow contract tests for the new scheduling boundary

## Type of Change

- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Bug fix
- [ ] Breaking change
- [x] CI

## Testing

- `pytest -q test/test_release_artifacts.py test/test_release_metadata.py test/actions/test_publish_action.py`: 23 passed
- pre-commit on both workflows and the release contract test
- YAML syntax validation through pre-commit

## Checklist

- [x] Pull requests still build, inspect, and upload release distributions
- [x] Main, tags, and release-test callers retain the complete verification matrix
- [x] Tag release runs cannot be cancelled by another ref
- [x] Scheduling behavior is asserted in unit tests
- [x] No production publishing credential or environment changed