### PR TITLE
feat(examples): add SweRank retrieve-rerank recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ agent or code-Wiki framework.
 
 ## News
 
-- **2026-08-05 — CodeNib 0.2.0 Alpha 2.** Hybrid retrieval is now the default,
-  and `codenib toolchain` manages pinned per-language SCIP/LSP providers.
+- **2026-08-05 — SweRank recipe.** Run
+  [SweRank](https://github.com/SalesforceAIResearch/SweRank) retrieval and
+  reranking over a local checkout. [Example](examples/swerank_retrieve_rerank.py)
+- **2026-08-05 — CodeNib 0.2 alpha.** Hybrid retrieval, managed SCIP/LSP
+  toolchains, and reusable Pages/MCP artifacts.
   [Release notes](https://docs.codenib.ai/releases/0.2.0/)
-- **2026-08-05 — CodeNib 0.2.0 Alpha 1.** `codenib publish` builds a static
-  Wiki and reusable context artifact for Pages or MCP.
-  [Pages guide](https://docs.codenib.ai/github_pages/)
 - **2026-08-04 — Native repository explorer.** CodeNib's planner now targets
   the [SWE-Explore](https://github.com/Qiushao-E/SWE-Explore-Bench)
   source-region protocol.

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -834,6 +834,7 @@ class RetrieveRerankPipeline:
             embedding_provider=embedding_provider,
             embedding_dimension=embedding_dimension,
             embedding_kwargs=embedding_kwargs,
+            embedding=vector_store.embedding,
             index_metric=self.index_metric,
             profiler=self.profiler,
         )

--- a/docs/rag_ops.md
+++ b/docs/rag_ops.md
@@ -88,6 +88,11 @@ The reproducible entry points are the
 [embedding sweep](https://github.com/sysevol-ai/CodeNib/blob/main/scripts/embeddings/eval_codenib_base_embeddings.sh)
 and
 [rerank matrix](https://github.com/sysevol-ai/CodeNib/blob/main/scripts/embeddings/eval_codenib_base_rerank_matrix.sh).
+For a repository-level invocation rather than a dataset sweep, use the
+[SweRank retrieve-rerank recipe](https://github.com/sysevol-ai/CodeNib/blob/main/examples/swerank_retrieve_rerank.py).
+It exposes a SweRankEmbed-Small → SweRankLLM-Small listwise path
+and a one-process SweRankEmbed-Small → SweRankEmbed-Large path over the same
+`RetrieveRerankPipeline` contract.
 Historical retrieval artifacts recorded model IDs but not immutable model
 revisions; the paper artifact reports that provenance limit. A model not listed
 here may still run through a generic adapter, but it is not a validated quality

--- a/examples/README.md
+++ b/examples/README.md
@@ -68,6 +68,7 @@ retrieval floor the agent builds on.
 | [`embedding_retrieve_baseline.py`](embedding_retrieve_baseline.py) | Dense embedding (FAISS) only. Supports **`--index-type flat\|ivf`** (see below). |
 | [`graph_retrieve_baseline.py`](graph_retrieve_baseline.py) | Symbol-graph / GraphRAG retrieval. |
 | [`retrieve_rerank.py`](retrieve_rerank.py) | Retrieve → rerank cascade (`RetrieveRerankPipeline`). |
+| [`swerank_retrieve_rerank.py`](swerank_retrieve_rerank.py) | Runnable SweRank recipe over one local repository. |
 | [`agentless.py`](agentless.py) | Agentless-style retrieval pipeline. |
 
 ```bash
@@ -76,6 +77,52 @@ python examples/embedding_retrieve_baseline.py \
     --embedding-model nomic-ai/CodeRankEmbed \
     --result-path results/embedding_baseline.json
 ```
+
+### SweRank retrieve → rerank
+
+The recipe makes the candidate funnel explicit: SweRankEmbed-Small retrieves
+100 L2 code chunks, the selected reranker scores the first 30, and CodeNib
+returns the final 10 by default. Install the semantic stack first:
+
+```bash
+pip install "codenib[semantic,agent]"
+```
+
+For the SweRankLLM listwise route, serve SweRankLLM-Small through an
+OpenAI-compatible endpoint and run the recipe in a second terminal:
+
+```bash
+pip install vllm
+vllm serve Salesforce/SweRankLLM-Small \
+  --served-model-name swerank-llm-small --port 9000
+
+python examples/swerank_retrieve_rerank.py /path/to/repo \
+  --query "Issue or change request to localize"
+```
+
+The one-process alternative uses SweRankEmbed-Large to rescore the candidate
+contents and does not need an LLM server. The model card requires a CUDA stack
+with FlashAttention for this 7B route:
+
+```bash
+python examples/swerank_retrieve_rerank.py /path/to/repo \
+  --query "Issue or change request to localize" \
+  --reranker embed-large
+```
+
+The default dense-index cache is outside the checkout and keyed by the clean
+Git commit or, for dirty and non-Git repositories, a source-content
+fingerprint. Pass `--index-dir` only when the caller manages that identity
+boundary itself.
+
+Both model routes apply the prompt names published by the model cards through
+CodeNib's embedding prompt registry and L2-normalize vectors before inner-product
+scoring. SweRank weights use CC-BY-NC-4.0 and were trained for issue localization
+on Python repositories; other languages are a supported execution path, not a
+retained quality claim. CodeNib implements the published RankGPT prompt and
+permutation parser but retains its own overlapping window score aggregation, so
+this is an integration recipe rather than a claim of bit-for-bit reproduction
+of the upstream evaluation harness.
 
 ### FAISS index type: flat vs IVF
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -112,8 +112,9 @@ python examples/swerank_retrieve_rerank.py /path/to/repo \
 
 The default dense-index cache is outside the checkout and keyed by the clean
 Git commit or, for dirty and non-Git repositories, a source-content
-fingerprint. Pass `--index-dir` only when the caller manages that identity
-boundary itself.
+fingerprint. A versioned build-profile key also separates language and chunking
+configurations. Pass `--index-dir` only when the caller manages those identity
+boundaries itself.
 
 Both model routes apply the prompt names published by the model cards through
 CodeNib's embedding prompt registry and L2-normalize vectors before inner-product

--- a/examples/swerank_retrieve_rerank.py
+++ b/examples/swerank_retrieve_rerank.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run a SweRank retrieve-then-rerank recipe over a local repository.
+
+The default recipe uses ``SweRankEmbed-Small`` to retrieve 100 code chunks,
+passes the first 30 to ``SweRankLLM-Small`` using its RankGPT-style listwise
+contract, and returns the requested top-k. A one-process dual-encoder variant
+uses ``SweRankEmbed-Large`` for the second-stage candidate scoring instead.
+
+Examples:
+    # SweRankLLM route. Start the vLLM command documented in examples/README.md.
+    python examples/swerank_retrieve_rerank.py . \
+        --query "Configuration reload ignores changes to nested includes"
+
+    # One-process alternative; no LLM endpoint is required.
+    python examples/swerank_retrieve_rerank.py . \
+        --query "Configuration reload ignores changes to nested includes" \
+        --reranker embed-large
+
+SweRank model weights are CC-BY-NC-4.0. Review their model cards before using
+this recipe outside research or other non-commercial settings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Sequence
+
+RETRIEVAL_MODEL = "Salesforce/SweRankEmbed-Small"
+RETRIEVAL_DIMENSION = 768
+EMBED_RERANK_MODEL = "Salesforce/SweRankEmbed-Large"
+EMBED_RERANK_DIMENSION = 3584
+LLM_RERANK_MODEL = "openai/swerank-llm-small"
+RETRIEVAL_TOP_K = 100
+DEFAULT_CANDIDATE_TOP_K = 30
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Search one repository with a SweRank retrieve-rerank cascade.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "repo",
+        nargs="?",
+        default=".",
+        help="Repository checkout to index and search.",
+    )
+    query = parser.add_mutually_exclusive_group(required=True)
+    query.add_argument("--query", help="Issue or change request to localize.")
+    query.add_argument(
+        "--query-file",
+        type=Path,
+        help="UTF-8 file containing the issue or change request.",
+    )
+    parser.add_argument(
+        "--reranker",
+        choices=("llm-small", "embed-large"),
+        default="llm-small",
+        help=(
+            "Second-stage SweRank model. llm-small uses the listwise model "
+            "recipe; embed-large is a one-process dual-encoder alternative."
+        ),
+    )
+    parser.add_argument(
+        "--llm-model",
+        default=LLM_RERANK_MODEL,
+        help=(
+            "LiteLLM model identifier for the OpenAI-compatible "
+            "SweRankLLM-Small server. Used only with --reranker llm-small."
+        ),
+    )
+    parser.add_argument(
+        "--api-base",
+        default="http://127.0.0.1:9000/v1",
+        help=(
+            "OpenAI-compatible endpoint for SweRankLLM-Small. Used only with "
+            "--reranker llm-small."
+        ),
+    )
+    parser.add_argument(
+        "--language",
+        action="append",
+        default=[],
+        help="Chunker language; repeat for multiple languages (auto-detected by default).",
+    )
+    parser.add_argument(
+        "--index-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Vector-index cache. The default is isolated by repository and "
+            "checkout content."
+        ),
+    )
+    parser.add_argument(
+        "--candidate-top-k",
+        type=int,
+        default=DEFAULT_CANDIDATE_TOP_K,
+        help="First-stage candidates passed to the reranker.",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=10,
+        help="Final number of reranked code chunks to return.",
+    )
+    parser.add_argument(
+        "--retrieval-batch-size",
+        type=int,
+        default=32,
+        help="SweRankEmbed-Small encoding batch size.",
+    )
+    parser.add_argument(
+        "--rerank-batch-size",
+        type=int,
+        default=2,
+        help="SweRankEmbed-Large encoding batch size.",
+    )
+    parser.add_argument(
+        "--max-lines-per-chunk",
+        type=int,
+        default=300,
+        help="Maximum source lines in one indexed chunk.",
+    )
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Sentence-Transformers device for embedding models (for example cuda:0).",
+    )
+    parser.add_argument(
+        "--snippet-lines",
+        type=int,
+        default=8,
+        help="Source lines printed for each result; use 0 to hide snippets.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable results, including complete chunk content.",
+    )
+    return parser
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.top_k <= 0:
+        parser.error("--top-k must be positive")
+    if not args.top_k <= args.candidate_top_k <= RETRIEVAL_TOP_K:
+        parser.error(
+            "--candidate-top-k must be between --top-k and the "
+            f"{RETRIEVAL_TOP_K}-candidate retrieval width"
+        )
+    for name in (
+        "retrieval_batch_size",
+        "rerank_batch_size",
+        "max_lines_per_chunk",
+    ):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be positive")
+    if args.snippet_lines < 0:
+        parser.error("--snippet-lines cannot be negative")
+    return args
+
+
+def read_query(args: argparse.Namespace) -> str:
+    text = args.query
+    if args.query_file is not None:
+        text = args.query_file.expanduser().read_text(encoding="utf-8")
+    normalized = (text or "").strip()
+    if not normalized:
+        raise ValueError("query must not be empty")
+    return normalized
+
+
+def resolve_languages(repo: Path, requested: Sequence[str]) -> list[str]:
+    from codenib.cli import detect_languages, normalize_languages
+
+    languages = normalize_languages(requested) if requested else detect_languages(repo)
+    if not languages:
+        raise ValueError(
+            "CodeNib found no supported source language; pass --language explicitly"
+        )
+    return languages
+
+
+def resolve_index_dir(args: argparse.Namespace, repo: Path) -> Path:
+    if args.index_dir is not None:
+        return args.index_dir.expanduser().resolve()
+
+    from codenib.compiler.checkout_identity import checkout_commit
+    from codenib.paths import repo_state_dir
+    from codenib.source_fingerprint import (
+        fingerprint_repository,
+        repository_source_is_dirty,
+    )
+
+    commit = checkout_commit(repo)
+    if commit and not repository_source_is_dirty(repo):
+        source_key = f"git-{commit.lower()}"
+    else:
+        fingerprint = fingerprint_repository(repo).value.removeprefix("sha256:")
+        source_key = f"source-{fingerprint}"
+
+    return repo_state_dir(repo) / "recipes" / "swerank-embed-small" / source_key
+
+
+def _embedding_runtime_kwargs(batch_size: int, device: str | None) -> dict[str, Any]:
+    model_kwargs = {"device": device} if device else {}
+    return {
+        "trust_remote_code": True,
+        "model_kwargs": model_kwargs,
+        "encode_kwargs": {
+            "batch_size": batch_size,
+            "normalize_embeddings": True,
+        },
+    }
+
+
+def build_pipeline_kwargs(
+    args: argparse.Namespace,
+    *,
+    repo: Path,
+    index_dir: Path,
+    languages: Sequence[str],
+) -> dict[str, Any]:
+    """Return the explicit pipeline contract without loading either model."""
+    from codenib.model import RetrieveStageConfig
+
+    kwargs: dict[str, Any] = {
+        "repo_path": str(repo),
+        "index_path": str(index_dir),
+        "retrieval_plan": [RetrieveStageConfig(engine="dense", top_k=RETRIEVAL_TOP_K)],
+        "retrieval_mode": "dense",
+        "retrieval_level": "l2",
+        "embedding_model": RETRIEVAL_MODEL,
+        "embedding_provider": "huggingface",
+        "embedding_dimension": RETRIEVAL_DIMENSION,
+        "embedding_model_kwargs": _embedding_runtime_kwargs(
+            args.retrieval_batch_size, args.device
+        ),
+        "languages": list(languages),
+        "max_lines_per_chunk": args.max_lines_per_chunk,
+        "rerank_candidate_top_k": args.candidate_top_k,
+    }
+
+    if args.reranker == "embed-large":
+        kwargs.update(
+            rerank_strategy="embedding",
+            rerank_embedding_model=EMBED_RERANK_MODEL,
+            rerank_embedding_provider="huggingface",
+            rerank_embedding_dimension=EMBED_RERANK_DIMENSION,
+            rerank_embedding_model_kwargs=_embedding_runtime_kwargs(
+                args.rerank_batch_size, args.device
+            ),
+        )
+    else:
+        kwargs.update(
+            rerank_strategy="llm",
+            rerank_model=args.llm_model,
+            rerank_listwise_format="rankgpt",
+            rerank_window_size=10,
+            rerank_window_step=10,
+        )
+    return kwargs
+
+
+def _repository_relative_file(value: str | None, repo: Path | None) -> str | None:
+    if value is None or repo is None:
+        return value
+    path = Path(value)
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return path.resolve().relative_to(repo).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _result_payload(result: Any, rank: int, repo: Path | None) -> dict[str, Any]:
+    start_line = result.start_line + 1 if result.start_line is not None else None
+    end_line = result.end_line + 1 if result.end_line is not None else None
+    return {
+        "rank": rank,
+        "file": _repository_relative_file(result.file, repo),
+        "start_line": start_line,
+        "end_line": end_line,
+        "symbol": result.node_name,
+        "type": result.type,
+        "score": result.score,
+        "content": result.content,
+    }
+
+
+def render_results(
+    results: Sequence[Any],
+    *,
+    snippet_lines: int,
+    as_json: bool,
+    repo: Path | None = None,
+) -> None:
+    payload = [
+        _result_payload(result, rank, repo) for rank, result in enumerate(results, 1)
+    ]
+    if as_json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return
+
+    if not payload:
+        print("No code chunks matched the query.")
+        return
+
+    for item in payload:
+        location = item["file"] or "<unknown>"
+        if item["start_line"] is not None:
+            location = f"{location}:{item['start_line']}"
+        symbol = item["symbol"] or item["type"] or "<chunk>"
+        score = item["score"]
+        score_text = f" score={score:.4f}" if score is not None else ""
+        print(f"[{item['rank']}] {location}  {symbol}{score_text}")
+        if snippet_lines and item["content"]:
+            for line in str(item["content"]).splitlines()[:snippet_lines]:
+                print(f"    {line}")
+
+
+def run(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).expanduser().resolve()
+    if not repo.is_dir():
+        raise ValueError(f"repository directory does not exist: {repo}")
+
+    query = read_query(args)
+    languages = resolve_languages(repo, args.language)
+    index_dir = resolve_index_dir(args, repo)
+
+    if args.reranker == "llm-small":
+        os.environ["OPENAI_API_BASE"] = args.api_base
+        if args.api_base.startswith(("http://127.0.0.1", "http://localhost")):
+            os.environ.setdefault("OPENAI_API_KEY", "local")
+
+    from codenib.model import RetrieveRerankPipeline
+
+    pipeline = RetrieveRerankPipeline(
+        **build_pipeline_kwargs(
+            args,
+            repo=repo,
+            index_dir=index_dir,
+            languages=languages,
+        )
+    )
+    try:
+        results = pipeline.query(query, top_k=args.top_k)
+    finally:
+        pipeline.close()
+
+    render_results(
+        results,
+        snippet_lines=args.snippet_lines,
+        as_json=args.json,
+        repo=repo,
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        return run(args)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise SystemExit(f"error: {exc}") from exc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/swerank_retrieve_rerank.py
+++ b/examples/swerank_retrieve_rerank.py
@@ -28,6 +28,7 @@ this recipe outside research or other non-commercial settings.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -40,6 +41,7 @@ EMBED_RERANK_DIMENSION = 3584
 LLM_RERANK_MODEL = "openai/swerank-llm-small"
 RETRIEVAL_TOP_K = 100
 DEFAULT_CANDIDATE_TOP_K = 30
+CACHE_PROFILE_VERSION = 1
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -96,8 +98,8 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help=(
-            "Vector-index cache. The default is isolated by repository and "
-            "checkout content."
+            "Vector-index cache. The default is isolated by repository "
+            "content and index build profile."
         ),
     )
     parser.add_argument(
@@ -192,7 +194,25 @@ def resolve_languages(repo: Path, requested: Sequence[str]) -> list[str]:
     return languages
 
 
-def resolve_index_dir(args: argparse.Namespace, repo: Path) -> Path:
+def _cache_profile_key(languages: Sequence[str], max_lines_per_chunk: int) -> str:
+    profile = {
+        "version": CACHE_PROFILE_VERSION,
+        "embedding_model": RETRIEVAL_MODEL,
+        "embedding_dimension": RETRIEVAL_DIMENSION,
+        "languages": list(languages),
+        "max_lines_per_chunk": max_lines_per_chunk,
+        "retrieval_level": "l2",
+        "normalize_embeddings": True,
+        "index_metric": "ip",
+    }
+    encoded = json.dumps(profile, sort_keys=True, separators=(",", ":")).encode()
+    digest = hashlib.sha256(encoded).hexdigest()[:16]
+    return f"profile-v{CACHE_PROFILE_VERSION}-{digest}"
+
+
+def resolve_index_dir(
+    args: argparse.Namespace, repo: Path, languages: Sequence[str]
+) -> Path:
     if args.index_dir is not None:
         return args.index_dir.expanduser().resolve()
 
@@ -210,7 +230,14 @@ def resolve_index_dir(args: argparse.Namespace, repo: Path) -> Path:
         fingerprint = fingerprint_repository(repo).value.removeprefix("sha256:")
         source_key = f"source-{fingerprint}"
 
-    return repo_state_dir(repo) / "recipes" / "swerank-embed-small" / source_key
+    profile_key = _cache_profile_key(languages, args.max_lines_per_chunk)
+    return (
+        repo_state_dir(repo)
+        / "recipes"
+        / "swerank-embed-small"
+        / source_key
+        / profile_key
+    )
 
 
 def _embedding_runtime_kwargs(batch_size: int, device: str | None) -> dict[str, Any]:
@@ -338,7 +365,7 @@ def run(args: argparse.Namespace) -> int:
 
     query = read_query(args)
     languages = resolve_languages(repo, args.language)
-    index_dir = resolve_index_dir(args, repo)
+    index_dir = resolve_index_dir(args, repo, languages)
 
     if args.reranker == "llm-small":
         os.environ["OPENAI_API_BASE"] = args.api_base

--- a/scripts/embeddings/RERANK_EXPERIMENTS.md
+++ b/scripts/embeddings/RERANK_EXPERIMENTS.md
@@ -145,7 +145,9 @@ Provider strings follow litellm conventions:
 - Anthropic: `anthropic/claude-sonnet-4-6`
 - OpenAI: `openai/gpt-4o-mini`
 - Google: `gemini/gemini-3-flash-preview` (verify exact ID via litellm docs)
-- Salesforce SweRankLLM: needs a custom listwise wrapper (TODO).
+- Salesforce SweRankLLM: use
+  `examples/swerank_retrieve_rerank.py --reranker llm-small`; it selects the
+  implemented RankGPT text contract rather than structured JSON output.
 
 ## Env knobs (matrix sweep)
 

--- a/test/examples/test_swerank_retrieve_rerank.py
+++ b/test/examples/test_swerank_retrieve_rerank.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the runnable SweRank recipe."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_RECIPE_PATH = (
+    Path(__file__).resolve().parents[2] / "examples" / "swerank_retrieve_rerank.py"
+)
+
+
+def _load_recipe():
+    spec = importlib.util.spec_from_file_location(
+        "swerank_retrieve_rerank_under_test", _RECIPE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def recipe():
+    return _load_recipe()
+
+
+def _args(recipe, *extra):
+    return recipe.parse_args([".", "--query", "fix nested configuration", *extra])
+
+
+def test_llm_recipe_uses_rankgpt_contract(recipe, tmp_path):
+    args = _args(recipe)
+    kwargs = recipe.build_pipeline_kwargs(
+        args,
+        repo=tmp_path,
+        index_dir=tmp_path / "index",
+        languages=["python"],
+    )
+
+    assert kwargs["embedding_model"] == "Salesforce/SweRankEmbed-Small"
+    assert kwargs["retrieval_plan"][0].top_k == 100
+    assert kwargs["rerank_candidate_top_k"] == 30
+    assert kwargs["rerank_strategy"] == "llm"
+    assert kwargs["rerank_model"] == "openai/swerank-llm-small"
+    assert kwargs["rerank_listwise_format"] == "rankgpt"
+    assert kwargs["rerank_window_size"] == 10
+    assert kwargs["rerank_window_step"] == 10
+
+
+def test_embedding_recipe_uses_independent_large_encoder(recipe, tmp_path):
+    args = _args(
+        recipe,
+        "--reranker",
+        "embed-large",
+        "--device",
+        "cuda:1",
+        "--rerank-batch-size",
+        "4",
+    )
+    kwargs = recipe.build_pipeline_kwargs(
+        args,
+        repo=tmp_path,
+        index_dir=tmp_path / "index",
+        languages=["python", "go"],
+    )
+
+    assert kwargs["rerank_strategy"] == "embedding"
+    assert kwargs["rerank_embedding_model"] == "Salesforce/SweRankEmbed-Large"
+    assert kwargs["rerank_embedding_dimension"] == 3584
+    assert kwargs["rerank_embedding_model_kwargs"] == {
+        "trust_remote_code": True,
+        "model_kwargs": {"device": "cuda:1"},
+        "encode_kwargs": {"batch_size": 4, "normalize_embeddings": True},
+    }
+    assert kwargs["embedding_model_kwargs"]["encode_kwargs"] == {
+        "batch_size": 32,
+        "normalize_embeddings": True,
+    }
+    assert kwargs["languages"] == ["python", "go"]
+
+
+def test_default_index_cache_is_keyed_by_clean_commit(recipe, monkeypatch, tmp_path):
+    from codenib import paths, source_fingerprint
+    from codenib.compiler import checkout_identity
+
+    state = tmp_path / "state"
+    monkeypatch.setattr(paths, "repo_state_dir", lambda repo: state)
+    monkeypatch.setattr(checkout_identity, "checkout_commit", lambda repo: "A" * 40)
+    monkeypatch.setattr(
+        source_fingerprint, "repository_source_is_dirty", lambda repo: False
+    )
+    monkeypatch.setattr(
+        source_fingerprint,
+        "fingerprint_repository",
+        lambda repo: pytest.fail("clean commits should not require content hashing"),
+    )
+
+    index_dir = recipe.resolve_index_dir(_args(recipe), tmp_path)
+
+    assert index_dir == (state / "recipes" / "swerank-embed-small" / f"git-{'a' * 40}")
+
+
+def test_default_index_cache_fingerprints_dirty_checkout(recipe, monkeypatch, tmp_path):
+    from codenib import paths, source_fingerprint
+    from codenib.compiler import checkout_identity
+
+    state = tmp_path / "state"
+    monkeypatch.setattr(paths, "repo_state_dir", lambda repo: state)
+    monkeypatch.setattr(checkout_identity, "checkout_commit", lambda repo: "a" * 40)
+    monkeypatch.setattr(
+        source_fingerprint, "repository_source_is_dirty", lambda repo: True
+    )
+    monkeypatch.setattr(
+        source_fingerprint,
+        "fingerprint_repository",
+        lambda repo: source_fingerprint.SourceFingerprint(
+            value=f"sha256:{'b' * 64}", file_count=3
+        ),
+    )
+
+    index_dir = recipe.resolve_index_dir(_args(recipe), tmp_path)
+
+    assert index_dir == (
+        state / "recipes" / "swerank-embed-small" / f"source-{'b' * 64}"
+    )
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ("--top-k", "0"),
+        ("--top-k", "20", "--candidate-top-k", "10"),
+        ("--candidate-top-k", "101"),
+    ],
+)
+def test_candidate_funnel_is_validated_before_model_loading(recipe, extra):
+    with pytest.raises(SystemExit) as exc_info:
+        _args(recipe, *extra)
+    assert exc_info.value.code == 2
+
+
+def test_render_results_reports_one_based_source_location(recipe, capsys):
+    result = SimpleNamespace(
+        file="src/config.py",
+        start_line=40,
+        end_line=44,
+        node_name="Config.reload",
+        type="method",
+        score=0.875,
+        content="def reload(self):\n    return self._read()",
+    )
+
+    recipe.render_results([result], snippet_lines=1, as_json=False)
+
+    output = capsys.readouterr().out
+    assert "[1] src/config.py:41  Config.reload score=0.8750" in output
+    assert "    def reload(self):" in output
+
+
+def test_render_results_makes_checkout_paths_repository_relative(
+    recipe, capsys, tmp_path
+):
+    result = SimpleNamespace(
+        file=str(tmp_path / "src" / "config.py"),
+        start_line=0,
+        end_line=1,
+        node_name="load",
+        type="function",
+        score=0.5,
+        content=None,
+    )
+
+    recipe.render_results([result], snippet_lines=0, as_json=False, repo=tmp_path)
+
+    assert "[1] src/config.py:1  load score=0.5000" in capsys.readouterr().out
+
+
+def test_run_wires_repository_query_and_closes_pipeline(
+    recipe, monkeypatch, tmp_path, capsys
+):
+    import codenib.model
+
+    observed = {}
+
+    class FakePipeline:
+        def __init__(self, **kwargs):
+            observed["kwargs"] = kwargs
+
+        def query(self, query, top_k):
+            observed["query"] = query
+            observed["top_k"] = top_k
+            return [
+                SimpleNamespace(
+                    file="src/config.py",
+                    start_line=2,
+                    end_line=5,
+                    node_name="reload",
+                    type="function",
+                    score=0.9,
+                    content="def reload(): pass",
+                )
+            ]
+
+        def close(self):
+            observed["closed"] = True
+
+    monkeypatch.setattr(codenib.model, "RetrieveRerankPipeline", FakePipeline)
+    monkeypatch.setattr(recipe, "resolve_languages", lambda repo, requested: ["python"])
+    monkeypatch.setattr(
+        recipe, "resolve_index_dir", lambda args, repo: tmp_path / "index"
+    )
+
+    args = recipe.parse_args(
+        [str(tmp_path), "--query", "  fix nested configuration  ", "--top-k", "1"]
+    )
+    assert recipe.run(args) == 0
+
+    assert observed["query"] == "fix nested configuration"
+    assert observed["top_k"] == 1
+    assert observed["kwargs"]["repo_path"] == str(tmp_path)
+    assert observed["closed"] is True
+    assert "[1] src/config.py:3  reload score=0.9000" in capsys.readouterr().out

--- a/test/examples/test_swerank_retrieve_rerank.py
+++ b/test/examples/test_swerank_retrieve_rerank.py
@@ -102,9 +102,16 @@ def test_default_index_cache_is_keyed_by_clean_commit(recipe, monkeypatch, tmp_p
         lambda repo: pytest.fail("clean commits should not require content hashing"),
     )
 
-    index_dir = recipe.resolve_index_dir(_args(recipe), tmp_path)
+    args = _args(recipe)
+    index_dir = recipe.resolve_index_dir(args, tmp_path, ["python"])
 
-    assert index_dir == (state / "recipes" / "swerank-embed-small" / f"git-{'a' * 40}")
+    assert index_dir == (
+        state
+        / "recipes"
+        / "swerank-embed-small"
+        / f"git-{'a' * 40}"
+        / recipe._cache_profile_key(["python"], args.max_lines_per_chunk)
+    )
 
 
 def test_default_index_cache_fingerprints_dirty_checkout(recipe, monkeypatch, tmp_path):
@@ -125,11 +132,36 @@ def test_default_index_cache_fingerprints_dirty_checkout(recipe, monkeypatch, tm
         ),
     )
 
-    index_dir = recipe.resolve_index_dir(_args(recipe), tmp_path)
+    args = _args(recipe)
+    index_dir = recipe.resolve_index_dir(args, tmp_path, ["python"])
 
     assert index_dir == (
-        state / "recipes" / "swerank-embed-small" / f"source-{'b' * 64}"
+        state
+        / "recipes"
+        / "swerank-embed-small"
+        / f"source-{'b' * 64}"
+        / recipe._cache_profile_key(["python"], args.max_lines_per_chunk)
     )
+
+
+def test_default_index_cache_separates_chunk_profiles(recipe, monkeypatch, tmp_path):
+    from codenib import paths, source_fingerprint
+    from codenib.compiler import checkout_identity
+
+    monkeypatch.setattr(paths, "repo_state_dir", lambda repo: tmp_path / "state")
+    monkeypatch.setattr(checkout_identity, "checkout_commit", lambda repo: "a" * 40)
+    monkeypatch.setattr(
+        source_fingerprint, "repository_source_is_dirty", lambda repo: False
+    )
+
+    default_args = _args(recipe)
+    shorter_args = _args(recipe, "--max-lines-per-chunk", "100")
+
+    python_index = recipe.resolve_index_dir(default_args, tmp_path, ["python"])
+    go_index = recipe.resolve_index_dir(default_args, tmp_path, ["go"])
+    shorter_index = recipe.resolve_index_dir(shorter_args, tmp_path, ["python"])
+
+    assert len({python_index, go_index, shorter_index}) == 3
 
 
 @pytest.mark.parametrize(
@@ -214,7 +246,9 @@ def test_run_wires_repository_query_and_closes_pipeline(
     monkeypatch.setattr(codenib.model, "RetrieveRerankPipeline", FakePipeline)
     monkeypatch.setattr(recipe, "resolve_languages", lambda repo, requested: ["python"])
     monkeypatch.setattr(
-        recipe, "resolve_index_dir", lambda args, repo: tmp_path / "index"
+        recipe,
+        "resolve_index_dir",
+        lambda args, repo, languages: tmp_path / "index",
     )
 
     args = recipe.parse_args(

--- a/test/model/test_retrieve_pipeline_indexer_routing.py
+++ b/test/model/test_retrieve_pipeline_indexer_routing.py
@@ -156,3 +156,49 @@ def test_graph_retrieve_pipeline_name_is_sparse_seeded_alias():
         pipeline_module.GraphRetrievePipeline,
         pipeline_module.SparseSeededGraphRetrievePipeline,
     )
+
+
+def test_retrieve_rerank_cache_miss_reuses_loaded_embedding(monkeypatch, tmp_path):
+    from codenib.model import retrieve_rerank_pipeline as pipeline_module
+
+    embedding = object()
+    built_store = object()
+    builder_calls = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            self.embedding = embedding
+            self.l0_documents = []
+            self.l2_documents = []
+
+    def fake_build_vector_store(**kwargs):
+        builder_calls.append(kwargs)
+        return built_store
+
+    monkeypatch.setattr(pipeline_module, "CodeVectorStore", FakeVectorStore)
+    monkeypatch.setattr(
+        pipeline_module,
+        "build_hierarchical_vector_store",
+        fake_build_vector_store,
+    )
+
+    pipeline = object.__new__(pipeline_module.RetrieveRerankPipeline)
+    pipeline.repo_path = str(tmp_path)
+    pipeline.index_path = tmp_path / "index"
+    pipeline.index_path.mkdir()
+    pipeline.retrieval_level = "l2"
+    pipeline.languages = ["python"]
+    pipeline.max_lines_per_chunk = 300
+    pipeline.index_metric = "ip"
+    pipeline.profiler = None
+
+    result = pipeline._initialize_vector_store(
+        embedding_model="Salesforce/SweRankEmbed-Small",
+        embedding_provider="huggingface",
+        embedding_dimension=768,
+        embedding_kwargs={"encode_kwargs": {"normalize_embeddings": True}},
+    )
+
+    assert result is built_store
+    assert len(builder_calls) == 1
+    assert builder_calls[0]["embedding"] is embedding


### PR DESCRIPTION
## Summary

Add a runnable repository-level SweRank retrieve-rerank recipe on top of CodeNib's existing `RetrieveRerankPipeline`. This closes the gap between the supported pipeline and the public examples without adding a parallel retrieval implementation.

## Changes

- Add a `SweRankEmbed-Small` dense retrieval recipe with an explicit 100-candidate first stage, 30-candidate rerank stage, and top-10 output.
- Support `SweRankLLM-Small` through the existing RankGPT listwise contract and `SweRankEmbed-Large` as a one-process embedding reranker.
- Normalize embeddings for inner-product scoring, emit repository-relative one-based source locations, and key default caches by clean commit or dirty source fingerprint.
- Reuse the already loaded first-stage encoder during a cache-miss index build.
- Document setup, model scope/license, aggregation semantics, and both runnable routes.
- Add focused recipe and encoder-reuse tests.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `2722 passed, 10 skipped, 183 deselected` in the unit tier.
- `mkdocs build --strict`.
- Changed-file pre-commit hooks.
- Real `SweRankEmbed-Small` chunk, L0/L2 index, FAISS, and query smoke on a local repository.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
