### PR TITLE
fix(rerank): preserve first-stage candidates

### DIFF
--- a/codenib/agent/rerank_agent.py
+++ b/codenib/agent/rerank_agent.py
@@ -7,6 +7,7 @@ Rerank agent for ranking code nodes based on relevance to a query.
 This module uses LLM APIs to rank NodeInfo objects and return QueriedNode objects.
 """
 
+import math
 import re
 from collections import Counter, defaultdict
 from typing import Dict, List, Literal, Optional, Sequence, Tuple
@@ -35,6 +36,7 @@ class RerankResult(BaseModel):
 # Max chars from each candidate's content embedded in a rankgpt-style prompt.
 # Approximate proxy for SweRank's 1024-token cap (≈3-4k chars for code).
 _RANKGPT_MAX_CONTENT_CHARS = 3000
+_LISTWISE_FORMATS = frozenset({"structured", "rankgpt"})
 
 
 class RerankAgent:
@@ -59,6 +61,10 @@ class RerankAgent:
                 (Salesforce/SweRankLLM-*, RankZephyr, etc.) — forcing JSON on
                 them collapses the output to the first index only.
         """
+        if listwise_format not in _LISTWISE_FORMATS:
+            supported = ", ".join(sorted(_LISTWISE_FORMATS))
+            raise ValueError(f"listwise_format must be one of: {supported}")
+
         self.llm = llm
         self.listwise_format = listwise_format
         self.structured_llm = (
@@ -100,6 +106,12 @@ class RerankAgent:
             When a sliding window is configured, each window is reranked independently and
             the averaged scores across all windows determine the final ordering.
         """
+        if top_k is not None and (
+            isinstance(top_k, bool) or not isinstance(top_k, int) or top_k < 0
+        ):
+            raise ValueError("top_k must be a non-negative integer or None")
+        if top_k == 0:
+            return []
         if not nodes:
             logger.warning("No nodes provided for reranking")
             return []
@@ -165,8 +177,10 @@ class RerankAgent:
                     appearance_count[original_idx] += 1
 
             if not aggregated_scores:
-                logger.warning("Reranker did not return any scores.")
-                return []
+                logger.warning(
+                    "Reranker did not return any usable scores; preserving "
+                    "the first-stage candidate order."
+                )
 
             averaged_scores = {
                 idx: aggregated_scores[idx] / appearance_count[idx]
@@ -176,6 +190,12 @@ class RerankAgent:
 
             sorted_indices = sorted(
                 averaged_scores.items(), key=lambda item: item[1], reverse=True
+            )
+            ranked_ids = {idx for idx, _score in sorted_indices}
+            sorted_indices.extend(
+                (original_idx, 0.0)
+                for original_idx, _node in valid_nodes
+                if original_idx not in ranked_ids
             )
 
             ranked_nodes: List[QueriedNode] = []
@@ -266,15 +286,32 @@ class RerankAgent:
             logger.error("LLM rerank invocation failed: %s", exc)
             return []
 
+        ranked_indices = getattr(rerank_result, "ranked_indices", [])
+        scores = getattr(rerank_result, "scores", [])
+        if not isinstance(ranked_indices, Sequence) or isinstance(
+            ranked_indices, (str, bytes)
+        ):
+            return []
+        if not isinstance(scores, Sequence) or isinstance(scores, (str, bytes)):
+            return []
         window_scores: List[Tuple[int, float]] = []
-        for local_position, ranked_idx in enumerate(rerank_result.ranked_indices):
-            if local_position >= len(rerank_result.scores):
-                break
+        seen_indices = set()
+        for ranked_idx, raw_score in zip(ranked_indices, scores, strict=False):
+            if isinstance(ranked_idx, bool) or not isinstance(ranked_idx, int):
+                continue
             if not 0 <= ranked_idx < len(window_nodes):
                 continue
-            score = rerank_result.scores[local_position]
+            if ranked_idx in seen_indices:
+                continue
+            try:
+                score = float(raw_score)
+            except (TypeError, ValueError):
+                continue
+            if not math.isfinite(score):
+                continue
+            seen_indices.add(ranked_idx)
             original_idx = window_nodes[ranked_idx][0]
-            window_scores.append((original_idx, float(score)))
+            window_scores.append((original_idx, min(1.0, max(0.0, score))))
 
         logger.debug(
             "Window rerank produced %s scored nodes (window size %s)",

--- a/codenib/agent/rerank_agent.py
+++ b/codenib/agent/rerank_agent.py
@@ -128,16 +128,21 @@ class RerankAgent:
                     valid_nodes.append((i, node))
 
             if not valid_nodes:
-                logger.warning("No nodes with content found for reranking")
-                return []
+                logger.warning(
+                    "No nodes with content found for reranking; preserving "
+                    "the first-stage candidate order."
+                )
+                return self._preserve_first_stage(
+                    nodes,
+                    top_k=top_k,
+                    include_content=include_content,
+                )
 
             logger.info(
                 f"Reranking {len(valid_nodes)} nodes with query: {query[:100]}..."
             )
 
-            node_lookup: Dict[int, NodeInfo] = {
-                original_idx: node for original_idx, node in valid_nodes
-            }
+            node_lookup: Dict[int, NodeInfo] = dict(enumerate(nodes))
 
             total_nodes = len(valid_nodes)
             window_size = window_size or total_nodes
@@ -193,8 +198,11 @@ class RerankAgent:
             )
             ranked_ids = {idx for idx, _score in sorted_indices}
             sorted_indices.extend(
-                (original_idx, 0.0)
-                for original_idx, _node in valid_nodes
+                (
+                    original_idx,
+                    float(node.score) if node.score is not None else 0.0,
+                )
+                for original_idx, node in enumerate(nodes)
                 if original_idx not in ranked_ids
             )
 
@@ -203,18 +211,13 @@ class RerankAgent:
                 node = node_lookup.get(original_idx)
                 if not node:
                     continue
-                payload = {
-                    "node_name": node.node_name,
-                    "type": node.type,
-                    "file": node.file,
-                    "node_id": node.node_id,
-                    "start_line": node.start_line,
-                    "end_line": node.end_line,
-                    "score": float(score),
-                }
-                if include_content:
-                    payload["content"] = node.content
-                ranked_nodes.append(QueriedNode(**payload))
+                ranked_nodes.append(
+                    self._to_queried_node(
+                        node,
+                        score=float(score),
+                        include_content=include_content,
+                    )
+                )
                 if top_k and len(ranked_nodes) >= top_k:
                     break
 
@@ -227,7 +230,49 @@ class RerankAgent:
 
         except Exception as e:
             logger.error(f"Error during reranking: {e}")
-            return []
+            return self._preserve_first_stage(
+                nodes,
+                top_k=top_k,
+                include_content=include_content,
+            )
+
+    @staticmethod
+    def _to_queried_node(
+        node: NodeInfo,
+        *,
+        score: float,
+        include_content: bool,
+    ) -> QueriedNode:
+        payload = {
+            "node_name": node.node_name,
+            "type": node.type,
+            "file": node.file,
+            "node_id": node.node_id,
+            "start_line": node.start_line,
+            "end_line": node.end_line,
+            "score": score,
+        }
+        if include_content:
+            payload["content"] = node.content
+        return QueriedNode(**payload)
+
+    @classmethod
+    def _preserve_first_stage(
+        cls,
+        nodes: Sequence[NodeInfo],
+        *,
+        top_k: Optional[int],
+        include_content: bool,
+    ) -> List[QueriedNode]:
+        limit = len(nodes) if top_k is None else top_k
+        return [
+            cls._to_queried_node(
+                node,
+                score=float(node.score) if node.score is not None else 0.0,
+                include_content=include_content,
+            )
+            for node in nodes[:limit]
+        ]
 
     def _rerank_window(
         self, query: str, window_nodes: Sequence[Tuple[int, NodeInfo]]

--- a/codenib/agent/rerank_agent.py
+++ b/codenib/agent/rerank_agent.py
@@ -419,6 +419,13 @@ class RerankAgent:
             return []
 
         permutation = self._parse_rankgpt_permutation(response_text, num)
+        if not permutation:
+            logger.warning(
+                "RankGPT reranker did not return any usable indices; "
+                "preserving the first-stage candidate order."
+            )
+            return []
+
         # Items not mentioned in the permutation keep their original order
         # behind the ranked items (matches SweRank's receive_permutation).
         ranked_set = set(permutation)

--- a/test/agent/test_rerank_agent.py
+++ b/test/agent/test_rerank_agent.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from codenib.agent.rerank_agent import RerankAgent, RerankResult
+from codenib.types import NodeInfo
+
+
+def _nodes(count=3):
+    return [
+        NodeInfo(
+            node_name=f"node_{index}",
+            type="function",
+            file=f"file_{index}.py",
+            node_id=str(index),
+            content=f"def node_{index}(): pass",
+        )
+        for index in range(count)
+    ]
+
+
+class _StructuredLLM:
+    model = "structured-test"
+
+    def __init__(self, result=None, error=None):
+        self.result = result
+        self.error = error
+
+    def with_structured_output(self, _schema):
+        return self
+
+    def invoke(self, _messages):
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _RankGPTLLM:
+    model = "rankgpt-test"
+
+    def __init__(self, response="", error=None):
+        self.response = response
+        self.error = error
+
+    def invoke(self, _messages):
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def test_partial_structured_output_preserves_unranked_candidates():
+    llm = _StructuredLLM(RerankResult(ranked_indices=[1], scores=[0.9]))
+
+    ranked = RerankAgent(llm).rerank_nodes("find bug", _nodes())
+
+    assert [node.node_name for node in ranked] == ["node_1", "node_0", "node_2"]
+    assert [node.score for node in ranked] == [0.9, 0.0, 0.0]
+
+
+def test_structured_output_ignores_duplicate_invalid_and_non_finite_entries():
+    llm = _StructuredLLM(
+        SimpleNamespace(
+            ranked_indices=[2, 2, 99, 1, 0],
+            scores=[5.0, 0.7, 0.6, float("nan")],
+        )
+    )
+
+    ranked = RerankAgent(llm).rerank_nodes("find bug", _nodes())
+
+    assert [node.node_name for node in ranked] == ["node_2", "node_0", "node_1"]
+    assert [node.score for node in ranked] == [1.0, 0.0, 0.0]
+
+
+def test_structured_invocation_failure_preserves_first_stage_top_k():
+    llm = _StructuredLLM(error=RuntimeError("provider unavailable"))
+
+    ranked = RerankAgent(llm).rerank_nodes("find bug", _nodes(), top_k=2)
+
+    assert [node.node_name for node in ranked] == ["node_0", "node_1"]
+
+
+def test_malformed_structured_output_preserves_first_stage_order():
+    llm = _StructuredLLM(SimpleNamespace(ranked_indices=None, scores=None))
+
+    ranked = RerankAgent(llm).rerank_nodes("find bug", _nodes())
+
+    assert [node.node_name for node in ranked] == ["node_0", "node_1", "node_2"]
+
+
+def test_rankgpt_invocation_failure_preserves_first_stage_top_k():
+    llm = _RankGPTLLM(error=RuntimeError("provider unavailable"))
+
+    ranked = RerankAgent(llm, listwise_format="rankgpt").rerank_nodes(
+        "find bug", _nodes(), top_k=2
+    )
+
+    assert [node.node_name for node in ranked] == ["node_0", "node_1"]
+
+
+def test_constructor_rejects_unknown_listwise_format():
+    with pytest.raises(ValueError, match="listwise_format"):
+        RerankAgent(_StructuredLLM(), listwise_format="unknown")
+
+
+def test_zero_top_k_skips_reranking():
+    llm = _StructuredLLM(error=AssertionError("must not invoke"))
+
+    assert RerankAgent(llm).rerank_nodes("find bug", _nodes(), top_k=0) == []
+
+
+@pytest.mark.parametrize("top_k", [-1, True, 1.5])
+def test_invalid_top_k_fails_locally(top_k):
+    with pytest.raises(ValueError, match="top_k"):
+        RerankAgent(_StructuredLLM()).rerank_nodes("find bug", _nodes(), top_k=top_k)

--- a/test/agent/test_rerank_agent.py
+++ b/test/agent/test_rerank_agent.py
@@ -93,6 +93,37 @@ def test_malformed_structured_output_preserves_first_stage_order():
     assert [node.node_name for node in ranked] == ["node_0", "node_1", "node_2"]
 
 
+def test_partial_output_preserves_candidates_without_content_and_scores():
+    nodes = _nodes()
+    nodes[0].score = 0.7
+    nodes[1].content = None
+    nodes[1].score = 0.6
+    nodes[2].score = 0.5
+    llm = _StructuredLLM(RerankResult(ranked_indices=[1], scores=[0.9]))
+
+    ranked = RerankAgent(llm).rerank_nodes("find bug", nodes)
+
+    assert [node.node_name for node in ranked] == ["node_2", "node_0", "node_1"]
+    assert [node.score for node in ranked] == [0.9, 0.7, 0.6]
+
+
+def test_unexpected_rerank_error_preserves_first_stage_order(monkeypatch):
+    nodes = _nodes()
+    nodes[0].score = 0.8
+    agent = RerankAgent(_StructuredLLM())
+
+    def fail_rerank(*_args, **_kwargs):
+        raise RuntimeError("malformed provider result")
+
+    monkeypatch.setattr(agent, "_rerank_window", fail_rerank)
+
+    ranked = agent.rerank_nodes("find bug", nodes, top_k=2, include_content=True)
+
+    assert [node.node_name for node in ranked] == ["node_0", "node_1"]
+    assert [node.score for node in ranked] == [0.8, 0.0]
+    assert ranked[0].content == nodes[0].content
+
+
 def test_rankgpt_invocation_failure_preserves_first_stage_top_k():
     llm = _RankGPTLLM(error=RuntimeError("provider unavailable"))
 

--- a/test/agent/test_rerank_agent.py
+++ b/test/agent/test_rerank_agent.py
@@ -134,6 +134,19 @@ def test_rankgpt_invocation_failure_preserves_first_stage_top_k():
     assert [node.node_name for node in ranked] == ["node_0", "node_1"]
 
 
+def test_malformed_rankgpt_output_preserves_first_stage_scores():
+    nodes = _nodes()
+    nodes[0].score = 0.8
+    nodes[1].score = 0.6
+    nodes[2].score = 0.4
+    llm = _RankGPTLLM(response="Unable to rank these candidates")
+
+    ranked = RerankAgent(llm, listwise_format="rankgpt").rerank_nodes("find bug", nodes)
+
+    assert [node.node_name for node in ranked] == ["node_0", "node_1", "node_2"]
+    assert [node.score for node in ranked] == [0.8, 0.6, 0.4]
+
+
 def test_constructor_rejects_unknown_listwise_format():
     with pytest.raises(ValueError, match="listwise_format"):
         RerankAgent(_StructuredLLM(), listwise_format="unknown")


### PR DESCRIPTION
## Summary

Keep every valid first-stage retrieval candidate when a listwise reranker returns a partial, malformed, or failed response. Provider and parsing failures now degrade to the original candidate order instead of silently erasing retrieval evidence. Closes #483.

## Changes
- append unranked candidates in their original relative order
- preserve candidates without content and retain existing first-stage scores
- preserve first-stage ordering when no usable rerank score is returned
- deduplicate indices and reject out-of-range, non-finite, and malformed entries
- clamp usable structured scores to the documented 0–1 interval
- apply failure fallback to structured, RankGPT, and unexpected parsing paths
- validate listwise format and `top_k` locally
- add deterministic unit coverage for partial output and provider failures

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/agent/test_rerank_agent.py test/model/test_graph_augmented_rerank_pipeline.py test/model/test_retrieve_pipeline_indexer_routing.py test/examples/test_swerank_retrieve_rerank.py --tb=short` (36 passed)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (3070 passed, 10 skipped, 180 deselected)
- `pre-commit run --files codenib/agent/rerank_agent.py test/agent/test_rerank_agent.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published