### PR TITLE
fix(compiler): reject partial source indexes

### DIFF
--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -233,7 +233,9 @@ class CodeChunker:
         return self._chunker.print_chunk_summary(chunks)
 
     # Repository-level methods
-    def chunk_repository(self, repo_path: str) -> List[CodeChunk]:
+    def chunk_repository(
+        self, repo_path: str, *, strict: bool = False
+    ) -> List[CodeChunk]:
         """
         Chunk all relevant files in a repository.
 
@@ -241,6 +243,8 @@ class CodeChunker:
             repo_path: Path to the repository root.
                 Languages come from RepoChunkingConfig; when empty they are inferred
                 from file extensions present in the repo.
+            strict: Raise when any discovered source file cannot be chunked instead
+                of returning a partial repository result.
 
         Returns:
             List of CodeChunk objects from all processed files
@@ -275,6 +279,11 @@ class CodeChunker:
                 processed_count += 1
 
             except Exception as e:
+                if strict:
+                    relative = file_path.relative_to(repo_path).as_posix()
+                    raise RuntimeError(
+                        f"Failed to chunk repository source {relative}: {e}"
+                    ) from e
                 logger.warning(f"Failed to process {file_path}: {e}")
                 continue
 

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -145,7 +145,7 @@ class BaseCodeChunker(ABC):
         # logger.debug(f"Chunking file: {file_path}")
 
         # Read the file
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
             code_content = f.read()
 
         # Parse the code

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -100,11 +100,12 @@ class BM25IndexBuilder:
 
     def artifact_identity(self) -> Dict[str, Any]:
         return {
-            # v6 also fixes source discovery order across filesystems.
-            "builder_schema": 6,
+            # v7 refuses to publish indexes with silently skipped source files.
+            "builder_schema": 7,
             "languages": list(self.languages),
             "max_k": self.max_k,
             "max_lines_per_chunk": self.max_lines_per_chunk,
+            "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 
@@ -121,7 +122,7 @@ class BM25IndexBuilder:
             repo_config=RepoChunkingConfig(languages=self.languages),
             max_lines_per_chunk=self.max_lines_per_chunk,
         )
-        chunks = chunker.chunk_repository(repo_path=repo_path)
+        chunks = chunker.chunk_repository(repo_path=repo_path, strict=True)
 
         indexer = BM25CodeIndexer(
             chunks=chunks,
@@ -182,7 +183,7 @@ class VectorIndexBuilder:
 
         route = self._embedding_route()
         return {
-            "builder_schema": 3,
+            "builder_schema": 4,
             "embedding_model": route.model,
             "embedding_provider": route.provider,
             "embedding_dimension": self.embedding_dimension,
@@ -195,6 +196,7 @@ class VectorIndexBuilder:
             "languages": list(self.languages),
             "levels": list(self.build_levels),
             "max_lines_per_chunk": self.max_lines_per_chunk,
+            "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 
@@ -291,6 +293,7 @@ class VectorIndexBuilder:
             # vectors be stamped with the current source fingerprint. Cross-
             # commit reuse belongs to ``incremental_update`` instead.
             force_rebuild=True,
+            strict_chunking=True,
         )
         self._validate_vector_dimension(vs)
 

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -100,12 +100,13 @@ class BM25IndexBuilder:
 
     def artifact_identity(self) -> Dict[str, Any]:
         return {
-            # v7 refuses to publish indexes with silently skipped source files.
-            "builder_schema": 7,
+            # v8 refuses skipped files and retains non-symbol source context.
+            "builder_schema": 8,
             "languages": list(self.languages),
             "max_k": self.max_k,
             "max_lines_per_chunk": self.max_lines_per_chunk,
             "chunking_failure_policy": "fail",
+            "include_header_epilogue": True,
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 
@@ -121,6 +122,7 @@ class BM25IndexBuilder:
             language=primary,
             repo_config=RepoChunkingConfig(languages=self.languages),
             max_lines_per_chunk=self.max_lines_per_chunk,
+            include_header_epilogue=True,
         )
         chunks = chunker.chunk_repository(repo_path=repo_path, strict=True)
 

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -68,6 +68,7 @@ def build_hierarchical_vector_store(
     ivf_nprobe: int = 8,
     profiler: Optional[Profiler] = None,
     force_rebuild: bool = False,
+    strict_chunking: bool = False,
     artifact_metadata: Optional[Dict[str, Any]] = None,
 ) -> CodeVectorStore:
     """Build (or load) a hierarchical vector store (L0/L2) for a repository.
@@ -152,7 +153,10 @@ def build_hierarchical_vector_store(
             f"chunking_{level}",
             {"level": level, "language": languages[0]},
         ):
-            chunks_by_level[level] = chunker.chunk_repository(repo_path=repo_path)
+            chunks_by_level[level] = chunker.chunk_repository(
+                repo_path=repo_path,
+                strict=strict_chunking,
+            )
         logger.info(
             f"Chunked {len(chunks_by_level[level])} {level} chunks "
             f"(lang={languages[0]})"

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -98,6 +98,27 @@ def test_l0_empty_skeleton_falls_back_to_full_file(monkeypatch, tmp_path):
     assert chunks[0].node_id == "include/declarations.h"
 
 
+def test_chunk_file_replaces_invalid_utf8_bytes(monkeypatch, tmp_path):
+    source = tmp_path / "legacy.py"
+    source.write_bytes(b"value = b\x80\n")
+
+    parser = SimpleNamespace(parse=lambda _code: SimpleNamespace(root_node=object()))
+    monkeypatch.setattr(
+        "codenib.code_chunking.base.get_language", lambda _lang: object()
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_create_parser",
+        staticmethod(lambda _language: parser),
+    )
+
+    chunker = StubCodeChunker("python", chunk_depth=0)
+    chunks = chunker.chunk_file(str(source), relative_path="legacy.py")
+
+    assert len(chunks) == 1
+    assert "\ufffd" in chunks[0].content
+
+
 @pytest.mark.parametrize(
     ("configured_limit", "expected_limit"),
     [(None, DEFAULT_L0_RAW_FALLBACK_MAX_LINES), (100, 100)],

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -6,6 +6,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from codenib.code_chunker import CodeChunker, RepoChunkingConfig
 from codenib.languages import extensions_for_language
 
@@ -60,6 +62,25 @@ def test_repo_discovery_respects_custom_extension_overrides(tmp_path: Path):
 
     assert stats["total_files"] == 1
     assert stats["files_by_language"]["python"][0]["path"] == "tool.pyw"
+
+
+def test_strict_repository_chunking_rejects_partial_results(tmp_path, monkeypatch):
+    source = tmp_path / "broken.py"
+    source.write_text("def broken():\n    pass\n", encoding="utf-8")
+    cfg = RepoChunkingConfig(languages=["python"], filter_tests=False)
+    chunker = CodeChunker(language="python", repo_config=cfg)
+
+    def fail_chunking(*_args):
+        raise ValueError("parser failed")
+
+    monkeypatch.setattr(chunker, "_chunk_file_with_language", fail_chunking)
+
+    assert chunker.chunk_repository(str(tmp_path)) == []
+    with pytest.raises(
+        RuntimeError,
+        match=r"Failed to chunk repository source broken\.py: parser failed",
+    ):
+        chunker.chunk_repository(str(tmp_path), strict=True)
 
 
 def test_repo_discovery_is_sorted_independently_of_walk_order(

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -129,14 +129,21 @@ class TestBM25IndexBuilder:
         assert status.metadata["file_count"] == 3
         assert status.metadata["chunk_count"] == 3
         assert status.metadata["source_file_count"] == 2
-        assert status.metadata["builder_schema"] == 7
+        assert status.metadata["builder_schema"] == 8
         assert status.metadata["chunking_failure_policy"] == "fail"
+        assert status.metadata["include_header_epilogue"] is True
         assert status.metadata["max_k"] == 64
         assert set(status.metadata["artifact_file_fingerprints"]) == {
             "documents.json",
             "bm25_metadata.json",
         }
         assert status.path == output
+        MockChunker.assert_called_once_with(
+            language="python",
+            repo_config=ANY,
+            max_lines_per_chunk=300,
+            include_header_epilogue=True,
+        )
         mock_chunker_instance.chunk_repository.assert_called_once_with(
             repo_path="/fake/repo", strict=True
         )
@@ -152,7 +159,31 @@ class TestBM25IndexBuilder:
             assert result == "result"
 
     def test_artifact_identity_tracks_source_body_indexing(self):
-        assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 7
+        assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 8
+
+    def test_build_indexes_source_without_symbol_definitions(self, tmp_path):
+        from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "settings.py").write_text(
+            'UNIQUE_RUNTIME_MODE = "safe_local"\n',
+            encoding="utf-8",
+        )
+        output = tmp_path / "bm25"
+
+        status = BM25IndexBuilder(languages=["python"]).build(
+            scope="current_repo",
+            repo_path=str(repo),
+            output_dir=str(output),
+        )
+
+        assert status.metadata["source_file_count"] == 1
+        index = BM25CodeIndexer()
+        index.load_index(str(output))
+        results = index.search("safe_local", top_k=1)
+        assert results
+        assert results[0].file == "settings.py"
 
 
 # ---------------------------------------------------------------------------

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -129,13 +129,17 @@ class TestBM25IndexBuilder:
         assert status.metadata["file_count"] == 3
         assert status.metadata["chunk_count"] == 3
         assert status.metadata["source_file_count"] == 2
-        assert status.metadata["builder_schema"] == 6
+        assert status.metadata["builder_schema"] == 7
+        assert status.metadata["chunking_failure_policy"] == "fail"
         assert status.metadata["max_k"] == 64
         assert set(status.metadata["artifact_file_fingerprints"]) == {
             "documents.json",
             "bm25_metadata.json",
         }
         assert status.path == output
+        mock_chunker_instance.chunk_repository.assert_called_once_with(
+            repo_path="/fake/repo", strict=True
+        )
         mock_indexer_instance.save_index.assert_called_once_with(output)
 
     def test_incremental_delegates_to_build(self):
@@ -148,7 +152,7 @@ class TestBM25IndexBuilder:
             assert result == "result"
 
     def test_artifact_identity_tracks_source_body_indexing(self):
-        assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 6
+        assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 7
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +191,7 @@ class TestVectorIndexBuilder:
         assert status.metadata["document_count"] == {"l0": 2, "l2": 3}
         mock_build_fn.assert_called_once()
         assert mock_build_fn.call_args.kwargs["force_rebuild"] is True
+        assert mock_build_fn.call_args.kwargs["strict_chunking"] is True
 
     def test_artifact_identity_is_shared_by_full_and_incremental_statuses(self):
         builder = VectorIndexBuilder(
@@ -198,7 +203,7 @@ class TestVectorIndexBuilder:
 
         identity = builder.artifact_identity()
         assert identity == {
-            "builder_schema": 3,
+            "builder_schema": 4,
             "embedding_model": "test-model",
             "embedding_provider": "huggingface",
             "embedding_dimension": 384,
@@ -219,6 +224,7 @@ class TestVectorIndexBuilder:
             "languages": ["python"],
             "levels": ["l0", "l2"],
             "max_lines_per_chunk": 300,
+            "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -22,7 +22,8 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
         def __init__(self, **kwargs):
             pass
 
-        def chunk_repository(self, repo_path):
+        def chunk_repository(self, repo_path, *, strict=False):
+            captured["strict_chunking"] = strict
             return [chunk]
 
     captured = {}
@@ -67,10 +68,12 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
         embedding=embedding,
         artifact_metadata={"commit": "a" * 40},
         force_rebuild=True,
+        strict_chunking=True,
     )
 
     assert captured["embedding"] is embedding
     assert captured["artifact_metadata"] == {"commit": "a" * 40}
+    assert captured["strict_chunking"] is True
     assert result.l2_documents
     assert all(not path.exists() for path in stale_files)
     assert unrelated.read_bytes() == b"other"


### PR DESCRIPTION
## Summary
Prevent compiler-managed BM25 and vector builds from publishing silently partial repository views. Source parsing failures now abort the build, invalid UTF-8 remains addressable through deterministic replacement decoding, and BM25 retains non-symbol module content instead of marking an empty index fresh.

## Changes
- Add strict repository chunking that raises with the affected repository-relative source path.
- Enable strict chunking for compiler BM25 and full vector builds and persist the failure policy in builder identity.
- Decode invalid UTF-8 bytes with replacement so text source remains indexable rather than being skipped.
- Include BM25 header and epilogue chunks so constant/configuration-only files remain searchable while symbol chunks stay available for graph expansion.
- Bump BM25/vector builder schemas so older incomplete artifacts rebuild deterministically.
- Add parser-failure, invalid-encoding, builder-contract, and persisted non-symbol search regressions.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- sparse/chunker/compiler tier: 99 passed
- full unit tier: 2819 passed, 10 skipped, 183 deselected
- integration tier before the BM25-only follow-up: 36 passed, 14 skipped

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published