### PR TITLE
feat(mcp): publish ranked context server

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -48,11 +48,20 @@ jobs:
           BUILD_VENV="$RUNNER_TEMP/codenib-release-build-${{ github.run_id }}-${{ github.run_attempt }}"
           python -m venv "$BUILD_VENV"
           "$BUILD_VENV/bin/python" -m pip install \
-            --upgrade pip build twine
+            --upgrade pip build "jsonschema>=4,<5" twine
           "$BUILD_VENV/bin/python" -m build
           "$BUILD_VENV/bin/python" -m twine check dist/*
           "$BUILD_VENV/bin/python" \
             scripts/verify_release_artifacts.py dist
+
+      - name: Validate MCP Registry metadata
+        run: |
+          BUILD_VENV="$RUNNER_TEMP/codenib-release-build-${{ github.run_id }}-${{ github.run_attempt }}"
+          curl --fail --location --retry 3 \
+            --output "$RUNNER_TEMP/mcp-server.schema.json" \
+            https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json
+          "$BUILD_VENV/bin/python" scripts/verify_mcp_registry.py \
+            --schema-file "$RUNNER_TEMP/mcp-server.schema.json"
 
       - name: Validate production release ref
         if: github.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ on:
       - "codenib/**"
       - "scripts/smoke_release_install.py"
       - "scripts/smoke_release_services.py"
+      - "scripts/verify_mcp_registry.py"
       - "scripts/verify_release_artifacts.py"
+      - "server.json"
+      - "test/test_mcp_registry.py"
       - "test/test_release_artifacts.py"
       - "web/**"
       - "CHANGELOG.md"
@@ -68,10 +71,56 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    if: github.ref_type == 'tag'
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    environment:
+      name: mcp-registry-publish
+      url: https://registry.modelcontextprotocol.io/v0.1/servers?search=ai.codenib%2Fcodenib
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Wait for the exact PyPI package
+        run: python scripts/verify_mcp_registry.py --check-pypi --timeout 900
+
+      - name: Install verified MCP publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
+        run: |
+          curl --fail --location --retry 3 \
+            --output mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum --check -
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          ./mcp-publisher --help >/dev/null
+
+      - name: Authenticate branded namespace
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+        run: |
+          test -n "$MCP_PRIVATE_KEY"
+          ./mcp-publisher login dns \
+            --domain codenib.ai \
+            --private-key "$MCP_PRIVATE_KEY"
+
+      - name: Publish server metadata
+        run: ./mcp-publisher publish
+
+      - name: Verify Registry discovery
+        run: python scripts/verify_mcp_registry.py --check-registry --timeout 300
+
   github-release:
     name: Create GitHub Release
     if: github.ref_type == 'tag'
-    needs: publish-pypi
+    needs:
+      - publish-pypi
+      - publish-mcp-registry
     runs-on: self-hosted
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ### Added
 
+- A capability-aware `search_context` MCP tool and version-matched metadata for
+  publishing the local stdio server as `ai.codenib/codenib` in the official MCP
+  Registry.
 - A repository-aware `codenib toolchain` command that detects graph and LSP
   providers from the language registry, installs pinned package-managed tools
   under `~/.codenib/toolchains`, and reports system or project prerequisites

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@
 graft web
 include CHANGELOG.md
 include CONTRIBUTING.md
+include server.json
 prune web/.next
 prune web/node_modules
 prune web/playwright-report

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@ SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->
+<!-- mcp-name: ai.codenib/codenib -->
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/sysevol-ai/CodeNib/main/assets/codenib_logo.svg" alt="CodeNib" width="560">
-  <h1>A Multi-View Data System for Serving Repository Context to Coding Agents</h1>
+  <h1>Searchable codebase wikis and context for coding agents</h1>
   <p>
-    Incremental compilation, explicit per-view manifests, and agent-native context serving.
+    Point it at any repo, get a searchable Wiki and an MCP server for your coding agent.
   </p>
   <p>
     <a href="https://arxiv.org/abs/2607.25431"><img src="https://img.shields.io/badge/arXiv-2607.25431-b31b1b.svg?logo=arxiv&amp;logoColor=white" alt="arXiv 2607.25431"></a>
@@ -38,16 +39,15 @@ SPDX-License-Identifier: Apache-2.0
   </p>
 </div>
 
-CodeNib is a multi-view data system for serving repository context to coding
-agents. Its native runtime compiles a checkout into manifest-linked lexical,
-semantic, structural, and static-navigation views, incrementally maintains
-supported transitions, and serves bounded source evidence through MCP,
-LSP-shaped providers, Python, and HTTP APIs.
+```bash
+python -m pip install "codenib[mcp,semantic]==0.2.0a2"
+codenib wiki /path/to/your/repo
+```
 
-The Wiki, Ask view, and Dependency Map are inspection clients of that same
-runtime, not the system boundary. The core implementation lives in CodeNib;
-optional model endpoints and language servers are providers rather than a host
-agent or code-Wiki framework.
+Local, open source, and no cloud required. CodeNib combines BM25 and dense code
+search, adds optional SCIP symbol graphs, and incrementally rebuilds repository
+indexes as commits change. The same index powers the Wiki, Dependency Map, Ask,
+and MCP tools instead of making every agent rediscover the codebase.
 
 ## News
 
@@ -175,8 +175,10 @@ codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```
 
-The MCP server advertises its full tool set and uses the compiled manifest to
-decide which calls have a fresh backing view. An agent can therefore reuse
+The MCP server advertises `search_context` as its default ranked entry point,
+then exposes the underlying BM25, vector, graph, and navigation operations for
+explicit control. It uses the compiled manifest to decide which calls have a
+fresh backing view. An agent can therefore reuse
 available repository work instead of rebuilding context through unbounded
 `grep` and `read` loops, while unavailable searches fail explicitly. BM25,
 semantic, regex, Zoekt, dependency, and static-navigation results retain source

--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -31,7 +31,8 @@ then serve their manifest.
 
 ### 1. Build the repository
 
-The default `fast` preset builds BM25:
+The default `auto` preset builds BM25+dense when semantic dependencies are
+installed and otherwise selects the no-model BM25 path:
 
 ```bash
 codenib index /path/to/repo
@@ -46,10 +47,11 @@ codenib index /path/to/repo --preset full
 
 CodeNib writes the manifest below
 `$CODENIB_HOME/repositories/<repo>-<id>/indexes` (default
-`~/.codenib/repositories/...`) and prints its exact path. `search_semantic`
-needs `vector`, `search_bm25` needs `bm25`, `search_regex` and the LSP-shaped
-tools need `symbol_graph`, and `search_zoekt` needs `zoekt`. A failed optional
-view is recorded without discarding successful independent views.
+`~/.codenib/repositories/...`) and prints its exact path. `search_context`
+plans over the loaded `bm25`, `vector`, and `symbol_graph` views;
+`search_semantic` forces `vector`, while `search_regex` and the LSP-shaped tools
+need `symbol_graph`, and `search_zoekt` needs `zoekt`. A failed optional view is
+recorded without discarding successful independent views.
 
 ### 2. Start the MCP server
 
@@ -67,6 +69,7 @@ also remain available. All forms accept
 
 | Tool | Backing index | Result granularity | Use for |
 |------|---------------|--------------------|---------|
+| `search_context` | loaded `bm25`, `vector`, `symbol_graph` | file / symbol | recommended capability-aware ranked retrieval |
 | `search_semantic` | `vector` | file (l0) / symbol (l2) | natural-language / conceptual queries |
 | `search_bm25` | `bm25` | symbol | exact-name / keyword lookups |
 | `search_regex` | `symbol_graph` | file / symbol | structural pattern matching |
@@ -79,6 +82,22 @@ also remain available. All forms accept
 
 All source locations returned by MCP use 1-based line numbers. Internal indexes
 remain 0-based; the MCP adapters perform the conversion once at the boundary.
+
+### `search_context`
+Plans and executes ranked retrieval without asking the agent to choose an index.
+
+- `query` (str): repository question or code query.
+- `top_k` (int, default 10): results returned, from 1 through 100.
+- `budget` (str, default `"balanced"`): `"fast"`, `"balanced"`, or
+  `"thorough"`.
+- `level` (str, default `"l2"`): dense file (`"l0"`) or symbol (`"l2"`)
+  granularity.
+- `filter_test` (bool, default `False`): excludes test files from BM25 branches.
+
+The response contains the concrete `plan`, repository/commit/source-fingerprint
+provenance under `source`, and 1-based source-linked `results`. Reranking is not
+hidden in this tool; the current MCP route uses deterministic retrieval fusion
+and graph expansion only.
 
 ### `search_semantic`
 Vector-embedding similarity search.

--- a/codenib/mcp/prompts.py
+++ b/codenib/mcp/prompts.py
@@ -7,12 +7,21 @@
 CODENIB_GUIDE = """\
 # CodeNib Tools Guide
 
-CodeNib provides several search modes over pre-built indexes. Results retain
-precise file locations and source content: BM25 primarily returns symbols,
-regex searches file and symbol nodes in the CodeGraph, and Zoekt searches raw
-repository files.
+CodeNib serves ranked context and precise navigation over pre-built repository
+indexes. Start with `search_context`: it selects a deterministic BM25, dense,
+hybrid-RRF, or graph-expanded route from the views that are actually loaded.
+Use the lower-level tools when you need to force one operation.
 
 ## When to use each tool
+
+### search_context
+Best default for repository questions. It returns the selected route, indexed
+commit, source fingerprint, and ranked source spans. Use `budget="fast"` for a
+smaller retrieval path or `budget="thorough"` when graph expansion is available.
+
+Examples:
+- "where is retry backoff implemented"
+- "who calls `refresh_credentials` and how is failure handled"
 
 ### search_bm25
 Best for **keyword / exact-name** lookups.  Use when you know (or can guess)
@@ -55,14 +64,18 @@ Examples:
 ### Choosing between them
 | Scenario | Tool |
 |----------|------|
+| General repository question | search_context |
 | Know the exact symbol name | search_bm25 |
 | Looking for a pattern across CodeGraph file/symbol nodes | search_regex |
-| Natural-language description of what the code does | search_bm25 |
+| Force vector similarity for a natural-language query | search_semantic |
 | Need structural filters (by file glob or node type) | search_regex |
 | Need raw-text occurrence anywhere in the repo, fast | search_zoekt |
 | Hit may live in comments / docs / configs (off-graph) | search_zoekt |
 
 ## Tips
+- `search_context` is capability-aware: it does not claim dense or graph
+  execution when those views are unavailable. Inspect its `plan` and `source`
+  fields before using the returned spans.
 - `search_bm25` returns results ranked by BM25 relevance.  Start with
   `top_k=10` and increase if the target is not in the first page.
 - `search_regex` returns **all** matches up to `top_k`.  Use `file_glob`

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -32,7 +32,7 @@ from .context import ServerContext
 from .prompts import CODENIB_GUIDE
 from .tools.dependency import dependency_subgraph_impl
 from .tools.lsp import lsp_definition_impl, lsp_references_impl, lsp_route_impl
-from .tools.search import search_bm25_impl, search_regex_impl
+from .tools.search import search_bm25_impl, search_context_impl, search_regex_impl
 from .tools.search import search_semantic as _search_semantic_impl
 from .tools.search import search_zoekt_impl
 
@@ -53,7 +53,9 @@ mcp = MCPServer(
     "codenib",
     instructions=(
         "CodeNib provides code search over pre-built indexes. "
-        "Use search_semantic for vector/embedding similarity, "
+        "Start with search_context for planned ranked retrieval over the "
+        "available lexical, dense, and structural views. Use search_semantic "
+        "for direct vector/embedding similarity, "
         "search_bm25 for keyword lookups, search_regex for CodeGraph "
         "file/symbol pattern matching, and search_zoekt for fast trigram-based "
         "substring/regex search across raw file contents. Use "
@@ -66,6 +68,36 @@ mcp = MCPServer(
 # ------------------------------------------------------------------
 # Tools
 # ------------------------------------------------------------------
+
+
+@mcp.tool(
+    name="search_context",
+    description=(
+        "Recommended ranked repository-context search. CodeNib selects and "
+        "executes a deterministic BM25, dense, hybrid-RRF, or graph-expanded "
+        "route from the loaded views and requested budget. Returns the selected "
+        "plan, repository provenance, and source-linked results."
+    ),
+)
+async def search_context(
+    query: str,
+    top_k: int = 10,
+    budget: str = "balanced",
+    level: str = "l2",
+    filter_test: bool = False,
+) -> dict[str, Any]:
+    """Execute capability-aware ranked retrieval over loaded repository views."""
+    if _ctx is None:
+        raise RuntimeError("Server not initialized")
+    return await asyncio.to_thread(
+        search_context_impl,
+        _ctx,
+        query,
+        top_k,
+        budget,
+        level,
+        filter_test,
+    )
 
 
 @mcp.tool(

--- a/codenib/mcp/tools/search.py
+++ b/codenib/mcp/tools/search.py
@@ -8,6 +8,7 @@ over backbone indexes."""
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
 
 from ...agent.boundary import to_agent_repr
@@ -18,6 +19,132 @@ from ..context import ServerContext
 def _node_to_dict(node: NodeInfo) -> Dict[str, Any]:
     """Serialize a NodeInfo at the 1-based agent boundary."""
     return to_agent_repr(node)
+
+
+def search_context_impl(
+    ctx: ServerContext,
+    query: str,
+    top_k: int = 10,
+    budget: str = "balanced",
+    level: str = "l2",
+    filter_test: bool = False,
+) -> Dict[str, Any]:
+    """Plan and execute ranked retrieval over the available repository views."""
+    normalized_query = (query or "").strip()
+    if not normalized_query:
+        raise ValueError("query must not be empty.")
+    if isinstance(top_k, bool) or not 1 <= top_k <= 100:
+        raise ValueError("top_k must be between 1 and 100.")
+    normalized_level = (level or "l2").strip().lower()
+    if normalized_level not in {"l0", "l2"}:
+        raise ValueError("level must be 'l0' or 'l2'.")
+
+    from ...model.retrieval_planner import RetrievalCapabilities, RetrievalPlanner
+    from ...ops.retrieve import execute_retrieval_stages
+
+    capabilities = RetrievalCapabilities(
+        has_dense=ctx.vector is not None,
+        has_sparse=ctx.bm25 is not None,
+        has_graph=ctx.symbol_graph is not None,
+        has_embedding_rerank=False,
+        has_llm_rerank=False,
+    )
+    planner = RetrievalPlanner()
+    resolved_budget = planner.normalize_budget(budget)
+    plan = planner.select(
+        normalized_query,
+        budget=resolved_budget,
+        capabilities=capabilities,
+    )
+
+    def execute_stage(active_query: str, stage: Any) -> List[NodeInfo]:
+        if stage.engine == "dense":
+            if ctx.vector is None:
+                raise RuntimeError("Dense retrieval selected without a vector index.")
+            return ctx.vector.search_with_content(
+                query=active_query,
+                top_k=stage.top_k or plan.retrieval_top_k,
+                level=normalized_level,
+                score_threshold=None,
+            )
+        if stage.engine == "sparse":
+            if ctx.bm25 is None:
+                raise RuntimeError("Sparse retrieval selected without a BM25 index.")
+            return ctx.bm25.search(
+                query=active_query,
+                top_k=stage.top_k or plan.retrieval_top_k,
+                return_code_content=True,
+                wrap_with_ln=False,
+                filter_test=filter_test,
+            )
+        raise RuntimeError(f"Unsupported retrieval engine: {stage.engine!r}.")
+
+    candidates = execute_retrieval_stages(
+        normalized_query,
+        plan.stages,
+        execute_stage,
+        top_k=plan.retrieval_top_k,
+        fusion=plan.fusion,
+    )
+    if plan.graph is not None:
+        from ...ops.expand import ExpandContext, expand_retrieval_candidates
+
+        graph = plan.graph
+        candidates = expand_retrieval_candidates(
+            ExpandContext(code_graph=ctx.symbol_graph),
+            candidates,
+            seed_top_k=graph.seed_top_k,
+            expand_top_k=graph.expand_top_k,
+            hops=graph.hops,
+            direction=graph.direction,
+            use_ppr=graph.use_ppr,
+            repo_path=ctx.manifest.repo_path,
+            include_content=True,
+        )
+
+    graph_plan = None
+    if plan.graph is not None:
+        graph_plan = {
+            "seed_top_k": plan.graph.seed_top_k,
+            "expand_top_k": plan.graph.expand_top_k,
+            "hops": plan.graph.hops,
+            "direction": plan.graph.direction,
+            "use_ppr": plan.graph.use_ppr,
+        }
+    artifact = ctx.artifact if isinstance(ctx.artifact, Mapping) else {}
+    results = [_node_to_dict(node) for node in candidates[:top_k]]
+    for result in results:
+        score = result.get("score")
+        if hasattr(score, "item"):
+            result["score"] = float(score.item())
+        elif isinstance(score, (int, float)):
+            result["score"] = float(score)
+
+    return {
+        "plan": {
+            "name": plan.name,
+            "intent": plan.intent,
+            "budget": resolved_budget.tier,
+            "fusion": plan.fusion,
+            "retrieval_top_k": plan.retrieval_top_k,
+            "stages": [
+                {
+                    "engine": stage.engine,
+                    "weight": stage.weight,
+                    "top_k": stage.top_k,
+                }
+                for stage in plan.stages
+            ],
+            "graph": graph_plan,
+            "rationale": plan.rationale,
+        },
+        "source": {
+            "repository": artifact.get("repository") or ctx.manifest.repo_path,
+            "commit": ctx.manifest.commit,
+            "source_fingerprint": ctx.manifest.source_fingerprint,
+        },
+        "results": results,
+    }
 
 
 # ------------------------------------------------------------------

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -16,11 +16,11 @@ from ..index.rerank.cross_encoder import build_reranker
 from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 from ..llm.litellm_chat import LiteLLMChat
 from ..log_utils import get_logger
-from ..ops.expand import ExpandContext, expand_graph_region
+from ..ops.expand import ExpandContext, expand_retrieval_candidates
 from ..ops.rerank import RerankContext, rerank_by_embedding
 from ..ops.retrieve import (
     RetrieveContext,
-    dedup_queried_nodes,
+    execute_retrieval_stages,
     merge_hybrid,
     to_queried_nodes,
 )
@@ -424,24 +424,14 @@ class RetrieveRerankPipeline:
             else RETRIEVAL_TOP_K
         )
 
-        # Step 1: Run each retrieval branch
-        branch_results: List[List[QueriedNode]] = []
-        for stage in active_plan:
-            results = self._run_retrieval_stage(query, stage)
-            branch_results.append(results)
-
-        # Step 2: Merge branches (hybrid if multiple)
-        if len(branch_results) == 1:
-            candidates = branch_results[0]
-        else:
-            weights = [stage.weight for stage in active_plan]
-            candidates = self._merge_hybrid(
-                branch_results,
-                weights,
-                merge_top_k,
-                fusion=fusion or self.fusion_strategy,
-                rrf_k=self.rrf_k,
-            )
+        candidates = execute_retrieval_stages(
+            query,
+            active_plan,
+            self._run_retrieval_stage,
+            top_k=merge_top_k,
+            fusion=fusion or self.fusion_strategy,
+            rrf_k=self.rrf_k,
+        )
 
         if selected_plan is not None and selected_plan.graph is not None:
             candidates = self._run_graph_expansion_plan(selected_plan, candidates)
@@ -574,27 +564,17 @@ class RetrieveRerankPipeline:
         graph_plan = selected_plan.graph
         if graph_plan is None:
             return seeds
-        if self.expand_context.code_graph is None:
-            raise RuntimeError("Graph expansion requested but no code graph is loaded.")
-
-        seed_cap = graph_plan.seed_top_k or len(seeds)
-        graph_seeds = list(seeds[:seed_cap])
-        if not graph_seeds:
-            return []
-
-        expanded = expand_graph_region(
+        return expand_retrieval_candidates(
             self.expand_context,
-            graph_seeds,
-            top_k=graph_plan.expand_top_k,
+            seeds,
+            seed_top_k=graph_plan.seed_top_k,
+            expand_top_k=graph_plan.expand_top_k,
             hops=graph_plan.hops,
             direction=graph_plan.direction,
             use_ppr=graph_plan.use_ppr,
             repo_path=self.repo_path,
             include_content=True,
         )
-
-        candidates = dedup_queried_nodes([*graph_seeds, *expanded])
-        return candidates[: graph_plan.expand_top_k]
 
     @staticmethod
     def _merge_hybrid(

--- a/codenib/ops/expand.py
+++ b/codenib/ops/expand.py
@@ -19,6 +19,7 @@ from ..types import (
     is_symbol_node,
     node_is_reference_only,
 )
+from .retrieve import dedup_queried_nodes
 
 logger = get_logger(__name__)
 
@@ -250,6 +251,42 @@ def expand_graph_region(
         repo_path=repo_path,
         include_content=include_content,
     )
+
+
+def expand_retrieval_candidates(
+    context: ExpandContext,
+    seeds: Sequence[QueriedNode],
+    *,
+    seed_top_k: Optional[int],
+    expand_top_k: int,
+    hops: int,
+    direction: str,
+    use_ppr: bool,
+    repo_path: Optional[str],
+    include_content: bool = True,
+) -> List[QueriedNode]:
+    """Apply a bounded graph expansion plan to ranked retrieval seeds."""
+    if context.code_graph is None:
+        raise RuntimeError("Graph expansion requested but no code graph is loaded.")
+    if expand_top_k <= 0:
+        raise ValueError("expand_top_k must be positive.")
+
+    seed_cap = seed_top_k or len(seeds)
+    graph_seeds = list(seeds[:seed_cap])
+    if not graph_seeds:
+        return []
+
+    expanded = expand_graph_region(
+        context,
+        graph_seeds,
+        top_k=expand_top_k,
+        hops=hops,
+        direction=direction,
+        use_ppr=use_ppr,
+        repo_path=repo_path,
+        include_content=include_content,
+    )
+    return dedup_queried_nodes([*graph_seeds, *expanded])[:expand_top_k]
 
 
 def _expand_neighbor_fallback(

--- a/codenib/ops/retrieve.py
+++ b/codenib/ops/retrieve.py
@@ -12,9 +12,11 @@ from typing import (
     Dict,
     List,
     Optional,
+    Protocol,
     Sequence,
     Set,
     Tuple,
+    TypeVar,
 )
 
 from ..log_utils import get_logger
@@ -26,6 +28,17 @@ if TYPE_CHECKING:
     from ..index.sparse_idx.bm25_index import BM25CodeIndexer
 
 logger = get_logger(__name__)
+
+
+class RetrievalStage(Protocol):
+    """Minimal branch contract consumed by retrieval-plan execution."""
+
+    engine: str
+    weight: float
+    top_k: Optional[int]
+
+
+_StageT = TypeVar("_StageT", bound=RetrievalStage)
 
 
 @dataclass
@@ -72,6 +85,38 @@ def to_queried_nodes(results: Sequence[object]) -> List[QueriedNode]:
             continue
         raise TypeError(f"Unsupported result type for normalization: {type(item)}")
     return converted
+
+
+def execute_retrieval_stages(
+    query: str,
+    stages: Sequence[_StageT],
+    execute_stage: Callable[[str, _StageT], Sequence[object]],
+    *,
+    top_k: int,
+    fusion: str = "weighted",
+    rrf_k: int = 60,
+) -> List[QueriedNode]:
+    """Execute and fuse a declarative set of retrieval branches.
+
+    The caller supplies backend-specific branch execution. Stage iteration,
+    result normalization, weighting, and fusion stay here so standalone
+    pipelines, agent runtimes, and protocol adapters share one implementation.
+    """
+    if not stages:
+        raise ValueError("At least one retrieval stage is required.")
+    if top_k <= 0:
+        raise ValueError("top_k must be positive.")
+
+    branches = [to_queried_nodes(execute_stage(query, stage)) for stage in stages]
+    if len(branches) == 1:
+        return branches[0][:top_k]
+    return merge_hybrid(
+        branches,
+        weights=[stage.weight for stage in stages],
+        top_k=top_k,
+        fusion=fusion,
+        rrf_k=rrf_k,
+    )
 
 
 def merge_hybrid(

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -91,12 +91,30 @@ Transport is stdio and logs go to stderr. A typical client configuration is:
 Use an absolute repository path because the client may launch the server from a
 different working directory.
 
+### MCP Registry
+
+CodeNib publishes its local stdio server as `ai.codenib/codenib` in the
+official MCP Registry. Registry clients request one required value: the
+absolute path to a repository previously indexed with `codenib index`. The
+declared launch is equivalent to:
+
+```bash
+uvx --with "codenib[mcp]==0.2.0a2" \
+  "codenib==0.2.0a2" mcp /absolute/path/to/repository
+```
+
+The Registry path is intentionally query-only and model-free. It can always
+serve the persisted BM25 view without downloading an embedding model. Use the
+normal client configuration above from an environment with `semantic` or
+`graph` installed when those richer persisted views are required.
+
 ## Tools
 
 Only tools whose backing views are fresh and available can return results.
 
 | Tool | Backing view | Granularity | Use for |
 |---|---|---|---|
+| `search_context` | available `bm25`, `vector`, and `symbol_graph` views | file/symbol | Recommended planned ranked search; reports the selected route and source identity |
 | `search_semantic` | `vector` | file/symbol (L0/L2) | Natural-language or conceptual queries |
 | `search_bm25` | `bm25` | symbol | Exact names and keyword lookups |
 | `search_regex` | `symbol_graph` | file / symbol | Structural pattern matching |
@@ -108,6 +126,12 @@ Only tools whose backing views are fresh and available can return results.
 | `get_manifest` | manifest | repository | Repository identity, languages, view states, and capabilities |
 
 All source locations returned by MCP use 1-based line numbers.
+
+`search_context` accepts `query`, `top_k` (1-100), `budget`
+(`fast`, `balanced`, or `thorough`), dense `level` (`l0` or `l2`), and
+`filter_test`. Its response separates the selected `plan`, indexed `source`
+(repository, commit, and source fingerprint), and ranked `results`. It never
+silently labels a sparse fallback as hybrid or graph-expanded execution.
 
 The `codenib-guide` prompt explains how to choose among available tools.
 Parameter and return schemas live in

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -12,6 +12,11 @@ BM25+dense retrieval the recommended local and Pages default, caches the local
 model in Actions, and adds repository-aware management for language-specific
 SCIP and LSP providers.
 
+The MCP server adds `search_context`, a capability-aware ranked entry point that
+reports its BM25, dense, hybrid-RRF, or graph-expanded route with indexed source
+identity. The PyPI package also carries the ownership and launch metadata for
+the official `ai.codenib/codenib` MCP Registry entry.
+
 The release remains an alpha: provider coverage, public Pages, artifact-backed
 MCP, and language toolchain installation are open for compatibility feedback.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -35,8 +35,11 @@ simple index. The workflow byte-compares the downloaded wheel with the verified
 build before installing it in a fresh environment and exercising a real BM25
 index build. Production publishing remains in the separate Release workflow
 and requires a `v<version>` tag that exactly matches `project.version`. After
-PyPI publication, the workflow creates a prerelease GitHub Release containing
-the distributions and `SHA256SUMS`.
+PyPI publication, the production workflow waits for that exact package and its
+MCP ownership marker, publishes `ai.codenib/codenib` to the official MCP
+Registry, verifies Registry discovery, and then creates the prerelease GitHub
+Release containing the distributions and `SHA256SUMS`. TestPyPI does not feed
+the MCP Registry because the Registry accepts only official PyPI packages.
 
 ## Trusted Publisher Setup
 
@@ -68,6 +71,33 @@ bootstrap; [issue #384](https://github.com/sysevol-ai/CodeNib/issues/384)
 tracks restoring its trusted publisher and revoking that token. No publishing
 workflow reads a runner-local `.pypirc`.
 
+## MCP Registry Namespace
+
+The production tag publishes the branded `ai.codenib/codenib` namespace from
+`server.json`. The package README carries the matching hidden `mcp-name` marker,
+and release verification keeps both Registry versions plus the fixed `uvx`
+extra synchronized with `project.version`.
+
+DNS authentication requires one Ed25519 proof record at the `codenib.ai` apex.
+Generate the key once on a trusted machine with OpenSSL 3, add the printed TXT
+record through the DNS provider, and store only the extracted private scalar in
+the protected GitHub environment:
+
+```bash
+openssl genpkey -algorithm Ed25519 -out key.pem
+PUBLIC_KEY="$(openssl pkey -in key.pem -pubout -outform DER | tail -c 32 | base64)"
+echo "codenib.ai. IN TXT \"v=MCPv1; k=ed25519; p=${PUBLIC_KEY}\""
+PRIVATE_KEY="$(openssl pkey -in key.pem -noout -text | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n')"
+printf '%s' "$PRIVATE_KEY" | gh secret set MCP_PRIVATE_KEY \
+  --repo sysevol-ai/CodeNib --env mcp-registry-publish
+```
+
+Do not commit `key.pem`. Configure `mcp-registry-publish` to allow only release
+tags and require a maintainer approval. The publish job deliberately runs on
+`ubuntu-latest`, not a self-hosted runner, and verifies the pinned publisher
+archive before exposing the environment secret. The DNS record belongs at the
+domain apex, not `_mcp-auth.codenib.ai`.
+
 ## Public Surface Gate
 
 Before the production tag, make the repository public and manually dispatch
@@ -88,8 +118,8 @@ on PyPI.
 
 1. Move relevant entries from `Unreleased` into a dated version section in
    `CHANGELOG.md`.
-2. Confirm `pyproject.toml` uses the release version and the README `Citation`
-   section still matches the current arXiv entry.
+2. Confirm `pyproject.toml` uses the release version, `server.json` matches it,
+   and the README citation and `mcp-name` marker remain present.
 3. Run `pre-commit run --all-files` and the local package smoke.
 4. Merge the release commit to `main` and confirm its package gates pass.
 5. Confirm the TestPyPI pending publisher is visible, then dispatch the
@@ -98,8 +128,11 @@ on PyPI.
 7. Complete the public-surface gate above.
 8. Confirm the production `pypi` environment still has its scoped publisher
    credential, or complete #384 and update the workflow to OIDC first.
-9. Create and push an annotated `v<version>` tag.
-10. Confirm the PyPI deployment and generated prerelease GitHub Release.
+9. Confirm the `codenib.ai` MCP proof TXT record and protected
+   `mcp-registry-publish` environment secret are active.
+10. Create and push an annotated `v<version>` tag.
+11. Confirm PyPI, MCP Registry discovery, and the generated prerelease GitHub
+    Release all identify the same version.
 
 Do not reuse a published version. If publication partially succeeds, increment
 the version and produce new artifacts.

--- a/scripts/smoke_release_services.py
+++ b/scripts/smoke_release_services.py
@@ -304,7 +304,12 @@ async def _assert_mcp_async(
                     async with Client(transport, mode=mode, cache=None) as client:
                         tools = await client.list_tools()
                         names = {tool.name for tool in tools.tools}
-                        required = {"get_manifest", "search_bm25", "search_semantic"}
+                        required = {
+                            "get_manifest",
+                            "search_context",
+                            "search_bm25",
+                            "search_semantic",
+                        }
                         if not required.issubset(names):
                             raise RuntimeError(
                                 f"MCP tools are missing in {mode} mode: "
@@ -327,6 +332,27 @@ async def _assert_mcp_async(
                         if "release_signature" not in hits[0].get("content", ""):
                             raise RuntimeError(
                                 f"MCP BM25 hit was unexpected: {hits[0]!r}"
+                            )
+
+                        ranked = await client.call_tool(
+                            "search_context",
+                            arguments={"query": "release_signature", "top_k": 5},
+                        )
+                        ranked_payload = _structured_result(ranked)
+                        ranked_result = ranked_payload.get("result", ranked_payload)
+                        if not isinstance(ranked_result, dict):
+                            raise RuntimeError(
+                                f"MCP ranked search returned no object: {ranked_payload!r}"
+                            )
+                        ranked_hits = ranked_result.get("results")
+                        if (
+                            ranked_result.get("plan", {}).get("name") != "fast_lexical"
+                            or not isinstance(ranked_hits, list)
+                            or not ranked_hits
+                        ):
+                            raise RuntimeError(
+                                "MCP ranked search did not execute its available "
+                                f"BM25 route: {ranked_result!r}"
                             )
 
                         unavailable = await client.call_tool(

--- a/scripts/verify_mcp_registry.py
+++ b/scripts/verify_mcp_registry.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate CodeNib's MCP Registry metadata and published identities."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+
+SERVER_NAME = "ai.codenib/codenib"
+PACKAGE_NAME = "codenib"
+SCHEMA_URL = (
+    "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+)
+PYPI_BASE_URL = "https://pypi.org"
+REGISTRY_API = "https://registry.modelcontextprotocol.io/v0.1/servers"
+
+
+class RegistryValidationError(RuntimeError):
+    """Registry metadata or a published identity violates the release contract."""
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise RegistryValidationError(f"{path} must contain a JSON object")
+    return value
+
+
+def _project(root: Path) -> dict[str, Any]:
+    with (root / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)["project"]
+
+
+def validate_registry_metadata(root: Path) -> tuple[str, dict[str, Any]]:
+    """Validate source metadata and return the package version and server object."""
+    project = _project(root)
+    version = str(project["version"])
+    if project["name"] != PACKAGE_NAME:
+        raise RegistryValidationError(
+            f"project name must be {PACKAGE_NAME!r}, found {project['name']!r}"
+        )
+
+    server = _load_json(root / "server.json")
+    if server.get("$schema") != SCHEMA_URL:
+        raise RegistryValidationError("server.json must use the pinned MCP schema")
+    if server.get("name") != SERVER_NAME:
+        raise RegistryValidationError(
+            f"server name must be {SERVER_NAME!r}, found {server.get('name')!r}"
+        )
+    if server.get("version") != version:
+        raise RegistryValidationError(
+            "server version does not match pyproject.toml: "
+            f"{server.get('version')!r} != {version!r}"
+        )
+
+    packages = server.get("packages")
+    if not isinstance(packages, list) or len(packages) != 1:
+        raise RegistryValidationError("server.json must declare exactly one package")
+    package = packages[0]
+    expected_package_fields = {
+        "registryType": "pypi",
+        "registryBaseUrl": PYPI_BASE_URL,
+        "identifier": PACKAGE_NAME,
+        "version": version,
+        "runtimeHint": "uvx",
+        "transport": {"type": "stdio"},
+    }
+    for field, expected in expected_package_fields.items():
+        if package.get(field) != expected:
+            raise RegistryValidationError(
+                f"server package {field} must be {expected!r}, "
+                f"found {package.get(field)!r}"
+            )
+
+    expected_extra = f"{PACKAGE_NAME}[mcp]=={version}"
+    runtime_arguments = package.get("runtimeArguments")
+    if not isinstance(runtime_arguments, list) or not any(
+        argument.get("type") == "named"
+        and argument.get("name") == "--with"
+        and argument.get("value") == expected_extra
+        for argument in runtime_arguments
+        if isinstance(argument, dict)
+    ):
+        raise RegistryValidationError(
+            f"uvx runtime arguments must install {expected_extra!r}"
+        )
+
+    package_arguments = package.get("packageArguments")
+    if not isinstance(package_arguments, list) or len(package_arguments) != 2:
+        raise RegistryValidationError(
+            "package arguments must contain fixed 'mcp' and one repository path"
+        )
+    if package_arguments[0] != {"type": "positional", "value": "mcp"}:
+        raise RegistryValidationError("the first package argument must select 'mcp'")
+    repository_argument = package_arguments[1]
+    if not (
+        repository_argument.get("type") == "positional"
+        and repository_argument.get("valueHint") == "repository"
+        and repository_argument.get("format") == "filepath"
+        and repository_argument.get("isRequired") is True
+    ):
+        raise RegistryValidationError(
+            "the repository package argument must be a required filepath"
+        )
+
+    extras = project.get("optional-dependencies", {})
+    mcp_dependencies = extras.get("mcp") if isinstance(extras, dict) else None
+    if not isinstance(mcp_dependencies, list) or not any(
+        str(dependency).startswith("mcp") for dependency in mcp_dependencies
+    ):
+        raise RegistryValidationError("the project must publish an MCP extra")
+
+    marker = f"mcp-name: {SERVER_NAME}"
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    if marker not in readme:
+        raise RegistryValidationError(f"README.md is missing {marker!r}")
+    return version, server
+
+
+def validate_server_schema(server: dict[str, Any], schema_path: Path) -> None:
+    """Validate server metadata against a pinned, locally supplied JSON schema."""
+    try:
+        import jsonschema
+    except ModuleNotFoundError as exc:
+        raise RegistryValidationError(
+            "JSON schema validation requires the 'jsonschema' package"
+        ) from exc
+
+    schema = _load_json(schema_path)
+    try:
+        validator_class = jsonschema.validators.validator_for(schema)
+        validator_class.check_schema(schema)
+        validator_class(schema).validate(server)
+    except jsonschema.exceptions.SchemaError as exc:
+        raise RegistryValidationError(
+            f"invalid MCP server schema: {exc.message}"
+        ) from exc
+    except jsonschema.exceptions.ValidationError as exc:
+        location = ".".join(str(part) for part in exc.absolute_path) or "<root>"
+        raise RegistryValidationError(
+            f"server.json violates MCP schema at {location}: {exc.message}"
+        ) from exc
+
+
+def _get_json(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"User-Agent": "codenib-release"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        value = json.load(response)
+    if not isinstance(value, dict):
+        raise RegistryValidationError(f"{url} returned a non-object response")
+    return value
+
+
+def _wait_for(
+    label: str,
+    probe: Callable[[], None],
+    *,
+    timeout: int,
+    interval: int = 10,
+) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while True:
+        try:
+            probe()
+            return
+        except (RegistryValidationError, urllib.error.URLError) as exc:
+            last_error = exc
+        if time.monotonic() >= deadline:
+            raise RegistryValidationError(
+                f"timed out waiting for {label}: {last_error}"
+            ) from last_error
+        time.sleep(interval)
+
+
+def wait_for_pypi(version: str, *, timeout: int) -> None:
+    """Wait until official PyPI exposes the exact package and ownership marker."""
+    marker = f"mcp-name: {SERVER_NAME}"
+    url = f"{PYPI_BASE_URL}/pypi/{PACKAGE_NAME}/{version}/json"
+
+    def probe() -> None:
+        payload = _get_json(url)
+        info = payload.get("info", {})
+        if info.get("version") != version:
+            raise RegistryValidationError("PyPI version metadata has not converged")
+        if marker not in str(info.get("description", "")):
+            raise RegistryValidationError("PyPI README lacks the MCP ownership marker")
+
+    _wait_for(f"PyPI {PACKAGE_NAME} {version}", probe, timeout=timeout)
+
+
+def wait_for_registry(version: str, *, timeout: int) -> None:
+    """Wait until the official Registry exposes CodeNib's exact server version."""
+    query = urllib.parse.urlencode({"search": SERVER_NAME, "version": version})
+
+    def probe() -> None:
+        payload = _get_json(f"{REGISTRY_API}?{query}")
+        for entry in payload.get("servers", []):
+            server = entry.get("server", {}) if isinstance(entry, dict) else {}
+            if server.get("name") == SERVER_NAME and server.get("version") == version:
+                return
+        raise RegistryValidationError(
+            "server version is not visible in Registry search"
+        )
+
+    _wait_for(f"MCP Registry {SERVER_NAME} {version}", probe, timeout=timeout)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--check-pypi", action="store_true")
+    parser.add_argument("--check-registry", action="store_true")
+    parser.add_argument("--schema-file", type=Path)
+    parser.add_argument("--timeout", type=int, default=600)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        version, server = validate_registry_metadata(args.root.resolve())
+        if args.schema_file:
+            validate_server_schema(server, args.schema_file.resolve())
+        if args.check_pypi:
+            wait_for_pypi(version, timeout=args.timeout)
+        if args.check_registry:
+            wait_for_registry(version, timeout=args.timeout)
+    except (OSError, RegistryValidationError, urllib.error.URLError) as exc:
+        print(f"MCP Registry validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"MCP Registry metadata verified: {SERVER_NAME} {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -30,6 +30,7 @@ README_CITATION_MARKERS = (
     "https://arxiv.org/abs/2607.25431",
     "@misc{yu2026codenibmultiviewdataserving,",
 )
+MCP_OWNERSHIP_MARKER = "mcp-name: ai.codenib/codenib"
 
 
 def validate_readme_citation(readme: str) -> None:
@@ -38,6 +39,14 @@ def validate_readme_citation(readme: str) -> None:
     if missing:
         raise ReleaseValidationError(
             "README.md is missing citation markers: " + ", ".join(missing)
+        )
+
+
+def validate_readme_mcp_ownership(readme: str) -> None:
+    """Require the official MCP Registry ownership marker in package metadata."""
+    if MCP_OWNERSHIP_MARKER not in readme:
+        raise ReleaseValidationError(
+            f"README.md is missing MCP ownership marker: {MCP_OWNERSHIP_MARKER}"
         )
 
 
@@ -115,6 +124,7 @@ def _validate_wheel(wheel: Path, name: str, version: str) -> None:
                 f"{wheel.name} has unexpected license expression "
                 f"{message['License-Expression']!r}"
             )
+        validate_readme_mcp_ownership(message.get_payload())
 
         entry_members = sorted(
             member
@@ -138,6 +148,7 @@ def _validate_sdist(sdist: Path, name: str, version: str) -> None:
         f"{root}/CHANGELOG.md",
         f"{root}/LICENSE",
         f"{root}/README.md",
+        f"{root}/server.json",
         f"{root}/pyproject.toml",
         f"{root}/web/package-lock.json",
     }
@@ -151,7 +162,9 @@ def _validate_sdist(sdist: Path, name: str, version: str) -> None:
         readme_file = archive.extractfile(f"{root}/README.md")
         if readme_file is None:  # guarded by the required-members check
             raise ReleaseValidationError(f"{sdist.name} has no readable README.md")
-        validate_readme_citation(readme_file.read().decode("utf-8"))
+        readme = readme_file.read().decode("utf-8")
+        validate_readme_citation(readme)
+        validate_readme_mcp_ownership(readme)
 
 
 def validate_release(

--- a/server.json
+++ b/server.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "ai.codenib/codenib",
+  "title": "CodeNib",
+  "description": "Ranked codebase search and static symbol navigation for coding agents.",
+  "websiteUrl": "https://codenib.ai",
+  "repository": {
+    "url": "https://github.com/sysevol-ai/CodeNib",
+    "source": "github"
+  },
+  "version": "0.2.0a2",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "codenib",
+      "version": "0.2.0a2",
+      "runtimeHint": "uvx",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--with",
+          "value": "codenib[mcp]==0.2.0a2",
+          "description": "Install the version-matched CodeNib MCP runtime extra."
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "valueHint": "repository",
+          "description": "Repository checkout previously indexed with CodeNib.",
+          "format": "filepath",
+          "isRequired": true
+        }
+      ]
+    }
+  ]
+}

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -55,7 +55,12 @@ def test_server_negotiates_modern_and_legacy_protocols() -> None:
     assert modern_version == LATEST_PROTOCOL_VERSION
     assert legacy_version != modern_version
     assert modern_tools == legacy_tools
-    assert {"get_manifest", "search_bm25", "search_semantic"} <= modern_tools
+    assert {
+        "get_manifest",
+        "search_context",
+        "search_bm25",
+        "search_semantic",
+    } <= modern_tools
 
 
 @pytest.fixture

--- a/test/mcp_server/test_server.py
+++ b/test/mcp_server/test_server.py
@@ -30,9 +30,12 @@ def _make_server_ctx(*, bm25_results=None, regex_results=None, zoekt_results=Non
         repo_path="/repo", commit="abc123", languages=["python"]
     )
     ctx.bm25 = MagicMock() if bm25_results is not None else None
+    ctx.vector = None
+    ctx.symbol_graph = None
     ctx.regex_index = MagicMock() if regex_results is not None else None
     ctx.zoekt = MagicMock() if zoekt_results is not None else None
     ctx.errors = {}
+    ctx.artifact = None
     if bm25_results is not None:
         ctx.bm25.search.return_value = bm25_results
     if regex_results is not None:
@@ -56,6 +59,20 @@ def test_search_bm25_tool() -> None:
 
     assert len(result) == 1
     assert result[0]["node_name"] == "foo"
+
+
+def test_search_context_tool() -> None:
+    nodes = [
+        NodeInfo(
+            node_name="foo", type="function", file="a.py", content="def foo(): pass"
+        )
+    ]
+    server_mod._ctx = _make_server_ctx(bm25_results=nodes)
+
+    result = asyncio.run(server_mod.search_context(query="foo", top_k=5))
+
+    assert result["plan"]["name"] == "fast_lexical"
+    assert result["results"][0]["node_name"] == "foo"
 
 
 def test_search_regex_tool() -> None:

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -6,14 +6,17 @@
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock
 
 import pytest
 
+from codenib.compiler.manifest import RepoManifest
 from codenib.index.trigram import ZoektUnavailableError
 from codenib.index.trigram.zoekt_searcher import _file_match_to_node
 from codenib.mcp.tools.search import (
     search_bm25_impl,
+    search_context_impl,
     search_regex_impl,
     search_zoekt_impl,
 )
@@ -24,13 +27,31 @@ from codenib.types import NodeInfo
 # ------------------------------------------------------------------
 
 
-def _make_ctx(*, bm25=None, regex_index=None, zoekt=None, errors=None):
+def _make_ctx(
+    *,
+    bm25=None,
+    vector=None,
+    symbol_graph=None,
+    regex_index=None,
+    zoekt=None,
+    errors=None,
+    artifact=None,
+):
     """Create a minimal mock ServerContext."""
     ctx = MagicMock()
+    ctx.manifest = RepoManifest(
+        repo_path="/repo",
+        commit="abc123",
+        source_fingerprint="sha256:source",
+        languages=["python"],
+    )
     ctx.bm25 = bm25
+    ctx.vector = vector
+    ctx.symbol_graph = symbol_graph
     ctx.regex_index = regex_index
     ctx.zoekt = zoekt
     ctx.errors = errors or {}
+    ctx.artifact = artifact
     return ctx
 
 
@@ -55,6 +76,131 @@ def _sample_nodes() -> list[NodeInfo]:
             score=0.0,
         ),
     ]
+
+
+class TestSearchContext:
+    def test_sparse_plan_returns_route_and_source_provenance(self) -> None:
+        mock_bm25 = MagicMock()
+        mock_bm25.search.return_value = _sample_nodes()
+        ctx = _make_ctx(
+            bm25=mock_bm25,
+            artifact={"repository": "sysevol-ai/CodeNib"},
+        )
+
+        response = search_context_impl(ctx, query="calculate_tax", top_k=1)
+
+        assert response["plan"]["name"] == "fast_lexical"
+        assert response["plan"]["stages"] == [
+            {"engine": "sparse", "weight": 1.0, "top_k": 100}
+        ]
+        assert response["source"] == {
+            "repository": "sysevol-ai/CodeNib",
+            "commit": "abc123",
+            "source_fingerprint": "sha256:source",
+        }
+        assert response["results"][0]["node_name"] == "calculate_tax"
+        assert response["results"][0]["start_line"] == 11
+
+    def test_sparse_plan_does_not_load_optional_graph_runtime(
+        self, monkeypatch
+    ) -> None:
+        mock_bm25 = MagicMock()
+        mock_bm25.search.return_value = _sample_nodes()
+        monkeypatch.setitem(sys.modules, "codenib.ops.expand", None)
+
+        response = search_context_impl(
+            _make_ctx(bm25=mock_bm25), query="calculate_tax", top_k=1
+        )
+
+        assert response["plan"]["name"] == "fast_lexical"
+        assert response["results"][0]["node_name"] == "calculate_tax"
+
+    def test_hybrid_plan_uses_shared_rrf_execution(self) -> None:
+        mock_vector = MagicMock()
+        mock_vector.search_with_content.return_value = [
+            NodeInfo(
+                node_name="shared",
+                node_id="src/shared.py:shared",
+                file="src/shared.py",
+                score=0.9,
+            ),
+            NodeInfo(node_name="dense", node_id="dense", score=0.8),
+        ]
+        mock_bm25 = MagicMock()
+        mock_bm25.search.return_value = [
+            NodeInfo(
+                node_name="shared",
+                node_id="src/shared.py:shared",
+                file="src/shared.py",
+                score=10.0,
+            ),
+            NodeInfo(node_name="sparse", node_id="sparse", score=9.0),
+        ]
+
+        response = search_context_impl(
+            _make_ctx(vector=mock_vector, bm25=mock_bm25),
+            query="explain `retry_handler` behavior",
+            top_k=3,
+        )
+
+        assert response["plan"]["name"] == "hybrid_fusion"
+        assert response["plan"]["fusion"] == "rrf"
+        assert [item["node_id"] for item in response["results"]] == [
+            "src/shared.py:shared",
+            "dense",
+            "sparse",
+        ]
+        mock_vector.search_with_content.assert_called_once()
+        mock_bm25.search.assert_called_once()
+
+    def test_structural_plan_delegates_graph_expansion(self, monkeypatch) -> None:
+        mock_bm25 = MagicMock()
+        mock_bm25.search.return_value = _sample_nodes()[:1]
+        expanded = NodeInfo(
+            node_name="caller", node_id="src/caller.py:caller", file="src/caller.py"
+        )
+        calls = []
+
+        def fake_expand(context, seeds, **kwargs):
+            calls.append((context.code_graph, seeds, kwargs))
+            from codenib.ops.retrieve import to_queried_nodes
+
+            return [*seeds, *to_queried_nodes([expanded])]
+
+        monkeypatch.setattr(
+            "codenib.ops.expand.expand_retrieval_candidates", fake_expand
+        )
+        graph = object()
+
+        response = search_context_impl(
+            _make_ctx(bm25=mock_bm25, symbol_graph=graph),
+            query="who calls calculate_tax",
+            top_k=5,
+        )
+
+        assert response["plan"]["name"] == "structural_graph"
+        assert response["plan"]["graph"]["hops"] == 2
+        assert [item["node_name"] for item in response["results"]] == [
+            "calculate_tax",
+            "caller",
+        ]
+        assert calls[0][0] is graph
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"query": ""}, "query must not be empty"),
+            ({"query": "x", "top_k": 0}, "top_k must be between"),
+            ({"query": "x", "level": "l1"}, "level must be"),
+        ],
+    )
+    def test_validates_request(self, kwargs, message) -> None:
+        with pytest.raises(ValueError, match=message):
+            search_context_impl(_make_ctx(bm25=MagicMock()), **kwargs)
+
+    def test_requires_a_ranked_retrieval_view(self) -> None:
+        with pytest.raises(ValueError, match="No retrieval backend"):
+            search_context_impl(_make_ctx(), query="find parser")
 
 
 # ------------------------------------------------------------------

--- a/test/ops/test_retrieve.py
+++ b/test/ops/test_retrieve.py
@@ -6,14 +6,64 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from codenib.ops.retrieve import (
     dedup_queried_nodes,
+    execute_retrieval_stages,
     merge_file_rankings,
     merge_hybrid,
     queried_file_key,
     queried_node_key,
 )
 from codenib.types import QueriedNode
+
+
+@dataclass(frozen=True)
+class _Stage:
+    engine: str
+    weight: float = 1.0
+    top_k: int | None = None
+
+
+def test_execute_retrieval_stages_runs_and_fuses_declared_branches():
+    stages = [_Stage("dense", 0.6, 3), _Stage("sparse", 0.4, 2)]
+    calls = []
+
+    def execute(query, stage):
+        calls.append((query, stage.engine, stage.top_k))
+        if stage.engine == "dense":
+            return [
+                QueriedNode(node_name="shared", node_id="shared", score=0.9),
+                QueriedNode(node_name="dense", node_id="dense", score=0.8),
+            ]
+        return [
+            QueriedNode(node_name="shared", node_id="shared", score=10.0),
+            QueriedNode(node_name="sparse", node_id="sparse", score=9.0),
+        ]
+
+    result = execute_retrieval_stages(
+        "retry behavior",
+        stages,
+        execute,
+        top_k=3,
+        fusion="rrf",
+    )
+
+    assert calls == [
+        ("retry behavior", "dense", 3),
+        ("retry behavior", "sparse", 2),
+    ]
+    assert [node.node_id for node in result] == ["shared", "dense", "sparse"]
+
+
+def test_execute_retrieval_stages_rejects_empty_plan():
+    try:
+        execute_retrieval_stages("query", [], lambda *_: [], top_k=10)
+    except ValueError as exc:
+        assert "At least one retrieval stage" in str(exc)
+    else:
+        raise AssertionError("empty retrieval plan should fail")
 
 
 def test_queried_node_key_prefers_node_id():

--- a/test/test_mcp_registry.py
+++ b/test/test_mcp_registry.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from scripts import verify_mcp_registry as registry
+
+
+def test_registry_metadata_matches_package_and_uvx_contract() -> None:
+    root = Path(__file__).resolve().parents[1]
+
+    version, server = registry.validate_registry_metadata(root)
+
+    assert version == "0.2.0a2"
+    assert server["name"] == "ai.codenib/codenib"
+    package = server["packages"][0]
+    assert package["identifier"] == "codenib"
+    assert package["runtimeArguments"][0]["value"] == ("codenib[mcp]==0.2.0a2")
+    assert package["packageArguments"][1]["format"] == "filepath"
+
+
+def test_registry_metadata_rejects_version_drift(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1]
+    for filename in ("pyproject.toml", "README.md", "server.json"):
+        shutil.copy2(root / filename, tmp_path / filename)
+    server = json.loads((tmp_path / "server.json").read_text(encoding="utf-8"))
+    server["packages"][0]["version"] = "0.2.0a1"
+    (tmp_path / "server.json").write_text(json.dumps(server), encoding="utf-8")
+
+    with pytest.raises(registry.RegistryValidationError, match="package version"):
+        registry.validate_registry_metadata(tmp_path)
+
+
+def test_pypi_probe_requires_exact_version_and_ownership_marker(monkeypatch) -> None:
+    monkeypatch.setattr(
+        registry,
+        "_get_json",
+        lambda _url: {
+            "info": {
+                "version": "0.2.0a2",
+                "description": "<!-- mcp-name: ai.codenib/codenib -->",
+            }
+        },
+    )
+
+    registry.wait_for_pypi("0.2.0a2", timeout=0)
+
+
+def test_registry_probe_reads_nested_official_response(monkeypatch) -> None:
+    monkeypatch.setattr(
+        registry,
+        "_get_json",
+        lambda _url: {
+            "servers": [
+                {
+                    "server": {
+                        "name": "ai.codenib/codenib",
+                        "version": "0.2.0a2",
+                    }
+                }
+            ]
+        },
+    )
+
+    registry.wait_for_registry("0.2.0a2", timeout=0)

--- a/test/test_namespace_contract.py
+++ b/test/test_namespace_contract.py
@@ -22,6 +22,7 @@ from codenib.mcp.server import mcp
 from codenib.web.config import CACHE_DIR_NAME, QAConfig
 
 _MCP_TOOL_NAMES = {
+    "search_context",
     "search_semantic",
     "search_bm25",
     "search_regex",

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -14,6 +14,7 @@ from scripts.verify_release_artifacts import (
     expected_tag,
     project_identity,
     validate_readme_citation,
+    validate_readme_mcp_ownership,
     validate_tag,
 )
 
@@ -42,6 +43,13 @@ https://arxiv.org/abs/2607.25431
 
     with pytest.raises(ReleaseValidationError, match="citation markers"):
         validate_readme_citation("# CodeNib\n")
+
+
+def test_packaged_readme_requires_mcp_registry_ownership() -> None:
+    validate_readme_mcp_ownership("<!-- mcp-name: ai.codenib/codenib -->")
+
+    with pytest.raises(ReleaseValidationError, match="MCP ownership marker"):
+        validate_readme_mcp_ownership("# CodeNib\n")
 
 
 def test_alpha_release_notes_use_production_pypi_and_pages_permissions() -> None:
@@ -126,6 +134,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert set(production["jobs"]) == {
         "verify",
         "publish-pypi",
+        "publish-mcp-registry",
         "github-release",
     }
     production_publisher = production["jobs"]["publish-pypi"]
@@ -134,6 +143,24 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert publisher_step(production_publisher)["with"]["password"] == (
         "${{ secrets.PYPI_API_TOKEN }}"
     )
+    registry_publisher = production["jobs"]["publish-mcp-registry"]
+    assert registry_publisher["needs"] == "publish-pypi"
+    assert registry_publisher["runs-on"] == "ubuntu-latest"
+    assert registry_publisher["environment"]["name"] == "mcp-registry-publish"
+    assert registry_publisher["permissions"] == {"contents": "read"}
+    registry_steps = {step["name"]: step for step in registry_publisher["steps"]}
+    assert "--check-pypi" in registry_steps["Wait for the exact PyPI package"]["run"]
+    assert (
+        "sha256sum --check" in registry_steps["Install verified MCP publisher"]["run"]
+    )
+    assert registry_steps["Authenticate branded namespace"]["env"] == {
+        "MCP_PRIVATE_KEY": "${{ secrets.MCP_PRIVATE_KEY }}"
+    }
+    assert "--check-registry" in registry_steps["Verify Registry discovery"]["run"]
+    assert production["jobs"]["github-release"]["needs"] == [
+        "publish-pypi",
+        "publish-mcp-registry",
+    ]
 
     assert set(test["jobs"]) == {
         "verify",


### PR DESCRIPTION
## Summary

Publish CodeNib as a discoverable local MCP server with one capability-aware ranked search entry point, version-matched PyPI metadata, and a guarded post-PyPI Registry release path.

## Changes

- Add `search_context`, which selects BM25, dense, hybrid-RRF, or graph-expanded retrieval from loaded views while reusing the shared retrieval and expansion operators.
- Add `server.json`, the PyPI `mcp-name` ownership marker, exact-version validation, and installed-wheel/stdio protocol coverage.
- Publish `ai.codenib/codenib` only after the exact official PyPI artifact is visible, using a protected DNS-authenticated GitHub environment and checksum-pinned publisher.
- Replace the README's paper-style opening with the local Wiki and MCP product path.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `2727 passed, 10 skipped, 183 deselected` in the full unit tier.
- `19 passed` frontend tests and a production frontend build.
- Built and verified the `0.2.0a2` wheel and sdist.
- Installed the wheel in a clean venv and passed Wiki, MCP, stale-checkout, and `search_context` service smoke tests.
- Started the local wheel through the Registry-shaped `uvx --with ... --from ...` command and completed MCP discovery plus a ranked query.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Deployment prerequisite: publish the generated MCP ownership TXT record at the `codenib.ai` apex before tagging `v0.2.0a2`. The protected environment and matching private key are already configured.
