### PR TITLE
chore(release): prepare CodeNib 0.2.0

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -136,6 +136,43 @@ jobs:
           codenib doctor --require core
           python "$GITHUB_WORKSPACE/scripts/smoke_release_install.py"
 
+  upgrade-smoke:
+    name: Upgrade from CodeNib 0.1
+    if: inputs.full
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout upgrade harness
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Exercise the supported upgrade boundary
+        run: |
+          VERSION="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          with Path("pyproject.toml").open("rb") as handle:
+              print(tomllib.load(handle)["project"]["version"])
+          PY
+          )"
+          WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$WHEEL"
+          python scripts/smoke_release_upgrade.py \
+            --wheel "$WHEEL" \
+            --expected-version "$VERSION"
+
   service-smoke:
     name: Installed Wiki and MCP services
     if: inputs.full

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Validate MCP Registry metadata
         run: |
           BUILD_VENV="$RUNNER_TEMP/codenib-release-build-${{ github.run_id }}-${{ github.run_attempt }}"
-          curl --fail --location --retry 3 \
+          curl --fail --location --retry 3 --retry-all-errors \
+            --connect-timeout 10 --max-time 90 \
             --output "$RUNNER_TEMP/mcp-server.schema.json" \
             https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json
           "$BUILD_VENV/bin/python" scripts/verify_mcp_registry.py \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
           MCP_PUBLISHER_VERSION: v1.8.0
           MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
         run: |
-          curl --fail --location --retry 3 \
+          curl --fail --location --retry 3 --retry-all-errors \
+            --connect-timeout 10 --max-time 90 \
             --output mcp-publisher.tar.gz \
             "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
           echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum --check -
@@ -126,7 +127,8 @@ jobs:
           MCP_PUBLISHER_VERSION: v1.8.0
           MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
         run: |
-          curl --fail --location --retry 3 \
+          curl --fail --location --retry 3 --retry-all-errors \
+            --connect-timeout 10 --max-time 90 \
             --output mcp-publisher.tar.gz \
             "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
           echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum --check -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
   registry-auth-preflight:
     name: Verify MCP Registry ownership
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     needs: verify
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
       - "codenib/**"
       - "scripts/smoke_release_install.py"
       - "scripts/smoke_release_services.py"
+      - "scripts/smoke_release_upgrade.py"
       - "scripts/verify_mcp_registry.py"
       - "scripts/verify_release_artifacts.py"
       - "server.json"
@@ -49,10 +50,42 @@ jobs:
     permissions:
       contents: read
 
+  registry-auth-preflight:
+    name: Verify MCP Registry ownership
+    if: github.ref_type == 'tag'
+    needs: verify
+    runs-on: ubuntu-latest
+    environment:
+      name: mcp-registry-publish
+      url: https://registry.modelcontextprotocol.io/v0.1/servers?search=ai.codenib%2Fcodenib
+    permissions:
+      contents: read
+    steps:
+      - name: Install verified MCP publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
+        run: |
+          curl --fail --location --retry 3 \
+            --output mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum --check -
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          ./mcp-publisher --help >/dev/null
+
+      - name: Verify branded namespace ownership
+        env:
+          MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+        run: |
+          test -n "$MCP_PRIVATE_KEY"
+          ./mcp-publisher login dns \
+            --domain codenib.ai \
+            --private-key "$MCP_PRIVATE_KEY"
+
   publish-pypi:
     name: Publish to PyPI
     if: github.ref_type == 'tag'
-    needs: verify
+    needs: registry-auth-preflight
     runs-on: self-hosted
     environment:
       name: pypi
@@ -74,7 +107,7 @@ jobs:
   publish-mcp-registry:
     name: Publish to MCP Registry
     if: github.ref_type == 'tag'
-    needs: publish-pypi
+    needs: verify-pypi-install
     runs-on: ubuntu-latest
     environment:
       name: mcp-registry-publish
@@ -115,6 +148,83 @@ jobs:
       - name: Verify Registry discovery
         run: python scripts/verify_mcp_registry.py --check-registry --timeout 300
 
+  verify-pypi-install:
+    name: Verify installed PyPI package
+    if: github.ref_type == 'tag'
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release smoke harness
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download verified distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Download and match the published wheel
+        run: |
+          VERSION="$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          with Path("pyproject.toml").open("rb") as handle:
+              print(tomllib.load(handle)["project"]["version"])
+          PY
+          )"
+          FETCH_DIR="$RUNNER_TEMP/pypi-download"
+          mkdir -p "$FETCH_DIR"
+          FOUND=0
+          for attempt in $(seq 1 30); do
+            find "$FETCH_DIR" -maxdepth 1 -name '*.whl' -delete
+            if python -m pip download \
+              --disable-pip-version-check \
+              --no-cache-dir \
+              --no-deps \
+              --only-binary=:all: \
+              --dest "$FETCH_DIR" \
+              "codenib==$VERSION"; then
+              FOUND=1
+              break
+            fi
+            if [ "$attempt" -lt 30 ]; then
+              sleep 10
+            fi
+          done
+          test "$FOUND" = 1
+
+          BUILT_WHEEL="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          PYPI_WHEEL="$(find "$FETCH_DIR" -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$BUILT_WHEEL"
+          test -n "$PYPI_WHEEL"
+          test "$(sha256sum "$BUILT_WHEEL" | cut -d' ' -f1)" = \
+            "$(sha256sum "$PYPI_WHEEL" | cut -d' ' -f1)"
+          echo "CODENIB_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "PYPI_WHEEL=$PYPI_WHEEL" >> "$GITHUB_ENV"
+
+      - name: Install the public package with MCP support
+        run: |
+          PUBLIC_VENV="$RUNNER_TEMP/codenib-pypi-smoke"
+          python -m venv "$PUBLIC_VENV"
+          echo "$PUBLIC_VENV/bin" >> "$GITHUB_PATH"
+          "$PUBLIC_VENV/bin/python" -m pip install --upgrade pip
+          "$PUBLIC_VENV/bin/python" -m pip install "${PYPI_WHEEL}[mcp]"
+
+      - name: Exercise public Wiki and MCP services
+        working-directory: ${{ runner.temp }}
+        run: |
+          test "$(codenib --version)" = "codenib $CODENIB_VERSION"
+          python "$GITHUB_WORKSPACE/scripts/smoke_release_services.py"
+
   github-release:
     name: Create GitHub Release
     if: github.ref_type == 'tag'
@@ -125,6 +235,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout release metadata
+        uses: actions/checkout@v4
+
       - name: Download distributions
         uses: actions/download-artifact@v4
         with:
@@ -135,10 +248,30 @@ jobs:
         working-directory: dist
         run: sha256sum *.whl *.tar.gz > SHA256SUMS
 
+      - name: Resolve release channel
+        id: channel
+        run: |
+          PRERELEASE="$(python - <<'PY'
+          import re
+          import tomllib
+          from pathlib import Path
+
+          with Path("pyproject.toml").open("rb") as handle:
+              version = str(tomllib.load(handle)["project"]["version"])
+          print("true" if re.search(r"(?:a|b|rc)\d+|\.dev\d+", version) else "false")
+          PY
+          )"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ steps.channel.outputs.prerelease }}
         run: |
+          RELEASE_FLAGS=(--latest)
+          if [ "$PRERELEASE" = "true" ]; then
+            RELEASE_FLAGS=(--prerelease)
+          fi
           gh release create "$GITHUB_REF_NAME" \
             dist/*.whl \
             dist/*.tar.gz \
@@ -146,5 +279,5 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --title "CodeNib $GITHUB_REF_NAME" \
             --generate-notes \
-            --prerelease \
+            "${RELEASE_FLAGS[@]}" \
             --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,6 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 [Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...v0.2.0
-[0.2.0a2]: https://github.com/sysevol-ai/CodeNib/compare/620a82d...v0.2.0a2
+[0.2.0a2]: https://github.com/sysevol-ai/CodeNib/compare/620a82d...78e12ac
 [0.2.0a1]: https://github.com/sysevol-ai/CodeNib/tree/620a82d
 [0.1.0]: https://github.com/sysevol-ai/CodeNib/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ All notable user-facing changes are recorded here. CodeNib follows
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-05
+
+### Added
+
+- A build-once distribution path that publishes a static Wiki and a verified,
+  commit-addressed context artifact for local or MCP reuse.
+- Capability-aware `search_context` serving through the official
+  `ai.codenib/codenib` MCP package, plus managed package-level SCIP and LSP
+  providers selected from repository languages.
+- Native repository-exploration adapters and quality-constrained token and
+  cost reports for supported agent localization policies.
+
+### Changed
+
+- Hybrid BM25+dense retrieval is the recommended installed default when the
+  semantic extra is present; the base package retains an explicit no-model
+  BM25 path.
+- Repository filtering, graph definition provenance, and TypeScript/TSX import
+  edges use updated builder contracts. Incompatible 0.1 views rebuild once;
+  compatible 0.2 views remain reusable.
+
+### Security
+
+- Downloaded context artifacts are inventory-checked, source-bound, and reject
+  unsafe archive members before any view is loaded.
+
 ## [0.2.0a2] - 2026-08-05
 
 ### Added
@@ -106,7 +132,8 @@ All notable user-facing changes are recorded here. CodeNib follows
 - Prepared secretless PyPI publishing through a dedicated GitHub Actions OIDC
   workflow.
 
-[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0a2...HEAD
+[Unreleased]: https://github.com/sysevol-ai/CodeNib/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/sysevol-ai/CodeNib/compare/v0.1.0...v0.2.0
 [0.2.0a2]: https://github.com/sysevol-ai/CodeNib/compare/620a82d...v0.2.0a2
 [0.2.0a1]: https://github.com/sysevol-ai/CodeNib/tree/620a82d
 [0.1.0]: https://github.com/sysevol-ai/CodeNib/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ SPDX-License-Identifier: Apache-2.0
     <a href="https://pypi.org/project/codenib/"><img src="https://img.shields.io/pypi/v/codenib.svg" alt="PyPI version"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
     <a href="https://github.com/sysevol-ai/CodeNib/blob/main/pyproject.toml"><img src="https://img.shields.io/badge/Python-3.10%2B-3776AB.svg" alt="Python 3.10+"></a>
-    <img src="https://img.shields.io/badge/Release-Developer_Preview-EA580C.svg" alt="Developer Preview">
+    <img src="https://img.shields.io/badge/Release-0.2.0-2563EB.svg" alt="CodeNib 0.2.0">
   </p>
 </div>
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0a2"
+python -m pip install "codenib[mcp,semantic]==0.2.0"
 codenib wiki /path/to/your/repo
 ```
 
@@ -51,12 +51,13 @@ and MCP tools instead of making every agent rediscover the codebase.
 
 ## News
 
+- **2026-08-05 — CodeNib 0.2.0.** Build a static Wiki and reusable context
+  artifact once, then serve it through Pages or the official MCP package.
+  Hybrid retrieval and managed SCIP/LSP providers ship in the same CLI.
+  [Release notes](https://docs.codenib.ai/releases/0.2.0/)
 - **2026-08-05 — SweRank recipe.** Run
   [SweRank](https://github.com/SalesforceAIResearch/SweRank) retrieval and
   reranking over a local checkout. [Example](examples/swerank_retrieve_rerank.py)
-- **2026-08-05 — CodeNib 0.2 alpha.** Hybrid retrieval, managed SCIP/LSP
-  toolchains, and reusable Pages/MCP artifacts.
-  [Release notes](https://docs.codenib.ai/releases/0.2.0/)
 - **2026-08-04 — Native repository explorer.** CodeNib's planner now targets
   the [SWE-Explore](https://github.com/Qiushao-E/SWE-Explore-Bench)
   source-region protocol.
@@ -98,13 +99,13 @@ Requires Python 3.10+ and Git. The recommended local path includes the pinned
 CodeRankEmbed model and serves hybrid BM25+dense retrieval:
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.0a2"
+python -m pip install "codenib[semantic]==0.2.0"
 codenib doctor --require core --require wiki
 codenib wiki /path/to/repository
 ```
 
 `codenib wiki` selects the semantic route because the installed environment
-contains its dependencies. A smaller `python -m pip install codenib==0.2.0a2`
+contains its dependencies. A smaller `python -m pip install codenib==0.2.0`
 installation selects the deterministic BM25 fallback and downloads no model.
 The [0.2 release notes](https://docs.codenib.ai/releases/0.2.0/) record the
 upgrade boundary and verification evidence.
@@ -128,7 +129,7 @@ only their package-level providers; operating-system and project prerequisites
 remain explicit:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.0a2"
+python -m pip install "codenib[graph]==0.2.0"
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
 ```
@@ -170,7 +171,7 @@ Install the MCP extra, build once, and serve the same repository manifest over
 stdio:
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0a2"
+python -m pip install "codenib[mcp,semantic]==0.2.0"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```

--- a/docs/agent_integrations.md
+++ b/docs/agent_integrations.md
@@ -230,7 +230,7 @@ reasoning loop while replacing its repository data plane with
 localization baselines:
 
 ```bash
-python -m pip install "codenib[agent,graph]==0.2.0a2"
+python -m pip install "codenib[agent,graph]==0.2.0"
 codenib toolchain install /path/to/repository --scope graph
 ```
 

--- a/docs/github_pages.md
+++ b/docs/github_pages.md
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0
 ```
 
 The prerelease tag keeps the compiler, frontend, Action, and artifact schema on
@@ -54,7 +54,7 @@ than natural-language retrieval quality:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0
     with:
       preset: fast
 ```
@@ -71,7 +71,7 @@ artifact or Pages workflow:
 ```yaml
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0
     with:
       preset: semantic
       embedding-provider: openai
@@ -141,7 +141,7 @@ The composite Action can be used directly when another static host or artifact
 store owns deployment:
 
 ```yaml
-- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.0a2
+- uses: sysevol-ai/CodeNib/.github/actions/publish@v0.2.0
   id: codenib
   with:
     preset: fast

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,18 +37,18 @@ This site tracks the `0.2` alpha. The recommended local install enables hybrid
 BM25+dense retrieval with the pinned CodeRankEmbed model.
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.0a2"
+python -m pip install "codenib[semantic]==0.2.0"
 codenib wiki /path/to/repository
 ```
 
 The CLI detects the installed semantic capability, writes a reusable manifest
 under `~/.codenib/repositories`, and opens the browser UI. Install
-`codenib==0.2.0a2` without extras for the smaller no-model BM25 fallback. Both
+`codenib==0.2.0` without extras for the smaller no-model BM25 fallback. Both
 paths leave the target checkout unchanged. Read the [Quickstart](quickstart.md)
 for provider setup and troubleshooting.
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0a2"
+python -m pip install "codenib[mcp,semantic]==0.2.0"
 codenib mcp /path/to/repository
 ```
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -18,21 +18,21 @@ installs MCP with semantic retrieval; the default `auto` preset resolves to
 BM25+dense in that environment:
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0a2"
+python -m pip install "codenib[mcp,semantic]==0.2.0"
 codenib index /path/to/repository
 ```
 
 Use the smaller no-model fallback when semantic retrieval is not required:
 
 ```bash
-python -m pip install "codenib[mcp]==0.2.0a2"
+python -m pip install "codenib[mcp]==0.2.0"
 codenib index /path/to/repository --preset fast
 ```
 
 Add static navigation and dependency tools without the embedding download:
 
 ```bash
-python -m pip install "codenib[graph,mcp]==0.2.0a2"
+python -m pip install "codenib[graph,mcp]==0.2.0"
 codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset graph
 ```
@@ -99,8 +99,8 @@ absolute path to a repository previously indexed with `codenib index`. The
 declared launch is equivalent to:
 
 ```bash
-uvx --with "codenib[mcp]==0.2.0a2" \
-  "codenib==0.2.0a2" mcp /absolute/path/to/repository
+uvx --with "codenib[mcp]==0.2.0" \
+  "codenib==0.2.0" mcp /absolute/path/to/repository
 ```
 
 The Registry path is intentionally query-only and model-free. It can always
@@ -142,7 +142,7 @@ Parameter and return schemas live in
 The `full` preset requests BM25, vectors, a symbol graph, and Zoekt:
 
 ```bash
-python -m pip install "codenib[full]==0.2.0a2"
+python -m pip install "codenib[full]==0.2.0"
 codenib toolchain install /path/to/repository --scope graph
 codenib index /path/to/repository --preset full
 ```

--- a/docs/product_roadmap.md
+++ b/docs/product_roadmap.md
@@ -168,9 +168,8 @@ remains part of M6 acceptance.
 
 ### M4: Product interaction
 
-Status: substantially complete for the Developer Preview. Index build progress
-is currently explicit in the CLI before the Wiki opens; in-page progress is a
-post-preview enhancement.
+Status: complete for 0.2.0. Index build progress is explicit in the CLI before
+the Wiki opens; in-page progress remains a post-0.2 enhancement.
 
 - Present build and generation progress in the Wiki.
 - Integrate Dependency Map, page-local graph snapshots, search, and source
@@ -180,8 +179,8 @@ post-preview enhancement.
 
 ### M5: Distribution
 
-Status: wheel path complete for the Developer Preview. Docker remains a
-post-preview distribution path.
+Status: wheel, Pages, and artifact-backed MCP paths complete for 0.2.0. Docker
+remains a post-0.2 distribution path.
 
 - Ship prebuilt frontend assets instead of installing a frontend development
   tree on first use.
@@ -191,7 +190,9 @@ post-preview distribution path.
 
 ### M6: Release acceptance
 
-Status: local acceptance complete; PR reconciliation and publication remain.
+Status: complete. Packaged acceptance covers the wheel, Wiki, MCP, Ask, graph,
+Pages, and commit-addressed artifact reuse paths; production publication is
+tracked by the release workflow.
 
 - Run the packaged product against representative Python, TypeScript, and
   mixed-language repositories.
@@ -234,11 +235,11 @@ Acceptance evidence on 2026-07-26:
 
 ## Hosted Distribution Program
 
-Status: active. Tracked by
-[RFC #415](https://github.com/sysevol-ai/CodeNib/issues/415).
+Status: complete for 0.2.0. The implementation and acceptance evidence are
+recorded in [RFC #415](https://github.com/sysevol-ai/CodeNib/issues/415).
 
-The local Developer Preview above established the compiler and runtime. The
-next product stage makes their output reusable across deployment surfaces:
+The local product baseline above established the compiler and runtime. The
+distribution stage makes their output reusable across deployment surfaces:
 
 > Build repository context once, then serve the same provenance-checked
 > artifact to people and coding agents.
@@ -329,7 +330,8 @@ tests and a focused end-to-end smoke run precede slow remote CI.
 
 ## Completion Rule
 
-The Developer Preview baseline is complete. The hosted product goal remains
-active until H1-H6 are implemented, locally verified, documented, and
-reproduced from pinned release artifacts. A single successful demo repository
-or green remote CI run does not complete the goal.
+The 0.2 product baseline is complete only when H1-H6 are implemented, locally
+verified, documented, and reproduced from pinned release artifacts. That bar
+was met by the pinned TestPyPI candidate and the matching release matrix; the
+stable tag remains a publication operation. Future hosted inference and
+enterprise storage work remains independent of the open-source 0.2 release.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,17 +15,17 @@ embedding model, so it needs no API key.
 - Python 3.10 or newer
 - Git
 
-This documentation tracks the `0.2` feature line. Install the exact alpha and
+This documentation tracks the `0.2` feature line. Install the exact release and
 its local semantic dependencies from PyPI:
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.0a2"
+python -m pip install "codenib[semantic]==0.2.0"
 codenib --version
 codenib doctor --require core --require wiki
 ```
 
-The version command must report `codenib 0.2.0a2`. Exact version pins keep an
-alpha environment reproducible. Install `codenib==0.2.0a2` without extras when
+The version command must report `codenib 0.2.0`. Exact version pins keep the
+environment reproducible. Install `codenib==0.2.0` without extras when
 a smaller, no-model BM25 fallback is more important than natural-language
 retrieval quality.
 
@@ -155,7 +155,7 @@ To keep embeddings out of the local process, use a BYO OpenAI-compatible
 embedding service:
 
 ```bash
-python -m pip install "codenib[semantic-remote]==0.2.0a2"
+python -m pip install "codenib[semantic-remote]==0.2.0"
 export EMBEDDING_API_KEY=...
 codenib doctor --require semantic \
   --embedding-provider openai \
@@ -225,7 +225,7 @@ clangd, and live LSP providers are language-specific executables, so CodeNib
 plans them from the detected repository rather than installing every language:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.0a2"
+python -m pip install "codenib[graph]==0.2.0"
 codenib toolchain status /path/to/repository --scope graph
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
@@ -272,7 +272,7 @@ Static Wiki pages are the default. To generate conceptual page narratives
 through a LiteLLM-supported provider:
 
 ```bash
-python -m pip install "codenib[agent,semantic]==0.2.0a2"
+python -m pip install "codenib[agent,semantic]==0.2.0"
 export OPENAI_API_KEY=...
 codenib doctor --require agent \
   --model openai/gpt-4o-mini --api-key-env OPENAI_API_KEY --probe-model
@@ -303,7 +303,7 @@ codenib wiki . --generate --model anthropic/claude-sonnet-4-5
 Vertex AI additionally requires CodeNib's `vertex` extra:
 
 ```bash
-python -m pip install "codenib[agent,semantic,vertex]==0.2.0a2"
+python -m pip install "codenib[agent,semantic,vertex]==0.2.0"
 gcloud auth application-default login
 codenib wiki . --generate \
   --model vertex_ai/gemini-2.5-flash \
@@ -358,7 +358,7 @@ continues to work.
 ## Serve The Index Over MCP
 
 ```bash
-python -m pip install "codenib[mcp,semantic]==0.2.0a2"
+python -m pip install "codenib[mcp,semantic]==0.2.0"
 codenib index /path/to/repository
 codenib mcp /path/to/repository
 ```

--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -4,37 +4,40 @@ SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# CodeNib 0.2.0 Alpha 2
+# CodeNib 0.2.0
 
-CodeNib 0.2.0 Alpha 2 packages the build-once, serve-everywhere
-repository-context path behind a normal PyPI prerelease. It makes hybrid
-BM25+dense retrieval the recommended local and Pages default, caches the local
-model in Actions, and adds repository-aware management for language-specific
-SCIP and LSP providers.
+CodeNib 0.2.0 packages the build-once, serve-everywhere repository-context
+path. One indexed commit can power a local Wiki, a serverless Pages site, and
+an MCP server without rebuilding the repository for each surface. Hybrid
+BM25+dense retrieval is the recommended local and Pages default, while the
+model-free BM25 path remains available.
 
 The MCP server adds `search_context`, a capability-aware ranked entry point that
 reports its BM25, dense, hybrid-RRF, or graph-expanded route with indexed source
-identity. The PyPI package also carries the ownership and launch metadata for
-the official `ai.codenib/codenib` MCP Registry entry.
-
-The release remains an alpha: provider coverage, public Pages, artifact-backed
-MCP, and language toolchain installation are open for compatibility feedback.
+identity. Verified context artifacts can be rebound to an exact checkout and
+served through the official `ai.codenib/codenib` MCP Registry entry. The CLI
+also detects repository languages and manages pinned package-level SCIP and LSP
+providers without mutating the target checkout.
 
 ## Upgrade
 
 ```bash
-python -m pip install --upgrade "codenib[semantic]==0.2.0a2"
+python -m pip install --upgrade "codenib[semantic]==0.2.0"
 codenib --version
 codenib doctor --require core --require wiki
 ```
 
-The version command must report `codenib 0.2.0a2`. The semantic extra enables
-the `auto` preset's BM25+dense route. Install `codenib==0.2.0a2` without extras
+The version command must report `codenib 0.2.0`. The semantic extra enables
+the `auto` preset's BM25+dense route. Install `codenib==0.2.0` without extras
 for the deterministic no-model fallback.
 
 Existing BM25 and vector manifests are checked when opened. CodeNib reuses a
 compatible view and rebuilds rather than silently substituting an incompatible
 provider or source identity.
+
+The repository filtering and BM25 builder contracts changed after 0.1.0, so an
+older BM25 view is rebuilt once and then reused by later 0.2 runs. This upgrade
+path is exercised by the installed-package release gate.
 
 Graph schema 5 changes definition provenance and TypeScript/TSX import edges.
 Rebuild graph artifacts created by 0.1.x once:
@@ -51,7 +54,7 @@ Language-specific graph and live-navigation providers are no longer exposed
 as a list of shell exports. Install only those needed by one checkout:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.0a2"
+python -m pip install "codenib[graph]==0.2.0"
 codenib toolchain install /path/to/repository --scope graph
 codenib toolchain install /path/to/repository --scope lsp
 codenib doctor /path/to/repository --require graph
@@ -70,7 +73,7 @@ permissions:
 
 jobs:
   publish:
-    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2
+    uses: sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0
 ```
 
 The default workflow publishes precomputed pages, citations, navigation, and
@@ -83,7 +86,7 @@ After checking out the recorded commit, reuse the artifact without another
 index build:
 
 ```bash
-python -m pip install --upgrade "codenib[mcp,semantic]==0.2.0a2"
+python -m pip install --upgrade "codenib[mcp,semantic]==0.2.0"
 export GH_TOKEN="$(gh auth token)"
 codenib artifact fetch owner/repository --repo /path/to/repository
 codenib artifact mcp-config \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,11 +21,14 @@ workflows. Pull requests build and inspect the distribution once. Pushes to
 3. Runs `twine check` and validates package contents and metadata.
 4. Installs the wheel on every supported Python minor version.
 5. Builds a real BM25 index through the installed `codenib` command.
-6. Exercises the installed Wiki and MCP services end to end.
-7. Runs sparse Ask through a local OpenAI-compatible endpoint, including a
+6. Installs the public 0.1.0 package, upgrades it to the candidate wheel,
+   verifies that an incompatible BM25 view rebuilds once, and then verifies
+   that the rebuilt view is reused.
+7. Exercises the installed Wiki and MCP services end to end.
+8. Runs sparse Ask through a local OpenAI-compatible endpoint, including a
    real BM25 tool call, final answer, and source citation, without installing
    semantic or graph extras.
-8. Installs the graph extra and a pinned Python SCIP provider, then verifies
+9. Installs the graph extra and a pinned Python SCIP provider, then verifies
    repository-aware diagnostics, a real caller-to-callee graph edge, source
    anchors, and the installed Dependency Map API.
 
@@ -34,12 +37,15 @@ publishes to TestPyPI, then downloads that exact version from TestPyPI's public
 simple index. The workflow byte-compares the downloaded wheel with the verified
 build before installing it in a fresh environment and exercising a real BM25
 index build. Production publishing remains in the separate Release workflow
-and requires a `v<version>` tag that exactly matches `project.version`. After
-PyPI publication, the production workflow waits for that exact package and its
-MCP ownership marker, publishes `ai.codenib/codenib` to the official MCP
-Registry, verifies Registry discovery, and then creates the prerelease GitHub
-Release containing the distributions and `SHA256SUMS`. TestPyPI does not feed
-the MCP Registry because the Registry accepts only official PyPI packages.
+and requires a `v<version>` tag that exactly matches `project.version`. Before
+any upload, the production workflow proves MCP DNS ownership so a missing
+record cannot leave a partial release. It then publishes to PyPI,
+downloads and byte-compares the exact public wheel, exercises its installed
+Wiki and MCP services, publishes `ai.codenib/codenib` to the official MCP
+Registry, and verifies Registry discovery. The final GitHub Release contains
+the distributions and `SHA256SUMS`; stable versions are marked latest and PEP
+440 prereleases remain prereleases. TestPyPI does not feed the MCP Registry
+because the Registry accepts only official PyPI packages.
 
 ## Trusted Publisher Setup
 
@@ -95,8 +101,10 @@ printf '%s' "$PRIVATE_KEY" | gh secret set MCP_PRIVATE_KEY \
 Do not commit `key.pem`. Configure `mcp-registry-publish` to allow only release
 tags and require a maintainer approval. The publish job deliberately runs on
 `ubuntu-latest`, not a self-hosted runner, and verifies the pinned publisher
-archive before exposing the environment secret. The DNS record belongs at the
-domain apex, not `_mcp-auth.codenib.ai`.
+archive before exposing the environment secret. A tag preflight performs this
+authentication before PyPI upload; the Registry job repeats it immediately
+before publication. The DNS record belongs at the domain apex, not
+`_mcp-auth.codenib.ai`.
 
 ## Public Surface Gate
 
@@ -131,8 +139,8 @@ on PyPI.
 9. Confirm the `codenib.ai` MCP proof TXT record and protected
    `mcp-registry-publish` environment secret are active.
 10. Create and push an annotated `v<version>` tag.
-11. Confirm PyPI, MCP Registry discovery, and the generated prerelease GitHub
-    Release all identify the same version.
+11. Confirm PyPI, MCP Registry discovery, and the generated GitHub Release all
+    identify the same version and that a stable release is marked latest.
 
 Do not reuse a published version. If publication partially succeeds, increment
 the version and produce new artifacts.

--- a/docs/scip_index.md
+++ b/docs/scip_index.md
@@ -23,7 +23,7 @@ Install the graph dependencies, check the target repository, and then select
 the graph preset:
 
 ```bash
-python -m pip install "codenib[graph]==0.2.0a2"
+python -m pip install "codenib[graph]==0.2.0"
 codenib toolchain install /path/to/repository --scope graph
 codenib doctor /path/to/repository --require graph
 codenib index /path/to/repository --preset graph

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -10,7 +10,7 @@ For one local repository, use the packaged two-command path in the
 [Quickstart](quickstart.md):
 
 ```bash
-python -m pip install "codenib[semantic]==0.2.0a2"
+python -m pip install "codenib[semantic]==0.2.0"
 codenib wiki /path/to/repository
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,7 +165,7 @@ nav:
   - Get Started:
       - get-started/index.md
       - Quickstart: quickstart.md
-      - Release 0.2.0 Alpha 2: releases/0.2.0.md
+      - Release 0.2.0: releases/0.2.0.md
       - GitHub Pages: github_pages.md
       - Web UI: web_demo.md
       - Running Locally: running-locally.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codenib"
-version = "0.2.0a2"
+version = "0.2.0"
 description = "A multi-view data system for serving repository context to coding agents"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,7 +22,7 @@ keywords = [
     "static-analysis",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",

--- a/scripts/smoke_release_upgrade.py
+++ b/scripts/smoke_release_upgrade.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise the supported CodeNib 0.1 to 0.2 package upgrade boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import venv
+from pathlib import Path
+from typing import Sequence
+
+BASELINE_VERSION = "0.1.0"
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    print("+", " ".join(str(part) for part in command), flush=True)
+    return subprocess.run(
+        [str(part) for part in command],
+        cwd=cwd,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _venv_command(root: Path, name: str) -> Path:
+    directory = "Scripts" if os.name == "nt" else "bin"
+    suffix = ".exe" if os.name == "nt" else ""
+    return root / directory / f"{name}{suffix}"
+
+
+def _manifest_path(
+    python: Path,
+    repo: Path,
+    *,
+    root: Path,
+    env: dict[str, str],
+) -> Path:
+    result = _run(
+        [
+            python,
+            "-c",
+            (
+                "import sys\n"
+                "from codenib.paths import repo_index_dir\n"
+                "print(repo_index_dir(sys.argv[1]) / 'repo_manifest.json')\n"
+            ),
+            repo,
+        ],
+        cwd=root,
+        env=env,
+    )
+    return Path(result.stdout.strip())
+
+
+def _load_bm25(manifest_path: Path) -> dict[str, object]:
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    bm25 = payload.get("indexes", {}).get("bm25")
+    if not isinstance(bm25, dict) or bm25.get("status") != "fresh":
+        raise RuntimeError(f"BM25 view is not fresh: {bm25!r}")
+    return bm25
+
+
+def smoke(wheel: Path, *, expected_version: str, root: Path) -> None:
+    repository = root / "upgrade-repository"
+    repository.mkdir(parents=True)
+    (repository / "calculator.py").write_text(
+        "def stable_upgrade_probe(left: int, right: int) -> int:\n"
+        "    return left + right\n",
+        encoding="utf-8",
+    )
+    _run(["git", "init", "--quiet"], cwd=repository, env=os.environ.copy())
+    _run(
+        ["git", "config", "user.email", "release-smoke@example.invalid"],
+        cwd=repository,
+        env=os.environ.copy(),
+    )
+    _run(
+        ["git", "config", "user.name", "CodeNib Release Smoke"],
+        cwd=repository,
+        env=os.environ.copy(),
+    )
+    _run(["git", "add", "."], cwd=repository, env=os.environ.copy())
+    _run(
+        ["git", "commit", "--quiet", "-m", "initial fixture"],
+        cwd=repository,
+        env=os.environ.copy(),
+    )
+
+    environment = os.environ.copy()
+    environment["HOME"] = str(root / "home")
+    environment["CODENIB_HOME"] = str(root / "state")
+    environment["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    Path(environment["HOME"]).mkdir()
+
+    virtualenv = root / "venv"
+    venv.EnvBuilder(with_pip=True).create(virtualenv)
+    python = _venv_command(virtualenv, "python")
+    pip = _venv_command(virtualenv, "pip")
+    codenib = _venv_command(virtualenv, "codenib")
+
+    _run(
+        [pip, "install", f"codenib=={BASELINE_VERSION}"],
+        cwd=root,
+        env=environment,
+    )
+    _run(
+        [codenib, "index", repository, "--preset", "fast"],
+        cwd=root,
+        env=environment,
+    )
+    manifest_path = _manifest_path(
+        python,
+        repository,
+        root=root,
+        env=environment,
+    )
+    baseline = _load_bm25(manifest_path)
+
+    _run([pip, "install", "--upgrade", wheel], cwd=root, env=environment)
+    version = _run([codenib, "--version"], cwd=root, env=environment).stdout.strip()
+    if version != f"codenib {expected_version}":
+        raise RuntimeError(f"unexpected upgraded version: {version!r}")
+
+    _run(
+        [codenib, "index", repository, "--preset", "fast"],
+        cwd=root,
+        env=environment,
+    )
+    upgraded = _load_bm25(manifest_path)
+    if upgraded.get("built_at") == baseline.get("built_at"):
+        raise RuntimeError("0.2 reused the incompatible 0.1 BM25 view")
+    upgraded_config = upgraded.get("config")
+    if not isinstance(upgraded_config, dict):
+        raise RuntimeError(f"upgraded BM25 view has no config: {upgraded!r}")
+    if upgraded_config.get("builder_schema") != 6:
+        raise RuntimeError(f"unexpected BM25 builder schema: {upgraded_config!r}")
+    if upgraded_config.get("repository_filter_policy") != 3:
+        raise RuntimeError(f"unexpected repository filter policy: {upgraded_config!r}")
+
+    _run(
+        [codenib, "index", repository, "--preset", "fast"],
+        cwd=root,
+        env=environment,
+    )
+    reused = _load_bm25(manifest_path)
+    if reused.get("built_at") != upgraded.get("built_at"):
+        raise RuntimeError("the compatible 0.2 BM25 view was rebuilt again")
+    status = _run(
+        ["git", "status", "--porcelain"],
+        cwd=repository,
+        env=environment,
+    ).stdout
+    if status:
+        raise RuntimeError(f"upgrade modified the target repository: {status!r}")
+    print(
+        f"Upgrade smoke passed: {BASELINE_VERSION} -> {expected_version}; "
+        "incompatible BM25 rebuilt once and then reused"
+    )
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wheel", type=Path, required=True)
+    parser.add_argument("--expected-version", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    wheel = args.wheel.expanduser().resolve()
+    if not wheel.is_file():
+        print(f"upgrade smoke failed: wheel not found: {wheel}", file=sys.stderr)
+        return 1
+    try:
+        with tempfile.TemporaryDirectory(prefix="codenib-upgrade-smoke-") as value:
+            smoke(wheel, expected_version=args.expected_version, root=Path(value))
+    except (OSError, RuntimeError, subprocess.CalledProcessError) as exc:
+        print(f"upgrade smoke failed: {exc}", file=sys.stderr)
+        if isinstance(exc, subprocess.CalledProcessError):
+            if exc.stdout:
+                print(exc.stdout, file=sys.stderr)
+            if exc.stderr:
+                print(exc.stderr, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.json
+++ b/server.json
@@ -8,19 +8,19 @@
     "url": "https://github.com/sysevol-ai/CodeNib",
     "source": "github"
   },
-  "version": "0.2.0a2",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "codenib",
-      "version": "0.2.0a2",
+      "version": "0.2.0",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {
           "type": "named",
           "name": "--with",
-          "value": "codenib[mcp]==0.2.0a2",
+          "value": "codenib[mcp]==0.2.0",
           "description": "Install the version-matched CodeNib MCP runtime extra."
         }
       ],

--- a/test/test_mcp_registry.py
+++ b/test/test_mcp_registry.py
@@ -18,11 +18,11 @@ def test_registry_metadata_matches_package_and_uvx_contract() -> None:
 
     version, server = registry.validate_registry_metadata(root)
 
-    assert version == "0.2.0a2"
+    assert version == "0.2.0"
     assert server["name"] == "ai.codenib/codenib"
     package = server["packages"][0]
     assert package["identifier"] == "codenib"
-    assert package["runtimeArguments"][0]["value"] == ("codenib[mcp]==0.2.0a2")
+    assert package["runtimeArguments"][0]["value"] == ("codenib[mcp]==0.2.0")
     assert package["packageArguments"][1]["format"] == "filepath"
 
 
@@ -44,13 +44,13 @@ def test_pypi_probe_requires_exact_version_and_ownership_marker(monkeypatch) -> 
         "_get_json",
         lambda _url: {
             "info": {
-                "version": "0.2.0a2",
+                "version": "0.2.0",
                 "description": "<!-- mcp-name: ai.codenib/codenib -->",
             }
         },
     )
 
-    registry.wait_for_pypi("0.2.0a2", timeout=0)
+    registry.wait_for_pypi("0.2.0", timeout=0)
 
 
 def test_registry_probe_reads_nested_official_response(monkeypatch) -> None:
@@ -62,11 +62,11 @@ def test_registry_probe_reads_nested_official_response(monkeypatch) -> None:
                 {
                     "server": {
                         "name": "ai.codenib/codenib",
-                        "version": "0.2.0a2",
+                        "version": "0.2.0",
                     }
                 }
             ]
         },
     )
 
-    registry.wait_for_registry("0.2.0a2", timeout=0)
+    registry.wait_for_registry("0.2.0", timeout=0)

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -24,13 +24,13 @@ def test_project_identity_and_tag_match_release_metadata() -> None:
     name, version = project_identity(root / "pyproject.toml")
 
     assert name == "codenib"
-    assert expected_tag(version) == "v0.2.0a2"
-    validate_tag("v0.2.0a2", version)
+    assert expected_tag(version) == "v0.2.0"
+    validate_tag("v0.2.0", version)
 
 
 def test_release_tag_must_match_project_version() -> None:
     with pytest.raises(ReleaseValidationError, match="does not match"):
-        validate_tag("v0.1.0", "0.2.0a2")
+        validate_tag("v0.1.0", "0.2.0")
 
 
 def test_packaged_readme_requires_the_arxiv_citation() -> None:
@@ -52,13 +52,13 @@ def test_packaged_readme_requires_mcp_registry_ownership() -> None:
         validate_readme_mcp_ownership("# CodeNib\n")
 
 
-def test_alpha_release_notes_use_production_pypi_and_pages_permissions() -> None:
+def test_stable_release_notes_use_production_pypi_and_pages_permissions() -> None:
     root = Path(__file__).resolve().parents[1]
     notes = (root / "docs" / "releases" / "0.2.0.md").read_text(encoding="utf-8")
 
-    assert '"codenib[semantic]==0.2.0a2"' in notes
-    assert '"codenib[mcp,semantic]==0.2.0a2"' in notes
-    assert "sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0a2" in notes
+    assert '"codenib[semantic]==0.2.0"' in notes
+    assert '"codenib[mcp,semantic]==0.2.0"' in notes
+    assert "sysevol-ai/CodeNib/.github/workflows/codenib-pages.yml@v0.2.0" in notes
     assert "test-files.pythonhosted.org" not in notes
     assert "--extra-index-url" not in notes
     assert "--index-url" not in notes
@@ -78,7 +78,7 @@ def test_alpha_release_notes_use_production_pypi_and_pages_permissions() -> None
         "docs/web_demo.md",
     ),
 )
-def test_public_alpha_install_commands_do_not_select_stable_0_1(
+def test_public_install_commands_select_the_current_stable_release(
     relative_path: str,
 ) -> None:
     root = Path(__file__).resolve().parents[1]
@@ -93,7 +93,7 @@ def test_public_alpha_install_commands_do_not_select_stable_0_1(
 
     assert install_lines
     assert "CODENIB_ALPHA_WHEEL=" not in text
-    assert all("==0.2.0a2" in line for line in install_lines)
+    assert all("==0.2.0" in line for line in install_lines)
 
 
 def test_registry_publishers_use_separate_workflows() -> None:
@@ -133,18 +133,43 @@ def test_registry_publishers_use_separate_workflows() -> None:
 
     assert set(production["jobs"]) == {
         "verify",
+        "registry-auth-preflight",
         "publish-pypi",
+        "verify-pypi-install",
         "publish-mcp-registry",
         "github-release",
     }
+    registry_preflight = production["jobs"]["registry-auth-preflight"]
+    assert registry_preflight["needs"] == "verify"
+    assert registry_preflight["runs-on"] == "ubuntu-latest"
+    assert registry_preflight["environment"]["name"] == "mcp-registry-publish"
+    preflight_steps = {step["name"]: step for step in registry_preflight["steps"]}
+    assert (
+        "sha256sum --check" in preflight_steps["Install verified MCP publisher"]["run"]
+    )
+    assert "login dns" in preflight_steps["Verify branded namespace ownership"]["run"]
     production_publisher = production["jobs"]["publish-pypi"]
+    assert production_publisher["needs"] == "registry-auth-preflight"
     assert production_publisher["environment"]["name"] == "pypi"
     assert production_publisher["permissions"] == {"contents": "read"}
     assert publisher_step(production_publisher)["with"]["password"] == (
         "${{ secrets.PYPI_API_TOKEN }}"
     )
+    pypi_install = production["jobs"]["verify-pypi-install"]
+    assert pypi_install["needs"] == "publish-pypi"
+    assert pypi_install["runs-on"] == "ubuntu-latest"
+    pypi_install_steps = {step["name"]: step for step in pypi_install["steps"]}
+    public_download = pypi_install_steps["Download and match the published wheel"][
+        "run"
+    ]
+    assert '"codenib==$VERSION"' in public_download
+    assert "sha256sum" in public_download
+    assert (
+        "scripts/smoke_release_services.py"
+        in pypi_install_steps["Exercise public Wiki and MCP services"]["run"]
+    )
     registry_publisher = production["jobs"]["publish-mcp-registry"]
-    assert registry_publisher["needs"] == "publish-pypi"
+    assert registry_publisher["needs"] == "verify-pypi-install"
     assert registry_publisher["runs-on"] == "ubuntu-latest"
     assert registry_publisher["environment"]["name"] == "mcp-registry-publish"
     assert registry_publisher["permissions"] == {"contents": "read"}
@@ -161,6 +186,14 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "publish-pypi",
         "publish-mcp-registry",
     ]
+    release_steps = {
+        step["name"]: step for step in production["jobs"]["github-release"]["steps"]
+    }
+    assert release_steps["Resolve release channel"]["id"] == "channel"
+    create_release = release_steps["Create release"]["run"]
+    assert "RELEASE_FLAGS=(--latest)" in create_release
+    assert "RELEASE_FLAGS=(--prerelease)" in create_release
+    assert '"${RELEASE_FLAGS[@]}"' in create_release
 
     assert set(test["jobs"]) == {
         "verify",
@@ -202,6 +235,7 @@ def test_registry_publishers_use_separate_workflows() -> None:
     }
     for job_name in (
         "install-smoke",
+        "upgrade-smoke",
         "service-smoke",
         "agent-smoke",
         "graph-smoke",

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -140,6 +140,9 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "github-release",
     }
     registry_preflight = production["jobs"]["registry-auth-preflight"]
+    assert registry_preflight["if"] == (
+        "github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'"
+    )
     assert registry_preflight["needs"] == "verify"
     assert registry_preflight["runs-on"] == "ubuntu-latest"
     assert registry_preflight["environment"]["name"] == "mcp-registry-publish"

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -147,9 +147,9 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert registry_preflight["runs-on"] == "ubuntu-latest"
     assert registry_preflight["environment"]["name"] == "mcp-registry-publish"
     preflight_steps = {step["name"]: step for step in registry_preflight["steps"]}
-    assert (
-        "sha256sum --check" in preflight_steps["Install verified MCP publisher"]["run"]
-    )
+    preflight_download = preflight_steps["Install verified MCP publisher"]["run"]
+    assert "sha256sum --check" in preflight_download
+    assert "--connect-timeout 10 --max-time 90" in preflight_download
     assert "login dns" in preflight_steps["Verify branded namespace ownership"]["run"]
     production_publisher = production["jobs"]["publish-pypi"]
     assert production_publisher["needs"] == "registry-auth-preflight"
@@ -180,6 +180,10 @@ def test_registry_publishers_use_separate_workflows() -> None:
     assert "--check-pypi" in registry_steps["Wait for the exact PyPI package"]["run"]
     assert (
         "sha256sum --check" in registry_steps["Install verified MCP publisher"]["run"]
+    )
+    assert (
+        "--connect-timeout 10 --max-time 90"
+        in registry_steps["Install verified MCP publisher"]["run"]
     )
     assert registry_steps["Authenticate branded namespace"]["env"] == {
         "MCP_PRIVATE_KEY": "${{ secrets.MCP_PRIVATE_KEY }}"
@@ -236,6 +240,13 @@ def test_registry_publishers_use_separate_workflows() -> None:
         "type": "boolean",
         "default": "true",
     }
+    verification_steps = {
+        step["name"]: step for step in verification["jobs"]["build"]["steps"]
+    }
+    assert (
+        "--connect-timeout 10 --max-time 90"
+        in verification_steps["Validate MCP Registry metadata"]["run"]
+    )
     for job_name in (
         "install-smoke",
         "upgrade-smoke",

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ wheels = [
 
 [[package]]
 name = "codenib"
-version = "0.2.0a2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Prepare the stable CodeNib 0.2.0 release without adding product scope. This promotes synchronized package, documentation, and MCP metadata; makes release-channel handling explicit; and closes the public distribution and upgrade-validation gaps found during the release audit.

The branded `ai.codenib/codenib` namespace is now verified against public DNS and the protected GitHub environment before any irreversible PyPI upload.

## Changes

- Promote `pyproject.toml`, `uv.lock`, `server.json`, public install commands, navigation, changelog, and release notes from `0.2.0a2` to `0.2.0`; classify the package as Beta.
- Select GitHub prerelease versus latest release from the package version instead of marking every tag as a prerelease.
- Add an MCP Registry authentication preflight before PyPI publication to prevent a DNS failure from leaving a partial release.
- Download the exact public PyPI wheel after publication, compare it byte-for-byte with the verified build, install its MCP extra, and exercise real Wiki/MCP services before Registry publication.
- Add an installed `0.1.0 -> 0.2.0` upgrade smoke that rejects the incompatible old BM25 view, rebuilds once under the current contracts, then proves the rebuilt view is reused.
- Replace stale Developer Preview and unfinished-hosting language with the verified 0.2 product boundary.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short`: 2739 passed, 10 skipped, 183 deselected.
- `pytest -q test/test_release_artifacts.py -x --tb=short`: 13 passed.
- Pre-commit and strict release artifact validation: passed.
- TestPyPI `0.2.0a2` run 31071545190: full Python 3.10-3.14, Wiki/MCP, Ask, graph, publish, hash, and installed-package matrix passed.
- Final stable dry run 31079044474: Python 3.10-3.14, Wiki/MCP, Ask, graph/Dependency Map, `0.1.0 -> 0.2.0` upgrade, and branded Registry authentication passed.
- Public DNS verification: exact MCP TXT key resolved through `1.1.1.1`, `8.8.8.8`, and the system resolver.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
