### PR TITLE
fix(eval): count unique retrieval hits

### DIFF
--- a/codenib/eval/retrieval_eval.py
+++ b/codenib/eval/retrieval_eval.py
@@ -106,11 +106,15 @@ def compute_metrics(
     targets: Sequence[str],
 ) -> Dict[str, float]:
     """Compute accuracy (hit@K), precision, recall, and hit counts for a single scope."""
-    hits = sum(1 for value in predictions if value in targets)
+    predicted_values = set(predictions)
+    target_values = set(targets)
+    hits = len(predicted_values.intersection(target_values))
     # Use issubset logic: accuracy=1.0 only if ALL targets are in predictions
-    accuracy = 1.0 if targets and set(targets).issubset(set(predictions)) else 0.0
+    accuracy = (
+        1.0 if target_values and target_values.issubset(predicted_values) else 0.0
+    )
     precision = hits / max(len(predictions), 1)
-    recall = hits / max(len(targets), 1) if targets else 0.0
+    recall = hits / len(target_values) if target_values else 0.0
     return {
         "accuracy": accuracy,
         "precision": precision,

--- a/test/eval/test_baseline.py
+++ b/test/eval/test_baseline.py
@@ -150,6 +150,45 @@ def test_build_baseline_result_entry_matches_existing_json_shape():
     assert entry["error"] is None
 
 
+def test_build_baseline_result_does_not_reward_duplicate_symbols():
+    duplicate = SimpleNamespace(
+        name="Parser.parse()",
+        type="method",
+        file_path="pkg/parser.py",
+        line_start=10,
+        line_end=20,
+        action="modify",
+        description="duplicate prediction",
+    )
+    result = SimpleNamespace(
+        success=True,
+        repo_path="/repos/demo",
+        locations=[duplicate, duplicate],
+        usage=None,
+    )
+    task = BaselineTask(
+        instance_id="demo__repo-1",
+        query="Fix parser edge case",
+        repo_path="/repos/demo",
+        target_symbols=("pkg/parser.py:Parser.parse()",),
+    )
+
+    entry = build_baseline_result_entry(
+        task=task,
+        agent_name="external",
+        model="model-a",
+        result=result,
+        metrics_k=[2],
+    )
+
+    assert entry["metrics"]["symbols"][2] == {
+        "accuracy": 1.0,
+        "precision": 0.5,
+        "recall": 1.0,
+        "hits": 1,
+    }
+
+
 def test_loc_agent_runner_build_result_entry_delegates_to_envelope():
     entry = build_result_entry(
         instance_id="demo__repo-1",

--- a/test/eval/test_retrieval_metrics_contract.py
+++ b/test/eval/test_retrieval_metrics_contract.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from codenib.eval.retrieval_eval import compute_metrics
+
+
+def test_duplicate_prediction_cannot_create_extra_hits():
+    metrics = compute_metrics(["target", "target"], ["target"])
+
+    assert metrics == {
+        "accuracy": 1.0,
+        "precision": 0.5,
+        "recall": 1.0,
+        "hits": 1,
+    }
+
+
+def test_duplicate_targets_require_only_one_matching_prediction():
+    metrics = compute_metrics(["target"], ["target", "target"])
+
+    assert metrics == {
+        "accuracy": 1.0,
+        "precision": 1.0,
+        "recall": 1.0,
+        "hits": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("predictions", "targets"),
+    [
+        ([], []),
+        (["miss", "miss"], ["target"]),
+        (["a", "a", "b", "b"], ["a", "b", "b"]),
+        (["a", "b", "c"], ["a", "a", "d"]),
+    ],
+)
+def test_metrics_remain_bounded_with_duplicate_inputs(predictions, targets):
+    metrics = compute_metrics(predictions, targets)
+
+    assert 0.0 <= metrics["accuracy"] <= 1.0
+    assert 0.0 <= metrics["precision"] <= 1.0
+    assert 0.0 <= metrics["recall"] <= 1.0
+    assert 0 <= metrics["hits"] <= len(set(targets))


### PR DESCRIPTION
## Summary

Prevent duplicate retrieval or localization predictions from creating extra hits and recall above 1.0. The central scorer previously counted each repeated correct identifier as a separate hit.

Closes #487.

## Changes

- compute hits from the intersection of unique prediction and target identifiers
- retain the original ranked-list length as the precision denominator
- collapse duplicate target labels for recall and all-target accuracy
- add bounded-metric and duplicate-input tests
- verify the correction through the external baseline result envelope

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Security hardening

## Testing

- `pytest -q test/eval/test_retrieval_metrics_contract.py test/eval/test_baseline.py` (15 passed)
- `pytest -q test/eval` (304 passed)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (2823 passed, 10 skipped, 183 deselected)
- `pre-commit run --files codenib/eval/retrieval_eval.py test/eval/test_retrieval_metrics_contract.py test/eval/test_baseline.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added tests that prove the fix
- [x] New and existing unit tests pass locally
- [x] The change preserves the existing metric output schema
