### PR TITLE
fix(vllm): require pinned trusted model code

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -92,7 +92,7 @@ For the SweRankLLM listwise route, serve SweRankLLM-Small through an
 OpenAI-compatible endpoint and run the recipe in a second terminal:
 
 ```bash
-pip install vllm
+pip install "vllm>=0.11.1"
 vllm serve Salesforce/SweRankLLM-Small \
   --revision 5f124b0dd0bb916d5919aa6f81b5b7817f7c991d \
   --served-model-name swerank-llm-small --port 9000

--- a/examples/README.md
+++ b/examples/README.md
@@ -94,6 +94,7 @@ OpenAI-compatible endpoint and run the recipe in a second terminal:
 ```bash
 pip install vllm
 vllm serve Salesforce/SweRankLLM-Small \
+  --revision 5f124b0dd0bb916d5919aa6f81b5b7817f7c991d \
   --served-model-name swerank-llm-small --port 9000
 
 python examples/swerank_retrieve_rerank.py /path/to/repo \

--- a/scripts/start_vllm_server.py
+++ b/scripts/start_vllm_server.py
@@ -13,22 +13,42 @@ Usage:
 """
 
 import argparse
+import re
+import shlex
 import subprocess
 import sys
+from pathlib import Path
+
+_FULL_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
 
 
-def start_vllm_server(
+def _build_vllm_command(
     model: str,
+    *,
     host: str = "localhost",
     port: int = 9000,
-    trust_remote_code: bool = True,
-    max_model_len: int = 4096,
-    gpu_memory_utilization: float = 0.8,
-):
-    """Start vLLM server with OpenAI-compatible API."""
+    revision: str | None = None,
+    code_revision: str | None = None,
+    tokenizer_revision: str | None = None,
+    trust_remote_code: bool = False,
+    max_model_len: int = 16384,
+    gpu_memory_utilization: float = 0.5,
+) -> list[str]:
+    """Build a vLLM command without executing it."""
+    is_local_model = Path(model).expanduser().is_dir()
+    if trust_remote_code and not is_local_model:
+        for option, value in (
+            ("--revision", revision),
+            ("--code-revision", code_revision),
+        ):
+            if not isinstance(value, str) or not _FULL_COMMIT_SHA.fullmatch(value):
+                raise ValueError(
+                    f"{option} must be a full 40-character lowercase commit SHA "
+                    "when trusting remote model code"
+                )
 
     cmd = [
-        "python",
+        sys.executable,
         "-m",
         "vllm.entrypoints.openai.api_server",
         "--model",
@@ -43,11 +63,45 @@ def start_vllm_server(
         str(gpu_memory_utilization),
     ]
 
+    for option, value in (
+        ("--revision", revision),
+        ("--code-revision", code_revision),
+        ("--tokenizer-revision", tokenizer_revision),
+    ):
+        if value:
+            cmd.extend((option, value))
     if trust_remote_code:
         cmd.append("--trust-remote-code")
+    return cmd
 
-    print(f"Starting vLLM server with command:")
-    print(" ".join(cmd))
+
+def start_vllm_server(
+    model: str,
+    host: str = "localhost",
+    port: int = 9000,
+    revision: str | None = None,
+    code_revision: str | None = None,
+    tokenizer_revision: str | None = None,
+    trust_remote_code: bool = False,
+    max_model_len: int = 16384,
+    gpu_memory_utilization: float = 0.5,
+):
+    """Start vLLM server with OpenAI-compatible API."""
+
+    cmd = _build_vllm_command(
+        model,
+        host=host,
+        port=port,
+        revision=revision,
+        code_revision=code_revision,
+        tokenizer_revision=tokenizer_revision,
+        trust_remote_code=trust_remote_code,
+        max_model_len=max_model_len,
+        gpu_memory_utilization=gpu_memory_utilization,
+    )
+
+    print("Starting vLLM server with command:")
+    print(shlex.join(cmd))
     print(f"\nServer will be available at: http://{host}:{port}/v1")
     print(
         "API documentation will be available at: http://{}:{}/docs".format(host, port)
@@ -86,10 +140,27 @@ def main():
         "--gpu-memory-utilization",
         type=float,
         default=0.5,
-        help="GPU memory utilization (default: 0.8)",
+        help="GPU memory utilization (default: 0.5)",
     )
     parser.add_argument(
-        "--no-trust-remote-code", action="store_true", help="Disable trust remote code"
+        "--revision",
+        help="Model revision (use a full commit SHA for reproducible serving)",
+    )
+    parser.add_argument(
+        "--code-revision",
+        help="Custom model-code revision on the Hugging Face Hub",
+    )
+    parser.add_argument(
+        "--tokenizer-revision",
+        help="Tokenizer revision on the Hugging Face Hub",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help=(
+            "Execute Hugging Face model repository code. Remote models require "
+            "full commit SHAs for --revision and --code-revision."
+        ),
     )
 
     args = parser.parse_args()
@@ -98,7 +169,10 @@ def main():
         model=args.model,
         host=args.host,
         port=args.port,
-        trust_remote_code=not args.no_trust_remote_code,
+        revision=args.revision,
+        code_revision=args.code_revision,
+        tokenizer_revision=args.tokenizer_revision,
+        trust_remote_code=args.trust_remote_code,
         max_model_len=args.max_model_len,
         gpu_memory_utilization=args.gpu_memory_utilization,
     )

--- a/scripts/start_vllm_server.py
+++ b/scripts/start_vllm_server.py
@@ -76,6 +76,7 @@ def _build_vllm_command(
         for option, value in (
             ("--revision", revision),
             ("--code-revision", code_revision),
+            ("--tokenizer-revision", tokenizer_revision),
         ):
             if not isinstance(value, str) or not _FULL_COMMIT_SHA.fullmatch(value):
                 raise ValueError(
@@ -196,7 +197,8 @@ def main():
         action="store_true",
         help=(
             "Execute Hugging Face model repository code. Remote models require "
-            "full commit SHAs for --revision and --code-revision."
+            "full commit SHAs for --revision, --code-revision, and "
+            "--tokenizer-revision."
         ),
     )
 

--- a/scripts/start_vllm_server.py
+++ b/scripts/start_vllm_server.py
@@ -17,9 +17,45 @@ import re
 import shlex
 import subprocess
 import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
 from pathlib import Path
 
 _FULL_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+_VLLM_RELEASE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(.*)$")
+# GHSA-8fr4-5q9j-m8gm: trust_remote_code could be bypassed before 0.11.1.
+_MIN_SAFE_VLLM_RELEASE = (0, 11, 1)
+
+
+def _require_safe_vllm_version() -> str:
+    """Reject releases affected by vLLM's remote-code trust bypass."""
+
+    try:
+        installed = package_version("vllm")
+    except PackageNotFoundError as exc:
+        raise RuntimeError("vLLM>=0.11.1 is required to start the server") from exc
+
+    match = _VLLM_RELEASE.fullmatch(installed)
+    if match is None:
+        raise RuntimeError(
+            f"cannot verify installed vLLM version {installed!r}; "
+            "install vLLM>=0.11.1"
+        )
+    release = tuple(int(part) for part in match.groups()[:3])
+    suffix = match.group(4)
+    minimum_prerelease = release == _MIN_SAFE_VLLM_RELEASE and suffix not in (
+        "",
+        "+",
+    )
+    minimum_postrelease = suffix.startswith((".post", "+"))
+    if release < _MIN_SAFE_VLLM_RELEASE or (
+        minimum_prerelease and not minimum_postrelease
+    ):
+        raise RuntimeError(
+            f"vLLM>=0.11.1 is required to enforce remote-code policy; "
+            f"found {installed}"
+        )
+    return installed
 
 
 def _build_vllm_command(
@@ -99,6 +135,7 @@ def start_vllm_server(
         max_model_len=max_model_len,
         gpu_memory_utilization=gpu_memory_utilization,
     )
+    _require_safe_vllm_version()
 
     print("Starting vLLM server with command:")
     print(shlex.join(cmd))

--- a/test/scripts/test_start_vllm_server.py
+++ b/test/scripts/test_start_vllm_server.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from scripts import start_vllm_server as module
+
+
+def test_command_uses_active_interpreter_and_does_not_trust_by_default():
+    command = module._build_vllm_command("vendor/standard-model")
+
+    assert command[:3] == [
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+    ]
+    assert "--trust-remote-code" not in command
+    assert "--revision" not in command
+    assert "--code-revision" not in command
+
+
+@pytest.mark.parametrize(
+    ("revision", "code_revision", "missing_option"),
+    [
+        (None, "b" * 40, "--revision"),
+        ("main", "b" * 40, "--revision"),
+        ("a" * 40, None, "--code-revision"),
+        ("a" * 40, "main", "--code-revision"),
+    ],
+)
+def test_trusted_hub_code_requires_immutable_revisions(
+    revision, code_revision, missing_option
+):
+    with pytest.raises(ValueError, match=missing_option):
+        module._build_vllm_command(
+            "vendor/custom-model",
+            revision=revision,
+            code_revision=code_revision,
+            trust_remote_code=True,
+        )
+
+
+def test_trusted_hub_code_forwards_pinned_revisions():
+    revision = "a" * 40
+    code_revision = "b" * 40
+
+    command = module._build_vllm_command(
+        "vendor/custom-model",
+        revision=revision,
+        code_revision=code_revision,
+        tokenizer_revision="tokenizer-v1",
+        trust_remote_code=True,
+    )
+
+    assert command[command.index("--revision") + 1] == revision
+    assert command[command.index("--code-revision") + 1] == code_revision
+    assert command[command.index("--tokenizer-revision") + 1] == "tokenizer-v1"
+    assert command[-1] == "--trust-remote-code"
+
+
+def test_local_model_can_explicitly_trust_code_without_hub_revisions(tmp_path):
+    model = tmp_path / "local model"
+    model.mkdir()
+
+    command = module._build_vllm_command(
+        str(model),
+        trust_remote_code=True,
+    )
+
+    assert command[command.index("--model") + 1] == str(model)
+    assert command[-1] == "--trust-remote-code"
+
+
+def test_start_runs_the_validated_command(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+
+    module.start_vllm_server(
+        "vendor/standard-model",
+        revision="release-v1",
+    )
+
+    [(args, kwargs)] = calls
+    [command] = args
+    assert command[command.index("--revision") + 1] == "release-v1"
+    assert "--trust-remote-code" not in command
+    assert kwargs == {"check": True}

--- a/test/scripts/test_start_vllm_server.py
+++ b/test/scripts/test_start_vllm_server.py
@@ -26,22 +26,25 @@ def test_command_uses_active_interpreter_and_does_not_trust_by_default():
 
 
 @pytest.mark.parametrize(
-    ("revision", "code_revision", "missing_option"),
+    ("revision", "code_revision", "tokenizer_revision", "missing_option"),
     [
-        (None, "b" * 40, "--revision"),
-        ("main", "b" * 40, "--revision"),
-        ("a" * 40, None, "--code-revision"),
-        ("a" * 40, "main", "--code-revision"),
+        (None, "b" * 40, "c" * 40, "--revision"),
+        ("main", "b" * 40, "c" * 40, "--revision"),
+        ("a" * 40, None, "c" * 40, "--code-revision"),
+        ("a" * 40, "main", "c" * 40, "--code-revision"),
+        ("a" * 40, "b" * 40, None, "--tokenizer-revision"),
+        ("a" * 40, "b" * 40, "main", "--tokenizer-revision"),
     ],
 )
 def test_trusted_hub_code_requires_immutable_revisions(
-    revision, code_revision, missing_option
+    revision, code_revision, tokenizer_revision, missing_option
 ):
     with pytest.raises(ValueError, match=missing_option):
         module._build_vllm_command(
             "vendor/custom-model",
             revision=revision,
             code_revision=code_revision,
+            tokenizer_revision=tokenizer_revision,
             trust_remote_code=True,
         )
 
@@ -49,18 +52,19 @@ def test_trusted_hub_code_requires_immutable_revisions(
 def test_trusted_hub_code_forwards_pinned_revisions():
     revision = "a" * 40
     code_revision = "b" * 40
+    tokenizer_revision = "c" * 40
 
     command = module._build_vllm_command(
         "vendor/custom-model",
         revision=revision,
         code_revision=code_revision,
-        tokenizer_revision="tokenizer-v1",
+        tokenizer_revision=tokenizer_revision,
         trust_remote_code=True,
     )
 
     assert command[command.index("--revision") + 1] == revision
     assert command[command.index("--code-revision") + 1] == code_revision
-    assert command[command.index("--tokenizer-revision") + 1] == "tokenizer-v1"
+    assert command[command.index("--tokenizer-revision") + 1] == tokenizer_revision
     assert command[-1] == "--trust-remote-code"
 
 

--- a/test/scripts/test_start_vllm_server.py
+++ b/test/scripts/test_start_vllm_server.py
@@ -77,8 +77,34 @@ def test_local_model_can_explicitly_trust_code_without_hub_revisions(tmp_path):
     assert command[-1] == "--trust-remote-code"
 
 
+@pytest.mark.parametrize("version", ["0.10.2", "0.11.0", "0.11.1rc1"])
+def test_unsafe_vllm_versions_are_rejected(monkeypatch, version):
+    monkeypatch.setattr(module, "package_version", lambda _package: version)
+
+    with pytest.raises(RuntimeError, match="vLLM>=0.11.1"):
+        module._require_safe_vllm_version()
+
+
+@pytest.mark.parametrize("version", ["0.11.1", "0.11.1.post1", "0.12.0.dev1"])
+def test_patched_vllm_versions_are_accepted(monkeypatch, version):
+    monkeypatch.setattr(module, "package_version", lambda _package: version)
+
+    assert module._require_safe_vllm_version() == version
+
+
+def test_missing_vllm_has_actionable_error(monkeypatch):
+    def missing(_package):
+        raise module.PackageNotFoundError
+
+    monkeypatch.setattr(module, "package_version", missing)
+
+    with pytest.raises(RuntimeError, match="vLLM>=0.11.1 is required"):
+        module._require_safe_vllm_version()
+
+
 def test_start_runs_the_validated_command(monkeypatch):
     calls = []
+    monkeypatch.setattr(module, "_require_safe_vllm_version", lambda: "0.11.1")
     monkeypatch.setattr(
         subprocess, "run", lambda *args, **kwargs: calls.append((args, kwargs))
     )


### PR DESCRIPTION
## Summary

Make CodeNib's vLLM launcher preserve a default-deny remote-code boundary, require immutable trusted Hub launches, and reject vLLM releases where that boundary can be bypassed. Closes #475.

## Changes
- default remote model code execution to disabled and require full model, code, and tokenizer commit SHAs before opt-in
- forward model, code, and tokenizer revisions while launching through the active Python interpreter
- reject vLLM releases older than 0.11.1, which are affected by GHSA-8fr4-5q9j-m8gm
- pin the documented SweRankLLM-Small serving recipe to the verified Hub revision
- add command-construction and installed-version coverage for untrusted, pinned remote, and local model paths

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/scripts/test_start_vllm_server.py --tb=short` (17 passed)

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (3030 passed, 10 skipped, 180 deselected)

`pre-commit run --files scripts/start_vllm_server.py test/scripts/test_start_vllm_server.py examples/README.md`

The pinned SweRankLLM-Small revision was verified against the current Hub `main` ref.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published