### PR TITLE
fix(index): align repository source filtering

### DIFF
--- a/.github/workflows/codenib-pages.yml
+++ b/.github/workflows/codenib-pages.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
+          path: repository
           persist-credentials: false
 
       - name: Checkout the exact CodeNib workflow revision
@@ -106,6 +107,7 @@ jobs:
           preset: ${{ inputs.preset }}
           python-version: ${{ inputs.python-version }}
           repository: ${{ github.repository }}
+          repository-path: repository
           retention-days: ${{ inputs.retention-days }}
           revision: ${{ job.workflow_sha }}
 

--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -23,7 +23,7 @@ from .languages import (
 )
 from .log_utils import get_logger
 from .paths import user_state_dir
-from .repository_filters import DEFAULT_IGNORED_DIRS
+from .repository_filters import DEFAULT_IGNORED_DIRS, repository_path_is_visible
 from .utils import is_test_file
 
 logger = get_logger(__name__)
@@ -397,13 +397,22 @@ class CodeChunker:
             root_path = Path(root)
 
             # Filter directories
-            dirs[:] = [d for d in dirs if self._should_include_directory(root_path / d)]
+            dirs[:] = [
+                directory
+                for directory in dirs
+                if repository_path_is_visible(
+                    (root_path / directory).relative_to(repo_path)
+                )
+                and self._should_include_directory(root_path / directory)
+            ]
 
             # Process files in current directory
             for file_name in files:
                 file_path = root_path / file_name
 
-                if self._should_process_file(file_path, extension_to_language):
+                if repository_path_is_visible(
+                    file_path.relative_to(repo_path)
+                ) and self._should_process_file(file_path, extension_to_language):
                     language = extension_to_language[file_path.suffix]
                     files_to_process.append((file_path, language))
 
@@ -632,12 +641,22 @@ class CodeChunker:
         # Count files by extension
         extension_counts = {}
         for root, dirs, files in os.walk(repo_path):
-            # Skip common ignore directories
-            dirs[:] = [d for d in dirs if d not in self.repo_config.ignore_dirs]
+            root_path = Path(root)
+            dirs[:] = [
+                directory
+                for directory in dirs
+                if repository_path_is_visible(
+                    (root_path / directory).relative_to(repo_path)
+                )
+                and self._should_include_directory(root_path / directory)
+            ]
 
             for file in files:
-                file_path = Path(root) / file
-                if file_path.suffix:
+                file_path = root_path / file
+                if (
+                    repository_path_is_visible(file_path.relative_to(repo_path))
+                    and file_path.suffix
+                ):
                     extension_counts[file_path.suffix] = (
                         extension_counts.get(file_path.suffix, 0) + 1
                     )

--- a/codenib/repository_filters.py
+++ b/codenib/repository_filters.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 from typing import Iterable, Iterator
 
-REPOSITORY_FILTER_POLICY_VERSION = 2
+REPOSITORY_FILTER_POLICY_VERSION = 3
 
 DEFAULT_IGNORED_DIRS = frozenset(
     {
@@ -83,7 +83,8 @@ def walk_repository_files(
         current = Path(current_root)
         for filename in sorted(files):
             path = current / filename
-            if not _is_within(path, excluded):
+            relative = path.relative_to(root_path)
+            if repository_path_is_visible(relative) and not _is_within(path, excluded):
                 yield path
 
 

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -124,12 +124,18 @@ for current_root, directories, files in os.walk(root):
     current = pathlib.Path(current_root)
     for filename in sorted(files):
         path = current / filename
+        relative_path = path.relative_to(root)
+        if any(
+            part in ignored or part.startswith('.codenib')
+            for part in relative_path.parts
+        ):
+            continue
         mode = path.lstat().st_mode
         if stat.S_ISLNK(mode):
             raise SystemExit('source fingerprint does not permit symlinks')
         if not stat.S_ISREG(mode):
             continue
-        relative = path.relative_to(root).as_posix().encode(
+        relative = relative_path.as_posix().encode(
             'utf-8', errors='surrogateescape'
         )
         hasher.update(b'F\0')

--- a/test/actions/test_publish_action.py
+++ b/test/actions/test_publish_action.py
@@ -291,6 +291,12 @@ def test_reusable_workflow_is_fork_safe_and_binds_its_exact_revision() -> None:
         "contents": "read",
         "pages": "write",
     }
+    caller_checkout = next(
+        step
+        for step in build["steps"]
+        if step.get("name") == "Checkout caller repository"
+    )
+    assert caller_checkout["with"]["path"] == "repository"
     exact_checkout = next(
         step
         for step in build["steps"]
@@ -298,6 +304,7 @@ def test_reusable_workflow_is_fork_safe_and_binds_its_exact_revision() -> None:
     )
     assert exact_checkout["with"]["repository"] == "${{ job.workflow_repository }}"
     assert exact_checkout["with"]["ref"] == "${{ job.workflow_sha }}"
+    assert exact_checkout["with"]["path"] == ".codenib-action"
     assert exact_checkout["with"]["persist-credentials"] == "false"
     secret_steps = [
         step for step in build["steps"] if "secrets.embedding_api_key" in str(step)
@@ -306,6 +313,7 @@ def test_reusable_workflow_is_fork_safe_and_binds_its_exact_revision() -> None:
         "Build Wiki and context artifact"
     ]
     publish = secret_steps[0]
+    assert publish["with"]["repository-path"] == "repository"
     secret_expression = publish["env"]["CODENIB_ACTION_EMBEDDING_KEY"]
     assert "inputs.preset == 'semantic'" in secret_expression
     assert "inputs.embedding-provider == 'openai'" in secret_expression

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -96,7 +96,14 @@ def test_repo_discovery_is_sorted_independently_of_walk_order(
 def test_repo_discovery_skips_generated_and_vendored_trees(tmp_path: Path):
     (tmp_path / "src").mkdir()
     (tmp_path / "src" / "app.py").write_text("def app():\n    return 1\n")
-    for directory in ("site", ".next", ".codenib_cache", "third_party", "vendor"):
+    for directory in (
+        "site",
+        ".next",
+        ".codenib_cache",
+        ".codenib-action",
+        "third_party",
+        "vendor",
+    ):
         ignored = tmp_path / directory
         ignored.mkdir()
         (ignored / "ignored.py").write_text("def ignored():\n    return 0\n")
@@ -120,6 +127,9 @@ def test_repo_language_detection_uses_registered_chunk_extensions(tmp_path: Path
     (tmp_path / "app.rb").write_text("class App\nend\n")
     (tmp_path / "index.php").write_text("<?php\nfunction index() {}\n")
     (tmp_path / "Main.kt").write_text("class Main {}\n")
+    hidden_tool = tmp_path / ".codenib-action"
+    hidden_tool.mkdir()
+    (hidden_tool / "Hidden.swift").write_text("struct Hidden {}\n")
 
     chunker = CodeChunker(language="python")
 

--- a/test/eval/test_swe_explore_benchmark.py
+++ b/test/eval/test_swe_explore_benchmark.py
@@ -474,8 +474,8 @@ def test_snapshot_audit_checks_commit_and_tracked_cleanliness(tmp_path: Path) ->
     assert not untracked.valid
     assert ignored.unexpected_source_files == ("ignored.py",)
     assert not ignored.valid
-    assert prefixed.unexpected_source_files == (".codenib-extra/a.py",)
-    assert not prefixed.valid
+    assert prefixed.unexpected_source_files == ()
+    assert prefixed.valid
     assert skipped.unexpected_source_files == ()
     assert skipped.valid
     assert submodule_skipped.unexpected_source_files == ()

--- a/test/test_source_fingerprint.py
+++ b/test/test_source_fingerprint.py
@@ -43,6 +43,16 @@ def test_fingerprint_ignores_generated_and_explicit_artifact_roots(tmp_path):
     )
 
 
+def test_fingerprint_ignores_git_worktree_pointer_file(tmp_path):
+    (tmp_path / "module.py").write_text("VALUE = 1\n")
+    initial = fingerprint_repository(tmp_path)
+
+    (tmp_path / ".git").write_text("gitdir: /shared/repository/.git/worktrees/test\n")
+
+    observed = fingerprint_repository(tmp_path)
+    assert observed == initial
+
+
 def test_fingerprint_includes_symlink_target_and_content(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary

Fix a source-identity split found by the public CodeNib Pages canary. The reusable workflow indexed 4,429 chunks from its own `.codenib-action` checkout, while the source fingerprint correctly excluded that directory. Artifact consumers then rejected the exact repository checkout because Git worktrees expose `.git` as a file and because artifact source anchors referenced the injected action checkout.

## Changes

- move the caller checkout into a dedicated `repository/` directory in the reusable Pages workflow
- apply the shared repository visibility policy to chunk discovery and language detection
- ignore reserved `.git` and `.codenib*` files as well as directories during source fingerprinting
- keep the sandbox fingerprint implementation aligned with the host implementation
- advance the repository filter policy to v3 so stale cached views rebuild
- add workflow, chunking, worktree, sandbox, and SWE-Explore regression coverage

## Type of Change

- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [x] Bug fix
- [ ] Breaking change
- [ ] Chore

## Testing

- full unit tier: 2,680 passed, 10 skipped, 183 deselected
- compiler/artifact/CLI tier: 150 passed
- static export and Wiki outline tier: 37 passed
- focused workflow/filter/sandbox tier: 53 passed
- pre-commit on every changed file
- local end-to-end publish with a tracked `.codenib-action/tool.py`: artifact contained only `app.py`
- verified that artifact against a detached Git worktree with exact commit, source fingerprint, file count, and source anchors

## Checklist

- [x] Source fingerprints and index source discovery use the same visibility policy
- [x] Existing view artifacts are invalidated through a policy version bump
- [x] Artifact verification remains strict
- [x] Reusable workflow checkouts cannot contaminate the indexed repository
- [x] No release metadata or publication is included