### PR TITLE
fix(eval): reject repository path escapes

### DIFF
--- a/codenib/eval/retrieval_eval.py
+++ b/codenib/eval/retrieval_eval.py
@@ -8,31 +8,52 @@ from __future__ import annotations
 
 import os
 import re
-from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from ..types import QueriedNode
 
 
 def normalize_file_path(value: Optional[str]) -> Optional[str]:
-    """Normalize file paths emitted by retrieval to canonical posix format."""
+    """Normalize a repository-relative path to canonical POSIX form.
+
+    Absolute paths and relative paths that escape above the repository root are
+    rejected. Callers that know the checkout root must first relativize through
+    :func:`_rel_norm`.
+    """
     if not value:
         return None
-    normalized = str(Path(value).as_posix())
-    return normalized.lstrip("./")
+    normalized = str(value).strip().replace("\\", "/")
+    if not normalized or "\x00" in normalized:
+        return None
+    if normalized.startswith("/") or re.match(r"^[A-Za-z]:/", normalized):
+        return None
+
+    parts: List[str] = []
+    for part in normalized.split("/"):
+        if not part or part == ".":
+            continue
+        if part == "..":
+            if not parts:
+                return None
+            parts.pop()
+            continue
+        parts.append(part)
+    return "/".join(parts) or None
 
 
 def normalize_symbol_identifier(value: Optional[str]) -> Optional[str]:
     """Normalize ``file:Symbol`` so the file portion matches the retrieved form."""
     if not value:
         return None
+    if re.match(r"^[A-Za-z]:[\\/]", value):
+        return None
     if ":" not in value:
         return value
     file_part, symbol_part = value.split(":", 1)
     normalized_file = normalize_file_path(file_part)
-    if normalized_file:
-        return f"{normalized_file}:{symbol_part}"
-    return value
+    if not normalized_file:
+        return None
+    return f"{normalized_file}:{symbol_part}"
 
 
 def collect_targets(
@@ -221,13 +242,14 @@ def _rel_norm(path: str, repo_path: str) -> Optional[str]:
     if not p:
         return None
     if repo_path and os.path.isabs(p):
+        repo_root = os.path.abspath(repo_path)
+        candidate = os.path.abspath(p)
         try:
-            p = os.path.relpath(p, repo_path)
+            if os.path.commonpath((repo_root, candidate)) != repo_root:
+                return None
+            p = os.path.relpath(candidate, repo_root)
         except ValueError:
-            # Path can't be made relative to repo_path (e.g. different drive on
-            # Windows, or an unrelated root): keep the original absolute path and
-            # let normalize_file_path handle it. Non-fatal — scoring tolerates it.
-            pass
+            return None
     return normalize_file_path(p)
 
 

--- a/codenib/eval/retrieval_eval.py
+++ b/codenib/eval/retrieval_eval.py
@@ -251,7 +251,7 @@ def _rel_norm(path: str, repo_path: str) -> Optional[str]:
             candidate_real = os.path.realpath(p)
             if os.path.commonpath((repo_root_real, candidate_real)) != repo_root_real:
                 return None
-            p = os.path.relpath(p, repo_root)
+            p = os.path.relpath(candidate_real, repo_root_real)
         except ValueError:
             return None
     return normalize_file_path(p)

--- a/codenib/eval/retrieval_eval.py
+++ b/codenib/eval/retrieval_eval.py
@@ -25,7 +25,7 @@ def normalize_file_path(value: Optional[str]) -> Optional[str]:
     normalized = str(value).strip().replace("\\", "/")
     if not normalized or "\x00" in normalized:
         return None
-    if normalized.startswith("/") or re.match(r"^[A-Za-z]:/", normalized):
+    if normalized.startswith("/") or re.match(r"^[A-Za-z]:", normalized):
         return None
 
     parts: List[str] = []
@@ -45,7 +45,7 @@ def normalize_symbol_identifier(value: Optional[str]) -> Optional[str]:
     """Normalize ``file:Symbol`` so the file portion matches the retrieved form."""
     if not value:
         return None
-    if re.match(r"^[A-Za-z]:[\\/]", value):
+    if re.match(r"^[A-Za-z]:", value):
         return None
     if ":" not in value:
         return value
@@ -234,6 +234,7 @@ _MD = r"[\s>#*_`\-]*"
 _FILES_LINE = re.compile(rf"(?im)^{_MD}files?{_MD}[:=]{_MD}\s*(.+)$")
 _SYMBOLS_LINE = re.compile(rf"(?im)^{_MD}symbols?{_MD}[:=]{_MD}\s*(.+)$")
 _PATH_TOKEN = re.compile(r"[\w./\\-]+\.[A-Za-z0-9_]+")
+_REJECTED_RANK_PREFIX = "\x00rejected-rank:"
 
 
 def _rel_norm(path: str, repo_path: str) -> Optional[str]:
@@ -243,11 +244,14 @@ def _rel_norm(path: str, repo_path: str) -> Optional[str]:
         return None
     if repo_path and os.path.isabs(p):
         repo_root = os.path.abspath(repo_path)
-        candidate = os.path.abspath(p)
         try:
-            if os.path.commonpath((repo_root, candidate)) != repo_root:
+            repo_root_real = os.path.realpath(repo_root)
+            # Resolve the original component sequence. Calling abspath first
+            # would collapse ``symlink/..`` before realpath follows the link.
+            candidate_real = os.path.realpath(p)
+            if os.path.commonpath((repo_root_real, candidate_real)) != repo_root_real:
                 return None
-            p = os.path.relpath(candidate, repo_root)
+            p = os.path.relpath(p, repo_root)
         except ValueError:
             return None
     return normalize_file_path(p)
@@ -255,8 +259,12 @@ def _rel_norm(path: str, repo_path: str) -> Optional[str]:
 
 def _dedup(seq: Sequence[Optional[str]]) -> List[str]:
     seen, out = set(), []
-    for x in seq:
-        if x and x not in seen:
+    for rank, x in enumerate(seq):
+        if x is None:
+            # Invalid predictions are misses, not absent predictions. Preserve
+            # their rank so a later valid path cannot move into a smaller k.
+            out.append(f"{_REJECTED_RANK_PREFIX}{rank}")
+        elif x and x not in seen:
             seen.add(x)
             out.append(x)
     return out

--- a/test/eval/test_query_sweep.py
+++ b/test/eval/test_query_sweep.py
@@ -44,13 +44,13 @@ run_metadata:
 def test_query_targets_normalizes_files_and_simplified_symbols():
     files, symbols = query_targets(
         {
-            "gt_files": ["/tmp/repo/src/app.py", ""],
+            "gt_files": ["./src/app.py", ""],
             "gt_symbols": ["src/app.py:App", "src/app.py:App.run()"],
         },
         simplified_symbols=True,
     )
 
-    assert files == ["tmp/repo/src/app.py"]
+    assert files == ["src/app.py"]
     assert symbols == ["src/app.py:App.run()"]
 
 

--- a/test/eval/test_retrieval_path_contract.py
+++ b/test/eval/test_retrieval_path_contract.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from codenib.eval.retrieval_eval import (
+    _rel_norm,
+    normalize_file_path,
+    normalize_symbol_identifier,
+    score_agent_localization,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("src/target.py", "src/target.py"),
+        ("./src/target.py", "src/target.py"),
+        ("src\\target.py", "src/target.py"),
+        ("src/generated/../target.py", "src/target.py"),
+        ("src//./target.py", "src/target.py"),
+    ],
+)
+def test_normalize_file_path_canonicalizes_safe_relative_paths(raw, expected):
+    assert normalize_file_path(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "../src/target.py",
+        "src/../../target.py",
+        "/tmp/repo/src/target.py",
+        r"C:\repo\src\target.py",
+        r"\\server\share\target.py",
+        "\x00target.py",
+    ],
+)
+def test_normalize_file_path_rejects_absolute_and_escaping_paths(raw):
+    assert normalize_file_path(raw) is None
+
+
+def test_repo_aware_normalization_accepts_only_contained_absolute_paths(tmp_path):
+    repo = tmp_path / "repo"
+    inside = repo / "src" / "target.py"
+    outside = tmp_path / "outside.py"
+
+    assert _rel_norm(str(inside), str(repo)) == "src/target.py"
+    assert _rel_norm(str(outside), str(repo)) is None
+
+
+def test_invalid_file_and_symbol_predictions_cannot_receive_hits(tmp_path):
+    metrics = score_agent_localization(
+        answer=("Files: ../src/target.py\n" "Symbols: ../src/target.py:target()"),
+        file_read_paths=[str(tmp_path / "outside.py")],
+        nodes=[],
+        target_files=["src/target.py"],
+        target_symbols=["src/target.py:target()"],
+        ks=[1],
+        repo_path=str(tmp_path / "repo"),
+    )
+
+    assert metrics["files"][1] == {
+        "accuracy": 0.0,
+        "precision": 0.0,
+        "recall": 0.0,
+        "hits": 0,
+    }
+    assert metrics["symbols"][1] == {
+        "accuracy": 0.0,
+        "precision": 0.0,
+        "recall": 0.0,
+        "hits": 0,
+    }
+    assert normalize_symbol_identifier("../src/target.py:target()") is None
+
+
+def test_contained_absolute_read_path_can_receive_a_hit(tmp_path):
+    repo = tmp_path / "repo"
+    target = repo / "src" / "target.py"
+
+    metrics = score_agent_localization(
+        answer="",
+        file_read_paths=[str(target)],
+        nodes=[],
+        target_files=["src/target.py"],
+        target_symbols=[],
+        ks=[1],
+        repo_path=str(repo),
+    )
+
+    assert metrics["files"][1]["recall"] == 1.0

--- a/test/eval/test_retrieval_path_contract.py
+++ b/test/eval/test_retrieval_path_contract.py
@@ -35,6 +35,7 @@ def test_normalize_file_path_canonicalizes_safe_relative_paths(raw, expected):
         "src/../../target.py",
         "/tmp/repo/src/target.py",
         r"C:\repo\src\target.py",
+        r"C:repo\src\target.py",
         r"\\server\share\target.py",
         "\x00target.py",
     ],
@@ -50,6 +51,29 @@ def test_repo_aware_normalization_accepts_only_contained_absolute_paths(tmp_path
 
     assert _rel_norm(str(inside), str(repo)) == "src/target.py"
     assert _rel_norm(str(outside), str(repo)) is None
+
+
+def test_repo_aware_normalization_rejects_symlink_escape(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside", encoding="utf-8")
+    link = repo / "linked.py"
+    link.symlink_to(outside)
+
+    assert _rel_norm(str(link), str(repo)) is None
+
+
+def test_repo_aware_normalization_resolves_symlink_before_parent_segments(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside_child = tmp_path / "outside" / "child"
+    outside_child.mkdir(parents=True)
+    (repo / "jump").symlink_to(outside_child, target_is_directory=True)
+
+    escaped = repo / "jump" / ".." / "target.py"
+
+    assert _rel_norm(str(escaped), str(repo)) is None
 
 
 def test_invalid_file_and_symbol_predictions_cannot_receive_hits(tmp_path):
@@ -93,3 +117,19 @@ def test_contained_absolute_read_path_can_receive_a_hit(tmp_path):
     )
 
     assert metrics["files"][1]["recall"] == 1.0
+
+
+def test_rejected_prediction_still_consumes_its_rank(tmp_path):
+    metrics = score_agent_localization(
+        answer="Files: ../outside.py, src/target.py",
+        file_read_paths=[],
+        nodes=[],
+        target_files=["src/target.py"],
+        target_symbols=[],
+        ks=[1, 2],
+        repo_path=str(tmp_path / "repo"),
+    )
+
+    assert metrics["files"][1]["recall"] == 0.0
+    assert metrics["files"][2]["recall"] == 1.0
+    assert metrics["files"][2]["precision"] == 0.5

--- a/test/eval/test_retrieval_path_contract.py
+++ b/test/eval/test_retrieval_path_contract.py
@@ -76,6 +76,21 @@ def test_repo_aware_normalization_resolves_symlink_before_parent_segments(tmp_pa
     assert _rel_norm(str(escaped), str(repo)) is None
 
 
+def test_repo_aware_normalization_canonicalizes_contained_symlink_parent_segments(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    child = repo / "other" / "child"
+    child.mkdir(parents=True)
+    target = repo / "other" / "target.py"
+    target.write_text("inside", encoding="utf-8")
+    (repo / "jump").symlink_to(child, target_is_directory=True)
+
+    aliased = repo / "jump" / ".." / "target.py"
+
+    assert _rel_norm(str(aliased), str(repo)) == "other/target.py"
+
+
 def test_invalid_file_and_symbol_predictions_cannot_receive_hits(tmp_path):
     metrics = score_agent_localization(
         answer=("Files: ../src/target.py\n" "Symbols: ../src/target.py:target()"),


### PR DESCRIPTION
## Summary

Make retrieval and agent-localization scoring accept only canonical repository-relative paths. Paths that escape lexically, through a platform-specific drive form, or through an absolute symlink can no longer become apparent benchmark hits. Closes #485.

## Changes
- canonicalize safe relative POSIX and backslash-separated paths
- resolve internal dot and parent segments while rejecting root escapes
- reject generic absolute, drive-relative, drive-absolute, UNC, and NUL-bearing paths
- permit absolute paths only through repo-aware lexical and realpath containment
- preserve the repository-relative logical address after containment validation
- reject invalid file portions in symbol identifiers
- replace an old test that codified pseudo-relative absolute paths
- add metric-level regression coverage for false hits and contained reads

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/eval/test_retrieval_path_contract.py test/eval/test_query_sweep.py test/eval/test_agent_scoring.py test/eval/test_span_localization.py --tb=short` (54 passed)
- `pytest -q test/eval --tb=short` (313 passed)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (3091 passed, 10 skipped, 180 deselected)
- `pre-commit run --files codenib/eval/retrieval_eval.py test/eval/test_retrieval_path_contract.py test/eval/test_query_sweep.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published