### PR TITLE
feat(web): reader customization of wiki pages (human prior injection)

### DIFF
--- a/.claude/design/wiki-customization-design.md
+++ b/.claude/design/wiki-customization-design.md
@@ -1,0 +1,128 @@
+# Wiki customization — human prior injection
+
+**Status:** design agreed, implementing. **Base:** `codenib/main`. **Written:** 2026-07-22.
+**Owner:** Yash. Discussed with Zhongming ("leave space for human prior injection").
+
+## Goal
+
+Let a reader inject their own *prior* — how they want a wiki page written — and see
+the page regenerated to match, without touching the grounded generation pipeline.
+The default wiki stays authoritative; customization is an ephemeral presentation
+layer on top.
+
+## Why a layer, not a rewrite of the generator
+
+`AgentWiki` is a grounded, quality-guarded pipeline (plan → page → repair →
+quality, `_PAGE_PROMPT_VERSION = "102"`) producing structured sections with
+citations. Threading a free-form human style instruction *through* it would fight
+the grounding/coverage guards and is high-risk before launch.
+
+The page already exposes a rendered `markdown` string (what the reader sees). So
+customization is a **post-generation transform**: `markdown + prior -> markdown`,
+run once on demand, preserving citation markers and factual claims. This is
+exactly Zhongming's "leave *space* for human prior injection" — a layer, not a
+pipeline change — and it keeps the grounded default untouched by construction.
+
+## The prior
+
+```
+Prior = { instruction: str, structure: Optional[list[str]] }
+```
+
+- **instruction** — free text: "explain like a blog, add intuition, fewer lists".
+- **structure** — optional section skeleton the rewrite must fill:
+  `["Intuition", "How it works", "Example", "Gotchas"]`.
+
+Scopes, cascading most-specific-wins:
+
+```
+whole-wiki prior   (base house style)
+    └─ page prior      (overrides / extends, for one page)
+```
+
+Section scope is deferred (needs section addressing + selection UI); noted below.
+
+## Two stores, kept separate
+
+| | Durable default | Ephemeral customization |
+|---|---|---|
+| Content | grounded wiki (`AgentWiki` disk cache) | active priors + transformed markdown |
+| Lives | on disk | **server RAM only** |
+| Survives restart | yes | no -> default returns |
+| Cleanup | n/a | idle-TTL + LRU cap, swept lazily on access |
+
+Separation makes "customization never corrupts the default" true by construction.
+
+## Components
+
+### `codenib/wiki/customizer.py` (new)
+`Customizer.apply(markdown, prior) -> str`. One LiteLLM pass (reuses the wiki
+model/creds). Prompt: rewrite the page to the reader's instruction and optional
+structure, **preserving every `[n]`/citation marker and all factual claims; add
+no new facts**. Fail-soft: on any error return the original markdown unchanged, so
+a customization failure degrades to the default rather than an error page.
+
+### `codenib/web/customization_store.py` (new)
+Global, in-RAM, behind a narrow interface so a later Redis/SQLite swap (needed
+only for multi-worker serving) is one file:
+
+```
+set_prior(scope, target, prior)          # scope in {"wiki","page"}; target = page_id or ""
+resolve(page_id) -> Prior | None         # cascade: wiki prior <- page prior (most specific wins)
+drop_prior(scope, target)
+transformed(page_id, prior, produce) -> markdown   # memoized by (page_id, prior_hash)
+```
+
+- Priors keyed by `(scope, target)`. `resolve(page_id)` merges the wiki-level and
+  page-level priors (page instruction appended after wiki instruction; page
+  structure overrides wiki structure if set).
+- `transformed()` memoizes the LLM output by `(page_id, sha1(prior))` so repeated
+  views don't re-call the model; `produce` is the transform thunk.
+- **Cleanup (lazy, on every access):** drop entries idle > `TTL` (30 min), then if
+  over `MAX_ENTRIES` (64) evict least-recently-used. No background thread — matters
+  for the single-process Spark deploy.
+- Global (not per-visitor) for v1: simplest, and "customize then show it" just
+  works. Per-visitor isolation is a later add (key by an anonymous session token);
+  the store's key already has room for it.
+
+### `codenib/web/app.py`
+- `POST /api/repos/{id}/customize` `{scope, target, instruction, structure?}` ->
+  store prior, transform the affected page(s), return the new markdown.
+- `DELETE /api/repos/{id}/customize` `{scope, target}` -> drop prior; default returns.
+- `GET /api/repos/{id}/wiki/{page_id}` -> if `resolve(page_id)` yields a prior,
+  serve `transformed(...)`; else the default page unchanged. A `customized: bool`
+  flag on the response tells the client which it got.
+
+Whole-wiki scope applies lazily: setting a wiki prior does not eagerly transform
+every page; each page transforms on first view and is then memoized.
+
+### Frontend
+Evolve the inert "Refresh this wiki" button into a **Customize panel**:
+scope selector (This page / Whole wiki), instruction textarea, optional structure
+field (one section per line), **Apply** + **Reset to default**. On Apply -> POST,
+loading state, swap in the returned markdown. A small "customized view" badge (not
+implying grounding was re-verified) marks a transformed page.
+
+## Correctness / honesty posture
+
+- The transform is instructed to preserve citations and add no facts, but it is
+  **not** re-run through the grounding guards. The customized view is therefore
+  labeled as a reader lens, never presented as grounding-verified — the same
+  `verified` vs `checked` discipline used elsewhere in the repo.
+- Fail-soft everywhere: a failed transform yields the default; a missing model
+  yields the default.
+
+## Scope for this PR
+
+In: core transform, ephemeral store with TTL+LRU, page scope, whole-wiki scope,
+structure template, reset, the Customize panel.
+Out (follow-ups): section scope + selection UI; per-visitor isolation;
+Redis-backed store for multi-worker.
+
+## Tests
+
+- `customizer`: preserves citation markers; returns input unchanged on empty
+  prior; fail-soft on client error.
+- `customization_store`: cascade resolution (wiki only / page only / both);
+  memoization; TTL expiry; LRU eviction; drop.
+- endpoints: customize round-trip; reset restores default; `customized` flag.

--- a/codenib/web/app.py
+++ b/codenib/web/app.py
@@ -35,6 +35,8 @@ from .repository_files import live_source_slice
 from .schemas import (
     ChatRequest,
     ChatResponse,
+    CustomizeRequest,
+    CustomizeResponse,
     EdgeLabelRequest,
     EdgeLabelResponse,
     RepoInfo,
@@ -79,6 +81,14 @@ async def lifespan(app: FastAPI):
     app.state.wiki_builders = {}
     app.state.edge_labelers = {}
     app.state.commit_windows = {}
+    # Ephemeral, in-RAM reader customizations (human prior injection). Not
+    # persisted: the durable wiki is authoritative and customizations vanish on
+    # restart. A single Customizer reuses the wiki model/creds.
+    from ..wiki.customizer import Customizer
+    from .customization_store import CustomizationStore
+
+    app.state.customizations = CustomizationStore()
+    app.state.customizer = Customizer(_wiki_llm(config))
     # Shared LLM narrator for DeepWiki-style prose; cached on disk, fails soft
     # to templated text when no model/creds are available.
     app.state.narrator = _wiki_narrator(config)
@@ -239,6 +249,39 @@ async def wiki_tree(repo_id: str) -> dict:
     return {"repo": _bundle(repo_id).entry.repo, "pages": pages}
 
 
+def _apply_customization(page: dict, page_id: str) -> dict:
+    """Rewrite ``page['markdown']`` to any active reader prior for *page_id*.
+
+    Runs in a worker thread (it may call the model). Fail-soft: the customizer
+    itself returns the original markdown on error, and a resolved-but-empty prior
+    leaves the page untouched. Sets ``customized`` so the client can label it.
+    """
+    store = getattr(app.state, "customizations", None)
+    customizer = getattr(app.state, "customizer", None)
+    page = {**page, "customized": False}
+    if store is None or customizer is None:
+        return page
+    prior = store.resolve(page_id)
+    if prior is None:
+        return page
+    markdown = page.get("markdown") or ""
+    if not markdown:
+        return page
+    new_markdown = store.transformed(
+        page_id,
+        markdown,
+        prior,
+        produce=lambda: customizer.apply(
+            markdown,
+            instruction=prior.instruction,
+            structure=list(prior.structure),
+        ),
+    )
+    if new_markdown and new_markdown != markdown:
+        page = {**page, "markdown": new_markdown, "customized": True}
+    return page
+
+
 @app.get("/api/repos/{repo_id}/wiki/{page_id}")
 async def wiki_page(repo_id: str, page_id: str) -> dict:
     page = await asyncio.to_thread(_wiki(repo_id).page, page_id)
@@ -260,7 +303,61 @@ async def wiki_page(repo_id: str, page_id: str) -> dict:
                 "relation_count": 0,
             },
         }
-    return page
+    return await asyncio.to_thread(_apply_customization, page, page_id)
+
+
+@app.post("/api/repos/{repo_id}/customize", response_model=CustomizeResponse)
+async def customize_wiki(repo_id: str, req: CustomizeRequest) -> CustomizeResponse:
+    """Set (or clear) a reader prior for a page or the whole wiki.
+
+    An empty instruction *and* empty structure clears any existing prior for the
+    scope/target. A page-scoped request returns the transformed markdown; a
+    wiki-scoped request stores the prior and lets pages transform lazily on view.
+    """
+    from ..wiki.customizer import clean_instruction, clean_structure
+    from .customization_store import SCOPE_PAGE, SCOPE_WIKI, Prior
+
+    _bundle(repo_id)  # 404 on unknown repo
+    scope = req.scope if req.scope in (SCOPE_WIKI, SCOPE_PAGE) else SCOPE_PAGE
+    store = app.state.customizations
+
+    prior = Prior(
+        instruction=clean_instruction(req.instruction),
+        structure=tuple(clean_structure(req.structure)),
+    )
+    target = req.target if scope == SCOPE_PAGE else ""
+    await asyncio.to_thread(store.set_prior, scope, target, prior)
+
+    if prior.is_empty():
+        return CustomizeResponse(ok=True, customized=False, scope=scope, target=target)
+
+    # Page scope: transform now so the client gets the result in one round-trip.
+    if scope == SCOPE_PAGE and target:
+        page = await asyncio.to_thread(_wiki(repo_id).page, target)
+        if page is not None:
+            applied = await asyncio.to_thread(_apply_customization, page, target)
+            return CustomizeResponse(
+                ok=True,
+                markdown=applied.get("markdown", ""),
+                customized=bool(applied.get("customized")),
+                scope=scope,
+                target=target,
+            )
+    return CustomizeResponse(ok=True, customized=True, scope=scope, target=target)
+
+
+@app.delete("/api/repos/{repo_id}/customize", response_model=CustomizeResponse)
+async def reset_customization(
+    repo_id: str, scope: str = "page", target: str = ""
+) -> CustomizeResponse:
+    """Drop a prior so the default page returns. Idempotent."""
+    from .customization_store import SCOPE_PAGE, SCOPE_WIKI
+
+    _bundle(repo_id)
+    scope = scope if scope in (SCOPE_WIKI, SCOPE_PAGE) else SCOPE_PAGE
+    target = target if scope == SCOPE_PAGE else ""
+    await asyncio.to_thread(app.state.customizations.drop_prior, scope, target)
+    return CustomizeResponse(ok=True, customized=False, scope=scope, target=target)
 
 
 @app.get("/api/repos/{repo_id}/wiki/{page_id}/graph")

--- a/codenib/web/customization_store.py
+++ b/codenib/web/customization_store.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ephemeral, in-memory store for reader customizations.
+
+A *prior* is how a reader asked a page to be written (a style instruction and/or
+a section structure). Priors are deliberately NOT persisted: the durable default
+wiki is authoritative, and a customization should last only while a reader is
+using it and vanish on restart. This store therefore lives in process memory,
+with lazy TTL + LRU cleanup and no background thread — which keeps the
+single-process demo deploy free of any scheduler.
+
+Two scopes, cascading most-specific-wins:
+
+    wiki prior   (base house style, applies to every page)
+        page prior   (overrides / extends, for one page)
+
+``resolve(page_id)`` merges them. The store also memoizes the transformed
+markdown per (page, prior) so repeated views don't re-run the model.
+
+The public surface is small on purpose: swapping this for a shared backend
+(needed only if the server ever runs multiple workers) is a single-file change.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+# Cleanup bounds. Idle priors are dropped after TTL; the total is capped so a
+# burst of distinct customizations cannot grow memory without bound.
+DEFAULT_TTL_SECONDS = 30 * 60
+DEFAULT_MAX_ENTRIES = 64
+
+SCOPE_WIKI = "wiki"
+SCOPE_PAGE = "page"
+
+
+@dataclass(frozen=True, slots=True)
+class Prior:
+    """A reader's stated preference for how a page should read."""
+
+    instruction: str = ""
+    structure: Tuple[str, ...] = ()
+
+    def is_empty(self) -> bool:
+        return not (self.instruction or self.structure)
+
+    def fingerprint(self) -> str:
+        """Stable key material for memoizing a transform of this prior."""
+        payload = self.instruction + "\0" + "\x1f".join(self.structure)
+        return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+
+@dataclass(slots=True)
+class _Entry:
+    prior: Prior
+    last_used: float
+    # Memoized transformed markdown, keyed by (source markdown hash + prior fp).
+    outputs: Dict[str, str] = field(default_factory=dict)
+
+
+def _key(scope: str, target: str) -> str:
+    # target is the page id for page scope, and "" for wiki scope.
+    return f"{scope}:{target}" if scope == SCOPE_PAGE else SCOPE_WIKI
+
+
+class CustomizationStore:
+    """Global, in-RAM prior store with lazy TTL + LRU cleanup."""
+
+    def __init__(
+        self,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._max = max_entries
+        self._entries: Dict[str, _Entry] = {}
+        self._lock = threading.RLock()
+
+    # -- mutation ---------------------------------------------------------
+
+    def set_prior(self, scope: str, target: str, prior: Prior) -> None:
+        """Store (or clear, when empty) a prior for a scope/target."""
+        if scope not in (SCOPE_WIKI, SCOPE_PAGE):
+            raise ValueError(f"unknown scope: {scope!r}")
+        key = _key(scope, target)
+        with self._lock:
+            self._sweep(time.time())
+            if prior.is_empty():
+                self._entries.pop(key, None)
+                return
+            self._entries[key] = _Entry(prior=prior, last_used=time.time())
+            self._evict_over_cap()
+
+    def drop_prior(self, scope: str, target: str) -> bool:
+        """Remove a prior. Returns True if one was present."""
+        key = _key(scope, target)
+        with self._lock:
+            return self._entries.pop(key, None) is not None
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    # -- read -------------------------------------------------------------
+
+    def resolve(self, page_id: str) -> Optional[Prior]:
+        """Merge the wiki-level and page-level priors for *page_id*.
+
+        Most-specific-wins: the page instruction is appended after the wiki
+        instruction, and a page structure replaces the wiki structure. Touching
+        either entry marks it used (so an actively-viewed customization does not
+        expire out from under the reader).
+        """
+        now = time.time()
+        with self._lock:
+            self._sweep(now)
+            wiki = self._entries.get(_key(SCOPE_WIKI, ""))
+            page = self._entries.get(_key(SCOPE_PAGE, page_id))
+            if wiki is None and page is None:
+                return None
+
+            instructions: List[str] = []
+            structure: Tuple[str, ...] = ()
+            for entry in (wiki, page):
+                if entry is None:
+                    continue
+                entry.last_used = now
+                if entry.prior.instruction:
+                    instructions.append(entry.prior.instruction)
+                if entry.prior.structure:
+                    structure = entry.prior.structure  # page overrides wiki
+            merged = Prior(
+                instruction="\n\n".join(instructions),
+                structure=structure,
+            )
+            return None if merged.is_empty() else merged
+
+    def transformed(
+        self,
+        page_id: str,
+        markdown: str,
+        prior: Prior,
+        produce: Callable[[], str],
+    ) -> str:
+        """Return the transformed markdown, memoized by (source, prior).
+
+        *produce* runs the (expensive) transform on a cache miss. It is called
+        outside the lock so a slow model call does not block other requests.
+        """
+        src_fp = hashlib.sha1(markdown.encode("utf-8")).hexdigest()[:16]
+        cache_key = f"{src_fp}:{prior.fingerprint()}"
+        page_key = _key(SCOPE_PAGE, page_id)
+        wiki_key = _key(SCOPE_WIKI, "")
+
+        with self._lock:
+            for key in (page_key, wiki_key):
+                entry = self._entries.get(key)
+                if entry and cache_key in entry.outputs:
+                    entry.last_used = time.time()
+                    return entry.outputs[cache_key]
+
+        result = produce()
+
+        with self._lock:
+            # Attach the memoized output to whichever scope entry exists, so it is
+            # dropped together with its prior. Prefer the page entry.
+            for key in (page_key, wiki_key):
+                entry = self._entries.get(key)
+                if entry is not None:
+                    entry.outputs[cache_key] = result
+                    entry.last_used = time.time()
+                    break
+        return result
+
+    # -- housekeeping (callers already hold the lock) --------------------
+
+    def _sweep(self, now: float) -> None:
+        expired = [k for k, e in self._entries.items() if now - e.last_used > self._ttl]
+        for k in expired:
+            self._entries.pop(k, None)
+
+    def _evict_over_cap(self) -> None:
+        while len(self._entries) > self._max:
+            oldest = min(self._entries, key=lambda k: self._entries[k].last_used)
+            self._entries.pop(oldest, None)
+
+    # -- introspection (tests / debug) -----------------------------------
+
+    def size(self) -> int:
+        with self._lock:
+            return len(self._entries)

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -328,3 +328,28 @@ def agent_result_to_response(result: Any, repo_path: str = "") -> ChatResponse:
         total_turns=result.total_turns,
         total_duration_ms=result.total_duration_ms,
     )
+
+
+class CustomizeRequest(BaseModel):
+    """Apply a reader prior to a page or the whole wiki.
+
+    ``scope`` is ``"page"`` (``target`` = page id) or ``"wiki"`` (``target``
+    ignored). At least one of ``instruction`` / ``structure`` should be present;
+    an empty prior clears any existing one for that scope/target.
+    """
+
+    scope: str = "page"
+    target: str = ""
+    instruction: str = ""
+    # Optional section skeleton the rewrite must follow, one entry per section.
+    structure: List[str] = Field(default_factory=list)
+
+
+class CustomizeResponse(BaseModel):
+    ok: bool = True
+    # The transformed page markdown when a page was regenerated; empty for a
+    # whole-wiki prior (which applies lazily on next page view) or a clear.
+    markdown: str = ""
+    customized: bool = False
+    scope: str = "page"
+    target: str = ""

--- a/codenib/wiki/customizer.py
+++ b/codenib/wiki/customizer.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rewrite a rendered wiki page to a reader's stated prior.
+
+This is a *presentation layer* over the grounded wiki: it takes the markdown a
+page already renders and rewrites it to how the reader asked to read it — a
+style instruction, an optional section structure, or both. It never touches the
+grounded generation pipeline, and it is fail-soft: any problem returns the
+original markdown unchanged, so a customization failure degrades to the default
+rather than an error.
+
+The transform is instructed to preserve every citation marker and add no new
+facts, but its output is NOT re-run through the wiki's grounding guards. Callers
+must therefore present a customized page as a reader lens, not as
+grounding-verified prose.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM = (
+    "You restyle an existing software wiki page to match a reader's stated "
+    "preference. You never add, remove, or alter facts, and you never invent "
+    "citations."
+)
+
+# Bounds enforced here too: a public endpoint must not trust the client's limits.
+MAX_INSTRUCTION_CHARS = 2000
+MAX_STRUCTURE_SECTIONS = 24
+MAX_SECTION_CHARS = 120
+
+
+def clean_instruction(text: Optional[str]) -> str:
+    """Trim and clip a free-text instruction."""
+    return (text or "").strip()[:MAX_INSTRUCTION_CHARS]
+
+
+def clean_structure(sections: Optional[Sequence[str]]) -> List[str]:
+    """Normalize a structure template: trim, drop blanks, clip count and length."""
+    if not sections:
+        return []
+    out: List[str] = []
+    for raw in sections:
+        name = str(raw).strip()[:MAX_SECTION_CHARS]
+        if name:
+            out.append(name)
+        if len(out) >= MAX_STRUCTURE_SECTIONS:
+            break
+    return out
+
+
+class Customizer:
+    """Applies a reader prior to page markdown via one LLM pass."""
+
+    def __init__(self, llm: Any) -> None:
+        """*llm* is any client exposing ``complete(messages, **overrides) -> str``."""
+        self._llm = llm
+
+    def apply(
+        self,
+        markdown: str,
+        *,
+        instruction: str = "",
+        structure: Optional[Sequence[str]] = None,
+    ) -> str:
+        """Return *markdown* rewritten to the prior, or *markdown* unchanged.
+
+        A no-op (empty markdown or empty prior) returns the input directly
+        without calling the model.
+        """
+        instruction = clean_instruction(instruction)
+        structure = clean_structure(structure)
+        if not markdown or not (instruction or structure):
+            return markdown
+
+        prompt = self._build_prompt(markdown, instruction, structure)
+        try:
+            out = self._llm.complete(
+                [
+                    {"role": "system", "content": _SYSTEM},
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=2048,
+                temperature=0.3,
+                timeout=90,
+            )
+        except Exception as exc:  # noqa: BLE001 - any failure falls back to default
+            logger.warning("wiki customizer call failed: %s", exc)
+            return markdown
+
+        out = (out or "").strip()
+        # Strip a wrapping ```markdown fence if the model added one.
+        if out.startswith("```"):
+            out = out.split("\n", 1)[-1]
+            if out.rstrip().endswith("```"):
+                out = out.rstrip()[:-3].rstrip()
+        return out or markdown
+
+    @staticmethod
+    def _build_prompt(markdown: str, instruction: str, structure: List[str]) -> str:
+        parts = [
+            "Rewrite the wiki page below to match the reader's preference.",
+            "",
+            "Hard rules:",
+            "- Preserve every citation marker exactly as written (tokens such as "
+            "[1], [`path/file.py`], or footnote-style references). Do not add or "
+            "remove citations.",
+            "- Do not introduce any fact, symbol, or claim that is not already in "
+            "the page. You are restyling, not researching.",
+            "- Keep it valid Markdown. Return only the rewritten page — no "
+            "preamble, no explanation.",
+        ]
+        if instruction:
+            parts += ["", f"Reader instruction: {instruction}"]
+        if structure:
+            listed = "\n".join(f"  {i + 1}. {s}" for i, s in enumerate(structure))
+            parts += [
+                "",
+                "Organize the page under exactly these sections, in order, "
+                "filling each only with facts already present in the page (omit a "
+                "section if the page truly has nothing for it):",
+                listed,
+            ]
+        parts += ["", "--- PAGE START ---", markdown, "--- PAGE END ---"]
+        return "\n".join(parts)

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -53,8 +53,18 @@ def test_wiki_generation_runs_off_event_loop(monkeypatch):
             "evidence_count": 0,
             "relation_count": 0,
         },
+        # No customization store on app.state in this test, so the page passes
+        # through _apply_customization untouched but flagged.
+        "customized": False,
     }
-    assert calls == [("page_tree", ()), ("page", ("overview",))]
+    # page_tree, then page generation, then the customization pass — all off the
+    # event loop. The customization arg is the pre-flag page dict, so assert the
+    # call sequence by name rather than by dict identity.
+    assert [name for name, _ in calls] == [
+        "page_tree",
+        "page",
+        "_apply_customization",
+    ]
 
 
 def test_template_wiki_disables_narrator(tmp_path):

--- a/test/web/test_customization.py
+++ b/test/web/test_customization.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for wiki customization: the store, the transform, and the endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import codenib.web.app as web_app
+from codenib.web.customization_store import (
+    SCOPE_PAGE,
+    SCOPE_WIKI,
+    CustomizationStore,
+    Prior,
+)
+from codenib.wiki.customizer import Customizer, clean_structure
+
+# --------------------------------------------------------------------------
+# CustomizationStore
+# --------------------------------------------------------------------------
+
+
+class TestCustomizationStore:
+    def test_resolve_none_without_priors(self):
+        assert CustomizationStore().resolve("overview") is None
+
+    def test_page_only_prior(self):
+        s = CustomizationStore()
+        s.set_prior(SCOPE_PAGE, "overview", Prior(instruction="blog"))
+        assert s.resolve("overview").instruction == "blog"
+        assert s.resolve("other") is None
+
+    def test_wiki_prior_applies_to_every_page(self):
+        s = CustomizationStore()
+        s.set_prior(SCOPE_WIKI, "", Prior(instruction="house style"))
+        assert s.resolve("overview").instruction == "house style"
+        assert s.resolve("anything").instruction == "house style"
+
+    def test_cascade_merges_wiki_then_page(self):
+        s = CustomizationStore()
+        s.set_prior(SCOPE_WIKI, "", Prior(instruction="house"))
+        s.set_prior(SCOPE_PAGE, "overview", Prior(instruction="page tweak"))
+        merged = s.resolve("overview")
+        assert merged.instruction == "house\n\npage tweak"
+
+    def test_page_structure_overrides_wiki_structure(self):
+        s = CustomizationStore()
+        s.set_prior(SCOPE_WIKI, "", Prior(structure=("A", "B")))
+        s.set_prior(SCOPE_PAGE, "overview", Prior(structure=("X",)))
+        assert s.resolve("overview").structure == ("X",)
+
+    def test_empty_prior_clears(self):
+        s = CustomizationStore()
+        s.set_prior(SCOPE_PAGE, "overview", Prior(instruction="x"))
+        s.set_prior(SCOPE_PAGE, "overview", Prior())  # empty -> clear
+        assert s.resolve("overview") is None
+
+    def test_drop_prior(self):
+        s = CustomizationStore()
+        s.set_prior(SCOPE_PAGE, "overview", Prior(instruction="x"))
+        assert s.drop_prior(SCOPE_PAGE, "overview") is True
+        assert s.drop_prior(SCOPE_PAGE, "overview") is False
+        assert s.resolve("overview") is None
+
+    def test_transformed_memoizes_by_prior(self):
+        s = CustomizationStore()
+        prior = Prior(instruction="blog")
+        s.set_prior(SCOPE_PAGE, "overview", prior)
+        calls = {"n": 0}
+
+        def produce():
+            calls["n"] += 1
+            return "OUT"
+
+        r1 = s.transformed("overview", "SRC", prior, produce)
+        r2 = s.transformed("overview", "SRC", prior, produce)
+        assert r1 == r2 == "OUT"
+        assert calls["n"] == 1  # second read hits the memo
+
+    def test_transformed_reruns_when_source_changes(self):
+        s = CustomizationStore()
+        prior = Prior(instruction="blog")
+        s.set_prior(SCOPE_PAGE, "overview", prior)
+        calls = {"n": 0}
+
+        def produce():
+            calls["n"] += 1
+            return f"OUT{calls['n']}"
+
+        s.transformed("overview", "SRC-A", prior, produce)
+        s.transformed("overview", "SRC-B", prior, produce)
+        assert calls["n"] == 2  # different source markdown -> re-transform
+
+    def test_ttl_expiry(self):
+        s = CustomizationStore(ttl_seconds=0)  # everything is immediately stale
+        s.set_prior(SCOPE_PAGE, "overview", Prior(instruction="x"))
+        # A subsequent access sweeps the expired entry.
+        assert s.resolve("overview") is None
+
+    def test_lru_cap_evicts_oldest(self):
+        s = CustomizationStore(max_entries=2)
+        s.set_prior(SCOPE_PAGE, "a", Prior(instruction="1"))
+        s.set_prior(SCOPE_PAGE, "b", Prior(instruction="2"))
+        s.set_prior(SCOPE_PAGE, "c", Prior(instruction="3"))
+        assert s.size() == 2
+        # "a" was least-recently-used and should be gone.
+        assert s.resolve("a") is None
+        assert s.resolve("c") is not None
+
+    def test_unknown_scope_rejected(self):
+        s = CustomizationStore()
+        try:
+            s.set_prior("nonsense", "x", Prior(instruction="y"))
+        except ValueError:
+            return
+        raise AssertionError("expected ValueError for unknown scope")
+
+
+# --------------------------------------------------------------------------
+# Customizer
+# --------------------------------------------------------------------------
+
+
+class _FakeLLM:
+    def __init__(self, out="# Rewritten [1]"):
+        self.out = out
+        self.last_prompt = None
+
+    def complete(self, messages, **kw):
+        self.last_prompt = messages[-1]["content"]
+        return self.out
+
+
+class _BoomLLM:
+    def complete(self, *a, **k):
+        raise RuntimeError("model down")
+
+
+class TestCustomizer:
+    def test_empty_prior_is_noop_without_llm_call(self):
+        llm = _FakeLLM()
+        assert Customizer(llm).apply("# Orig [1]") == "# Orig [1]"
+        assert llm.last_prompt is None  # never called
+
+    def test_transform_returns_model_output(self):
+        out = Customizer(_FakeLLM("# New [1]")).apply("# Orig [1]", instruction="blog")
+        assert out == "# New [1]"
+
+    def test_fail_soft_returns_original(self):
+        assert (
+            Customizer(_BoomLLM()).apply("# Keep [1]", instruction="x") == "# Keep [1]"
+        )
+
+    def test_prompt_carries_rules_and_structure(self):
+        llm = _FakeLLM()
+        Customizer(llm).apply(
+            "body [1]", instruction="blog", structure=["Intro", "Gotchas"]
+        )
+        assert "citation marker" in llm.last_prompt
+        assert "Intro" in llm.last_prompt and "Gotchas" in llm.last_prompt
+
+    def test_strips_markdown_code_fence(self):
+        out = Customizer(_FakeLLM("```markdown\n# Fenced [1]\n```")).apply(
+            "x", instruction="y"
+        )
+        assert out == "# Fenced [1]"
+
+    def test_clean_structure_bounds(self):
+        assert clean_structure(["  a ", "", "b"]) == ["a", "b"]
+        assert clean_structure(None) == []
+
+
+# --------------------------------------------------------------------------
+# Endpoints
+# --------------------------------------------------------------------------
+
+
+def _install_state(monkeypatch, *, page_markdown="# Default [1]"):
+    """Wire app.state with a store + a fake customizer, and a fake wiki/bundle."""
+    store = CustomizationStore()
+    customizer = Customizer(_FakeLLM(f"# CUSTOM\n\n{page_markdown} restyled [1]"))
+    monkeypatch.setattr(web_app.app.state, "customizations", store, raising=False)
+    monkeypatch.setattr(web_app.app.state, "customizer", customizer, raising=False)
+
+    class Wiki:
+        def page(self, page_id):
+            return {"id": page_id, "title": "Overview", "markdown": page_markdown}
+
+    monkeypatch.setattr(web_app, "_wiki", lambda _r: Wiki())
+    monkeypatch.setattr(
+        web_app,
+        "_bundle",
+        lambda _r: SimpleNamespace(entry=SimpleNamespace(repo="o/r")),
+    )
+
+    async def fake_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(web_app.asyncio, "to_thread", fake_to_thread)
+    return store
+
+
+def test_customize_page_round_trip(monkeypatch):
+    _install_state(monkeypatch)
+    from codenib.web.schemas import CustomizeRequest
+
+    res = asyncio.run(
+        web_app.customize_wiki(
+            "repo",
+            CustomizeRequest(scope="page", target="overview", instruction="blog"),
+        )
+    )
+    assert res.ok and res.customized
+    assert "restyled" in res.markdown
+
+    # The page endpoint now serves the customized markdown + flag.
+    page = asyncio.run(web_app.wiki_page("repo", "overview"))
+    assert page["customized"] is True
+    assert "restyled" in page["markdown"]
+
+
+def test_reset_restores_default(monkeypatch):
+    _install_state(monkeypatch)
+    from codenib.web.schemas import CustomizeRequest
+
+    asyncio.run(
+        web_app.customize_wiki(
+            "repo",
+            CustomizeRequest(scope="page", target="overview", instruction="blog"),
+        )
+    )
+    asyncio.run(web_app.reset_customization("repo", scope="page", target="overview"))
+
+    page = asyncio.run(web_app.wiki_page("repo", "overview"))
+    assert page["customized"] is False
+    assert page["markdown"] == "# Default [1]"
+
+
+def test_empty_customize_clears(monkeypatch):
+    store = _install_state(monkeypatch)
+    from codenib.web.schemas import CustomizeRequest
+
+    asyncio.run(
+        web_app.customize_wiki(
+            "repo",
+            CustomizeRequest(scope="page", target="overview", instruction="blog"),
+        )
+    )
+    # An empty instruction + no structure clears the prior.
+    res = asyncio.run(
+        web_app.customize_wiki(
+            "repo", CustomizeRequest(scope="page", target="overview", instruction="")
+        )
+    )
+    assert res.customized is False
+    assert store.resolve("overview") is None
+
+
+def test_wiki_scope_applies_lazily_on_view(monkeypatch):
+    _install_state(monkeypatch)
+    from codenib.web.schemas import CustomizeRequest
+
+    res = asyncio.run(
+        web_app.customize_wiki(
+            "repo", CustomizeRequest(scope="wiki", instruction="house style")
+        )
+    )
+    # Wiki scope stores the prior but returns no markdown (applies on view).
+    assert res.ok and res.markdown == ""
+    page = asyncio.run(web_app.wiki_page("repo", "overview"))
+    assert page["customized"] is True

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -4,9 +4,11 @@ import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
 import Header from "@/components/Header";
 import Markdown from "@/components/Markdown";
 import AskBar from "@/components/AskBar";
+import CustomizePanel from "@/components/CustomizePanel";
 import { AppLink } from "@/lib/router";
 import { isStaticRuntime } from "@/lib/runtime";
 import {
+  customizationAvailable,
   fetchCommits,
   fetchRepos,
   fetchWikiGraph,
@@ -631,7 +633,23 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
           ) : (
             <div className="muted small">—</div>
           )}
-          {repo && (
+          {repo && customizationAvailable() && (
+            <CustomizePanel
+              repoId={repoId}
+              pageId={activeId}
+              pageTitle={page?.title ?? ""}
+              customized={Boolean(page?.customized)}
+              onApplied={(markdown) =>
+                setPage((prev) =>
+                  prev ? { ...prev, markdown, customized: true } : prev
+                )
+              }
+              onReset={() => {
+                fetchWikiPage(repoId, activeId).then(setPage).catch(() => {});
+              }}
+            />
+          )}
+          {repo && !customizationAvailable() && (
             <button
               className="refresh-wiki"
               title="Re-fetch this wiki page"

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3843,3 +3843,114 @@ a.codepanel-name:hover {
 .addrepo-foot a {
   color: var(--accent);
 }
+
+/* ── Wiki customization (human prior injection) ────────────────────────────── */
+
+.cz-trigger { margin-top: 6px; }
+
+.cz-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.cz-dialog {
+  width: 100%;
+  max-width: 500px;
+  box-sizing: border-box;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+.cz-title { margin: 0 0 4px; font-size: 15px; font-weight: 600; color: var(--fg); }
+.cz-sub { margin: 0 0 14px; font-size: 12px; line-height: 1.5; color: var(--muted); }
+
+.cz-scopes { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+.cz-scope {
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+.cz-scope:hover { color: var(--fg); }
+.cz-scope.on { border-color: var(--fg); color: var(--fg); font-weight: 600; }
+
+.cz-label {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 8px 0 4px;
+}
+.cz-hint { text-transform: none; letter-spacing: 0; }
+
+.cz-text {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  resize: vertical;
+}
+.cz-text:focus-visible { outline: 2px solid var(--fg); outline-offset: 1px; }
+.cz-structure { font-family: var(--mono, ui-monospace, monospace); }
+
+.cz-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+  gap: 10px;
+}
+.cz-count { font-size: 11px; color: var(--muted); }
+.cz-actions { display: flex; gap: 8px; }
+
+.cz-ghost {
+  padding: 6px 12px;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+}
+.cz-ghost:hover { border-color: var(--fg); }
+.cz-ghost:disabled { opacity: 0.5; cursor: default; }
+
+.cz-error { margin: 10px 0 0; font-size: 12px; color: #c0392b; }
+
+/* "customized view" badge on a transformed page */
+.cz-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+@media (max-width: 560px) {
+  .cz-dialog { max-width: 100%; }
+}

--- a/web/components/CustomizePanel.tsx
+++ b/web/components/CustomizePanel.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  customizeWiki,
+  resetCustomization,
+  type CustomizeScope,
+} from "@/lib/api";
+
+const MAX_CHARS = 2000;
+
+/**
+ * Reader "human prior" injection: rewrite the current wiki page (or the whole
+ * wiki) to how the reader wants it read — a style instruction and/or a section
+ * structure. Server-side, ephemeral: customizations vanish on restart and the
+ * default page is always one Reset away.
+ *
+ * `onApplied` hands back the transformed markdown so the page can swap it in
+ * without a re-fetch; `onReset` tells the page to re-fetch the default.
+ */
+export default function CustomizePanel({
+  repoId,
+  pageId,
+  pageTitle,
+  customized,
+  onApplied,
+  onReset,
+}: {
+  repoId: string;
+  pageId: string;
+  pageTitle: string;
+  customized: boolean;
+  onApplied: (markdown: string) => void;
+  onReset: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [scope, setScope] = useState<CustomizeScope>("page");
+  const [instruction, setInstruction] = useState("");
+  const [structure, setStructure] = useState("");
+  const [state, setState] = useState<"idle" | "working" | "error">("idle");
+  const [error, setError] = useState("");
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    taRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  function structureList(): string[] {
+    return structure
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  async function apply() {
+    if (state === "working") return;
+    const instr = instruction.trim();
+    const sections = structureList();
+    if (!instr && sections.length === 0) {
+      setError("Add an instruction or at least one section.");
+      setState("error");
+      return;
+    }
+    setState("working");
+    setError("");
+    try {
+      const res = await customizeWiki(repoId, {
+        scope,
+        target: scope === "page" ? pageId : "",
+        instruction: instr,
+        structure: sections,
+      });
+      // Page scope returns the transformed markdown directly. Whole-wiki applies
+      // lazily on view, so re-fetch to pull this page through the transform.
+      if (scope === "page" && res.markdown) onApplied(res.markdown);
+      else onReset(); // triggers a re-fetch, which now returns the customized page
+      setOpen(false);
+    } catch (e) {
+      setState("error");
+      setError(String(e).includes("live backend")
+        ? "Customization needs the live demo (not available in the static build)."
+        : "Could not apply. Try a shorter instruction or again in a moment.");
+      return;
+    }
+    setState("idle");
+  }
+
+  async function reset() {
+    setState("working");
+    try {
+      await resetCustomization(repoId, "page", pageId);
+      await resetCustomization(repoId, "wiki", "");
+      onReset();
+      setOpen(false);
+    } catch {
+      /* reset is best-effort; the page re-fetch still shows current state */
+      onReset();
+      setOpen(false);
+    }
+    setState("idle");
+  }
+
+  return (
+    <>
+      <button
+        className="refresh-wiki cz-trigger"
+        title="Rewrite this page the way you want to read it"
+        onClick={() => setOpen(true)}
+      >
+        {customized ? "✎ Customized — edit" : "✎ Customize this wiki"}
+      </button>
+
+      {open && (
+        <div className="cz-scrim" onClick={() => setOpen(false)} role="presentation">
+          <div
+            className="cz-dialog"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Customize wiki"
+          >
+            <p className="cz-title">Customize the wiki</p>
+            <p className="cz-sub">
+              Rewrite it to how you like to read — your instruction and/or a
+              section structure. Facts and citations are kept; this is a reader
+              lens, not a re-check of grounding. Resets on server restart.
+            </p>
+
+            <div className="cz-scopes" role="tablist" aria-label="Scope">
+              <button
+                type="button"
+                className={`cz-scope ${scope === "page" ? "on" : ""}`}
+                onClick={() => setScope("page")}
+              >
+                This page{pageTitle ? ` · ${pageTitle}` : ""}
+              </button>
+              <button
+                type="button"
+                className={`cz-scope ${scope === "wiki" ? "on" : ""}`}
+                onClick={() => setScope("wiki")}
+              >
+                Whole wiki
+              </button>
+            </div>
+
+            <label className="cz-label">Instruction</label>
+            <textarea
+              ref={taRef}
+              className="cz-text"
+              value={instruction}
+              maxLength={MAX_CHARS}
+              onChange={(e) => setInstruction(e.target.value)}
+              placeholder="e.g. Explain like a blog post with intuition first, fewer bullet lists, a worked example."
+              rows={4}
+            />
+
+            <label className="cz-label">
+              Structure <span className="cz-hint">(optional — one section per line)</span>
+            </label>
+            <textarea
+              className="cz-text cz-structure"
+              value={structure}
+              onChange={(e) => setStructure(e.target.value)}
+              placeholder={"Intuition\nHow it works\nWorked example\nGotchas"}
+              rows={4}
+            />
+
+            <div className="cz-foot">
+              <span className="cz-count">{instruction.length}/{MAX_CHARS}</span>
+              <div className="cz-actions">
+                {customized && (
+                  <button className="cz-ghost" onClick={reset} type="button" disabled={state === "working"}>
+                    Reset to default
+                  </button>
+                )}
+                <button className="cz-ghost" onClick={() => setOpen(false)} type="button">
+                  Cancel
+                </button>
+                <button
+                  className="btn-primary"
+                  onClick={apply}
+                  type="button"
+                  disabled={state === "working"}
+                >
+                  {state === "working" ? "Rewriting…" : "Apply"}
+                </button>
+              </div>
+            </div>
+            {state === "error" && <p className="cz-error">{error}</p>}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -84,6 +84,8 @@ export interface WikiPage {
   id: string;
   title: string;
   markdown: string;
+  // True when a reader prior rewrote this page (ephemeral, server-side).
+  customized?: boolean;
   citations: Citation[];
   diagram: string;
   evidence?: {
@@ -538,5 +540,66 @@ export async function fetchEdgeLabel(
     }
   );
   if (!res.ok) throw new Error(`Failed to load edge label (${res.status})`);
+  return res.json();
+}
+
+// --- Wiki customization (human prior injection) ----------------------------
+// Ephemeral, server-side. Requires a live backend; a no-op in static export.
+
+export type CustomizeScope = "page" | "wiki";
+
+export interface CustomizeInput {
+  scope: CustomizeScope;
+  target?: string; // page id for page scope; ignored for wiki scope
+  instruction?: string;
+  structure?: string[];
+}
+
+export interface CustomizeResult {
+  ok: boolean;
+  markdown: string;
+  customized: boolean;
+  scope: CustomizeScope;
+  target: string;
+}
+
+export function customizationAvailable(): boolean {
+  return !isStaticRuntime();
+}
+
+export async function customizeWiki(
+  repoId: string,
+  input: CustomizeInput
+): Promise<CustomizeResult> {
+  if (isStaticRuntime()) throw new Error("customization needs a live backend");
+  const res = await fetch(
+    `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/customize`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: input.scope,
+        target: input.target ?? "",
+        instruction: input.instruction ?? "",
+        structure: input.structure ?? [],
+      }),
+    }
+  );
+  if (!res.ok) throw new Error(`Customize failed (${res.status})`);
+  return res.json();
+}
+
+export async function resetCustomization(
+  repoId: string,
+  scope: CustomizeScope,
+  target = ""
+): Promise<CustomizeResult> {
+  if (isStaticRuntime()) throw new Error("customization needs a live backend");
+  const params = new URLSearchParams({ scope, target });
+  const res = await fetch(
+    `${API_BASE}/api/repos/${encodeURIComponent(repoId)}/customize?${params}`,
+    { method: "DELETE" }
+  );
+  if (!res.ok) throw new Error(`Reset failed (${res.status})`);
   return res.json();
 }


### PR DESCRIPTION
## Summary

Turns the inert "Refresh this wiki" button into a **Customize** control: a reader
states how they want a page written — a free-text instruction and/or a section
structure — and the page is regenerated to match. This is the "human prior
injection" space discussed for the demo (Zhongming: *"leave space for human prior
injection"*): the grounded wiki stays authoritative, and the reader gets to layer
their own intuition on top.

Key design choice: this is a **presentation layer, not a change to the grounded
generation pipeline** (`AgentWiki`, `_PAGE_PROMPT_VERSION = "102"`, plan → page →
repair → quality guards). The page already exposes rendered markdown; the
`Customizer` rewrites *that markdown* in one LLM pass, instructed to preserve
every citation marker and add no facts. It never touches the plan/quality-guarded
generator, so it can't destabilize grounding — and it's fail-soft: any error
returns the default markdown unchanged.

## Changes

- **`codenib/wiki/customizer.py`** (new) — `Customizer.apply(markdown, instruction,
  structure) -> markdown`. One LLM pass reusing the wiki model/creds; preserves
  citations, strips a stray ```` ```markdown ```` fence, returns the input
  unchanged on empty prior or any error.
- **`codenib/web/customization_store.py`** (new) — global, in-RAM prior store.
  Two scopes (`wiki`, `page`) cascade most-specific-wins; `resolve(page_id)`
  merges them. Memoizes transformed markdown per `(source, prior)`. Lazy cleanup
  on access: idle-TTL (30 min) + LRU cap (64) — no background thread, so the
  single-process deploy needs no scheduler. Narrow interface so a shared backend
  (only needed for multi-worker serving) is a one-file swap.
- **`codenib/web/app.py`** — `POST /api/repos/{id}/customize` (set/return),
  `DELETE …/customize` (clear), and `GET …/wiki/{page_id}` applies any active
  prior and sets a `customized` flag. Whole-wiki priors apply lazily on view.
  A single `Customizer` + `CustomizationStore` are created in `lifespan`.
- **`codenib/web/schemas.py`** — `CustomizeRequest` / `CustomizeResponse`.
- **Frontend** — `CustomizePanel.tsx` (scope selector, instruction textarea,
  optional structure field, Apply, Reset), replacing the refresh button; gated
  off in the static export (`customizationAvailable()`), which has no backend.
  `WikiPage.customized` + `customizeWiki` / `resetCustomization` in `lib/api.ts`.

Design doc: `.claude/design/wiki-customization-design.md`.

## Behavior

- **Ephemeral & global.** Priors live in RAM, never on disk. The durable default
  wiki is authoritative; customizations vanish on restart (and after idle-TTL).
- **Cascade.** A whole-wiki "house style" plus per-page overrides; the page
  instruction appends after the wiki one, a page structure replaces the wiki one.
- **Honesty.** A customized page is labeled a *reader lens* — the transform is
  told to preserve citations and add no facts, but it is **not** re-run through
  the grounding guards, so it is never presented as re-grounded.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/web/` — **186 passed**. New `test/web/test_customization.py` covers
the store (cascade / override / memoize / TTL / LRU / drop / unknown-scope), the
customizer (transform / no-op-without-LLM-call / fail-soft / fence-strip /
citation-preserving prompt / bounds), and the endpoints (page round-trip, reset
restores default, empty clears, whole-wiki applies lazily on view).
`test/web/test_app_runtime.py` updated for the new `customized` flag.
`tsc --noEmit` clean; black, isort, flake8, and the CodeNib namespace check pass.

**Out of scope (follow-ups):** section-level scope + selection UI; per-visitor
isolation (session token — the store key already has room); a shared/Redis store
for multi-worker serving.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
