### PR TITLE
fix(logging): honor configured console levels

### DIFF
--- a/codenib/log_utils.py
+++ b/codenib/log_utils.py
@@ -4,13 +4,12 @@
 
 import logging
 import os
+import sys
 from typing import Dict, Optional
 
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.style import Style
-
-logging.basicConfig(level=logging.INFO)
 
 # Add custom logging level for SCIP debugging
 SCIP_DEBUG = 5  # Lower than DEBUG (10)
@@ -77,18 +76,48 @@ class LoggingManager:
         else:
             raise TypeError("Logging level must be a name or integer")
 
-        if numeric_level != SCIP_DEBUG:
+        if numeric_level == SCIP_DEBUG:
+            self._set_scip_debug_enabled(True)
+        else:
             self.console_log_level = numeric_level
+            self._set_scip_debug_enabled(False)
         self.rich_handler.setLevel(numeric_level)
 
         root_logger = logging.getLogger()
-        root_logger.setLevel(numeric_level)
+        if not root_logger.handlers:
+            logging.basicConfig(
+                level=numeric_level,
+                format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+                stream=sys.stderr,
+            )
         for handler in root_logger.handlers:
             if isinstance(handler, logging.StreamHandler) and not isinstance(
                 handler, logging.FileHandler
             ):
                 handler.setLevel(numeric_level)
+        root_logger.setLevel(
+            min(
+                (handler.level for handler in root_logger.handlers),
+                default=numeric_level,
+            )
+        )
         return numeric_level
+
+    def _set_scip_debug_enabled(self, enabled: bool) -> None:
+        """Align registered SCIP loggers and diagnostic file handlers."""
+        self.scip_debug_enabled = enabled
+        logger_level = SCIP_DEBUG if enabled else logging.DEBUG
+        file_level = SCIP_DEBUG if enabled else logging.DEBUG
+
+        for logger_name in self.scip_loggers:
+            logger = self.loggers.get(logger_name)
+            if logger is not None:
+                logger.setLevel(logger_level)
+
+        for logger in self.loggers.values():
+            for handler in logger.handlers:
+                if isinstance(handler, logging.FileHandler):
+                    handler.setLevel(file_level)
 
     def get_logger(self, name: str) -> logging.Logger:
         if name in self.loggers:
@@ -303,41 +332,11 @@ def register_scip_logger(logger_name: str) -> None:
 
 def enable_scip_debug() -> None:
     """Enable SCIP debug logging for all registered SCIP loggers."""
-    # Set the global flag
-    logging_manager.scip_debug_enabled = True
-
-    # Set handler level to ensure SCIP_DEBUG messages are shown
+    logging_manager._set_scip_debug_enabled(True)
     logging_manager.rich_handler.setLevel(SCIP_DEBUG)
-
-    # Enable SCIP debug for all registered loggers
-    for logger_name in logging_manager.scip_loggers:
-        if logger_name in logging_manager.loggers:
-            logger = logging_manager.loggers[logger_name]
-            logger.setLevel(SCIP_DEBUG)
-
-    # Update ALL file handlers to SCIP_DEBUG level (not just per-logger)
-    for logger in logging_manager.loggers.values():
-        for handler in logger.handlers:
-            if isinstance(handler, logging.FileHandler):
-                handler.setLevel(SCIP_DEBUG)
 
 
 def disable_scip_debug() -> None:
     """Disable SCIP debug logging for all registered SCIP loggers."""
-    # Clear the global flag
-    logging_manager.scip_debug_enabled = False
-
-    # Restore normal handler levels
+    logging_manager._set_scip_debug_enabled(False)
     logging_manager.rich_handler.setLevel(logging_manager.console_log_level)
-
-    # Disable SCIP debug for all registered loggers
-    for logger_name in logging_manager.scip_loggers:
-        if logger_name in logging_manager.loggers:
-            logger = logging_manager.loggers[logger_name]
-            logger.setLevel(logging.DEBUG)
-
-    # Restore file handlers to normal DEBUG level
-    for logger in logging_manager.loggers.values():
-        for handler in logger.handlers:
-            if isinstance(handler, logging.FileHandler):
-                handler.setLevel(logging.DEBUG)

--- a/codenib/log_utils.py
+++ b/codenib/log_utils.py
@@ -52,7 +52,43 @@ class LoggingManager:
             show_time=bool(os.environ.get("LOG_TIME", False)),
             show_path=bool(os.environ.get("LOG_PATH", False)),
         )
-        self.rich_handler.setLevel(logging.DEBUG)
+        self.console_log_level = logging.INFO
+        self.rich_handler.setLevel(self.console_log_level)
+
+    def set_console_log_level(self, level: str | int) -> int:
+        """Set the minimum severity emitted by console handlers.
+
+        Managed CodeNib loggers do not propagate and therefore cannot be
+        configured through ``logging.basicConfig``. Keep their Rich handler
+        aligned with the root console logger while leaving file handlers at
+        their existing diagnostic level.
+        """
+        if isinstance(level, str):
+            normalized = level.upper()
+            numeric_level = (
+                SCIP_DEBUG
+                if normalized == "SCIP_DEBUG"
+                else getattr(logging, normalized, None)
+            )
+            if not isinstance(numeric_level, int):
+                raise ValueError(f"Invalid logging level: {level!r}")
+        elif isinstance(level, int):
+            numeric_level = level
+        else:
+            raise TypeError("Logging level must be a name or integer")
+
+        if numeric_level != SCIP_DEBUG:
+            self.console_log_level = numeric_level
+        self.rich_handler.setLevel(numeric_level)
+
+        root_logger = logging.getLogger()
+        root_logger.setLevel(numeric_level)
+        for handler in root_logger.handlers:
+            if isinstance(handler, logging.StreamHandler) and not isinstance(
+                handler, logging.FileHandler
+            ):
+                handler.setLevel(numeric_level)
+        return numeric_level
 
     def get_logger(self, name: str) -> logging.Logger:
         if name in self.loggers:
@@ -167,6 +203,10 @@ def get_logger(name: str) -> logging.Logger:
     return logging_manager.get_logger(name)
 
 
+def set_console_log_level(level: str | int) -> int:
+    return logging_manager.set_console_log_level(level)
+
+
 def set_log_dir(new_dir: str) -> None:
     logging_manager.set_log_dir(new_dir)
 
@@ -216,6 +256,8 @@ def setup_detailed_logging(
         numeric_level = SCIP_DEBUG
     else:
         numeric_level = getattr(logging, level.upper(), logging.DEBUG)
+    if numeric_level != SCIP_DEBUG:
+        logging_manager.console_log_level = numeric_level
     logging_manager.rich_handler.setLevel(numeric_level)
 
     # Enable SCIP debug logging if requested
@@ -286,13 +328,13 @@ def disable_scip_debug() -> None:
     logging_manager.scip_debug_enabled = False
 
     # Restore normal handler levels
-    logging_manager.rich_handler.setLevel(logging.DEBUG)
+    logging_manager.rich_handler.setLevel(logging_manager.console_log_level)
 
     # Disable SCIP debug for all registered loggers
     for logger_name in logging_manager.scip_loggers:
         if logger_name in logging_manager.loggers:
             logger = logging_manager.loggers[logger_name]
-            logger.setLevel(logging.INFO)
+            logger.setLevel(logging.DEBUG)
 
     # Restore file handlers to normal DEBUG level
     for logger in logging_manager.loggers.values():

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -29,6 +29,7 @@ from mcp.server import MCPServer
 from pydantic import Field
 
 from ..compiler.manifest import RepoManifest
+from ..log_utils import set_console_log_level
 from .context import ServerContext
 from .prompts import CODENIB_GUIDE
 from .tools._validation import (
@@ -589,6 +590,7 @@ def main(argv: list[str] | None = None) -> None:
     """Run the ``codenib-mcp`` console entry point."""
     program_name = _cli_program_name()
     args = _parse_args(argv)
+    set_console_log_level(args.log_level)
     manifest_path = args.manifest_flag or args.manifest
     if args.artifact and manifest_path:
         logger.error("Choose either a manifest or --artifact, not both")
@@ -602,12 +604,6 @@ def main(argv: list[str] | None = None) -> None:
             program_name,
         )
         sys.exit(1)
-
-    logging.basicConfig(
-        level=getattr(logging, args.log_level),
-        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
-        stream=sys.stderr,
-    )
 
     try:
         if args.artifact:
@@ -638,7 +634,8 @@ def main(argv: list[str] | None = None) -> None:
         logger.error(str(exc))
         sys.exit(1)
     except Exception as exc:
-        logger.error("Failed to start server: %s", exc, exc_info=True)
+        logger.error("Failed to start server: %s", exc)
+        logger.debug("MCP server startup failure", exc_info=True)
         sys.exit(1)
 
 

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -72,22 +72,34 @@ def get_context() -> ServerContext:
     return _ctx
 
 
-mcp = MCPServer(
-    "codenib",
-    instructions=(
-        "CodeNib provides code search over pre-built indexes. "
-        "Start with search_context for planned ranked retrieval over the "
-        "available lexical, dense, and structural views. Use search_semantic "
-        "for direct vector/embedding similarity, "
-        "search_bm25 for keyword lookups, search_regex for CodeGraph "
-        "file/symbol pattern matching, and search_zoekt for fast trigram-based "
-        "substring/regex search across raw file contents. Use "
-        "lsp_definition, lsp_references, and lsp_route for graph-backed "
-        "LSP-shaped symbol navigation."
-        " Use read_source to inspect a bounded source window after search or "
-        "navigation returns a location."
-    ),
-)
+# MCPServer configures the process-wide root logger while it is constructed.
+# Keep imports safe for embedding applications; `main()` configures logging
+# explicitly after parsing the requested CLI level.
+_root_logger = logging.getLogger()
+_import_logging_guard: logging.NullHandler | None = None
+if not _root_logger.handlers:
+    _import_logging_guard = logging.NullHandler()
+    _root_logger.addHandler(_import_logging_guard)
+try:
+    mcp = MCPServer(
+        "codenib",
+        instructions=(
+            "CodeNib provides code search over pre-built indexes. "
+            "Start with search_context for planned ranked retrieval over the "
+            "available lexical, dense, and structural views. Use search_semantic "
+            "for direct vector/embedding similarity, "
+            "search_bm25 for keyword lookups, search_regex for CodeGraph "
+            "file/symbol pattern matching, and search_zoekt for fast trigram-based "
+            "substring/regex search across raw file contents. Use "
+            "lsp_definition, lsp_references, and lsp_route for graph-backed "
+            "LSP-shaped symbol navigation."
+            " Use read_source to inspect a bounded source window after search or "
+            "navigation returns a location."
+        ),
+    )
+finally:
+    if _import_logging_guard is not None:
+        _root_logger.removeHandler(_import_logging_guard)
 
 
 # ------------------------------------------------------------------

--- a/test/mcp_server/test_server.py
+++ b/test/mcp_server/test_server.py
@@ -151,3 +151,51 @@ def test_parse_args_with_manifest_flag() -> None:
 def test_parse_args_with_log_level() -> None:
     args = server_mod._parse_args(["/tmp/m.json", "--log-level", "DEBUG"])
     assert args.log_level == "DEBUG"
+
+
+def test_main_applies_log_level_before_initialization(monkeypatch) -> None:
+    events = []
+    monkeypatch.setattr(
+        server_mod,
+        "set_console_log_level",
+        lambda level: events.append(("log_level", level)),
+    )
+    monkeypatch.setattr(
+        server_mod,
+        "init_server",
+        lambda manifest_path: events.append(("init", manifest_path)),
+    )
+    monkeypatch.setattr(
+        server_mod.mcp,
+        "run",
+        lambda *, transport: events.append(("run", transport)),
+    )
+
+    server_mod.main(["/tmp/m.json", "--log-level", "ERROR"])
+
+    assert events == [
+        ("log_level", "ERROR"),
+        ("init", "/tmp/m.json"),
+        ("run", "stdio"),
+    ]
+
+
+def test_main_keeps_startup_traceback_at_debug_level(monkeypatch) -> None:
+    failure = ValueError("artifact identity mismatch")
+
+    def fail_init(manifest_path) -> None:
+        raise failure
+
+    monkeypatch.setattr(server_mod, "set_console_log_level", lambda level: None)
+    monkeypatch.setattr(server_mod, "init_server", fail_init)
+    error = MagicMock()
+    debug = MagicMock()
+    monkeypatch.setattr(server_mod.logger, "error", error)
+    monkeypatch.setattr(server_mod.logger, "debug", debug)
+
+    with pytest.raises(SystemExit) as exit_info:
+        server_mod.main(["/tmp/m.json"])
+
+    assert exit_info.value.code == 1
+    error.assert_called_once_with("Failed to start server: %s", failure)
+    debug.assert_called_once_with("MCP server startup failure", exc_info=True)

--- a/test/mcp_server/test_server.py
+++ b/test/mcp_server/test_server.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import asyncio
+import subprocess
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -178,6 +180,26 @@ def test_main_applies_log_level_before_initialization(monkeypatch) -> None:
         ("init", "/tmp/m.json"),
         ("run", "stdio"),
     ]
+
+
+def test_import_does_not_configure_root_logging() -> None:
+    script = """\
+import logging
+
+root_logger = logging.getLogger()
+root_logger.handlers.clear()
+import codenib.mcp.server  # noqa: F401,E402
+assert not root_logger.handlers
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_main_keeps_startup_traceback_at_debug_level(monkeypatch) -> None:

--- a/test/test_log_utils.py
+++ b/test/test_log_utils.py
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
+import pytest
+
+from codenib import log_utils
 from codenib.log_utils import LoggingManager
 
 
@@ -9,3 +14,67 @@ def test_console_logs_use_stderr() -> None:
     manager = LoggingManager()
 
     assert manager.rich_handler.console.stderr is True
+    assert manager.rich_handler.level == logging.INFO
+
+
+def test_console_log_level_updates_console_handlers_only(tmp_path) -> None:
+    manager = LoggingManager()
+    root_logger = logging.getLogger()
+    original_root_level = root_logger.level
+    original_handler_levels = {
+        handler: handler.level for handler in root_logger.handlers
+    }
+    console_handler = logging.StreamHandler()
+    file_handler = logging.FileHandler(tmp_path / "diagnostic.log")
+    console_handler.setLevel(logging.DEBUG)
+    file_handler.setLevel(logging.DEBUG)
+    root_logger.addHandler(console_handler)
+    root_logger.addHandler(file_handler)
+
+    try:
+        assert manager.set_console_log_level("ERROR") == logging.ERROR
+        assert manager.rich_handler.level == logging.ERROR
+        assert manager.console_log_level == logging.ERROR
+        assert root_logger.level == logging.ERROR
+        assert console_handler.level == logging.ERROR
+        assert file_handler.level == logging.DEBUG
+    finally:
+        root_logger.removeHandler(console_handler)
+        root_logger.removeHandler(file_handler)
+        file_handler.close()
+        root_logger.setLevel(original_root_level)
+        for handler, level in original_handler_levels.items():
+            handler.setLevel(level)
+
+
+def test_console_log_level_rejects_unknown_name() -> None:
+    manager = LoggingManager()
+
+    with pytest.raises(ValueError, match="Invalid logging level"):
+        manager.set_console_log_level("verbose")
+
+
+def test_disabling_scip_debug_restores_selected_console_level(monkeypatch) -> None:
+    manager = LoggingManager()
+    logger_name = "test.log_utils.scip_restore"
+    logger = logging.getLogger(logger_name)
+    original_level = logger.level
+    original_handlers = list(logger.handlers)
+    original_propagate = logger.propagate
+    monkeypatch.setattr(log_utils, "logging_manager", manager)
+
+    try:
+        manager.console_log_level = logging.WARNING
+        manager.rich_handler.setLevel(logging.WARNING)
+        log_utils.register_scip_logger(logger_name)
+        log_utils.enable_scip_debug()
+        assert manager.rich_handler.level == log_utils.SCIP_DEBUG
+        assert manager.get_logger(logger_name).level == log_utils.SCIP_DEBUG
+
+        log_utils.disable_scip_debug()
+        assert manager.rich_handler.level == logging.WARNING
+        assert manager.get_logger(logger_name).level == logging.DEBUG
+    finally:
+        logger.handlers[:] = original_handlers
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate

--- a/test/test_log_utils.py
+++ b/test/test_log_utils.py
@@ -35,9 +35,12 @@ def test_console_log_level_updates_console_handlers_only(tmp_path) -> None:
         assert manager.set_console_log_level("ERROR") == logging.ERROR
         assert manager.rich_handler.level == logging.ERROR
         assert manager.console_log_level == logging.ERROR
-        assert root_logger.level == logging.ERROR
+        assert root_logger.level <= logging.DEBUG
         assert console_handler.level == logging.ERROR
         assert file_handler.level == logging.DEBUG
+        root_logger.debug("diagnostic detail")
+        file_handler.flush()
+        assert "diagnostic detail" in (tmp_path / "diagnostic.log").read_text()
     finally:
         root_logger.removeHandler(console_handler)
         root_logger.removeHandler(file_handler)
@@ -52,6 +55,32 @@ def test_console_log_level_rejects_unknown_name() -> None:
 
     with pytest.raises(ValueError, match="Invalid logging level"):
         manager.set_console_log_level("verbose")
+
+
+def test_console_log_level_enables_registered_scip_loggers() -> None:
+    manager = LoggingManager()
+    logger_name = "test.log_utils.scip_selection"
+    logger = logging.getLogger(logger_name)
+    original_level = logger.level
+    original_handlers = list(logger.handlers)
+    original_propagate = logger.propagate
+
+    try:
+        manager.scip_loggers.add(logger_name)
+        managed_logger = manager.get_logger(logger_name)
+
+        assert manager.set_console_log_level("SCIP_DEBUG") == log_utils.SCIP_DEBUG
+        assert manager.scip_debug_enabled is True
+        assert managed_logger.level == log_utils.SCIP_DEBUG
+
+        manager.set_console_log_level("INFO")
+        assert manager.scip_debug_enabled is False
+        assert managed_logger.level == logging.DEBUG
+        assert manager.rich_handler.level == logging.INFO
+    finally:
+        logger.handlers[:] = original_handlers
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
 
 
 def test_disabling_scip_debug_restores_selected_console_level(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Make normal CodeNib console output default to `INFO`, and make the public MCP `--log-level` option control managed Rich output and root console output before validation, manifest loading, and request serving. Expected startup failures remain concise unless `DEBUG` is selected. Closes #489.

## Changes
- track the selected normal console level in `LoggingManager`, defaulting to `INFO`
- apply MCP log selection before startup and restore the selected level after temporary SCIP debugging
- keep file handlers at `DEBUG` for diagnostics
- emit a one-line startup error at normal levels and retain the traceback at `DEBUG`
- cover handler isolation, default severity, SCIP restoration, entry-point ordering, and traceback severity

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/test_log_utils.py test/mcp_server/test_server.py --tb=short` (16 passed)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (3091 passed, 10 skipped, 180 deselected)
- `pre-commit run --files codenib/log_utils.py codenib/mcp/server.py test/test_log_utils.py test/mcp_server/test_server.py`
- real stdio MCP `search_bm25` request with `--log-level ERROR`: request succeeded and captured stderr was empty
- real artifact identity mismatch: one-line error at `ERROR`, full traceback at `DEBUG`
- real Python graph rebuild: normal progress remained visible and no CodeNib `DEBUG` records were emitted

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published