### PR TITLE
fix(mcp): bound agent tool requests

### DIFF
--- a/codenib/graph/dependency.py
+++ b/codenib/graph/dependency.py
@@ -121,9 +121,11 @@ class DependencyAnalyzer:
         """What *symbol* (transitively) depends on — transitive callees."""
         return self._bfs(symbol, "forward", "callees", max_depth, max_nodes)
 
-    def subgraph(self, symbol: str, radius: int = 1) -> DependencyResult:
+    def subgraph(
+        self, symbol: str, radius: int = 1, max_nodes: int = 200
+    ) -> DependencyResult:
         """Compact callers+callees neighborhood for a frontend dependency view."""
-        return self._bfs(symbol, "both", "both", radius, max_nodes=200)
+        return self._bfs(symbol, "both", "both", radius, max_nodes=max_nodes)
 
     def call_path(self, from_symbol: str, to_symbol: str) -> DependencyResult:
         """Shortest call path from *from_symbol* to *to_symbol* (empty if none)."""
@@ -193,6 +195,10 @@ class DependencyAnalyzer:
                 )
                 for src, tgt, _w, attr in edges:
                     neighbor = tgt if d == "forward" else src
+                    already_seen = neighbor in seen
+                    if not already_seen and len(seen) >= max_nodes:
+                        res.truncated = True
+                        continue
                     res.edges.append(
                         DepEdge(
                             self.code_graph.display_name(src),
@@ -200,10 +206,7 @@ class DependencyAnalyzer:
                             attr.get("type", "reference"),
                         )
                     )
-                    if neighbor in seen:
-                        continue
-                    if len(seen) >= max_nodes:
-                        res.truncated = True
+                    if already_seen:
                         continue
                     seen.add(neighbor)
                     res.nodes.append(self._node(neighbor, depth + 1))

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -23,13 +23,21 @@ import asyncio
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from mcp.server import MCPServer
+from pydantic import Field
 
 from ..compiler.manifest import RepoManifest
 from .context import ServerContext
 from .prompts import CODENIB_GUIDE
+from .tools._validation import (
+    MAX_GRAPH_DEPTH,
+    MAX_GRAPH_NODES,
+    MAX_ROUTE_SYMBOLS,
+    MAX_TOOL_RESULTS,
+    MAX_TOOL_TEXT_CHARS,
+)
 from .tools.dependency import dependency_subgraph_impl
 from .tools.lsp import lsp_definition_impl, lsp_references_impl, lsp_route_impl
 from .tools.search import search_bm25_impl, search_context_impl, search_regex_impl
@@ -37,6 +45,12 @@ from .tools.search import search_semantic as _search_semantic_impl
 from .tools.search import search_zoekt_impl
 
 logger = logging.getLogger(__name__)
+
+_ToolText = Annotated[str, Field(min_length=1, max_length=MAX_TOOL_TEXT_CHARS)]
+_ToolTopK = Annotated[int, Field(ge=1, le=MAX_TOOL_RESULTS)]
+_GraphDepth = Annotated[int, Field(ge=1, le=MAX_GRAPH_DEPTH)]
+_GraphNodes = Annotated[int, Field(ge=1, le=MAX_GRAPH_NODES)]
+_RouteSymbols = Annotated[list[str], Field(min_length=1, max_length=MAX_ROUTE_SYMBOLS)]
 
 # Global context is set once at startup before the event loop runs tools.
 _ctx: Optional[ServerContext] = None
@@ -80,8 +94,8 @@ mcp = MCPServer(
     ),
 )
 async def search_context(
-    query: str,
-    top_k: int = 10,
+    query: _ToolText,
+    top_k: _ToolTopK = 10,
     budget: str = "balanced",
     level: str = "l2",
     filter_test: bool = False,
@@ -109,8 +123,8 @@ async def search_context(
     ),
 )
 async def semantic_search(
-    query: str,
-    top_k: int = 10,
+    query: _ToolText,
+    top_k: _ToolTopK = 10,
     level: str = "l2",
     score_threshold: float = 0.0,
 ) -> list[dict[str, Any]] | dict[str, str]:
@@ -141,8 +155,8 @@ async def semantic_search(
     ),
 )
 async def search_bm25(
-    query: str,
-    top_k: int = 20,
+    query: _ToolText,
+    top_k: _ToolTopK = 20,
     filter_test: bool = False,
 ) -> list[dict[str, Any]]:
     """BM25 keyword search over indexed code symbols."""
@@ -163,8 +177,8 @@ async def search_bm25(
     ),
 )
 async def search_regex(
-    pattern: str,
-    top_k: int = 20,
+    pattern: _ToolText,
+    top_k: _ToolTopK = 20,
     file_glob: str = "",
     node_type: str = "",
     case_sensitive: bool = False,
@@ -195,8 +209,8 @@ async def search_regex(
     ),
 )
 async def search_zoekt(
-    query: str,
-    top_k: int = 20,
+    query: _ToolText,
+    top_k: _ToolTopK = 20,
     file_filter: str = "",
 ) -> list[dict[str, Any]]:
     """Trigram-based search over raw repository contents."""
@@ -224,10 +238,10 @@ async def search_zoekt(
     ),
 )
 async def dependency_subgraph(
-    symbol: str,
-    direction: str = "both",
-    depth: int = 2,
-    max_nodes: int = 60,
+    symbol: _ToolText,
+    direction: Literal["impact", "dependencies", "both"] = "both",
+    depth: _GraphDepth = 2,
+    max_nodes: _GraphNodes = 60,
 ) -> dict[str, Any]:
     """Call-graph dependency/impact subgraph for *symbol* (nodes+edges JSON)."""
     if _ctx is None:
@@ -250,7 +264,7 @@ async def lsp_definition(
     line: int | None = None,
     character: int | None = None,
     symbol: str = "",
-    top_k: int = 8,
+    top_k: _ToolTopK = 8,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Graph-backed definition lookup over the static symbol graph."""
     if _ctx is None:
@@ -280,7 +294,7 @@ async def lsp_references(
     character: int | None = None,
     symbol: str = "",
     include_declaration: bool = True,
-    top_k: int = 40,
+    top_k: _ToolTopK = 40,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Graph-backed reference lookup over the static symbol graph."""
     if _ctx is None:
@@ -307,9 +321,9 @@ async def lsp_references(
     ),
 )
 async def lsp_route(
-    symbols: list[str],
+    symbols: _RouteSymbols,
     query: str = "",
-    top_k: int = 12,
+    top_k: _ToolTopK = 12,
     include_neighbors: bool = True,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Graph-backed route map over the static symbol graph."""

--- a/codenib/mcp/tools/_validation.py
+++ b/codenib/mcp/tools/_validation.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared request bounds for MCP tools exposed to coding agents."""
+
+from __future__ import annotations
+
+MAX_TOOL_RESULTS = 100
+MAX_TOOL_TEXT_CHARS = 16_000
+MAX_GRAPH_DEPTH = 10
+MAX_GRAPH_NODES = 200
+MAX_ROUTE_SYMBOLS = 32
+
+
+def bounded_int(
+    value: int,
+    *,
+    name: str,
+    minimum: int = 1,
+    maximum: int = MAX_TOOL_RESULTS,
+) -> int:
+    """Return an integer within an explicit tool boundary."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer between {minimum} and {maximum}.")
+    if not minimum <= value <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}.")
+    return value
+
+
+def bounded_text(
+    value: str,
+    *,
+    name: str,
+    maximum: int = MAX_TOOL_TEXT_CHARS,
+    strip: bool = True,
+) -> str:
+    """Normalize non-empty tool text while rejecting oversized requests."""
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string.")
+    if not value.strip():
+        raise ValueError(f"{name} must not be empty.")
+    if len(value) > maximum:
+        raise ValueError(f"{name} must not exceed {maximum} characters.")
+    return value.strip() if strip else value

--- a/codenib/mcp/tools/dependency.py
+++ b/codenib/mcp/tools/dependency.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from ...agent.boundary import AGENT_LINE_OFFSET
+from ._validation import MAX_GRAPH_DEPTH, MAX_GRAPH_NODES, bounded_int, bounded_text
 
 
 def dependency_subgraph_impl(
@@ -31,6 +32,17 @@ def dependency_subgraph_impl(
     dependency view). Returns ``{"error": ...}`` when the symbol graph is
     unavailable, so callers can recover gracefully.
     """
+    symbol = bounded_text(symbol, name="symbol")
+    depth = bounded_int(
+        depth,
+        name="depth",
+        maximum=MAX_GRAPH_DEPTH,
+    )
+    max_nodes = bounded_int(
+        max_nodes,
+        name="max_nodes",
+        maximum=MAX_GRAPH_NODES,
+    )
     graph = getattr(ctx, "symbol_graph", None)
     if graph is None:
         return {"error": "symbol_graph index not available"}
@@ -38,16 +50,23 @@ def dependency_subgraph_impl(
     from ...graph.dependency import DependencyAnalyzer
 
     analyzer = DependencyAnalyzer(graph)
-    d = (direction or "both").lower()
-    depth = max(1, int(depth or 1))
-    if d.startswith("impact") or d == "callers":
-        result = analyzer.impact(symbol, max_depth=depth, max_nodes=int(max_nodes))
-    elif d.startswith("dep") or d == "callees":
-        result = analyzer.dependencies(
-            symbol, max_depth=depth, max_nodes=int(max_nodes)
-        )
+    d = (direction or "both").strip().lower()
+    aliases = {
+        "impact": "impact",
+        "callers": "impact",
+        "dependencies": "dependencies",
+        "callees": "dependencies",
+        "both": "both",
+    }
+    resolved_direction = aliases.get(d)
+    if resolved_direction is None:
+        raise ValueError("direction must be 'impact', 'dependencies', or 'both'.")
+    if resolved_direction == "impact":
+        result = analyzer.impact(symbol, max_depth=depth, max_nodes=max_nodes)
+    elif resolved_direction == "dependencies":
+        result = analyzer.dependencies(symbol, max_depth=depth, max_nodes=max_nodes)
     else:
-        result = analyzer.subgraph(symbol, radius=depth)
+        result = analyzer.subgraph(symbol, radius=depth, max_nodes=max_nodes)
     payload = result.to_dict()
     for node in payload["nodes"]:
         line = node.get("line")

--- a/codenib/mcp/tools/lsp.py
+++ b/codenib/mcp/tools/lsp.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
+from ._validation import MAX_ROUTE_SYMBOLS, bounded_int, bounded_text
+
 
 def _coerce_symbols(symbols: Sequence[str] | str) -> list[str]:
     if isinstance(symbols, str):
@@ -47,6 +49,7 @@ def lsp_definition_impl(
     from ...agent.boundary import from_agent_repr
     from ...agent.lsp_provider import StaticLSPProvider
 
+    top_k = bounded_int(top_k, name="top_k")
     graph_line = from_agent_repr(line)
     try:
         results = StaticLSPProvider(graph).definition(
@@ -54,7 +57,7 @@ def lsp_definition_impl(
             line=graph_line,
             character=character,
             symbol=symbol or None,
-            top_k=max(1, int(top_k or 8)),
+            top_k=top_k,
         )
     except ValueError as exc:
         return {"error": str(exc)}
@@ -78,6 +81,7 @@ def lsp_references_impl(
     from ...agent.boundary import from_agent_repr
     from ...agent.lsp_provider import StaticLSPProvider
 
+    top_k = bounded_int(top_k, name="top_k")
     graph_line = from_agent_repr(line)
     try:
         results = StaticLSPProvider(graph).references(
@@ -86,7 +90,7 @@ def lsp_references_impl(
             character=character,
             symbol=symbol or None,
             include_declaration=bool(include_declaration),
-            top_k=max(1, int(top_k or 40)),
+            top_k=top_k,
         )
     except ValueError as exc:
         return {"error": str(exc)}
@@ -107,13 +111,17 @@ def lsp_route_impl(
 
     from ...agent.lsp_provider import StaticLSPProvider
 
+    top_k = bounded_int(top_k, name="top_k")
     seeds = _coerce_symbols(symbols)
     if not seeds:
         return []
+    if len(seeds) > MAX_ROUTE_SYMBOLS:
+        raise ValueError(f"symbols must contain at most {MAX_ROUTE_SYMBOLS} entries.")
+    seeds = [bounded_text(seed, name="symbol") for seed in seeds]
     results = StaticLSPProvider(graph).route(
         symbols=seeds,
         query=query or None,
-        top_k=max(1, int(top_k or 12)),
+        top_k=top_k,
         include_neighbors=bool(include_neighbors),
     )
     return [_node_to_dict(node) for node in results]

--- a/codenib/mcp/tools/search.py
+++ b/codenib/mcp/tools/search.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 from ...agent.boundary import to_agent_repr
 from ...types import NodeInfo
 from ..context import ServerContext
+from ._validation import bounded_int, bounded_text
 
 
 def _node_to_dict(node: NodeInfo) -> Dict[str, Any]:
@@ -30,11 +31,8 @@ def search_context_impl(
     filter_test: bool = False,
 ) -> Dict[str, Any]:
     """Plan and execute ranked retrieval over the available repository views."""
-    normalized_query = (query or "").strip()
-    if not normalized_query:
-        raise ValueError("query must not be empty.")
-    if isinstance(top_k, bool) or not 1 <= top_k <= 100:
-        raise ValueError("top_k must be between 1 and 100.")
+    normalized_query = bounded_text(query, name="query")
+    top_k = bounded_int(top_k, name="top_k")
     normalized_level = (level or "l2").strip().lower()
     if normalized_level not in {"l0", "l2"}:
         raise ValueError("level must be 'l0' or 'l2'.")
@@ -174,19 +172,22 @@ async def search_semantic(
         List of NodeInfo dicts with scores and content. On missing index,
         returns ``{"error": ...}`` so callers can handle gracefully.
     """
+    query = bounded_text(query, name="query")
+    top_k = bounded_int(top_k, name="top_k")
+    normalized_level = (level or "l2").strip().lower()
+    if normalized_level not in {"l0", "l2"}:
+        raise ValueError("level must be 'l0' or 'l2'.")
+
     if ctx.vector is None:
         return {
             "error": "Vector index not loaded. Re-run indexing with embedding enabled."
         }
 
-    if level is None:
-        level = "l2"
-
     results = await asyncio.to_thread(
         ctx.vector.search_with_content,
         query=query,
         top_k=top_k,
-        level=level,
+        level=normalized_level,
         score_threshold=score_threshold,
     )
 
@@ -224,6 +225,9 @@ def search_bm25_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content, score.
     """
+    query = bounded_text(query, name="query")
+    top_k = bounded_int(top_k, name="top_k")
+
     if ctx.bm25 is None:
         raise RuntimeError(
             "BM25 index is not available. "
@@ -267,6 +271,9 @@ def search_regex_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content.
     """
+    pattern = bounded_text(pattern, name="pattern", strip=False)
+    top_k = bounded_int(top_k, name="top_k")
+
     if ctx.regex_index is None:
         raise RuntimeError(
             "Regex index is not available. "
@@ -326,6 +333,9 @@ def search_zoekt_impl(
         (``"file"``), ``file``, ``start_line``, ``end_line``, ``content``,
         ``score``, ``node_id`` (language hint, when reported).
     """
+    query = bounded_text(query, name="query")
+    top_k = bounded_int(top_k, name="top_k")
+
     if ctx.zoekt is None:
         raise RuntimeError(
             "Zoekt index is not available. "

--- a/test/graph/test_dependency.py
+++ b/test/graph/test_dependency.py
@@ -105,6 +105,16 @@ def test_subgraph_frontend_json():
     assert all({"source", "target", "type"} == set(e) for e in d["edges"])
 
 
+def test_subgraph_honors_node_limit():
+    g = _make_graph()
+    res = DependencyAnalyzer(g).subgraph("mid", radius=1, max_nodes=2)
+
+    assert len(res.nodes) == 1
+    assert res.truncated is True
+    names = {res.root, *(node.name for node in res.nodes)}
+    assert all(edge.source in names and edge.target in names for edge in res.edges)
+
+
 def test_files_nearest_first():
     g = _make_graph()
     res = DependencyAnalyzer(g).impact("leaf", max_depth=3)

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -26,7 +26,11 @@ from mcp.types import LATEST_PROTOCOL_VERSION
 import codenib.mcp.server as server_module
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
-from codenib.mcp.tools.lsp import lsp_definition_impl, lsp_references_impl
+from codenib.mcp.tools.lsp import (
+    lsp_definition_impl,
+    lsp_references_impl,
+    lsp_route_impl,
+)
 
 
 def test_server_import_keeps_optional_index_runtimes_lazy() -> None:
@@ -61,6 +65,41 @@ def test_server_negotiates_modern_and_legacy_protocols() -> None:
         "search_bm25",
         "search_semantic",
     } <= modern_tools
+
+
+def test_server_publishes_tool_request_bounds() -> None:
+    async def schemas() -> dict[str, dict]:
+        async with Client(server_module.mcp, cache=None) as client:
+            tools = await client.list_tools()
+            return {tool.name: tool.input_schema for tool in tools.tools}
+
+    by_name = asyncio.run(schemas())
+
+    for tool_name in (
+        "search_context",
+        "search_semantic",
+        "search_bm25",
+        "search_regex",
+        "search_zoekt",
+        "lsp_definition",
+        "lsp_references",
+        "lsp_route",
+    ):
+        top_k = by_name[tool_name]["properties"]["top_k"]
+        assert (top_k["minimum"], top_k["maximum"]) == (1, 100)
+
+    dependency = by_name["dependency_subgraph"]["properties"]
+    assert (dependency["depth"]["minimum"], dependency["depth"]["maximum"]) == (
+        1,
+        10,
+    )
+    assert (
+        dependency["max_nodes"]["minimum"],
+        dependency["max_nodes"]["maximum"],
+    ) == (1, 200)
+    assert dependency["direction"]["enum"] == ["impact", "dependencies", "both"]
+    symbols = by_name["lsp_route"]["properties"]["symbols"]
+    assert (symbols["minItems"], symbols["maxItems"]) == (1, 32)
 
 
 @pytest.fixture
@@ -251,6 +290,24 @@ def test_lsp_tools_reuse_agent_line_boundary():
         lsp_definition_impl(ctx, file_path="caller.py", line=0)
 
     assert mock_definition.call_args.kwargs["line"] == 0
+
+
+@pytest.mark.parametrize("top_k", [0, -1, 101, True])
+def test_lsp_definition_rejects_unbounded_top_k(top_k):
+    with pytest.raises(ValueError, match="top_k must be"):
+        lsp_definition_impl(
+            MagicMock(symbol_graph=MagicMock()),
+            symbol="load_config",
+            top_k=top_k,
+        )
+
+
+def test_lsp_route_bounds_symbol_seed_count():
+    with pytest.raises(ValueError, match="at most 32"):
+        lsp_route_impl(
+            MagicMock(symbol_graph=MagicMock()),
+            symbols=[f"symbol_{index}" for index in range(33)],
+        )
 
 
 def test_server_status_resource(mock_manifest: Path):

--- a/test/mcp_server/test_dependency_tool.py
+++ b/test/mcp_server/test_dependency_tool.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import igraph as ig
+import pytest
 
 from codenib.graph.code_graph import CodeGraph
 from codenib.mcp.tools.dependency import dependency_subgraph_impl
@@ -48,6 +49,36 @@ def test_both_direction_neighborhood():
     ctx = SimpleNamespace(symbol_graph=_graph())
     out = dependency_subgraph_impl(ctx, "mid", direction="both", depth=1)
     assert {n["name"] for n in out["nodes"]} == {"a.c:caller()", "b.c:leaf()"}
+
+
+def test_both_direction_honors_max_nodes():
+    ctx = SimpleNamespace(symbol_graph=_graph())
+    out = dependency_subgraph_impl(ctx, "mid", direction="both", depth=1, max_nodes=2)
+
+    assert len(out["nodes"]) == 1
+    assert out["truncated"] is True
+    names = {out["root"], *(node["name"] for node in out["nodes"])}
+    assert all(
+        edge["source"] in names and edge["target"] in names for edge in out["edges"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"direction": "sideways"}, "direction must be"),
+        ({"depth": 0}, "depth must be between"),
+        ({"depth": 11}, "depth must be between"),
+        ({"max_nodes": 0}, "max_nodes must be between"),
+        ({"max_nodes": 201}, "max_nodes must be between"),
+        ({"max_nodes": True}, "max_nodes must be an integer"),
+    ],
+)
+def test_rejects_invalid_request_bounds(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        dependency_subgraph_impl(
+            SimpleNamespace(symbol_graph=_graph()), "mid", **kwargs
+        )
 
 
 def test_missing_graph_returns_error():

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from unittest.mock import MagicMock
 
@@ -18,6 +19,7 @@ from codenib.mcp.tools.search import (
     search_bm25_impl,
     search_context_impl,
     search_regex_impl,
+    search_semantic,
     search_zoekt_impl,
 )
 from codenib.types import NodeInfo
@@ -256,6 +258,11 @@ class TestSearchBM25:
         assert "file" not in results[0]
         assert "score" not in results[0]
 
+    @pytest.mark.parametrize("top_k", [0, -1, 101, True])
+    def test_rejects_unbounded_top_k(self, top_k) -> None:
+        with pytest.raises(ValueError, match="top_k must be"):
+            search_bm25_impl(_make_ctx(bm25=MagicMock()), query="tax", top_k=top_k)
+
 
 # ------------------------------------------------------------------
 # search_regex
@@ -302,6 +309,14 @@ class TestSearchRegex:
         assert kwargs["node_type"] == "class"
         assert kwargs["case_sensitive"] is True
 
+    def test_preserves_significant_pattern_whitespace(self) -> None:
+        mock_regex = MagicMock()
+        mock_regex.search.return_value = []
+
+        search_regex_impl(_make_ctx(regex_index=mock_regex), pattern=" def ")
+
+        assert mock_regex.search.call_args.kwargs["pattern"] == " def "
+
     def test_top_k_truncation(self) -> None:
         many_nodes = [
             NodeInfo(node_name=f"func_{i}", type="function", content="x")
@@ -327,6 +342,13 @@ class TestSearchRegex:
 
         with pytest.raises(RuntimeError, match="Invalid regex pattern"):
             search_regex_impl(ctx, pattern=r"[")
+
+    @pytest.mark.parametrize("top_k", [0, -1, 101, True])
+    def test_rejects_unbounded_top_k(self, top_k) -> None:
+        with pytest.raises(ValueError, match="top_k must be"):
+            search_regex_impl(
+                _make_ctx(regex_index=MagicMock()), pattern="class", top_k=top_k
+            )
 
 
 # ------------------------------------------------------------------
@@ -435,3 +457,34 @@ class TestSearchZoekt:
             RuntimeError, match="Zoekt search failed.*connection refused"
         ):
             search_zoekt_impl(ctx, query="x")
+
+    @pytest.mark.parametrize("top_k", [0, -1, 101, True])
+    def test_rejects_unbounded_top_k(self, top_k) -> None:
+        with pytest.raises(ValueError, match="top_k must be"):
+            search_zoekt_impl(_make_ctx(zoekt=MagicMock()), query="TODO", top_k=top_k)
+
+
+@pytest.mark.parametrize("top_k", [0, -1, 101, True])
+def test_semantic_search_rejects_unbounded_top_k(top_k) -> None:
+    with pytest.raises(ValueError, match="top_k must be"):
+        asyncio.run(
+            search_semantic(
+                _make_ctx(vector=MagicMock()),
+                query="authentication flow",
+                top_k=top_k,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: search_bm25_impl(_make_ctx(bm25=MagicMock()), query=" "),
+        lambda: search_regex_impl(_make_ctx(regex_index=MagicMock()), pattern=" "),
+        lambda: search_zoekt_impl(_make_ctx(zoekt=MagicMock()), query=" "),
+        lambda: asyncio.run(search_semantic(_make_ctx(vector=MagicMock()), query=" ")),
+    ],
+)
+def test_search_tools_reject_empty_text(call) -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        call()


### PR DESCRIPTION
## Summary

Bound MCP retrieval and graph requests so coding-agent calls cannot request negative or unbounded result sets, and keep truncated dependency subgraphs structurally valid.

## Changes

- publish result, graph-depth, graph-node, query-size, and route-seed bounds in MCP tool JSON Schemas
- enforce the same limits inside semantic, BM25, regex, Zoekt, LSP, and dependency implementations
- make `dependency_subgraph(direction="both")` honor `max_nodes`
- omit edges to nodes excluded by graph truncation while preserving significant regex whitespace
- add request-bound, schema, and truncated-subgraph regression coverage

## Type of Change

- [x] Bug fix

## Testing

- [x] `pre-commit run --files ...`
- [x] `pytest -q test/mcp test/mcp_server --disable-warnings --maxfail=1` (127 passed, 14 skipped)
- [x] `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (2851 passed, 10 skipped)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
