### PR TITLE
fix(dataset): use canonical CodeNib Base ID

### DIFF
--- a/codenib/dataset/codenib_base.py
+++ b/codenib/dataset/codenib_base.py
@@ -16,6 +16,7 @@ from datasets import Features
 from datasets import Sequence as Seq
 from datasets import Value
 
+from ..dataset_ids import CODENIB_BASE_DATASET
 from ..git_snapshot import restore_git_worktree
 from ..log_utils import get_logger
 from .base import DatasetBase
@@ -49,7 +50,7 @@ class CodeNibBaseDataset(DatasetBase):
 
     def __init__(
         self,
-        dataset: str = "fishmingyu/codeminer-base-dataset",
+        dataset: str = CODENIB_BASE_DATASET,
         split: str = "test",
         filter_instance: str = ".*",
         root: str | None = None,

--- a/codenib/dataset_ids.py
+++ b/codenib/dataset_ids.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical identifiers for externally hosted CodeNib datasets."""
+
+CODENIB_BASE_DATASET = "fishmingyu/codenib-base-dataset"
+
+__all__ = ["CODENIB_BASE_DATASET"]

--- a/codenib/eval/agent_runner/loc_baseline.py
+++ b/codenib/eval/agent_runner/loc_baseline.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Set
 from codenib.dataset.codenib_base import CodeNibBaseDataset
 from codenib.dataset.locbench import LocbenchDataset
 from codenib.dataset.swebench import SwebenchDataset
+from codenib.dataset_ids import CODENIB_BASE_DATASET
 from codenib.eval.agent_runner.baseline import (
     BaselineLocation,
     BaselineTask,
@@ -51,7 +52,7 @@ def build_dataset(args):
     """Mirror of embedding_retrieve_baseline._build_dataset()."""
     if args.dataset == "codenib_base":
         return CodeNibBaseDataset(
-            dataset="fishmingyu/codeminer-base-dataset",
+            dataset=CODENIB_BASE_DATASET,
             split=args.split,
             filter_instance=args.filter_instance,
             repo_root=os.path.expanduser(args.repo_cache_dir),

--- a/codenib/eval/agent_runner/sweep_config.py
+++ b/codenib/eval/agent_runner/sweep_config.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
+from codenib.dataset_ids import CODENIB_BASE_DATASET
 from codenib.paths import prebuilt_data_dir
 
 
@@ -61,7 +62,7 @@ class SweepConfig:
     max_tokens: int = 4096
     topk: int = 50
     num_retries: int = 8
-    dataset: str = "fishmingyu/codeminer-base-dataset"
+    dataset: str = CODENIB_BASE_DATASET
     dataset_revision: Optional[str] = None
     split: str = "test"
     prebuilt_dir: str = field(default_factory=lambda: str(prebuilt_data_dir()))

--- a/codenib/eval/experiments/lsp_agent_study_policy.py
+++ b/codenib/eval/experiments/lsp_agent_study_policy.py
@@ -4,7 +4,9 @@
 
 """Pinned policy constants for the CodeNib Base native-LSP study."""
 
-DEFAULT_BASE_DATASET = "fishmingyu/codeminer-base-dataset"
+from codenib.dataset_ids import CODENIB_BASE_DATASET
+
+DEFAULT_BASE_DATASET = CODENIB_BASE_DATASET
 DEFAULT_BASE_REVISION = "4eb84e2e8918474969ce68c5b06facf14d6be604"
 DEFAULT_MODEL = "vertex_ai/claude-haiku-4-5"
 

--- a/codenib/web/config.py
+++ b/codenib/web/config.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
+from ..dataset_ids import CODENIB_BASE_DATASET
 from ..llm.options import (
     merge_model_options,
     parse_model_options_json,
@@ -123,7 +124,7 @@ class QAConfig:
     )
 
     # --- instance selection (used by the build script) ---
-    dataset: str = "fishmingyu/codeminer-base-dataset"
+    dataset: str = CODENIB_BASE_DATASET
     split: str = "test"
     # Explicit instance ids to feature; if empty, sample `per_language` from
     # each of `languages` (a varied set).

--- a/docs/diagnose_query_leak.md
+++ b/docs/diagnose_query_leak.md
@@ -15,7 +15,7 @@ Running `examples/eval_synthesized_queries.py` with `Salesforce/SweRankEmbed-Sma
 against the current 96 synthesized behavioral queries scores file-recall@10 = 0.92
 and symbol-recall@10 = 0.73. The score is saturated relative to the same embedder
 on calibration data (0.39–0.77 on CodeNib Base,
-`fishmingyu/codeminer-base-dataset`), suggesting the
+`fishmingyu/codenib-base-dataset`), suggesting the
 synthesizer prompt is leaking domain vocabulary into the query. The scripts below
 let us measure how much.
 

--- a/docs/experiments/agent_compile.md
+++ b/docs/experiments/agent_compile.md
@@ -51,7 +51,7 @@ The frozen per-subset report for this run is archived at
 
 | | |
 |---|---|
-| Dataset | `fishmingyu/codeminer-base-dataset` (100 instances, 5 language groups) |
+| Dataset | `fishmingyu/codenib-base-dataset` (100 instances, 5 language groups) |
 | Sample | 5 instances, 4 languages, both Python scenarios (see below) |
 | Agent model | `vertex_ai/claude-haiku-4-5` @ `us-east5`, temp 0.0, max_turns 20 |
 | Embeddings | `Qwen/Qwen3-Embedding-0.6B` (dim 1024), L2 chunks |

--- a/docs/experiments/system_paper_plan.md
+++ b/docs/experiments/system_paper_plan.md
@@ -95,7 +95,7 @@ The snapshot-reuse profiler produces the following exact counts:
 
 ```bash
 python scripts/profiling/analyze_snapshot_reuse.py \
-  --dataset fishmingyu/codeminer-base-dataset \
+  --dataset fishmingyu/codenib-base-dataset \
   --dataset sysevol-ai/codeminer-synthesis
 ```
 
@@ -259,7 +259,7 @@ under `${CODENIB_RESULTS_DIR}/lsp_agent_ab_multilang`.
 
 ### CodeNib Base agent ablation
 
-The task-level study uses `fishmingyu/codeminer-base-dataset` test split at
+The task-level study uses `fishmingyu/codenib-base-dataset` test split at
 revision `4eb84e2e8918474969ce68c5b06facf14d6be604` (local dataset fingerprint
 `d265af65e9ba4985`). Its sampling frame is every currently supported Go, Rust,
 and TypeScript/JavaScript row: 60 tasks, 15 repositories, and 60 exact source

--- a/docs/synthesis_pipeline.md
+++ b/docs/synthesis_pipeline.md
@@ -283,7 +283,7 @@ python scripts/generate_codenib_synthesis_config.py \
 
 Flags: `--config` (required; one of `ALL_CONFIGS`), `--instance-id` (required),
 `--split` (default `test`), `--source-dataset` (default
-`fishmingyu/codeminer-base-dataset`), `--counts` (comma-separated `category=N`;
+`fishmingyu/codenib-base-dataset`), `--counts` (comma-separated `category=N`;
 defaults to the base 50-row mix; include `traversal=10` to add traversal rows),
 `--include-traversal` (shortcut for base mix + `traversal=10`),
 `--traversal-stance-counts` (default = even split, so `traversal=10` becomes

--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -65,7 +65,7 @@ python scripts/build_qa_index.py        # needs network: HuggingFace + git
 ```
 
 This selects instances from the CodeNib Base dataset
-(`fishmingyu/codeminer-base-dataset` on the Hub), checks out each repo at
+(`fishmingyu/codenib-base-dataset` on the Hub), checks out each repo at
 its `base_commit`, builds indexes under `data_dir` (default `.codenib_qa/`),
 and writes `qa_registry.json`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ double as the evaluation harnesses used in the experiments under
 | `make dev` (editable install) | always |
 | An embedding model (e.g. `nomic-ai/CodeRankEmbed`, GPU recommended) | embedding / rerank / agent retrieval |
 | LLM credentials (`litellm` provider env, e.g. `GOOGLE_APPLICATION_CREDENTIALS` for Vertex) | anything with an LLM (agent loop, rerank, query synthesis) |
-| A dataset — `fishmingyu/codeminer-base-dataset`, SWE-bench, or LocBench (cached under `~/.codenib/`) | every eval script |
+| A dataset — `fishmingyu/codenib-base-dataset`, SWE-bench, or LocBench (cached under `~/.codenib/`) | every eval script |
 
 Most scripts accept `--filter-instance <regex>` to run a single instance and
 `--result-path <file.json>` to write metrics. Generated output is **gitignored**

--- a/examples/codenib_base_rerank_matrix.py
+++ b/examples/codenib_base_rerank_matrix.py
@@ -143,7 +143,7 @@ def parse_args():
     p.add_argument(
         "--dataset",
         type=str,
-        default="fishmingyu/codeminer-base-dataset",
+        default="fishmingyu/codenib-base-dataset",
         help="HuggingFace dataset name.",
     )
     p.add_argument("--split", type=str, default="test")

--- a/examples/embedding_retrieve_baseline.py
+++ b/examples/embedding_retrieve_baseline.py
@@ -331,7 +331,7 @@ def _build_dataset(args):
         from codenib.dataset.codenib_base import CodeNibBaseDataset
 
         return CodeNibBaseDataset(
-            dataset="fishmingyu/codeminer-base-dataset",
+            dataset="fishmingyu/codenib-base-dataset",
             split=args.split,
             filter_instance=args.filter_instance,
             repo_root=args.repo_cache_dir,

--- a/examples/graph_retrieve_baseline.py
+++ b/examples/graph_retrieve_baseline.py
@@ -226,7 +226,7 @@ def _build_dataset(args):
         from codenib.dataset.codenib_base import CodeNibBaseDataset
 
         return CodeNibBaseDataset(
-            dataset="fishmingyu/codeminer-base-dataset",
+            dataset="fishmingyu/codenib-base-dataset",
             split=args.split,
             filter_instance=args.filter_instance,
             repo_root=args.repo_cache_dir,

--- a/examples/retrieve_rerank.py
+++ b/examples/retrieve_rerank.py
@@ -478,7 +478,7 @@ def run_pipeline(args):
     elif dataset == "codenib_base":
         from codenib.dataset.codenib_base import CodeNibBaseDataset
 
-        dataset_name = "fishmingyu/codeminer-base-dataset"
+        dataset_name = "fishmingyu/codenib-base-dataset"
         dataset_split = args.split
         dataset_class = CodeNibBaseDataset
     else:

--- a/qa_config.yaml
+++ b/qa_config.yaml
@@ -71,7 +71,7 @@ cors_origins:
   - http://127.0.0.1:3001
 
 # --- which repos to feature (from the codenib-base-dataset) ---
-dataset: fishmingyu/codeminer-base-dataset
+dataset: fishmingyu/codenib-base-dataset
 split: test
 
 # Either pin explicit instance ids here:

--- a/scripts/agent_compile/configs/design_space.yaml
+++ b/scripts/agent_compile/configs/design_space.yaml
@@ -53,7 +53,7 @@ max_tokens: 4096
 topk: 50
 num_retries: 8
 
-dataset: fishmingyu/codeminer-base-dataset
+dataset: fishmingyu/codenib-base-dataset
 split: test
 # prebuilt_dir defaults to CODENIB_PREBUILT_DIR (or CODENIB_HOME/prebuilt).
 embedding_model: Qwen/Qwen3-Embedding-0.6B

--- a/scripts/check_namespace.py
+++ b/scripts/check_namespace.py
@@ -19,10 +19,9 @@ _FORMER_LOWER = "code" + "miner"
 _FORMER_UPPER = "CODE" + "MINER"
 _FORMER_IDENTIFIERS = (_FORMER_CAMEL, _FORMER_LOWER, _FORMER_UPPER)
 
-# These datasets have not been republished under new owners. They are immutable
-# data addresses, not supported package, command, environment, or state aliases.
+# This dataset has not been republished under a new identifier. It is an
+# immutable data address, not a supported package, command, or state alias.
 _EXTERNAL_IDENTITY_PATTERNS = (
-    re.compile(rf"fishmingyu/{_FORMER_LOWER}-base-dataset" r"(?=$|[^A-Za-z0-9_.-])"),
     re.compile(rf"sysevol-ai/{_FORMER_LOWER}-synthesis" r"(?=$|[^A-Za-z0-9_.-])"),
 )
 

--- a/scripts/embeddings/build_codenib_base_embeddings.sh
+++ b/scripts/embeddings/build_codenib_base_embeddings.sh
@@ -23,11 +23,11 @@ CODENIB_PREBUILT_DIR="${CODENIB_PREBUILT_DIR:-${CODENIB_HOME}/prebuilt}"
 #   FILTER="^(astropy__astropy-12907)$" bash scripts/embeddings/build_codenib_base_embeddings.sh
 #
 #   # Override storage / dataset
-#   STORAGE_DIR=/tmp/emb DATASET=fishmingyu/codeminer-base-dataset \
+#   STORAGE_DIR=/tmp/emb DATASET=fishmingyu/codenib-base-dataset \
 #     bash scripts/embeddings/build_codenib_base_embeddings.sh
 
 STORAGE_DIR="${STORAGE_DIR:-${CODENIB_PREBUILT_DIR}}"
-DATASET="${DATASET:-fishmingyu/codeminer-base-dataset}"
+DATASET="${DATASET:-fishmingyu/codenib-base-dataset}"
 SPLIT="${SPLIT:-test}"
 FILTER="${FILTER:-.*}"
 PROFILE_TAG="${PROFILE_TAG:-codenib_base_${SPLIT}}"

--- a/scripts/embeddings/build_embeddings.py
+++ b/scripts/embeddings/build_embeddings.py
@@ -17,7 +17,7 @@ Usage:
     # CodeNib-base (multi-language, auto-detects language per instance)
     python scripts/embeddings/build_embeddings.py \\
         --dataset-class codenib_base \\
-        --dataset fishmingyu/codeminer-base-dataset \\
+        --dataset fishmingyu/codenib-base-dataset \\
         --enable-profiler
 """
 
@@ -89,7 +89,7 @@ def parse_args():
         help=(
             "HuggingFace dataset name. Defaults to "
             "'princeton-nlp/SWE-bench_Lite' for swebench, "
-            "'fishmingyu/codeminer-base-dataset' for codenib_base."
+            "'fishmingyu/codenib-base-dataset' for codenib_base."
         ),
     )
     parser.add_argument(
@@ -284,7 +284,7 @@ def parse_args():
 _DATASET_DEFAULTS = {
     "swebench": "princeton-nlp/SWE-bench_Lite",
     "swebench_multilingual": "SWE-bench/SWE-bench_Multilingual",
-    "codenib_base": "fishmingyu/codeminer-base-dataset",
+    "codenib_base": "fishmingyu/codenib-base-dataset",
 }
 
 

--- a/scripts/embeddings/profile_dataset_stats.py
+++ b/scripts/embeddings/profile_dataset_stats.py
@@ -143,7 +143,7 @@ def main():
 
     _DATASET_DEFAULTS = {
         "swebench": "princeton-nlp/SWE-bench_Lite",
-        "codenib_base": "fishmingyu/codeminer-base-dataset",
+        "codenib_base": "fishmingyu/codenib-base-dataset",
     }
     load_args = SimpleNamespace(
         dataset_class=args.dataset_class,

--- a/scripts/generate_codenib_synthesis_config.py
+++ b/scripts/generate_codenib_synthesis_config.py
@@ -231,7 +231,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--config", required=True, choices=ALL_CONFIGS)
     p.add_argument("--instance-id", required=True)
     p.add_argument("--split", default="test")
-    p.add_argument("--source-dataset", default="fishmingyu/codeminer-base-dataset")
+    p.add_argument("--source-dataset", default="fishmingyu/codenib-base-dataset")
     p.add_argument(
         "--counts",
         default="",

--- a/scripts/mcp_benchmark_codenib_base.py
+++ b/scripts/mcp_benchmark_codenib_base.py
@@ -5,7 +5,7 @@
 """
 MCP server benchmark on the CodeNib base dataset.
 
-Loads `fishmingyu/codeminer-base-dataset` (test split) and runs semantic
+Loads `fishmingyu/codenib-base-dataset` (test split) and runs semantic
 search via the MCP server's `search_semantic` tool against pre-built
 indexes under CODENIB_DATA/<instance_id>. Reports file-level and
 symbol-level accuracy@k, broken down by language_group and
@@ -34,7 +34,7 @@ CODENIB_DATA = prebuilt_data_dir()
 # benchmark default. Override with --model.
 DEFAULT_EMBEDDING_MODEL = "Salesforce/SweRankEmbed-Small"
 DEFAULT_DIMENSION = 768
-DATASET_NAME = "fishmingyu/codeminer-base-dataset"
+DATASET_NAME = "fishmingyu/codenib-base-dataset"
 DATASET_SPLIT = "test"
 
 # language_group (from codenib-base schema) -> manifest `languages` list.

--- a/scripts/swebench_graph_index.py
+++ b/scripts/swebench_graph_index.py
@@ -111,7 +111,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--codenib-base-dataset",
         type=str,
-        default="fishmingyu/codeminer-base-dataset",
+        default="fishmingyu/codenib-base-dataset",
         help="Dataset name used when source is codenib_base.",
     )
     parser.add_argument(

--- a/scripts/synthesize_swebench.py
+++ b/scripts/synthesize_swebench.py
@@ -261,7 +261,7 @@ def main() -> None:
             "swebench_lite": "princeton-nlp/SWE-bench_Lite",
             "swebench_verified": "princeton-nlp/SWE-bench_Verified",
             "swebench_multilingual": "SWE-bench/SWE-bench_Multilingual",
-            "codenib_base": "fishmingyu/codeminer-base-dataset",
+            "codenib_base": "fishmingyu/codenib-base-dataset",
         }
         dataset_name = dataset_name_map[args.dataset]
         filter_pattern = (

--- a/test/examples/test_graph_retrieve_baseline.py
+++ b/test/examples/test_graph_retrieve_baseline.py
@@ -696,7 +696,7 @@ def test_build_dataset_codenib_base(runner, monkeypatch):
         lambda **kw: captured.update(kw) or SimpleNamespace(),
     )
     runner._build_dataset(_ds_args("codenib_base"))
-    assert captured["dataset"] == "fishmingyu/codeminer-base-dataset"
+    assert captured["dataset"] == "fishmingyu/codenib-base-dataset"
     assert captured["filter_instance"] == "^(x)$"
 
 

--- a/test/test_namespace.py
+++ b/test/test_namespace.py
@@ -83,9 +83,9 @@ def test_namespace_check_allows_only_exact_external_identity(tmp_path: Path) -> 
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
     former = "code" + "miner"
     allowed = tmp_path / "external.txt"
-    allowed.write_text(f"fishmingyu/{former}-base-dataset\n")
+    allowed.write_text(f"sysevol-ai/{former}-synthesis\n")
     disallowed = tmp_path / "nearby.txt"
-    disallowed.write_text(f"fishmingyu/{former}-base-dataset-cache\n")
+    disallowed.write_text(f"sysevol-ai/{former}-synthesis-cache\n")
     subprocess.run(
         ["git", "add", allowed.name, disallowed.name],
         cwd=tmp_path,

--- a/test/test_namespace_contract.py
+++ b/test/test_namespace_contract.py
@@ -18,6 +18,7 @@ from codenib.compiler.index_compiler import IndexCompilerConfig
 from codenib.dataset.base import DatasetBase
 from codenib.dataset.codenib_base import CodeNibBaseDataset
 from codenib.dataset.codenib_synthesis import DEFAULT_DATASET
+from codenib.dataset_ids import CODENIB_BASE_DATASET
 from codenib.mcp.server import mcp
 from codenib.web.config import CACHE_DIR_NAME, QAConfig
 
@@ -62,8 +63,10 @@ def test_runtime_state_roots_use_codenib(tmp_path: Path) -> None:
     dataset = DatasetBase(root=str(tmp_path))
     qa_config = QAConfig()
 
-    # These are immutable remote dataset addresses, not runtime aliases.
-    assert base_dataset_default == "fishmingyu/" + "code" + "miner-base-dataset"
+    assert CODENIB_BASE_DATASET == "fishmingyu/codenib-base-dataset"
+    assert base_dataset_default == CODENIB_BASE_DATASET
+    assert qa_config.dataset == CODENIB_BASE_DATASET
+    # Synthesis has not yet been republished under a new Hub identifier.
     assert DEFAULT_DATASET == "sysevol-ai/" + "code" + "miner-synthesis"
     assert IndexCompilerConfig().cache_dir_name == ".codenib_cache"
     assert CACHE_DIR_NAME == ".codenib_cache"


### PR DESCRIPTION
## Summary
Use the renamed CodeNib Base Hugging Face repository consistently across runtime defaults, experiments, examples, and documentation. Closes #510.

## Changes
- Add a lightweight `CODENIB_BASE_DATASET` constant and reuse it in dataset, QA, sweep, localization, and LSP-study defaults.
- Replace the redirected `fishmingyu/codeminer-base-dataset` ID with the canonical `fishmingyu/codenib-base-dataset` ID in configs, scripts, examples, tests, and docs.
- Remove the old Base ID from the namespace audit allowlist so future occurrences fail validation.
- Keep the separately hosted CodeNib Synthesis ID unchanged until that external resource is renamed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/test_namespace_contract.py test/web/test_repo_registry.py test/eval/test_sweep.py test/examples/test_graph_retrieve_baseline.py` (100 passed)
- Canonical dataset streaming smoke loaded the first `test` row from Hugging Face.
- Exact Docs workflow chain: namespace and capability checks, strict MkDocs build, public-doc boundary.
- `pre-commit run --files ...`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
