### PR TITLE
fix(mcp): enable query-seeded LSP routes

### DIFF
--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -163,9 +163,10 @@ before graph resolution.
   `include_declaration` defaults to `true` and `top_k` to 40.
 - `lsp_route`: provide `symbols`, with optional `query`, `top_k` (default 12),
   and `include_neighbors` (default `true`) to rank endpoint, bridge/factory,
-  provider/value, and type anchors. At most 100 non-empty symbol seeds are
-  accepted per request; comma-separated seed text is limited to 16,000
-  characters before splitting.
+  provider/value, and type anchors. If no reliable symbol is known, pass
+  `symbols=[]` with a non-blank query to select route seeds from the graph.
+  At most 100 non-empty symbol seeds are accepted per request; comma-separated
+  seed text is limited to 16,000 characters before splitting.
 
 ### `get_manifest`
 Returns the manifest version; a nested `repo` object containing path, commit,

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -301,8 +301,9 @@ async def lsp_references(
     name="lsp_route",
     description=(
         "Return compact route anchors from CodeNib's static symbol graph for "
-        "one or more symbol seeds. Use this when multiple symbols need a route "
-        "map across endpoint, bridge/factory, provider/value, or type anchors. "
+        "symbol seeds, or use a query alone when no reliable symbol is known. "
+        "Use this for a route map across endpoint, bridge/factory, "
+        "provider/value, or type anchors. "
         "Results are locations only; read source before finalizing."
     ),
 )

--- a/codenib/mcp/tools/lsp.py
+++ b/codenib/mcp/tools/lsp.py
@@ -190,14 +190,15 @@ def lsp_route_impl(
         )
     except ValueError as exc:
         return {"error": str(exc)}
-    if not seeds:
+    normalized_query = requested_query.strip()
+    if not seeds and not normalized_query:
         return []
 
     from ...agent.lsp_provider import StaticLSPProvider
 
     results = StaticLSPProvider(graph).route(
         symbols=seeds,
-        query=requested_query or None,
+        query=normalized_query or None,
         top_k=limit,
         include_neighbors=bool(include_neighbors),
     )

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -122,7 +122,7 @@ Only tools whose backing views are fresh and available can return results.
 | `dependency_subgraph` | `symbol_graph` | call graph | Caller impact, callee dependencies, or a one-hop neighborhood |
 | `lsp_definition` | `symbol_graph` | location | Static go-to-definition-shaped lookup |
 | `lsp_references` | `symbol_graph` | locations | Static find-references-shaped lookup |
-| `lsp_route` | `symbol_graph` | locations | Compact route anchors among related symbols |
+| `lsp_route` | `symbol_graph` | locations | Compact route anchors from symbol seeds or query-seeded graph matches |
 | `get_manifest` | manifest | repository | Repository identity, languages, view states, and capabilities |
 
 All source locations returned by MCP use 1-based line numbers.

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -285,6 +285,43 @@ def test_lsp_route_rejects_oversized_symbol_list_before_provider():
     provider.assert_not_called()
 
 
+def test_lsp_route_uses_query_fallback_without_symbol_seeds():
+    from codenib.graph.code_graph import CodeGraph
+
+    graph = CodeGraph()
+    graph._add_vertex(
+        "src/cache.py:CachePathResolver.resolve()",
+        {
+            "type": "method",
+            "file": "src/cache.py",
+            "start_line": 4,
+            "end_line": 12,
+            "unified_name": "CachePathResolver.resolve()",
+        },
+    )
+
+    result = lsp_route_impl(
+        MagicMock(symbol_graph=graph),
+        symbols=[],
+        query="resolve cached path",
+        top_k=5,
+    )
+
+    assert isinstance(result, list)
+    assert [node["node_name"] for node in result] == ["CachePathResolver.resolve()"]
+    assert result[0]["file"] == "src/cache.py"
+    assert result[0]["start_line"] == 5
+
+
+def test_lsp_route_skips_provider_without_symbols_or_query():
+    ctx = MagicMock(symbol_graph=MagicMock())
+    with patch("codenib.agent.lsp_provider.StaticLSPProvider") as provider:
+        result = lsp_route_impl(ctx, symbols=[], query="   ")
+
+    assert result == []
+    provider.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("impl", "kwargs", "error"),
     [


### PR DESCRIPTION
## Summary

Expose the native query-seeded `lsp_route` fallback through MCP when an external agent does not yet know a reliable symbol. Closes #505.

This PR is stacked on #498 because query-only repository scans must retain that PR's text, seed-count, and result bounds.

## Changes

- allow `symbols=[]` with a non-blank query to reach the shared static LSP provider
- keep empty symbols plus a blank query as a provider-free no-op
- normalize surrounding query whitespace after enforcing the bounded raw-input contract
- verify query fallback through a real `CodeGraph` and `StaticLSPProvider`
- align MCP tool descriptions and docs with the existing native agent skill contract

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- `pytest -q test/mcp/test_mcp_server.py -k 'lsp'` (`29 passed`)
- `pytest -q test/mcp test/mcp_server --tb=short` (`119 passed, 14 skipped`)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (`2841 passed, 10 skipped`)
- `mkdocs build --strict`
- `python scripts/check_public_docs.py`
- `pre-commit run --files codenib/mcp/tools/lsp.py codenib/mcp/server.py codenib/mcp/README.md docs/mcp.md test/mcp/test_mcp_server.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] I have updated relevant documentation
- [x] The stacked dependency on #498 is explicit
