### PR TITLE
fix(index): preserve portable vector identities

### DIFF
--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -230,6 +230,27 @@ def _to_document(obj: Any) -> _Document:
     )
 
 
+def _result_source_file(metadata: Dict[str, Any]) -> str:
+    """Prefer the repository-relative file identity encoded in ``node_id``."""
+    raw_file = str(metadata.get("file") or "").replace("\\", "/")
+    node_id = str(metadata.get("node_id") or "").replace("\\", "/")
+    if not raw_file or not node_id:
+        return raw_file
+
+    # ``chunk_file`` can be used outside a repository and then carries the
+    # same absolute path in both fields. Preserve that direct-file contract.
+    if node_id == raw_file or node_id.startswith(f"{raw_file}:"):
+        return raw_file
+
+    node_file = node_id.split(":", 1)[0].removeprefix("./")
+    comparable_file = raw_file.removeprefix("./")
+    if node_file and (
+        comparable_file == node_file or comparable_file.endswith(f"/{node_file}")
+    ):
+        return node_file
+    return raw_file
+
+
 class CodeVectorStore:
     """
     Vector store for code embeddings using FAISS and sentence-transformers.
@@ -704,7 +725,7 @@ class CodeVectorStore:
             node_with_score = NodeInfo(
                 node_name=metadata.get("name", "unknown"),
                 type=metadata.get("chunk_type", "unknown"),
-                file=metadata.get("file", ""),
+                file=_result_source_file(metadata),
                 node_id=metadata.get("node_id", ""),
                 start_line=metadata.get("start_line", 0),
                 end_line=metadata.get("end_line", 0),
@@ -764,7 +785,7 @@ class CodeVectorStore:
             node_with_content = NodeInfo(
                 node_name=metadata.get("name", "unknown"),
                 type=metadata.get("chunk_type", "unknown"),
-                file=metadata.get("file", ""),
+                file=_result_source_file(metadata),
                 node_id=metadata.get("node_id", ""),
                 start_line=metadata.get("start_line", 0),
                 end_line=metadata.get("end_line", 0),
@@ -844,7 +865,7 @@ class CodeVectorStore:
                 NodeInfo(
                     node_name=metadata.get("name", "unknown"),
                     type=metadata.get("chunk_type", "unknown"),
-                    file=metadata.get("file", ""),
+                    file=_result_source_file(metadata),
                     node_id=metadata.get("node_id", ""),
                     start_line=metadata.get("start_line", 0),
                     end_line=metadata.get("end_line", 0),

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -979,13 +979,23 @@ class CodeVectorStore:
 
         model_suffix = self.embedding_model.replace("/", "__")
 
-        # Save L0
-        if self.l0_index is not None and self.l0_documents:
-            self._save_level(save_path, "l0", model_suffix)
+        level_state = {}
+        for level in ("l0", "l2"):
+            index, documents = self._get_index_and_docs(level)
+            if documents:
+                if index is None or int(index.ntotal) != len(documents):
+                    vector_count = 0 if index is None else int(index.ntotal)
+                    raise ValueError(
+                        f"Cannot save misaligned {level} vector store: "
+                        f"{vector_count} vectors for {len(documents)} documents"
+                    )
+            level_state[level] = (index, documents)
 
-        # Save L2
-        if self.l2_index is not None and self.l2_documents:
-            self._save_level(save_path, "l2", model_suffix)
+        for level, (_index, documents) in level_state.items():
+            if documents:
+                self._save_level(save_path, level, model_suffix)
+            else:
+                self._remove_level_files(save_path, level, model_suffix)
 
         # Save top-level configuration
         config_path = save_path / f"config_{model_suffix}.json"
@@ -1004,6 +1014,24 @@ class CodeVectorStore:
             json.dump(config, f, indent=2)
 
         logger.info("Vector store saved successfully")
+
+    @staticmethod
+    def _remove_level_files(save_path: Path, level: str, model_suffix: str) -> None:
+        """Remove persisted files when a vector level becomes empty."""
+
+        level_path = save_path / level
+        for name in (
+            f"config_{model_suffix}.json",
+            f"index_{model_suffix}.faiss",
+            f"documents_{model_suffix}.pkl",
+            f"documents_{model_suffix}.json",
+            f"index_{model_suffix}.pkl",
+        ):
+            (level_path / name).unlink(missing_ok=True)
+        try:
+            level_path.rmdir()
+        except OSError:
+            pass
 
     def _save_level(self, save_path: Path, level: str, model_suffix: str) -> None:
         """Save a single level (l0 or l2) to disk."""

--- a/codenib/index/incremental/index_updater.py
+++ b/codenib/index/incremental/index_updater.py
@@ -225,13 +225,14 @@ class IncrementalIndexUpdater:
                     embeddings_cache.put(vc.content_hash, vec)
                     hits.append((vc, vec))
 
-            # Rebuild FAISS for this level (delta when possible)
-            if hits:
-                documents, embeddings = self._build_doc_embedding_pairs(hits)
-                changed_hashes = {vc.content_hash for vc in misses}
-                vector_store.delta_update(
-                    documents, embeddings, changed_hashes, level=level
-                )
+            # Rebuild FAISS for this level (delta when possible).  Empty target
+            # levels must still reach the vector store so pure deletions clear
+            # the previous index rather than leaving ghost documents behind.
+            documents, embeddings = self._build_doc_embedding_pairs(hits)
+            changed_hashes = {vc.content_hash for vc in misses}
+            vector_store.delta_update(
+                documents, embeddings, changed_hashes, level=level
+            )
 
         result.total_chunks = chunk_store.chunk_count()
         result.chunks_from_cache = total_from_cache

--- a/codenib/index/incremental/index_updater.py
+++ b/codenib/index/incremental/index_updater.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
@@ -142,10 +143,20 @@ class IncrementalIndexUpdater:
             return result
 
         # ---- Step 2: rechunk affected files (L2 + optional L0) ----------
+        repo_root = Path(repo_path).resolve()
         for file_path in changes.affected:
+            try:
+                relative_path = Path(file_path).relative_to(repo_root).as_posix()
+            except ValueError as exc:
+                raise ValueError(
+                    f"Changed source file is outside the repository: {file_path}"
+                ) from exc
+
             # L2 rechunk
             try:
-                new_chunks = self._chunker.chunk_file(file_path)
+                new_chunks = self._chunker.chunk_file(
+                    file_path, relative_path=relative_path
+                )
             except Exception as exc:
                 logger.warning("Failed to L2-chunk %s: %s", file_path, exc)
                 new_chunks = []
@@ -160,7 +171,9 @@ class IncrementalIndexUpdater:
             if self._l0_chunker is not None:
                 try:
                     l0_chunks = self._l0_chunker.chunk_file(
-                        file_path, skeleton_mode=True
+                        file_path,
+                        relative_path=relative_path,
+                        skeleton_mode=True,
                     )
                 except Exception as exc:
                     logger.warning(

--- a/test/index/incremental/test_e2e_real_faiss.py
+++ b/test/index/incremental/test_e2e_real_faiss.py
@@ -323,7 +323,7 @@ class TestEdgeCases:
         assert result.files_changed >= 1
 
     def test_renamed_file_treated_as_modify(self, tmp_path):
-        """Git renames should be detected and handled."""
+        """A rename should replace the old vector address without a ghost entry."""
         repo = tmp_path / "repo"
         repo.mkdir()
         _run(["git", "init"], str(repo))
@@ -339,12 +339,61 @@ class TestEdgeCases:
 
         _run(["git", "mv", "old_name.py", "new_name.py"], str(repo))
         _run(["git", "commit", "-m", "rename"], str(repo))
+        commit_b = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
 
-        detector = GitDiffDetector(supported_extensions={".py"})
-        changes = detector.detect_changes(str(repo), commit_a)
+        embedding_model = _make_mock_embedding_model()
+        vector_store = _build_real_vector_store(embedding_model)
+        chunker = CodeChunker(
+            language="python",
+            repo_config=RepoChunkingConfig(languages=["python"], filter_tests=False),
+        )
 
-        # Rename treated as modification of new path
-        assert len(changes.modified) >= 1 or len(changes.added) >= 1
+        _run(["git", "checkout", commit_a], str(repo))
+        initial_chunks = chunker.chunk_repository(repo_path=str(repo))
+        chunk_store = IncrementalChunkStore.from_chunks(initial_chunks, commit_a)
+        initial_vectors = [
+            np.asarray(embedding_model.embed_documents([chunk.content])[0])
+            for chunk in initial_chunks
+        ]
+        initial_docs = IncrementalIndexUpdater._build_doc_embedding_pairs(
+            [
+                (versioned, vector)
+                for versioned, vector in zip(
+                    chunk_store.get_all_versioned(), initial_vectors, strict=True
+                )
+            ]
+        )
+        vector_store.rebuild_from_embeddings(*initial_docs, level="l2")
+        emb_cache = EmbeddingsCache()
+        for chunk, vector in zip(initial_chunks, initial_vectors, strict=True):
+            emb_cache.put(_hash_content(chunk.content), vector)
+
+        _run(["git", "checkout", commit_b], str(repo))
+        updater = IncrementalIndexUpdater(
+            chunker=chunker,
+            embedding_model=embedding_model,
+            diff_detector=GitDiffDetector(supported_extensions={".py"}),
+        )
+        result = updater.update(
+            repo_path=str(repo),
+            vector_store=vector_store,
+            chunk_store=chunk_store,
+            embeddings_cache=emb_cache,
+            last_commit=commit_a,
+        )
+
+        assert result.total_chunks == len(initial_chunks)
+        assert vector_store.l2_index.ntotal == len(vector_store.l2_documents)
+        node_ids = [doc.metadata["node_id"] for doc in vector_store.l2_documents]
+        assert node_ids
+        assert all(node_id.startswith("new_name.py") for node_id in node_ids)
+        assert all("old_name.py" not in node_id for node_id in node_ids)
 
     def test_binary_file_in_diff_ignored(self, tmp_path):
         """Binary files in git diff should be silently skipped."""

--- a/test/index/incremental/test_incremental_pipeline.py
+++ b/test/index/incremental/test_incremental_pipeline.py
@@ -407,3 +407,4 @@ class TestIncrementalIndexUpdater:
 
         assert chunk_store.chunk_count() == 0
         assert str(repo / "dead.py") not in chunk_store._store
+        mock_store.delta_update.assert_called_once_with([], [], set(), level="l2")

--- a/test/index/incremental/test_incremental_pipeline.py
+++ b/test/index/incremental/test_incremental_pipeline.py
@@ -31,6 +31,7 @@ from codenib.index.incremental import (
     GitDiffDetector,
     IncrementalChunkStore,
     IncrementalIndexUpdater,
+    RepoChanges,
 )
 from codenib.index.incremental.chunk_store import _hash_content
 from codenib.index.incremental.index_updater import UpdateResult
@@ -241,6 +242,52 @@ class TestIncrementalIndexUpdater:
             result.chunks_from_cache >= 1
         ), f"Expected at least gamma from cache, got {result.chunks_from_cache}"
         assert result.cache_hit_rate > 0
+        node_files = {
+            chunk.node_id.split(":", 1)[0] for chunk in chunk_store.get_all_chunks()
+        }
+        assert {"file_a.py", "file_b.py", "file_c.py"}.issubset(node_files)
+        assert all(not Path(file_path).is_absolute() for file_path in node_files)
+
+    def test_chunkers_receive_repository_relative_identity(self, tmp_path):
+        repo = tmp_path / "repo"
+        source = repo / "nested" / "service.py"
+        source.parent.mkdir(parents=True)
+        source.write_text("def run():\n    return 1\n")
+
+        l2_chunker = MagicMock()
+        l2_chunker.chunk_file.return_value = []
+        l0_chunker = MagicMock()
+        l0_chunker.chunk_file.return_value = []
+        detector = MagicMock()
+        detector.detect_changes.return_value = RepoChanges(
+            modified=[str(source.resolve())],
+            old_commit="a" * 40,
+            new_commit="b" * 40,
+        )
+        embedding_model = _make_mock_embedding_model(DIM)
+        updater = IncrementalIndexUpdater(
+            chunker=l2_chunker,
+            l0_chunker=l0_chunker,
+            embedding_model=embedding_model,
+            diff_detector=detector,
+        )
+
+        updater.update(
+            repo_path=str(repo),
+            vector_store=_make_mock_vector_store(embedding_model, DIM),
+            chunk_store=IncrementalChunkStore(),
+            embeddings_cache=EmbeddingsCache(),
+            last_commit="a" * 40,
+        )
+
+        l2_chunker.chunk_file.assert_called_once_with(
+            str(source.resolve()), relative_path="nested/service.py"
+        )
+        l0_chunker.chunk_file.assert_called_once_with(
+            str(source.resolve()),
+            relative_path="nested/service.py",
+            skeleton_mode=True,
+        )
 
     def test_rebuild_from_embeddings_called(self, py_repo):
         """Verify that rebuild_from_embeddings is called with the full chunk set."""

--- a/test/index/test_vector_store_candidate_search.py
+++ b/test/index/test_vector_store_candidate_search.py
@@ -5,7 +5,11 @@
 import numpy as np
 import pytest
 
-from codenib.index.embedding.vector_store import CodeVectorStore, _Document
+from codenib.index.embedding.vector_store import (
+    CodeVectorStore,
+    _Document,
+    _result_source_file,
+)
 
 
 class _FakeIndex:
@@ -35,6 +39,40 @@ class _FakeEmbedding:
         if query == "different query":
             return [0.0, 1.0]
         raise AssertionError(f"unexpected query: {query}")
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected"),
+    [
+        (
+            {
+                "file": "/tmp/checkout/src/service.py",
+                "node_id": "src/service.py:run()",
+            },
+            "src/service.py",
+        ),
+        (
+            {
+                "file": "/tmp/checkout/src/service.py",
+                "node_id": "src/service.py",
+            },
+            "src/service.py",
+        ),
+        (
+            {"file": "src/service.py", "node_id": "src/service.py:run()"},
+            "src/service.py",
+        ),
+        (
+            {
+                "file": "/tmp/service.py",
+                "node_id": "/tmp/service.py:run()",
+            },
+            "/tmp/service.py",
+        ),
+    ],
+)
+def test_result_source_file_prefers_stable_repository_identity(metadata, expected):
+    assert _result_source_file(metadata) == expected
 
 
 def test_search_within_ids_deduplicates_before_top_k():
@@ -79,6 +117,32 @@ def test_search_stages_reuse_the_same_query_embedding_within_request_scope():
 
     store.search_with_content("different query", top_k=3, level="l2")
     assert store.embedding.calls == 2
+
+
+def test_vector_search_apis_return_repository_relative_files():
+    store = CodeVectorStore.__new__(CodeVectorStore)
+    store.index_metric = "ip"
+    store.embedding = _FakeEmbedding()
+    store.l2_index = _FakeIndex([[1.0, 0.0], [0.5, 0.0], [0.25, 0.0]])
+    store.l2_documents = [
+        _Document(
+            "target",
+            {
+                "node_id": "src/service.py:run()",
+                "name": "run",
+                "file": "/tmp/checkout/src/service.py",
+            },
+        ),
+        _Document("other", {"node_id": "b", "name": "b", "file": "b.py"}),
+        _Document("last", {"node_id": "c", "name": "c", "file": "c.py"}),
+    ]
+
+    assert store.search("query", top_k=1)[0].file == "src/service.py"
+    assert store.search_with_content("query", top_k=1)[0].file == "src/service.py"
+    assert (
+        store.search_within_ids("query", {"src/service.py:run()"}, top_k=1)[0].file
+        == "src/service.py"
+    )
 
 
 def test_repeated_requests_do_not_reuse_query_embeddings():

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -169,6 +169,35 @@ def test_ivf_save_load_roundtrip(tmp_path):
     assert res and res[0].node_name == chunks[1]["name"]
 
 
+def test_save_removes_persisted_level_after_last_document_is_deleted(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+    assert (path / "l2" / "index_test__model.faiss").exists()
+
+    store.clear("l2")
+    store.save(str(path))
+
+    assert not (path / "l2").exists()
+    config = json.loads((path / "config_test__model.json").read_text())
+    assert config["l2_documents"] == 0
+
+    loaded = _make_store(embedding_model="test/model", store_path=str(path))
+    loaded.load()
+    assert loaded.l2_index.ntotal == 0
+    assert loaded.l2_documents == []
+
+
+def test_save_rejects_misaligned_vectors_and_documents(tmp_path):
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.l2_documents.pop()
+
+    with pytest.raises(ValueError, match="2 vectors for 1 documents"):
+        store.save(str(tmp_path / "vs"))
+
+
 def test_load_prefers_portable_json_documents(tmp_path):
     path = tmp_path / "vs"
     store = _make_store(embedding_model="test/model")


### PR DESCRIPTION
## Summary
Preserve repository-relative source identities throughout dense retrieval and incremental updates, including rename and delete-only transitions across process restarts. The defects were reproduced through public MCP semantic search and real FAISS/CodeRankEmbed cycles.

## Changes
- Derive dense result paths from stable repository-relative vector `node_id` values.
- Preserve absolute paths only for direct single-file chunks without repository identity.
- Pass repository-relative POSIX paths to both L0 and L2 chunkers during incremental updates.
- Keep absolute paths as internal chunk-store keys so git-diff/cache behavior remains intact.
- Clear vector levels when deletion leaves no target documents, preventing in-memory ghost results.
- Remove persisted files for empty levels so deleted results cannot reappear after restart.
- Reject vector saves whose FAISS and document cardinalities are misaligned.
- Cover all vector search APIs plus incremental rename/delete identity continuity.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- incremental/vector persistence/runtime tier (134 passed)
- full unit tier before the persistence follow-up (2814 passed, 10 skipped)
- default HTTPie semantic index: five MCP hits were repository-relative
- three-commit CodeRankEmbed cycle: one L2 chunk re-embedded, one L0 vector reused, latest dense/BM25 content matched, and both returned `sample.py`
- real FAISS rename/delete regressions preserve only current repository-relative addresses across reload

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published