### PR TITLE
fix(web): bound commit-window snapshot caches

### DIFF
--- a/codenib/web/commit_window.py
+++ b/codenib/web/commit_window.py
@@ -19,7 +19,8 @@ import json
 import logging
 import os
 import threading
-from typing import TYPE_CHECKING, Dict, List, Optional
+from collections import OrderedDict
+from typing import TYPE_CHECKING, List, Optional
 
 from ..paths import legacy_repo_index_dir, repo_index_dir
 from .repository_files import git_source_slice
@@ -31,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 WINDOW_DIRNAME = "commit_window"
 MANIFEST_NAME = "commit_window.json"
+# CodeGraph snapshots can be large; retain the current and previous selection.
+_MAX_CACHED_GRAPHS = 2
 
 
 def window_dir(repo_dir: str) -> str:
@@ -101,9 +104,9 @@ def window_stats(commits: List[dict]) -> Optional[dict]:
 class CommitWindow:
     """Read-only view over one repo's per-commit graph snapshots.
 
-    Graphs are loaded lazily and cached by commit SHA. A repo with no window
-    on disk yields ``available == False`` and callers fall back to the single
-    manifest-linked graph.
+    Graphs are loaded lazily and retained in a small LRU by commit SHA. A repo
+    with no window on disk yields ``available == False`` and callers fall back
+    to the single manifest-linked graph.
     """
 
     def __init__(self, repo_dir: str) -> None:
@@ -111,7 +114,7 @@ class CommitWindow:
         self._manifest: Optional[dict] = None
         self._manifest_path: Optional[str] = None
         self._mtime: Optional[float] = None
-        self._graphs: Dict[str, Optional["CodeGraph"]] = {}
+        self._graphs: OrderedDict[str, Optional["CodeGraph"]] = OrderedDict()
         self._lock = threading.RLock()
 
     # -- manifest ---------------------------------------------------------
@@ -219,7 +222,9 @@ class CommitWindow:
         sha = str(entry.get("sha", ""))
         with self._lock:
             if sha in self._graphs:
-                return self._graphs[sha]
+                graph = self._graphs.pop(sha)
+                self._graphs[sha] = graph
+                return graph
 
             path = entry.get("graph_path")
             # Manifests record absolute paths at build time; tolerate a moved
@@ -260,6 +265,8 @@ class CommitWindow:
                     "commit-window: no usable snapshot for %s", entry.get("short")
                 )
             self._graphs[sha] = graph
+            while len(self._graphs) > _MAX_CACHED_GRAPHS:
+                self._graphs.popitem(last=False)
             return graph
 
     def source_for(

--- a/codenib/web/repository_files.py
+++ b/codenib/web/repository_files.py
@@ -14,6 +14,9 @@ from typing import Optional
 
 _COMMIT_RE = re.compile(r"[0-9a-fA-F]{7,64}\Z")
 _MAX_SOURCE_BYTES = 8 * 1024 * 1024
+# These values can contain every tracked path in a large repository. Retain the
+# current and previous immutable trees instead of scaling with window length.
+_MAX_GIT_SNAPSHOT_CACHE_ENTRIES = 2
 
 
 def valid_commit(commit: object) -> bool:
@@ -97,7 +100,7 @@ def git_blob_head(
     return _git_blob(repo_dir, commit, relative, max_bytes, allow_truncated=True)
 
 
-@lru_cache(maxsize=64)
+@lru_cache(maxsize=_MAX_GIT_SNAPSHOT_CACHE_ENTRIES)
 def git_grep_paths(repo_dir: str, commit: str, pattern: str) -> frozenset[str]:
     """Return paths matching *pattern* at *commit* using one Git process."""
     if not valid_commit(commit):
@@ -134,7 +137,7 @@ def git_grep_paths(repo_dir: str, commit: str, pattern: str) -> frozenset[str]:
     )
 
 
-@lru_cache(maxsize=64)
+@lru_cache(maxsize=_MAX_GIT_SNAPSHOT_CACHE_ENTRIES)
 def git_tree_paths(repo_dir: str, commit: str) -> Optional[frozenset[str]]:
     """Repository paths at *commit*, or ``None`` when it is unavailable."""
     if not valid_commit(commit):

--- a/test/web/test_commit_window.py
+++ b/test/web/test_commit_window.py
@@ -10,6 +10,7 @@ import subprocess
 
 import pytest
 
+from codenib.graph.code_graph import CodeGraph
 from codenib.paths import legacy_repo_index_dir, repo_index_dir
 from codenib.web.commit_window import CommitWindow, window_dir
 
@@ -191,6 +192,45 @@ class TestGraphFor:
     def test_unknown_commit_returns_none(self, tmp_path):
         _write_manifest(tmp_path, [_commit("a" * 40, "aaaaaaa", method="cold")])
         assert CommitWindow(str(tmp_path)).graph_for("deadbeef") is None
+
+    def test_graph_cache_evicts_the_least_recently_used_snapshot(
+        self, tmp_path, monkeypatch
+    ):
+        commits = []
+        graphs = {}
+        for marker in ("a", "b", "c"):
+            graph_path = tmp_path / f"graph_{marker}.pkl"
+            graph_path.touch()
+            sha = marker * 40
+            commits.append(
+                _commit(
+                    sha,
+                    marker * 7,
+                    graph_path=str(graph_path),
+                )
+            )
+            graphs[str(graph_path)] = object()
+        _write_manifest(tmp_path, commits)
+        loads = []
+
+        def load_graph(path):
+            loads.append(path)
+            return graphs[path]
+
+        monkeypatch.setattr(CodeGraph, "load_graph", load_graph)
+        window = CommitWindow(str(tmp_path))
+
+        assert window.graph_for("a" * 7) is graphs[str(tmp_path / "graph_a.pkl")]
+        assert window.graph_for("b" * 7) is graphs[str(tmp_path / "graph_b.pkl")]
+        assert window.graph_for("a" * 7) is graphs[str(tmp_path / "graph_a.pkl")]
+        assert window.graph_for("c" * 7) is graphs[str(tmp_path / "graph_c.pkl")]
+
+        assert tuple(window._graphs) == ("a" * 40, "c" * 40)
+        assert len(loads) == 3
+
+        assert window.graph_for("b" * 7) is graphs[str(tmp_path / "graph_b.pkl")]
+        assert tuple(window._graphs) == ("c" * 40, "b" * 40)
+        assert len(loads) == 4
 
 
 class TestSourceFor:

--- a/test/web/test_repository_files.py
+++ b/test/web/test_repository_files.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded immutable-repository reads used by the Web runtime."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codenib.web.repository_files import git_grep_paths, git_tree_paths
+
+
+@pytest.fixture(autouse=True)
+def _clear_snapshot_caches():
+    git_grep_paths.cache_clear()
+    git_tree_paths.cache_clear()
+    yield
+    git_grep_paths.cache_clear()
+    git_tree_paths.cache_clear()
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_git_snapshot_caches_evict_old_commits(tmp_path: Path) -> None:
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    commits = []
+    for revision in range(3):
+        (tmp_path / "source.py").write_text(
+            f"# generated revision {revision}\nVALUE = {revision}\n"
+        )
+        _git(tmp_path, "add", "source.py")
+        _git(tmp_path, "commit", "-qm", f"revision {revision}")
+        commits.append(_git(tmp_path, "rev-parse", "HEAD"))
+
+    for commit in commits:
+        assert git_tree_paths(str(tmp_path), commit) == frozenset({"source.py"})
+        assert git_grep_paths(str(tmp_path), commit, "generated") == frozenset(
+            {"source.py"}
+        )
+
+    assert git_tree_paths.cache_info().currsize == 2
+    assert git_grep_paths.cache_info().currsize == 2
+
+    tree_misses = git_tree_paths.cache_info().misses
+    grep_misses = git_grep_paths.cache_info().misses
+    git_tree_paths(str(tmp_path), commits[0])
+    git_grep_paths(str(tmp_path), commits[0], "generated")
+    assert git_tree_paths.cache_info().misses == tree_misses + 1
+    assert git_grep_paths.cache_info().misses == grep_misses + 1


### PR DESCRIPTION
## Summary

Bound the heavyweight caches used while browsing Commit Window snapshots. The server previously retained every selected full `CodeGraph`, tracked-path set, and generated-file set, so resident memory could grow linearly with the number of commits visited.

## Changes

- Replace the unbounded per-repository graph dictionary with a two-entry LRU.
- Bound immutable Git tree and generated-file path caches to the current and previous snapshots.
- Refresh recency on graph hits and reload snapshots after eviction.
- Keep existing manifest-rebuild invalidation behavior.
- Add regressions for graph LRU ordering and Git snapshot cache misses after eviction.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/web/test_commit_window.py test/web/test_app_runtime.py` (44 passed)
- `pytest -q test/web` (166 passed)
- `pre-commit run --files codenib/web/commit_window.py codenib/web/repository_files.py test/web/test_commit_window.py test/web/test_repository_files.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
