### PR TITLE
docs(rag): link embedding rerank models

### DIFF
--- a/docs/rag_ops.md
+++ b/docs/rag_ops.md
@@ -77,7 +77,7 @@ quality sweep.
 
 | Model or family | Strategy | Retained benchmark coverage |
 | --- | --- | --- |
-| SweRankEmbed-Large, jina-code-embeddings-1.5b, Qwen3-Embedding-4B | Dual-encoder candidate rerank | Complete 2 first-stage models x 3 rerank models matrix, 100 rows per pair |
+| [SweRankEmbed-Large](https://huggingface.co/fishmingyu/SweRankEmbed-Large), [jina-code-embeddings-1.5b](https://huggingface.co/jinaai/jina-code-embeddings-1.5b), [Qwen3-Embedding-4B](https://huggingface.co/Qwen/Qwen3-Embedding-4B) | Dual-encoder candidate rerank | Complete 2 first-stage models x 3 rerank models matrix, 100 rows per pair |
 | [Qwen3-Reranker-0.6B](https://huggingface.co/Qwen/Qwen3-Reranker-0.6B) | Pairwise yes/no scoring | 100 rows at candidate widths 30, 50, and 100 |
 | [Qwen3-Reranker-4B](https://huggingface.co/Qwen/Qwen3-Reranker-4B) | Pairwise yes/no scoring | 100-row runs across first-stage models and candidate widths 30, 50, and 100 |
 | [Qwen3-Reranker-8B](https://huggingface.co/Qwen/Qwen3-Reranker-8B) | Pairwise yes/no scoring | 100 rows at candidate widths 30, 50, and 100 with SweRankEmbed-Small |


### PR DESCRIPTION
## Summary
Link the three embedding models grouped under the validated dual-encoder rerank configuration.

## Changes
- Add direct Hugging Face links for SweRankEmbed-Large, jina-code-embeddings-1.5b, and Qwen3-Embedding-4B.
- Keep the retained benchmark coverage and strategy description unchanged.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing
- [x] Tests pass locally
- [ ] Added new tests for the changes

Validated with `pre-commit run --files docs/rag_ops.md`, `python -m mkdocs build --strict --site-dir /tmp/codenib-rag-links-site`, generated HTML inspection, and HTTP 200 checks for all three model pages.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published