### PR TITLE
chore(release): prepare version 0.2.0a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,49 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+## [0.2.0a1] - 2026-08-05
+
 ### Added
 
+- A reusable GitHub Pages workflow and composite Action that build a no-model
+  static Wiki plus a commit-addressed BM25 context artifact. Semantic builds
+  can use a pinned local CodeRankEmbed model or an explicit OpenAI-compatible
+  embedding endpoint.
+- Portable context artifacts with complete file inventories, source identity,
+  capability metadata, and an artifact-backed MCP path that reuses BM25 and
+  vector views without rebuilding the repository.
+- Secret-free inference route identities for local and remote embeddings,
+  compatibility fingerprints, provider-aware diagnostics, and fail-closed
+  handling of the retired GitHub Models service.
+- A native repository explorer with selective view loading and revision-pinned
+  compatibility layers for SWE-Explore, Agentless, CoSIL, LocAgent, and
+  OrcaLoca SearchAgent contracts.
+- Quality-constrained cost reports that pair localization success with token,
+  USD, and amortized build cost rather than reporting cost without a quality
+  denominator.
 - Graph schema 5 records semantic symbol kinds, explicit definition
   provenance, and anchored TypeScript/TSX import and re-export edges.
-- Revision-pinned LocAgent and OrcaLoca SearchAgent adapters can reuse
-  manifest-backed repository views without introducing upstream agent
-  dependencies into the base package.
 
 ### Changed
 
+- Static Wiki exports now preserve mount paths, source citations, generated
+  pages, and dependency data while keeping query engines in the local or MCP
+  runtime.
+- Pull requests build and inspect distributions once; the complete
+  cross-version and installed-service release matrix runs on `main`, release
+  tags, and explicit TestPyPI dispatches.
 - Static navigation and source adapters no longer treat reference-only symbol
   provenance as a definition location. Existing schema 4 graph artifacts need
   a one-time `codenib index <repo> --preset graph --rebuild`.
+
+### Security
+
+- Downloaded context artifacts reject pickle payloads, unsafe archive paths,
+  symbolic and special files, unbounded expansion, inventory mismatches, and
+  source checkouts that do not match the recorded commit and fingerprint.
+- GitHub artifact downloads verify the API digest and never forward the GitHub
+  bearer token to redirects. Pages publication scans outputs for configured
+  credentials and rejects secret-bearing fork execution paths.
 
 ## [0.1.0] - 2026-07-26
 
@@ -52,5 +82,6 @@ All notable user-facing changes are recorded here. CodeNib follows
 - Prepared secretless PyPI publishing through a dedicated GitHub Actions OIDC
   workflow.
 
-[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0a1...HEAD
+[0.2.0a1]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...v0.2.0a1
 [0.1.0]: https://github.com/sysevol-ai/CodeNib/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ SPDX-License-Identifier: Apache-2.0
   </p>
   <p>
     <a href="https://github.com/sysevol-ai/CodeNib/actions/workflows/ci.yml"><img src="https://github.com/sysevol-ai/CodeNib/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+    <a href="https://pypi.org/project/codenib/"><img src="https://img.shields.io/pypi/v/codenib.svg" alt="PyPI version"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/pyproject.toml"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB.svg" alt="Python 3.10+"></a>
     <img src="https://img.shields.io/badge/Release-Developer_Preview-EA580C.svg" alt="Developer Preview">
@@ -50,12 +51,14 @@ agent or code-Wiki framework.
 
 ## News
 
-- **2026-08-04 — Commit-addressed Pages publishing.**
-  [`codenib publish`](docs/github_pages.md) and the reusable GitHub workflow
-  deploy a no-model static Wiki and retain a matching BM25 or opt-in
-  vector-enhanced context artifact for the indexed commit. Incremental caches
-  remain private build state rather than part of the downloadable serving
-  artifact.
+- **2026-08-05 — CodeNib 0.2.0 Alpha 1: build once, serve everywhere.**
+  [`codenib publish`](https://docs.codenib.ai/github_pages/) and the reusable
+  GitHub workflow deploy a no-model static Wiki and retain a matching BM25 or
+  opt-in vector-enhanced context artifact for the indexed commit. The verified
+  artifact can be rebound to that checkout and served through MCP without
+  rebuilding; incremental caches remain private build state rather than part
+  of the downloadable serving artifact. See the
+  [0.2.0 Alpha 1 notes](https://docs.codenib.ai/releases/0.2.0/).
 - **2026-08-04 — Native repository explorer.**
   [`RepositoryContextExplorer`](codenib/agent/runtime/explorer.py) plans BM25,
   dense, hybrid, reranked, and graph routes over manifest-backed views and

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -18,9 +18,15 @@ release-blocking compatibility or security issue.
 ## Upgrade
 
 ```bash
-python -m pip install --upgrade "codenib==0.2.0a1"
+python -m pip install --upgrade --pre \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "codenib==0.2.0a1"
 codenib doctor --require core --require wiki
 ```
+
+The exact CodeNib prerelease comes from TestPyPI; the extra index supplies its
+normal runtime dependencies from PyPI.
 
 Existing BM25 and vector manifests are checked when opened. CodeNib reuses a
 compatible view and rebuilds rather than silently substituting an incompatible
@@ -43,6 +49,11 @@ Call the reusable workflow from a public repository and pin it to the immutable
 commit associated with the 0.2.0 Alpha 1 release:
 
 ```yaml
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   publish:
     uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@<release-sha>
@@ -58,7 +69,10 @@ After checking out the recorded commit, reuse the artifact without another
 index build:
 
 ```bash
-python -m pip install --upgrade "codenib[mcp]==0.2.0a1"
+python -m pip install --upgrade --pre \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  "codenib[mcp]==0.2.0a1"
 export GH_TOKEN=github_pat_...
 codenib artifact fetch owner/repository --repo /path/to/repository
 codenib artifact mcp-config \

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -1,0 +1,83 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CodeNib 0.2.0 Alpha 1
+
+CodeNib 0.2.0 Alpha 1 is an early preview of the build-once, serve-everywhere
+repository-context path. A repository can publish a no-model static Wiki in
+GitHub Pages, retain the matching BM25 or vector artifact, and reuse that
+artifact through MCP at the exact indexed commit.
+
+The alpha is intended for TestPyPI, public Pages, and artifact/MCP canary
+validation. A release candidate follows only after those paths pass without a
+release-blocking compatibility or security issue.
+
+## Upgrade
+
+```bash
+python -m pip install --upgrade "codenib==0.2.0a1"
+codenib doctor --require core --require wiki
+```
+
+Existing BM25 and vector manifests are checked when opened. CodeNib reuses a
+compatible view and rebuilds rather than silently substituting an incompatible
+provider or source identity.
+
+Graph schema 5 changes definition provenance and TypeScript/TSX import edges.
+Rebuild graph artifacts created by 0.1.x once:
+
+```bash
+codenib index /path/to/repository --preset graph --rebuild
+```
+
+GitHub Models is no longer a valid provider because GitHub retired the service.
+Use the model-free `fast` route, local Hugging Face embeddings, or an explicit
+OpenAI-compatible endpoint.
+
+## Publish And Reuse
+
+Call the reusable workflow from a public repository and pin it to the immutable
+commit associated with the 0.2.0 Alpha 1 release:
+
+```yaml
+jobs:
+  publish:
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@<release-sha>
+```
+
+The default workflow publishes precomputed pages, citations, navigation, and
+available dependency data without a model credential. BM25 and dense queries
+run from the separately retained context artifact, not inside the static
+browser application. See [GitHub Pages](../github_pages.md) for semantic and
+BYO endpoint inputs.
+
+After checking out the recorded commit, reuse the artifact without another
+index build:
+
+```bash
+python -m pip install --upgrade "codenib[mcp]==0.2.0a1"
+export GH_TOKEN=github_pat_...
+codenib artifact fetch owner/repository --repo /path/to/repository
+codenib artifact mcp-config \
+  ~/.codenib/artifacts/owner/repository/<full-commit> \
+  --repo /path/to/repository \
+  --repository owner/repository \
+  --host codex
+```
+
+## Security Boundary
+
+Artifact verification proves byte integrity, repository identity, commit, and
+source compatibility. It does not make an arbitrary publishing workflow
+trusted. Consume artifacts only from a workflow and pinned CodeNib revision
+you trust, and review a semantic artifact's provider and endpoint before
+exposing model credentials to the MCP process.
+
+Downloaded artifacts cannot contain pickle, symbolic links, special files, or
+unbounded ZIP expansion. The runtime verifies every inventoried file and binds
+source locations to an exact local checkout before loading an index. Keep BYO
+credentials in the Action secret or MCP process environment; they are not part
+of the Pages site, artifact, manifest, or generated client configuration.

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -18,15 +18,20 @@ release-blocking compatibility or security issue.
 ## Upgrade
 
 ```bash
-python -m pip install --upgrade --pre \
+ALPHA_DIR="$(mktemp -d)"
+python -m pip download --no-deps --only-binary=:all: --pre \
   --index-url https://test.pypi.org/simple/ \
-  --extra-index-url https://pypi.org/simple/ \
+  --dest "$ALPHA_DIR" \
   "codenib==0.2.0a1"
+python -m pip install --upgrade \
+  "$ALPHA_DIR/codenib-0.2.0a1-py3-none-any.whl"
 codenib doctor --require core --require wiki
 ```
 
-The exact CodeNib prerelease comes from TestPyPI; the extra index supplies its
-normal runtime dependencies from PyPI.
+The first command downloads only the exact CodeNib prerelease from TestPyPI.
+Installing that local wheel then resolves normal runtime dependencies from the
+default PyPI index without mixing the two registries during dependency
+selection.
 
 Existing BM25 and vector manifests are checked when opened. CodeNib reuses a
 compatible view and rebuilds rather than silently substituting an incompatible
@@ -69,10 +74,13 @@ After checking out the recorded commit, reuse the artifact without another
 index build:
 
 ```bash
-python -m pip install --upgrade --pre \
+ALPHA_DIR="$(mktemp -d)"
+python -m pip download --no-deps --only-binary=:all: --pre \
   --index-url https://test.pypi.org/simple/ \
-  --extra-index-url https://pypi.org/simple/ \
+  --dest "$ALPHA_DIR" \
   "codenib[mcp]==0.2.0a1"
+python -m pip install --upgrade \
+  "$ALPHA_DIR/codenib-0.2.0a1-py3-none-any.whl[mcp]"
 export GH_TOKEN=github_pat_...
 codenib artifact fetch owner/repository --repo /path/to/repository
 codenib artifact mcp-config \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,7 +13,8 @@ installed distribution metadata generated from it.
 ## Automated Gates
 
 The reusable Release verification workflow runs from both publishing
-workflows. It:
+workflows. Pull requests build and inspect the distribution once. Pushes to
+`main`, version tags, and explicit TestPyPI dispatches run the complete gate:
 
 1. Tests and production-builds the packaged Wiki frontend.
 2. Builds one sdist and one universal wheel.
@@ -61,8 +62,11 @@ that each pending publisher appears on the corresponding registry account page
 before dispatching a publish workflow.
 
 The corresponding GitHub environments should restrict deployments to trusted
-maintainers. Each publishing workflow receives `id-token: write` only in its
-publishing job; no long-lived PyPI token or runner-local `.pypirc` is used.
+maintainers. TestPyPI currently publishes through OIDC. Production PyPI uses
+the environment-scoped `PYPI_API_TOKEN` fallback added after the `v0.1.0`
+bootstrap; [issue #384](https://github.com/sysevol-ai/CodeNib/issues/384)
+tracks restoring its trusted publisher and revoking that token. No publishing
+workflow reads a runner-local `.pypirc`.
 
 ## Public Surface Gate
 
@@ -92,7 +96,8 @@ on PyPI.
    TestPyPI Release workflow from `main`.
 6. Confirm the TestPyPI registry-download and installed-CLI smoke job passes.
 7. Complete the public-surface gate above.
-8. Confirm the PyPI pending publisher is visible.
+8. Confirm the production `pypi` environment still has its scoped publisher
+   credential, or complete #384 and update the workflow to OIDC first.
 9. Create and push an annotated `v<version>` tag.
 10. Confirm the PyPI deployment and generated prerelease GitHub Release.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,7 @@ nav:
   - Get Started:
       - get-started/index.md
       - Quickstart: quickstart.md
+      - Release 0.2.0 Alpha 1: releases/0.2.0.md
       - GitHub Pages: github_pages.md
       - Web UI: web_demo.md
       - Running Locally: running-locally.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codenib"
-version = "0.1.0"
+version = "0.2.0a1"
 description = "A multi-view data system for serving repository context to coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -44,6 +44,16 @@ https://arxiv.org/abs/2607.25431
         validate_readme_citation("# CodeNib\n")
 
 
+def test_alpha_release_notes_use_test_registry_and_pages_permissions() -> None:
+    root = Path(__file__).resolve().parents[1]
+    notes = (root / "docs" / "releases" / "0.2.0.md").read_text(encoding="utf-8")
+
+    assert notes.count("--index-url https://test.pypi.org/simple/") == 2
+    assert notes.count("--extra-index-url https://pypi.org/simple/") == 2
+    for permission in ("contents: read", "pages: write", "id-token: write"):
+        assert permission in notes
+
+
 def test_registry_publishers_use_separate_workflows() -> None:
     workflows = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -23,13 +23,13 @@ def test_project_identity_and_tag_match_release_metadata() -> None:
     name, version = project_identity(root / "pyproject.toml")
 
     assert name == "codenib"
-    assert expected_tag(version) == "v0.1.0"
-    validate_tag("v0.1.0", version)
+    assert expected_tag(version) == "v0.2.0a1"
+    validate_tag("v0.2.0a1", version)
 
 
 def test_release_tag_must_match_project_version() -> None:
     with pytest.raises(ReleaseValidationError, match="does not match"):
-        validate_tag("v0.2.0", "0.1.0")
+        validate_tag("v0.1.0", "0.2.0a1")
 
 
 def test_packaged_readme_requires_the_arxiv_citation() -> None:

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -49,7 +49,8 @@ def test_alpha_release_notes_use_test_registry_and_pages_permissions() -> None:
     notes = (root / "docs" / "releases" / "0.2.0.md").read_text(encoding="utf-8")
 
     assert notes.count("--index-url https://test.pypi.org/simple/") == 2
-    assert notes.count("--extra-index-url https://pypi.org/simple/") == 2
+    assert notes.count("--no-deps --only-binary=:all:") == 2
+    assert "--extra-index-url" not in notes
     for permission in ("contents: read", "pages: write", "id-token: write"):
         assert permission in notes
 

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "codenib"
-version = "0.1.0"
+version = "0.2.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Prepare CodeNib 0.2.0a1 as an early preview of the build-once, serve-everywhere product surface: static Pages publication, portable BM25/vector artifacts, verified MCP reuse, local/BYO provider contracts, native explorer integrations, and quality-constrained cost reporting.

This PR changes release metadata and documentation only. Alpha 1 may be promoted to TestPyPI after the package checks pass; the post-publish gate merged in #433 will then download the public registry wheel, bind it to the verified build by SHA-256, and exercise a fresh install. No tag or registry publication occurs in this PR, and no final 0.2.0 release is planned from it.

## Changes

- bump the package and lockfile version from 0.1.0 to 0.2.0a1
- move accumulated user-facing changes into a dated 0.2.0a1 changelog section
- add concise upgrade, graph-schema migration, Pages/MCP reuse, and artifact/provider security guidance
- add a PyPI badge and a 0.2.0 Alpha 1 product entry to the README
- correct the release guide to reflect TestPyPI OIDC and the current production PyPI token fallback tracked by #384
- update release metadata tests for the `v0.2.0a1` tag, TestPyPI install commands, and required Pages permissions

## Type of Change

- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Tests
- [ ] Bug fix
- [ ] Breaking change
- [x] Chore

## Testing

- release metadata tests: 5 passed
- strict MkDocs build
- pre-commit on every changed file
- `uv lock --check`
- built `codenib-0.2.0a1-py3-none-any.whl` and `codenib-0.2.0a1.tar.gz`
- repository release verifier passed with `--tag v0.2.0a1`
- `twine check` passed for wheel and sdist
- isolated wheel install reported `codenib 0.2.0a1`; `doctor --require core --require wiki` passed
- merged-main public canary published Pages, verified the downloaded artifact against a detached checkout, and served a real BM25 query over stdio MCP without rebuilding
- combined #433 + release tree passed the release contracts and strict documentation build before restacking

## Checklist

- [x] Version sources and lockfile agree
- [x] Changelog and release-note links are versioned
- [x] Graph schema migration is explicit
- [x] Static Pages and query-runtime capabilities are not conflated
- [x] Artifact integrity and workflow/provider trust are distinguished
- [x] Alpha remains gated by the TestPyPI registry round trip
- [x] No tag or registry publication occurs in this PR
