### PR TITLE
fix(agent): bound default tool I/O while streaming

### DIFF
--- a/codenib/agent/tools/defaults.py
+++ b/codenib/agent/tools/defaults.py
@@ -64,9 +64,10 @@ import shutil
 import signal
 import subprocess
 import tempfile
+import threading
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import BinaryIO, Dict, List, Optional, Tuple
 
 from .spec import ToolInputSpec, ToolRegistry, ToolSpec
 
@@ -79,7 +80,10 @@ _MAX_RESULTS_DEFAULT: int = 50
 _GLOB_MAX_RESULTS: int = 100  # mirrors the reference Glob's documented cap
 _GREP_TIMEOUT_SECONDS: int = 30
 _BASH_TIMEOUT_MS_DEFAULT: int = 30_000  # 30s, expressed in ms (reference units)
+_BASH_TIMEOUT_MS_MAX: int = 600_000
+_BASH_MAX_COMMAND_CHARS: int = 32_000
 _BASH_MAX_OUTPUT_CHARS: int = 16_000  # matches runner._MAX_RESULT_CHARS
+_BASH_READ_CHUNK_BYTES: int = 64 * 1024
 
 # Directories to skip during recursive search (avoids scanning VCS / cache noise).
 _SKIP_DIR_PREFIXES = frozenset(
@@ -421,9 +425,12 @@ def _grep_python(
 
 def _terminate_process_group(proc: subprocess.Popen[bytes]) -> None:
     try:
-        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-    except OSError:
-        proc.kill()
+        # ``start_new_session=True`` makes the child PID its process-group ID.
+        # Use it directly because the group can outlive an already-exited shell.
+        os.killpg(proc.pid, signal.SIGKILL)
+    except (AttributeError, OSError):
+        if proc.poll() is None:
+            proc.kill()
 
 
 def _grep_ripgrep(
@@ -864,6 +871,70 @@ def _build_glob_tool() -> ToolSpec:
 # ---------------------------------------------------------------------------
 
 
+class _BoundedPipeOutput:
+    """Drain a subprocess pipe while retaining only a fixed byte prefix."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._buffer = bytearray()
+        self.truncated = False
+
+    def drain(self, stream: BinaryIO) -> None:
+        try:
+            while chunk := stream.read(_BASH_READ_CHUNK_BYTES):
+                remaining = self._limit - len(self._buffer)
+                if remaining > 0:
+                    self._buffer.extend(chunk[:remaining])
+                if len(chunk) > remaining:
+                    self.truncated = True
+        except (OSError, ValueError):
+            # Forced process-group cleanup may close a pipe under the reader.
+            pass
+        finally:
+            try:
+                stream.close()
+            except OSError:
+                pass
+
+    def text(self) -> str:
+        return bytes(self._buffer).decode("utf-8", errors="replace")
+
+
+def _wait_for_bash(
+    proc: subprocess.Popen[bytes],
+    readers: tuple[threading.Thread, threading.Thread],
+    *,
+    timeout_seconds: float,
+) -> bool:
+    """Wait for both the shell and inherited output pipes until one deadline."""
+
+    deadline = time.monotonic() + timeout_seconds
+    timed_out = False
+    try:
+        proc.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+
+    if not timed_out:
+        for reader in readers:
+            reader.join(max(0.0, deadline - time.monotonic()))
+        # A background child can inherit the pipes after its shell exits. Treat
+        # that child as part of the command under the same wall-clock deadline.
+        timed_out = any(reader.is_alive() for reader in readers)
+
+    if timed_out:
+        _terminate_process_group(proc)
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=1)
+        for reader in readers:
+            reader.join(timeout=1)
+    return timed_out
+
+
 def _bash(
     command: str,
     timeout: int = _BASH_TIMEOUT_MS_DEFAULT,
@@ -882,41 +953,56 @@ def _bash(
     accepted for parity with the reference and is otherwise unused. Loose safety
     policy — see the "Safety" section of the skill_doc.
     """
+    if not isinstance(command, str) or not command.strip():
+        return "Error: command must be a non-empty string"
+    if len(command) > _BASH_MAX_COMMAND_CHARS:
+        return f"Error: command exceeds {_BASH_MAX_COMMAND_CHARS} characters"
+    if isinstance(timeout, bool):
+        return "Error: timeout must be an integer (milliseconds)"
     try:
         timeout_ms = int(timeout)
     except (TypeError, ValueError):
         return "Error: timeout must be an integer (milliseconds)"
-    # Convert ms -> whole seconds for subprocess, flooring at 1s so a small
-    # sub-second value never becomes a 0s (i.e. immediate) timeout.
-    timeout_s = max(1, timeout_ms // 1000)
+    if not 1 <= timeout_ms <= _BASH_TIMEOUT_MS_MAX:
+        return f"Error: timeout must be between 1 and {_BASH_TIMEOUT_MS_MAX} ms"
+    timeout_s = max(1.0, timeout_ms / 1000.0)
 
     try:
         proc = subprocess.Popen(  # noqa: S602 — loose shell policy by design
             command,
             shell=True,
             cwd=cwd,
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
             start_new_session=True,
         )
-    except (OSError, ValueError) as exc:
+    except (OSError, TypeError, ValueError) as exc:
         return f"Error executing command {command!r}: {exc}"
 
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout_s)
-    except subprocess.TimeoutExpired:
-        # Kill the whole process group, not just the shell, then reap.
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except OSError:  # incl. ProcessLookupError / PermissionError
-            proc.kill()
-        proc.communicate()
-        return f"Error: command timed out after {timeout_s}s: {command!r}"
-    except (OSError, ValueError) as exc:
-        proc.kill()
-        proc.communicate()
-        return f"Error executing command {command!r}: {exc}"
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    stdout_capture = _BoundedPipeOutput(_BASH_MAX_OUTPUT_CHARS)
+    stderr_capture = _BoundedPipeOutput(_BASH_MAX_OUTPUT_CHARS)
+    readers = (
+        threading.Thread(
+            target=stdout_capture.drain,
+            args=(proc.stdout,),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=stderr_capture.drain,
+            args=(proc.stderr,),
+            daemon=True,
+        ),
+    )
+    for reader in readers:
+        reader.start()
+    if _wait_for_bash(proc, readers, timeout_seconds=timeout_s):
+        return f"Error: command timed out after {timeout_s:g}s: {command!r}"
+
+    stdout = stdout_capture.text()
+    stderr = stderr_capture.text()
 
     parts: List[str] = [f"$ {command}", f"(exit code: {proc.returncode})"]
     if stdout:
@@ -925,7 +1011,11 @@ def _bash(
         parts.append(f"--- stderr ---\n{stderr.rstrip()}")
     text = "\n".join(parts)
 
-    if len(text) > _BASH_MAX_OUTPUT_CHARS:
+    if (
+        stdout_capture.truncated
+        or stderr_capture.truncated
+        or len(text) > _BASH_MAX_OUTPUT_CHARS
+    ):
         text = text[:_BASH_MAX_OUTPUT_CHARS] + "\n... (output truncated)"
     return text
 
@@ -941,15 +1031,15 @@ test runners.
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `command` | str | *required* | Shell command line to run. |
-| `timeout` | int | 30000 | Wall-clock **milliseconds** before kill. |
+| `command` | str | *required* | Shell command line to run (up to 32k chars). |
+| `timeout` | int | 30000 | Wall-clock **milliseconds** before kill (1–600000). |
 | `description` | str | null | Short human label (accepted for parity; unused). |
 | `cwd` | str | null | Working directory for the command. |
 
 ## Output
 
-`$ <cmd>` / `(exit code: N)` / stdout / stderr sections, capped at 16k chars.
-On timeout or spawn failure, an `Error: ...` string.
+`$ <cmd>` / `(exit code: N)` / stdout / stderr sections, capped while streaming
+at 16k chars. On timeout or spawn failure, an `Error: ...` string.
 
 ## Safety
 
@@ -958,8 +1048,9 @@ allow/deny list, and no path jail** — loose by design. An in-process filter is
 either too restrictive (blocks legitimate `pytest`/`git`) or trivially bypassed
 (`bash -c '...'`), so the trust boundary is the *environment*: callers running
 the agent on untrusted input MUST sandbox at the container / VM / process level.
-`timeout` guards against hangs; a 16k-char output cap guards against runaway
-producers (`yes`, `seq`).
+`timeout` guards against hangs; a 16k-char retained-output cap guards against
+runaway producers (`yes`, `seq`), and stdin is closed so commands cannot consume
+the agent's protocol stream.
 
 ## Note vs the reference
 
@@ -986,7 +1077,8 @@ def _build_bash_tool() -> ToolSpec:
                 default=_BASH_TIMEOUT_MS_DEFAULT,
                 description=(
                     "Wall-clock milliseconds before kill "
-                    f"(default {_BASH_TIMEOUT_MS_DEFAULT})."
+                    f"(1–{_BASH_TIMEOUT_MS_MAX}; "
+                    f"default {_BASH_TIMEOUT_MS_DEFAULT})."
                 ),
             ),
             ToolInputSpec(

--- a/codenib/agent/tools/defaults.py
+++ b/codenib/agent/tools/defaults.py
@@ -57,6 +57,7 @@ convention), #153 (1-based boundary).
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import select
@@ -64,6 +65,7 @@ import shutil
 import signal
 import stat
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -82,8 +84,13 @@ _READ_MAX_LINE_BYTES: int = 8_000
 _READ_MAX_OUTPUT_CHARS: int = 16_000
 _READ_CHUNK_BYTES: int = 64 * 1024
 _MAX_RESULTS_DEFAULT: int = 50
+_MAX_RESULTS_LIMIT: int = 1_000
 _GLOB_MAX_RESULTS: int = 100  # mirrors the reference Glob's documented cap
 _GREP_TIMEOUT_SECONDS: int = 30
+_GREP_MAX_PATTERN_CHARS: int = 32_000
+_GREP_MAX_LINE_BYTES: int = 8_000
+_GREP_MAX_OUTPUT_CHARS: int = 16_000
+_GREP_MAX_MULTILINE_FILE_BYTES: int = 8 * 1024 * 1024
 _BASH_TIMEOUT_MS_DEFAULT: int = 30_000  # 30s, expressed in ms (reference units)
 _BASH_TIMEOUT_MS_MAX: int = 600_000
 _BASH_MAX_COMMAND_CHARS: int = 32_000
@@ -373,6 +380,10 @@ def _grep_python(
     ``head_limit`` caps the number of emitted rows (matches in content mode,
     files in the other two). A no-match message is returned when nothing hits.
     """
+    if not isinstance(pattern, str) or not pattern:
+        return "Error: pattern must be a non-empty string"
+    if len(pattern) > _GREP_MAX_PATTERN_CHARS:
+        return f"Error: pattern must not exceed {_GREP_MAX_PATTERN_CHARS} characters"
     if output_mode not in _GREP_OUTPUT_MODES:
         return (
             f"Error: invalid output_mode {output_mode!r}; "
@@ -382,6 +393,8 @@ def _grep_python(
         head_limit = max(1, int(head_limit))
     except (TypeError, ValueError):
         return "Error: head_limit must be an integer"
+    if head_limit > _MAX_RESULTS_LIMIT:
+        return f"Error: head_limit must not exceed {_MAX_RESULTS_LIMIT} rows"
 
     flags = 0 if case_insensitive is False else re.IGNORECASE
     if multiline:
@@ -394,10 +407,13 @@ def _grep_python(
     root = Path(path)
     if not root.exists():
         return f"Error: path {path!r} does not exist"
+    if not root.is_dir() and not root.is_file():
+        return f"Error: path {path!r} is not a regular file or directory"
 
     content_rows: List[str] = []  # "{rel}:{lineno}: {line}"
     file_match_count: "Dict[str, int]" = {}  # rel -> match count, insertion order
     capped = False
+    skipped_multiline_files = 0
 
     def _rel(file_path: Path) -> str:
         if root.is_dir():
@@ -409,25 +425,44 @@ def _grep_python(
 
     def _scan(file_path: Path) -> bool:
         """Record matches for *file_path*; return True if the head cap was hit."""
+        nonlocal skipped_multiline_files
         rel = _rel(file_path)
         try:
             if multiline:
+                file_stat = file_path.stat()
+                if not stat.S_ISREG(file_stat.st_mode):
+                    return False
+                if file_stat.st_size > _GREP_MAX_MULTILINE_FILE_BYTES:
+                    skipped_multiline_files += 1
+                    return False
                 text = file_path.read_text(encoding="utf-8", errors="replace")
                 for m in compiled.finditer(text):
                     lineno = text.count("\n", 0, m.start()) + 1
                     snippet = text[m.start() : m.end()].splitlines()[0]
+                    if len(snippet) > _GREP_MAX_LINE_BYTES:
+                        snippet = (
+                            snippet[:_GREP_MAX_LINE_BYTES] + " ... [line truncated]"
+                        )
                     file_match_count[rel] = file_match_count.get(rel, 0) + 1
                     if output_mode == "content":
                         content_rows.append(f"{rel}:{lineno}: {snippet}")
                         if len(content_rows) >= head_limit:
                             return True
             else:
-                with open(file_path, encoding="utf-8", errors="replace") as fh:
-                    for lineno, line in enumerate(fh, start=1):
+                with open(file_path, "rb") as fh:
+                    if not stat.S_ISREG(os.fstat(fh.fileno()).st_mode):
+                        return False
+                    for lineno, (raw, line_truncated) in enumerate(
+                        _bounded_binary_lines(fh), start=1
+                    ):
+                        line = raw.decode("utf-8", errors="replace")
                         if compiled.search(line):
                             file_match_count[rel] = file_match_count.get(rel, 0) + 1
                             if output_mode == "content":
-                                content_rows.append(f"{rel}:{lineno}: {line.rstrip()}")
+                                content = line.rstrip()
+                                if line_truncated:
+                                    content += " ... [line truncated]"
+                                content_rows.append(f"{rel}:{lineno}: {content}")
                                 if len(content_rows) >= head_limit:
                                     return True
         except OSError:
@@ -439,7 +474,7 @@ def _grep_python(
         return False
 
     if root.is_file():
-        _scan(root)
+        capped = _scan(root)
     else:
         try:
             for file_path in _grep_candidate_files(root, glob, type):
@@ -450,7 +485,13 @@ def _grep_python(
             return f"Error: invalid glob {glob!r}: {exc}"
 
     if not file_match_count:
-        return "No matches found."
+        text = "No matches found."
+        if skipped_multiline_files:
+            text += (
+                f" ({skipped_multiline_files} file(s) exceeded the "
+                f"{_GREP_MAX_MULTILINE_FILE_BYTES}-byte multiline fallback limit.)"
+            )
+        return text
 
     if output_mode == "content":
         rows = content_rows
@@ -463,7 +504,16 @@ def _grep_python(
         cap_unit = "files"
 
     text = "\n".join(rows)
-    if capped:
+    output_truncated = False
+    if len(text) > _GREP_MAX_OUTPUT_CHARS:
+        text = text[:_GREP_MAX_OUTPUT_CHARS]
+        output_truncated = True
+    if output_truncated:
+        text += (
+            f"\n... ({_GREP_MAX_OUTPUT_CHARS}-character output limit reached; "
+            "narrow with `glob`/`type` or a more specific `pattern`)"
+        )
+    elif capped:
         text += (
             f"\n... (head_limit={head_limit} {cap_unit} reached; "
             "narrow with `glob`/`type` or a more specific `pattern`)"
@@ -479,6 +529,69 @@ def _terminate_process_group(proc: subprocess.Popen[bytes]) -> None:
     except (AttributeError, OSError):
         if proc.poll() is None:
             proc.kill()
+
+
+def _grep_python_isolated(
+    pattern: str,
+    path: str,
+    glob: Optional[str],
+    type_: Optional[str],
+    output_mode: str,
+    case_insensitive: bool,
+    multiline: bool,
+    head_limit: int,
+) -> str:
+    """Run the backtracking Python regex fallback outside the agent process."""
+
+    payload = json.dumps(
+        {
+            "pattern": pattern,
+            "path": path,
+            "glob": glob,
+            "type": type_,
+            "output_mode": output_mode,
+            "case_insensitive": case_insensitive,
+            "multiline": multiline,
+            "head_limit": head_limit,
+        }
+    ).encode("utf-8")
+    command = [sys.executable, "-m", "codenib.agent.tools.grep_worker"]
+    with (
+        tempfile.TemporaryFile() as stdout_file,
+        tempfile.TemporaryFile() as stderr_file,
+    ):
+        try:
+            proc = subprocess.Popen(  # noqa: S603 - fixed interpreter and module
+                command,
+                stdin=subprocess.PIPE,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                start_new_session=True,
+            )
+        except (OSError, ValueError) as exc:
+            return f"Error executing Python grep fallback: {exc}"
+        try:
+            proc.communicate(input=payload, timeout=_GREP_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            _terminate_process_group(proc)
+            proc.communicate()
+            return f"Error: grep timed out after {_GREP_TIMEOUT_SECONDS}s"
+
+        stdout_file.seek(0)
+        output = stdout_file.read(_GREP_MAX_OUTPUT_CHARS + 1)
+        stderr_file.seek(0)
+        stderr = stderr_file.read(_GREP_MAX_OUTPUT_CHARS).decode(
+            "utf-8", errors="replace"
+        )
+
+    if proc.returncode != 0:
+        detail = stderr.strip() or f"worker exited with status {proc.returncode}"
+        return f"Error executing Python grep fallback: {detail}"
+    truncated = len(output) > _GREP_MAX_OUTPUT_CHARS
+    text = output[:_GREP_MAX_OUTPUT_CHARS].decode("utf-8", errors="replace")
+    if truncated:
+        text += "\n... (grep output truncated)"
+    return text
 
 
 def _grep_ripgrep(
@@ -500,6 +613,8 @@ def _grep_ripgrep(
         "--hidden",
         "--no-ignore",
         "--text",
+        "--max-columns",
+        str(_GREP_MAX_LINE_BYTES),
     ]
     if case_insensitive is not False:
         command.append("--ignore-case")
@@ -620,7 +735,16 @@ def _grep_ripgrep(
     if not rows:
         return "No matches found."
     text = "\n".join(rows)
-    if capped:
+    output_truncated = False
+    if len(text) > _GREP_MAX_OUTPUT_CHARS:
+        text = text[:_GREP_MAX_OUTPUT_CHARS]
+        output_truncated = True
+    if output_truncated:
+        text += (
+            f"\n... ({_GREP_MAX_OUTPUT_CHARS}-character output limit reached; "
+            "narrow with `glob`/`type` or a more specific `pattern`)"
+        )
+    elif capped:
         cap_unit = "matches" if output_mode == "content" else "files"
         text += (
             f"\n... (head_limit={head_limit} {cap_unit} reached; "
@@ -640,6 +764,10 @@ def _grep(
     head_limit: int = _MAX_RESULTS_DEFAULT,
 ) -> str:
     """Regex content search with a bounded ripgrep backend when available."""
+    if not isinstance(pattern, str) or not pattern:
+        return "Error: pattern must be a non-empty string"
+    if len(pattern) > _GREP_MAX_PATTERN_CHARS:
+        return f"Error: pattern must not exceed {_GREP_MAX_PATTERN_CHARS} characters"
     if output_mode not in _GREP_OUTPUT_MODES:
         return (
             f"Error: invalid output_mode {output_mode!r}; "
@@ -649,6 +777,8 @@ def _grep(
         head_limit = max(1, int(head_limit))
     except (TypeError, ValueError):
         return "Error: head_limit must be an integer"
+    if head_limit > _MAX_RESULTS_LIMIT:
+        return f"Error: head_limit must not exceed {_MAX_RESULTS_LIMIT} rows"
 
     root = Path(path)
     if not root.exists():
@@ -669,15 +799,15 @@ def _grep(
             multiline,
             head_limit,
         )
-    return _grep_python(
+    return _grep_python_isolated(
         pattern,
-        path=path,
-        glob=glob,
-        type=type,
-        output_mode=output_mode,
-        case_insensitive=case_insensitive,
-        multiline=multiline,
-        head_limit=head_limit,
+        path,
+        glob,
+        type,
+        output_mode,
+        case_insensitive,
+        multiline,
+        head_limit,
     )
 
 
@@ -699,7 +829,7 @@ mainstream Claude Code `Grep` tool. Searches use ripgrep when installed, with a
 | `output_mode` | str | `content` | `content` / `files_with_matches` / `count`. |
 | `case_insensitive` | bool | true | Case-insensitive matching (reference `-i`). |
 | `multiline` | bool | false | Let `.`/`^`/`$` span lines (reference `multiline`). |
-| `head_limit` | int | 50 | Cap on rows (matches, or files in the other modes). |
+| `head_limit` | int | 50 | Cap on rows (hard maximum 1,000). |
 
 ## Output
 
@@ -788,7 +918,8 @@ def _build_grep_tool() -> ToolSpec:
                 default=_MAX_RESULTS_DEFAULT,
                 description=(
                     "Cap on rows returned (matches in content mode, files "
-                    f"otherwise; default {_MAX_RESULTS_DEFAULT})."
+                    f"otherwise; 1–{_MAX_RESULTS_LIMIT}, default "
+                    f"{_MAX_RESULTS_DEFAULT})."
                 ),
             ),
         ],

--- a/codenib/agent/tools/defaults.py
+++ b/codenib/agent/tools/defaults.py
@@ -96,6 +96,8 @@ _BASH_TIMEOUT_MS_MAX: int = 600_000
 _BASH_MAX_COMMAND_CHARS: int = 32_000
 _BASH_MAX_OUTPUT_CHARS: int = 16_000  # matches runner._MAX_RESULT_CHARS
 _BASH_READ_CHUNK_BYTES: int = 64 * 1024
+_BASH_COMMAND_DISPLAY_CHARS: int = 2_000
+_OUTPUT_TRUNCATED_NOTICE: str = "\n... (output truncated)"
 
 # Directories to skip during recursive search (avoids scanning VCS / cache noise).
 _SKIP_DIR_PREFIXES = frozenset(
@@ -138,6 +140,30 @@ TYPE_EXTENSIONS: Dict[str, Tuple[str, ...]] = {
 _TYPE_EXTENSIONS = TYPE_EXTENSIONS
 
 _GREP_OUTPUT_MODES = ("content", "files_with_matches", "count")
+
+
+def _bounded_text(
+    text: str,
+    limit: int,
+    notice: str = _OUTPUT_TRUNCATED_NOTICE,
+) -> str:
+    """Return a fixed-size text prefix plus an explicit truncation notice."""
+
+    if len(text) <= limit:
+        return text
+    return text[:limit] + notice
+
+
+def _display_command(command: str, *, quoted: bool = False) -> str:
+    """Render a bounded command label without hiding the command result."""
+
+    truncated = len(command) > _BASH_COMMAND_DISPLAY_CHARS
+    prefix = command[:_BASH_COMMAND_DISPLAY_CHARS]
+    rendered = repr(prefix) if quoted else prefix
+    if truncated:
+        rendered += " ... [command truncated]"
+    return rendered
+
 
 # ---------------------------------------------------------------------------
 # read
@@ -531,6 +557,20 @@ def _terminate_process_group(proc: subprocess.Popen[bytes]) -> None:
             proc.kill()
 
 
+def _process_group_alive(proc: subprocess.Popen[bytes]) -> bool:
+    """Return whether the command's original process group still exists."""
+
+    try:
+        os.killpg(proc.pid, 0)
+    except (AttributeError, ProcessLookupError):
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return proc.poll() is None
+    return True
+
+
 def _grep_python_isolated(
     pattern: str,
     path: str,
@@ -651,65 +691,88 @@ def _grep_ripgrep(
         target = "."
     command.extend(("--", pattern, target))
 
-    with tempfile.TemporaryFile() as stderr_file:
-        try:
-            proc = subprocess.Popen(  # noqa: S603 - fixed executable and argv
-                command,
-                cwd=cwd,
-                stdout=subprocess.PIPE,
-                stderr=stderr_file,
-                bufsize=0,
-                start_new_session=True,
-            )
-        except (OSError, ValueError) as exc:
-            return f"Error executing grep: {exc}"
+    try:
+        proc = subprocess.Popen(  # noqa: S603 - fixed executable and argv
+            command,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            start_new_session=True,
+        )
+    except (OSError, ValueError) as exc:
+        return _bounded_text(f"Error executing grep: {exc}", _GREP_MAX_OUTPUT_CHARS)
 
-        assert proc.stdout is not None
-        deadline = time.monotonic() + _GREP_TIMEOUT_SECONDS
-        pending = bytearray()
-        rows: List[str] = []
-        timed_out = False
-        eof = False
-        while len(rows) <= head_limit and not eof:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                timed_out = True
-                break
-            ready, _, _ = select.select((proc.stdout.fileno(),), (), (), remaining)
-            if not ready:
-                timed_out = True
-                break
-            chunk = os.read(proc.stdout.fileno(), 64 * 1024)
-            if not chunk:
-                eof = True
-            else:
-                pending.extend(chunk)
-            while b"\n" in pending and len(rows) <= head_limit:
-                raw, _, remainder = pending.partition(b"\n")
-                pending = bytearray(remainder)
-                rows.append(raw.rstrip(b"\r").decode("utf-8", errors="replace"))
-        if eof and pending and len(rows) <= head_limit:
-            rows.append(bytes(pending).rstrip(b"\r").decode("utf-8", errors="replace"))
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    stderr_capture = _BoundedPipeOutput(_GREP_MAX_OUTPUT_CHARS)
+    stderr_reader = threading.Thread(
+        target=stderr_capture.drain,
+        args=(proc.stderr,),
+        daemon=True,
+    )
+    stderr_reader.start()
 
-        capped = len(rows) > head_limit
-        if timed_out or capped:
-            _terminate_process_group(proc)
+    deadline = time.monotonic() + _GREP_TIMEOUT_SECONDS
+    pending = bytearray()
+    rows: List[str] = []
+    timed_out = False
+    eof = False
+    while len(rows) <= head_limit and not eof:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        ready, _, _ = select.select((proc.stdout.fileno(),), (), (), remaining)
+        if not ready:
+            timed_out = True
+            break
+        chunk = os.read(proc.stdout.fileno(), 64 * 1024)
+        if not chunk:
+            eof = True
+        else:
+            pending.extend(chunk)
+        while b"\n" in pending and len(rows) <= head_limit:
+            raw, _, remainder = pending.partition(b"\n")
+            pending = bytearray(remainder)
+            rows.append(raw.rstrip(b"\r").decode("utf-8", errors="replace"))
+    if eof and pending and len(rows) <= head_limit:
+        rows.append(bytes(pending).rstrip(b"\r").decode("utf-8", errors="replace"))
+
+    capped = len(rows) > head_limit
+    if not timed_out and not capped:
+        remaining = max(0.0, deadline - time.monotonic())
         try:
-            proc.wait(timeout=1)
+            proc.wait(timeout=remaining)
         except subprocess.TimeoutExpired:
-            _terminate_process_group(proc)
-            proc.wait()
-        stderr_file.seek(0)
-        stderr = stderr_file.read().decode("utf-8", errors="replace")
-        proc.stdout.close()
+            timed_out = True
+        if not timed_out:
+            stderr_reader.join(max(0.0, deadline - time.monotonic()))
+            timed_out = stderr_reader.is_alive()
+    if timed_out or capped:
+        _terminate_process_group(proc)
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        _terminate_process_group(proc)
+        proc.wait()
+    stderr_reader.join(timeout=1)
+    stderr = stderr_capture.text()
+    proc.stdout.close()
 
     if timed_out:
         return f"Error: grep timed out after {_GREP_TIMEOUT_SECONDS}s"
     if not capped and proc.returncode not in (0, 1):
         detail = stderr.strip() or f"ripgrep exited with status {proc.returncode}"
         if "regex parse error" in detail.lower():
-            return f"Error: invalid regex {pattern!r}: {detail}"
-        return f"Error executing grep for pattern {pattern!r}: {detail}"
+            return _bounded_text(
+                f"Error: invalid regex {pattern!r}: {detail}",
+                _GREP_MAX_OUTPUT_CHARS,
+            )
+        return _bounded_text(
+            f"Error executing grep for pattern {pattern!r}: {detail}",
+            _GREP_MAX_OUTPUT_CHARS,
+        )
 
     rows = rows[:head_limit]
     if output_mode == "content":
@@ -1101,6 +1164,18 @@ def _wait_for_bash(
         # that child as part of the command under the same wall-clock deadline.
         timed_out = any(reader.is_alive() for reader in readers)
 
+    if not timed_out:
+        # A background child may redirect both inherited pipes before the shell
+        # exits. The readers cannot observe that child, so keep watching the
+        # original process group. ``run_in_background`` is intentionally not a
+        # supported Bash mode; no descendant may escape the command deadline.
+        while _process_group_alive(proc):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            time.sleep(min(0.01, remaining))
+
     if timed_out:
         _terminate_process_group(proc)
         try:
@@ -1144,7 +1219,7 @@ def _bash(
         return "Error: timeout must be an integer (milliseconds)"
     if not 1 <= timeout_ms <= _BASH_TIMEOUT_MS_MAX:
         return f"Error: timeout must be between 1 and {_BASH_TIMEOUT_MS_MAX} ms"
-    timeout_s = max(1.0, timeout_ms / 1000.0)
+    timeout_s = timeout_ms / 1000.0
 
     try:
         proc = subprocess.Popen(  # noqa: S602 — loose shell policy by design
@@ -1157,7 +1232,11 @@ def _bash(
             start_new_session=True,
         )
     except (OSError, TypeError, ValueError) as exc:
-        return f"Error executing command {command!r}: {exc}"
+        return _bounded_text(
+            f"Error executing command {_display_command(command, quoted=True)}: "
+            f"{exc}",
+            _BASH_MAX_OUTPUT_CHARS,
+        )
 
     assert proc.stdout is not None
     assert proc.stderr is not None
@@ -1177,13 +1256,42 @@ def _bash(
     )
     for reader in readers:
         reader.start()
-    if _wait_for_bash(proc, readers, timeout_seconds=timeout_s):
-        return f"Error: command timed out after {timeout_s:g}s: {command!r}"
+    try:
+        timed_out = _wait_for_bash(proc, readers, timeout_seconds=timeout_s)
+    except (OSError, ValueError) as exc:
+        _terminate_process_group(proc)
+        try:
+            proc.wait(timeout=1)
+        except (OSError, subprocess.TimeoutExpired):
+            if proc.poll() is None:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=1)
+                except OSError:
+                    pass
+                except subprocess.TimeoutExpired:
+                    pass
+        for reader in readers:
+            reader.join(timeout=1)
+        return _bounded_text(
+            f"Error executing command {_display_command(command, quoted=True)}: "
+            f"{exc}",
+            _BASH_MAX_OUTPUT_CHARS,
+        )
+    if timed_out:
+        return _bounded_text(
+            f"Error: command timed out after {timeout_s:g}s: "
+            f"{_display_command(command, quoted=True)}",
+            _BASH_MAX_OUTPUT_CHARS,
+        )
 
     stdout = stdout_capture.text()
     stderr = stderr_capture.text()
 
-    parts: List[str] = [f"$ {command}", f"(exit code: {proc.returncode})"]
+    parts: List[str] = [
+        f"$ {_display_command(command)}",
+        f"(exit code: {proc.returncode})",
+    ]
     if stdout:
         parts.append(f"--- stdout ---\n{stdout.rstrip()}")
     if stderr:
@@ -1195,7 +1303,7 @@ def _bash(
         or stderr_capture.truncated
         or len(text) > _BASH_MAX_OUTPUT_CHARS
     ):
-        text = text[:_BASH_MAX_OUTPUT_CHARS] + "\n... (output truncated)"
+        text = _bounded_text(text, _BASH_MAX_OUTPUT_CHARS)
     return text
 
 

--- a/codenib/agent/tools/defaults.py
+++ b/codenib/agent/tools/defaults.py
@@ -62,6 +62,7 @@ import re
 import select
 import shutil
 import signal
+import stat
 import subprocess
 import tempfile
 import threading
@@ -76,6 +77,10 @@ DEFAULT_TOOL_IDS: frozenset[str] = frozenset({"read", "grep", "glob", "bash"})
 
 # Sensible token-safety caps.
 _MAX_LINES_DEFAULT: int = 200
+_MAX_LINES_LIMIT: int = 2_000
+_READ_MAX_LINE_BYTES: int = 8_000
+_READ_MAX_OUTPUT_CHARS: int = 16_000
+_READ_CHUNK_BYTES: int = 64 * 1024
 _MAX_RESULTS_DEFAULT: int = 50
 _GLOB_MAX_RESULTS: int = 100  # mirrors the reference Glob's documented cap
 _GREP_TIMEOUT_SECONDS: int = 30
@@ -132,6 +137,25 @@ _GREP_OUTPUT_MODES = ("content", "files_with_matches", "count")
 # ---------------------------------------------------------------------------
 
 
+def _bounded_binary_lines(handle: BinaryIO):
+    """Yield bounded physical-line prefixes without materializing long lines."""
+
+    while True:
+        raw = handle.readline(_READ_MAX_LINE_BYTES + 1)
+        if not raw:
+            return
+
+        complete = raw.endswith(b"\n") or len(raw) <= _READ_MAX_LINE_BYTES
+        truncated = len(raw.rstrip(b"\r\n")) > _READ_MAX_LINE_BYTES
+        prefix = raw[:_READ_MAX_LINE_BYTES]
+        if not complete:
+            truncated = True
+            while tail := handle.readline(_READ_CHUNK_BYTES):
+                if tail.endswith(b"\n") or len(tail) < _READ_CHUNK_BYTES:
+                    break
+        yield prefix, truncated
+
+
 def _read(
     file_path: str,
     offset: int = 1,
@@ -148,43 +172,68 @@ def _read(
         file_path: Absolute or repo-relative path to the file.
         offset: First line to read (1-based, inclusive). Defaults to 1. Mirrors
             the reference ``Read.offset``.
-        limit: Hard cap on lines returned for token safety. Defaults to 200. A
-            truncation notice with the next ``offset`` is appended when the cap
-            is reached. Mirrors the reference ``Read.limit``.
+        limit: Hard cap on lines returned for token safety. Defaults to 200 and
+            cannot exceed 2,000. A truncation notice with the next ``offset`` is
+            appended when the line or output cap is reached.
 
     Returns:
         Formatted string, or an error message prefixed with ``"Error: "``.
     """
-    # Coerce inputs up front: a non-integer arg returns an Error string (the
-    # module contract) instead of raising into the caller. `limit` is floored at
-    # 1 so `limit=0` cannot emit a "0 lines; continue at the same offset" notice
-    # that loops forever.
+    if not isinstance(file_path, str) or not file_path:
+        return "Error: file_path must be a non-empty string"
     try:
         start = max(1, int(offset))
         limit = max(1, int(limit))
     except (TypeError, ValueError):
         return "Error: offset and limit must be integers"
+    if limit > _MAX_LINES_LIMIT:
+        return f"Error: limit must not exceed {_MAX_LINES_LIMIT} lines"
 
-    # Stream the file: keep at most `limit` lines in memory and merely *count*
-    # any further lines (for the truncation notice) without storing them, so a
-    # huge file is never fully materialised.
-    selected: List[str] = []
-    extra = 0  # lines present beyond the kept window
-    total = 0
+    path = Path(file_path)
     try:
-        with open(file_path, encoding="utf-8", errors="replace") as fh:
-            for idx, line in enumerate(fh, start=1):
+        mode = path.stat().st_mode
+    except FileNotFoundError:
+        return f"Error: file not found: {file_path!r}"
+    except OSError as exc:
+        return f"Error reading {file_path!r}: {exc}"
+    if stat.S_ISDIR(mode):
+        return f"Error: {file_path!r} is a directory, not a file"
+    if not stat.S_ISREG(mode):
+        return f"Error: {file_path!r} is not a regular file"
+
+    selected: List[str] = []
+    selected_chars = 0
+    total = 0
+    has_more = False
+    next_start: int | None = None
+    try:
+        with open(file_path, "rb") as fh:
+            if not stat.S_ISREG(os.fstat(fh.fileno()).st_mode):
+                return f"Error: {file_path!r} is not a regular file"
+            for idx, (raw, line_truncated) in enumerate(
+                _bounded_binary_lines(fh),
+                start=1,
+            ):
                 total = idx
                 if idx < start:
                     continue
-                if len(selected) < limit:
-                    selected.append(line)
-                else:
-                    extra += 1
+                if len(selected) >= limit:
+                    has_more = True
+                    next_start = idx
+                    break
+                content = raw.decode("utf-8", errors="replace").rstrip()
+                if line_truncated:
+                    content += " ... [line truncated]"
+                rendered = f"{idx:6d} | {content}"
+                separator = 1 if selected else 0
+                if selected_chars + separator + len(rendered) > _READ_MAX_OUTPUT_CHARS:
+                    has_more = True
+                    next_start = idx
+                    break
+                selected.append(rendered)
+                selected_chars += separator + len(rendered)
     except FileNotFoundError:
         return f"Error: file not found: {file_path!r}"
-    except IsADirectoryError:
-        return f"Error: {file_path!r} is a directory, not a file"
     except OSError as exc:
         return f"Error reading {file_path!r}: {exc}"
 
@@ -193,15 +242,10 @@ def _read(
     if start > total:
         return f"Error: offset {start} exceeds file length {total} in {file_path!r}"
 
-    lines_out = [
-        f"{lineno:6d} | {line.rstrip()}"
-        for lineno, line in enumerate(selected, start=start)
-    ]
-    result = "\n".join(lines_out)
+    result = "\n".join(selected)
 
-    if extra > 0:
-        next_start = start + limit  # first omitted line (1-based)
-        result += f"\n... ({extra} more lines; " f"use offset={next_start} to continue)"
+    if has_more and next_start is not None:
+        result += f"\n... (more lines; use offset={next_start} to continue)"
 
     return result
 
@@ -218,12 +262,13 @@ Shape mirrors the mainstream Claude Code `Read` tool.
 |------|------|---------|-------------|
 | `file_path` | `str` | *(required)* | Absolute or repo-relative file path. |
 | `offset` | `int` | `1` | First line to read (1-based, inclusive). |
-| `limit` | `int` | `200` | Max lines returned; prevents context blowup. |
+| `limit` | `int` | `200` | Max lines returned (hard maximum 2,000). |
 
 ## Output
 
-Lines formatted as `{lineno:6d} | {content}` (opencode-style, 1-based).
-A truncation notice with the next `offset` is appended when `limit` is reached.
+Lines formatted as `{lineno:6d} | {content}` (opencode-style, 1-based). Long
+physical lines and total output are bounded while streaming. A notice with the
+next `offset` is appended when more lines remain.
 
 ## When to Use
 
@@ -263,7 +308,10 @@ def _build_read_tool() -> ToolSpec:
                 type_hint="int",
                 required=False,
                 default=_MAX_LINES_DEFAULT,
-                description=(f"Max lines returned (default {_MAX_LINES_DEFAULT})."),
+                description=(
+                    f"Max lines returned (1–{_MAX_LINES_LIMIT}; "
+                    f"default {_MAX_LINES_DEFAULT})."
+                ),
             ),
         ],
         executor_fn=_read,

--- a/codenib/agent/tools/grep_worker.py
+++ b/codenib/agent/tools/grep_worker.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Isolated process entry point for the Python regex grep fallback."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from .defaults import _grep_python
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        result = _grep_python(**payload)
+    except Exception as exc:
+        print(f"grep fallback rejected its request: {exc}", file=sys.stderr)
+        return 2
+    sys.stdout.write(result)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the parent
+    raise SystemExit(main())

--- a/test/agent/test_default_tools.py
+++ b/test/agent/test_default_tools.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import shlex
 import shutil
 import sys
@@ -44,6 +45,8 @@ from codenib.agent.skills.registry import SkillRegistry
 from codenib.agent.tool_schema import tool_to_schema
 from codenib.agent.tools.defaults import (
     _BASH_MAX_OUTPUT_CHARS,
+    _MAX_LINES_LIMIT,
+    _READ_MAX_OUTPUT_CHARS,
     DEFAULT_TOOL_IDS,
     _bash,
     _BoundedPipeOutput,
@@ -147,6 +150,47 @@ class TestRead:
 
     def test_offset_beyond_eof_returns_error(self, sample_file):
         assert _read(str(sample_file), offset=9999).startswith("Error:")
+
+    def test_stops_after_detecting_one_omitted_line(self, tmp_path, monkeypatch):
+        source = tmp_path / "source.py"
+        source.write_text("placeholder\n", encoding="utf-8")
+
+        def bounded_lines(_handle):
+            yield b"first\n", False
+            yield b"second\n", False
+            raise AssertionError("read scanned beyond the first omitted line")
+
+        monkeypatch.setattr(
+            "codenib.agent.tools.defaults._bounded_binary_lines",
+            bounded_lines,
+        )
+
+        result = _read(str(source), limit=1)
+
+        assert "first" in result
+        assert "offset=2" in result
+
+    def test_bounds_long_lines_and_total_output(self, tmp_path):
+        source = tmp_path / "long.py"
+        source.write_bytes((b"x" * 1_000_000 + b"\n") * 4)
+
+        result = _read(str(source), limit=4)
+
+        assert "[line truncated]" in result
+        assert len(result) <= _READ_MAX_OUTPUT_CHARS + 100
+        assert "use offset=" in result
+
+    def test_rejects_nonregular_files(self, tmp_path):
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFO creation is unavailable")
+        fifo = tmp_path / "input.fifo"
+        os.mkfifo(fifo)
+
+        assert "not a regular file" in _read(str(fifo))
+
+    def test_rejects_unbounded_line_limits(self, sample_file):
+        result = _read(str(sample_file), limit=_MAX_LINES_LIMIT + 1)
+        assert result.startswith("Error: limit must not exceed")
 
 
 # ---------------------------------------------------------------------------

--- a/test/agent/test_default_tools.py
+++ b/test/agent/test_default_tools.py
@@ -45,6 +45,7 @@ from codenib.agent.skills.registry import SkillRegistry
 from codenib.agent.tool_schema import tool_to_schema
 from codenib.agent.tools.defaults import (
     _BASH_MAX_OUTPUT_CHARS,
+    _GREP_MAX_OUTPUT_CHARS,
     _MAX_LINES_LIMIT,
     _MAX_RESULTS_LIMIT,
     _READ_MAX_OUTPUT_CHARS,
@@ -331,6 +332,27 @@ class TestGrep:
 
         assert result == "Error: grep timed out after 0.05s"
 
+    def test_ripgrep_stderr_is_drained_into_a_bounded_prefix(
+        self, tmp_path, monkeypatch
+    ):
+        noisy_rg = tmp_path / "noisy-rg"
+        script = "import sys; sys.stderr.write('x' * 1000000); raise SystemExit(2)"
+        noisy_rg.write_text(
+            f"#!{sys.executable}\n{script}\n",
+            encoding="utf-8",
+        )
+        noisy_rg.chmod(0o755)
+        monkeypatch.setattr(
+            "codenib.agent.tools.defaults.shutil.which",
+            lambda _command: str(noisy_rg),
+        )
+
+        result = _grep("needle", path=str(tmp_path))
+
+        assert result.startswith("Error executing grep")
+        assert "(output truncated)" in result
+        assert len(result) <= _GREP_MAX_OUTPUT_CHARS + 200
+
     def test_invalid_output_mode_returns_error(self, sample_dir):
         result = _grep("x", path=str(sample_dir), output_mode="bogus")
         assert result.startswith("Error:") and "output_mode" in result
@@ -427,12 +449,31 @@ class TestBash:
         result = _bash("sleep 2", timeout=1000)
         assert result.startswith("Error:") and "timed out" in result
 
+    def test_subsecond_timeout_is_not_rounded_to_one_second(self):
+        result = _bash("sleep 2", timeout=100)
+
+        assert result.startswith("Error:")
+        assert "timed out after 0.1s" in result
+
     def test_timeout_kills_background_process_group(self):
         started = time.monotonic()
         result = _bash("sleep 5 &", timeout=1000)
 
         assert result.startswith("Error:") and "timed out" in result
         assert time.monotonic() - started < 3
+
+    def test_timeout_kills_background_process_with_redirected_pipes(self, tmp_path):
+        marker = tmp_path / "escaped"
+        command = (
+            f"(sleep 0.5; printf escaped > {shlex.quote(str(marker))}) "
+            ">/dev/null 2>&1 &"
+        )
+
+        result = _bash(command, timeout=100)
+        time.sleep(0.6)
+
+        assert result.startswith("Error:") and "timed out" in result
+        assert not marker.exists()
 
     def test_description_accepted(self):
         """The reference `description` metadata field is accepted and ignored."""
@@ -448,6 +489,61 @@ class TestBash:
         result = _bash("yes hello | head -n 20000")
         assert "(output truncated)" in result
         assert len(result) <= _BASH_MAX_OUTPUT_CHARS + 200
+
+    def test_stdout_stderr_and_decode_stay_bounded(self):
+        script = (
+            "import os; "
+            "os.write(1, b'\\xff' * 100000); "
+            "os.write(2, b'\\xfe' * 100000)"
+        )
+        command = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+
+        result = _bash(command, timeout=5000)
+
+        assert "(output truncated)" in result
+        assert "\N{REPLACEMENT CHARACTER}" in result
+        assert len(result) <= _BASH_MAX_OUTPUT_CHARS + 200
+
+    def test_long_command_label_does_not_hide_result(self):
+        command = "printf visible #" + ("x" * 30_000)
+
+        result = _bash(command)
+
+        assert "[command truncated]" in result
+        assert "exit code: 0" in result
+        assert "visible" in result
+
+    def test_timeout_error_bounds_long_command(self):
+        command = "sleep 2 #" + ("x" * 30_000)
+
+        result = _bash(command, timeout=100)
+
+        assert result.startswith("Error:") and "[command truncated]" in result
+        assert len(result) <= _BASH_MAX_OUTPUT_CHARS + 200
+
+    def test_spawn_error_is_bounded(self, monkeypatch):
+        def reject_spawn(*_args, **_kwargs):
+            raise OSError("x" * 100_000)
+
+        monkeypatch.setattr(
+            "codenib.agent.tools.defaults.subprocess.Popen", reject_spawn
+        )
+
+        result = _bash("true")
+
+        assert result.startswith("Error executing command")
+        assert "(output truncated)" in result
+        assert len(result) <= _BASH_MAX_OUTPUT_CHARS + 200
+
+    def test_wait_error_kills_command_and_returns_error(self, monkeypatch):
+        def reject_wait(*_args, **_kwargs):
+            raise OSError("wait failed")
+
+        monkeypatch.setattr("codenib.agent.tools.defaults._wait_for_bash", reject_wait)
+
+        result = _bash("sleep 5")
+
+        assert result == "Error executing command 'sleep 5': wait failed"
 
     def test_output_cap_does_not_cancel_command_side_effects(self, tmp_path):
         marker = tmp_path / "completed"

--- a/test/agent/test_default_tools.py
+++ b/test/agent/test_default_tools.py
@@ -46,6 +46,7 @@ from codenib.agent.tool_schema import tool_to_schema
 from codenib.agent.tools.defaults import (
     _BASH_MAX_OUTPUT_CHARS,
     _MAX_LINES_LIMIT,
+    _MAX_RESULTS_LIMIT,
     _READ_MAX_OUTPUT_CHARS,
     DEFAULT_TOOL_IDS,
     _bash,
@@ -279,6 +280,27 @@ class TestGrep:
         hits = [line for line in result.splitlines() if "many.py" in line]
         assert len(hits) <= 5
 
+    def test_rejects_unbounded_head_limit(self, sample_dir):
+        result = _grep(
+            "foo",
+            path=str(sample_dir),
+            head_limit=_MAX_RESULTS_LIMIT + 1,
+        )
+
+        assert result == f"Error: head_limit must not exceed {_MAX_RESULTS_LIMIT} rows"
+
+    @pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep is unavailable")
+    def test_ripgrep_bounds_a_long_matching_line(self, tmp_path):
+        (tmp_path / "long.py").write_text(
+            "needle " + ("x" * 100_000) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _grep("needle", path=str(tmp_path), head_limit=1)
+
+        assert len(result) < 1_000
+        assert "Omitted long matching line" in result
+
     def test_invalid_regex_returns_error(self, sample_dir):
         result = _grep("[invalid", path=str(sample_dir))
         assert result.startswith("Error:") and "invalid regex" in result
@@ -323,6 +345,22 @@ class TestGrep:
         )
         result = _grep("def foo", path=str(sample_dir))
         assert "a.py:1:" in result and "def foo" in result
+
+    def test_python_fallback_timeout_isolated_from_agent(self, tmp_path, monkeypatch):
+        (tmp_path / "catastrophic.txt").write_text(
+            ("a" * 5_000) + "!\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "codenib.agent.tools.defaults.shutil.which", lambda _command: None
+        )
+        monkeypatch.setattr("codenib.agent.tools.defaults._GREP_TIMEOUT_SECONDS", 0.25)
+
+        started = time.monotonic()
+        result = _grep(r"(a+)+$", path=str(tmp_path))
+
+        assert result == "Error: grep timed out after 0.25s"
+        assert time.monotonic() - started < 2
 
 
 # ---------------------------------------------------------------------------

--- a/test/agent/test_default_tools.py
+++ b/test/agent/test_default_tools.py
@@ -26,10 +26,13 @@ Test layout:
 
 from __future__ import annotations
 
+import io
 import json
+import shlex
 import shutil
 import sys
 import textwrap
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -43,6 +46,7 @@ from codenib.agent.tools.defaults import (
     _BASH_MAX_OUTPUT_CHARS,
     DEFAULT_TOOL_IDS,
     _bash,
+    _BoundedPipeOutput,
     _glob,
     _grep,
     _read,
@@ -341,6 +345,13 @@ class TestBash:
         result = _bash("sleep 2", timeout=1000)
         assert result.startswith("Error:") and "timed out" in result
 
+    def test_timeout_kills_background_process_group(self):
+        started = time.monotonic()
+        result = _bash("sleep 5 &", timeout=1000)
+
+        assert result.startswith("Error:") and "timed out" in result
+        assert time.monotonic() - started < 3
+
     def test_description_accepted(self):
         """The reference `description` metadata field is accepted and ignored."""
         result = _bash("echo labelled", description="say hello")
@@ -355,6 +366,45 @@ class TestBash:
         result = _bash("yes hello | head -n 20000")
         assert "(output truncated)" in result
         assert len(result) <= _BASH_MAX_OUTPUT_CHARS + 200
+
+    def test_output_cap_does_not_cancel_command_side_effects(self, tmp_path):
+        marker = tmp_path / "completed"
+        script = "import sys; sys.stdout.write('x' * 1000000)"
+        command = (
+            f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}; "
+            f"printf done > {shlex.quote(str(marker))}"
+        )
+
+        result = _bash(command, timeout=5000)
+
+        assert "(output truncated)" in result
+        assert marker.read_text(encoding="utf-8") == "done"
+
+    def test_pipe_capture_drains_beyond_retained_prefix(self):
+        class TrackingStream(io.BytesIO):
+            final_position = 0
+
+            def close(self) -> None:
+                self.final_position = self.tell()
+                super().close()
+
+        payload = b"x" * (_BASH_MAX_OUTPUT_CHARS * 8)
+        source = TrackingStream(payload)
+        capture = _BoundedPipeOutput(_BASH_MAX_OUTPUT_CHARS)
+
+        capture.drain(source)
+
+        assert source.final_position == len(payload)
+        assert len(capture.text()) == _BASH_MAX_OUTPUT_CHARS
+        assert capture.truncated is True
+
+    @pytest.mark.parametrize("command", ["", "   ", None])
+    def test_rejects_empty_or_non_string_commands(self, command):
+        assert _bash(command).startswith("Error: command must be")
+
+    @pytest.mark.parametrize("timeout", [False, 0, -1, 600_001])
+    def test_rejects_invalid_timeouts(self, timeout):
+        assert _bash("true", timeout=timeout).startswith("Error: timeout must be")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Make the always-on agent `read`, `grep`, and `bash` tools enforce their advertised bounds during execution rather than after unbounded data has already been consumed. Large files and runaway commands now retain fixed-size output, protocol stdin stays isolated, and backtracking regex fallback cannot stall the agent process.

## Changes
- Drain shell stdout and stderr concurrently while retaining only bounded prefixes.
- Continue draining discarded shell output so truncation does not cancel command side effects.
- Close subprocess stdin and enforce command-length and timeout bounds before spawn.
- Kill the original process group even when its shell exits before a background child closes inherited pipes.
- Stream regular-file reads with bounded physical-line prefixes and total output.
- Stop after detecting one omitted line instead of scanning the complete file for an exact remainder count.
- Reject nonregular files and unbounded line-limit requests.
- Bound grep patterns, row counts, matching-line output, multiline file size, and total output.
- Run the Python regex fallback in a timeout-controlled worker so catastrophic backtracking cannot block the runner.
- Ask ripgrep to omit unbounded matching lines while preserving its normal output modes.
- Add regressions for long lines, early read termination, FIFOs, bounded command draining, side effects, malformed inputs, background-child cleanup, oversized grep requests, and catastrophic regexes.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest test/agent/test_default_tools.py test/agent/test_runner.py test/agent/test_tool_schema.py -q --tb=short` (`116 passed`).

`pytest test/agent test/sandbox -q --tb=short` (`501 passed, 7 skipped`).

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2833 passed, 10 skipped, 183 deselected`).

`pre-commit run --files codenib/agent/tools/defaults.py codenib/agent/tools/grep_worker.py test/agent/test_default_tools.py` passed.

A 128 MiB stdout probe returned the bounded 16,023-character response with `max_rss_kb=16896`. A catastrophic Python regex was isolated and terminated at the injected 0.25-second deadline while the runner remained responsive. The fallback worker is present in setuptools' wheel build tree.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published