### PR TITLE
ci: reuse parser cache and classify release changes

### DIFF
--- a/.github/actions/prewarm-parsers/action.yml
+++ b/.github/actions/prewarm-parsers/action.yml
@@ -1,0 +1,133 @@
+name: Prewarm tree-sitter parsers
+description: Reuse versioned parser payloads with a bounded cold-start path
+
+inputs:
+  cold-cache:
+    description: Use a run-scoped empty cache before prewarming
+    required: false
+    default: "false"
+  timeout-seconds:
+    description: Maximum wall time for one preload attempt
+    required: false
+    default: "75"
+
+outputs:
+  cache-hit:
+    description: Whether parser payloads existed before this invocation
+    value: ${{ steps.cache.outputs.cache-hit }}
+  cache-key:
+    description: Language-pack version and runner platform cache identity
+    value: ${{ steps.cache.outputs.cache-key }}
+  cache-dir:
+    description: Effective XDG cache root
+    value: ${{ steps.cache.outputs.cache-dir }}
+  cold-run-dir:
+    description: Run-scoped directory to remove after the final cold-cache consumer
+    value: ${{ steps.cache.outputs.cold-run-dir }}
+
+runs:
+  using: composite
+  steps:
+    - name: Select parser cache
+      id: cache
+      shell: bash -l {0}
+      env:
+        COLD_CACHE: ${{ inputs.cold-cache }}
+      run: |
+        set -euo pipefail
+        PARSER_VERSION="$({
+          python - <<'PY'
+        import tomllib
+
+        with open("uv.lock", "rb") as handle:
+            lock = tomllib.load(handle)
+        matches = [
+            package["version"]
+            for package in lock.get("package", [])
+            if package.get("name") == "tree-sitter-language-pack"
+        ]
+        if len(matches) != 1:
+            raise SystemExit("uv.lock must pin one tree-sitter-language-pack version")
+        print(matches[0])
+        PY
+        })"
+        PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
+        CACHE_KEY="${PLATFORM}-tree-sitter-language-pack-${PARSER_VERSION}"
+        CACHE_PARENT="${{ github.workspace }}/../.cache"
+        COLD_RUN_DIR=""
+        if [[ "$COLD_CACHE" == "true" ]]; then
+          COLD_PARENT="$CACHE_PARENT/tree-sitter-language-pack/cold"
+          mkdir -p "$COLD_PARENT"
+          find "$COLD_PARENT" -mindepth 1 -maxdepth 1 -type d -mtime +7 \
+            -exec rm -rf -- {} +
+          COLD_RUN_DIR="$COLD_PARENT/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          XDG_ROOT="$COLD_RUN_DIR/xdg"
+        else
+          XDG_ROOT="$CACHE_PARENT/xdg"
+        fi
+        PARSER_CACHE="$XDG_ROOT/tree-sitter-language-pack/v$PARSER_VERSION"
+        CACHE_HIT=false
+        if find "$PARSER_CACHE" -type f -print -quit 2>/dev/null | grep -q .; then
+          CACHE_HIT=true
+        fi
+        mkdir -p "$XDG_ROOT"
+        echo "XDG_CACHE_HOME=$XDG_ROOT" >> "$GITHUB_ENV"
+        echo "cache-hit=$CACHE_HIT" >> "$GITHUB_OUTPUT"
+        echo "cache-key=$CACHE_KEY" >> "$GITHUB_OUTPUT"
+        echo "cache-dir=$XDG_ROOT" >> "$GITHUB_OUTPUT"
+        echo "cold-run-dir=$COLD_RUN_DIR" >> "$GITHUB_OUTPUT"
+        echo "parser-cache key=$CACHE_KEY hit=$CACHE_HIT cold=$COLD_CACHE dir=$XDG_ROOT"
+
+    - name: Download missing parsers with bounded retries
+      shell: bash -l {0}
+      env:
+        TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
+      run: |
+        set -euo pipefail
+        if ! [[ "$TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+          echo "timeout-seconds must be a positive integer" >&2
+          exit 2
+        fi
+        if ! command -v timeout >/dev/null 2>&1; then
+          echo "GNU timeout is required to bound parser downloads" >&2
+          exit 2
+        fi
+        for attempt in 1 2; do
+          echo "parser preload attempt $attempt/2 (timeout=${TIMEOUT_SECONDS}s)"
+          if timeout --foreground --signal=TERM --kill-after=5s \
+            "${TIMEOUT_SECONDS}s" python -u - <<'PY'
+        from tree_sitter_language_pack import cache_dir, downloaded_languages, get_language
+
+        languages = (
+            "python",
+            "go",
+            "rust",
+            "cpp",
+            "csharp",
+            "java",
+            "ruby",
+            "php",
+            "kotlin",
+            "swift",
+            "scala",
+            "lua",
+            "javascript",
+            "typescript",
+        )
+        print(f"parser cache: {cache_dir()}", flush=True)
+        print(f"already cached: {downloaded_languages()}", flush=True)
+        for language in languages:
+            print(f"prewarming {language}", flush=True)
+            get_language(language)
+        print(f"prewarmed {len(languages)} tree-sitter parsers", flush=True)
+        PY
+          then
+            exit 0
+          else
+            status=$?
+          fi
+          echo "parser preload attempt $attempt failed with status $status" >&2
+          sleep "$attempt"
+        done
+        echo "parser preload failed after two bounded attempts; cache=$XDG_CACHE_HOME" >&2
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ on:
         options:
           - light
           - full
+      cold_parser_cache:
+        description: "Start parser prewarm from an empty run-scoped cache"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -65,13 +70,6 @@ jobs:
   # =============================================================
   preflight:
     runs-on: self-hosted
-    # paths-filter fetches the PR's changed-file list via the GitHub API
-    # (base is empty for pull_request events), which needs pull-requests:read.
-    # Job-level permissions replace the top-level block, so contents:read is
-    # repeated here for actions/checkout.
-    permissions:
-      contents: read
-      pull-requests: read
     outputs:
       should-run: ${{ steps.check.outputs.should-run }}
       run-serial: ${{ steps.serial.outputs.run-serial }}
@@ -81,6 +79,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Evaluate skip condition
         id: check
@@ -106,45 +106,29 @@ jobs:
             echo "should-run=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Detect changes that can affect the expensive serial-chain jobs:
-      # repo mutation, SCIP/LSP indexing, graph patching, dataset location, or
-      # C++ decoder parity. Agent/runtime/model/retrieval changes use the
-      # faster unit + integration tier unless a maintainer requests full CI.
-      - name: Detect serial-chain source changes
-        id: filter
-        uses: dorny/paths-filter@v3
+      - name: Set up classifier Python
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: actions/setup-python@v5
         with:
-          base: ${{ github.event_name == 'push' && github.event.before || '' }}
-          filters: |
-            serial:
-              - ".github/workflows/ci.yml"
-              - ".github/actions/setup-env/**"
-              - "pyproject.toml"
-              - "third_party/**"
-              - "core/**"
-              - "codenib/code_chunking/**"
-              - "codenib/dataset/**"
-              - "codenib/graph/**"
-              - "codenib/index/**"
-              - "codenib/ls_index/**"
-              - "codenib/ls_router.py"
-              - "codenib/types.py"
-              - "scripts/check_graph_route_alignment.py"
-              - "scripts/smoke_lsp_graph.py"
-              - "scripts/smoke_scip_cold_start.py"
-              - "scripts/swebench_graph_index.py"
-              - "test/chunker/**"
-              - "test/dataset/**"
-              - "test/graph/**"
-              - "test/index/**"
-              - "test/ls_index/**"
-              - "test/scip/**"
+          python-version: "3.11"
+
+      - name: Classify serial-chain source changes
+        id: filter
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          python scripts/classify_ci_changes.py \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --github-output >> "$GITHUB_OUTPUT"
 
       - name: Compute run-serial
         id: serial
         run: |
-          RUN_SERIAL=false
-          REASON="not requested and no serial-chain paths changed"
+          RUN_SERIAL=true
+          REASON="event was not classified; running conservatively"
           case "${{ github.event_name }}" in
             schedule)
               RUN_SERIAL=true
@@ -154,21 +138,20 @@ jobs:
                 RUN_SERIAL=true
                 REASON="manual full tier"
               else
+                RUN_SERIAL=false
                 REASON="manual light tier"
               fi ;;
             push)
-              if [[ "${{ steps.filter.outputs.serial }}" == "true" ]]; then
-                RUN_SERIAL=true
-                REASON="serial-chain path changed on main/master push"
-              fi ;;
+              RUN_SERIAL="${{ steps.filter.outputs.run-serial }}"
+              REASON="${{ steps.filter.outputs.serial-reason }}" ;;
             pull_request)
               if [[ "${{ contains(github.event.pull_request.labels.*.name, 'full-ci') }}" == "true" ]] || \
                  [[ "${{ contains(github.event.pull_request.labels.*.name, 'serial-ci') }}" == "true" ]]; then
                 RUN_SERIAL=true
                 REASON="PR label requested serial/full CI"
-              elif [[ "${{ steps.filter.outputs.serial }}" == "true" ]]; then
-                RUN_SERIAL=true
-                REASON="serial-chain path changed"
+              else
+                RUN_SERIAL="${{ steps.filter.outputs.run-serial }}"
+                REASON="${{ steps.filter.outputs.serial-reason }}"
               fi ;;
           esac
           echo "run-serial=$RUN_SERIAL" >> "$GITHUB_OUTPUT"
@@ -217,7 +200,6 @@ jobs:
       TMPDIR: ${{ github.workspace }}/../.tmp
       TMP: ${{ github.workspace }}/../.tmp
       TEMP: ${{ github.workspace }}/../.tmp
-      XDG_CACHE_HOME: ${{ github.workspace }}/../.cache/xdg
     steps:
       - name: Prepare temp HOME
         run: |
@@ -248,35 +230,24 @@ jobs:
           pip install -e ".[test]"
 
       - name: Prewarm tree-sitter parsers
-        shell: bash -l {0}
-        run: |
-          python - <<'PY'
-          from tree_sitter_language_pack import get_language
-
-          languages = [
-              "python",
-              "go",
-              "rust",
-              "cpp",
-              "csharp",
-              "java",
-              "ruby",
-              "php",
-              "kotlin",
-              "typescript",
-              "swift",
-              "scala",
-              "lua",
-          ]
-          for language in languages:
-              print(f"prewarming {language}", flush=True)
-              get_language(language)
-          print(f"prewarmed {len(languages)} tree-sitter parsers")
-          PY
+        id: parsers
+        uses: ./.github/actions/prewarm-parsers
+        with:
+          cold-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.cold_parser_cache) }}
 
       - name: Run unit tests
+        id: unit-tests
         shell: bash -l {0}
         run: pytest -n auto -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short --timeout=180 --durations=20
+
+      - name: Remove incomplete run-scoped parser cache
+        if: always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.cold_parser_cache)) && (steps.parsers.outcome != 'success' || steps.unit-tests.outcome != 'success')
+        env:
+          COLD_RUN_DIR: ${{ github.workspace }}/../.cache/tree-sitter-language-pack/cold/${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          if [[ -n "$COLD_RUN_DIR" ]]; then
+            rm -rf -- "$COLD_RUN_DIR"
+          fi
 
   # =============================================================
   # Job 2 — Integration tests  (read-only, parallel-safe, ~2 min)
@@ -313,48 +284,24 @@ jobs:
           install-bear: "true"
 
       - name: Preload tree-sitter parsers
-        shell: bash -l {0}
-        run: |
-          python - <<'PY'
-          import time
-
-          from tree_sitter_language_pack import get_language
-
-          languages = (
-              "python",
-              "go",
-              "rust",
-              "cpp",
-              "csharp",
-              "java",
-              "ruby",
-              "php",
-              "kotlin",
-              "swift",
-              "scala",
-              "lua",
-              "javascript",
-              "typescript",
-          )
-
-          for language in languages:
-              for attempt in range(1, 4):
-                  try:
-                      get_language(language)
-                      break
-                  except Exception as exc:
-                      if attempt == 3:
-                          raise
-                      print(
-                          "Retrying tree-sitter parser preload for "
-                          f"{language}: {exc}"
-                      )
-                      time.sleep(attempt)
-          PY
+        id: parsers
+        uses: ./.github/actions/prewarm-parsers
+        with:
+          cold-cache: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.cold_parser_cache) }}
 
       - name: Run integration tests (parallel)
+        id: integration-tests
         shell: bash -l {0}
         run: pytest -n 4 -m "integration and not slow" --tb=short --timeout=600 --durations=20
+
+      - name: Remove run-scoped parser cache
+        if: always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.cold_parser_cache))
+        env:
+          COLD_RUN_DIR: ${{ github.workspace }}/../.cache/tree-sitter-language-pack/cold/${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          if [[ -n "$COLD_RUN_DIR" ]]; then
+            rm -rf -- "$COLD_RUN_DIR"
+          fi
 
   # =============================================================
   # Job 3 — Integration serial  (mutates repos, ~25 min)

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -36,7 +36,7 @@ GitHub Actions has seven workflow files:
 | `push` to `main` / `master` | Subject to `paths-ignore` (see [Skip mechanisms](#skip-mechanisms)). |
 | `pull_request` to any branch (`"*"`) | Subject to `paths-ignore`. Concurrency cancels older in-flight runs for the same PR head ref. |
 | `schedule` — `cron: "0 7 * * *"` | 07:00 UTC daily. Forces a **full serial-chain run** so the `graph.pkl` cache and C++ parity never silently rot on light-only weeks. |
-| `workflow_dispatch` | Manual run with a `skip_tests` boolean input and a `test_tier` choice (`light` / `full`, default `full`). |
+| `workflow_dispatch` | Manual run with `skip_tests`, a `test_tier` choice (`light` / `full`, default `full`), and an optional `cold_parser_cache` bootstrap check. |
 
 The separate docs workflow runs on pushes/PRs that touch Markdown, `docs/**`,
 `mkdocs.yml`, `pyproject.toml`, the `Makefile`, Python under `codenib/`, the
@@ -118,14 +118,14 @@ other job gates on:
 Both decisions also expose a human-readable `serial-reason` / `slow-reason`
 output explaining the choice (echoed into the job log).
 
-`run-serial` is computed **fail-open** (defaults to `false`). It is set to
-`true` only when one of these holds:
+`run-serial` is computed conservatively: an unreadable or ambiguous diff runs
+the chain. It is set to `true` when one of these holds:
 
 - the event is a `schedule` run (the daily full run);
 - the event is a `workflow_dispatch` with `test_tier=full` (the `light` tier
   leaves it `false`);
-- the push / PR touches the **serial-chain path allowlist** below (detected
-  with `dorny/paths-filter@v3`); or
+- the push / PR touches the **serial-chain path allowlist** below (classified
+  by `scripts/classify_ci_changes.py`); or
 - the PR carries the `full-ci` or `serial-ci` label.
 
 The allowlist names the sources that can affect the expensive serial-chain
@@ -135,8 +135,12 @@ C++ decoder parity:
 ```yaml
 serial:
   - ".github/workflows/ci.yml"
+  - ".github/actions/prewarm-parsers/**"
   - ".github/actions/setup-env/**"
+  - "Makefile"
   - "pyproject.toml"
+  - "uv.lock"
+  - "setup.py"
   - "third_party/**"
   - "core/**"
   - "codenib/code_chunking/**"
@@ -147,6 +151,7 @@ serial:
   - "codenib/ls_router.py"
   - "codenib/types.py"
   - "scripts/check_graph_route_alignment.py"
+  - "scripts/classify_ci_changes.py"
   - "scripts/smoke_lsp_graph.py"
   - "scripts/smoke_scip_cold_start.py"
   - "scripts/swebench_graph_index.py"
@@ -157,6 +162,12 @@ serial:
   - "test/ls_index/**"
   - "test/scip/**"
 ```
+
+The classifier parses `pyproject.toml` and `uv.lock` rather than trusting file
+names alone. A synchronized change to only the editable CodeNib package version
+skips the serial chain; dependency, build, source, schema, test, malformed, or
+unpaired metadata changes run it. Unit, integration, and release-artifact checks
+still run for a release-only version change.
 
 Changes outside this list — agent, runtime, model, retrieval, eval — use the
 faster unit + integration tier by default; a maintainer opts a PR into the
@@ -182,6 +193,16 @@ The CPU `torch` preinstall keeps the non-GPU unit tier from resolving PyPI's
 default CUDA wheels through `sentence-transformers`. Tests that require real
 HuggingFace downloads, CUDA, or LLM credentials must be marked `slow` instead of
 running in this tier.
+
+Unit prewarms all configured tree-sitter languages into a persistent
+self-hosted-runner cache keyed by the pinned `tree-sitter-language-pack`
+version and runner platform. Integration uses the same cache instead of
+downloading the payload again. Each cold preload attempt has a process-level
+timeout and two attempts with cache diagnostics. Scheduled CI uses a unique
+run-scoped empty cache before integration reuses it; manual dispatch can select
+the same path with `cold_parser_cache=true`. Integration removes that run-scoped
+payload after its final use, failed unit runs clean it immediately, and later
+cold runs prune abandoned directories older than seven days.
 
 ### integration
 

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Classify whether a Git diff requires CodeNib's serial CI chain."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Mapping
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    import tomli as tomllib
+
+_VERSION_FILES = frozenset({"pyproject.toml", "uv.lock"})
+_SERIAL_EXACT = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        "Makefile",
+        "pyproject.toml",
+        "scripts/classify_ci_changes.py",
+        "scripts/check_graph_route_alignment.py",
+        "scripts/smoke_lsp_graph.py",
+        "scripts/smoke_scip_cold_start.py",
+        "scripts/swebench_graph_index.py",
+        "setup.py",
+        "uv.lock",
+        "codenib/ls_router.py",
+        "codenib/types.py",
+    }
+)
+_SERIAL_PREFIXES = (
+    ".github/actions/prewarm-parsers/",
+    ".github/actions/setup-env/",
+    "third_party/",
+    "core/",
+    "codenib/code_chunking/",
+    "codenib/dataset/",
+    "codenib/graph/",
+    "codenib/index/",
+    "codenib/ls_index/",
+    "test/chunker/",
+    "test/dataset/",
+    "test/graph/",
+    "test/index/",
+    "test/ls_index/",
+    "test/scip/",
+)
+
+FileReader = Callable[[str], bytes]
+
+
+@dataclass(frozen=True, slots=True)
+class SerialDecision:
+    run_serial: bool
+    reason: str
+
+
+def _affects_serial_chain(path: str) -> bool:
+    return path in _SERIAL_EXACT or path.startswith(_SERIAL_PREFIXES)
+
+
+def _project_without_release_metadata(
+    payload: bytes,
+) -> tuple[str, Mapping[str, object]]:
+    document = tomllib.loads(payload.decode("utf-8"))
+    project = document.get("project")
+    if not isinstance(project, dict) or not isinstance(project.get("version"), str):
+        raise ValueError("pyproject.toml has no project.version")
+    version = project["version"]
+    normalized = copy.deepcopy(document)
+    normalized_project = normalized["project"]
+    del normalized_project["version"]
+    classifiers = normalized_project.get("classifiers", [])
+    if not isinstance(classifiers, list):
+        raise ValueError("project.classifiers must be an array")
+    development = [
+        value
+        for value in classifiers
+        if isinstance(value, str) and value.startswith("Development Status :: ")
+    ]
+    if len(development) > 1:
+        raise ValueError("project has multiple development-status classifiers")
+    if development:
+        normalized_project["classifiers"] = [
+            value for value in classifiers if value != development[0]
+        ]
+    return version, normalized
+
+
+def _lock_without_project_version(
+    payload: bytes,
+) -> tuple[str, Mapping[str, object]]:
+    document = tomllib.loads(payload.decode("utf-8"))
+    packages = document.get("package")
+    if not isinstance(packages, list):
+        raise ValueError("uv.lock has no package table")
+    matches = [
+        index
+        for index, package in enumerate(packages)
+        if isinstance(package, dict)
+        and package.get("name") == "codenib"
+        and package.get("source") == {"editable": "."}
+    ]
+    if len(matches) != 1:
+        raise ValueError("uv.lock must contain one editable codenib package")
+    normalized = copy.deepcopy(document)
+    package = normalized["package"][matches[0]]
+    version = package.get("version")
+    if not isinstance(version, str):
+        raise ValueError("uv.lock codenib package has no version")
+    del package["version"]
+    return version, normalized
+
+
+def _is_synchronized_version_update(
+    read_before: FileReader,
+    read_after: FileReader,
+) -> bool:
+    old_project_version, old_project = _project_without_release_metadata(
+        read_before("pyproject.toml")
+    )
+    new_project_version, new_project = _project_without_release_metadata(
+        read_after("pyproject.toml")
+    )
+    old_lock_version, old_lock = _lock_without_project_version(read_before("uv.lock"))
+    new_lock_version, new_lock = _lock_without_project_version(read_after("uv.lock"))
+    return bool(
+        old_project_version == old_lock_version
+        and new_project_version == new_lock_version
+        and old_project_version != new_project_version
+        and old_project == new_project
+        and old_lock == new_lock
+    )
+
+
+def classify_serial_changes(
+    changed_paths: Iterable[str],
+    *,
+    read_before: FileReader,
+    read_after: FileReader,
+) -> SerialDecision:
+    """Return a conservative serial-chain decision for *changed_paths*."""
+
+    paths = tuple(sorted(set(changed_paths)))
+    serial_paths = tuple(path for path in paths if _affects_serial_chain(path))
+    if not serial_paths:
+        return SerialDecision(False, "no serial-chain paths changed")
+
+    non_version_paths = tuple(
+        path for path in serial_paths if path not in _VERSION_FILES
+    )
+    if non_version_paths:
+        preview = ", ".join(json.dumps(path) for path in non_version_paths[:3])
+        suffix = " ..." if len(non_version_paths) > 3 else ""
+        return SerialDecision(True, f"serial-chain path changed: {preview}{suffix}")
+
+    if set(serial_paths) != _VERSION_FILES:
+        return SerialDecision(
+            True,
+            "release metadata changed without a synchronized pyproject/lock pair",
+        )
+    try:
+        version_only = _is_synchronized_version_update(read_before, read_after)
+    except (KeyError, TypeError, ValueError, tomllib.TOMLDecodeError):
+        version_only = False
+    if version_only:
+        return SerialDecision(
+            False,
+            "synchronized project-version metadata update only",
+        )
+    return SerialDecision(
+        True,
+        "pyproject or lock content changed beyond the project version",
+    )
+
+
+def _git(repo: Path, *args: str, text: bool = False) -> bytes | str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=repo,
+        capture_output=True,
+        check=True,
+        text=text,
+        timeout=60,
+    )
+    return result.stdout
+
+
+def classify_refs(repo: Path, base: str, head: str) -> SerialDecision:
+    raw_paths = _git(
+        repo,
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "--diff-filter=ACDMRTUXB",
+        "-z",
+        base,
+        head,
+    )
+    assert isinstance(raw_paths, bytes)
+    paths = [
+        value.decode("utf-8", errors="surrogateescape")
+        for value in raw_paths.split(b"\0")
+        if value
+    ]
+
+    def reader(revision: str) -> FileReader:
+        def read(path: str) -> bytes:
+            value = _git(repo, "show", f"{revision}:{path}")
+            assert isinstance(value, bytes)
+            return value
+
+        return read
+
+    return classify_serial_changes(
+        paths,
+        read_before=reader(base),
+        read_after=reader(head),
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--github-output", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        decision = classify_refs(args.repo.resolve(), args.base, args.head)
+    except (OSError, subprocess.SubprocessError) as exc:
+        decision = SerialDecision(
+            True,
+            f"change classification failed conservatively: {type(exc).__name__}",
+        )
+    if args.github_output:
+        print(f"run-serial={'true' if decision.run_serial else 'false'}")
+        print(f"serial-reason={decision.reason}")
+    else:
+        print(
+            json.dumps(
+                {
+                    "run_serial": decision.run_serial,
+                    "reason": decision.reason,
+                },
+                sort_keys=True,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit contracts for expensive CI selection and parser caching."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.classify_ci_changes import classify_refs, classify_serial_changes
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _pyproject(
+    version: str,
+    dependency: str = "fastapi>=0.100.0",
+    development_status: str = "3 - Alpha",
+) -> bytes:
+    return (
+        "[project]\n"
+        'name = "codenib"\n'
+        f"version = {version!r}\n"
+        f"dependencies = [{dependency!r}]\n"
+        f'classifiers = ["Development Status :: {development_status}"]\n'
+    ).encode()
+
+
+def _lock(version: str, dependency: str = "fastapi") -> bytes:
+    return (
+        "version = 1\n"
+        "[[package]]\n"
+        'name = "codenib"\n'
+        f"version = {version!r}\n"
+        'source = { editable = "." }\n'
+        f"dependencies = [{{ name = {dependency!r} }}]\n"
+    ).encode()
+
+
+def _classify(paths, before=None, after=None):
+    before = before or {}
+    after = after or {}
+    return classify_serial_changes(
+        paths,
+        read_before=before.__getitem__,
+        read_after=after.__getitem__,
+    )
+
+
+def test_docs_only_change_skips_serial_chain() -> None:
+    decision = _classify(["README.md", "docs/releases/0.2.0.md"])
+
+    assert decision.run_serial is False
+    assert decision.reason == "no serial-chain paths changed"
+
+
+def test_synchronized_project_version_update_skips_serial_chain() -> None:
+    before = {
+        "pyproject.toml": _pyproject("0.1.0"),
+        "uv.lock": _lock("0.1.0"),
+    }
+    after = {
+        "pyproject.toml": _pyproject("0.2.0", development_status="4 - Beta"),
+        "uv.lock": _lock("0.2.0"),
+    }
+
+    decision = _classify(["CHANGELOG.md", "pyproject.toml", "uv.lock"], before, after)
+
+    assert decision.run_serial is False
+    assert "version metadata" in decision.reason
+
+
+def test_dependency_change_with_version_bump_runs_serial_chain() -> None:
+    before = {
+        "pyproject.toml": _pyproject("0.1.0"),
+        "uv.lock": _lock("0.1.0"),
+    }
+    after = {
+        "pyproject.toml": _pyproject("0.2.0", "fastapi>=0.200.0"),
+        "uv.lock": _lock("0.2.0", "fastapi-next"),
+    }
+
+    decision = _classify(["pyproject.toml", "uv.lock"], before, after)
+
+    assert decision.run_serial is True
+    assert "beyond the project version" in decision.reason
+
+
+def test_unpaired_release_metadata_change_runs_serial_chain() -> None:
+    decision = _classify(["pyproject.toml"])
+
+    assert decision.run_serial is True
+    assert "synchronized" in decision.reason
+
+
+def test_graph_or_ci_inputs_run_serial_chain() -> None:
+    for path in (
+        "codenib/graph/code_graph.py",
+        "core/CMakeLists.txt",
+        ".github/actions/prewarm-parsers/action.yml",
+        "scripts/classify_ci_changes.py",
+    ):
+        assert _classify([path]).run_serial is True
+
+
+def test_serial_reason_escapes_control_characters_in_paths() -> None:
+    decision = _classify(["codenib/graph/bad\nrun-serial=false.py"])
+
+    assert decision.run_serial is True
+    assert "\n" not in decision.reason
+    assert r"\nrun-serial=false.py" in decision.reason
+
+
+def test_renaming_serial_file_outside_allowlist_runs_serial_chain(
+    tmp_path: Path,
+) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "ci-policy@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "CI Policy"], cwd=tmp_path, check=True
+    )
+    source = tmp_path / "codenib" / "graph" / "route.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("GRAPH = True\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=tmp_path, check=True)
+    base = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True
+    ).strip()
+
+    target = tmp_path / "notes" / "route.py"
+    target.parent.mkdir()
+    source.rename(target)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "move"], cwd=tmp_path, check=True)
+    head = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, text=True
+    ).strip()
+
+    decision = classify_refs(tmp_path, base, head)
+
+    assert decision.run_serial is True
+    assert "codenib/graph/route.py" in decision.reason
+
+
+def test_ci_workflow_reuses_a_versioned_bounded_parser_cache() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    action = (ROOT / ".github/actions/prewarm-parsers/action.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert workflow.count("uses: ./.github/actions/prewarm-parsers") == 2
+    assert "cold_parser_cache" in workflow
+    assert "dorny/paths-filter" not in workflow
+    assert "scripts/classify_ci_changes.py" in workflow
+    assert "Set up classifier Python" in workflow
+    assert 'python-version: "3.11"' in workflow
+    assert 'RUN_SERIAL=false\n                REASON="manual light tier"' in workflow
+    assert "Remove incomplete run-scoped parser cache" in workflow
+    assert "Remove run-scoped parser cache" in workflow
+    assert "tree-sitter-language-pack-${PARSER_VERSION}" in action
+    assert 'XDG_ROOT="$CACHE_PARENT/xdg"' in action
+    assert "XDG_CACHE_HOME" in action
+    assert "timeout --foreground" in action
+    assert "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" in action
+    assert action.count("shell: bash -l {0}") == 2
+    assert "cold-run-dir" in action
+    assert "-mtime +7" in action


### PR DESCRIPTION
## Summary

Closes #434.

Reuse the pinned tree-sitter parser payload across CI tiers and avoid routing synchronized release-only version metadata changes through the expensive serial graph chain.

## Changes
- Add one conda-aware composite parser-prewarm action shared by unit and integration jobs.
- Key parser state by the pinned language-pack version, bound every download attempt, and expose an explicit cold-cache validation path.
- Remove completed/failed run-scoped cold caches and prune abandoned state after hard cancellations.
- Replace path-only release classification with a conservative TOML-aware classifier for pyproject.toml and uv.lock.
- Provision a deterministic preflight interpreter, classify renames safely, and escape changed-path diagnostics.
- Preserve an explicit manual light tier while keeping ambiguous events and dependency/build/source changes conservative.
- Document the policy and cover release, dependency, rename, cache, and fail-safe cases.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/test_ci_policy.py test/test_release_artifacts.py test/test_release_metadata.py` (25 passed)

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (2745 passed, 10 skipped before the final isolated CI-policy cases)

`pre-commit run --files .github/workflows/ci.yml .github/actions/prewarm-parsers/action.yml docs/ci_cd.md scripts/classify_ci_changes.py test/test_ci_policy.py`

Validated both composite shell blocks with `bash -n`, the classifier against the real v0.2.0 metadata commit, the action against the existing runner cache (14 parsers in about 1.3 seconds), and an empty cache with an unreachable parser endpoint (two bounded 75-second attempts, then an actionable failure).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published