### PR TITLE
fix(index): detect torn embedding cache writes

### DIFF
--- a/codenib/index/incremental/embeddings_cache.py
+++ b/codenib/index/incremental/embeddings_cache.py
@@ -14,7 +14,9 @@ is never sent to the embedding model twice.
 from __future__ import annotations
 
 import json
+import os
 import pickle
+import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
@@ -128,9 +130,50 @@ class EmbeddingsCache:
         json_path = path.with_suffix(".json")
         npz_path = path.with_suffix(".npz")
 
-        with open(json_path, "w") as f:
-            json.dump(hashes, f, separators=(",", ":"))
-        np.savez_compressed(npz_path, vectors=vectors)
+        hash_width = max((len(value) for value in hashes), default=1)
+        embedded_hashes = np.asarray(hashes, dtype=f"<U{hash_width}")
+
+        # Publish the self-describing NPZ first. If the process stops before
+        # the JSON replace, the loader sees a generation mismatch instead of
+        # binding old vectors to new hashes with the same cardinality.
+        temp_npz = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w+b",
+                dir=npz_path.parent,
+                prefix=f".{npz_path.name}.",
+                delete=False,
+            ) as handle:
+                temp_npz = Path(handle.name)
+                np.savez_compressed(
+                    handle,
+                    vectors=vectors,
+                    hashes=embedded_hashes,
+                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_npz, npz_path)
+        finally:
+            if temp_npz is not None:
+                temp_npz.unlink(missing_ok=True)
+
+        temp_json = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=json_path.parent,
+                prefix=f".{json_path.name}.",
+                delete=False,
+            ) as handle:
+                temp_json = Path(handle.name)
+                json.dump(hashes, handle, separators=(",", ":"))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_json, json_path)
+        finally:
+            if temp_json is not None:
+                temp_json.unlink(missing_ok=True)
 
         # Also write pickle for backward compat
         with open(path, "wb") as f:
@@ -152,17 +195,49 @@ class EmbeddingsCache:
         cache = cls()
 
         if json_path.exists() and npz_path.exists():
-            with open(json_path, "r") as f:
+            with open(json_path, "r", encoding="utf-8") as f:
                 hashes = json.load(f)
-            data = np.load(npz_path)
-            vectors = data["vectors"]
+            if (
+                not isinstance(hashes, list)
+                or not all(isinstance(value, str) for value in hashes)
+                or len(set(hashes)) != len(hashes)
+            ):
+                raise ValueError(
+                    f"EmbeddingsCache corrupted: invalid hash index in {json_path}"
+                )
+
+            with np.load(npz_path, allow_pickle=False) as data:
+                if "vectors" not in data:
+                    raise ValueError(
+                        f"EmbeddingsCache corrupted: vectors missing from {npz_path}"
+                    )
+                vectors = np.asarray(data["vectors"], dtype=np.float32).copy()
+                embedded_hashes = None
+                if "hashes" in data:
+                    raw_hashes = data["hashes"].tolist()
+                    if not isinstance(raw_hashes, list):
+                        raise ValueError(
+                            "EmbeddingsCache corrupted: embedded hash index "
+                            f"is invalid in {npz_path}"
+                        )
+                    embedded_hashes = [str(value) for value in raw_hashes]
+
+            if vectors.ndim != 2:
+                raise ValueError(
+                    f"EmbeddingsCache corrupted: expected a vector matrix in {npz_path}"
+                )
             if len(hashes) != vectors.shape[0]:
                 raise ValueError(
                     f"EmbeddingsCache corrupted: {len(hashes)} hashes "
                     f"but {vectors.shape[0]} vectors in {json_path}"
                 )
+            if embedded_hashes is not None and embedded_hashes != hashes:
+                raise ValueError(
+                    "EmbeddingsCache corrupted: JSON hash order does not match "
+                    f"the vector generation in {npz_path}"
+                )
             for i, h in enumerate(hashes):
-                cache._cache[h] = vectors[i].astype(np.float32)
+                cache._cache[h] = vectors[i]
             logger.debug(
                 "EmbeddingsCache loaded from JSON+NPZ (%d entries) ← %s",
                 cache.size(),

--- a/codenib/index/incremental/embeddings_cache.py
+++ b/codenib/index/incremental/embeddings_cache.py
@@ -194,7 +194,15 @@ class EmbeddingsCache:
         npz_path = path.with_suffix(".npz")
         cache = cls()
 
-        if json_path.exists() and npz_path.exists():
+        json_exists = json_path.exists()
+        npz_exists = npz_path.exists()
+        if json_exists != npz_exists:
+            raise ValueError(
+                "EmbeddingsCache corrupted: incomplete JSON+NPZ generation at "
+                f"{path}"
+            )
+
+        if json_exists and npz_exists:
             with open(json_path, "r", encoding="utf-8") as f:
                 hashes = json.load(f)
             if (
@@ -214,13 +222,13 @@ class EmbeddingsCache:
                 vectors = np.asarray(data["vectors"], dtype=np.float32).copy()
                 embedded_hashes = None
                 if "hashes" in data:
-                    raw_hashes = data["hashes"].tolist()
-                    if not isinstance(raw_hashes, list):
+                    raw_hashes = np.asarray(data["hashes"])
+                    if raw_hashes.ndim != 1 or raw_hashes.dtype.kind != "U":
                         raise ValueError(
                             "EmbeddingsCache corrupted: embedded hash index "
                             f"is invalid in {npz_path}"
                         )
-                    embedded_hashes = [str(value) for value in raw_hashes]
+                    embedded_hashes = raw_hashes.tolist()
 
             if vectors.ndim != 2:
                 raise ValueError(

--- a/codenib/index/incremental/embeddings_cache.py
+++ b/codenib/index/incremental/embeddings_cache.py
@@ -271,7 +271,10 @@ class EmbeddingsCache:
         path = Path(path)
         json_path = path.with_suffix(".json")
         npz_path = path.with_suffix(".npz")
-        if (json_path.exists() and npz_path.exists()) or path.exists():
+        # Any modern sidecar means a generation was started. Delegate to
+        # ``load`` so a torn JSON/NPZ pair is reported as corruption instead
+        # of being mistaken for a cache that has never been built.
+        if json_path.exists() or npz_path.exists() or path.exists():
             return cls.load(path)
         return cls()
 

--- a/test/index/incremental/test_embeddings_cache.py
+++ b/test/index/incremental/test_embeddings_cache.py
@@ -128,6 +128,19 @@ class TestPersistence:
         loaded = EmbeddingsCache.load_or_empty(path)
         assert loaded.size() == 1
 
+    @pytest.mark.parametrize("present_suffix", [".json", ".npz"])
+    def test_load_or_empty_rejects_partial_modern_generation_without_pickle(
+        self,
+        tmp_path: Path,
+        present_suffix: str,
+    ):
+        path = tmp_path / "cache.pkl"
+        sidecar = path.with_suffix(present_suffix)
+        sidecar.write_bytes(b"[]" if present_suffix == ".json" else b"partial")
+
+        with pytest.raises(ValueError, match=r"incomplete JSON\+NPZ generation"):
+            EmbeddingsCache.load_or_empty(path)
+
     def test_load_rejects_hash_vector_generation_mismatch(self, tmp_path: Path):
         cache = EmbeddingsCache()
         cache.put("h1", make_vec(1.0))

--- a/test/index/incremental/test_embeddings_cache.py
+++ b/test/index/incremental/test_embeddings_cache.py
@@ -6,9 +6,12 @@
 Unit tests for EmbeddingsCache.
 """
 
+import json
+import os
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from codenib.index.incremental.embeddings_cache import EmbeddingsCache
 
@@ -124,3 +127,71 @@ class TestPersistence:
 
         loaded = EmbeddingsCache.load_or_empty(path)
         assert loaded.size() == 1
+
+    def test_load_rejects_hash_vector_generation_mismatch(self, tmp_path: Path):
+        cache = EmbeddingsCache()
+        cache.put("h1", make_vec(1.0))
+        cache.put("h2", make_vec(2.0))
+        path = tmp_path / "cache.pkl"
+        cache.save(path)
+
+        path.with_suffix(".json").write_text(
+            json.dumps(["other1", "other2"]),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="hash order does not match"):
+            EmbeddingsCache.load(path)
+
+    def test_saved_npz_carries_hash_order(self, tmp_path: Path):
+        cache = EmbeddingsCache()
+        cache.put("h1", make_vec(1.0))
+        cache.put("h2", make_vec(2.0))
+        path = tmp_path / "cache.pkl"
+
+        cache.save(path)
+
+        with np.load(path.with_suffix(".npz"), allow_pickle=False) as data:
+            assert data["hashes"].tolist() == ["h1", "h2"]
+
+    def test_legacy_npz_without_embedded_hashes_still_loads(self, tmp_path: Path):
+        path = tmp_path / "cache.pkl"
+        path.with_suffix(".json").write_text(
+            json.dumps(["legacy"]),
+            encoding="utf-8",
+        )
+        np.savez_compressed(
+            path.with_suffix(".npz"),
+            vectors=np.stack([make_vec(3.0)]),
+        )
+
+        loaded = EmbeddingsCache.load(path)
+
+        np.testing.assert_array_equal(loaded.get("legacy"), make_vec(3.0))
+
+    def test_interrupted_publish_fails_closed(self, tmp_path: Path, monkeypatch):
+        path = tmp_path / "cache.pkl"
+        old_cache = EmbeddingsCache()
+        old_cache.put("old1", make_vec(1.0))
+        old_cache.put("old2", make_vec(2.0))
+        old_cache.save(path)
+
+        new_cache = EmbeddingsCache()
+        new_cache.put("new1", make_vec(3.0))
+        new_cache.put("new2", make_vec(4.0))
+        real_replace = os.replace
+
+        def interrupt_json_replace(source, destination):
+            if Path(destination).suffix == ".json":
+                raise OSError("simulated interruption")
+            real_replace(source, destination)
+
+        monkeypatch.setattr(
+            "codenib.index.incremental.embeddings_cache.os.replace",
+            interrupt_json_replace,
+        )
+
+        with pytest.raises(OSError, match="simulated interruption"):
+            new_cache.save(path)
+        with pytest.raises(ValueError, match="hash order does not match"):
+            EmbeddingsCache.load(path)

--- a/test/index/incremental/test_embeddings_cache.py
+++ b/test/index/incremental/test_embeddings_cache.py
@@ -169,6 +169,35 @@ class TestPersistence:
 
         np.testing.assert_array_equal(loaded.get("legacy"), make_vec(3.0))
 
+    @pytest.mark.parametrize("missing_suffix", [".json", ".npz"])
+    def test_incomplete_modern_generation_does_not_fall_back_to_pickle(
+        self,
+        tmp_path: Path,
+        missing_suffix: str,
+    ):
+        path = tmp_path / "cache.pkl"
+        cache = EmbeddingsCache()
+        cache.put("hash", make_vec(1.0))
+        cache.save(path)
+        path.with_suffix(missing_suffix).unlink()
+
+        with pytest.raises(ValueError, match=r"incomplete JSON\+NPZ generation"):
+            EmbeddingsCache.load(path)
+
+    def test_embedded_hash_index_must_use_saved_string_encoding(self, tmp_path: Path):
+        path = tmp_path / "cache.pkl"
+        cache = EmbeddingsCache()
+        cache.put("1", make_vec(1.0))
+        cache.save(path)
+        np.savez_compressed(
+            path.with_suffix(".npz"),
+            vectors=np.stack([make_vec(1.0)]),
+            hashes=np.asarray([1]),
+        )
+
+        with pytest.raises(ValueError, match="embedded hash index is invalid"):
+            EmbeddingsCache.load(path)
+
     def test_interrupted_publish_fails_closed(self, tmp_path: Path, monkeypatch):
         path = tmp_path / "cache.pkl"
         old_cache = EmbeddingsCache()


### PR DESCRIPTION
## Summary
Prevent interrupted embedding-cache updates from silently binding stale or mismatched vectors to content hashes. Modern JSON+NPZ generations fail closed instead of falling back to an older pickle or appearing to be an unbuilt cache.

## Changes
- Persist the ordered content hashes inside each new NPZ vector generation
- Publish NPZ before JSON through same-directory temporary files and atomic replaces
- Cross-check JSON and NPZ hash order before constructing the cache
- Reject incomplete JSON+NPZ generations, including orphaned sidecars without a legacy pickle
- Validate hash-index type, shape, uniqueness, vector presence, and matrix shape
- Retain read compatibility for legacy NPZ files without embedded hashes

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- embedding-cache unit file: 24 passed
- complete incremental index tier after restacking: 101 passed
- combined verification invocation: 125 passed
- pre-commit: passed

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published