### PR TITLE
fix(chunker): expose parser cache readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ python -m pip install "codenib[mcp,semantic]==0.2.0"
 codenib wiki /path/to/your/repo
 ```
 
-Local, open source, and no cloud required. CodeNib combines BM25 and dense code
-search, adds optional SCIP symbol graphs, and incrementally rebuilds repository
-indexes as commits change. The same index powers the Wiki, Dependency Map, Ask,
-and MCP tools instead of making every agent rediscover the codebase.
+Local, open source, and no hosted service or API key required. CodeNib combines
+BM25 and dense code search, adds optional SCIP symbol graphs, and incrementally
+rebuilds repository indexes as commits change. The same index powers the Wiki,
+Dependency Map, Ask, and MCP tools instead of making every agent rediscover the
+codebase.
 
 ## News
 

--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -1101,7 +1101,7 @@ def _doctor_model_config(
 
 def _doctor_rows(
     args: argparse.Namespace | None = None,
-) -> dict[str, list[tuple[str, bool, str]]]:
+) -> dict[str, list[tuple[str, bool | None, str]]]:
     from .web.launcher import (
         find_frontend_dir,
         is_prebuilt_frontend,
@@ -1179,7 +1179,7 @@ def _doctor_rows(
                 "language pack",
                 _check_module("tree_sitter_language_pack"),
                 (
-                    "installed"
+                    "installed; parser binaries are cached on first use"
                     if _check_module("tree_sitter_language_pack")
                     else "missing"
                 ),
@@ -1262,6 +1262,30 @@ def _doctor_rows(
         if model_check is not None:
             rows["agent"].append(model_check)
     return rows
+
+
+def _language_parser_cache_check(
+    languages: Sequence[str],
+) -> tuple[str, bool | None, str]:
+    """Describe parser cache readiness without causing a network download."""
+
+    if not _check_module("tree_sitter_language_pack"):
+        return ("Language parsers", False, "language pack is missing")
+    try:
+        from tree_sitter_language_pack import downloaded_languages
+
+        cached = set(downloaded_languages())
+    except Exception as exc:  # noqa: BLE001 - doctor reports diagnostic failures
+        return ("Language parsers", False, f"cache inspection failed: {exc}")
+
+    missing = [language for language in languages if language not in cached]
+    if missing:
+        return (
+            "Language parsers",
+            None,
+            "first-use download required: " + ", ".join(missing),
+        )
+    return ("Language parsers", True, "cached: " + ", ".join(languages))
 
 
 def _model_probe_error(exc: BaseException, *, api_key: str | None) -> str:
@@ -1477,6 +1501,7 @@ def _run_doctor(args: argparse.Namespace) -> int:
 
         repo_path = resolve_repo_path(args.repo)
         languages = _selected_languages(repo_path, args.language)
+        rows["core"].append(_language_parser_cache_check(languages))
         graph_report = diagnose_graph_setup(repo_path, languages)
     if args.probe_model:
         rows["agent"].extend(_probe_doctor_model(args))
@@ -1488,9 +1513,9 @@ def _run_doctor(args: argparse.Namespace) -> int:
         marker = "required" if group in required else "optional"
         print(f"\n{group} ({marker})")
         for label, ok, detail in checks:
-            status = "OK" if ok else "MISSING"
+            status = "OK" if ok is True else "PENDING" if ok is None else "MISSING"
             print(f"  [{status:<7}] {label}: {detail}")
-            if group in required and not ok:
+            if group in required and ok is False:
                 failed_required = True
         if group == "graph" and graph_report is not None:
             for setup in graph_report.languages:

--- a/codenib/code_chunker.py
+++ b/codenib/code_chunker.py
@@ -233,7 +233,9 @@ class CodeChunker:
         return self._chunker.print_chunk_summary(chunks)
 
     # Repository-level methods
-    def chunk_repository(self, repo_path: str) -> List[CodeChunk]:
+    def chunk_repository(
+        self, repo_path: str, *, strict: bool = False
+    ) -> List[CodeChunk]:
         """
         Chunk all relevant files in a repository.
 
@@ -241,6 +243,8 @@ class CodeChunker:
             repo_path: Path to the repository root.
                 Languages come from RepoChunkingConfig; when empty they are inferred
                 from file extensions present in the repo.
+            strict: Raise when any discovered source file cannot be chunked instead
+                of returning a partial repository result.
 
         Returns:
             List of CodeChunk objects from all processed files
@@ -275,6 +279,11 @@ class CodeChunker:
                 processed_count += 1
 
             except Exception as e:
+                if strict:
+                    relative = file_path.relative_to(repo_path).as_posix()
+                    raise RuntimeError(
+                        f"Failed to chunk repository source {relative}: {e}"
+                    ) from e
                 logger.warning(f"Failed to process {file_path}: {e}")
                 continue
 

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -10,7 +10,6 @@ Base code chunker class with common functionality.
 
 import json
 import os
-import sys
 import threading
 from abc import ABC, abstractmethod
 from collections import namedtuple
@@ -18,7 +17,7 @@ from pathlib import Path
 from typing import ClassVar, List, Optional, Tuple
 
 from tree_sitter import Parser
-from tree_sitter_language_pack import get_language
+from tree_sitter_language_pack import downloaded_languages, get_language
 
 from ..log_utils import get_logger
 
@@ -95,15 +94,28 @@ class BaseCodeChunker(ABC):
                 "Successfully loaded %s language parser from tree-sitter-language-pack",
                 language,
             )
-        except Exception as e:
-            logger.error("Error loading %s parser: %s", language, e)
-            sys.exit(1)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Unable to load the {language} tree-sitter parser. "
+                "Parser binaries are downloaded and cached on first use; "
+                f"check network access and retry. Cause: {exc}"
+            ) from exc
 
     @classmethod
     def _get_tree_sitter_language(cls, language: str):
         """Load each tree-sitter language once per process."""
         with cls._language_cache_lock:
             if language not in cls._language_cache:
+                try:
+                    cached = language in downloaded_languages()
+                except Exception:  # noqa: BLE001 - status is diagnostic only
+                    cached = True
+                if not cached:
+                    logger.info(
+                        "Preparing the %s tree-sitter parser for first use; "
+                        "this one-time step downloads and caches a parser bundle",
+                        language,
+                    )
                 cls._language_cache[language] = get_language(language)
             return cls._language_cache[language]
 

--- a/codenib/code_chunking/base.py
+++ b/codenib/code_chunking/base.py
@@ -145,7 +145,7 @@ class BaseCodeChunker(ABC):
         # logger.debug(f"Chunking file: {file_path}")
 
         # Read the file
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
             code_content = f.read()
 
         # Parse the code

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -100,11 +100,12 @@ class BM25IndexBuilder:
 
     def artifact_identity(self) -> Dict[str, Any]:
         return {
-            # v6 also fixes source discovery order across filesystems.
-            "builder_schema": 6,
+            # v7 refuses to publish indexes with silently skipped source files.
+            "builder_schema": 7,
             "languages": list(self.languages),
             "max_k": self.max_k,
             "max_lines_per_chunk": self.max_lines_per_chunk,
+            "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 
@@ -121,7 +122,7 @@ class BM25IndexBuilder:
             repo_config=RepoChunkingConfig(languages=self.languages),
             max_lines_per_chunk=self.max_lines_per_chunk,
         )
-        chunks = chunker.chunk_repository(repo_path=repo_path)
+        chunks = chunker.chunk_repository(repo_path=repo_path, strict=True)
 
         indexer = BM25CodeIndexer(
             chunks=chunks,
@@ -182,7 +183,7 @@ class VectorIndexBuilder:
 
         route = self._embedding_route()
         return {
-            "builder_schema": 3,
+            "builder_schema": 4,
             "embedding_model": route.model,
             "embedding_provider": route.provider,
             "embedding_dimension": self.embedding_dimension,
@@ -195,6 +196,7 @@ class VectorIndexBuilder:
             "languages": list(self.languages),
             "levels": list(self.build_levels),
             "max_lines_per_chunk": self.max_lines_per_chunk,
+            "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 
@@ -291,6 +293,7 @@ class VectorIndexBuilder:
             # vectors be stamped with the current source fingerprint. Cross-
             # commit reuse belongs to ``incremental_update`` instead.
             force_rebuild=True,
+            strict_chunking=True,
         )
         self._validate_vector_dimension(vs)
 

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -100,12 +100,13 @@ class BM25IndexBuilder:
 
     def artifact_identity(self) -> Dict[str, Any]:
         return {
-            # v7 refuses to publish indexes with silently skipped source files.
-            "builder_schema": 7,
+            # v8 refuses skipped files and retains non-symbol source context.
+            "builder_schema": 8,
             "languages": list(self.languages),
             "max_k": self.max_k,
             "max_lines_per_chunk": self.max_lines_per_chunk,
             "chunking_failure_policy": "fail",
+            "include_header_epilogue": True,
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 
@@ -121,6 +122,7 @@ class BM25IndexBuilder:
             language=primary,
             repo_config=RepoChunkingConfig(languages=self.languages),
             max_lines_per_chunk=self.max_lines_per_chunk,
+            include_header_epilogue=True,
         )
         chunks = chunker.chunk_repository(repo_path=repo_path, strict=True)
 

--- a/codenib/index/embedding/builders.py
+++ b/codenib/index/embedding/builders.py
@@ -68,6 +68,7 @@ def build_hierarchical_vector_store(
     ivf_nprobe: int = 8,
     profiler: Optional[Profiler] = None,
     force_rebuild: bool = False,
+    strict_chunking: bool = False,
     artifact_metadata: Optional[Dict[str, Any]] = None,
 ) -> CodeVectorStore:
     """Build (or load) a hierarchical vector store (L0/L2) for a repository.
@@ -152,7 +153,10 @@ def build_hierarchical_vector_store(
             f"chunking_{level}",
             {"level": level, "language": languages[0]},
         ):
-            chunks_by_level[level] = chunker.chunk_repository(repo_path=repo_path)
+            chunks_by_level[level] = chunker.chunk_repository(
+                repo_path=repo_path,
+                strict=strict_chunking,
+            )
         logger.info(
             f"Chunked {len(chunks_by_level[level])} {level} chunks "
             f"(lang={languages[0]})"

--- a/docs/gt_locator.md
+++ b/docs/gt_locator.md
@@ -25,7 +25,8 @@ Supports Python, Go, Rust, C/C++, C#, Java, Ruby, PHP, Kotlin, Swift, Scala, Lua
 
 ## Prerequisites
 
-- `tree-sitter-language-pack` (bundled with CodeNib, provides parsers for all supported languages)
+- `tree-sitter-language-pack` (installed with CodeNib; parser binaries are
+  downloaded and cached on first use for the selected languages)
 - `git` (for cloning and checking out repos)
 
 ## Usage

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,6 +54,13 @@ prepare project-local dependencies such as `node_modules`; run those profiles
 from a clean checkout when that distinction matters. Press `Ctrl-C` once to
 stop both services.
 
+On the first parse with a new `tree-sitter-language-pack` version, the language
+pack downloads and caches the parser bundle for the detected languages. CodeNib
+prints that preparation step instead of appearing idle, and `codenib doctor
+/path/to/repository` reports uncached parsers as `PENDING`. Once cached, the
+`fast` BM25 path can run offline. This parser cache is independent of the larger
+CodeRankEmbed download used by the semantic preset.
+
 Use different ports or keep the browser closed when needed:
 
 ```bash

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -74,6 +74,42 @@ def test_tree_sitter_language_load_is_cached_per_language(monkeypatch):
     assert third.tree_sitter_language is languages["go"]
 
 
+def test_tree_sitter_language_reports_first_use_download(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        "codenib.code_chunking.base.logger.info",
+        lambda message, *args: messages.append(message % args),
+    )
+    monkeypatch.setattr("codenib.code_chunking.base.downloaded_languages", lambda: [])
+    monkeypatch.setattr(
+        "codenib.code_chunking.base.get_language", lambda _language: object()
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_create_parser",
+        staticmethod(lambda _language: object()),
+    )
+
+    StubCodeChunker("python")
+
+    assert any(
+        "Preparing the python tree-sitter parser for first use" in message
+        for message in messages
+    )
+
+
+def test_tree_sitter_language_failure_raises_instead_of_exiting(monkeypatch):
+    monkeypatch.setattr("codenib.code_chunking.base.downloaded_languages", lambda: [])
+
+    def fail_load(_language: str):
+        raise OSError("offline")
+
+    monkeypatch.setattr("codenib.code_chunking.base.get_language", fail_load)
+
+    with pytest.raises(RuntimeError, match="downloaded and cached on first use"):
+        StubCodeChunker("python")
+
+
 def test_l0_empty_skeleton_falls_back_to_full_file(monkeypatch, tmp_path):
     source = tmp_path / "declarations.h"
     content = "#define VALUE 1\n"

--- a/test/chunker/test_base_chunker.py
+++ b/test/chunker/test_base_chunker.py
@@ -98,6 +98,27 @@ def test_l0_empty_skeleton_falls_back_to_full_file(monkeypatch, tmp_path):
     assert chunks[0].node_id == "include/declarations.h"
 
 
+def test_chunk_file_replaces_invalid_utf8_bytes(monkeypatch, tmp_path):
+    source = tmp_path / "legacy.py"
+    source.write_bytes(b"value = b\x80\n")
+
+    parser = SimpleNamespace(parse=lambda _code: SimpleNamespace(root_node=object()))
+    monkeypatch.setattr(
+        "codenib.code_chunking.base.get_language", lambda _lang: object()
+    )
+    monkeypatch.setattr(
+        BaseCodeChunker,
+        "_create_parser",
+        staticmethod(lambda _language: parser),
+    )
+
+    chunker = StubCodeChunker("python", chunk_depth=0)
+    chunks = chunker.chunk_file(str(source), relative_path="legacy.py")
+
+    assert len(chunks) == 1
+    assert "\ufffd" in chunks[0].content
+
+
 @pytest.mark.parametrize(
     ("configured_limit", "expected_limit"),
     [(None, DEFAULT_L0_RAW_FALLBACK_MAX_LINES), (100, 100)],

--- a/test/chunker/test_repo_chunking_config.py
+++ b/test/chunker/test_repo_chunking_config.py
@@ -6,6 +6,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from codenib.code_chunker import CodeChunker, RepoChunkingConfig
 from codenib.languages import extensions_for_language
 
@@ -60,6 +62,25 @@ def test_repo_discovery_respects_custom_extension_overrides(tmp_path: Path):
 
     assert stats["total_files"] == 1
     assert stats["files_by_language"]["python"][0]["path"] == "tool.pyw"
+
+
+def test_strict_repository_chunking_rejects_partial_results(tmp_path, monkeypatch):
+    source = tmp_path / "broken.py"
+    source.write_text("def broken():\n    pass\n", encoding="utf-8")
+    cfg = RepoChunkingConfig(languages=["python"], filter_tests=False)
+    chunker = CodeChunker(language="python", repo_config=cfg)
+
+    def fail_chunking(*_args):
+        raise ValueError("parser failed")
+
+    monkeypatch.setattr(chunker, "_chunk_file_with_language", fail_chunking)
+
+    assert chunker.chunk_repository(str(tmp_path)) == []
+    with pytest.raises(
+        RuntimeError,
+        match=r"Failed to chunk repository source broken\.py: parser failed",
+    ):
+        chunker.chunk_repository(str(tmp_path), strict=True)
 
 
 def test_repo_discovery_is_sorted_independently_of_walk_order(

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -129,14 +129,21 @@ class TestBM25IndexBuilder:
         assert status.metadata["file_count"] == 3
         assert status.metadata["chunk_count"] == 3
         assert status.metadata["source_file_count"] == 2
-        assert status.metadata["builder_schema"] == 7
+        assert status.metadata["builder_schema"] == 8
         assert status.metadata["chunking_failure_policy"] == "fail"
+        assert status.metadata["include_header_epilogue"] is True
         assert status.metadata["max_k"] == 64
         assert set(status.metadata["artifact_file_fingerprints"]) == {
             "documents.json",
             "bm25_metadata.json",
         }
         assert status.path == output
+        MockChunker.assert_called_once_with(
+            language="python",
+            repo_config=ANY,
+            max_lines_per_chunk=300,
+            include_header_epilogue=True,
+        )
         mock_chunker_instance.chunk_repository.assert_called_once_with(
             repo_path="/fake/repo", strict=True
         )
@@ -152,7 +159,31 @@ class TestBM25IndexBuilder:
             assert result == "result"
 
     def test_artifact_identity_tracks_source_body_indexing(self):
-        assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 7
+        assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 8
+
+    def test_build_indexes_source_without_symbol_definitions(self, tmp_path):
+        from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "settings.py").write_text(
+            'UNIQUE_RUNTIME_MODE = "safe_local"\n',
+            encoding="utf-8",
+        )
+        output = tmp_path / "bm25"
+
+        status = BM25IndexBuilder(languages=["python"]).build(
+            scope="current_repo",
+            repo_path=str(repo),
+            output_dir=str(output),
+        )
+
+        assert status.metadata["source_file_count"] == 1
+        index = BM25CodeIndexer()
+        index.load_index(str(output))
+        results = index.search("safe_local", top_k=1)
+        assert results
+        assert results[0].file == "settings.py"
 
 
 # ---------------------------------------------------------------------------

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -129,13 +129,17 @@ class TestBM25IndexBuilder:
         assert status.metadata["file_count"] == 3
         assert status.metadata["chunk_count"] == 3
         assert status.metadata["source_file_count"] == 2
-        assert status.metadata["builder_schema"] == 6
+        assert status.metadata["builder_schema"] == 7
+        assert status.metadata["chunking_failure_policy"] == "fail"
         assert status.metadata["max_k"] == 64
         assert set(status.metadata["artifact_file_fingerprints"]) == {
             "documents.json",
             "bm25_metadata.json",
         }
         assert status.path == output
+        mock_chunker_instance.chunk_repository.assert_called_once_with(
+            repo_path="/fake/repo", strict=True
+        )
         mock_indexer_instance.save_index.assert_called_once_with(output)
 
     def test_incremental_delegates_to_build(self):
@@ -148,7 +152,7 @@ class TestBM25IndexBuilder:
             assert result == "result"
 
     def test_artifact_identity_tracks_source_body_indexing(self):
-        assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 6
+        assert BM25IndexBuilder().artifact_identity()["builder_schema"] == 7
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +191,7 @@ class TestVectorIndexBuilder:
         assert status.metadata["document_count"] == {"l0": 2, "l2": 3}
         mock_build_fn.assert_called_once()
         assert mock_build_fn.call_args.kwargs["force_rebuild"] is True
+        assert mock_build_fn.call_args.kwargs["strict_chunking"] is True
 
     def test_artifact_identity_is_shared_by_full_and_incremental_statuses(self):
         builder = VectorIndexBuilder(
@@ -198,7 +203,7 @@ class TestVectorIndexBuilder:
 
         identity = builder.artifact_identity()
         assert identity == {
-            "builder_schema": 3,
+            "builder_schema": 4,
             "embedding_model": "test-model",
             "embedding_provider": "huggingface",
             "embedding_dimension": 384,
@@ -219,6 +224,7 @@ class TestVectorIndexBuilder:
             "languages": ["python"],
             "levels": ["l0", "l2"],
             "max_lines_per_chunk": 300,
+            "chunking_failure_policy": "fail",
             "repository_filter_policy": REPOSITORY_FILTER_POLICY_VERSION,
         }
 

--- a/test/index/test_embedding_builders.py
+++ b/test/index/test_embedding_builders.py
@@ -22,7 +22,8 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
         def __init__(self, **kwargs):
             pass
 
-        def chunk_repository(self, repo_path):
+        def chunk_repository(self, repo_path, *, strict=False):
+            captured["strict_chunking"] = strict
             return [chunk]
 
     captured = {}
@@ -67,10 +68,12 @@ def test_hierarchical_builder_reuses_a_supplied_embedding(monkeypatch, tmp_path)
         embedding=embedding,
         artifact_metadata={"commit": "a" * 40},
         force_rebuild=True,
+        strict_chunking=True,
     )
 
     assert captured["embedding"] is embedding
     assert captured["artifact_metadata"] == {"commit": "a" * 40}
+    assert captured["strict_chunking"] is True
     assert result.l2_documents
     assert all(not path.exists() for path in stale_files)
     assert unrelated.read_bytes() == b"other"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1206,6 +1206,47 @@ def test_doctor_does_not_require_node_for_prebuilt_frontend(
     assert wiki["npm"] == (True, "not required (prebuilt frontend)")
 
 
+def test_doctor_reports_uncached_repository_parsers_as_pending(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "main.py").write_text("VALUE = 1\n")
+    monkeypatch.setattr("tree_sitter_language_pack.downloaded_languages", lambda: [])
+    monkeypatch.setattr(
+        "codenib.graph.setup.diagnose_graph_setup",
+        lambda _repo, _languages: SimpleNamespace(
+            languages=[], install_hints=[], ready=True
+        ),
+    )
+
+    assert cli.run(["doctor", str(tmp_path)]) == 0
+
+    output = capsys.readouterr().out
+    assert "[PENDING] Language parsers" in output
+    assert "first-use download required: python" in output
+
+
+def test_doctor_reports_cached_repository_parsers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "main.py").write_text("VALUE = 1\n")
+    monkeypatch.setattr(
+        "tree_sitter_language_pack.downloaded_languages", lambda: ["python"]
+    )
+    monkeypatch.setattr(
+        "codenib.graph.setup.diagnose_graph_setup",
+        lambda _repo, _languages: SimpleNamespace(
+            languages=[], install_hints=[], ready=True
+        ),
+    )
+
+    assert cli.run(["doctor", str(tmp_path)]) == 0
+    assert "[OK     ] Language parsers: cached: python" in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
     ("version", "expected_ok"),
     [


### PR DESCRIPTION
## Summary

Make the default parser cold-start path observable and recoverable. The tree-sitter language pack downloads its parser bundle on first use, but CodeNib previously appeared idle during that download and terminated library callers with `SystemExit` on failure.

Depends on #457.

## Changes

- Report uncached repository parsers as non-failing `PENDING` checks in `codenib doctor`.
- Log the one-time parser preparation step before the first language-pack download.
- Raise a contextual `RuntimeError` instead of exiting the host process when parser loading fails.
- Document the first-use cache boundary and correct the no-hosted-service claim.
- Add regression coverage for cached, pending, and failed parser states.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/chunker test/test_cli.py test/compiler/test_index_compiler.py` (207 passed)
- `make test` (2960 passed, 56 skipped)
- `pre-commit run --files ...`
- strict MkDocs build
- wheel and sdist build, `twine check`, and `scripts/verify_release_artifacts.py`
- isolated default-dependency wheel smoke from an empty parser cache (`doctor` pending -> `index --preset fast` -> cached)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
