### PR TITLE
fix(index): respect embedding position capacity

### DIFF
--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -126,10 +126,21 @@ class _HuggingFaceEmbeddingWrapper:
         self, model_name: str, max_seq_length: Optional[int]
     ) -> None:
         """Cap tokenizer input to the model's usable position capacity."""
+        if max_seq_length is not None and (
+            isinstance(max_seq_length, bool)
+            or not isinstance(max_seq_length, int)
+            or max_seq_length <= 0
+        ):
+            raise ValueError("max_seq_length must be a positive integer")
+
+        effective_max = max_seq_length
         try:
-            tok = self._model.tokenizer
             auto_model = self._model[0].auto_model
-            max_pos = getattr(auto_model.config, "max_position_embeddings", None)
+            max_pos = getattr(
+                getattr(auto_model, "config", None),
+                "max_position_embeddings",
+                None,
+            )
 
             # RoBERTa-derived models number non-padding positions after their
             # padding index. Their embedding table can therefore hold fewer
@@ -145,46 +156,67 @@ class _HuggingFaceEmbeddingWrapper:
             capacities = [
                 value
                 for value in (max_pos, table_size)
-                if isinstance(value, int) and value > 0
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0
             ]
             model_capacity = min(capacities) if capacities else None
             padding_idx = getattr(position_embeddings, "padding_idx", None)
             if (
                 isinstance(model_capacity, int)
                 and isinstance(padding_idx, int)
+                and not isinstance(padding_idx, bool)
                 and padding_idx >= 0
             ):
                 model_capacity -= padding_idx + 1
 
-            effective_max = max_seq_length
             if isinstance(model_capacity, int) and model_capacity > 0:
                 effective_max = (
                     min(max_seq_length, model_capacity)
                     if max_seq_length is not None
                     else model_capacity
                 )
-            if effective_max:
-                if tok.model_max_length > effective_max:
-                    tok.model_max_length = effective_max
-                if self._model.max_seq_length > effective_max:
-                    logger.info(
-                        "Capping max_seq_length from %s to %s for model %s",
-                        self._model.max_seq_length,
-                        effective_max,
-                        model_name,
-                    )
-                    self._model.max_seq_length = effective_max
         except Exception as e:
             if max_seq_length is not None:
                 logger.warning(
-                    "--max-seq-length %s was requested but could not be "
-                    "applied to model %s: %s. CUDA OOM may occur.",
-                    max_seq_length,
+                    "Could not inspect position capacity for model %s: %s. "
+                    "Applying requested --max-seq-length %s as a best-effort cap.",
                     model_name,
                     e,
+                    max_seq_length,
                 )
             else:
-                logger.debug("Could not check tokenizer max length: %s", e)
+                logger.debug("Could not inspect tokenizer position capacity: %s", e)
+
+        if effective_max is None:
+            return
+
+        failures = []
+        try:
+            tok = self._model.tokenizer
+            if tok.model_max_length > effective_max:
+                tok.model_max_length = effective_max
+        except Exception as e:
+            failures.append(f"tokenizer: {e}")
+
+        try:
+            if self._model.max_seq_length > effective_max:
+                logger.info(
+                    "Capping max_seq_length from %s to %s for model %s",
+                    self._model.max_seq_length,
+                    effective_max,
+                    model_name,
+                )
+                self._model.max_seq_length = effective_max
+        except Exception as e:
+            failures.append(f"sentence transformer: {e}")
+
+        if failures:
+            logger.warning(
+                "Sequence-length cap %s could not be fully applied to model %s "
+                "(%s). CUDA OOM or position-index errors may occur.",
+                effective_max,
+                model_name,
+                "; ".join(failures),
+            )
 
     def _build_encode_kwargs(
         self,

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -125,15 +125,38 @@ class _HuggingFaceEmbeddingWrapper:
     def _apply_max_seq_length(
         self, model_name: str, max_seq_length: Optional[int]
     ) -> None:
-        """Cap tokeniser / model sequence length to prevent OOM."""
+        """Cap tokenizer input to the model's usable position capacity."""
         try:
             tok = self._model.tokenizer
-            max_pos = getattr(
-                self._model[0].auto_model.config,
-                "max_position_embeddings",
+            auto_model = self._model[0].auto_model
+            max_pos = getattr(auto_model.config, "max_position_embeddings", None)
+            model_capacity = max_pos
+
+            # RoBERTa-derived models number non-padding positions after their
+            # padding index. Their embedding table can therefore hold fewer
+            # input tokens than ``max_position_embeddings`` suggests. For
+            # example, UniXcoder advertises 1026 positions but accepts 1024
+            # tokens (including special tokens).
+            position_embeddings = getattr(
+                getattr(auto_model, "embeddings", None),
+                "position_embeddings",
                 None,
             )
-            effective_max = max_seq_length or max_pos
+            padding_idx = getattr(position_embeddings, "padding_idx", None)
+            if (
+                isinstance(model_capacity, int)
+                and isinstance(padding_idx, int)
+                and padding_idx >= 0
+            ):
+                model_capacity -= padding_idx + 1
+
+            effective_max = max_seq_length
+            if isinstance(model_capacity, int) and model_capacity > 0:
+                effective_max = (
+                    min(max_seq_length, model_capacity)
+                    if max_seq_length is not None
+                    else model_capacity
+                )
             if effective_max:
                 if tok.model_max_length > effective_max:
                     tok.model_max_length = effective_max

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -130,7 +130,6 @@ class _HuggingFaceEmbeddingWrapper:
             tok = self._model.tokenizer
             auto_model = self._model[0].auto_model
             max_pos = getattr(auto_model.config, "max_position_embeddings", None)
-            model_capacity = max_pos
 
             # RoBERTa-derived models number non-padding positions after their
             # padding index. Their embedding table can therefore hold fewer
@@ -142,6 +141,13 @@ class _HuggingFaceEmbeddingWrapper:
                 "position_embeddings",
                 None,
             )
+            table_size = getattr(position_embeddings, "num_embeddings", None)
+            capacities = [
+                value
+                for value in (max_pos, table_size)
+                if isinstance(value, int) and value > 0
+            ]
+            model_capacity = min(capacities) if capacities else None
             padding_idx = getattr(position_embeddings, "padding_idx", None)
             if (
                 isinstance(model_capacity, int)

--- a/test/index/test_embedding_sequence_length.py
+++ b/test/index/test_embedding_sequence_length.py
@@ -37,6 +37,15 @@ class _FakeSentenceTransformer:
         return self._transformer
 
 
+class _UnavailableModelMetadata:
+    def __init__(self):
+        self.tokenizer = SimpleNamespace(model_max_length=4096)
+        self.max_seq_length = 4096
+
+    def __getitem__(self, index):
+        raise RuntimeError("model metadata is unavailable")
+
+
 @pytest.mark.parametrize(
     ("max_positions", "position_padding_idx", "requested", "expected"),
     [
@@ -73,3 +82,22 @@ def test_huggingface_sequence_length_uses_the_loaded_embedding_table(
 
     assert wrapper._model.tokenizer.model_max_length == 1024
     assert wrapper._model.max_seq_length == 1024
+
+
+def test_huggingface_sequence_length_applies_explicit_cap_without_metadata():
+    wrapper = _HuggingFaceEmbeddingWrapper.__new__(_HuggingFaceEmbeddingWrapper)
+    wrapper._model = _UnavailableModelMetadata()
+
+    wrapper._apply_max_seq_length("test/model", 128)
+
+    assert wrapper._model.tokenizer.model_max_length == 128
+    assert wrapper._model.max_seq_length == 128
+
+
+@pytest.mark.parametrize("requested", [0, -1, True, 128.5, "128"])
+def test_huggingface_sequence_length_rejects_invalid_explicit_cap(requested):
+    wrapper = _HuggingFaceEmbeddingWrapper.__new__(_HuggingFaceEmbeddingWrapper)
+    wrapper._model = _FakeSentenceTransformer(1026, 1)
+
+    with pytest.raises(ValueError, match="positive integer"):
+        wrapper._apply_max_seq_length("test/model", requested)

--- a/test/index/test_embedding_sequence_length.py
+++ b/test/index/test_embedding_sequence_length.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from codenib.index.embedding.vector_store import _HuggingFaceEmbeddingWrapper
+
+
+class _FakeSentenceTransformer:
+    def __init__(self, max_positions, position_padding_idx):
+        self.tokenizer = SimpleNamespace(model_max_length=10**30)
+        self.max_seq_length = max_positions
+        position_embeddings = SimpleNamespace(padding_idx=position_padding_idx)
+        auto_model = SimpleNamespace(
+            config=SimpleNamespace(max_position_embeddings=max_positions),
+            embeddings=SimpleNamespace(position_embeddings=position_embeddings),
+        )
+        self._transformer = SimpleNamespace(auto_model=auto_model)
+
+    def __getitem__(self, index):
+        assert index == 0
+        return self._transformer
+
+
+@pytest.mark.parametrize(
+    ("max_positions", "position_padding_idx", "requested", "expected"),
+    [
+        (512, None, None, 512),
+        (1026, 1, None, 1024),
+        (1026, 1, 256, 256),
+        (1026, 1, 2048, 1024),
+    ],
+)
+def test_huggingface_sequence_length_respects_position_capacity(
+    max_positions, position_padding_idx, requested, expected
+):
+    wrapper = _HuggingFaceEmbeddingWrapper.__new__(_HuggingFaceEmbeddingWrapper)
+    wrapper._model = _FakeSentenceTransformer(max_positions, position_padding_idx)
+
+    wrapper._apply_max_seq_length("test/model", requested)
+
+    assert wrapper._model.tokenizer.model_max_length == expected
+    assert wrapper._model.max_seq_length == expected

--- a/test/index/test_embedding_sequence_length.py
+++ b/test/index/test_embedding_sequence_length.py
@@ -10,10 +10,22 @@ from codenib.index.embedding.vector_store import _HuggingFaceEmbeddingWrapper
 
 
 class _FakeSentenceTransformer:
-    def __init__(self, max_positions, position_padding_idx):
+    def __init__(
+        self,
+        max_positions,
+        position_padding_idx,
+        *,
+        embedding_positions=None,
+    ):
         self.tokenizer = SimpleNamespace(model_max_length=10**30)
-        self.max_seq_length = max_positions
-        position_embeddings = SimpleNamespace(padding_idx=position_padding_idx)
+        table_size = (
+            embedding_positions if embedding_positions is not None else max_positions
+        )
+        self.max_seq_length = max_positions or table_size
+        position_embeddings = SimpleNamespace(
+            num_embeddings=table_size,
+            padding_idx=position_padding_idx,
+        )
         auto_model = SimpleNamespace(
             config=SimpleNamespace(max_position_embeddings=max_positions),
             embeddings=SimpleNamespace(position_embeddings=position_embeddings),
@@ -44,3 +56,20 @@ def test_huggingface_sequence_length_respects_position_capacity(
 
     assert wrapper._model.tokenizer.model_max_length == expected
     assert wrapper._model.max_seq_length == expected
+
+
+@pytest.mark.parametrize("configured_positions", [None, 4096])
+def test_huggingface_sequence_length_uses_the_loaded_embedding_table(
+    configured_positions,
+):
+    wrapper = _HuggingFaceEmbeddingWrapper.__new__(_HuggingFaceEmbeddingWrapper)
+    wrapper._model = _FakeSentenceTransformer(
+        configured_positions,
+        1,
+        embedding_positions=1026,
+    )
+
+    wrapper._apply_max_seq_length("test/model", None)
+
+    assert wrapper._model.tokenizer.model_max_length == 1024
+    assert wrapper._model.max_seq_length == 1024

--- a/test/index/test_vector_store.py
+++ b/test/index/test_vector_store.py
@@ -118,6 +118,9 @@ def test_vector_store_with_huggingface(tmp_path):
     )
     try:
         assert vector_store.embedding.client.max_seq_length <= 1024
+        long_query_embedding = vector_store.embedding.embed_query("identifier " * 2048)
+        assert len(long_query_embedding) == 768
+
         chunks = create_sample_code_chunks()
         vector_store.add_code_chunks(chunks)
         assert vector_store.get_stats()["total_documents"] == len(chunks)

--- a/test/index/test_vector_store.py
+++ b/test/index/test_vector_store.py
@@ -4,14 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Test script for the CodeVectorStore functionality.
-Demonstrates how to use the vector store for semantic search over code chunks.
-"""
-
-import subprocess
-import sys
-from pathlib import Path
+"""Slow end-to-end tests for HuggingFace-backed semantic search."""
 
 import pytest
 
@@ -19,23 +12,6 @@ from codenib.code_chunking import create_chunker
 from codenib.index import create_code_vector_store
 
 pytestmark = pytest.mark.slow
-
-HTTPIE_REPO_URL = "https://github.com/httpie/cli.git"
-HTTPIE_REPO_PATH = Path("/tmp/httpie-cli")
-
-
-def ensure_httpie_repo() -> Path:
-    """Clone the httpie/cli repository if needed and return its path."""
-    if not HTTPIE_REPO_PATH.exists():
-        subprocess.run(
-            ["git", "clone", "--depth", "1", HTTPIE_REPO_URL, str(HTTPIE_REPO_PATH)],
-            check=True,
-        )
-    return HTTPIE_REPO_PATH
-
-
-# Add the parent directory to the path to import codenib modules
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 def create_sample_code_chunks():
@@ -132,130 +108,65 @@ MAX_RETRIES = 3""",
     return chunks
 
 
-def test_vector_store_with_huggingface():
+def test_vector_store_with_huggingface(tmp_path):
     """Test vector store with HuggingFace embeddings."""
-    print("\n=== Testing CodeVectorStore with UniXcoder Embeddings ===")
-
+    vector_store = create_code_vector_store(
+        embedding_model="microsoft/unixcoder-base",
+        embedding_provider="huggingface",
+        dimension=768,
+        store_path=str(tmp_path / "unixcoder"),
+    )
     try:
-        # Create vector store with UniXcoder embeddings
-        vector_store = create_code_vector_store(
-            embedding_model="microsoft/unixcoder-base",
-            embedding_provider="huggingface",
-            dimension=768,  # UniXcoder dimension
-            store_path="./test_vector_store_unixcoder",
-        )
-
-        # Add sample code chunks
         chunks = create_sample_code_chunks()
         vector_store.add_code_chunks(chunks)
+        assert vector_store.get_stats()["total_documents"] == len(chunks)
 
-        print(f"Added {len(chunks)} code chunks to UniXcoder vector store")
-        print(f"Vector store stats: {vector_store.get_stats()}")
-
-        # Test search
-        test_queries = [
+        for query in [
             "fibonacci recursive function",
             "binary tree class",
             "sorting quicksort",
-        ]
-
-        for query in test_queries:
-            print(f"\nSearching for: {query!r}")
-            results = vector_store.search(query, top_k=5)  # Show all results
-
-            for i, result in enumerate(results, 1):
-                print(f"  {i}. {result.node_name} (score: {result.score:.4f})")
-                print(f"     Type: {result.type}")
-
-        print("✅ UniXcoder vector store test completed successfully!")
-
-    except Exception as e:
-        print(f"❌ HuggingFace test failed: {e}")
-        print(
-            "Note: You may need to install additional dependencies for HuggingFace embeddings"
-        )
+        ]:
+            results = vector_store.search(query, top_k=len(chunks))
+            assert results, f"Semantic search returned no results for {query!r}"
+            assert len(results) == len(chunks)
+    finally:
+        vector_store.close()
 
 
-def test_with_real_code_chunks(httpie_cli_repo=None):
+def test_with_real_code_chunks(httpie_cli_repo, tmp_path):
     """Test with real code chunks from the httpie CLI repository."""
-    print("\n=== Testing with Real Code Chunks ===")
+    sample_file = httpie_cli_repo / "httpie" / "core.py"
+    assert sample_file.is_file()
 
+    chunks = create_chunker("python").chunk_file(str(sample_file))
+    assert chunks, "Chunking httpie/core.py produced no chunks"
+
+    chunk_dicts = [
+        {
+            "content": chunk.content,
+            "chunk_type": chunk.chunk_type,
+            "name": chunk.name,
+            "file": chunk.file,
+            "start_line": chunk.start_line,
+            "end_line": chunk.end_line,
+            "node_id": chunk.node_id,
+        }
+        for chunk in chunks
+    ]
+
+    vector_store = create_code_vector_store(
+        embedding_model="microsoft/unixcoder-base",
+        embedding_provider="huggingface",
+        dimension=768,
+        store_path=str(tmp_path / "real-unixcoder"),
+    )
     try:
-        repo_path = httpie_cli_repo or ensure_httpie_repo()
-        sample_file = repo_path / "httpie" / "core.py"
-        if not sample_file.exists():
-            print(f"Target file not found: {sample_file}")
-            return
-
-        # Create chunker and chunk the file
-        chunker = create_chunker("python")
-        chunks = chunker.chunk_file(str(sample_file))
-
-        if not chunks:
-            print("No chunks generated from httpie/core.py")
-            return
-
-        print(f"Generated {len(chunks)} chunks from {sample_file}")
-
-        # Convert chunks to dict format
-        chunk_dicts = []
-        for chunk in chunks:
-            chunk_dict = {
-                "content": chunk.content,
-                "chunk_type": chunk.chunk_type,
-                "name": chunk.name,
-                "file": chunk.file,
-                "start_line": chunk.start_line,
-                "end_line": chunk.end_line,
-                "node_id": chunk.node_id,
-            }
-            chunk_dicts.append(chunk_dict)
-
-        # Create vector store with UniXcoder embeddings
-        vector_store = create_code_vector_store(
-            embedding_model="microsoft/unixcoder-base",
-            embedding_provider="huggingface",
-            dimension=768,
-            store_path="./test_vector_store_real_unixcoder",
-        )
-
-        # Add chunks
         vector_store.add_code_chunks(chunk_dicts)
+        assert vector_store.get_stats()["total_documents"] == len(chunk_dicts)
 
-        # Test search
-        search_queries = [
-            "raw_main",
-            "Environment",
-        ]
-
-        for query in search_queries:
-            print(f"\nSearching for: {query!r}")
+        for query in ["raw_main", "Environment"]:
             results = vector_store.search(query, top_k=3)
-
-            for i, result in enumerate(results, 1):
-                print(f"  {i}. {result.node_name} (score: {result.score:.4f})")
-                print(
-                    f"     Type: {result.type}, Lines: {result.start_line}-{result.end_line}"
-                )
-
-        print("✅ Real code chunks test completed successfully!")
-
-    except Exception as e:
-        print(f"❌ Real code chunks test failed: {e}")
-
-
-def main():
-    """Main test function."""
-    print("Testing CodeVectorStore functionality...\n")
-
-    # Test with sample chunks
-    test_vector_store_with_huggingface()
-
-    # Test with real code chunks
-    test_with_real_code_chunks()
-
-    print("\n🎉 All vector store tests completed!")
-
-
-if __name__ == "__main__":
-    main()
+            assert results, f"Semantic search returned no results for {query!r}"
+            assert len(results) <= 3
+    finally:
+        vector_store.close()

--- a/test/index/test_vector_store.py
+++ b/test/index/test_vector_store.py
@@ -117,6 +117,7 @@ def test_vector_store_with_huggingface(tmp_path):
         store_path=str(tmp_path / "unixcoder"),
     )
     try:
+        assert vector_store.embedding.client.max_seq_length <= 1024
         chunks = create_sample_code_chunks()
         vector_store.add_code_chunks(chunks)
         assert vector_store.get_stats()["total_documents"] == len(chunks)


### PR DESCRIPTION
## Summary
Prevent HuggingFace semantic indexing from exceeding a transformer's usable position-embedding capacity. This fixes a real `IndexError` when embedding long repository chunks with UniXcoder.

## Changes
- Derive usable token capacity from both model configuration and the loaded position table, including its padding offset.
- Clamp explicit `max_seq_length` requests to the model capacity.
- Add unit coverage for BERT-like, RoBERTa-like, missing-config, and stale-config limits.
- Convert the HuggingFace slow smoke into asserted synthetic and real-repository tests using temporary storage, including the applied UniXcoder limit.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- capacity and CPU-backed UniXcoder tier (8 passed)
- focused index/compiler/provider tier (367 passed)
- full unit tier before the final capacity hardening (2812 passed, 10 skipped)
- `pre-commit run --files ...`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
