### PR TITLE
fix(compiler): enforce manifest artifact integrity

### DIFF
--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -18,7 +18,10 @@ from typing import Any, Iterable, Mapping, Sequence
 
 from .. import compat_pickle
 from .._version import package_version
-from ..compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
+from ..compiler.artifact_fingerprints import (
+    bm25_artifact_file_fingerprints,
+    require_bm25_manifest_artifact,
+)
 from ..compiler.checkout_identity import validate_checkout_identity
 from ..compiler.manifest import MANIFEST_FILENAME, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
@@ -440,6 +443,11 @@ def stage_context_artifact(
                         route.model.replace("/", "__"),
                         expected_config,
                     )
+            elif view == "bm25":
+                # Validate the committed source generation before copying and
+                # rewriting its machine-local metadata. Otherwise staging
+                # could bless a torn or tampered source with fresh hashes.
+                require_bm25_manifest_artifact(entry)
             relative = _copy_view(source, stage, view)
             adjustments = _normalize_copied_view(
                 stage,

--- a/codenib/compiler/artifact_fingerprints.py
+++ b/codenib/compiler/artifact_fingerprints.py
@@ -56,7 +56,38 @@ def bm25_artifact_files_match(
     return observed == dict(expected_fingerprints)
 
 
+def require_bm25_manifest_artifact(entry: object) -> bool:
+    """Validate a manifest-backed BM25 artifact before loading it.
+
+    Returns ``False`` for legacy entries that predate persisted fingerprints.
+    Once an entry records fingerprints, malformed or mismatched records are a
+    hard failure rather than permission to load potentially mixed generations.
+    """
+
+    missing = object()
+    expected: object = missing
+    for field_name in ("config", "metadata"):
+        field = getattr(entry, field_name, None)
+        if isinstance(field, Mapping) and "artifact_file_fingerprints" in field:
+            expected = field["artifact_file_fingerprints"]
+            break
+    if expected is missing:
+        return False
+
+    root = getattr(entry, "path", None)
+    if not isinstance(root, (str, Path)) or not bm25_artifact_files_match(
+        root,
+        expected_fingerprints=expected,
+    ):
+        raise ValueError(
+            "BM25 artifact does not match its manifest fingerprints; "
+            "rebuild or restore the view before loading it"
+        )
+    return True
+
+
 __all__ = [
     "bm25_artifact_file_fingerprints",
     "bm25_artifact_files_match",
+    "require_bm25_manifest_artifact",
 ]

--- a/codenib/compiler/manifest.py
+++ b/codenib/compiler/manifest.py
@@ -141,7 +141,7 @@ class RepoManifest:
         )
 
     def save(self, path: str | Path) -> None:
-        """Atomically replace the manifest with a durable JSON generation."""
+        """Atomically replace the manifest after flushing the JSON payload."""
 
         p = Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -152,10 +152,13 @@ class RepoManifest:
         )
         temporary_path = Path(temporary)
         try:
-            mode = p.stat().st_mode & 0o777 if p.exists() else 0o644
+            try:
+                mode = p.stat().st_mode & 0o777
+            except FileNotFoundError:
+                mode = None
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 fchmod = getattr(os, "fchmod", None)
-                if fchmod is not None:
+                if fchmod is not None and mode is not None:
                     fchmod(handle.fileno(), mode)
                 json.dump(self.to_dict(), handle, indent=2)
                 handle.flush()

--- a/codenib/compiler/manifest.py
+++ b/codenib/compiler/manifest.py
@@ -16,6 +16,8 @@ Phase 2 (``AgentRunner`` + ``ResourceGuard``) reads the manifest via
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -139,16 +141,33 @@ class RepoManifest:
         )
 
     def save(self, path: str | Path) -> None:
-        """Write the manifest to a JSON file."""
+        """Atomically replace the manifest with a durable JSON generation."""
+
         p = Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
-        with open(p, "w") as f:
-            json.dump(self.to_dict(), f, indent=2)
+        fd, temporary = tempfile.mkstemp(
+            dir=str(p.parent),
+            prefix=f".{p.name}.",
+            suffix=".tmp",
+        )
+        temporary_path = Path(temporary)
+        try:
+            mode = p.stat().st_mode & 0o777 if p.exists() else 0o644
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                fchmod = getattr(os, "fchmod", None)
+                if fchmod is not None:
+                    fchmod(handle.fileno(), mode)
+                json.dump(self.to_dict(), handle, indent=2)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_path, p)
+        finally:
+            temporary_path.unlink(missing_ok=True)
 
     @classmethod
     def load(cls, path: str | Path) -> RepoManifest:
         """Load a manifest from a JSON file."""
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         return cls.from_dict(data)
 

--- a/codenib/compiler/skill_context.py
+++ b/codenib/compiler/skill_context.py
@@ -43,6 +43,7 @@ from ..index.embedding.model_policy import (
 )
 from ..paths import REPO_INDEX_DIRNAME
 from ..provider_routes import resolve_embedding_artifact_route
+from .artifact_fingerprints import require_bm25_manifest_artifact
 from .index_builders import IndexBuilderRegistry, register_default_builders
 from .index_compiler import IndexCompiler, IndexCompilerConfig
 from .manifest import RepoManifest
@@ -560,7 +561,9 @@ def load_contexts_from_manifest(
 
     loaded: Dict[str, Any] = {}
     if "bm25" in needed:
-        loaded["bm25"] = _load_bm25(manifest.indexes["bm25"].path)
+        bm25_entry = manifest.indexes["bm25"]
+        require_bm25_manifest_artifact(bm25_entry)
+        loaded["bm25"] = _load_bm25(bm25_entry.path)
     if "vector" in needed:
         vec_entry = manifest.indexes["vector"]
         route = resolve_embedding_artifact_route(vec_entry.config)

--- a/codenib/mcp/context.py
+++ b/codenib/mcp/context.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from threading import RLock
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
 
+from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
 from ..provider_routes import resolve_embedding_artifact_route
 
@@ -283,6 +284,7 @@ class ServerContext:
         try:
             from ..index.sparse_idx import BM25CodeIndexer
 
+            require_bm25_manifest_artifact(entry)
             indexer = BM25CodeIndexer()
             indexer.load_index(entry.path)
             if indexer.project_root == "source":

--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -19,6 +19,7 @@ from importlib.util import find_spec
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
+from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
 from ..log_utils import get_logger
 from ..provider_routes import normalize_endpoint, resolve_embedding_artifact_route
@@ -474,6 +475,7 @@ class RepoRegistry:
 
         bm25_entry = manifest.indexes.get("bm25")
         if bm25_entry is not None and manifest.index_is_current("bm25"):
+            require_bm25_manifest_artifact(bm25_entry)
             bm25_index = BM25CodeIndexer()
             bm25_index.load_index(bm25_entry.path)
 

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -20,6 +20,7 @@ from urllib.parse import quote, unquote, urlsplit
 from .._atomic_directory import publish_staged_directory
 from .._version import package_version
 from ..artifacts.security import assert_publishable_tree, file_sha256
+from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.manifest import RepoManifest
 from .launcher import find_frontend_dir
 from .local import prepare_local_wiki
@@ -360,6 +361,7 @@ def _load_static_bundle(local: Any, manifest_path: Path) -> Any:
     bm25_entry = manifest.indexes.get("bm25")
     if bm25_entry is None or not manifest.index_is_current("bm25"):
         raise ValueError("static Wiki export requires a current bm25 view")
+    require_bm25_manifest_artifact(bm25_entry)
 
     entries = load_registry(str(local.data_dir / REGISTRY_FILENAME))
     entry = next((item for item in entries if item.instance_id == local.repo_id), None)

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -17,6 +17,7 @@ from codenib.artifacts import (
     CONTEXT_ARTIFACT_SCHEMA,
     stage_context_artifact,
 )
+from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
@@ -54,6 +55,10 @@ def _fixture_manifest(
             )
             + "\n"
         )
+    view_config = {
+        "artifact_file_fingerprints": bm25_artifact_file_fingerprints(view_path),
+        **(config or {}),
+    }
     manifest_path = index_root / "repo_manifest.json"
     source_fingerprint = fingerprint_repository(repo).value
     RepoManifest(
@@ -71,7 +76,7 @@ def _fixture_manifest(
                 built_at="2026-08-04T00:00:00+00:00",
                 built_at_epoch=1.0,
                 status=status,
-                config=dict(config or {}),
+                config=view_config,
                 commit="a" * 40,
                 source_fingerprint=source_fingerprint,
             )
@@ -342,6 +347,23 @@ def test_context_artifact_rejects_tampered_vector_level(tmp_path: Path) -> None:
             manifest_path,
             tmp_path / "publish" / "context",
             repository="example/vector-project",
+        )
+
+
+def test_context_artifact_rejects_tampered_bm25_generation(tmp_path: Path) -> None:
+    repo, manifest_path, bm25 = _fixture_manifest(tmp_path)
+    documents = bm25 / "documents.json"
+    documents.write_text(
+        documents.read_text(encoding="utf-8").replace("value", "other"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="manifest fingerprints"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+            repository="example/project",
         )
 
 

--- a/test/compiler/test_artifact_fingerprints.py
+++ b/test/compiler/test_artifact_fingerprints.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from codenib.compiler.artifact_fingerprints import (
+    bm25_artifact_file_fingerprints,
+    require_bm25_manifest_artifact,
+)
+
+
+def _bm25_artifact(tmp_path):
+    root = tmp_path / "bm25"
+    root.mkdir()
+    (root / "documents.json").write_text('[{"content":"alpha"}]')
+    (root / "bm25_metadata.json").write_text('{"max_k":10}')
+    return root
+
+
+def test_manifest_bm25_integrity_accepts_recorded_artifact(tmp_path):
+    root = _bm25_artifact(tmp_path)
+    entry = SimpleNamespace(
+        path=str(root),
+        config={"artifact_file_fingerprints": bm25_artifact_file_fingerprints(root)},
+        metadata={},
+    )
+
+    assert require_bm25_manifest_artifact(entry) is True
+
+
+def test_manifest_bm25_integrity_rejects_same_size_tamper(tmp_path):
+    root = _bm25_artifact(tmp_path)
+    entry = SimpleNamespace(
+        path=str(root),
+        config={"artifact_file_fingerprints": bm25_artifact_file_fingerprints(root)},
+        metadata={},
+    )
+    documents = root / "documents.json"
+    documents.write_text(documents.read_text().replace("alpha", "omega"))
+
+    with pytest.raises(ValueError, match="manifest fingerprints"):
+        require_bm25_manifest_artifact(entry)
+
+
+def test_manifest_bm25_integrity_allows_legacy_entry_without_record(tmp_path):
+    root = _bm25_artifact(tmp_path)
+    entry = SimpleNamespace(path=str(root), config={}, metadata={})
+
+    assert require_bm25_manifest_artifact(entry) is False
+
+
+def test_manifest_bm25_integrity_does_not_hide_malformed_config_record(tmp_path):
+    root = _bm25_artifact(tmp_path)
+    entry = SimpleNamespace(
+        path=str(root),
+        config={"artifact_file_fingerprints": None},
+        metadata={"artifact_file_fingerprints": bm25_artifact_file_fingerprints(root)},
+    )
+
+    with pytest.raises(ValueError, match="manifest fingerprints"):
+        require_bm25_manifest_artifact(entry)

--- a/test/compiler/test_manifest.py
+++ b/test/compiler/test_manifest.py
@@ -11,6 +11,7 @@ import time
 
 import pytest
 
+from codenib.compiler import manifest as manifest_module
 from codenib.compiler.manifest import (
     MANIFEST_VERSION,
     IndexEntry,
@@ -175,6 +176,30 @@ class TestRepoManifest:
         nested = tmp_path / "a" / "b" / "manifest.json"
         m.save(nested)
         assert nested.exists()
+
+    def test_failed_manifest_replace_preserves_previous_generation(
+        self, tmp_path, monkeypatch
+    ):
+        manifest_path = tmp_path / "repo_manifest.json"
+        previous = _sample_manifest()
+        previous.commit = "previous"
+        previous.save(manifest_path)
+        previous_bytes = manifest_path.read_bytes()
+
+        replacement = _sample_manifest()
+        replacement.commit = "replacement"
+
+        def fail_replace(_source, _destination):
+            raise OSError("simulated publication failure")
+
+        monkeypatch.setattr(manifest_module.os, "replace", fail_replace)
+
+        with pytest.raises(OSError, match="publication failure"):
+            replacement.save(manifest_path)
+
+        assert manifest_path.read_bytes() == previous_bytes
+        assert RepoManifest.load(manifest_path).commit == "previous"
+        assert list(tmp_path.glob(".repo_manifest.json.*.tmp")) == []
 
     def test_derive_capabilities_full(self):
         m = _sample_manifest()

--- a/test/compiler/test_manifest.py
+++ b/test/compiler/test_manifest.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import stat
 import time
 
 import pytest
@@ -176,6 +177,22 @@ class TestRepoManifest:
         nested = tmp_path / "a" / "b" / "manifest.json"
         m.save(nested)
         assert nested.exists()
+
+    def test_new_manifest_is_not_world_readable(self, tmp_path):
+        manifest_path = tmp_path / "repo_manifest.json"
+
+        _sample_manifest().save(manifest_path)
+
+        assert stat.S_IMODE(manifest_path.stat().st_mode) & 0o077 == 0
+
+    def test_replaced_manifest_preserves_existing_permissions(self, tmp_path):
+        manifest_path = tmp_path / "repo_manifest.json"
+        manifest_path.write_text("{}", encoding="utf-8")
+        manifest_path.chmod(0o640)
+
+        _sample_manifest().save(manifest_path)
+
+        assert stat.S_IMODE(manifest_path.stat().st_mode) == 0o640
 
     def test_failed_manifest_replace_preserves_previous_generation(
         self, tmp_path, monkeypatch

--- a/test/compiler/test_skill_context.py
+++ b/test/compiler/test_skill_context.py
@@ -39,6 +39,7 @@ from codenib.agent.skills.core import (
 from codenib.agent.skills.registry import SkillRegistry
 from codenib.compiler import resources as compiler_resources
 from codenib.compiler import skill_context
+from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.model_policy import DEFAULT_EMBEDDING_REVISION
 
@@ -771,6 +772,31 @@ def test_manifest_missing_required_index_raises(mixed_registry, mocked_build):
             skill_ids=["mixed_search"],
             skill_registry=mixed_registry,
         )
+
+
+def test_manifest_rejects_bm25_artifact_that_no_longer_matches(
+    mixed_registry, mocked_build, tmp_path
+):
+    bm25_dir = tmp_path / "bm25"
+    bm25_dir.mkdir()
+    documents = bm25_dir / "documents.json"
+    documents.write_text('[{"content":"alpha"}]')
+    (bm25_dir / "bm25_metadata.json").write_text('{"max_k":10}')
+    entry = _fresh_entry("bm25", str(bm25_dir))
+    entry.config["artifact_file_fingerprints"] = bm25_artifact_file_fingerprints(
+        bm25_dir
+    )
+    documents.write_text(documents.read_text().replace("alpha", "omega"))
+    manifest = RepoManifest(indexes={"bm25": entry})
+
+    with pytest.raises(ValueError, match="manifest fingerprints"):
+        skill_context.load_contexts_from_manifest(
+            manifest,
+            skill_ids=["mixed_search"],
+            skill_registry=mixed_registry,
+        )
+
+    assert mocked_build["loaded"] == []
 
 
 def test_corrupt_optional_graph_degrades_not_crash(

--- a/test/mcp_server/test_context.py
+++ b/test/mcp_server/test_context.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.mcp.context import RUNTIME_VIEW_NAMES, ServerContext
 from codenib.provider_routes import resolve_inference_route
@@ -177,6 +178,25 @@ def test_load_missing_bm25_path(tmp_path: Path) -> None:
     ctx = ServerContext.load(tmp_path / "repo_manifest.json")
     assert ctx.bm25 is None
     assert "bm25" in ctx.errors
+
+
+def test_load_rejects_bm25_that_no_longer_matches_manifest(
+    manifest_dir: Path,
+) -> None:
+    manifest_path = manifest_dir / "repo_manifest.json"
+    manifest = RepoManifest.load(manifest_path)
+    entry = manifest.indexes["bm25"]
+    entry.config["artifact_file_fingerprints"] = bm25_artifact_file_fingerprints(
+        entry.path
+    )
+    manifest.save(manifest_path)
+    documents = Path(entry.path) / "documents.json"
+    documents.write_text(documents.read_text().replace("foo", "bar"))
+
+    ctx = ServerContext.load(manifest_path)
+
+    assert ctx.bm25 is None
+    assert "manifest fingerprints" in ctx.errors["bm25"]
 
 
 def test_skip_non_fresh_index(tmp_path: Path) -> None:

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -9,6 +9,8 @@ from types import SimpleNamespace
 import pytest
 
 from codenib.agent.skills.registry import SkillRegistry
+from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
+from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.web.config import (
     QAConfig,
     RepoEntry,
@@ -102,6 +104,32 @@ def test_bundle_reports_partial_graph_language_coverage():
     assert coverage.available_languages == ["python", "ts"]
     assert coverage.unavailable_languages == ["cpp", "rust"]
     assert coverage.partial is True
+
+
+def test_repo_views_reject_bm25_that_no_longer_matches_manifest(tmp_path):
+    bm25_dir = tmp_path / "bm25"
+    bm25_dir.mkdir()
+    documents = bm25_dir / "documents.json"
+    documents.write_text('[{"content":"alpha"}]')
+    (bm25_dir / "bm25_metadata.json").write_text('{"max_k":10}')
+    entry = IndexEntry(
+        index_type="bm25",
+        path=str(bm25_dir),
+        built_at="2026-08-06T00:00:00Z",
+        built_at_epoch=0.0,
+        status="fresh",
+        config={
+            "artifact_file_fingerprints": bm25_artifact_file_fingerprints(bm25_dir)
+        },
+    )
+    manifest = RepoManifest(indexes={"bm25": entry})
+    documents.write_text(documents.read_text().replace("alpha", "omega"))
+    bundle = SimpleNamespace(manifest=manifest, bm25=None, vector_store=None)
+
+    with pytest.raises(ValueError, match="manifest fingerprints"):
+        RepoRegistry._load_repo_views(object(), bundle)
+
+    assert bundle.bm25 is None
 
 
 @pytest.mark.parametrize(

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -11,9 +11,11 @@ from types import SimpleNamespace
 import pytest
 
 from codenib.artifacts.security import assert_publishable_tree
+from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.web.static_export import (
     STATIC_EXPORT_MANIFEST,
+    _load_static_bundle,
     export_static_wiki,
     normalize_base_path,
 )
@@ -175,6 +177,26 @@ def _tree_bytes(root: Path) -> dict[str, bytes]:
         for path in sorted(root.rglob("*"))
         if path.is_file()
     }
+
+
+def test_static_bundle_rejects_bm25_that_no_longer_matches_manifest(tmp_path):
+    artifact = tmp_path / "artifact"
+    bm25_dir = artifact / "bm25"
+    bm25_dir.mkdir(parents=True)
+    documents = bm25_dir / "documents.json"
+    documents.write_text('[{"content":"alpha"}]')
+    (bm25_dir / "bm25_metadata.json").write_text('{"max_k":10}')
+    _, manifest_path = _manifest(tmp_path / "repo", artifact)
+    manifest = RepoManifest.load(manifest_path)
+    manifest.indexes["bm25"].config["artifact_file_fingerprints"] = (
+        bm25_artifact_file_fingerprints(bm25_dir)
+    )
+    manifest.save(manifest_path)
+    documents.write_text(documents.read_text().replace("alpha", "omega"))
+    local = SimpleNamespace(data_dir=artifact / "wiki", repo_id="demo")
+
+    with pytest.raises(ValueError, match="manifest fingerprints"):
+        _load_static_bundle(local, manifest_path)
 
 
 def test_static_export_is_deterministic_and_publishable(


### PR DESCRIPTION
## Summary
Keep manifest publication and manifest-backed BM25 consumption on complete artifact generations. A failed manifest replacement preserves the prior manifest, and runtimes or portable staging reject BM25 files that no longer match recorded fingerprints.

## Changes
- Publish repository manifests through a flushed same-directory temporary file and atomic replace
- Preserve existing manifest permissions while keeping newly created manifests private
- Preserve the previous manifest and remove temporary files when publication fails
- Add a dependency-free BM25 manifest-entry integrity guard with legacy compatibility
- Enforce recorded BM25 fingerprints before Agent, MCP, Wiki runtime, static export, and portable artifact loads
- Prevent portable staging from re-signing a torn or tampered BM25 generation
- Cover same-size valid-JSON tampering and every production loading path

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- focused compiler/MCP/web/artifact tier after restacking: 154 passed
- pre-commit: passed

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published