### PR TITLE
ci(release): verify TestPyPI installation

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -41,3 +41,105 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  verify-testpypi-install:
+    name: Verify installed TestPyPI artifact
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout smoke harness
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Resolve release version
+        id: version
+        run: |
+          VERSION="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          with Path("pyproject.toml").open("rb") as handle:
+              print(tomllib.load(handle)["project"]["version"])
+          PY
+          )"
+          test -n "$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download and verify the TestPyPI wheel
+        env:
+          CODENIB_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          export FETCH_DIR="$RUNNER_TEMP/testpypi-download"
+          mkdir -p "$FETCH_DIR"
+          FOUND=0
+          for attempt in $(seq 1 18); do
+            rm -f "$FETCH_DIR"/*.whl
+            if python -m pip download \
+              --disable-pip-version-check \
+              --no-cache-dir \
+              --no-deps \
+              --only-binary=:all: \
+              --pre \
+              --index-url https://test.pypi.org/simple/ \
+              --dest "$FETCH_DIR" \
+              "codenib==$CODENIB_VERSION"; then
+              FOUND=1
+              break
+            fi
+            if [ "$attempt" -lt 18 ]; then
+              sleep 10
+            fi
+          done
+          test "$FOUND" = 1
+
+          python - <<'PY'
+          import hashlib
+          import os
+          from pathlib import Path
+
+          built = list(Path("dist").glob("*.whl"))
+          fetched = list(Path(os.environ["FETCH_DIR"]).glob("*.whl"))
+          if len(built) != 1 or len(fetched) != 1:
+              raise SystemExit(
+                  f"expected one built and fetched wheel, got {built!r}, {fetched!r}"
+              )
+
+          def digest(path: Path) -> str:
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          if digest(built[0]) != digest(fetched[0]):
+              raise SystemExit("TestPyPI wheel does not match the verified build")
+          with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"TESTPYPI_WHEEL={fetched[0].resolve()}\n")
+          PY
+
+      - name: Install the registry wheel
+        run: |
+          SMOKE_VENV="$RUNNER_TEMP/codenib-testpypi-smoke"
+          python -m venv "$SMOKE_VENV"
+          echo "SMOKE_VENV=$SMOKE_VENV" >> "$GITHUB_ENV"
+          echo "$SMOKE_VENV/bin" >> "$GITHUB_PATH"
+          "$SMOKE_VENV/bin/python" -m pip install --upgrade pip
+          "$SMOKE_VENV/bin/python" -m pip install "$TESTPYPI_WHEEL"
+
+      - name: Exercise the installed CLI
+        working-directory: ${{ runner.temp }}
+        env:
+          CODENIB_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          test "$(codenib --version)" = "codenib $CODENIB_VERSION"
+          codenib doctor --require core --require wiki
+          python "$GITHUB_WORKSPACE/scripts/smoke_release_install.py"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -28,11 +28,14 @@ workflows. It:
    repository-aware diagnostics, a real caller-to-callee graph edge, source
    anchors, and the installed Dependency Map API.
 
-Manually dispatching the TestPyPI Release workflow from `main` runs these gates
-and then publishes to TestPyPI. Production publishing remains in the separate
-Release workflow and requires a `v<version>` tag that exactly matches
-`project.version`. After PyPI publication, the workflow creates a prerelease
-GitHub Release containing the distributions and `SHA256SUMS`.
+Manually dispatching the TestPyPI Release workflow from `main` runs these gates,
+publishes to TestPyPI, then downloads that exact version from TestPyPI's public
+simple index. The workflow byte-compares the downloaded wheel with the verified
+build before installing it in a fresh environment and exercising a real BM25
+index build. Production publishing remains in the separate Release workflow
+and requires a `v<version>` tag that exactly matches `project.version`. After
+PyPI publication, the workflow creates a prerelease GitHub Release containing
+the distributions and `SHA256SUMS`.
 
 ## Trusted Publisher Setup
 
@@ -87,7 +90,7 @@ on PyPI.
 4. Merge the release commit to `main` and confirm its package gates pass.
 5. Confirm the TestPyPI pending publisher is visible, then dispatch the
    TestPyPI Release workflow from `main`.
-6. Install and test the TestPyPI artifact in a clean environment.
+6. Confirm the TestPyPI registry-download and installed-CLI smoke job passes.
 7. Complete the public-surface gate above.
 8. Confirm the PyPI pending publisher is visible.
 9. Create and push an annotated `v<version>` tag.

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -91,13 +91,37 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "${{ secrets.PYPI_API_TOKEN }}"
     )
 
-    assert set(test["jobs"]) == {"verify", "publish-testpypi"}
+    assert set(test["jobs"]) == {
+        "verify",
+        "publish-testpypi",
+        "verify-testpypi-install",
+    }
     test_publisher = test["jobs"]["publish-testpypi"]
     assert test_publisher["environment"]["name"] == "testpypi"
     assert (
         publisher_step(test_publisher)["with"]["repository-url"]
         == "https://test.pypi.org/legacy/"
     )
+    test_install = test["jobs"]["verify-testpypi-install"]
+    assert test_install["needs"] == "publish-testpypi"
+    assert test_install["runs-on"] == "ubuntu-latest"
+    assert test_install["permissions"] == {"contents": "read"}
+    step_names = [step["name"] for step in test_install["steps"]]
+    assert step_names.index("Resolve release version") < step_names.index(
+        "Download and verify the TestPyPI wheel"
+    )
+    assert step_names.index("Download and verify the TestPyPI wheel") < (
+        step_names.index("Install the registry wheel")
+    )
+    install_steps = {step["name"]: step for step in test_install["steps"]}
+    assert install_steps["Resolve release version"]["id"] == "version"
+    download = install_steps["Download and verify the TestPyPI wheel"]["run"]
+    assert "--index-url https://test.pypi.org/simple/" in download
+    assert "--no-deps" in download
+    assert "hashlib.sha256" in download
+    exercise = install_steps["Exercise the installed CLI"]["run"]
+    assert "doctor --require core --require wiki" in exercise
+    assert "scripts/smoke_release_install.py" in exercise
 
     assert set(verification["on"]) == {"workflow_call"}
     assert verification["on"]["workflow_call"]["inputs"]["full"] == {


### PR DESCRIPTION
## Summary

Make the TestPyPI workflow prove the public registry path, not only the upload. After publishing, a separate GitHub-hosted job downloads the exact version from TestPyPI, byte-compares that wheel with the verified build, installs it in a fresh environment, and runs the installed BM25 CLI smoke.

This should merge before #430 so the 0.2.0a1 dispatch includes the registry round-trip gate.

## Changes

- add a post-publication TestPyPI install job with bounded index-consistency retries
- fetch CodeNib only from TestPyPI while resolving dependencies from normal PyPI after wheel verification
- reject missing, duplicate, or byte-mismatched registry wheels
- exercise the installed version, core/Wiki doctor checks, and a real BM25 index build
- document that a successful TestPyPI workflow now includes install-from-index validation
- extend the release workflow contract test with dependency, ordering, origin, and smoke assertions

## Type of Change

- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Bug fix
- [ ] Breaking change
- [x] Chore

## Testing

- `uv run pytest test/test_release_artifacts.py -q --tb=short` (4 passed)
- `uv run pre-commit run --files .github/workflows/release-test.yml test/test_release_artifacts.py docs/releasing.md`
- `git diff --check`

The real network leg is intentionally executed only after a TestPyPI upload; its success is the new workflow gate.

## Checklist

- [x] TestPyPI publication remains OIDC-scoped to the `testpypi` environment
- [x] The post-publication job receives no publishing credential
- [x] The exact package version is downloaded with dependencies disabled
- [x] Registry and verified-build wheel hashes must match
- [x] Retry time is bounded
- [x] Production PyPI and release-tag workflows are unchanged
