### PR TITLE
fix(web): confine manifest entry points

### DIFF
--- a/codenib/web/entrypoints.py
+++ b/codenib/web/entrypoints.py
@@ -96,8 +96,11 @@ def _normalize(path: str) -> Optional[str]:
 def _repo_path_is(repo_dir: str, relative: str, *, directory: bool) -> bool:
     """Return whether *relative* resolves to the requested kind inside the repo."""
 
+    normalized = _normalize(relative)
+    if normalized is None:
+        return False
     root = os.path.realpath(repo_dir)
-    candidate = os.path.realpath(os.path.join(root, *PurePosixPath(relative).parts))
+    candidate = os.path.realpath(os.path.join(root, *PurePosixPath(normalized).parts))
     try:
         if os.path.commonpath((root, candidate)) != root:
             return False
@@ -223,7 +226,8 @@ def _npm_workspaces(repo_dir: str, workspaces: Any) -> List[EntryPoint]:
             continue
         for directory in _expand_glob(repo_dir, pattern):
             member_root = os.path.join(repo_dir, directory)
-            if not os.path.isfile(os.path.join(member_root, "package.json")):
+            manifest = f"{directory}/package.json"
+            if not _repo_path_is(repo_dir, manifest, directory=False):
                 continue
             for entry in _package_json_entries(member_root):
                 entries.append(
@@ -313,7 +317,7 @@ def _cargo_entries(repo_dir: str) -> List[EntryPoint]:
             entries.append(EntryPoint(resolved, "library", name))
     # Cargo's conventional targets need no declaration.
     for relative, kind in (("src/main.rs", "binary"), ("src/lib.rs", "library")):
-        if os.path.isfile(os.path.join(repo_dir, relative)):
+        if _repo_path_is(repo_dir, relative, directory=False):
             entries.append(EntryPoint(relative, kind, name))
 
     # A workspace root (tokio, ruff) has no targets of its own — its members do.
@@ -334,7 +338,7 @@ def _workspace_members(repo_dir: str, members: Any) -> List[EntryPoint]:
         for directory in _expand_glob(repo_dir, member):
             for suffix, kind in (("src/lib.rs", "library"), ("src/main.rs", "binary")):
                 relative = f"{directory}/{suffix}"
-                if os.path.isfile(os.path.join(repo_dir, relative)):
+                if _repo_path_is(repo_dir, relative, directory=False):
                     entries.append(
                         EntryPoint(relative, kind, directory.rsplit("/", 1)[-1])
                     )
@@ -365,19 +369,21 @@ def _expand_glob(repo_dir: str, pattern: str) -> List[str]:
 
 
 def _go_entries(repo_dir: str) -> List[EntryPoint]:
-    if not os.path.isfile(os.path.join(repo_dir, "go.mod")):
+    if not _repo_path_is(repo_dir, "go.mod", directory=False):
         return []
     entries: List[EntryPoint] = []
-    if os.path.isfile(os.path.join(repo_dir, "main.go")):
+    if _repo_path_is(repo_dir, "main.go", directory=False):
         entries.append(EntryPoint("main.go", "binary", os.path.basename(repo_dir)))
     cmd_dir = os.path.join(repo_dir, "cmd")
+    if not _repo_path_is(repo_dir, "cmd", directory=True):
+        return entries
     try:
         children = sorted(os.listdir(cmd_dir))
     except OSError:
         return entries
     for child in children:
         relative = f"cmd/{child}/main.go"
-        if os.path.isfile(os.path.join(repo_dir, relative)):
+        if _repo_path_is(repo_dir, relative, directory=False):
             entries.append(EntryPoint(relative, "binary", child))
     return entries
 

--- a/codenib/web/entrypoints.py
+++ b/codenib/web/entrypoints.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import PurePosixPath
 from typing import Any, Dict, Iterable, List, Optional, Set
 
 try:  # Python 3.11+
@@ -74,12 +75,39 @@ class EntryPoint:
         return f"EntryPoint({self.path!r}, {self.kind!r}, {self.label!r})"
 
 
-def _normalize(path: str) -> str:
-    return path.replace("\\", "/").lstrip("./").strip("/")
+def _normalize(path: str) -> Optional[str]:
+    """Return a lexical repository-relative manifest path, or ``None``."""
+
+    raw = path.replace("\\", "/").strip()
+    while raw.startswith("./"):
+        raw = raw[2:]
+    if not raw or "\x00" in raw:
+        return None
+
+    value = PurePosixPath(raw)
+    if value.is_absolute() or not value.parts or ".." in value.parts:
+        return None
+    first = value.parts[0]
+    if len(first) >= 2 and first[0].isalpha() and first[1] == ":":
+        return None
+    return value.as_posix()
+
+
+def _repo_path_is(repo_dir: str, relative: str, *, directory: bool) -> bool:
+    """Return whether *relative* resolves to the requested kind inside the repo."""
+
+    root = os.path.realpath(repo_dir)
+    candidate = os.path.realpath(os.path.join(root, *PurePosixPath(relative).parts))
+    try:
+        if os.path.commonpath((root, candidate)) != root:
+            return False
+    except ValueError:
+        return False
+    return os.path.isdir(candidate) if directory else os.path.isfile(candidate)
 
 
 def _under_build_dir(path: str) -> bool:
-    parts = _normalize(path).split("/")
+    parts = path.split("/")
     return any(part in _BUILD_DIRS for part in parts[:-1])
 
 
@@ -98,7 +126,7 @@ def _resolve_in_repo(repo_dir: str, path: str) -> Optional[str]:
         # A declaration entry is worth a second look; a bundle is not.
         stem = _declaration_sibling(repo_dir, relative)
         return stem
-    if os.path.isfile(os.path.join(repo_dir, relative)):
+    if _repo_path_is(repo_dir, relative, directory=False):
         return relative
     return None
 
@@ -113,7 +141,7 @@ def _declaration_sibling(repo_dir: str, relative: str) -> Optional[str]:
         stem = relative[: -len(suffix)]
         for extension in candidates:
             candidate = f"{stem}{extension}"
-            if os.path.isfile(os.path.join(repo_dir, candidate)):
+            if _repo_path_is(repo_dir, candidate, directory=False):
                 return candidate
         return None
     return None
@@ -248,8 +276,8 @@ def _module_to_file(repo_dir: str, module: str) -> Optional[str]:
     stem = module.replace(".", "/")
     for candidate in (f"{stem}.py", f"{stem}/__init__.py"):
         for prefix in ("", "src/", "lib/"):
-            relative = f"{prefix}{candidate}"
-            if os.path.isfile(os.path.join(repo_dir, relative)):
+            relative = _normalize(f"{prefix}{candidate}")
+            if relative and _repo_path_is(repo_dir, relative, directory=False):
                 return relative
     return None
 
@@ -319,13 +347,20 @@ def _expand_glob(repo_dir: str, pattern: str) -> List[str]:
     import glob as _glob
 
     normalized = _normalize(pattern)
+    if normalized is None:
+        return []
     if "*" not in normalized:
-        return [normalized] if os.path.isdir(os.path.join(repo_dir, normalized)) else []
-    matches = _glob.glob(os.path.join(repo_dir, normalized))
+        return (
+            [normalized] if _repo_path_is(repo_dir, normalized, directory=True) else []
+        )
+    matches = _glob.glob(os.path.join(repo_dir, *PurePosixPath(normalized).parts))
     return sorted(
-        os.path.relpath(match, repo_dir).replace("\\", "/")
+        relative
         for match in matches
-        if os.path.isdir(match)
+        if (
+            (relative := _normalize(os.path.relpath(match, repo_dir))) is not None
+            and _repo_path_is(repo_dir, relative, directory=True)
+        )
     )
 
 

--- a/test/web/test_entrypoints.py
+++ b/test/web/test_entrypoints.py
@@ -170,6 +170,61 @@ def test_npm_workspaces_are_walked_when_the_root_exports_nothing(tmp_path):
     ]
 
 
+def test_package_manifest_paths_cannot_escape_the_repository(tmp_path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    _write(repo, "nested/.keep")
+    _write(outside, "secret.js", "export const secret = true;\n")
+    (repo / "linked").symlink_to(outside, target_is_directory=True)
+    _write(
+        repo,
+        "package.json",
+        json.dumps(
+            {
+                "name": "unsafe",
+                "source": "nested/../../outside/secret.js",
+                "exports": {"./linked": "./linked/secret.js"},
+            }
+        ),
+    )
+
+    assert discover_entry_points(str(repo)) == []
+
+
+def test_workspace_members_cannot_escape_the_repository(tmp_path):
+    npm_repo = tmp_path / "npm-repo"
+    cargo_repo = tmp_path / "cargo-repo"
+    outside = tmp_path / "outside"
+    _write(npm_repo, "nested/.keep")
+    _write(cargo_repo, "nested/.keep")
+    _write(outside, "src/index.js", "export const secret = true;\n")
+    _write(outside, "src/lib.rs", "pub fn secret() {}\n")
+    _write(
+        outside,
+        "package.json",
+        json.dumps({"name": "outside", "source": "src/index.js"}),
+    )
+    _write(
+        npm_repo,
+        "package.json",
+        json.dumps(
+            {
+                "name": "unsafe-workspace",
+                "private": True,
+                "workspaces": ["nested/../../outside"],
+            }
+        ),
+    )
+    _write(
+        cargo_repo,
+        "Cargo.toml",
+        '[workspace]\nmembers = ["nested/../../outside"]\n',
+    )
+
+    assert discover_entry_points(str(npm_repo)) == []
+    assert discover_entry_points(str(cargo_repo)) == []
+
+
 def test_a_broken_or_absent_manifest_yields_nothing(tmp_path):
     assert discover_entry_points(str(tmp_path)) == []
     assert discover_entry_points(None) == []

--- a/test/web/test_entrypoints.py
+++ b/test/web/test_entrypoints.py
@@ -170,6 +170,86 @@ def test_npm_workspaces_are_walked_when_the_root_exports_nothing(tmp_path):
     ]
 
 
+def test_npm_workspace_manifest_symlink_cannot_be_read_outside_repo(
+    tmp_path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    _write(repo, "packages/core/src/index.js")
+    external_manifest = _write(
+        outside,
+        "package.json",
+        json.dumps({"name": "outside", "source": "src/index.js"}),
+    )
+    (repo / "packages/core/package.json").symlink_to(external_manifest)
+    _write(
+        repo,
+        "package.json",
+        json.dumps({"private": True, "workspaces": ["packages/*"]}),
+    )
+
+    loaded = []
+    load = json.load
+
+    def record_load(handle):
+        loaded.append(handle.name)
+        return load(handle)
+
+    monkeypatch.setattr(json, "load", record_load)
+
+    assert discover_entry_points(str(repo)) == []
+    assert str(repo / "packages/core/package.json") not in loaded
+
+
+def test_cargo_conventional_target_symlink_cannot_escape_repo(tmp_path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    _write(repo, "Cargo.toml", '[package]\nname = "root"\n')
+    _write(repo, "src/lib.rs", "pub fn safe() {}\n")
+    external_main = _write(outside, "main.rs", "fn main() {}\n")
+    (repo / "src/main.rs").symlink_to(external_main)
+
+    assert entry_point_files(str(repo)) == {"src/lib.rs"}
+
+
+def test_cargo_workspace_target_symlink_cannot_escape_repo(tmp_path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    _write(repo, "crates/safe/src/lib.rs", "pub fn safe() {}\n")
+    external_main = _write(outside, "main.rs", "fn main() {}\n")
+    escaped_target = repo / "crates/escaped/src/main.rs"
+    escaped_target.parent.mkdir(parents=True)
+    escaped_target.symlink_to(external_main)
+    _write(repo, "Cargo.toml", '[workspace]\nmembers = ["crates/*"]\n')
+
+    assert entry_point_files(str(repo)) == {"crates/safe/src/lib.rs"}
+
+
+def test_go_target_symlinks_cannot_escape_repo(tmp_path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    _write(repo, "go.mod", "module example.com/thing\n")
+    _write(repo, "cmd/safe/main.go", "package main\n")
+    external_root = _write(outside, "root-main.go", "package main\n")
+    external_cmd = _write(outside, "tool-main.go", "package main\n")
+    (repo / "main.go").symlink_to(external_root)
+    escaped_cmd = repo / "cmd/escaped/main.go"
+    escaped_cmd.parent.mkdir()
+    escaped_cmd.symlink_to(external_cmd)
+
+    assert entry_point_files(str(repo)) == {"cmd/safe/main.go"}
+
+
+def test_go_cmd_directory_symlink_cannot_escape_repo(tmp_path):
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    _write(repo, "go.mod", "module example.com/thing\n")
+    _write(outside, "cmd/tool/main.go", "package main\n")
+    (repo / "cmd").symlink_to(outside / "cmd", target_is_directory=True)
+
+    assert discover_entry_points(str(repo)) == []
+
+
 def test_package_manifest_paths_cannot_escape_the_repository(tmp_path):
     repo = tmp_path / "repo"
     outside = tmp_path / "outside"


### PR DESCRIPTION
## Summary

Confine package and workspace entry-point discovery to the indexed repository, including paths that traverse through symlinks.

Closes #507.

## Changes
- Parse manifest paths as lexical repository-relative POSIX paths and reject absolute, parent-traversing, NUL-containing, and drive-qualified values.
- Verify package targets and npm/Cargo workspace matches resolve inside the repository before accepting them.
- Add regressions for direct manifest traversal, escaping symlinks, npm workspaces, and Cargo members.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/web/test_entrypoints.py --tb=short` (11 passed)
- `pytest -q test/web --tb=short` (166 passed)
- `pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (2818 passed, 10 skipped)
- `pre-commit run --files codenib/web/entrypoints.py test/web/test_entrypoints.py`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published