### PR TITLE
fix(runtime): harden portable MCP serving

### DIFF
--- a/codenib/artifacts/archive.py
+++ b/codenib/artifacts/archive.py
@@ -6,13 +6,13 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import stat
 import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
 
+from .._atomic_directory import publish_staged_directory
 from .context import CONTEXT_ARTIFACT_MANIFEST
 from .runtime import VerifiedContextArtifact, verify_context_artifact
 
@@ -188,9 +188,7 @@ def extract_context_artifact_archive(
             max_files=max_files,
             max_bytes=max_bytes,
         )
-        if output.exists():
-            shutil.rmtree(output)
-        os.replace(stage, output)
+        publish_staged_directory(stage, output)
     except zipfile.BadZipFile as exc:
         shutil.rmtree(stage, ignore_errors=True)
         raise ValueError(

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -344,7 +344,7 @@ def _selected_views(
 ) -> tuple[str, ...]:
     available = {name for name in manifest.indexes if manifest.index_is_current(name)}
     if requested is None:
-        selected = sorted(available)
+        selected = sorted(available & PORTABLE_CONTEXT_VIEWS)
     else:
         selected = list(dict.fromkeys(str(name).strip() for name in requested))
         missing = sorted(name for name in selected if name not in available)
@@ -353,7 +353,10 @@ def _selected_views(
                 "context artifact requires current views: " + ", ".join(missing)
             )
     if not selected:
-        raise ValueError("context artifact requires at least one current view")
+        raise ValueError(
+            "context artifact requires at least one current view that is portable "
+            "(bm25 or vector)"
+        )
     return tuple(selected)
 
 

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -17,6 +17,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping, Sequence
 
 from .. import compat_pickle
+from .._atomic_directory import publish_staged_directory
 from .._version import package_version
 from ..compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from ..compiler.checkout_identity import validate_checkout_identity
@@ -506,9 +507,7 @@ def stage_context_artifact(
             label="context artifact",
         )
 
-        if output_dir.exists():
-            shutil.rmtree(output_dir)
-        os.replace(stage, output_dir)
+        publish_staged_directory(stage, output_dir)
     except BaseException:
         shutil.rmtree(stage, ignore_errors=True)
         raise

--- a/codenib/graph/dependency.py
+++ b/codenib/graph/dependency.py
@@ -121,9 +121,14 @@ class DependencyAnalyzer:
         """What *symbol* (transitively) depends on — transitive callees."""
         return self._bfs(symbol, "forward", "callees", max_depth, max_nodes)
 
-    def subgraph(self, symbol: str, radius: int = 1) -> DependencyResult:
+    def subgraph(
+        self,
+        symbol: str,
+        radius: int = 1,
+        max_nodes: int = 200,
+    ) -> DependencyResult:
         """Compact callers+callees neighborhood for a frontend dependency view."""
-        return self._bfs(symbol, "both", "both", radius, max_nodes=200)
+        return self._bfs(symbol, "both", "both", radius, max_nodes=max_nodes)
 
     def call_path(self, from_symbol: str, to_symbol: str) -> DependencyResult:
         """Shortest call path from *from_symbol* to *to_symbol* (empty if none)."""
@@ -193,6 +198,13 @@ class DependencyAnalyzer:
                 )
                 for src, tgt, _w, attr in edges:
                     neighbor = tgt if d == "forward" else src
+                    if neighbor not in seen:
+                        if len(seen) >= max_nodes:
+                            res.truncated = True
+                            continue
+                        seen.add(neighbor)
+                        res.nodes.append(self._node(neighbor, depth + 1))
+                        queue.append((neighbor, depth + 1))
                     res.edges.append(
                         DepEdge(
                             self.code_graph.display_name(src),
@@ -200,14 +212,6 @@ class DependencyAnalyzer:
                             attr.get("type", "reference"),
                         )
                     )
-                    if neighbor in seen:
-                        continue
-                    if len(seen) >= max_nodes:
-                        res.truncated = True
-                        continue
-                    seen.add(neighbor)
-                    res.nodes.append(self._node(neighbor, depth + 1))
-                    queue.append((neighbor, depth + 1))
         return res
 
     def _node(self, canonical_name: str, depth: int) -> DepNode:

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -23,13 +23,20 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from mcp.server import MCPServer
+from pydantic import Field
 
 from ..compiler.manifest import RepoManifest
 from .context import ServerContext
 from .prompts import CODENIB_GUIDE
+from .tools._validation import (
+    MAX_GRAPH_DEPTH,
+    MAX_LSP_POSITION,
+    MAX_ROUTE_SYMBOLS,
+    MAX_TOOL_RESULTS,
+)
 from .tools.dependency import dependency_subgraph_impl
 from .tools.lsp import lsp_definition_impl, lsp_references_impl, lsp_route_impl
 from .tools.search import search_bm25_impl, search_context_impl, search_regex_impl
@@ -40,6 +47,18 @@ logger = logging.getLogger(__name__)
 
 # Global context is set once at startup before the event loop runs tools.
 _ctx: Optional[ServerContext] = None
+_SearchText = Annotated[str, Field(min_length=1)]
+_SearchTopK = Annotated[int, Field(ge=1, le=MAX_TOOL_RESULTS)]
+_SearchLevel = Literal["l0", "l2"]
+_FiniteScore = Annotated[float, Field(allow_inf_nan=False)]
+_GraphDirection = Literal["impact", "dependencies", "both"]
+_GraphDepth = Annotated[int, Field(ge=1, le=MAX_GRAPH_DEPTH)]
+_PositiveLine = Annotated[int, Field(ge=1, le=MAX_LSP_POSITION)]
+_Character = Annotated[int, Field(ge=0, le=MAX_LSP_POSITION)]
+_RouteSymbols = Annotated[
+    list[str],
+    Field(min_length=1, max_length=MAX_ROUTE_SYMBOLS),
+]
 
 
 def get_context() -> ServerContext:
@@ -80,10 +99,10 @@ mcp = MCPServer(
     ),
 )
 async def search_context(
-    query: str,
-    top_k: int = 10,
+    query: _SearchText,
+    top_k: _SearchTopK = 10,
     budget: str = "balanced",
-    level: str = "l2",
+    level: _SearchLevel = "l2",
     filter_test: bool = False,
 ) -> dict[str, Any]:
     """Execute capability-aware ranked retrieval over loaded repository views."""
@@ -109,10 +128,10 @@ async def search_context(
     ),
 )
 async def semantic_search(
-    query: str,
-    top_k: int = 10,
-    level: str = "l2",
-    score_threshold: float = 0.0,
+    query: _SearchText,
+    top_k: _SearchTopK = 10,
+    level: _SearchLevel = "l2",
+    score_threshold: _FiniteScore = 0.0,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Semantic search over indexed code using vector embeddings.
 
@@ -141,8 +160,8 @@ async def semantic_search(
     ),
 )
 async def search_bm25(
-    query: str,
-    top_k: int = 20,
+    query: _SearchText,
+    top_k: _SearchTopK = 20,
     filter_test: bool = False,
 ) -> list[dict[str, Any]]:
     """BM25 keyword search over indexed code symbols."""
@@ -163,8 +182,8 @@ async def search_bm25(
     ),
 )
 async def search_regex(
-    pattern: str,
-    top_k: int = 20,
+    pattern: _SearchText,
+    top_k: _SearchTopK = 20,
     file_glob: str = "",
     node_type: str = "",
     case_sensitive: bool = False,
@@ -195,8 +214,8 @@ async def search_regex(
     ),
 )
 async def search_zoekt(
-    query: str,
-    top_k: int = 20,
+    query: _SearchText,
+    top_k: _SearchTopK = 20,
     file_filter: str = "",
 ) -> list[dict[str, Any]]:
     """Trigram-based search over raw repository contents."""
@@ -224,10 +243,10 @@ async def search_zoekt(
     ),
 )
 async def dependency_subgraph(
-    symbol: str,
-    direction: str = "both",
-    depth: int = 2,
-    max_nodes: int = 60,
+    symbol: _SearchText,
+    direction: _GraphDirection = "both",
+    depth: _GraphDepth = 2,
+    max_nodes: _SearchTopK = 60,
 ) -> dict[str, Any]:
     """Call-graph dependency/impact subgraph for *symbol* (nodes+edges JSON)."""
     if _ctx is None:
@@ -247,10 +266,10 @@ async def dependency_subgraph(
 )
 async def lsp_definition(
     file_path: str = "",
-    line: int | None = None,
-    character: int | None = None,
+    line: _PositiveLine | None = None,
+    character: _Character | None = None,
     symbol: str = "",
-    top_k: int = 8,
+    top_k: _SearchTopK = 8,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Graph-backed definition lookup over the static symbol graph."""
     if _ctx is None:
@@ -276,11 +295,11 @@ async def lsp_definition(
 )
 async def lsp_references(
     file_path: str = "",
-    line: int | None = None,
-    character: int | None = None,
+    line: _PositiveLine | None = None,
+    character: _Character | None = None,
     symbol: str = "",
     include_declaration: bool = True,
-    top_k: int = 40,
+    top_k: _SearchTopK = 40,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Graph-backed reference lookup over the static symbol graph."""
     if _ctx is None:
@@ -307,9 +326,9 @@ async def lsp_references(
     ),
 )
 async def lsp_route(
-    symbols: list[str],
+    symbols: _RouteSymbols,
     query: str = "",
-    top_k: int = 12,
+    top_k: _SearchTopK = 12,
     include_neighbors: bool = True,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Graph-backed route map over the static symbol graph."""

--- a/codenib/mcp/tools/_validation.py
+++ b/codenib/mcp/tools/_validation.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared request bounds for MCP tools that return repository context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+MAX_TOOL_RESULTS = 100
+MAX_GRAPH_DEPTH = 8
+MAX_ROUTE_SYMBOLS = 32
+MAX_LSP_POSITION = 2**31 - 1
+
+
+def required_text(value: Any, *, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must not be empty.")
+    return value.strip()
+
+
+def bounded_integer(
+    value: Any,
+    *,
+    name: str,
+    minimum: int = 1,
+    maximum: int,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not minimum <= value <= maximum
+    ):
+        raise ValueError(f"{name} must be between {minimum} and {maximum}.")
+    return value

--- a/codenib/mcp/tools/dependency.py
+++ b/codenib/mcp/tools/dependency.py
@@ -15,6 +15,12 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from ...agent.boundary import AGENT_LINE_OFFSET
+from ._validation import (
+    MAX_GRAPH_DEPTH,
+    MAX_TOOL_RESULTS,
+    bounded_integer,
+    required_text,
+)
 
 
 def dependency_subgraph_impl(
@@ -31,6 +37,23 @@ def dependency_subgraph_impl(
     dependency view). Returns ``{"error": ...}`` when the symbol graph is
     unavailable, so callers can recover gracefully.
     """
+    symbol = required_text(symbol, name="symbol")
+    depth = bounded_integer(depth, name="depth", maximum=MAX_GRAPH_DEPTH)
+    max_nodes = bounded_integer(
+        max_nodes,
+        name="max_nodes",
+        maximum=MAX_TOOL_RESULTS,
+    )
+    direction = (direction or "").strip().lower()
+    if direction in {"impact", "callers"}:
+        operation = "impact"
+    elif direction in {"dependencies", "dependency", "callees"}:
+        operation = "dependencies"
+    elif direction == "both":
+        operation = "both"
+    else:
+        raise ValueError("direction must be 'impact', 'dependencies', or 'both'.")
+
     graph = getattr(ctx, "symbol_graph", None)
     if graph is None:
         return {"error": "symbol_graph index not available"}
@@ -38,17 +61,17 @@ def dependency_subgraph_impl(
     from ...graph.dependency import DependencyAnalyzer
 
     analyzer = DependencyAnalyzer(graph)
-    d = (direction or "both").lower()
-    depth = max(1, int(depth or 1))
-    if d.startswith("impact") or d == "callers":
-        result = analyzer.impact(symbol, max_depth=depth, max_nodes=int(max_nodes))
-    elif d.startswith("dep") or d == "callees":
-        result = analyzer.dependencies(
-            symbol, max_depth=depth, max_nodes=int(max_nodes)
-        )
+    if operation == "impact":
+        result = analyzer.impact(symbol, max_depth=depth, max_nodes=max_nodes)
+    elif operation == "dependencies":
+        result = analyzer.dependencies(symbol, max_depth=depth, max_nodes=max_nodes)
     else:
-        result = analyzer.subgraph(symbol, radius=depth)
+        result = analyzer.subgraph(symbol, radius=depth, max_nodes=max_nodes)
     payload = result.to_dict()
+    max_edges = max_nodes * 4
+    if len(payload["edges"]) > max_edges:
+        payload["edges"] = payload["edges"][:max_edges]
+        payload["truncated"] = True
     for node in payload["nodes"]:
         line = node.get("line")
         if isinstance(line, int) and not isinstance(line, bool):

--- a/codenib/mcp/tools/lsp.py
+++ b/codenib/mcp/tools/lsp.py
@@ -8,6 +8,13 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
+from ._validation import (
+    MAX_LSP_POSITION,
+    MAX_ROUTE_SYMBOLS,
+    MAX_TOOL_RESULTS,
+    bounded_integer,
+)
+
 
 def _coerce_symbols(symbols: Sequence[str] | str) -> list[str]:
     if isinstance(symbols, str):
@@ -40,6 +47,16 @@ def lsp_definition_impl(
     top_k: int = 8,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Return graph-backed definition locations."""
+    top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
+    if line is not None:
+        bounded_integer(line, name="line", maximum=MAX_LSP_POSITION)
+    if character is not None:
+        bounded_integer(
+            character,
+            name="character",
+            minimum=0,
+            maximum=MAX_LSP_POSITION,
+        )
     graph = _symbol_graph(ctx)
     if graph is None:
         return {"error": "symbol_graph index not available"}
@@ -54,7 +71,7 @@ def lsp_definition_impl(
             line=graph_line,
             character=character,
             symbol=symbol or None,
-            top_k=max(1, int(top_k or 8)),
+            top_k=top_k,
         )
     except ValueError as exc:
         return {"error": str(exc)}
@@ -71,6 +88,16 @@ def lsp_references_impl(
     top_k: int = 40,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Return graph-backed reference locations."""
+    top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
+    if line is not None:
+        bounded_integer(line, name="line", maximum=MAX_LSP_POSITION)
+    if character is not None:
+        bounded_integer(
+            character,
+            name="character",
+            minimum=0,
+            maximum=MAX_LSP_POSITION,
+        )
     graph = _symbol_graph(ctx)
     if graph is None:
         return {"error": "symbol_graph index not available"}
@@ -86,7 +113,7 @@ def lsp_references_impl(
             character=character,
             symbol=symbol or None,
             include_declaration=bool(include_declaration),
-            top_k=max(1, int(top_k or 40)),
+            top_k=top_k,
         )
     except ValueError as exc:
         return {"error": str(exc)}
@@ -101,19 +128,22 @@ def lsp_route_impl(
     include_neighbors: bool = True,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Return graph-backed route anchors for one or more symbol seeds."""
+    top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
+    seeds = _coerce_symbols(symbols)
+    if not seeds:
+        raise ValueError("symbols must contain at least one non-empty seed.")
+    if len(seeds) > MAX_ROUTE_SYMBOLS:
+        raise ValueError(f"symbols must contain at most {MAX_ROUTE_SYMBOLS} seeds.")
     graph = _symbol_graph(ctx)
     if graph is None:
         return {"error": "symbol_graph index not available"}
 
     from ...agent.lsp_provider import StaticLSPProvider
 
-    seeds = _coerce_symbols(symbols)
-    if not seeds:
-        return []
     results = StaticLSPProvider(graph).route(
         symbols=seeds,
         query=query or None,
-        top_k=max(1, int(top_k or 12)),
+        top_k=top_k,
         include_neighbors=bool(include_neighbors),
     )
     return [_node_to_dict(node) for node in results]

--- a/codenib/mcp/tools/search.py
+++ b/codenib/mcp/tools/search.py
@@ -8,12 +8,14 @@ over backbone indexes."""
 from __future__ import annotations
 
 import asyncio
+import math
 from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
 
 from ...agent.boundary import to_agent_repr
 from ...types import NodeInfo
 from ..context import ServerContext
+from ._validation import MAX_TOOL_RESULTS, bounded_integer, required_text
 
 
 def _node_to_dict(node: NodeInfo) -> Dict[str, Any]:
@@ -30,11 +32,8 @@ def search_context_impl(
     filter_test: bool = False,
 ) -> Dict[str, Any]:
     """Plan and execute ranked retrieval over the available repository views."""
-    normalized_query = (query or "").strip()
-    if not normalized_query:
-        raise ValueError("query must not be empty.")
-    if isinstance(top_k, bool) or not 1 <= top_k <= 100:
-        raise ValueError("top_k must be between 1 and 100.")
+    normalized_query = required_text(query, name="query")
+    top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     normalized_level = (level or "l2").strip().lower()
     if normalized_level not in {"l0", "l2"}:
         raise ValueError("level must be 'l0' or 'l2'.")
@@ -159,7 +158,7 @@ async def search_semantic(
     level: Optional[str] = None,
     score_threshold: Optional[float] = None,
     transform: Optional[str] = None,  # reserved for Phase 3 HyDE/expand
-) -> list[dict]:
+) -> list[dict] | dict[str, str]:
     """Semantic code search using vector embeddings.
 
     Args:
@@ -174,19 +173,27 @@ async def search_semantic(
         List of NodeInfo dicts with scores and content. On missing index,
         returns ``{"error": ...}`` so callers can handle gracefully.
     """
+    normalized_query = required_text(query, name="query")
+    top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
+    normalized_level = (level or "l2").strip().lower()
+    if normalized_level not in {"l0", "l2"}:
+        raise ValueError("level must be 'l0' or 'l2'.")
+    if score_threshold is not None and (
+        isinstance(score_threshold, bool)
+        or not isinstance(score_threshold, (int, float))
+        or not math.isfinite(float(score_threshold))
+    ):
+        raise ValueError("score_threshold must be a finite number.")
     if ctx.vector is None:
         return {
             "error": "Vector index not loaded. Re-run indexing with embedding enabled."
         }
 
-    if level is None:
-        level = "l2"
-
     results = await asyncio.to_thread(
         ctx.vector.search_with_content,
-        query=query,
+        query=normalized_query,
         top_k=top_k,
-        level=level,
+        level=normalized_level,
         score_threshold=score_threshold,
     )
 
@@ -224,6 +231,8 @@ def search_bm25_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content, score.
     """
+    normalized_query = required_text(query, name="query")
+    top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     if ctx.bm25 is None:
         raise RuntimeError(
             "BM25 index is not available. "
@@ -231,7 +240,7 @@ def search_bm25_impl(
         )
 
     results: List[NodeInfo] = ctx.bm25.search(
-        query=query,
+        query=normalized_query,
         top_k=top_k,
         return_code_content=True,
         wrap_with_ln=False,
@@ -267,6 +276,8 @@ def search_regex_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content.
     """
+    required_text(pattern, name="pattern")
+    top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     if ctx.regex_index is None:
         raise RuntimeError(
             "Regex index is not available. "
@@ -326,6 +337,8 @@ def search_zoekt_impl(
         (``"file"``), ``file``, ``start_line``, ``end_line``, ``content``,
         ``score``, ``node_id`` (language hint, when reported).
     """
+    normalized_query = required_text(query, name="query")
+    top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     if ctx.zoekt is None:
         raise RuntimeError(
             "Zoekt index is not available. "
@@ -341,7 +354,7 @@ def search_zoekt_impl(
 
     try:
         results: List[NodeInfo] = ctx.zoekt.search(
-            query=query,
+            query=normalized_query,
             top_k=top_k,
             file_filter=file_filter or None,
         )

--- a/scripts/smoke_release_services.py
+++ b/scripts/smoke_release_services.py
@@ -316,6 +316,21 @@ async def _assert_mcp_async(
                                 f"{sorted(required - names)}"
                             )
 
+                        tool_by_name = {tool.name: tool for tool in tools.tools}
+                        bm25_schema = tool_by_name["search_bm25"].input_schema
+                        top_k_schema = bm25_schema.get("properties", {}).get(
+                            "top_k",
+                            {},
+                        )
+                        if (
+                            top_k_schema.get("minimum") != 1
+                            or top_k_schema.get("maximum") != 100
+                        ):
+                            raise RuntimeError(
+                                "installed MCP service did not publish bounded "
+                                f"search inputs: {bm25_schema!r}"
+                            )
+
                         if mode == "legacy":
                             continue
 

--- a/scripts/smoke_release_services.py
+++ b/scripts/smoke_release_services.py
@@ -277,10 +277,10 @@ def _structured_result(result: Any) -> dict[str, Any]:
 
 async def _assert_mcp_async(
     root: Path,
-    repo: Path,
     *,
     executable: str,
     env: dict[str, str],
+    arguments: Sequence[str],
 ) -> None:
     from mcp import Client, StdioServerParameters
     from mcp.client.stdio import stdio_client
@@ -292,7 +292,7 @@ async def _assert_mcp_async(
 
     parameters = StdioServerParameters(
         command=executable,
-        args=["mcp", str(repo)],
+        args=list(arguments),
         cwd=root,
         env=env,
     )
@@ -394,13 +394,83 @@ async def _assert_mcp_async(
 
 def _assert_mcp(
     root: Path,
+    *,
+    executable: str,
+    env: dict[str, str],
+    arguments: Sequence[str],
+) -> None:
+    print("+", executable, *arguments, flush=True)
+    asyncio.run(
+        _assert_mcp_async(
+            root,
+            executable=executable,
+            env=env,
+            arguments=arguments,
+        )
+    )
+
+
+def _assert_portable_artifact_mcp(
+    root: Path,
     repo: Path,
     *,
     executable: str,
     env: dict[str, str],
 ) -> None:
-    print("+", executable, "mcp", repo, flush=True)
-    asyncio.run(_assert_mcp_async(root, repo, executable=executable, env=env))
+    """Pack, rebind, and query the release artifact from another checkout."""
+
+    artifact = root / "context-artifact"
+    checkout = root / "artifact-checkout"
+    repository = "example/release-smoke"
+    _run(
+        [
+            executable,
+            "artifact",
+            "pack",
+            str(repo),
+            "--output",
+            str(artifact),
+            "--repository",
+            repository,
+            "--view",
+            "bm25",
+        ],
+        cwd=root,
+        env=env,
+    )
+    _run(
+        ["git", "clone", "--quiet", "--no-hardlinks", str(repo), str(checkout)],
+        cwd=root,
+        env=env,
+    )
+    _run(
+        [
+            executable,
+            "artifact",
+            "verify",
+            str(artifact),
+            "--repo",
+            str(checkout),
+            "--repository",
+            repository,
+        ],
+        cwd=root,
+        env=env,
+    )
+    _assert_mcp(
+        root,
+        executable=executable,
+        env=env,
+        arguments=[
+            "mcp",
+            "--artifact",
+            str(artifact),
+            "--repo",
+            str(checkout),
+            "--repository",
+            repository,
+        ],
+    )
 
 
 def _assert_stale_snapshot_rejected(
@@ -481,14 +551,25 @@ def smoke(root: Path, *, executable: str = "codenib") -> None:
         raise RuntimeError(
             f"one-command Wiki startup modified the target repository: {status!r}"
         )
-    _assert_mcp(root, repo, executable=executable, env=env)
+    _assert_mcp(
+        root,
+        executable=executable,
+        env=env,
+        arguments=["mcp", str(repo)],
+    )
+    _assert_portable_artifact_mcp(
+        root,
+        repo,
+        executable=executable,
+        env=env,
+    )
     _assert_stale_snapshot_rejected(
         root,
         repo,
         executable=executable,
         env=env,
     )
-    print("Installed one-command Wiki and MCP service smoke passed")
+    print("Installed Wiki, MCP, and portable artifact service smoke passed")
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -257,6 +257,37 @@ def test_context_artifact_is_deterministic_for_one_manifest(tmp_path: Path) -> N
     )
 
 
+def test_context_artifact_default_ignores_nonportable_current_views(
+    tmp_path: Path,
+) -> None:
+    repo, manifest_path, _view_path = _fixture_manifest(tmp_path)
+    graph = manifest_path.parent / "symbol_graph"
+    graph.mkdir()
+    (graph / "graph.bin").write_bytes(b"nonportable graph")
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["symbol_graph"] = IndexEntry(
+        index_type="symbol_graph",
+        path=str(graph),
+        built_at="2026-08-04T00:00:00+00:00",
+        built_at_epoch=1.0,
+        status="fresh",
+        commit=manifest.commit,
+        source_fingerprint=manifest.source_fingerprint,
+    )
+    manifest.save(manifest_path)
+
+    result = stage_context_artifact(
+        repo,
+        manifest_path,
+        tmp_path / "publish" / "context",
+        repository="example/project",
+    )
+
+    assert result.views == ("bm25",)
+    portable = RepoManifest.load(result.manifest_path)
+    assert set(portable.indexes) == {"bm25"}
+
+
 def test_context_artifact_keeps_only_portable_vector_serving_state(
     tmp_path: Path,
 ) -> None:

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import pickle
 from pathlib import Path
 from types import SimpleNamespace
@@ -255,6 +256,43 @@ def test_context_artifact_is_deterministic_for_one_manifest(tmp_path: Path) -> N
     assert _tree(tmp_path / "first" / "context") == _tree(
         tmp_path / "second" / "context"
     )
+
+
+def test_context_artifact_restores_previous_output_on_publish_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, manifest_path, view_path = _fixture_manifest(tmp_path)
+    output = tmp_path / "publish" / "context"
+    stage_context_artifact(
+        repo,
+        manifest_path,
+        output,
+        repository="example/project",
+    )
+    previous = _tree(output)
+    (view_path / "documents.json").write_text("[]\n", encoding="utf-8")
+    real_replace = os.replace
+
+    def fail_final_publish(source, target):
+        source_path = Path(source)
+        if source_path.name.startswith(".context.tmp-") and Path(target) == output:
+            raise OSError("injected context publish failure")
+        return real_replace(source, target)
+
+    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_final_publish)
+
+    with pytest.raises(OSError, match="injected context publish failure"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            output,
+            repository="example/project",
+        )
+
+    assert _tree(output) == previous
+    assert not list(output.parent.glob(".context.tmp-*"))
+    assert not list(output.parent.glob(".context.previous-*"))
 
 
 def test_context_artifact_default_ignores_nonportable_current_views(

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -9,6 +9,7 @@ import hashlib
 import io
 import json
 import math
+import os
 import shlex
 import shutil
 import stat
@@ -463,6 +464,38 @@ def test_extract_archive_verifies_and_removes_single_root_prefix(
     assert verified.metadata_path == tmp_path / "extracted" / (
         CONTEXT_ARTIFACT_MANIFEST
     )
+
+
+def test_extract_archive_restores_previous_output_on_publish_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    output = tmp_path / "extracted"
+    extract_context_artifact_archive(archive, output)
+    marker = output / "previous-output.marker"
+    marker.write_text("preserve", encoding="utf-8")
+    real_replace = os.replace
+
+    def fail_final_publish(source, target):
+        source_path = Path(source)
+        if (
+            source_path.name.startswith(".extracted.extract-")
+            and Path(target) == output
+        ):
+            raise OSError("injected archive publish failure")
+        return real_replace(source, target)
+
+    monkeypatch.setattr("codenib._atomic_directory.os.replace", fail_final_publish)
+
+    with pytest.raises(OSError, match="injected archive publish failure"):
+        extract_context_artifact_archive(archive, output)
+
+    assert marker.read_text(encoding="utf-8") == "preserve"
+    assert not list(output.parent.glob(".extracted.extract-*"))
+    assert not list(output.parent.glob(".extracted.previous-*"))
 
 
 def test_extract_archive_rejects_traversal_and_symlink(tmp_path: Path) -> None:

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -26,7 +26,11 @@ from mcp.types import LATEST_PROTOCOL_VERSION
 import codenib.mcp.server as server_module
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
-from codenib.mcp.tools.lsp import lsp_definition_impl, lsp_references_impl
+from codenib.mcp.tools.lsp import (
+    lsp_definition_impl,
+    lsp_references_impl,
+    lsp_route_impl,
+)
 
 
 def test_server_import_keeps_optional_index_runtimes_lazy() -> None:
@@ -61,6 +65,47 @@ def test_server_negotiates_modern_and_legacy_protocols() -> None:
         "search_bm25",
         "search_semantic",
     } <= modern_tools
+
+
+def test_search_tool_schemas_publish_bounded_inputs() -> None:
+    tools = {tool.name: tool for tool in asyncio.run(server_module.mcp.list_tools())}
+
+    for name in (
+        "search_context",
+        "search_semantic",
+        "search_bm25",
+        "search_regex",
+        "search_zoekt",
+    ):
+        schema = tools[name].input_schema
+        text_field = "pattern" if name == "search_regex" else "query"
+        assert schema["properties"][text_field]["minLength"] == 1
+        assert schema["properties"]["top_k"] == {
+            "default": 10 if name in {"search_context", "search_semantic"} else 20,
+            "maximum": 100,
+            "minimum": 1,
+            "title": "Top K",
+            "type": "integer",
+        }
+
+    semantic = tools["search_semantic"].input_schema["properties"]
+    assert semantic["level"]["enum"] == ["l0", "l2"]
+
+    dependency = tools["dependency_subgraph"].input_schema["properties"]
+    assert dependency["direction"]["enum"] == ["impact", "dependencies", "both"]
+    assert dependency["depth"]["minimum"] == 1
+    assert dependency["depth"]["maximum"] == 8
+    assert dependency["max_nodes"]["maximum"] == 100
+
+    route_symbols = tools["lsp_route"].input_schema["properties"]["symbols"]
+    assert route_symbols["minItems"] == 1
+    assert route_symbols["maxItems"] == 32
+    assert (
+        tools["lsp_definition"].input_schema["properties"]["line"]["anyOf"][0][
+            "minimum"
+        ]
+        == 1
+    )
 
 
 @pytest.fixture
@@ -240,17 +285,29 @@ def test_lsp_references_tool_delegates_to_core():
     assert kwargs["include_declaration"] is False
 
 
-def test_lsp_tools_reuse_agent_line_boundary():
-    """MCP LSP tools share the agent 1-based input boundary."""
+def test_lsp_tools_reject_zero_based_input_lines():
+    """MCP rejects malformed 0-based lines instead of silently clamping them."""
     ctx = MagicMock(symbol_graph=MagicMock())
     with patch(
         "codenib.agent.lsp_provider.StaticLSPProvider.definition"
     ) as mock_definition:
         mock_definition.return_value = []
 
-        lsp_definition_impl(ctx, file_path="caller.py", line=0)
+        with pytest.raises(ValueError, match="line must be between 1"):
+            lsp_definition_impl(ctx, file_path="caller.py", line=0)
 
-    assert mock_definition.call_args.kwargs["line"] == 0
+    mock_definition.assert_not_called()
+
+
+def test_lsp_tools_validate_result_and_seed_bounds():
+    ctx = MagicMock(symbol_graph=MagicMock())
+
+    with pytest.raises(ValueError, match="top_k must be between"):
+        lsp_references_impl(ctx, symbol="load_config", top_k=101)
+    with pytest.raises(ValueError, match="at least one non-empty seed"):
+        lsp_route_impl(ctx, symbols=[])
+    with pytest.raises(ValueError, match="at most 32 seeds"):
+        lsp_route_impl(ctx, symbols=[f"symbol_{index}" for index in range(33)])
 
 
 def test_server_status_resource(mock_manifest: Path):

--- a/test/mcp/test_search_semantic.py
+++ b/test/mcp/test_search_semantic.py
@@ -126,3 +126,23 @@ def test_search_semantic_empty_results(mock_context):
 
     assert results == []
     assert isinstance(results, list)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"query": ""}, "query must not be empty"),
+        ({"query": "test", "top_k": 0}, "top_k must be between"),
+        ({"query": "test", "top_k": 101}, "top_k must be between"),
+        ({"query": "test", "level": "l1"}, "level must be"),
+        (
+            {"query": "test", "score_threshold": float("nan")},
+            "score_threshold must be a finite number",
+        ),
+    ],
+)
+def test_search_semantic_validates_bounded_request(mock_context, kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        asyncio.run(search_semantic(mock_context, **kwargs))
+
+    mock_context.vector.search_with_content.assert_not_called()

--- a/test/mcp_server/test_dependency_tool.py
+++ b/test/mcp_server/test_dependency_tool.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import igraph as ig
+import pytest
 
 from codenib.graph.code_graph import CodeGraph
 from codenib.mcp.tools.dependency import dependency_subgraph_impl
@@ -32,6 +33,30 @@ def _graph() -> CodeGraph:
     return g
 
 
+def _dense_graph(size: int = 12) -> CodeGraph:
+    g = CodeGraph()
+    graph = ig.Graph(directed=True)
+    graph.add_vertices(size)
+    names = [f"hash{index}" for index in range(size)]
+    graph.vs["name"] = names
+    graph.vs["unified_name"] = [f"dense.py:node_{index}()" for index in range(size)]
+    graph.vs["type"] = ["function"] * size
+    graph.vs["file"] = ["dense.py"] * size
+    graph.vs["start_line"] = list(range(size))
+    graph.vs["end_line"] = list(range(size))
+    graph.add_edges(
+        (source, target)
+        for source in range(size)
+        for target in range(size)
+        if source != target
+    )
+    graph.es["type"] = ["reference"] * graph.ecount()
+    g.graph = graph
+    g.name_to_vertex = {name: index for index, name in enumerate(names)}
+    g._unified_to_names = {}
+    return g
+
+
 def test_impact_direction_returns_transitive_callers():
     ctx = SimpleNamespace(symbol_graph=_graph())
     out = dependency_subgraph_impl(ctx, "leaf", direction="impact", depth=3)
@@ -48,6 +73,53 @@ def test_both_direction_neighborhood():
     ctx = SimpleNamespace(symbol_graph=_graph())
     out = dependency_subgraph_impl(ctx, "mid", direction="both", depth=1)
     assert {n["name"] for n in out["nodes"]} == {"a.c:caller()", "b.c:leaf()"}
+
+
+def test_both_direction_honors_node_limit_without_dangling_edges():
+    ctx = SimpleNamespace(symbol_graph=_graph())
+
+    out = dependency_subgraph_impl(
+        ctx,
+        "mid",
+        direction="both",
+        depth=3,
+        max_nodes=2,
+    )
+
+    names = {out["root"], *(node["name"] for node in out["nodes"])}
+    assert len(out["nodes"]) == 1
+    assert out["truncated"] is True
+    assert all(
+        edge["source"] in names and edge["target"] in names for edge in out["edges"]
+    )
+
+
+def test_dependency_tool_caps_dense_edge_output():
+    out = dependency_subgraph_impl(
+        SimpleNamespace(symbol_graph=_dense_graph()),
+        "node_0",
+        direction="both",
+        depth=2,
+        max_nodes=10,
+    )
+
+    assert len(out["nodes"]) <= 9
+    assert len(out["edges"]) == 40
+    assert out["truncated"] is True
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"symbol": ""}, "symbol must not be empty"),
+        ({"symbol": "mid", "direction": "sideways"}, "direction must be"),
+        ({"symbol": "mid", "depth": 9}, "depth must be between"),
+        ({"symbol": "mid", "max_nodes": 101}, "max_nodes must be between"),
+    ],
+)
+def test_dependency_tool_validates_bounded_request(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        dependency_subgraph_impl(SimpleNamespace(symbol_graph=_graph()), **kwargs)
 
 
 def test_missing_graph_returns_error():

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -256,6 +256,20 @@ class TestSearchBM25:
         assert "file" not in results[0]
         assert "score" not in results[0]
 
+    @pytest.mark.parametrize(
+        ("query", "top_k", "message"),
+        [
+            ("", 10, "query must not be empty"),
+            ("tax", 0, "top_k must be between"),
+            ("tax", 101, "top_k must be between"),
+        ],
+    )
+    def test_validates_bounded_request(self, query, top_k, message) -> None:
+        mock_bm25 = MagicMock()
+        with pytest.raises(ValueError, match=message):
+            search_bm25_impl(_make_ctx(bm25=mock_bm25), query=query, top_k=top_k)
+        mock_bm25.search.assert_not_called()
+
 
 # ------------------------------------------------------------------
 # search_regex
@@ -327,6 +341,24 @@ class TestSearchRegex:
 
         with pytest.raises(RuntimeError, match="Invalid regex pattern"):
             search_regex_impl(ctx, pattern=r"[")
+
+    @pytest.mark.parametrize(
+        ("pattern", "top_k", "message"),
+        [
+            ("", 10, "pattern must not be empty"),
+            ("x", -1, "top_k must be between"),
+            ("x", 101, "top_k must be between"),
+        ],
+    )
+    def test_validates_bounded_request(self, pattern, top_k, message) -> None:
+        mock_regex = MagicMock()
+        with pytest.raises(ValueError, match=message):
+            search_regex_impl(
+                _make_ctx(regex_index=mock_regex),
+                pattern=pattern,
+                top_k=top_k,
+            )
+        mock_regex.search.assert_not_called()
 
 
 # ------------------------------------------------------------------
@@ -435,3 +467,21 @@ class TestSearchZoekt:
             RuntimeError, match="Zoekt search failed.*connection refused"
         ):
             search_zoekt_impl(ctx, query="x")
+
+    @pytest.mark.parametrize(
+        ("query", "top_k", "message"),
+        [
+            ("", 10, "query must not be empty"),
+            ("token", False, "top_k must be between"),
+            ("token", 101, "top_k must be between"),
+        ],
+    )
+    def test_validates_bounded_request(self, query, top_k, message) -> None:
+        mock_zoekt = MagicMock()
+        with pytest.raises(ValueError, match=message):
+            search_zoekt_impl(
+                _make_ctx(zoekt=mock_zoekt),
+                query=query,
+                top_k=top_k,
+            )
+        mock_zoekt.search.assert_not_called()


### PR DESCRIPTION
## Summary
Exercise the installed portable-artifact MCP path and harden user-visible contracts around packaging and serving repository context. Malformed tool calls cannot expand into unbounded responses, zero-argument packaging selects only portable current views, and failed artifact replacement preserves the last published output.

## Changes
- Validate non-empty search inputs, finite semantic thresholds, bounded result counts, graph depth, LSP positions, and route seed counts.
- Publish matching constraints in MCP JSON schemas so clients can reject invalid calls before dispatch.
- Honor `max_nodes` for bidirectional dependency traversal, preserve node/edge closure under truncation, and cap dense edge payloads.
- Default artifact packaging to the current BM25/vector intersection while preserving strict errors for explicitly requested unsupported views.
- Publish staged context artifacts and verified ZIP extractions without deleting the previous output before the final rename succeeds.
- Extend the installed-wheel release smoke through direct and portable-artifact MCP sessions and assert the published search bounds.
- Add failure-injection coverage for both artifact publication paths.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

After restacking onto `main`, targeted artifact/MCP/release coverage passes `129 passed`; the full unit tier passes `2930 passed, 10 skipped, 180 deselected`. Pre-commit passed for every changed file.

A production wheel smoke previously exercised Wiki startup, direct MCP, portable artifact pack/verify/rebind/query, bounded schema publication, and stale-checkout rejection.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published