### PR TITLE
fix(web): bound interactive API requests

### DIFF
--- a/codenib/web/edge_label.py
+++ b/codenib/web/edge_label.py
@@ -47,7 +47,7 @@ _MAX_WORDS = 6
 _MAX_TOKENS = 1024
 _LLM_TIMEOUT_S = 30
 _MAX_CODE_CHARS = 1500  # per symbol body fed to the LLM
-_MAX_ANCHORS = 3
+MAX_EDGE_LABEL_ANCHORS = 3
 _UNIT_SEP = "\x1f"
 _PROMPT_VERSION = "2"
 
@@ -172,7 +172,7 @@ class EdgeLabeler:
 
     def _anchor_block(self, anchors: List[dict]) -> str:
         snippets: List[str] = []
-        for a in anchors[:_MAX_ANCHORS]:
+        for a in anchors[:MAX_EDGE_LABEL_ANCHORS]:
             file = a.get("file") or ""
             line = a.get("line")
             if not file or not isinstance(line, int):

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -14,9 +14,13 @@ import os
 import re
 from typing import Any, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from codenib.agent.boundary import to_agent_repr
+
+MAX_CHAT_MESSAGES = 32
+MAX_CHAT_MESSAGE_CHARS = 16_000
+MAX_CHAT_REQUEST_CHARS = 64_000
 
 
 class WindowStats(BaseModel):
@@ -109,7 +113,7 @@ class ChatMessage(BaseModel):
     """One conversation message (text only — citations stay client-side)."""
 
     role: Literal["user", "assistant"]
-    content: str
+    content: str = Field(max_length=MAX_CHAT_MESSAGE_CHARS)
 
 
 class ChatRequest(BaseModel):
@@ -117,7 +121,18 @@ class ChatRequest(BaseModel):
     # Full conversation, oldest first; the last message is the current question
     # and must be from the user (OpenAI/DeepWiki-style). Earlier messages give
     # the agent context for follow-ups.
-    messages: List[ChatMessage]
+    messages: List[ChatMessage] = Field(max_length=MAX_CHAT_MESSAGES)
+
+    @field_validator("messages")
+    @classmethod
+    def _bound_total_content(cls, messages: List[ChatMessage]) -> List[ChatMessage]:
+        total_chars = sum(len(message.content) for message in messages)
+        if total_chars > MAX_CHAT_REQUEST_CHARS:
+            raise ValueError(
+                "chat message content exceeds the "
+                f"{MAX_CHAT_REQUEST_CHARS}-character request limit"
+            )
+        return messages
 
 
 class Citation(BaseModel):

--- a/codenib/web/schemas.py
+++ b/codenib/web/schemas.py
@@ -18,9 +18,14 @@ from pydantic import BaseModel, Field, field_validator
 
 from codenib.agent.boundary import to_agent_repr
 
+from .edge_label import MAX_EDGE_LABEL_ANCHORS
+
 MAX_CHAT_MESSAGES = 32
 MAX_CHAT_MESSAGE_CHARS = 16_000
 MAX_CHAT_REQUEST_CHARS = 64_000
+MAX_EDGE_LABEL_FILE_CHARS = 4_096
+MAX_EDGE_LABEL_NAME_CHARS = 1_024
+MAX_EDGE_LABEL_COMMIT_CHARS = 128
 
 
 class WindowStats(BaseModel):
@@ -75,8 +80,8 @@ class RepoInfo(BaseModel):
 class CallSite(BaseModel):
     """An exact call site (1-based line), mirroring the frontend ``CallSite``."""
 
-    file: str = ""
-    line: Optional[int] = None
+    file: str = Field(default="", max_length=MAX_EDGE_LABEL_FILE_CHARS)
+    line: Optional[int] = Field(default=None, ge=1)
 
 
 class EdgeEndpoint(BaseModel):
@@ -87,10 +92,13 @@ class EdgeEndpoint(BaseModel):
     is addressed by (file, line span) rather than a symbol name.
     """
 
-    file: str
-    line: Optional[int] = None  # 1-based start
-    end_line: Optional[int] = None  # 1-based end
-    label: str = ""  # display name, for the prompt only (not identity)
+    file: str = Field(max_length=MAX_EDGE_LABEL_FILE_CHARS)
+    line: Optional[int] = Field(default=None, ge=1)  # 1-based start
+    end_line: Optional[int] = Field(default=None, ge=1)  # 1-based end
+    label: str = Field(
+        default="",
+        max_length=MAX_EDGE_LABEL_NAME_CHARS,
+    )  # display name, for the prompt only (not identity)
 
 
 class EdgeLabelRequest(BaseModel):
@@ -98,9 +106,12 @@ class EdgeLabelRequest(BaseModel):
 
     source: EdgeEndpoint
     target: EdgeEndpoint
-    commit: Optional[str] = None
+    commit: Optional[str] = Field(default=None, max_length=MAX_EDGE_LABEL_COMMIT_CHARS)
     # Exact call sites where source references target (1-based), if known.
-    anchors: List[CallSite] = Field(default_factory=list)
+    anchors: List[CallSite] = Field(
+        default_factory=list,
+        max_length=MAX_EDGE_LABEL_ANCHORS,
+    )
 
 
 class EdgeLabelResponse(BaseModel):

--- a/codenib/web/static_server.py
+++ b/codenib/web/static_server.py
@@ -26,6 +26,7 @@ _HOP_BY_HOP_HEADERS = {
     "transfer-encoding",
     "upgrade",
 }
+MAX_PROXY_REQUEST_BODY_BYTES = 1024 * 1024
 
 
 def runtime_config(api_base: str) -> bytes:
@@ -92,7 +93,21 @@ class WikiStaticHandler(SimpleHTTPRequestHandler):
             self.send_error(404)
             return
 
-        content_length = int(self.headers.get("Content-Length") or 0)
+        try:
+            content_length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            self._send_api_error(400, "invalid Content-Length header")
+            return
+        if content_length < 0:
+            self._send_api_error(400, "Content-Length must not be negative")
+            return
+        if content_length > MAX_PROXY_REQUEST_BODY_BYTES:
+            self._send_api_error(
+                413,
+                "API request body exceeds the "
+                f"{MAX_PROXY_REQUEST_BODY_BYTES}-byte limit",
+            )
+            return
         body = self.rfile.read(content_length) if content_length else None
         headers = {
             name: value
@@ -118,15 +133,7 @@ class WikiStaticHandler(SimpleHTTPRequestHandler):
             response = exc
         except (OSError, urllib_error.URLError) as exc:
             reason = getattr(exc, "reason", exc)
-            payload = json.dumps(
-                {"detail": f"CodeNib API is unavailable: {reason}"}
-            ).encode("utf-8")
-            self.send_response(502)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(payload)))
-            self.end_headers()
-            if self.command != "HEAD":
-                self.wfile.write(payload)
+            self._send_api_error(502, f"CodeNib API is unavailable: {reason}")
             return
 
         try:
@@ -147,6 +154,17 @@ class WikiStaticHandler(SimpleHTTPRequestHandler):
                 self.wfile.write(payload)
         finally:
             response.close()
+
+    def _send_api_error(self, status: int, detail: str) -> None:
+        payload = json.dumps({"detail": detail}).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.close_connection = True
+        if self.command != "HEAD":
+            self.wfile.write(payload)
 
     def end_headers(self) -> None:
         request_path = urlsplit(self.path).path

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -207,6 +207,10 @@ The backend exposes (all under `/api`):
 | `POST /api/repos/{id}/edge-label` | Short LLM phrase for how a graph edge's source uses its target (opt-in via `edge_labels`; returns `disabled` when off) |
 | `POST /api/chat` | Ask: answer + citations |
 
+Ask requests accept at most 32 text messages, 16,000 characters per message,
+and 64,000 characters across the request. FastAPI rejects larger histories
+before loading a repository runtime or calling the configured model.
+
 The `/commits` endpoint and the `commit` parameter are served from per-commit
 graph snapshots — see [Per-commit graph snapshots](#per-commit-graph-snapshots)
 below.

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -209,7 +209,9 @@ The backend exposes (all under `/api`):
 
 Ask requests accept at most 32 text messages, 16,000 characters per message,
 and 64,000 characters across the request. FastAPI rejects larger histories
-before loading a repository runtime or calling the configured model.
+before loading a repository runtime or calling the configured model. The
+installed same-origin proxy also rejects API request bodies larger than 1 MiB
+before buffering or forwarding them.
 
 The `/commits` endpoint and the `commit` parameter are served from per-commit
 graph snapshots — see [Per-commit graph snapshots](#per-commit-graph-snapshots)

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -204,7 +204,7 @@ The backend exposes (all under `/api`):
 | `GET /api/repos/{id}/commits` | Commit window for the graph view, newest first (`available: false` without a prebuilt window) |
 | `GET /api/repos/{id}/codemap` | Dependency subgraph around a symbol (`symbol`, `direction`, `depth`, `max_nodes`, `commit`) |
 | `GET /api/repos/{id}/source` | Source lines for the code/peek panels |
-| `POST /api/repos/{id}/edge-label` | Short LLM phrase for how a graph edge's source uses its target (opt-in via `edge_labels`; returns `disabled` when off) |
+| `POST /api/repos/{id}/edge-label` | Short LLM phrase for how a graph edge's source uses its target (opt-in via `edge_labels`; returns `disabled` when off; accepts at most three call-site anchors) |
 | `POST /api/chat` | Ask: answer + citations |
 
 Ask requests accept at most 32 text messages, 16,000 characters per message,

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -9,7 +9,28 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+from fastapi.testclient import TestClient
+
 import codenib.web.app as web_app
+
+
+def test_oversized_chat_request_is_rejected_before_runtime_lookup(monkeypatch):
+    def unexpected_registry_lookup():
+        raise AssertionError("invalid chat payload reached the repository runtime")
+
+    monkeypatch.setattr(web_app, "_registry", unexpected_registry_lookup)
+    client = TestClient(web_app.app)
+
+    response = client.post(
+        "/api/chat",
+        json={
+            "repo_id": "missing",
+            "messages": [{"role": "user", "content": "bounded"} for _ in range(33)],
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["type"] == "too_long"
 
 
 def test_wiki_generation_runs_off_event_loop(monkeypatch):

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -4,9 +4,60 @@
 
 """Unit tests for the demo API response mapping (pure logic, no indexes)."""
 
+import pytest
+from pydantic import ValidationError
+
 from codenib.agent.agent_types import AgentResult, ToolCallRecord
 from codenib.types import QueriedNode
-from codenib.web.schemas import agent_result_to_response
+from codenib.web.schemas import (
+    MAX_CHAT_MESSAGE_CHARS,
+    MAX_CHAT_MESSAGES,
+    MAX_CHAT_REQUEST_CHARS,
+    ChatRequest,
+    agent_result_to_response,
+)
+
+
+def test_chat_request_accepts_bounded_follow_up_history():
+    request = ChatRequest(
+        repo_id="demo",
+        messages=[
+            {"role": "user", "content": "Where is indexing configured?"},
+            {"role": "assistant", "content": "See `codenib/compiler`."},
+            {"role": "user", "content": "What calls it?"},
+        ],
+    )
+
+    assert len(request.messages) == 3
+    assert request.messages[-1].role == "user"
+
+
+def test_chat_request_rejects_too_many_messages():
+    with pytest.raises(ValidationError, match="at most 32 items"):
+        ChatRequest(
+            repo_id="demo",
+            messages=[
+                {"role": "user", "content": "bounded"}
+                for _ in range(MAX_CHAT_MESSAGES + 1)
+            ],
+        )
+
+
+def test_chat_request_rejects_oversized_message():
+    with pytest.raises(ValidationError, match="at most 16000 characters"):
+        ChatRequest(
+            repo_id="demo",
+            messages=[{"role": "user", "content": "x" * (MAX_CHAT_MESSAGE_CHARS + 1)}],
+        )
+
+
+def test_chat_request_rejects_oversized_aggregate_content():
+    per_message = MAX_CHAT_REQUEST_CHARS // 5 + 1
+    with pytest.raises(ValidationError, match="character request limit"):
+        ChatRequest(
+            repo_id="demo",
+            messages=[{"role": "user", "content": "x" * per_message} for _ in range(5)],
+        )
 
 
 def _node(file, start, end, name="fn", score=1.0):

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -13,7 +13,11 @@ from codenib.web.schemas import (
     MAX_CHAT_MESSAGE_CHARS,
     MAX_CHAT_MESSAGES,
     MAX_CHAT_REQUEST_CHARS,
+    MAX_EDGE_LABEL_COMMIT_CHARS,
+    MAX_EDGE_LABEL_FILE_CHARS,
+    MAX_EDGE_LABEL_NAME_CHARS,
     ChatRequest,
+    EdgeLabelRequest,
     agent_result_to_response,
 )
 
@@ -58,6 +62,61 @@ def test_chat_request_rejects_oversized_aggregate_content():
             repo_id="demo",
             messages=[{"role": "user", "content": "x" * per_message} for _ in range(5)],
         )
+
+
+def _edge_label_request(**overrides):
+    data = {
+        "source": {"file": "src/source.py", "line": 1, "label": "source"},
+        "target": {"file": "src/target.py", "line": 2, "label": "target"},
+        "commit": "a" * 40,
+        "anchors": [{"file": "src/source.py", "line": line} for line in range(1, 4)],
+    }
+    data.update(overrides)
+    return EdgeLabelRequest(**data)
+
+
+def test_edge_label_request_accepts_three_bounded_anchors():
+    request = _edge_label_request()
+
+    assert len(request.anchors) == 3
+
+
+def test_edge_label_request_rejects_unused_anchor_tail():
+    with pytest.raises(ValidationError, match="at most 3 items"):
+        _edge_label_request(
+            anchors=[{"file": "src/source.py", "line": line} for line in range(1, 5)]
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        (
+            {"source": {"file": "f" * (MAX_EDGE_LABEL_FILE_CHARS + 1)}},
+            "at most 4096 characters",
+        ),
+        (
+            {
+                "target": {
+                    "file": "target.py",
+                    "label": "n" * (MAX_EDGE_LABEL_NAME_CHARS + 1),
+                }
+            },
+            "at most 1024 characters",
+        ),
+        (
+            {"commit": "c" * (MAX_EDGE_LABEL_COMMIT_CHARS + 1)},
+            "at most 128 characters",
+        ),
+        (
+            {"anchors": [{"file": "anchor.py", "line": 0}]},
+            "greater than or equal to 1",
+        ),
+    ],
+)
+def test_edge_label_request_rejects_oversized_or_invalid_fields(overrides, error):
+    with pytest.raises(ValidationError, match=error):
+        _edge_label_request(**overrides)
 
 
 def _node(file, start, end, name="fn", score=1.0):

--- a/test/web/test_static_server.py
+++ b/test/web/test_static_server.py
@@ -10,7 +10,42 @@ import threading
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-from codenib.web.static_server import build_server
+from codenib.web.static_server import MAX_PROXY_REQUEST_BODY_BYTES, build_server
+
+
+def test_static_server_rejects_invalid_api_content_lengths(tmp_path):
+    (tmp_path / "index.html").write_text("<title>CodeNib Wiki</title>")
+    server = build_server(
+        tmp_path,
+        api_base="http://127.0.0.1:9",
+        host="127.0.0.1",
+        port=0,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    cases = (
+        ("invalid", 400, "invalid Content-Length"),
+        ("-1", 400, "must not be negative"),
+        (str(MAX_PROXY_REQUEST_BODY_BYTES + 1), 413, "byte limit"),
+    )
+    try:
+        for content_length, expected_status, expected_detail in cases:
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", server.server_port, timeout=2
+            )
+            connection.putrequest("POST", "/api/chat")
+            connection.putheader("Content-Length", content_length)
+            connection.endheaders()
+            response = connection.getresponse()
+            payload = json.loads(response.read())
+            connection.close()
+
+            assert response.status == expected_status
+            assert expected_detail in payload["detail"]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
 
 
 def test_static_server_uses_same_origin_api_and_falls_back_to_spa(tmp_path):

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -512,6 +512,8 @@ export interface EdgeLabelResult {
   disabled: boolean; // feature is off in server config
 }
 
+const EDGE_LABEL_ANCHOR_LIMIT = 3;
+
 // Short LLM phrase describing how the source symbol uses the target. On-demand +
 // cached server-side; returns an empty label when the feature is disabled or
 // nothing could be generated (the UI then shows nothing extra).
@@ -533,7 +535,12 @@ export async function fetchEdgeLabel(
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
+      body: JSON.stringify({
+        ...body,
+        // The server reads only this bounded sample when constructing the
+        // label prompt; keep large graph edges from replaying every call site.
+        anchors: body.anchors.slice(0, EDGE_LABEL_ANCHOR_LIMIT),
+      }),
       signal: opts.signal,
     }
   );


### PR DESCRIPTION
## Summary

Bound interactive Ask and edge-label payloads at the installed same-origin proxy and FastAPI schema boundaries, before repository loading or model invocation. Closes #501.

## Changes

- limit chat requests to 32 messages, 16,000 characters per message, and 64,000 aggregate characters
- enforce chat limits in the Pydantic request schema so invalid payloads fail before runtime lookup
- reject malformed, negative, and greater-than-1-MiB API body lengths before the installed proxy buffers or forwards them
- cap edge-label paths, labels, commit identity, line positions, and call-site anchors before source reads or LLM prompt construction
- send only the three call-site anchors the edge-label generator actually consumes
- preserve valid multi-turn follow-up histories, graph interactions, and existing endpoint role checks
- document public request budgets and add schema, FastAPI route, frontend, and real proxy regressions

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- `pytest -q test/web` (`176 passed`)
- `npm test` in `web/` (`19 passed`)
- `npm run build` in `web/`
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2828 passed, 10 skipped`)
- `pre-commit run --files codenib/web/edge_label.py codenib/web/schemas.py codenib/web/static_server.py docs/web_demo.md test/web/test_schemas.py test/web/test_app_runtime.py test/web/test_static_server.py web/lib/api.ts`
- `mkdocs build --strict`
- `python scripts/check_public_docs.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
