### PR TITLE
fix(mcp): enforce LSP request bounds

### DIFF
--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -153,6 +153,9 @@ Each node's optional `line` is 1-based.
 Static LSP-shaped navigation over the loaded `symbol_graph`. These tools return
 compact locations only; clients should read source before finalizing.
 All three tools require integer `top_k` values from 1 through 100.
+Paths are limited to 4,096 characters, individual symbol names to 1,024
+characters, and route queries to 16,000 characters so malformed requests fail
+before graph resolution.
 
 - `lsp_definition`: provide either `symbol`, or `file_path` + 1-based `line`
   with optional 0-based `character`; `top_k` defaults to 8.
@@ -161,7 +164,8 @@ All three tools require integer `top_k` values from 1 through 100.
 - `lsp_route`: provide `symbols`, with optional `query`, `top_k` (default 12),
   and `include_neighbors` (default `true`) to rank endpoint, bridge/factory,
   provider/value, and type anchors. At most 100 non-empty symbol seeds are
-  accepted per request.
+  accepted per request; comma-separated seed text is limited to 16,000
+  characters before splitting.
 
 ### `get_manifest`
 Returns the manifest version; a nested `repo` object containing path, commit,

--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -152,6 +152,7 @@ Each node's optional `line` is 1-based.
 ### `lsp_definition` / `lsp_references` / `lsp_route`
 Static LSP-shaped navigation over the loaded `symbol_graph`. These tools return
 compact locations only; clients should read source before finalizing.
+All three tools require integer `top_k` values from 1 through 100.
 
 - `lsp_definition`: provide either `symbol`, or `file_path` + 1-based `line`
   with optional 0-based `character`; `top_k` defaults to 8.
@@ -159,7 +160,8 @@ compact locations only; clients should read source before finalizing.
   `include_declaration` defaults to `true` and `top_k` to 40.
 - `lsp_route`: provide `symbols`, with optional `query`, `top_k` (default 12),
   and `include_neighbors` (default `true`) to rank endpoint, bridge/factory,
-  provider/value, and type anchors.
+  provider/value, and type anchors. At most 100 non-empty symbol seeds are
+  accepted per request.
 
 ### `get_manifest`
 Returns the manifest version; a nested `repo` object containing path, commit,

--- a/codenib/mcp/tools/lsp.py
+++ b/codenib/mcp/tools/lsp.py
@@ -10,6 +10,10 @@ from typing import Any, Sequence
 
 MAX_LSP_RESULTS = 100
 MAX_LSP_ROUTE_SYMBOLS = 100
+MAX_LSP_PATH_CHARS = 4_096
+MAX_LSP_SYMBOL_CHARS = 1_024
+MAX_LSP_QUERY_CHARS = 16_000
+MAX_LSP_ROUTE_TEXT_CHARS = 16_000
 
 
 def _validate_top_k(top_k: int) -> int:
@@ -22,10 +26,42 @@ def _validate_top_k(top_k: int) -> int:
     return top_k
 
 
+def _validate_text(value: str, *, name: str, max_chars: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    if len(value) > max_chars:
+        raise ValueError(f"{name} must contain at most {max_chars} characters")
+    return value
+
+
 def _coerce_symbols(symbols: Sequence[str] | str) -> list[str]:
     if isinstance(symbols, str):
-        return [s.strip() for s in symbols.split(",") if s.strip()]
-    return [str(s).strip() for s in symbols or [] if str(s).strip()]
+        _validate_text(
+            symbols,
+            name="symbols",
+            max_chars=MAX_LSP_ROUTE_TEXT_CHARS,
+        )
+        values = symbols.split(",")
+    else:
+        values = symbols or []
+
+    normalized: list[str] = []
+    for value in values:
+        seed = str(value).strip()
+        if not seed:
+            continue
+        _validate_text(
+            seed,
+            name="each symbol",
+            max_chars=MAX_LSP_SYMBOL_CHARS,
+        )
+        normalized.append(seed)
+        if len(normalized) > MAX_LSP_ROUTE_SYMBOLS:
+            raise ValueError(
+                "symbols must contain at most "
+                f"{MAX_LSP_ROUTE_SYMBOLS} non-empty entries"
+            )
+    return normalized
 
 
 def _node_to_dict(node: Any) -> dict[str, Any]:
@@ -58,16 +94,28 @@ def lsp_definition_impl(
         return {"error": "symbol_graph index not available"}
 
     from ...agent.boundary import from_agent_repr
-    from ...agent.lsp_provider import StaticLSPProvider
 
     graph_line = from_agent_repr(line)
     try:
         limit = _validate_top_k(top_k)
+        requested_path = _validate_text(
+            file_path,
+            name="file_path",
+            max_chars=MAX_LSP_PATH_CHARS,
+        )
+        requested_symbol = _validate_text(
+            symbol,
+            name="symbol",
+            max_chars=MAX_LSP_SYMBOL_CHARS,
+        )
+
+        from ...agent.lsp_provider import StaticLSPProvider
+
         results = StaticLSPProvider(graph).definition(
-            file_path=file_path or None,
+            file_path=requested_path or None,
             line=graph_line,
             character=character,
-            symbol=symbol or None,
+            symbol=requested_symbol or None,
             top_k=limit,
         )
     except ValueError as exc:
@@ -90,16 +138,28 @@ def lsp_references_impl(
         return {"error": "symbol_graph index not available"}
 
     from ...agent.boundary import from_agent_repr
-    from ...agent.lsp_provider import StaticLSPProvider
 
     graph_line = from_agent_repr(line)
     try:
         limit = _validate_top_k(top_k)
+        requested_path = _validate_text(
+            file_path,
+            name="file_path",
+            max_chars=MAX_LSP_PATH_CHARS,
+        )
+        requested_symbol = _validate_text(
+            symbol,
+            name="symbol",
+            max_chars=MAX_LSP_SYMBOL_CHARS,
+        )
+
+        from ...agent.lsp_provider import StaticLSPProvider
+
         results = StaticLSPProvider(graph).references(
-            file_path=file_path or None,
+            file_path=requested_path or None,
             line=graph_line,
             character=character,
-            symbol=symbol or None,
+            symbol=requested_symbol or None,
             include_declaration=bool(include_declaration),
             top_k=limit,
         )
@@ -122,24 +182,22 @@ def lsp_route_impl(
 
     try:
         limit = _validate_top_k(top_k)
+        seeds = _coerce_symbols(symbols)
+        requested_query = _validate_text(
+            query,
+            name="query",
+            max_chars=MAX_LSP_QUERY_CHARS,
+        )
     except ValueError as exc:
         return {"error": str(exc)}
-    seeds = _coerce_symbols(symbols)
     if not seeds:
         return []
-    if len(seeds) > MAX_LSP_ROUTE_SYMBOLS:
-        return {
-            "error": (
-                "symbols must contain at most "
-                f"{MAX_LSP_ROUTE_SYMBOLS} non-empty entries"
-            )
-        }
 
     from ...agent.lsp_provider import StaticLSPProvider
 
     results = StaticLSPProvider(graph).route(
         symbols=seeds,
-        query=query or None,
+        query=requested_query or None,
         top_k=limit,
         include_neighbors=bool(include_neighbors),
     )

--- a/codenib/mcp/tools/lsp.py
+++ b/codenib/mcp/tools/lsp.py
@@ -8,6 +8,19 @@ from __future__ import annotations
 
 from typing import Any, Sequence
 
+MAX_LSP_RESULTS = 100
+MAX_LSP_ROUTE_SYMBOLS = 100
+
+
+def _validate_top_k(top_k: int) -> int:
+    if (
+        isinstance(top_k, bool)
+        or not isinstance(top_k, int)
+        or not 1 <= top_k <= MAX_LSP_RESULTS
+    ):
+        raise ValueError("top_k must be an integer between 1 and 100")
+    return top_k
+
 
 def _coerce_symbols(symbols: Sequence[str] | str) -> list[str]:
     if isinstance(symbols, str):
@@ -49,12 +62,13 @@ def lsp_definition_impl(
 
     graph_line = from_agent_repr(line)
     try:
+        limit = _validate_top_k(top_k)
         results = StaticLSPProvider(graph).definition(
             file_path=file_path or None,
             line=graph_line,
             character=character,
             symbol=symbol or None,
-            top_k=max(1, int(top_k or 8)),
+            top_k=limit,
         )
     except ValueError as exc:
         return {"error": str(exc)}
@@ -80,13 +94,14 @@ def lsp_references_impl(
 
     graph_line = from_agent_repr(line)
     try:
+        limit = _validate_top_k(top_k)
         results = StaticLSPProvider(graph).references(
             file_path=file_path or None,
             line=graph_line,
             character=character,
             symbol=symbol or None,
             include_declaration=bool(include_declaration),
-            top_k=max(1, int(top_k or 40)),
+            top_k=limit,
         )
     except ValueError as exc:
         return {"error": str(exc)}
@@ -105,15 +120,27 @@ def lsp_route_impl(
     if graph is None:
         return {"error": "symbol_graph index not available"}
 
-    from ...agent.lsp_provider import StaticLSPProvider
-
+    try:
+        limit = _validate_top_k(top_k)
+    except ValueError as exc:
+        return {"error": str(exc)}
     seeds = _coerce_symbols(symbols)
     if not seeds:
         return []
+    if len(seeds) > MAX_LSP_ROUTE_SYMBOLS:
+        return {
+            "error": (
+                "symbols must contain at most "
+                f"{MAX_LSP_ROUTE_SYMBOLS} non-empty entries"
+            )
+        }
+
+    from ...agent.lsp_provider import StaticLSPProvider
+
     results = StaticLSPProvider(graph).route(
         symbols=seeds,
         query=query or None,
-        top_k=max(1, int(top_k or 12)),
+        top_k=limit,
         include_neighbors=bool(include_neighbors),
     )
     return [_node_to_dict(node) for node in results]

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -285,6 +285,55 @@ def test_lsp_route_rejects_oversized_symbol_list_before_provider():
     provider.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("impl", "kwargs", "error"),
+    [
+        (
+            lsp_definition_impl,
+            {"symbol": "s" * 1_025},
+            "symbol must contain at most 1024 characters",
+        ),
+        (
+            lsp_references_impl,
+            {"symbol": "s" * 1_025},
+            "symbol must contain at most 1024 characters",
+        ),
+        (
+            lsp_definition_impl,
+            {"file_path": "p" * 4_097, "line": 1},
+            "file_path must contain at most 4096 characters",
+        ),
+        (
+            lsp_references_impl,
+            {"file_path": "p" * 4_097, "line": 1},
+            "file_path must contain at most 4096 characters",
+        ),
+        (
+            lsp_route_impl,
+            {"symbols": ["s" * 1_025]},
+            "each symbol must contain at most 1024 characters",
+        ),
+        (
+            lsp_route_impl,
+            {"symbols": ["load_config"], "query": "q" * 16_001},
+            "query must contain at most 16000 characters",
+        ),
+        (
+            lsp_route_impl,
+            {"symbols": "s," * 8_001},
+            "symbols must contain at most 16000 characters",
+        ),
+    ],
+)
+def test_lsp_tools_reject_oversized_text_before_provider(impl, kwargs, error):
+    ctx = MagicMock(symbol_graph=MagicMock())
+    with patch("codenib.agent.lsp_provider.StaticLSPProvider") as provider:
+        result = impl(ctx, **kwargs)
+
+    assert result == {"error": error}
+    provider.assert_not_called()
+
+
 def test_server_status_resource(mock_manifest: Path):
     """Test server_status resource returns correct info."""
     mock_vector = MagicMock(spec=CodeVectorStore)

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -26,7 +26,11 @@ from mcp.types import LATEST_PROTOCOL_VERSION
 import codenib.mcp.server as server_module
 from codenib.index.embedding.vector_store import CodeVectorStore
 from codenib.mcp.context import ServerContext
-from codenib.mcp.tools.lsp import lsp_definition_impl, lsp_references_impl
+from codenib.mcp.tools.lsp import (
+    lsp_definition_impl,
+    lsp_references_impl,
+    lsp_route_impl,
+)
 
 
 def test_server_import_keeps_optional_index_runtimes_lazy() -> None:
@@ -251,6 +255,34 @@ def test_lsp_tools_reuse_agent_line_boundary():
         lsp_definition_impl(ctx, file_path="caller.py", line=0)
 
     assert mock_definition.call_args.kwargs["line"] == 0
+
+
+@pytest.mark.parametrize("top_k", [True, 0, -1, 101, 1.5])
+@pytest.mark.parametrize(
+    ("impl", "kwargs"),
+    [
+        (lsp_definition_impl, {"symbol": "load_config"}),
+        (lsp_references_impl, {"symbol": "load_config"}),
+        (lsp_route_impl, {"symbols": ["load_config"]}),
+    ],
+)
+def test_lsp_tools_reject_invalid_result_budgets_before_provider(top_k, impl, kwargs):
+    ctx = MagicMock(symbol_graph=MagicMock())
+    with patch("codenib.agent.lsp_provider.StaticLSPProvider") as provider:
+        result = impl(ctx, top_k=top_k, **kwargs)
+
+    assert result == {"error": "top_k must be an integer between 1 and 100"}
+    provider.assert_not_called()
+
+
+def test_lsp_route_rejects_oversized_symbol_list_before_provider():
+    ctx = MagicMock(symbol_graph=MagicMock())
+    symbols = [f"symbol_{index}" for index in range(101)]
+    with patch("codenib.agent.lsp_provider.StaticLSPProvider") as provider:
+        result = lsp_route_impl(ctx, symbols=symbols)
+
+    assert result == {"error": "symbols must contain at most 100 non-empty entries"}
+    provider.assert_not_called()
 
 
 def test_server_status_resource(mock_manifest: Path):


### PR DESCRIPTION
## Summary

Make MCP LSP-shaped navigation honor explicit, finite caller budgets for both result counts and graph-resolution inputs. Closes #497.

## Changes

- require integer `top_k` values from 1 through 100 for definition, references, and route
- return structured errors instead of silently rewriting zero and negative values
- reject route requests with more than 100 normalized symbol seeds before provider execution
- cap paths at 4,096 characters, individual symbols at 1,024, and route seed/query text at 16,000
- fail malformed text before fuzzy symbol resolution or repository-wide route scans
- preserve existing selector behavior, static provider execution, and 1-based MCP line conversion
- document result, seed-count, and text limits

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation-only change

## Testing

- `pytest -q test/mcp/test_mcp_server.py -k 'lsp'` (`27 passed`)
- `pytest -q test/mcp test/mcp_server --tb=short` (`117 passed, 14 skipped`)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2839 passed, 10 skipped`)
- `uv run --no-sync mkdocs build --strict`
- `python scripts/check_public_docs.py`
- `pre-commit run --files codenib/mcp/tools/lsp.py codenib/mcp/README.md test/mcp/test_mcp_server.py`
- real SCIP-backed Python artifact rejects zero, negative, oversized-result requests; valid definition/reference/route requests still return `1/2/2` locations

## Checklist

- [x] I have performed a self-review of my changes.
- [x] I have added tests that prove the fix is effective.
- [x] I have updated relevant documentation.
- [x] My changes preserve existing ownership boundaries.
