### PR TITLE
feat(guardian): add local-specification review client

### DIFF
--- a/codenib/clients/__init__.py
+++ b/codenib/clients/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Third-party policy clients used as end-to-end localization baselines."""
+"""Runnable agent policies and external-agent execution adapters."""

--- a/codenib/clients/execution/__init__.py
+++ b/codenib/clients/execution/__init__.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Execution adapters for installed external coding-agent harnesses.
+
+This package owns invocation and trajectory normalization. Agent policies such
+as Guardian own prompts, rollout allocation, and interpretation of responses.
+"""
+
+from .codex import CodexExecutor
+from .process import (
+    ExecutableNotFoundError,
+    LocalProcessRunner,
+    ProcessLaunchError,
+    ProcessRequest,
+    ProcessResult,
+    ProcessRunner,
+)
+from .protocol import AgentExecutor
+from .sandbox import SandboxProcessRunner
+from .types import (
+    AgentEvent,
+    AgentEventKind,
+    AgentRole,
+    AgentRunError,
+    AgentRunErrorCode,
+    AgentRunRequest,
+    AgentRunResult,
+    ExecutionIsolation,
+    ExecutionPolicy,
+    FilesystemAccess,
+    NetworkAccess,
+    RunStatus,
+    TokenUsage,
+)
+
+__all__ = [
+    "AgentEvent",
+    "AgentEventKind",
+    "AgentExecutor",
+    "AgentRole",
+    "AgentRunError",
+    "AgentRunErrorCode",
+    "AgentRunRequest",
+    "AgentRunResult",
+    "CodexExecutor",
+    "ExecutableNotFoundError",
+    "ExecutionIsolation",
+    "ExecutionPolicy",
+    "FilesystemAccess",
+    "LocalProcessRunner",
+    "NetworkAccess",
+    "ProcessLaunchError",
+    "ProcessRequest",
+    "ProcessResult",
+    "ProcessRunner",
+    "RunStatus",
+    "SandboxProcessRunner",
+    "TokenUsage",
+]

--- a/codenib/clients/execution/codex.py
+++ b/codenib/clients/execution/codex.py
@@ -1,0 +1,297 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Codex CLI implementation of the external-agent execution protocol."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from .process import (
+    ExecutableNotFoundError,
+    LocalProcessRunner,
+    ProcessLaunchError,
+    ProcessRequest,
+    ProcessResult,
+    ProcessRunner,
+)
+from .types import (
+    AgentEvent,
+    AgentEventKind,
+    AgentRunError,
+    AgentRunErrorCode,
+    AgentRunRequest,
+    AgentRunResult,
+    ExecutionIsolation,
+    FilesystemAccess,
+    NetworkAccess,
+    RunStatus,
+    TokenUsage,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedCodexStream:
+    events: tuple[AgentEvent, ...]
+    final_message: str
+    usage: TokenUsage
+    malformed_lines: tuple[str, ...]
+
+
+def _event_kind(event_type: str, payload: Mapping[str, object]) -> AgentEventKind:
+    if event_type in {"thread.started", "turn.started"}:
+        return AgentEventKind.LIFECYCLE
+    if event_type == "turn.completed":
+        return AgentEventKind.USAGE
+    if event_type == "error":
+        return AgentEventKind.ERROR
+    if event_type in {"item.started", "item.completed"}:
+        item = payload.get("item")
+        item_type = item.get("type") if isinstance(item, dict) else None
+        if item_type == "agent_message":
+            return AgentEventKind.MESSAGE
+        return AgentEventKind.TOOL
+    return AgentEventKind.UNKNOWN
+
+
+def _token_count(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _parse_codex_stream(raw_output: str) -> _ParsedCodexStream:
+    events: list[AgentEvent] = []
+    malformed: list[str] = []
+    final_message = ""
+    usage = TokenUsage()
+
+    for line in raw_output.splitlines():
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            malformed.append(line)
+            continue
+        if not isinstance(payload, dict) or not isinstance(payload.get("type"), str):
+            malformed.append(line)
+            continue
+
+        event_type = payload["type"]
+        events.append(
+            AgentEvent(
+                sequence=len(events),
+                kind=_event_kind(event_type, payload),
+                provider_type=event_type,
+                payload=payload,
+            )
+        )
+        if event_type == "item.completed":
+            item = payload.get("item")
+            if isinstance(item, dict) and item.get("type") == "agent_message":
+                text = item.get("text")
+                if isinstance(text, str):
+                    final_message = text
+        elif event_type == "turn.completed":
+            raw_usage = payload.get("usage")
+            if isinstance(raw_usage, dict):
+                usage = TokenUsage(
+                    input_tokens=_token_count(raw_usage.get("input_tokens")),
+                    cached_input_tokens=_token_count(
+                        raw_usage.get("cached_input_tokens")
+                    ),
+                    cache_write_input_tokens=_token_count(
+                        raw_usage.get("cache_write_input_tokens")
+                    ),
+                    output_tokens=_token_count(raw_usage.get("output_tokens")),
+                    reasoning_output_tokens=_token_count(
+                        raw_usage.get("reasoning_output_tokens")
+                    ),
+                )
+
+    return _ParsedCodexStream(
+        events=tuple(events),
+        final_message=final_message,
+        usage=usage,
+        malformed_lines=tuple(malformed),
+    )
+
+
+class CodexExecutor:
+    """Invoke Codex CLI while leaving its native agent loop intact."""
+
+    def __init__(
+        self,
+        *,
+        executable: str = "codex",
+        process_runner: ProcessRunner | None = None,
+        max_output_bytes: int = 8 * 1024**2,
+    ) -> None:
+        if not executable or "\x00" in executable:
+            raise ValueError("executable must be a non-empty, NUL-free string")
+        if max_output_bytes <= 0:
+            raise ValueError("max_output_bytes must be positive")
+        self._executable = executable
+        self._process_runner = process_runner or LocalProcessRunner()
+        self._max_output_bytes = max_output_bytes
+
+    def _unsupported_policy(self, request: AgentRunRequest) -> AgentRunResult | None:
+        if request.policy.network is NetworkAccess.DISABLED:
+            return self._failure(
+                code=AgentRunErrorCode.UNSUPPORTED_POLICY,
+                message=(
+                    "Codex native sandbox cannot guarantee disabled network access; "
+                    "run it inside a codenib.sandbox environment instead"
+                ),
+            )
+        return None
+
+    def _command(self, request: AgentRunRequest) -> tuple[str, ...]:
+        sandbox = {
+            FilesystemAccess.READ_ONLY: "read-only",
+            FilesystemAccess.WORKSPACE_WRITE: "workspace-write",
+        }[request.policy.filesystem]
+        command = [
+            self._executable,
+            "exec",
+            "--json",
+            "--ephemeral",
+            "--color",
+            "never",
+            "--skip-git-repo-check",
+            "--cd",
+            str(request.workspace),
+        ]
+        if request.policy.isolation is ExecutionIsolation.EXTERNAL:
+            command.append("--dangerously-bypass-approvals-and-sandbox")
+        else:
+            command.extend(
+                ("--sandbox", sandbox, "--config", 'approval_policy="never"')
+            )
+        if request.model:
+            command.extend(("--model", request.model))
+        if request.reasoning_effort:
+            encoded = json.dumps(request.reasoning_effort)
+            command.extend(("--config", f"model_reasoning_effort={encoded}"))
+        command.append("-")
+        return tuple(command)
+
+    @staticmethod
+    def _failure(
+        *,
+        code: AgentRunErrorCode,
+        message: str,
+        status: RunStatus = RunStatus.FAILED,
+        duration_seconds: float = 0.0,
+        process: ProcessResult | None = None,
+        events: Sequence[AgentEvent] = (),
+        usage: TokenUsage | None = None,
+        final_message: str = "",
+    ) -> AgentRunResult:
+        return AgentRunResult(
+            status=status,
+            final_message=final_message,
+            trajectory=events,
+            usage=usage or TokenUsage(),
+            duration_seconds=(
+                process.duration_seconds if process is not None else duration_seconds
+            ),
+            raw_output=process.stdout if process is not None else "",
+            stderr=process.stderr if process is not None else "",
+            exit_code=process.exit_code if process is not None else None,
+            error=AgentRunError(code=code, message=message),
+        )
+
+    async def run(self, request: AgentRunRequest) -> AgentRunResult:
+        unsupported = self._unsupported_policy(request)
+        if unsupported is not None:
+            return unsupported
+
+        process_request = ProcessRequest(
+            argv=self._command(request),
+            cwd=request.workspace,
+            stdin=request.instruction.encode("utf-8"),
+            environment=request.environment,
+            timeout_seconds=request.timeout_seconds,
+            max_output_bytes=self._max_output_bytes,
+        )
+        started = time.monotonic()
+        try:
+            process = await self._process_runner.run(process_request)
+        except ExecutableNotFoundError as exc:
+            return self._failure(
+                code=AgentRunErrorCode.EXECUTABLE_NOT_FOUND,
+                message=str(exc),
+                duration_seconds=time.monotonic() - started,
+            )
+        except ProcessLaunchError as exc:
+            return self._failure(
+                code=AgentRunErrorCode.LAUNCH_FAILED,
+                message=str(exc),
+                duration_seconds=time.monotonic() - started,
+            )
+        except asyncio.CancelledError:
+            return self._failure(
+                code=AgentRunErrorCode.CANCELLED,
+                message="Codex execution was cancelled",
+                status=RunStatus.CANCELLED,
+                duration_seconds=time.monotonic() - started,
+            )
+
+        parsed = _parse_codex_stream(process.stdout)
+        common: dict[str, Any] = {
+            "process": process,
+            "events": parsed.events,
+            "usage": parsed.usage,
+            "final_message": parsed.final_message,
+        }
+        if process.timed_out:
+            return self._failure(
+                code=AgentRunErrorCode.TIMEOUT,
+                message=f"Codex exceeded {request.timeout_seconds:g} seconds",
+                status=RunStatus.TIMED_OUT,
+                **common,
+            )
+        if process.exit_code != 0:
+            return self._failure(
+                code=AgentRunErrorCode.CLI_EXIT,
+                message=f"Codex exited with status {process.exit_code}",
+                **common,
+            )
+        if parsed.malformed_lines or process.stdout_truncated:
+            detail = (
+                f"{len(parsed.malformed_lines)} malformed JSONL line(s)"
+                if parsed.malformed_lines
+                else "JSONL output exceeded the configured size limit"
+            )
+            return self._failure(
+                code=AgentRunErrorCode.MALFORMED_EVENT_STREAM,
+                message=detail,
+                **common,
+            )
+        if not parsed.final_message:
+            return self._failure(
+                code=AgentRunErrorCode.EMPTY_RESPONSE,
+                message="Codex completed without an agent message",
+                **common,
+            )
+        return AgentRunResult(
+            status=RunStatus.COMPLETED,
+            final_message=parsed.final_message,
+            trajectory=parsed.events,
+            usage=parsed.usage,
+            duration_seconds=process.duration_seconds,
+            raw_output=process.stdout,
+            stderr=process.stderr,
+            exit_code=process.exit_code,
+        )
+
+
+__all__ = ["CodexExecutor"]

--- a/codenib/clients/execution/process.py
+++ b/codenib/clients/execution/process.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shell-free, bounded asynchronous subprocess execution."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import signal
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping, Protocol, Sequence, runtime_checkable
+
+
+class ProcessLaunchError(RuntimeError):
+    """A process could not be created."""
+
+
+class ExecutableNotFoundError(ProcessLaunchError):
+    """The requested executable does not exist or cannot be resolved."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessRequest:
+    argv: Sequence[str]
+    cwd: Path
+    stdin: bytes | None = None
+    environment: Mapping[str, str] = field(default_factory=dict)
+    timeout_seconds: float = 300.0
+    max_output_bytes: int = 8 * 1024**2
+
+    def __post_init__(self) -> None:
+        if isinstance(self.argv, (str, bytes)):
+            raise TypeError("argv must be a sequence of strings")
+        argv = tuple(self.argv)
+        if not argv or any(
+            not isinstance(value, str) or not value or "\x00" in value for value in argv
+        ):
+            raise ValueError("argv must contain non-empty, NUL-free strings")
+        cwd = Path(self.cwd).expanduser().resolve()
+        if not cwd.is_dir():
+            raise ValueError(f"cwd must be an existing directory: {cwd}")
+        if self.stdin is not None and not isinstance(self.stdin, bytes):
+            raise TypeError("stdin must be bytes when provided")
+        if (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, (int, float))
+            or not math.isfinite(float(self.timeout_seconds))
+            or self.timeout_seconds <= 0
+        ):
+            raise ValueError("timeout_seconds must be a finite positive number")
+        if (
+            isinstance(self.max_output_bytes, bool)
+            or not isinstance(self.max_output_bytes, int)
+            or self.max_output_bytes <= 0
+        ):
+            raise ValueError("max_output_bytes must be a positive integer")
+        environment = dict(self.environment)
+        for key, value in environment.items():
+            if (
+                not isinstance(key, str)
+                or not key
+                or "\x00" in key
+                or "=" in key
+                or not isinstance(value, str)
+                or "\x00" in value
+            ):
+                raise ValueError(f"invalid process environment entry: {key!r}")
+        object.__setattr__(self, "argv", argv)
+        object.__setattr__(self, "cwd", cwd)
+        object.__setattr__(self, "environment", MappingProxyType(environment))
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessResult:
+    argv: tuple[str, ...]
+    exit_code: int | None
+    stdout: str
+    stderr: str
+    duration_seconds: float
+    timed_out: bool = False
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+
+
+@runtime_checkable
+class ProcessRunner(Protocol):
+    async def run(self, request: ProcessRequest) -> ProcessResult: ...
+
+
+async def _read_bounded(stream: asyncio.StreamReader, limit: int) -> tuple[bytes, bool]:
+    chunks: list[bytes] = []
+    retained = 0
+    truncated = False
+    while True:
+        chunk = await stream.read(64 * 1024)
+        if not chunk:
+            break
+        available = max(0, limit - retained)
+        if available:
+            kept = chunk[:available]
+            chunks.append(kept)
+            retained += len(kept)
+        if len(chunk) > available:
+            truncated = True
+    return b"".join(chunks), truncated
+
+
+async def _write_stdin(
+    stream: asyncio.StreamWriter | None, content: bytes | None
+) -> None:
+    if stream is None:
+        return
+    try:
+        if content:
+            stream.write(content)
+            await stream.drain()
+    except (BrokenPipeError, ConnectionResetError):
+        pass
+    finally:
+        stream.close()
+
+
+async def _kill_process_tree(process: asyncio.subprocess.Process) -> None:
+    """Kill the isolated process group created for one agent invocation."""
+
+    if process.returncode is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:  # pragma: no cover - exercised on Windows runners
+            process.kill()
+    except ProcessLookupError:
+        pass
+    await process.wait()
+
+
+class LocalProcessRunner:
+    """Run an argv directly on the host without invoking a shell."""
+
+    async def run(self, request: ProcessRequest) -> ProcessResult:
+        started = time.monotonic()
+        environment = os.environ.copy()
+        environment.update(request.environment)
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *request.argv,
+                cwd=str(request.cwd),
+                env=environment,
+                stdin=(
+                    asyncio.subprocess.PIPE
+                    if request.stdin is not None
+                    else asyncio.subprocess.DEVNULL
+                ),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=os.name == "posix",
+            )
+        except FileNotFoundError as exc:
+            raise ExecutableNotFoundError(str(exc)) from exc
+        except OSError as exc:
+            raise ProcessLaunchError(str(exc)) from exc
+
+        assert process.stdout is not None
+        assert process.stderr is not None
+        stdout_task = asyncio.create_task(
+            _read_bounded(process.stdout, request.max_output_bytes)
+        )
+        stderr_task = asyncio.create_task(
+            _read_bounded(process.stderr, request.max_output_bytes)
+        )
+        stdin_task = asyncio.create_task(_write_stdin(process.stdin, request.stdin))
+        timed_out = False
+        try:
+            await asyncio.wait_for(process.wait(), timeout=request.timeout_seconds)
+        except asyncio.TimeoutError:
+            timed_out = True
+            await _kill_process_tree(process)
+        except asyncio.CancelledError:
+            await _kill_process_tree(process)
+            await asyncio.gather(stdout_task, stderr_task, stdin_task)
+            raise
+
+        stdout_result, stderr_result, _ = await asyncio.gather(
+            stdout_task, stderr_task, stdin_task
+        )
+        stdout, stdout_truncated = stdout_result
+        stderr, stderr_truncated = stderr_result
+        return ProcessResult(
+            argv=tuple(request.argv),
+            exit_code=process.returncode,
+            stdout=stdout.decode("utf-8", errors="replace"),
+            stderr=stderr.decode("utf-8", errors="replace"),
+            duration_seconds=time.monotonic() - started,
+            timed_out=timed_out,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
+        )
+
+
+__all__ = [
+    "ExecutableNotFoundError",
+    "LocalProcessRunner",
+    "ProcessLaunchError",
+    "ProcessRequest",
+    "ProcessResult",
+    "ProcessRunner",
+]

--- a/codenib/clients/execution/protocol.py
+++ b/codenib/clients/execution/protocol.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Protocol implemented by installed external-agent backends."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .types import AgentRunRequest, AgentRunResult
+
+
+@runtime_checkable
+class AgentExecutor(Protocol):
+    """Run one request through an external agent's native inner loop."""
+
+    async def run(self, request: AgentRunRequest) -> AgentRunResult: ...
+
+
+__all__ = ["AgentExecutor"]

--- a/codenib/clients/execution/sandbox.py
+++ b/codenib/clients/execution/sandbox.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-runner adapter backed by a fresh :mod:`codenib.sandbox` session."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path, PurePosixPath
+from typing import Mapping
+
+from ...sandbox import ExecRequest, SandboxPolicy, SandboxProvider, SandboxSpec
+from ...sandbox.protocol import SandboxError
+from .process import ProcessLaunchError, ProcessRequest, ProcessResult
+
+
+def _source_revision(workspace: Path) -> str:
+    try:
+        return subprocess.run(
+            ("git", "rev-parse", "HEAD"),
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=15,
+            env={
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_TERMINAL_PROMPT": "0",
+                "PATH": "/usr/bin:/bin",
+                "LANG": "C.UTF-8",
+            },
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ProcessLaunchError(
+            f"cannot resolve sandbox source revision: {exc}"
+        ) from exc
+
+
+class SandboxProcessRunner:
+    """Run every process request in an independent copied repository.
+
+    The source checkout is never mounted into model-controlled commands.  A
+    rollout may write to its private workspace, but closing the session drops
+    those changes.  This is the useful read-only guarantee for reviewers: they
+    cannot mutate either the solver checkout or another rollout's view.
+
+    ``staged_files`` is intended for controller-provided runtime material such
+    as a short-lived CLI credential.  The files exist only in the disposable
+    workspace and are not copied back or included in the returned process log.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: SandboxProvider,
+        image: str,
+        platform: str,
+        policy: SandboxPolicy,
+        staged_files: Mapping[str | PurePosixPath, bytes] | None = None,
+        environment: Mapping[str, str] | None = None,
+        task_id_prefix: str = "guardian",
+    ) -> None:
+        self._provider = provider
+        self._image = image
+        self._platform = platform
+        self._policy = policy
+        self._staged_files = {
+            PurePosixPath(path): bytes(content)
+            for path, content in (staged_files or {}).items()
+        }
+        self._environment = dict(environment or {})
+        self._task_id_prefix = task_id_prefix
+
+    @staticmethod
+    def _container_argv(request: ProcessRequest) -> tuple[str, ...]:
+        host_workspace = str(request.cwd)
+        return tuple(
+            "/workspace" if value == host_workspace else value for value in request.argv
+        )
+
+    async def run(self, request: ProcessRequest) -> ProcessResult:
+        revision = _source_revision(request.cwd)
+        spec = SandboxSpec(
+            source_dir=request.cwd,
+            source_revision=revision,
+            image=self._image,
+            platform=self._platform,
+            task_id=f"{self._task_id_prefix}-{revision[:12]}",
+            policy=self._policy,
+        )
+
+        def execute() -> ProcessResult:
+            try:
+                with self._provider.create(spec) as session:
+                    for path, content in self._staged_files.items():
+                        session.write_file(path, content, create_parents=True)
+                    result = session.execute(
+                        ExecRequest(
+                            argv=self._container_argv(request),
+                            cwd=PurePosixPath("."),
+                            stdin=request.stdin,
+                            environment={**self._environment, **request.environment},
+                            timeout_seconds=request.timeout_seconds,
+                        )
+                    )
+            except (SandboxError, OSError, ValueError) as exc:
+                raise ProcessLaunchError(f"sandbox execution failed: {exc}") from exc
+            return ProcessResult(
+                argv=tuple(request.argv),
+                exit_code=result.exit_code,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                duration_seconds=result.duration_ms / 1000.0,
+                timed_out=result.timed_out,
+                stdout_truncated=result.stdout_truncated or result.output_limited,
+                stderr_truncated=result.stderr_truncated or result.output_limited,
+            )
+
+        return await asyncio.to_thread(execute)
+
+
+__all__ = ["SandboxProcessRunner"]

--- a/codenib/clients/execution/types.py
+++ b/codenib/clients/execution/types.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider-neutral value types for external agent execution."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Mapping, Sequence
+
+
+class AgentRole(str, Enum):
+    """Guardian role assigned to one external-agent rollout."""
+
+    EXPLORER = "explorer"
+    AGGREGATOR = "aggregator"
+    VERIFIER = "verifier"
+    REVISION = "revision"
+
+
+class FilesystemAccess(str, Enum):
+    """Filesystem capability requested from the agent harness."""
+
+    READ_ONLY = "read-only"
+    WORKSPACE_WRITE = "workspace-write"
+
+
+class NetworkAccess(str, Enum):
+    """Network guarantees understood by the local execution layer.
+
+    Native Codex sandbox modes do not provide a portable egress guarantee, so
+    the first execution backend only accepts ``INHERIT``. Network isolation is
+    the responsibility of an outer :mod:`codenib.sandbox` environment.
+    """
+
+    INHERIT = "inherit"
+    DISABLED = "disabled"
+
+
+class ExecutionIsolation(str, Enum):
+    """Where enforcement of process isolation is owned."""
+
+    NATIVE = "native"
+    EXTERNAL = "external"
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionPolicy:
+    """Capabilities that an executor must enforce or reject explicitly."""
+
+    filesystem: FilesystemAccess = FilesystemAccess.READ_ONLY
+    network: NetworkAccess = NetworkAccess.INHERIT
+    isolation: ExecutionIsolation = ExecutionIsolation.NATIVE
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "filesystem", FilesystemAccess(self.filesystem))
+        object.__setattr__(self, "network", NetworkAccess(self.network))
+        object.__setattr__(self, "isolation", ExecutionIsolation(self.isolation))
+
+
+def _validate_string_mapping(
+    values: Mapping[str, str], *, name: str
+) -> Mapping[str, str]:
+    clean: dict[str, str] = {}
+    for key, value in values.items():
+        if not isinstance(key, str) or not key or "\x00" in key or "=" in key:
+            raise ValueError(f"{name} contains an invalid key: {key!r}")
+        if not isinstance(value, str) or "\x00" in value:
+            raise ValueError(f"{name} contains an invalid value for {key!r}")
+        clean[key] = value
+    return MappingProxyType(clean)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRunRequest:
+    """One normalized request to an installed coding-agent harness."""
+
+    instruction: str
+    workspace: Path
+    role: AgentRole
+    timeout_seconds: float
+    model: str | None = None
+    reasoning_effort: str | None = None
+    policy: ExecutionPolicy = field(default_factory=ExecutionPolicy)
+    environment: Mapping[str, str] = field(default_factory=dict)
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.instruction, str) or not self.instruction.strip():
+            raise ValueError("instruction must be a non-empty string")
+        workspace = Path(self.workspace).expanduser().resolve()
+        if not workspace.is_dir():
+            raise ValueError(f"workspace must be an existing directory: {workspace}")
+        object.__setattr__(self, "workspace", workspace)
+        object.__setattr__(self, "role", AgentRole(self.role))
+        if (
+            isinstance(self.timeout_seconds, bool)
+            or not isinstance(self.timeout_seconds, (int, float))
+            or not math.isfinite(float(self.timeout_seconds))
+            or self.timeout_seconds <= 0
+        ):
+            raise ValueError("timeout_seconds must be a finite positive number")
+        for name in ("model", "reasoning_effort"):
+            value = getattr(self, name)
+            if value is not None and (
+                not isinstance(value, str) or not value.strip() or "\x00" in value
+            ):
+                raise ValueError(f"{name} must be a non-empty, NUL-free string")
+        object.__setattr__(
+            self,
+            "environment",
+            _validate_string_mapping(self.environment, name="environment"),
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            _validate_string_mapping(self.metadata, name="metadata"),
+        )
+
+
+class RunStatus(str, Enum):
+    """Operational outcome of an external-agent invocation."""
+
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMED_OUT = "timed_out"
+    CANCELLED = "cancelled"
+
+
+class AgentEventKind(str, Enum):
+    """Small common vocabulary for normalized harness events."""
+
+    LIFECYCLE = "lifecycle"
+    MESSAGE = "message"
+    TOOL = "tool"
+    USAGE = "usage"
+    ERROR = "error"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentEvent:
+    """One normalized trajectory event with its original payload retained."""
+
+    sequence: int
+    kind: AgentEventKind
+    provider_type: str
+    payload: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "kind", AgentEventKind(self.kind))
+        object.__setattr__(self, "payload", MappingProxyType(dict(self.payload)))
+
+
+@dataclass(frozen=True, slots=True)
+class TokenUsage:
+    """Provider-neutral token accounting for one complete agent run."""
+
+    input_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_write_input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_output_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+class AgentRunErrorCode(str, Enum):
+    """Operational failure categories kept separate from agent quality."""
+
+    UNSUPPORTED_POLICY = "unsupported_policy"
+    EXECUTABLE_NOT_FOUND = "executable_not_found"
+    LAUNCH_FAILED = "launch_failed"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+    CLI_EXIT = "cli_exit"
+    MALFORMED_EVENT_STREAM = "malformed_event_stream"
+    EMPTY_RESPONSE = "empty_response"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRunError:
+    code: AgentRunErrorCode
+    message: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "code", AgentRunErrorCode(self.code))
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRunResult:
+    """Normalized result returned to Guardian policy code."""
+
+    status: RunStatus
+    final_message: str
+    trajectory: Sequence[AgentEvent]
+    usage: TokenUsage
+    duration_seconds: float
+    raw_output: str
+    stderr: str
+    exit_code: int | None
+    error: AgentRunError | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "status", RunStatus(self.status))
+        object.__setattr__(self, "trajectory", tuple(self.trajectory))
+
+    @property
+    def succeeded(self) -> bool:
+        return self.status is RunStatus.COMPLETED
+
+
+__all__ = [
+    "AgentEvent",
+    "AgentEventKind",
+    "AgentRole",
+    "AgentRunError",
+    "AgentRunErrorCode",
+    "AgentRunRequest",
+    "AgentRunResult",
+    "ExecutionPolicy",
+    "ExecutionIsolation",
+    "FilesystemAccess",
+    "NetworkAccess",
+    "RunStatus",
+    "TokenUsage",
+]

--- a/codenib/clients/guardian/__init__.py
+++ b/codenib/clients/guardian/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Independent, evidence-backed local-specification reviewer."""
+
+from .agent import GuardianAgent
+from .artifacts import render_markdown
+from .types import (
+    ContextMessage,
+    Evidence,
+    EvidenceAuthority,
+    FindingStatus,
+    GuardianConfig,
+    GuardianFinding,
+    GuardianRequest,
+    GuardianResult,
+    LocalSpecification,
+    ReviewStatus,
+)
+
+__all__ = [
+    "ContextMessage",
+    "Evidence",
+    "EvidenceAuthority",
+    "FindingStatus",
+    "GuardianAgent",
+    "GuardianConfig",
+    "GuardianFinding",
+    "GuardianRequest",
+    "GuardianResult",
+    "LocalSpecification",
+    "ReviewStatus",
+    "render_markdown",
+]

--- a/codenib/clients/guardian/agent.py
+++ b/codenib/clients/guardian/agent.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guardian orchestration for local-specification discovery and admission."""
+
+from __future__ import annotations
+
+from ..execution import AgentExecutor, CodexExecutor
+from .aggregation import aggregate
+from .discovery import discover
+from .types import (
+    EvidenceAuthority,
+    FindingStatus,
+    GuardianConfig,
+    GuardianRequest,
+    GuardianResult,
+    ReviewStatus,
+)
+
+
+class GuardianAgent:
+    """Review a candidate patch without implementing changes itself."""
+
+    def __init__(
+        self,
+        config: GuardianConfig,
+        *,
+        executor: AgentExecutor | None = None,
+    ) -> None:
+        self.config = config
+        self.executor = executor or CodexExecutor()
+
+    async def review(self, request: GuardianRequest) -> GuardianResult:
+        candidates, explorer_rollouts, errors = await discover(
+            request, self.config, self.executor
+        )
+        if not candidates:
+            return GuardianResult(
+                base_commit=request.base_commit,
+                candidate_commit=request.candidate_commit,
+                status=ReviewStatus.FAILED,
+                candidates=(),
+                rollouts=explorer_rollouts,
+                errors=errors or ("no evidence-backed candidates were produced",),
+            )
+
+        summary, assessed, aggregation_rollout, aggregation_error = await aggregate(
+            request, self.config, self.executor, candidates
+        )
+        all_errors = errors + ((aggregation_error,) if aggregation_error else ())
+        rollouts = explorer_rollouts + (aggregation_rollout,)
+        if aggregation_error:
+            return GuardianResult(
+                base_commit=request.base_commit,
+                candidate_commit=request.candidate_commit,
+                status=ReviewStatus.FAILED,
+                candidates=candidates,
+                rollouts=rollouts,
+                errors=all_errors,
+            )
+
+        findings = tuple(
+            finding
+            for finding in assessed
+            if finding.status is FindingStatus.VIOLATED
+            and finding.confidence >= 0.70
+            and any(
+                evidence.authority is not EvidenceAuthority.SOLVER
+                for evidence in finding.evidence
+            )
+        )[: self.config.max_findings]
+        backlog = tuple(
+            finding
+            for finding in assessed
+            if (
+                finding.status is FindingStatus.UNCERTAIN
+                or (
+                    finding.status is FindingStatus.VIOLATED and finding not in findings
+                )
+            )
+            and any(
+                evidence.authority is not EvidenceAuthority.SOLVER
+                for evidence in finding.evidence
+            )
+        )
+        status = ReviewStatus.DEGRADED if errors else ReviewStatus.COMPLETE
+        return GuardianResult(
+            base_commit=request.base_commit,
+            candidate_commit=request.candidate_commit,
+            status=status,
+            candidates=candidates,
+            findings=findings,
+            backlog=backlog,
+            summary=summary,
+            rollouts=rollouts,
+            errors=all_errors,
+        )
+
+
+__all__ = ["GuardianAgent"]

--- a/codenib/clients/guardian/agent.py
+++ b/codenib/clients/guardian/agent.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from ..execution import AgentExecutor, CodexExecutor
 from .aggregation import aggregate
 from .discovery import discover
+from .evidence import validate_candidates, validate_findings
+from .provenance import validate_request_provenance
 from .types import (
     EvidenceAuthority,
     FindingStatus,
@@ -32,9 +34,22 @@ class GuardianAgent:
         self.executor = executor or CodexExecutor()
 
     async def review(self, request: GuardianRequest) -> GuardianResult:
+        provenance_error = validate_request_provenance(request)
+        if provenance_error:
+            return GuardianResult(
+                base_commit=request.base_commit,
+                candidate_commit=request.candidate_commit,
+                status=ReviewStatus.FAILED,
+                errors=(provenance_error,),
+            )
+
         candidates, explorer_rollouts, errors = await discover(
             request, self.config, self.executor
         )
+        candidates, candidate_errors = validate_candidates(
+            request.workspace, candidates
+        )
+        errors += candidate_errors
         if not candidates:
             return GuardianResult(
                 base_commit=request.base_commit,
@@ -48,7 +63,12 @@ class GuardianAgent:
         summary, assessed, aggregation_rollout, aggregation_error = await aggregate(
             request, self.config, self.executor, candidates
         )
-        all_errors = errors + ((aggregation_error,) if aggregation_error else ())
+        assessed, finding_errors = validate_findings(request.workspace, assessed)
+        all_errors = (
+            errors
+            + finding_errors
+            + ((aggregation_error,) if aggregation_error else ())
+        )
         rollouts = explorer_rollouts + (aggregation_rollout,)
         if aggregation_error:
             return GuardianResult(
@@ -84,7 +104,7 @@ class GuardianAgent:
                 for evidence in finding.evidence
             )
         )
-        status = ReviewStatus.DEGRADED if errors else ReviewStatus.COMPLETE
+        status = ReviewStatus.DEGRADED if all_errors else ReviewStatus.COMPLETE
         return GuardianResult(
             base_commit=request.base_commit,
             candidate_commit=request.candidate_commit,

--- a/codenib/clients/guardian/aggregation.py
+++ b/codenib/clients/guardian/aggregation.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strong-model evidence admission for explorer candidates."""
+
+from __future__ import annotations
+
+from ..execution import (
+    AgentExecutor,
+    AgentRole,
+    AgentRunRequest,
+    AgentRunResult,
+    ExecutionPolicy,
+    FilesystemAccess,
+)
+from .normalization import GuardianResponseError, parse_findings
+from .prompts import aggregation_prompt
+from .types import GuardianConfig, GuardianFinding, GuardianRequest, LocalSpecification
+
+
+async def aggregate(
+    request: GuardianRequest,
+    config: GuardianConfig,
+    executor: AgentExecutor,
+    candidates: tuple[LocalSpecification, ...],
+) -> tuple[str, tuple[GuardianFinding, ...], AgentRunResult, str | None]:
+    rollout = await executor.run(
+        AgentRunRequest(
+            instruction=aggregation_prompt(request, candidates, config.max_findings),
+            workspace=request.workspace,
+            role=AgentRole.AGGREGATOR,
+            timeout_seconds=config.rollout_timeout_seconds,
+            model=config.aggregator_model,
+            reasoning_effort=config.aggregator_reasoning_effort,
+            policy=ExecutionPolicy(
+                filesystem=FilesystemAccess.READ_ONLY,
+                isolation=config.execution_isolation,
+            ),
+            metadata={"guardian_stage": "aggregation"},
+        )
+    )
+    if not rollout.succeeded:
+        message = rollout.error.message if rollout.error else rollout.status.value
+        return "", (), rollout, f"aggregator: {message}"
+    try:
+        summary, findings = parse_findings(rollout.final_message)
+    except GuardianResponseError as exc:
+        return "", (), rollout, f"aggregator: {exc}"
+    return summary, findings, rollout, None
+
+
+__all__ = ["aggregate"]

--- a/codenib/clients/guardian/artifacts.py
+++ b/codenib/clients/guardian/artifacts.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Human-readable and durable Guardian result rendering."""
+
+from __future__ import annotations
+
+from .types import GuardianFinding, GuardianResult
+
+
+def _finding_markdown(finding: GuardianFinding, index: int) -> list[str]:
+    lines = [
+        f"## {index}. {finding.statement}",
+        "",
+        f"Status: `{finding.status.value}` · confidence: {finding.confidence:.2f}",
+        "",
+        finding.patch_assessment or "No patch assessment supplied.",
+        "",
+    ]
+    if finding.recommendation:
+        lines.extend((f"Recommendation: {finding.recommendation}", ""))
+    lines.append("Evidence:")
+    lines.append("")
+    for evidence in finding.evidence:
+        location = f"{evidence.path}:{evidence.line_start}"
+        lines.append(
+            f"- `{location}` ({evidence.authority.value}): {evidence.description}"
+        )
+    lines.append("")
+    return lines
+
+
+def render_markdown(result: GuardianResult) -> str:
+    lines = [
+        "# Repository Guardian Report",
+        "",
+        f"Candidate: `{result.candidate_commit}`",
+        f"Analysis status: `{result.status.value}`",
+        f"Discovered candidates: {len(result.candidates)}",
+        f"Admitted findings: {len(result.findings)}",
+        f"Backlog: {len(result.backlog)}",
+        "",
+    ]
+    if result.summary:
+        lines.extend((result.summary, ""))
+    if result.errors:
+        lines.extend(("## Analysis limitations", ""))
+        lines.extend(f"- {error}" for error in result.errors)
+        lines.append("")
+    if not result.findings:
+        lines.extend(
+            (
+                "No evidence-backed violated local specification was admitted.",
+                "",
+            )
+        )
+    else:
+        for index, finding in enumerate(result.findings, 1):
+            lines.extend(_finding_markdown(finding, index))
+    if result.backlog:
+        lines.extend(("# Uncertain backlog", ""))
+        for index, finding in enumerate(result.backlog, 1):
+            lines.extend(_finding_markdown(finding, index))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+__all__ = ["render_markdown"]

--- a/codenib/clients/guardian/discovery.py
+++ b/codenib/clients/guardian/discovery.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parallel local-specification exploration."""
+
+from __future__ import annotations
+
+import asyncio
+
+from ..execution import (
+    AgentExecutor,
+    AgentRole,
+    AgentRunRequest,
+    AgentRunResult,
+    ExecutionPolicy,
+    FilesystemAccess,
+)
+from .normalization import GuardianResponseError, parse_candidates
+from .prompts import explorer_prompt
+from .types import GuardianConfig, GuardianRequest, LocalSpecification
+
+
+async def discover(
+    request: GuardianRequest,
+    config: GuardianConfig,
+    executor: AgentExecutor,
+) -> tuple[tuple[LocalSpecification, ...], tuple[AgentRunResult, ...], tuple[str, ...]]:
+    """Run independent explorers concurrently and retain per-rollout provenance."""
+
+    async def one(index: int) -> AgentRunResult:
+        return await executor.run(
+            AgentRunRequest(
+                instruction=explorer_prompt(request, index),
+                workspace=request.workspace,
+                role=AgentRole.EXPLORER,
+                timeout_seconds=config.rollout_timeout_seconds,
+                model=config.explorer_model,
+                reasoning_effort=config.explorer_reasoning_effort,
+                policy=ExecutionPolicy(
+                    filesystem=FilesystemAccess.READ_ONLY,
+                    isolation=config.execution_isolation,
+                ),
+                metadata={"guardian_stage": "discovery", "explorer": str(index + 1)},
+            )
+        )
+
+    rollouts = tuple(
+        await asyncio.gather(*(one(index) for index in range(config.explorer_count)))
+    )
+    candidates: list[LocalSpecification] = []
+    errors: list[str] = []
+    for index, rollout in enumerate(rollouts):
+        label = f"explorer_{index + 1}"
+        if not rollout.succeeded:
+            message = rollout.error.message if rollout.error else rollout.status.value
+            errors.append(f"{label}: {message}")
+            continue
+        try:
+            candidates.extend(parse_candidates(rollout.final_message, explorer=label))
+        except GuardianResponseError as exc:
+            errors.append(f"{label}: {exc}")
+    return tuple(candidates), rollouts, tuple(errors)
+
+
+__all__ = ["discover"]

--- a/codenib/clients/guardian/evidence.py
+++ b/codenib/clients/guardian/evidence.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workspace-backed validation for model-produced Guardian evidence."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+
+from .types import Evidence, GuardianFinding, LocalSpecification
+
+
+def _validate_location(
+    workspace: Path, evidence: Evidence
+) -> tuple[Evidence | None, str]:
+    raw_path = evidence.path.strip()
+    if "\\" in raw_path:
+        return None, "path must use repository-relative POSIX separators"
+
+    relative = PurePosixPath(raw_path)
+    if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+        return None, "path is not repository-relative"
+
+    target = workspace.joinpath(*relative.parts)
+    try:
+        resolved = target.resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None, "path does not resolve to a repository file"
+    if not resolved.is_relative_to(workspace) or not resolved.is_file():
+        return None, "path does not resolve to a repository file"
+
+    try:
+        with resolved.open("rb") as handle:
+            for line_number, _ in enumerate(handle, start=1):
+                if line_number >= evidence.line_end:
+                    return replace(evidence, path=relative.as_posix()), ""
+    except OSError:
+        return None, "repository file could not be read"
+    return None, "line range exceeds the repository file"
+
+
+def _validated_evidence(
+    workspace: Path,
+    evidence: tuple[Evidence, ...],
+    *,
+    label: str,
+) -> tuple[tuple[Evidence, ...], tuple[str, ...]]:
+    valid: list[Evidence] = []
+    errors: list[str] = []
+    for index, item in enumerate(evidence, start=1):
+        checked, error = _validate_location(workspace, item)
+        if checked is not None:
+            valid.append(checked)
+        else:
+            errors.append(f"{label} evidence {index} ({item.path!r}): {error}")
+    return tuple(valid), tuple(errors)
+
+
+def validate_candidates(
+    workspace: Path,
+    candidates: tuple[LocalSpecification, ...],
+) -> tuple[tuple[LocalSpecification, ...], tuple[str, ...]]:
+    """Discard candidate evidence that cannot be verified in *workspace*."""
+
+    valid: list[LocalSpecification] = []
+    errors: list[str] = []
+    for index, candidate in enumerate(candidates, start=1):
+        evidence, evidence_errors = _validated_evidence(
+            workspace,
+            candidate.evidence,
+            label=f"{candidate.explorer or 'explorer'} candidate {index}",
+        )
+        errors.extend(evidence_errors)
+        if evidence:
+            valid.append(replace(candidate, evidence=evidence))
+    return tuple(valid), tuple(errors)
+
+
+def validate_findings(
+    workspace: Path,
+    findings: tuple[GuardianFinding, ...],
+) -> tuple[tuple[GuardianFinding, ...], tuple[str, ...]]:
+    """Discard aggregate findings without a verifiable source location."""
+
+    valid: list[GuardianFinding] = []
+    errors: list[str] = []
+    for index, finding in enumerate(findings, start=1):
+        evidence, evidence_errors = _validated_evidence(
+            workspace,
+            finding.evidence,
+            label=f"aggregator finding {index}",
+        )
+        errors.extend(evidence_errors)
+        if evidence:
+            valid.append(replace(finding, evidence=evidence))
+    return tuple(valid), tuple(errors)
+
+
+__all__ = ["validate_candidates", "validate_findings"]

--- a/codenib/clients/guardian/exchange.py
+++ b/codenib/clients/guardian/exchange.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Commit-addressed filesystem exchange for external Guardian controllers.
+
+The coding-agent environment is an untrusted publisher.  It writes a Git
+bundle and a small manifest into a controller-owned exchange directory.  The
+controller validates both before materializing a fresh checkout for review.
+No path supplied by the publisher is interpreted as an arbitrary host path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+_REVISION = re.compile(r"^[0-9a-f]{40}$")
+_REQUEST_ID = re.compile(r"^[0-9a-f]{40}$")
+SCHEMA_VERSION = 1
+DEFAULT_MAX_BUNDLE_BYTES = 256 * 1024**2
+
+
+class ExchangeProtocolError(ValueError):
+    """An exchange artifact is malformed, stale, or fails validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewExchangeRequest:
+    """A request to review one exact transition between Git commits."""
+
+    request_id: str
+    base_commit: str
+    candidate_commit: str
+    bundle_name: str
+    bundle_sha256: str
+    schema_version: int = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ExchangeProtocolError(
+                f"unsupported exchange schema version: {self.schema_version}"
+            )
+        for name in ("request_id", "base_commit", "candidate_commit"):
+            value = getattr(self, name)
+            pattern = _REQUEST_ID if name == "request_id" else _REVISION
+            if not isinstance(value, str) or not pattern.fullmatch(value):
+                raise ExchangeProtocolError(f"{name} must be a full lowercase Git SHA")
+        if self.request_id != self.candidate_commit:
+            raise ExchangeProtocolError("request_id must equal candidate_commit")
+        expected_bundle = f"{self.request_id}.bundle"
+        if self.bundle_name != expected_bundle:
+            raise ExchangeProtocolError(
+                f"bundle_name must be the canonical name {expected_bundle!r}"
+            )
+        if not re.fullmatch(r"[0-9a-f]{64}", self.bundle_sha256):
+            raise ExchangeProtocolError("bundle_sha256 must be a lowercase SHA-256")
+        if self.base_commit == self.candidate_commit:
+            raise ExchangeProtocolError("base and candidate commits must differ")
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, raw: object) -> "ReviewExchangeRequest":
+        if not isinstance(raw, dict):
+            raise ExchangeProtocolError("request manifest must be a JSON object")
+        try:
+            return cls(
+                schema_version=int(raw["schema_version"]),
+                request_id=str(raw["request_id"]),
+                base_commit=str(raw["base_commit"]),
+                candidate_commit=str(raw["candidate_commit"]),
+                bundle_name=str(raw["bundle_name"]),
+                bundle_sha256=str(raw["bundle_sha256"]),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            if isinstance(exc, ExchangeProtocolError):
+                raise
+            raise ExchangeProtocolError(f"invalid request manifest: {exc}") from exc
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def load_exchange_request(
+    exchange_root: Path,
+    manifest_path: Path,
+    *,
+    max_bundle_bytes: int = DEFAULT_MAX_BUNDLE_BYTES,
+) -> tuple[ReviewExchangeRequest, Path]:
+    """Load a manifest and resolve its bundle below ``exchange_root``."""
+
+    root = exchange_root.resolve(strict=True)
+    manifest = manifest_path.resolve(strict=True)
+    requests_dir = (root / "requests").resolve(strict=True)
+    if manifest.parent != requests_dir or manifest.suffix != ".json":
+        raise ExchangeProtocolError("manifest is outside the canonical requests dir")
+    try:
+        request = ReviewExchangeRequest.from_dict(
+            json.loads(manifest.read_text(encoding="utf-8"))
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ExchangeProtocolError(f"cannot read request manifest: {exc}") from exc
+    if manifest.name != f"{request.request_id}.json":
+        raise ExchangeProtocolError("manifest filename does not match request_id")
+
+    bundle = root / "bundles" / request.bundle_name
+    try:
+        bundle = bundle.resolve(strict=True)
+    except OSError as exc:
+        raise ExchangeProtocolError(f"bundle is unavailable: {exc}") from exc
+    bundles_dir = (root / "bundles").resolve(strict=True)
+    if bundle.parent != bundles_dir or not bundle.is_file():
+        raise ExchangeProtocolError("bundle is outside the canonical bundles dir")
+    size = bundle.stat().st_size
+    if size <= 0 or size > max_bundle_bytes:
+        raise ExchangeProtocolError(f"bundle size {size} is outside the accepted range")
+    if _sha256(bundle) != request.bundle_sha256:
+        raise ExchangeProtocolError("bundle checksum does not match manifest")
+    return request, bundle
+
+
+def _git(*args: str, cwd: Path | None = None) -> str:
+    try:
+        result = subprocess.run(
+            ("git", *args),
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+            env={
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_TERMINAL_PROMPT": "0",
+                "PATH": "/usr/bin:/bin",
+                "LANG": "C.UTF-8",
+            },
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ExchangeProtocolError(f"Git bundle validation failed: {exc}") from exc
+    return result.stdout.strip()
+
+
+def materialize_exchange_request(
+    request: ReviewExchangeRequest,
+    bundle: Path,
+    destination: Path,
+) -> Path:
+    """Validate the advertised commits and create a detached candidate checkout."""
+
+    destination.mkdir(parents=True, exist_ok=False)
+    _git("init", "--quiet", cwd=destination)
+    _git(
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        str(bundle),
+        "refs/guardian/base:refs/guardian/base",
+        "refs/guardian/candidate:refs/guardian/candidate",
+        cwd=destination,
+    )
+    base = _git("rev-parse", "refs/guardian/base^{commit}", cwd=destination)
+    candidate = _git("rev-parse", "refs/guardian/candidate^{commit}", cwd=destination)
+    if base != request.base_commit or candidate != request.candidate_commit:
+        raise ExchangeProtocolError("bundle refs do not match the advertised commits")
+    _git("merge-base", "--is-ancestor", base, candidate, cwd=destination)
+    _git("checkout", "--quiet", "--detach", candidate, cwd=destination)
+    return destination
+
+
+__all__ = [
+    "DEFAULT_MAX_BUNDLE_BYTES",
+    "ExchangeProtocolError",
+    "ReviewExchangeRequest",
+    "SCHEMA_VERSION",
+    "load_exchange_request",
+    "materialize_exchange_request",
+]

--- a/codenib/clients/guardian/interaction.py
+++ b/codenib/clients/guardian/interaction.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Append-only, untrusted messages addressed to Guardian."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+MAX_MESSAGE_CHARS = 16_000
+MAX_SCOPE_ITEMS = 32
+MAX_SCOPE_CHARS = 512
+
+
+def _head(repo_path: str) -> str:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+@dataclass(frozen=True, slots=True)
+class GuardianMessage:
+    id: str
+    sequence: int
+    sender: str
+    content: str
+    observed_head: str
+    created_at: str
+    scope: list[str]
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, object]) -> "GuardianMessage":
+        scope = raw.get("scope", [])
+        return cls(
+            id=str(raw["id"]),
+            sequence=int(raw["sequence"]),
+            sender=str(raw["sender"]),
+            content=str(raw["content"]),
+            observed_head=str(raw.get("observed_head", "")),
+            created_at=str(raw["created_at"]),
+            scope=[str(item) for item in scope] if isinstance(scope, list) else [],
+        )
+
+
+class MessageInbox:
+    def __init__(self, path: str | Path, *, repo_path: str | Path) -> None:
+        self.path = Path(path)
+        self.repo_path = str(repo_path)
+
+    @staticmethod
+    def _normalize_scope(scope: Optional[Iterable[str]]) -> list[str]:
+        values = [str(item).strip() for item in (scope or []) if str(item).strip()]
+        if len(values) > MAX_SCOPE_ITEMS:
+            raise ValueError(f"scope accepts at most {MAX_SCOPE_ITEMS} entries")
+        if any(len(item) > MAX_SCOPE_CHARS for item in values):
+            raise ValueError(
+                f"each scope entry accepts at most {MAX_SCOPE_CHARS} characters"
+            )
+        return values
+
+    def append(
+        self,
+        content: str,
+        *,
+        sender: str,
+        scope: Optional[Iterable[str]] = None,
+    ) -> GuardianMessage:
+        normalized = str(content).strip()
+        if not normalized:
+            raise ValueError("message must not be empty")
+        if len(normalized) > MAX_MESSAGE_CHARS:
+            raise ValueError(f"message exceeds the {MAX_MESSAGE_CHARS}-character limit")
+        sender = str(sender).strip()
+        if not sender:
+            raise ValueError("sender must not be empty")
+        normalized_scope = self._normalize_scope(scope)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a+", encoding="utf-8") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            handle.seek(0)
+            sequence = 1
+            for line in handle:
+                try:
+                    sequence = max(
+                        sequence, int(json.loads(line).get("sequence", 0)) + 1
+                    )
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    continue
+            message = GuardianMessage(
+                id=f"msg_{sequence:08d}",
+                sequence=sequence,
+                sender=sender,
+                content=normalized,
+                observed_head=_head(self.repo_path),
+                created_at=datetime.now(timezone.utc).isoformat(),
+                scope=normalized_scope,
+            )
+            handle.seek(0, os.SEEK_END)
+            handle.write(json.dumps(message.to_dict(), sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return message
+
+    def read_recent(self, *, limit: int = 20) -> list[GuardianMessage]:
+        if not self.path.exists():
+            return []
+        messages: list[GuardianMessage] = []
+        with self.path.open(encoding="utf-8") as handle:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_SH)
+            for line in handle:
+                try:
+                    value = json.loads(line)
+                    if isinstance(value, dict):
+                        messages.append(GuardianMessage.from_dict(value))
+                except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                    continue
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return messages[-max(1, min(int(limit), 100)) :]
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inbox", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--scope", action="append", default=[])
+    args = parser.parse_args(argv)
+    message = MessageInbox(args.inbox, repo_path=args.repo).append(
+        sys.stdin.read(), sender="solver:filesystem", scope=args.scope
+    )
+    print(json.dumps(message.to_dict(), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+
+
+__all__ = ["GuardianMessage", "MessageInbox"]

--- a/codenib/clients/guardian/normalization.py
+++ b/codenib/clients/guardian/normalization.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict semantic normalization for Guardian agent responses."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .types import (
+    Evidence,
+    EvidenceAuthority,
+    FindingStatus,
+    GuardianFinding,
+    LocalSpecification,
+)
+
+_FENCE = re.compile(r"```(?:json)?\s*(\{.*\})\s*```", re.DOTALL)
+
+
+class GuardianResponseError(ValueError):
+    """An agent completed without a valid Guardian response."""
+
+
+def _object(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    match = _FENCE.search(stripped)
+    if match:
+        stripped = match.group(1)
+    try:
+        value = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        raise GuardianResponseError(f"response is not valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise GuardianResponseError("response must be a JSON object")
+    return value
+
+
+def _evidence(raw: object) -> tuple[Evidence, ...]:
+    if not isinstance(raw, list):
+        return ()
+    values: list[Evidence] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        try:
+            authority = EvidenceAuthority(str(item.get("authority", "repository")))
+        except ValueError:
+            authority = EvidenceAuthority.REPOSITORY
+        try:
+            start = max(1, int(item.get("line_start", 1)))
+            end = max(start, int(item.get("line_end", start)))
+        except (TypeError, ValueError):
+            start = end = 1
+        path = str(item.get("path", "")).strip()
+        description = str(item.get("description", "")).strip()
+        if path and description:
+            values.append(
+                Evidence(
+                    path=path,
+                    line_start=start,
+                    line_end=end,
+                    description=description,
+                    authority=authority,
+                )
+            )
+    return tuple(values)
+
+
+def _confidence(value: object) -> float:
+    try:
+        return min(1.0, max(0.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def parse_candidates(text: str, *, explorer: str) -> tuple[LocalSpecification, ...]:
+    rows = _object(text).get("candidates")
+    if not isinstance(rows, list):
+        raise GuardianResponseError("response has no candidates array")
+    values: list[LocalSpecification] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        statement = str(row.get("statement", "")).strip()
+        evidence = _evidence(row.get("evidence"))
+        if not statement or not evidence:
+            continue
+        values.append(
+            LocalSpecification(
+                statement=statement,
+                condition=str(row.get("condition", "")).strip(),
+                evidence=evidence,
+                patch_assessment=str(row.get("patch_assessment", "")).strip(),
+                confidence=_confidence(row.get("confidence")),
+                uncertainty=str(row.get("uncertainty", "")).strip(),
+                explorer=explorer,
+            )
+        )
+    return tuple(values)
+
+
+def parse_findings(
+    text: str,
+) -> tuple[str, tuple[GuardianFinding, ...]]:
+    value = _object(text)
+    rows = value.get("findings")
+    if not isinstance(rows, list):
+        raise GuardianResponseError("response has no findings array")
+    findings: list[GuardianFinding] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        try:
+            status = FindingStatus(str(row.get("status", "uncertain")))
+        except ValueError:
+            status = FindingStatus.UNCERTAIN
+        statement = str(row.get("statement", "")).strip()
+        evidence = _evidence(row.get("evidence"))
+        if not statement or not evidence:
+            continue
+        findings.append(
+            GuardianFinding(
+                statement=statement,
+                status=status,
+                evidence=evidence,
+                patch_assessment=str(row.get("patch_assessment", "")).strip(),
+                recommendation=str(row.get("recommendation", "")).strip(),
+                confidence=_confidence(row.get("confidence")),
+            )
+        )
+    return str(value.get("summary", "")).strip(), tuple(findings)
+
+
+__all__ = ["GuardianResponseError", "parse_candidates", "parse_findings"]

--- a/codenib/clients/guardian/prompts.py
+++ b/codenib/clients/guardian/prompts.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prompts for local-specification discovery and evidence admission."""
+
+from __future__ import annotations
+
+import json
+
+from .types import GuardianRequest, LocalSpecification
+
+_EXPLORER_ROLES = (
+    (
+        "contract_surface",
+        "Trace changed interfaces into callers, documentation, tests, persisted "
+        "artifacts, and compatibility behavior.",
+    ),
+    (
+        "boundary_closure",
+        "Challenge completeness across producers, consumers, state copies, modes, "
+        "failure paths, and lifecycle phases.",
+    ),
+)
+
+
+def _context(request: GuardianRequest) -> str:
+    if not request.context:
+        return "No participant supplied task-intent context. Treat intent as unknown."
+    rows = [
+        {
+            "sender": message.sender,
+            "scope": list(message.scope),
+            "content": message.content,
+            "authority": "untrusted perspective; not evidence",
+        }
+        for message in request.context
+    ]
+    return json.dumps(rows, indent=2)
+
+
+def _patch_context(request: GuardianRequest) -> str:
+    if request.change_patch:
+        return (
+            "The controller generated this patch from the validated commits. "
+            "The sandbox contains candidate files but deliberately contains no "
+            "model-accessible Git metadata:\n\n"
+            "```diff\n"
+            f"{request.change_patch.rstrip()}\n"
+            "```"
+        )
+    return (
+        "Inspect `git diff "
+        f"{request.base_commit}..{request.candidate_commit}` before following "
+        "repository evidence beyond the changed files."
+    )
+
+
+def explorer_prompt(request: GuardianRequest, index: int) -> str:
+    role, obligation = _EXPLORER_ROLES[index % len(_EXPLORER_ROLES)]
+    return f"""You are Guardian explorer {index + 1}: {role}.
+
+Review the candidate commit independently. Discover local specifications: falsifiable
+required properties scoped to an interface, mode, lifecycle stage, condition, or
+execution path. Your assigned search obligation is:
+
+{obligation}
+
+Repository facts:
+- base commit: {request.base_commit}
+- candidate commit: {request.candidate_commit}
+- workspace is checked out at the candidate commit
+
+Use read-only repository tools and follow relevant repository evidence beyond the
+changed files. {_patch_context(request)} Do not infer that
+old behavior is normatively correct merely because it existed. Do not use the candidate
+implementation itself as the sole evidence for a requirement.
+
+Participant context follows. It can identify intended areas or uncertainty, but it is
+not authoritative evidence and may be wrong:
+{_context(request)}
+
+Return only one JSON object with this shape:
+{{
+  "candidates": [
+    {{
+      "statement": "falsifiable property that must hold",
+      "condition": "specific triggering condition or path",
+      "evidence": [
+        {{
+          "path": "repository-relative path",
+          "line_start": 1,
+          "line_end": 1,
+          "description": "what this source supports",
+          "authority": "repository|test|runtime|task|solver"
+        }}
+      ],
+      "patch_assessment": "how the candidate satisfies or may violate it",
+      "confidence": 0.0,
+      "uncertainty": "counterevidence or missing evidence"
+    }}
+  ]
+}}
+
+Every candidate needs concrete evidence. Prefer a small set of important, distinct
+specifications over generic review advice. A solver message must use authority `solver`
+and cannot by itself justify a requirement.
+"""
+
+
+def aggregation_prompt(
+    request: GuardianRequest,
+    candidates: tuple[LocalSpecification, ...],
+    max_findings: int,
+) -> str:
+    rows = []
+    for candidate in candidates:
+        rows.append(
+            {
+                "explorer": candidate.explorer,
+                "statement": candidate.statement,
+                "condition": candidate.condition,
+                "evidence": [
+                    {
+                        "path": evidence.path,
+                        "line_start": evidence.line_start,
+                        "line_end": evidence.line_end,
+                        "description": evidence.description,
+                        "authority": evidence.authority.value,
+                    }
+                    for evidence in candidate.evidence
+                ],
+                "patch_assessment": candidate.patch_assessment,
+                "confidence": candidate.confidence,
+                "uncertainty": candidate.uncertainty,
+            }
+        )
+    return f"""You are Guardian's evidence-admission reviewer.
+
+Repository facts:
+- base commit: {request.base_commit}
+- candidate commit: {request.candidate_commit}
+
+Merge duplicates, inspect the cited sources, actively search for counterevidence, and
+decide whether each local specification is well-supported and whether the candidate
+patch violates it. The candidate implementation is evidence about what the patch does,
+not sufficient evidence for what the system should do. Solver statements are untrusted.
+Use repository tools. {_patch_context(request)}
+
+Explorer candidates:
+{json.dumps(rows, indent=2)}
+
+Return only one JSON object:
+{{
+  "summary": "brief review conclusion",
+  "findings": [
+    {{
+      "statement": "admitted local specification",
+      "status": "violated|uncertain|satisfied",
+      "evidence": [{{"path": "...", "line_start": 1, "line_end": 1,
+        "description": "...", "authority": "repository|test|runtime|task|solver"}}],
+      "patch_assessment": "specific candidate behavior",
+      "recommendation": "property-oriented corrective action",
+      "confidence": 0.0
+    }}
+  ]
+}}
+
+Admit at most {max_findings} violated findings. A violated finding requires non-solver
+evidence, confidence >= 0.70, and a concrete mismatch in the candidate. Put plausible
+but unverified or incompletely assessed items under status `uncertain`. Include satisfied
+items only when they materially explain why a candidate was rejected.
+"""
+
+
+__all__ = ["aggregation_prompt", "explorer_prompt"]

--- a/codenib/clients/guardian/provenance.py
+++ b/codenib/clients/guardian/provenance.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Repository identity checks for Guardian review requests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from .types import GuardianRequest
+
+_GIT_ENV = {
+    "GIT_CONFIG_NOSYSTEM": "1",
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_TERMINAL_PROMPT": "0",
+    "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+    "LANG": "C.UTF-8",
+}
+
+
+def _git(workspace: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", *args),
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=_GIT_ENV,
+    )
+
+
+def validate_request_provenance(request: GuardianRequest) -> str | None:
+    """Return an error when *request* is not the advertised candidate checkout."""
+
+    try:
+        resolved: dict[str, str] = {}
+        for name, revision in (
+            ("HEAD", "HEAD"),
+            ("base", request.base_commit),
+            ("candidate", request.candidate_commit),
+        ):
+            result = _git(
+                request.workspace, "rev-parse", "--verify", f"{revision}^{{commit}}"
+            )
+            if result.returncode != 0:
+                return f"repository provenance check could not resolve {name} commit"
+            resolved[name] = result.stdout.strip().lower()
+
+        if resolved["HEAD"] != resolved["candidate"]:
+            return "workspace HEAD does not match the advertised candidate commit"
+        ancestry = _git(
+            request.workspace,
+            "merge-base",
+            "--is-ancestor",
+            resolved["base"],
+            resolved["candidate"],
+        )
+        if ancestry.returncode != 0:
+            return "base commit is not an ancestor of the candidate commit"
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"repository provenance check failed: {type(exc).__name__}"
+    return None
+
+
+__all__ = ["validate_request_provenance"]

--- a/codenib/clients/guardian/types.py
+++ b/codenib/clients/guardian/types.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Value types for evidence-backed local-specification review."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Sequence
+
+from ..execution import AgentRunResult, ExecutionIsolation, TokenUsage
+
+_REVISION = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+class EvidenceAuthority(str, Enum):
+    TASK = "task"
+    REPOSITORY = "repository"
+    TEST = "test"
+    RUNTIME = "runtime"
+    SOLVER = "solver"
+
+
+@dataclass(frozen=True, slots=True)
+class ContextMessage:
+    """Non-authoritative context supplied by a solver or another participant."""
+
+    content: str
+    sender: str = "solver"
+    scope: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class Evidence:
+    path: str
+    line_start: int
+    line_end: int
+    description: str
+    authority: EvidenceAuthority = EvidenceAuthority.REPOSITORY
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "authority", EvidenceAuthority(self.authority))
+
+
+@dataclass(frozen=True, slots=True)
+class LocalSpecification:
+    statement: str
+    condition: str
+    evidence: tuple[Evidence, ...]
+    patch_assessment: str
+    confidence: float
+    uncertainty: str = ""
+    explorer: str = ""
+
+
+class FindingStatus(str, Enum):
+    VIOLATED = "violated"
+    UNCERTAIN = "uncertain"
+    SATISFIED = "satisfied"
+
+
+@dataclass(frozen=True, slots=True)
+class GuardianFinding:
+    statement: str
+    status: FindingStatus
+    evidence: tuple[Evidence, ...]
+    patch_assessment: str
+    recommendation: str
+    confidence: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "status", FindingStatus(self.status))
+
+
+@dataclass(frozen=True, slots=True)
+class GuardianRequest:
+    workspace: Path
+    base_commit: str
+    candidate_commit: str
+    context: tuple[ContextMessage, ...] = ()
+    change_patch: str = ""
+
+    def __post_init__(self) -> None:
+        workspace = Path(self.workspace).expanduser().resolve()
+        if not workspace.is_dir():
+            raise ValueError(f"workspace must be an existing directory: {workspace}")
+        for name in ("base_commit", "candidate_commit"):
+            revision = getattr(self, name).lower()
+            if not _REVISION.fullmatch(revision):
+                raise ValueError(f"{name} must be a 7-40 character lowercase Git SHA")
+            object.__setattr__(self, name, revision)
+        object.__setattr__(self, "workspace", workspace)
+        object.__setattr__(self, "context", tuple(self.context))
+        if not isinstance(self.change_patch, str):
+            raise TypeError("change_patch must be a string")
+        if len(self.change_patch.encode("utf-8")) > 2 * 1024**2:
+            raise ValueError("change_patch exceeds the 2 MiB request limit")
+
+
+@dataclass(frozen=True, slots=True)
+class GuardianConfig:
+    explorer_model: str
+    aggregator_model: str
+    explorer_count: int = 2
+    explorer_reasoning_effort: str = "medium"
+    aggregator_reasoning_effort: str = "medium"
+    rollout_timeout_seconds: float = 600.0
+    max_findings: int = 5
+    execution_isolation: ExecutionIsolation = ExecutionIsolation.NATIVE
+
+    def __post_init__(self) -> None:
+        if self.explorer_count < 1:
+            raise ValueError("explorer_count must be positive")
+        if self.max_findings < 1:
+            raise ValueError("max_findings must be positive")
+        object.__setattr__(
+            self,
+            "execution_isolation",
+            ExecutionIsolation(self.execution_isolation),
+        )
+
+
+class ReviewStatus(str, Enum):
+    COMPLETE = "complete"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+
+
+def _usage_total(rollouts: Sequence[AgentRunResult]) -> TokenUsage:
+    fields = (
+        "input_tokens",
+        "cached_input_tokens",
+        "cache_write_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+    )
+    totals = {
+        field: sum(getattr(rollout.usage, field) for rollout in rollouts)
+        for field in fields
+    }
+    return TokenUsage(**totals)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardianResult:
+    base_commit: str
+    candidate_commit: str
+    status: ReviewStatus
+    candidates: tuple[LocalSpecification, ...] = ()
+    findings: tuple[GuardianFinding, ...] = ()
+    backlog: tuple[GuardianFinding, ...] = ()
+    summary: str = ""
+    rollouts: tuple[AgentRunResult, ...] = field(default=(), repr=False)
+    errors: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "status", ReviewStatus(self.status))
+
+    @property
+    def usage(self) -> TokenUsage:
+        return _usage_total(self.rollouts)
+
+    def to_dict(self) -> dict[str, object]:
+        def specification(value: LocalSpecification) -> dict[str, object]:
+            row = asdict(value)
+            for evidence in row["evidence"]:
+                evidence["authority"] = evidence["authority"].value
+            return row
+
+        def finding(value: GuardianFinding) -> dict[str, object]:
+            row = asdict(value)
+            row["status"] = value.status.value
+            for evidence in row["evidence"]:
+                evidence["authority"] = evidence["authority"].value
+            return row
+
+        return {
+            "base_commit": self.base_commit,
+            "candidate_commit": self.candidate_commit,
+            "status": self.status.value,
+            "summary": self.summary,
+            "candidates": [specification(value) for value in self.candidates],
+            "findings": [finding(value) for value in self.findings],
+            "backlog": [finding(value) for value in self.backlog],
+            "candidate_count": len(self.candidates),
+            "errors": list(self.errors),
+            "usage": {
+                "input_tokens": self.usage.input_tokens,
+                "cached_input_tokens": self.usage.cached_input_tokens,
+                "cache_write_input_tokens": self.usage.cache_write_input_tokens,
+                "output_tokens": self.usage.output_tokens,
+                "reasoning_output_tokens": self.usage.reasoning_output_tokens,
+                "total_tokens": self.usage.total_tokens,
+            },
+        }
+
+
+__all__ = [
+    "ContextMessage",
+    "Evidence",
+    "EvidenceAuthority",
+    "FindingStatus",
+    "GuardianConfig",
+    "GuardianFinding",
+    "GuardianRequest",
+    "GuardianResult",
+    "LocalSpecification",
+    "ReviewStatus",
+]

--- a/codenib/clients/guardian/types.py
+++ b/codenib/clients/guardian/types.py
@@ -43,6 +43,24 @@ class Evidence:
     authority: EvidenceAuthority = EvidenceAuthority.REPOSITORY
 
     def __post_init__(self) -> None:
+        if not isinstance(self.path, str) or not self.path.strip():
+            raise ValueError("evidence path must be a non-empty string")
+        if not isinstance(self.description, str) or not self.description.strip():
+            raise ValueError("evidence description must be a non-empty string")
+        if (
+            isinstance(self.line_start, bool)
+            or not isinstance(self.line_start, int)
+            or self.line_start < 1
+        ):
+            raise ValueError("evidence line_start must be a positive integer")
+        if (
+            isinstance(self.line_end, bool)
+            or not isinstance(self.line_end, int)
+            or self.line_end < self.line_start
+        ):
+            raise ValueError("evidence line_end must not precede line_start")
+        object.__setattr__(self, "path", self.path.strip())
+        object.__setattr__(self, "description", self.description.strip())
         object.__setattr__(self, "authority", EvidenceAuthority(self.authority))
 
 

--- a/codenib/eval/benchmarks/deepswe/__init__.py
+++ b/codenib/eval/benchmarks/deepswe/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Portable analysis of artifacts produced by the DeepSWE benchmark harness.
+
+This package does not launch DeepSWE or own its task containers.  It reads the
+fixed-slot trial artifacts produced by the external harness and provides the
+metric, cost, and reporting logic shared by command-line tools and dashboards.
+"""
+
+from .metrics import (
+    DEFAULT_PRICES_USD_PER_MTOK,
+    Pricing,
+    add_costs,
+    metric_mean,
+    metric_sum,
+    pricing_for_model,
+)
+from .reports import (
+    export_dashboard_data,
+    summary_rows,
+    task_rows,
+    trial_row,
+    write_summary,
+)
+from .results import COUNTED_JOB_IDS, load_rows, metadata_paths
+
+__all__ = [
+    "COUNTED_JOB_IDS",
+    "DEFAULT_PRICES_USD_PER_MTOK",
+    "Pricing",
+    "add_costs",
+    "export_dashboard_data",
+    "load_rows",
+    "metadata_paths",
+    "metric_mean",
+    "metric_sum",
+    "pricing_for_model",
+    "summary_rows",
+    "task_rows",
+    "trial_row",
+    "write_summary",
+]

--- a/codenib/eval/benchmarks/deepswe/metrics.py
+++ b/codenib/eval/benchmarks/deepswe/metrics.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSWE metric aggregation and token-cost normalization."""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+DEFAULT_PRICES_USD_PER_MTOK = {
+    "gpt-5.6-luna": {
+        "input": 2.50,
+        "cached_input": 0.25,
+        "output": 15.00,
+    },
+    "gpt-5.6-terra": {
+        "input": 2.50,
+        "cached_input": 0.25,
+        "output": 15.00,
+    },
+}
+
+
+@dataclass(frozen=True)
+class Pricing:
+    """Per-million-token rates used to cost one DeepSWE trial."""
+
+    input_usd_per_mtok: float | None
+    cached_input_usd_per_mtok: float | None
+    output_usd_per_mtok: float | None
+    output_includes_reasoning: bool = True
+
+
+def pricing_for_model(
+    model: str,
+    *,
+    input_usd_per_mtok: float | None = None,
+    cached_input_usd_per_mtok: float | None = None,
+    output_usd_per_mtok: float | None = None,
+    output_includes_reasoning: bool = True,
+) -> Pricing:
+    """Resolve optional overrides against the known rates for *model*."""
+
+    defaults = DEFAULT_PRICES_USD_PER_MTOK.get(model, {})
+    return Pricing(
+        input_usd_per_mtok=(
+            input_usd_per_mtok
+            if input_usd_per_mtok is not None
+            else defaults.get("input")
+        ),
+        cached_input_usd_per_mtok=(
+            cached_input_usd_per_mtok
+            if cached_input_usd_per_mtok is not None
+            else defaults.get("cached_input")
+        ),
+        output_usd_per_mtok=(
+            output_usd_per_mtok
+            if output_usd_per_mtok is not None
+            else defaults.get("output")
+        ),
+        output_includes_reasoning=output_includes_reasoning,
+    )
+
+
+def _main_cost(row: Mapping[str, Any], pricing: Pricing) -> float | None:
+    if (
+        pricing.input_usd_per_mtok is None
+        or pricing.cached_input_usd_per_mtok is None
+        or pricing.output_usd_per_mtok is None
+        or row.get("main_input_tokens") is None
+    ):
+        return None
+    input_tokens = float(row.get("main_input_tokens") or 0)
+    cached_tokens = float(row.get("main_cached_input_tokens") or 0)
+    output_tokens = float(row.get("main_output_tokens") or 0)
+    if not pricing.output_includes_reasoning:
+        output_tokens += float(row.get("main_reasoning_output_tokens") or 0)
+    uncached_tokens = max(0.0, input_tokens - cached_tokens)
+    return (
+        uncached_tokens / 1_000_000 * pricing.input_usd_per_mtok
+        + cached_tokens / 1_000_000 * pricing.cached_input_usd_per_mtok
+        + output_tokens / 1_000_000 * pricing.output_usd_per_mtok
+    )
+
+
+def _guardian_cost(row: Mapping[str, Any], pricing: Pricing) -> float | None:
+    if (
+        pricing.input_usd_per_mtok is None
+        or pricing.output_usd_per_mtok is None
+        or row.get("guardian_prompt_tokens") is None
+    ):
+        return None
+    prompt = float(row.get("guardian_prompt_tokens") or 0)
+    cached = float(row.get("guardian_cached_input_tokens") or 0)
+    completion = float(row.get("guardian_completion_tokens") or 0)
+    uncached = max(0.0, prompt - cached)
+    cached_rate = (
+        pricing.cached_input_usd_per_mtok
+        if pricing.cached_input_usd_per_mtok is not None
+        else pricing.input_usd_per_mtok
+    )
+    return (
+        uncached / 1_000_000 * pricing.input_usd_per_mtok
+        + cached / 1_000_000 * cached_rate
+        + completion / 1_000_000 * pricing.output_usd_per_mtok
+    )
+
+
+def add_costs(
+    row: Mapping[str, Any],
+    *,
+    input_usd_per_mtok: float | None = None,
+    cached_input_usd_per_mtok: float | None = None,
+    output_usd_per_mtok: float | None = None,
+    output_includes_reasoning: bool = True,
+) -> dict[str, Any]:
+    """Return a copy of one trial row with normalized cost fields."""
+
+    result = dict(row)
+    pricing = pricing_for_model(
+        str(result.get("model") or ""),
+        input_usd_per_mtok=input_usd_per_mtok,
+        cached_input_usd_per_mtok=cached_input_usd_per_mtok,
+        output_usd_per_mtok=output_usd_per_mtok,
+        output_includes_reasoning=output_includes_reasoning,
+    )
+    main_cost = _main_cost(result, pricing)
+    guardian_cost = _guardian_cost(result, pricing)
+    result["main_cost_usd"] = main_cost
+    result["guardian_cost_usd"] = guardian_cost
+    result["total_cost_usd"] = (
+        (main_cost or 0) + (guardian_cost or 0)
+        if main_cost is not None or guardian_cost is not None
+        else None
+    )
+    return result
+
+
+def metric_mean(rows: Sequence[Mapping[str, Any]], key: str) -> float | None:
+    """Return the arithmetic mean of numeric values for *key*."""
+
+    values = [row.get(key) for row in rows]
+    numeric = [value for value in values if isinstance(value, (int, float))]
+    return float(statistics.fmean(numeric)) if numeric else None
+
+
+def metric_sum(rows: Sequence[Mapping[str, Any]], key: str) -> float | None:
+    """Return the sum of numeric values for *key*."""
+
+    values = [row.get(key) for row in rows]
+    numeric = [value for value in values if isinstance(value, (int, float))]
+    return float(sum(numeric)) if numeric else None

--- a/codenib/eval/benchmarks/deepswe/reports.py
+++ b/codenib/eval/benchmarks/deepswe/reports.py
@@ -29,9 +29,8 @@ def _format_cell(value: Any) -> str:
 def write_summary(rows: Sequence[Mapping[str, Any]], summary_csv: Path) -> None:
     """Write aggregate trial metrics grouped by task, arm, model, and effort."""
 
-    successful = [row for row in rows if row.get("returncode") == 0]
     groups: dict[tuple[str, str, str, str], list[Mapping[str, Any]]] = {}
-    for row in successful:
+    for row in rows:
         key = (
             str(row.get("task") or ""),
             str(row.get("baseline") or ""),
@@ -45,7 +44,9 @@ def write_summary(rows: Sequence[Mapping[str, Any]], summary_csv: Path) -> None:
         "baseline",
         "model",
         "reasoning_effort",
+        "n_recorded_trials",
         "n_trials",
+        "n_execution_failures",
         "avg_reward",
         "avg_f2p",
         "avg_p2p",
@@ -74,43 +75,46 @@ def write_summary(rows: Sequence[Mapping[str, Any]], summary_csv: Path) -> None:
         writer = csv.DictWriter(handle, fieldnames=fields)
         writer.writeheader()
         for (task, baseline, model, effort), group in sorted(groups.items()):
+            valid = [row for row in group if row.get("returncode") == 0]
             latest = max(group, key=lambda row: str(row.get("created_at") or ""))
             output = {
                 "task": task,
                 "baseline": baseline,
                 "model": model,
                 "reasoning_effort": effort,
-                "n_trials": len(group),
-                "avg_reward": metric_mean(group, "reward"),
-                "avg_f2p": metric_mean(group, "f2p"),
-                "avg_p2p": metric_mean(group, "p2p"),
-                "avg_partial": metric_mean(group, "partial"),
-                "avg_f2p_passed": metric_mean(group, "f2p_passed"),
-                "avg_f2p_total": metric_mean(group, "f2p_total"),
-                "avg_p2p_passed": metric_mean(group, "p2p_passed"),
-                "avg_p2p_total": metric_mean(group, "p2p_total"),
-                "pass_rate": metric_mean(group, "reward"),
-                "avg_main_input_tokens": metric_mean(group, "main_input_tokens"),
+                "n_recorded_trials": len(group),
+                "n_trials": len(valid),
+                "n_execution_failures": len(group) - len(valid),
+                "avg_reward": metric_mean(valid, "reward"),
+                "avg_f2p": metric_mean(valid, "f2p"),
+                "avg_p2p": metric_mean(valid, "p2p"),
+                "avg_partial": metric_mean(valid, "partial"),
+                "avg_f2p_passed": metric_mean(valid, "f2p_passed"),
+                "avg_f2p_total": metric_mean(valid, "f2p_total"),
+                "avg_p2p_passed": metric_mean(valid, "p2p_passed"),
+                "avg_p2p_total": metric_mean(valid, "p2p_total"),
+                "pass_rate": metric_mean(valid, "reward"),
+                "avg_main_input_tokens": metric_mean(valid, "main_input_tokens"),
                 "avg_main_cached_input_tokens": metric_mean(
-                    group, "main_cached_input_tokens"
+                    valid, "main_cached_input_tokens"
                 ),
-                "avg_main_output_tokens": metric_mean(group, "main_output_tokens"),
+                "avg_main_output_tokens": metric_mean(valid, "main_output_tokens"),
                 "avg_main_reasoning_output_tokens": metric_mean(
-                    group, "main_reasoning_output_tokens"
+                    valid, "main_reasoning_output_tokens"
                 ),
                 "avg_guardian_prompt_tokens": metric_mean(
-                    group, "guardian_prompt_tokens"
+                    valid, "guardian_prompt_tokens"
                 ),
                 "avg_guardian_cached_input_tokens": metric_mean(
-                    group, "guardian_cached_input_tokens"
+                    valid, "guardian_cached_input_tokens"
                 ),
                 "avg_guardian_completion_tokens": metric_mean(
-                    group, "guardian_completion_tokens"
+                    valid, "guardian_completion_tokens"
                 ),
-                "avg_main_cost_usd": metric_mean(group, "main_cost_usd"),
-                "avg_guardian_cost_usd": metric_mean(group, "guardian_cost_usd"),
-                "avg_total_cost_usd": metric_mean(group, "total_cost_usd"),
-                "sum_total_cost_usd": metric_sum(group, "total_cost_usd"),
+                "avg_main_cost_usd": metric_mean(valid, "main_cost_usd"),
+                "avg_guardian_cost_usd": metric_mean(valid, "guardian_cost_usd"),
+                "avg_total_cost_usd": metric_mean(valid, "total_cost_usd"),
+                "sum_total_cost_usd": metric_sum(valid, "total_cost_usd"),
                 "latest_output_dir": latest.get("output_dir") or "",
                 "latest_result_json": latest.get("result_json") or "",
             }
@@ -195,18 +199,18 @@ def _group_key(row: Mapping[str, Any]) -> tuple[str, str, str, str]:
 
 
 def summary_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
-    """Aggregate successful trials for dashboard display."""
+    """Aggregate valid trials while retaining every recorded slot in counts."""
 
     groups: dict[tuple[str, str, str, str], list[Mapping[str, Any]]] = {}
     for row in rows:
-        if row.get("returncode") == 0:
-            groups.setdefault(_group_key(row), []).append(row)
+        groups.setdefault(_group_key(row), []).append(row)
 
     result: list[dict[str, Any]] = []
     for (task, baseline, model, effort), group in sorted(groups.items()):
+        valid = [row for row in group if row.get("returncode") == 0]
         rewards = [
             float(value)
-            for row in group
+            for row in valid
             if isinstance((value := row.get("reward")), (int, float))
         ]
         result.append(
@@ -216,26 +220,32 @@ def summary_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
                 "model": model,
                 "reasoning_effort": effort,
                 "label": f"{baseline} / {model} / {effort}",
-                "n_trials": len(group),
-                "pass_rate": metric_mean(group, "reward"),
-                "avg_reward": metric_mean(group, "reward"),
-                "avg_f2p": metric_mean(group, "f2p"),
-                "avg_p2p": metric_mean(group, "p2p"),
-                "avg_partial": metric_mean(group, "partial"),
-                "avg_main_input_tokens": metric_mean(group, "main_input_tokens"),
-                "avg_main_output_tokens": metric_mean(group, "main_output_tokens"),
+                "n_recorded_trials": len(group),
+                "n_trials": len(valid),
+                "n_execution_failures": len(group) - len(valid),
+                "pass_rate": metric_mean(valid, "reward"),
+                "avg_reward": metric_mean(valid, "reward"),
+                "avg_f2p": metric_mean(valid, "f2p"),
+                "avg_p2p": metric_mean(valid, "p2p"),
+                "avg_partial": metric_mean(valid, "partial"),
+                "avg_main_input_tokens": metric_mean(valid, "main_input_tokens"),
+                "avg_main_output_tokens": metric_mean(valid, "main_output_tokens"),
                 "avg_guardian_prompt_tokens": metric_mean(
-                    group, "guardian_prompt_tokens"
+                    valid, "guardian_prompt_tokens"
                 ),
                 "avg_guardian_cached_input_tokens": metric_mean(
-                    group, "guardian_cached_input_tokens"
+                    valid, "guardian_cached_input_tokens"
                 ),
                 "avg_guardian_completion_tokens": metric_mean(
-                    group, "guardian_completion_tokens"
+                    valid, "guardian_completion_tokens"
                 ),
-                "avg_total_cost_usd": metric_mean(group, "total_cost_usd"),
-                "sum_total_cost_usd": metric_sum(group, "total_cost_usd"),
-                "std_reward": (statistics.pstdev(rewards) if len(rewards) > 1 else 0.0),
+                "avg_total_cost_usd": metric_mean(valid, "total_cost_usd"),
+                "sum_total_cost_usd": metric_sum(valid, "total_cost_usd"),
+                "std_reward": (
+                    statistics.pstdev(rewards)
+                    if len(rewards) > 1
+                    else 0.0 if rewards else None
+                ),
                 "latest_output_dir": max(
                     group, key=lambda row: str(row.get("created_at") or "")
                 ).get("output_dir"),
@@ -259,13 +269,15 @@ def task_rows(summaries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
     for (task, model, effort), rows in sorted(grouped.items()):
         solo = next((row for row in rows if row["baseline"] == "solo"), None)
         guardian = next((row for row in rows if row["baseline"] == "guardian"), None)
+        solo_pass_rate = (solo or {}).get("pass_rate")
+        guardian_pass_rate = (guardian or {}).get("pass_rate")
         result.append(
             {
                 "task": task,
                 "model": model,
                 "reasoning_effort": effort,
-                "solo_pass_rate": (solo or {}).get("pass_rate"),
-                "guardian_pass_rate": (guardian or {}).get("pass_rate"),
+                "solo_pass_rate": solo_pass_rate,
+                "guardian_pass_rate": guardian_pass_rate,
                 "solo_avg_f2p": (solo or {}).get("avg_f2p"),
                 "guardian_avg_f2p": (guardian or {}).get("avg_f2p"),
                 "solo_avg_p2p": (solo or {}).get("avg_p2p"),
@@ -273,13 +285,17 @@ def task_rows(summaries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
                 "solo_avg_partial": (solo or {}).get("avg_partial"),
                 "guardian_avg_partial": (guardian or {}).get("avg_partial"),
                 "delta_pass_rate": (
-                    (guardian or {}).get("pass_rate", 0)
-                    - (solo or {}).get("pass_rate", 0)
-                    if solo and guardian
+                    guardian_pass_rate - solo_pass_rate
+                    if isinstance(solo_pass_rate, (int, float))
+                    and isinstance(guardian_pass_rate, (int, float))
                     else None
                 ),
                 "solo_trials": (solo or {}).get("n_trials", 0),
                 "guardian_trials": (guardian or {}).get("n_trials", 0),
+                "solo_recorded_trials": (solo or {}).get("n_recorded_trials", 0),
+                "guardian_recorded_trials": (guardian or {}).get(
+                    "n_recorded_trials", 0
+                ),
                 "guardian_avg_cost_usd": (guardian or {}).get("avg_total_cost_usd"),
             }
         )

--- a/codenib/eval/benchmarks/deepswe/reports.py
+++ b/codenib/eval/benchmarks/deepswe/reports.py
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CSV and dashboard reports for externally produced DeepSWE trials."""
+
+from __future__ import annotations
+
+import csv
+import math
+import statistics
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .metrics import add_costs, metric_mean, metric_sum
+from .results import COUNTED_JOB_IDS, load_rows
+
+
+def _format_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        if math.isnan(value):
+            return ""
+        return f"{value:.6g}"
+    return str(value)
+
+
+def write_summary(rows: Sequence[Mapping[str, Any]], summary_csv: Path) -> None:
+    """Write aggregate trial metrics grouped by task, arm, model, and effort."""
+
+    successful = [row for row in rows if row.get("returncode") == 0]
+    groups: dict[tuple[str, str, str, str], list[Mapping[str, Any]]] = {}
+    for row in successful:
+        key = (
+            str(row.get("task") or ""),
+            str(row.get("baseline") or ""),
+            str(row.get("model") or ""),
+            str(row.get("reasoning_effort") or ""),
+        )
+        groups.setdefault(key, []).append(row)
+
+    fields = [
+        "task",
+        "baseline",
+        "model",
+        "reasoning_effort",
+        "n_trials",
+        "avg_reward",
+        "avg_f2p",
+        "avg_p2p",
+        "avg_partial",
+        "avg_f2p_passed",
+        "avg_f2p_total",
+        "avg_p2p_passed",
+        "avg_p2p_total",
+        "pass_rate",
+        "avg_main_input_tokens",
+        "avg_main_cached_input_tokens",
+        "avg_main_output_tokens",
+        "avg_main_reasoning_output_tokens",
+        "avg_guardian_prompt_tokens",
+        "avg_guardian_cached_input_tokens",
+        "avg_guardian_completion_tokens",
+        "avg_main_cost_usd",
+        "avg_guardian_cost_usd",
+        "avg_total_cost_usd",
+        "sum_total_cost_usd",
+        "latest_output_dir",
+        "latest_result_json",
+    ]
+    summary_csv.parent.mkdir(parents=True, exist_ok=True)
+    with summary_csv.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for (task, baseline, model, effort), group in sorted(groups.items()):
+            latest = max(group, key=lambda row: str(row.get("created_at") or ""))
+            output = {
+                "task": task,
+                "baseline": baseline,
+                "model": model,
+                "reasoning_effort": effort,
+                "n_trials": len(group),
+                "avg_reward": metric_mean(group, "reward"),
+                "avg_f2p": metric_mean(group, "f2p"),
+                "avg_p2p": metric_mean(group, "p2p"),
+                "avg_partial": metric_mean(group, "partial"),
+                "avg_f2p_passed": metric_mean(group, "f2p_passed"),
+                "avg_f2p_total": metric_mean(group, "f2p_total"),
+                "avg_p2p_passed": metric_mean(group, "p2p_passed"),
+                "avg_p2p_total": metric_mean(group, "p2p_total"),
+                "pass_rate": metric_mean(group, "reward"),
+                "avg_main_input_tokens": metric_mean(group, "main_input_tokens"),
+                "avg_main_cached_input_tokens": metric_mean(
+                    group, "main_cached_input_tokens"
+                ),
+                "avg_main_output_tokens": metric_mean(group, "main_output_tokens"),
+                "avg_main_reasoning_output_tokens": metric_mean(
+                    group, "main_reasoning_output_tokens"
+                ),
+                "avg_guardian_prompt_tokens": metric_mean(
+                    group, "guardian_prompt_tokens"
+                ),
+                "avg_guardian_cached_input_tokens": metric_mean(
+                    group, "guardian_cached_input_tokens"
+                ),
+                "avg_guardian_completion_tokens": metric_mean(
+                    group, "guardian_completion_tokens"
+                ),
+                "avg_main_cost_usd": metric_mean(group, "main_cost_usd"),
+                "avg_guardian_cost_usd": metric_mean(group, "guardian_cost_usd"),
+                "avg_total_cost_usd": metric_mean(group, "total_cost_usd"),
+                "sum_total_cost_usd": metric_sum(group, "total_cost_usd"),
+                "latest_output_dir": latest.get("output_dir") or "",
+                "latest_result_json": latest.get("result_json") or "",
+            }
+            writer.writerow({key: _format_cell(output.get(key)) for key in fields})
+
+
+def _latest_episode_dir(row: Mapping[str, Any]) -> str:
+    output_dir = Path(str(row.get("output_dir") or ""))
+    episodes = sorted((output_dir / "agent_logs" / "guardian_episodes").glob("*"))
+    return str(episodes[-1]) if episodes else ""
+
+
+def trial_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize one metadata row for the static dashboard."""
+
+    output_dir = str(row.get("output_dir") or "")
+    latest_episode = _latest_episode_dir(row)
+    return {
+        "task": row.get("task"),
+        "baseline": row.get("baseline"),
+        "job_id": row.get("job_id"),
+        "model": row.get("model"),
+        "reasoning_effort": row.get("reasoning_effort"),
+        "reward": row.get("reward"),
+        "f2p": row.get("f2p"),
+        "f2p_passed": row.get("f2p_passed"),
+        "f2p_total": row.get("f2p_total"),
+        "p2p": row.get("p2p"),
+        "p2p_passed": row.get("p2p_passed"),
+        "p2p_total": row.get("p2p_total"),
+        "partial": row.get("partial"),
+        "returncode": row.get("returncode"),
+        "main_input_tokens": row.get("main_input_tokens"),
+        "main_cached_input_tokens": row.get("main_cached_input_tokens"),
+        "main_output_tokens": row.get("main_output_tokens"),
+        "main_reasoning_output_tokens": row.get("main_reasoning_output_tokens"),
+        "guardian_findings": row.get("guardian_findings"),
+        "guardian_backlog": row.get("guardian_backlog"),
+        "guardian_high_confidence_backlog": row.get("guardian_high_confidence_backlog"),
+        "guardian_degraded": row.get("guardian_degraded"),
+        "guardian_analysis_status": row.get("guardian_analysis_status"),
+        "guardian_cycle_count": row.get("guardian_cycle_count"),
+        "guardian_exit_reasons": row.get("guardian_exit_reasons"),
+        "guardian_llm_backend": row.get("guardian_llm_backend"),
+        "guardian_prompt_tokens": row.get("guardian_prompt_tokens"),
+        "guardian_cached_input_tokens": row.get("guardian_cached_input_tokens"),
+        "guardian_completion_tokens": row.get("guardian_completion_tokens"),
+        "guardian_total_tokens": row.get("guardian_total_tokens"),
+        "main_cost_usd": row.get("main_cost_usd"),
+        "guardian_cost_usd": row.get("guardian_cost_usd"),
+        "total_cost_usd": row.get("total_cost_usd"),
+        "created_at": row.get("created_at"),
+        "output_dir": output_dir,
+        "pier_result_json": row.get("pier_result_json") or row.get("result_json"),
+        "metadata_path": row.get("metadata_path"),
+        "codex_log": f"{output_dir}/agent_logs/codex.txt" if output_dir else "",
+        "codex_bridge_log": (
+            f"{output_dir}/agent_logs/codex_bridge.log"
+            if row.get("baseline") == "guardian" and output_dir
+            else ""
+        ),
+        "latest_guardian_episode": latest_episode,
+        "latest_guardian_findings": (
+            f"{latest_episode}/findings.md" if latest_episode else ""
+        ),
+        "latest_guardian_status": (
+            f"{latest_episode}/status.json" if latest_episode else ""
+        ),
+        "latest_guardian_log": (
+            f"{latest_episode}/guardian.log" if latest_episode else ""
+        ),
+    }
+
+
+def _group_key(row: Mapping[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(row.get("task") or ""),
+        str(row.get("baseline") or ""),
+        str(row.get("model") or ""),
+        str(row.get("reasoning_effort") or ""),
+    )
+
+
+def summary_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Aggregate successful trials for dashboard display."""
+
+    groups: dict[tuple[str, str, str, str], list[Mapping[str, Any]]] = {}
+    for row in rows:
+        if row.get("returncode") == 0:
+            groups.setdefault(_group_key(row), []).append(row)
+
+    result: list[dict[str, Any]] = []
+    for (task, baseline, model, effort), group in sorted(groups.items()):
+        rewards = [
+            float(value)
+            for row in group
+            if isinstance((value := row.get("reward")), (int, float))
+        ]
+        result.append(
+            {
+                "task": task,
+                "baseline": baseline,
+                "model": model,
+                "reasoning_effort": effort,
+                "label": f"{baseline} / {model} / {effort}",
+                "n_trials": len(group),
+                "pass_rate": metric_mean(group, "reward"),
+                "avg_reward": metric_mean(group, "reward"),
+                "avg_f2p": metric_mean(group, "f2p"),
+                "avg_p2p": metric_mean(group, "p2p"),
+                "avg_partial": metric_mean(group, "partial"),
+                "avg_main_input_tokens": metric_mean(group, "main_input_tokens"),
+                "avg_main_output_tokens": metric_mean(group, "main_output_tokens"),
+                "avg_guardian_prompt_tokens": metric_mean(
+                    group, "guardian_prompt_tokens"
+                ),
+                "avg_guardian_cached_input_tokens": metric_mean(
+                    group, "guardian_cached_input_tokens"
+                ),
+                "avg_guardian_completion_tokens": metric_mean(
+                    group, "guardian_completion_tokens"
+                ),
+                "avg_total_cost_usd": metric_mean(group, "total_cost_usd"),
+                "sum_total_cost_usd": metric_sum(group, "total_cost_usd"),
+                "std_reward": (statistics.pstdev(rewards) if len(rewards) > 1 else 0.0),
+                "latest_output_dir": max(
+                    group, key=lambda row: str(row.get("created_at") or "")
+                ).get("output_dir"),
+            }
+        )
+    return result
+
+
+def task_rows(summaries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Pair solo and Guardian summaries for each task/model setting."""
+
+    grouped: dict[tuple[str, str, str], list[Mapping[str, Any]]] = {}
+    for row in summaries:
+        key = (
+            str(row["task"]),
+            str(row["model"]),
+            str(row["reasoning_effort"]),
+        )
+        grouped.setdefault(key, []).append(row)
+    result = []
+    for (task, model, effort), rows in sorted(grouped.items()):
+        solo = next((row for row in rows if row["baseline"] == "solo"), None)
+        guardian = next((row for row in rows if row["baseline"] == "guardian"), None)
+        result.append(
+            {
+                "task": task,
+                "model": model,
+                "reasoning_effort": effort,
+                "solo_pass_rate": (solo or {}).get("pass_rate"),
+                "guardian_pass_rate": (guardian or {}).get("pass_rate"),
+                "solo_avg_f2p": (solo or {}).get("avg_f2p"),
+                "guardian_avg_f2p": (guardian or {}).get("avg_f2p"),
+                "solo_avg_p2p": (solo or {}).get("avg_p2p"),
+                "guardian_avg_p2p": (guardian or {}).get("avg_p2p"),
+                "solo_avg_partial": (solo or {}).get("avg_partial"),
+                "guardian_avg_partial": (guardian or {}).get("avg_partial"),
+                "delta_pass_rate": (
+                    (guardian or {}).get("pass_rate", 0)
+                    - (solo or {}).get("pass_rate", 0)
+                    if solo and guardian
+                    else None
+                ),
+                "solo_trials": (solo or {}).get("n_trials", 0),
+                "guardian_trials": (guardian or {}).get("n_trials", 0),
+                "guardian_avg_cost_usd": (guardian or {}).get("avg_total_cost_usd"),
+            }
+        )
+    return result
+
+
+def export_dashboard_data(
+    output_root: Path,
+    *,
+    input_usd_per_mtok: float | None = None,
+    cached_input_usd_per_mtok: float | None = None,
+    output_usd_per_mtok: float | None = None,
+    output_includes_reasoning: bool = True,
+) -> dict[str, Any]:
+    """Build the complete serializable payload consumed by the dashboard."""
+
+    rows = [
+        add_costs(
+            row,
+            input_usd_per_mtok=input_usd_per_mtok,
+            cached_input_usd_per_mtok=cached_input_usd_per_mtok,
+            output_usd_per_mtok=output_usd_per_mtok,
+            output_includes_reasoning=output_includes_reasoning,
+        )
+        for row in load_rows(output_root)
+    ]
+    summaries = summary_rows(rows)
+    return {
+        "schema_version": 1,
+        "output_root": str(output_root),
+        "counted_job_ids": sorted(COUNTED_JOB_IDS),
+        "summary": summaries,
+        "tasks": task_rows(summaries),
+        "trials": [trial_row(row) for row in rows],
+    }

--- a/codenib/eval/benchmarks/deepswe/results.py
+++ b/codenib/eval/benchmarks/deepswe/results.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load fixed-slot results emitted by external DeepSWE runs."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+COUNTED_JOB_IDS = frozenset(f"job_{index}" for index in range(1, 5))
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _row_setting_key(row: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(row.get("task") or ""),
+        str(row.get("baseline") or ""),
+        str(row.get("model") or ""),
+        str(row.get("reasoning_effort") or ""),
+    )
+
+
+def metadata_paths(output_root: Path) -> list[Path]:
+    """Discover counted solo and Guardian trial metadata below *output_root*."""
+
+    paths: list[Path] = []
+    for path in output_root.rglob("metadata.json"):
+        job_id = path.parent.name
+        baseline = path.parent.parent.name if path.parent.parent else ""
+        if job_id in COUNTED_JOB_IDS and baseline in {"solo", "guardian"}:
+            paths.append(path)
+    return sorted(paths)
+
+
+def load_rows(output_root: Path) -> list[dict[str, Any]]:
+    """Load trial rows, preferring setting-scoped layout over legacy rows."""
+
+    rows: list[dict[str, Any]] = []
+    for path in metadata_paths(output_root):
+        job_id = path.parent.name
+        row = _load_json(path)
+        if not row:
+            print(f"[warn] ignoring unreadable metadata: {path}", file=sys.stderr)
+            continue
+        if str(row.get("job_id") or job_id) not in COUNTED_JOB_IDS:
+            continue
+        row["job_id"] = job_id
+        row.setdefault("metadata_path", str(path))
+        row["_layout"] = (
+            "setting" if len(path.relative_to(output_root).parts) >= 5 else "legacy"
+        )
+        rows.append(row)
+
+    setting_keys = {
+        _row_setting_key(row) for row in rows if row.get("_layout") == "setting"
+    }
+    filtered = [
+        row
+        for row in rows
+        if row.get("_layout") == "setting" or _row_setting_key(row) not in setting_keys
+    ]
+    for row in filtered:
+        row.pop("_layout", None)
+    return filtered

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance and experiment tooling."""

--- a/scripts/guardian/__init__.py
+++ b/scripts/guardian/__init__.py
@@ -1,0 +1,1 @@
+"""Repository Guardian operational tooling."""

--- a/scripts/guardian/deepswe/README.md
+++ b/scripts/guardian/deepswe/README.md
@@ -46,3 +46,5 @@ checkpoint command but cannot launch another Guardian review.
 
 Generated trial data belongs under `data/deepswe_outputs/`; generated
 `dashboard/data.json` is ignored and can be recreated by the exporter.
+Set `CODENIB_DEEPSWE_ROOT` to use a DeepSWE checkout outside the default
+sibling directory, and `CODENIB_DEEPSWE_OUTPUT_ROOT` to relocate trial data.

--- a/scripts/guardian/deepswe/README.md
+++ b/scripts/guardian/deepswe/README.md
@@ -1,0 +1,48 @@
+# DeepSWE Guardian tooling
+
+This directory owns CodeNib's external DeepSWE experiment integration:
+
+- `harness/` is the DeepSWE adapter and host-side sandbox controller;
+- `ablation.py` and `solo_matrix.py` launch trials;
+- `results.py` and `export_dashboard.py` are thin command-line adapters over
+  `codenib.eval.benchmarks.deepswe`;
+- `outputs.py` maintains externally produced artifacts;
+- `dashboard/` provides the static results viewer.
+
+The packaged `codenib.eval.benchmarks.deepswe` modules load, cost, aggregate,
+and report DeepSWE results. They deliberately do not launch the benchmark or
+depend on its runtime. The external harness boundary remains in this directory.
+
+The harness deliberately lives outside `codenib`. The external benchmark host
+imports the custom agent before it starts a task container. Guardian policy and
+execution abstractions remain packaged under `codenib.clients`; only the Pier
+lifecycle and commit-exchange adapter live here.
+
+Run tools as modules from the repository root, for example:
+
+```bash
+python -m scripts.guardian.deepswe.ablation --help
+python -m scripts.guardian.deepswe.solo_matrix --help
+python -m scripts.guardian.deepswe.results --help
+python -m scripts.guardian.deepswe.export_dashboard --help
+```
+
+The DeepSWE runner loads the Guardian wrapper through:
+
+```text
+scripts.guardian.deepswe.harness.agent:GuardianCodingAgent
+```
+
+The wrapper delegates local-specification discovery and aggregation to
+`codenib.clients.guardian`. Its host-specific responsibility is limited to
+launching the solver, validating commit-scoped exchange artifacts, and creating
+independent sibling sandboxes for Guardian rollouts. CodeNib and its Python
+environment are not mounted into the solver container.
+
+Guardian performs at most three review cycles by default. Configure this with
+`--guardian-max-cycles`. The final allowed report is marked terminal and keeps
+its unresolved findings; subsequent solver edits can be acknowledged by the
+checkpoint command but cannot launch another Guardian review.
+
+Generated trial data belongs under `data/deepswe_outputs/`; generated
+`dashboard/data.json` is ignored and can be recreated by the exporter.

--- a/scripts/guardian/deepswe/__init__.py
+++ b/scripts/guardian/deepswe/__init__.py
@@ -1,0 +1,1 @@
+"""DeepSWE experiment runners and reporting tools."""

--- a/scripts/guardian/deepswe/__init__.py
+++ b/scripts/guardian/deepswe/__init__.py
@@ -1,1 +1,28 @@
 """DeepSWE experiment runners and reporting tools."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _environment_path(name: str, default: Path) -> Path:
+    return Path(os.environ.get(name, default)).expanduser()
+
+
+DEFAULT_CODENIB_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_DEEPSWE_ROOT = _environment_path(
+    "CODENIB_DEEPSWE_ROOT", DEFAULT_CODENIB_ROOT.parent / "deep-swe"
+)
+DEFAULT_OUTPUT_ROOT = _environment_path(
+    "CODENIB_DEEPSWE_OUTPUT_ROOT",
+    DEFAULT_CODENIB_ROOT / "data" / "deepswe_outputs",
+)
+DEFAULT_JOBS_DIR = DEFAULT_DEEPSWE_ROOT / "jobs"
+
+__all__ = [
+    "DEFAULT_CODENIB_ROOT",
+    "DEFAULT_DEEPSWE_ROOT",
+    "DEFAULT_JOBS_DIR",
+    "DEFAULT_OUTPUT_ROOT",
+]

--- a/scripts/guardian/deepswe/ablation.py
+++ b/scripts/guardian/deepswe/ablation.py
@@ -58,10 +58,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-DEFAULT_CODENIB_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_DEEPSWE_ROOT = Path("/home/xiangye/deep-swe")
-DEFAULT_OUTPUT_ROOT = Path("/mnt/data/xiangye/deepswe_outputs")
-DEFAULT_JOBS_DIR = DEFAULT_DEEPSWE_ROOT / "jobs"
+from scripts.guardian.deepswe import (
+    DEFAULT_CODENIB_ROOT,
+    DEFAULT_DEEPSWE_ROOT,
+    DEFAULT_JOBS_DIR,
+    DEFAULT_OUTPUT_ROOT,
+)
+
 DEEPSWE_HARNESS_RELATIVE_PATH = Path("scripts/guardian/deepswe/harness")
 
 

--- a/scripts/guardian/deepswe/ablation.py
+++ b/scripts/guardian/deepswe/ablation.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run DeepSWE Codex-vs-Guardian ablations.
+
+Example:
+
+    python -m scripts.guardian.deepswe.ablation \\
+        --model gpt-5.6-terra \\
+        --reasoning-effort medium \\
+        --tasks igel-persist-feature-schema
+
+The script runs two baselines for each task:
+
+* ``solo``: Pier's regular Codex agent, no Guardian.
+* ``guardian``: GuardianCodingAgent wrapping Codex with the Guardian sidecar.
+
+Pass ``--guardian-no-budget-limit`` to measure Guardian's natural token cost.
+This disables only the cycle token ceiling; turn and wall-clock limits remain.
+
+Each requested baseline is run ``--runs`` times.  Results are stored in fixed
+slots keyed by model setting:
+
+    deepswe_outputs/<model>_<reasoning_effort>/<task_name>/<baseline_name>/job_1/
+    ...
+    deepswe_outputs/<model>_<reasoning_effort>/<task_name>/<baseline_name>/job_4/
+
+Each job directory is self-contained:
+
+    command.json          exact ``pier run`` argv
+    metadata.json         normalized metrics/tokens/provenance for table scans
+    pier_result.json      copied Pier aggregate result.json
+    pier_stdout.txt       raw Pier stdout/stderr
+    agent_logs/           Codex transcript, token log, bridge log
+    agent_logs/guardian_episodes/
+                         per-cycle Guardian logs and reports
+
+Guardian per-cycle debug logs are under:
+
+    agent_logs/guardian_episodes/<cycle>_<commit>/guardian.log
+
+The table generator only counts ``job_1`` through ``job_4``.  Existing solo
+slots are skipped by default; Guardian slots are refreshed when run again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CODEMINER_ROOT = Path("/home/xiangye/CodeMiner")
+DEFAULT_DEEPSWE_ROOT = Path("/home/xiangye/deep-swe")
+DEFAULT_OUTPUT_ROOT = Path("/mnt/data/xiangye/deepswe_outputs")
+DEFAULT_JOBS_DIR = DEFAULT_DEEPSWE_ROOT / "jobs"
+DEEPSWE_HARNESS_RELATIVE_PATH = Path("scripts/guardian/deepswe/harness")
+
+
+def _harness_path(codeminer_root: Path) -> Path:
+    """Return the dependency-isolated Pier harness in the CodeNib checkout."""
+
+    return codeminer_root / DEEPSWE_HARNESS_RELATIVE_PATH
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+
+
+def _setting_slug(model: str, reasoning_effort: str) -> str:
+    return f"{_slug(model)}_{_slug(reasoning_effort)}"
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+
+
+def _write_json(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(row, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _extract_metrics(result: dict[str, Any] | None) -> dict[str, float | None]:
+    empty = {
+        "reward": None,
+        "f2p": None,
+        "f2p_passed": None,
+        "f2p_total": None,
+        "p2p": None,
+        "p2p_passed": None,
+        "p2p_total": None,
+        "partial": None,
+    }
+    if not result:
+        return empty
+    evals = (result.get("stats") or {}).get("evals") or {}
+    for eval_row in evals.values():
+        metrics = eval_row.get("metrics") or []
+        if metrics:
+            return {k: metrics[0].get(k) for k in empty}
+    return empty
+
+
+def _guardian_run_status(logs_dir: Path) -> dict[str, Any] | None:
+    """Combine run-wide health and usage with the final cycle's state."""
+
+    rows = [
+        (path, status)
+        for path in (logs_dir / "guardian_episodes").glob("*/status.json")
+        if (status := _load_json(path)) is not None
+    ]
+    if rows and all(
+        isinstance(status.get("cycle_index"), int) for _path, status in rows
+    ):
+        rows.sort(key=lambda row: int(row[1]["cycle_index"]))
+    else:
+        rows.sort(key=lambda row: (row[0].stat().st_mtime_ns, row[0].parent.name))
+    statuses = [status for _path, status in rows]
+    if not statuses:
+        return None
+
+    summary = dict(statuses[-1])
+    token_fields = ("prompt", "cached_input", "completion", "total")
+    summary["llm_tokens"] = {
+        field: sum(
+            int((status.get("llm_tokens") or {}).get(field, 0) or 0)
+            for status in statuses
+        )
+        for field in token_fields
+    }
+    summary["cycle_count"] = sum(
+        bool(status.get("review_performed", True)) for status in statuses
+    )
+    summary["exit_reasons"] = [
+        str(status.get("exit_reason") or "") for status in statuses
+    ]
+    summary["degraded"] = any(bool(status.get("degraded")) for status in statuses)
+
+    health = {str(status.get("analysis_status") or "") for status in statuses}
+    if "failed" in health:
+        summary["analysis_status"] = "failed"
+    elif health - {"complete", "degraded"}:
+        summary["analysis_status"] = "incomplete"
+    elif summary["degraded"] or "degraded" in health:
+        summary["analysis_status"] = "degraded"
+    else:
+        summary["analysis_status"] = "complete"
+    return summary
+
+
+def _codex_tokens_from_log(log_path: Path) -> dict[str, int] | None:
+    totals = {
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_output_tokens": 0,
+    }
+    seen = False
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except FileNotFoundError:
+        return None
+
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        usage = event.get("usage")
+        if event.get("type") != "turn.completed" or not isinstance(usage, dict):
+            continue
+        seen = True
+        for key in totals:
+            value = usage.get(key)
+            if isinstance(value, int):
+                totals[key] += value
+    return totals if seen else None
+
+
+def _find_result_path(stdout: str, jobs_dir: Path, started_at: float) -> Path | None:
+    match = re.search(r"Results written to (.+/result\.json)", stdout)
+    if match:
+        path = Path(match.group(1).strip())
+        if path.exists():
+            return path
+    candidates = [
+        p for p in jobs_dir.glob("*/result.json") if p.stat().st_mtime >= started_at - 2
+    ]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _common_mounts(args: argparse.Namespace, logs_dir: Path) -> list[dict[str, str]]:
+    return [
+        {"type": "bind", "source": str(logs_dir), "target": "/logs/agent"},
+        {
+            "type": "bind",
+            "source": str(_harness_path(args.codeminer_root) / "task_venv_profile.sh"),
+            "target": "/etc/profile.d/zz-deepswe-task-venv.sh",
+        },
+    ]
+
+
+def _guardian_mounts(
+    args: argparse.Namespace,
+    logs_dir: Path,
+) -> list[dict[str, object]]:
+    mounts: list[dict[str, object]] = list(_common_mounts(args, logs_dir))
+    for name in ("responses", "latest"):
+        mounts.append(
+            {
+                "type": "bind",
+                "source": str(logs_dir / "guardian_exchange" / name),
+                "target": f"/logs/agent/guardian_exchange/{name}",
+                "read_only": True,
+            }
+        )
+    mounts.append(
+        {
+            "type": "bind",
+            "source": str(logs_dir / "guardian_episodes"),
+            "target": "/logs/agent/guardian_episodes",
+            "read_only": True,
+        }
+    )
+    return mounts
+
+
+def _prepare_host_output_dirs(
+    *,
+    base_dir: Path,
+    logs_dir: Path,
+) -> None:
+    """Create mount targets on the host so container-created files are removable.
+
+    Pier/Docker can write mounted files as a container UID that maps to host
+    ``nobody``.  Deletion is controlled by write permission on the parent
+    directory, so keep the parent directories host-owned and writable.
+    """
+    dirs = [
+        base_dir,
+        logs_dir,
+        logs_dir / "guardian_episodes",
+        logs_dir / "guardian_exchange",
+        logs_dir / "guardian_exchange" / "responses",
+        logs_dir / "guardian_exchange" / "latest",
+    ]
+    for path in dirs:
+        path.mkdir(parents=True, exist_ok=True)
+        path.chmod(0o777)
+
+
+def _repair_output_permissions(path: Path) -> None:
+    """Make an output tree manageable by the current host user.
+
+    Container-created files may be owned by a mapped UID such as ``nobody``.
+    We avoid requiring sudo here; broad user/group/other write+execute on the
+    output tree is enough for the owner of ancestor dirs to clean it up.
+    """
+    if not path.exists():
+        return
+    for child in path.rglob("*"):
+        try:
+            if child.is_dir():
+                child.chmod(0o777)
+            else:
+                child.chmod(0o666)
+        except OSError:
+            pass
+    try:
+        path.chmod(0o777)
+    except OSError:
+        pass
+
+
+def _build_pier_command(
+    args: argparse.Namespace,
+    *,
+    task: str,
+    baseline: str,
+    logs_dir: Path,
+) -> list[str]:
+    task_path = args.deepswe_root / "tasks" / task
+    cmd = [
+        "pier",
+        "run",
+        "-p",
+        str(task_path),
+        "--model",
+        args.model,
+        "--ae",
+        "CODEX_FORCE_AUTH_JSON=1",
+        "--ak",
+        f"reasoning_effort={args.reasoning_effort}",
+        "--jobs-dir",
+        str(args.jobs_dir),
+        "-y",
+    ]
+    env_pythonpath = os.environ.get("PYTHONPATH", "")
+    if baseline == "guardian":
+        cmd.extend(
+            [
+                "--agent-import-path",
+                "scripts.guardian.deepswe.harness.agent:GuardianCodingAgent",
+                "--ak",
+                "solver=codex",
+                "--ak",
+                f"guardian_model={args.guardian_model}",
+                "--ak",
+                f"guardian_explorer_count={args.guardian_explorer_count}",
+                "--ak",
+                f"guardian_max_findings={args.guardian_max_findings}",
+                "--ak",
+                f"guardian_max_cycles={args.guardian_max_cycles}",
+                "--ak",
+                f"guardian_rollout_timeout={args.guardian_rollout_timeout}",
+                "--ak",
+                "guardian_host_exchange_dir=" f"{logs_dir / 'guardian_exchange'}",
+                "--mounts-json",
+                json.dumps(_guardian_mounts(args, logs_dir)),
+            ]
+        )
+        if str(args.codeminer_root) not in env_pythonpath.split(os.pathsep):
+            os.environ["PYTHONPATH"] = (
+                str(args.codeminer_root)
+                if not env_pythonpath
+                else f"{args.codeminer_root}{os.pathsep}{env_pythonpath}"
+            )
+    else:
+        cmd.extend(
+            [
+                "--agent",
+                "codex",
+                "--mounts-json",
+                json.dumps(_common_mounts(args, logs_dir)),
+            ]
+        )
+        prompt_template_path = getattr(args, "prompt_template_path", None)
+        if prompt_template_path is not None:
+            cmd.extend(
+                [
+                    "--ak",
+                    f"prompt_template_path={prompt_template_path}",
+                ]
+            )
+    return cmd
+
+
+def _run_trial(
+    args: argparse.Namespace,
+    *,
+    task: str,
+    baseline: str,
+    repeat_index: int,
+) -> dict[str, Any]:
+    job_id = f"job_{repeat_index}"
+    setting = _setting_slug(args.model, args.reasoning_effort)
+    base_dir = args.output_root / setting / _slug(task) / baseline / job_id
+    if baseline == "guardian" and base_dir.exists():
+        _repair_output_permissions(base_dir)
+        shutil.rmtree(base_dir)
+    logs_dir = base_dir / "agent_logs"
+    _prepare_host_output_dirs(
+        base_dir=base_dir,
+        logs_dir=logs_dir,
+    )
+
+    cmd = _build_pier_command(
+        args,
+        task=task,
+        baseline=baseline,
+        logs_dir=logs_dir,
+    )
+    _write_json(
+        base_dir / "command.json",
+        {
+            "cwd": str(args.codeminer_root),
+            "argv": cmd,
+        },
+    )
+    stdout_path = base_dir / "pier_stdout.txt"
+    started = time.time()
+    print(f"[run] {task} {baseline} #{repeat_index}: {base_dir}", flush=True)
+    proc = subprocess.run(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=args.codeminer_root,
+        check=False,
+    )
+    _repair_output_permissions(base_dir)
+    stdout_path.write_text(proc.stdout, encoding="utf-8")
+    result_path = _find_result_path(proc.stdout, args.jobs_dir, started)
+    local_result_path = base_dir / "pier_result.json"
+    if result_path:
+        shutil.copy2(result_path, local_result_path)
+    result = _load_json(result_path) if result_path else None
+    metrics = _extract_metrics(result)
+
+    codex_tokens = _load_json(logs_dir / "codex_tokens.json") or _codex_tokens_from_log(
+        logs_dir / "codex.txt"
+    )
+    guardian_status = _guardian_run_status(logs_dir) if baseline == "guardian" else None
+
+    row: dict[str, Any] = {
+        "created_at": datetime.now().isoformat(timespec="seconds"),
+        "task": task,
+        "baseline": baseline,
+        "job_id": job_id,
+        "model": args.model,
+        "reasoning_effort": args.reasoning_effort,
+        "context_injection_source": str(
+            getattr(args, "context_injection_source", "") or ""
+        ),
+        "context_injection_sha256": str(
+            getattr(args, "context_injection_sha256", "") or ""
+        ),
+        "guardian_model": args.guardian_model if baseline == "guardian" else "",
+        "guardian_explorer_count": (
+            args.guardian_explorer_count if baseline == "guardian" else None
+        ),
+        "guardian_max_findings": (
+            args.guardian_max_findings if baseline == "guardian" else None
+        ),
+        "guardian_max_cycles": (
+            args.guardian_max_cycles if baseline == "guardian" else None
+        ),
+        "guardian_rollout_timeout": (
+            args.guardian_rollout_timeout if baseline == "guardian" else None
+        ),
+        "repeat_index": repeat_index,
+        "returncode": proc.returncode,
+        "output_dir": str(base_dir),
+        "pier_result_json": str(local_result_path) if result_path else "",
+        "source_result_json": str(result_path) if result_path else "",
+        "result_json": str(local_result_path) if result_path else "",
+        "main_input_tokens": (codex_tokens or {}).get("input_tokens"),
+        "main_cached_input_tokens": (codex_tokens or {}).get("cached_input_tokens"),
+        "main_output_tokens": (codex_tokens or {}).get("output_tokens"),
+        "main_reasoning_output_tokens": (codex_tokens or {}).get(
+            "reasoning_output_tokens"
+        ),
+        "guardian_llm_backend": (guardian_status or {}).get("llm_backend"),
+        "guardian_findings": (guardian_status or {}).get("findings"),
+        "guardian_backlog": (guardian_status or {}).get("backlog"),
+        "guardian_high_confidence_backlog": (guardian_status or {}).get(
+            "high_confidence_backlog"
+        ),
+        "guardian_degraded": (guardian_status or {}).get("degraded"),
+        "guardian_analysis_status": (guardian_status or {}).get("analysis_status"),
+        "guardian_cycle_count": (guardian_status or {}).get("cycle_count"),
+        "guardian_exit_reasons": (guardian_status or {}).get("exit_reasons"),
+        "guardian_terminal": (guardian_status or {}).get("terminal"),
+        "guardian_termination_reason": (guardian_status or {}).get(
+            "termination_reason"
+        ),
+        "guardian_prompt_tokens": ((guardian_status or {}).get("llm_tokens") or {}).get(
+            "prompt"
+        ),
+        "guardian_cached_input_tokens": (
+            (guardian_status or {}).get("llm_tokens") or {}
+        ).get("cached_input"),
+        "guardian_completion_tokens": (
+            (guardian_status or {}).get("llm_tokens") or {}
+        ).get("completion"),
+        "guardian_total_tokens": ((guardian_status or {}).get("llm_tokens") or {}).get(
+            "total"
+        ),
+    }
+    row.update(metrics)
+    _write_json(base_dir / "metadata.json", row)
+    return row
+
+
+def _existing_jobs(
+    output_root: Path,
+    *,
+    task: str,
+    baseline: str,
+    model: str,
+    reasoning_effort: str,
+) -> list[dict[str, Any]]:
+    base = output_root / _setting_slug(model, reasoning_effort) / _slug(task) / baseline
+    rows: list[dict[str, Any]] = []
+    for path in sorted(base.glob("job_*/metadata.json")):
+        row = _load_json(path)
+        if not row:
+            continue
+        if (
+            row.get("model") == model
+            and row.get("reasoning_effort") == reasoning_effort
+            and str(row.get("job_id") or "").removeprefix("job_").isdigit()
+        ):
+            rows.append(row)
+    return rows
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--reasoning-effort", required=True)
+    parser.add_argument("--tasks", nargs="+", required=True, help="DeepSWE task names")
+    parser.add_argument("--runs", type=int, default=4)
+    parser.add_argument(
+        "--baselines",
+        nargs="+",
+        choices=("solo", "guardian"),
+        default=("solo", "guardian"),
+        help="Select which experiment arms to run",
+    )
+    parser.add_argument("--guardian-model", default=None)
+    parser.add_argument(
+        "--guardian-explorer-count",
+        type=int,
+        default=2,
+        help="Number of independent local-specification explorers",
+    )
+    parser.add_argument(
+        "--guardian-max-findings",
+        type=int,
+        default=5,
+        help="Maximum evidence-admitted findings delivered per review",
+    )
+    parser.add_argument(
+        "--guardian-max-cycles",
+        type=int,
+        default=3,
+        help="Maximum completed Guardian reviews before terminal handoff",
+    )
+    parser.add_argument(
+        "--guardian-rollout-timeout",
+        type=float,
+        default=600.0,
+        help="Timeout in seconds for each explorer or aggregator rollout",
+    )
+    parser.add_argument("--codeminer-root", type=Path, default=DEFAULT_CODEMINER_ROOT)
+    parser.add_argument("--deepswe-root", type=Path, default=DEFAULT_DEEPSWE_ROOT)
+    parser.add_argument("--jobs-dir", type=Path, default=DEFAULT_JOBS_DIR)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument(
+        "--force-solo",
+        action="store_true",
+        help="Run solo even when this table already has solo data for the setting.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned Pier commands without running them.",
+    )
+    args = parser.parse_args(argv)
+    if args.runs < 1 or args.runs > 4:
+        raise ValueError(
+            "--runs must be between 1 and 4; analysis only counts job_1..job_4"
+        )
+    if args.guardian_max_cycles < 1:
+        raise ValueError("--guardian-max-cycles must be positive")
+    if args.guardian_model is None:
+        args.guardian_model = f"codex:{args.model}"
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    for task in args.tasks:
+        for task_path in [args.deepswe_root / "tasks" / task]:
+            if not task_path.exists():
+                raise FileNotFoundError(f"task does not exist: {task_path}")
+
+        plan: list[tuple[str, int]] = []
+        if "solo" in args.baselines:
+            solo_existing = {
+                int(str(row.get("job_id", "")).removeprefix("job_"))
+                for row in _existing_jobs(
+                    args.output_root,
+                    task=task,
+                    baseline="solo",
+                    model=args.model,
+                    reasoning_effort=args.reasoning_effort,
+                )
+                if str(row.get("job_id", "")).removeprefix("job_").isdigit()
+            }
+            for idx in range(1, args.runs + 1):
+                if idx in solo_existing and not args.force_solo:
+                    existing_dir = (
+                        args.output_root
+                        / _setting_slug(args.model, args.reasoning_effort)
+                        / _slug(task)
+                        / "solo"
+                        / f"job_{idx}"
+                    )
+                    print(
+                        f"[skip] {task} solo job_{idx}: existing trial in "
+                        f"{existing_dir}"
+                    )
+                else:
+                    plan.append(("solo", idx))
+        if "guardian" in args.baselines:
+            plan.extend(("guardian", i + 1) for i in range(args.runs))
+
+        if args.dry_run:
+            for baseline, idx in plan:
+                job_id = f"job_{idx}"
+                base_dir = (
+                    args.output_root
+                    / _setting_slug(args.model, args.reasoning_effort)
+                    / _slug(task)
+                    / baseline
+                    / job_id
+                )
+                logs_dir = base_dir / "agent_logs"
+                cmd = _build_pier_command(
+                    args,
+                    task=task,
+                    baseline=baseline,
+                    logs_dir=logs_dir,
+                )
+                print(" ".join(subprocess.list2cmdline([part]) for part in cmd))
+            continue
+
+        for baseline, idx in plan:
+            _run_trial(
+                args,
+                task=task,
+                baseline=baseline,
+                repeat_index=idx,
+            )
+
+    if not args.dry_run:
+        print(f"[done] output root: {args.output_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/guardian/deepswe/ablation.py
+++ b/scripts/guardian/deepswe/ablation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Run DeepSWE Codex-vs-Guardian ablations.
@@ -58,17 +58,17 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-DEFAULT_CODEMINER_ROOT = Path("/home/xiangye/CodeMiner")
+DEFAULT_CODENIB_ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_DEEPSWE_ROOT = Path("/home/xiangye/deep-swe")
 DEFAULT_OUTPUT_ROOT = Path("/mnt/data/xiangye/deepswe_outputs")
 DEFAULT_JOBS_DIR = DEFAULT_DEEPSWE_ROOT / "jobs"
 DEEPSWE_HARNESS_RELATIVE_PATH = Path("scripts/guardian/deepswe/harness")
 
 
-def _harness_path(codeminer_root: Path) -> Path:
+def _harness_path(codenib_root: Path) -> Path:
     """Return the dependency-isolated Pier harness in the CodeNib checkout."""
 
-    return codeminer_root / DEEPSWE_HARNESS_RELATIVE_PATH
+    return codenib_root / DEEPSWE_HARNESS_RELATIVE_PATH
 
 
 def _slug(value: str) -> str:
@@ -207,7 +207,7 @@ def _common_mounts(args: argparse.Namespace, logs_dir: Path) -> list[dict[str, s
         {"type": "bind", "source": str(logs_dir), "target": "/logs/agent"},
         {
             "type": "bind",
-            "source": str(_harness_path(args.codeminer_root) / "task_venv_profile.sh"),
+            "source": str(_harness_path(args.codenib_root) / "task_venv_profile.sh"),
             "target": "/etc/profile.d/zz-deepswe-task-venv.sh",
         },
     ]
@@ -332,11 +332,11 @@ def _build_pier_command(
                 json.dumps(_guardian_mounts(args, logs_dir)),
             ]
         )
-        if str(args.codeminer_root) not in env_pythonpath.split(os.pathsep):
+        if str(args.codenib_root) not in env_pythonpath.split(os.pathsep):
             os.environ["PYTHONPATH"] = (
-                str(args.codeminer_root)
+                str(args.codenib_root)
                 if not env_pythonpath
-                else f"{args.codeminer_root}{os.pathsep}{env_pythonpath}"
+                else f"{args.codenib_root}{os.pathsep}{env_pythonpath}"
             )
     else:
         cmd.extend(
@@ -386,7 +386,7 @@ def _run_trial(
     _write_json(
         base_dir / "command.json",
         {
-            "cwd": str(args.codeminer_root),
+            "cwd": str(args.codenib_root),
             "argv": cmd,
         },
     )
@@ -398,7 +398,7 @@ def _run_trial(
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        cwd=args.codeminer_root,
+        cwd=args.codenib_root,
         check=False,
     )
     _repair_output_permissions(base_dir)
@@ -546,7 +546,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=600.0,
         help="Timeout in seconds for each explorer or aggregator rollout",
     )
-    parser.add_argument("--codeminer-root", type=Path, default=DEFAULT_CODEMINER_ROOT)
+    parser.add_argument("--codenib-root", type=Path, default=DEFAULT_CODENIB_ROOT)
     parser.add_argument("--deepswe-root", type=Path, default=DEFAULT_DEEPSWE_ROOT)
     parser.add_argument("--jobs-dir", type=Path, default=DEFAULT_JOBS_DIR)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)

--- a/scripts/guardian/deepswe/dashboard/app.js
+++ b/scripts/guardian/deepswe/dashboard/app.js
@@ -13,7 +13,7 @@ const metricLabels = {
   sum_total_cost_usd: "Total cost",
   avg_main_input_tokens: "Avg input tokens",
   avg_main_output_tokens: "Avg output tokens",
-  n_trials: "Trials",
+  n_trials: "Valid trials",
 };
 
 function fmt(value, kind = "number") {
@@ -105,7 +105,7 @@ function renderHeatmap() {
       const el = document.createElement("div");
       el.className = "heat-cell";
       el.style.background = heatColor(value, metric);
-      el.innerHTML = `<span class="cell-main">${fmt(value, metricKind(metric))}</span><span class="cell-sub">${row ? `${row.n_trials} trial(s)` : ""}</span>`;
+      el.innerHTML = `<span class="cell-main">${fmt(value, metricKind(metric))}</span><span class="cell-sub">${row ? `${row.n_trials}/${row.n_recorded_trials} valid` : ""}</span>`;
       grid.appendChild(el);
     }
   }
@@ -136,8 +136,8 @@ function renderTasks() {
       "Guardian avg P2P",
       "Solo avg partial",
       "Guardian avg partial",
-      "Solo n",
-      "Guardian n",
+      "Solo valid/recorded",
+      "Guardian valid/recorded",
       "Guardian avg cost",
     ],
     state.data.tasks.map((r) => [
@@ -153,8 +153,8 @@ function renderTasks() {
       fmt(r.guardian_avg_p2p, "pct"),
       fmt(r.solo_avg_partial, "pct"),
       fmt(r.guardian_avg_partial, "pct"),
-      fmt(r.solo_trials),
-      fmt(r.guardian_trials),
+      `${fmt(r.solo_trials)}/${fmt(r.solo_recorded_trials)}`,
+      `${fmt(r.guardian_trials)}/${fmt(r.guardian_recorded_trials)}`,
       fmt(r.guardian_avg_cost_usd, "cost"),
     ]),
     [

--- a/scripts/guardian/deepswe/dashboard/app.js
+++ b/scripts/guardian/deepswe/dashboard/app.js
@@ -1,0 +1,271 @@
+const state = {
+  data: null,
+  metric: "pass_rate",
+  trialFilter: "all",
+};
+
+const metricLabels = {
+  pass_rate: "Pass rate",
+  avg_f2p: "Avg F2P",
+  avg_p2p: "Avg P2P",
+  avg_partial: "Avg partial",
+  avg_total_cost_usd: "Avg cost",
+  sum_total_cost_usd: "Total cost",
+  avg_main_input_tokens: "Avg input tokens",
+  avg_main_output_tokens: "Avg output tokens",
+  n_trials: "Trials",
+};
+
+function fmt(value, kind = "number") {
+  if (value === null || value === undefined || Number.isNaN(value)) return "";
+  const n = Number(value);
+  if (!Number.isFinite(n)) return String(value);
+  if (kind === "pct") return `${(n * 100).toFixed(0)}%`;
+  if (kind === "cost") return `$${n.toFixed(3)}`;
+  if (Math.abs(n) >= 1000000) return `${(n / 1000000).toFixed(2)}M`;
+  if (Math.abs(n) >= 1000) return `${(n / 1000).toFixed(1)}K`;
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(3);
+}
+
+function metricKind(metric) {
+  if (["pass_rate", "avg_f2p", "avg_p2p", "avg_partial"].includes(metric)) {
+    return "pct";
+  }
+  if (metric.includes("cost")) return "cost";
+  return "number";
+}
+
+function heatColor(value, metric) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) return "#f3f4f6";
+  const n = Number(value);
+  if (["pass_rate", "avg_f2p", "avg_p2p", "avg_partial"].includes(metric)) {
+    const hue = 8 + Math.max(0, Math.min(1, n)) * 135;
+    return `hsl(${hue} 64% 86%)`;
+  }
+  if (metric.includes("cost")) {
+    const x = Math.min(1, n / 1.5);
+    return `hsl(${45 - x * 35} 75% 88%)`;
+  }
+  const x = Math.min(1, n / 1000000);
+  return `hsl(${215 - x * 80} 72% 88%)`;
+}
+
+function columns() {
+  return ["solo", "guardian"];
+}
+
+function settings() {
+  const seen = new Set();
+  const rows = [];
+  for (const row of state.data.summary) {
+    const key = `${row.task}:::${row.model}:::${row.reasoning_effort}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      rows.push({
+        key,
+        task: row.task,
+        model: row.model,
+        reasoning_effort: row.reasoning_effort,
+      });
+    }
+  }
+  return rows.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function settingLabel(row) {
+  return `${row.task} · ${row.model} · ${row.reasoning_effort}`;
+}
+
+function renderHeatmap() {
+  const host = document.getElementById("heatmap");
+  const cols = columns();
+  const rows = settings();
+  const metric = state.metric;
+  const lookup = new Map(
+    state.data.summary.map((r) => [
+      `${r.task}:::${r.model}:::${r.reasoning_effort}:::${r.baseline}`,
+      r,
+    ]),
+  );
+
+  host.innerHTML = "";
+  const grid = document.createElement("div");
+  grid.className = "heat-grid";
+  grid.style.gridTemplateColumns = `minmax(420px, 1.6fr) repeat(${cols.length}, minmax(160px, 1fr))`;
+
+  grid.appendChild(cell("Task / Model / Effort", "heat-head"));
+  for (const col of cols) grid.appendChild(cell(col, "heat-head"));
+
+  for (const rowInfo of rows) {
+    grid.appendChild(cell(settingLabel(rowInfo), "heat-task"));
+    for (const col of cols) {
+      const row = lookup.get(`${rowInfo.key}:::${col}`);
+      const value = row ? row[metric] : null;
+      const el = document.createElement("div");
+      el.className = "heat-cell";
+      el.style.background = heatColor(value, metric);
+      el.innerHTML = `<span class="cell-main">${fmt(value, metricKind(metric))}</span><span class="cell-sub">${row ? `${row.n_trials} trial(s)` : ""}</span>`;
+      grid.appendChild(el);
+    }
+  }
+  host.appendChild(grid);
+  document.getElementById("heatmap-note").textContent = metricLabels[metric] || metric;
+}
+
+function cell(text, className) {
+  const el = document.createElement("div");
+  el.className = className;
+  el.textContent = text;
+  return el;
+}
+
+function renderTasks() {
+  const table = document.getElementById("tasks-table");
+  table.innerHTML = tableHtml(
+    [
+      "Task",
+      "Model",
+      "Effort",
+      "Solo",
+      "Guardian",
+      "Delta",
+      "Solo avg F2P",
+      "Guardian avg F2P",
+      "Solo avg P2P",
+      "Guardian avg P2P",
+      "Solo avg partial",
+      "Guardian avg partial",
+      "Solo n",
+      "Guardian n",
+      "Guardian avg cost",
+    ],
+    state.data.tasks.map((r) => [
+      r.task,
+      r.model,
+      r.reasoning_effort,
+      fmt(r.solo_pass_rate, "pct"),
+      fmt(r.guardian_pass_rate, "pct"),
+      fmt(r.delta_pass_rate, "pct"),
+      fmt(r.solo_avg_f2p, "pct"),
+      fmt(r.guardian_avg_f2p, "pct"),
+      fmt(r.solo_avg_p2p, "pct"),
+      fmt(r.guardian_avg_p2p, "pct"),
+      fmt(r.solo_avg_partial, "pct"),
+      fmt(r.guardian_avg_partial, "pct"),
+      fmt(r.solo_trials),
+      fmt(r.guardian_trials),
+      fmt(r.guardian_avg_cost_usd, "cost"),
+    ]),
+    [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ],
+  );
+}
+
+function filteredTrials() {
+  const f = state.trialFilter;
+  return state.data.trials.filter((r) => {
+    if (f === "passed") return Number(r.reward) === 1;
+    if (f === "failed") return Number(r.reward) !== 1;
+    if (f === "guardian") return r.baseline === "guardian";
+    if (f === "solo") return r.baseline === "solo";
+    return true;
+  });
+}
+
+function renderTrials() {
+  const rows = filteredTrials();
+  document.getElementById("trial-count").textContent = `${rows.length} trial(s)`;
+  const table = document.getElementById("trials-table");
+  table.innerHTML = tableHtml(
+    [
+      "Task",
+      "Model",
+      "Effort",
+      "Baseline",
+      "Job",
+      "Reward",
+      "F2P",
+      "P2P",
+      "Cost",
+      "Main tokens",
+      "Guardian tokens",
+    ],
+    rows.map((r) => [
+      r.task,
+      r.model,
+      r.reasoning_effort,
+      r.baseline,
+      r.job_id,
+      `<span class="${Number(r.reward) === 1 ? "status-pass" : "status-fail"}">${fmt(r.reward)}</span>`,
+      `${fmt(r.f2p, "pct")} (${fmt(r.f2p_passed)}/${fmt(r.f2p_total)})`,
+      `${fmt(r.p2p, "pct")} (${fmt(r.p2p_passed)}/${fmt(r.p2p_total)})`,
+      fmt(r.total_cost_usd, "cost"),
+      fmt(r.main_input_tokens),
+      fmt((Number(r.guardian_prompt_tokens) || 0) + (Number(r.guardian_completion_tokens) || 0)),
+    ]),
+    [false, false, false, false, false, true, true, true, true, true],
+  );
+}
+
+function tableHtml(headers, rows, numeric) {
+  const head = `<thead><tr>${headers.map((h) => `<th>${h}</th>`).join("")}</tr></thead>`;
+  const body = rows
+    .map(
+      (row) =>
+        `<tr>${row
+          .map((v, i) => `<td class="${numeric[i] ? "num" : ""}">${v ?? ""}</td>`)
+          .join("")}</tr>`,
+    )
+    .join("");
+  return `${head}<tbody>${body}</tbody>`;
+}
+
+function render() {
+  renderHeatmap();
+  renderTasks();
+  renderTrials();
+}
+
+async function init() {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  const response = await fetch(`data.json?v=${Date.now()}`, {
+    cache: "no-store",
+    signal: controller.signal,
+  });
+  clearTimeout(timeout);
+  if (!response.ok) {
+    throw new Error(`data.json returned HTTP ${response.status}`);
+  }
+  state.data = await response.json();
+  document.getElementById("subtitle").textContent = `${state.data.output_root} · ${state.data.trials.length} fixed-slot trial(s) · ${state.data.counted_job_ids.join(", ")}`;
+  document.getElementById("metric-select").addEventListener("change", (event) => {
+    state.metric = event.target.value;
+    renderHeatmap();
+  });
+  document.getElementById("trial-filter").addEventListener("change", (event) => {
+    state.trialFilter = event.target.value;
+    renderTrials();
+  });
+  render();
+}
+
+init().catch((error) => {
+  document.getElementById("subtitle").textContent = `Failed to load data.json: ${error}`;
+});

--- a/scripts/guardian/deepswe/dashboard/index.html
+++ b/scripts/guardian/deepswe/dashboard/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DeepSWE Guardian Results</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div>
+        <h1>DeepSWE Guardian Results</h1>
+        <p id="subtitle">Loading local evaluation data...</p>
+      </div>
+      <div class="controls">
+        <label>
+          Metric
+          <select id="metric-select">
+            <option value="pass_rate">Pass rate</option>
+            <option value="avg_f2p">Avg F2P</option>
+            <option value="avg_p2p">Avg P2P</option>
+            <option value="avg_partial">Avg partial</option>
+            <option value="avg_total_cost_usd">Avg cost</option>
+            <option value="sum_total_cost_usd">Total cost</option>
+            <option value="avg_main_input_tokens">Avg input tokens</option>
+            <option value="avg_main_output_tokens">Avg output tokens</option>
+            <option value="n_trials">Trials</option>
+          </select>
+        </label>
+        <label>
+          Trials
+          <select id="trial-filter">
+            <option value="all">All</option>
+            <option value="passed">Passed</option>
+            <option value="failed">Failed</option>
+            <option value="guardian">Guardian</option>
+            <option value="solo">Solo</option>
+          </select>
+        </label>
+      </div>
+    </header>
+
+    <main>
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Heatmap</h2>
+          <span id="heatmap-note"></span>
+        </div>
+        <div id="heatmap" class="heatmap"></div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Task Comparison</h2>
+          <span>solo vs guardian</span>
+        </div>
+        <div class="table-wrap">
+          <table id="tasks-table"></table>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Trials</h2>
+          <span id="trial-count"></span>
+        </div>
+        <div class="table-wrap">
+          <table id="trials-table"></table>
+        </div>
+      </section>
+    </main>
+
+    <script src="app.js?v=3"></script>
+  </body>
+</html>

--- a/scripts/guardian/deepswe/dashboard/style.css
+++ b/scripts/guardian/deepswe/dashboard/style.css
@@ -1,0 +1,214 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --text: #171a1f;
+  --muted: #626b7a;
+  --line: #d9dee7;
+  --soft: #edf0f5;
+  --good: #0c7a43;
+  --warn: #aa5b00;
+  --bad: #b3261e;
+  --accent: #1458d4;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.topbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 22px;
+  font-weight: 650;
+}
+
+h2 {
+  font-size: 15px;
+  font-weight: 650;
+}
+
+#subtitle,
+.panel-head span {
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+label {
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+select {
+  min-width: 150px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: white;
+  color: var(--text);
+  padding: 7px 9px;
+}
+
+main {
+  padding: 18px 24px 32px;
+  display: grid;
+  gap: 18px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.heatmap {
+  overflow: auto;
+  padding: 14px;
+}
+
+.heat-grid {
+  display: grid;
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  width: max-content;
+  min-width: 100%;
+}
+
+.heat-cell,
+.heat-head,
+.heat-task {
+  min-height: 42px;
+  padding: 8px;
+  background: white;
+  display: flex;
+  align-items: center;
+}
+
+.heat-head {
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--muted);
+}
+
+.heat-task {
+  min-width: 420px;
+  font-weight: 600;
+}
+
+.heat-cell {
+  min-width: 160px;
+  justify-content: space-between;
+  gap: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cell-main {
+  font-weight: 650;
+}
+
+.cell-sub {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.table-wrap {
+  overflow: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--line);
+  padding: 8px 10px;
+  text-align: left;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+th {
+  position: sticky;
+  top: 0;
+  background: var(--soft);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+  z-index: 1;
+}
+
+td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.status-pass {
+  color: var(--good);
+  font-weight: 650;
+}
+
+.status-fail {
+  color: var(--bad);
+  font-weight: 650;
+}
+
+@media (max-width: 760px) {
+  .topbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/scripts/guardian/deepswe/export_dashboard.py
+++ b/scripts/guardian/deepswe/export_dashboard.py
@@ -14,11 +14,7 @@ from typing import Any
 from codenib.eval.benchmarks.deepswe import (
     export_dashboard_data as _export_dashboard_data,
 )
-from codenib.eval.benchmarks.deepswe import (
-    summary_rows,
-    task_rows,
-    trial_row,
-)
+from codenib.eval.benchmarks.deepswe import summary_rows, task_rows, trial_row
 
 from .results import DEFAULT_OUTPUT_ROOT
 

--- a/scripts/guardian/deepswe/export_dashboard.py
+++ b/scripts/guardian/deepswe/export_dashboard.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export fixed-slot DeepSWE Guardian outputs for the static dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from codenib.eval.benchmarks.deepswe import (
+    export_dashboard_data as _export_dashboard_data,
+)
+from codenib.eval.benchmarks.deepswe import (
+    summary_rows,
+    task_rows,
+    trial_row,
+)
+
+from .results import DEFAULT_OUTPUT_ROOT
+
+DEFAULT_DASHBOARD_DIR = Path(__file__).resolve().parent / "dashboard"
+
+# Compatibility aliases for tests and scripts that imported the old helpers.
+_summary_rows = summary_rows
+_task_rows = task_rows
+_trial_row = trial_row
+
+
+def export_dashboard_data(args: argparse.Namespace) -> dict[str, Any]:
+    """Compatibility adapter from the historical CLI namespace to the API."""
+
+    return _export_dashboard_data(
+        args.output_root,
+        input_usd_per_mtok=args.input_usd_per_mtok,
+        cached_input_usd_per_mtok=args.cached_input_usd_per_mtok,
+        output_usd_per_mtok=args.output_usd_per_mtok,
+        output_includes_reasoning=not args.output_excludes_reasoning,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--dashboard-dir", type=Path, default=DEFAULT_DASHBOARD_DIR)
+    parser.add_argument("--input-usd-per-mtok", type=float)
+    parser.add_argument("--cached-input-usd-per-mtok", type=float)
+    parser.add_argument("--output-usd-per-mtok", type=float)
+    parser.add_argument("--output-excludes-reasoning", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    data = export_dashboard_data(args)
+    args.dashboard_dir.mkdir(parents=True, exist_ok=True)
+    path = args.dashboard_dir / "data.json"
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"[done] wrote {path}")
+    print(f"[done] trials={len(data['trials'])} summary_rows={len(data['summary'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/guardian/deepswe/harness/agent.py
+++ b/scripts/guardian/deepswe/harness/agent.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/guardian/deepswe/harness/agent.py
+++ b/scripts/guardian/deepswe/harness/agent.py
@@ -1,0 +1,423 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GuardianCodingAgent — Pier solver plus host-controlled Guardian reviews.
+
+Registers with Pier via::
+
+    pier run \\
+      --agent-import-path scripts.guardian.deepswe.harness.agent:GuardianCodingAgent \\
+      --model gpt-5.6-luna \\
+      --ak solver=codex \\
+      --ak reasoning_effort=max \\
+      --ae "CODEX_FORCE_AUTH_JSON=1" \\
+      --mounts-json '<log mounts>' \\
+      -p deep-swe/tasks/<task>
+
+Architecture:
+
+    host controller
+    ├── Pier solver container publishes commit bundles through /logs/agent
+    └── each Guardian rollout runs in a fresh codenib.sandbox container
+
+The solver never shares its writable checkout with Guardian.  It receives
+filesystem ``guardian-start``, ``guardian-message``, and
+``guardian-checkpoint`` actions while the installed Codex harness continues to
+own the implementation loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import re
+import shlex
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+_PROMPTS = Path(__file__).parent / "prompts"
+_CODEX_PROMPT_PATH = _PROMPTS / "codex_file_bridge.md"
+
+from pier.agents.base import BaseAgent
+from pier.agents.installed.base import BaseInstalledAgent
+from pier.environments.base import BaseEnvironment
+from pier.models.agent.context import AgentContext
+from pier.models.agent.install import InstallStep
+from pier.models.agent.network import NetworkAllowlist
+
+from codenib.clients.execution import ExecutionIsolation
+from codenib.clients.guardian import GuardianConfig
+
+from .checkpoint import guardian_checkpoint_script
+from .controller import GuardianHostController, sandbox_reviewer_factory
+from .message import guardian_message_script
+
+if TYPE_CHECKING:
+    from pier.models.agent.install import AgentInstallSpec
+
+# ---------------------------------------------------------------------------
+# Solver registry — maps --ak solver=<name> to the Pier agent class
+# ---------------------------------------------------------------------------
+
+_SOLVER_REGISTRY: dict[str, tuple[str, str]] = {
+    "codex": ("pier.agents.installed.codex", "Codex"),
+}
+
+
+def _quote_shell_path(path: str) -> str:
+    """Quote a shell path while preserving the conventional ``~/`` shortcut."""
+    if path == "~":
+        return "$HOME"
+    if path.startswith("~/"):
+        return "$HOME/" + shlex.quote(path[2:])
+    return shlex.quote(path)
+
+
+def _load_solver_class(name: str) -> type[BaseAgent]:
+    try:
+        module_path, class_name = _SOLVER_REGISTRY[name]
+    except KeyError as exc:
+        known = ", ".join(_SOLVER_REGISTRY)
+        raise ValueError(
+            f"Unknown solver {name!r}. Known solvers: {known}. "
+            "Pass --ak solver=<name> to choose."
+        ) from exc
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+
+# ---------------------------------------------------------------------------
+# GuardianCodingAgent
+# ---------------------------------------------------------------------------
+
+
+class GuardianCodingAgent(BaseInstalledAgent):
+    """Pier custom agent: Codex solver plus a Guardian review sidecar."""
+
+    def __init__(
+        self,
+        logs_dir: Path,
+        model_name: str | None = None,
+        logger: logging.Logger | None = None,
+        mcp_servers: list[Any] | None = None,
+        skills_dir: str | None = None,
+        # Guardian kwargs (from --ak)
+        solver: str = "codex",
+        guardian_repo: str = "/app",
+        guardian_model: str = "codex:gpt-5.6-luna",
+        guardian_explorer_count: int = 2,
+        guardian_max_findings: int = 5,
+        guardian_max_cycles: int = 3,
+        guardian_rollout_timeout: float = 600,
+        guardian_poll_interval: int = 10,
+        guardian_findings_dir: str = "/logs/agent/guardian_exchange/latest",
+        guardian_checkpoint_dir: str = "/app/.guardian/bin",
+        guardian_exchange_dir: str = "/logs/agent/guardian_exchange",
+        guardian_host_exchange_dir: str | None = None,
+        guardian_docker_host: str = "unix:///var/run/docker.sock",
+        guardian_platform: str = "linux/amd64",
+        guardian_codex_bin: str = "/usr/local/bin/codex-guardian",
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            logs_dir,
+            model_name=model_name,
+            logger=logger,
+            mcp_servers=mcp_servers,
+            skills_dir=skills_dir,
+        )
+
+        self._solver_name = solver
+        self._guardian_repo = guardian_repo
+        self._guardian_model = guardian_model
+        self._guardian_explorer_count = int(guardian_explorer_count)
+        self._guardian_max_findings = int(guardian_max_findings)
+        self._guardian_max_cycles = int(guardian_max_cycles)
+        self._guardian_rollout_timeout = float(guardian_rollout_timeout)
+        self._guardian_poll_interval = int(guardian_poll_interval)
+        self._guardian_findings_dir = guardian_findings_dir
+        self._guardian_checkpoint_dir = guardian_checkpoint_dir
+        self._guardian_baseline_file = "/app/.guardian/base_commit"
+        self._guardian_exchange_dir = guardian_exchange_dir
+        self._guardian_host_exchange_dir = (
+            Path(guardian_host_exchange_dir).expanduser().resolve()
+            if guardian_host_exchange_dir
+            else self.logs_dir / "guardian_exchange"
+        )
+        self._guardian_message_inbox = f"{guardian_exchange_dir}/messages.jsonl"
+        self._guardian_start_path = f"{guardian_checkpoint_dir}/guardian-start"
+        self._guardian_message_path = f"{guardian_checkpoint_dir}/guardian-message"
+        self._guardian_docker_host = guardian_docker_host
+        self._guardian_platform = guardian_platform
+        self._guardian_codex_bin = guardian_codex_bin
+        self._guardian_baseline_commit = ""
+        self._guardian_image = ""
+
+        # Instantiate the inner solver, forwarding all remaining kwargs
+        # so that solver-specific flags (e.g. reasoning_effort for codex) pass through.
+        solver_cls = _load_solver_class(solver)
+        self._inner: BaseAgent = solver_cls(
+            logs_dir,
+            *args,
+            model_name=model_name,
+            logger=logger,
+            mcp_servers=list(mcp_servers or []),
+            skills_dir=skills_dir,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------------
+    # Pier agent identity
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def name() -> str:
+        return "guardian-coding-agent"
+
+    def version(self) -> str | None:
+        return self._inner.version()
+
+    # ------------------------------------------------------------------
+    # Pier lifecycle — delegate to inner solver
+    # ------------------------------------------------------------------
+
+    def network_allowlist(self) -> NetworkAllowlist:
+        inner = self._inner.network_allowlist()
+        extra = [
+            "chatgpt.com",
+            "ab.chatgpt.com",
+            "auth.openai.com",
+            "api.openai.com",
+        ]
+        return NetworkAllowlist(domains=inner.domains + extra)
+
+    def install_spec(self) -> "AgentInstallSpec | None":
+        spec = self._inner.install_spec()
+        if spec is None or self._solver_name != "codex":
+            return spec
+        # Pier's Codex installation may leave /usr/local/bin/codex as a
+        # symlink into an agent home. Docker's no-new-privileges policy can
+        # deny a different non-root UID access through that home. Materialize
+        # an ordinary executable in the prepared image for sibling sandboxes.
+        step = InstallStep(
+            user="root",
+            run=(
+                "set -euo pipefail; "
+                'source_path="$(readlink -f /usr/local/bin/codex '
+                '2>/dev/null || true)"; '
+                'if [ ! -f "$source_path" ]; then '
+                'source_path="$(find /root/.nvm /usr/local/lib /usr/lib '
+                "-type f -path '*/@openai/codex-*/vendor/*/bin/codex' "
+                '-print -quit 2>/dev/null)"; fi; '
+                'test -n "$source_path"; '
+                'install -m 0755 "$source_path" /usr/local/bin/codex-guardian'
+            ),
+        )
+        return spec.model_copy(update={"steps": [*spec.steps, step]})
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        self._inner.populate_context_post_run(context)
+        # Populate token counts from codex_tokens.json written by _write_codex_token_summary.
+        # Only fills fields that the inner solver left null (codex + ChatGPT subscription
+        # never reports tokens through Pier's normal path).
+        if self._solver_name == "codex" and context.n_input_tokens is None:
+            import json as _json
+
+            tokens_path = self.logs_dir / "codex_tokens.json"
+            try:
+                tok = _json.loads(tokens_path.read_text())
+                context.n_input_tokens = tok.get("input_tokens")
+                context.n_cache_tokens = tok.get("cached_input_tokens")
+                context.n_output_tokens = tok.get("output_tokens")
+            except Exception:
+                pass
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        await self._record_guardian_baseline(environment)
+        await self._inner.setup(environment)
+        self._guardian_image = self._resolve_environment_image(environment)
+        await self._install_codex_actions(environment)
+
+    async def _record_guardian_baseline(self, environment: BaseEnvironment) -> None:
+        """Persist cycle-0 HEAD without starting a Guardian model cycle."""
+
+        baseline = shlex.quote(self._guardian_baseline_file)
+        repo = shlex.quote(self._guardian_repo)
+        checkpoint_dir = _quote_shell_path(self._guardian_checkpoint_dir)
+        findings_dir = _quote_shell_path(self._guardian_findings_dir)
+        result = await environment.exec(
+            f"mkdir -p {checkpoint_dir} {findings_dir} && "
+            f"git -C {repo} rev-parse HEAD > {baseline}.tmp && "
+            f"mv {baseline}.tmp {baseline} && cat {baseline}"
+        )
+        self._guardian_baseline_commit = result.stdout.strip()
+
+    @staticmethod
+    def _resolve_environment_image(environment: BaseEnvironment) -> str:
+        """Resolve the already-built Pier image used by a local Docker trial."""
+
+        if getattr(environment, "_use_prebuilt", False):
+            task_config = getattr(environment, "task_env_config", None)
+            image = getattr(task_config, "docker_image", None)
+        else:
+            session_id = getattr(environment, "session_id", None)
+            if isinstance(session_id, str) and session_id:
+                project = session_id.lower()
+                if not re.match(r"^[a-z0-9]", project):
+                    project = "0" + project
+                project = re.sub(r"[^a-z0-9_-]", "-", project)
+                image = f"{project}-main:latest"
+            else:
+                image = None
+        if not isinstance(image, str) or not image:
+            raise RuntimeError(
+                "Guardian sibling sandboxes currently require Pier's Docker "
+                "environment and its prepared agent image"
+            )
+        return image
+
+    def _resolve_codex_auth_json_path(self) -> Path | None:
+        """Resolve the host Codex auth.json path for Guardian's nested Codex calls."""
+        explicit = self._get_env("CODEX_AUTH_JSON_PATH")
+        if explicit:
+            path = Path(explicit)
+            if not path.is_file():
+                raise ValueError(
+                    f"CODEX_AUTH_JSON_PATH points to non-existent file: {explicit}"
+                )
+            return path
+
+        force = (self._get_env("CODEX_FORCE_AUTH_JSON") or "").strip().lower()
+        if force in {"1", "true", "yes", "y", "on"}:
+            path = Path.home() / ".codex" / "auth.json"
+            if not path.is_file():
+                raise ValueError(
+                    f"CODEX_FORCE_AUTH_JSON is set but {path} does not exist"
+                )
+            return path
+
+        default = Path.home() / ".codex" / "auth.json"
+        if self._guardian_model.startswith("codex:") and default.is_file():
+            return default
+
+        return None
+
+    async def _install_codex_actions(self, environment: BaseEnvironment) -> None:
+        """Install exchange-backed start, message, and checkpoint actions."""
+
+        findings_dir = _quote_shell_path(self._guardian_findings_dir)
+        checkpoint_bin_dir = _quote_shell_path(self._guardian_checkpoint_dir)
+        checkpoint_path = _quote_shell_path(
+            f"{self._guardian_checkpoint_dir}/guardian-checkpoint"
+        )
+        start_path = _quote_shell_path(self._guardian_start_path)
+        message_path = _quote_shell_path(self._guardian_message_path)
+        checkpoint_script = shlex.quote(
+            guardian_checkpoint_script(
+                start_command=self._guardian_start_path,
+                baseline_file=self._guardian_baseline_file,
+                exchange_dir=self._guardian_exchange_dir,
+            )
+        )
+        start_script = shlex.quote(
+            "#!/bin/sh\n"
+            f"mkdir -p {shlex.quote(self._guardian_exchange_dir)}/requests "
+            f"{shlex.quote(self._guardian_exchange_dir)}/bundles "
+            f"{shlex.quote(self._guardian_exchange_dir)}/responses\n"
+            "echo 'Guardian host controller is ready for checkpoints.'\n"
+        )
+        message_script = shlex.quote(
+            guardian_message_script(
+                inbox=self._guardian_message_inbox,
+                repo=self._guardian_repo,
+            )
+        )
+        await environment.exec(
+            f"mkdir -p {findings_dir} {checkpoint_bin_dir} "
+            f"{shlex.quote(self._guardian_exchange_dir)} && "
+            f"printf %s {start_script} > {start_path} && "
+            f"chmod +x {start_path} && "
+            f"printf %s {checkpoint_script} > {checkpoint_path} && "
+            f"chmod +x {checkpoint_path} && "
+            f"printf %s {message_script} > {message_path} && "
+            f"chmod +x {message_path}"
+        )
+
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        guardian_preamble = _CODEX_PROMPT_PATH.read_text()
+        augmented = f"{guardian_preamble}\n\n---\n\n{instruction}"
+        auth_path = self._resolve_codex_auth_json_path()
+        auth_json = auth_path.read_bytes() if auth_path is not None else None
+        model = self._guardian_model.removeprefix("codex:")
+        config = GuardianConfig(
+            explorer_model=model,
+            aggregator_model=model,
+            explorer_count=self._guardian_explorer_count,
+            rollout_timeout_seconds=self._guardian_rollout_timeout,
+            max_findings=self._guardian_max_findings,
+            execution_isolation=ExecutionIsolation.EXTERNAL,
+        )
+        reviewer_factory = sandbox_reviewer_factory(
+            config=config,
+            image=self._guardian_image,
+            codex_executable=self._guardian_codex_bin,
+            auth_json=auth_json,
+            docker_host=self._guardian_docker_host,
+            platform=self._guardian_platform,
+        )
+        controller = GuardianHostController(
+            exchange_root=self._guardian_host_exchange_dir,
+            episodes_root=self._guardian_host_exchange_dir.parent / "guardian_episodes",
+            config=config,
+            reviewer_factory=reviewer_factory,
+            initial_base_commit=self._guardian_baseline_commit,
+            max_cycles=self._guardian_max_cycles,
+            poll_interval_seconds=self._guardian_poll_interval,
+        )
+        stop = asyncio.Event()
+        controller_task = asyncio.create_task(controller.serve(stop))
+        try:
+            await self._inner.run(augmented, environment, context)
+        finally:
+            stop.set()
+            await controller_task
+            await self._write_codex_token_summary(environment)
+
+    async def _write_codex_token_summary(self, environment: BaseEnvironment) -> None:
+        """Parse codex turn.completed events and write token totals to codex_tokens.json."""
+        script = r"""
+import json, sys
+keys = ['input_tokens', 'cached_input_tokens', 'output_tokens', 'reasoning_output_tokens']
+totals = {k: 0 for k in keys}
+try:
+    with open('/logs/agent/codex.txt') as f:
+        for line in f:
+            line = line.strip()
+            if '"turn.completed"' not in line:
+                continue
+            try:
+                u = json.loads(line).get('usage', {})
+                for k in keys:
+                    totals[k] += u.get(k, 0)
+            except Exception:
+                pass
+except FileNotFoundError:
+    pass
+with open('/logs/agent/codex_tokens.json', 'w') as f:
+    json.dump(totals, f, indent=2)
+print(json.dumps(totals))
+"""
+        try:
+            result = await environment.exec(f"python3 -c {shlex.quote(script)}")
+            if result.stdout:
+                self.logger.info("codex tokens: %s", result.stdout.strip())
+        except Exception as exc:  # noqa: BLE001
+            self.logger.warning("failed to write codex token summary: %s", exc)

--- a/scripts/guardian/deepswe/harness/checkpoint.py
+++ b/scripts/guardian/deepswe/harness/checkpoint.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guardian checkpoint script installed for Codex-in-Pier runs."""
+
+from __future__ import annotations
+
+
+def guardian_checkpoint_script(
+    *,
+    start_command: str = "",
+    baseline_file: str = "",
+    exchange_dir: str = "",
+) -> str:
+    """Return the executable script Codex runs before final handoff."""
+    return r"""#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_START_COMMAND = %r
+DEFAULT_BASELINE_FILE = %r
+DEFAULT_EXCHANGE_DIR = %r
+
+
+def _head(repo: str) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _load_status(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError("status.json is not an object")
+    return data
+
+
+def _publish(repo: str, exchange: Path, base: str, candidate: str) -> Path:
+    requests = exchange / "requests"
+    bundles = exchange / "bundles"
+    responses = exchange / "responses"
+    for path in (requests, bundles, responses):
+        path.mkdir(parents=True, exist_ok=True)
+    manifest = requests / (candidate + ".json")
+    response = responses / candidate
+    if manifest.exists():
+        return response
+
+    bundle = bundles / (candidate + ".bundle")
+    temporary_bundle = bundles / (candidate + ".bundle.tmp")
+    base_ref = "refs/guardian/base"
+    candidate_ref = "refs/guardian/candidate"
+    try:
+        subprocess.run(
+            ["git", "update-ref", base_ref, base], cwd=repo, check=True
+        )
+        subprocess.run(
+            ["git", "update-ref", candidate_ref, candidate], cwd=repo, check=True
+        )
+        subprocess.run(
+            [
+                "git",
+                "bundle",
+                "create",
+                str(temporary_bundle),
+                base_ref,
+                candidate_ref,
+            ],
+            cwd=repo,
+            check=True,
+        )
+        os.replace(temporary_bundle, bundle)
+    finally:
+        subprocess.run(
+            ["git", "update-ref", "-d", base_ref], cwd=repo, check=False
+        )
+        subprocess.run(
+            ["git", "update-ref", "-d", candidate_ref], cwd=repo, check=False
+        )
+        try:
+            temporary_bundle.unlink()
+        except FileNotFoundError:
+            pass
+
+    digest = hashlib.sha256()
+    with bundle.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    payload = {
+        "schema_version": 1,
+        "request_id": candidate,
+        "base_commit": base,
+        "candidate_commit": candidate,
+        "bundle_name": bundle.name,
+        "bundle_sha256": digest.hexdigest(),
+    }
+    temporary_manifest = manifest.with_suffix(".json.tmp")
+    temporary_manifest.write_text(
+        json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(temporary_manifest, manifest)
+    return response
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Wait for Repository Guardian's report for the current HEAD."
+    )
+    parser.add_argument("--repo", default=os.getcwd())
+    parser.add_argument("--guardian-dir", default="/app/.guardian/out")
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument("--start-command", default=DEFAULT_START_COMMAND)
+    parser.add_argument("--baseline-file", default=DEFAULT_BASELINE_FILE)
+    parser.add_argument("--exchange-dir", default=DEFAULT_EXCHANGE_DIR)
+    args = parser.parse_args()
+
+    repo = os.path.abspath(args.repo)
+    guardian_dir = Path(os.path.expanduser(args.guardian_dir))
+    status_path = guardian_dir / "status.json"
+    findings_path = guardian_dir / "findings.md"
+
+    if args.start_command:
+        started = subprocess.run(
+            [os.path.expanduser(args.start_command)],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if started.stdout:
+            print(started.stdout, end="")
+        if started.returncode != 0:
+            if started.stderr:
+                print(started.stderr, end="", file=sys.stderr)
+            print(
+                "Guardian checkpoint: could not start Guardian",
+                file=sys.stderr,
+            )
+            return 6
+
+    try:
+        head = _head(repo)
+    except Exception as exc:
+        print(f"Guardian checkpoint: cannot resolve HEAD: {exc}", file=sys.stderr)
+        return 2
+
+    if args.baseline_file:
+        try:
+            baseline = Path(
+                os.path.expanduser(args.baseline_file)
+            ).read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            print(
+                f"Guardian checkpoint: cannot read baseline: {exc}",
+                file=sys.stderr,
+            )
+            return 7
+        if baseline == head:
+            print(
+                "Guardian checkpoint: current HEAD is the repository baseline; "
+                "no coding-agent commit is available to analyze.",
+                file=sys.stderr,
+            )
+            return 8
+
+    if args.exchange_dir:
+        exchange = Path(os.path.expanduser(args.exchange_dir))
+        last_reviewed = exchange / "last_reviewed_commit"
+        latest_status_path = exchange / "latest" / "status.json"
+        latest_findings_path = exchange / "latest" / "findings.md"
+        try:
+            base = (
+                last_reviewed.read_text(encoding="utf-8").strip()
+                if last_reviewed.exists()
+                else baseline
+            )
+            latest_status = (
+                _load_status(latest_status_path)
+                if latest_status_path.exists()
+                else {}
+            )
+            if latest_status.get("terminal") and base != head:
+                print(
+                    "Guardian checkpoint: review limit reached; current commit "
+                    f"{head[:12]} was not reviewed."
+                )
+                print(
+                    "Verify remaining findings and the final edits independently; "
+                    "Guardian will not start another review."
+                )
+                print(f"last reviewed commit: {base}")
+                print(
+                    "cycles: "
+                    f"{latest_status.get('cycle_index', 0)}/"
+                    f"{latest_status.get('max_cycles', 0)}"
+                )
+                print("terminal: true")
+                if latest_findings_path.exists():
+                    print("")
+                    print(latest_findings_path.read_text(encoding="utf-8"), end="")
+                return 0
+            response = _publish(repo, exchange, base, head)
+        except Exception as exc:
+            print(
+                f"Guardian checkpoint: cannot publish review request: {exc}",
+                file=sys.stderr,
+            )
+            return 10
+        guardian_dir = response
+        status_path = guardian_dir / "status.json"
+        findings_path = guardian_dir / "findings.md"
+
+    print(f"Guardian checkpoint: waiting for commit {head[:12]}...", flush=True)
+    deadline = time.time() + max(1, args.timeout)
+    last_status = None
+    last_error = ""
+    while time.time() < deadline:
+        try:
+            status = _load_status(status_path)
+            last_status = status
+        except FileNotFoundError:
+            last_error = f"missing {status_path}"
+            time.sleep(max(0.1, args.interval))
+            continue
+        except Exception as exc:
+            last_error = f"cannot read {status_path}: {exc}"
+            time.sleep(max(0.1, args.interval))
+            continue
+
+        error = status.get("error")
+        if error:
+            print(f"Guardian checkpoint: Guardian failed: {error}", file=sys.stderr)
+            return 3
+
+        status_commit = str(status.get("commit") or "")
+        running = bool(status.get("running"))
+        if status_commit == head and not running:
+            if not findings_path.exists():
+                print(
+                    f"Guardian checkpoint: report ready but {findings_path} is missing",
+                    file=sys.stderr,
+                )
+                return 4
+
+            analysis_status = str(status.get("analysis_status") or "unknown")
+            exit_reason = str(status.get("exit_reason") or "")
+            terminal = bool(status.get("terminal"))
+            review_performed = bool(status.get("review_performed", True))
+            submitted = (
+                exit_reason in {"ReportSubmitted", "ReviewCompleted"}
+                and analysis_status in {"complete", "degraded"}
+            ) or (terminal and exit_reason == "ReviewLimitReached")
+            print(
+                "Guardian checkpoint: "
+                + ("report ready" if submitted else "report incomplete")
+            )
+            print(f"model: {status.get('llm_model', '')}")
+            print(f"backend: {status.get('llm_backend', '')}")
+            print(f"findings: {status.get('findings', 0)}")
+            print(f"backlog: {status.get('backlog', 0)}")
+            print(
+                "high-confidence backlog: "
+                f"{status.get('high_confidence_backlog', 0)}"
+            )
+            print(f"analysis status: {analysis_status}")
+            print(f"exit reason: {exit_reason or 'unknown'}")
+            print(
+                "cycles: "
+                f"{status.get('cycle_index', 0)}/{status.get('max_cycles', 0)}"
+            )
+            print(f"terminal: {'true' if terminal else 'false'}")
+            if terminal:
+                print(
+                    "Guardian review limit reached. Verify any remaining findings "
+                    "independently; no further Guardian review will run."
+                )
+            if status.get("degraded"):
+                print(
+                    "WARNING: Guardian analysis was degraded; this report must "
+                    "not be treated as a complete clean review.",
+                    file=sys.stderr,
+                )
+            tokens = status.get("llm_tokens")
+            if isinstance(tokens, dict):
+                print(f"tokens: {tokens.get('total', 0)}")
+            else:
+                print(f"tokens: {tokens or 0}")
+            print("")
+            print(findings_path.read_text(encoding="utf-8"), end="")
+            if not submitted:
+                print(
+                    "Guardian checkpoint: cycle did not submit a report; "
+                    "absence of findings is not a clean review.",
+                    file=sys.stderr,
+                )
+                return 9
+            if args.exchange_dir and review_performed:
+                temporary = last_reviewed.with_suffix(".tmp")
+                temporary.write_text(head + "\n", encoding="utf-8")
+                os.replace(temporary, last_reviewed)
+            return 0
+
+        time.sleep(max(0.1, args.interval))
+
+    print(
+        f"Guardian checkpoint: timed out waiting for {head[:12]}",
+        file=sys.stderr,
+    )
+    if last_status is not None:
+        print(
+            "last status: "
+            + json.dumps(
+                {
+                    "commit": last_status.get("commit"),
+                    "running": last_status.get("running"),
+                    "llm_backend": last_status.get("llm_backend"),
+                    "findings": last_status.get("findings"),
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+    elif last_error:
+        print(f"last status: {last_error}", file=sys.stderr)
+    return 5
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+""" % (start_command, baseline_file, exchange_dir)

--- a/scripts/guardian/deepswe/harness/checkpoint.py
+++ b/scripts/guardian/deepswe/harness/checkpoint.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/scripts/guardian/deepswe/harness/checkpoint.py
+++ b/scripts/guardian/deepswe/harness/checkpoint.py
@@ -340,4 +340,8 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-""" % (start_command, baseline_file, exchange_dir)
+""" % (
+        start_command,
+        baseline_file,
+        exchange_dir,
+    )

--- a/scripts/guardian/deepswe/harness/controller.py
+++ b/scripts/guardian/deepswe/harness/controller.py
@@ -1,0 +1,504 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-side controller for commit-addressed DeepSWE Guardian reviews."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+from codenib.clients.execution import CodexExecutor, SandboxProcessRunner
+from codenib.clients.guardian import (
+    ContextMessage,
+    GuardianAgent,
+    GuardianConfig,
+    GuardianRequest,
+    GuardianResult,
+    ReviewStatus,
+    render_markdown,
+)
+from codenib.clients.guardian.exchange import (
+    ReviewExchangeRequest,
+    load_exchange_request,
+    materialize_exchange_request,
+)
+from codenib.clients.guardian.interaction import MessageInbox
+from codenib.sandbox import (
+    DockerSandboxProvider,
+    NetworkMode,
+    SandboxLimits,
+    SandboxPolicy,
+)
+
+ReviewerFactory = Callable[[Path], GuardianAgent]
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(text, encoding="utf-8")
+    temporary.replace(path)
+
+
+def _write_json_atomic(path: Path, value: object) -> None:
+    _write_text_atomic(path, json.dumps(value, indent=2, default=str) + "\n")
+
+
+def _copy_report(source: Path, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    for path in source.iterdir():
+        target = destination / path.name
+        if path.is_dir():
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(path, target)
+        else:
+            shutil.copy2(path, target)
+
+
+def _tokens(result: GuardianResult) -> dict[str, int]:
+    return {
+        "prompt": result.usage.input_tokens,
+        "cached_input": result.usage.cached_input_tokens,
+        "completion": result.usage.output_tokens,
+        "total": result.usage.total_tokens,
+    }
+
+
+def _write_result(
+    path: Path,
+    result: GuardianResult,
+    *,
+    model: str,
+    cycle_index: int,
+    max_cycles: int,
+) -> None:
+    terminal = result.status is not ReviewStatus.FAILED and cycle_index >= max_cycles
+    _write_text_atomic(path / "findings.md", render_markdown(result))
+    _write_json_atomic(path / "findings.json", result.to_dict())
+    rollout_dir = path / "rollouts"
+    rollout_dir.mkdir(parents=True, exist_ok=True)
+    for index, rollout in enumerate(result.rollouts, 1):
+        prefix = rollout_dir / f"rollout_{index:02d}"
+        _write_text_atomic(prefix.with_suffix(".jsonl"), rollout.raw_output)
+        _write_text_atomic(prefix.with_suffix(".stderr.txt"), rollout.stderr)
+        _write_json_atomic(
+            prefix.with_suffix(".metadata.json"),
+            {
+                "status": rollout.status.value,
+                "exit_code": rollout.exit_code,
+                "duration_seconds": rollout.duration_seconds,
+                "error": (
+                    {
+                        "code": rollout.error.code.value,
+                        "message": rollout.error.message,
+                    }
+                    if rollout.error
+                    else None
+                ),
+                "usage": {
+                    "input_tokens": rollout.usage.input_tokens,
+                    "cached_input_tokens": rollout.usage.cached_input_tokens,
+                    "output_tokens": rollout.usage.output_tokens,
+                    "reasoning_output_tokens": (rollout.usage.reasoning_output_tokens),
+                },
+            },
+        )
+    _write_json_atomic(
+        path / "status.json",
+        {
+            "commit": result.candidate_commit,
+            "base_commit": result.base_commit,
+            "findings": len(result.findings),
+            "backlog": len(result.backlog),
+            "high_confidence_backlog": sum(
+                finding.confidence >= 0.8 for finding in result.backlog
+            ),
+            "candidate_count": len(result.candidates),
+            "degraded": result.status is not ReviewStatus.COMPLETE,
+            "analysis_status": result.status.value,
+            "exit_reason": "ReviewCompleted",
+            "review_performed": True,
+            "cycle_index": cycle_index,
+            "max_cycles": max_cycles,
+            "terminal": terminal,
+            "termination_reason": "max_cycles_reached" if terminal else "",
+            "llm_model": model,
+            "llm_backend": "codex-cli+codenib-sandbox",
+            "llm_transport_history": ["codex-cli+codenib-sandbox"],
+            "llm_tokens": _tokens(result),
+            "running": False,
+            "error": (
+                ""
+                if result.status is not ReviewStatus.FAILED
+                else "; ".join(result.errors)
+            ),
+        },
+    )
+
+
+def _write_limit_response(
+    path: Path,
+    *,
+    request_id: str,
+    base_commit: str,
+    model: str,
+    completed_cycles: int,
+    max_cycles: int,
+) -> None:
+    _write_text_atomic(
+        path / "findings.md",
+        "# Repository Guardian Review Limit\n\n"
+        f"Candidate `{request_id}` was not reviewed because Guardian already "
+        f"completed its configured {max_cycles} review cycles. Any findings "
+        "from the terminal reviewed commit remain unresolved unless the solver "
+        "verified them independently.\n",
+    )
+    _write_json_atomic(
+        path / "status.json",
+        {
+            "commit": request_id,
+            "base_commit": base_commit,
+            "findings": 0,
+            "backlog": 0,
+            "high_confidence_backlog": 0,
+            "candidate_count": 0,
+            "degraded": False,
+            "analysis_status": "not_run",
+            "exit_reason": "ReviewLimitReached",
+            "review_performed": False,
+            "cycle_index": completed_cycles,
+            "max_cycles": max_cycles,
+            "terminal": True,
+            "termination_reason": "max_cycles_reached",
+            "llm_model": model,
+            "llm_backend": "codex-cli+codenib-sandbox",
+            "llm_tokens": {"prompt": 0, "cached_input": 0, "completion": 0, "total": 0},
+            "running": False,
+            "error": "",
+        },
+    )
+
+
+def _write_failure(
+    path: Path,
+    *,
+    request_id: str,
+    error: str,
+    model: str,
+    cycle_index: int,
+    max_cycles: int,
+) -> None:
+    _write_text_atomic(
+        path / "findings.md",
+        "# Repository Guardian Report\n\n"
+        f"Guardian review failed for `{request_id}`: {error}\n",
+    )
+    _write_json_atomic(
+        path / "status.json",
+        {
+            "commit": request_id,
+            "findings": 0,
+            "backlog": 0,
+            "high_confidence_backlog": 0,
+            "candidate_count": 0,
+            "degraded": True,
+            "analysis_status": "failed",
+            "exit_reason": "OperationalFailure",
+            "review_performed": False,
+            "cycle_index": cycle_index,
+            "max_cycles": max_cycles,
+            "terminal": False,
+            "termination_reason": "",
+            "llm_model": model,
+            "llm_backend": "codex-cli+codenib-sandbox",
+            "llm_tokens": {"prompt": 0, "cached_input": 0, "completion": 0, "total": 0},
+            "running": False,
+            "error": error,
+        },
+    )
+
+
+def _git_patch(workspace: Path, base: str, candidate: str) -> str:
+    return subprocess.run(
+        ("git", "diff", "--no-ext-diff", "--binary", f"{base}..{candidate}"),
+        cwd=workspace,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+        env={
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_TERMINAL_PROMPT": "0",
+            "PATH": "/usr/bin:/bin",
+            "LANG": "C.UTF-8",
+        },
+    ).stdout
+
+
+def _copy_bundle_to_controller_storage(
+    bundle: Path, destination: Path, expected_sha256: str
+) -> Path:
+    """Copy a shared bundle and verify the controller-owned copy."""
+
+    digest = hashlib.sha256()
+    with bundle.open("rb") as source, destination.open("xb") as target:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            target.write(block)
+            digest.update(block)
+    if digest.hexdigest() != expected_sha256:
+        destination.unlink(missing_ok=True)
+        raise ValueError("bundle changed while the controller copied it")
+    return destination
+
+
+def _context(exchange_root: Path, workspace: Path) -> tuple[ContextMessage, ...]:
+    inbox = MessageInbox(exchange_root / "messages.jsonl", repo_path=workspace)
+    return tuple(
+        ContextMessage(
+            content=message.content,
+            sender=message.sender,
+            scope=tuple(message.scope),
+        )
+        for message in inbox.read_recent(limit=20)
+    )
+
+
+class GuardianHostController:
+    """Consume solver checkpoints and publish reports without sharing a workspace."""
+
+    def __init__(
+        self,
+        *,
+        exchange_root: Path,
+        episodes_root: Path,
+        config: GuardianConfig,
+        reviewer_factory: ReviewerFactory,
+        initial_base_commit: str | None = None,
+        max_cycles: int = 3,
+        poll_interval_seconds: float = 1.0,
+    ) -> None:
+        if isinstance(max_cycles, bool) or not isinstance(max_cycles, int):
+            raise TypeError("max_cycles must be an integer")
+        if max_cycles < 1:
+            raise ValueError("max_cycles must be positive")
+        self.exchange_root = exchange_root
+        self.episodes_root = episodes_root
+        self.config = config
+        self.reviewer_factory = reviewer_factory
+        self._expected_base_commit = initial_base_commit
+        self.max_cycles = max_cycles
+        self._completed_cycles = 0
+        self._cycle_state_loaded = False
+        self.poll_interval_seconds = poll_interval_seconds
+
+    def _prepare(self) -> None:
+        for name in ("requests", "bundles", "responses", "latest"):
+            (self.exchange_root / name).mkdir(parents=True, exist_ok=True)
+        self.episodes_root.mkdir(parents=True, exist_ok=True)
+        if not self._cycle_state_loaded:
+            self._completed_cycles = sum(
+                1
+                for path in self.episodes_root.glob("*/status.json")
+                if self._is_completed_review(path)
+            )
+            self._cycle_state_loaded = True
+
+    @staticmethod
+    def _is_completed_review(path: Path) -> bool:
+        try:
+            status = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return False
+        return bool(
+            isinstance(status, dict)
+            and status.get("review_performed", True)
+            and status.get("exit_reason") == "ReviewCompleted"
+            and status.get("analysis_status") in {"complete", "degraded"}
+        )
+
+    async def process_manifest(self, manifest: Path) -> None:
+        self._prepare()
+        request_id = manifest.stem
+        response = self.exchange_root / "responses" / request_id
+        if (response / "status.json").exists():
+            return
+        response.mkdir(parents=True, exist_ok=True)
+        try:
+            request, bundle = load_exchange_request(self.exchange_root, manifest)
+            if (
+                self._expected_base_commit is not None
+                and request.base_commit != self._expected_base_commit
+            ):
+                raise ValueError(
+                    "request base does not match the controller-owned review head: "
+                    f"expected {self._expected_base_commit}, got {request.base_commit}"
+                )
+            if self._completed_cycles >= self.max_cycles:
+                _write_limit_response(
+                    response,
+                    request_id=request_id,
+                    base_commit=request.base_commit,
+                    model=self.config.aggregator_model,
+                    completed_cycles=self._completed_cycles,
+                    max_cycles=self.max_cycles,
+                )
+            else:
+                await self._review_request(
+                    request=request,
+                    bundle=bundle,
+                    response=response,
+                )
+        except Exception as exc:  # noqa: BLE001
+            _write_failure(
+                response,
+                request_id=request_id,
+                error=f"{type(exc).__name__}: {exc}",
+                model=self.config.aggregator_model,
+                cycle_index=self._completed_cycles + 1,
+                max_cycles=self.max_cycles,
+            )
+        episode = self.episodes_root / request_id
+        _copy_report(response, episode)
+        latest = self.exchange_root / "latest"
+        latest.mkdir(parents=True, exist_ok=True)
+        for stale in latest.iterdir():
+            if stale.is_dir():
+                shutil.rmtree(stale)
+            else:
+                stale.unlink()
+        _copy_report(response, latest)
+
+    async def _review_request(
+        self,
+        *,
+        request: ReviewExchangeRequest,
+        bundle: Path,
+        response: Path,
+    ) -> None:
+        cycle_index = self._completed_cycles + 1
+        with tempfile.TemporaryDirectory(prefix="guardian-review-") as temporary:
+            trusted_bundle = _copy_bundle_to_controller_storage(
+                bundle,
+                Path(temporary) / request.bundle_name,
+                request.bundle_sha256,
+            )
+            workspace = materialize_exchange_request(
+                request, trusted_bundle, Path(temporary) / "repository"
+            )
+            patch = _git_patch(workspace, request.base_commit, request.candidate_commit)
+            reviewer = self.reviewer_factory(workspace)
+            result = await reviewer.review(
+                GuardianRequest(
+                    workspace=workspace,
+                    base_commit=request.base_commit,
+                    candidate_commit=request.candidate_commit,
+                    context=_context(self.exchange_root, workspace),
+                    change_patch=patch,
+                )
+            )
+            _write_result(
+                response,
+                result,
+                model=self.config.aggregator_model,
+                cycle_index=cycle_index,
+                max_cycles=self.max_cycles,
+            )
+            if result.status is not ReviewStatus.FAILED:
+                self._expected_base_commit = request.candidate_commit
+                self._completed_cycles = cycle_index
+
+    async def process_pending(self) -> int:
+        self._prepare()
+        processed = 0
+        for manifest in sorted((self.exchange_root / "requests").glob("*.json")):
+            response = self.exchange_root / "responses" / manifest.stem / "status.json"
+            if response.exists():
+                continue
+            await self.process_manifest(manifest)
+            processed += 1
+        return processed
+
+    async def serve(self, stop: asyncio.Event) -> None:
+        self._prepare()
+        while not stop.is_set():
+            await self.process_pending()
+            try:
+                await asyncio.wait_for(
+                    stop.wait(), timeout=max(0.1, self.poll_interval_seconds)
+                )
+            except asyncio.TimeoutError:
+                pass
+        await self.process_pending()
+
+
+def sandbox_reviewer_factory(
+    *,
+    config: GuardianConfig,
+    image: str,
+    codex_executable: str,
+    auth_json: bytes | None,
+    docker_host: str = "unix:///var/run/docker.sock",
+    platform: str = "linux/amd64",
+) -> ReviewerFactory:
+    """Build reviewers whose every rollout receives a fresh sibling sandbox."""
+
+    provider = DockerSandboxProvider(
+        allowed_images={image},
+        docker_host=docker_host,
+        work_root=None,
+        retain_audit_logs=False,
+    )
+    limits = SandboxLimits(
+        cpus=2.0,
+        memory_bytes=4 * 1024**3,
+        pids=512,
+        command_timeout_seconds=config.rollout_timeout_seconds,
+        output_bytes=8 * 1024**2,
+        audit_log_bytes=16 * 1024**2,
+        stdin_bytes=4 * 1024**2,
+        tmpfs_bytes=512 * 1024**2,
+    )
+    policy = SandboxPolicy(
+        network=NetworkMode.BRIDGE,
+        require_rootless_runtime=False,
+        allow_unpinned_image=True,
+        limits=limits,
+    )
+    staged = {".guardian-runtime/auth.json": auth_json} if auth_json is not None else {}
+
+    def factory(_workspace: Path) -> GuardianAgent:
+        runner = SandboxProcessRunner(
+            provider=provider,
+            image=image,
+            platform=platform,
+            policy=policy,
+            staged_files=staged,
+            environment={"CODEX_HOME": "/workspace/.guardian-runtime"},
+        )
+        return GuardianAgent(
+            config,
+            executor=CodexExecutor(
+                executable=codex_executable,
+                process_runner=runner,
+                max_output_bytes=limits.output_bytes,
+            ),
+        )
+
+    return factory
+
+
+__all__ = [
+    "GuardianHostController",
+    "ReviewerFactory",
+    "sandbox_reviewer_factory",
+]

--- a/scripts/guardian/deepswe/harness/message.py
+++ b/scripts/guardian/deepswe/harness/message.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone solver-message action installed into a Pier task container."""
+
+from __future__ import annotations
+
+
+def guardian_message_script(*, inbox: str, repo: str) -> str:
+    """Return an append-only message publisher with no CodeNib dependency."""
+
+    return r"""#!/usr/bin/env python3
+import argparse
+import fcntl
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+INBOX = %r
+REPO = %r
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scope", action="append", default=[])
+    args = parser.parse_args()
+    content = sys.stdin.read().strip()
+    if not content or len(content) > 16000:
+        raise SystemExit("message must contain 1-16000 characters")
+    if len(args.scope) > 32 or any(len(item) > 512 for item in args.scope):
+        raise SystemExit("message scope exceeds its limit")
+    try:
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except Exception:
+        head = ""
+    path = Path(INBOX)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        handle.seek(0)
+        sequence = 1
+        for line in handle:
+            try:
+                sequence = max(sequence, int(json.loads(line).get("sequence", 0)) + 1)
+            except Exception:
+                pass
+        value = {
+            "id": "msg_%%08d" %% sequence,
+            "sequence": sequence,
+            "sender": "solver:filesystem",
+            "content": content,
+            "observed_head": head,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "scope": args.scope,
+        }
+        handle.seek(0, os.SEEK_END)
+        handle.write(json.dumps(value, sort_keys=True) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    print(json.dumps(value, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()
+""" % (inbox, repo)
+
+
+__all__ = ["guardian_message_script"]

--- a/scripts/guardian/deepswe/harness/message.py
+++ b/scripts/guardian/deepswe/harness/message.py
@@ -73,7 +73,10 @@ def main():
 
 if __name__ == "__main__":
     main()
-""" % (inbox, repo)
+""" % (
+        inbox,
+        repo,
+    )
 
 
 __all__ = ["guardian_message_script"]

--- a/scripts/guardian/deepswe/harness/prompts/codex_file_bridge.md
+++ b/scripts/guardian/deepswe/harness/prompts/codex_file_bridge.md
@@ -1,0 +1,84 @@
+# Repository Guardian for Codex
+
+In this Pier task, Guardian is also exposed through the filesystem so you can
+use it even if MCP tool calls are unavailable.
+
+Guardian's host controller starts with the solver. Confirm that its exchange is
+ready with:
+
+```bash
+/app/.guardian/bin/guardian-start
+```
+
+You may voluntarily send Guardian your current understanding or a concern
+before committing:
+
+```bash
+printf '%s' 'I believe this change adds X; I am least certain about Y.' |
+  /app/.guardian/bin/guardian-message --scope path/to/file.py
+```
+
+This does not start or interrupt a review. The message is untrusted context,
+not evidence, and is snapshotted by the next commit cycle. Do not forward the
+benchmark instruction mechanically; communicate your own useful understanding.
+
+This action is idempotent. The initial checkout recorded during setup is cycle
+0 and spends no model tokens. Each checkpoint publishes an exact Git bundle;
+Guardian analyzes it in separate disposable sandboxes.
+
+Guardian publishes its latest report here:
+
+```bash
+/logs/agent/guardian_exchange/latest/findings.md
+/logs/agent/guardian_exchange/latest/findings.json
+/logs/agent/guardian_exchange/latest/status.json
+```
+
+The synchronized checkpoint command is:
+
+```bash
+/app/.guardian/bin/guardian-checkpoint
+```
+
+This command publishes the current commit, waits until the host controller has
+finished its report, prints the Guardian model/backend/token summary, then
+prints the full report. If `HEAD` is still the initial baseline it exits without
+running an analysis. If it otherwise fails or times out, do not silently ignore
+it; inspect the matching response under
+`/logs/agent/guardian_exchange/responses/` and explain the failure before
+finalizing.
+
+Read the latest completed report with your shell tool:
+
+```bash
+cat /logs/agent/guardian_exchange/latest/findings.md
+```
+
+Use it at these checkpoints:
+
+1. Near the start of the task, after you inspect the repository, run
+   `guardian-start` to confirm the exchange without analyzing the baseline.
+2. After each commit or substantial refactor.
+3. When tests fail in a way you did not expect.
+4. Before finalizing, always run:
+
+   ```bash
+   /app/.guardian/bin/guardian-checkpoint
+   ```
+
+   Address verified findings and high-confidence backlog items with another
+   edit/commit, or explicitly explain why no code change is needed. If
+   `analysis status` is degraded, do not describe zero findings as a clean
+   review: perform the missing validation yourself and explain the limitation.
+   Do not give your final answer until this checkpoint has succeeded for the
+   current `HEAD`.
+
+   A report marked `terminal: true` is the last Guardian review allowed for
+   this task. Verify its remaining findings yourself. You may edit and test the
+   repository afterward, but a later checkpoint will acknowledge that the new
+   commit is unreviewed and will not invoke Guardian again. Finish the task
+   after that acknowledgement instead of seeking another review cycle.
+
+At final handoff, use `/app/.guardian/bin/guardian-checkpoint` so you read the
+fresh report for the current commit. Guardian findings are advisory context;
+verify them against the code and tests before acting.

--- a/scripts/guardian/deepswe/harness/task_venv_profile.sh
+++ b/scripts/guardian/deepswe/harness/task_venv_profile.sh
@@ -1,0 +1,10 @@
+# Preserve the task image's declared virtual environment in login shells.
+#
+# Codex executes repository commands through ``bash -lc``. Some base images'
+# /etc/profile replaces Docker's configured PATH, silently selecting the system
+# interpreter instead of the task environment. Keep this arm-blind: the
+# ablation launcher mounts the same profile fragment for solo and Guardian.
+if [ -n "${VIRTUAL_ENV:-}" ] && [ -d "${VIRTUAL_ENV}/bin" ]; then
+    PATH="${VIRTUAL_ENV}/bin:${PATH}"
+    export PATH
+fi

--- a/scripts/guardian/deepswe/outputs.py
+++ b/scripts/guardian/deepswe/outputs.py
@@ -12,7 +12,7 @@ import shutil
 import sys
 from pathlib import Path
 
-DEFAULT_OUTPUT_ROOT = Path("/mnt/data/xiangye/deepswe_outputs")
+from scripts.guardian.deepswe import DEFAULT_OUTPUT_ROOT
 
 
 def _is_writable_dir(path: Path) -> bool:

--- a/scripts/guardian/deepswe/outputs.py
+++ b/scripts/guardian/deepswe/outputs.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Audit, fix, or delete DeepSWE evaluation output trees."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+DEFAULT_OUTPUT_ROOT = Path("/mnt/data/xiangye/deepswe_outputs")
+
+
+def _is_writable_dir(path: Path) -> bool:
+    return os.access(path, os.W_OK | os.X_OK)
+
+
+def audit(root: Path) -> int:
+    problems = 0
+    for path in sorted(root.rglob("*")):
+        try:
+            st = path.stat()
+        except OSError as exc:
+            problems += 1
+            print(f"[bad] cannot stat {path}: {exc}")
+            continue
+        if path.is_dir() and not _is_writable_dir(path):
+            problems += 1
+            print(
+                f"[bad] directory not writable: {path} mode={oct(st.st_mode & 0o777)}"
+            )
+    if problems:
+        print(f"[audit] {problems} issue(s)")
+    else:
+        print(f"[audit] ok: {root}")
+    return 1 if problems else 0
+
+
+def chmod_manageable(root: Path) -> None:
+    if not root.exists():
+        return
+    for path in sorted(root.rglob("*")):
+        try:
+            if path.is_dir():
+                path.chmod(0o777)
+            else:
+                path.chmod(0o666)
+        except OSError as exc:
+            print(f"[warn] chmod failed for {path}: {exc}", file=sys.stderr)
+    try:
+        root.chmod(0o777)
+    except OSError as exc:
+        print(f"[warn] chmod failed for {root}: {exc}", file=sys.stderr)
+
+
+def delete_tree(root: Path) -> None:
+    chmod_manageable(root)
+    shutil.rmtree(root)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--audit", action="store_true")
+    group.add_argument("--fix-permissions", action="store_true")
+    group.add_argument("--delete", action="store_true")
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Confirm --delete without an interactive prompt.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    root = args.root.expanduser().resolve()
+    if args.audit:
+        return audit(root)
+    if args.fix_permissions:
+        chmod_manageable(root)
+        print(f"[done] permissions relaxed: {root}")
+        return 0
+    if args.delete:
+        if not args.yes:
+            answer = input(f"Delete {root}? Type 'yes' to continue: ")
+            if answer != "yes":
+                print("[abort]")
+                return 1
+        delete_tree(root)
+        print(f"[done] deleted: {root}")
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/guardian/deepswe/outputs.py
+++ b/scripts/guardian/deepswe/outputs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Audit, fix, or delete DeepSWE evaluation output trees."""

--- a/scripts/guardian/deepswe/results.py
+++ b/scripts/guardian/deepswe/results.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate an aggregate table from DeepSWE Guardian ablation outputs.
+
+The reusable artifact and reporting logic lives in
+``codenib.eval.benchmarks.deepswe``.  This module retains the historical CLI
+and private aliases used by existing experiment scripts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+from codenib.eval.benchmarks.deepswe import COUNTED_JOB_IDS as _COUNTED_JOB_IDS
+from codenib.eval.benchmarks.deepswe import (
+    DEFAULT_PRICES_USD_PER_MTOK as _DEFAULT_PRICES_USD_PER_MTOK,
+)
+from codenib.eval.benchmarks.deepswe import (
+    Pricing,
+    add_costs,
+    load_rows,
+    metric_mean,
+    metric_sum,
+    pricing_for_model,
+    write_summary,
+)
+
+DEFAULT_OUTPUT_ROOT = Path("/mnt/data/xiangye/deepswe_outputs")
+DEFAULT_SUMMARY_CSV = DEFAULT_OUTPUT_ROOT / "guardian_ablation_summary.csv"
+
+# Compatibility aliases for existing experiment imports.
+COUNTED_JOB_IDS = _COUNTED_JOB_IDS
+DEFAULT_PRICES_USD_PER_MTOK = _DEFAULT_PRICES_USD_PER_MTOK
+_load_rows = load_rows
+_metric_mean = metric_mean
+_metric_sum = metric_sum
+
+
+def _pricing_for_model(model: str, args: argparse.Namespace) -> Pricing:
+    return pricing_for_model(
+        model,
+        input_usd_per_mtok=args.input_usd_per_mtok,
+        cached_input_usd_per_mtok=args.cached_input_usd_per_mtok,
+        output_usd_per_mtok=args.output_usd_per_mtok,
+        output_includes_reasoning=not args.output_excludes_reasoning,
+    )
+
+
+def _with_costs(row: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    return add_costs(
+        row,
+        input_usd_per_mtok=args.input_usd_per_mtok,
+        cached_input_usd_per_mtok=args.cached_input_usd_per_mtok,
+        output_usd_per_mtok=args.output_usd_per_mtok,
+        output_includes_reasoning=not args.output_excludes_reasoning,
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--summary-csv", type=Path, default=DEFAULT_SUMMARY_CSV)
+    parser.add_argument("--input-usd-per-mtok", type=float)
+    parser.add_argument("--cached-input-usd-per-mtok", type=float)
+    parser.add_argument("--output-usd-per-mtok", type=float)
+    parser.add_argument(
+        "--output-excludes-reasoning",
+        action="store_true",
+        help="Add reasoning_output_tokens to output_tokens for main Codex cost.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    rows = [_with_costs(row, args) for row in load_rows(args.output_root)]
+    write_summary(rows, args.summary_csv)
+    print(f"[done] scanned {len(rows)} trial(s)")
+    print(f"[done] summary: {args.summary_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/guardian/deepswe/results.py
+++ b/scripts/guardian/deepswe/results.py
@@ -29,8 +29,8 @@ from codenib.eval.benchmarks.deepswe import (
     pricing_for_model,
     write_summary,
 )
+from scripts.guardian.deepswe import DEFAULT_OUTPUT_ROOT
 
-DEFAULT_OUTPUT_ROOT = Path("/mnt/data/xiangye/deepswe_outputs")
 DEFAULT_SUMMARY_CSV = DEFAULT_OUTPUT_ROOT / "guardian_ablation_summary.csv"
 
 # Compatibility aliases for existing experiment imports.

--- a/scripts/guardian/deepswe/solo_matrix.py
+++ b/scripts/guardian/deepswe/solo_matrix.py
@@ -39,7 +39,7 @@ from typing import Any
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-from scripts.guardian.deepswe import ablation
+from scripts.guardian.deepswe import DEFAULT_CODENIB_ROOT, DEFAULT_OUTPUT_ROOT, ablation
 
 DEFAULT_TASKS = (
     "igel-persist-feature-schema",
@@ -56,8 +56,6 @@ DEFAULT_MODELS = (
 DEFAULT_REASONING_EFFORT = "medium"
 DEFAULT_RUNS = 4
 DEFAULT_CONCURRENCY = 3
-DEFAULT_CODENIB_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_OUTPUT_ROOT = DEFAULT_CODENIB_ROOT / "data" / "deepswe_outputs"
 
 
 @dataclass(frozen=True)

--- a/scripts/guardian/deepswe/solo_matrix.py
+++ b/scripts/guardian/deepswe/solo_matrix.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 # SPDX-License-Identifier: Apache-2.0
 
 """Run the initial DeepSWE solo baseline matrix.
@@ -15,8 +15,7 @@ interrupted slot without valid metadata is archived before it is retried.
 
 Example:
 
-    /home/xiangye/miniconda3/envs/codeminer/bin/python \
-      -m scripts.guardian.deepswe.solo_matrix --dry-run
+    python -m scripts.guardian.deepswe.solo_matrix --dry-run
 
 Remove ``--dry-run`` to launch the pending trials. Use ``--rerun-recorded`` only
 when all selected slots should be replaced with fresh trials; old artifacts are
@@ -57,8 +56,8 @@ DEFAULT_MODELS = (
 DEFAULT_REASONING_EFFORT = "medium"
 DEFAULT_RUNS = 4
 DEFAULT_CONCURRENCY = 3
-DEFAULT_CODEMINER_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_OUTPUT_ROOT = DEFAULT_CODEMINER_ROOT / "data" / "deepswe_outputs"
+DEFAULT_CODENIB_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_OUTPUT_ROOT = DEFAULT_CODENIB_ROOT / "data" / "deepswe_outputs"
 
 
 @dataclass(frozen=True)
@@ -90,7 +89,7 @@ def _trial_jobs_dir(args: argparse.Namespace, trial: Trial) -> Path:
     ).hexdigest()[:12]
     return (
         args.jobs_dir
-        / "_codeminer_matrix"
+        / "_codenib_matrix"
         / output_key
         / setting
         / trial.task
@@ -222,8 +221,8 @@ def _ablation_args(args: argparse.Namespace, trial: Trial) -> argparse.Namespace
             trial.task,
             "--runs",
             str(args.runs),
-            "--codeminer-root",
-            str(args.codeminer_root),
+            "--codenib-root",
+            str(args.codenib_root),
             "--deepswe-root",
             str(args.deepswe_root),
             "--jobs-dir",
@@ -351,7 +350,7 @@ def _validate(args: argparse.Namespace) -> None:
         if missing_contexts:
             paths = ", ".join(str(path) for path in missing_contexts)
             raise FileNotFoundError(f"task context files do not exist: {paths}")
-    profile = ablation._harness_path(args.codeminer_root) / "task_venv_profile.sh"
+    profile = ablation._harness_path(args.codenib_root) / "task_venv_profile.sh"
     if not profile.is_file():
         raise FileNotFoundError(f"task virtualenv profile does not exist: {profile}")
     if not args.dry_run and shutil.which("pier") is None:
@@ -394,9 +393,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="With --dry-run, print every pending Pier command.",
     )
     parser.add_argument(
-        "--codeminer-root",
+        "--codenib-root",
         type=Path,
-        default=DEFAULT_CODEMINER_ROOT,
+        default=DEFAULT_CODENIB_ROOT,
     )
     parser.add_argument(
         "--deepswe-root",

--- a/scripts/guardian/deepswe/solo_matrix.py
+++ b/scripts/guardian/deepswe/solo_matrix.py
@@ -1,0 +1,618 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the initial DeepSWE solo baseline matrix.
+
+The default matrix is the five Python tasks selected for the Guardian study,
+three Codex model variants, and four fixed trial slots per setting: 60 slots in
+total. Up to three trials run concurrently by default and use the same artifact
+contract as ``scripts.guardian.deepswe.ablation``.
+
+The runner is resumable. A slot with valid ``metadata.json`` is treated as a
+recorded trial, including a trial whose Pier return code is non-zero. An
+interrupted slot without valid metadata is archived before it is retried.
+
+Example:
+
+    /home/xiangye/miniconda3/envs/codeminer/bin/python \
+      -m scripts.guardian.deepswe.solo_matrix --dry-run
+
+Remove ``--dry-run`` to launch the pending trials. Use ``--rerun-recorded`` only
+when all selected slots should be replaced with fresh trials; old artifacts are
+archived rather than deleted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from scripts.guardian.deepswe import ablation
+
+DEFAULT_TASKS = (
+    "igel-persist-feature-schema",
+    "textual-kitty-key-phases",
+    "ipython-session-bundle-replay",
+    "fastapi-implicit-head-options",
+    "sqlite-utils-safe-import-checkpoints",
+)
+DEFAULT_MODELS = (
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "gpt-5.6-sol",
+)
+DEFAULT_REASONING_EFFORT = "medium"
+DEFAULT_RUNS = 4
+DEFAULT_CONCURRENCY = 3
+DEFAULT_CODEMINER_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_OUTPUT_ROOT = DEFAULT_CODEMINER_ROOT / "data" / "deepswe_outputs"
+
+
+@dataclass(frozen=True)
+class Trial:
+    model: str
+    task: str
+    repeat_index: int
+
+    @property
+    def job_id(self) -> str:
+        return f"job_{self.repeat_index}"
+
+    @property
+    def key(self) -> str:
+        return f"{self.model}|{self.task}|{self.job_id}"
+
+
+def _trial_dir(args: argparse.Namespace, trial: Trial) -> Path:
+    setting = ablation._setting_slug(trial.model, args.reasoning_effort)
+    return args.output_root / setting / trial.task / "solo" / trial.job_id
+
+
+def _trial_jobs_dir(args: argparse.Namespace, trial: Trial) -> Path:
+    """Return a Pier jobs directory isolated from every concurrent trial."""
+
+    setting = ablation._setting_slug(trial.model, args.reasoning_effort)
+    output_key = hashlib.sha256(
+        str(args.output_root.resolve()).encode("utf-8")
+    ).hexdigest()[:12]
+    return (
+        args.jobs_dir
+        / "_codeminer_matrix"
+        / output_key
+        / setting
+        / trial.task
+        / trial.job_id
+    )
+
+
+def _recorded_metadata(
+    args: argparse.Namespace,
+    trial: Trial,
+) -> dict[str, Any] | None:
+    row = ablation._load_json(_trial_dir(args, trial) / "metadata.json")
+    if not row:
+        return None
+    expected = {
+        "model": trial.model,
+        "task": trial.task,
+        "baseline": "solo",
+        "job_id": trial.job_id,
+        "reasoning_effort": args.reasoning_effort,
+    }
+    context_digest = _context_digest(args, trial.task)
+    if context_digest:
+        expected["context_injection_sha256"] = context_digest
+    if any(row.get(field) != value for field, value in expected.items()):
+        return None
+    return row
+
+
+def _build_plan(args: argparse.Namespace) -> list[Trial]:
+    plan: list[Trial] = []
+    for repeat_index in range(1, args.runs + 1):
+        # Stagger model/task pairs so the default three-worker wave exercises
+        # different models and, when available, different tasks.
+        for task_offset in range(len(args.tasks)):
+            for model_offset, model in enumerate(args.models):
+                task = args.tasks[(task_offset + model_offset) % len(args.tasks)]
+                plan.append(
+                    Trial(
+                        model=model,
+                        task=task,
+                        repeat_index=repeat_index,
+                    )
+                )
+    return plan
+
+
+def _archive_trial_dir(
+    args: argparse.Namespace,
+    trial: Trial,
+) -> Path | None:
+    source = _trial_dir(args, trial)
+    if not source.exists():
+        return None
+
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+    archive_root = args.output_root / "_matrix_runs" / "archived_trials"
+    setting = ablation._setting_slug(trial.model, args.reasoning_effort)
+    destination = archive_root / setting / trial.task / f"{trial.job_id}_{timestamp}"
+    suffix = 1
+    while destination.exists():
+        suffix += 1
+        destination = (
+            archive_root / setting / trial.task / f"{trial.job_id}_{timestamp}_{suffix}"
+        )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    ablation._repair_output_permissions(source)
+    shutil.move(str(source), str(destination))
+
+    # Aggregate scans recurse through the output root looking for this exact
+    # filename. Preserve the row without counting an archived attempt twice.
+    archived_metadata = destination / "metadata.json"
+    if archived_metadata.exists():
+        archived_metadata.rename(destination / "archived_metadata.json")
+    return destination
+
+
+def _write_state(
+    args: argparse.Namespace,
+    plan: list[Trial],
+    statuses: dict[str, dict[str, Any]],
+    *,
+    started_at: str,
+) -> None:
+    counts: dict[str, int] = {}
+    for row in statuses.values():
+        status = str(row["status"])
+        counts[status] = counts.get(status, 0) + 1
+    ablation._write_json(
+        args.state_path,
+        {
+            "updated_at": datetime.now().isoformat(timespec="seconds"),
+            "started_at": started_at,
+            "reasoning_effort": args.reasoning_effort,
+            "concurrency": args.concurrency,
+            "context_injection_source": (
+                str(args.context_file) if args.context_file is not None else ""
+            ),
+            "context_injection_sha256": args.context_injection_sha256,
+            "task_context_injection_sources": {
+                task: str(path)
+                for task, path in getattr(
+                    args,
+                    "context_injection_sources_by_task",
+                    {},
+                ).items()
+            },
+            "task_context_injection_sha256": (
+                getattr(args, "context_injection_sha256_by_task", {})
+            ),
+            "runs_per_setting": args.runs,
+            "tasks": args.tasks,
+            "models": args.models,
+            "slot_count": len(plan),
+            "counts": counts,
+            "trials": [statuses[trial.key] for trial in plan],
+        },
+    )
+
+
+def _ablation_args(args: argparse.Namespace, trial: Trial) -> argparse.Namespace:
+    trial_args = ablation.parse_args(
+        [
+            "--model",
+            trial.model,
+            "--reasoning-effort",
+            args.reasoning_effort,
+            "--tasks",
+            trial.task,
+            "--runs",
+            str(args.runs),
+            "--codeminer-root",
+            str(args.codeminer_root),
+            "--deepswe-root",
+            str(args.deepswe_root),
+            "--jobs-dir",
+            str(_trial_jobs_dir(args, trial)),
+            "--output-root",
+            str(args.output_root),
+        ]
+    )
+    trial_args.prompt_template_path = args.prompt_template_paths_by_task.get(
+        trial.task,
+        args.prompt_template_path,
+    )
+    trial_args.context_injection_source = args.context_injection_sources_by_task.get(
+        trial.task,
+        args.context_file,
+    )
+    trial_args.context_injection_sha256 = _context_digest(args, trial.task)
+    return trial_args
+
+
+def _context_digest(args: argparse.Namespace, task: str) -> str:
+    return getattr(args, "context_injection_sha256_by_task", {}).get(
+        task,
+        getattr(args, "context_injection_sha256", ""),
+    )
+
+
+def _write_context_template(
+    args: argparse.Namespace,
+    context_path: Path,
+) -> tuple[Path, str]:
+    context_path = context_path.resolve()
+    context = context_path.read_text(encoding="utf-8").strip()
+    digest = hashlib.sha256(context.encode("utf-8")).hexdigest()
+    template_dir = args.output_root / "_matrix_runs" / "prompt_templates"
+    template_dir.mkdir(parents=True, exist_ok=True)
+    template_path = template_dir / f"{context_path.stem}_{digest[:12]}.jinja2"
+    rendered_source = (
+        "{{ instruction }}\n\n"
+        "---\n\n"
+        "## Additional review context\n\n"
+        f"{context}\n"
+    )
+    template_path.write_text(rendered_source, encoding="utf-8")
+    return template_path.resolve(), digest
+
+
+def _prepare_context_template(args: argparse.Namespace) -> None:
+    """Build Pier prompt templates from shared or task-specific context."""
+
+    args.prompt_template_path = None
+    args.prompt_template_paths_by_task = {}
+    args.context_injection_sources_by_task = {}
+    args.context_injection_sha256 = ""
+    args.context_injection_sha256_by_task = {}
+    if args.context_file is None:
+        if args.task_context_dir is None:
+            return
+        for task in args.tasks:
+            context_path = (args.task_context_dir / f"{task}.md").resolve()
+            template_path, digest = _write_context_template(args, context_path)
+            args.prompt_template_paths_by_task[task] = template_path
+            args.context_injection_sources_by_task[task] = context_path
+            args.context_injection_sha256_by_task[task] = digest
+        return
+
+    context_path = args.context_file.resolve()
+    template_path, digest = _write_context_template(args, context_path)
+    args.context_file = context_path
+    args.context_injection_sha256 = digest
+    args.prompt_template_path = template_path
+
+
+def _initial_status(
+    args: argparse.Namespace,
+    trial: Trial,
+) -> dict[str, Any]:
+    metadata = _recorded_metadata(args, trial)
+    status = "recorded" if metadata is not None else "pending"
+    return {
+        **asdict(trial),
+        "job_id": trial.job_id,
+        "key": trial.key,
+        "status": status,
+        "output_dir": str(_trial_dir(args, trial)),
+        "returncode": (metadata or {}).get("returncode"),
+        "reward": (metadata or {}).get("reward"),
+        "f2p": (metadata or {}).get("f2p"),
+        "p2p": (metadata or {}).get("p2p"),
+        "partial": (metadata or {}).get("partial"),
+    }
+
+
+def _validate(args: argparse.Namespace) -> None:
+    if args.runs < 1 or args.runs > 4:
+        raise ValueError("--runs must be between 1 and 4")
+    if args.concurrency < 1:
+        raise ValueError("--concurrency must be at least 1")
+    if len(set(args.models)) != len(args.models):
+        raise ValueError("--models contains duplicates")
+    if len(set(args.tasks)) != len(args.tasks):
+        raise ValueError("--tasks contains duplicates")
+    missing = [
+        args.deepswe_root / "tasks" / task
+        for task in args.tasks
+        if not (args.deepswe_root / "tasks" / task).is_dir()
+    ]
+    if missing:
+        paths = ", ".join(str(path) for path in missing)
+        raise FileNotFoundError(f"DeepSWE task directories do not exist: {paths}")
+    if args.context_file is not None and not args.context_file.is_file():
+        raise FileNotFoundError(
+            f"context injection file does not exist: {args.context_file}"
+        )
+    if args.task_context_dir is not None:
+        if not args.task_context_dir.is_dir():
+            raise FileNotFoundError(
+                f"task context directory does not exist: {args.task_context_dir}"
+            )
+        missing_contexts = [
+            args.task_context_dir / f"{task}.md"
+            for task in args.tasks
+            if not (args.task_context_dir / f"{task}.md").is_file()
+        ]
+        if missing_contexts:
+            paths = ", ".join(str(path) for path in missing_contexts)
+            raise FileNotFoundError(f"task context files do not exist: {paths}")
+    profile = ablation._harness_path(args.codeminer_root) / "task_venv_profile.sh"
+    if not profile.is_file():
+        raise FileNotFoundError(f"task virtualenv profile does not exist: {profile}")
+    if not args.dry_run and shutil.which("pier") is None:
+        raise FileNotFoundError("pier is not on PATH")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--models", nargs="+", default=list(DEFAULT_MODELS))
+    parser.add_argument("--tasks", nargs="+", default=list(DEFAULT_TASKS))
+    parser.add_argument(
+        "--reasoning-effort",
+        default=DEFAULT_REASONING_EFFORT,
+    )
+    parser.add_argument("--runs", type=int, default=DEFAULT_RUNS)
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=DEFAULT_CONCURRENCY,
+        help="Maximum number of Pier trials to run concurrently (default: 3).",
+    )
+    parser.add_argument(
+        "--rerun-recorded",
+        action="store_true",
+        help="Archive and rerun slots that already have valid metadata.",
+    )
+    parser.add_argument(
+        "--stop-on-launcher-error",
+        action="store_true",
+        help="Stop after a Python/Pier launcher exception instead of continuing.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and print the matrix without launching Pier.",
+    )
+    parser.add_argument(
+        "--show-commands",
+        action="store_true",
+        help="With --dry-run, print every pending Pier command.",
+    )
+    parser.add_argument(
+        "--codeminer-root",
+        type=Path,
+        default=DEFAULT_CODEMINER_ROOT,
+    )
+    parser.add_argument(
+        "--deepswe-root",
+        type=Path,
+        default=ablation.DEFAULT_DEEPSWE_ROOT,
+    )
+    parser.add_argument(
+        "--jobs-dir",
+        type=Path,
+        default=ablation.DEFAULT_JOBS_DIR,
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT,
+    )
+    context_group = parser.add_mutually_exclusive_group()
+    context_group.add_argument(
+        "--context-file",
+        type=Path,
+        default=None,
+        help=(
+            "Append this Markdown file to the original task instruction using "
+            "Pier's Codex prompt template support."
+        ),
+    )
+    context_group.add_argument(
+        "--task-context-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Append task-specific context from <dir>/<task>.md using Pier's "
+            "Codex prompt template support."
+        ),
+    )
+    parser.add_argument(
+        "--state-path",
+        type=Path,
+        default=None,
+        help="Progress JSON path (default: <output-root>/_matrix_runs/...).",
+    )
+    args = parser.parse_args(argv)
+    if args.state_path is None:
+        args.state_path = (
+            args.output_root / "_matrix_runs" / "solo_python_5x3x4_medium.json"
+        )
+    return args
+
+
+def _run_plan(
+    args: argparse.Namespace,
+    plan: list[Trial],
+    statuses: dict[str, dict[str, Any]],
+    *,
+    started_at: str,
+) -> tuple[int, int]:
+    """Run pending slots with bounded concurrency.
+
+    Only the coordinator thread mutates ``statuses`` or writes the state file.
+    Worker threads are restricted to one isolated Pier trial each.
+    """
+
+    scheduled: list[tuple[int, Trial]] = []
+    for ordinal, trial in enumerate(plan, 1):
+        status = statuses[trial.key]
+        if status["status"] == "recorded" and not args.rerun_recorded:
+            print(
+                f"[{ordinal}/{len(plan)} skip] {trial.model} {trial.task} "
+                f"{trial.job_id}"
+            )
+            continue
+        scheduled.append((ordinal, trial))
+
+    launcher_errors = 0
+    run_count = 0
+    next_trial = 0
+    stop_scheduling = False
+    running: dict[Future[dict[str, Any]], tuple[int, Trial]] = {}
+
+    with ThreadPoolExecutor(
+        max_workers=args.concurrency,
+        thread_name_prefix="deepswe-trial",
+    ) as executor:
+        while next_trial < len(scheduled) or running:
+            while (
+                not stop_scheduling
+                and next_trial < len(scheduled)
+                and len(running) < args.concurrency
+            ):
+                ordinal, trial = scheduled[next_trial]
+                next_trial += 1
+                status = statuses[trial.key]
+                archived = _archive_trial_dir(args, trial)
+                if archived is not None:
+                    status["archived_output_dir"] = str(archived)
+                status["status"] = "running"
+                status["started_at"] = datetime.now().isoformat(timespec="seconds")
+                _write_state(args, plan, statuses, started_at=started_at)
+                print(
+                    f"[{ordinal}/{len(plan)} run] {trial.model} {trial.task} "
+                    f"{trial.job_id}",
+                    flush=True,
+                )
+                future = executor.submit(
+                    ablation._run_trial,
+                    _ablation_args(args, trial),
+                    task=trial.task,
+                    baseline="solo",
+                    repeat_index=trial.repeat_index,
+                )
+                running[future] = (ordinal, trial)
+
+            if not running:
+                break
+
+            completed, _ = wait(running, return_when=FIRST_COMPLETED)
+            for future in completed:
+                _, trial = running.pop(future)
+                status = statuses[trial.key]
+                try:
+                    row = future.result()
+                except Exception as exc:
+                    launcher_errors += 1
+                    status["status"] = "launcher_error"
+                    status["error"] = f"{type(exc).__name__}: {exc}"
+                    status["finished_at"] = datetime.now().isoformat(timespec="seconds")
+                    print(
+                        f"[launcher-error] {trial.model} {trial.task} "
+                        f"{trial.job_id}: {status['error']}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    if args.stop_on_launcher_error:
+                        stop_scheduling = True
+                else:
+                    run_count += 1
+                    status.update(
+                        {
+                            "status": (
+                                "recorded"
+                                if row.get("returncode") == 0
+                                else "recorded_nonzero"
+                            ),
+                            "returncode": row.get("returncode"),
+                            "reward": row.get("reward"),
+                            "f2p": row.get("f2p"),
+                            "p2p": row.get("p2p"),
+                            "partial": row.get("partial"),
+                            "finished_at": datetime.now().isoformat(timespec="seconds"),
+                        }
+                    )
+                _write_state(args, plan, statuses, started_at=started_at)
+
+    return run_count, launcher_errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    _validate(args)
+    _prepare_context_template(args)
+    plan = _build_plan(args)
+    statuses = {trial.key: _initial_status(args, trial) for trial in plan}
+    recorded = sum(row["status"] == "recorded" for row in statuses.values())
+    pending = len(plan) if args.rerun_recorded else len(plan) - recorded
+
+    print(
+        f"[matrix] {len(args.models)} models x {len(args.tasks)} tasks x "
+        f"{args.runs} trials = {len(plan)} slots"
+    )
+    print(
+        f"[matrix] recorded={recorded} pending={pending} "
+        f"reasoning_effort={args.reasoning_effort} concurrency={args.concurrency}"
+    )
+
+    if args.dry_run:
+        for trial in plan:
+            status = statuses[trial.key]["status"]
+            action = "run" if args.rerun_recorded or status == "pending" else "skip"
+            print(
+                f"[{action}] {trial.model} {trial.task} {trial.job_id}: "
+                f"{_trial_dir(args, trial)}"
+            )
+            if action == "run" and args.show_commands:
+                trial_args = _ablation_args(args, trial)
+                command = ablation._build_pier_command(
+                    trial_args,
+                    task=trial.task,
+                    baseline="solo",
+                    logs_dir=_trial_dir(args, trial) / "agent_logs",
+                )
+                print("  " + " ".join(command))
+        return 0
+
+    started_at = datetime.now().isoformat(timespec="seconds")
+    _write_state(args, plan, statuses, started_at=started_at)
+    matrix_started = time.monotonic()
+    run_count, launcher_errors = _run_plan(
+        args,
+        plan,
+        statuses,
+        started_at=started_at,
+    )
+
+    elapsed = time.monotonic() - matrix_started
+    final_counts: dict[str, int] = {}
+    for row in statuses.values():
+        status_name = str(row["status"])
+        final_counts[status_name] = final_counts.get(status_name, 0) + 1
+    print(
+        f"[done] launched={run_count} launcher_errors={launcher_errors} "
+        f"elapsed_hours={elapsed / 3600:.2f}"
+    )
+    print(f"[done] state: {args.state_path}")
+    print(f"[done] statuses: {json.dumps(final_counts, sort_keys=True)}")
+    return 1 if launcher_errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/clients/test_execution.py
+++ b/test/clients/test_execution.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for external-agent execution adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from codenib.clients.execution import (
+    AgentEventKind,
+    AgentExecutor,
+    AgentRole,
+    AgentRunErrorCode,
+    AgentRunRequest,
+    CodexExecutor,
+    ExecutableNotFoundError,
+    ExecutionIsolation,
+    ExecutionPolicy,
+    FilesystemAccess,
+    LocalProcessRunner,
+    NetworkAccess,
+    ProcessRequest,
+    ProcessResult,
+    RunStatus,
+    SandboxProcessRunner,
+)
+from codenib.sandbox import (
+    ExecResult,
+    NetworkMode,
+    SandboxCapabilities,
+    SandboxMetadata,
+    SandboxPolicy,
+)
+
+
+class FakeProcessRunner:
+    def __init__(self, result: ProcessResult) -> None:
+        self.result = result
+        self.requests: list[ProcessRequest] = []
+
+    async def run(self, request: ProcessRequest) -> ProcessResult:
+        self.requests.append(request)
+        return self.result
+
+
+class FakeSandboxSession:
+    def __init__(self) -> None:
+        self.requests = []
+        self.writes = []
+        self.closed = False
+        self.sandbox_id = "sbx-test"
+        self.capabilities = SandboxCapabilities(
+            provider="fake",
+            isolation="test",
+            non_root_user=True,
+            network_isolation=False,
+            read_only_rootfs=True,
+            resource_limits=True,
+            process_tree_cleanup=True,
+            disk_quota=False,
+        )
+        self.metadata = SandboxMetadata(
+            sandbox_id="sbx-test",
+            task_id="guardian-test",
+            provider="fake",
+            image="test",
+            image_id="test",
+            platform="linux/amd64",
+            source_revision=None,
+            network="bridge",
+            rootless_runtime=False,
+        )
+
+    def write_file(self, path, data, *, create_parents=False):
+        self.writes.append((path, data, create_parents))
+
+    def execute(self, request):
+        self.requests.append(request)
+        return ExecResult(
+            command_id="command",
+            argv=tuple(request.argv),
+            exit_code=0,
+            stdout="sandbox output",
+            stderr="",
+            duration_ms=1250,
+        )
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        self.close()
+
+
+class FakeSandboxProvider:
+    def __init__(self) -> None:
+        self.specs = []
+        self.sessions = []
+
+    @property
+    def capabilities(self):
+        return FakeSandboxSession().capabilities
+
+    def create(self, spec):
+        self.specs.append(spec)
+        session = FakeSandboxSession()
+        self.sessions.append(session)
+        return session
+
+
+def _process_result(
+    stdout: str,
+    *,
+    exit_code: int = 0,
+    timed_out: bool = False,
+    stdout_truncated: bool = False,
+) -> ProcessResult:
+    return ProcessResult(
+        argv=("codex",),
+        exit_code=exit_code,
+        stdout=stdout,
+        stderr="diagnostic",
+        duration_seconds=1.25,
+        timed_out=timed_out,
+        stdout_truncated=stdout_truncated,
+    )
+
+
+def _request(tmp_path: Path, **overrides: object) -> AgentRunRequest:
+    values = {
+        "instruction": "Discover local specifications.",
+        "workspace": tmp_path,
+        "role": AgentRole.EXPLORER,
+        "timeout_seconds": 30,
+        "model": "gpt-test",
+        "reasoning_effort": "medium",
+    }
+    values.update(overrides)
+    return AgentRunRequest(**values)  # type: ignore[arg-type]
+
+
+def _jsonl(*events: dict[str, object]) -> str:
+    return "\n".join(json.dumps(event) for event in events) + "\n"
+
+
+def test_codex_executor_normalizes_command_events_and_usage(tmp_path: Path) -> None:
+    output = _jsonl(
+        {"type": "thread.started", "thread_id": "thread-1"},
+        {"type": "turn.started"},
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "item-1",
+                "type": "command_execution",
+                "command": "rg feature",
+                "status": "completed",
+            },
+        },
+        {
+            "type": "item.completed",
+            "item": {
+                "id": "item-2",
+                "type": "agent_message",
+                "text": "The feature must preserve aliases.",
+            },
+        },
+        {
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": 100,
+                "cached_input_tokens": 40,
+                "cache_write_input_tokens": 5,
+                "output_tokens": 20,
+                "reasoning_output_tokens": 7,
+            },
+        },
+    )
+    runner = FakeProcessRunner(_process_result(output))
+    executor = CodexExecutor(process_runner=runner)
+
+    result = asyncio.run(executor.run(_request(tmp_path)))
+
+    assert isinstance(executor, AgentExecutor)
+    assert result.status is RunStatus.COMPLETED
+    assert result.final_message == "The feature must preserve aliases."
+    assert result.usage.input_tokens == 100
+    assert result.usage.cached_input_tokens == 40
+    assert result.usage.output_tokens == 20
+    assert result.usage.total_tokens == 120
+    assert [event.kind for event in result.trajectory] == [
+        AgentEventKind.LIFECYCLE,
+        AgentEventKind.LIFECYCLE,
+        AgentEventKind.TOOL,
+        AgentEventKind.MESSAGE,
+        AgentEventKind.USAGE,
+    ]
+
+    launched = runner.requests[0]
+    assert launched.stdin == b"Discover local specifications."
+    assert launched.cwd == tmp_path.resolve()
+    assert launched.argv[:3] == ("codex", "exec", "--json")
+    assert ("--sandbox", "read-only") == (
+        launched.argv[launched.argv.index("--sandbox")],
+        launched.argv[launched.argv.index("--sandbox") + 1],
+    )
+    assert launched.argv[-1] == "-"
+    assert "gpt-test" in launched.argv
+    assert 'model_reasoning_effort="medium"' in launched.argv
+
+
+def test_codex_executor_translates_workspace_write_policy(tmp_path: Path) -> None:
+    output = _jsonl(
+        {
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": "done"},
+        }
+    )
+    runner = FakeProcessRunner(_process_result(output))
+    policy = ExecutionPolicy(filesystem=FilesystemAccess.WORKSPACE_WRITE)
+
+    result = asyncio.run(
+        CodexExecutor(process_runner=runner).run(
+            _request(tmp_path, policy=policy, model=None, reasoning_effort=None)
+        )
+    )
+
+    assert result.succeeded
+    command = runner.requests[0].argv
+    assert command[command.index("--sandbox") + 1] == "workspace-write"
+    assert "--model" not in command
+
+
+def test_codex_executor_delegates_sandboxing_only_when_explicit(tmp_path: Path) -> None:
+    output = _jsonl(
+        {
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": "done"},
+        }
+    )
+    runner = FakeProcessRunner(_process_result(output))
+    policy = ExecutionPolicy(isolation=ExecutionIsolation.EXTERNAL)
+
+    result = asyncio.run(
+        CodexExecutor(process_runner=runner).run(_request(tmp_path, policy=policy))
+    )
+
+    assert result.succeeded
+    command = runner.requests[0].argv
+    assert "--dangerously-bypass-approvals-and-sandbox" in command
+    assert "--sandbox" not in command
+
+
+def test_codex_executor_rejects_unenforceable_network_policy(tmp_path: Path) -> None:
+    runner = FakeProcessRunner(_process_result(""))
+    policy = ExecutionPolicy(network=NetworkAccess.DISABLED)
+
+    result = asyncio.run(
+        CodexExecutor(process_runner=runner).run(_request(tmp_path, policy=policy))
+    )
+
+    assert result.status is RunStatus.FAILED
+    assert result.error is not None
+    assert result.error.code is AgentRunErrorCode.UNSUPPORTED_POLICY
+    assert runner.requests == []
+
+
+@pytest.mark.parametrize(
+    ("process", "expected_code", "expected_status"),
+    [
+        (
+            _process_result("", exit_code=2),
+            AgentRunErrorCode.CLI_EXIT,
+            RunStatus.FAILED,
+        ),
+        (
+            _process_result("", exit_code=-9, timed_out=True),
+            AgentRunErrorCode.TIMEOUT,
+            RunStatus.TIMED_OUT,
+        ),
+        (
+            _process_result("not-json\n"),
+            AgentRunErrorCode.MALFORMED_EVENT_STREAM,
+            RunStatus.FAILED,
+        ),
+        (
+            _process_result(_jsonl({"type": "turn.completed", "usage": {}})),
+            AgentRunErrorCode.EMPTY_RESPONSE,
+            RunStatus.FAILED,
+        ),
+    ],
+)
+def test_codex_executor_classifies_operational_failures(
+    tmp_path: Path,
+    process: ProcessResult,
+    expected_code: AgentRunErrorCode,
+    expected_status: RunStatus,
+) -> None:
+    result = asyncio.run(
+        CodexExecutor(process_runner=FakeProcessRunner(process)).run(_request(tmp_path))
+    )
+
+    assert result.status is expected_status
+    assert result.error is not None
+    assert result.error.code is expected_code
+
+
+def test_local_process_runner_bounds_output(tmp_path: Path) -> None:
+    request = ProcessRequest(
+        argv=(sys.executable, "-c", "print('x' * 200)"),
+        cwd=tmp_path,
+        max_output_bytes=32,
+        timeout_seconds=2,
+    )
+
+    result = asyncio.run(LocalProcessRunner().run(request))
+
+    assert result.exit_code == 0
+    assert len(result.stdout.encode()) == 32
+    assert result.stdout_truncated
+
+
+def test_local_process_runner_kills_timed_out_process(tmp_path: Path) -> None:
+    request = ProcessRequest(
+        argv=(sys.executable, "-c", "import time; time.sleep(10)"),
+        cwd=tmp_path,
+        timeout_seconds=0.05,
+    )
+
+    result = asyncio.run(LocalProcessRunner().run(request))
+
+    assert result.timed_out
+    assert result.exit_code is not None
+
+
+def test_local_process_runner_reports_missing_executable(tmp_path: Path) -> None:
+    request = ProcessRequest(
+        argv=("definitely-not-a-codenib-executable",),
+        cwd=tmp_path,
+        timeout_seconds=1,
+    )
+
+    with pytest.raises(ExecutableNotFoundError):
+        asyncio.run(LocalProcessRunner().run(request))
+
+
+def test_sandbox_process_runner_copies_source_and_rewrites_workspace(
+    tmp_path: Path,
+) -> None:
+    subprocess.run(("git", "init", "--quiet"), cwd=tmp_path, check=True)
+    subprocess.run(
+        ("git", "config", "user.email", "sandbox@example.com"),
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(("git", "config", "user.name", "Sandbox"), cwd=tmp_path, check=True)
+    (tmp_path / "file.py").write_text("value = 1\n", encoding="utf-8")
+    subprocess.run(("git", "add", "file.py"), cwd=tmp_path, check=True)
+    subprocess.run(
+        ("git", "commit", "--quiet", "-m", "source"), cwd=tmp_path, check=True
+    )
+    provider = FakeSandboxProvider()
+    runner = SandboxProcessRunner(
+        provider=provider,
+        image="guardian:test",
+        platform="linux/amd64",
+        policy=SandboxPolicy(
+            network=NetworkMode.BRIDGE,
+            require_rootless_runtime=False,
+            allow_unpinned_image=True,
+        ),
+        staged_files={".guardian-runtime/auth.json": b"secret"},
+    )
+    request = ProcessRequest(
+        argv=("codex", "exec", "--cd", str(tmp_path), "-"),
+        cwd=tmp_path,
+        stdin=b"review",
+        environment={"CODEX_HOME": "/workspace/.guardian-runtime"},
+        timeout_seconds=10,
+    )
+
+    result = asyncio.run(runner.run(request))
+
+    assert result.stdout == "sandbox output"
+    assert result.duration_seconds == 1.25
+    assert provider.specs[0].source_dir == tmp_path.resolve()
+    session = provider.sessions[0]
+    assert session.closed
+    assert session.writes == [
+        (PurePosixPath(".guardian-runtime/auth.json"), b"secret", True)
+    ]
+    launched = session.requests[0]
+    assert launched.argv == ("codex", "exec", "--cd", "/workspace", "-")
+    assert launched.stdin == b"review"

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the local-specification Guardian policy."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from codenib.clients.execution import (
+    AgentRunError,
+    AgentRunErrorCode,
+    AgentRunRequest,
+    AgentRunResult,
+    RunStatus,
+    TokenUsage,
+)
+from codenib.clients.guardian import (
+    ContextMessage,
+    GuardianAgent,
+    GuardianConfig,
+    GuardianRequest,
+    ReviewStatus,
+    render_markdown,
+)
+
+
+def _result(message: str, *, success: bool = True) -> AgentRunResult:
+    return AgentRunResult(
+        status=RunStatus.COMPLETED if success else RunStatus.FAILED,
+        final_message=message if success else "",
+        trajectory=(),
+        usage=TokenUsage(input_tokens=100, output_tokens=20),
+        duration_seconds=1,
+        raw_output="",
+        stderr="",
+        exit_code=0 if success else 1,
+        error=(
+            None
+            if success
+            else AgentRunError(AgentRunErrorCode.CLI_EXIT, "synthetic explorer failure")
+        ),
+    )
+
+
+class ScriptedExecutor:
+    def __init__(self, results: list[AgentRunResult]) -> None:
+        self.results = results
+        self.requests: list[AgentRunRequest] = []
+
+    async def run(self, request: AgentRunRequest) -> AgentRunResult:
+        self.requests.append(request)
+        return self.results.pop(0)
+
+
+def _candidate(statement: str, authority: str = "test") -> dict[str, object]:
+    return {
+        "statement": statement,
+        "condition": "when the public entry point copies state",
+        "evidence": [
+            {
+                "path": "tests/test_contract.py",
+                "line_start": 10,
+                "line_end": 14,
+                "description": "the public-path contract",
+                "authority": authority,
+            }
+        ],
+        "patch_assessment": "the new copy omits the field",
+        "confidence": 0.9,
+        "uncertainty": "",
+    }
+
+
+def _finding(
+    statement: str, status: str, authority: str = "test", confidence: float = 0.9
+) -> dict[str, object]:
+    value = _candidate(statement, authority)
+    return {
+        "statement": value["statement"],
+        "status": status,
+        "evidence": value["evidence"],
+        "patch_assessment": value["patch_assessment"],
+        "recommendation": "preserve the field on the public copy path",
+        "confidence": confidence,
+    }
+
+
+def _request(tmp_path: Path) -> GuardianRequest:
+    return GuardianRequest(
+        workspace=tmp_path,
+        base_commit="a" * 40,
+        candidate_commit="b" * 40,
+        context=(
+            ContextMessage(
+                content="I think all state copies are covered.",
+                sender="solver:test",
+                scope=("src/state.py",),
+            ),
+        ),
+    )
+
+
+def test_guardian_discovers_aggregates_and_filters_delivery(tmp_path: Path) -> None:
+    executor = ScriptedExecutor(
+        [
+            _result(json.dumps({"candidates": [_candidate("Copies preserve mode")]})),
+            _result(
+                json.dumps(
+                    {"candidates": [_candidate("Failure leaves state unchanged")]}
+                )
+            ),
+            _result(
+                json.dumps(
+                    {
+                        "summary": "One repository-backed mismatch remains.",
+                        "findings": [
+                            _finding("Copies preserve mode", "violated"),
+                            _finding(
+                                "Solver intended an extra alias",
+                                "violated",
+                                authority="solver",
+                            ),
+                            _finding("Failure is atomic", "uncertain"),
+                            _finding("Legacy path is preserved", "satisfied"),
+                        ],
+                    }
+                )
+            ),
+        ]
+    )
+    agent = GuardianAgent(
+        GuardianConfig(explorer_model="cheap", aggregator_model="strong"),
+        executor=executor,
+    )
+
+    result = asyncio.run(agent.review(_request(tmp_path)))
+
+    assert result.status is ReviewStatus.COMPLETE
+    assert [finding.statement for finding in result.findings] == [
+        "Copies preserve mode"
+    ]
+    assert [finding.statement for finding in result.backlog] == ["Failure is atomic"]
+    assert result.usage.input_tokens == 300
+    assert result.usage.output_tokens == 60
+    assert [request.model for request in executor.requests] == [
+        "cheap",
+        "cheap",
+        "strong",
+    ]
+    assert all(
+        request.policy.filesystem.value == "read-only" for request in executor.requests
+    )
+    markdown = render_markdown(result)
+    assert "Copies preserve mode" in markdown
+    assert "Solver intended an extra alias" not in markdown
+
+
+def test_guardian_marks_partial_exploration_degraded(tmp_path: Path) -> None:
+    executor = ScriptedExecutor(
+        [
+            _result("", success=False),
+            _result(json.dumps({"candidates": [_candidate("Copies preserve mode")]})),
+            _result(
+                json.dumps(
+                    {
+                        "summary": "Review completed with one explorer.",
+                        "findings": [_finding("Copies preserve mode", "violated")],
+                    }
+                )
+            ),
+        ]
+    )
+    agent = GuardianAgent(
+        GuardianConfig(explorer_model="cheap", aggregator_model="strong"),
+        executor=executor,
+    )
+
+    result = asyncio.run(agent.review(_request(tmp_path)))
+
+    assert result.status is ReviewStatus.DEGRADED
+    assert result.findings
+    assert result.errors == ("explorer_1: synthetic explorer failure",)
+
+
+def test_guardian_fails_closed_without_candidates(tmp_path: Path) -> None:
+    executor = ScriptedExecutor(
+        [
+            _result(json.dumps({"candidates": []})),
+            _result("not JSON"),
+        ]
+    )
+    agent = GuardianAgent(
+        GuardianConfig(explorer_model="cheap", aggregator_model="strong"),
+        executor=executor,
+    )
+
+    result = asyncio.run(agent.review(_request(tmp_path)))
+
+    assert result.status is ReviewStatus.FAILED
+    assert not result.findings
+    assert len(executor.requests) == 2
+    assert result.errors

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 from codenib.clients.execution import (
@@ -89,11 +91,53 @@ def _finding(
     }
 
 
+def _git(tmp_path: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
 def _request(tmp_path: Path) -> GuardianRequest:
+    evidence = tmp_path / "tests" / "test_contract.py"
+    evidence.parent.mkdir(parents=True, exist_ok=True)
+    evidence.write_text("\n".join(f"line {line}" for line in range(1, 21)) + "\n")
+    _git(tmp_path, "init", "--quiet")
+    _git(tmp_path, "add", ".")
+    _git(
+        tmp_path,
+        "-c",
+        "user.name=CodeNib Test",
+        "-c",
+        "user.email=test@codenib.ai",
+        "commit",
+        "--quiet",
+        "-m",
+        "base",
+    )
+    base = _git(tmp_path, "rev-parse", "HEAD")
+    evidence.write_text(evidence.read_text() + "candidate line\n")
+    _git(tmp_path, "add", ".")
+    _git(
+        tmp_path,
+        "-c",
+        "user.name=CodeNib Test",
+        "-c",
+        "user.email=test@codenib.ai",
+        "commit",
+        "--quiet",
+        "-m",
+        "candidate",
+    )
+    candidate = _git(tmp_path, "rev-parse", "HEAD")
     return GuardianRequest(
         workspace=tmp_path,
-        base_commit="a" * 40,
-        candidate_commit="b" * 40,
+        base_commit=base,
+        candidate_commit=candidate,
         context=(
             ContextMessage(
                 content="I think all state copies are covered.",
@@ -204,3 +248,92 @@ def test_guardian_fails_closed_without_candidates(tmp_path: Path) -> None:
     assert not result.findings
     assert len(executor.requests) == 2
     assert result.errors
+
+
+def test_guardian_fails_closed_when_workspace_is_not_candidate(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path)
+    executor = ScriptedExecutor([])
+    agent = GuardianAgent(
+        GuardianConfig(explorer_model="cheap", aggregator_model="strong"),
+        executor=executor,
+    )
+
+    result = asyncio.run(
+        agent.review(replace(request, candidate_commit=request.base_commit))
+    )
+
+    assert result.status is ReviewStatus.FAILED
+    assert result.errors == (
+        "workspace HEAD does not match the advertised candidate commit",
+    )
+    assert not executor.requests
+
+
+def test_guardian_rejects_candidates_with_unverifiable_evidence(
+    tmp_path: Path,
+) -> None:
+    candidate = _candidate("Copies preserve mode")
+    candidate["evidence"] = [
+        {
+            "path": "../outside.py",
+            "line_start": 1,
+            "line_end": 1,
+            "description": "a path outside the candidate workspace",
+            "authority": "repository",
+        },
+        {
+            "path": "tests/test_contract.py",
+            "line_start": 100,
+            "line_end": 100,
+            "description": "a line beyond the file",
+            "authority": "test",
+        },
+    ]
+    executor = ScriptedExecutor([_result(json.dumps({"candidates": [candidate]}))])
+    agent = GuardianAgent(
+        GuardianConfig(
+            explorer_model="cheap",
+            aggregator_model="strong",
+            explorer_count=1,
+        ),
+        executor=executor,
+    )
+
+    result = asyncio.run(agent.review(_request(tmp_path)))
+
+    assert result.status is ReviewStatus.FAILED
+    assert not result.candidates
+    assert len(executor.requests) == 1
+    assert any("not repository-relative" in error for error in result.errors)
+    assert any("line range exceeds" in error for error in result.errors)
+
+
+def test_guardian_rejects_aggregate_findings_with_invalid_lines(
+    tmp_path: Path,
+) -> None:
+    finding = _finding("Copies preserve mode", "violated")
+    finding["evidence"][0]["line_start"] = 999
+    finding["evidence"][0]["line_end"] = 999
+    executor = ScriptedExecutor(
+        [
+            _result(json.dumps({"candidates": [_candidate("Copies preserve mode")]})),
+            _result(json.dumps({"summary": "Unverified.", "findings": [finding]})),
+        ]
+    )
+    agent = GuardianAgent(
+        GuardianConfig(
+            explorer_model="cheap",
+            aggregator_model="strong",
+            explorer_count=1,
+        ),
+        executor=executor,
+    )
+
+    result = asyncio.run(agent.review(_request(tmp_path)))
+
+    assert result.status is ReviewStatus.DEGRADED
+    assert not result.findings
+    assert not result.backlog
+    assert any("aggregator finding" in error for error in result.errors)

--- a/test/clients/test_guardian_exchange.py
+++ b/test/clients/test_guardian_exchange.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the commit-addressed Guardian exchange protocol."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codenib.clients.guardian.exchange import (
+    ExchangeProtocolError,
+    load_exchange_request,
+    materialize_exchange_request,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ("git", *args),
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _exchange(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    repo = tmp_path / "source"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.email", "guardian@example.com")
+    _git(repo, "config", "user.name", "Guardian")
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "--quiet", "-m", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+    (repo / "feature.py").write_text("value = 2\n", encoding="utf-8")
+    _git(repo, "commit", "--quiet", "-am", "candidate")
+    candidate = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-ref", "refs/guardian/base", base)
+    _git(repo, "update-ref", "refs/guardian/candidate", candidate)
+
+    root = tmp_path / "exchange"
+    requests = root / "requests"
+    bundles = root / "bundles"
+    requests.mkdir(parents=True)
+    bundles.mkdir()
+    bundle = bundles / f"{candidate}.bundle"
+    _git(
+        repo,
+        "bundle",
+        "create",
+        str(bundle),
+        "refs/guardian/base",
+        "refs/guardian/candidate",
+    )
+    digest = hashlib.sha256(bundle.read_bytes()).hexdigest()
+    manifest = requests / f"{candidate}.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "request_id": candidate,
+                "base_commit": base,
+                "candidate_commit": candidate,
+                "bundle_name": bundle.name,
+                "bundle_sha256": digest,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return root, manifest, base, candidate
+
+
+def test_exchange_materializes_exact_candidate(tmp_path: Path) -> None:
+    root, manifest, base, candidate = _exchange(tmp_path)
+
+    request, bundle = load_exchange_request(root, manifest)
+    checkout = materialize_exchange_request(request, bundle, tmp_path / "checkout")
+
+    assert request.base_commit == base
+    assert request.candidate_commit == candidate
+    assert _git(checkout, "rev-parse", "HEAD") == candidate
+    assert (checkout / "feature.py").read_text(encoding="utf-8") == "value = 2\n"
+
+
+def test_exchange_rejects_tampered_bundle(tmp_path: Path) -> None:
+    root, manifest, _base, candidate = _exchange(tmp_path)
+    bundle = root / "bundles" / f"{candidate}.bundle"
+    bundle.write_bytes(bundle.read_bytes() + b"tampered")
+
+    with pytest.raises(ExchangeProtocolError, match="checksum"):
+        load_exchange_request(root, manifest)
+
+
+def test_exchange_rejects_noncanonical_manifest_path(tmp_path: Path) -> None:
+    root, manifest, _base, _candidate = _exchange(tmp_path)
+    moved = root / "outside.json"
+    moved.write_bytes(manifest.read_bytes())
+
+    with pytest.raises(ExchangeProtocolError, match="canonical requests"):
+        load_exchange_request(root, moved)

--- a/test/eval/test_deepswe_benchmark.py
+++ b/test/eval/test_deepswe_benchmark.py
@@ -87,3 +87,46 @@ def test_dashboard_export_uses_packaged_deepswe_analysis(tmp_path):
     assert report["summary"][0]["avg_p2p"] == 1.0
     assert report["summary"][0]["avg_partial"] == 0.75
     assert report["trials"][0]["task"] == "fixture-task"
+
+
+def test_dashboard_exposes_failed_fixed_slots_without_scoring_them(tmp_path):
+    root = tmp_path / "gpt-5.6-terra_medium" / "fixture-task" / "guardian"
+    _write_metadata(root / "job_1" / "metadata.json")
+    _write_metadata(
+        root / "job_2" / "metadata.json",
+        returncode=1,
+        reward=None,
+        f2p=None,
+        p2p=None,
+        partial=None,
+    )
+
+    report = export_dashboard_data(tmp_path)
+
+    summary = report["summary"][0]
+    assert summary["n_recorded_trials"] == 2
+    assert summary["n_trials"] == 1
+    assert summary["n_execution_failures"] == 1
+    assert summary["pass_rate"] == 1.0
+
+
+def test_dashboard_keeps_an_all_failed_setting_visible(tmp_path):
+    root = tmp_path / "gpt-5.6-terra_medium" / "fixture-task"
+    _write_metadata(
+        root / "solo" / "job_1" / "metadata.json",
+        baseline="solo",
+        returncode=1,
+        reward=None,
+    )
+    _write_metadata(
+        root / "guardian" / "job_1" / "metadata.json",
+        returncode=1,
+        reward=None,
+    )
+
+    report = export_dashboard_data(tmp_path)
+
+    assert len(report["summary"]) == 2
+    assert all(row["n_trials"] == 0 for row in report["summary"])
+    assert all(row["n_execution_failures"] == 1 for row in report["summary"])
+    assert report["tasks"][0]["delta_pass_rate"] is None

--- a/test/eval/test_deepswe_benchmark.py
+++ b/test/eval/test_deepswe_benchmark.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for portable DeepSWE result analysis."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codenib.eval.benchmarks.deepswe import add_costs, export_dashboard_data, load_rows
+
+
+def _write_metadata(path, **overrides):
+    path.parent.mkdir(parents=True)
+    payload = {
+        "task": "fixture-task",
+        "baseline": "guardian",
+        "job_id": path.parent.name,
+        "model": "gpt-5.6-terra",
+        "reasoning_effort": "medium",
+        "returncode": 0,
+        "reward": 1.0,
+        "f2p": 0.5,
+        "p2p": 1.0,
+        "partial": 0.75,
+        **overrides,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_add_costs_normalizes_main_and_guardian_usage():
+    row = add_costs(
+        {
+            "model": "gpt-5.6-terra",
+            "main_input_tokens": 1_000_000,
+            "main_cached_input_tokens": 400_000,
+            "main_output_tokens": 100_000,
+            "guardian_prompt_tokens": 200_000,
+            "guardian_cached_input_tokens": 100_000,
+            "guardian_completion_tokens": 50_000,
+        }
+    )
+
+    assert row["main_cost_usd"] == pytest.approx(3.1)
+    assert row["guardian_cost_usd"] == pytest.approx(1.025)
+    assert row["total_cost_usd"] == pytest.approx(4.125)
+
+
+def test_load_rows_prefers_setting_layout_over_matching_legacy_row(tmp_path):
+    _write_metadata(
+        tmp_path / "fixture-task" / "guardian" / "job_1" / "metadata.json",
+        output_dir="legacy",
+    )
+    _write_metadata(
+        tmp_path
+        / "gpt-5.6-terra_medium"
+        / "fixture-task"
+        / "guardian"
+        / "job_1"
+        / "metadata.json",
+        output_dir="setting",
+    )
+
+    rows = load_rows(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0]["output_dir"] == "setting"
+
+
+def test_dashboard_export_uses_packaged_deepswe_analysis(tmp_path):
+    _write_metadata(
+        tmp_path
+        / "gpt-5.6-terra_medium"
+        / "fixture-task"
+        / "guardian"
+        / "job_1"
+        / "metadata.json"
+    )
+
+    report = export_dashboard_data(tmp_path)
+
+    assert report["counted_job_ids"] == ["job_1", "job_2", "job_3", "job_4"]
+    assert report["summary"][0]["avg_f2p"] == 0.5
+    assert report["summary"][0]["avg_p2p"] == 1.0
+    assert report["summary"][0]["avg_partial"] == 0.75
+    assert report["trials"][0]["task"] == "fixture-task"

--- a/test/guardian/deepswe/__init__.py
+++ b/test/guardian/deepswe/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the DeepSWE Guardian experiment harness."""

--- a/test/guardian/deepswe/test_ablation.py
+++ b/test/guardian/deepswe/test_ablation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -112,7 +112,7 @@ def test_task_virtualenv_profile_is_mounted_in_both_arms(tmp_path):
             "medium",
             "--tasks",
             "fixture-task",
-            "--codeminer-root",
+            "--codenib-root",
             str(tmp_path),
         ]
     )
@@ -149,7 +149,7 @@ def test_guardian_mounts_controller_outputs_read_only(tmp_path):
             "medium",
             "--tasks",
             "fixture-task",
-            "--codeminer-root",
+            "--codenib-root",
             str(tmp_path),
         ]
     )

--- a/test/guardian/deepswe/test_ablation.py
+++ b/test/guardian/deepswe/test_ablation.py
@@ -1,0 +1,401 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Guardian DeepSWE ablation command construction."""
+
+import json
+from pathlib import Path
+
+from scripts.guardian.deepswe import ablation
+from scripts.guardian.deepswe import export_dashboard as dashboard
+
+
+def test_local_specification_rollout_controls_are_forwarded(tmp_path):
+    args = ablation.parse_args(
+        [
+            "--model",
+            "gpt-5.6-terra",
+            "--reasoning-effort",
+            "medium",
+            "--tasks",
+            "fixture-task",
+            "--guardian-explorer-count",
+            "3",
+            "--guardian-max-findings",
+            "4",
+            "--guardian-max-cycles",
+            "2",
+            "--guardian-rollout-timeout",
+            "123",
+        ]
+    )
+
+    command = ablation._build_pier_command(
+        args,
+        task="fixture-task",
+        baseline="guardian",
+        logs_dir=Path(tmp_path),
+    )
+
+    assert "guardian_explorer_count=3" in command
+    assert "guardian_max_findings=4" in command
+    assert "guardian_max_cycles=2" in command
+    assert "guardian_rollout_timeout=123.0" in command
+
+
+def test_reframed_guardian_defaults_are_explicit(tmp_path):
+    args = ablation.parse_args(
+        [
+            "--model",
+            "gpt-5.6-terra",
+            "--reasoning-effort",
+            "medium",
+            "--tasks",
+            "fixture-task",
+        ]
+    )
+
+    command = ablation._build_pier_command(
+        args,
+        task="fixture-task",
+        baseline="guardian",
+        logs_dir=Path(tmp_path),
+    )
+
+    assert "guardian_explorer_count=2" in command
+    assert "guardian_max_findings=5" in command
+    assert "guardian_max_cycles=3" in command
+    assert "guardian_rollout_timeout=600.0" in command
+
+
+def test_baseline_selection_can_run_only_guardian(tmp_path, monkeypatch):
+    task = tmp_path / "deep-swe" / "tasks" / "fixture-task"
+    task.mkdir(parents=True)
+    seen = []
+    monkeypatch.setattr(
+        ablation,
+        "_run_trial",
+        lambda _args, **kwargs: seen.append(kwargs) or {},
+    )
+
+    assert (
+        ablation.main(
+            [
+                "--model",
+                "gpt-5.6-terra",
+                "--reasoning-effort",
+                "medium",
+                "--tasks",
+                "fixture-task",
+                "--runs",
+                "1",
+                "--baselines",
+                "guardian",
+                "--deepswe-root",
+                str(tmp_path / "deep-swe"),
+                "--output-root",
+                str(tmp_path / "outputs"),
+            ]
+        )
+        == 0
+    )
+    assert seen == [{"task": "fixture-task", "baseline": "guardian", "repeat_index": 1}]
+
+
+def test_task_virtualenv_profile_is_mounted_in_both_arms(tmp_path):
+    args = ablation.parse_args(
+        [
+            "--model",
+            "gpt-5.6-terra",
+            "--reasoning-effort",
+            "medium",
+            "--tasks",
+            "fixture-task",
+            "--codeminer-root",
+            str(tmp_path),
+        ]
+    )
+
+    for baseline in ("solo", "guardian"):
+        command = ablation._build_pier_command(
+            args,
+            task="fixture-task",
+            baseline=baseline,
+            logs_dir=tmp_path / baseline,
+        )
+        mounts = json.loads(command[command.index("--mounts-json") + 1])
+        profile = next(
+            item
+            for item in mounts
+            if item["target"] == "/etc/profile.d/zz-deepswe-task-venv.sh"
+        )
+        assert profile["source"] == str(
+            tmp_path
+            / "scripts"
+            / "guardian"
+            / "deepswe"
+            / "harness"
+            / "task_venv_profile.sh"
+        )
+
+
+def test_guardian_mounts_controller_outputs_read_only(tmp_path):
+    args = ablation.parse_args(
+        [
+            "--model",
+            "gpt-5.6-terra",
+            "--reasoning-effort",
+            "medium",
+            "--tasks",
+            "fixture-task",
+            "--codeminer-root",
+            str(tmp_path),
+        ]
+    )
+    command = ablation._build_pier_command(
+        args,
+        task="fixture-task",
+        baseline="guardian",
+        logs_dir=tmp_path / "logs",
+    )
+    assert (
+        f"guardian_host_exchange_dir={tmp_path / 'logs' / 'guardian_exchange'}"
+        in command
+    )
+    mounts = json.loads(command[command.index("--mounts-json") + 1])
+    by_target = {item["target"]: item for item in mounts}
+    assert set(by_target) == {
+        "/logs/agent",
+        "/etc/profile.d/zz-deepswe-task-venv.sh",
+        "/logs/agent/guardian_exchange/responses",
+        "/logs/agent/guardian_exchange/latest",
+        "/logs/agent/guardian_episodes",
+    }
+    assert by_target["/logs/agent"].get("read_only") is None
+    assert by_target["/logs/agent/guardian_exchange/responses"]["read_only"] is True
+    assert by_target["/logs/agent/guardian_exchange/latest"]["read_only"] is True
+    assert by_target["/logs/agent/guardian_episodes"]["read_only"] is True
+
+
+def test_guardian_run_status_aggregates_every_cycle(tmp_path):
+    episodes = tmp_path / "guardian_episodes"
+    rows = [
+        {
+            "commit": "first",
+            "findings": 1,
+            "backlog": 2,
+            "degraded": True,
+            "analysis_status": "degraded",
+            "exit_reason": "ReportSubmitted",
+            "llm_tokens": {
+                "prompt": 100,
+                "cached_input": 60,
+                "completion": 10,
+                "total": 110,
+            },
+        },
+        {
+            "commit": "second",
+            "findings": 0,
+            "backlog": 0,
+            "degraded": False,
+            "analysis_status": "complete",
+            "exit_reason": "ReportSubmitted",
+            "llm_tokens": {
+                "prompt": 200,
+                "cached_input": 150,
+                "completion": 20,
+                "total": 220,
+            },
+        },
+    ]
+    for index, row in enumerate(rows, 1):
+        path = episodes / f"{index:04d}_commit" / "status.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(row), encoding="utf-8")
+
+    status = ablation._guardian_run_status(tmp_path)
+
+    assert status["commit"] == "second"
+    assert status["findings"] == 0
+    assert status["backlog"] == 0
+    assert status["cycle_count"] == 2
+    assert status["exit_reasons"] == ["ReportSubmitted", "ReportSubmitted"]
+    assert status["degraded"] is True
+    assert status["analysis_status"] == "degraded"
+    assert status["llm_tokens"] == {
+        "prompt": 300,
+        "cached_input": 210,
+        "completion": 30,
+        "total": 330,
+    }
+
+
+def test_guardian_run_status_preserves_incomplete_cycle_health(tmp_path):
+    episodes = tmp_path / "guardian_episodes"
+    for index, analysis_status in enumerate(("complete", "incomplete"), 1):
+        path = episodes / f"{index:04d}_commit" / "status.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "analysis_status": analysis_status,
+                    "exit_reason": (
+                        "ReportSubmitted"
+                        if analysis_status == "complete"
+                        else "NoProgress"
+                    ),
+                    "llm_tokens": {"total": index},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    status = ablation._guardian_run_status(tmp_path)
+
+    assert status["analysis_status"] == "incomplete"
+    assert status["llm_tokens"]["total"] == 3
+
+
+def test_guardian_run_status_does_not_count_limit_response_as_review(tmp_path):
+    episodes = tmp_path / "guardian_episodes"
+    rows = [
+        {
+            "analysis_status": "complete",
+            "exit_reason": "ReviewCompleted",
+            "review_performed": True,
+            "terminal": True,
+            "termination_reason": "max_cycles_reached",
+        },
+        {
+            "analysis_status": "not_run",
+            "exit_reason": "ReviewLimitReached",
+            "review_performed": False,
+            "terminal": True,
+            "termination_reason": "max_cycles_reached",
+        },
+    ]
+    for index, row in enumerate(rows, 1):
+        path = episodes / f"{index:04d}_commit" / "status.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(row), encoding="utf-8")
+
+    status = ablation._guardian_run_status(tmp_path)
+
+    assert status["cycle_count"] == 1
+    assert status["terminal"] is True
+    assert status["termination_reason"] == "max_cycles_reached"
+
+
+def test_guardian_run_status_orders_sha_directories_by_cycle_index(tmp_path):
+    episodes = tmp_path / "guardian_episodes"
+    rows = [
+        (
+            "ffffffffffffffffffffffffffffffffffffffff",
+            {
+                "commit": "first",
+                "cycle_index": 1,
+                "terminal": False,
+                "analysis_status": "complete",
+                "exit_reason": "ReviewCompleted",
+            },
+        ),
+        (
+            "0000000000000000000000000000000000000000",
+            {
+                "commit": "second",
+                "cycle_index": 2,
+                "terminal": True,
+                "termination_reason": "max_cycles_reached",
+                "analysis_status": "complete",
+                "exit_reason": "ReviewCompleted",
+            },
+        ),
+    ]
+    for directory, row in rows:
+        path = episodes / directory / "status.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(row), encoding="utf-8")
+
+    status = ablation._guardian_run_status(tmp_path)
+
+    assert status["commit"] == "second"
+    assert status["cycle_count"] == 2
+    assert status["terminal"] is True
+    assert status["termination_reason"] == "max_cycles_reached"
+
+
+def test_dashboard_preserves_guardian_analysis_health_fields():
+    row = dashboard._trial_row(
+        {
+            "baseline": "guardian",
+            "guardian_findings": 0,
+            "guardian_backlog": 3,
+            "guardian_high_confidence_backlog": 2,
+            "guardian_degraded": True,
+            "guardian_analysis_status": "degraded",
+            "guardian_cycle_count": 3,
+            "guardian_exit_reasons": ["ReportSubmitted"] * 3,
+            "guardian_total_tokens": 291_925,
+        }
+    )
+
+    assert row["guardian_findings"] == 0
+    assert row["guardian_backlog"] == 3
+    assert row["guardian_high_confidence_backlog"] == 2
+    assert row["guardian_degraded"] is True
+    assert row["guardian_analysis_status"] == "degraded"
+    assert row["guardian_cycle_count"] == 3
+    assert row["guardian_exit_reasons"] == ["ReportSubmitted"] * 3
+    assert row["guardian_total_tokens"] == 291_925
+
+
+def test_dashboard_task_rows_include_average_test_metrics():
+    rows = dashboard._task_rows(
+        [
+            {
+                "task": "fixture-task",
+                "baseline": "solo",
+                "model": "fixture-model",
+                "reasoning_effort": "medium",
+                "pass_rate": 0.25,
+                "avg_f2p": 0.5,
+                "avg_p2p": 0.75,
+                "avg_partial": 0.625,
+                "n_trials": 4,
+            },
+            {
+                "task": "fixture-task",
+                "baseline": "guardian",
+                "model": "fixture-model",
+                "reasoning_effort": "medium",
+                "pass_rate": 0.5,
+                "avg_f2p": 0.625,
+                "avg_p2p": 1.0,
+                "avg_partial": 0.75,
+                "avg_total_cost_usd": 1.25,
+                "n_trials": 4,
+            },
+        ]
+    )
+
+    assert rows == [
+        {
+            "task": "fixture-task",
+            "model": "fixture-model",
+            "reasoning_effort": "medium",
+            "solo_pass_rate": 0.25,
+            "guardian_pass_rate": 0.5,
+            "solo_avg_f2p": 0.5,
+            "guardian_avg_f2p": 0.625,
+            "solo_avg_p2p": 0.75,
+            "guardian_avg_p2p": 1.0,
+            "solo_avg_partial": 0.625,
+            "guardian_avg_partial": 0.75,
+            "delta_pass_rate": 0.25,
+            "solo_trials": 4,
+            "guardian_trials": 4,
+            "guardian_avg_cost_usd": 1.25,
+        }
+    ]

--- a/test/guardian/deepswe/test_ablation.py
+++ b/test/guardian/deepswe/test_ablation.py
@@ -364,6 +364,7 @@ def test_dashboard_task_rows_include_average_test_metrics():
                 "avg_p2p": 0.75,
                 "avg_partial": 0.625,
                 "n_trials": 4,
+                "n_recorded_trials": 4,
             },
             {
                 "task": "fixture-task",
@@ -376,6 +377,7 @@ def test_dashboard_task_rows_include_average_test_metrics():
                 "avg_partial": 0.75,
                 "avg_total_cost_usd": 1.25,
                 "n_trials": 4,
+                "n_recorded_trials": 4,
             },
         ]
     )
@@ -396,6 +398,8 @@ def test_dashboard_task_rows_include_average_test_metrics():
             "delta_pass_rate": 0.25,
             "solo_trials": 4,
             "guardian_trials": 4,
+            "solo_recorded_trials": 4,
+            "guardian_recorded_trials": 4,
             "guardian_avg_cost_usd": 1.25,
         }
     ]

--- a/test/guardian/deepswe/test_checkpoint.py
+++ b/test/guardian/deepswe/test_checkpoint.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/test/guardian/deepswe/test_checkpoint.py
+++ b/test/guardian/deepswe/test_checkpoint.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Guardian final checkpoint script."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from scripts.guardian.deepswe.harness.checkpoint import guardian_checkpoint_script
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "checkpoint@example.com")
+    _git(repo, "config", "user.name", "Checkpoint")
+    (repo / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "mod.py")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo, _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _write_script(tmp_path, *, start_command="", baseline_file="", exchange_dir=""):
+    path = tmp_path / "guardian-checkpoint"
+    path.write_text(
+        guardian_checkpoint_script(
+            start_command=start_command,
+            baseline_file=baseline_file,
+            exchange_dir=exchange_dir,
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def test_guardian_checkpoint_prints_fresh_report(tmp_path):
+    repo, head = _init_repo(tmp_path)
+    guardian_dir = tmp_path / "guardian"
+    guardian_dir.mkdir()
+    (guardian_dir / "status.json").write_text(
+        json.dumps(
+            {
+                "commit": head,
+                "running": False,
+                "findings": 1,
+                "backlog": 1,
+                "high_confidence_backlog": 1,
+                "degraded": True,
+                "analysis_status": "degraded",
+                "exit_reason": "ReportSubmitted",
+                "llm_model": "codex:gpt-5.6-luna",
+                "llm_backend": "codex-sdk",
+                "llm_tokens": {"total": 123},
+                "error": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (guardian_dir / "findings.md").write_text(
+        "# Findings\n\nRisk found.\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_write_script(tmp_path)),
+            "--repo",
+            str(repo),
+            "--guardian-dir",
+            str(guardian_dir),
+            "--timeout",
+            "1",
+            "--interval",
+            "0.1",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "Guardian checkpoint: report ready" in result.stdout
+    assert "backend: codex-sdk" in result.stdout
+    assert "backlog: 1" in result.stdout
+    assert "high-confidence backlog: 1" in result.stdout
+    assert "analysis status: degraded" in result.stdout
+    assert "tokens: 123" in result.stdout
+    assert "Risk found." in result.stdout
+    assert "must not be treated as a complete clean review" in result.stderr
+
+
+def test_guardian_checkpoint_times_out_on_stale_report(tmp_path):
+    repo, _head = _init_repo(tmp_path)
+    guardian_dir = tmp_path / "guardian"
+    guardian_dir.mkdir()
+    (guardian_dir / "status.json").write_text(
+        json.dumps(
+            {
+                "commit": "old",
+                "running": False,
+                "findings": 0,
+                "llm_backend": "codex-sdk",
+                "error": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (guardian_dir / "findings.md").write_text("# Old report\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_write_script(tmp_path)),
+            "--repo",
+            str(repo),
+            "--guardian-dir",
+            str(guardian_dir),
+            "--timeout",
+            "1",
+            "--interval",
+            "0.1",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 5
+    assert "timed out waiting" in result.stderr
+    assert '"commit": "old"' in result.stderr
+
+
+def test_guardian_checkpoint_starts_guardian_before_waiting(tmp_path):
+    repo, baseline = _init_repo(tmp_path)
+    baseline_file = tmp_path / "base_commit"
+    baseline_file.write_text(baseline + "\n", encoding="utf-8")
+    marker = tmp_path / "started"
+    starter = tmp_path / "guardian-start"
+    starter.write_text(
+        f"#!/bin/sh\nprintf started > {marker}\n",
+        encoding="utf-8",
+    )
+    starter.chmod(0o755)
+
+    (repo / "mod.py").write_text("x = 2\n", encoding="utf-8")
+    _git(repo, "add", "mod.py")
+    _git(repo, "commit", "-q", "-m", "agent change")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    guardian_dir = tmp_path / "guardian"
+    guardian_dir.mkdir()
+    (guardian_dir / "status.json").write_text(
+        json.dumps(
+            {
+                "commit": head,
+                "running": False,
+                "findings": 0,
+                "analysis_status": "complete",
+                "exit_reason": "ReportSubmitted",
+                "llm_backend": "codex-sdk",
+                "error": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (guardian_dir / "findings.md").write_text("# No findings\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(
+                _write_script(
+                    tmp_path,
+                    start_command=str(starter),
+                    baseline_file=str(baseline_file),
+                )
+            ),
+            "--repo",
+            str(repo),
+            "--guardian-dir",
+            str(guardian_dir),
+            "--timeout",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert marker.read_text(encoding="utf-8") == "started"
+    assert "Guardian checkpoint: report ready" in result.stdout
+
+
+def test_guardian_checkpoint_rejects_no_progress_as_incomplete(tmp_path):
+    repo, head = _init_repo(tmp_path)
+    guardian_dir = tmp_path / "guardian"
+    guardian_dir.mkdir()
+    (guardian_dir / "status.json").write_text(
+        json.dumps(
+            {
+                "commit": head,
+                "running": False,
+                "findings": 0,
+                "backlog": 0,
+                "degraded": False,
+                "analysis_status": "incomplete",
+                "exit_reason": "NoProgress",
+                "llm_backend": "codex-sdk",
+                "error": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (guardian_dir / "findings.md").write_text(
+        "# Incomplete report\n\nNo findings were verified.\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_write_script(tmp_path)),
+            "--repo",
+            str(repo),
+            "--guardian-dir",
+            str(guardian_dir),
+            "--timeout",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 9
+    assert "Guardian checkpoint: report incomplete" in result.stdout
+    assert "analysis status: incomplete" in result.stdout
+    assert "exit reason: NoProgress" in result.stdout
+    assert "absence of findings is not a clean review" in result.stderr
+
+
+def test_guardian_checkpoint_rejects_unchanged_baseline_without_waiting(tmp_path):
+    repo, baseline = _init_repo(tmp_path)
+    baseline_file = tmp_path / "base_commit"
+    baseline_file.write_text(baseline + "\n", encoding="utf-8")
+    marker = tmp_path / "started"
+    starter = tmp_path / "guardian-start"
+    starter.write_text(
+        f"#!/bin/sh\nprintf started > {marker}\n",
+        encoding="utf-8",
+    )
+    starter.chmod(0o755)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(
+                _write_script(
+                    tmp_path,
+                    start_command=str(starter),
+                    baseline_file=str(baseline_file),
+                )
+            ),
+            "--repo",
+            str(repo),
+            "--guardian-dir",
+            str(tmp_path / "guardian"),
+            "--timeout",
+            "30",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 8
+    assert marker.read_text(encoding="utf-8") == "started"
+    assert "repository baseline" in result.stderr
+
+
+def test_guardian_checkpoint_publishes_bundle_and_reads_response(tmp_path):
+    repo, baseline = _init_repo(tmp_path)
+    baseline_file = tmp_path / "base_commit"
+    baseline_file.write_text(baseline + "\n", encoding="utf-8")
+    (repo / "mod.py").write_text("x = 2\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "candidate")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    exchange = tmp_path / "exchange"
+    script = _write_script(
+        tmp_path,
+        baseline_file=str(baseline_file),
+        exchange_dir=str(exchange),
+    )
+
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(script),
+            "--repo",
+            str(repo),
+            "--timeout",
+            "5",
+            "--interval",
+            "0.05",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    manifest = exchange / "requests" / f"{head}.json"
+    for _ in range(100):
+        if manifest.exists():
+            break
+        import time
+
+        time.sleep(0.05)
+    assert manifest.exists()
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert payload["base_commit"] == baseline
+    assert payload["candidate_commit"] == head
+    assert (exchange / "bundles" / payload["bundle_name"]).is_file()
+
+    response = exchange / "responses" / head
+    response.mkdir(parents=True)
+    (response / "findings.md").write_text("# Sandboxed report\n", encoding="utf-8")
+    (response / "status.json").write_text(
+        json.dumps(
+            {
+                "commit": head,
+                "running": False,
+                "findings": 0,
+                "backlog": 0,
+                "analysis_status": "complete",
+                "exit_reason": "ReviewCompleted",
+                "llm_backend": "codex-cli+codenib-sandbox",
+                "error": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+    stdout, stderr = process.communicate(timeout=5)
+
+    assert process.returncode == 0, stderr
+    assert "Sandboxed report" in stdout
+    assert (exchange / "last_reviewed_commit").read_text().strip() == head
+
+
+def test_guardian_checkpoint_does_not_publish_after_terminal_cycle(tmp_path):
+    repo, baseline = _init_repo(tmp_path)
+    baseline_file = tmp_path / "base_commit"
+    baseline_file.write_text(baseline + "\n", encoding="utf-8")
+    (repo / "mod.py").write_text("x = 2\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "reviewed candidate")
+    reviewed = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    exchange = tmp_path / "exchange"
+    latest = exchange / "latest"
+    latest.mkdir(parents=True)
+    (exchange / "last_reviewed_commit").write_text(reviewed + "\n", encoding="utf-8")
+    (latest / "findings.md").write_text(
+        "# Terminal report\n\nOne finding remains.\n", encoding="utf-8"
+    )
+    (latest / "status.json").write_text(
+        json.dumps(
+            {
+                "commit": reviewed,
+                "analysis_status": "complete",
+                "exit_reason": "ReviewCompleted",
+                "review_performed": True,
+                "cycle_index": 3,
+                "max_cycles": 3,
+                "terminal": True,
+                "termination_reason": "max_cycles_reached",
+                "running": False,
+                "error": "",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (repo / "mod.py").write_text("x = 3\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "final unreviewed revision")
+    final_head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(
+                _write_script(
+                    tmp_path,
+                    baseline_file=str(baseline_file),
+                    exchange_dir=str(exchange),
+                )
+            ),
+            "--repo",
+            str(repo),
+            "--timeout",
+            "1",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "review limit reached" in result.stdout
+    assert f"current commit {final_head[:12]} was not reviewed" in result.stdout
+    assert "One finding remains" in result.stdout
+    assert not (exchange / "requests" / f"{final_head}.json").exists()
+    assert (exchange / "last_reviewed_commit").read_text().strip() == reviewed

--- a/test/guardian/deepswe/test_controller.py
+++ b/test/guardian/deepswe/test_controller.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the host-side DeepSWE Guardian controller."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+from codenib.clients.guardian import GuardianConfig, GuardianResult, ReviewStatus
+from scripts.guardian.deepswe.harness.controller import GuardianHostController
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ("git", *args),
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _publish(tmp_path: Path) -> tuple[Path, str, str]:
+    repo = tmp_path / "solver"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.email", "solver@example.com")
+    _git(repo, "config", "user.name", "Solver")
+    (repo / "feature.py").write_text("enabled = False\n", encoding="utf-8")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "--quiet", "-m", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+    (repo / "feature.py").write_text("enabled = True\n", encoding="utf-8")
+    _git(repo, "commit", "--quiet", "-am", "candidate")
+    candidate = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-ref", "refs/guardian/base", base)
+    _git(repo, "update-ref", "refs/guardian/candidate", candidate)
+
+    exchange = tmp_path / "exchange"
+    (exchange / "requests").mkdir(parents=True)
+    (exchange / "bundles").mkdir()
+    bundle = exchange / "bundles" / f"{candidate}.bundle"
+    _git(
+        repo,
+        "bundle",
+        "create",
+        str(bundle),
+        "refs/guardian/base",
+        "refs/guardian/candidate",
+    )
+    (exchange / "requests" / f"{candidate}.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "request_id": candidate,
+                "base_commit": base,
+                "candidate_commit": candidate,
+                "bundle_name": bundle.name,
+                "bundle_sha256": hashlib.sha256(bundle.read_bytes()).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return exchange, base, candidate
+
+
+def _publish_next(repo: Path, exchange: Path, base: str) -> str:
+    (repo / "feature.py").write_text("enabled = 'revised'\n", encoding="utf-8")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "--quiet", "-m", "revision")
+    candidate = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "update-ref", "refs/guardian/base", base)
+    _git(repo, "update-ref", "refs/guardian/candidate", candidate)
+    bundle = exchange / "bundles" / f"{candidate}.bundle"
+    _git(
+        repo,
+        "bundle",
+        "create",
+        str(bundle),
+        "refs/guardian/base",
+        "refs/guardian/candidate",
+    )
+    (exchange / "requests" / f"{candidate}.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "request_id": candidate,
+                "base_commit": base,
+                "candidate_commit": candidate,
+                "bundle_name": bundle.name,
+                "bundle_sha256": hashlib.sha256(bundle.read_bytes()).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return candidate
+
+
+class FakeReviewer:
+    def __init__(self, requests: list) -> None:
+        self.requests = requests
+
+    async def review(self, request):
+        self.requests.append(request)
+        return GuardianResult(
+            base_commit=request.base_commit,
+            candidate_commit=request.candidate_commit,
+            status=ReviewStatus.COMPLETE,
+            summary="No admitted violation.",
+        )
+
+
+def test_host_controller_reviews_materialized_snapshot(tmp_path: Path) -> None:
+    exchange, base, candidate = _publish(tmp_path)
+    requests = []
+    config = GuardianConfig(explorer_model="luna", aggregator_model="terra")
+    controller = GuardianHostController(
+        exchange_root=exchange,
+        episodes_root=tmp_path / "episodes",
+        config=config,
+        reviewer_factory=lambda _workspace: FakeReviewer(requests),
+        initial_base_commit=base,
+        poll_interval_seconds=0.01,
+    )
+
+    assert asyncio.run(controller.process_pending()) == 1
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.base_commit == base
+    assert request.candidate_commit == candidate
+    assert "-enabled = False" in request.change_patch
+    assert "+enabled = True" in request.change_patch
+    status = json.loads(
+        (exchange / "responses" / candidate / "status.json").read_text()
+    )
+    assert status["analysis_status"] == "complete"
+    assert status["llm_backend"] == "codex-cli+codenib-sandbox"
+    assert status["cycle_index"] == 1
+    assert status["max_cycles"] == 3
+    assert status["terminal"] is False
+    assert (exchange / "latest" / "findings.md").is_file()
+    assert (tmp_path / "episodes" / candidate / "status.json").is_file()
+
+
+def test_host_controller_reports_invalid_bundle_without_review(tmp_path: Path) -> None:
+    exchange, base, candidate = _publish(tmp_path)
+    bundle = exchange / "bundles" / f"{candidate}.bundle"
+    bundle.write_bytes(bundle.read_bytes() + b"tampered")
+    requests = []
+    config = GuardianConfig(explorer_model="luna", aggregator_model="terra")
+    controller = GuardianHostController(
+        exchange_root=exchange,
+        episodes_root=tmp_path / "episodes",
+        config=config,
+        reviewer_factory=lambda _workspace: FakeReviewer(requests),
+        initial_base_commit=base,
+    )
+
+    assert asyncio.run(controller.process_pending()) == 1
+
+    assert requests == []
+    status = json.loads(
+        (exchange / "responses" / candidate / "status.json").read_text()
+    )
+    assert status["analysis_status"] == "failed"
+    assert "checksum" in status["error"]
+
+
+def test_host_controller_stops_before_review_beyond_cycle_limit(tmp_path: Path) -> None:
+    exchange, base, candidate = _publish(tmp_path)
+    requests = []
+    config = GuardianConfig(explorer_model="luna", aggregator_model="terra")
+    controller = GuardianHostController(
+        exchange_root=exchange,
+        episodes_root=tmp_path / "episodes",
+        config=config,
+        reviewer_factory=lambda _workspace: FakeReviewer(requests),
+        initial_base_commit=base,
+        max_cycles=1,
+    )
+
+    assert asyncio.run(controller.process_pending()) == 1
+    first_status = json.loads(
+        (exchange / "responses" / candidate / "status.json").read_text()
+    )
+    assert first_status["review_performed"] is True
+    assert first_status["terminal"] is True
+    assert first_status["termination_reason"] == "max_cycles_reached"
+
+    repo = tmp_path / "solver"
+    revised = _publish_next(repo, exchange, candidate)
+    restarted = GuardianHostController(
+        exchange_root=exchange,
+        episodes_root=tmp_path / "episodes",
+        config=config,
+        reviewer_factory=lambda _workspace: FakeReviewer(requests),
+        initial_base_commit=candidate,
+        max_cycles=1,
+    )
+    assert asyncio.run(restarted.process_pending()) == 1
+
+    assert len(requests) == 1
+    terminal_status = json.loads(
+        (exchange / "responses" / revised / "status.json").read_text()
+    )
+    assert terminal_status["review_performed"] is False
+    assert terminal_status["analysis_status"] == "not_run"
+    assert terminal_status["exit_reason"] == "ReviewLimitReached"
+    assert terminal_status["terminal"] is True

--- a/test/guardian/deepswe/test_message.py
+++ b/test/guardian/deepswe/test_message.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the standalone Guardian message action."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.guardian.deepswe.harness.message import guardian_message_script
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ("git", *args),
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_message_action_appends_solver_context_without_codenib(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.email", "solver@example.com")
+    _git(repo, "config", "user.name", "Solver")
+    (repo / "file.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "file.py")
+    _git(repo, "commit", "--quiet", "-m", "base")
+    head = _git(repo, "rev-parse", "HEAD")
+    inbox = tmp_path / "exchange" / "messages.jsonl"
+    script = tmp_path / "guardian-message"
+    script.write_text(
+        guardian_message_script(inbox=str(inbox), repo=str(repo)),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--scope", "file.py"],
+        input="The public path may need the same behavior.",
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    value = json.loads(result.stdout)
+    assert value["content"] == "The public path may need the same behavior."
+    assert value["scope"] == ["file.py"]
+    assert value["observed_head"] == head
+    assert json.loads(inbox.read_text())["id"] == "msg_00000001"

--- a/test/guardian/deepswe/test_solo_matrix.py
+++ b/test/guardian/deepswe/test_solo_matrix.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the resumable DeepSWE solo matrix runner."""
+
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from scripts.guardian.deepswe import solo_matrix as matrix
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _args(tmp_path, *extra):
+    codeminer_root = tmp_path / "codeminer"
+    deepswe_root = tmp_path / "deep-swe"
+    harness = codeminer_root / matrix.ablation.DEEPSWE_HARNESS_RELATIVE_PATH
+    harness.mkdir(parents=True)
+    (harness / "task_venv_profile.sh").touch()
+    for task in matrix.DEFAULT_TASKS:
+        (deepswe_root / "tasks" / task).mkdir(parents=True)
+    return matrix.parse_args(
+        [
+            "--codeminer-root",
+            str(codeminer_root),
+            "--deepswe-root",
+            str(deepswe_root),
+            "--jobs-dir",
+            str(deepswe_root / "jobs"),
+            "--output-root",
+            str(tmp_path / "outputs"),
+            *extra,
+        ]
+    )
+
+
+def test_default_plan_has_sixty_unique_fixed_slots(tmp_path):
+    args = _args(tmp_path)
+
+    plan = matrix._build_plan(args)
+
+    assert len(plan) == 60
+    assert len({trial.key for trial in plan}) == 60
+    assert {trial.model for trial in plan} == set(matrix.DEFAULT_MODELS)
+    assert {trial.task for trial in plan} == set(matrix.DEFAULT_TASKS)
+    assert {trial.repeat_index for trial in plan} == {1, 2, 3, 4}
+    assert args.concurrency == 3
+    assert len({trial.model for trial in plan[:3]}) == 3
+    assert len({trial.task for trial in plan[:3]}) == 3
+
+
+def test_each_trial_has_an_isolated_pier_jobs_directory(tmp_path):
+    args = _args(tmp_path)
+    plan = matrix._build_plan(args)
+
+    jobs_dirs = [matrix._trial_jobs_dir(args, trial) for trial in plan]
+
+    assert len(jobs_dirs) == len(set(jobs_dirs))
+    assert all(args.jobs_dir in path.parents for path in jobs_dirs)
+
+
+def test_matching_metadata_makes_a_slot_resumable(tmp_path):
+    args = _args(tmp_path)
+    trial = matrix.Trial(
+        model="gpt-5.6-terra",
+        task="igel-persist-feature-schema",
+        repeat_index=1,
+    )
+    trial_dir = matrix._trial_dir(args, trial)
+    trial_dir.mkdir(parents=True)
+    (trial_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "model": trial.model,
+                "task": trial.task,
+                "baseline": "solo",
+                "job_id": trial.job_id,
+                "reasoning_effort": args.reasoning_effort,
+                "returncode": 0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status = matrix._initial_status(args, trial)
+
+    assert status["status"] == "recorded"
+    assert status["returncode"] == 0
+
+
+def test_mismatched_or_malformed_metadata_does_not_skip_slot(tmp_path):
+    args = _args(tmp_path)
+    trial = matrix.Trial(
+        model="gpt-5.6-terra",
+        task="igel-persist-feature-schema",
+        repeat_index=1,
+    )
+    trial_dir = matrix._trial_dir(args, trial)
+    trial_dir.mkdir(parents=True)
+    (trial_dir / "metadata.json").write_text("{bad json", encoding="utf-8")
+    assert matrix._initial_status(args, trial)["status"] == "pending"
+
+    (trial_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "model": "different-model",
+                "task": trial.task,
+                "baseline": "solo",
+                "job_id": trial.job_id,
+                "reasoning_effort": args.reasoning_effort,
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert matrix._initial_status(args, trial)["status"] == "pending"
+
+
+def test_archive_preserves_metadata_without_double_count_filename(tmp_path):
+    args = _args(tmp_path)
+    trial = matrix.Trial(
+        model="gpt-5.6-terra",
+        task="igel-persist-feature-schema",
+        repeat_index=1,
+    )
+    trial_dir = matrix._trial_dir(args, trial)
+    trial_dir.mkdir(parents=True)
+    (trial_dir / "metadata.json").write_text("{}", encoding="utf-8")
+    (trial_dir / "pier_stdout.txt").write_text("kept", encoding="utf-8")
+
+    archived = matrix._archive_trial_dir(args, trial)
+
+    assert archived is not None
+    assert not trial_dir.exists()
+    assert (archived / "archived_metadata.json").exists()
+    assert not (archived / "metadata.json").exists()
+    assert (archived / "pier_stdout.txt").read_text(encoding="utf-8") == "kept"
+
+
+def test_context_file_builds_reproducible_pier_prompt_template(tmp_path):
+    context_file = tmp_path / "review.md"
+    context_file.write_text("Challenge unsupported beliefs.", encoding="utf-8")
+    args = _args(tmp_path, "--context-file", str(context_file))
+    matrix._validate(args)
+    matrix._prepare_context_template(args)
+    trial = matrix.Trial(
+        model="gpt-5.6-terra",
+        task="igel-persist-feature-schema",
+        repeat_index=1,
+    )
+
+    template = args.prompt_template_path.read_text(encoding="utf-8")
+    command = matrix.ablation._build_pier_command(
+        matrix._ablation_args(args, trial),
+        task=trial.task,
+        baseline="solo",
+        logs_dir=matrix._trial_dir(args, trial) / "agent_logs",
+    )
+
+    assert template.startswith("{{ instruction }}")
+    assert "Challenge unsupported beliefs." in template
+    assert len(args.context_injection_sha256) == 64
+    assert f"prompt_template_path={args.prompt_template_path}" in command
+
+
+def test_task_context_directory_builds_distinct_templates(tmp_path):
+    tasks = matrix.DEFAULT_TASKS[:2]
+    context_dir = tmp_path / "contexts"
+    context_dir.mkdir()
+    for index, task in enumerate(tasks):
+        (context_dir / f"{task}.md").write_text(
+            f"Task-specific obligation {index}.",
+            encoding="utf-8",
+        )
+    args = _args(
+        tmp_path,
+        "--tasks",
+        *tasks,
+        "--task-context-dir",
+        str(context_dir),
+    )
+    matrix._validate(args)
+    matrix._prepare_context_template(args)
+
+    assert set(args.prompt_template_paths_by_task) == set(tasks)
+    assert len(set(args.prompt_template_paths_by_task.values())) == 2
+    assert len(set(args.context_injection_sha256_by_task.values())) == 2
+    for index, task in enumerate(tasks):
+        trial = matrix.Trial(
+            model="gpt-5.6-terra",
+            task=task,
+            repeat_index=1,
+        )
+        trial_args = matrix._ablation_args(args, trial)
+        template = trial_args.prompt_template_path.read_text(encoding="utf-8")
+        assert f"Task-specific obligation {index}." in template
+        assert (
+            trial_args.context_injection_source
+            == (context_dir / f"{task}.md").resolve()
+        )
+        assert (
+            trial_args.context_injection_sha256
+            == args.context_injection_sha256_by_task[task]
+        )
+
+
+def test_run_plan_limits_parallel_trials_to_configured_concurrency(
+    tmp_path, monkeypatch
+):
+    args = _args(
+        tmp_path,
+        "--tasks",
+        *matrix.DEFAULT_TASKS[:3],
+        "--runs",
+        "1",
+        "--concurrency",
+        "3",
+    )
+    matrix._prepare_context_template(args)
+    plan = matrix._build_plan(args)[:6]
+    statuses = {trial.key: matrix._initial_status(args, trial) for trial in plan}
+    lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+    seen_jobs_dirs = set()
+
+    def fake_run_trial(trial_args, *, task, baseline, repeat_index):
+        nonlocal active, maximum_active
+        with lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+            seen_jobs_dirs.add(trial_args.jobs_dir)
+        time.sleep(0.03)
+        with lock:
+            active -= 1
+        return {
+            "returncode": 0,
+            "reward": 1.0,
+            "f2p": 1.0,
+            "p2p": 1.0,
+            "partial": 1.0,
+        }
+
+    monkeypatch.setattr(matrix.ablation, "_run_trial", fake_run_trial)
+
+    run_count, launcher_errors = matrix._run_plan(
+        args,
+        plan,
+        statuses,
+        started_at="2026-01-01T00:00:00",
+    )
+
+    assert run_count == 6
+    assert launcher_errors == 0
+    assert maximum_active == 3
+    assert len(seen_jobs_dirs) == 6
+    assert {status["status"] for status in statuses.values()} == {"recorded"}
+
+
+def test_runner_module_can_be_invoked_directly():
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.guardian.deepswe.solo_matrix",
+            "--help",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "--rerun-recorded" in proc.stdout

--- a/test/guardian/deepswe/test_solo_matrix.py
+++ b/test/guardian/deepswe/test_solo_matrix.py
@@ -144,7 +144,7 @@ def test_archive_preserves_metadata_without_double_count_filename(tmp_path):
 def test_context_file_builds_reproducible_pier_prompt_template(tmp_path):
     context_file = tmp_path / "review.md"
     context_file.write_text("Challenge unsupported beliefs.", encoding="utf-8")
-    args = _args(tmp_path, "--context-file", str(context_file))
+    args = _args(tmp_path, "--dry-run", "--context-file", str(context_file))
     matrix._validate(args)
     matrix._prepare_context_template(args)
     trial = matrix.Trial(
@@ -178,6 +178,7 @@ def test_task_context_directory_builds_distinct_templates(tmp_path):
         )
     args = _args(
         tmp_path,
+        "--dry-run",
         "--tasks",
         *tasks,
         "--task-context-dir",

--- a/test/guardian/deepswe/test_solo_matrix.py
+++ b/test/guardian/deepswe/test_solo_matrix.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 CodeMiner Contributors
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -17,17 +17,17 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _args(tmp_path, *extra):
-    codeminer_root = tmp_path / "codeminer"
+    codenib_root = tmp_path / "codenib"
     deepswe_root = tmp_path / "deep-swe"
-    harness = codeminer_root / matrix.ablation.DEEPSWE_HARNESS_RELATIVE_PATH
+    harness = codenib_root / matrix.ablation.DEEPSWE_HARNESS_RELATIVE_PATH
     harness.mkdir(parents=True)
     (harness / "task_venv_profile.sh").touch()
     for task in matrix.DEFAULT_TASKS:
         (deepswe_root / "tasks" / task).mkdir(parents=True)
     return matrix.parse_args(
         [
-            "--codeminer-root",
-            str(codeminer_root),
+            "--codenib-root",
+            str(codenib_root),
             "--deepswe-root",
             str(deepswe_root),
             "--jobs-dir",


### PR DESCRIPTION
## Summary

Add a local-specification Guardian client, reusable agent execution primitives, and a bounded DeepSWE experimental harness for evaluating Guardian-assisted coding runs.

## Changes

- Add typed Codex execution, process, protocol, and sandbox adapters under `codenib.clients.execution`.
- Add local-specification discovery, aggregation, interaction, artifact, and exchange components under `codenib.clients.guardian`.
- Fail closed when a review workspace does not match the advertised candidate history, and validate model-produced evidence against repository files and line ranges before admission.
- Add explicit DeepSWE benchmark result metrics and reports under `codenib.eval.benchmarks.deepswe`, including recorded, valid, and execution-failure denominators.
- Add bounded solo/Guardian experiment controllers, checkpointing, reporting, and dashboard scripts with portable path defaults.
- Add focused unit coverage for the execution layer, Guardian client, benchmark analysis, and DeepSWE harness.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/clients/test_execution.py test/clients/test_guardian.py test/clients/test_guardian_exchange.py test/eval/test_deepswe_benchmark.py test/guardian/deepswe/test_ablation.py test/guardian/deepswe/test_checkpoint.py test/guardian/deepswe/test_controller.py test/guardian/deepswe/test_message.py test/guardian/deepswe/test_solo_matrix.py -x --tb=short` (56 passed)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (2,795 passed, 10 skipped)
- `pre-commit run --all-files`
- `node --check scripts/guardian/deepswe/dashboard/app.js`
- Completed a bounded real DeepSWE `igel-persist-feature-schema` Guardian smoke run with a clean process exit.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
