### PR TITLE
feat(serving): add retrieval-augmented speculative serving

### DIFF
--- a/codenib/serving/__init__.py
+++ b/codenib/serving/__init__.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Retrieval-augmented speculative serving for code agents.
+
+CodeNib indexes a repository; this package spends that index on *decode*. A
+speculative-decoding loop drafts continuations — from the prompt itself
+(:mod:`~codenib.serving.drafter.copy`) and from the retrieval index
+(:mod:`~codenib.serving.drafter.retrieval`) — and a target model verifies them
+in one forward pass. Acceptance is greedy-exact, so the emitted text is
+identical to plain autoregressive decoding; only the tokens-per-forward-pass
+changes.
+
+The HTTP surface is OpenAI-compatible (``codenib-serve``), so an agent or a
+LiteLLM gateway calls it exactly as it would call OpenAI. See ``deploy/`` for a
+gateway config and ``examples/serving_agent_demo.py`` for an end-to-end agent.
+
+Heavy dependencies (torch, transformers, sse-starlette) live behind the
+``serving`` extra and are imported lazily, so importing this package on a
+machine without a GPU stack is free.
+
+Originally developed as the RetroSpec research project and vendored here when
+serving became product surface.
+"""
+
+from codenib.serving.types import DraftNode, DraftTree
+
+__all__ = ["DraftNode", "DraftTree"]

--- a/codenib/serving/drafter/__init__.py
+++ b/codenib/serving/drafter/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Draft sources for speculative decoding.
+
+A drafter proposes a :class:`~codenib.serving.types.DraftTree` of candidate tokens for
+the target model to verify. CodeNib serving ships three:
+
+* :class:`~codenib.serving.drafter.copy.CopyDrafter` — exact repeated spans (CopySpec).
+* :class:`~codenib.serving.drafter.retrieval.RetrievalDrafter` — retrieved code (RASD).
+* :class:`~codenib.serving.drafter.suffix_automaton.SuffixAutomatonDrafter` — exact
+  longest-suffix match over context + corpus (SAM-Decoding / SuffixDecoding).
+* fusion via :func:`~codenib.serving.drafter.fusion.fuse` — merge several draft trees.
+"""
+
+from codenib.serving.drafter.base import Drafter
+from codenib.serving.drafter.copy import (
+    DEFAULT_MAX_MATCH,
+    DEFAULT_MIN_MATCH,
+    CopyDrafter,
+)
+from codenib.serving.drafter.fusion import fuse
+from codenib.serving.drafter.retrieval import (
+    DEFAULT_RETRIEVAL_K,
+    CodeNibBackend,
+    NgramRetrievalBackend,
+    RetrievalBackend,
+    RetrievalDrafter,
+)
+from codenib.serving.drafter.suffix_automaton import SuffixAutomatonDrafter
+
+__all__ = [
+    "Drafter",
+    "CopyDrafter",
+    "RetrievalDrafter",
+    "RetrievalBackend",
+    "NgramRetrievalBackend",
+    "CodeNibBackend",
+    "SuffixAutomatonDrafter",
+    "fuse",
+    "DEFAULT_MIN_MATCH",
+    "DEFAULT_MAX_MATCH",
+    "DEFAULT_RETRIEVAL_K",
+]

--- a/codenib/serving/drafter/base.py
+++ b/codenib/serving/drafter/base.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""The drafter interface."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+from codenib.serving.types import DraftTree, TokenId
+
+
+class Drafter(ABC):
+    """Proposes candidate continuations for the target model to verify.
+
+    Implementations must be cheap relative to a target-model forward pass — a
+    drafter that costs more than the tokens it saves is a net loss. ``draft`` is
+    called once per decoding step with the tokens generated so far.
+    """
+
+    #: Provenance label attached to nodes this drafter produces.
+    source: str = "drafter"
+
+    @abstractmethod
+    def draft(self, context: Sequence[TokenId], max_tokens: int) -> DraftTree:
+        """Return a draft tree of at most ``max_tokens`` candidate positions.
+
+        Args:
+            context: token ids generated so far (prompt + decoded suffix).
+            max_tokens: speculation budget — the verification tree should not
+                exceed this many non-root nodes.
+
+        Returns an empty tree when the drafter has no confident proposal; the
+        caller then falls back to other sources or plain decoding.
+        """
+        raise NotImplementedError

--- a/codenib/serving/drafter/copy.py
+++ b/codenib/serving/drafter/copy.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Copy-based speculation (CopySpec / prompt-lookup).
+
+Find the most recent earlier occurrence of the current context suffix and
+speculate that the tokens which followed it last time will follow again. This is
+the exact-match draft path: zero model cost, no extra GPU memory, and very high
+acceptance on repetitive text such as code (boilerplate, repeated signatures,
+edit-then-restate patterns).
+
+See: "CopySpec: Accelerating LLMs with Speculative Copy-and-Paste" (2502.08923).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from codenib.serving.drafter.base import Drafter
+from codenib.serving.types import DraftTree, TokenId
+
+#: Copy-drafting defaults, named so the server and the offline acceptance
+#: harness provably draft with the same parameters — the harness exists to
+#: predict serving throughput, so a silent divergence would invalidate it.
+DEFAULT_MIN_MATCH = 2
+DEFAULT_MAX_MATCH = 32
+
+
+class CopyDrafter(Drafter):
+    """Suffix-match copy drafter.
+
+    For decreasing n-gram lengths in ``[min_match, max_match]`` it takes the last
+    ``n`` context tokens as a pattern and looks for the most recent earlier
+    occurrence of that pattern. The longest pattern that matches wins (longer
+    match -> higher-precision copy), and the tokens following the matched
+    occurrence become a single linear draft branch.
+    """
+
+    source = "copy"
+
+    def __init__(
+        self,
+        min_match: int = DEFAULT_MIN_MATCH,
+        max_match: int = DEFAULT_MAX_MATCH,
+        max_draft: int = 16,
+    ) -> None:
+        if min_match < 1:
+            raise ValueError("min_match must be >= 1")
+        if max_match < min_match:
+            raise ValueError("max_match must be >= min_match")
+        self.min_match = min_match
+        self.max_match = max_match
+        self.max_draft = max_draft
+
+    def draft(self, context: Sequence[TokenId], max_tokens: int) -> DraftTree:
+        tree = DraftTree()
+        budget = min(max_tokens, self.max_draft)
+        if budget <= 0:
+            return tree
+
+        ctx = list(context)
+        continuation = self._lookup(ctx, budget)
+        if continuation:
+            tree.add_sequence(continuation, source=self.source)
+        return tree
+
+    def _lookup(self, ctx: List[TokenId], budget: int) -> Optional[List[TokenId]]:
+        n = len(ctx)
+        if n < self.min_match + 1:
+            return None
+
+        upper = min(self.max_match, n - 1)
+        for match_len in range(upper, self.min_match - 1, -1):
+            pattern = ctx[n - match_len :]
+            # Search backwards for the most recent earlier occurrence, excluding
+            # the suffix itself (search space ends before the pattern's start).
+            start = self._rfind(ctx, pattern, n - match_len - 1)
+            if start == -1:
+                continue
+            after = start + match_len
+            continuation = ctx[after : after + budget]
+            if continuation:
+                return continuation
+        return None
+
+    @staticmethod
+    def _rfind(seq: List[TokenId], pattern: List[TokenId], last_start: int) -> int:
+        """Index of the last occurrence of ``pattern`` in ``seq[: last_start+m]``.
+
+        ``last_start`` is the highest index at which a match may *begin*. Returns
+        -1 if not found. Linear scan from the right — adequate for per-step
+        context sizes; swap for a suffix-automaton if profiling demands it.
+        """
+        m = len(pattern)
+        for i in range(min(last_start, len(seq) - m), -1, -1):
+            if seq[i : i + m] == pattern:
+                return i
+        return -1

--- a/codenib/serving/drafter/fusion.py
+++ b/codenib/serving/drafter/fusion.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Draft-tree fusion.
+
+Merge several draft trees (copy, retrieval, base-model) into one verification
+tree via longest-prefix matching, so candidate continuations that agree for the
+first k tokens share a single branch for those tokens. This is RASD's "tree
+fusion": one forward pass verifies all sources at once, and the fused tree is
+pruned to the speculation budget.
+
+See: "RASD: Retrieval-Augmented Speculative Decoding" (2503.03434).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from codenib.serving.types import DraftNode, DraftTree
+
+
+def fuse(trees: Iterable[DraftTree], max_tokens: int | None = None) -> DraftTree:
+    """Fuse ``trees`` into a single tree, optionally pruned to ``max_tokens``.
+
+    Branches from later trees merge onto shared prefixes of earlier ones; a node
+    keeps the ``source`` of whichever tree introduced it first. When pruning, a
+    breadth-first frontier is kept so the highest, most-shared (most likely to be
+    accepted) tokens survive over deep speculative tails.
+    """
+    fused = DraftTree()
+    for tree in trees:
+        _merge_into(fused.root, tree.root)
+    if max_tokens is not None:
+        _prune(fused, max_tokens)
+    return fused
+
+
+def _merge_into(dst: DraftNode, src: DraftNode) -> None:
+    """Recursively merge ``src``'s children onto ``dst`` by token identity."""
+    for src_child in src.children:
+        match = next((c for c in dst.children if c.token == src_child.token), None)
+        if match is None:
+            match = DraftNode(
+                token=src_child.token,
+                source=src_child.source,
+                score=src_child.score,
+            )
+            dst.children.append(match)
+        _merge_into(match, src_child)
+
+
+def _prune(tree: DraftTree, max_tokens: int) -> None:
+    """Keep at most ``max_tokens`` nodes, breadth-first from the root.
+
+    BFS favours shallow tokens — those nearest the current position, which the
+    target model is most likely to accept — and drops deep speculative tails
+    first. Surviving nodes have their out-of-budget children removed.
+    """
+    if max_tokens <= 0:
+        tree.root.children = []
+        return
+
+    kept = 0
+    frontier = [tree.root]
+    while frontier:
+        node = frontier.pop(0)
+        survivors = []
+        for child in node.children:
+            if kept >= max_tokens:
+                break
+            survivors.append(child)
+            kept += 1
+            frontier.append(child)
+        node.children = survivors

--- a/codenib/serving/drafter/retrieval.py
+++ b/codenib/serving/drafter/retrieval.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Retrieval-augmented speculation (RASD).
+
+Use a retrieval index over the codebase to fetch candidate continuations and
+build a draft tree from them. On an unfamiliar repo this is where a small draft
+model is weakest and retrieval is strongest, because the tokens the agent needs
+usually already exist in the corpus even when they are not in the prompt.
+
+The retrieval source is abstracted behind :class:`RetrievalBackend` so CodeNib serving
+does not hard-depend on any one index. A CodeNib adapter (symbol graph + BM25 +
+embeddings + trigram) is the intended production backend; see
+``CodeNibBackend`` below for the integration seam.
+"""
+
+from __future__ import annotations
+
+import warnings
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import FrozenSet, List, Protocol, Sequence, Tuple
+
+from codenib.serving.drafter.base import Drafter
+from codenib.serving.types import DraftTree, TokenId
+
+#: Candidate continuations requested per retrieval step. Shared by the server
+#: and the acceptance harness for the same reason as the copy defaults above.
+DEFAULT_RETRIEVAL_K = 6
+
+
+class SnippetTokenizer(Protocol):
+    """The text↔token surface a retrieval backend needs.
+
+    Narrower than the serving ``Tokenizer`` on purpose: retrieval only decodes a
+    query and encodes snippets, so anything with ``encode``/``decode`` — the
+    serving wrapper, an experiment proxy, a test fake — can be injected.
+    """
+
+    def encode(self, text: str) -> Sequence[int]: ...
+
+    def decode(self, ids: List[int]) -> str: ...
+
+
+class RetrievalBackend(ABC):
+    """Returns candidate token continuations for the current context.
+
+    Implementations own detokenization/tokenization and ranking; CodeNib serving only
+    consumes ranked token-id continuations. ``retrieve`` must be latency-bounded:
+    it runs on (or just ahead of) the decode critical path, so a slow backend
+    erases the speculation win.
+    """
+
+    @abstractmethod
+    def retrieve(
+        self, context: Sequence[TokenId], k: int, max_tokens: int
+    ) -> List[List[TokenId]]:
+        """Return up to ``k`` candidate continuations, each <= ``max_tokens``."""
+        raise NotImplementedError
+
+
+class RetrievalDrafter(Drafter):
+    """Builds a draft tree from a :class:`RetrievalBackend`'s candidates.
+
+    Each retrieved continuation is added as a branch; shared prefixes collapse
+    automatically via :meth:`DraftTree.add_sequence`. Pruning to the global
+    speculation budget is left to :func:`codenib.serving.drafter.fusion.fuse`, which
+    sees all sources together.
+    """
+
+    source = "retrieval"
+
+    def __init__(self, backend: RetrievalBackend, k: int = 4, max_draft: int = 16):
+        self.backend = backend
+        self.k = k
+        self.max_draft = max_draft
+
+    def draft(self, context: Sequence[TokenId], max_tokens: int) -> DraftTree:
+        tree = DraftTree()
+        budget = min(max_tokens, self.max_draft)
+        if budget <= 0:
+            return tree
+
+        for cand in self.backend.retrieve(context, k=self.k, max_tokens=budget):
+            tree.add_sequence(cand[:budget], source=self.source)
+        return tree
+
+
+def _path_parts(path: object) -> Tuple[str, ...]:
+    return Path(str(path)).parts
+
+
+def _same_file(a: Tuple[str, ...], b: Tuple[str, ...]) -> bool:
+    """Whether two path part-tuples denote the same file.
+
+    Compares from the right so an absolute index path and a repo-relative one
+    still match (``/repo/pkg/x.py`` vs ``pkg/x.py``). A bare filename therefore
+    matches any file with that name — deliberately over-, never under-matching,
+    because the caller is using this to *hold data out*.
+    """
+    n = min(len(a), len(b))
+    return n > 0 and a[-n:] == b[-n:]
+
+
+class CodeNibBackend(RetrievalBackend):
+    """Adapter onto a CodeNib index (in-process).
+
+    CodeNib deals in *text* — its searchers take a query string and return code
+    snippets, with no notion of token ids. So this backend bridges the gap in four
+    steps:
+
+    1. **Query.** Decode the tail of the context to text (what the model is
+       currently writing) and use it as the retrieval query.
+    2. **Retrieve.** Ask CodeNib in-process for the most relevant snippets
+       (``ctx.bm25.search`` by default; ``vector`` for dense). Retrieval runs on
+       the decode critical path, so only the fast in-process indexes are used.
+    3. **Tokenize.** Encode each returned snippet back to token ids.
+    4. **Align.** Reuse :class:`NgramRetrievalBackend`'s suffix-match over those
+       snippets as a transient corpus — it finds where the current context suffix
+       recurs inside a snippet and returns the tokens that follow. That is exactly
+       the RASD "align retrieved code to the cursor" step, already unit-tested.
+
+    The CodeNib ``ctx`` is injected (like the model in
+    :class:`~codenib.serving.server.hf_engine.HFTreeEngine`) so the adapter is testable
+    with a fake context and no ``codenib`` install; use :meth:`from_manifest` to
+    load a prebuilt ``.codenib_cache`` index. ``tokenizer`` is any
+    :class:`SnippetTokenizer` (e.g. ``codenib.serving.server.tokenization.Tokenizer``).
+    """
+
+    def __init__(
+        self,
+        ctx: object,
+        tokenizer: SnippetTokenizer,
+        *,
+        index: str = "bm25",
+        top_k: int = 20,
+        key_len: int = 4,
+        query_suffix_tokens: int = 64,
+        exclude_files: Sequence[object] = (),
+    ) -> None:
+        self.ctx = ctx
+        self.tokenizer = tokenizer
+        self.index = index
+        self.top_k = top_k
+        self.key_len = key_len
+        self.query_suffix_tokens = query_suffix_tokens
+        self.exclude_files: FrozenSet[Tuple[str, ...]] = frozenset(
+            _path_parts(p) for p in exclude_files
+        )
+        self._warned_empty_content = False
+        self._warned_unattributed = False
+
+    def excluding(self, *paths: object) -> "CodeNibBackend":
+        """Return a view of this backend that never returns hits from ``paths``.
+
+        The index (``ctx``) is shared, so this is cheap enough to build per
+        target file. Use it whenever the caller already knows the answer for
+        some file — an oracle replay retrieving the very file it is predicting
+        would draft the ground-truth continuation and report acceptance that no
+        live run could reproduce.
+        """
+        view = CodeNibBackend(
+            self.ctx,
+            self.tokenizer,
+            index=self.index,
+            top_k=self.top_k,
+            key_len=self.key_len,
+            query_suffix_tokens=self.query_suffix_tokens,
+            exclude_files=paths,
+        )
+        # Union rather than replace: views compose, and `self` is untouched.
+        view.exclude_files = self.exclude_files | view.exclude_files
+        return view
+
+    def _is_excluded(self, hit: object) -> bool:
+        """Whether ``hit`` must be dropped because it comes from a held-out file."""
+        if not self.exclude_files:
+            return False
+        raw = getattr(hit, "file", None) or getattr(hit, "file_path", None)
+        if not raw:
+            # No provenance: the hit cannot be *shown* to come from another
+            # file, so drop it rather than risk leaking the held-out one. Say so
+            # once — silently dropping every hit would look like "retrieval
+            # found nothing" instead of "the index has no file metadata".
+            if not self._warned_unattributed:
+                self._warned_unattributed = True
+                warnings.warn(
+                    "CodeNib hit has no file/file_path attribute, so it "
+                    "cannot be checked against the held-out files; dropping it "
+                    "to stay conservative.",
+                    RuntimeWarning,
+                    stacklevel=3,
+                )
+            return True
+        parts = _path_parts(raw)
+        return any(_same_file(parts, ex) for ex in self.exclude_files)
+
+    @classmethod
+    def from_manifest(
+        cls,
+        manifest_path: str,
+        tokenizer: SnippetTokenizer,
+        *,
+        index: str = "bm25",
+        top_k: int = 20,
+        key_len: int = 4,
+        query_suffix_tokens: int = 64,
+    ) -> "CodeNibBackend":
+        """Load a prebuilt CodeNib index (``.codenib_cache/repo_manifest.json``).
+
+        A thin wrapper over ``ServerContext.load``: CodeNib's persisted index
+        already round-trips everything ``search(return_code_content=True)``
+        needs (``project_root`` via ``bm25_metadata.json``, and each document's
+        ``file``/``start_line``/``end_line``), so there is nothing to repair
+        here. The keyword arguments are spelled out rather than forwarded as
+        ``**kwargs`` so they keep their types into the constructor.
+        """
+        from codenib.mcp.context import ServerContext
+
+        return cls(
+            ServerContext.load(manifest_path),
+            tokenizer,
+            index=index,
+            top_k=top_k,
+            key_len=key_len,
+            query_suffix_tokens=query_suffix_tokens,
+        )
+
+    def _search(self, query: str) -> list:
+        """Return CodeNib hits (objects with a ``.content`` snippet) for ``query``."""
+        if self.index == "bm25":
+            bm25 = getattr(self.ctx, "bm25", None)
+            if bm25 is None:
+                return []
+            # wrap_with_ln=False: keep snippets as clean code so drafted tokens
+            # can match the model's output (line-number prefixes like "6 | "
+            # never would).
+            return bm25.search(
+                query,
+                top_k=self.top_k,
+                return_code_content=True,
+                wrap_with_ln=False,
+            )
+        if self.index == "vector":
+            vector = getattr(self.ctx, "vector", None)
+            if vector is None:
+                return []
+            return vector.search_with_content(query, top_k=self.top_k)
+        raise ValueError(f"unknown CodeNib index: {self.index!r}")
+
+    def retrieve(
+        self, context: Sequence[TokenId], k: int, max_tokens: int
+    ) -> List[List[TokenId]]:
+        ctx_ids = list(context)
+        if len(ctx_ids) < self.key_len:
+            return []
+        query = self.tokenizer.decode(ctx_ids[-self.query_suffix_tokens :])
+        if not query.strip():
+            return []
+
+        corpus: List[List[TokenId]] = []
+        hits = [h for h in self._search(query) if not self._is_excluded(h)]
+        for hit in hits:
+            content = getattr(hit, "content", None)
+            if not content:
+                continue
+            ids = list(self.tokenizer.encode(content))
+            if ids:
+                corpus.append(ids)
+        if not corpus:
+            if hits and not self._warned_empty_content:
+                # The index matched but carries no snippet text — e.g. a
+                # legacy index saved without bm25_metadata.json, so
+                # project_root is None and content lookup silently fails.
+                # Say so once rather than reporting zero acceptance as a
+                # measurement.
+                self._warned_empty_content = True
+                warnings.warn(
+                    f"CodeNib returned {len(hits)} hit(s) with no snippet "
+                    "content; retrieval will draft nothing. The index is "
+                    "likely loaded without its symbol graph.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+            return []
+
+        # Suffix-align the current context against the retrieved snippets.
+        aligner = NgramRetrievalBackend(corpus, key_len=self.key_len)
+        return aligner.retrieve(ctx_ids, k=k, max_tokens=max_tokens)
+
+
+class NgramRetrievalBackend(RetrievalBackend):
+    """Corpus n-gram lookup backend — a real, dependency-free retrieval source.
+
+    Indexes every ``key_len``-gram in a token-id corpus (e.g. the other files in
+    a repo). At query time it looks up the context suffix, extends each hit
+    leftward to score by match length, and returns the continuations of the
+    best-matching occurrences. This is "prompt-lookup over the whole corpus":
+    it gives CodeNib serving retrieval *reach beyond the context window* without a
+    model or a vector store, and is the default backend for offline acceptance
+    measurement. CodeNib's symbol-graph/BM25/embedding retrieval is the
+    production upgrade (see :class:`CodeNibBackend`).
+    """
+
+    def __init__(
+        self,
+        corpus: Sequence[Sequence[TokenId]],
+        key_len: int = 4,
+        max_candidates: int = 16,
+    ) -> None:
+        if key_len < 1:
+            raise ValueError("key_len must be >= 1")
+        self.key_len = key_len
+        self.max_candidates = max_candidates
+        self._flat: List[TokenId] = []
+        # For each flat position, the exclusive end of the document it belongs to
+        # so continuations never bleed across document boundaries.
+        self._doc_end: List[int] = []
+        self._index: dict = {}
+        for doc in corpus:
+            base = len(self._flat)
+            self._flat.extend(doc)
+            end = len(self._flat)
+            self._doc_end.extend([end] * (end - base))
+            for i in range(base, end - key_len + 1):
+                key = tuple(self._flat[i : i + key_len])
+                self._index.setdefault(key, []).append(i)
+
+    def retrieve(
+        self, context: Sequence[TokenId], k: int, max_tokens: int
+    ) -> List[List[TokenId]]:
+        if len(context) < self.key_len:
+            return []
+        ctx = list(context)
+        key = tuple(ctx[-self.key_len :])
+        positions = self._index.get(key)
+        if not positions:
+            return []
+
+        scored = []
+        for pos in positions[-self.max_candidates :]:
+            # Extend the match leftward to measure how much context agrees.
+            match = self.key_len
+            a, b = len(ctx) - self.key_len - 1, pos - 1
+            while a >= 0 and b >= 0 and ctx[a] == self._flat[b]:
+                match += 1
+                a -= 1
+                b -= 1
+            cont_start = pos + self.key_len
+            cont_end = min(cont_start + max_tokens, self._doc_end[pos])
+            cont = self._flat[cont_start:cont_end]
+            if cont:
+                scored.append((match, cont))
+
+        scored.sort(key=lambda mc: mc[0], reverse=True)
+        return [cont for _, cont in scored[:k]]

--- a/codenib/serving/drafter/suffix_automaton.py
+++ b/codenib/serving/drafter/suffix_automaton.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Suffix-automaton drafting (SAM-Decoding / SuffixDecoding style).
+
+CopySpec and prompt-lookup match a *fixed-length* n-gram suffix; ``CopyDrafter``
+even scans candidate lengths one by one. A suffix automaton instead indexes
+**every** substring of a reference string and finds the *exact longest* suffix of
+the current context that occurs in it, in amortized O(1) per step — strictly more
+powerful than fixed n-gram copy, and it scales to a whole-repo corpus.
+
+This one drafter subsumes two of CodeNib serving's draft sources:
+
+* a **static** automaton over a corpus (the rest of the repo) -> retrieval reach,
+* a **dynamic** automaton over the generated context -> in-context copy,
+
+and drafts the continuation that followed the most recent occurrence of the
+longest match, picking whichever automaton offers the longer match. It drops into
+``fuse`` exactly like ``CopyDrafter``/``RetrievalDrafter``.
+
+See: "SAM-Decoding: Speculative Decoding via Suffix Automaton" (2411.10666) and
+"SuffixDecoding" (2411.04975). Prototype notes: the dynamic automaton is rebuilt
+per step (O(context)); a production build extends it incrementally as tokens are
+emitted. Continuations stop at document boundaries (sentinel ids < 0).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from codenib.serving.drafter.base import Drafter
+from codenib.serving.types import DraftTree, TokenId
+
+
+class _SuffixAutomaton:
+    """Online suffix automaton over a token string (Blumer et al.).
+
+    State 0 is the initial state. ``end[s]`` holds a representative end position
+    of an occurrence of the substrings recognised by ``s`` — after
+    :meth:`finalize` it is the *most recent* (maximum) such position, so reading
+    forward from it yields the latest continuation.
+    """
+
+    def __init__(self) -> None:
+        self.trans: List[Dict[TokenId, int]] = [{}]
+        self.link: List[int] = [-1]
+        self.length: List[int] = [0]
+        self.end: List[int] = [-1]
+        self.last = 0
+
+    def _new(self, length: int, end: int) -> int:
+        self.trans.append({})
+        self.link.append(-1)
+        self.length.append(length)
+        self.end.append(end)
+        return len(self.length) - 1
+
+    def extend(self, c: TokenId, pos: int) -> None:
+        cur = self._new(self.length[self.last] + 1, pos)
+        p = self.last
+        while p != -1 and c not in self.trans[p]:
+            self.trans[p][c] = cur
+            p = self.link[p]
+        if p == -1:
+            self.link[cur] = 0
+        else:
+            q = self.trans[p][c]
+            if self.length[p] + 1 == self.length[q]:
+                self.link[cur] = q
+            else:
+                clone = self._new(self.length[p] + 1, self.end[q])
+                self.trans[clone].update(self.trans[q])
+                self.link[clone] = self.link[q]
+                while p != -1 and self.trans[p].get(c) == q:
+                    self.trans[p][c] = clone
+                    p = self.link[p]
+                self.link[q] = clone
+                self.link[cur] = clone
+        self.last = cur
+
+    def finalize(self) -> None:
+        """Propagate the most-recent end position up the suffix links."""
+        # States in decreasing length: a state's end-position set is a subset of
+        # its suffix-link parent's, so max-propagating gives each state the most
+        # recent occurrence of any substring it recognises.
+        order = sorted(
+            range(len(self.length)), key=lambda s: self.length[s], reverse=True
+        )
+        for v in order:
+            pl = self.link[v]
+            if pl != -1 and self.end[v] > self.end[pl]:
+                self.end[pl] = self.end[v]
+
+    def longest_suffix_match(self, query: Sequence[TokenId]) -> Tuple[int, int]:
+        """Return ``(state, length)`` of the longest suffix of ``query`` that is a
+        substring of the reference. ``end[state]`` locates that occurrence."""
+        v, length = 0, 0
+        for c in query:
+            while v != 0 and c not in self.trans[v]:
+                v = self.link[v]
+                length = self.length[v]
+            nxt = self.trans[v].get(c)
+            if nxt is not None:
+                v = nxt
+                length += 1
+            else:
+                v, length = 0, 0
+        return v, length
+
+
+def _build(reference: Sequence[TokenId]) -> _SuffixAutomaton:
+    sam = _SuffixAutomaton()
+    for pos, tok in enumerate(reference):
+        sam.extend(tok, pos)
+    sam.finalize()
+    return sam
+
+
+def _read_continuation(
+    reference: Sequence[TokenId], end: int, budget: int
+) -> List[TokenId]:
+    """Tokens following position ``end`` in ``reference``, up to a doc boundary."""
+    out: List[TokenId] = []
+    i = end + 1
+    n = len(reference)
+    while i < n and len(out) < budget:
+        tok = reference[i]
+        if tok < 0:  # document-boundary sentinel
+            break
+        out.append(tok)
+        i += 1
+    return out
+
+
+class SuffixAutomatonDrafter(Drafter):
+    """Exact-longest-suffix drafter backed by suffix automata.
+
+    Args:
+        corpus: optional reference documents (e.g. the other files in the repo).
+            Indexed once into a static automaton for retrieval reach. Omit for a
+            pure in-context (copy-style) drafter.
+        min_match: minimum matched suffix length to draft (precision floor).
+        max_draft: cap on drafted tokens per step.
+    """
+
+    source = "suffix_automaton"
+
+    def __init__(
+        self,
+        corpus: Optional[Sequence[Sequence[TokenId]]] = None,
+        min_match: int = 2,
+        max_draft: int = 16,
+    ) -> None:
+        if min_match < 1:
+            raise ValueError("min_match must be >= 1")
+        self.min_match = min_match
+        self.max_draft = max_draft
+        self._ref: List[TokenId] = []
+        self._sam: Optional[_SuffixAutomaton] = None
+        if corpus:
+            for i, doc in enumerate(corpus):
+                if i:
+                    self._ref.append(-(i))  # distinct negative boundary sentinel
+                self._ref.extend(doc)
+            self._sam = _build(self._ref)
+
+    def draft(self, context: Sequence[TokenId], max_tokens: int) -> DraftTree:
+        tree = DraftTree()
+        budget = min(max_tokens, self.max_draft)
+        if budget <= 0:
+            return tree
+
+        ctx = list(context)
+        best_len = self.min_match - 1
+        best_cont: Optional[List[TokenId]] = None
+
+        # Static corpus automaton: longest suffix of ctx occurring in the repo.
+        if self._sam is not None and len(ctx) >= self.min_match:
+            v, length = self._sam.longest_suffix_match(ctx)
+            if length > best_len:
+                cont = _read_continuation(self._ref, self._sam.end[v], budget)
+                if cont:
+                    best_len, best_cont = length, cont
+
+        # Dynamic context automaton: most recent *earlier* occurrence of a context
+        # suffix. Built over ctx[:-1] so the trailing self-match is excluded; the
+        # full ctx is the read source. Ties prefer this (more local) source.
+        if len(ctx) >= self.min_match + 1:
+            dyn = _build(ctx[:-1])
+            v, length = dyn.longest_suffix_match(ctx)
+            if length >= self.min_match and length >= best_len:
+                cont = _read_continuation(ctx, dyn.end[v], budget)
+                if cont:
+                    best_len, best_cont = length, cont
+
+        if best_cont:
+            tree.add_sequence(best_cont, source=self.source)
+        return tree

--- a/codenib/serving/server/__init__.py
+++ b/codenib/serving/server/__init__.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Serving integration: feed fused draft trees into SGLang speculative decoding."""
+
+from codenib.serving.server.hf_engine import CachedHFTreeEngine, HFTreeEngine
+from codenib.serving.server.sglang import SGLangTreeEngine, SGLangVerifier, TargetEngine
+from codenib.serving.server.worker import (
+    OracleVerifier,
+    RunResult,
+    SpeculativeConfig,
+    SpeculativeServer,
+    Verifier,
+    VerifyResult,
+)
+
+__all__ = [
+    "SpeculativeServer",
+    "SpeculativeConfig",
+    "Verifier",
+    "VerifyResult",
+    "RunResult",
+    "OracleVerifier",
+    "SGLangVerifier",
+    "TargetEngine",
+    "SGLangTreeEngine",
+    "HFTreeEngine",
+    "CachedHFTreeEngine",
+]

--- a/codenib/serving/server/api.py
+++ b/codenib/serving/server/api.py
@@ -1,0 +1,421 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI-compatible HTTP endpoint in front of the speculative-decoding loop.
+
+This is the serving seam: a code agent (or LiteLLM in front of it) calls
+``POST /v1/chat/completions`` exactly as it would call OpenAI, and CodeNib serving
+answers by running the existing ``SpeculativeServer`` loop and streaming the
+result back. Nothing about speculation is visible on the wire.
+
+Scope (v1): **greedy only** — the loop is lossless greedy decoding, so a request
+with ``temperature > 0`` (or ``top_p < 1``) is rejected rather than silently
+served as greedy. Concurrency is single-flight: ``CachedHFTreeEngine`` keeps a
+per-request KV cache, so a fresh engine is built per request over the shared,
+read-only model and generations are serialized by one lock. Batching is future
+work.
+
+``main()`` wires the real HF engine + tokenizer; tests build :class:`AppState`
+with fakes and drive :func:`create_app` via ``TestClient`` — no GPU, no model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional, Sequence
+
+from fastapi import FastAPI, HTTPException
+from sse_starlette.sse import EventSourceResponse
+
+from codenib.serving.drafter.base import Drafter
+from codenib.serving.drafter.copy import CopyDrafter
+from codenib.serving.drafter.retrieval import (
+    DEFAULT_RETRIEVAL_K,
+    CodeNibBackend,
+    RetrievalDrafter,
+)
+from codenib.serving.server.hf_engine import CachedHFTreeEngine, HFTreeEngine
+from codenib.serving.server.schemas import (
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatMessage,
+    Choice,
+    ChunkChoice,
+    DeltaMessage,
+    ModelCard,
+    ModelList,
+    Usage,
+)
+from codenib.serving.server.sglang import SGLangVerifier, TargetEngine
+from codenib.serving.server.tokenization import Tokenizer
+from codenib.serving.server.worker import SpeculativeConfig, SpeculativeServer
+from codenib.serving.types import TokenId
+
+
+@dataclass
+class AppState:
+    """Everything the endpoint needs to serve requests.
+
+    ``engine_factory`` returns a fresh :class:`TargetEngine` per request (the
+    cached HF engine is per-request stateful); ``drafters`` are stateless and
+    shared. ``lock`` serializes generations; :func:`create_app` rebinds it so
+    each app gets its own, but it is never ``None`` — the request handlers rely
+    on that, and an ``Optional`` here would only push the check to every use.
+    """
+
+    served_model_name: str
+    tokenizer: Tokenizer
+    engine_factory: Callable[[], TargetEngine]
+    drafters: List[Drafter]
+    config: SpeculativeConfig = field(default_factory=SpeculativeConfig)
+    default_max_new_tokens: int = 256
+    # asyncio primitives bind to the running loop lazily (3.10+), so building
+    # this outside a loop is safe.
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+def _completion_id() -> str:
+    return f"chatcmpl-{uuid.uuid4().hex}"
+
+
+def _check_greedy(req: ChatCompletionRequest) -> None:
+    """Reject non-greedy requests — v1 serves lossless greedy only."""
+    if req.temperature not in (None, 0, 0.0):
+        raise HTTPException(
+            status_code=400,
+            detail="only greedy decoding (temperature=0) is supported in v1",
+        )
+    if req.top_p is not None and req.top_p < 1.0:
+        raise HTTPException(
+            status_code=400,
+            detail="only greedy decoding (top_p=1) is supported in v1",
+        )
+
+
+def _build_prompt_ids(state: AppState, messages: List[ChatMessage]) -> List[TokenId]:
+    """Turn chat messages into prompt token ids via the model's chat template.
+
+    Falls back to a plain ``role: content`` concatenation for tokenizers without
+    a chat template.
+    """
+    msgs = [{"role": m.role, "content": m.content} for m in messages]
+    try:
+        text = state.tokenizer.hf.apply_chat_template(
+            msgs, tokenize=False, add_generation_prompt=True
+        )
+    except Exception:  # noqa: BLE001 - any templating failure falls back to plain text
+        text = "".join(f"{m['role']}: {m['content']}\n" for m in msgs) + "assistant: "
+    return state.tokenizer.encode(text)
+
+
+def _max_new_tokens(state: AppState, req: ChatCompletionRequest) -> int:
+    return req.max_completion_tokens or req.max_tokens or state.default_max_new_tokens
+
+
+def _run_full(state: AppState, prompt_ids: List[TokenId], max_new: int):
+    """Blocking full generation; returns (completion_ids, finish_reason)."""
+    engine = state.engine_factory()
+    verifier = SGLangVerifier(engine, eos_token_id=state.tokenizer.eos_token_id)
+    server = SpeculativeServer(drafters=list(state.drafters), config=state.config)
+    result = server.run(prompt_ids, verifier, max_new_tokens=max_new)
+    finish = "length" if len(result.tokens) >= max_new else "stop"
+    return result.tokens, finish
+
+
+#: U+FFFD REPLACEMENT CHARACTER — what a UTF-8 decoder emits for bytes it cannot
+#: decode, i.e. what ``decode()`` returns when a token ends mid-character.
+#: Spelled as an escape, not the glyph: the literal is indistinguishable from
+#: real mojibake in a diff, and would be silently destroyed by a bad re-encode.
+_REPLACEMENT = "\ufffd"
+
+
+class _IncrementalDecoder:
+    """Turn a growing token-id list into *stable* text deltas.
+
+    ``decode(prefix)`` is not guaranteed to be a character prefix of
+    ``decode(prefix + more)``. A token can end mid-way through a multi-byte
+    UTF-8 sequence, which decodes to ``U+FFFD`` until its continuation arrives
+    and then collapses into a different character entirely — so computing a
+    delta by slicing off ``len(previous_text)`` emits mojibake and then
+    mis-aligns every delta after it.
+
+    This holds back the trailing undecodable run instead, so only text that can
+    no longer change is emitted. :meth:`flush` releases whatever is left when
+    the stream ends, so nothing is dropped.
+    """
+
+    def __init__(self, tokenizer: Tokenizer) -> None:
+        self._tok = tokenizer
+        self._ids: List[TokenId] = []
+        self._emitted = ""
+
+    def push(self, ids: Sequence[TokenId]) -> str:
+        """Append ``ids`` and return the delta that is now safe to send."""
+        self._ids.extend(ids)
+        stable = self._tok.decode(self._ids).rstrip(_REPLACEMENT)
+        if len(stable) < len(self._emitted):
+            return ""  # nothing new has become stable yet
+        return self._advance(stable)
+
+    def flush(self) -> str:
+        """Return the tail held back at end of stream (replacement chars incl.)."""
+        return self._advance(self._tok.decode(self._ids))
+
+    def _advance(self, text: str) -> str:
+        if not text.startswith(self._emitted):
+            # Defensive: a tokenizer that rewrites already-emitted characters.
+            # Resync on the common prefix rather than replaying the whole text.
+            i = 0
+            limit = min(len(text), len(self._emitted))
+            while i < limit and text[i] == self._emitted[i]:
+                i += 1
+            self._emitted = text[:i]
+        delta = text[len(self._emitted) :]
+        self._emitted = text
+        return delta
+
+
+def _chunk_json(
+    cid: str,
+    created: int,
+    model: str,
+    *,
+    role: Optional[str] = None,
+    content: Optional[str] = None,
+    finish_reason: Optional[str] = None,
+) -> str:
+    chunk = ChatCompletionChunk(
+        id=cid,
+        created=created,
+        model=model,
+        choices=[
+            ChunkChoice(
+                delta=DeltaMessage(role=role, content=content),
+                finish_reason=finish_reason,
+            )
+        ],
+    )
+    return chunk.model_dump_json()
+
+
+def create_app(state: AppState) -> FastAPI:
+    """Build the FastAPI app bound to ``state``."""
+    app = FastAPI(title="CodeNib Serving", version="0.1.0")
+    state.lock = asyncio.Lock()
+
+    @app.get("/health")
+    async def health() -> dict:
+        return {"status": "ok"}
+
+    @app.get("/v1/models")
+    async def models() -> ModelList:
+        return ModelList(
+            data=[ModelCard(id=state.served_model_name, created=int(time.time()))]
+        )
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(req: ChatCompletionRequest):
+        _check_greedy(req)
+        prompt_ids = _build_prompt_ids(state, req.messages)
+        max_new = _max_new_tokens(state, req)
+        model_name = req.model or state.served_model_name
+
+        if req.stream:
+            return EventSourceResponse(_stream(state, prompt_ids, max_new, model_name))
+
+        async with state.lock:
+            completion_ids, finish = await asyncio.to_thread(
+                _run_full, state, prompt_ids, max_new
+            )
+        text = state.tokenizer.decode(completion_ids)
+        return ChatCompletionResponse(
+            id=_completion_id(),
+            created=int(time.time()),
+            model=model_name,
+            choices=[
+                Choice(
+                    message=ChatMessage(role="assistant", content=text),
+                    finish_reason=finish,
+                )
+            ],
+            usage=Usage(
+                prompt_tokens=len(prompt_ids),
+                completion_tokens=len(completion_ids),
+                total_tokens=len(prompt_ids) + len(completion_ids),
+            ),
+        )
+
+    return app
+
+
+async def _stream(
+    state: AppState, prompt_ids: List[TokenId], max_new: int, model_name: str
+):
+    """Async SSE generator bridging the sync decode loop through a queue.
+
+    The blocking ``run_iter`` runs in a worker thread and pushes decoded text
+    deltas onto an asyncio queue; this coroutine drains it and emits OpenAI
+    ``chat.completion.chunk`` events. The lock is held for the whole stream, so
+    only one generation runs at a time — including when the client disconnects
+    mid-stream (see the acquire/release comment below).
+    """
+    created = int(time.time())
+    cid = _completion_id()
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue = asyncio.Queue()
+    done = object()
+    stop = threading.Event()
+
+    def produce() -> None:
+        try:
+            engine = state.engine_factory()
+            verifier = SGLangVerifier(engine, eos_token_id=state.tokenizer.eos_token_id)
+            server = SpeculativeServer(
+                drafters=list(state.drafters), config=state.config
+            )
+            decoder = _IncrementalDecoder(state.tokenizer)
+            produced = 0
+            for step in server.run_iter(prompt_ids, verifier, max_new_tokens=max_new):
+                if stop.is_set():
+                    # The consumer is gone; stop occupying the GPU. Checked per
+                    # step because a step itself is not interruptible.
+                    return
+                if not step.emitted:
+                    continue
+                produced += len(step.emitted)
+                delta = decoder.push(step.emitted)
+                if delta:
+                    loop.call_soon_threadsafe(queue.put_nowait, ("delta", delta))
+            tail = decoder.flush()
+            if tail:
+                loop.call_soon_threadsafe(queue.put_nowait, ("delta", tail))
+            finish = "length" if produced >= max_new else "stop"
+            loop.call_soon_threadsafe(queue.put_nowait, ("finish", finish))
+        except Exception as exc:  # noqa: BLE001 - surfaced to the consumer below
+            loop.call_soon_threadsafe(queue.put_nowait, ("error", exc))
+        finally:
+            loop.call_soon_threadsafe(queue.put_nowait, done)
+
+    # Acquired and released by hand rather than with ``async with``: a client
+    # disconnect cancels this generator at an ``await``, and a lexical
+    # ``async with`` would unwind and hand the lock to the next request while
+    # this request's worker thread is still generating on the GPU — two
+    # concurrent generations, which is exactly what the lock exists to prevent.
+    # The release below is therefore deferred until the worker has stopped.
+    await state.lock.acquire()
+    fut: Optional[asyncio.Future] = None
+    try:
+        yield {"data": _chunk_json(cid, created, model_name, role="assistant")}
+        fut = loop.run_in_executor(None, produce)
+        error: Optional[BaseException] = None
+        finish = "stop"
+        while True:
+            item = await queue.get()
+            if item is done:
+                break
+            kind, payload = item
+            if kind == "delta":
+                yield {"data": _chunk_json(cid, created, model_name, content=payload)}
+            elif kind == "finish":
+                finish = payload
+            elif kind == "error":
+                error = payload
+        await fut
+        if error is not None:
+            raise error
+        yield {"data": _chunk_json(cid, created, model_name, finish_reason=finish)}
+        yield {"data": "[DONE]"}
+    finally:
+        stop.set()
+        if fut is None or fut.done():
+            state.lock.release()
+        else:
+            fut.add_done_callback(lambda _f: state.lock.release())
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    """Parse ``codenib-serve`` arguments (``argv`` is injected by tests)."""
+    parser = argparse.ArgumentParser(
+        description="CodeNib OpenAI-compatible serving endpoint"
+    )
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("CODENIB_SERVE_MODEL", "Qwen/Qwen2.5-Coder-0.5B"),
+    )
+    parser.add_argument("--served-model-name", default=None)
+    parser.add_argument(
+        "--device", default=os.environ.get("CODENIB_SERVE_DEVICE", "cuda")
+    )
+    parser.add_argument("--host", default="0.0.0.0")  # noqa: S104
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--max-new-tokens", type=int, default=256)
+    parser.add_argument("--max-draft-tokens", type=int, default=16)
+    parser.add_argument(
+        "--manifest",
+        default=os.environ.get("CODENIB_SERVE_MANIFEST"),
+        help=(
+            "path to <repo>/.codenib_cache/repo_manifest.json. When given, a "
+            "retrieval drafter over that index is fused in alongside the copy "
+            "drafter; without it, serving is copy-only."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _build_drafters(args: argparse.Namespace, tokenizer: Tokenizer) -> List[Drafter]:
+    """Ordered draft sources for ``args``.
+
+    :class:`~codenib.serving.drafter.copy.CopyDrafter` comes first — it is near-free and
+    owns shared prefixes, so retrieval grafts onto it during fusion. The retrieval
+    drafter is opt-in: it needs a prebuilt CodeNib index, and loading one costs a
+    ``codenib`` install plus startup time, so it is only built when
+    ``--manifest`` is supplied.
+
+    ``tokenizer`` must be the *serving* tokenizer: the backend decodes the context
+    tail into a query and re-encodes retrieved snippets, so its ids have to line up
+    with the ones the target model is emitting.
+    """
+    drafters: List[Drafter] = [CopyDrafter(max_draft=args.max_draft_tokens)]
+    if args.manifest:
+        backend = CodeNibBackend.from_manifest(args.manifest, tokenizer)
+        drafters.append(
+            RetrievalDrafter(
+                backend, k=DEFAULT_RETRIEVAL_K, max_draft=args.max_draft_tokens
+            )
+        )
+    return drafters
+
+
+def main() -> None:
+    """CLI entry point (``codenib-serve``): load the HF engine and serve."""
+    args = _parse_args()
+
+    # Imported here, not at module scope: this module only *defines* the app, so
+    # embedding it behind another ASGI server should not require uvicorn. It is
+    # the one import ``tests/test_api.py`` does not declare via importorskip.
+    import uvicorn
+
+    base = HFTreeEngine.from_pretrained(args.model, device=args.device)
+    model = base.model
+    tokenizer = Tokenizer.from_pretrained(args.model)
+    state = AppState(
+        served_model_name=args.served_model_name or args.model,
+        tokenizer=tokenizer,
+        engine_factory=lambda: CachedHFTreeEngine(model, device=args.device),
+        drafters=_build_drafters(args, tokenizer),
+        config=SpeculativeConfig(max_draft_tokens=args.max_draft_tokens),
+        default_max_new_tokens=args.max_new_tokens,
+    )
+    app = create_app(state)
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/codenib/serving/server/hf_engine.py
+++ b/codenib/serving/server/hf_engine.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""HF-transformers tree-attention ``TargetEngine``.
+
+The first *real* :class:`~codenib.serving.server.sglang.TargetEngine`: it runs an HF
+``AutoModelForCausalLM`` over a whole flattened draft tree in **one forward pass**
+and returns each position's greedy next-token prediction, which is exactly what
+:class:`~codenib.serving.server.sglang.SGLangVerifier` consumes. Unlike the linear
+``RealModelVerifier`` (which verifies one branch), this verifies every branch of
+a fused tree simultaneously via a tree-attention mask.
+
+How the single forward encodes the tree (all metadata comes from
+:func:`~codenib.serving.server.sglang.flatten`):
+
+* ``input_ids`` = ``context ++ flat.tokens``.
+* ``position_ids`` = ``range(context_len) ++ flat.positions`` — sibling draft
+  tokens share a position id (they are alternatives for the same slot), so every
+  root-to-leaf branch sees a contiguous ``0..n`` position sequence.
+* a **4D additive attention mask** (:meth:`HFTreeEngine._tree_allow`, a
+  vectorized equivalent of :func:`~codenib.serving.server.sglang.attention_mask`):
+  context is causal and each draft token attends to all context plus its own
+  ancestor chain (never sibling or cousin branches). Allowed pairs map to
+  ``0.0``, disallowed to the dtype's most-negative value.
+
+The model is loaded with ``attn_implementation="eager"`` so the custom 4D mask is
+honored — fused/flash kernels ignore an explicit mask and re-derive a plain
+causal one, which would let branches see each other.
+
+**Scope:** greedy verification. :class:`HFTreeEngine` re-forwards the whole
+context each step — a faithful *tokens/forward-pass* (tau) reference but not a
+wall-clock one. :class:`CachedHFTreeEngine` adds committed-prefix KV reuse so
+only the draft (plus newly committed tokens) is forwarded per step, which is the
+wall-clock engine. The SGLang tree-attention kernel remains a follow-up; see
+``docs/superpowers/specs/2026-07-03-hf-tree-engine-design.md``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from codenib.serving.server.sglang import FlatDraft, TargetEngine
+from codenib.serving.types import TokenId
+
+
+class HFTreeEngine(TargetEngine):
+    """Tree-attention target forward backed by an HF causal LM.
+
+    The model is injected so the engine is testable with a tiny random-weights
+    model on CPU; use :meth:`from_pretrained` for a real checkpoint.
+
+    Args:
+        model: a loaded HF ``*ForCausalLM`` returning ``.logits`` of shape
+            ``[batch, seq, vocab]``. Should be loaded with
+            ``attn_implementation="eager"`` (see :meth:`from_pretrained`).
+        device: torch device string for the input tensors; must match the model.
+    """
+
+    def __init__(self, model: object, *, device: str = "cuda") -> None:
+        self.model = model
+        self.device = device
+        #: Running count of token-positions pushed through the model. Lets a
+        #: benchmark quantify the work saved by KV-cache reuse
+        #: (see :class:`CachedHFTreeEngine`).
+        self.forwarded_positions = 0
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name: str,
+        *,
+        device: str = "cuda",
+        dtype: object = None,
+        model_class: object = None,
+    ) -> "HFTreeEngine":
+        """Load ``model_name`` as an eager-attention causal LM on ``device``.
+
+        Shares :func:`~codenib.serving.server.real_model._load_lm` with
+        ``RealModelVerifier``, so the same ``model_class`` escape hatch applies
+        (pass an explicit auto-class for a target the ``AutoModelForCausalLM``
+        mapping rejects). ``attn_implementation="eager"`` is required by the
+        custom 4D tree mask and is always forced here.
+        """
+        import torch
+
+        from codenib.serving.server.real_model import _load_lm
+
+        model = (
+            _load_lm(
+                model_name,
+                dtype=dtype or torch.bfloat16,
+                model_class=model_class,
+                attn_implementation="eager",
+            )
+            .to(device)
+            .eval()
+        )
+        return cls(model, device=device)
+
+    def _tree_allow(self, flat: FlatDraft):
+        """Boolean allow-matrix ``[total_len, total_len]`` for the full tree.
+
+        Identical to :func:`~codenib.serving.server.sglang.attention_mask` but built
+        with vectorized torch ops: the context-causal block (the only
+        O(context^2) part) is a single ``tril`` instead of a Python double loop,
+        so a long context no longer costs O(context^2) *Python* work every step.
+        The remaining loop is over draft tokens only (bounded by the speculation
+        budget), independent of context length.
+        """
+        import torch
+
+        c = flat.context_len
+        total = flat.total_len
+        allow = torch.zeros((total, total), dtype=torch.bool, device=self.device)
+        allow[:c, :c] = torch.tril(
+            torch.ones((c, c), dtype=torch.bool, device=self.device)
+        )
+        if flat.size:
+            allow[c:, :c] = True  # every draft token attends to all context
+            for off in range(flat.size):  # self + ancestor chain among drafts
+                a = c + off
+                while a >= c:
+                    allow[c + off, a] = True
+                    a = flat.parents[a - c]
+        return allow
+
+    def predict(self, context: Sequence[TokenId], flat: FlatDraft) -> List[TokenId]:
+        import torch
+
+        n = flat.total_len
+        input_ids = torch.tensor(
+            [list(context) + list(flat.tokens)], dtype=torch.long, device=self.device
+        )
+        position_ids = torch.tensor(
+            [list(range(flat.context_len)) + list(flat.positions)],
+            dtype=torch.long,
+            device=self.device,
+        )
+
+        # Boolean allow-matrix (context causal + each draft token's ancestor
+        # chain) -> 4D additive float mask the model consumes as an attention bias.
+        param_dtype = next(self.model.parameters()).dtype
+        allow = self._tree_allow(flat)
+        bias = torch.zeros((1, 1, n, n), dtype=param_dtype, device=self.device)
+        bias.masked_fill_(~allow, torch.finfo(param_dtype).min)
+
+        with torch.no_grad():
+            out = self.model(
+                input_ids=input_ids,
+                attention_mask=bias,
+                position_ids=position_ids,
+            )
+        self.forwarded_positions += n
+        return out.logits[0].argmax(dim=-1).tolist()
+
+
+class CachedHFTreeEngine(HFTreeEngine):
+    """:class:`HFTreeEngine` that reuses the committed context's KV cache.
+
+    The stateless base re-forwards the whole ``context`` every step — the KV of
+    every already-generated token is recomputed from scratch, so wall-clock
+    tokens/s is dominated by re-prefill and the measured speedup is muted (this
+    is the caveat throughout the speculative path). This subclass keeps a
+    ``DynamicCache`` of the committed prefix and, each step, forwards only the
+    **newly committed tokens plus the draft** against that cache — O(draft) work
+    per step instead of O(context).
+
+    It is behaviourally identical to the base engine (same greedy predictions,
+    hence the same accepted path and bonus token, up to bf16 ties); only the
+    amount of compute differs. The mechanics:
+
+    * **Reset** when ``context`` no longer extends the cached prefix — a new run
+      (or first call). The cache is per-run state.
+    * **Incremental forward** of ``context[cached_len:] ++ flat.tokens`` with a
+      compact ``[m, kv_len]`` mask: newly committed tokens are causal; draft
+      tokens attend to all committed context plus their own ancestor chain. RoPE
+      ``position_ids`` are absolute (siblings share a slot); ``cache_position``
+      is the contiguous write slot.
+    * **Crop** the cache back to the committed length after each step, discarding
+      the KV of every rejected draft branch. Accepted tokens are re-forwarded
+      (cheaply) as "newly committed" on the next step, which keeps the cache a
+      simple linear prefix rather than a tree.
+
+    Within a run ``context`` must extend monotonically (the speculation loop
+    guarantees this).
+    """
+
+    def __init__(self, model: object, *, device: str = "cuda") -> None:
+        super().__init__(model, device=device)
+        self._cache: object = None
+        self._committed: List[TokenId] = []
+        self._cached_len: int = 0
+
+    def _reset(self) -> None:
+        from transformers import DynamicCache
+
+        self._cache = DynamicCache()
+        self._committed = []
+        self._cached_len = 0
+
+    def _incremental_allow(self, flat: FlatDraft, p: int, m: int, kv_len: int):
+        """Boolean allow-matrix ``[m, kv_len]`` for the new tokens only.
+
+        Keys are global positions ``0..kv_len-1`` (cached context, then newly
+        committed, then draft). Row ``j`` is the query at global position
+        ``p + j``. Committed rows are causal; draft rows attend to all committed
+        context (cols ``< context_len``) plus their ancestor chain among the
+        draft tokens.
+        """
+        import torch
+
+        length = flat.context_len
+        n_committed = length - p
+        allow = torch.zeros((m, kv_len), dtype=torch.bool, device=self.device)
+        for j in range(m):
+            g = p + j
+            if j < n_committed:
+                allow[j, : g + 1] = True  # causal over cached + prior committed
+            else:
+                allow[j, :length] = True  # all committed context
+                a = g
+                while a >= length:  # self + draft ancestor chain
+                    allow[j, a] = True
+                    a = flat.parents[a - length]
+        return allow
+
+    def predict(self, context: Sequence[TokenId], flat: FlatDraft) -> List[TokenId]:
+        import torch
+
+        ctx = list(context)
+        length = flat.context_len  # == len(context)
+
+        if (
+            self._cache is None
+            or self._cached_len > length
+            or ctx[: self._cached_len] != self._committed[: self._cached_len]
+        ):
+            self._reset()
+
+        p = self._cached_len
+        new_tokens = ctx[p:length] + list(flat.tokens)
+        m = len(new_tokens)
+        if m == 0:
+            # Nothing new to forward: the context did not advance and the draft
+            # tree is empty, so the only read position (the bonus slot at the
+            # last context token) already lives in the committed KV cache and its
+            # logits are not recomputed here. The speculation loop always appends
+            # >= 1 token before the next predict(), so this signals that
+            # monotonic-growth precondition was violated by the caller.
+            raise ValueError(
+                "CachedHFTreeEngine.predict called with no new tokens to "
+                "forward (context did not advance and the draft tree is empty)"
+            )
+        kv_len = p + m
+
+        param_dtype = next(self.model.parameters()).dtype
+        input_ids = torch.tensor([new_tokens], dtype=torch.long, device=self.device)
+        position_ids = torch.tensor(
+            [list(range(p, length)) + list(flat.positions)],
+            dtype=torch.long,
+            device=self.device,
+        )
+        cache_position = torch.arange(p, p + m, device=self.device)
+
+        allow = self._incremental_allow(flat, p, m, kv_len)
+        bias = torch.zeros((1, 1, m, kv_len), dtype=param_dtype, device=self.device)
+        bias.masked_fill_(~allow, torch.finfo(param_dtype).min)
+
+        with torch.no_grad():
+            out = self.model(
+                input_ids=input_ids,
+                attention_mask=bias,
+                position_ids=position_ids,
+                past_key_values=self._cache,
+                cache_position=cache_position,
+                use_cache=True,
+            )
+        self.forwarded_positions += m
+        argmax = out.logits[0].argmax(dim=-1).tolist()
+
+        # Full-length result addressed by global index; only the last context
+        # position and the draft nodes are read by SGLangVerifier. New token j
+        # sits at global index p + j.
+        preds: List[TokenId] = [-1] * flat.total_len
+        for j in range(m):
+            preds[p + j] = argmax[j]
+
+        # Commit the context KV, drop every draft branch, advance the prefix.
+        self._cache = out.past_key_values
+        self._cache.crop(length)
+        self._committed = ctx[:length]
+        self._cached_len = length
+        return preds

--- a/codenib/serving/server/real_model.py
+++ b/codenib/serving/server/real_model.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Real-model verifier for the HF-transformers POC.
+
+This is the first non-stub :class:`~codenib.serving.server.worker.Verifier`: instead of
+replaying a known continuation (``OracleVerifier``) it loads a real target model
+and verifies drafts against the model's own greedy continuation. It is the seam
+the real benchmark numbers come from.
+
+**Losslessness.** In exact arithmetic the loop is equivalent to vanilla
+autoregressive generation: a drafted token is accepted only when it equals the
+model's argmax at that position, and the bonus token is the model's argmax at the
+next position. So the emitted sequence is identical to greedy AR — drafting only
+changes *how many* tokens come out per forward pass, never *which*. The
+vanilla-AR baseline is the same object driven with no drafters
+(``SpeculativeServer(drafters=[]).run(prompt, verifier)``), which makes the
+speedup comparison fair within one runtime.
+
+The one caveat is numerical, not logical: verifying a *chunk* runs the model over
+``context + draft`` (a prefill-shaped forward), while AR decodes one token at a
+time, and in bf16 those two paths can produce last-bit-different logits (GPU
+matmul reductions are non-associative in the sequence dimension). At an argmax
+*tie* — two tokens with equal top logits — that last bit flips which one wins, so
+the drafted and AR streams can diverge at a tied position. Empirically this is
+rare and only at genuine ties; it is the standard
+"lossless up to numerics" property of real speculative decoding, and it does not
+affect the acceptance metrics (the drafted run is self-consistent).
+
+**POC scope.** ``verify`` flattens the (usually linear) draft tree to a single
+best-scored branch and runs one full forward over ``context + draft`` with no KV
+cache reuse. That keeps the mean-accepted-length (tau) measurement exact;
+wall-clock tokens/s is muted by the missing cache and is only meaningful once KV
+reuse / tree attention lands (a follow-up). Multi-branch tree verification is
+also deferred.
+
+**Multimodal targets.** Targets load as ``AutoModelForCausalLM``. Even
+``Qwen/Qwen3.5-4B`` — whose config architecture is
+``Qwen3_5ForConditionalGeneration`` with a ``vision_config`` — maps cleanly:
+``transformers`` (>= 5.2) registers ``Qwen3_5ForCausalLM`` in the causal-LM
+auto-mapping, so ``AutoModelForCausalLM.from_pretrained`` returns the text model
+directly (verified on transformers 5.12). For any model the causal-LM mapping
+genuinely rejects, pass an explicit ``model_class`` (e.g.
+``AutoModelForImageTextToText``, whose ``input_ids``-only forward also emits
+next-token text ``.logits``); ``RealModelVerifier`` forwards it to :func:`_load_lm`.
+
+torch/transformers are imported lazily so this module (and ``best_linear_path``)
+stay importable without the ``bench`` extra installed.
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from codenib.serving.server.worker import Verifier, VerifyResult
+from codenib.serving.types import DraftTree, TokenId
+
+
+def best_linear_path(tree: DraftTree) -> List[TokenId]:
+    """Flatten a draft tree to one linear branch for single-path verification.
+
+    Walks from the root, always taking the highest-scored child (ties broken by
+    insertion order), down to a leaf. Our drafters mostly emit linear trees, so
+    this is usually loss-free; for genuinely branching fused trees it picks the
+    most-confident branch and leaves the rest to a future tree-attention verify.
+    """
+    path: List[TokenId] = []
+    node = tree.root
+    while node.children:
+        node = max(node.children, key=lambda c: c.score)
+        path.append(node.token)
+    return path
+
+
+def _load_lm(
+    model_name: str,
+    *,
+    dtype: object,
+    model_class: object = None,
+    **from_pretrained_kwargs,
+):
+    """Load a model that exposes causal-LM ``.logits`` from a text-only forward.
+
+    Uses ``AutoModelForCausalLM`` by default (covers every target we run,
+    including ``Qwen/Qwen3.5-4B`` — its ``Qwen3_5ForCausalLM`` is in the causal-LM
+    auto-mapping on transformers >= 5.2). For a model that mapping genuinely
+    rejects, pass an explicit ``model_class`` (e.g. ``AutoModelForImageTextToText``,
+    whose ``input_ids``-only forward also emits next-token text logits) — it wins
+    over the default. Either way the result returns ``.logits`` from a text-only
+    forward, which is all :meth:`RealModelVerifier.verify` needs.
+
+    Extra ``from_pretrained_kwargs`` are forwarded verbatim, so callers with
+    stricter loading needs can pass them through — e.g. the tree engine loads
+    with ``attn_implementation="eager"`` (see :meth:`HFTreeEngine.from_pretrained`).
+    """
+    from transformers import AutoModelForCausalLM
+
+    cls = model_class if model_class is not None else AutoModelForCausalLM
+    return cls.from_pretrained(model_name, dtype=dtype, **from_pretrained_kwargs)
+
+
+class RealModelVerifier(Verifier):
+    """Verify drafts against a real HF ``AutoModelForCausalLM`` (greedy, lossless).
+
+    Args:
+        model_name: HF id or local path of the target model.
+        device: torch device for the model and inputs (default ``"cuda"``).
+        dtype: parameter dtype; defaults to ``torch.bfloat16``.
+        model_class: optional explicit auto-class to load with, for a target the
+            ``AutoModelForCausalLM`` mapping rejects (e.g.
+            ``AutoModelForImageTextToText``); forwarded to :func:`_load_lm`.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        device: str = "cuda",
+        dtype: object = None,
+        model_class: object = None,
+    ) -> None:
+        import torch
+        from transformers import AutoTokenizer
+
+        self.device = device
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = (
+            _load_lm(
+                model_name,
+                dtype=dtype or torch.bfloat16,
+                model_class=model_class,
+            )
+            .to(device)
+            .eval()
+        )
+
+        # eos can be a single id or a list; normalise to a set for membership.
+        eos = self.model.config.eos_token_id
+        if eos is None:
+            eos = self.tokenizer.eos_token_id
+        if eos is None:
+            self._eos = set()
+        elif isinstance(eos, int):
+            self._eos = {eos}
+        else:
+            self._eos = set(eos)
+
+    def verify(self, context: Sequence[TokenId], tree: DraftTree) -> VerifyResult:
+        import torch
+
+        if len(context) == 0:
+            raise ValueError("RealModelVerifier requires a non-empty context")
+
+        draft = best_linear_path(tree)
+        input_ids = torch.tensor(
+            [list(context) + draft], dtype=torch.long, device=self.device
+        )
+        with torch.no_grad():
+            logits = self.model(input_ids).logits[0]  # [T, vocab], T == L + k
+
+        offset = len(context) - 1  # logits[offset] predicts the first new token
+        accepted: List[TokenId] = []
+        for j, drafted in enumerate(draft):
+            pred = int(logits[offset + j].argmax(-1))
+            if pred != drafted:
+                break
+            accepted.append(drafted)
+
+        bonus = int(logits[offset + len(accepted)].argmax(-1))
+        return VerifyResult(
+            accepted=accepted,
+            bonus=None if bonus in self._eos else bonus,
+        )

--- a/codenib/serving/server/schemas.py
+++ b/codenib/serving/server/schemas.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI-compatible request/response models for the serving endpoint.
+
+A minimal subset of the OpenAI Chat Completions schema — enough for a code agent
+(or LiteLLM in front of one) to call CodeNib serving exactly as it would call OpenAI.
+Sampling fields (``temperature``/``top_p``) are accepted for wire-compatibility
+but v1 only serves greedy; the endpoint rejects non-greedy values (see
+:mod:`codenib.serving.server.api`).
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel
+
+
+class ChatMessage(BaseModel):
+    """A single chat message (``role`` is typically system/user/assistant)."""
+
+    role: str
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    """The subset of ``POST /v1/chat/completions`` fields CodeNib serving honors."""
+
+    model: str
+    messages: List[ChatMessage]
+    max_tokens: Optional[int] = None
+    max_completion_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    stream: bool = False
+
+
+class Choice(BaseModel):
+    """One non-streamed completion choice."""
+
+    index: int = 0
+    message: ChatMessage
+    finish_reason: Optional[str] = None
+
+
+class Usage(BaseModel):
+    """Token accounting for a completion."""
+
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class ChatCompletionResponse(BaseModel):
+    """A non-streamed ``chat.completion`` response."""
+
+    id: str
+    object: Literal["chat.completion"] = "chat.completion"
+    created: int
+    model: str
+    choices: List[Choice]
+    usage: Usage
+
+
+class DeltaMessage(BaseModel):
+    """The incremental payload of a streaming chunk."""
+
+    role: Optional[str] = None
+    content: Optional[str] = None
+
+
+class ChunkChoice(BaseModel):
+    """One streamed choice delta."""
+
+    index: int = 0
+    delta: DeltaMessage
+    finish_reason: Optional[str] = None
+
+
+class ChatCompletionChunk(BaseModel):
+    """A single ``chat.completion.chunk`` streamed over SSE."""
+
+    id: str
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+    created: int
+    model: str
+    choices: List[ChunkChoice]
+
+
+class ModelCard(BaseModel):
+    """One entry in ``GET /v1/models``."""
+
+    id: str
+    object: Literal["model"] = "model"
+    created: int
+    owned_by: str = "codenib"
+
+
+class ModelList(BaseModel):
+    """The ``GET /v1/models`` response."""
+
+    object: Literal["list"] = "list"
+    data: List[ModelCard]

--- a/codenib/serving/server/sglang.py
+++ b/codenib/serving/server/sglang.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-backed tree verification.
+
+This is the GPU-side verifier that turns CodeNib serving's *projected* speedup into a
+*measured* one. ``OracleVerifier`` (in :mod:`codenib.serving.server.worker`) answers
+"is this draft token correct?" by comparing to a known ``truth`` array — only
+possible when replaying existing files. In real serving there is no truth array;
+the only authority on the next token is the **target model itself**. This module
+runs that model over the whole draft tree in **one forward pass** and accepts a
+draft token iff it equals what the model would have produced anyway, which keeps
+output identical to non-speculative greedy decoding.
+
+The work splits cleanly into two layers:
+
+* **Engine-agnostic plumbing (real, tested here):** flatten a :class:`DraftTree`
+  into a linear sequence with per-token *position ids* and a *tree-attention*
+  parent map, then recover the longest accepted root-to-leaf path from the
+  model's per-position next-token predictions. All CPU, no GPU, unit-tested with
+  a fake engine.
+* **The model forward (``TargetEngine`` boundary):** given the flattened tree,
+  return each position's greedy next-token prediction. The production
+  implementation (:class:`SGLangTreeEngine`) submits the flattened tree to
+  SGLang's tree-attention verify kernel; it is the one piece that needs a live
+  GPU engine and is left as a documented stub.
+
+Scope of this first cut: **greedy** verification (argmax). Sampling-based
+verification (modified rejection sampling that preserves the target's exact
+distribution) is future work and noted at the call site.
+
+See: speculative decoding (Leviathan et al. 2211.17192), tree attention
+verification (Medusa/SpecInfer), and RASD tree fusion (2503.03434).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+from codenib.serving.server.worker import Verifier, VerifyResult
+from codenib.serving.types import DraftNode, DraftTree, TokenId
+
+
+@dataclass
+class FlatDraft:
+    """A :class:`DraftTree` flattened for a single batched forward pass.
+
+    The model is fed ``context`` followed by ``tokens`` (the draft nodes in
+    pre-order). Each draft token carries the metadata a tree-attention kernel
+    needs to verify every branch in one pass:
+
+    * ``positions[i]`` — the position id of draft token ``i``. Siblings at the
+      same tree depth share a position id (they are alternative tokens *for the
+      same slot*), so each branch sees a contiguous 0..n position sequence.
+    * ``parents[i]`` — the *global* sequence index (into ``context`` ++
+      ``tokens``) that draft token ``i`` attends back to: its tree parent, or the
+      last context token for a depth-1 node. This is the tree-attention mask in
+      compressed form (see :func:`attention_mask`).
+
+    ``node_index`` maps each :class:`DraftNode` to its global sequence index so
+    the accepted path can be read back after the forward pass.
+    """
+
+    context_len: int
+    tokens: List[TokenId] = field(default_factory=list)
+    positions: List[int] = field(default_factory=list)
+    parents: List[int] = field(default_factory=list)
+    # id(DraftNode) -> global sequence index (context_len + offset into tokens).
+    node_index: Dict[int, int] = field(default_factory=dict)
+
+    @property
+    def size(self) -> int:
+        return len(self.tokens)
+
+    @property
+    def total_len(self) -> int:
+        """Length of the full fed sequence (context + draft tokens)."""
+        return self.context_len + len(self.tokens)
+
+
+def flatten(context_len: int, tree: DraftTree) -> FlatDraft:
+    """Flatten ``tree`` into a :class:`FlatDraft` for a forward pass over a
+    sequence of length ``context_len`` followed by the draft tokens.
+
+    Pre-order DFS keeps every root-to-node path contiguous in attention terms
+    (a node's ancestors always precede it). Depth-1 nodes attend to the last
+    context token (``context_len - 1``); deeper nodes attend to their tree
+    parent.
+    """
+    flat = FlatDraft(context_len=context_len)
+
+    def visit(node: DraftNode, parent_global: int, depth: int) -> None:
+        for child in node.children:
+            g = context_len + len(flat.tokens)
+            flat.node_index[id(child)] = g
+            flat.tokens.append(child.token)
+            # Depth d node fills generation slot d-1 -> position context_len+d-1.
+            flat.positions.append(context_len + depth - 1)
+            flat.parents.append(parent_global)
+            visit(child, g, depth + 1)
+
+    # Root's children attend back to the final context token.
+    visit(tree.root, context_len - 1, 1)
+    return flat
+
+
+def attention_mask(flat: FlatDraft) -> List[List[bool]]:
+    """Expand ``flat``'s parent links into a full boolean attention mask.
+
+    ``mask[i][j]`` is True when query position ``i`` may attend to key position
+    ``j``. Context tokens are causal; each draft token attends to all context
+    plus its own ancestor chain (and itself) — never to sibling or cousin
+    branches. Provided for adapters/engines that consume a dense mask; the
+    compressed ``parents`` map is the source of truth.
+    """
+    n = flat.total_len
+    c = flat.context_len
+    mask = [[False] * n for _ in range(n)]
+    # Causal block over the context.
+    for i in range(c):
+        for j in range(i + 1):
+            mask[i][j] = True
+    # Each draft token: all context + ancestor chain + self.
+    for off in range(flat.size):
+        i = c + off
+        for j in range(c):
+            mask[i][j] = True
+        anc = i
+        while anc >= c:
+            mask[i][anc] = True
+            anc = flat.parents[anc - c]
+        # anc is now the last context token (parent of the depth-1 ancestor).
+    return mask
+
+
+class TargetEngine(ABC):
+    """The target model's forward pass over a flattened draft tree.
+
+    Implementations run one batched forward and return, for each fed sequence
+    position, the model's **greedy next-token id** — i.e. ``argmax`` of the
+    logits at that position. CodeNib serving reads only the predictions it needs (the
+    last context token and each accepted draft node), but returning the full
+    aligned vector keeps the contract simple and matches what a real engine
+    computes anyway.
+    """
+
+    @abstractmethod
+    def predict(self, context: Sequence[TokenId], flat: FlatDraft) -> List[TokenId]:
+        """Return greedy next-token predictions aligned to the fed sequence.
+
+        The result has length ``flat.total_len``; ``result[i]`` is the token the
+        model would emit immediately after sequence position ``i`` (context
+        positions ``0..context_len-1`` followed by the draft tokens). Only
+        ``result[context_len-1]`` and the draft-node positions are consulted.
+        """
+        raise NotImplementedError
+
+
+@dataclass
+class SGLangVerifier(Verifier):
+    """Greedy tree verifier driven by a :class:`TargetEngine`.
+
+    Walks the fused draft tree along the model's own greedy predictions,
+    accepting each draft token that matches what the model would have generated,
+    and emits the model's next token as the always-present bonus (this is the
+    free token standard speculative decoding yields per step). Output is
+    therefore token-identical to non-speculative greedy decoding.
+
+    ``eos_token_id`` maps the engine's end-of-sequence prediction to a ``None``
+    bonus so :meth:`SpeculativeServer.run` halts.
+    """
+
+    engine: TargetEngine
+    eos_token_id: Optional[TokenId] = None
+
+    def verify(self, context: Sequence[TokenId], tree: DraftTree) -> VerifyResult:
+        c = len(context)
+        flat = flatten(c, tree)
+        preds = self.engine.predict(context, flat)
+        if len(preds) != flat.total_len:
+            raise ValueError(
+                f"engine returned {len(preds)} predictions; "
+                f"expected {flat.total_len}"
+            )
+
+        accepted: List[TokenId] = []
+        node = tree.root
+        pred_idx = c - 1  # prediction after the last context token = next slot
+        while node.children:
+            want = preds[pred_idx]
+            child = next((ch for ch in node.children if ch.token == want), None)
+            if child is None:
+                break  # model diverges from every drafted branch here
+            accepted.append(child.token)
+            node = child
+            pred_idx = flat.node_index[id(child)]
+
+        bonus: Optional[TokenId] = preds[pred_idx]
+        if self.eos_token_id is not None and bonus == self.eos_token_id:
+            bonus = None
+        return VerifyResult(accepted=accepted, bonus=bonus)
+
+
+class SGLangTreeEngine(TargetEngine):
+    """Production :class:`TargetEngine` backed by a live SGLang engine. **Stub.**
+
+    Planned wiring (the one remaining GPU-side task):
+
+    1. Build the batched forward inputs from a :class:`FlatDraft`: ``input_ids``
+       = context ++ ``flat.tokens``, ``positions`` = context range ++
+       ``flat.positions``, and a tree-attention bias from ``flat.parents`` (or
+       the dense :func:`attention_mask`) so each draft token attends only to its
+       ancestor chain.
+    2. Run SGLang's tree-attention verify kernel once, reusing the prefilled
+       context KV cache.
+    3. Return per-position ``argmax`` of the output logits as the greedy
+       predictions (sampling-based rejection verification is a later upgrade).
+
+    Kept as an explicit stub so the verifier logic above stays importable and
+    fully unit-tested without sglang or a GPU.
+    """
+
+    def __init__(self, engine: object | None = None) -> None:
+        self.engine = engine
+
+    def predict(self, context: Sequence[TokenId], flat: FlatDraft) -> List[TokenId]:
+        raise NotImplementedError(
+            "SGLangTreeEngine needs a live SGLang engine. Build the tree-attention "
+            "forward from FlatDraft (input_ids/positions/parents), run one verify "
+            "pass, and return per-position argmax. SGLangVerifier already drives "
+            "any TargetEngine — see the fake engine in the tests for the contract."
+        )

--- a/codenib/serving/server/tokenization.py
+++ b/codenib/serving/server/tokenization.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""The text↔token seam for the serving layer.
+
+Everything in :mod:`codenib.serving` speaks token-ids (``TokenId = int``) and is
+deliberately tokenizer-agnostic. A serving endpoint, however, receives text and
+must return text, and the CodeNib retrieval backend must tokenize the snippets
+it fetches. This module is the single place that bridges the two — a thin wrapper
+over an HF ``AutoTokenizer`` exposing exactly what the rest of the stack needs:
+``encode``, ``decode``, and the ``eos_token_id`` that
+:class:`~codenib.serving.server.sglang.SGLangVerifier` uses to stop.
+
+The tokenizer is injected (like the model in :class:`HFTreeEngine`) so tests can
+pass a tiny fake; use :meth:`from_pretrained` for a real checkpoint. Importing
+this module requires ``transformers`` (the ``serve``/``bench`` extra), which the
+serving layer needs anyway; injection keeps the *tests* free of it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Protocol, Sequence
+
+from codenib.serving.types import TokenId
+
+
+class TokenizerLike(Protocol):
+    """The exact slice of an HF tokenizer that :class:`Tokenizer` delegates to.
+
+    Declaring it structurally keeps the injection seam open — an HF
+    ``PreTrainedTokenizer*`` and a hand-rolled test fake both satisfy it — while
+    still letting the delegating calls below be type-checked.
+    """
+
+    def encode(self, text: str, *, add_special_tokens: bool = ...) -> Sequence[int]: ...
+
+    # ``ids`` is List, not Sequence: the wrapper always materializes a list
+    # before delegating, and HF tokenizers/fakes annotate the narrower type.
+    def decode(self, ids: List[int], *, skip_special_tokens: bool = ...) -> str: ...
+
+    @property
+    def eos_token_id(self) -> Optional[int]: ...
+
+
+class Tokenizer:
+    """Minimal encode/decode bridge around an HF tokenizer.
+
+    Args:
+        tokenizer: any object satisfying :class:`TokenizerLike` — an HF
+            ``PreTrainedTokenizer*`` or a compatible fake.
+    """
+
+    def __init__(self, tokenizer: TokenizerLike) -> None:
+        #: The underlying HF tokenizer, deliberately untyped. Exposed so callers
+        #: that need extra capabilities (e.g. ``apply_chat_template``) can reach
+        #: them directly without this wrapper re-exporting — or this module
+        #: re-declaring — the whole tokenizer surface.
+        self.hf: Any = tokenizer
+        #: The same object under its checked, narrow type. The three delegating
+        #: methods go through this so they stay type-checkable.
+        self._tok: TokenizerLike = tokenizer
+
+    @classmethod
+    def from_pretrained(cls, model_name: str, **kwargs: Any) -> "Tokenizer":
+        """Load ``model_name``'s tokenizer (like ``HFTreeEngine.from_pretrained``)."""
+        # Imported here, not at module scope, to match the rest of the serving
+        # package: wrapping an injected tokenizer must not require the
+        # ``serving`` extra, so only the *loading* path pulls in transformers.
+        from transformers import AutoTokenizer
+
+        return cls(AutoTokenizer.from_pretrained(model_name, **kwargs))
+
+    def encode(self, text: str, *, add_special_tokens: bool = False) -> List[TokenId]:
+        """Encode ``text`` to token ids.
+
+        Defaults to ``add_special_tokens=False``: the serving layer builds its
+        prompt via a chat template (which already inserts the model's special
+        tokens), so re-adding them here would double them.
+        """
+        return list(self._tok.encode(text, add_special_tokens=add_special_tokens))
+
+    def decode(
+        self, ids: Sequence[TokenId], *, skip_special_tokens: bool = True
+    ) -> str:
+        """Decode token ids back to text."""
+        return self._tok.decode(list(ids), skip_special_tokens=skip_special_tokens)
+
+    @property
+    def eos_token_id(self) -> Optional[TokenId]:
+        """The end-of-sequence id, passed to ``SGLangVerifier`` to halt generation."""
+        return self._tok.eos_token_id

--- a/codenib/serving/server/worker.py
+++ b/codenib/serving/server/worker.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang speculative-decoding integration.
+
+This module is the seam between CodeNib serving's drafters and the target engine. The
+draft-assembly logic (``build_draft``) is engine-agnostic; the speculation loop
+(``SpeculativeServer.run``) drives it against any object implementing the
+``Verifier`` protocol. The production verifier lives in
+:mod:`codenib.serving.server.sglang` (``SGLangVerifier`` over a ``TargetEngine``); its
+only stubbed part is the GPU model forward. The loop itself is real and is
+exercised offline by ``OracleVerifier`` (and in the experiments harness).
+
+Per-step loop::
+
+    context = prompt
+    while not done:
+        tree   = build_draft(drafters, context, budget)   # this module
+        result = verifier.verify(context, tree)           # SGLang forward / oracle
+        context += result.emitted                         # >= 1 token / step
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Iterator, List, Optional, Sequence
+
+from codenib.serving.drafter.base import Drafter
+from codenib.serving.drafter.fusion import fuse
+from codenib.serving.types import DraftTree, TokenId
+
+
+@dataclass
+class SpeculativeConfig:
+    """Tuning knobs for the speculation loop."""
+
+    #: Max candidate positions per verification tree (the speculation budget).
+    max_draft_tokens: int = 16
+    #: Skip verification overhead when fewer than this many tokens were drafted.
+    min_draft_tokens: int = 1
+
+
+def build_draft(
+    drafters: Sequence[Drafter],
+    context: Sequence[TokenId],
+    config: SpeculativeConfig,
+) -> DraftTree:
+    """Run every drafter and fuse the results into one budgeted tree.
+
+    Drafters are consulted in order, so earlier ones (typically the near-free
+    copy drafter) own shared prefixes; retrieval and model drafts graft on. The
+    fused tree is pruned to ``config.max_draft_tokens``.
+    """
+    trees = [d.draft(context, config.max_draft_tokens) for d in drafters]
+    trees = [t for t in trees if not t.is_empty()]
+    return fuse(trees, max_tokens=config.max_draft_tokens)
+
+
+@dataclass
+class VerifyResult:
+    """Outcome of verifying one draft tree against the target.
+
+    ``accepted`` are drafted tokens the target confirmed along its chosen path
+    (>= 0). ``bonus`` is the one free token the target emits for the next
+    position, or ``None`` when generation should stop (EOS / budget reached).
+    """
+
+    accepted: List[TokenId]
+    bonus: Optional[TokenId]
+
+    @property
+    def emitted(self) -> List[TokenId]:
+        """All tokens to append to the context this step (accepted + bonus)."""
+        if self.bonus is None:
+            return list(self.accepted)
+        return [*self.accepted, self.bonus]
+
+
+class Verifier(ABC):
+    """Confirms a draft tree against the target model.
+
+    A verifier consumes the current ``context`` and a ``DraftTree`` and returns
+    the prefix of drafted tokens the target accepts plus one bonus token. The
+    real engine (``SGLangVerifier``) verifies the whole tree in a single forward
+    pass; ``OracleVerifier`` stands in for offline evaluation and tests.
+    """
+
+    @abstractmethod
+    def verify(self, context: Sequence[TokenId], tree: DraftTree) -> VerifyResult: ...
+
+
+@dataclass
+class StepResult:
+    """One decoding step's outcome, yielded by ``SpeculativeServer.run_iter``.
+
+    ``emitted`` are the tokens appended to the context this step (accepted draft
+    tokens plus the bonus, possibly empty on a terminal no-emit step). ``accepted``
+    counts how many of those were drafted tokens the target confirmed. ``stop`` is
+    True on the last step (EOS reached or nothing left to emit).
+    """
+
+    emitted: List[TokenId]
+    accepted: int
+    stop: bool
+
+
+@dataclass
+class RunResult:
+    """Aggregate stats from a full ``SpeculativeServer.run``."""
+
+    tokens: List[TokenId]
+    forward_passes: int
+    accepted_tokens: int
+
+    @property
+    def speedup(self) -> float:
+        """Tokens emitted per forward pass (1.0 == no speculation benefit)."""
+        return len(self.tokens) / self.forward_passes if self.forward_passes else 1.0
+
+
+@dataclass
+class OracleVerifier(Verifier):
+    """Reference verifier whose "target" is a known true continuation.
+
+    Accepts the longest draft-tree path that matches ``truth`` from the current
+    context length, then emits one bonus truth token. This makes the speculation
+    loop runnable and testable without a GPU; it is the same acceptance math used
+    by ``experiments/acceptance.py``. ``context`` must be a prefix of ``truth``
+    (the loop maintains this when started from ``truth[:k]``).
+    """
+
+    truth: Sequence[TokenId]
+
+    def verify(self, context: Sequence[TokenId], tree: DraftTree) -> VerifyResult:
+        pos = len(context)
+        n = len(self.truth)
+        accepted: List[TokenId] = []
+        node = tree.root
+        while node.children and pos + len(accepted) < n:
+            want = self.truth[pos + len(accepted)]
+            child = next((c for c in node.children if c.token == want), None)
+            if child is None:
+                break
+            accepted.append(child.token)
+            node = child
+        nxt = pos + len(accepted)
+        bonus = self.truth[nxt] if nxt < n else None
+        return VerifyResult(accepted=accepted, bonus=bonus)
+
+
+# The production verifier backed by a live SGLang engine lives in
+# ``codenib.serving.server.sglang`` (``SGLangVerifier`` + ``TargetEngine``). It is kept
+# out of this module so the speculation loop here stays engine-agnostic and
+# importable without sglang or a GPU.
+
+
+@dataclass
+class SpeculativeServer:
+    """Drives CodeNib serving drafting through a speculative-decoding loop.
+
+    ``drafters`` are the ordered draft sources (e.g. ``[CopyDrafter(),
+    RetrievalDrafter(backend)]``). ``step`` builds one fused draft tree; ``run``
+    closes the loop against any :class:`Verifier`.
+    """
+
+    drafters: List[Drafter] = field(default_factory=list)
+    config: SpeculativeConfig = field(default_factory=SpeculativeConfig)
+
+    def step(self, context: Sequence[TokenId]) -> DraftTree:
+        """Produce the draft tree for one decoding step (engine-agnostic)."""
+        return build_draft(self.drafters, context, self.config)
+
+    def run_iter(
+        self,
+        prompt: Sequence[TokenId],
+        verifier: Verifier,
+        *,
+        max_new_tokens: int = 256,
+    ) -> Iterator[StepResult]:
+        """Speculatively decode, yielding one :class:`StepResult` per forward pass.
+
+        Each iteration drafts a fused tree, has ``verifier`` confirm a prefix plus
+        a bonus token, appends the result to the context (>= 1 token/pass), and
+        yields it — so a streaming caller can emit tokens as they are produced.
+        Generation ends at EOS, at ``max_new_tokens``, or when the verifier emits
+        nothing. This is the single decoding loop; :meth:`run` aggregates it.
+        """
+        context: List[TokenId] = list(prompt)
+        produced = 0
+
+        while produced < max_new_tokens:
+            tree = self.step(context)
+            result = verifier.verify(context, tree)
+
+            emitted = result.emitted[: max_new_tokens - produced]
+            accepted = min(len(result.accepted), len(emitted))
+            stop = not emitted or result.bonus is None
+            if emitted:
+                context.extend(emitted)
+                produced += len(emitted)
+
+            yield StepResult(emitted=emitted, accepted=accepted, stop=stop)
+            if stop:
+                return
+
+    def run(
+        self,
+        prompt: Sequence[TokenId],
+        verifier: Verifier,
+        *,
+        max_new_tokens: int = 256,
+    ) -> RunResult:
+        """Speculatively decode up to ``max_new_tokens`` tokens after ``prompt``.
+
+        Drives :meth:`run_iter` to completion and aggregates the generated tokens
+        and the forward-pass / acceptance counts that determine the realized
+        speedup. Output is identical to consuming ``run_iter`` directly.
+        """
+        generated: List[TokenId] = []
+        passes = 0
+        accepted_total = 0
+
+        for step in self.run_iter(prompt, verifier, max_new_tokens=max_new_tokens):
+            passes += 1
+            generated.extend(step.emitted)
+            accepted_total += step.accepted
+
+        return RunResult(
+            tokens=generated, forward_passes=passes, accepted_tokens=accepted_total
+        )

--- a/codenib/serving/types.py
+++ b/codenib/serving/types.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Core data structures shared across drafters and the serving worker.
+
+A *draft* is a tree of candidate token ids that the target model verifies in a
+single forward pass. We model it explicitly (rather than as a flat sequence) so
+that multiple draft sources — copy, retrieval, base-model — can be fused into one
+tree before verification, following RASD's tree-fusion design.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterator, List, Optional, Sequence
+
+# A token id, kept as a plain int so drafters stay tokenizer-agnostic.
+TokenId = int
+
+
+@dataclass
+class DraftNode:
+    """A single node in a draft tree.
+
+    Each node carries one candidate token and links to continuation children.
+    The path from the root to any node is one speculated continuation.
+    """
+
+    token: TokenId
+    children: List["DraftNode"] = field(default_factory=list)
+    # Free-form provenance, e.g. "copy", "retrieval:bm25", "model". Useful for
+    # acceptance-rate accounting per draft source.
+    source: Optional[str] = None
+    # Optional drafter confidence in [0, 1]; used to rank/prune branches.
+    score: float = 1.0
+
+    def add_path(
+        self, tokens: Sequence[TokenId], source: Optional[str] = None
+    ) -> "DraftNode":
+        """Merge a linear continuation into the tree under this node.
+
+        Shared prefixes reuse existing children (longest-prefix merge), so two
+        candidate continuations that agree for k tokens only cost one branch for
+        those k tokens. Returns the deepest node of the inserted path.
+        """
+        node = self
+        for tok in tokens:
+            match = next((c for c in node.children if c.token == tok), None)
+            if match is None:
+                match = DraftNode(token=tok, source=source)
+                node.children.append(match)
+            node = match
+        return node
+
+    def __iter__(self) -> Iterator["DraftNode"]:
+        """Pre-order traversal over this node and its descendants."""
+        yield self
+        for child in self.children:
+            yield from child
+
+
+@dataclass
+class DraftTree:
+    """A verification tree rooted at the current generation position.
+
+    The root is a sentinel that holds no token; its children are the first
+    speculated tokens. ``size`` counts real (non-root) candidate tokens — the
+    number of positions the target model must verify.
+    """
+
+    root: DraftNode = field(default_factory=lambda: DraftNode(token=-1, source="root"))
+
+    @property
+    def size(self) -> int:
+        return sum(1 for _ in self.root) - 1  # exclude the sentinel root
+
+    def is_empty(self) -> bool:
+        return not self.root.children
+
+    def add_sequence(
+        self, tokens: Sequence[TokenId], source: Optional[str] = None
+    ) -> None:
+        """Add a linear candidate continuation from the root."""
+        if tokens:
+            self.root.add_path(tokens, source=source)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,64 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Deploying CodeNib serving behind LiteLLM
+
+This directory wires the CodeNib serving endpoint behind a [LiteLLM](https://github.com/BerriAI/litellm)
+gateway so a code agent can call it exactly as it would call OpenAI — with an
+automatic fallback to a plain model if CodeNib serving is unavailable.
+
+```
+agent ──POST /v1/chat/completions──▶ LiteLLM ──POST /v1/chat/completions──▶ codenib-serve ──▶ HF model (GPU)
+                                        └── fallback ─────────────────────▶ plain model
+```
+
+Both hops speak the **same** OpenAI protocol; LiteLLM only decides *which backend*
+answers and handles retries/fallback. (CodeNib retrieval is a separate,
+in-process call inside `codenib-serve` — it does **not** go through LiteLLM.)
+
+## 1. Start the CodeNib serving endpoint
+
+```bash
+pip install -e ".[serve]"
+codenib-serve --model Qwen/Qwen2.5-Coder-0.5B --device cuda --port 8000
+# GET http://localhost:8000/health  ->  {"status":"ok"}
+```
+
+## 2. Start the LiteLLM gateway
+
+```bash
+pip install litellm
+litellm --config deploy/litellm.config.yaml --port 4000
+```
+
+Edit `litellm.config.yaml` to point the **fallback** entry at your baseline
+(a second endpoint, a vLLM server, or a hosted API).
+
+## 3. Smoke test — same request shape reaches CodeNib serving
+
+```bash
+curl -s http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+        "model": "codenib-qwen-coder",
+        "messages": [{"role": "user", "content": "Finish this:\n\ndef add(a, b):"}]
+      }' | jq .
+```
+
+Streaming:
+
+```bash
+curl -N http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"codenib-qwen-coder","messages":[{"role":"user","content":"hi"}],"stream":true}'
+```
+
+## Notes
+
+- **Greedy only (v1).** A request with `temperature > 0` (or `top_p < 1`) is
+  rejected with HTTP 400 — CodeNib serving serves lossless greedy decoding. Sampling is
+  a future track.
+- **Fallback demo.** Kill `codenib-serve` and repeat the smoke test: LiteLLM
+  routes the same request to the fallback backend instead.

--- a/deploy/litellm.config.yaml
+++ b/deploy/litellm.config.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# LiteLLM gateway config for CodeNib serving.
+#
+# LiteLLM is a router that speaks the OpenAI chat-completions API on both sides:
+# an agent calls LiteLLM, LiteLLM forwards to a backend. Here the primary backend
+# is the CodeNib serving accelerated endpoint (`codenib-serve`), with a plain model as
+# a fallback so a CodeNib serving outage never breaks the agent — "never net-negative".
+#
+# Run:
+#   codenib-serve --model Qwen/Qwen2.5-Coder-0.5B --port 8000   # primary (fast)
+#   litellm --config deploy/litellm.config.yaml --port 4000
+# Then point the agent's OpenAI base_url at http://<host>:4000/v1 and call the
+# model "codenib-qwen-coder".
+
+model_list:
+  # Primary: CodeNib serving's speculative-decoding endpoint. It is OpenAI-compatible,
+  # so LiteLLM treats it as an "openai/" provider pointed at the CodeNib serving host.
+  - model_name: codenib-qwen-coder
+    litellm_params:
+      model: openai/Qwen/Qwen2.5-Coder-0.5B
+      api_base: http://localhost:8000/v1
+      api_key: "none"                       # CodeNib serving does not check keys in v1
+
+  # Fallback: a plain (non-speculative) OpenAI-compatible backend serving the same
+  # model — e.g. a second `codenib-serve` without drafters, a vLLM server, or a
+  # hosted API. Swap api_base/model for your baseline.
+  - model_name: codenib-qwen-coder-fallback
+    litellm_params:
+      model: openai/Qwen/Qwen2.5-Coder-0.5B
+      api_base: http://localhost:8001/v1
+      api_key: "none"
+
+router_settings:
+  # If the primary errors or times out, retry the same request against the
+  # fallback. The agent sees one model name; the failover is invisible.
+  fallbacks:
+    - codenib-qwen-coder: ["codenib-qwen-coder-fallback"]
+  num_retries: 1
+  timeout: 120

--- a/examples/serving_agent_demo.py
+++ b/examples/serving_agent_demo.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""A minimal code agent that uses CodeNib for context and CodeNib serving to generate.
+
+This is the concrete shape of the serving stack from the outside — the two calls
+a code agent makes:
+
+1. **Retrieve context** from CodeNib (in-process index lookup) to ground the prompt.
+2. **Generate** by calling LiteLLM (which routes to CodeNib serving) over the OpenAI
+   chat-completions API — exactly as it would call OpenAI.
+
+CodeNib is *not* an agent; it is the retrieval library this agent queries. The
+LLM call is a plain OpenAI request, so nothing here knows speculation is happening.
+
+The pieces (``retrieve_context`` / ``generate``) take injectable ``ctx``/``client``
+so the flow is unit-testable without a running CodeNib index or LLM. ``main``
+wires the real ones.
+
+Run::
+
+    python -m examples.agent_demo \\
+        --manifest /path/to/repo/.codenib_cache/repo_manifest.json \\
+        --base-url http://localhost:4000/v1 \\
+        --model codenib-qwen-coder \\
+        --task "Add a docstring to the parse_config function"
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, List, Optional, Protocol
+
+
+class _Completions(Protocol):
+    """``client.chat.completions`` — the one call this demo makes."""
+
+    def create(
+        self, model: str, messages: List[dict], stream: bool = ...
+    ) -> Any: ...  # a response, or an iterable of chunks when stream=True
+
+
+class _Chat(Protocol):
+    @property
+    def completions(self) -> _Completions: ...
+
+
+class OpenAIClient(Protocol):
+    """The slice of an OpenAI-style client this demo depends on.
+
+    Declared structurally so the real ``openai.OpenAI`` and the test fake are
+    both accepted, without the example having to import ``openai`` to be
+    type-checked.
+    """
+
+    @property
+    def chat(self) -> _Chat: ...
+
+
+_SYSTEM_PROMPT = (
+    "You are a coding assistant. Use the repository context below to answer "
+    "accurately; prefer the project's own conventions."
+)
+
+
+def retrieve_context(
+    query: str,
+    *,
+    ctx: object = None,
+    manifest_path: Optional[str] = None,
+    top_k: int = 5,
+) -> str:
+    """Fetch relevant code snippets from CodeNib and join them into a context block.
+
+    ``ctx`` is a CodeNib ``ServerContext`` (injected for tests); if omitted it is
+    loaded from ``manifest_path``.
+    """
+    if ctx is None:
+        from codenib.mcp.context import ServerContext
+
+        ctx = ServerContext.load(manifest_path)
+
+    bm25 = getattr(ctx, "bm25", None)
+    if bm25 is None:
+        return ""
+    hits = bm25.search(query, top_k=top_k, return_code_content=True)
+    snippets = []
+    for hit in hits:
+        content = getattr(hit, "content", None)
+        if content:
+            where = getattr(hit, "file", None) or getattr(hit, "node_name", "")
+            snippets.append(f"# {where}\n{content}" if where else content)
+    return "\n\n".join(snippets)
+
+
+def build_messages(task: str, context: str) -> List[dict]:
+    """Assemble the chat messages from the task and retrieved context."""
+    user = f"Repository context:\n{context}\n\nTask:\n{task}" if context else task
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user},
+    ]
+
+
+def generate(
+    messages: List[dict],
+    *,
+    base_url: str,
+    model: str,
+    api_key: str = "none",
+    stream: bool = False,
+    client: Optional[OpenAIClient] = None,
+    echo: bool = False,
+) -> str:
+    """Call LiteLLM/CodeNib serving over the OpenAI API and return the completion text.
+
+    ``client`` is an OpenAI-style client (injected for tests); if omitted a real
+    ``openai.OpenAI`` pointed at ``base_url`` is created.
+    """
+    if client is None:
+        from openai import OpenAI
+
+        client = OpenAI(base_url=base_url, api_key=api_key)
+
+    if stream:
+        parts: List[str] = []
+        for chunk in client.chat.completions.create(
+            model=model, messages=messages, stream=True
+        ):
+            delta = chunk.choices[0].delta.content
+            if delta:
+                parts.append(delta)
+                if echo:
+                    print(delta, end="", flush=True)
+        if echo:
+            print()
+        return "".join(parts)
+
+    resp = client.chat.completions.create(model=model, messages=messages)
+    text = resp.choices[0].message.content or ""
+    if echo:
+        print(text)
+    return text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CodeNib serving agent demo")
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        help="path to <repo>/.codenib_cache/repo_manifest.json",
+    )
+    parser.add_argument("--task", required=True, help="the coding task / question")
+    parser.add_argument("--base-url", default="http://localhost:4000/v1")
+    parser.add_argument("--model", default="codenib-qwen-coder")
+    parser.add_argument("--api-key", default="none")
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--no-stream", action="store_true")
+    args = parser.parse_args()
+
+    context = retrieve_context(args.task, manifest_path=args.manifest, top_k=args.top_k)
+    messages = build_messages(args.task, context)
+    generate(
+        messages,
+        base_url=args.base_url,
+        model=args.model,
+        api_key=args.api_key,
+        stream=not args.no_stream,
+        echo=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ codenib-lsp-agent-study-run = "codenib.eval.agent_runner.lsp_agent_study_runner:
 codenib-artifact-bundle = "codenib.eval.artifact_bundle:main"
 codenib-swe-explore-benchmark = "codenib.eval.benchmarks.swe_explore_runner:main"
 codenib-quality-cost-report = "codenib.eval.reports.quality_cost:main"
+codenib-serve = "codenib.serving.server.api:main"
 
 [project.optional-dependencies]
 agent = [
@@ -94,6 +95,16 @@ semantic-remote = [
     "faiss-cpu>=1.7.0",
     "numpy>=1.24.0",
     "openai>=1.0.0",
+]
+# Speculative serving (``codenib-serve``). fastapi/uvicorn/pydantic are already
+# core dependencies, so this only adds the streaming transport and the model
+# runtime. Deliberately kept out of `full`: torch would make the aggregate
+# extra multi-gigabyte for users who only want retrieval.
+serving = [
+    "numpy>=1.24.0",
+    "sse-starlette>=2.0.0",
+    "torch>=2.2.0",
+    "transformers>=4.44.0",
 ]
 # Vertex AI backends (``vertex_ai/...`` model strings, via gcloud ADC).
 # Keep the provider SDK coupled to LiteLLM's own compatibility constraint
@@ -150,6 +161,10 @@ test = [
     "pytest-xdist>=3.0.0",
     "requests>=2.25.0",
     "sentence-transformers>=2.2.0",
+    # Lets the serving endpoint tests run in the default tier. torch and
+    # transformers are deliberately *not* here: the only test that needs the
+    # model runtime is marked `slow`.
+    "sse-starlette>=2.0.0",
     "tomli>=1.1.0; python_version < '3.11'",
 ]
 

--- a/test/examples/test_serving_agent_demo.py
+++ b/test/examples/test_serving_agent_demo.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the example agent (``examples/serving_agent_demo.py``).
+
+CodeNib and the OpenAI client are both injected as fakes, so the two-call
+flow (retrieve context -> generate) is exercised with no index and no network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+
+# Load examples/serving_agent_demo.py by path (``examples/`` is not a package).
+_MODULE_PATH = (
+    Path(__file__).resolve().parent.parent.parent / "examples" / "serving_agent_demo.py"
+)
+_spec = importlib.util.spec_from_file_location("serving_agent_demo", _MODULE_PATH)
+assert _spec and _spec.loader
+serving_agent_demo = importlib.util.module_from_spec(_spec)
+sys.modules["serving_agent_demo"] = serving_agent_demo
+_spec.loader.exec_module(serving_agent_demo)
+
+build_messages = serving_agent_demo.build_messages
+generate = serving_agent_demo.generate
+retrieve_context = serving_agent_demo.retrieve_context
+
+
+class _Hit:
+    __slots__ = ("content", "file")
+
+    def __init__(self, content: str, file: str = "") -> None:
+        self.content = content
+        self.file = file
+
+
+class _FakeBM25:
+    def __init__(self, hits: List[_Hit]) -> None:
+        self.hits = hits
+        self.last_query = None
+
+    def search(self, query, top_k=5, return_code_content=False):
+        self.last_query = query
+        return self.hits
+
+
+def _ctx(hits, has_bm25: bool = True):
+    return SimpleNamespace(bm25=_FakeBM25(hits) if has_bm25 else None)
+
+
+class _FakeCompletions:
+    def __init__(self, text: str, pieces: List[str]) -> None:
+        self.text = text
+        self.pieces = pieces
+        self.calls: List[dict] = []
+
+    def create(self, model, messages, stream=False):
+        self.calls.append({"model": model, "messages": messages, "stream": stream})
+        if stream:
+            return iter(
+                SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content=p))]
+                )
+                for p in self.pieces
+            )
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=self.text))]
+        )
+
+
+def _client(text="DONE", pieces=("wor", "ld")):
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=_FakeCompletions(text, list(pieces)))
+    )
+
+
+# --- retrieve_context --------------------------------------------------------
+
+
+def test_retrieve_context_joins_snippets_with_location() -> None:
+    ctx = _ctx([_Hit("def a(): ...", file="a.py"), _Hit("def b(): ...", file="b.py")])
+    out = retrieve_context("do something", ctx=ctx, top_k=2)
+    assert "a.py" in out and "def a()" in out
+    assert "b.py" in out and "def b()" in out
+
+
+def test_retrieve_context_passes_query_to_index() -> None:
+    ctx = _ctx([_Hit("x")])
+    retrieve_context("my query", ctx=ctx)
+    assert ctx.bm25.last_query == "my query"
+
+
+def test_retrieve_context_without_index_returns_empty() -> None:
+    assert retrieve_context("q", ctx=_ctx([], has_bm25=False)) == ""
+
+
+# --- build_messages ----------------------------------------------------------
+
+
+def test_build_messages_includes_context_and_task() -> None:
+    msgs = build_messages("fix the bug", "some context")
+    assert msgs[0]["role"] == "system"
+    assert "some context" in msgs[1]["content"]
+    assert "fix the bug" in msgs[1]["content"]
+
+
+def test_build_messages_without_context_uses_task_only() -> None:
+    msgs = build_messages("just this", "")
+    assert msgs[1]["content"] == "just this"
+
+
+# --- generate ----------------------------------------------------------------
+
+
+def test_generate_non_stream_returns_message_content() -> None:
+    client = _client(text="RESULT")
+    out = generate(
+        [{"role": "user", "content": "hi"}],
+        base_url="http://x/v1",
+        model="m",
+        client=client,
+    )
+    assert out == "RESULT"
+    assert client.chat.completions.calls[0]["stream"] is False
+
+
+def test_generate_stream_concatenates_deltas() -> None:
+    client = _client(pieces=["wor", "ld"])
+    out = generate(
+        [{"role": "user", "content": "hi"}],
+        base_url="http://x/v1",
+        model="m",
+        stream=True,
+        client=client,
+    )
+    assert out == "world"
+    assert client.chat.completions.calls[0]["stream"] is True
+
+
+# --- end-to-end flow ---------------------------------------------------------
+
+
+def test_full_flow_retrieve_then_generate() -> None:
+    ctx = _ctx([_Hit("def parse(): ...", file="cfg.py")])
+    client = _client(text="added a docstring")
+    context = retrieve_context("document parse", ctx=ctx)
+    messages = build_messages("document parse", context)
+    out = generate(messages, base_url="http://x/v1", model="m", client=client)
+    assert out == "added a docstring"
+    # The retrieved snippet made it into the prompt the model saw.
+    assert "def parse()" in client.chat.completions.calls[0]["messages"][1]["content"]

--- a/test/serving/test_api.py
+++ b/test/serving/test_api.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the OpenAI-compatible endpoint (:mod:`codenib.serving.server.api`).
+
+Driven with a fake tokenizer (char <-> id) and a ``_GreedyTruthEngine`` that
+continues a known ``truth`` sequence, so the whole request path runs on CPU with
+no model download. The fakes mirror the patterns in ``test_sglang_verifier.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import List, Sequence
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("sse_starlette")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from codenib.serving.server.api import AppState  # noqa: E402
+from codenib.serving.server.api import (
+    _REPLACEMENT,
+    _IncrementalDecoder,
+    _stream,
+    create_app,
+)
+from codenib.serving.server.sglang import TargetEngine  # noqa: E402
+from codenib.serving.server.tokenization import Tokenizer  # noqa: E402
+from codenib.serving.server.worker import SpeculativeConfig  # noqa: E402
+from codenib.serving.types import TokenId  # noqa: E402
+
+_EOS = 0
+_COMPLETION = " world"
+
+
+class _FakeTok:
+    """Char-code tokenizer with a trivial chat template (concatenate contents)."""
+
+    eos_token_id = _EOS
+
+    def apply_chat_template(self, msgs, tokenize=False, add_generation_prompt=True):
+        return "".join(m["content"] for m in msgs)
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        return [ord(c) for c in text]
+
+    def decode(self, ids: List[int], skip_special_tokens: bool = True) -> str:
+        return "".join(chr(i) for i in ids if not (skip_special_tokens and i == _EOS))
+
+
+class _GreedyTruthEngine(TargetEngine):
+    """Greedily continues ``truth``; predicts ``eos`` once past its end."""
+
+    def __init__(self, truth: Sequence[TokenId], eos: int = _EOS) -> None:
+        self.truth = list(truth)
+        self.eos = eos
+
+    def predict(self, context: Sequence[TokenId], flat) -> List[TokenId]:
+        positions = list(range(flat.context_len)) + list(flat.positions)
+        n = len(self.truth)
+        return [self.truth[p + 1] if p + 1 < n else self.eos for p in positions]
+
+
+def _make_client() -> TestClient:
+    tok = Tokenizer(_FakeTok())
+    prompt_ids = tok.encode("hi")  # matches apply_chat_template of the message below
+    truth = prompt_ids + tok.encode(_COMPLETION)
+    state = AppState(
+        served_model_name="codenib-test",
+        tokenizer=tok,
+        engine_factory=lambda: _GreedyTruthEngine(truth),
+        drafters=[],
+        config=SpeculativeConfig(max_draft_tokens=8),
+        default_max_new_tokens=64,
+    )
+    return TestClient(create_app(state))
+
+
+_MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+def test_health() -> None:
+    client = _make_client()
+    assert client.get("/health").json() == {"status": "ok"}
+
+
+def test_models_lists_served_model() -> None:
+    client = _make_client()
+    data = client.get("/v1/models").json()
+    assert data["object"] == "list"
+    assert data["data"][0]["id"] == "codenib-test"
+
+
+def test_chat_completion_returns_greedy_continuation() -> None:
+    client = _make_client()
+    resp = client.post(
+        "/v1/chat/completions", json={"model": "m", "messages": _MESSAGES}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "chat.completion"
+    assert data["choices"][0]["message"]["content"] == _COMPLETION
+    assert data["choices"][0]["finish_reason"] == "stop"
+    assert data["usage"]["completion_tokens"] == len(_COMPLETION)
+    assert data["usage"]["prompt_tokens"] == 2
+
+
+def test_temperature_above_zero_is_rejected() -> None:
+    client = _make_client()
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "m", "messages": _MESSAGES, "temperature": 0.7},
+    )
+    assert resp.status_code == 400
+    assert "greedy" in resp.json()["detail"]
+
+
+def test_top_p_below_one_is_rejected() -> None:
+    client = _make_client()
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "m", "messages": _MESSAGES, "top_p": 0.5},
+    )
+    assert resp.status_code == 400
+
+
+def test_streaming_chunks_reassemble_to_completion() -> None:
+    client = _make_client()
+    content = ""
+    finish_seen = False
+    done_seen = False
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={"model": "m", "messages": _MESSAGES, "stream": True},
+    ) as resp:
+        assert resp.status_code == 200
+        for line in resp.iter_lines():
+            if not line.startswith("data: "):
+                continue
+            payload = line[len("data: ") :]
+            if payload == "[DONE]":
+                done_seen = True
+                continue
+            chunk = json.loads(payload)
+            assert chunk["object"] == "chat.completion.chunk"
+            delta = chunk["choices"][0]["delta"]
+            if delta.get("content"):
+                content += delta["content"]
+            if chunk["choices"][0]["finish_reason"] == "stop":
+                finish_seen = True
+    assert content == _COMPLETION
+    assert finish_seen
+    assert done_seen
+
+
+# --- regression: multi-byte-safe streaming deltas -------------------------
+
+
+class _ByteTok:
+    """UTF-8 *byte* tokenizer: one id per byte, so characters straddle tokens.
+
+    This is the shape that breaks naive ``full[len(text_so_far):]`` slicing —
+    decoding a prefix that ends mid-character yields U+FFFD, which then vanishes
+    once the continuation byte arrives.
+    """
+
+    eos_token_id = _EOS
+
+    def apply_chat_template(self, msgs, tokenize=False, add_generation_prompt=True):
+        return "".join(m["content"] for m in msgs)
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        return list(text.encode("utf-8"))
+
+    def decode(self, ids: List[int], skip_special_tokens: bool = True) -> str:
+        keep = bytes(i for i in ids if not (skip_special_tokens and i == _EOS))
+        return keep.decode("utf-8", errors="replace")
+
+
+_MULTIBYTE = " héllo 😀!"
+
+
+def test_incremental_decoder_holds_back_incomplete_multibyte() -> None:
+    tok = Tokenizer(_ByteTok())
+    decoder = _IncrementalDecoder(tok)
+    # Feed one byte at a time — the worst case for prefix-slicing.
+    out = "".join(decoder.push([i]) for i in tok.encode(_MULTIBYTE))
+    out += decoder.flush()
+    assert out == _MULTIBYTE
+    assert _REPLACEMENT not in out
+
+
+def test_incremental_decoder_emits_nothing_until_a_character_completes() -> None:
+    tok = Tokenizer(_ByteTok())
+    decoder = _IncrementalDecoder(tok)
+    emoji = list("😀".encode("utf-8"))
+    assert [decoder.push([b]) for b in emoji[:-1]] == ["", "", ""]
+    assert decoder.push([emoji[-1]]) == "😀"
+
+
+def _make_byte_client() -> TestClient:
+    tok = Tokenizer(_ByteTok())
+    prompt_ids = tok.encode("hi")
+    truth = prompt_ids + tok.encode(_MULTIBYTE)
+    state = AppState(
+        served_model_name="codenib-test",
+        tokenizer=tok,
+        engine_factory=lambda: _GreedyTruthEngine(truth),
+        drafters=[],
+        config=SpeculativeConfig(max_draft_tokens=8),
+        default_max_new_tokens=64,
+    )
+    return TestClient(create_app(state))
+
+
+def test_streaming_does_not_corrupt_multibyte_characters() -> None:
+    client = _make_byte_client()
+    content = ""
+    with client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={"model": "m", "messages": _MESSAGES, "stream": True},
+    ) as resp:
+        assert resp.status_code == 200
+        for line in resp.iter_lines():
+            if not line.startswith("data: "):
+                continue
+            payload = line[len("data: ") :]
+            if payload == "[DONE]":
+                continue
+            delta = json.loads(payload)["choices"][0]["delta"]
+            if delta.get("content"):
+                content += delta["content"]
+    assert content == _MULTIBYTE
+    assert _REPLACEMENT not in content
+
+
+# --- regression: a disconnect must not release the single-flight lock -----
+
+
+def test_disconnect_holds_lock_until_worker_stops() -> None:
+    """Cancelling the stream must not hand the lock on mid-generation.
+
+    Otherwise the next request starts a second generation while this one is
+    still on the GPU, which is exactly what the single-flight lock exists to
+    prevent.
+    """
+    started = threading.Event()
+    release = threading.Event()
+
+    tok = Tokenizer(_FakeTok())
+    prompt_ids = tok.encode("hi")
+    truth = prompt_ids + tok.encode(_COMPLETION)
+
+    class _BlockingEngine(_GreedyTruthEngine):
+        """Stands in for a generation step that is still occupying the GPU."""
+
+        def predict(self, context, flat):
+            started.set()
+            release.wait(10)
+            return super().predict(context, flat)
+
+    state = AppState(
+        served_model_name="codenib-test",
+        tokenizer=tok,
+        engine_factory=lambda: _BlockingEngine(truth),
+        drafters=[],
+        config=SpeculativeConfig(max_draft_tokens=8),
+        default_max_new_tokens=64,
+    )
+
+    async def scenario() -> None:
+        agen = _stream(state, prompt_ids, 64, "m")
+        await agen.asend(None)  # role chunk; the lock is now held
+        assert state.lock.locked()
+
+        # Resuming past the first yield starts the worker thread. It blocks in
+        # predict(), so this send never completes — it stands in for a consumer
+        # waiting on deltas.
+        pump = asyncio.create_task(agen.asend(None))
+        await asyncio.to_thread(started.wait, 10)
+        assert started.is_set()
+
+        pump.cancel()  # the client disconnects
+        with pytest.raises(asyncio.CancelledError):
+            await pump
+
+        # The worker is still inside predict(): the lock must NOT be free yet.
+        assert state.lock.locked()
+
+        release.set()
+        for _ in range(1000):
+            if not state.lock.locked():
+                break
+            await asyncio.sleep(0.01)
+        assert not state.lock.locked()
+
+    asyncio.run(scenario())
+
+
+# --- CLI wiring: --manifest -> RetrievalDrafter ------------------
+# `main()` is not directly testable (it calls uvicorn.run), so the two decisions
+# it makes are factored out: argument parsing and drafter construction. These
+# cover the wiring only; CodeNibBackend's own behaviour lives in
+# test_codenib_backend.py.
+
+
+def test_parse_args_defaults_to_no_manifest() -> None:
+    from codenib.serving.server.api import _parse_args
+
+    assert _parse_args([]).manifest is None
+
+
+def test_parse_args_accepts_manifest() -> None:
+    from codenib.serving.server.api import _parse_args
+
+    args = _parse_args(["--manifest", "/repo/.codenib_cache/m.json"])
+    assert args.manifest == "/repo/.codenib_cache/m.json"
+
+
+def test_build_drafters_without_manifest_is_copy_only() -> None:
+    from codenib.serving.drafter.copy import CopyDrafter
+    from codenib.serving.server.api import _build_drafters, _parse_args
+
+    drafters = _build_drafters(_parse_args([]), Tokenizer(_FakeTok()))
+
+    assert len(drafters) == 1
+    assert isinstance(drafters[0], CopyDrafter)
+
+
+def test_build_drafters_with_manifest_appends_retrieval_drafter(monkeypatch) -> None:
+    """A manifest must load a CodeNibBackend and fuse it in after copy.
+
+    ``from_manifest`` is the one call that needs the ``codenib`` package and a
+    prebuilt index on disk, so it is stubbed; everything either side is real.
+    """
+    from codenib.serving.drafter.copy import CopyDrafter
+    from codenib.serving.drafter.retrieval import CodeNibBackend, RetrievalDrafter
+    from codenib.serving.server.api import _build_drafters, _parse_args
+
+    sentinel = object()
+    seen = {}
+
+    def _fake_from_manifest(path, tokenizer, **kwargs):
+        seen["path"] = path
+        seen["tokenizer"] = tokenizer
+        return sentinel
+
+    monkeypatch.setattr(CodeNibBackend, "from_manifest", _fake_from_manifest)
+
+    tok = Tokenizer(_FakeTok())
+    drafters = _build_drafters(_parse_args(["--manifest", "/m.json"]), tok)
+
+    assert [type(d) for d in drafters] == [CopyDrafter, RetrievalDrafter]
+    retr = drafters[1]
+    assert isinstance(retr, RetrievalDrafter)  # narrows List[Drafter] for mypy
+    assert retr.backend is sentinel  # the loaded index, not a fresh one
+    assert seen["path"] == "/m.json"
+    assert seen["tokenizer"] is tok  # serving tokenizer, so ids line up

--- a/test/serving/test_codenib_backend.py
+++ b/test/serving/test_codenib_backend.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for :class:`codenib.serving.drafter.retrieval.CodeNibBackend`.
+
+The CodeNib context and tokenizer are injected, so the whole adapter is
+exercised on CPU without installing ``codenib`` or building an index. A
+char-level tokenizer makes the suffix-alignment easy to assert exactly.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import List
+
+import pytest
+
+from codenib.serving.drafter.retrieval import CodeNibBackend
+
+
+class _CharTok:
+    """Char-code tokenizer (id == ord(char)); no special tokens."""
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        return [ord(c) for c in text]
+
+    def decode(self, ids: List[int], skip_special_tokens: bool = True) -> str:
+        return "".join(chr(i) for i in ids)
+
+
+class _Hit:
+    """A stand-in for CodeNib's ``NodeInfo`` — only ``.content`` is read."""
+
+    __slots__ = ("content",)
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeBM25:
+    def __init__(self, hits: List[_Hit]) -> None:
+        self._hits = hits
+        self.last_query = None
+        self.last_kwargs = None
+
+    def search(self, query, top_k=None, return_code_content=False, **kwargs):
+        self.last_query = query
+        self.last_kwargs = {
+            "top_k": top_k,
+            "return_code_content": return_code_content,
+            **kwargs,
+        }
+        return self._hits
+
+
+class _FakeVector:
+    def __init__(self, hits: List[_Hit]) -> None:
+        self._hits = hits
+
+    def search_with_content(self, query, top_k=10, **kwargs):
+        return self._hits
+
+
+class _FakeCtx:
+    __slots__ = ("bm25", "vector")
+
+    def __init__(self, bm25=None, vector=None) -> None:
+        self.bm25 = bm25
+        self.vector = vector
+
+
+_SNIPPET = "def add(a, b): return a + b"
+
+
+def _backend(ctx, **kw) -> CodeNibBackend:
+    return CodeNibBackend(ctx, _CharTok(), key_len=4, top_k=5, **kw)
+
+
+def test_aligns_retrieved_snippet_to_context_suffix() -> None:
+    ctx = _FakeCtx(bm25=_FakeBM25([_Hit(_SNIPPET)]))
+    backend = _backend(ctx)
+    context = _CharTok().encode("def add(a, b): return ")
+    cands = backend.retrieve(context, k=3, max_tokens=8)
+    assert cands, "expected a continuation drafted from the retrieved snippet"
+    # The suffix "urn " recurs in the snippet; what follows is "a + b".
+    assert _CharTok().decode(cands[0]) == "a + b"
+
+
+def test_query_is_the_decoded_context_suffix() -> None:
+    bm25 = _FakeBM25([_Hit(_SNIPPET)])
+    backend = _backend(_FakeCtx(bm25=bm25), query_suffix_tokens=5)
+    context = _CharTok().encode("xxxxxreturn ")
+    backend.retrieve(context, k=1, max_tokens=4)
+    # Only the last 5 tokens are decoded into the query.
+    assert bm25.last_query == "turn "
+
+
+def test_context_shorter_than_key_len_returns_empty() -> None:
+    backend = _backend(_FakeCtx(bm25=_FakeBM25([_Hit(_SNIPPET)])))
+    assert backend.retrieve([1, 2], k=3, max_tokens=8) == []
+
+
+def test_no_hits_returns_empty() -> None:
+    backend = _backend(_FakeCtx(bm25=_FakeBM25([])))
+    context = _CharTok().encode("def add(a, b): return ")
+    assert backend.retrieve(context, k=3, max_tokens=8) == []
+
+
+def test_missing_index_returns_empty() -> None:
+    backend = _backend(_FakeCtx(bm25=None))  # index built but unavailable
+    context = _CharTok().encode("def add(a, b): return ")
+    assert backend.retrieve(context, k=3, max_tokens=8) == []
+
+
+def test_vector_index_path() -> None:
+    ctx = _FakeCtx(vector=_FakeVector([_Hit(_SNIPPET)]))
+    backend = _backend(ctx, index="vector")
+    context = _CharTok().encode("def add(a, b): return ")
+    cands = backend.retrieve(context, k=3, max_tokens=8)
+    assert cands and _CharTok().decode(cands[0]) == "a + b"
+
+
+def test_unknown_index_raises() -> None:
+    backend = _backend(_FakeCtx(), index="symbol_graph")
+    context = _CharTok().encode("def add(a, b): return ")
+    with pytest.raises(ValueError, match="unknown CodeNib index"):
+        backend.retrieve(context, k=3, max_tokens=8)
+
+
+def test_bm25_search_requests_clean_snippets() -> None:
+    # wrap_with_ln=False keeps line-number prefixes out of the drafted tokens.
+    bm25 = _FakeBM25([_Hit(_SNIPPET)])
+    backend = _backend(_FakeCtx(bm25=bm25))
+    backend.retrieve(_CharTok().encode("def add(a, b): return "), k=1, max_tokens=4)
+    assert bm25.last_kwargs["return_code_content"] is True
+    assert bm25.last_kwargs["wrap_with_ln"] is False
+
+
+def test_hits_without_content_warn_instead_of_silently_drafting_nothing() -> None:
+    backend = _backend(_FakeCtx(bm25=_FakeBM25([_Hit("")])))
+    context = _CharTok().encode("def add(a, b): return ")
+    with pytest.warns(RuntimeWarning, match="no snippet content"):
+        assert backend.retrieve(context, k=3, max_tokens=8) == []
+
+
+def test_empty_content_warning_is_emitted_once() -> None:
+    backend = _backend(_FakeCtx(bm25=_FakeBM25([_Hit("")])))
+    context = _CharTok().encode("def add(a, b): return ")
+    with pytest.warns(RuntimeWarning):
+        backend.retrieve(context, k=3, max_tokens=8)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # a second warning would fail here
+        assert backend.retrieve(context, k=3, max_tokens=8) == []
+
+
+def test_codenib_backend_is_exported_from_the_drafter_package() -> None:
+    """``codenib.serving.drafter`` re-exports the other backends; this one belongs too."""
+    import codenib.serving.drafter as pkg
+
+    assert pkg.CodeNibBackend is CodeNibBackend
+    assert "CodeNibBackend" in pkg.__all__

--- a/test/serving/test_copy.py
+++ b/test/serving/test_copy.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the copy (CopySpec / prompt-lookup) drafter."""
+
+from codenib.serving.drafter.copy import CopyDrafter
+
+
+def _linear(tree):
+    """Flatten a single-branch draft tree to a token list (root excluded)."""
+    tokens = []
+    node = tree.root
+    while node.children:
+        assert len(node.children) == 1, "copy drafter should emit one branch"
+        node = node.children[0]
+        tokens.append(node.token)
+    return tokens
+
+
+def test_copies_continuation_after_repeated_prefix():
+    # "a b c d" appeared once; context now ends in "a b c" -> predict "d ...".
+    context = [1, 2, 3, 4, 9, 9, 1, 2, 3]
+    drafter = CopyDrafter(min_match=2, max_match=8, max_draft=4)
+    tree = drafter.draft(context, max_tokens=4)
+    assert _linear(tree) == [4, 9, 9, 1]
+
+
+def test_prefers_longer_match():
+    # Context ends in [8, 2, 3]. The length-2 suffix [2, 3] most-recently
+    # continues with 99, but the length-3 suffix [8, 2, 3] continues with 42.
+    # Longest-match-first must pick 42, not the nearer-but-shorter 99.
+    context = [8, 2, 3, 42, 2, 3, 99, 8, 2, 3]
+    drafter = CopyDrafter(min_match=2, max_match=8, max_draft=3)
+    tree = drafter.draft(context, max_tokens=3)
+    assert _linear(tree)[0] == 42
+
+
+def test_no_match_returns_empty_tree():
+    drafter = CopyDrafter(min_match=3)
+    tree = drafter.draft([1, 2, 3, 4, 5], max_tokens=4)
+    assert tree.is_empty()
+
+
+def test_respects_draft_budget():
+    context = [1, 2, 3, 4, 5, 6, 1, 2]
+    drafter = CopyDrafter(min_match=2, max_match=8, max_draft=10)
+    tree = drafter.draft(context, max_tokens=2)
+    assert tree.size <= 2
+
+
+def test_short_context_is_safe():
+    drafter = CopyDrafter(min_match=2)
+    assert drafter.draft([], 4).is_empty()
+    assert drafter.draft([7], 4).is_empty()

--- a/test/serving/test_fusion.py
+++ b/test/serving/test_fusion.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for draft-tree fusion and pruning."""
+
+from codenib.serving.drafter.fusion import fuse
+from codenib.serving.types import DraftTree
+
+
+def _make(*sequences, source="x"):
+    tree = DraftTree()
+    for seq in sequences:
+        tree.add_sequence(list(seq), source=source)
+    return tree
+
+
+def test_shared_prefix_merges_into_single_branch():
+    a = _make([1, 2, 3])
+    b = _make([1, 2, 9])  # shares prefix [1, 2]
+    fused = fuse([a, b])
+    # root -> 1 -> 2 -> {3, 9}: five real nodes, not six.
+    assert fused.size == 4
+    first = fused.root.children
+    assert len(first) == 1 and first[0].token == 1
+    branch = first[0].children[0]  # token 2
+    assert sorted(c.token for c in branch.children) == [3, 9]
+
+
+def test_disjoint_roots_stay_separate():
+    fused = fuse([_make([1, 2]), _make([8, 9])])
+    assert sorted(c.token for c in fused.root.children) == [1, 8]
+    assert fused.size == 4
+
+
+def test_prune_is_breadth_first():
+    # Two depth-3 branches, budget 3 -> keep both roots + one second-level token.
+    fused = fuse([_make([1, 2, 3]), _make([8, 9, 10])], max_tokens=3)
+    assert fused.size == 3
+    depth1 = sorted(c.token for c in fused.root.children)
+    assert depth1 == [1, 8]  # shallowest tokens survive
+
+
+def test_prune_zero_empties_tree():
+    fused = fuse([_make([1, 2, 3])], max_tokens=0)
+    assert fused.is_empty()
+
+
+def test_fuse_empty_input():
+    assert fuse([]).is_empty()

--- a/test/serving/test_hf_engine.py
+++ b/test/serving/test_hf_engine.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for HFTreeEngine — the HF-transformers tree-attention TargetEngine.
+
+The correctness property that matters is that the tree-attention mask isolates
+each branch: the model's greedy prediction after any draft node, computed in the
+single batched tree forward, must equal the prediction it would make if that
+node's root-to-node branch were fed as an ordinary flat sequence. A mock cannot
+validate that — it needs a real forward — so these build a tiny random-weights
+causal LM on CPU and compare the two. They need torch + transformers (the
+``bench`` extra), so they skip when those are unavailable.
+"""
+
+from typing import List, Tuple
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+# Needs the model runtime from the ``serving`` extra, so it is not part of the
+# default unit tier.
+pytestmark = pytest.mark.slow
+
+from codenib.serving.drafter.copy import CopyDrafter  # noqa: E402
+from codenib.serving.server.hf_engine import CachedHFTreeEngine  # noqa: E402
+from codenib.serving.server.hf_engine import HFTreeEngine
+from codenib.serving.server.sglang import SGLangVerifier  # noqa: E402
+from codenib.serving.server.sglang import attention_mask, flatten
+from codenib.serving.server.worker import SpeculativeConfig  # noqa: E402
+from codenib.serving.server.worker import SpeculativeServer
+from codenib.serving.types import DraftNode, DraftTree  # noqa: E402
+
+
+def _tiny_model():
+    """A tiny random-weights Llama causal LM on CPU, eager attention.
+
+    Built from config (no download). Eager attention is required so a custom 4D
+    attention mask is honored rather than ignored by a fused kernel.
+    """
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    torch.manual_seed(0)
+    cfg = LlamaConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=128,
+        attn_implementation="eager",
+    )
+    return LlamaForCausalLM(cfg).eval()
+
+
+def _branches(tree: DraftTree) -> List[Tuple[DraftNode, List[int]]]:
+    """Every non-root node paired with its root-to-node token list."""
+    out: List[Tuple[DraftNode, List[int]]] = []
+
+    def walk(node: DraftNode, prefix: List[int]) -> None:
+        for ch in node.children:
+            path = prefix + [ch.token]
+            out.append((ch, path))
+            walk(ch, path)
+
+    walk(tree.root, [])
+    return out
+
+
+def _flat_argmax_after(model, seq: List[int]) -> int:
+    """Greedy next-token id the model predicts after the flat sequence ``seq``."""
+    with torch.no_grad():
+        logits = model(torch.tensor([seq], dtype=torch.long)).logits[0]
+    return int(logits[len(seq) - 1].argmax())
+
+
+def test_predict_returns_one_prediction_per_fed_position():
+    model = _tiny_model()
+    engine = HFTreeEngine(model, device="cpu")
+    context = [3, 1, 4, 1, 5]
+    tree = DraftTree()
+    tree.add_sequence([9, 2, 6])
+    flat = flatten(len(context), tree)
+    preds = engine.predict(context, flat)
+    assert len(preds) == flat.total_len
+
+
+def test_tree_verify_matches_per_branch_flat_forward():
+    # The core property: each branch's prediction in the batched tree forward
+    # equals the prediction from feeding that branch alone as a flat sequence.
+    model = _tiny_model()
+    engine = HFTreeEngine(model, device="cpu")
+    context = [3, 1, 4, 1, 5, 9, 2]
+    tree = DraftTree()
+    tree.add_sequence([9, 2, 6])  # branch A
+    tree.add_sequence([9, 5, 3])  # branch B — shares prefix token 9 with A
+    tree.add_sequence([1, 8])  # branch C — separate depth-1 alternative
+    flat = flatten(len(context), tree)
+
+    preds = engine.predict(context, flat)
+
+    # Bonus slot: prediction after the last context token must match a plain
+    # forward over the context alone.
+    assert preds[len(context) - 1] == _flat_argmax_after(model, context)
+
+    # Every draft node: tree-forward prediction == isolated flat-branch prediction.
+    for node, branch in _branches(tree):
+        gidx = flat.node_index[id(node)]
+        assert preds[gidx] == _flat_argmax_after(model, context + branch)
+
+
+def test_drives_sglang_verifier_end_to_end():
+    # HFTreeEngine must drop into SGLangVerifier unchanged and produce a coherent
+    # accept/bonus result (accepted prefix consistent with the emitted bonus).
+    model = _tiny_model()
+    engine = HFTreeEngine(model, device="cpu")
+    context = [7, 7, 1, 2, 3]
+    tree = DraftTree()
+    tree.add_sequence([4, 5, 6])
+    verifier = SGLangVerifier(engine)
+    result = verifier.verify(context, tree)
+    assert isinstance(result.accepted, list)
+    assert result.bonus is not None
+    # Bonus equals the model's greedy token after the accepted prefix.
+    assert result.bonus == _flat_argmax_after(model, context + result.accepted)
+
+
+# --- vectorized tree mask (follow-up #1): must match the reference helper ------
+
+
+def test_tree_allow_matches_reference_attention_mask():
+    # HFTreeEngine builds its 4D mask with vectorized torch ops instead of the
+    # O(total_len^2) Python attention_mask() helper. It must be byte-identical to
+    # that trusted reference for every tree shape.
+    engine = HFTreeEngine(_tiny_model(), device="cpu")
+
+    linear = DraftTree()
+    linear.add_sequence([10, 11, 12])
+
+    branching = DraftTree()
+    branching.add_sequence([7, 8])
+    branching.add_sequence([7, 9])  # shared prefix 7
+    branching.add_sequence([3])  # separate depth-1 branch
+
+    empty = DraftTree()  # no draft -> pure causal context
+
+    for context_len, tree in [(5, linear), (4, branching), (6, empty)]:
+        flat = flatten(context_len, tree)
+        allow = engine._tree_allow(flat)
+        assert allow.tolist() == attention_mask(flat)
+
+
+# --- CachedHFTreeEngine: KV-cache reuse, must be behaviourally identical -------
+
+
+def _spec_tokens(engine, prompt, max_new=40):
+    server = SpeculativeServer(
+        drafters=[CopyDrafter(min_match=2, max_match=8, max_draft=6)],
+        config=SpeculativeConfig(max_draft_tokens=6),
+    )
+    return server.run(prompt, SGLangVerifier(engine), max_new_tokens=max_new).tokens
+
+
+def test_cached_predict_equals_stateless_at_read_positions():
+    # Simulate a growing run: at each step both engines predict on the same
+    # (context, tree); the positions the verifier reads (last context + every
+    # node) must be identical. Cached forwards only the delta against its KV.
+    model = _tiny_model()
+    stateless = HFTreeEngine(model, device="cpu")
+    cached = CachedHFTreeEngine(model, device="cpu")
+
+    context = [3, 1, 4, 1, 5, 9, 2, 6]
+    for grow in ([9, 2], [1, 1, 2], [3], [4, 5]):
+        tree = DraftTree()
+        tree.add_sequence([7, 8])
+        tree.add_sequence([7, 3])  # shares prefix 7 with the first branch
+        tree.add_sequence([2])
+        flat = flatten(len(context), tree)
+
+        s = stateless.predict(context, flat)
+        c = cached.predict(context, flat)
+
+        assert c[len(context) - 1] == s[len(context) - 1]  # bonus slot
+        for node, _ in _branches(tree):
+            gi = flat.node_index[id(node)]
+            assert c[gi] == s[gi]
+
+        context = context + grow  # commit (any monotonic extension is valid)
+
+
+def test_cached_engine_emits_identical_sequence_end_to_end():
+    model = _tiny_model()
+    prompt = [5, 5, 1, 2, 3, 1, 2, 3]
+    cached = _spec_tokens(CachedHFTreeEngine(model, device="cpu"), prompt)
+    stateless = _spec_tokens(HFTreeEngine(model, device="cpu"), prompt)
+    assert cached == stateless
+
+
+def test_cached_engine_resets_between_runs():
+    # Reusing one cached engine across different prompts must not leak KV state:
+    # each run still matches the stateless reference.
+    model = _tiny_model()
+    engine = CachedHFTreeEngine(model, device="cpu")
+    for prompt in ([1, 2, 3, 4, 1, 2, 3, 4], [9, 8, 7, 6, 9, 8, 7, 6]):
+        got = _spec_tokens(engine, prompt)
+        want = _spec_tokens(HFTreeEngine(model, device="cpu"), prompt)
+        assert got == want
+
+
+def test_cached_predict_rejects_nonadvancing_empty_draft():
+    # Defensive guard: once a context is committed to the cache, calling predict
+    # again with the same context and an empty draft leaves nothing new to
+    # forward — the bonus-slot logits live only in the cache and are not
+    # recomputed, so it must raise rather than run a zero-length forward. The
+    # speculation loop never does this (context always advances >= 1 token).
+    model = _tiny_model()
+    cached = CachedHFTreeEngine(model, device="cpu")
+    context = [3, 1, 4, 1, 5]
+    tree = DraftTree()
+    tree.add_sequence([9, 2])
+    cached.predict(context, flatten(len(context), tree))  # commit the prefix
+    with pytest.raises(ValueError):
+        cached.predict(context, flatten(len(context), DraftTree()))
+
+
+def test_cached_engine_forwards_fewer_positions():
+    # The whole point: cache reuse means far fewer token-positions are pushed
+    # through the model than re-forwarding the full context every step.
+    model = _tiny_model()
+    prompt = [5, 5, 1, 2, 3, 1, 2, 3]
+    cached = CachedHFTreeEngine(model, device="cpu")
+    stateless = HFTreeEngine(model, device="cpu")
+    _spec_tokens(cached, prompt)
+    _spec_tokens(stateless, prompt)
+    assert cached.forwarded_positions < stateless.forwarded_positions

--- a/test/serving/test_real_model.py
+++ b/test/serving/test_real_model.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the real-model verifier.
+
+The ``best_linear_path`` flattening logic is pure and always runs. The
+losslessness check needs a GPU + the ``bench`` extra + a target model, so it is
+marked ``slow`` and skips unless ``CODENIB_SERVE_TEST_MODEL`` points at a loadable
+checkpoint.
+"""
+
+import os
+import sys
+import types
+
+import pytest
+
+from codenib.serving.server.real_model import _load_lm, best_linear_path
+from codenib.serving.types import DraftNode, DraftTree
+
+
+def test_best_linear_path_on_linear_tree():
+    tree = DraftTree()
+    tree.add_sequence([4, 5, 6])
+    assert best_linear_path(tree) == [4, 5, 6]
+
+
+def test_best_linear_path_empty_tree():
+    assert best_linear_path(DraftTree()) == []
+
+
+def test_best_linear_path_picks_highest_scored_branch():
+    # Two branches diverge at the first token; the higher-scored one wins.
+    low = DraftNode(token=1, score=0.2)
+    low.children.append(DraftNode(token=2, score=0.2))
+    high = DraftNode(token=9, score=0.9)
+    high.children.append(DraftNode(token=8, score=0.9))
+    tree = DraftTree()
+    tree.root.children.extend([low, high])
+    assert best_linear_path(tree) == [9, 8]
+
+
+def _fake_transformers(*, causal_raises: bool):
+    """A stand-in ``transformers`` module recording which auto-class was used.
+
+    ``AutoModelForCausalLM`` raises ``ValueError`` (mimicking an unmapped
+    architecture) when ``causal_raises``, else returns a sentinel string tagging
+    the class that loaded.
+    """
+    mod = types.ModuleType("transformers")
+
+    class _CausalLM:
+        @staticmethod
+        def from_pretrained(name, dtype=None):
+            if causal_raises:
+                raise ValueError("architecture not mapped for causal LM")
+            return f"causal:{name}"
+
+    mod.AutoModelForCausalLM = _CausalLM
+    return mod
+
+
+def test_load_lm_uses_causal_lm_by_default(monkeypatch):
+    # Every target we run — including Qwen3.5-4B, whose Qwen3_5ForCausalLM is in
+    # the causal-LM auto-mapping on transformers >= 5.2 — loads this way.
+    monkeypatch.setitem(
+        sys.modules, "transformers", _fake_transformers(causal_raises=False)
+    )
+    assert _load_lm("some/causal-model", dtype=None) == "causal:some/causal-model"
+
+
+def test_load_lm_does_not_silently_fall_back(monkeypatch):
+    # If the causal-LM mapping genuinely rejects a model, the error propagates —
+    # there is no automatic multimodal fallback; callers pass an explicit
+    # model_class instead (see test below).
+    monkeypatch.setitem(
+        sys.modules, "transformers", _fake_transformers(causal_raises=True)
+    )
+    with pytest.raises(ValueError):
+        _load_lm("x/y", dtype=None)
+
+
+def test_load_lm_honours_explicit_model_class(monkeypatch):
+    # Explicit override wins over the causal-LM default and is used even when the
+    # causal-LM mapping would have rejected the model.
+    monkeypatch.setitem(
+        sys.modules, "transformers", _fake_transformers(causal_raises=True)
+    )
+
+    class _Forced:
+        @staticmethod
+        def from_pretrained(name, dtype=None):
+            return f"forced:{name}"
+
+    assert _load_lm("x/y", dtype=None, model_class=_Forced) == "forced:x/y"
+
+
+@pytest.mark.slow
+def test_real_model_verifier_is_lossless_vs_vanilla_ar():
+    """Drafted greedy output must be byte-identical to vanilla AR greedy output."""
+    model_name = os.environ.get("CODENIB_SERVE_TEST_MODEL")
+    if not model_name:
+        pytest.skip("set CODENIB_SERVE_TEST_MODEL to a loadable checkpoint to run")
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    from codenib.serving.drafter.copy import CopyDrafter
+    from codenib.serving.server.real_model import RealModelVerifier
+    from codenib.serving.server.worker import SpeculativeConfig, SpeculativeServer
+
+    verifier = RealModelVerifier(model_name)
+    prompt = verifier.tokenizer("def add(a, b):", return_tensors=None)["input_ids"]
+
+    config = SpeculativeConfig(max_draft_tokens=8)
+    ar = SpeculativeServer(drafters=[], config=config)
+    spec = SpeculativeServer(
+        drafters=[CopyDrafter(min_match=2, max_match=16, max_draft=8)],
+        config=config,
+    )
+
+    ar_out = ar.run(prompt, verifier, max_new_tokens=48)
+    spec_out = spec.run(prompt, verifier, max_new_tokens=48)
+
+    # Same tokens (lossless), and speculation never costs extra forward passes.
+    assert spec_out.tokens == ar_out.tokens
+    assert spec_out.forward_passes <= ar_out.forward_passes

--- a/test/serving/test_retrieval.py
+++ b/test/serving/test_retrieval.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the retrieval drafter and the n-gram corpus backend."""
+
+from codenib.serving.drafter.retrieval import NgramRetrievalBackend, RetrievalDrafter
+
+
+def test_ngram_backend_finds_continuation_in_other_doc():
+    # The pattern [1,2,3,4] lives in doc 0; querying with [..,1,2,3,4] should
+    # surface its continuation [5,6,7] even though it is not in the context.
+    corpus = [[9, 1, 2, 3, 4, 5, 6, 7], [0, 0, 0]]
+    backend = NgramRetrievalBackend(corpus, key_len=4)
+    out = backend.retrieve([1, 2, 3, 4], k=2, max_tokens=3)
+    assert out and out[0] == [5, 6, 7]
+
+
+def test_ngram_backend_ranks_by_match_length():
+    # Two occurrences of [2,3]; the one with a longer left-context match wins.
+    corpus = [[7, 1, 2, 3, 40], [8, 9, 1, 2, 3, 99]]
+    backend = NgramRetrievalBackend(corpus, key_len=2)
+    out = backend.retrieve([9, 1, 2, 3], k=1, max_tokens=1)
+    assert out[0] == [99]
+
+
+def test_ngram_backend_respects_doc_boundaries():
+    # Continuation must not bleed past the end of the matched document.
+    corpus = [[1, 2, 3], [4, 5, 6]]
+    backend = NgramRetrievalBackend(corpus, key_len=2)
+    out = backend.retrieve([1, 2], k=1, max_tokens=5)
+    assert out[0] == [3]  # stops at doc 0's boundary, no [4,5,6]
+
+
+def test_ngram_backend_miss_returns_empty():
+    backend = NgramRetrievalBackend([[1, 2, 3, 4]], key_len=4)
+    assert backend.retrieve([7, 8, 9, 10], k=2, max_tokens=3) == []
+
+
+def test_retrieval_drafter_builds_tree_from_backend():
+    backend = NgramRetrievalBackend([[1, 2, 3, 4, 5, 6]], key_len=3)
+    drafter = RetrievalDrafter(backend, k=2, max_draft=4)
+    tree = drafter.draft([1, 2, 3], max_tokens=4)
+    assert not tree.is_empty()
+    # First speculated token after [1,2,3] is 4.
+    assert tree.root.children[0].token == 4

--- a/test/serving/test_server.py
+++ b/test/serving/test_server.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for engine-agnostic draft assembly in the serving worker."""
+
+from typing import List, Sequence
+
+from codenib.serving.drafter.copy import CopyDrafter
+from codenib.serving.drafter.retrieval import RetrievalBackend, RetrievalDrafter
+from codenib.serving.server.worker import (
+    OracleVerifier,
+    SpeculativeConfig,
+    SpeculativeServer,
+    build_draft,
+)
+from codenib.serving.types import TokenId
+
+
+class _FakeBackend(RetrievalBackend):
+    def __init__(self, candidates: List[List[TokenId]]):
+        self._candidates = candidates
+
+    def retrieve(
+        self, context: Sequence[TokenId], k: int, max_tokens: int
+    ) -> List[List[TokenId]]:
+        return [c[:max_tokens] for c in self._candidates[:k]]
+
+
+def test_build_draft_fuses_copy_and_retrieval():
+    context = [1, 2, 3, 1, 2]  # copy predicts -> 3
+    copy = CopyDrafter(min_match=2, max_match=8, max_draft=4)
+    retr = RetrievalDrafter(_FakeBackend([[3, 7, 8]]), k=1, max_draft=4)
+    config = SpeculativeConfig(max_draft_tokens=8)
+
+    tree = build_draft([copy, retr], context, config)
+    # Both sources start with token 3; the shared prefix must collapse.
+    roots = [c.token for c in tree.root.children]
+    assert roots.count(3) == 1
+    assert not tree.is_empty()
+
+
+def test_build_draft_respects_budget():
+    context = [5, 6, 7, 5, 6]
+    copy = CopyDrafter(min_match=2, max_match=8, max_draft=16)
+    config = SpeculativeConfig(max_draft_tokens=2)
+    assert build_draft([copy], context, config).size <= 2
+
+
+def test_server_step_delegates_to_build_draft():
+    server = SpeculativeServer(
+        drafters=[CopyDrafter(min_match=2, max_match=8, max_draft=4)],
+        config=SpeculativeConfig(max_draft_tokens=4),
+    )
+    assert server.step([1, 2, 3, 1, 2]).size >= 1
+
+
+def _copy_server(budget: int = 8) -> SpeculativeServer:
+    return SpeculativeServer(
+        drafters=[CopyDrafter(min_match=2, max_match=16, max_draft=budget)],
+        config=SpeculativeConfig(max_draft_tokens=budget),
+    )
+
+
+def test_run_reconstructs_truth_against_oracle():
+    # A repetitive sequence the copy drafter can speculate through.
+    truth = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 5]
+    server = _copy_server()
+    result = server.run(truth[:4], OracleVerifier(truth), max_new_tokens=64)
+    # The loop must regenerate the true continuation exactly.
+    assert truth[:4] + result.tokens == truth
+
+
+def test_run_makes_forward_progress_and_reports_speedup():
+    truth = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 5]
+    server = _copy_server()
+    result = server.run(truth[:4], OracleVerifier(truth), max_new_tokens=64)
+    generated = len(result.tokens)
+    # Each pass emits its accepted drafts plus one bonus token; the only pass
+    # that can emit no bonus is a trailing one (no EOS in `truth`).
+    bonuses = generated - result.accepted_tokens
+    assert bonuses in (result.forward_passes, result.forward_passes - 1)
+    # Speculation actually helped on this repetitive stream.
+    assert result.speedup > 1.0
+
+
+def test_run_respects_max_new_tokens():
+    truth = list(range(100)) + list(range(100))
+    server = _copy_server()
+    result = server.run(truth[:100], OracleVerifier(truth), max_new_tokens=5)
+    assert len(result.tokens) == 5
+
+
+def test_run_stops_at_end_of_truth():
+    truth = [7, 8, 9]
+    server = _copy_server()
+    result = server.run(truth[:1], OracleVerifier(truth), max_new_tokens=64)
+    assert truth[:1] + result.tokens == truth

--- a/test/serving/test_sglang_verifier.py
+++ b/test/serving/test_sglang_verifier.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the SGLang tree verifier's engine-agnostic plumbing.
+
+The real GPU forward (``SGLangTreeEngine``) is stubbed, so these exercise the
+parts that run without a GPU: tree flattening (positions + tree-attention parent
+map), the dense mask expansion, and the greedy accept-path recovery. A
+``_GreedyTruthEngine`` stands in for the target model — it predicts the next
+token of a known ``truth`` at each position, i.e. a greedy model that continues
+``truth``. Driving ``SGLangVerifier`` with it must reproduce ``OracleVerifier``'s
+behaviour, proving the flatten/recover machinery is faithful.
+"""
+
+from typing import List, Sequence
+
+import pytest
+
+from codenib.serving.drafter.copy import CopyDrafter
+from codenib.serving.server.sglang import (
+    SGLangTreeEngine,
+    SGLangVerifier,
+    TargetEngine,
+    attention_mask,
+    flatten,
+)
+from codenib.serving.server.worker import (
+    OracleVerifier,
+    SpeculativeConfig,
+    SpeculativeServer,
+)
+from codenib.serving.types import DraftTree, TokenId
+
+
+class _GreedyTruthEngine(TargetEngine):
+    """Fake target model: greedily continues a known ``truth`` sequence.
+
+    For every fed position ``i`` with position id ``p`` it predicts
+    ``truth[p + 1]`` — exactly what a greedy model conditioned on ``truth[:p+1]``
+    would emit. ``context`` must be a prefix of ``truth`` (the loop maintains
+    this when started from ``truth[:k]``).
+    """
+
+    def __init__(self, truth: Sequence[TokenId], eos: int = -999) -> None:
+        self.truth = list(truth)
+        self.eos = eos
+
+    def predict(self, context: Sequence[TokenId], flat) -> List[TokenId]:
+        preds: List[TokenId] = []
+        n = len(self.truth)
+        # Context positions are 0..context_len-1; draft positions come from flat.
+        positions = list(range(flat.context_len)) + list(flat.positions)
+        for p in positions:
+            preds.append(self.truth[p + 1] if p + 1 < n else self.eos)
+        return preds
+
+
+def _linear_tree(tokens: List[TokenId]) -> DraftTree:
+    tree = DraftTree()
+    tree.add_sequence(tokens, source="test")
+    return tree
+
+
+# --- flatten -----------------------------------------------------------------
+
+
+def test_flatten_linear_positions_and_parents():
+    # context length 5, a single linear branch of 3 draft tokens.
+    flat = flatten(5, _linear_tree([10, 11, 12]))
+    assert flat.tokens == [10, 11, 12]
+    # Depth 1,2,3 -> positions 5,6,7 (fill the next three generation slots).
+    assert flat.positions == [5, 6, 7]
+    # Depth-1 node attends to last context token (4); then each to its parent.
+    assert flat.parents == [4, 5, 6]
+    assert flat.total_len == 8
+
+
+def test_flatten_branching_shares_context_parent():
+    # Two depth-1 alternatives, each is its own branch.
+    tree = DraftTree()
+    tree.add_sequence([1, 2], source="a")
+    tree.add_sequence([3, 4], source="b")
+    flat = flatten(2, tree)
+    # Pre-order: 1,2 then 3,4. Both depth-1 nodes (1 and 3) share position 2 and
+    # attend to the last context token (index 1).
+    assert flat.tokens == [1, 2, 3, 4]
+    assert flat.positions == [2, 3, 2, 3]
+    assert flat.parents == [1, 2, 1, 4]
+
+
+def test_shared_prefix_collapses_in_flatten():
+    # Two continuations agreeing on the first token must share one branch.
+    tree = DraftTree()
+    tree.add_sequence([7, 8], source="a")
+    tree.add_sequence([7, 9], source="b")
+    flat = flatten(3, tree)
+    # 7 appears once (shared), with two children 8 and 9 both at position 4.
+    assert flat.tokens == [7, 8, 9]
+    assert flat.positions == [3, 4, 4]
+    assert flat.parents == [2, 3, 3]
+
+
+# --- attention mask ----------------------------------------------------------
+
+
+def test_attention_mask_tree_structure():
+    # context [c0, c1]; branch 7 -> 8, sibling 9 off the same parent 7.
+    tree = DraftTree()
+    tree.add_sequence([7, 8], source="a")
+    tree.add_sequence([7, 9], source="b")
+    flat = flatten(2, tree)  # globals: 7@2, 8@3, 9@4
+    m = attention_mask(flat)
+    # Context is causal.
+    assert m[0] == [True, False, False, False, False]
+    assert m[1] == [True, True, False, False, False]
+    # 7 (idx 2): all context + self.
+    assert m[2] == [True, True, True, False, False]
+    # 8 (idx 3): context + ancestor 7 + self, NOT sibling 9.
+    assert m[3] == [True, True, True, True, False]
+    # 9 (idx 4): context + ancestor 7 + self, NOT sibling 8.
+    assert m[4] == [True, True, True, False, True]
+
+
+# --- SGLangVerifier ----------------------------------------------------------
+
+
+def test_verify_accepts_full_correct_branch():
+    truth = [1, 2, 3, 4, 5, 6]
+    context = truth[:3]  # [1,2,3]; next true tokens are 4,5,6
+    tree = _linear_tree([4, 5, 99])  # 4,5 correct; 99 wrong
+    v = SGLangVerifier(_GreedyTruthEngine(truth))
+    result = v.verify(context, tree)
+    assert result.accepted == [4, 5]
+    assert result.bonus == 6  # model's own next token after the accepted prefix
+
+
+def test_verify_rejects_at_first_divergence():
+    truth = [1, 2, 3, 4]
+    tree = _linear_tree([9, 9])  # diverges immediately
+    v = SGLangVerifier(_GreedyTruthEngine(truth))
+    result = v.verify(truth[:2], tree)
+    assert result.accepted == []
+    assert result.bonus == 3  # bonus token always emitted -> forward progress
+
+
+def test_verify_picks_correct_branch_among_siblings():
+    truth = [1, 2, 3, 4, 5]
+    tree = DraftTree()
+    tree.add_sequence([9, 9], source="wrong")
+    tree.add_sequence([3, 4], source="right")  # matches truth
+    v = SGLangVerifier(_GreedyTruthEngine(truth))
+    result = v.verify(truth[:2], tree)
+    assert result.accepted == [3, 4]
+    assert result.bonus == 5
+
+
+def test_verify_matches_oracle_on_same_tree():
+    truth = [5, 6, 7, 8, 9, 10]
+    context = truth[:2]
+    tree = _linear_tree([7, 8, 42])
+    oracle = OracleVerifier(truth).verify(context, tree)
+    sglang = SGLangVerifier(_GreedyTruthEngine(truth)).verify(context, tree)
+    assert sglang.accepted == oracle.accepted
+    assert sglang.bonus == oracle.bonus
+
+
+def test_verify_empty_tree_still_emits_bonus():
+    truth = [1, 2, 3]
+    v = SGLangVerifier(_GreedyTruthEngine(truth))
+    result = v.verify(truth[:1], DraftTree())
+    assert result.accepted == []
+    assert result.bonus == 2
+
+
+def test_eos_prediction_ends_generation():
+    truth = [1, 2, 3]
+    v = SGLangVerifier(_GreedyTruthEngine(truth, eos=-999), eos_token_id=-999)
+    # Context is the whole truth; next prediction runs off the end -> eos.
+    result = v.verify(truth, DraftTree())
+    assert result.bonus is None
+
+
+def test_verify_raises_on_mismatched_prediction_count():
+    class _BadEngine(TargetEngine):
+        def predict(self, context, flat):
+            return [0]  # wrong length
+
+    with pytest.raises(ValueError):
+        SGLangVerifier(_BadEngine()).verify([1, 2], _linear_tree([3]))
+
+
+# --- end-to-end through the speculation loop ---------------------------------
+
+
+def test_run_reconstructs_truth_with_sglang_verifier():
+    # Same guarantee as the OracleVerifier loop test, but driven through the
+    # real flatten/recover path of SGLangVerifier with a greedy fake engine.
+    truth = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 5]
+    server = SpeculativeServer(
+        drafters=[CopyDrafter(min_match=2, max_match=16, max_draft=8)],
+        config=SpeculativeConfig(max_draft_tokens=8),
+    )
+    verifier = SGLangVerifier(_GreedyTruthEngine(truth), eos_token_id=-999)
+    result = server.run(truth[:4], verifier, max_new_tokens=64)
+    assert truth[:4] + result.tokens == truth
+    assert result.speedup > 1.0  # copy speculation actually helped
+
+
+# --- production engine stub ---------------------------------------------------
+
+
+def test_sglang_tree_engine_is_stub():
+    with pytest.raises(NotImplementedError):
+        SGLangTreeEngine().predict([1, 2, 3], flatten(3, _linear_tree([4])))

--- a/test/serving/test_suffix_automaton.py
+++ b/test/serving/test_suffix_automaton.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the suffix-automaton drafter."""
+
+from typing import List
+
+from codenib.serving.drafter.copy import CopyDrafter
+from codenib.serving.drafter.suffix_automaton import (
+    SuffixAutomatonDrafter,
+    _build,
+    _read_continuation,
+)
+from codenib.serving.server.worker import SpeculativeConfig, build_draft
+
+
+def _branches(tree) -> List[List[int]]:
+    """Flatten a (linear) draft tree into its root-to-leaf token paths."""
+    paths = []
+
+    def walk(node, acc):
+        acc = acc + [node.token] if node.token != -1 else acc
+        if not node.children:
+            if acc:
+                paths.append(acc)
+            return
+        for c in node.children:
+            walk(c, acc)
+
+    walk(tree.root, [])
+    return paths
+
+
+# --- automaton primitive -------------------------------------------------
+
+
+def test_automaton_finds_longest_suffix_match():
+    ref = [1, 2, 3, 4, 1, 2, 3]
+    sam = _build(ref)
+    # Longest suffix of the query that is a substring of ref is [1, 2, 3].
+    state, length = sam.longest_suffix_match([9, 9, 1, 2, 3])
+    assert length == 3
+    # Most-recent occurrence of [1,2,3] ends at index 6 -> read from 7 (empty).
+    assert sam.end[state] == 6
+
+
+def test_automaton_no_match_returns_zero():
+    sam = _build([1, 2, 3])
+    _, length = sam.longest_suffix_match([7, 8, 9])
+    assert length == 0
+
+
+def test_read_continuation_stops_at_doc_boundary():
+    ref = [1, 2, -1, 3, 4]
+    assert _read_continuation(ref, 0, 8) == [2]  # stops at the -1 sentinel
+
+
+# --- in-context (copy-style) drafting ------------------------------------
+
+
+def test_context_only_predicts_repeat():
+    drafter = SuffixAutomatonDrafter(min_match=2, max_draft=8)
+    # Suffix [1,2,3] recurs; the earlier occurrence was followed by 4.
+    context = [1, 2, 3, 4, 5, 1, 2, 3]
+    paths = _branches(drafter.draft(context, max_tokens=8))
+    assert paths and paths[0][0] == 4
+
+
+def test_matches_or_beats_copy_drafter_length():
+    # Suffix-automaton finds the exact longest match; copy must not beat it.
+    context = [7, 1, 2, 3, 4, 8, 1, 2, 3, 4]
+    sam = SuffixAutomatonDrafter(min_match=2, max_draft=16)
+    cpy = CopyDrafter(min_match=2, max_match=32, max_draft=16)
+    sam_pred = _branches(sam.draft(context, 16))
+    cpy_pred = _branches(cpy.draft(context, 16))
+    # Both should predict the continuation after "1,2,3,4" -> nothing past it
+    # here, so use a case with a real continuation:
+    context2 = [1, 2, 3, 9, 0, 1, 2, 3]
+    sam_pred = _branches(sam.draft(context2, 16))
+    cpy_pred = _branches(cpy.draft(context2, 16))
+    assert sam_pred and cpy_pred
+    assert len(sam_pred[0]) >= len(cpy_pred[0])
+    assert sam_pred[0][0] == cpy_pred[0][0] == 9
+
+
+def test_no_draft_without_repeat():
+    drafter = SuffixAutomatonDrafter(min_match=2, max_draft=8)
+    assert drafter.draft([1, 2, 3, 4, 5], max_tokens=8).is_empty()
+
+
+# --- static corpus (retrieval reach) -------------------------------------
+
+
+def test_corpus_gives_reach_beyond_context():
+    # The continuation lives in another "file", not in the context at all.
+    corpus = [[100, 101, 102, 103, 104], [200, 201, 202]]
+    drafter = SuffixAutomatonDrafter(corpus=corpus, min_match=2, max_draft=8)
+    paths = _branches(drafter.draft([100, 101, 102], max_tokens=8))
+    assert paths and paths[0][:2] == [103, 104]
+
+
+def test_corpus_continuation_respects_doc_boundary():
+    corpus = [[1, 2, 3], [4, 5, 6]]  # match in doc 0 must not bleed into doc 1
+    drafter = SuffixAutomatonDrafter(corpus=corpus, min_match=2, max_draft=8)
+    # Suffix [2,3] ends doc 0; there is no continuation -> no cross-doc draft.
+    assert drafter.draft([2, 3], max_tokens=8).is_empty()
+
+
+# --- drops into fusion ---------------------------------------------------
+
+
+def test_drops_into_fusion_with_other_drafters():
+    context = [1, 2, 3, 4, 1, 2, 3]
+    corpus = [[5, 6, 7, 8]]
+    sam = SuffixAutomatonDrafter(corpus=corpus, min_match=2, max_draft=8)
+    copy = CopyDrafter(min_match=2, max_match=8, max_draft=8)
+    config = SpeculativeConfig(max_draft_tokens=8)
+    tree = build_draft([copy, sam], context, config)
+    assert not tree.is_empty()
+    assert tree.size <= 8

--- a/test/serving/test_tokenization.py
+++ b/test/serving/test_tokenization.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the text↔token bridge (:mod:`codenib.serving.server.tokenization`)."""
+
+from __future__ import annotations
+
+from typing import List
+
+from codenib.serving.server.tokenization import Tokenizer
+
+# Sentinel ids for the fake's "special" tokens.
+_BOS = 1
+_EOS = 2
+
+
+class _FakeHF:
+    """A tiny stand-in for an HF tokenizer: char code <-> id, with specials.
+
+    Mirrors the real ``encode``/``decode``/``eos_token_id`` surface the wrapper
+    delegates to, so the bridge is tested without downloading a model.
+    """
+
+    eos_token_id = _EOS
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        ids = [ord(c) for c in text]
+        return [_BOS, *ids] if add_special_tokens else ids
+
+    def decode(self, ids: List[int], skip_special_tokens: bool = True) -> str:
+        keep = [i for i in ids if not (skip_special_tokens and i in (_BOS, _EOS))]
+        return "".join(chr(i) for i in keep)
+
+
+def test_encode_omits_special_tokens_by_default() -> None:
+    tok = Tokenizer(_FakeHF())
+    assert tok.encode("ab") == [ord("a"), ord("b")]
+
+
+def test_encode_can_add_special_tokens() -> None:
+    tok = Tokenizer(_FakeHF())
+    assert tok.encode("ab", add_special_tokens=True) == [_BOS, ord("a"), ord("b")]
+
+
+def test_decode_round_trips_encoded_text() -> None:
+    tok = Tokenizer(_FakeHF())
+    text = "def add(a, b): return a + b"
+    assert tok.decode(tok.encode(text)) == text
+
+
+def test_decode_skips_special_tokens_by_default() -> None:
+    tok = Tokenizer(_FakeHF())
+    assert tok.decode([_BOS, ord("x"), _EOS]) == "x"
+
+
+def test_decode_can_keep_special_tokens() -> None:
+    tok = Tokenizer(_FakeHF())
+    out = tok.decode([_BOS, ord("x")], skip_special_tokens=False)
+    assert out == chr(_BOS) + "x"
+
+
+def test_eos_token_id_is_exposed() -> None:
+    tok = Tokenizer(_FakeHF())
+    assert tok.eos_token_id == _EOS
+
+
+def test_hf_tokenizer_is_reachable_for_extras() -> None:
+    # The raw tokenizer is exposed so callers can use e.g. apply_chat_template.
+    fake = _FakeHF()
+    assert Tokenizer(fake).hf is fake

--- a/uv.lock
+++ b/uv.lock
@@ -643,6 +643,14 @@ semantic-remote = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "openai" },
 ]
+serving = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sse-starlette" },
+    { name = "torch" },
+    { name = "transformers" },
+]
 test = [
     { name = "datasets" },
     { name = "einops" },
@@ -664,6 +672,7 @@ test = [
     { name = "pytest-xdist" },
     { name = "requests" },
     { name = "sentence-transformers" },
+    { name = "sse-starlette" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 vertex = [
@@ -720,6 +729,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'full'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'semantic'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'semantic-remote'", specifier = ">=1.24.0" },
+    { name = "numpy", marker = "extra == 'serving'", specifier = ">=1.24.0" },
     { name = "numpy", marker = "extra == 'test'", specifier = ">=1.24.0" },
     { name = "openai", marker = "extra == 'agent'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'full'", specifier = ">=1.0.0" },
@@ -743,12 +753,16 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'full'", specifier = ">=2.2.0" },
     { name = "sentence-transformers", marker = "extra == 'semantic'", specifier = ">=2.2.0" },
     { name = "sentence-transformers", marker = "extra == 'test'", specifier = ">=2.2.0" },
+    { name = "sse-starlette", marker = "extra == 'serving'", specifier = ">=2.0.0" },
+    { name = "sse-starlette", marker = "extra == 'test'", specifier = ">=2.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'test'", specifier = ">=1.1.0" },
+    { name = "torch", marker = "extra == 'serving'", specifier = ">=2.2.0" },
+    { name = "transformers", marker = "extra == 'serving'", specifier = ">=4.44.0" },
     { name = "tree-sitter", specifier = ">=0.25.2" },
     { name = "tree-sitter-language-pack", specifier = ">=1.8.1,<1.9.0" },
     { name = "uvicorn", specifier = ">=0.20.0" },
 ]
-provides-extras = ["agent", "datasets", "graph", "mcp", "semantic", "semantic-remote", "vertex", "zoekt", "full", "dev", "test"]
+provides-extras = ["agent", "datasets", "graph", "mcp", "semantic", "semantic-remote", "serving", "vertex", "zoekt", "full", "dev", "test"]
 
 [package.metadata.requires-dev]
 docs = [


### PR DESCRIPTION
## Summary

CodeNib indexes a repository. This spends that index on *decode*: a speculative-decoding server whose draft tokens come from the retrieval index rather than a draft model, behind an OpenAI-compatible endpoint (`codenib-serve`).

It consolidates six PRs built in the RetroSpec research repo — #11 (tokenizer bridge), #12 (endpoint + SSE), #13 (retrieval backend), #10 (LiteLLM gateway + demo agent), #14 and #28 (wiring) — into one change here. RetroSpec stays the research repo; serving lives here from now on. Design record: [sysevol-ai/RetroSpec#29](https://github.com/sysevol-ai/RetroSpec/pull/29).

The six PRs are not self-contained — `server/api.py` transitively needs the drafters and the tree engine from earlier work — so the whole engine is vendored rather than partially ported. The alternative, having CodeNib depend on `retrospec`, would not install for anyone outside the org (RetroSpec is private) and would close a dependency cycle against the existing `retrospec[retrieval] = ["codenib"]`.

Acceptance is greedy-exact: a drafted token is kept only when it equals the target model's argmax, so emitted text is identical to plain autoregressive decoding. Drafting changes how many tokens come out per forward pass, never which.

## Changes

- `codenib/serving/drafter/` — copy, retrieval, fusion, and suffix-automaton draft sources. `CodeNibBackend` queries a prebuilt index through `ServerContext` and suffix-aligns snippets against the decode context.
- `codenib/serving/server/` — speculative worker, HF tree-attention engine with KV reuse, tree-verify plumbing, tokenizer bridge, and the OpenAI-compatible endpoint (`/v1/chat/completions` with SSE streaming, `/v1/models`, `/health`). Greedy-only: sampling requests are rejected with HTTP 400.
- `deploy/` — LiteLLM gateway config routing to `codenib-serve` with a plain-model fallback, plus a README.
- `examples/serving_agent_demo.py` — retrieve context (CodeNib) → build messages → generate (OpenAI client → LiteLLM).
- `pyproject.toml` — new `serving` extra and `codenib-serve` console script.

Two changes were made to the ported code rather than copying it verbatim:

- `tokenization.py` imported `transformers` at module scope in RetroSpec, which forced the whole model runtime just to import the endpoint. It is now lazy, matching the rest of the package.
- Three test fakes gained `__slots__` to satisfy bugbear's `B903`, which CodeNib's flake8 config selects (via `B9`) and RetroSpec's did not.

## Type of Change

- [x] New feature

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

12 test files, ~1,700 lines, in `test/serving/` plus `test/examples/test_serving_agent_demo.py`.

- **With the `serving` extra:** 99 passed, 1 skipped (an env-gated GPU test).
- **With no serving dependencies installed at all** — what the default CI job sees: 76 passed, `test_api` skipping cleanly via `importorskip`. This is the case the lazy-import fix above enables.
- **Wider unit tier:** 2834 passed, unchanged. The 4 failures and 6 collection errors in my environment are pre-existing (a missing optional `mcp` package) and reproduce identically with this change stashed.
- `black`, `isort --profile black`, `flake8` clean.

Only `test_hf_engine.py` carries the `slow` marker; `torch`/`transformers` are imported lazily inside methods everywhere else, so the rest run in the default tier. `sse-starlette` was added to the `test` extra so the endpoint tests actually execute in CI — without it, `test_console_entry_points_load` would fail on the new `codenib-serve` script.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Follow-up, not in this PR

A separate RetroSpec PR re-points `experiments/` at `codenib.serving.*` and drops the vendored copy. Until it lands, both repos work independently against byte-identical code. The research harness `experiments/acceptance.py` deliberately stays in RetroSpec — one test that cross-checked it against the server's drafters was dropped here and belongs there.