### PR TITLE
feat(cli): add adaptive defaults and managed toolchains

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: ""
   preset:
     description: Portable CodeNib view preset (fast or semantic).
-    default: fast
+    default: semantic
   python-version:
     description: Python runtime used to build the artifact.
     default: "3.12"
@@ -202,6 +202,14 @@ runs:
         } | sha256sum | cut -d' ' -f1)"
         cache_prefix="codenib-${RUNNER_OS}-${repository_key}-${identity}"
         cache_key="${cache_prefix}-${source_commit}"
+        embedding_cache_key=""
+        if [[ "$embedding_provider" == "huggingface" ]]; then
+          embedding_identity="$({
+            printf '%s\0' "$INPUT_EMBEDDING_MODEL" "$INPUT_EMBEDDING_DIMENSION"
+            sha256sum "$source_path/codenib/index/embedding/model_policy.py"
+          } | sha256sum | cut -d' ' -f1)"
+          embedding_cache_key="codenib-huggingface-${RUNNER_OS}-${embedding_identity}"
+        fi
         safe_repository="$({
           printf '%s' "$repository" | tr '[:upper:]' '[:lower:]' | \
             tr '/:@ ' '----' | tr -cd 'a-z0-9_.-'
@@ -219,6 +227,7 @@ runs:
           echo "cache_prefix=$cache_prefix-"
           echo "context_manifest=$context_path/codenib-context.json"
           echo "context_path=$context_path"
+          echo "embedding_cache_key=$embedding_cache_key"
           echo "embedding_provider=$embedding_provider"
           echo "extras=$extras"
           echo "frontend_path=$frontend_path"
@@ -239,6 +248,15 @@ runs:
         node-version: "22"
         cache: npm
         cache-dependency-path: ${{ steps.inputs.outputs.source_path }}/web/package-lock.json
+
+    - name: Cache local embedding model
+      if: >-
+        inputs.cache == 'true' &&
+        steps.inputs.outputs.embedding_provider == 'huggingface'
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: ~/.cache/huggingface
+        key: ${{ steps.inputs.outputs.embedding_cache_key }}
 
     - name: Restore incremental repository state
       id: restore

--- a/.github/workflows/codenib-pages.yml
+++ b/.github/workflows/codenib-pages.yml
@@ -10,7 +10,7 @@ on:
       preset:
         description: CodeNib view preset.
         type: string
-        default: fast
+        default: semantic
       python-version:
         description: Python runtime used for indexing.
         type: string

--- a/.github/workflows/codenib-publish-smoke.yml
+++ b/.github/workflows/codenib-publish-smoke.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           base-path: /publish-smoke
           cache: "false"
+          preset: fast
           repository-path: ${{ steps.fixture.outputs.path }}
           upload-context: "false"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+## [0.2.0a2] - 2026-08-05
+
+### Added
+
+- A repository-aware `codenib toolchain` command that detects graph and LSP
+  providers from the language registry, installs pinned package-managed tools
+  under `~/.codenib/toolchains`, and reports system or project prerequisites
+  without invoking `sudo` or mutating the target checkout.
+
+### Changed
+
+- Local `index` and `wiki` commands now select semantic hybrid retrieval when
+  the semantic extra is installed and explicitly report the no-model BM25
+  fallback otherwise. The reusable Pages workflow selects semantic retrieval
+  by default and caches its pinned local embedding model; `fast` remains an
+  explicit no-model route.
+- CodeNib processes automatically prefer the managed tool directory, removing
+  the shell `PATH` export previously required after source-checkout installs.
+- The public quickstart recommends BM25+dense serving and uses a normal,
+  version-pinned PyPI command instead of exposing a TestPyPI wheel URL.
+
 ## [0.2.0a1] - 2026-08-05
 
 ### Added
@@ -82,6 +103,7 @@ All notable user-facing changes are recorded here. CodeNib follows
 - Prepared secretless PyPI publishing through a dedicated GitHub Actions OIDC
   workflow.
 
-[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0a1...HEAD
-[0.2.0a1]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...v0.2.0a1
+[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0a2...HEAD
+[0.2.0a2]: https://github.com/sysevol-ai/CodeNib/compare/620a82d...v0.2.0a2
+[0.2.0a1]: https://github.com/sysevol-ai/CodeNib/tree/620a82d
 [0.1.0]: https://github.com/sysevol-ai/CodeNib/releases/tag/v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ GO_URL ?= https://go.dev/dl/go$(GO_VERSION).$(GO_OS)-$(GO_ARCH).tar.gz
 SCIP_GO_MODULE ?= github.com/scip-code/scip-go/cmd/scip-go
 SCIP_GO_VERSION ?= v0.2.7
 GOPLS_VERSION ?= v0.22.0
+RUST_TOOLCHAIN ?= nightly-2026-02-22
 SCIP_CLANG_VERSION ?= v0.4.0
 SCIP_PYTHON_VERSION ?= 0.6.6
 SCIP_TYPESCRIPT_VERSION ?= 0.4.0
@@ -299,10 +300,10 @@ rust-tool:
 	@if ! command -v rustup >/dev/null 2>&1; then \
 		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; \
 	fi
-	PATH="$$HOME/.cargo/bin:$$PATH" rustup toolchain install stable
-	PATH="$$HOME/.cargo/bin:$$PATH" rustup component add rust-analyzer --toolchain stable
+	PATH="$$HOME/.cargo/bin:$$PATH" rustup toolchain install "$(RUST_TOOLCHAIN)"
+	PATH="$$HOME/.cargo/bin:$$PATH" rustup component add rust-analyzer --toolchain "$(RUST_TOOLCHAIN)"
 	mkdir -p "$(CODENIB_SCIP_TOOLS_DIR)"
-	@rust_analyzer="$$(PATH="$$HOME/.cargo/bin:$$PATH" rustup which --toolchain stable rust-analyzer)"; \
+	@rust_analyzer="$$(PATH="$$HOME/.cargo/bin:$$PATH" rustup which --toolchain "$(RUST_TOOLCHAIN)" rust-analyzer)"; \
 		ln -sf "$$rust_analyzer" "$(CODENIB_SCIP_TOOLS_DIR)/rust-analyzer"
 
 scip-python-tool:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ agent or code-Wiki framework.
 
 ## News
 
+- **2026-08-05 — CodeNib 0.2.0 Alpha 2: stronger defaults and managed
+  language providers.** The local CLI and reusable Pages workflow now select
+  BM25+dense retrieval by default, while retaining an explicit no-model
+  fallback for resource-constrained environments.
+  `codenib toolchain` detects repository languages, installs pinned
+  package-managed SCIP/LSP providers under `~/.codenib/toolchains`, and leaves
+  system and project prerequisites explicit.
 - **2026-08-05 — CodeNib 0.2.0 Alpha 1: build once, serve everywhere.**
   [`codenib publish`](https://docs.codenib.ai/github_pages/) and the reusable
   GitHub workflow deploy a no-model static Wiki and retain a matching BM25 or
@@ -58,7 +65,7 @@ agent or code-Wiki framework.
   artifact can be rebound to that checkout and served through MCP without
   rebuilding; incremental caches remain private build state rather than part
   of the downloadable serving artifact. See the
-  [0.2.0 Alpha 1 notes](https://docs.codenib.ai/releases/0.2.0/).
+  [0.2 release notes](https://docs.codenib.ai/releases/0.2.0/).
 - **2026-08-04 — Native repository explorer.**
   [`RepositoryContextExplorer`](codenib/agent/runtime/explorer.py) plans BM25,
   dense, hybrid, reranked, and graph routes over manifest-backed views and
@@ -105,22 +112,20 @@ publishing a partially updated view.
 
 ## Quickstart
 
-Requires Python 3.10+ and Git.
-
-The documentation on `main` describes the `0.2` feature line, currently
-published as `0.2.0a1` on TestPyPI. Install its immutable wheel directly so
-normal dependencies continue to resolve only from PyPI:
+Requires Python 3.10+ and Git. The recommended local path includes the pinned
+CodeRankEmbed model and serves hybrid BM25+dense retrieval:
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install "codenib @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[semantic]==0.2.0a2"
 codenib doctor --require core --require wiki
 codenib wiki /path/to/repository
 ```
 
-For the stable `0.1` line, use `python -m pip install codenib`. The
-[0.2 Alpha 1 notes](https://docs.codenib.ai/releases/0.2.0/) record the exact
-package, workflow revision, upgrade boundary, and verification evidence.
+`codenib wiki` selects the semantic route because the installed environment
+contains its dependencies. A smaller `python -m pip install codenib==0.2.0a2`
+installation selects the deterministic BM25 fallback and downloads no model.
+The [0.2 release notes](https://docs.codenib.ai/releases/0.2.0/) record the
+upgrade boundary and verification evidence.
 
 CodeNib detects the repository languages, builds a reusable index under
 `~/.codenib/repositories`, launches the local Wiki, and opens
@@ -134,6 +139,16 @@ Check the environment or index without opening the Wiki:
 ```bash
 codenib doctor --require core --require wiki
 codenib index /path/to/repository
+```
+
+For a structural view, CodeNib detects the repository languages and manages
+only their package-level providers; operating-system and project prerequisites
+remain explicit:
+
+```bash
+python -m pip install "codenib[graph]==0.2.0a2"
+codenib toolchain install /path/to/repository --scope graph
+codenib doctor /path/to/repository --require graph
 ```
 
 Export that indexed commit as a serverless Wiki when a live Ask backend is not
@@ -150,11 +165,12 @@ the local or MCP serving path.
 
 For a repository-hosted Wiki, CodeNib also ships a reusable GitHub workflow
 that incrementally builds the same manifest, deploys the static site to Pages,
-and uploads the matching commit-addressed context artifact. Its default `fast`
-route needs no model credential or model download. The optional `semantic`
-route builds the matching vector artifact with a local Hugging Face model or an
-explicit BYO OpenAI-compatible endpoint; query-time search remains in the local
-or MCP runtime. See [GitHub Pages](https://docs.codenib.ai/github_pages/).
+and uploads the matching commit-addressed context artifact. Its default
+`semantic` route builds BM25 and vector views with a cached local Hugging Face
+model and needs no API key. An explicit `fast` route avoids the model download;
+a BYO OpenAI-compatible endpoint can replace local embedding. Query-time search
+remains in the local or MCP runtime. See
+[GitHub Pages](https://docs.codenib.ai/github_pages/).
 The published BM25/vector artifact can then be verified against an exact local
 checkout and served through MCP without rebuilding the repository views.
 
@@ -172,7 +188,7 @@ Install the MCP extra, build once, and serve the same repository manifest over
 stdio:
 
 ```bash
-python -m pip install "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[mcp,semantic]==0.2.0a2"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -11,6 +11,7 @@ import importlib.util
 import json
 import os
 import re
+import shlex
 import shutil
 import sys
 from collections import Counter
@@ -33,6 +34,7 @@ _PRESET_VIEWS = {
     "graph": ("bm25", "symbol_graph"),
     "full": ("bm25", "vector", "symbol_graph", "zoekt"),
 }
+_PRESET_CHOICES = ("auto", *_PRESET_VIEWS)
 _REMOTE_EMBEDDING_DEFAULTS = {
     "openai": ("text-embedding-3-small", 1536),
 }
@@ -308,6 +310,34 @@ def _selected_views(preset: str, explicit: Iterable[str]) -> list[str]:
     return list(dict.fromkeys(views))
 
 
+def _selected_views_for_args(args: argparse.Namespace) -> list[str]:
+    explicit = _split_values(args.view)
+    if explicit or args.preset != "auto":
+        return _selected_views(args.preset, explicit)
+
+    route = _embedding_route_for_args(args)
+    embedding_module = (
+        "sentence_transformers" if route.provider == "huggingface" else "openai"
+    )
+    resolved = (
+        "semantic"
+        if _embedding_identity_is_configured(args)
+        or (_check_module("faiss") and _check_module(embedding_module))
+        else "fast"
+    )
+    reason = (
+        "explicit embedding route"
+        if _embedding_identity_is_configured(args)
+        else (
+            "dense dependencies available"
+            if resolved == "semantic"
+            else "no-model fallback"
+        )
+    )
+    print(f"Auto preset: {resolved} ({reason})")
+    return list(_PRESET_VIEWS[resolved])
+
+
 def index_repository(
     repo_path: Path,
     *,
@@ -321,6 +351,9 @@ def index_repository(
     embedding_credential_env: str | None = None,
 ):
     """Build or update the requested repository views."""
+    from .toolchains import activate_managed_toolchain
+
+    activate_managed_toolchain()
     from .compiler.index_builders import IndexBuilderRegistry, register_default_builders
     from .compiler.index_compiler import IndexCompiler, IndexCompilerConfig
     from .compiler.manifest import MANIFEST_FILENAME
@@ -399,10 +432,18 @@ def _print_index_summary(manifest, views: Sequence[str]) -> None:
         print(f"  {view:<14} {entry.status}{suffix}")
 
 
-def _run_index(args: argparse.Namespace) -> int:
+def _run_index(
+    args: argparse.Namespace,
+    *,
+    selected_views: Sequence[str] | None = None,
+) -> int:
     repo_path = resolve_repo_path(args.repo)
     languages = _selected_languages(repo_path, args.language)
-    views = _selected_views(args.preset, args.view)
+    views = (
+        list(selected_views)
+        if selected_views is not None
+        else _selected_views_for_args(args)
+    )
     embedding_route = None
     if "vector" in views:
         embedding_route = _embedding_route_for_args(args)
@@ -638,14 +679,14 @@ def _run_artifact_mcp_config(args: argparse.Namespace) -> int:
 
 
 def _run_publish(args: argparse.Namespace) -> int:
-    selected_views = _selected_views(args.preset, args.view)
+    selected_views = _selected_views_for_args(args)
     unsupported = sorted(set(selected_views) - {"bm25", "vector"})
     if unsupported:
         raise CLIError(
             "portable publication currently supports bm25 and vector views; "
             f"unsupported: {', '.join(unsupported)}"
         )
-    index_result = _run_index(args)
+    index_result = _run_index(args, selected_views=selected_views)
     if index_result:
         return index_result
 
@@ -832,7 +873,11 @@ def _manifest_embedding_route(
 def _run_wiki(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
     languages = _selected_languages(repo_path, args.language)
-    views = _selected_views(args.preset, args.view)
+    if args.no_index and args.preset == "auto" and not _split_values(args.view):
+        views = list(_PRESET_VIEWS["fast"])
+        print("Auto preset: reuse manifest capabilities")
+    else:
+        views = _selected_views_for_args(args)
     audit = bool(args.audit or args.audit_json)
     model_options = _model_options_for_args(args)
     if (
@@ -1477,6 +1522,81 @@ def _run_doctor(args: argparse.Namespace) -> int:
     return 1 if failed_required else 0
 
 
+def _toolchain_scopes(value: str) -> tuple[str, ...]:
+    return ("graph", "lsp") if value == "all" else (value,)
+
+
+def _toolchain_plan_for_args(args: argparse.Namespace):
+    from .toolchains import plan_repository_toolchain
+
+    repo_path = resolve_repo_path(args.repo)
+    languages = _selected_languages(repo_path, args.language)
+    return plan_repository_toolchain(
+        repo_path,
+        languages,
+        scopes=_toolchain_scopes(args.scope),
+    )
+
+
+def _print_toolchain_plan(plan) -> None:
+    print(f"Repository: {plan.repository}")
+    print(f"Languages:  {', '.join(plan.languages)}")
+    print(f"Managed:    {plan.root}")
+    print("Providers:")
+    if not plan.requirements:
+        print("  none")
+    for requirement in plan.requirements:
+        status = "OK" if requirement.ready else "MISSING"
+        resolved = requirement.resolved or requirement.detail or "not found"
+        print(
+            f"  [{status:<7}] {requirement.display_name:<12} "
+            f"{requirement.scope:<5} {requirement.executable}: {resolved}"
+        )
+    if plan.notes:
+        print("Notes:")
+        for note in plan.notes:
+            print(f"  - {note}")
+
+
+def _run_toolchain_status(args: argparse.Namespace) -> int:
+    plan = _toolchain_plan_for_args(args)
+    _print_toolchain_plan(plan)
+    return 0 if plan.ready else 1
+
+
+def _run_toolchain_install(args: argparse.Namespace) -> int:
+    from .toolchains import install_requirements
+
+    plan = _toolchain_plan_for_args(args)
+    try:
+        commands, manual = install_requirements(
+            plan.missing,
+            root=plan.root,
+            dry_run=args.dry_run,
+        )
+    except RuntimeError as exc:
+        raise CLIError(str(exc)) from exc
+
+    heading = "Planned commands" if args.dry_run else "Executed commands"
+    print(f"{heading}:")
+    if commands:
+        for command in commands:
+            print(f"  {shlex.join(command)}")
+    else:
+        print("  none")
+    if manual:
+        print("Manual prerequisites:")
+        for item in manual:
+            print(f"  - {item}")
+    if args.dry_run:
+        return 0
+
+    refreshed = _toolchain_plan_for_args(args)
+    print()
+    _print_toolchain_plan(refreshed)
+    return 0 if refreshed.ready else 1
+
+
 def _add_embedding_route_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--embedding-provider",
@@ -1522,7 +1642,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     index_parser.add_argument("repo", nargs="?", default=".")
-    index_parser.add_argument("--preset", choices=tuple(_PRESET_VIEWS), default="fast")
+    index_parser.add_argument("--preset", choices=_PRESET_CHOICES, default="auto")
     index_parser.add_argument(
         "--language",
         action="append",
@@ -1549,7 +1669,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     wiki_parser.add_argument("repo", nargs="?", default=".")
-    wiki_parser.add_argument("--preset", choices=tuple(_PRESET_VIEWS), default="fast")
+    wiki_parser.add_argument("--preset", choices=_PRESET_CHOICES, default="auto")
     wiki_parser.add_argument("--language", action="append", default=[])
     wiki_parser.add_argument("--view", action="append", default=[])
     wiki_parser.add_argument("--rebuild", action="store_true")
@@ -1746,8 +1866,8 @@ def build_parser() -> argparse.ArgumentParser:
     publish_parser.add_argument("repo", nargs="?", default=".")
     publish_parser.add_argument(
         "--preset",
-        choices=("fast", "semantic"),
-        default="fast",
+        choices=("auto", "fast", "semantic"),
+        default="auto",
     )
     publish_parser.add_argument("--language", action="append", default=[])
     publish_parser.add_argument("--view", action="append", default=[])
@@ -1800,6 +1920,44 @@ def build_parser() -> argparse.ArgumentParser:
         default="INFO",
     )
     mcp_parser.set_defaults(handler=_run_mcp)
+
+    toolchain_parser = subparsers.add_parser(
+        "toolchain",
+        help="inspect or install repository language providers",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    toolchain_subparsers = toolchain_parser.add_subparsers(
+        dest="toolchain_command",
+        required=True,
+    )
+    for command, handler in (
+        ("status", _run_toolchain_status),
+        ("install", _run_toolchain_install),
+    ):
+        command_parser = toolchain_subparsers.add_parser(
+            command,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        command_parser.add_argument("repo", nargs="?", default=".")
+        command_parser.add_argument(
+            "--language",
+            action="append",
+            default=[],
+            help="source language override; repeat or use a comma-separated list",
+        )
+        command_parser.add_argument(
+            "--scope",
+            choices=("graph", "lsp", "all"),
+            default="graph",
+            help="provider surface to inspect or install",
+        )
+        if command == "install":
+            command_parser.add_argument(
+                "--dry-run",
+                action="store_true",
+                help="print pinned package-manager commands without running them",
+            )
+        command_parser.set_defaults(handler=handler)
 
     doctor_parser = subparsers.add_parser(
         "doctor",
@@ -1871,6 +2029,9 @@ def run(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
+        from .toolchains import activate_managed_toolchain
+
+        activate_managed_toolchain()
         return int(args.handler(args) or 0)
     except CLIError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/codenib/graph/incremental/lsp_client.py
+++ b/codenib/graph/incremental/lsp_client.py
@@ -17,7 +17,6 @@ import atexit
 import json
 import os
 import select
-import shutil
 import subprocess
 import sys
 import time
@@ -27,6 +26,7 @@ from typing import Any, Optional
 from ...languages import lsp_command_for_language, normalize_graph_language
 from ...log_utils import get_logger
 from ...scip_interface.rust_analyzer import rust_toolchain
+from ...toolchains import activate_managed_toolchain, resolve_command
 
 logger = get_logger(__name__)
 
@@ -135,10 +135,10 @@ _EXTRA_BIN_DIRS = [
 def resolve_lsp_binary(binary: str) -> Optional[str]:
     """Find the full path to an LSP binary.
 
-    Searches: PATH (via shutil.which) → common install locations.
+    Searches: CodeNib-managed tools → PATH → common install locations.
     Returns resolved path or None.
     """
-    resolved = shutil.which(binary)
+    resolved = resolve_command(binary)
     if resolved:
         return resolved
     for dir_fn in _EXTRA_BIN_DIRS:
@@ -157,6 +157,7 @@ def _lsp_process_env(
     project_root: str | Path | None = None,
 ) -> dict[str, str]:
     env = os.environ.copy()
+    activate_managed_toolchain(env)
     # Bypass a repository-pinned Rust toolchain so rust-analyzer uses the
     # CodeNib-selected toolchain instead.
     if language == "rust":

--- a/codenib/graph/setup.py
+++ b/codenib/graph/setup.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
-import shutil
+import shlex
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Callable, Literal, Sequence
@@ -20,6 +20,7 @@ from ..languages import (
     scip_cold_start_command_for_language,
 )
 from ..repository_filters import DEFAULT_IGNORED_DIRS
+from ..toolchains import resolve_command
 
 GraphSetupState = Literal["ready", "missing", "unsupported"]
 CommandResolver = Callable[[str], str | None]
@@ -31,16 +32,22 @@ _TOOL_HINTS = {
     "clangd": "Install clangd from LLVM.",
     "cmake": "Install CMake or provide compile_commands.json.",
     "composer": "Install Composer, or provide an Intelephense LSP command.",
-    "intelephense": "Install Intelephense for the PHP LSP fallback.",
-    "ruby-lsp": "Install ruby-lsp for the Ruby LSP fallback.",
-    "rust-analyzer": "Install rust-analyzer with SCIP support.",
-    "scip-dotnet": "Install scip-dotnet or set CODENIB_CSHARP_SCIP_CMD.",
+    "intelephense": (
+        "Install the managed Intelephense provider with `codenib toolchain install`."
+    ),
+    "ruby-lsp": "Install the managed Ruby LSP provider with `codenib toolchain install`.",
+    "rust-analyzer": (
+        "Install the managed rust-analyzer provider with `codenib toolchain install`."
+    ),
+    "scip-dotnet": "Install the managed scip-dotnet provider with `codenib toolchain install`.",
     "scip-go": "Install scip-go and make it available on PATH.",
     "scip-java": "Install scip-java or set the language-specific SCIP command.",
-    "scip-python": "Install @sourcegraph/scip-python and expose `scip-python` on PATH.",
+    "scip-python": (
+        "Install the managed `scip-python` provider with `codenib toolchain install`."
+    ),
     "scip-ruby": "Prepare scip-ruby in the repository bundle.",
     "scip-typescript": (
-        "Install @sourcegraph/scip-typescript and expose `scip-typescript` on PATH."
+        "Install the managed `scip-typescript` provider with `codenib toolchain install`."
     ),
 }
 
@@ -155,6 +162,11 @@ class GraphSetupReport:
         commands = []
         if not self.runtime.ready:
             commands.append('pip install "codenib[graph]"')
+        if self.unavailable_languages:
+            commands.append(
+                f"codenib toolchain install {shlex.quote(self.repository)} "
+                "--scope graph"
+            )
         commands.extend(
             [
                 "codenib doctor . --require graph",
@@ -639,7 +651,7 @@ def diagnose_graph_setup(
     """
 
     root = Path(repository).expanduser().resolve()
-    command_resolver = command_resolver or shutil.which
+    command_resolver = command_resolver or resolve_command
     module_checker = module_checker or _module_available
     missing_runtime = [
         name for name in ("igraph", "google.protobuf") if not module_checker(name)

--- a/codenib/ls_router.py
+++ b/codenib/ls_router.py
@@ -43,6 +43,7 @@ from .languages import (
 )
 from .log_utils import get_logger
 from .profiler import Profiler
+from .toolchains import activate_managed_toolchain
 
 logger = get_logger("ls_router")
 
@@ -157,6 +158,7 @@ class LSIndexer:
         decoder_backend: Optional[str] = None,
         graph_route: str = ACTIVE_GRAPH_ROUTE,
     ):
+        activate_managed_toolchain()
         self.project_root = Path(project_root).absolute()
         self.graph_route = graph_route
         self.language = _normalize_language(language, graph_route=graph_route)

--- a/codenib/paths.py
+++ b/codenib/paths.py
@@ -16,10 +16,13 @@ CODENIB_HOME_ENV = "CODENIB_HOME"
 CODENIB_PREBUILT_DIR_ENV = "CODENIB_PREBUILT_DIR"
 CODENIB_RESULTS_DIR_ENV = "CODENIB_RESULTS_DIR"
 CODENIB_TEMP_DIR_ENV = "CODENIB_TEMP_DIR"
+CODENIB_TOOLCHAIN_DIR_ENV = "CODENIB_TOOLCHAIN_DIR"
+CODENIB_LEGACY_TOOLCHAIN_DIR_ENV = "CODENIB_SCIP_TOOLS_DIR"
 
 USER_STATE_DIRNAME = ".codenib"
 REPO_INDEX_DIRNAME = ".codenib_cache"
 REPOSITORIES_DIRNAME = "repositories"
+TOOLCHAINS_DIRNAME = "toolchains"
 QA_DATA_DIRNAME = ".codenib_qa"
 CLANGD_INDEX_DIRNAME = ".codenib-index"
 PROJECT_INSTALL_SENTINEL = ".codenib_install_cache"
@@ -61,6 +64,21 @@ def temp_state_dir() -> Path:
         CODENIB_TEMP_DIR_ENV,
         Path(tempfile.gettempdir()) / "codenib",
     )
+
+
+def toolchain_dir() -> Path:
+    """Return the durable root for CodeNib-managed language tools.
+
+    ``CODENIB_SCIP_TOOLS_DIR`` remains a source-checkout compatibility alias.
+    New installations should use ``CODENIB_TOOLCHAIN_DIR``.
+    """
+
+    configured = os.environ.get(CODENIB_TOOLCHAIN_DIR_ENV) or os.environ.get(
+        CODENIB_LEGACY_TOOLCHAIN_DIR_ENV
+    )
+    if configured:
+        return Path(configured).expanduser()
+    return user_state_dir() / TOOLCHAINS_DIRNAME
 
 
 def repository_state_key(repo_root: str | Path) -> str:

--- a/codenib/scip_interface/rust_analyzer.py
+++ b/codenib/scip_interface/rust_analyzer.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import os
 import shutil
 
-DEFAULT_RUST_TOOLCHAIN = "nightly"
+from ..toolchains import RUST_TOOLCHAIN
+
+DEFAULT_RUST_TOOLCHAIN = RUST_TOOLCHAIN
 
 
 def rust_toolchain() -> str:

--- a/codenib/toolchains.py
+++ b/codenib/toolchains.py
@@ -1,0 +1,538 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Managed external language tools for graph and LSP providers.
+
+Python extras install CodeNib runtimes. Language indexers and language servers
+are separate executables, so this module gives wheel users one repository-aware
+place to inspect and install the package-managed subset. System packages and
+project-local tools remain explicit rather than invoking ``sudo`` or mutating a
+target checkout behind the user's back.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Literal, Mapping, Sequence
+
+from .languages import get_language_spec, lsp_command_for_language
+from .paths import toolchain_dir
+
+ToolScope = Literal["graph", "lsp"]
+ToolManager = Literal["npm", "go", "rustup", "dotnet", "gem", "external"]
+
+
+@dataclass(frozen=True, slots=True)
+class PackagePin:
+    """One package-manager coordinate pinned by the release."""
+
+    name: str
+    version: str
+
+
+@dataclass(frozen=True, slots=True)
+class ToolRecipe:
+    """Installation recipe for one provider executable."""
+
+    manager: ToolManager
+    packages: tuple[PackagePin, ...] = ()
+    prerequisite: str | None = None
+    hint: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ToolRequirement:
+    """Resolved provider requirement for one repository language."""
+
+    language: str
+    display_name: str
+    scope: ToolScope
+    executable: str
+    ready: bool
+    resolved: str | None = None
+    detail: str = ""
+
+    @property
+    def recipe(self) -> ToolRecipe | None:
+        return TOOL_RECIPES.get(self.executable)
+
+
+@dataclass(frozen=True, slots=True)
+class ToolchainPlan:
+    """Repository-aware graph/LSP tool requirements."""
+
+    repository: Path
+    root: Path
+    languages: tuple[str, ...]
+    requirements: tuple[ToolRequirement, ...]
+    notes: tuple[str, ...] = ()
+
+    @property
+    def missing(self) -> tuple[ToolRequirement, ...]:
+        return tuple(item for item in self.requirements if not item.ready)
+
+    @property
+    def ready(self) -> bool:
+        return not self.missing and not any(
+            note.startswith("MISSING:") for note in self.notes
+        )
+
+
+SCIP_PYTHON_VERSION = "0.6.6"
+SCIP_TYPESCRIPT_VERSION = "0.4.0"
+TYPESCRIPT_LANGUAGE_SERVER_VERSION = "5.3.0"
+TYPESCRIPT_VERSION = "6.0.3"
+YARN_VERSION = "1.22.22"
+PNPM_VERSION = "11.8.0"
+BASEDPYRIGHT_VERSION = "1.39.8"
+SCIP_GO_VERSION = "v0.2.7"
+GOPLS_VERSION = "v0.22.0"
+RUST_TOOLCHAIN = "nightly-2026-02-22"
+SCIP_DOTNET_VERSION = "0.2.14"
+CSHARP_LS_VERSION = "0.25.0"
+BUNDLER_VERSION = "2.6.9"
+SCIP_RUBY_VERSION = "0.4.7"
+RUBY_LSP_VERSION = "0.26.9"
+INTELEPHENSE_VERSION = "1.18.4"
+
+
+TOOL_RECIPES: Mapping[str, ToolRecipe] = {
+    "scip-python": ToolRecipe(
+        manager="npm",
+        packages=(PackagePin("@sourcegraph/scip-python", SCIP_PYTHON_VERSION),),
+        prerequisite="npm",
+    ),
+    "basedpyright-langserver": ToolRecipe(
+        manager="npm",
+        packages=(PackagePin("basedpyright", BASEDPYRIGHT_VERSION),),
+        prerequisite="npm",
+    ),
+    "scip-typescript": ToolRecipe(
+        manager="npm",
+        packages=(
+            PackagePin("@sourcegraph/scip-typescript", SCIP_TYPESCRIPT_VERSION),
+            PackagePin("yarn", YARN_VERSION),
+            PackagePin("pnpm", PNPM_VERSION),
+        ),
+        prerequisite="npm",
+    ),
+    "typescript-language-server": ToolRecipe(
+        manager="npm",
+        packages=(
+            PackagePin(
+                "typescript-language-server", TYPESCRIPT_LANGUAGE_SERVER_VERSION
+            ),
+            PackagePin("typescript", TYPESCRIPT_VERSION),
+        ),
+        prerequisite="npm",
+    ),
+    "scip-go": ToolRecipe(
+        manager="go",
+        packages=(
+            PackagePin("github.com/scip-code/scip-go/cmd/scip-go", SCIP_GO_VERSION),
+        ),
+        prerequisite="go",
+    ),
+    "gopls": ToolRecipe(
+        manager="go",
+        packages=(PackagePin("golang.org/x/tools/gopls", GOPLS_VERSION),),
+        prerequisite="go",
+    ),
+    "rust-analyzer": ToolRecipe(
+        manager="rustup",
+        prerequisite="rustup",
+        hint=f"install the rust-analyzer component for {RUST_TOOLCHAIN}",
+    ),
+    "clangd": ToolRecipe(
+        manager="external",
+        hint="install clangd from the operating system's LLVM packages",
+    ),
+    "scip-java": ToolRecipe(
+        manager="external",
+        hint="install the pinned scip-java provider; see SCIP And Graph Indexing",
+    ),
+    "jdtls": ToolRecipe(
+        manager="external",
+        hint="install Eclipse JDT LS; see SCIP And Graph Indexing",
+    ),
+    "kotlin-language-server": ToolRecipe(
+        manager="external",
+        hint="install the Kotlin language server; see SCIP And Graph Indexing",
+    ),
+    "scip-dotnet": ToolRecipe(
+        manager="dotnet",
+        packages=(PackagePin("scip-dotnet", SCIP_DOTNET_VERSION),),
+        prerequisite="dotnet",
+    ),
+    "csharp-ls": ToolRecipe(
+        manager="dotnet",
+        packages=(PackagePin("csharp-ls", CSHARP_LS_VERSION),),
+        prerequisite="dotnet",
+    ),
+    "bundle": ToolRecipe(
+        manager="gem",
+        packages=(
+            PackagePin("bundler", BUNDLER_VERSION),
+            PackagePin("scip-ruby", SCIP_RUBY_VERSION),
+        ),
+        prerequisite="gem",
+    ),
+    "ruby-lsp": ToolRecipe(
+        manager="gem",
+        packages=(PackagePin("ruby-lsp", RUBY_LSP_VERSION),),
+        prerequisite="gem",
+    ),
+    "scip-php": ToolRecipe(
+        manager="external",
+        hint=(
+            "scip-php is project-local; use Composer in a disposable or clean "
+            "checkout, or let CodeNib use its Intelephense fallback"
+        ),
+    ),
+    "intelephense": ToolRecipe(
+        manager="npm",
+        packages=(PackagePin("intelephense", INTELEPHENSE_VERSION),),
+        prerequisite="npm",
+    ),
+}
+
+
+def managed_bin_dirs(root: Path | None = None) -> tuple[Path, ...]:
+    """Return managed executable directories in resolution order."""
+
+    root = (root or toolchain_dir()).expanduser()
+    directories = [
+        root,
+        root / "node-tools" / "node_modules" / ".bin",
+        root / "go-tools" / "bin",
+        root / "dotnet-tools",
+        root / "dotnet",
+        root / "gems" / "bin",
+        root / "python-tools" / "bin",
+    ]
+    directories.extend(sorted(root.glob("gradle-*/bin")))
+    return tuple(directories)
+
+
+def managed_path(root: Path | None = None, *, current: str | None = None) -> str:
+    """Return a PATH that prefers release-pinned CodeNib tools."""
+
+    entries = [str(path) for path in managed_bin_dirs(root)]
+    existing = current if current is not None else os.environ.get("PATH", "")
+    entries.extend(part for part in existing.split(os.pathsep) if part)
+    return os.pathsep.join(dict.fromkeys(entries))
+
+
+def activate_managed_toolchain(
+    environ: dict[str, str] | None = None,
+    *,
+    root: Path | None = None,
+) -> Path:
+    """Expose managed tools to CodeNib subprocesses without shell exports."""
+
+    environ = os.environ if environ is None else environ
+    root = (root or toolchain_dir()).expanduser()
+    environ["CODENIB_TOOLCHAIN_DIR"] = str(root)
+    environ.setdefault("CODENIB_SCIP_TOOLS_DIR", str(root))
+    environ["PATH"] = managed_path(root, current=environ.get("PATH", ""))
+    dotnet = root / "dotnet"
+    if dotnet.is_dir():
+        environ.setdefault("DOTNET_ROOT", str(dotnet))
+    gems = root / "gems"
+    if gems.is_dir():
+        environ.setdefault("GEM_HOME", str(gems))
+        environ.setdefault("GEM_PATH", str(gems))
+    return root
+
+
+def resolve_command(command: str, *, root: Path | None = None) -> str | None:
+    """Resolve a command from the managed root first, then the host PATH."""
+
+    suffixes = ("",)
+    if os.name == "nt":
+        suffixes += tuple(
+            suffix.lower()
+            for suffix in os.environ.get("PATHEXT", ".EXE;.CMD;.BAT").split(";")
+            if suffix
+        )
+    for directory in managed_bin_dirs(root):
+        for suffix in suffixes:
+            candidate = directory / f"{command}{suffix}"
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return str(candidate)
+    return shutil.which(command)
+
+
+def _canonical_lsp_executable(language: str, command: Sequence[str]) -> str:
+    if language == "rust":
+        return "rust-analyzer"
+    return Path(command[0]).name
+
+
+def plan_repository_toolchain(
+    repository: str | os.PathLike[str],
+    languages: Sequence[str],
+    *,
+    scopes: Iterable[ToolScope] = ("graph",),
+    root: Path | None = None,
+    command_resolver: Callable[[str], str | None] | None = None,
+    module_checker: Callable[[str], bool] | None = None,
+) -> ToolchainPlan:
+    """Build a read-only install/status plan for a repository."""
+
+    from .graph.setup import diagnose_graph_setup
+
+    repo = Path(repository).expanduser().resolve()
+    root = (root or toolchain_dir()).expanduser()
+    resolver = command_resolver or (lambda command: resolve_command(command, root=root))
+    selected_scopes = frozenset(scopes)
+    requirements: list[ToolRequirement] = []
+    notes: list[str] = []
+
+    if "graph" in selected_scopes:
+        report = diagnose_graph_setup(
+            repo,
+            languages,
+            command_resolver=resolver,
+            module_checker=module_checker,
+        )
+        if not report.runtime.ready:
+            notes.append(
+                'MISSING: Python graph runtime; install with `pip install "codenib[graph]"`'
+            )
+        for setup in report.languages:
+            if setup.state == "unsupported":
+                notes.append(
+                    f"INFO: {setup.display_name} has no registered symbol-graph provider"
+                )
+                continue
+            for prerequisite in setup.prerequisites:
+                if prerequisite.kind == "command":
+                    requirements.append(
+                        ToolRequirement(
+                            language=setup.language,
+                            display_name=setup.display_name,
+                            scope="graph",
+                            executable=prerequisite.name,
+                            ready=prerequisite.ready,
+                            resolved=prerequisite.resolved,
+                            detail=prerequisite.detail,
+                        )
+                    )
+                elif not prerequisite.ready:
+                    notes.append(
+                        f"MISSING: {setup.display_name} project prerequisite "
+                        f"{prerequisite.name}: {prerequisite.detail}"
+                    )
+
+    if "lsp" in selected_scopes:
+        for language in languages:
+            spec = get_language_spec(language)
+            if spec is None:
+                continue
+            command = lsp_command_for_language(spec.key) or []
+            if not command:
+                notes.append(
+                    f"INFO: {spec.display_name} has no registered live LSP provider"
+                )
+                continue
+            executable = _canonical_lsp_executable(spec.key, command)
+            resolved = resolver(executable)
+            requirements.append(
+                ToolRequirement(
+                    language=spec.key,
+                    display_name=spec.display_name,
+                    scope="lsp",
+                    executable=executable,
+                    ready=resolved is not None,
+                    resolved=resolved,
+                    detail=" ".join(command),
+                )
+            )
+
+    unique: dict[tuple[str, ToolScope, str], ToolRequirement] = {}
+    for requirement in requirements:
+        unique[(requirement.language, requirement.scope, requirement.executable)] = (
+            requirement
+        )
+    return ToolchainPlan(
+        repository=repo,
+        root=root,
+        languages=tuple(languages),
+        requirements=tuple(unique.values()),
+        notes=tuple(dict.fromkeys(notes)),
+    )
+
+
+def _package_coordinate(package: PackagePin) -> str:
+    return f"{package.name}@{package.version}"
+
+
+def recipe_commands(recipe: ToolRecipe, root: Path) -> tuple[tuple[str, ...], ...]:
+    """Render non-shell installation commands for a managed recipe."""
+
+    if recipe.manager == "npm":
+        return (
+            (
+                "npm",
+                "install",
+                "--prefix",
+                str(root / "node-tools"),
+                "--no-audit",
+                "--no-fund",
+                *(_package_coordinate(package) for package in recipe.packages),
+            ),
+        )
+    if recipe.manager == "go":
+        return tuple(
+            ("go", "install", _package_coordinate(package))
+            for package in recipe.packages
+        )
+    if recipe.manager == "rustup":
+        return (
+            ("rustup", "toolchain", "install", RUST_TOOLCHAIN),
+            (
+                "rustup",
+                "component",
+                "add",
+                "rust-analyzer",
+                "--toolchain",
+                RUST_TOOLCHAIN,
+            ),
+        )
+    if recipe.manager == "dotnet":
+        return tuple(
+            (
+                "dotnet",
+                "tool",
+                "update",
+                "--tool-path",
+                str(root / "dotnet-tools"),
+                package.name,
+                "--version",
+                package.version,
+            )
+            for package in recipe.packages
+        )
+    if recipe.manager == "gem":
+        return tuple(
+            (
+                "gem",
+                "install",
+                package.name,
+                "-v",
+                package.version,
+                "--no-document",
+            )
+            for package in recipe.packages
+        )
+    return ()
+
+
+def _install_environment(root: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    activate_managed_toolchain(env, root=root)
+    env["GOBIN"] = str(root / "go-tools" / "bin")
+    env["GOPATH"] = str(root / "go-tools")
+    env["GEM_HOME"] = str(root / "gems")
+    env["GEM_PATH"] = str(root / "gems")
+    return env
+
+
+def install_requirements(
+    requirements: Sequence[ToolRequirement],
+    *,
+    root: Path | None = None,
+    dry_run: bool = False,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> tuple[list[tuple[str, ...]], list[str]]:
+    """Install missing package-managed requirements and return an audit log."""
+
+    root = (root or toolchain_dir()).expanduser()
+    env = _install_environment(root)
+    commands: list[tuple[str, ...]] = []
+    manual: list[str] = []
+    seen_recipes: set[ToolRecipe] = set()
+    installs_rust_analyzer = False
+
+    for requirement in requirements:
+        if requirement.ready:
+            continue
+        recipe = requirement.recipe
+        if recipe is None:
+            manual.append(f"{requirement.executable}: no install recipe registered")
+            continue
+        if recipe.manager == "external":
+            manual.append(f"{requirement.executable}: {recipe.hint}")
+            continue
+        if recipe in seen_recipes:
+            continue
+        seen_recipes.add(recipe)
+        prerequisite = recipe.prerequisite or recipe.manager
+        if resolve_command(prerequisite, root=root) is None:
+            manual.append(
+                f"{requirement.executable}: install prerequisite `{prerequisite}` first"
+            )
+            continue
+        commands.extend(recipe_commands(recipe, root))
+        installs_rust_analyzer = installs_rust_analyzer or recipe.manager == "rustup"
+
+    if dry_run:
+        return commands, manual
+
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "node-tools").mkdir(exist_ok=True)
+    (root / "go-tools" / "bin").mkdir(parents=True, exist_ok=True)
+    (root / "dotnet-tools").mkdir(exist_ok=True)
+    (root / "gems").mkdir(exist_ok=True)
+
+    for command in tuple(commands):
+        result = runner(command, check=False, env=env)
+        if result.returncode == 0:
+            continue
+        if len(command) >= 3 and command[0:3] == ("dotnet", "tool", "update"):
+            fallback = list(command)
+            fallback[2] = "install"
+            fallback_command = tuple(fallback)
+            commands.append(fallback_command)
+            fallback_result = runner(fallback_command, check=False, env=env)
+            if fallback_result.returncode == 0:
+                continue
+        raise RuntimeError(
+            f"tool installation failed ({result.returncode}): {' '.join(command)}"
+        )
+
+    if installs_rust_analyzer:
+        resolved = runner(
+            ("rustup", "which", "--toolchain", RUST_TOOLCHAIN, "rust-analyzer"),
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if resolved.returncode == 0 and resolved.stdout.strip():
+            link = root / "rust-analyzer"
+            link.unlink(missing_ok=True)
+            link.symlink_to(resolved.stdout.strip())
+
+    return commands, manual
+
+
+__all__ = [
+    "ToolRecipe",
+    "ToolRequirement",
+    "ToolScope",
+    "ToolchainPlan",
+    "activate_managed_toolchain",
+    "install_requirements",
+    "managed_bin_dirs",
+    "managed_path",
+    "plan_repository_toolchain",
+    "recipe_commands",
+    "resolve_command",
+]

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -226,8 +226,8 @@ reasoning loop while replacing its repository data plane with
 localization baselines:
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install "codenib[agent,graph] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[agent,graph]==0.2.0a2"
+codenib toolchain install /path/to/repository --scope graph
 ```
 
 ```python
@@ -634,8 +634,7 @@ Prepare a broad, reproducible CodeNib-only coverage set before running the
 policy:
 
 ```bash
-make scip-python-tool
-export PATH="${CODENIB_SCIP_TOOLS_DIR:-/tmp/codenib/scip-tools}:$PATH"
+codenib toolchain install . --language python --scope graph
 export CODENIB_SCIP_PYTHON_INDEX_TIMEOUT_SECONDS=900
 
 python scripts/analysis/prepare_swebench_policy_cases.py \

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -14,8 +14,8 @@ SPDX-License-Identifier: Apache-2.0
 
 <div class="codenib-section-lede" markdown>
 
-Build the smallest useful CodeNib setup first, then add semantic, graph, or
-agent-backed capabilities only when your workflow needs them.
+Start with hybrid repository retrieval, then add graph or agent-backed
+capabilities when the workload needs them.
 
 </div>
 
@@ -25,8 +25,8 @@ agent-backed capabilities only when your workflow needs them.
 
     **Quickstart**
 
-    Turn a local repository into a deterministic, source-linked Wiki with no
-    API key or model download.
+    Turn a local repository into a source-linked Wiki with reusable hybrid
+    retrieval and no API key.
 
     [Launch your first repository →](../quickstart.md)
 
@@ -59,9 +59,9 @@ agent-backed capabilities only when your workflow needs them.
 
 </div>
 
-## Pick a repository profile
+## Add language providers
 
-Start with `fast` for a zero-model BM25 index. Move to `semantic`, `graph`, or
-`full` only when the query workload needs those views. The
-[Quickstart](../quickstart.md#select-repository-views) lists the package and
-toolchain requirements for each profile.
+CodeNib detects installed semantic capabilities automatically. Structural and
+live-navigation providers are language-specific; use `codenib toolchain` to
+inspect or install only the tools needed by one repository. The
+[Quickstart](../quickstart.md#language-toolchains) shows the complete flow.

--- a/docs/github_pages.md
+++ b/docs/github_pages.md
@@ -8,10 +8,10 @@ SPDX-License-Identifier: Apache-2.0
 
 CodeNib can build repository context in GitHub Actions, deploy a source-linked
 static Wiki to GitHub Pages, and retain the matching context views as one
-downloadable artifact. The default path uses BM25 and needs no model, API key,
-or model download.
+downloadable artifact. The default path builds BM25 and dense-vector views with
+a cached local embedding model and needs no API key.
 
-## No-Model Starter
+## Publish Hybrid Context
 
 Create a caller workflow in the repository that should receive a Wiki:
 
@@ -30,40 +30,38 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@620a82d1bf55897cbf4afa0b8563ed5da0997d27
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2
 ```
 
-The pinned commit is the source revision for CodeNib 0.2.0 Alpha 1. A commit SHA
-keeps the compiler, frontend, Action, and artifact schema on one reviewed
-revision. In the repository's **Settings > Pages**, select **GitHub Actions** as
-the source.
+The prerelease tag keeps the compiler, frontend, Action, and artifact schema on
+one reviewed version. Production deployments may replace it with the tag's
+resolved commit SHA. In the repository's **Settings > Pages**, select
+**GitHub Actions** as the source.
 
 The workflow checks out the caller's exact commit, incrementally builds the
-`fast` preset, exports the Wiki at the Pages-provided mount path, and deploys it
-through the `github-pages` environment. It also uploads an artifact named from
-the repository and commit. BM25 belongs to that context artifact; the static
-Wiki serves precomputed pages, citations, and navigation without executing a
-query engine in the browser.
+`semantic` preset, exports the Wiki at the Pages-provided mount path, and
+deploys it through the `github-pages` environment. It also uploads an artifact
+named from the repository and commit. The workflow caches both repository
+views and the pinned Hugging Face model. The static Wiki serves precomputed
+pages, citations, and navigation without executing a query engine in the
+browser; BM25 and vector views remain reusable through local or MCP serving.
 
-## Build Semantic Context With A Local Model
+## Use The No-Model Fallback
 
-Select the semantic preset to build BM25 and dense-vector views. It defaults to
-a local Hugging Face embedding model and needs no API credential:
+Select `fast` when cold-start time or avoiding a model download matters more
+than natural-language retrieval quality:
 
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@620a82d1bf55897cbf4afa0b8563ed5da0997d27
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2
     with:
-      preset: semantic
+      preset: fast
 ```
 
-The first build downloads the default embedding model into the ephemeral Action
-runner. The resulting vector view is stored in the commit-addressed context
-artifact and reused through CodeNib's repository cache on later builds. Serve
-that artifact through the local or MCP runtime for semantic queries; the Pages
-site remains a precomputed inspection surface. Keep the default `fast` preset
-when a model download is undesirable.
+This builds only the deterministic BM25 artifact and downloads no model. It is
+an explicit compatibility and resource-constrained route rather than the
+recommended retrieval default.
 
 ## Bring Your Own Embedding Endpoint
 
@@ -73,7 +71,7 @@ artifact or Pages workflow:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@620a82d1bf55897cbf4afa0b8563ed5da0997d27
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2
     with:
       preset: semantic
       embedding-provider: openai
@@ -143,7 +141,7 @@ The composite Action can be used directly when another static host or artifact
 store owns deployment:
 
 ```yaml
-- uses: sysevol-ai/CodeNib/.github/actions/publish@620a82d1bf55897cbf4afa0b8563ed5da0997d27
+- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.0a2
   id: codenib
   with:
     preset: fast
@@ -205,9 +203,9 @@ codenib artifact mcp-config \
 before running or placing it. CodeNib does not edit a client configuration
 automatically.
 
-BM25 serving requires no model credential. A semantic artifact reuses its
-stored vectors but still needs the manifest-selected embedding provider for
-each query embedding. Provider credentials stay in the MCP process environment
-and are never copied into client configuration or the context artifact. When
-GitHub CLI is unavailable, set `GH_TOKEN` to a fine-grained token with
-**Actions: read** access to the repository.
+Local semantic and BM25 serving require no model credential. A semantic
+artifact reuses its stored vectors but still needs the manifest-selected
+embedding provider for each query embedding. Provider credentials stay in the
+MCP process environment and are never copied into client configuration or the
+context artifact. When GitHub CLI is unavailable, set `GH_TOKEN` to a
+fine-grained token with **Actions: read** access to the repository.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,23 +33,22 @@ core decoder parity.
 
 ## Quick Start
 
-This site tracks the `0.2` alpha. Install its immutable wheel directly; plain
-`pip install codenib` still selects the stable `0.1` line.
+This site tracks the `0.2` alpha. The recommended local install enables hybrid
+BM25+dense retrieval with the pinned CodeRankEmbed model.
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install "codenib @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[semantic]==0.2.0a2"
 codenib wiki /path/to/repository
 ```
 
-The default Wiki is deterministic, uses BM25, and needs no API key. CodeNib
-detects repository languages, writes a reusable manifest under
-`~/.codenib/repositories`, and opens the browser UI. This default `fast` profile
-leaves the target checkout unchanged. Read the
-[Quickstart](quickstart.md) for profiles and troubleshooting.
+The CLI detects the installed semantic capability, writes a reusable manifest
+under `~/.codenib/repositories`, and opens the browser UI. Install
+`codenib==0.2.0a2` without extras for the smaller no-model BM25 fallback. Both
+paths leave the target checkout unchanged. Read the [Quickstart](quickstart.md)
+for provider setup and troubleshooting.
 
 ```bash
-python -m pip install "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[mcp,semantic]==0.2.0a2"
 codenib mcp /path/to/repository
 ```
 

--- a/docs/language_capabilities.md
+++ b/docs/language_capabilities.md
@@ -13,8 +13,11 @@ tree-sitter-only.
 
 `yes` and `active` describe registered CodeNib capabilities, not the tools
 installed on the current machine. Run
+`codenib toolchain status /path/to/repository --scope all` to inspect the exact
+SCIP/LSP providers, and run
 `codenib doctor /path/to/repository --require graph` before building a graph
-view.
+view. See [SCIP And Graph Indexing](scip_index.md#language-provider-map) for the
+package map and installation boundary.
 
 Update the registry first, then refresh this table:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,28 +13,27 @@ then reuse that manifest across agent sessions.
 
 ## Install And Index
 
-This page describes the current `0.2` alpha. Set the same immutable wheel URL
-used by the [Quickstart](quickstart.md#install), then select the views required
-by the MCP server:
+This page describes the current `0.2` alpha. The recommended agent-serving path
+installs MCP with semantic retrieval; the default `auto` preset resolves to
+BM25+dense in that environment:
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[mcp,semantic]==0.2.0a2"
 codenib index /path/to/repository
 ```
 
-The default `fast` preset builds BM25 without a model download. Add semantic
-search when needed:
+Use the smaller no-model fallback when semantic retrieval is not required:
 
 ```bash
-python -m pip install "codenib[mcp,semantic] @ ${CODENIB_ALPHA_WHEEL}"
-codenib index /path/to/repository --preset semantic
+python -m pip install "codenib[mcp]==0.2.0a2"
+codenib index /path/to/repository --preset fast
 ```
 
 Add static navigation and dependency tools without the embedding download:
 
 ```bash
-python -m pip install "codenib[graph,mcp] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[graph,mcp]==0.2.0a2"
+codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset graph
 ```
 
@@ -119,7 +118,8 @@ Parameter and return schemas live in
 The `full` preset requests BM25, vectors, a symbol graph, and Zoekt:
 
 ```bash
-python -m pip install "codenib[full] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[full]==0.2.0a2"
+codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset full
 ```
 

--- a/docs/product_roadmap.md
+++ b/docs/product_roadmap.md
@@ -21,12 +21,13 @@ Passing unit tests or publishing a wheel is necessary but not sufficient.
 ## North-Star Journey
 
 ```bash
-pip install codenib
+pip install "codenib[semantic]"
 codenib wiki /path/to/repository
 ```
 
-The default command must produce a useful offline Wiki. Optional generation
-must be explicit about model use and cost:
+The CLI should use hybrid retrieval when the semantic capability is installed
+and retain an explicit no-model fallback for smaller environments. Optional
+generation must be explicit about model use and cost:
 
 ```bash
 codenib wiki /path/to/repository --generate \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,29 +7,27 @@ SPDX-License-Identifier: Apache-2.0
 # Quickstart
 
 This guide turns a local repository into a source-linked CodeNib Wiki. The
-default path uses deterministic page generation and BM25 search, so it needs
-neither an API key nor a model download.
+recommended path combines BM25 and dense retrieval through a pinned local
+embedding model, so it needs no API key.
 
 ## Install
 
 - Python 3.10 or newer
 - Git
 
-This documentation tracks the `0.2` feature line. Install the current alpha
-from its immutable, hash-pinned TestPyPI wheel; dependencies continue to
-resolve from PyPI rather than from a mixed package index:
+This documentation tracks the `0.2` feature line. Install the exact alpha and
+its local semantic dependencies from PyPI:
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install "codenib @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[semantic]==0.2.0a2"
 codenib --version
 codenib doctor --require core --require wiki
 ```
 
-The version command must report `codenib 0.2.0a1`. For the stable `0.1` line,
-use `python -m pip install codenib`; features documented as new in 0.2 require
-the alpha above. Reuse `CODENIB_ALPHA_WHEEL` when adding an optional extra, for
-example `"codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"`.
+The version command must report `codenib 0.2.0a2`. Exact version pins keep an
+alpha environment reproducible. Install `codenib==0.2.0a2` without extras when
+a smaller, no-model BM25 fallback is more important than natural-language
+retrieval quality.
 
 ## Launch A Repository Wiki
 
@@ -40,7 +38,8 @@ codenib wiki /path/to/repository
 CodeNib performs four steps:
 
 1. Detects supported source languages.
-2. Builds or updates repository views under
+2. Selects BM25+dense views when semantic dependencies are installed, or
+   reports a no-model BM25 fallback, then builds or updates those views under
    `~/.codenib/repositories/<repo>-<id>/indexes`.
 3. Registers the repository with a local FastAPI service.
 4. Serves the packaged production frontend and opens
@@ -49,7 +48,7 @@ CodeNib performs four steps:
 The release wheel contains the compiled frontend, so this path does not need
 Node.js, npm, or a source checkout. CodeNib-owned indexes and manifests stay
 outside the target repository; set `CODENIB_HOME` to relocate that state. The
-`fast` and `semantic` presets leave the checkout unchanged. Some language-aware
+lexical and semantic views leave the checkout unchanged. Some language-aware
 graph backends must invoke the repository's build or package manager and may
 prepare project-local dependencies such as `node_modules`; run those profiles
 from a clean checkout when that distinction matters. Press `Ctrl-C` once to
@@ -141,10 +140,11 @@ embedding model, and BYO endpoint configurations.
 | `graph` | `codenib[graph]` | BM25 and symbol graph |
 | `full` | `codenib[full]` | BM25, dense vectors, symbol graph, and Zoekt |
 
-For natural-language search:
+The recommended installation already selects `semantic` through the default
+`auto` preset. Select it explicitly in automation when the artifact contract
+must not depend on the installed environment:
 
 ```bash
-python -m pip install "codenib[semantic] @ ${CODENIB_ALPHA_WHEEL}"
 codenib wiki /path/to/repository --preset semantic
 ```
 
@@ -155,7 +155,7 @@ To keep embeddings out of the local process, use a BYO OpenAI-compatible
 embedding service:
 
 ```bash
-python -m pip install "codenib[semantic-remote] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[semantic-remote]==0.2.0a2"
 export EMBEDDING_API_KEY=...
 codenib doctor --require semantic \
   --embedding-provider openai \
@@ -179,9 +179,10 @@ provider or endpoint.
 
 ## Credentials And Tokens
 
-The default Wiki, BM25 index, static export, and local CodeRankEmbed route need
-no credential. GitHub Pages also uses GitHub's short-lived workflow token for
-deployment; users do not provide a personal token for the default workflow.
+The default local CodeRankEmbed route, BM25 fallback, static export, and Wiki
+shell need no credential. GitHub Pages also uses GitHub's short-lived workflow
+token for deployment; users do not provide a personal token for the default
+workflow.
 
 Use environment variables for the capabilities that do need authentication:
 
@@ -217,12 +218,32 @@ Secrets and variables > Actions**, then map it to the reusable workflow's
 the credential variable, never its value. Secrets are excluded from manifests,
 context artifacts, generated MCP configuration, and static Pages output.
 
-The `graph` extra supplies the Python graph and protobuf runtimes, while each
-repository language still needs its own SCIP/LSP executable. Check the exact
-repository instead of testing for an unrelated tool:
+## Language Toolchains
+
+The `graph` extra supplies the Python graph and protobuf runtimes. SCIP,
+clangd, and live LSP providers are language-specific executables, so CodeNib
+plans them from the detected repository rather than installing every language:
 
 ```bash
+python -m pip install "codenib[graph]==0.2.0a2"
+codenib toolchain status /path/to/repository --scope graph
+codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
+```
+
+Package-managed providers are pinned under `~/.codenib/toolchains` and are
+automatically visible to CodeNib processes; no shell `PATH` export is needed.
+The installer never invokes `sudo` and never silently edits the target
+checkout. It reports system dependencies such as clangd or a JDK, and
+project-local requirements such as `compile_commands.json` or `scip-php`, for
+the user to satisfy explicitly.
+
+Static graph construction and live incremental navigation are separate
+surfaces. Install live language servers only when that path is needed:
+
+```bash
+codenib toolchain install /path/to/repository --scope lsp
+codenib toolchain status /path/to/repository --scope all
 ```
 
 The full preset also needs `zoekt-git-index` and `zoekt-webserver` on `PATH`.
@@ -251,7 +272,7 @@ Static Wiki pages are the default. To generate conceptual page narratives
 through a LiteLLM-supported provider:
 
 ```bash
-python -m pip install "codenib[agent] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[agent,semantic]==0.2.0a2"
 export OPENAI_API_KEY=...
 codenib doctor --require agent \
   --model openai/gpt-4o-mini --api-key-env OPENAI_API_KEY --probe-model
@@ -282,7 +303,7 @@ codenib wiki . --generate --model anthropic/claude-sonnet-4-5
 Vertex AI additionally requires CodeNib's `vertex` extra:
 
 ```bash
-python -m pip install "codenib[agent,vertex] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[agent,semantic,vertex]==0.2.0a2"
 gcloud auth application-default login
 codenib wiki . --generate \
   --model vertex_ai/gemini-2.5-flash \
@@ -337,7 +358,7 @@ continues to work.
 ## Serve The Index Over MCP
 
 ```bash
-python -m pip install "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[mcp,semantic]==0.2.0a2"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -4,29 +4,28 @@ SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# CodeNib 0.2.0 Alpha 1
+# CodeNib 0.2.0 Alpha 2
 
-CodeNib 0.2.0 Alpha 1 is an early preview of the build-once, serve-everywhere
-repository-context path. A repository can publish a no-model static Wiki in
-GitHub Pages, retain the matching BM25 or vector artifact, and reuse that
-artifact through MCP at the exact indexed commit.
+CodeNib 0.2.0 Alpha 2 packages the build-once, serve-everywhere
+repository-context path behind a normal PyPI prerelease. It makes hybrid
+BM25+dense retrieval the recommended local and Pages default, caches the local
+model in Actions, and adds repository-aware management for language-specific
+SCIP and LSP providers.
 
-The alpha is intended for TestPyPI, public Pages, and artifact/MCP canary
-validation. A release candidate follows only after those paths pass without a
-release-blocking compatibility or security issue.
+The release remains an alpha: provider coverage, public Pages, artifact-backed
+MCP, and language toolchain installation are open for compatibility feedback.
 
 ## Upgrade
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install --upgrade "codenib @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install --upgrade "codenib[semantic]==0.2.0a2"
 codenib --version
 codenib doctor --require core --require wiki
 ```
 
-The URL selects the exact TestPyPI wheel and verifies its published SHA-256.
-Normal dependencies resolve from PyPI, so this command does not mix TestPyPI
-into dependency selection. The version command must report `codenib 0.2.0a1`.
+The version command must report `codenib 0.2.0a2`. The semantic extra enables
+the `auto` preset's BM25+dense route. Install `codenib==0.2.0a2` without extras
+for the deterministic no-model fallback.
 
 Existing BM25 and vector manifests are checked when opened. CodeNib reuses a
 compatible view and rebuilds rather than silently substituting an incompatible
@@ -43,10 +42,20 @@ GitHub Models is no longer a valid provider because GitHub retired the service.
 Use the model-free `fast` route, local Hugging Face embeddings, or an explicit
 OpenAI-compatible endpoint.
 
+Language-specific graph and live-navigation providers are no longer exposed
+as a list of shell exports. Install only those needed by one checkout:
+
+```bash
+python -m pip install "codenib[graph]==0.2.0a2"
+codenib toolchain install /path/to/repository --scope graph
+codenib toolchain install /path/to/repository --scope lsp
+codenib doctor /path/to/repository --require graph
+```
+
 ## Publish And Reuse
 
-Call the reusable workflow from a public repository and pin it to the immutable
-commit associated with the 0.2.0 Alpha 1 release:
+Call the reusable workflow from a public repository and pin it to the release
+tag:
 
 ```yaml
 permissions:
@@ -56,7 +65,7 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@620a82d1bf55897cbf4afa0b8563ed5da0997d27
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2
 ```
 
 The default workflow publishes precomputed pages, citations, navigation, and
@@ -69,8 +78,7 @@ After checking out the recorded commit, reuse the artifact without another
 index build:
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install --upgrade "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install --upgrade "codenib[mcp,semantic]==0.2.0a2"
 export GH_TOKEN="$(gh auth token)"
 codenib artifact fetch owner/repository --repo /path/to/repository
 codenib artifact mcp-config \
@@ -80,7 +88,7 @@ codenib artifact mcp-config \
   --host codex
 ```
 
-The default `fast` Wiki, export, and MCP paths need no model token. A BYO
+The no-model `fast` Wiki, export, and MCP paths need no model token. A BYO
 embedding endpoint receives the environment variable named by
 `--embedding-api-key-env`; agent-authored pages receive the provider variable
 named by `--api-key-env`. Repository Actions pass embedding credentials through

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -23,15 +23,16 @@ Install the graph dependencies, check the target repository, and then select
 the graph preset:
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install "codenib[graph] @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[graph]==0.2.0a2"
+codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
 codenib index /path/to/repository --preset graph
 ```
 
-`codenib doctor` detects the repository languages and reports missing
-executables with installation hints. Use `--language` when detection is
-ambiguous:
+`codenib toolchain` detects the repository languages, installs pinned
+package-managed providers under `~/.codenib/toolchains`, and reports system or
+project-local prerequisites it cannot safely install. `codenib doctor` then
+checks the complete build route. Use `--language` when detection is ambiguous:
 
 ```bash
 codenib doctor /path/to/repository \
@@ -47,10 +48,40 @@ target checkout. Some language indexers still need to resolve project
 dependencies and may create normal toolchain files such as `node_modules` or a
 project-local bundle.
 
+## Language Provider Map
+
+Cold-start graph construction and live LSP navigation are separate provider
+surfaces. A static graph can serve LSP-shaped definition and reference requests
+without launching the live server after construction.
+
+| Language | Graph construction | Optional live LSP |
+|---|---|---|
+| Python | `scip-python` | `basedpyright-langserver` |
+| JavaScript / TypeScript | `scip-typescript` | `typescript-language-server` |
+| Go | `scip-go` | `gopls` |
+| Rust | `rust-analyzer scip` | `rust-analyzer` |
+| C / C++ | clangd index | `clangd` |
+| Java | `scip-java` | Eclipse JDT LS |
+| Kotlin | `scip-java` | Kotlin language server |
+| Scala | `scip-java` | not registered |
+| C# | `scip-dotnet` | `csharp-ls` |
+| Ruby | `scip-ruby`, with Ruby LSP fallback | `ruby-lsp` |
+| PHP | project-local `scip-php`, with Intelephense fallback | `intelephense` |
+
+The manager handles pinned npm, Go, Rustup, .NET tool, and RubyGem providers
+when their host runtime is present. OS packages such as clangd, JDKs, and build
+tools remain explicit. Preview the exact operations without writing anything:
+
+```bash
+codenib toolchain install . --scope all --dry-run
+```
+
 ## Install Local Toolchains From Source
 
-For a CodeNib source checkout, the Makefile installs pinned SCIP and LSP tools
-below `$CODENIB_SCIP_TOOLS_DIR`:
+For a CodeNib source checkout, the Makefile retains broad maintainer and CI
+bootstrap targets. End users should prefer `codenib toolchain`; source
+developers can install every smoke-test provider below
+`$CODENIB_SCIP_TOOLS_DIR`:
 
 ```bash
 # Ubuntu system packages, Python development dependencies, and all toolchains

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -10,8 +10,7 @@ For one local repository, use the packaged two-command path in the
 [Quickstart](quickstart.md):
 
 ```bash
-export CODENIB_ALPHA_WHEEL="https://test-files.pythonhosted.org/packages/3d/3d/8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/codenib-0.2.0a1-py3-none-any.whl#sha256=915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-python -m pip install "codenib @ ${CODENIB_ALPHA_WHEEL}"
+python -m pip install "codenib[semantic]==0.2.0a2"
 codenib wiki /path/to/repository
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,7 +165,7 @@ nav:
   - Get Started:
       - get-started/index.md
       - Quickstart: quickstart.md
-      - Release 0.2.0 Alpha 1: releases/0.2.0.md
+      - Release 0.2.0 Alpha 2: releases/0.2.0.md
       - GitHub Pages: github_pages.md
       - Web UI: web_demo.md
       - Running Locally: running-locally.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codenib"
-version = "0.2.0a1"
+version = "0.2.0a2"
 description = "A multi-view data system for serving repository context to coding agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/smoke_release_install.py
+++ b/scripts/smoke_release_install.py
@@ -86,6 +86,19 @@ def smoke(root: Path, *, executable: str = "codenib") -> None:
         cwd=root,
         env=env,
     )
+    _run(
+        [
+            executable,
+            "toolchain",
+            "install",
+            str(repo),
+            "--scope",
+            "lsp",
+            "--dry-run",
+        ],
+        cwd=root,
+        env=env,
+    )
     _run([executable, "index", str(repo)], cwd=root, env=env)
 
     manifest_path = _installed_manifest_path(repo, root=root, env=env)

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -77,6 +77,7 @@ def _validate_wheel(wheel: Path, name: str, version: str) -> None:
         "codenib/sandbox/docker.py",
         "codenib/sandbox/protocol.py",
         "codenib/sandbox/types.py",
+        "codenib/toolchains.py",
         "codenib/web/frontend/index.html",
         "codenib/web/frontend/codenib-icon.svg",
         "codenib/web/frontend/runtime-config.js",

--- a/test/actions/test_publish_action.py
+++ b/test/actions/test_publish_action.py
@@ -361,6 +361,7 @@ def test_hosted_publish_smoke_is_narrow_and_sha_pinned() -> None:
         if step.get("name") == "Exercise local publish Action"
     )
     assert publish["with"]["cache"] == "false"
+    assert publish["with"]["preset"] == "fast"
     assert publish["with"]["upload-context"] == "false"
     assert publish["with"]["repository-path"] == "${{ steps.fixture.outputs.path }}"
     _assert_external_actions_are_sha_pinned(workflow)

--- a/test/actions/test_publish_action.py
+++ b/test/actions/test_publish_action.py
@@ -104,7 +104,7 @@ def test_publish_action_has_secret_free_inputs_and_stable_outputs() -> None:
         "cache-key",
         "source-commit",
     } <= set(action["outputs"])
-    assert action["inputs"]["preset"]["default"] == "fast"
+    assert action["inputs"]["preset"]["default"] == "semantic"
     resolve = next(step for step in _steps(action) if step.get("id") == "inputs")
     assert "fast|semantic)" in resolve["run"]
     assert "graph|full" not in resolve["run"]
@@ -266,6 +266,16 @@ def test_publish_action_cache_identity_is_public_and_commit_addressed() -> None:
     assert "INPUT_EMBEDDING_PROVIDER" in script
     assert "INPUT_EMBEDDING_ENDPOINT" in script
     assert "API_KEY" not in script
+    model_cache = next(
+        step
+        for step in _steps(action)
+        if step.get("name") == "Cache local embedding model"
+    )
+    assert model_cache["with"]["path"] == "~/.cache/huggingface"
+    assert model_cache["with"]["key"] == (
+        "${{ steps.inputs.outputs.embedding_cache_key }}"
+    )
+    assert "embedding_provider == 'huggingface'" in model_cache["if"]
     restore = next(
         step
         for step in _steps(action)
@@ -282,6 +292,9 @@ def test_publish_action_cache_identity_is_public_and_commit_addressed() -> None:
 
 def test_reusable_workflow_is_fork_safe_and_binds_its_exact_revision() -> None:
     workflow = _load(WORKFLOW_PATH)
+    assert workflow["on"]["workflow_call"]["inputs"]["preset"]["default"] == (
+        "semantic"
+    )
     build = workflow["jobs"]["build"]
     condition = build["if"]
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -24,6 +24,17 @@ def test_parser_exposes_release_commands() -> None:
         args = parser.parse_args([command])
         assert args.command == command
 
+    toolchain = parser.parse_args(
+        ["toolchain", "install", ".", "--scope", "all", "--dry-run"]
+    )
+    assert toolchain.command == "toolchain"
+    assert toolchain.toolchain_command == "install"
+    assert toolchain.scope == "all"
+    assert toolchain.dry_run is True
+
+    publish = parser.parse_args(["publish", "."])
+    assert publish.preset == "auto"
+
 
 def test_export_parser_accepts_pages_mount_options() -> None:
     args = cli.build_parser().parse_args(
@@ -595,12 +606,13 @@ def test_resolve_manifest_path_falls_back_to_legacy_repository_cache(
     assert cli.resolve_manifest_path(str(tmp_path)) == manifest
 
 
-def test_index_command_uses_fast_preset_by_default(
+def test_index_command_auto_preset_falls_back_without_dense_dependencies(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     (tmp_path / "main.py").write_text("def main():\n    return 0\n")
     captured = {}
+    monkeypatch.setattr(cli, "_check_module", lambda _module: False)
 
     def fake_index(repo_path, *, languages, views, rebuild):
         captured.update(
@@ -629,6 +641,27 @@ def test_index_command_uses_fast_preset_by_default(
         "views": ["bm25"],
         "rebuild": False,
     }
+
+
+def test_auto_preset_selects_hybrid_views_when_semantic_extra_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = cli.build_parser().parse_args(["index", "."])
+    monkeypatch.setattr(cli, "_check_module", lambda _module: True)
+
+    assert args.preset == "auto"
+    assert cli._selected_views_for_args(args) == ["bm25", "vector"]
+
+
+def test_auto_preset_preserves_an_explicit_embedding_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    args = cli.build_parser().parse_args(
+        ["index", ".", "--embedding-provider", "openai"]
+    )
+    monkeypatch.setattr(cli, "_check_module", lambda _module: False)
+
+    assert cli._selected_views_for_args(args) == ["bm25", "vector"]
 
 
 def test_fast_index_builds_fresh_bm25_manifest(

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -23,13 +23,13 @@ def test_project_identity_and_tag_match_release_metadata() -> None:
     name, version = project_identity(root / "pyproject.toml")
 
     assert name == "codenib"
-    assert expected_tag(version) == "v0.2.0a1"
-    validate_tag("v0.2.0a1", version)
+    assert expected_tag(version) == "v0.2.0a2"
+    validate_tag("v0.2.0a2", version)
 
 
 def test_release_tag_must_match_project_version() -> None:
     with pytest.raises(ReleaseValidationError, match="does not match"):
-        validate_tag("v0.1.0", "0.2.0a1")
+        validate_tag("v0.1.0", "0.2.0a2")
 
 
 def test_packaged_readme_requires_the_arxiv_citation() -> None:
@@ -44,20 +44,14 @@ https://arxiv.org/abs/2607.25431
         validate_readme_citation("# CodeNib\n")
 
 
-def test_alpha_release_notes_use_test_registry_and_pages_permissions() -> None:
+def test_alpha_release_notes_use_production_pypi_and_pages_permissions() -> None:
     root = Path(__file__).resolve().parents[1]
     notes = (root / "docs" / "releases" / "0.2.0.md").read_text(encoding="utf-8")
 
-    wheel = (
-        "https://test-files.pythonhosted.org/packages/3d/3d/"
-        "8e7ce04893c0d64146b96dda6bda448638a00753806f76f7d5cd1e7b1e4d/"
-        "codenib-0.2.0a1-py3-none-any.whl#sha256="
-        "915356bc00e6ae58b1938baf105f79466da4b55ae612a84cc922a3bec09ecb07"
-    )
-    assert notes.count(wheel) == 2
-    assert "codenib @ ${CODENIB_ALPHA_WHEEL}" in notes
-    assert "codenib[mcp] @ ${CODENIB_ALPHA_WHEEL}" in notes
-    assert "620a82d1bf55897cbf4afa0b8563ed5da0997d27" in notes
+    assert '"codenib[semantic]==0.2.0a2"' in notes
+    assert '"codenib[mcp,semantic]==0.2.0a2"' in notes
+    assert "sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2" in notes
+    assert "test-files.pythonhosted.org" not in notes
     assert "--extra-index-url" not in notes
     assert "--index-url" not in notes
     for permission in ("contents: read", "pages: write", "id-token: write"):
@@ -90,8 +84,8 @@ def test_public_alpha_install_commands_do_not_select_stable_0_1(
     ]
 
     assert install_lines
-    assert "CODENIB_ALPHA_WHEEL=" in text
-    assert all("@ ${CODENIB_ALPHA_WHEEL}" in line for line in install_lines)
+    assert "CODENIB_ALPHA_WHEEL=" not in text
+    assert all("==0.2.0a2" in line for line in install_lines)
 
 
 def test_registry_publishers_use_separate_workflows() -> None:

--- a/test/test_release_metadata.py
+++ b/test/test_release_metadata.py
@@ -31,7 +31,7 @@ def _names(requirements: list[str]) -> set[str]:
     }
 
 
-def test_default_install_is_the_fast_wiki_runtime() -> None:
+def test_base_install_is_the_lightweight_wiki_runtime() -> None:
     project = _project()
     base = _names(project["dependencies"])
 

--- a/test/test_toolchains.py
+++ b/test/test_toolchains.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from codenib import toolchains
+from codenib.paths import toolchain_dir
+
+
+@pytest.mark.parametrize(
+    ("make_name", "packaged_value"),
+    (
+        ("SCIP_PYTHON_VERSION", toolchains.SCIP_PYTHON_VERSION),
+        ("SCIP_TYPESCRIPT_VERSION", toolchains.SCIP_TYPESCRIPT_VERSION),
+        (
+            "TYPESCRIPT_LANGUAGE_SERVER_VERSION",
+            toolchains.TYPESCRIPT_LANGUAGE_SERVER_VERSION,
+        ),
+        ("TYPESCRIPT_VERSION", toolchains.TYPESCRIPT_VERSION),
+        ("BASEDPYRIGHT_VERSION", toolchains.BASEDPYRIGHT_VERSION),
+        ("SCIP_GO_VERSION", toolchains.SCIP_GO_VERSION),
+        ("GOPLS_VERSION", toolchains.GOPLS_VERSION),
+        ("RUST_TOOLCHAIN", toolchains.RUST_TOOLCHAIN),
+        ("SCIP_DOTNET_VERSION", toolchains.SCIP_DOTNET_VERSION),
+        ("CSHARP_LS_VERSION", toolchains.CSHARP_LS_VERSION),
+        ("BUNDLER_VERSION", toolchains.BUNDLER_VERSION),
+        ("SCIP_RUBY_VERSION", toolchains.SCIP_RUBY_VERSION),
+        ("RUBY_LSP_VERSION", toolchains.RUBY_LSP_VERSION),
+        ("INTELEPHENSE_VERSION", toolchains.INTELEPHENSE_VERSION),
+    ),
+)
+def test_packaged_tool_versions_match_source_bootstrap(
+    make_name: str,
+    packaged_value: str,
+) -> None:
+    makefile = Path(__file__).resolve().parents[1] / "Makefile"
+    match = re.search(
+        rf"^{re.escape(make_name)} \?= (\S+)$",
+        makefile.read_text(encoding="utf-8"),
+        flags=re.MULTILINE,
+    )
+
+    assert match is not None
+    assert match.group(1) == packaged_value
+
+
+def test_toolchain_dir_is_durable_and_supports_explicit_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("CODENIB_TOOLCHAIN_DIR", raising=False)
+    monkeypatch.delenv("CODENIB_SCIP_TOOLS_DIR", raising=False)
+
+    assert toolchain_dir() == tmp_path / "home" / "toolchains"
+
+    monkeypatch.setenv("CODENIB_TOOLCHAIN_DIR", str(tmp_path / "custom"))
+    assert toolchain_dir() == tmp_path / "custom"
+
+
+def test_activate_managed_toolchain_prepends_all_provider_bins(
+    tmp_path: Path,
+) -> None:
+    env = {"PATH": "/usr/bin"}
+
+    root = toolchains.activate_managed_toolchain(env, root=tmp_path / "tools")
+
+    path = env["PATH"].split(":")
+    assert root == tmp_path / "tools"
+    assert path[0] == str(root)
+    assert str(root / "node-tools" / "node_modules" / ".bin") in path
+    assert str(root / "go-tools" / "bin") in path
+    assert path[-1] == "/usr/bin"
+
+
+def test_repository_plan_uses_language_registry_for_graph_and_lsp(
+    tmp_path: Path,
+) -> None:
+    available = {
+        "scip-python": "/managed/scip-python",
+        "basedpyright-langserver": "/managed/basedpyright-langserver",
+    }
+
+    plan = toolchains.plan_repository_toolchain(
+        tmp_path,
+        ["python"],
+        scopes=("graph", "lsp"),
+        command_resolver=available.get,
+        module_checker=lambda _name: True,
+    )
+
+    assert plan.ready is True
+    assert [
+        (item.scope, item.executable, item.resolved) for item in plan.requirements
+    ] == [
+        ("graph", "scip-python", "/managed/scip-python"),
+        ("lsp", "basedpyright-langserver", "/managed/basedpyright-langserver"),
+    ]
+
+
+def test_dry_run_renders_pinned_npm_install_without_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "tools"
+    requirement = toolchains.ToolRequirement(
+        language="python",
+        display_name="Python",
+        scope="graph",
+        executable="scip-python",
+        ready=False,
+    )
+    monkeypatch.setattr(
+        toolchains,
+        "resolve_command",
+        lambda command, **_kwargs: f"/usr/bin/{command}",
+    )
+
+    commands, manual = toolchains.install_requirements(
+        [requirement],
+        root=root,
+        dry_run=True,
+    )
+
+    assert manual == []
+    assert commands == [
+        (
+            "npm",
+            "install",
+            "--prefix",
+            str(root / "node-tools"),
+            "--no-audit",
+            "--no-fund",
+            "@sourcegraph/scip-python@0.6.6",
+        )
+    ]
+    assert not root.exists()
+
+
+def test_external_provider_remains_an_explicit_manual_prerequisite(
+    tmp_path: Path,
+) -> None:
+    requirement = toolchains.ToolRequirement(
+        language="cpp",
+        display_name="C/C++",
+        scope="graph",
+        executable="clangd",
+        ready=False,
+    )
+
+    commands, manual = toolchains.install_requirements(
+        [requirement],
+        root=tmp_path / "tools",
+        dry_run=True,
+    )
+
+    assert commands == []
+    assert manual == [
+        "clangd: install clangd from the operating system's LLVM packages"
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "codenib"
-version = "0.2.0a1"
+version = "0.2.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Make hybrid retrieval the default CodeNib product path and provide one repository-aware interface for language-specific SCIP and LSP providers. This removes the TestPyPI wheel URL from public setup instructions and prepares the verified `0.2.0a2` prerelease contract.

## Changes

- Add `codenib toolchain status/install` with release-pinned npm, Go, Rustup, .NET, and RubyGem recipes under `~/.codenib/toolchains`; report OS and project prerequisites without invoking `sudo` or mutating the target checkout.
- Make `index`, `wiki`, and `publish` select BM25+dense views when semantic dependencies are installed. Make the reusable Pages workflow explicitly semantic by default, cache its local Hugging Face model, and retain `fast` as the no-model fallback.
- Replace the long TestPyPI wheel URL with exact normal-PyPI prerelease commands, document the per-language graph/LSP provider map, and include the toolchain manager in release artifact checks.
- Bump the developer preview to `0.2.0a2` and add focused CLI, action, toolchain, and release tests.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2709 passed, 10 skipped`)

`pre-commit run --files $(git ls-files --modified --others --exclude-standard)`

`python -m mkdocs build --strict`

Built wheel and sdist; ran repository artifact validation, `twine check`, an isolated base-wheel install smoke, an actual package-managed Python/TypeScript LSP installation, and a real semantic `codenib publish` producing BM25 and vector views.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
