### PR TITLE
test: enforce integration failure contracts

### DIFF
--- a/test/agent/test_vertex_ai.py
+++ b/test/agent/test_vertex_ai.py
@@ -9,6 +9,7 @@ Simple test script for Vertex AI LLM generation using LiteLLMChat.
 """
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -19,9 +20,20 @@ pytestmark = pytest.mark.slow
 
 @pytest.fixture(autouse=True)
 def require_vertex_credentials():
-    """Skip external provider tests unless Vertex credentials are explicit."""
-    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
-        pytest.skip("GOOGLE_APPLICATION_CREDENTIALS is not configured")
+    """Skip only when neither explicit nor application-default creds exist."""
+    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        return
+
+    cloud_config = Path(
+        os.environ.get("CLOUDSDK_CONFIG", Path.home() / ".config" / "gcloud")
+    )
+    adc_path = cloud_config / "application_default_credentials.json"
+    try:
+        has_adc = bool(adc_path.read_text(encoding="utf-8").strip())
+    except OSError:
+        has_adc = False
+    if not has_adc:
+        pytest.skip("Vertex application-default credentials are not configured")
 
 
 def test_vertex_ai_gemini():

--- a/test/agent/test_vertex_ai.py
+++ b/test/agent/test_vertex_ai.py
@@ -17,96 +17,68 @@ from codenib.llm.litellm_chat import LiteLLMChat, human_message
 pytestmark = pytest.mark.slow
 
 
+@pytest.fixture(autouse=True)
+def require_vertex_credentials():
+    """Skip external provider tests unless Vertex credentials are explicit."""
+    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        pytest.skip("GOOGLE_APPLICATION_CREDENTIALS is not configured")
+
+
 def test_vertex_ai_gemini():
     """Test that Vertex AI Gemini can successfully generate text."""
     print("Testing Vertex AI Gemini text generation...")
 
-    try:
-        llm = LiteLLMChat(
-            model="vertex_ai/gemini-2.5-flash",
-            temperature=0.7,
-            max_tokens=1024,
-        )
+    llm = LiteLLMChat(
+        model="vertex_ai/gemini-2.5-flash",
+        temperature=0.7,
+        max_tokens=1024,
+    )
 
-        response = llm.invoke(
-            [
-                human_message(
-                    "What is machine learning? Please provide a brief explanation."
-                )
-            ]
-        )
+    response = llm.invoke(
+        [human_message("What is machine learning? Please provide a brief explanation.")]
+    )
 
-        print(f"Response: {response}")
-
-        assert response, "Response content is empty"
-        assert len(response.strip()) > 0, "Response content is just whitespace"
-
-        print("Vertex AI Gemini generation test passed!\n")
-        return True
-
-    except Exception as e:
-        print(f"Vertex AI Gemini generation test failed: {e}")
-        return False
+    print(f"Response: {response}")
+    assert response, "Response content is empty"
+    assert response.strip(), "Response content is just whitespace"
 
 
 def test_vertex_ai_gemini_flash():
     """Test that Vertex AI Gemini Flash can successfully generate text."""
     print("Testing Vertex AI Gemini Flash text generation...")
 
-    try:
-        llm = LiteLLMChat(
-            model="vertex_ai/gemini-2.0-flash",
-            temperature=0.7,
-            max_tokens=150,
-        )
+    llm = LiteLLMChat(
+        model="vertex_ai/gemini-2.0-flash",
+        temperature=0.7,
+        max_tokens=150,
+    )
 
-        response = llm.invoke(
-            [
-                human_message(
-                    "How many R's are in the word 'strawberry'? Count carefully."
-                )
-            ]
-        )
+    response = llm.invoke(
+        [human_message("How many R's are in the word 'strawberry'? Count carefully.")]
+    )
 
-        print(f"Response: {response}")
-
-        assert response, "Response content is empty"
-        assert len(response.strip()) > 0, "Response content is just whitespace"
-
-        print("Vertex AI Gemini Flash generation test passed!\n")
-        return True
-
-    except Exception as e:
-        print(f"Vertex AI Gemini Flash generation test failed: {e}")
-        return False
+    print(f"Response: {response}")
+    assert response, "Response content is empty"
+    assert response.strip(), "Response content is just whitespace"
 
 
 def test_anthropic_vertex():
     """Test Vertex AI with Anthropic Claude model."""
     print("Testing Vertex AI with Anthropic Claude...")
 
-    try:
-        llm = LiteLLMChat(
-            model="vertex_ai/claude-sonnet-4@20250514",
-            temperature=0.7,
-            max_tokens=1024,
-        )
+    llm = LiteLLMChat(
+        model="vertex_ai/claude-sonnet-4@20250514",
+        temperature=0.7,
+        max_tokens=1024,
+    )
 
-        response = llm.invoke(
-            [human_message("What are the benefits of using cloud computing?")]
-        )
+    response = llm.invoke(
+        [human_message("What are the benefits of using cloud computing?")]
+    )
 
-        print(f"Response: {response}")
-
-        assert response, "Response content is empty"
-        assert len(response.strip()) > 0, "Response content is just whitespace"
-
-        print("Vertex AI Anthropic Claude test passed!\n")
-        return True
-
-    except Exception as e:
-        print(f"Vertex AI Anthropic Claude test failed: {e}")
-        return False
+    print(f"Response: {response}")
+    assert response, "Response content is empty"
+    assert response.strip(), "Response content is just whitespace"
 
 
 def print_config_info():
@@ -160,7 +132,13 @@ if __name__ == "__main__":
 
     for test_name, test_func in tests:
         print(f"Running {test_name} test...")
-        success = test_func()
+        try:
+            test_func()
+        except Exception as exc:  # pragma: no cover - standalone diagnostics
+            print(f"{test_name} failed: {exc}")
+            success = False
+        else:
+            success = True
         results.append((test_name, success))
         print("-" * 50)
 

--- a/test/graph/test_traverse_graph.py
+++ b/test/graph/test_traverse_graph.py
@@ -19,7 +19,6 @@ from codenib.types import (
     NODE_TYPE_FILE,
     NODE_TYPE_FUNCTION,
     NODE_TYPE_METHOD,
-    NODE_TYPE_SYMBOL,
 )
 
 pytestmark = pytest.mark.integration
@@ -38,237 +37,80 @@ def ensure_httpie_repo() -> Path:
     return HTTPIE_REPO_PATH
 
 
-def test_transgraph_simple(httpie_cli_repo=None, tmp_path_factory=None):
-    """Test traverse functions with the httpie CLI repository."""
+def _nodes_by_type(graph, node_type):
+    return [
+        vertex.attributes()
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("type") == node_type
+    ]
 
-    repo_path = httpie_cli_repo or ensure_httpie_repo()
-    if tmp_path_factory:
-        output_path = tmp_path_factory.mktemp("httpie_cli_transgraph")
-    else:
-        output_path = Path("/tmp") / "httpie_cli_transgraph"
-        output_path.mkdir(parents=True, exist_ok=True)
 
-    print(f"Testing with repository: {repo_path}")
-    print(f"Output directory: {output_path}")
+def run_traverse_graph_smoke(repo_path: Path, output_path: Path) -> None:
+    """Exercise indexing and graph traversal against a real Python repository."""
+    assert repo_path.is_dir(), f"Test repository not found: {repo_path}"
 
-    # Ensure the test repo exists
-    if not repo_path.exists():
-        print(f"Error: Test repository not found at {repo_path}")
-        return False
-
-    # Setup codegraph
-    repo_indexer = LSIndexer(repo_path, output_dir=output_path)
-
-    print("\n" + "=" * 50)
-    print("GENERATING SCIP INDEX")
-    print("=" * 50)
-
-    # Run the indexing pipeline
-    graph = repo_indexer.run_pipeline(
+    graph = LSIndexer(repo_path, output_dir=output_path).run_pipeline(
         project_name="httpie_cli_test", skip_level="graph"
     )
+    assert graph is not None, "LSIndexer did not produce a graph"
 
-    if not graph:
-        print("Failed to generate graph!")
-        return False
+    file_names = {node["name"] for node in _nodes_by_type(graph, NODE_TYPE_FILE)}
+    assert "httpie/core.py" in file_names
+    assert _nodes_by_type(graph, NODE_TYPE_CLASS)
+    assert _nodes_by_type(graph, NODE_TYPE_FUNCTION)
+    assert _nodes_by_type(graph, NODE_TYPE_METHOD)
+    assert _nodes_by_type(graph, NODE_TYPE_FIELD)
 
-    print("Graph generated successfully!")
+    root_file = "httpie/core.py"
+    target_function = "httpie/core.py:raw_main()"
+    downstream = traverse_tree_structure(
+        graph,
+        root_file,
+        direction="downstream",
+        hops=2,
+        node_type_filter=[NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD],
+    )
+    assert downstream.startswith(root_file)
+    assert target_function in downstream
+    assert EDGE_TYPE_CONTAIN in downstream
 
-    # Print basic graph info
-    print(f"\n--- Basic Graph Information ---")
-    graph.print_graph_basic_info()
+    searcher = RepoDependencySearcher(graph)
+    contain_nodes, contain_edges = searcher.get_neighbors(
+        root_file,
+        direction="forward",
+        etype_filter=[EDGE_TYPE_CONTAIN],
+    )
+    assert target_function in contain_nodes
+    assert contain_edges
+    assert all(edge[3]["type"] == EDGE_TYPE_CONTAIN for edge in contain_edges)
 
-    # Test traverse functionality
-    print("\n" + "=" * 50)
-    print("TESTING TRAVERSE FUNCTIONS")
-    print("=" * 50)
+    parent_nodes, parent_edges = searcher.get_neighbors(
+        target_function,
+        direction="backward",
+        ntype_filter=[NODE_TYPE_FILE],
+        etype_filter=[EDGE_TYPE_CONTAIN],
+    )
+    assert root_file in parent_nodes
+    assert any(
+        edge[0] == root_file and edge[1] == target_function for edge in parent_edges
+    )
 
-    dependency_searcher = RepoDependencySearcher(graph)
+    upstream = traverse_tree_structure(
+        graph,
+        target_function,
+        direction="upstream",
+        hops=1,
+        node_type_filter=[NODE_TYPE_FILE],
+        edge_type_filter=[EDGE_TYPE_CONTAIN],
+    )
+    assert upstream.startswith(target_function)
+    assert root_file in upstream
 
-    def nodes_by_type(ntype):
-        return [
-            v.attributes()
-            for v in graph.graph.vs
-            if "type" in v.attributes() and v["type"] == ntype
-        ]
 
-    # Get sample nodes
-    print("\n--- Getting sample nodes ---")
-    file_nodes = nodes_by_type(NODE_TYPE_FILE)
-    symbol_nodes = nodes_by_type(NODE_TYPE_SYMBOL)
-
-    print(f"Found {len(file_nodes)} file nodes")
-    print(f"Found {len(symbol_nodes)} symbol nodes")
-
-    if file_nodes:
-        print(f"Sample file nodes:")
-        for i, node in enumerate(file_nodes[:5]):
-            print(f"  {i+1}. {node['name']}")
-
-    if symbol_nodes:
-        print(f"Sample symbol nodes:")
-        for i, node in enumerate(symbol_nodes[:10]):
-            print(f"  {i+1}. {node['name']} (type: {node.get('type', 'unknown')})")
-
-    # Test specific symbol types
-    print("\n--- Testing specific symbol types ---")
-    class_nodes = nodes_by_type(NODE_TYPE_CLASS)
-    function_nodes = nodes_by_type(NODE_TYPE_FUNCTION)
-    method_nodes = nodes_by_type(NODE_TYPE_METHOD)
-    field_nodes = nodes_by_type(NODE_TYPE_FIELD)
-
-    print(f"Found {len(class_nodes)} class nodes")
-    print(f"Found {len(function_nodes)} function nodes")
-    print(f"Found {len(method_nodes)} method nodes")
-    print(f"Found {len(field_nodes)} field nodes")
-
-    if class_nodes:
-        print("Sample class nodes:")
-        for i, node in enumerate(class_nodes[:3]):
-            print(f"  {i+1}. {node['name']}")
-
-    if field_nodes:
-        print("Sample field nodes:")
-        for i, node in enumerate(field_nodes[:3]):
-            print(f"  {i+1}. {node['name']}")
-
-    # Test traverse_tree_structure
-    if file_nodes:
-        print(f"\n--- Testing traverse_tree_structure ---")
-
-        preferred_file = "httpie/core.py"
-        available_files = {node["name"] for node in file_nodes}
-        if preferred_file in available_files:
-            main_file = preferred_file
-        else:
-            main_file = file_nodes[0]["name"]
-
-        if main_file:
-
-            # Test downstream traversal
-            tree_result_downstream = traverse_tree_structure(
-                graph,
-                main_file,
-                direction="downstream",
-                hops=2,
-                node_type_filter=[
-                    NODE_TYPE_FILE,
-                    NODE_TYPE_CLASS,
-                    NODE_TYPE_FUNCTION,
-                    NODE_TYPE_METHOD,
-                ],
-                # edge_type_filter=[EDGE_TYPE_CONTAIN]
-            )
-            print("Tree structure (downstream, 2 hops):")
-            print(tree_result_downstream)
-
-            # Test with unlimited hops
-            tree_result_unlimited = traverse_tree_structure(
-                graph,
-                main_file,
-                direction="downstream",
-                hops=-1,  # Unlimited
-                node_type_filter=[
-                    NODE_TYPE_FILE,
-                    NODE_TYPE_CLASS,
-                    NODE_TYPE_FUNCTION,
-                    NODE_TYPE_METHOD,
-                ],
-            )
-            print(f"\nTree structure (downstream, unlimited hops):")
-            print(tree_result_unlimited)
-
-    # Test with a symbol node if available
-    if symbol_nodes:
-        print(f"\n--- Testing with Symbol Node ---")
-
-        target_symbol = next(
-            (node["name"] for node in symbol_nodes if "raw_main" in node["name"]),
-            symbol_nodes[0]["name"],
-        )
-
-        print(f"Symbol: {target_symbol}")
-
-        # Test upstream traversal
-        tree_result_upstream = traverse_tree_structure(
-            graph,
-            target_symbol,
-            direction="upstream",
-            hops=2,
-            node_type_filter=[NODE_TYPE_FILE, NODE_TYPE_SYMBOL],
-        )
-        print("Tree structure (upstream from symbol, 2 hops):")
-        print(tree_result_upstream)
-
-    # Basic node structure check (replaces RepoEntitySearcher coverage)
-    print(f"\n--- Node Attribute Inspection ---")
-    if file_nodes:
-        sample_file = file_nodes[0]
-        print(f"Sample file node: {sample_file}")
-
-    # Test RepoDependencySearcher functionality
-    print(f"\n--- Testing RepoDependencySearcher ---")
-
-    if file_nodes:
-        test_file = file_nodes[0]["name"]
-
-        # Get forward neighbors (what this file contains)
-        forward_nodes, forward_edges = dependency_searcher.get_neighbors(
-            test_file, direction="forward", ntype_filter=[NODE_TYPE_SYMBOL]
-        )
-        print(f"Forward neighbors of {test_file!r}: {len(forward_nodes)} nodes")
-        if forward_nodes:
-            print("Forward neighbors:")
-            for node in forward_nodes[:5]:
-                print(f"  - {node}")
-
-        print(f"Forward edges: {len(forward_edges)}")
-        if forward_edges:
-            print("Forward edges:")
-            for edge in forward_edges[:5]:
-                print(f"  - {edge[0]} -> {edge[1]} ({edge[3]['type']})")
-
-    # Test with symbol nodes
-    if symbol_nodes:
-        test_symbol = symbol_nodes[0]["name"]
-
-        # Get backward neighbors (what contains this symbol)
-        backward_nodes, backward_edges = dependency_searcher.get_neighbors(
-            test_symbol, direction="backward", ntype_filter=[NODE_TYPE_FILE]
-        )
-        print(f"\nBackward neighbors of {test_symbol!r}: {len(backward_nodes)} nodes")
-        if backward_nodes:
-            print("Backward neighbors:")
-            for node in backward_nodes:
-                print(f"  - {node}")
-
-        print(f"Backward edges: {len(backward_edges)}")
-        if backward_edges:
-            print("Backward edges:")
-            for edge in backward_edges:
-                print(f"  - {edge[0]} -> {edge[1]} ({edge[3]['type']})")
-
-    # Test edge filtering
-    print(f"\n--- Testing Edge Filtering ---")
-    if file_nodes:
-        test_file = file_nodes[0]["name"]
-        contain_nodes, contain_edges = dependency_searcher.get_neighbors(
-            test_file, direction="forward", etype_filter=[EDGE_TYPE_CONTAIN]
-        )
-        print(f"Nodes connected via {EDGE_TYPE_CONTAIN!r} edges: {len(contain_nodes)}")
-        if contain_nodes:
-            for node in contain_nodes[:3]:
-                print(f"  - {node}")
-
-    print(f"\n--- Test Summary ---")
-    print(f"✅ Graph indexing: SUCCESS")
-    print(f"✅ Entity searching: SUCCESS")
-    print(f"✅ Dependency searching: SUCCESS")
-    print(f"✅ Tree traversal: SUCCESS")
-    print(f"✅ Node filtering: SUCCESS")
-    print(f"✅ Edge filtering: SUCCESS")
-
-    return True
+def test_transgraph_simple(httpie_cli_repo, tmp_path_factory):
+    """Index a pinned checkout and verify traversal contracts end to end."""
+    output_path = tmp_path_factory.mktemp("httpie_cli_transgraph")
+    run_traverse_graph_smoke(httpie_cli_repo, output_path)
 
 
 # Example usage
@@ -277,11 +119,7 @@ if __name__ == "__main__":
     setup_detailed_logging(
         log_dir="logs", run_name="httpie_cli_test", mode="both", level="scip_debug"
     )
-    success = test_transgraph_simple()
-
-    if success:
-        print("\n🎉 All tests completed successfully!")
-
-    else:
-        print("\n❌ Some tests failed!")
-        exit(1)
+    standalone_output = Path("/tmp") / "httpie_cli_transgraph"
+    standalone_output.mkdir(parents=True, exist_ok=True)
+    run_traverse_graph_smoke(ensure_httpie_repo(), standalone_output)
+    print("\nAll tests completed successfully.")

--- a/test/index/test_dense_compatibility.py
+++ b/test/index/test_dense_compatibility.py
@@ -4,9 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test to check if all dense chunk node_ids exist in BM25 graph nodes."""
-
-import warnings
+"""Check that dense chunks can be joined to BM25 documents by node ID."""
 
 import pytest
 
@@ -31,21 +29,6 @@ def test_dense_compatibility(httpie_cli_repo, tmp_path_factory):
     if not graph:
         pytest.fail("Failed to create BM25 graph")
 
-    # target_file = "httpie/cookies.py"
-    # target_nodes = []
-    # for vertex in graph.graph.vs:
-    #     attrs = vertex.attributes()
-    #     if vertex["name"] == target_file or attrs.get("file") == target_file:
-    #         target_nodes.append(
-    #             {
-    #                 "name": vertex["name"],
-    #                 "type": attrs.get("type"),
-    #                 "start_line": attrs.get("start_line"),
-    #                 "end_line": attrs.get("end_line"),
-    #             }
-    #         )
-    # print(f"Graph nodes for {target_file}: {target_nodes}")
-
     bm25_indexer = BM25CodeIndexer(code_graph=graph)
     bm25_node_ids = {
         doc.metadata.get("node_id")
@@ -61,24 +44,10 @@ def test_dense_compatibility(httpie_cli_repo, tmp_path_factory):
 
     dense_node_ids = {chunk.node_id for chunk in chunks if chunk.node_id}
 
-    compatible_ids = dense_node_ids.intersection(bm25_node_ids)
     missing_ids = dense_node_ids - bm25_node_ids
-    extra_bm25_ids = bm25_node_ids - dense_node_ids
-
-    compatibility_rate = (
-        len(compatible_ids) / len(dense_node_ids) * 100 if dense_node_ids else 0
-    )
-
+    assert dense_node_ids, "Dense chunking produced no addressable chunks"
+    assert bm25_node_ids, "BM25 indexing produced no addressable documents"
     assert not missing_ids, (
-        "Found dense node IDs missing in BM25: "
-        f"{sorted(missing_ids)} (compatibility={compatibility_rate:.1f}%)"
+        f"{len(missing_ids)}/{len(dense_node_ids)} dense node IDs are missing "
+        f"from BM25; sample={sorted(missing_ids)[:10]}"
     )
-
-    # Report extra BM25 IDs as context rather than failing the test. Some indices
-    # may contain auxiliary nodes that dense chunking intentionally omits.
-    if extra_bm25_ids:
-        warnings.warn(
-            f"BM25 contains node IDs without dense chunks: {sorted(extra_bm25_ids)}",
-            UserWarning,
-            stacklevel=1,
-        )


### PR DESCRIPTION
## Summary
Make integration and provider smoke tests fail on real regressions instead of returning or logging success, while removing an expected unbounded compatibility warning.

## Changes
- Assert pinned HTTPie graph indexing, containment edges, and bidirectional traversal results.
- Skip Vertex tests only when neither explicit nor application-default credentials are configured, and surface provider errors when configured.
- Express dense/BM25 identity compatibility as a non-empty subset contract with bounded failure diagnostics.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- unit tier (2816 passed, 10 skipped)
- `pytest -m "integration and not slow" --tb=short -W error::pytest.PytestReturnNotNoneWarning -W error::UserWarning --timeout=600` (36 passed, 14 skipped)
- credential-free Vertex path (3 skipped)
- `pre-commit run --files ...`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
