### PR TITLE
fix(claude): enforce read-only localization tools

### DIFF
--- a/codenib/clients/claude_agent.py
+++ b/codenib/clients/claude_agent.py
@@ -12,6 +12,7 @@ without making any modifications.
 """
 
 import asyncio
+import inspect
 import json
 import os
 import re
@@ -22,6 +23,59 @@ from typing import Any, Dict, List, Optional
 from claude_agent_sdk import ClaudeAgentOptions, query
 
 from ..log_utils import get_logger
+
+_READ_ONLY_TOOLS = ("Read", "Glob", "Grep")
+_DISALLOWED_TOOLS = (
+    "Bash",
+    "Edit",
+    "MultiEdit",
+    "NotebookEdit",
+    "Task",
+    "WebFetch",
+    "WebSearch",
+    "Write",
+)
+_SAFE_PERMISSION_MODES = frozenset({"default", "dontAsk"})
+_REQUIRED_SDK_OPTIONS = frozenset(
+    {
+        "agents",
+        "allowed_tools",
+        "disallowed_tools",
+        "mcp_servers",
+        "permission_mode",
+        "plugins",
+        "setting_sources",
+        "skills",
+        "strict_mcp_config",
+        "tools",
+    }
+)
+
+
+def _require_read_only_sdk_options() -> None:
+    """Fail closed when the installed SDK cannot enforce session isolation."""
+    try:
+        parameters = inspect.signature(ClaudeAgentOptions).parameters
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "Cannot verify that the installed claude-agent-sdk supports "
+            "CodeNib's read-only session isolation; upgrade claude-agent-sdk"
+        ) from exc
+
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    ):
+        return
+
+    missing = sorted(_REQUIRED_SDK_OPTIONS.difference(parameters))
+    if missing:
+        raise RuntimeError(
+            "Installed claude-agent-sdk cannot enforce CodeNib's read-only "
+            "session isolation; upgrade claude-agent-sdk "
+            f"(missing options: {', '.join(missing)})"
+        )
+
 
 # Canonical chunker-format rules for the `name` field. Shared with
 # codex_agent so both system prompts derive from a single source of truth.
@@ -152,9 +206,37 @@ class ClaudeLocAgent:
         max_turns: int = 100,
         system_prompt: Optional[str] = None,
         allowed_tools: Optional[List[str]] = None,
-        permission_mode: str = "bypassPermissions",
+        permission_mode: str = "dontAsk",
         model: str = "sonnet",
     ):
+        if (
+            not isinstance(max_turns, int)
+            or isinstance(max_turns, bool)
+            or max_turns <= 0
+        ):
+            raise ValueError("max_turns must be a positive integer")
+        requested_tools = list(
+            _READ_ONLY_TOOLS if allowed_tools is None else allowed_tools
+        )
+        unsupported = sorted(
+            {
+                str(tool)
+                for tool in requested_tools
+                if not isinstance(tool, str) or tool not in _READ_ONLY_TOOLS
+            }
+        )
+        if unsupported:
+            raise ValueError(
+                "ClaudeLocAgent supports only read-only tools: "
+                + ", ".join(_READ_ONLY_TOOLS)
+                + f"; rejected: {', '.join(unsupported)}"
+            )
+        if permission_mode not in _SAFE_PERMISSION_MODES:
+            raise ValueError(
+                "ClaudeLocAgent permission_mode must be 'default' or 'dontAsk'"
+            )
+        _require_read_only_sdk_options()
+
         self.logger = get_logger(__name__)
         self.max_turns = max_turns
         self.permission_mode = permission_mode
@@ -166,8 +248,7 @@ class ClaudeLocAgent:
             "that are relevant to a given issue or query.\n\n"
             "CRITICAL RULES:\n"
             "- You are a READ-ONLY agent. DO NOT modify, create, or delete any files.\n"
-            "- Thoroughly explore the codebase using the available tools (Read, Glob, "
-            "Grep, Bash for git commands, etc.).\n"
+            "- Thoroughly explore the codebase using Read, Glob, and Grep.\n"
             "- Trace through call chains, imports, and dependencies to find ALL "
             "relevant locations.\n"
             "- For each relevant symbol (function, class, method, field, etc.), "
@@ -196,14 +277,7 @@ class ClaudeLocAgent:
             "than continuing to explore.\n"
         )
 
-        # Read-only tool set — no Edit/Write/NotebookEdit
-        self.allowed_tools = allowed_tools or [
-            "Task",
-            "Bash",
-            "Glob",
-            "Grep",
-            "Read",
-        ]
+        self.allowed_tools = requested_tools
 
     async def locate_code(
         self,
@@ -237,9 +311,17 @@ class ClaudeLocAgent:
                 max_turns=self.max_turns,
                 system_prompt=self.system_prompt,
                 cwd=Path(repo_path),
+                tools=self.allowed_tools,
                 allowed_tools=self.allowed_tools,
+                disallowed_tools=list(_DISALLOWED_TOOLS),
                 permission_mode=self.permission_mode,
                 model=self.model,
+                setting_sources=[],
+                skills=[],
+                plugins=[],
+                agents={},
+                mcp_servers={},
+                strict_mcp_config=True,
                 output_format={
                     "type": "json_schema",
                     "schema": LOC_OUTPUT_SCHEMA,
@@ -291,9 +373,18 @@ class ClaudeLocAgent:
 
             # Log usage summary
             if usage_info:
+                cost_usd = usage_info["total_cost_usd"]
+                try:
+                    cost_text = (
+                        f"${float(cost_usd):.4f}"
+                        if cost_usd is not None
+                        else "unavailable"
+                    )
+                except (TypeError, ValueError):
+                    cost_text = "unavailable"
                 self.logger.info(
                     f"Usage: turns={usage_info['num_turns']}, "
-                    f"cost=${usage_info['total_cost_usd']:.4f}, "
+                    f"cost={cost_text}, "
                     f"input={usage_info['input_tokens']}, "
                     f"cache_read={usage_info['cache_read_input_tokens']}, "
                     f"cache_create={usage_info['cache_creation_input_tokens']}, "

--- a/test/clients/test_claude_agent.py
+++ b/test/clients/test_claude_agent.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def claude_module(monkeypatch):
+    calls = SimpleNamespace(options=None, prompt=None, total_cost_usd=0.01)
+    sdk = ModuleType("claude_agent_sdk")
+
+    class ClaudeAgentOptions:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class ResultMessage:
+        structured_output = {
+            "locations": [
+                {
+                    "name": "target()",
+                    "type": "function",
+                    "file_path": "module.py",
+                    "line_start": 1,
+                    "line_end": 2,
+                    "action": "modify",
+                    "description": "Relevant implementation",
+                }
+            ]
+        }
+        result = None
+        usage = {"input_tokens": 10, "output_tokens": 2}
+        num_turns = 1
+        total_cost_usd = 0.01
+        duration_ms = 20
+
+    async def query(*, prompt, options):
+        calls.prompt = prompt
+        calls.options = options
+        message = ResultMessage()
+        message.total_cost_usd = calls.total_cost_usd
+        yield message
+
+    sdk.ClaudeAgentOptions = ClaudeAgentOptions
+    sdk.query = query
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", sdk)
+    sys.modules.pop("codenib.clients.claude_agent", None)
+    module = importlib.import_module("codenib.clients.claude_agent")
+    try:
+        yield module, calls
+    finally:
+        sys.modules.pop("codenib.clients.claude_agent", None)
+
+
+def test_default_session_exposes_only_read_only_tools(claude_module, tmp_path):
+    module, calls = claude_module
+    agent = module.ClaudeLocAgent(max_turns=2)
+
+    result = asyncio.run(agent.locate_code("find target", str(tmp_path)))
+
+    assert result.success is True
+    assert [location.name for location in result.locations] == ["target()"]
+    options = calls.options
+    assert options.tools == ["Read", "Glob", "Grep"]
+    assert options.allowed_tools == options.tools
+    assert options.permission_mode == "dontAsk"
+    assert {
+        "Bash",
+        "Edit",
+        "MultiEdit",
+        "NotebookEdit",
+        "Task",
+        "WebFetch",
+        "WebSearch",
+        "Write",
+    } <= set(options.disallowed_tools)
+
+
+def test_session_ignores_external_extensions(claude_module, tmp_path):
+    module, calls = claude_module
+    agent = module.ClaudeLocAgent(allowed_tools=["Read"])
+
+    asyncio.run(agent.locate_code("find target", str(tmp_path)))
+
+    options = calls.options
+    assert options.tools == ["Read"]
+    assert options.setting_sources == []
+    assert options.skills == []
+    assert options.plugins == []
+    assert options.agents == {}
+    assert options.mcp_servers == {}
+    assert options.strict_mcp_config is True
+
+
+def test_constructor_rejects_sdk_without_isolation_options(claude_module):
+    module, _calls = claude_module
+
+    class LegacyClaudeAgentOptions:
+        __slots__ = ("allowed_tools", "permission_mode")
+
+        def __init__(self, *, allowed_tools, permission_mode):
+            self.allowed_tools = allowed_tools
+            self.permission_mode = permission_mode
+
+    module.ClaudeAgentOptions = LegacyClaudeAgentOptions
+
+    with pytest.raises(RuntimeError, match="cannot enforce.*read-only"):
+        module.ClaudeLocAgent()
+
+
+def test_missing_cost_does_not_discard_successful_result(claude_module, tmp_path):
+    module, calls = claude_module
+    calls.total_cost_usd = None
+
+    result = asyncio.run(
+        module.ClaudeLocAgent().locate_code("find target", str(tmp_path))
+    )
+
+    assert result.success is True
+    assert result.usage["total_cost_usd"] is None
+
+
+@pytest.mark.parametrize(
+    "tool",
+    ["Bash", "Task", "Write", "Edit", "NotebookEdit", "mcp__custom__read"],
+)
+def test_constructor_rejects_tools_outside_the_read_only_contract(claude_module, tool):
+    module, _calls = claude_module
+
+    with pytest.raises(ValueError, match="supports only read-only tools"):
+        module.ClaudeLocAgent(allowed_tools=["Read", tool])
+
+
+@pytest.mark.parametrize("permission_mode", ["bypassPermissions", "acceptEdits"])
+def test_constructor_rejects_unsafe_permission_modes(claude_module, permission_mode):
+    module, _calls = claude_module
+
+    with pytest.raises(ValueError, match="permission_mode"):
+        module.ClaudeLocAgent(permission_mode=permission_mode)
+
+
+@pytest.mark.parametrize("max_turns", [0, -1, True])
+def test_constructor_rejects_invalid_turn_limits(claude_module, max_turns):
+    module, _calls = claude_module
+
+    with pytest.raises(ValueError, match="max_turns"):
+        module.ClaudeLocAgent(max_turns=max_turns)


### PR DESCRIPTION
## Summary\n\nEnforce the documented read-only boundary in the Claude localization client. The Claude Agent SDK treats  as an auto-approval list rather than a tool-availability allowlist, so the previous defaults still exposed mutating tools and loaded external settings.\n\nCloses #479.\n\n## Changes\n\n- expose only the built-in , , and  tools\n- explicitly deny mutating, shell, delegation, and network tools\n- disable project/user settings, skills, plugins, agents, and MCP servers\n- fail closed when the installed SDK lacks required isolation options\n- reject unsafe permission modes, unsupported tools, and invalid turn limits\n- preserve successful results when the SDK omits cost metadata\n- add regression coverage for the exact SDK option contract and structured result path\n\n## Type of Change\n\n- [x] Bug fix\n- [ ] New feature\n- [ ] Breaking change\n- [ ] Documentation update\n- [x] Security hardening\n\n## Testing\n\n- ...............                                                          [100%]
15 passed in 0.07s (15 passed)\n- ============================= test session starts ==============================
platform linux -- Python 3.11.5, pytest-7.4.0, pluggy-1.6.0
rootdir: /mnt/data/zhongming/codenib-claude-readonly
configfile: pyproject.toml
testpaths: test
plugins: anyio-4.14.2, xdist-3.8.0, timeout-2.4.0, cov-7.0.0, langsmith-0.4.13
collected 3217 items / 180 deselected / 1 skipped / 3037 selected

test/test_atomic_directory.py ...                                        [  0%]
test/test_ci_policy.py ...............                                   [  0%]
test/test_cli.py ....................................................... [  2%]
.....                                                                    [  2%]
test/test_cli_entrypoints.py ................                            [  3%]
test/test_cli_remote_embeddings.py .                                     [  3%]
test/test_compat_pickle.py ....                                          [  3%]
test/test_context_delivery.py .....                                      [  3%]
test/test_git_snapshot.py .....                                          [  3%]
test/test_language_capability_matrix.py .                                [  3%]
test/test_languages.py .............                                     [  4%]
test/test_lazy_imports.py ....                                           [  4%]
test/test_log_utils.py .                                                 [  4%]
test/test_ls_router_registry.py ........................................ [  5%]
...................                                                      [  6%]
test/test_mcp_registry.py ....                                           [  6%]
test/test_namespace.py .....                                             [  6%]
test/test_namespace_contract.py ...                                      [  6%]
test/test_paths.py ......                                                [  6%]
test/test_provider_routes.py ...........................                 [  7%]
test/test_release_artifacts.py .............                             [  8%]
test/test_release_metadata.py ....                                       [  8%]
test/test_repository_summary.py .......                                  [  8%]
test/test_search.py .............                                        [  8%]
test/test_source_classification.py ........                              [  9%]
test/test_source_fingerprint.py .....                                    [  9%]
test/test_toolchains.py .....................                            [  9%]
test/actions/test_publish_action.py ...............                      [ 10%]
test/agent/test_bm25_search_skill.py .....                               [ 10%]
test/agent/test_boundary.py ................................             [ 11%]
test/agent/test_codenib_context.py ....                                  [ 11%]
test/agent/test_compile.py ............................................. [ 13%]
..................                                                       [ 13%]
test/agent/test_compile_runtime.py ........                              [ 14%]
test/agent/test_context_ledger.py ...                                    [ 14%]
test/agent/test_default_tools.py ....................................... [ 15%]
...............                                                          [ 16%]
test/agent/test_embedding_search_skill.py ....                           [ 16%]
test/agent/test_graph_nav.py ............                                [ 16%]
test/agent/test_harness_spec.py ..........                               [ 16%]
test/agent/test_history.py ................                              [ 17%]
test/agent/test_import_boundaries.py ....                                [ 17%]
test/agent/test_lsp_graph.py ..............                              [ 18%]
test/agent/test_lsp_provider.py ......                                   [ 18%]
test/agent/test_query.py ............                                    [ 18%]
test/agent/test_query_manifest.py ..........                             [ 18%]
test/agent/test_repository_search.py ...............                     [ 19%]
test/agent/test_route_context.py .........                               [ 19%]
test/agent/test_runner.py ........................                       [ 20%]
test/agent/test_runner_allow_skills.py ...................               [ 21%]
test/agent/test_runner_env_prompt.py ...                                 [ 21%]
test/agent/test_runner_history_retry.py .....                            [ 21%]
test/agent/test_runner_lsp_route_context.py ......                       [ 21%]
test/agent/test_runner_sandbox.py ................                       [ 22%]
test/agent/test_runner_usage.py .................                        [ 22%]
test/agent/test_runtime_trace.py .....                                   [ 22%]
test/agent/test_tool_schema.py .....................                     [ 23%]
test/agent/test_typecheck.py ..........                                  [ 23%]
test/agent_compile/test_aggregate_compact_results.py ...                 [ 23%]
test/agent_compile/test_aggregate_honest_cli.py .                        [ 24%]
test/agent_compile/test_aggregate_synthesis.py .                         [ 24%]
test/agent_compile/test_compat_shims.py ..                               [ 24%]
test/agent_compile/test_config.py ...                                    [ 24%]
test/agent_compile/test_feedback_summary_cli.py .                        [ 24%]
test/agent_compile/test_pareto_ci_cli.py .                               [ 24%]
test/artifacts/test_context_artifact.py .................                [ 24%]
test/artifacts/test_publish.py ........                                  [ 25%]
test/artifacts/test_runtime.py ........................                  [ 25%]
test/chunker/test_base_chunker.py .....                                  [ 26%]
test/chunker/test_chunker_registry.py ....................               [ 26%]
test/chunker/test_csharp_chunker.py ....                                 [ 26%]
test/chunker/test_java_chunker.py ....                                   [ 26%]
test/chunker/test_kotlin_chunker.py ....                                 [ 27%]
test/chunker/test_lua_chunker.py ...                                     [ 27%]
test/chunker/test_php_chunker.py ....                                    [ 27%]
test/chunker/test_repo_chunking_config.py .......                        [ 27%]
test/chunker/test_ruby_chunker.py ....                                   [ 27%]
test/chunker/test_scala_chunker.py ....                                  [ 27%]
test/chunker/test_swift_chunker.py ....                                  [ 27%]
test/clients/test_claude_agent.py ...............                        [ 28%]
test/clients/test_execution.py ............                              [ 28%]
test/clients/test_guardian.py ......                                     [ 29%]
test/clients/test_guardian_exchange.py ...                               [ 29%]
test/compiler/test_artifact_fingerprints.py ....                         [ 29%]
test/compiler/test_artifact_quality.py .....                             [ 29%]
test/compiler/test_checkout_identity.py ..                               [ 29%]
test/compiler/test_index_compiler.py ................................... [ 30%]
.............................................                            [ 32%]
test/compiler/test_manifest.py ........................                  [ 32%]
test/compiler/test_params.py ................                            [ 33%]
test/compiler/test_resources.py ................                         [ 33%]
test/compiler/test_skill_context.py .................................... [ 35%]
..                                                                       [ 35%]
test/compiler/test_skill_loader.py ..............                        [ 35%]
test/compiler/test_snapshot_store.py ......                              [ 35%]
test/dataset/test_codenib_synthesis.py .....                             [ 36%]
test/dataset/test_gt_locate.py .................................         [ 37%]
test/dataset/test_synthesis_query_cleanup.py ...........                 [ 37%]
test/dataset/test_synthesis_span_resolution.py ....                      [ 37%]
test/dataset/test_synthesize_vocab_guard.py .............                [ 38%]
test/eval/test_agent_contexts.py ....                                    [ 38%]
test/eval/test_agent_metrics.py ....                                     [ 38%]
test/eval/test_agent_pareto.py .                                         [ 38%]
test/eval/test_agent_results.py ..                                       [ 38%]
test/eval/test_agent_scoring.py ...                                      [ 38%]
test/eval/test_artifact_bundle.py .......                                [ 38%]
test/eval/test_baseline.py ........                                      [ 39%]
test/eval/test_baseline_batch.py ...                                     [ 39%]
test/eval/test_cost_arm_report.py .......                                [ 39%]
test/eval/test_deepswe_benchmark.py .....                                [ 39%]
test/eval/test_feedback_plan.py .....                                    [ 39%]
test/eval/test_feedback_summary.py ...                                   [ 39%]
test/eval/test_format_diagnostics.py ..                                  [ 39%]
test/eval/test_live_lsp_provider.py ........                             [ 40%]
test/eval/test_locagent_benchmark_adapter.py ........                    [ 40%]
test/eval/test_lsp_agent_ab.py .....                                     [ 40%]
test/eval/test_lsp_agent_study.py ...........                            [ 40%]
test/eval/test_lsp_agent_study_runner.py .....                           [ 41%]
test/eval/test_lsp_baseline.py ......                                    [ 41%]
test/eval/test_lsp_latency.py .                                          [ 41%]
test/eval/test_lsp_provider_cli.py ....                                  [ 41%]
test/eval/test_lsp_provider_validation.py .....                          [ 41%]
test/eval/test_lsp_replay_benchmark.py .......                           [ 41%]
test/eval/test_orcaloca_benchmark_adapter.py .........                   [ 42%]
test/eval/test_orcaloca_metrics.py .........                             [ 42%]
test/eval/test_orchestrator.py ......                                    [ 42%]
test/eval/test_policy_benchmark.py .............                         [ 43%]
test/eval/test_policy_compat.py ............                             [ 43%]
test/eval/test_prebuilt.py ................                              [ 43%]
test/eval/test_preload.py .......                                        [ 44%]
test/eval/test_pricing.py ......                                         [ 44%]
test/eval/test_promotion.py ......                                       [ 44%]
test/eval/test_quality_cost_report.py .............                      [ 45%]
test/eval/test_query_sweep.py ...........                                [ 45%]
test/eval/test_span_localization.py ........................             [ 46%]
test/eval/test_swe_explore_benchmark.py ........                         [ 46%]
test/eval/test_swe_explore_runner.py .......                             [ 46%]
test/eval/test_swebench_policy_cases.py ...............                  [ 47%]
test/eval/test_sweep.py .......                                          [ 47%]
test/eval/test_trace_summary.py .....                                    [ 47%]
test/eval/test_verify_expand.py .........                                [ 47%]
test/examples/test_experiment_runner.py ......................           [ 48%]
test/examples/test_graph_retrieve_baseline.py .......................... [ 49%]
.................................                                        [ 50%]
test/examples/test_swerank_retrieve_rerank.py ...........                [ 50%]
test/graph/test_anchor_invariants.py ..                                  [ 50%]
test/graph/test_backend_alignment.py .....                               [ 51%]
test/graph/test_codegraph_content.py .                                   [ 51%]
test/graph/test_codegraph_merge.py ..                                    [ 51%]
test/graph/test_dependency.py ...........                                [ 51%]
test/graph/test_hierarchy.py ....                                        [ 51%]
test/graph/test_layers.py ........s                                      [ 51%]
test/graph/test_range_queries.py ...................                     [ 52%]
test/graph/test_range_query_api.py .................                     [ 53%]
test/graph/test_setup.py .........                                       [ 53%]
test/graph/test_source_coverage.py ...                                   [ 53%]
test/graph/test_traverse_test_filter.py ...                              [ 53%]
test/graph/test_typed_adjacency.py .                                     [ 53%]
test/graph/incremental/test_document_symbol_readiness.py ...             [ 53%]
test/graph/incremental/test_graph_patcher_registry.py .................. [ 54%]
............                                                             [ 54%]
test/graph/incremental/test_lsp_decoder.py .........................     [ 55%]
test/graph/incremental/test_patcher_commit_context.py ..                 [ 55%]
test/graph/incremental/test_patcher_multiedge.py ....................... [ 56%]
..                                                                       [ 56%]
test/graph/incremental/test_reference_resolver.py .........              [ 56%]
test/graph/incremental/test_subgraph_mgr.py .                            [ 56%]
test/graph/incremental/test_subgraph_removal.py ...............          [ 57%]
test/guardian/deepswe/test_ablation.py ...........                       [ 57%]
test/guardian/deepswe/test_checkpoint.py .......                         [ 57%]
test/guardian/deepswe/test_controller.py ...                             [ 58%]
test/guardian/deepswe/test_message.py .                                  [ 58%]
test/guardian/deepswe/test_solo_matrix.py .........                      [ 58%]
test/index/test_embedding_builders.py .                                  [ 58%]
test/index/test_embedding_model_policy.py ....                           [ 58%]
test/index/test_regex_idx_unit.py .                                      [ 58%]
test/index/test_reranker_model_loading.py .............                  [ 58%]
test/index/test_vector_artifact_identity.py ....                         [ 59%]
test/index/test_vector_store_candidate_search.py ........                [ 59%]
test/index/test_vector_store_ivf.py ........................             [ 60%]
test/index/incremental/test_cache_seeding.py .....                       [ 60%]
test/index/incremental/test_chunk_store.py .................             [ 60%]
test/index/incremental/test_delta_faiss.py .......                       [ 61%]
test/index/incremental/test_embeddings_cache.py ........................ [ 61%]
                                                                         [ 61%]
test/index/incremental/test_git_diff.py ...........                      [ 62%]
test/index/incremental/test_incremental_pipeline.py .........            [ 62%]
test/index/incremental/test_l0_incremental.py .......                    [ 62%]
test/index/incremental/test_persistence_migration.py ...........         [ 63%]
test/index/incremental/test_state.py .......                             [ 63%]
test/index/sparse_idx/test_bm25_chunk_metadata.py ...                    [ 63%]
test/index/sparse_idx/test_bm25_chunk_spans.py ..                        [ 63%]
test/index/sparse_idx/test_bm25_identifier_occurrences.py ...            [ 63%]
test/index/sparse_idx/test_bm25_unified_name.py .....                    [ 63%]
test/integrations/test_agentless.py ..........                           [ 64%]
test/integrations/test_agentless_policy.py ......................        [ 64%]
test/integrations/test_cosil.py .............                            [ 65%]
test/integrations/test_cosil_policy.py ............                      [ 65%]
test/integrations/test_locagent.py .........................             [ 66%]
test/integrations/test_orcaloca.py ................                      [ 67%]
test/integrations/test_swe_explore.py .............                      [ 67%]
test/llm/test_diagnostics.py .......                                     [ 67%]
test/llm/test_litellm_retry.py ....................                      [ 68%]
test/llm/test_options.py .......                                         [ 68%]
test/llm/test_prompt_caching.py .........                                [ 68%]
test/llm/test_structured_output.py ....                                  [ 69%]
test/ls_index/test_clangd_progress_reader.py .......                     [ 69%]
test/ls_index/test_index_quality.py ........                             [ 69%]
test/ls_index/test_lsp_indexer.py ..............                         [ 69%]
test/mcp/test_mcp_server.py ..............                               [ 70%]
test/mcp/test_search_semantic.py ..........                              [ 70%]
test/mcp_server/test_context.py .......................                  [ 71%]
test/mcp_server/test_dependency_tool.py .........                        [ 71%]
test/mcp_server/test_integration.py ......                               [ 72%]
test/mcp_server/test_server.py ..........                                [ 72%]
test/mcp_server/test_source_tool.py ..............                       [ 72%]
test/mcp_server/test_tools_search.py ................................... [ 73%]
...                                                                      [ 74%]
test/mcp_server/test_zoekt_integration.py sssssss                        [ 74%]
test/mcp_server/test_zoekt_searcher.py ............                      [ 74%]
test/model/test_agentless_pipeline.py .                                  [ 74%]
test/model/test_graph_augmented_rerank_pipeline.py .........             [ 75%]
test/model/test_retrieval_planner.py ...........                         [ 75%]
test/model/test_retrieve_pipeline_indexer_routing.py ....                [ 75%]
test/ops/test_expand.py ...............                                  [ 75%]
test/ops/test_filter.py .....                                            [ 76%]
test/ops/test_rerank.py ........                                         [ 76%]
test/ops/test_retrieve.py .......                                        [ 76%]
test/sandbox/test_contract.py ................................           [ 77%]
test/sandbox/test_docker.py ...........................                  [ 78%]
test/scip/test_lsp_occurrence_index.py ....                              [ 78%]
test/scip/test_scip_core_registry.py .s.                                 [ 78%]
test/scip/test_scip_csharp.py ....                                       [ 78%]
test/scip/test_scip_decode_rust.py ..                                    [ 79%]
test/scip/test_scip_decode_ts_schema_v5.py .........                     [ 79%]
test/scip/test_scip_decode_utils.py ...                                  [ 79%]
test/scip/test_scip_java.py ..............                               [ 79%]
test/scip/test_scip_php.py ...........                                   [ 80%]
test/scip/test_scip_python_runtime.py ...................                [ 80%]
test/scip/test_scip_ruby.py .............                                [ 81%]
test/scip/test_scip_typescript_runtime.py ..                             [ 81%]
test/scripts/test_aggregate_lsp_replay.py .                              [ 81%]
test/scripts/test_analyze_semantic_service_break_even.py .               [ 81%]
test/scripts/test_analyze_snapshot_reuse.py .                            [ 81%]
test/scripts/test_check_ask_retrieval.py ..                              [ 81%]
test/scripts/test_check_public_docs.py ..............                    [ 81%]
test/scripts/test_graph_route_alignment.py ...                           [ 82%]
test/scripts/test_graphrag_retrieve.py ..                                [ 82%]
test/scripts/test_index_repo.py ....                                     [ 82%]
test/scripts/test_lsp_graph_smoke.py .............                       [ 82%]
test/scripts/test_profile_graph_layers.py ....                           [ 82%]
test/scripts/test_profile_incremental_graph.py ......................... [ 83%]
..................                                                       [ 84%]
test/scripts/test_profile_large_scip_repos.py .........                  [ 84%]
test/scripts/test_profile_lsp_graph_decode.py .                          [ 84%]
test/scripts/test_scaffold_language.py .........                         [ 84%]
test/scripts/test_scip_cold_start_smoke.py ....................          [ 85%]
test/scripts/test_smoke_release_agent.py ..                              [ 85%]
test/scripts/test_smoke_release_upgrade.py ..                            [ 85%]
test/scripts/test_snapshot_artifact_builders.py ...............          [ 86%]
test/web/test_app_runtime.py ..........                                  [ 86%]
test/web/test_codemap.py ................                                [ 87%]
test/web/test_commit_window.py .................................         [ 88%]
test/web/test_config.py .                                                [ 88%]
test/web/test_edge_label.py .................                            [ 88%]
test/web/test_entrypoints.py .........                                   [ 89%]
test/web/test_modulemap.py .............                                 [ 89%]
test/web/test_ports.py .............                                     [ 89%]
test/web/test_repo_registry.py ................................          [ 90%]
test/web/test_repository_files.py ...                                    [ 91%]
test/web/test_request_limits.py .....                                    [ 91%]
test/web/test_schemas.py .................                               [ 91%]
test/web/test_static_export.py ...................                       [ 92%]
test/web/test_static_server.py ...........                               [ 92%]
test/wiki/test_agent_wiki.py ........................................... [ 94%]
..............................................................           [ 96%]
test/wiki/test_builder.py ...................                            [ 96%]
test/wiki/test_evidence.py ............................................. [ 98%]
                                                                         [ 98%]
test/wiki/test_outline.py ...................                            [ 98%]
test/wiki/test_quality.py .................................              [100%]

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

<frozen importlib._bootstrap>:241
  <frozen importlib._bootstrap>:241: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======== 3028 passed, 10 skipped, 180 deselected, 3 warnings in 38.04s ========= (3028 passed, 10 skipped, 180 deselected)\n- \n- \n- \n\n## Checklist\n\n- [x] My code follows the project's style guidelines\n- [x] I have performed a self-review\n- [x] I have added tests that prove the fix\n- [x] New and existing unit tests pass locally\n- [x] The change is scoped to the affected client and its tests