### PR TITLE
ci: restore PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/codenib
     permissions:
-      contents: read
+      id-token: write
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v4
@@ -102,8 +102,6 @@ jobs:
 
       - name: Publish distributions
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   publish-mcp-registry:
     name: Publish to MCP Registry

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -71,11 +71,9 @@ that each pending publisher appears on the corresponding registry account page
 before dispatching a publish workflow.
 
 The corresponding GitHub environments should restrict deployments to trusted
-maintainers. TestPyPI currently publishes through OIDC. Production PyPI uses
-the environment-scoped `PYPI_API_TOKEN` fallback added after the `v0.1.0`
-bootstrap; [issue #384](https://github.com/sysevol-ai/CodeNib/issues/384)
-tracks restoring its trusted publisher and revoking that token. No publishing
-workflow reads a runner-local `.pypirc`.
+maintainers. Both registries publish through OIDC; neither workflow accepts an
+API-token password or reads a runner-local `.pypirc`. After the first successful
+production OIDC publication, revoke any remaining bootstrap API token.
 
 ## MCP Registry Namespace
 
@@ -130,17 +128,19 @@ on PyPI.
    and the README citation and `mcp-name` marker remain present.
 3. Run `pre-commit run --all-files` and the local package smoke.
 4. Merge the release commit to `main` and confirm its package gates pass.
-5. Confirm the TestPyPI pending publisher is visible, then dispatch the
+5. Confirm the TestPyPI trusted publisher is visible, then dispatch the
    TestPyPI Release workflow from `main`.
 6. Confirm the TestPyPI registry-download and installed-CLI smoke job passes.
 7. Complete the public-surface gate above.
-8. Confirm the production `pypi` environment still has its scoped publisher
-   credential, or complete #384 and update the workflow to OIDC first.
+8. Confirm the production PyPI publisher exactly names owner `sysevol-ai`,
+   repository `CodeNib`, workflow `release.yml`, and environment `pypi`.
 9. Confirm the `codenib.ai` MCP proof TXT record and protected
    `mcp-registry-publish` environment secret are active.
 10. Create and push an annotated `v<version>` tag.
 11. Confirm PyPI, MCP Registry discovery, and the generated GitHub Release all
     identify the same version and that a stable release is marked latest.
+12. After the first successful production OIDC publication, revoke the
+    bootstrap PyPI token from the GitHub environment and local configuration.
 
 Do not reuse a published version. If publication partially succeeds, increment
 the version and produce new artifacts.

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -154,10 +154,9 @@ def test_registry_publishers_use_separate_workflows() -> None:
     production_publisher = production["jobs"]["publish-pypi"]
     assert production_publisher["needs"] == "registry-auth-preflight"
     assert production_publisher["environment"]["name"] == "pypi"
-    assert production_publisher["permissions"] == {"contents": "read"}
-    assert publisher_step(production_publisher)["with"]["password"] == (
-        "${{ secrets.PYPI_API_TOKEN }}"
-    )
+    assert production_publisher["permissions"] == {"id-token": "write"}
+    assert "password" not in publisher_step(production_publisher).get("with", {})
+    assert "PYPI_API_TOKEN" not in str(production_publisher)
     pypi_install = production["jobs"]["verify-pypi-install"]
     assert pypi_install["needs"] == "publish-pypi"
     assert pypi_install["runs-on"] == "ubuntu-latest"


### PR DESCRIPTION
## Summary

Advances #384 by restoring secretless production PyPI publication now that the trusted publisher is registered. The issue remains open until the next production tag proves the OIDC exchange and the bootstrap token is revoked.

## Changes
- Grant the production publish job only the OIDC token permission it needs.
- Remove the PyPI API-token password from the release workflow.
- Lock the secretless publisher boundary in release tests.
- Update the release guide to describe OIDC for both registries and token revocation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/test_release_artifacts.py test/test_release_metadata.py` (17 passed)

`pre-commit run --files .github/workflows/release.yml test/test_release_artifacts.py docs/releasing.md`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published