### PR TITLE
fix(codex): pin read-only localization sandbox

### DIFF
--- a/codenib/clients/codex_agent.py
+++ b/codenib/clients/codex_agent.py
@@ -66,6 +66,8 @@ _DEFAULT_SYSTEM_PROMPT = (
     "output_schema (a `locations` array of symbol objects).\n"
 )
 
+_REASONING_EFFORTS = frozenset({"minimal", "low", "medium", "high"})
+
 
 class CodexLocAgent:
     """
@@ -85,6 +87,16 @@ class CodexLocAgent:
         sandbox: SandboxMode = SandboxMode.read_only,
         reasoning_effort: str = "medium",
     ):
+        if sandbox is not SandboxMode.read_only:
+            raise ValueError("CodexLocAgent sandbox must be SandboxMode.read_only")
+        if approval_mode is not ApprovalMode.deny_all:
+            raise ValueError(
+                "CodexLocAgent approval_mode must be ApprovalMode.deny_all"
+            )
+        if reasoning_effort not in _REASONING_EFFORTS:
+            supported = ", ".join(sorted(_REASONING_EFFORTS))
+            raise ValueError(f"reasoning_effort must be one of: {supported}")
+
         self.logger = get_logger(__name__)
         self.model = model
         self.system_prompt = system_prompt or _DEFAULT_SYSTEM_PROMPT

--- a/codenib/clients/codex_agent.py
+++ b/codenib/clients/codex_agent.py
@@ -28,7 +28,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from openai_codex import ApprovalMode, AsyncCodex
-from openai_codex.types import SandboxMode
+from openai_codex.types import ReasoningEffort, SandboxMode
 
 from ..log_utils import get_logger
 from .claude_agent import (
@@ -66,7 +66,7 @@ _DEFAULT_SYSTEM_PROMPT = (
     "output_schema (a `locations` array of symbol objects).\n"
 )
 
-_REASONING_EFFORTS = frozenset({"minimal", "low", "medium", "high"})
+_REASONING_EFFORTS = frozenset(effort.value for effort in ReasoningEffort)
 
 
 class CodexLocAgent:

--- a/examples/codex_loc_agent.py
+++ b/examples/codex_loc_agent.py
@@ -68,8 +68,10 @@ def parse_args():
         "--reasoning-effort",
         type=str,
         default="medium",
-        choices=["minimal", "low", "medium", "high"],
-        help="model_reasoning_effort passed to openai_codex thread config.",
+        help=(
+            "model_reasoning_effort passed to openai_codex; supported values "
+            "are validated against the installed SDK."
+        ),
     )
     return parser.parse_args()
 

--- a/test/clients/test_codex_agent.py
+++ b/test/clients/test_codex_agent.py
@@ -35,6 +35,14 @@ def codex_module(monkeypatch):
         workspace_write = "workspace-write"
         danger_full_access = "danger-full-access"
 
+    class ReasoningEffort(Enum):
+        none = "none"
+        minimal = "minimal"
+        low = "low"
+        medium = "medium"
+        high = "high"
+        xhigh = "xhigh"
+
     class Thread:
         async def run(self, prompt, *, output_schema):
             calls.prompt = prompt
@@ -74,6 +82,7 @@ def codex_module(monkeypatch):
 
     codex_sdk.ApprovalMode = ApprovalMode
     codex_sdk.AsyncCodex = AsyncCodex
+    codex_types.ReasoningEffort = ReasoningEffort
     codex_types.SandboxMode = SandboxMode
     monkeypatch.setitem(sys.modules, "openai_codex", codex_sdk)
     monkeypatch.setitem(sys.modules, "openai_codex.types", codex_types)
@@ -114,6 +123,15 @@ def test_constructor_rejects_auto_review(codex_module):
 
     with pytest.raises(ValueError, match="ApprovalMode.deny_all"):
         module.CodexLocAgent(approval_mode=module.ApprovalMode.auto_review)
+
+
+@pytest.mark.parametrize("reasoning_effort", ["none", "minimal", "xhigh"])
+def test_constructor_accepts_sdk_reasoning_efforts(codex_module, reasoning_effort):
+    module, _calls = codex_module
+
+    agent = module.CodexLocAgent(reasoning_effort=reasoning_effort)
+
+    assert agent.reasoning_effort == reasoning_effort
 
 
 @pytest.mark.parametrize("reasoning_effort", ["", "extreme", None, True])

--- a/test/clients/test_codex_agent.py
+++ b/test/clients/test_codex_agent.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+from enum import Enum
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def codex_module(monkeypatch):
+    calls = SimpleNamespace(thread_start=None, prompt=None, output_schema=None)
+
+    claude_sdk = ModuleType("claude_agent_sdk")
+    claude_sdk.ClaudeAgentOptions = object
+    claude_sdk.query = object
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", claude_sdk)
+
+    codex_sdk = ModuleType("openai_codex")
+    codex_types = ModuleType("openai_codex.types")
+
+    class ApprovalMode(Enum):
+        deny_all = "deny_all"
+        auto_review = "auto_review"
+
+    class SandboxMode(Enum):
+        read_only = "read-only"
+        workspace_write = "workspace-write"
+        danger_full_access = "danger-full-access"
+
+    class Thread:
+        async def run(self, prompt, *, output_schema):
+            calls.prompt = prompt
+            calls.output_schema = output_schema
+            return SimpleNamespace(
+                final_response=json.dumps(
+                    {
+                        "locations": [
+                            {
+                                "name": "target()",
+                                "type": "function",
+                                "file_path": "module.py",
+                                "line_start": 1,
+                                "line_end": 2,
+                                "action": "modify",
+                                "description": "Relevant implementation",
+                            }
+                        ]
+                    }
+                ),
+                items=[],
+                usage=None,
+                duration_ms=20,
+                status=None,
+            )
+
+    class AsyncCodex:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def thread_start(self, **kwargs):
+            calls.thread_start = kwargs
+            return Thread()
+
+    codex_sdk.ApprovalMode = ApprovalMode
+    codex_sdk.AsyncCodex = AsyncCodex
+    codex_types.SandboxMode = SandboxMode
+    monkeypatch.setitem(sys.modules, "openai_codex", codex_sdk)
+    monkeypatch.setitem(sys.modules, "openai_codex.types", codex_types)
+    sys.modules.pop("codenib.clients.codex_agent", None)
+
+    module = importlib.import_module("codenib.clients.codex_agent")
+    try:
+        yield module, calls
+    finally:
+        sys.modules.pop("codenib.clients.codex_agent", None)
+
+
+def test_default_session_pins_read_only_sandbox(codex_module, tmp_path):
+    module, calls = codex_module
+    agent = module.CodexLocAgent(model="codex-test")
+
+    result = asyncio.run(agent.locate_code("find target", str(tmp_path)))
+
+    assert result.success is True
+    assert [location.name for location in result.locations] == ["target()"]
+    options = calls.thread_start
+    assert options["sandbox"] is module.SandboxMode.read_only
+    assert options["approval_mode"] is module.ApprovalMode.deny_all
+    assert options["config"] == {"model_reasoning_effort": "medium"}
+    assert options["model"] == "codex-test"
+
+
+@pytest.mark.parametrize("sandbox_name", ["workspace_write", "danger_full_access"])
+def test_constructor_rejects_writable_sandboxes(codex_module, sandbox_name):
+    module, _calls = codex_module
+
+    with pytest.raises(ValueError, match="SandboxMode.read_only"):
+        module.CodexLocAgent(sandbox=getattr(module.SandboxMode, sandbox_name))
+
+
+def test_constructor_rejects_auto_review(codex_module):
+    module, _calls = codex_module
+
+    with pytest.raises(ValueError, match="ApprovalMode.deny_all"):
+        module.CodexLocAgent(approval_mode=module.ApprovalMode.auto_review)
+
+
+@pytest.mark.parametrize("reasoning_effort", ["", "extreme", None, True])
+def test_constructor_rejects_invalid_reasoning_effort(codex_module, reasoning_effort):
+    module, _calls = codex_module
+
+    with pytest.raises(ValueError, match="reasoning_effort"):
+        module.CodexLocAgent(reasoning_effort=reasoning_effort)


### PR DESCRIPTION
## Summary

Make `CodexLocAgent` enforce the read-only sandbox contract documented by the class. Callers can no longer substitute writable SDK modes, while valid reasoning settings remain synchronized with the installed revision-pinned SDK. Closes #481.

## Changes
- reject every sandbox except `SandboxMode.read_only`
- reject every approval mode except `ApprovalMode.deny_all`
- validate reasoning effort from the SDK's `ReasoningEffort` enum before starting a remote run
- remove the example CLI's duplicated, incomplete reasoning-effort list
- add dependency-isolated coverage for the exact `thread_start` contract
- preserve structured localization and usage behavior

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/clients/test_codex_agent.py --tb=short` (11 passed)
- `pytest -q test/clients test/test_lazy_imports.py test/test_release_artifacts.py --tb=short` (64 passed)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (3039 passed, 10 skipped, 180 deselected)
- `pre-commit run --files codenib/clients/codex_agent.py test/clients/test_codex_agent.py examples/codex_loc_agent.py`
- verified the supported reasoning values against the revision-pinned official SDK at `e389e01f8347a4861ed139b01956fe64aa0c0fda`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published