### PR TITLE
fix(rerank): require explicit remote code trust

### DIFF
--- a/codenib/index/rerank/cross_encoder.py
+++ b/codenib/index/rerank/cross_encoder.py
@@ -21,6 +21,7 @@ Use :func:`build_reranker` as a factory; it dispatches by model name.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import re
 from pathlib import Path
@@ -53,6 +54,60 @@ def _model_load_kwargs(
     kwargs: dict[str, object] = {"trust_remote_code": trust_remote_code}
     if revision is not None:
         kwargs["revision"] = revision
+    return kwargs
+
+
+def _cross_encoder_kwargs(
+    cross_encoder: object,
+    model_name: str,
+    *,
+    revision: Optional[str],
+    trust_remote_code: bool,
+    torch_dtype: Optional[str],
+) -> dict[str, object]:
+    """Adapt model-loading arguments across sentence-transformers releases."""
+
+    load_kwargs = _model_load_kwargs(
+        model_name,
+        revision=revision,
+        trust_remote_code=trust_remote_code,
+    )
+    try:
+        parameters = inspect.signature(cross_encoder).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    accepts_extra_kwargs = not parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
+
+    def accepts(name: str) -> bool:
+        return accepts_extra_kwargs or name in parameters
+
+    kwargs: dict[str, object] = {}
+    for name, value in load_kwargs.items():
+        if accepts(name):
+            kwargs[name] = value
+        elif name == "trust_remote_code" and value is False:
+            # sentence-transformers 2.x predates this opt-in flag and keeps
+            # remote code disabled in its underlying Transformers calls.
+            continue
+        else:
+            raise RuntimeError(
+                "The installed sentence-transformers CrossEncoder cannot honor "
+                f"the requested {name}; upgrade sentence-transformers"
+            )
+
+    if torch_dtype is not None:
+        if accepts("model_kwargs"):
+            kwargs["model_kwargs"] = {"torch_dtype": torch_dtype}
+        elif accepts("automodel_args"):
+            kwargs["automodel_args"] = {"torch_dtype": torch_dtype}
+        else:
+            raise RuntimeError(
+                "The installed sentence-transformers CrossEncoder cannot set "
+                "torch_dtype; upgrade sentence-transformers"
+            )
     return kwargs
 
 
@@ -94,19 +149,17 @@ class STCrossEncoderWrapper:
                 instruction,
             )
 
-        kwargs = _model_load_kwargs(
+        kwargs = _cross_encoder_kwargs(
+            CrossEncoder,
             model_name,
             revision=revision,
             trust_remote_code=trust_remote_code,
+            torch_dtype=torch_dtype,
         )
         if max_length is not None:
             kwargs["max_length"] = max_length
         if device is not None:
             kwargs["device"] = device
-        # CrossEncoder forwards ``model_kwargs`` to the underlying HF model.
-        if torch_dtype is not None:
-            kwargs["model_kwargs"] = {"torch_dtype": torch_dtype}
-
         self._model = CrossEncoder(model_name, **kwargs)
         logger.info(
             "Loaded ST CrossEncoder: %s (revision=%s, max_length=%s, " "batch_size=%d)",

--- a/codenib/index/rerank/cross_encoder.py
+++ b/codenib/index/rerank/cross_encoder.py
@@ -22,9 +22,38 @@ Use :func:`build_reranker` as a factory; it dispatches by model name.
 from __future__ import annotations
 
 import logging
+import re
+from pathlib import Path
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
+
+_IMMUTABLE_REVISION_RE = re.compile(r"[0-9a-f]{40}\Z")
+
+
+def _model_load_kwargs(
+    model_name: str,
+    *,
+    revision: Optional[str],
+    trust_remote_code: bool,
+) -> dict[str, object]:
+    """Build least-privilege Hugging Face model-loading arguments."""
+
+    is_local_model = Path(model_name).expanduser().is_dir()
+    if (
+        trust_remote_code
+        and not is_local_model
+        and not (revision and _IMMUTABLE_REVISION_RE.fullmatch(revision))
+    ):
+        raise ValueError(
+            "trust_remote_code=True for a remote reranker requires revision to "
+            "be a full 40-character lowercase commit SHA"
+        )
+
+    kwargs: dict[str, object] = {"trust_remote_code": trust_remote_code}
+    if revision is not None:
+        kwargs["revision"] = revision
+    return kwargs
 
 
 # ---------------------------------------------------------------------------
@@ -45,7 +74,8 @@ class STCrossEncoderWrapper:
         *,
         max_length: Optional[int] = None,
         batch_size: int = 16,
-        trust_remote_code: bool = True,
+        revision: Optional[str] = None,
+        trust_remote_code: bool = False,
         device: Optional[str] = None,
         torch_dtype: Optional[str] = None,
         instruction: Optional[
@@ -64,7 +94,11 @@ class STCrossEncoderWrapper:
                 instruction,
             )
 
-        kwargs = {"trust_remote_code": trust_remote_code}
+        kwargs = _model_load_kwargs(
+            model_name,
+            revision=revision,
+            trust_remote_code=trust_remote_code,
+        )
         if max_length is not None:
             kwargs["max_length"] = max_length
         if device is not None:
@@ -75,8 +109,9 @@ class STCrossEncoderWrapper:
 
         self._model = CrossEncoder(model_name, **kwargs)
         logger.info(
-            "Loaded ST CrossEncoder: %s (max_length=%s, batch_size=%d)",
+            "Loaded ST CrossEncoder: %s (revision=%s, max_length=%s, " "batch_size=%d)",
             model_name,
+            revision,
             max_length,
             batch_size,
         )
@@ -158,7 +193,8 @@ class QwenRerankerWrapper:
         instruction: str = _QWEN_DEFAULT_INSTRUCTION,
         device: Optional[str] = None,
         torch_dtype: Optional[str] = "auto",
-        trust_remote_code: bool = True,
+        revision: Optional[str] = None,
+        trust_remote_code: bool = False,
     ) -> None:
         import torch
         from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -168,13 +204,16 @@ class QwenRerankerWrapper:
         self.batch_size = batch_size
         self.instruction = instruction
 
-        self._tokenizer = AutoTokenizer.from_pretrained(
+        load_kwargs = _model_load_kwargs(
             model_name,
-            padding_side="left",
+            revision=revision,
             trust_remote_code=trust_remote_code,
         )
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            model_name, padding_side="left", **load_kwargs
+        )
 
-        model_kwargs = {"trust_remote_code": trust_remote_code}
+        model_kwargs = dict(load_kwargs)
         if torch_dtype is not None:
             model_kwargs["torch_dtype"] = torch_dtype
         self._model = AutoModelForCausalLM.from_pretrained(model_name, **model_kwargs)
@@ -202,9 +241,10 @@ class QwenRerankerWrapper:
         )
 
         logger.info(
-            "Loaded Qwen reranker: %s (device=%s, max_length=%d, "
+            "Loaded Qwen reranker: %s (revision=%s, device=%s, max_length=%d, "
             "batch_size=%d, instruction=%r)",
             model_name,
+            revision,
             device,
             max_length,
             batch_size,

--- a/codenib/model/retrieve_rerank_pipeline.py
+++ b/codenib/model/retrieve_rerank_pipeline.py
@@ -127,6 +127,9 @@ class RetrieveRerankPipeline:
         rerank_index_metric: Similarity metric for the rerank vector index.
         crossencoder_model: Model used by cross-encoder reranking.
         crossencoder_batch_size: Batch size used by the cross-encoder.
+        crossencoder_revision: Optional Hugging Face model revision.
+        crossencoder_trust_remote_code: Whether to execute model repository
+            code. Remote models require an immutable commit revision.
         languages: Languages to chunk for indexing (default: ["python"]).
         max_lines_per_chunk: Maximum lines per chunk passed to chunker.
         sparse_max_k: Upper bound for BM25 index fan-out; defaults to 128.
@@ -169,6 +172,8 @@ class RetrieveRerankPipeline:
         rerank_index_metric: str = "ip",
         crossencoder_model: str = "Qwen/Qwen3-Reranker-0.6B",
         crossencoder_batch_size: int = 8,
+        crossencoder_revision: Optional[str] = None,
+        crossencoder_trust_remote_code: bool = False,
         languages: Optional[List[str]] = None,
         max_lines_per_chunk: int = 100,
         sparse_max_k: int = 128,
@@ -275,6 +280,8 @@ class RetrieveRerankPipeline:
             self.cross_encoder = build_reranker(
                 crossencoder_model,
                 batch_size=crossencoder_batch_size,
+                revision=crossencoder_revision,
+                trust_remote_code=crossencoder_trust_remote_code,
             )
             logger.info(
                 "Cross-encoder reranker loaded",

--- a/codenib/ops/rerank.py
+++ b/codenib/ops/rerank.py
@@ -36,11 +36,17 @@ class CrossEncoderContext:
             (Qwen3-Reranker logit trick), or ``None`` to auto-detect from
             the model name (``"Qwen3-Reranker"`` in name → qwen; else st).
         batch_size: Scoring batch size forwarded to the wrapper.
+        revision: Optional Hugging Face model revision. Remote model code may
+            only be trusted when this is a full immutable commit SHA.
+        trust_remote_code: Whether to execute model code supplied by the model
+            repository. Disabled by default.
     """
 
     model_name: str
     backend: Optional[str] = None
     batch_size: int = 16
+    revision: Optional[str] = None
+    trust_remote_code: bool = False
     _wrapper: Any = field(default=None, init=False, repr=False)
 
     def ensure_wrapper(self) -> Any:
@@ -51,6 +57,8 @@ class CrossEncoderContext:
                 self.model_name,
                 backend=self.backend,
                 batch_size=self.batch_size,
+                revision=self.revision,
+                trust_remote_code=self.trust_remote_code,
             )
             logger.info(
                 "Loaded cross-encoder: %s (backend=%s)", self.model_name, self.backend

--- a/docs/rag_ops.md
+++ b/docs/rag_ops.md
@@ -98,6 +98,12 @@ revisions; the paper artifact reports that provenance limit. A model not listed
 here may still run through a generic adapter, but it is not a validated quality
 claim.
 
+Remote model code is disabled by default for cross-encoder rerankers. The
+validated Qwen3 and mxbai rerankers load through standard library adapters. A
+custom remote model that requires repository code must opt in explicitly and
+pin `revision` to its full 40-character commit SHA; local model directories may
+opt in without a Hub revision.
+
 ## Query-Aware Planner
 
 `RetrievalPlanner` is deterministic. It does not call an LLM. It maps three

--- a/test/index/test_reranker_model_loading.py
+++ b/test/index/test_reranker_model_loading.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from codenib.index.rerank.cross_encoder import (
+    QwenRerankerWrapper,
+    STCrossEncoderWrapper,
+)
+from codenib.ops.rerank import CrossEncoderContext
+
+
+def _install_fake_sentence_transformers(monkeypatch, calls):
+    module = ModuleType("sentence_transformers")
+
+    class FakeCrossEncoder:
+        def __init__(self, model_name, **kwargs):
+            calls.append((model_name, kwargs))
+
+    module.CrossEncoder = FakeCrossEncoder
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+
+
+def _install_fake_qwen_dependencies(monkeypatch, tokenizer_calls, model_calls):
+    torch_module = ModuleType("torch")
+    torch_module.cuda = SimpleNamespace(is_available=lambda: False)
+    monkeypatch.setitem(sys.modules, "torch", torch_module)
+
+    class FakeTokenizer:
+        def convert_tokens_to_ids(self, token):
+            return {"yes": 1, "no": 2}[token]
+
+        def encode(self, text, *, add_special_tokens):
+            return []
+
+    class FakeAutoTokenizer:
+        @classmethod
+        def from_pretrained(cls, model_name, **kwargs):
+            tokenizer_calls.append((model_name, kwargs))
+            return FakeTokenizer()
+
+    class FakeModel:
+        def to(self, device):
+            return self
+
+        def eval(self):
+            return self
+
+    class FakeAutoModelForCausalLM:
+        @classmethod
+        def from_pretrained(cls, model_name, **kwargs):
+            model_calls.append((model_name, kwargs))
+            return FakeModel()
+
+    transformers_module = ModuleType("transformers")
+    transformers_module.AutoTokenizer = FakeAutoTokenizer
+    transformers_module.AutoModelForCausalLM = FakeAutoModelForCausalLM
+    monkeypatch.setitem(sys.modules, "transformers", transformers_module)
+
+
+def test_st_reranker_denies_remote_code_by_default(monkeypatch):
+    calls = []
+    _install_fake_sentence_transformers(monkeypatch, calls)
+
+    STCrossEncoderWrapper("vendor/reranker")
+
+    assert calls == [("vendor/reranker", {"trust_remote_code": False})]
+
+
+def test_qwen_reranker_denies_remote_code_by_default(monkeypatch):
+    tokenizer_calls = []
+    model_calls = []
+    _install_fake_qwen_dependencies(monkeypatch, tokenizer_calls, model_calls)
+
+    QwenRerankerWrapper("Qwen/Qwen3-Reranker-0.6B")
+
+    assert tokenizer_calls == [
+        (
+            "Qwen/Qwen3-Reranker-0.6B",
+            {"padding_side": "left", "trust_remote_code": False},
+        )
+    ]
+    assert model_calls == [
+        (
+            "Qwen/Qwen3-Reranker-0.6B",
+            {"torch_dtype": "auto", "trust_remote_code": False},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    "revision",
+    [None, "main", "a" * 39, "g" * 40],
+)
+def test_remote_code_requires_immutable_revision(monkeypatch, revision):
+    _install_fake_sentence_transformers(monkeypatch, [])
+
+    with pytest.raises(ValueError, match="full 40-character lowercase commit SHA"):
+        STCrossEncoderWrapper(
+            "vendor/custom-reranker",
+            revision=revision,
+            trust_remote_code=True,
+        )
+
+
+def test_qwen_remote_code_uses_same_pinned_revision(monkeypatch):
+    tokenizer_calls = []
+    model_calls = []
+    _install_fake_qwen_dependencies(monkeypatch, tokenizer_calls, model_calls)
+    revision = "a" * 40
+
+    QwenRerankerWrapper(
+        "vendor/custom-reranker",
+        revision=revision,
+        trust_remote_code=True,
+    )
+
+    assert tokenizer_calls[0][1]["revision"] == revision
+    assert tokenizer_calls[0][1]["trust_remote_code"] is True
+    assert model_calls[0][1]["revision"] == revision
+    assert model_calls[0][1]["trust_remote_code"] is True
+
+
+def test_local_reranker_can_trust_local_code_without_revision(monkeypatch, tmp_path):
+    calls = []
+    _install_fake_sentence_transformers(monkeypatch, calls)
+    model_path = tmp_path / "model"
+    model_path.mkdir()
+
+    STCrossEncoderWrapper(str(model_path), trust_remote_code=True)
+
+    assert calls == [(str(model_path), {"trust_remote_code": True})]
+
+
+def test_lazy_context_forwards_model_loading_policy(monkeypatch):
+    from codenib.index.rerank import cross_encoder as module
+
+    wrapper = object()
+    calls = []
+
+    def fake_build_reranker(model_name, **kwargs):
+        calls.append((model_name, kwargs))
+        return wrapper
+
+    monkeypatch.setattr(module, "build_reranker", fake_build_reranker)
+    revision = "b" * 40
+    context = CrossEncoderContext(
+        "vendor/custom-reranker",
+        backend="st",
+        batch_size=4,
+        revision=revision,
+        trust_remote_code=True,
+    )
+
+    assert context.ensure_wrapper() is wrapper
+    assert calls == [
+        (
+            "vendor/custom-reranker",
+            {
+                "backend": "st",
+                "batch_size": 4,
+                "revision": revision,
+                "trust_remote_code": True,
+            },
+        )
+    ]
+
+
+def test_pipeline_forwards_model_loading_policy(monkeypatch, tmp_path):
+    from codenib.model import retrieve_rerank_pipeline as module
+
+    wrapper = object()
+    calls = []
+
+    def fake_build_reranker(model_name, **kwargs):
+        calls.append((model_name, kwargs))
+        return wrapper
+
+    monkeypatch.setattr(module, "build_reranker", fake_build_reranker)
+    monkeypatch.setattr(
+        module.RetrieveRerankPipeline,
+        "_initialize_bm25_index",
+        lambda self, *, max_k: object(),
+    )
+    revision = "c" * 40
+
+    pipeline = module.RetrieveRerankPipeline(
+        repo_path=str(tmp_path),
+        index_path=str(tmp_path / "index"),
+        retrieval_mode="sparse",
+        rerank_strategy="crossencoder",
+        crossencoder_model="vendor/custom-reranker",
+        crossencoder_batch_size=2,
+        crossencoder_revision=revision,
+        crossencoder_trust_remote_code=True,
+    )
+
+    assert pipeline.cross_encoder is wrapper
+    assert calls == [
+        (
+            "vendor/custom-reranker",
+            {
+                "batch_size": 2,
+                "revision": revision,
+                "trust_remote_code": True,
+            },
+        )
+    ]

--- a/test/index/test_reranker_model_loading.py
+++ b/test/index/test_reranker_model_loading.py
@@ -27,6 +27,35 @@ def _install_fake_sentence_transformers(monkeypatch, calls):
     monkeypatch.setitem(sys.modules, "sentence_transformers", module)
 
 
+def _install_legacy_sentence_transformers(monkeypatch, calls):
+    module = ModuleType("sentence_transformers")
+
+    class LegacyCrossEncoder:
+        def __init__(
+            self,
+            model_name,
+            num_labels=None,
+            max_length=None,
+            device=None,
+            tokenizer_args=None,
+            automodel_args=None,
+            default_activation_function=None,
+        ):
+            calls.append(
+                (
+                    model_name,
+                    {
+                        "max_length": max_length,
+                        "device": device,
+                        "automodel_args": automodel_args,
+                    },
+                )
+            )
+
+    module.CrossEncoder = LegacyCrossEncoder
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+
+
 def _install_fake_qwen_dependencies(monkeypatch, tokenizer_calls, model_calls):
     torch_module = ModuleType("torch")
     torch_module.cuda = SimpleNamespace(is_available=lambda: False)
@@ -71,6 +100,53 @@ def test_st_reranker_denies_remote_code_by_default(monkeypatch):
     STCrossEncoderWrapper("vendor/reranker")
 
     assert calls == [("vendor/reranker", {"trust_remote_code": False})]
+
+
+def test_st_reranker_routes_dtype_through_model_kwargs(monkeypatch):
+    calls = []
+    _install_fake_sentence_transformers(monkeypatch, calls)
+
+    STCrossEncoderWrapper("vendor/reranker", torch_dtype="float16")
+
+    assert calls == [
+        (
+            "vendor/reranker",
+            {
+                "trust_remote_code": False,
+                "model_kwargs": {"torch_dtype": "float16"},
+            },
+        )
+    ]
+
+
+def test_st_reranker_supports_legacy_automodel_args(monkeypatch):
+    calls = []
+    _install_legacy_sentence_transformers(monkeypatch, calls)
+
+    STCrossEncoderWrapper(
+        "vendor/reranker",
+        max_length=512,
+        device="cpu",
+        torch_dtype="float16",
+    )
+
+    assert calls == [
+        (
+            "vendor/reranker",
+            {
+                "max_length": 512,
+                "device": "cpu",
+                "automodel_args": {"torch_dtype": "float16"},
+            },
+        )
+    ]
+
+
+def test_st_reranker_rejects_revision_on_legacy_api(monkeypatch):
+    _install_legacy_sentence_transformers(monkeypatch, [])
+
+    with pytest.raises(RuntimeError, match="requested revision"):
+        STCrossEncoderWrapper("vendor/reranker", revision="a" * 40)
 
 
 def test_qwen_reranker_denies_remote_code_by_default(monkeypatch):


### PR DESCRIPTION
## Summary

Default cross-encoder model loading to least privilege and require immutable model identity before executing Hugging Face repository code. Closes #471.

## Changes
- default Sentence-Transformers and Qwen rerankers to `trust_remote_code=False`
- require explicit trust plus a full 40-character commit SHA for remote models while retaining local-directory opt-in
- pass revision and trust policy through lazy `CrossEncoderContext` and eager `RetrieveRerankPipeline` construction
- apply one revision/trust policy to both Qwen tokenizer and model loading
- adapt dtype and identity options across modern and legacy Sentence-Transformers CrossEncoder APIs
- document the boundary and add mocked regressions without downloading weights

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/index/test_reranker_model_loading.py test/ops/test_rerank.py --tb=short` (21 passed)

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (3013 passed, 10 skipped, 180 deselected)

`pre-commit run --files codenib/index/rerank/cross_encoder.py test/index/test_reranker_model_loading.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published