### PR TITLE
docs(release): clarify alpha setup and runner service

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,20 @@ publishing a partially updated view.
 
 Requires Python 3.10+ and Git.
 
+The documentation on `main` describes the `0.2` feature line, currently
+published as `0.2.0a1` on TestPyPI. Install its immutable wheel directly so
+normal dependencies continue to resolve only from PyPI:
+
 ```bash
-pip install codenib
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install "codenib @ ${CODENIB_ALPHA_WHEEL}"
+codenib doctor --require core --require wiki
 codenib wiki /path/to/repository
 ```
+
+For the stable `0.1` line, use `python -m pip install codenib`. The
+[0.2 Alpha 1 notes](https://docs.codenib.ai/releases/0.2.0/) record the exact
+package, workflow revision, upgrade boundary, and verification evidence.
 
 CodeNib detects the repository languages, builds a reusable index under
 `~/.codenib/repositories`, launches the local Wiki, and opens
@@ -162,7 +172,7 @@ Install the MCP extra, build once, and serve the same repository manifest over
 stdio:
 
 ```bash
-pip install "codenib[mcp]"
+python -m pip install "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```
@@ -221,7 +231,7 @@ records chunking, graph, incremental, and C++ decoder support.
 Build the documentation site locally with:
 
 ```bash
-pip install "codenib[dev]"
+python -m pip install -e ".[dev]"
 mkdocs serve
 ```
 

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -226,7 +226,8 @@ reasoning loop while replacing its repository data plane with
 localization baselines:
 
 ```bash
-pip install "codenib[agent,graph]"
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install "codenib[agent,graph] @ ${CODENIB_ALPHA_WHEEL}"
 ```
 
 ```python

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -358,6 +358,38 @@ use the `./.github/actions/setup-env` composite action, which provisions:
   serial / core / consumer jobs).
 - **bear** — optional C/C++ compilation-database tool, via `install-bear`.
 
+## Self-Hosted Runner Service
+
+The runner must be installed as an operating-system service. Starting
+`./run.sh` in a shell is useful only for diagnosis: the listener disappears
+when that shell, SSH session, or machine restarts, leaving jobs queued even
+though no test has failed.
+
+On Linux, wait until GitHub reports the runner as idle, stop the foreground
+`run.sh` process with `Ctrl-C`, and use the service helper shipped with that
+runner installation:
+
+```bash
+cd /path/to/actions-runner
+sudo ./svc.sh install "$(id -un)"
+sudo ./svc.sh start
+sudo ./svc.sh status
+```
+
+`svc.sh install` creates and enables an `actions.runner.*.service` systemd unit,
+so the listener starts after a reboot without an interactive login. Confirm
+both the local unit and GitHub registration before dispatching expensive jobs:
+
+```bash
+systemctl list-units 'actions.runner.*' --all
+gh api repos/sysevol-ai/CodeNib/actions/runners \
+  --jq '.runners[] | {name, status, busy}'
+```
+
+Do not start the service while a manual listener or `Runner.Worker` is still
+active. Do not stop a busy runner merely to install the service; wait for its
+current job to finish first.
+
 ## Failure triage
 
 Two CI failure modes are easy to confuse:

--- a/docs/github_pages.md
+++ b/docs/github_pages.md
@@ -30,11 +30,11 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@<release-sha>
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@620a82d1bf55897cbf4afa0b8563ed5da0997d27
 ```
 
-Replace `<release-sha>` with a published CodeNib release commit. A commit SHA
-keeps the compiler, frontend, action, and artifact schema on one reviewed
+The pinned commit is the source revision for CodeNib 0.2.0 Alpha 1. A commit SHA
+keeps the compiler, frontend, Action, and artifact schema on one reviewed
 revision. In the repository's **Settings > Pages**, select **GitHub Actions** as
 the source.
 
@@ -53,7 +53,7 @@ a local Hugging Face embedding model and needs no API credential:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@<release-sha>
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@620a82d1bf55897cbf4afa0b8563ed5da0997d27
     with:
       preset: semantic
 ```
@@ -73,7 +73,7 @@ artifact or Pages workflow:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@<release-sha>
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@620a82d1bf55897cbf4afa0b8563ed5da0997d27
     with:
       preset: semantic
       embedding-provider: openai
@@ -83,6 +83,11 @@ jobs:
     secrets:
       embedding_api_key: ${{ secrets.CODENIB_EMBEDDING_API_KEY }}
 ```
+
+Create `CODENIB_EMBEDDING_API_KEY` under **Settings > Secrets and variables >
+Actions > New repository secret**. The caller maps that repository secret to
+the reusable workflow's `embedding_api_key`; the workflow never places its
+value in the cache key, artifact, manifest, or Pages output.
 
 Provider, model, vector dimension, endpoint, Python version, and CodeNib source
 revision participate in cache compatibility. The credential value does not.
@@ -138,7 +143,7 @@ The composite Action can be used directly when another static host or artifact
 store owns deployment:
 
 ```yaml
-- uses: sysevol-ai/CodeNib/.github/actions/publish@<release-sha>
+- uses: sysevol-ai/CodeNib/.github/actions/publish@620a82d1bf55897cbf4afa0b8563ed5da0997d27
   id: codenib
   with:
     preset: fast
@@ -156,7 +161,7 @@ artifact with a token that has **Actions: read** permission:
 
 ```bash
 git -C /path/to/repository checkout <full-commit>
-export GH_TOKEN=github_pat_...
+export GH_TOKEN="$(gh auth token)"
 
 codenib artifact fetch owner/repository \
   --repo /path/to/repository \
@@ -203,4 +208,6 @@ automatically.
 BM25 serving requires no model credential. A semantic artifact reuses its
 stored vectors but still needs the manifest-selected embedding provider for
 each query embedding. Provider credentials stay in the MCP process environment
-and are never copied into client configuration or the context artifact.
+and are never copied into client configuration or the context artifact. When
+GitHub CLI is unavailable, set `GH_TOKEN` to a fine-grained token with
+**Actions: read** access to the repository.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,8 +33,12 @@ core decoder parity.
 
 ## Quick Start
 
+This site tracks the `0.2` alpha. Install its immutable wheel directly; plain
+`pip install codenib` still selects the stable `0.1` line.
+
 ```bash
-pip install codenib
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install "codenib @ ${CODENIB_ALPHA_WHEEL}"
 codenib wiki /path/to/repository
 ```
 
@@ -45,14 +49,16 @@ leaves the target checkout unchanged. Read the
 [Quickstart](quickstart.md) for profiles and troubleshooting.
 
 ```bash
-pip install "codenib[mcp]"
+python -m pip install "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
 codenib mcp /path/to/repository
 ```
 
 ## Serving Docs Locally
 
 ```bash
-pip install "codenib[dev]"
+git clone https://github.com/sysevol-ai/CodeNib.git
+cd CodeNib
+python -m pip install -e ".[dev]"
 mkdocs serve
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,8 +13,13 @@ then reuse that manifest across agent sessions.
 
 ## Install And Index
 
+This page describes the current `0.2` alpha. Set the same immutable wheel URL
+used by the [Quickstart](quickstart.md#install), then select the views required
+by the MCP server:
+
 ```bash
-pip install "codenib[mcp]"
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
 codenib index /path/to/repository
 ```
 
@@ -22,14 +27,14 @@ The default `fast` preset builds BM25 without a model download. Add semantic
 search when needed:
 
 ```bash
-pip install "codenib[mcp,semantic]"
+python -m pip install "codenib[mcp,semantic] @ ${CODENIB_ALPHA_WHEEL}"
 codenib index /path/to/repository --preset semantic
 ```
 
 Add static navigation and dependency tools without the embedding download:
 
 ```bash
-pip install "codenib[graph,mcp]"
+python -m pip install "codenib[graph,mcp] @ ${CODENIB_ALPHA_WHEEL}"
 codenib index /path/to/repository --preset graph
 ```
 
@@ -114,7 +119,7 @@ Parameter and return schemas live in
 The `full` preset requests BM25, vectors, a symbol graph, and Zoekt:
 
 ```bash
-pip install "codenib[full]"
+python -m pip install "codenib[full] @ ${CODENIB_ALPHA_WHEEL}"
 codenib index /path/to/repository --preset full
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,17 +10,26 @@ This guide turns a local repository into a source-linked CodeNib Wiki. The
 default path uses deterministic page generation and BM25 search, so it needs
 neither an API key nor a model download.
 
-## Prerequisites
+## Install
 
 - Python 3.10 or newer
 - Git
 
-Install CodeNib and verify the local runtime:
+This documentation tracks the `0.2` feature line. Install the current alpha
+from its immutable, hash-pinned TestPyPI wheel; dependencies continue to
+resolve from PyPI rather than from a mixed package index:
 
 ```bash
-pip install codenib
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install "codenib @ ${CODENIB_ALPHA_WHEEL}"
+codenib --version
 codenib doctor --require core --require wiki
 ```
+
+The version command must report `codenib 0.2.0a1`. For the stable `0.1` line,
+use `python -m pip install codenib`; features documented as new in 0.2 require
+the alpha above. Reuse `CODENIB_ALPHA_WHEEL` when adding an optional extra, for
+example `"codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"`.
 
 ## Launch A Repository Wiki
 
@@ -135,7 +144,7 @@ embedding model, and BYO endpoint configurations.
 For natural-language search:
 
 ```bash
-pip install "codenib[semantic]"
+python -m pip install "codenib[semantic] @ ${CODENIB_ALPHA_WHEEL}"
 codenib wiki /path/to/repository --preset semantic
 ```
 
@@ -146,7 +155,7 @@ To keep embeddings out of the local process, use a BYO OpenAI-compatible
 embedding service:
 
 ```bash
-pip install "codenib[semantic-remote]"
+python -m pip install "codenib[semantic-remote] @ ${CODENIB_ALPHA_WHEEL}"
 export EMBEDDING_API_KEY=...
 codenib doctor --require semantic \
   --embedding-provider openai \
@@ -167,6 +176,46 @@ Provider, model, endpoint, dimension, and vector-shaping options become part of
 the vector artifact identity. Credentials, retries, timeouts, and batching stay
 process-local, and CodeNib refuses to reopen an artifact through a different
 provider or endpoint.
+
+## Credentials And Tokens
+
+The default Wiki, BM25 index, static export, and local CodeRankEmbed route need
+no credential. GitHub Pages also uses GitHub's short-lived workflow token for
+deployment; users do not provide a personal token for the default workflow.
+
+Use environment variables for the capabilities that do need authentication:
+
+| Capability | Credential | How CodeNib receives it |
+|---|---|---|
+| BYO OpenAI-compatible embeddings | Provider API key | Name the variable with `--embedding-api-key-env` |
+| Generated Wiki pages and Ask | LiteLLM provider key | Use the provider's normal variable or `--api-key-env` |
+| Download a GitHub Actions context artifact | Fine-grained token with **Actions: read** | Export it as `GH_TOKEN` |
+
+For example:
+
+```bash
+# Remote embeddings. The key value never appears in the command line.
+export CODENIB_EMBEDDING_API_KEY=...
+codenib wiki . --preset semantic \
+  --embedding-provider openai \
+  --embedding-endpoint https://embeddings.example.com/v1 \
+  --embedding-api-key-env CODENIB_EMBEDDING_API_KEY
+
+# Agent-authored pages through an OpenAI-compatible chat endpoint.
+export OPENAI_API_KEY=...
+codenib wiki . --generate \
+  --model openai/gpt-4o-mini \
+  --api-key-env OPENAI_API_KEY
+
+# Reuse the token already managed by GitHub CLI for artifact download.
+export GH_TOKEN="$(gh auth token)"
+```
+
+For GitHub Actions, create `CODENIB_EMBEDDING_API_KEY` under **Settings >
+Secrets and variables > Actions**, then map it to the reusable workflow's
+`embedding_api_key` secret. CodeNib records provider identity and the name of
+the credential variable, never its value. Secrets are excluded from manifests,
+context artifacts, generated MCP configuration, and static Pages output.
 
 The `graph` extra supplies the Python graph and protobuf runtimes, while each
 repository language still needs its own SCIP/LSP executable. Check the exact
@@ -202,7 +251,7 @@ Static Wiki pages are the default. To generate conceptual page narratives
 through a LiteLLM-supported provider:
 
 ```bash
-pip install "codenib[agent]"
+python -m pip install "codenib[agent] @ ${CODENIB_ALPHA_WHEEL}"
 export OPENAI_API_KEY=...
 codenib doctor --require agent \
   --model openai/gpt-4o-mini --api-key-env OPENAI_API_KEY --probe-model
@@ -233,7 +282,7 @@ codenib wiki . --generate --model anthropic/claude-sonnet-4-5
 Vertex AI additionally requires CodeNib's `vertex` extra:
 
 ```bash
-pip install "codenib[agent,vertex]"
+python -m pip install "codenib[agent,vertex] @ ${CODENIB_ALPHA_WHEEL}"
 gcloud auth application-default login
 codenib wiki . --generate \
   --model vertex_ai/gemini-2.5-flash \
@@ -288,7 +337,7 @@ continues to work.
 ## Serve The Index Over MCP
 
 ```bash
-pip install "codenib[mcp]"
+python -m pip install "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -18,20 +18,15 @@ release-blocking compatibility or security issue.
 ## Upgrade
 
 ```bash
-ALPHA_DIR="$(mktemp -d)"
-python -m pip download --no-deps --only-binary=:all: --pre \
-  --index-url https://test.pypi.org/simple/ \
-  --dest "$ALPHA_DIR" \
-  "codenib==0.2.0a1"
-python -m pip install --upgrade \
-  "$ALPHA_DIR/codenib-0.2.0a1-py3-none-any.whl"
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install --upgrade "codenib @ ${CODENIB_ALPHA_WHEEL}"
+codenib --version
 codenib doctor --require core --require wiki
 ```
 
-The first command downloads only the exact CodeNib prerelease from TestPyPI.
-Installing that local wheel then resolves normal runtime dependencies from the
-default PyPI index without mixing the two registries during dependency
-selection.
+The URL selects the exact TestPyPI wheel and verifies its published SHA-256.
+Normal dependencies resolve from PyPI, so this command does not mix TestPyPI
+into dependency selection. The version command must report `codenib 0.2.0a1`.
 
 Existing BM25 and vector manifests are checked when opened. CodeNib reuses a
 compatible view and rebuilds rather than silently substituting an incompatible
@@ -61,7 +56,7 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@<release-sha>
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@620a82d1bf55897cbf4afa0b8563ed5da0997d27
 ```
 
 The default workflow publishes precomputed pages, citations, navigation, and
@@ -74,14 +69,9 @@ After checking out the recorded commit, reuse the artifact without another
 index build:
 
 ```bash
-ALPHA_DIR="$(mktemp -d)"
-python -m pip download --no-deps --only-binary=:all: --pre \
-  --index-url https://test.pypi.org/simple/ \
-  --dest "$ALPHA_DIR" \
-  "codenib[mcp]==0.2.0a1"
-python -m pip install --upgrade \
-  "$ALPHA_DIR/codenib-0.2.0a1-py3-none-any.whl[mcp]"
-export GH_TOKEN=github_pat_...
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install --upgrade "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
+export GH_TOKEN="$(gh auth token)"
 codenib artifact fetch owner/repository --repo /path/to/repository
 codenib artifact mcp-config \
   ~/.codenib/artifacts/owner/repository/<full-commit> \
@@ -89,6 +79,14 @@ codenib artifact mcp-config \
   --repository owner/repository \
   --host codex
 ```
+
+The default `fast` Wiki, export, and MCP paths need no model token. A BYO
+embedding endpoint receives the environment variable named by
+`--embedding-api-key-env`; agent-authored pages receive the provider variable
+named by `--api-key-env`. Repository Actions pass embedding credentials through
+the optional `embedding_api_key` secret. `GH_TOKEN` is used only to read the
+commit-addressed Actions artifact. See the [Quickstart](../quickstart.md#credentials-and-tokens)
+for copyable local examples.
 
 ## Security Boundary
 

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -23,7 +23,8 @@ Install the graph dependencies, check the target repository, and then select
 the graph preset:
 
 ```bash
-pip install "codenib[graph]"
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install "codenib[graph] @ ${CODENIB_ALPHA_WHEEL}"
 codenib doctor /path/to/repository --require graph
 codenib index /path/to/repository --preset graph
 ```

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -10,7 +10,8 @@ For one local repository, use the packaged two-command path in the
 [Quickstart](quickstart.md):
 
 ```bash
-pip install codenib
+export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+python -m pip install "codenib @ ${CODENIB_ALPHA_WHEEL}"
 codenib wiki /path/to/repository
 ```
 

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -48,11 +48,50 @@ def test_alpha_release_notes_use_test_registry_and_pages_permissions() -> None:
     root = Path(__file__).resolve().parents[1]
     notes = (root / "docs" / "releases" / "0.2.0.md").read_text(encoding="utf-8")
 
-    assert notes.count("--index-url https://test.pypi.org/simple/") == 2
-    assert notes.count("--no-deps --only-binary=:all:") == 2
+    wheel = (
+        "https://test-files.pythonhosted.org/packages/3d/3d/"
+        "8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/"
+        "codenib-0.2.0a1-py3-none-any.whl#sha256="
+        "915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
+    )
+    assert notes.count(wheel) == 2
+    assert "codenib @ ${CODENIB_ALPHA_WHEEL}" in notes
+    assert "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}" in notes
+    assert "620a82d1bf55897cbf4afa0b8563ed5da0997d27" in notes
     assert "--extra-index-url" not in notes
+    assert "--index-url" not in notes
     for permission in ("contents: read", "pages: write", "id-token: write"):
         assert permission in notes
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "README.md",
+        "docs/agent_integrations.md",
+        "docs/index.md",
+        "docs/mcp.md",
+        "docs/quickstart.md",
+        "docs/scip_index.md",
+        "docs/web_demo.md",
+    ),
+)
+def test_public_alpha_install_commands_do_not_select_stable_0_1(
+    relative_path: str,
+) -> None:
+    root = Path(__file__).resolve().parents[1]
+    text = (root / relative_path).read_text(encoding="utf-8")
+    install_lines = [
+        line.strip()
+        for line in text.splitlines()
+        if line.lstrip().startswith(("pip install ", "python -m pip install "))
+        and "codenib" in line
+        and " -e " not in line
+    ]
+
+    assert install_lines
+    assert "CODENIB_ALPHA_WHEEL=" in text
+    assert all("@ ${CODENIB_ALPHA_WHEEL}" in line for line in install_lines)
 
 
 def test_registry_publishers_use_separate_workflows() -> None:


### PR DESCRIPTION
## Summary

Make the public 0.2 Alpha 1 path install the package version that the documentation describes, explain when credentials are required, and record the supported service-mode setup for the self-hosted runner.

## Changes

- replace misleading stable-0.1 install commands on 0.2 pages with the immutable, SHA-256-pinned TestPyPI wheel
- document first-run Wiki and MCP commands plus local, BYO embedding, LLM, GitHub Actions, and artifact token boundaries
- pin the reusable Pages workflow to the Alpha 1 source revision
- document official `svc.sh`/systemd runner operation and cancelled-job triage
- add regression coverage that rejects unqualified stable installs on public alpha pages

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/test_release_artifacts.py -q` (12 passed)

`pytest test/test_cli.py test/actions/test_publish_action.py -q` (67 passed)

`mkdocs build --strict --site-dir /tmp/codenib-alpha-docs-site-2`

`pre-commit run --files README.md docs/agent_integrations.md docs/ci_cd.md docs/github_pages.md docs/index.md docs/mcp.md docs/quickstart.md docs/releases/0.2.0.md docs/scip_index.md docs/web_demo.md test/test_release_artifacts.py`

Fresh virtual environments also installed the published `0.2.0a1` wheel for the base and `[mcp]` requirements and passed the corresponding `codenib doctor` gates.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published