### PR TITLE
fix(index): recover vector updates by generation

### DIFF
--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -28,6 +28,7 @@ from ..compiler.manifest import MANIFEST_FILENAME, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
 from ..index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    require_complete_vector_view,
     validate_vector_config_artifact,
     validate_vector_generation_artifacts,
     vector_config_artifact_record,
@@ -277,6 +278,7 @@ def _normalize_vector_view(
 ) -> dict[str, Any]:
     if not target.is_dir():
         raise ValueError("portable vector view must be a directory")
+    require_complete_vector_view(target)
     interrupted = sorted(target.glob(".config_*.json.save-in-progress"))
     if interrupted:
         raise ValueError(
@@ -440,6 +442,7 @@ def stage_context_artifact(
                 route = resolve_embedding_artifact_route(entry.config)
             source = _view_source(entry.path, manifest_root, view=view)
             if view == "vector":
+                require_complete_vector_view(source)
                 expected_config = entry.config.get("persistence_config_fingerprint")
                 if expected_config is not None:
                     validate_vector_config_artifact(

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -185,8 +185,8 @@ class VectorIndexBuilder:
 
         route = self._embedding_route()
         return {
-            # v5 binds each manifest entry to one committed vector config.
-            "builder_schema": 5,
+            # v6 commits vector, chunk, cache, and incremental state together.
+            "builder_schema": 6,
             "embedding_model": route.model,
             "embedding_provider": route.provider,
             "embedding_dimension": self.embedding_dimension,
@@ -270,6 +270,18 @@ class VectorIndexBuilder:
         return vector_config_artifact_record(output_dir, model_suffix)
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
+        from ..index.embedding.artifact_integrity import (
+            begin_vector_view_update,
+            finish_vector_view_update,
+        )
+
+        output_dir: str = kwargs["output_dir"]
+        begin_vector_view_update(output_dir)
+        status = self._build_once(scope, **kwargs)
+        finish_vector_view_update(output_dir)
+        return status
+
+    def _build_once(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
         output_dir: str = kwargs["output_dir"]
 
@@ -382,7 +394,7 @@ class VectorIndexBuilder:
             last_commit=head_commit,
             chunk_store_path="chunk_store.pkl",
             embeddings_cache_path="embeddings_cache.pkl",
-            index_path=output_dir,
+            index_path=str(Path(output_dir).expanduser().resolve()),
             build_levels=list(self.build_levels),
         )
         inc_state.save(Path(output_dir))
@@ -411,7 +423,9 @@ class VectorIndexBuilder:
         except Exception as exc:  # noqa: BLE001 - failed deltas must not publish
             logger.warning("vector: incremental update failed (%s); rebuilding", exc)
             build_kwargs = {
-                key: value for key, value in kwargs.items() if key != "last_commit"
+                key: value
+                for key, value in kwargs.items()
+                if key not in {"last_commit", "previous_artifact_config"}
             }
             status = self.build(scope, **build_kwargs)
             status.metadata["update_mode"] = "full_rebuild"
@@ -436,8 +450,8 @@ class VectorIndexBuilder:
         and ``EmbeddingsCache`` from *output_dir*, runs the incremental update
         pipeline, then saves all state back to disk.
 
-        Missing state falls back directly to a full ``build()``. Other failures
-        propagate to :meth:`incremental_update`, which rebuilds conservatively.
+        Missing or incompatible state propagates to :meth:`incremental_update`,
+        which rebuilds conservatively exactly once.
         """
         from pathlib import Path
 
@@ -455,41 +469,69 @@ class VectorIndexBuilder:
         output_dir: str = kwargs["output_dir"]
         last_commit: str = kwargs.get("last_commit", "")
 
-        # Load persisted state — auto-resolve last_commit if not provided
+        from ..index.embedding.artifact_integrity import (
+            begin_vector_view_update,
+            finish_vector_view_update,
+            require_complete_vector_view,
+        )
+
+        require_complete_vector_view(output_dir)
         inc_state = IncrementalState.load(Path(output_dir))
-        if not last_commit and inc_state is not None:
+        if inc_state is None:
+            raise ValueError("incremental state is missing")
+        if not last_commit:
             last_commit = inc_state.last_commit
+        if not last_commit or inc_state.last_commit != last_commit:
+            raise ValueError(
+                "incremental state commit does not match the manifest start commit"
+            )
+        if inc_state.build_levels != list(self.build_levels):
+            raise ValueError("incremental state levels do not match the vector view")
+        if inc_state.chunk_store_path != "chunk_store.pkl":
+            raise ValueError("incremental state has a non-canonical chunk store path")
+        if inc_state.embeddings_cache_path != "embeddings_cache.pkl":
+            raise ValueError(
+                "incremental state has a non-canonical embeddings cache path"
+            )
+        expected_index_path = Path(output_dir).expanduser().resolve()
+        if (
+            not inc_state.index_path
+            or Path(inc_state.index_path).expanduser().resolve() != expected_index_path
+        ):
+            raise ValueError("incremental state points to a different vector view")
 
         chunk_store_path = Path(output_dir) / "chunk_store.pkl"
         embeddings_cache_path = Path(output_dir) / "embeddings_cache.pkl"
 
-        # Check both JSON and pickle formats (JSON+NPZ is the new default)
+        # Schema-v6 compiler state always uses the canonical JSON/NPZ forms.
+        # Legacy pickle-only state is rebuilt through the builder-schema gate.
         chunk_store_json = chunk_store_path.with_suffix(".json")
         emb_cache_json = embeddings_cache_path.with_suffix(".json")
         emb_cache_npz = embeddings_cache_path.with_suffix(".npz")
 
-        has_chunk_store = chunk_store_json.exists() or chunk_store_path.exists()
-        has_emb_cache = (
-            emb_cache_json.exists() and emb_cache_npz.exists()
-        ) or embeddings_cache_path.exists()
+        has_chunk_store = chunk_store_json.is_file()
+        has_emb_cache = emb_cache_json.is_file() and emb_cache_npz.is_file()
 
-        # Fall back to full build when incremental state is missing
         if not has_chunk_store or not has_emb_cache:
-            logger.info(
-                "Incremental state not found in %s; falling back to full build.",
-                output_dir,
-            )
-            return self.build(scope, **kwargs)
+            raise ValueError("incremental chunk or embedding state is missing")
 
         # Load existing artifacts
         artifact_identity = self.artifact_identity()
+        previous_artifact = kwargs.get("previous_artifact_config")
+        if previous_artifact is not None and not isinstance(previous_artifact, dict):
+            raise ValueError("previous vector artifact config must be a mapping")
+        load_identity = (
+            dict(previous_artifact)
+            if previous_artifact is not None
+            else artifact_identity
+        )
         vector_store = CodeVectorStore(
             embedding_model=artifact_identity["embedding_model"],
             embedding_provider=artifact_identity["embedding_provider"],
             dimension=self.embedding_dimension,
             index_metric=self.index_metric,
             store_path=output_dir,
-            artifact_metadata=artifact_identity,
+            artifact_metadata=load_identity,
             **self._embedding_call_kwargs(),
         )
         self._validate_vector_dimension(vector_store)
@@ -533,22 +575,26 @@ class VectorIndexBuilder:
             embeddings_cache=embeddings_cache,
             last_commit=last_commit,
         )
+        if not result.new_commit:
+            raise ValueError("incremental update did not resolve a target commit")
 
         # Persist updated state
+        begin_vector_view_update(output_dir)
         vector_store.save(output_dir)
         chunk_store.save(chunk_store_path)
         embeddings_cache.save(embeddings_cache_path)
 
-        # Update incremental state with the new commit
+        # Update incremental state with the new commit.
         new_state = IncrementalState(
             last_commit=result.new_commit,
             chunk_store_path="chunk_store.pkl",
             embeddings_cache_path="embeddings_cache.pkl",
-            index_path=output_dir,
+            index_path=str(expected_index_path),
             build_levels=list(self.build_levels),
         )
         new_state.save(Path(output_dir))
         persistence_config = self._persistence_config_fingerprint(output_dir)
+        finish_vector_view_update(output_dir)
 
         doc_count = {}
         if vector_store.l0_documents:

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -404,8 +404,23 @@ class VectorIndexBuilder:
         )
 
     def incremental_update(self, scope: str, **kwargs: Any) -> IndexStatus:
+        """Update the vector view, rebuilding on any incremental-path failure."""
+
+        try:
+            return self._incremental_update_once(scope, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - failed deltas must not publish
+            logger.warning("vector: incremental update failed (%s); rebuilding", exc)
+            build_kwargs = {
+                key: value for key, value in kwargs.items() if key != "last_commit"
+            }
+            status = self.build(scope, **build_kwargs)
+            status.metadata["update_mode"] = "full_rebuild"
+            status.metadata["incremental_fallback_reason"] = type(exc).__name__
+            return status
+
+    def _incremental_update_once(self, scope: str, **kwargs: Any) -> IndexStatus:
         """
-        Update the vector index incrementally using git diff detection.
+        Attempt one vector-index update using git diff detection.
 
         Required kwargs
         ---------------
@@ -421,8 +436,8 @@ class VectorIndexBuilder:
         and ``EmbeddingsCache`` from *output_dir*, runs the incremental update
         pipeline, then saves all state back to disk.
 
-        Falls back to a full ``build()`` call when incremental state files are
-        missing (i.e. on first run or after a manual cache wipe).
+        Missing state falls back directly to a full ``build()``. Other failures
+        propagate to :meth:`incremental_update`, which rebuilds conservatively.
         """
         from pathlib import Path
 

--- a/codenib/compiler/index_compiler.py
+++ b/codenib/compiler/index_compiler.py
@@ -27,7 +27,7 @@ import subprocess
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from filelock import FileLock
 
@@ -358,6 +358,11 @@ class IndexCompiler:
                 repo_path,
                 output_dir,
                 last_commit=incremental_from,
+                previous_artifact_config=(
+                    copy.deepcopy(previous_entry.config)
+                    if incremental_from and previous_entry is not None
+                    else None
+                ),
             )
             if (
                 idx_type == "symbol_graph"
@@ -497,6 +502,7 @@ class IndexCompiler:
         output_dir: str,
         *,
         last_commit: Optional[str] = None,
+        previous_artifact_config: Optional[Dict[str, Any]] = None,
     ) -> BuildResult:
         """Build a single index, catching errors.
 
@@ -507,11 +513,16 @@ class IndexCompiler:
         start = time.monotonic()
         try:
             if last_commit:
+                update_kwargs: Dict[str, Any] = {
+                    "repo_path": repo_path,
+                    "output_dir": output_dir,
+                    "last_commit": last_commit,
+                }
+                if previous_artifact_config is not None:
+                    update_kwargs["previous_artifact_config"] = previous_artifact_config
                 status = builder.incremental_update(
                     scope="current_repo",
-                    repo_path=repo_path,
-                    output_dir=output_dir,
-                    last_commit=last_commit,
+                    **update_kwargs,
                 )
             else:
                 status = builder.build(

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from pathlib import Path
 from typing import Any, Mapping
 
 VECTOR_PERSISTENCE_SCHEMA = 1
+VECTOR_VIEW_UPDATE_MARKER = ".vector-view.update-in-progress"
 _DIGEST_BYTES = 1024 * 1024
+_UPDATE_MARKER_PAYLOAD = b'{"schema":"codenib.vector-view-update.v1"}\n'
 
 
 def _file_record(path: Path) -> dict[str, Any]:
@@ -56,6 +59,48 @@ def vector_config_artifact_record(
     """Fingerprint the top-level record that commits all vector levels."""
 
     return _file_record(Path(root) / f"config_{model_suffix}.json")
+
+
+def require_complete_vector_view(root: str | Path) -> None:
+    """Reject a vector view whose multi-artifact update did not finish."""
+
+    marker = Path(root) / VECTOR_VIEW_UPDATE_MARKER
+    if marker.exists() or marker.is_symlink():
+        raise ValueError(f"vector view has an incomplete update marker: {marker}")
+
+
+def begin_vector_view_update(root: str | Path) -> Path:
+    """Publish a crash marker before replacing any vector-view component."""
+
+    directory = Path(root)
+    directory.mkdir(parents=True, exist_ok=True)
+    marker = directory / VECTOR_VIEW_UPDATE_MARKER
+    if marker.is_symlink():
+        raise ValueError(f"refusing symlinked vector update marker: {marker}")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(marker, flags, 0o600)
+    try:
+        remaining = memoryview(_UPDATE_MARKER_PAYLOAD)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError("could not persist vector view update marker")
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    return marker
+
+
+def finish_vector_view_update(root: str | Path) -> None:
+    """Remove the marker only after every vector-view component is written."""
+
+    marker = Path(root) / VECTOR_VIEW_UPDATE_MARKER
+    if not marker.exists() and not marker.is_symlink():
+        raise ValueError(f"vector view update marker disappeared: {marker}")
+    marker.unlink()
 
 
 def validate_vector_config_artifact(
@@ -184,6 +229,10 @@ def validate_vector_generation_artifacts(
 
 __all__ = [
     "VECTOR_PERSISTENCE_SCHEMA",
+    "VECTOR_VIEW_UPDATE_MARKER",
+    "begin_vector_view_update",
+    "finish_vector_view_update",
+    "require_complete_vector_view",
     "validate_vector_config_artifact",
     "validate_vector_generation_artifacts",
     "validate_vector_level_artifacts",

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -27,6 +27,7 @@ from ...provider_routes import normalize_provider
 from ...types import NodeInfo
 from .artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    require_complete_vector_view,
     validate_vector_config_artifact,
     validate_vector_level_artifacts,
     vector_level_artifact_records,
@@ -1132,6 +1133,7 @@ class CodeVectorStore:
             raise FileNotFoundError(f"Vector store not found at {load_path}")
 
         logger.info(f"Loading vector store from {load_path}")
+        require_complete_vector_view(load_path)
 
         model_suffix = self.embedding_model.replace("/", "__")
 

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -1617,13 +1617,15 @@ class CodeVectorStore:
         threshold: float = 0.1,
     ) -> None:
         """
-        Patch the FAISS index in place when the change set is small.
+        Patch a flat FAISS index in place when the change set is small.
 
         When the fraction of changed chunks is below *threshold*, this uses
         ``IndexFlat.remove_ids`` + ``add`` to modify only the affected rows,
-        keeping unchanged vectors and their aligned documents untouched.  If
-        the change ratio exceeds the threshold (or the index is empty), it
-        falls back to a full rebuild via :meth:`rebuild_from_embeddings`.
+        keeping unchanged vectors and their aligned documents untouched. IVF
+        indexes are rebuilt because removing their implicit IDs does not
+        compact the remaining labels to match the document array. If the
+        change ratio exceeds the threshold (or the index is empty), this also
+        falls back to :meth:`rebuild_from_embeddings`.
 
         Args:
             all_documents: The complete desired set of documents for *level*
@@ -1651,6 +1653,7 @@ class CodeVectorStore:
             index is None
             or index.ntotal == 0
             or not current_docs
+            or self.index_type != "flat"
             or change_ratio > threshold
         ):
             logger.info(

--- a/codenib/index/incremental/index_updater.py
+++ b/codenib/index/incremental/index_updater.py
@@ -45,6 +45,7 @@ from .git_diff import GitDiffDetector, RepoChanges
 
 if TYPE_CHECKING:
     from ...code_chunker import CodeChunker
+    from ...code_chunking.base import CodeChunk
     from ..embedding.vector_store import CodeVectorStore
 
 logger = get_logger(__name__)
@@ -142,8 +143,11 @@ class IncrementalIndexUpdater:
             result.duration_seconds = time.monotonic() - t_start
             return result
 
-        # ---- Step 2: rechunk affected files (L2 + optional L0) ----------
+        # ---- Step 2: stage affected files (L2 + optional L0) ------------
         repo_root = Path(repo_path).resolve()
+        staged_chunks: List[
+            Tuple[str, List["CodeChunk"], Optional[List["CodeChunk"]]]
+        ] = []
         for file_path in changes.affected:
             try:
                 relative_path = Path(file_path).relative_to(repo_root).as_posix()
@@ -158,16 +162,10 @@ class IncrementalIndexUpdater:
                     file_path, relative_path=relative_path
                 )
             except Exception as exc:
-                logger.warning("Failed to L2-chunk %s: %s", file_path, exc)
-                new_chunks = []
-
-            added, removed = chunk_store.update_file(
-                file_path, new_chunks, changes.new_commit, level="l2"
-            )
-            result.chunks_added += len(added)
-            result.chunks_removed += len(removed)
+                raise RuntimeError(f"Failed to L2-chunk {file_path}: {exc}") from exc
 
             # L0 rechunk (file skeleton)
+            l0_chunks = None
             if self._l0_chunker is not None:
                 try:
                     l0_chunks = self._l0_chunker.chunk_file(
@@ -176,12 +174,22 @@ class IncrementalIndexUpdater:
                         skeleton_mode=True,
                     )
                 except Exception as exc:
-                    logger.warning(
-                        "Failed to L0-chunk %s: %s — keeping previous L0 data",
-                        file_path,
-                        exc,
-                    )
-                    continue
+                    raise RuntimeError(
+                        f"Failed to L0-chunk {file_path}: {exc}"
+                    ) from exc
+
+            staged_chunks.append((file_path, new_chunks, l0_chunks))
+
+        # Apply only after every affected file has chunked successfully.  This
+        # prevents one parser failure from publishing a mixed-commit store.
+        for file_path, new_chunks, l0_chunks in staged_chunks:
+            added, removed = chunk_store.update_file(
+                file_path, new_chunks, changes.new_commit, level="l2"
+            )
+            result.chunks_added += len(added)
+            result.chunks_removed += len(removed)
+
+            if l0_chunks is not None:
                 chunk_store.update_file(
                     file_path, l0_chunks, changes.new_commit, level="l0"
                 )

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -22,6 +22,7 @@ from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprin
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    VECTOR_VIEW_UPDATE_MARKER,
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
@@ -385,6 +386,21 @@ def test_context_artifact_rejects_interrupted_vector_save(tmp_path: Path) -> Non
     (vector / ".config_test__model.json.save-in-progress").write_text("{}")
 
     with pytest.raises(ValueError, match="interrupted save marker"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+            repository="example/vector-project",
+        )
+
+
+def test_context_artifact_rejects_incomplete_vector_view_update(
+    tmp_path: Path,
+) -> None:
+    repo, manifest_path, vector = _fixture_vector_manifest(tmp_path)
+    (vector / VECTOR_VIEW_UPDATE_MARKER).write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="incomplete update marker"):
         stage_context_artifact(
             repo,
             manifest_path,

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -39,7 +39,9 @@ from codenib.compiler.resources import (
     IndexStatus,
     ResourceResolver,
 )
+from codenib.index.embedding.artifact_integrity import VECTOR_VIEW_UPDATE_MARKER
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
+from codenib.index.incremental import IncrementalState
 from codenib.ls_router import GraphBuildResult
 from codenib.repository_filters import (
     REPOSITORY_FILTER_POLICY_VERSION,
@@ -234,6 +236,7 @@ class TestVectorIndexBuilder:
         mock_build_fn.assert_called_once()
         assert mock_build_fn.call_args.kwargs["force_rebuild"] is True
         assert mock_build_fn.call_args.kwargs["strict_chunking"] is True
+        assert not (output_path / VECTOR_VIEW_UPDATE_MARKER).exists()
 
     def test_incremental_failure_falls_back_to_full_build(self, tmp_path):
         builder = VectorIndexBuilder(
@@ -274,6 +277,159 @@ class TestVectorIndexBuilder:
         assert result.metadata["update_mode"] == "full_rebuild"
         assert result.metadata["incremental_fallback_reason"] == "ValueError"
 
+    def test_missing_incremental_state_attempts_one_rebuild(self, tmp_path):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+
+        with patch.object(
+            builder,
+            "build",
+            side_effect=RuntimeError("rebuild failed"),
+        ) as mock_build:
+            with pytest.raises(RuntimeError, match="rebuild failed"):
+                builder.incremental_update(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(tmp_path / "vector"),
+                    last_commit="a" * 40,
+                )
+
+        mock_build.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("last_commit", "b" * 40),
+            ("build_levels", ["l2"]),
+            ("chunk_store_path", "../chunk_store.pkl"),
+            ("embeddings_cache_path", "../embeddings_cache.pkl"),
+            ("index_path", "/different/vector/view"),
+        ],
+    )
+    def test_incompatible_incremental_state_forces_rebuild(
+        self,
+        tmp_path,
+        field,
+        value,
+    ):
+        output_path = tmp_path / "vector"
+        state = IncrementalState(
+            last_commit="a" * 40,
+            chunk_store_path="chunk_store.pkl",
+            embeddings_cache_path="embeddings_cache.pkl",
+            index_path=str(output_path.resolve()),
+            build_levels=["l0", "l2"],
+        )
+        setattr(state, field, value)
+        state.save(output_path)
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        rebuilt = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            path=str(output_path),
+            metadata={},
+        )
+
+        with patch.object(builder, "build", return_value=rebuilt) as mock_build:
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_path),
+                last_commit="a" * 40,
+            )
+
+        mock_build.assert_called_once()
+        assert result.metadata["update_mode"] == "full_rebuild"
+
+    def test_incremental_load_uses_previous_manifest_generation(self, tmp_path):
+        output_path = tmp_path / "vector"
+        IncrementalState(
+            last_commit="a" * 40,
+            chunk_store_path="chunk_store.pkl",
+            embeddings_cache_path="embeddings_cache.pkl",
+            index_path=str(output_path.resolve()),
+            build_levels=["l0", "l2"],
+        ).save(output_path)
+        (output_path / "chunk_store.json").write_text("{}", encoding="utf-8")
+        (output_path / "embeddings_cache.json").write_text("[]", encoding="utf-8")
+        (output_path / "embeddings_cache.npz").write_bytes(b"placeholder")
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        previous = {
+            **builder.artifact_identity(),
+            "persistence_config_fingerprint": {
+                "file": "config_test-model.json",
+                "size": 1,
+                "sha256": "0" * 64,
+            },
+        }
+        vector_store = MagicMock(dimension=384)
+        vector_store.load.side_effect = RuntimeError("stop after generation check")
+
+        with patch(
+            "codenib.index.embedding.vector_store.CodeVectorStore",
+            return_value=vector_store,
+        ) as store_type:
+            with pytest.raises(RuntimeError, match="generation check"):
+                builder._incremental_update_once(
+                    scope="current_repo",
+                    repo_path=str(tmp_path),
+                    output_dir=str(output_path),
+                    last_commit="a" * 40,
+                    previous_artifact_config=previous,
+                )
+
+        assert store_type.call_args.kwargs["artifact_metadata"] == previous
+
+    @pytest.mark.parametrize("missing", ["chunk_json", "embedding_pair"])
+    def test_pickle_only_incremental_state_forces_rebuild(self, tmp_path, missing):
+        output_path = tmp_path / "vector"
+        IncrementalState(
+            last_commit="a" * 40,
+            chunk_store_path="chunk_store.pkl",
+            embeddings_cache_path="embeddings_cache.pkl",
+            index_path=str(output_path.resolve()),
+            build_levels=["l0", "l2"],
+        ).save(output_path)
+        (output_path / "chunk_store.pkl").write_bytes(b"legacy")
+        (output_path / "embeddings_cache.pkl").write_bytes(b"legacy")
+        if missing != "chunk_json":
+            (output_path / "chunk_store.json").write_text("{}", encoding="utf-8")
+        if missing != "embedding_pair":
+            (output_path / "embeddings_cache.json").write_text(
+                "[]",
+                encoding="utf-8",
+            )
+            (output_path / "embeddings_cache.npz").write_bytes(b"placeholder")
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        rebuilt = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            path=str(output_path),
+            metadata={},
+        )
+
+        with patch.object(builder, "build", return_value=rebuilt) as mock_build:
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(output_path),
+                last_commit="a" * 40,
+            )
+
+        mock_build.assert_called_once()
+        assert result.metadata["update_mode"] == "full_rebuild"
+
     def test_artifact_identity_is_shared_by_full_and_incremental_statuses(self):
         builder = VectorIndexBuilder(
             embedding_model="test-model",
@@ -284,7 +440,7 @@ class TestVectorIndexBuilder:
 
         identity = builder.artifact_identity()
         assert identity == {
-            "builder_schema": 5,
+            "builder_schema": 6,
             "embedding_model": "test-model",
             "embedding_provider": "huggingface",
             "embedding_dimension": 384,
@@ -348,12 +504,14 @@ class TestVectorIndexBuilder:
             embedding_dimension=768,
         )
 
+        output_path = tmp_path / "vector"
         with pytest.raises(ValueError, match="returned dimension 1024, expected 768"):
             builder.build(
                 scope="current_repo",
                 repo_path="/fake/repo",
-                output_dir=str(tmp_path / "vector"),
+                output_dir=str(output_path),
             )
+        assert (output_path / VECTOR_VIEW_UPDATE_MARKER).is_file()
 
     @patch("codenib.index.embedding.builders.build_hierarchical_vector_store")
     def test_remote_runtime_secret_is_not_persisted(self, mock_build_fn, tmp_path):
@@ -1417,6 +1575,46 @@ class TestUpdateRepo:
 
         compiler.update_repo(str(tmp_path))
         assert calls[-2] == ("incremental_update", first)
+
+    def test_incremental_builder_receives_previous_manifest_config(self, tmp_path):
+        _git_repo(tmp_path)
+        observed = []
+
+        class ManifestAwareBuilder:
+            def artifact_identity(self):
+                return {"builder_schema": 7}
+
+            def _status(self, scope, output_dir):
+                return IndexStatus(
+                    index_type="rec",
+                    state=IndexState.FRESH,
+                    scope=scope,
+                    path=output_dir,
+                    metadata={
+                        **self.artifact_identity(),
+                        "generation": "recorded",
+                    },
+                )
+
+            def build(self, scope: str, **kwargs) -> IndexStatus:
+                return self._status(scope, kwargs["output_dir"])
+
+            def incremental_update(self, scope: str, **kwargs) -> IndexStatus:
+                observed.append(kwargs["previous_artifact_config"])
+                return self._status(scope, kwargs["output_dir"])
+
+        registry = IndexBuilderRegistry()
+        registry.register("rec", ManifestAwareBuilder())
+        compiler = IndexCompiler(
+            registry,
+            IndexCompilerConfig(index_types=["rec"], languages=["python"]),
+        )
+        first_manifest = compiler.compile_repo(str(tmp_path))
+        _commit(tmp_path, "b.py")
+
+        compiler.update_repo(str(tmp_path))
+
+        assert observed == [first_manifest.indexes["rec"].config]
 
     def test_incremental_graph_preserves_partial_language_coverage(self, tmp_path):
         first = _git_repo(tmp_path)

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -235,6 +235,45 @@ class TestVectorIndexBuilder:
         assert mock_build_fn.call_args.kwargs["force_rebuild"] is True
         assert mock_build_fn.call_args.kwargs["strict_chunking"] is True
 
+    def test_incremental_failure_falls_back_to_full_build(self, tmp_path):
+        builder = VectorIndexBuilder(
+            embedding_model="test-model",
+            embedding_dimension=384,
+        )
+        rebuilt = IndexStatus(
+            index_type="vector",
+            state=IndexState.FRESH,
+            last_built=1.0,
+            age_seconds=0.0,
+            scope="current_repo",
+            path=str(tmp_path / "vector"),
+            metadata={},
+        )
+
+        with (
+            patch.object(
+                builder,
+                "_incremental_update_once",
+                side_effect=ValueError("corrupt cache"),
+            ),
+            patch.object(builder, "build", return_value=rebuilt) as mock_build,
+        ):
+            result = builder.incremental_update(
+                scope="current_repo",
+                repo_path=str(tmp_path),
+                output_dir=str(tmp_path / "vector"),
+                last_commit="a" * 40,
+            )
+
+        mock_build.assert_called_once_with(
+            "current_repo",
+            repo_path=str(tmp_path),
+            output_dir=str(tmp_path / "vector"),
+        )
+        assert result is rebuilt
+        assert result.metadata["update_mode"] == "full_rebuild"
+        assert result.metadata["incremental_fallback_reason"] == "ValueError"
+
     def test_artifact_identity_is_shared_by_full_and_incremental_statuses(self):
         builder = VectorIndexBuilder(
             embedding_model="test-model",

--- a/test/index/incremental/test_delta_faiss.py
+++ b/test/index/incremental/test_delta_faiss.py
@@ -96,6 +96,40 @@ def _build_store_with_docs(contents: List[str]):
 class TestDeltaUpdate:
     """Verify delta_update logic."""
 
+    def test_ivf_delta_preserves_search_label_document_alignment(self):
+        store, docs, _ = _build_store_with_docs([f"document {i}" for i in range(DIM)])
+        store.index_type = "ivf"
+        store.ivf_nlist = 2
+        store.ivf_nprobe = 2
+        vectors = np.eye(DIM, dtype=np.float32)
+        store.l2_index = store._build_faiss_index()
+        store._add_to_index("l2", vectors)
+        original_index = store.l2_index
+
+        replacement = _Document(
+            page_content="replacement",
+            metadata={**docs[0].metadata, "content_hash": _md5("replacement")},
+        )
+        target_docs = [replacement, *docs[1:]]
+        target_vectors = [
+            -vectors[0],
+            *[vectors[index] for index in range(1, DIM)],
+        ]
+
+        store.delta_update(
+            target_docs,
+            target_vectors,
+            {_md5("replacement")},
+            level="l2",
+            threshold=0.5,
+        )
+
+        _distances, labels = store.l2_index.search(vectors[1].reshape(1, -1), 1)
+        label = int(labels[0, 0])
+        assert label >= 0
+        assert store.l2_index is not original_index
+        assert store.l2_documents[label].page_content == docs[1].page_content
+
     def test_small_delta_patches_index(self):
         """With 1 out of 10 chunks changed, delta path should be used."""
         contents = [f"def func_{i}():\n    return {i}\n" for i in range(10)]

--- a/test/index/incremental/test_incremental_pipeline.py
+++ b/test/index/incremental/test_incremental_pipeline.py
@@ -289,6 +289,76 @@ class TestIncrementalIndexUpdater:
             skeleton_mode=True,
         )
 
+    @pytest.mark.parametrize("failed_level", ["l2", "l0"])
+    def test_chunk_failure_leaves_existing_state_unchanged(
+        self, tmp_path, failed_level
+    ):
+        repo = tmp_path / "repo"
+        source = repo / "service.py"
+        repo.mkdir()
+        source.write_text("def current():\n    return 2\n")
+        source_path = str(source.resolve())
+
+        old_l2 = CodeChunk(
+            content="service.py:current()\ndef current():\n    return 1\n",
+            start_line=0,
+            end_line=1,
+            chunk_type="function",
+            name="current",
+            file=source_path,
+            node_id="service.py:current()",
+        )
+        old_l0 = CodeChunk(
+            content="def current():",
+            start_line=0,
+            end_line=1,
+            chunk_type="file",
+            name="service.py",
+            file=source_path,
+            node_id="service.py",
+        )
+        chunk_store = IncrementalChunkStore.from_chunks([old_l2], "a" * 40)
+        chunk_store.add_chunks([old_l0], "a" * 40, level="l0")
+
+        new_l2 = old_l2._replace(content=old_l2.content.replace("1", "2"))
+        l2_chunker = MagicMock()
+        l0_chunker = MagicMock()
+        if failed_level == "l2":
+            l2_chunker.chunk_file.side_effect = ValueError("broken L2 parser")
+        else:
+            l2_chunker.chunk_file.return_value = [new_l2]
+            l0_chunker.chunk_file.side_effect = ValueError("broken L0 parser")
+
+        detector = MagicMock()
+        detector.detect_changes.return_value = RepoChanges(
+            modified=[source_path],
+            old_commit="a" * 40,
+            new_commit="b" * 40,
+        )
+        embedding_model = _make_mock_embedding_model(DIM)
+        vector_store = _make_mock_vector_store(embedding_model, DIM)
+        updater = IncrementalIndexUpdater(
+            chunker=l2_chunker,
+            l0_chunker=l0_chunker,
+            embedding_model=embedding_model,
+            diff_detector=detector,
+        )
+
+        with pytest.raises(
+            RuntimeError, match=f"Failed to {failed_level.upper()}-chunk"
+        ):
+            updater.update(
+                repo_path=str(repo),
+                vector_store=vector_store,
+                chunk_store=chunk_store,
+                embeddings_cache=EmbeddingsCache(),
+                last_commit="a" * 40,
+            )
+
+        assert chunk_store.get_chunks_for_file(source_path, level="l2") == [old_l2]
+        assert chunk_store.get_chunks_for_file(source_path, level="l0") == [old_l0]
+        vector_store.delta_update.assert_not_called()
+
     def test_rebuild_from_embeddings_called(self, py_repo):
         """Verify that rebuild_from_embeddings is called with the full chunk set."""
         repo_path = py_repo["repo_path"]

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -24,6 +24,7 @@ import pytest
 
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    VECTOR_VIEW_UPDATE_MARKER,
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
@@ -242,6 +243,18 @@ def test_failed_save_blocks_load_until_successful_retry(tmp_path):
     assert not marker.exists()
     loaded.load()
     assert len(loaded.l2_documents) == 2
+
+
+def test_load_rejects_incomplete_multi_artifact_update(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+    (path / VECTOR_VIEW_UPDATE_MARKER).write_text("{}", encoding="utf-8")
+
+    loaded = _make_store(embedding_model="test/model", store_path=str(path))
+    with pytest.raises(ValueError, match="incomplete update marker"):
+        loaded.load()
 
 
 def test_load_prefers_portable_json_documents(tmp_path):


### PR DESCRIPTION
## Summary
Prevent incremental vector updates from publishing mixed repository generations or misaligning FAISS labels with source documents. File rechunking is staged before mutation, all mutable vector-view components share one crash marker, persisted state must match the prior manifest generation, and any invalid delta path rebuilds exactly once.

## Changes
- Stage L2 and optional L0 chunks for every affected file before mutating the chunk store
- Surface parser failures instead of converting failed L2 chunks into deletions or mixing fresh L2 with stale L0
- Bind incremental loading to the prior manifest vector generation
- Require state commit, levels, index path, and canonical JSON/NPZ artifacts to match
- Cover vector, chunk, embedding-cache, and incremental-state writes with one crash marker
- Reject incomplete generations in runtime and portable artifact loaders
- Fall back to one complete rebuild after invalid incremental state or update failure
- Rebuild IVF indexes on updates so sparse FAISS IDs cannot point at the wrong source document
- Bump the vector builder schema so older mutable state rebuilds deterministically

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- focused incremental/compiler/vector/artifact tier after restacking: 223 passed
- unit tier: 2934 passed, 9 skipped, 180 deselected
- pre-commit: passed

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published