### PR TITLE
fix(artifact): require clean publication checkout

### DIFF
--- a/codenib/cli.py
+++ b/codenib/cli.py
@@ -544,6 +544,19 @@ def _publication_environment(credential_env: str | None = None) -> dict[str, str
     return environment
 
 
+def _require_clean_artifact_checkout(repo_path: Path) -> None:
+    """Require portable artifacts to describe the checked-out Git commit."""
+
+    from .source_fingerprint import repository_source_is_dirty
+
+    if repository_source_is_dirty(repo_path):
+        raise CLIError(
+            "portable context artifacts require a clean Git checkout at HEAD. "
+            "Commit or stash source-visible changes, or use `codenib wiki` or "
+            "`codenib export` to inspect the current working tree."
+        )
+
+
 def _paths_overlap(first: Path, second: Path) -> bool:
     return first == second or first in second.parents or second in first.parents
 
@@ -585,6 +598,7 @@ def _validate_publish_outputs(
 
 def _run_artifact_pack(args: argparse.Namespace) -> int:
     repo_path = resolve_repo_path(args.repo)
+    _require_clean_artifact_checkout(repo_path)
     manifest_path = resolve_manifest_path(str(repo_path))
     from .artifacts import stage_context_artifact
     from .compiler.manifest import RepoManifest
@@ -733,6 +747,7 @@ def _run_publish(args: argparse.Namespace) -> int:
         site_output=site_output,
         context_output=context_output,
     )
+    _require_clean_artifact_checkout(repo_path)
 
     selected_views = _selected_views_for_args(args)
     unsupported = sorted(set(selected_views) - {"bm25", "vector"})

--- a/test/artifacts/test_publish.py
+++ b/test/artifacts/test_publish.py
@@ -39,6 +39,14 @@ def test_publish_builds_static_site_and_portable_context_without_model(
     (repo / "runtime.py").write_text(
         "def run(value: int) -> int:\n    return value + 1\n"
     )
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.name", "CodeNib Test")
+    _git(repo, "config", "user.email", "codenib@example.invalid")
+    _git(repo, "add", "runtime.py")
+    _git(repo, "commit", "--quiet", "-m", "initial")
+    generated = repo / "dist"
+    generated.mkdir()
+    (generated / "bundle.js").write_text("generated output\n")
     site = tmp_path / "published" / "site"
     context = tmp_path / "published" / "context"
     monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "home"))
@@ -82,6 +90,74 @@ def _git(repo: Path, *args: str) -> str:
         text=True,
     )
     return result.stdout.strip()
+
+
+def _clean_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--quiet")
+    _git(repo, "config", "user.name", "CodeNib Test")
+    _git(repo, "config", "user.email", "codenib@example.invalid")
+    (repo / "runtime.py").write_text("VALUE = 1\n")
+    _git(repo, "add", "runtime.py")
+    _git(repo, "commit", "--quiet", "-m", "initial")
+    return repo
+
+
+@pytest.mark.parametrize("change", ["tracked", "untracked"])
+def test_publish_rejects_source_visible_dirty_checkout_before_indexing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    change: str,
+) -> None:
+    repo = _clean_repo(tmp_path)
+    if change == "tracked":
+        (repo / "runtime.py").write_text("VALUE = 2\n")
+    else:
+        (repo / "new_module.py").write_text("VALUE = 2\n")
+    monkeypatch.setenv("CODENIB_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(
+        cli,
+        "_run_index",
+        lambda *_args, **_kwargs: pytest.fail("publish indexed a dirty checkout"),
+    )
+
+    result = cli.run(
+        [
+            "publish",
+            str(repo),
+            "--site-output",
+            str(tmp_path / "site"),
+            "--context-output",
+            str(tmp_path / "context"),
+        ]
+    )
+
+    assert result == 2
+    assert "require a clean Git checkout" in capsys.readouterr().err
+
+
+def test_artifact_pack_rejects_non_git_checkout(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "runtime.py").write_text("VALUE = 1\n")
+
+    result = cli.run(
+        [
+            "artifact",
+            "pack",
+            str(repo),
+            "--output",
+            str(tmp_path / "context"),
+        ]
+    )
+
+    assert result == 2
+    assert "require a clean Git checkout" in capsys.readouterr().err
 
 
 def test_publish_second_commit_uses_incremental_compiler_state(


### PR DESCRIPTION
## Summary
Prevent portable context artifacts from claiming a clean `HEAD` commit while containing source-visible working-tree changes. Closes #491.

## Changes
- Reject dirty and non-Git checkouts in `codenib publish` and `codenib artifact pack`.
- Reuse the source-fingerprint visibility policy, so generated directories do not block publication.
- Keep local index, Wiki, and static export available for working-tree inspection.
- Add clean, tracked-dirty, untracked-dirty, generated-output, and non-Git regressions.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/artifacts/test_publish.py --tb=short` (8 passed)
- `pytest -q test/test_cli.py test/artifacts/test_publish.py --tb=short` (68 passed)
- pre-commit passed after restacking onto `main`

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published