### PR TITLE
fix(mcp): validate direct search bounds

### DIFF
--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -82,8 +82,8 @@ also remain available. All forms accept
 
 All source locations returned by MCP use 1-based line numbers. Internal indexes
 remain 0-based; the MCP adapters perform the conversion once at the boundary.
-All search tools reject blank queries and accept integer `top_k` values from 1
-through 100.
+All search tools reject blank queries and query text longer than 16,000
+characters. They accept integer `top_k` values from 1 through 100.
 
 ### `search_context`
 Plans and executes ranked retrieval without asking the agent to choose an index.

--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -82,6 +82,8 @@ also remain available. All forms accept
 
 All source locations returned by MCP use 1-based line numbers. Internal indexes
 remain 0-based; the MCP adapters perform the conversion once at the boundary.
+All search tools reject blank queries and accept integer `top_k` values from 1
+through 100.
 
 ### `search_context`
 Plans and executes ranked retrieval without asking the agent to choose an index.
@@ -103,7 +105,7 @@ and graph expansion only.
 Vector-embedding similarity search.
 
 - `query` (str): natural-language or code query.
-- `top_k` (int, default 10): max results.
+- `top_k` (int, default 10): max results, from 1 through 100.
 - `level` (str, default `"l2"`): hierarchy level — `"l0"` (files), `"l2"`
   (functions/methods).
 - `score_threshold` (float, default 0.0): minimum similarity; `0` disables the filter.
@@ -115,14 +117,15 @@ returns `{"error": ...}` so callers can recover gracefully.
 ### `search_bm25`
 BM25 keyword retrieval over indexed symbols.
 
-- `query` (str), `top_k` (int, default 20), `filter_test` (bool, default `False`) —
+- `query` (str), `top_k` (int, default 20, from 1 through 100),
+  `filter_test` (bool, default `False`) —
   when `True`, excludes results from test files.
 
 ### `search_regex`
 Grep-like regex over CodeGraph nodes.
 
 - `pattern` (str): Python `re` pattern.
-- `top_k` (int, default 20).
+- `top_k` (int, default 20): from 1 through 100.
 - `file_glob` (str, default `""`): restrict by file path (e.g. `*.py`).
 - `node_type` (str, default `""`): filter by type (`function`, `class`, `method`,
   `file`, …).
@@ -134,7 +137,7 @@ file-level (`type="file"`).
 
 - `query` (str): plain substring, regex (`regex:foo`), or atoms like `case:yes` /
   `lang:python`.
-- `top_k` (int, default 20).
+- `top_k` (int, default 20): from 1 through 100.
 - `file_filter` (str, default `""`): glob/regex appended as `file:<expr>`.
 
 ### `dependency_subgraph`

--- a/codenib/mcp/tools/search.py
+++ b/codenib/mcp/tools/search.py
@@ -16,11 +16,14 @@ from ...types import NodeInfo
 from ..context import ServerContext
 
 MAX_SEARCH_RESULTS = 100
+MAX_SEARCH_QUERY_CHARS = 16_000
 
 
-def _require_nonempty(value: str, name: str) -> str:
+def _validate_search_text(value: str, name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{name} must not be empty.")
+    if len(value) > MAX_SEARCH_QUERY_CHARS:
+        raise ValueError(f"{name} must not exceed {MAX_SEARCH_QUERY_CHARS} characters.")
     return value
 
 
@@ -48,7 +51,7 @@ def search_context_impl(
     filter_test: bool = False,
 ) -> Dict[str, Any]:
     """Plan and execute ranked retrieval over the available repository views."""
-    normalized_query = _require_nonempty(query, "query").strip()
+    normalized_query = _validate_search_text(query, "query").strip()
     top_k = _validate_top_k(top_k)
     normalized_level = (level or "l2").strip().lower()
     if normalized_level not in {"l0", "l2"}:
@@ -189,7 +192,7 @@ async def search_semantic(
         List of NodeInfo dicts with scores and content. On missing index,
         returns ``{"error": ...}`` so callers can handle gracefully.
     """
-    query = _require_nonempty(query, "query")
+    query = _validate_search_text(query, "query")
     top_k = _validate_top_k(top_k)
     if ctx.vector is None:
         return {
@@ -241,7 +244,7 @@ def search_bm25_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content, score.
     """
-    query = _require_nonempty(query, "query")
+    query = _validate_search_text(query, "query")
     top_k = _validate_top_k(top_k)
     if ctx.bm25 is None:
         raise RuntimeError(
@@ -286,7 +289,7 @@ def search_regex_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content.
     """
-    pattern = _require_nonempty(pattern, "pattern")
+    pattern = _validate_search_text(pattern, "pattern")
     top_k = _validate_top_k(top_k)
     if ctx.regex_index is None:
         raise RuntimeError(
@@ -347,7 +350,7 @@ def search_zoekt_impl(
         (``"file"``), ``file``, ``start_line``, ``end_line``, ``content``,
         ``score``, ``node_id`` (language hint, when reported).
     """
-    query = _require_nonempty(query, "query")
+    query = _validate_search_text(query, "query")
     top_k = _validate_top_k(top_k)
     if ctx.zoekt is None:
         raise RuntimeError(

--- a/codenib/mcp/tools/search.py
+++ b/codenib/mcp/tools/search.py
@@ -15,6 +15,24 @@ from ...agent.boundary import to_agent_repr
 from ...types import NodeInfo
 from ..context import ServerContext
 
+MAX_SEARCH_RESULTS = 100
+
+
+def _require_nonempty(value: str, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must not be empty.")
+    return value
+
+
+def _validate_top_k(top_k: int) -> int:
+    if (
+        isinstance(top_k, bool)
+        or not isinstance(top_k, int)
+        or not 1 <= top_k <= MAX_SEARCH_RESULTS
+    ):
+        raise ValueError("top_k must be an integer between 1 and 100.")
+    return top_k
+
 
 def _node_to_dict(node: NodeInfo) -> Dict[str, Any]:
     """Serialize a NodeInfo at the 1-based agent boundary."""
@@ -30,11 +48,8 @@ def search_context_impl(
     filter_test: bool = False,
 ) -> Dict[str, Any]:
     """Plan and execute ranked retrieval over the available repository views."""
-    normalized_query = (query or "").strip()
-    if not normalized_query:
-        raise ValueError("query must not be empty.")
-    if isinstance(top_k, bool) or not 1 <= top_k <= 100:
-        raise ValueError("top_k must be between 1 and 100.")
+    normalized_query = _require_nonempty(query, "query").strip()
+    top_k = _validate_top_k(top_k)
     normalized_level = (level or "l2").strip().lower()
     if normalized_level not in {"l0", "l2"}:
         raise ValueError("level must be 'l0' or 'l2'.")
@@ -174,6 +189,8 @@ async def search_semantic(
         List of NodeInfo dicts with scores and content. On missing index,
         returns ``{"error": ...}`` so callers can handle gracefully.
     """
+    query = _require_nonempty(query, "query")
+    top_k = _validate_top_k(top_k)
     if ctx.vector is None:
         return {
             "error": "Vector index not loaded. Re-run indexing with embedding enabled."
@@ -224,6 +241,8 @@ def search_bm25_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content, score.
     """
+    query = _require_nonempty(query, "query")
+    top_k = _validate_top_k(top_k)
     if ctx.bm25 is None:
         raise RuntimeError(
             "BM25 index is not available. "
@@ -267,6 +286,8 @@ def search_regex_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content.
     """
+    pattern = _require_nonempty(pattern, "pattern")
+    top_k = _validate_top_k(top_k)
     if ctx.regex_index is None:
         raise RuntimeError(
             "Regex index is not available. "
@@ -326,6 +347,8 @@ def search_zoekt_impl(
         (``"file"``), ``file``, ``start_line``, ``end_line``, ``content``,
         ``score``, ``node_id`` (language hint, when reported).
     """
+    query = _require_nonempty(query, "query")
+    top_k = _validate_top_k(top_k)
     if ctx.zoekt is None:
         raise RuntimeError(
             "Zoekt index is not available. "

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -125,7 +125,9 @@ Only tools whose backing views are fresh and available can return results.
 | `lsp_route` | `symbol_graph` | locations | Compact route anchors among related symbols |
 | `get_manifest` | manifest | repository | Repository identity, languages, view states, and capabilities |
 
-All source locations returned by MCP use 1-based line numbers.
+All source locations returned by MCP use 1-based line numbers. Search tools
+reject blank query text, cap it at 16,000 characters, and accept `top_k` values
+from 1 through 100.
 
 `search_context` accepts `query`, `top_k` (1-100), `budget`
 (`fast`, `balanced`, or `thorough`), dense `level` (`l0` or `l2`), and

--- a/test/mcp/test_search_semantic.py
+++ b/test/mcp/test_search_semantic.py
@@ -126,3 +126,19 @@ def test_search_semantic_empty_results(mock_context):
 
     assert results == []
     assert isinstance(results, list)
+
+
+@pytest.mark.parametrize("query", ["", " \t"])
+def test_search_semantic_rejects_blank_query_before_provider(mock_context, query):
+    with pytest.raises(ValueError, match="query must not be empty"):
+        asyncio.run(search_semantic(mock_context, query=query))
+
+    mock_context.vector.search_with_content.assert_not_called()
+
+
+@pytest.mark.parametrize("top_k", [True, 0, -1, 101, 1.5])
+def test_search_semantic_rejects_invalid_budget_before_provider(mock_context, top_k):
+    with pytest.raises(ValueError, match="top_k must be an integer between"):
+        asyncio.run(search_semantic(mock_context, query="test", top_k=top_k))
+
+    mock_context.vector.search_with_content.assert_not_called()

--- a/test/mcp/test_search_semantic.py
+++ b/test/mcp/test_search_semantic.py
@@ -15,7 +15,7 @@ import pytest
 
 from codenib.compiler.manifest import RepoManifest
 from codenib.mcp.context import ServerContext
-from codenib.mcp.tools.search import search_semantic
+from codenib.mcp.tools.search import MAX_SEARCH_QUERY_CHARS, search_semantic
 from codenib.types import NodeInfo
 
 
@@ -132,6 +132,18 @@ def test_search_semantic_empty_results(mock_context):
 def test_search_semantic_rejects_blank_query_before_provider(mock_context, query):
     with pytest.raises(ValueError, match="query must not be empty"):
         asyncio.run(search_semantic(mock_context, query=query))
+
+    mock_context.vector.search_with_content.assert_not_called()
+
+
+def test_search_semantic_rejects_oversized_query_before_provider(mock_context):
+    with pytest.raises(ValueError, match="must not exceed 16000 characters"):
+        asyncio.run(
+            search_semantic(
+                mock_context,
+                query="x" * (MAX_SEARCH_QUERY_CHARS + 1),
+            )
+        )
 
     mock_context.vector.search_with_content.assert_not_called()
 

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -78,6 +78,48 @@ def _sample_nodes() -> list[NodeInfo]:
     ]
 
 
+@pytest.mark.parametrize(
+    ("impl", "context_key", "query_key"),
+    [
+        (search_bm25_impl, "bm25", "query"),
+        (search_regex_impl, "regex_index", "pattern"),
+        (search_zoekt_impl, "zoekt", "query"),
+    ],
+)
+@pytest.mark.parametrize("value", ["", " \t"])
+def test_direct_search_rejects_blank_input_before_provider(
+    impl, context_key, query_key, value
+) -> None:
+    provider = MagicMock()
+    ctx = _make_ctx(**{context_key: provider})
+
+    with pytest.raises(ValueError, match=f"{query_key} must not be empty"):
+        impl(ctx, **{query_key: value})
+
+    provider.search.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("impl", "context_key", "query_key", "query"),
+    [
+        (search_bm25_impl, "bm25", "query", "tax"),
+        (search_regex_impl, "regex_index", "pattern", "tax"),
+        (search_zoekt_impl, "zoekt", "query", "tax"),
+    ],
+)
+@pytest.mark.parametrize("top_k", [True, 0, -1, 101, 1.5])
+def test_direct_search_rejects_invalid_budget_before_provider(
+    impl, context_key, query_key, query, top_k
+) -> None:
+    provider = MagicMock()
+    ctx = _make_ctx(**{context_key: provider})
+
+    with pytest.raises(ValueError, match="top_k must be an integer between"):
+        impl(ctx, top_k=top_k, **{query_key: query})
+
+    provider.search.assert_not_called()
+
+
 class TestSearchContext:
     def test_sparse_plan_returns_route_and_source_provenance(self) -> None:
         mock_bm25 = MagicMock()
@@ -190,7 +232,8 @@ class TestSearchContext:
         ("kwargs", "message"),
         [
             ({"query": ""}, "query must not be empty"),
-            ({"query": "x", "top_k": 0}, "top_k must be between"),
+            ({"query": "x", "top_k": 0}, "top_k must be an integer"),
+            ({"query": "x", "top_k": 1.5}, "top_k must be an integer"),
             ({"query": "x", "level": "l1"}, "level must be"),
         ],
     )

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -15,6 +15,7 @@ from codenib.compiler.manifest import RepoManifest
 from codenib.index.trigram import ZoektUnavailableError
 from codenib.index.trigram.zoekt_searcher import _file_match_to_node
 from codenib.mcp.tools.search import (
+    MAX_SEARCH_QUERY_CHARS,
     search_bm25_impl,
     search_context_impl,
     search_regex_impl,
@@ -95,6 +96,27 @@ def test_direct_search_rejects_blank_input_before_provider(
 
     with pytest.raises(ValueError, match=f"{query_key} must not be empty"):
         impl(ctx, **{query_key: value})
+
+    provider.search.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("impl", "context_key", "query_key"),
+    [
+        (search_context_impl, "bm25", "query"),
+        (search_bm25_impl, "bm25", "query"),
+        (search_regex_impl, "regex_index", "pattern"),
+        (search_zoekt_impl, "zoekt", "query"),
+    ],
+)
+def test_search_rejects_oversized_input_before_provider(
+    impl, context_key, query_key
+) -> None:
+    provider = MagicMock()
+    ctx = _make_ctx(**{context_key: provider})
+
+    with pytest.raises(ValueError, match="must not exceed 16000 characters"):
+        impl(ctx, **{query_key: "x" * (MAX_SEARCH_QUERY_CHARS + 1)})
 
     provider.search.assert_not_called()
 


### PR DESCRIPTION
## Summary

Apply one bounded input contract to planned, semantic, BM25, regex, and Zoekt MCP search routes. Closes #495.

## Changes

- Reject blank and greater-than-16,000-character query text before provider execution.
- Require integer `top_k` values from 1 through 100 on every direct and planned search route.
- Prevent negative slicing and empty-query full-index dumps from direct BM25, regex, and Zoekt calls.
- Keep valid search behavior and result serialization unchanged.
- Document the public query and result budgets and add provider-call regressions for all five routes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/mcp/test_search_semantic.py test/mcp_server/test_tools_search.py --tb=short` (`63 passed`)

`pytest -q test/mcp test/mcp_server --tb=short` (`128 passed, 14 skipped`)

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2850 passed, 10 skipped`)

`pre-commit run --files codenib/mcp/tools/search.py test/mcp/test_search_semantic.py test/mcp_server/test_tools_search.py codenib/mcp/README.md docs/mcp.md`

`mkdocs build --strict`

A real persisted BM25/graph artifact confirmed that invalid requests are rejected before provider execution and valid result counts remain bounded.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
