### PR TITLE
fix(index): reject incomplete vector artifacts

### DIFF
--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -22,6 +22,10 @@ from ..compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from ..compiler.checkout_identity import validate_checkout_identity
 from ..compiler.manifest import MANIFEST_FILENAME, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
+from ..index.embedding.artifact_integrity import (
+    VECTOR_PERSISTENCE_SCHEMA,
+    vector_level_artifact_records,
+)
 from ..provider_routes import resolve_embedding_artifact_route
 from .security import assert_no_credential_fields, assert_publishable_tree, file_sha256
 
@@ -215,9 +219,52 @@ def _convert_vector_documents(path: Path, repo_path: Path) -> Path:
     return output
 
 
+def _refresh_vector_persistence_records(target: Path) -> None:
+    """Commit the portable JSON/index pairs in copied vector configs."""
+
+    for config_path in sorted(target.glob("config_*.json")):
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(config, dict):
+            raise ValueError(f"portable vector config must be an object: {config_path}")
+        embedding_model = config.get("embedding_model")
+        if not isinstance(embedding_model, str) or not embedding_model:
+            continue
+        model_suffix = embedding_model.replace("/", "__")
+        level_artifacts: dict[str, dict[str, dict[str, Any]]] = {}
+        has_level_counts = False
+        for level in ("l0", "l2"):
+            count = config.get(f"{level}_documents")
+            if count is None:
+                continue
+            has_level_counts = True
+            if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+                raise ValueError(
+                    f"portable vector config has invalid {level} count: {count!r}"
+                )
+            if count == 0:
+                continue
+            level_path = target / level
+            documents_path = level_path / f"documents_{model_suffix}.json"
+            level_artifacts[level] = vector_level_artifact_records(
+                level_path,
+                model_suffix,
+                documents_file=documents_path.name,
+            )
+        if has_level_counts:
+            config["persistence_schema"] = VECTOR_PERSISTENCE_SCHEMA
+            config["level_artifacts"] = level_artifacts
+            config_path.write_bytes(_json_bytes(config))
+
+
 def _normalize_vector_view(target: Path, repo_path: Path) -> dict[str, Any]:
     if not target.is_dir():
         raise ValueError("portable vector view must be a directory")
+    interrupted = sorted(target.glob(".config_*.json.save-in-progress"))
+    if interrupted:
+        raise ValueError(
+            "portable vector view contains an interrupted save marker: "
+            f"{interrupted[0].name}"
+        )
 
     # Query serving does not need the mutable state used to build the next
     # commit. Excluding it keeps the downloadable artifact smaller and avoids
@@ -245,6 +292,7 @@ def _normalize_vector_view(target: Path, repo_path: Path) -> dict[str, Any]:
     # Leaving both formats would retain duplicate absolute source paths.
     for legacy in target.glob("l[02]/index_*.pkl"):
         legacy.unlink()
+    _refresh_vector_persistence_records(target)
     return {
         "artifact_scope": "query-serving",
         "portable_document_format": "codenib.vector-documents.v1",

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -24,6 +24,8 @@ from ..compiler.manifest import MANIFEST_FILENAME, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
 from ..index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    validate_vector_config_artifact,
+    vector_config_artifact_record,
     vector_level_artifact_records,
 )
 from ..provider_routes import resolve_embedding_artifact_route
@@ -142,12 +144,18 @@ def _normalize_copied_view(
     repo_path: Path,
     view: str,
     relative: str,
+    view_config: Mapping[str, Any],
 ) -> dict[str, Any]:
     """Rewrite view-local machine paths and return identity adjustments."""
 
     target = stage.joinpath(*PurePosixPath(relative).parts)
     if view == "vector":
-        return _normalize_vector_view(target, repo_path)
+        route = resolve_embedding_artifact_route(view_config)
+        return _normalize_vector_view(
+            target,
+            repo_path,
+            embedding_model=route.model,
+        )
     if view != "bm25":
         raise ValueError(
             f"view {view!r} is not yet supported by portable context artifacts; "
@@ -256,7 +264,12 @@ def _refresh_vector_persistence_records(target: Path) -> None:
             config_path.write_bytes(_json_bytes(config))
 
 
-def _normalize_vector_view(target: Path, repo_path: Path) -> dict[str, Any]:
+def _normalize_vector_view(
+    target: Path,
+    repo_path: Path,
+    *,
+    embedding_model: str,
+) -> dict[str, Any]:
     if not target.is_dir():
         raise ValueError("portable vector view must be a directory")
     interrupted = sorted(target.glob(".config_*.json.save-in-progress"))
@@ -293,9 +306,14 @@ def _normalize_vector_view(target: Path, repo_path: Path) -> dict[str, Any]:
     for legacy in target.glob("l[02]/index_*.pkl"):
         legacy.unlink()
     _refresh_vector_persistence_records(target)
+    model_suffix = embedding_model.replace("/", "__")
     return {
         "artifact_scope": "query-serving",
         "portable_document_format": "codenib.vector-documents.v1",
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            target,
+            model_suffix,
+        ),
     }
 
 
@@ -407,14 +425,23 @@ def stage_context_artifact(
                 source=f"view {view!r} metadata",
             )
             if view == "vector":
-                resolve_embedding_artifact_route(entry.config)
+                route = resolve_embedding_artifact_route(entry.config)
             source = _view_source(entry.path, manifest_root, view=view)
+            if view == "vector":
+                expected_config = entry.config.get("persistence_config_fingerprint")
+                if expected_config is not None:
+                    validate_vector_config_artifact(
+                        source,
+                        route.model.replace("/", "__"),
+                        expected_config,
+                    )
             relative = _copy_view(source, stage, view)
             adjustments = _normalize_copied_view(
                 stage,
                 repo_path=repo_path,
                 view=view,
                 relative=relative,
+                view_config=entry.config,
             )
             entry_data = entry.to_dict()
             entry_data["path"] = relative

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -25,6 +25,7 @@ from ..compiler.snapshot_store import normalize_repo
 from ..index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     validate_vector_config_artifact,
+    validate_vector_generation_artifacts,
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
@@ -279,6 +280,11 @@ def _normalize_vector_view(
             f"{interrupted[0].name}"
         )
 
+    model_suffix = embedding_model.replace("/", "__")
+    # Validate the source generation before replacing its trusted local pickle
+    # with portable JSON. Recomputing records first would bless torn level files.
+    validate_vector_generation_artifacts(target, model_suffix)
+
     # Query serving does not need the mutable state used to build the next
     # commit. Excluding it keeps the downloadable artifact smaller and avoids
     # publishing build-machine paths from incremental caches.
@@ -306,7 +312,6 @@ def _normalize_vector_view(
     for legacy in target.glob("l[02]/index_*.pkl"):
         legacy.unlink()
     _refresh_vector_persistence_records(target)
-    model_suffix = embedding_model.replace("/", "__")
     return {
         "artifact_scope": "query-serving",
         "portable_document_format": "codenib.vector-documents.v1",

--- a/codenib/compiler/index_builders.py
+++ b/codenib/compiler/index_builders.py
@@ -185,7 +185,8 @@ class VectorIndexBuilder:
 
         route = self._embedding_route()
         return {
-            "builder_schema": 4,
+            # v5 binds each manifest entry to one committed vector config.
+            "builder_schema": 5,
             "embedding_model": route.model,
             "embedding_provider": route.provider,
             "embedding_dimension": self.embedding_dimension,
@@ -261,6 +262,12 @@ class VectorIndexBuilder:
                 "embedding provider returned dimension "
                 f"{actual}, expected {self.embedding_dimension}"
             )
+
+    def _persistence_config_fingerprint(self, output_dir: str) -> Dict[str, Any]:
+        from ..index.embedding.artifact_integrity import vector_config_artifact_record
+
+        model_suffix = self._embedding_route().model.replace("/", "__")
+        return vector_config_artifact_record(output_dir, model_suffix)
 
     def build(self, scope: str, **kwargs: Any) -> IndexStatus:
         repo_path: str = kwargs["repo_path"]
@@ -379,6 +386,7 @@ class VectorIndexBuilder:
             build_levels=list(self.build_levels),
         )
         inc_state.save(Path(output_dir))
+        persistence_config = self._persistence_config_fingerprint(output_dir)
 
         return IndexStatus(
             index_type="vector",
@@ -389,6 +397,7 @@ class VectorIndexBuilder:
             path=output_dir,
             metadata={
                 **artifact_identity,
+                "persistence_config_fingerprint": persistence_config,
                 "document_count": doc_count,
                 "last_commit": head_commit,
             },
@@ -524,6 +533,7 @@ class VectorIndexBuilder:
             build_levels=list(self.build_levels),
         )
         new_state.save(Path(output_dir))
+        persistence_config = self._persistence_config_fingerprint(output_dir)
 
         doc_count = {}
         if vector_store.l0_documents:
@@ -540,6 +550,7 @@ class VectorIndexBuilder:
             path=output_dir,
             metadata={
                 **self.artifact_identity(),
+                "persistence_config_fingerprint": persistence_config,
                 "document_count": doc_count,
                 "chunks_reembedded": result.chunks_reembedded,
                 "chunks_from_cache": result.chunks_from_cache,

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dependency-free integrity records for persisted vector levels."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Mapping
+
+VECTOR_PERSISTENCE_SCHEMA = 1
+_DIGEST_BYTES = 1024 * 1024
+
+
+def _file_record(path: Path) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"invalid vector artifact file: {path}")
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        while block := handle.read(_DIGEST_BYTES):
+            digest.update(block)
+            size += len(block)
+    return {"file": path.name, "size": size, "sha256": digest.hexdigest()}
+
+
+def vector_level_artifact_records(
+    level_path: Path,
+    model_suffix: str,
+    *,
+    documents_file: str,
+) -> dict[str, dict[str, Any]]:
+    """Fingerprint the index/document pair committed for one vector level."""
+
+    allowed_documents = {
+        f"documents_{model_suffix}.pkl",
+        f"documents_{model_suffix}.json",
+    }
+    if documents_file not in allowed_documents:
+        raise ValueError(
+            f"unsupported vector document artifact for {level_path}: {documents_file}"
+        )
+    return {
+        "index": _file_record(level_path / f"index_{model_suffix}.faiss"),
+        "documents": _file_record(level_path / documents_file),
+    }
+
+
+def validate_vector_level_artifacts(
+    level_path: Path,
+    model_suffix: str,
+    expected: object,
+) -> tuple[Path, Path]:
+    """Validate one committed pair and return its index/document paths."""
+
+    if not isinstance(expected, Mapping) or set(expected) != {"index", "documents"}:
+        raise ValueError(f"invalid committed vector artifacts for {level_path}")
+
+    allowed_names = {
+        "index": {f"index_{model_suffix}.faiss"},
+        "documents": {
+            f"documents_{model_suffix}.pkl",
+            f"documents_{model_suffix}.json",
+        },
+    }
+    paths: dict[str, Path] = {}
+    for kind in ("index", "documents"):
+        record = expected[kind]
+        if not isinstance(record, Mapping):
+            raise ValueError(f"invalid {kind} vector artifact record for {level_path}")
+        filename = record.get("file")
+        size = record.get("size")
+        digest = record.get("sha256")
+        if filename not in allowed_names[kind]:
+            raise ValueError(
+                f"invalid {kind} vector artifact filename for {level_path}: "
+                f"{filename!r}"
+            )
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise ValueError(f"invalid {kind} vector artifact size for {level_path}")
+        if (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+        ):
+            raise ValueError(f"invalid {kind} vector artifact digest for {level_path}")
+
+        path = level_path / filename
+        observed = _file_record(path)
+        if observed != {"file": filename, "size": size, "sha256": digest}:
+            raise ValueError(f"committed {kind} vector artifact does not match {path}")
+        paths[kind] = path
+
+    return paths["index"], paths["documents"]
+
+
+__all__ = [
+    "VECTOR_PERSISTENCE_SCHEMA",
+    "validate_vector_level_artifacts",
+    "vector_level_artifact_records",
+]

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -127,9 +128,64 @@ def validate_vector_level_artifacts(
     return paths["index"], paths["documents"]
 
 
+def validate_vector_generation_artifacts(
+    root: str | Path,
+    model_suffix: str,
+) -> dict[str, Any]:
+    """Validate every file committed by one modern top-level vector config."""
+
+    config_path = Path(root) / f"config_{model_suffix}.json"
+    if config_path.is_symlink() or not config_path.is_file():
+        raise ValueError(f"invalid vector generation config: {config_path}")
+    with config_path.open(encoding="utf-8") as handle:
+        config = json.load(handle)
+    if not isinstance(config, dict):
+        raise ValueError(f"vector generation config must be an object: {config_path}")
+
+    persistence_schema = config.get("persistence_schema")
+    committed_levels = config.get("level_artifacts")
+    if persistence_schema is None and committed_levels is None:
+        return config
+    if persistence_schema != VECTOR_PERSISTENCE_SCHEMA:
+        raise ValueError(
+            "vector generation has unsupported persistence schema: "
+            f"{persistence_schema!r}"
+        )
+    if not isinstance(committed_levels, Mapping) or not set(committed_levels) <= {
+        "l0",
+        "l2",
+    }:
+        raise ValueError("vector generation has invalid committed levels")
+
+    for level in ("l0", "l2"):
+        count = config.get(f"{level}_documents")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError(
+                f"vector generation has invalid {level} document count: {count!r}"
+            )
+        artifacts = committed_levels.get(level)
+        if count == 0:
+            if artifacts is not None:
+                raise ValueError(
+                    f"vector generation commits artifacts for empty {level} level"
+                )
+            continue
+        if artifacts is None:
+            raise ValueError(
+                f"vector generation is missing committed artifacts for {level}"
+            )
+        validate_vector_level_artifacts(
+            Path(root) / level,
+            model_suffix,
+            artifacts,
+        )
+    return config
+
+
 __all__ = [
     "VECTOR_PERSISTENCE_SCHEMA",
     "validate_vector_config_artifact",
+    "validate_vector_generation_artifacts",
     "validate_vector_level_artifacts",
     "vector_config_artifact_record",
     "vector_level_artifact_records",

--- a/codenib/index/embedding/artifact_integrity.py
+++ b/codenib/index/embedding/artifact_integrity.py
@@ -48,6 +48,37 @@ def vector_level_artifact_records(
     }
 
 
+def vector_config_artifact_record(
+    root: str | Path,
+    model_suffix: str,
+) -> dict[str, Any]:
+    """Fingerprint the top-level record that commits all vector levels."""
+
+    return _file_record(Path(root) / f"config_{model_suffix}.json")
+
+
+def validate_vector_config_artifact(
+    root: str | Path,
+    model_suffix: str,
+    expected: object,
+) -> Path:
+    """Validate the vector generation selected by a manifest entry."""
+
+    expected_name = f"config_{model_suffix}.json"
+    if not isinstance(expected, Mapping) or set(expected) != {
+        "file",
+        "size",
+        "sha256",
+    }:
+        raise ValueError("invalid vector config fingerprint in manifest")
+    if expected.get("file") != expected_name:
+        raise ValueError("invalid vector config filename in manifest")
+    path = Path(root) / expected_name
+    if _file_record(path) != dict(expected):
+        raise ValueError("vector config does not match its manifest fingerprint")
+    return path
+
+
 def validate_vector_level_artifacts(
     level_path: Path,
     model_suffix: str,
@@ -98,6 +129,8 @@ def validate_vector_level_artifacts(
 
 __all__ = [
     "VECTOR_PERSISTENCE_SCHEMA",
+    "validate_vector_config_artifact",
     "validate_vector_level_artifacts",
+    "vector_config_artifact_record",
     "vector_level_artifact_records",
 ]

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -10,10 +10,12 @@ of code chunks for semantic similarity search.
 
 import hashlib
 import json
+import os
 import pickle
+import tempfile
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple
 
 import faiss
 import numpy as np
@@ -23,10 +25,50 @@ from ...log_utils import get_logger
 from ...profiler import Profiler
 from ...provider_routes import normalize_provider
 from ...types import NodeInfo
+from .artifact_integrity import (
+    VECTOR_PERSISTENCE_SCHEMA,
+    validate_vector_level_artifacts,
+    vector_level_artifact_records,
+)
 
 logger = get_logger(__name__)
 
 Level = Literal["l0", "l2"]
+
+
+def _atomic_replace(target: Path, writer: Callable[[Path], None]) -> None:
+    """Write a sibling temporary file and atomically publish it."""
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        writer(temporary)
+        with temporary.open("rb") as handle:
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_json_dump(target: Path, value: object) -> None:
+    def _write(path: Path) -> None:
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2)
+            handle.write("\n")
+
+    _atomic_replace(target, _write)
+
+
+def _atomic_pickle_dump(target: Path, value: object) -> None:
+    def _write(path: Path) -> None:
+        with path.open("wb") as handle:
+            pickle.dump(value, handle)
+
+    _atomic_replace(target, _write)
 
 
 class _Document:
@@ -975,27 +1017,44 @@ class CodeVectorStore:
                     )
             level_state[level] = (index, documents)
 
-        for level, (_index, documents) in level_state.items():
-            if documents:
-                self._save_level(save_path, level, model_suffix)
-            else:
-                self._remove_level_files(save_path, level, model_suffix)
-
-        # Save top-level configuration
         config_path = save_path / f"config_{model_suffix}.json"
-        config = {
-            "embedding_model": self.embedding_model,
-            "embedding_provider": self.embedding_provider,
-            "dimension": self.dimension,
-            "index_type": self.index_type,
-            "index_metric": self.index_metric,
-            "l0_documents": len(self.l0_documents),
-            "l2_documents": len(self.l2_documents),
-        }
-        if self.artifact_metadata:
-            config["artifact"] = self.artifact_metadata
-        with open(config_path, "w") as f:
-            json.dump(config, f, indent=2)
+        save_marker = save_path / f".{config_path.name}.save-in-progress"
+        _atomic_json_dump(
+            save_marker,
+            {"persistence_schema": VECTOR_PERSISTENCE_SCHEMA},
+        )
+        try:
+            level_artifacts: dict[str, dict[str, dict[str, Any]]] = {}
+            for level, (_index, documents) in level_state.items():
+                if documents:
+                    level_artifacts[level] = self._save_level(
+                        save_path, level, model_suffix
+                    )
+                else:
+                    self._remove_level_files(save_path, level, model_suffix)
+
+            config = {
+                "embedding_model": self.embedding_model,
+                "embedding_provider": self.embedding_provider,
+                "dimension": self.dimension,
+                "index_type": self.index_type,
+                "index_metric": self.index_metric,
+                "l0_documents": len(self.l0_documents),
+                "l2_documents": len(self.l2_documents),
+                "persistence_schema": VECTOR_PERSISTENCE_SCHEMA,
+                "level_artifacts": level_artifacts,
+            }
+            if self.artifact_metadata:
+                config["artifact"] = self.artifact_metadata
+            # This config is the commit record for both levels. Publishing it
+            # last makes an interrupted multi-file save detectable on load.
+            _atomic_json_dump(config_path, config)
+        except Exception:
+            # Keep the marker so a later load cannot accept a partially
+            # replaced legacy artifact. A successful retry removes it.
+            raise
+        else:
+            save_marker.unlink()
 
         logger.info("Vector store saved successfully")
 
@@ -1017,7 +1076,9 @@ class CodeVectorStore:
         except OSError:
             pass
 
-    def _save_level(self, save_path: Path, level: str, model_suffix: str) -> None:
+    def _save_level(
+        self, save_path: Path, level: str, model_suffix: str
+    ) -> dict[str, dict[str, Any]]:
         """Save a single level (l0 or l2) to disk."""
         index, documents = self._get_index_and_docs(level)
 
@@ -1026,12 +1087,17 @@ class CodeVectorStore:
 
         # Write raw FAISS index
         index_name = f"index_{model_suffix}"
-        faiss.write_index(index, str(level_path / f"{index_name}.faiss"))
+        index_path = level_path / f"{index_name}.faiss"
+        _atomic_replace(index_path, lambda path: faiss.write_index(index, str(path)))
 
         # Save documents (list of _Document)
         docs_path = level_path / f"documents_{model_suffix}.pkl"
-        with open(docs_path, "wb") as f:
-            pickle.dump(documents, f)
+        _atomic_pickle_dump(docs_path, documents)
+        artifacts = vector_level_artifact_records(
+            level_path,
+            model_suffix,
+            documents_file=docs_path.name,
+        )
 
         # Save level config
         config_path = level_path / f"config_{model_suffix}.json"
@@ -1044,10 +1110,10 @@ class CodeVectorStore:
             "level": level,
             "num_documents": len(documents),
         }
-        with open(config_path, "w") as f:
-            json.dump(config, f, indent=2)
+        _atomic_json_dump(config_path, config)
 
         logger.info(f"Saved {level.upper()} store with {len(documents)} documents")
+        return artifacts
 
     def load(self, path: Optional[str] = None) -> None:
         """
@@ -1072,10 +1138,16 @@ class CodeVectorStore:
         config_path = load_path / f"config_{model_suffix}.json"
         if not config_path.exists():
             config_path = load_path / "config.json"
+        save_marker = load_path / f".config_{model_suffix}.json.save-in-progress"
+        if save_marker.exists():
+            raise ValueError(
+                f"Vector store has an interrupted save marker: {save_marker}"
+            )
 
         expected_artifact = dict(self.artifact_metadata)
         loaded_artifact = expected_artifact
         expected_counts: Dict[str, Optional[int]] = {"l0": None, "l2": None}
+        committed_levels: Optional[dict[str, object]] = None
         if config_path.exists():
             with open(config_path, "r") as f:
                 config = json.load(f)
@@ -1136,6 +1208,25 @@ class CodeVectorStore:
                         f"Vector config has invalid {level} document count: {value!r}"
                     )
                 expected_counts[level] = value
+
+            persistence_schema = config.get("persistence_schema")
+            raw_levels = config.get("level_artifacts")
+            if persistence_schema is not None or raw_levels is not None:
+                if persistence_schema != VECTOR_PERSISTENCE_SCHEMA:
+                    raise ValueError(
+                        "Vector config has unsupported persistence schema: "
+                        f"{persistence_schema!r}"
+                    )
+                if not isinstance(raw_levels, dict) or not set(raw_levels) <= {
+                    "l0",
+                    "l2",
+                }:
+                    raise ValueError("Vector config has invalid committed levels")
+                committed_levels = dict(raw_levels)
+                if any(expected_counts[level] is None for level in ("l0", "l2")):
+                    raise ValueError(
+                        "Vector config with committed artifacts requires level counts"
+                    )
         elif expected_artifact.get("embedding_fingerprint") is not None:
             raise ValueError("Vector store is missing its top-level configuration")
 
@@ -1144,15 +1235,36 @@ class CodeVectorStore:
             expected_count = expected_counts[level]
             level_path = load_path / level
             faiss_path = level_path / f"index_{model_suffix}.faiss"
+            committed_artifacts = (
+                committed_levels.get(level) if committed_levels is not None else None
+            )
 
             # A zero count in the top-level config is authoritative. Older
             # writers could leave stale level files behind after deletions.
             if expected_count == 0:
+                if committed_artifacts is not None:
+                    raise ValueError(
+                        f"Vector config commits artifacts for empty {level} level"
+                    )
                 loaded_levels[level] = (self._build_faiss_index(), [])
                 continue
 
-            if faiss_path.exists():
-                index, documents = self._load_level(level_path, model_suffix)
+            if (
+                committed_levels is not None
+                and expected_count is not None
+                and expected_count > 0
+                and committed_artifacts is None
+            ):
+                raise ValueError(
+                    f"Vector config is missing committed artifacts for {level}"
+                )
+
+            if committed_artifacts is not None or faiss_path.exists():
+                index, documents = self._load_level(
+                    level_path,
+                    model_suffix,
+                    committed_artifacts=committed_artifacts,
+                )
             elif expected_count is not None and expected_count > 0:
                 raise FileNotFoundError(
                     f"Vector config expects {expected_count} {level} documents, "
@@ -1203,7 +1315,11 @@ class CodeVectorStore:
         )
 
     def _load_level(
-        self, level_path: Path, model_suffix: str
+        self,
+        level_path: Path,
+        model_suffix: str,
+        *,
+        committed_artifacts: object = None,
     ) -> tuple[faiss.Index, List[_Document]]:
         """Load a single level from disk.
 
@@ -1211,7 +1327,15 @@ class CodeVectorStore:
         legacy LangChain format (FAISS + docstore pkl) transparently.
         """
         index_name = f"index_{model_suffix}"
-        faiss_path = level_path / f"{index_name}.faiss"
+        committed_documents_path = None
+        if committed_artifacts is not None:
+            faiss_path, committed_documents_path = validate_vector_level_artifacts(
+                level_path,
+                model_suffix,
+                committed_artifacts,
+            )
+        else:
+            faiss_path = level_path / f"{index_name}.faiss"
 
         if not faiss_path.exists():
             raise FileNotFoundError(f"FAISS index not found at {faiss_path}")
@@ -1232,7 +1356,20 @@ class CodeVectorStore:
         # never unpickled. Local indexes retain the pickle fallback for
         # compatibility with previously built artifacts.
         json_path = level_path / f"documents_{model_suffix}.json"
-        if json_path.exists():
+        if committed_documents_path is not None:
+            if committed_documents_path.suffix == ".json":
+                documents = self._load_documents_json(committed_documents_path)
+            else:
+                try:
+                    with committed_documents_path.open("rb") as handle:
+                        raw_docs = compat_pickle.load(handle)
+                    documents = [_to_document(document) for document in raw_docs]
+                except Exception as exc:
+                    raise ValueError(
+                        "Could not load committed vector documents from "
+                        f"{committed_documents_path}: {exc}"
+                    ) from exc
+        elif json_path.exists():
             documents = self._load_documents_json(json_path)
         else:
             documents = None

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -542,26 +542,10 @@ class CodeVectorStore:
     def swap_index(self, path: str) -> None:
         """Hot-swap the FAISS index without reloading the embedding model.
 
-        Frees the current L0/L2 FAISS indices and documents from memory, then
-        loads a new index from *path*.  The embedding model is left intact so
-        the caller can reuse the same model across many instances.
+        The replacement is fully loaded and validated before the current
+        L0/L2 state is released. The embedding model is left intact so the
+        caller can reuse the same model across many instances.
         """
-        # Free current FAISS index memory (GPU or CPU).
-        for index in (self.l0_index, self.l2_index):
-            if index is None:
-                continue
-            reset = getattr(index, "reset", None)
-            if callable(reset):
-                reset()
-
-        # Reinitialise to empty indices (guards against a partially-failed
-        # subsequent load leaving the store in a mixed state).
-        self.l0_index = self._build_faiss_index()
-        self.l0_documents = []
-        self.l2_index = self._build_faiss_index()
-        self.l2_documents = []
-
-        self.store_path = Path(path)
         self.load(path)
 
     def close(self) -> None:
@@ -1090,6 +1074,8 @@ class CodeVectorStore:
             config_path = load_path / "config.json"
 
         expected_artifact = dict(self.artifact_metadata)
+        loaded_artifact = expected_artifact
+        expected_counts: Dict[str, Optional[int]] = {"l0": None, "l2": None}
         if config_path.exists():
             with open(config_path, "r") as f:
                 config = json.load(f)
@@ -1114,14 +1100,18 @@ class CodeVectorStore:
                     f"Vector config dimension mismatch: expected {self.dimension}, "
                     f"found {saved_dimension}"
                 )
+            saved_index_type = config.get("index_type")
+            if saved_index_type and saved_index_type != self.index_type:
+                raise ValueError(
+                    f"Vector config index type mismatch: expected {self.index_type!r}, "
+                    f"found {saved_index_type!r}"
+                )
             saved_metric = config.get("index_metric")
             if saved_metric and saved_metric != self.index_metric:
-                logger.warning(
-                    "Index metric mismatch: expected %s, got %s",
-                    self.index_metric,
-                    saved_metric,
+                raise ValueError(
+                    f"Vector config metric mismatch: expected {self.index_metric!r}, "
+                    f"found {saved_metric!r}"
                 )
-                self.index_metric = saved_metric
             saved_artifact = config.get("artifact")
             if isinstance(saved_artifact, dict):
                 expected_fingerprint = expected_artifact.get("embedding_fingerprint")
@@ -1133,27 +1123,78 @@ class CodeVectorStore:
                     raise ValueError(
                         "Vector artifact embedding fingerprint does not match manifest"
                     )
-                self.artifact_metadata = dict(saved_artifact)
+                loaded_artifact = dict(saved_artifact)
             elif expected_artifact.get("embedding_fingerprint") is not None:
                 raise ValueError("Vector config is missing embedding artifact identity")
+
+            for level in ("l0", "l2"):
+                value = config.get(f"{level}_documents")
+                if value is None:
+                    continue
+                if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                    raise ValueError(
+                        f"Vector config has invalid {level} document count: {value!r}"
+                    )
+                expected_counts[level] = value
         elif expected_artifact.get("embedding_fingerprint") is not None:
             raise ValueError("Vector store is missing its top-level configuration")
 
-        # Load L0
-        l0_path = load_path / "l0"
-        if l0_path.exists():
-            loaded = self._load_level(l0_path, model_suffix)
-            if loaded is not None:
-                self.l0_index, self.l0_documents = loaded
-                logger.info(f"Loaded L0 store with {len(self.l0_documents)} documents")
+        loaded_levels = {}
+        for level in ("l0", "l2"):
+            expected_count = expected_counts[level]
+            level_path = load_path / level
+            faiss_path = level_path / f"index_{model_suffix}.faiss"
 
-        # Load L2
-        l2_path = load_path / "l2"
-        if l2_path.exists():
-            loaded = self._load_level(l2_path, model_suffix)
-            if loaded is not None:
-                self.l2_index, self.l2_documents = loaded
-                logger.info(f"Loaded L2 store with {len(self.l2_documents)} documents")
+            # A zero count in the top-level config is authoritative. Older
+            # writers could leave stale level files behind after deletions.
+            if expected_count == 0:
+                loaded_levels[level] = (self._build_faiss_index(), [])
+                continue
+
+            if faiss_path.exists():
+                index, documents = self._load_level(level_path, model_suffix)
+            elif expected_count is not None and expected_count > 0:
+                raise FileNotFoundError(
+                    f"Vector config expects {expected_count} {level} documents, "
+                    f"but {faiss_path} is missing"
+                )
+            else:
+                index, documents = self._build_faiss_index(), []
+
+            if expected_count is not None and len(documents) != expected_count:
+                raise ValueError(
+                    f"{level} config expects {expected_count} documents, "
+                    f"loaded {len(documents)}"
+                )
+            loaded_levels[level] = (index, documents)
+
+        old_indices = (self.l0_index, self.l2_index)
+        self.l0_index, self.l0_documents = loaded_levels["l0"]
+        self.l2_index, self.l2_documents = loaded_levels["l2"]
+        self.artifact_metadata = loaded_artifact
+        self.store_path = load_path
+
+        for old_index in old_indices:
+            if (
+                old_index is None
+                or old_index is self.l0_index
+                or old_index is self.l2_index
+            ):
+                continue
+            reset = getattr(old_index, "reset", None)
+            if callable(reset):
+                try:
+                    reset()
+                except Exception as exc:
+                    logger.debug("Could not release replaced FAISS index: %s", exc)
+
+        for level, (_index, documents) in loaded_levels.items():
+            if documents:
+                logger.info(
+                    "Loaded %s store with %d documents",
+                    level.upper(),
+                    len(documents),
+                )
 
         total_docs = len(self.l0_documents) + len(self.l2_documents)
         logger.info(
@@ -1163,7 +1204,7 @@ class CodeVectorStore:
 
     def _load_level(
         self, level_path: Path, model_suffix: str
-    ) -> Optional[tuple[faiss.Index, List[_Document]]]:
+    ) -> tuple[faiss.Index, List[_Document]]:
         """Load a single level from disk.
 
         Handles both the new format (raw FAISS + _Document list) and the
@@ -1173,14 +1214,14 @@ class CodeVectorStore:
         faiss_path = level_path / f"{index_name}.faiss"
 
         if not faiss_path.exists():
-            logger.warning(f"FAISS index not found at {faiss_path}")
-            return None
+            raise FileNotFoundError(f"FAISS index not found at {faiss_path}")
 
         try:
             index = faiss.read_index(str(faiss_path))
         except Exception as e:
-            logger.warning(f"Could not load FAISS index from {faiss_path}: {e}")
-            return None
+            raise ValueError(
+                f"Could not load FAISS index from {faiss_path}: {e}"
+            ) from e
         if int(index.d) != self.dimension:
             raise ValueError(
                 f"FAISS dimension mismatch at {faiss_path}: "
@@ -1193,38 +1234,52 @@ class CodeVectorStore:
         json_path = level_path / f"documents_{model_suffix}.json"
         if json_path.exists():
             documents = self._load_documents_json(json_path)
-            return index, documents
+        else:
+            documents = None
 
-        # Try loading the local documents pickle (works for both new _Document
-        # and legacy LangChain Document objects via duck-typing conversion).
-        docs_path = level_path / f"documents_{model_suffix}.pkl"
-        if docs_path.exists():
-            try:
-                with open(docs_path, "rb") as f:
-                    raw_docs = compat_pickle.load(f)
-                documents = [_to_document(d) for d in raw_docs]
-                return index, documents
-            except Exception as e:
-                logger.warning(f"Could not load documents from {docs_path}: {e}")
+            # Try loading the local documents pickle (works for both new
+            # _Document and legacy LangChain Document objects).
+            docs_path = level_path / f"documents_{model_suffix}.pkl"
+            if docs_path.exists():
+                try:
+                    with open(docs_path, "rb") as f:
+                        raw_docs = compat_pickle.load(f)
+                    documents = [_to_document(d) for d in raw_docs]
+                except Exception as exc:
+                    logger.warning(
+                        "Could not load documents from %s: %s", docs_path, exc
+                    )
 
-        # Fallback: try LangChain FAISS pkl (index_name.pkl contains
-        # (InMemoryDocstore, index_to_docstore_id) tuple).
-        lc_pkl_path = level_path / f"{index_name}.pkl"
-        if lc_pkl_path.exists():
-            try:
-                documents = self._load_langchain_pkl(lc_pkl_path)
-                logger.info(
-                    "Loaded %d documents from legacy LangChain format",
-                    len(documents),
-                )
-                return index, documents
-            except Exception as e:
-                logger.warning(
-                    f"Could not load legacy LangChain pkl from {lc_pkl_path}: {e}"
-                )
+            # Fallback: LangChain stores use index_name.pkl for their docstore.
+            lc_pkl_path = level_path / f"{index_name}.pkl"
+            if documents is None and lc_pkl_path.exists():
+                try:
+                    documents = self._load_langchain_pkl(lc_pkl_path)
+                    logger.info(
+                        "Loaded %d documents from legacy LangChain format",
+                        len(documents),
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Could not load legacy LangChain pkl from %s: %s",
+                        lc_pkl_path,
+                        exc,
+                    )
 
-        logger.warning(f"No document store found for {level_path}")
-        return index, []
+            if documents is None:
+                if int(index.ntotal) == 0:
+                    documents = []
+                else:
+                    raise ValueError(
+                        f"No readable document store found for {level_path}"
+                    )
+
+        if int(index.ntotal) != len(documents):
+            raise ValueError(
+                f"Misaligned vector level {level_path}: {int(index.ntotal)} vectors "
+                f"for {len(documents)} documents"
+            )
+        return index, documents
 
     @staticmethod
     def _load_documents_json(path: Path) -> List[_Document]:

--- a/codenib/index/embedding/vector_store.py
+++ b/codenib/index/embedding/vector_store.py
@@ -27,6 +27,7 @@ from ...provider_routes import normalize_provider
 from ...types import NodeInfo
 from .artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    validate_vector_config_artifact,
     validate_vector_level_artifacts,
     vector_level_artifact_records,
 )
@@ -1145,6 +1146,13 @@ class CodeVectorStore:
             )
 
         expected_artifact = dict(self.artifact_metadata)
+        expected_config = expected_artifact.get("persistence_config_fingerprint")
+        if expected_config is not None:
+            config_path = validate_vector_config_artifact(
+                load_path,
+                model_suffix,
+                expected_config,
+            )
         loaded_artifact = expected_artifact
         expected_counts: Dict[str, Optional[int]] = {"l0": None, "l2": None}
         committed_levels: Optional[dict[str, object]] = None

--- a/codenib/model/embedding_retrieve_pipeline.py
+++ b/codenib/model/embedding_retrieve_pipeline.py
@@ -113,9 +113,10 @@ class EmbeddingRetrievePipeline:
     def load_index(self, index_path: str) -> None:
         """Hot-swap the FAISS index without reloading the embedding model.
 
-        Frees the current index and loads the pre-built index at *index_path*.
-        The embedding model stays in memory, so this is much faster than
-        creating a new :class:`EmbeddingRetrievePipeline` for each instance.
+        Validates the pre-built index at *index_path* before releasing the
+        current one. The embedding model stays in memory, so this is much
+        faster than creating a new :class:`EmbeddingRetrievePipeline` for each
+        instance, and a failed replacement leaves the current index available.
         """
         self.vector_store.swap_index(index_path)
 

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -20,6 +20,7 @@ from codenib.artifacts import (
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    vector_config_artifact_record,
     vector_level_artifact_records,
 )
 from codenib.source_fingerprint import fingerprint_repository
@@ -149,6 +150,10 @@ def _fixture_vector_manifest(root: Path) -> tuple[Path, Path, Path]:
         "dimension": 4,
         "embedding_kwargs": {},
         "index_metric": "ip",
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            vector,
+            "test__model",
+        ),
     }
     manifest_path = index_root / "repo_manifest.json"
     source_fingerprint = fingerprint_repository(repo).value
@@ -288,6 +293,10 @@ def test_context_artifact_keeps_only_portable_vector_serving_state(
         portable["indexes"]["vector"]["config"]["portable_document_format"]
         == "codenib.vector-documents.v1"
     )
+    vector_config = portable["indexes"]["vector"]["config"]
+    assert vector_config["persistence_config_fingerprint"] == (
+        vector_config_artifact_record(output / "views" / "vector", "test__model")
+    )
     assert not list(output.rglob("*.pkl"))
     assert str(repo).encode() not in b"".join(_tree(output).values())
 
@@ -297,6 +306,23 @@ def test_context_artifact_rejects_interrupted_vector_save(tmp_path: Path) -> Non
     (vector / ".config_test__model.json.save-in-progress").write_text("{}")
 
     with pytest.raises(ValueError, match="interrupted save marker"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+            repository="example/vector-project",
+        )
+
+
+def test_context_artifact_rejects_unpublished_vector_generation(tmp_path: Path) -> None:
+    repo, manifest_path, vector = _fixture_vector_manifest(tmp_path)
+    config_path = vector / "config_test__model.json"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="manifest fingerprint"):
         stage_context_artifact(
             repo,
             manifest_path,

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -331,6 +331,20 @@ def test_context_artifact_rejects_unpublished_vector_generation(tmp_path: Path) 
         )
 
 
+def test_context_artifact_rejects_tampered_vector_level(tmp_path: Path) -> None:
+    repo, manifest_path, vector = _fixture_vector_manifest(tmp_path)
+    documents = vector / "l2" / "documents_test__model.pkl"
+    documents.write_bytes(documents.read_bytes() + b"\n")
+
+    with pytest.raises(ValueError, match="committed documents vector artifact"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+            repository="example/vector-project",
+        )
+
+
 def test_context_artifact_rejects_credential_shaped_config(tmp_path: Path) -> None:
     repo, manifest_path, _view_path = _fixture_manifest(
         tmp_path,

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -18,6 +18,10 @@ from codenib.artifacts import (
     stage_context_artifact,
 )
 from codenib.compiler.manifest import IndexEntry, RepoManifest
+from codenib.index.embedding.artifact_integrity import (
+    VECTOR_PERSISTENCE_SCHEMA,
+    vector_level_artifact_records,
+)
 from codenib.source_fingerprint import fingerprint_repository
 
 
@@ -115,6 +119,27 @@ def _fixture_vector_manifest(root: Path) -> tuple[Path, Path, Path]:
     (vector / "embeddings_cache.npz").write_bytes(b"mutable-cache")
     (vector / "incremental_state.json").write_text(
         json.dumps({"index_path": str(vector)})
+    )
+    (vector / "config_test__model.json").write_text(
+        json.dumps(
+            {
+                "embedding_model": "test/model",
+                "embedding_provider": "huggingface",
+                "dimension": 4,
+                "index_type": "flat",
+                "index_metric": "ip",
+                "l0_documents": 0,
+                "l2_documents": 1,
+                "persistence_schema": VECTOR_PERSISTENCE_SCHEMA,
+                "level_artifacts": {
+                    "l2": vector_level_artifact_records(
+                        level,
+                        "test__model",
+                        documents_file="documents_test__model.pkl",
+                    )
+                },
+            }
+        )
     )
     config = {
         "builder_schema": 2,
@@ -249,6 +274,12 @@ def test_context_artifact_keeps_only_portable_vector_serving_state(
     assert not (vector / "l2" / "documents_test__model.pkl").exists()
     documents = json.loads((vector / "l2" / "documents_test__model.json").read_text())
     assert documents[0]["metadata"]["file"] == "sample.py"
+    vector_config = json.loads((vector / "config_test__model.json").read_text())
+    committed_documents = vector_config["level_artifacts"]["l2"]["documents"]
+    assert committed_documents["file"] == "documents_test__model.json"
+    payload = (vector / "l2" / committed_documents["file"]).read_bytes()
+    assert committed_documents["size"] == len(payload)
+    assert committed_documents["sha256"] == hashlib.sha256(payload).hexdigest()
     portable = json.loads((output / "repo_manifest.json").read_text())
     assert portable["indexes"]["vector"]["config"]["artifact_scope"] == (
         "query-serving"
@@ -259,6 +290,19 @@ def test_context_artifact_keeps_only_portable_vector_serving_state(
     )
     assert not list(output.rglob("*.pkl"))
     assert str(repo).encode() not in b"".join(_tree(output).values())
+
+
+def test_context_artifact_rejects_interrupted_vector_save(tmp_path: Path) -> None:
+    repo, manifest_path, vector = _fixture_vector_manifest(tmp_path)
+    (vector / ".config_test__model.json.save-in-progress").write_text("{}")
+
+    with pytest.raises(ValueError, match="interrupted save marker"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+            repository="example/vector-project",
+        )
 
 
 def test_context_artifact_rejects_credential_shaped_config(tmp_path: Path) -> None:

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -204,7 +204,13 @@ class TestVectorIndexBuilder:
             embedding_model="test-model",
             embedding_dimension=384,
         )
-        output = str(tmp_path / "vector")
+        output_path = tmp_path / "vector"
+        output_path.mkdir()
+        (output_path / "config_test-model.json").write_text(
+            '{"level_artifacts": {}}',
+            encoding="utf-8",
+        )
+        output = str(output_path)
         status = builder.build(
             scope="current_repo",
             repo_path="/fake/repo",
@@ -219,6 +225,9 @@ class TestVectorIndexBuilder:
         assert status.metadata["dimension"] == 384
         assert status.metadata["embedding_kwargs"] == {}
         assert status.metadata["index_metric"] == "ip"
+        assert status.metadata["persistence_config_fingerprint"]["file"] == (
+            "config_test-model.json"
+        )
         assert status.metadata["document_count"] == {"l0": 2, "l2": 3}
         mock_build_fn.assert_called_once()
         assert mock_build_fn.call_args.kwargs["force_rebuild"] is True
@@ -234,7 +243,7 @@ class TestVectorIndexBuilder:
 
         identity = builder.artifact_identity()
         assert identity == {
-            "builder_schema": 4,
+            "builder_schema": 5,
             "embedding_model": "test-model",
             "embedding_provider": "huggingface",
             "embedding_dimension": 384,
@@ -309,6 +318,12 @@ class TestVectorIndexBuilder:
     def test_remote_runtime_secret_is_not_persisted(self, mock_build_fn, tmp_path):
         mock_vs = MagicMock(l0_documents=[], l2_documents=["doc"])
         mock_build_fn.return_value = mock_vs
+        output_path = tmp_path / "vector"
+        output_path.mkdir()
+        (output_path / "config_text-embedding-3-small.json").write_text(
+            '{"level_artifacts": {}}',
+            encoding="utf-8",
+        )
         builder = VectorIndexBuilder(
             embedding_model="text-embedding-3-small",
             embedding_provider="openai",
@@ -321,7 +336,7 @@ class TestVectorIndexBuilder:
         status = builder.build(
             scope="current_repo",
             repo_path="/fake/repo",
-            output_dir=str(tmp_path / "vector"),
+            output_dir=str(output_path),
         )
 
         serialized = json.dumps(status.metadata, sort_keys=True)

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -24,6 +24,7 @@ import pytest
 
 from codenib.index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
+    vector_config_artifact_record,
     vector_level_artifact_records,
 )
 from codenib.index.embedding.vector_store import CodeVectorStore
@@ -360,6 +361,28 @@ def test_load_rejects_same_count_torn_document_write(tmp_path):
         ValueError,
         match="committed documents vector artifact does not match",
     ):
+        loaded.load()
+
+
+def test_load_rejects_vector_config_from_another_manifest_generation(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+    expected = vector_config_artifact_record(path, "test__model")
+
+    config_path = path / "config_test__model.json"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+    loaded = _make_store(
+        embedding_model="test/model",
+        store_path=str(path),
+        artifact_metadata={"persistence_config_fingerprint": expected},
+    )
+
+    with pytest.raises(ValueError, match="manifest fingerprint"):
         loaded.load()
 
 

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -15,12 +15,17 @@ from __future__ import annotations
 
 import hashlib
 import json
+import pickle
 from unittest.mock import patch
 
 import faiss
 import numpy as np
 import pytest
 
+from codenib.index.embedding.artifact_integrity import (
+    VECTOR_PERSISTENCE_SCHEMA,
+    vector_level_artifact_records,
+)
 from codenib.index.embedding.vector_store import CodeVectorStore
 
 _DIM = 16
@@ -70,6 +75,19 @@ def _chunks(n: int) -> list:
         }
         for i in range(n)
     ]
+
+
+def _commit_portable_documents(path, model_suffix: str) -> None:
+    config_path = path / f"config_{model_suffix}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    level_path = path / "l2"
+    config["persistence_schema"] = VECTOR_PERSISTENCE_SCHEMA
+    config["level_artifacts"]["l2"] = vector_level_artifact_records(
+        level_path,
+        model_suffix,
+        documents_file=f"documents_{model_suffix}.json",
+    )
+    config_path.write_text(json.dumps(config), encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +216,33 @@ def test_save_rejects_misaligned_vectors_and_documents(tmp_path):
         store.save(str(tmp_path / "vs"))
 
 
+def test_failed_save_blocks_load_until_successful_retry(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+
+    with (
+        patch(
+            "codenib.index.embedding.vector_store.faiss.write_index",
+            side_effect=RuntimeError("interrupted"),
+        ),
+        pytest.raises(RuntimeError, match="interrupted"),
+    ):
+        store.save(str(path))
+
+    marker = path / ".config_test__model.json.save-in-progress"
+    assert marker.is_file()
+    loaded = _make_store(embedding_model="test/model", store_path=str(path))
+    with pytest.raises(ValueError, match="interrupted save marker"):
+        loaded.load()
+
+    store.save(str(path))
+    assert not marker.exists()
+    loaded.load()
+    assert len(loaded.l2_documents) == 2
+
+
 def test_load_prefers_portable_json_documents(tmp_path):
     path = tmp_path / "vs"
     store = _make_store(embedding_model="test/model")
@@ -225,6 +270,7 @@ def test_load_prefers_portable_json_documents(tmp_path):
         ),
         encoding="utf-8",
     )
+    _commit_portable_documents(path, "test__model")
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     loaded.load()
@@ -247,6 +293,7 @@ def test_load_rejects_invalid_portable_json_documents(tmp_path):
         '[{"page_content": 7, "metadata": {}}]',
         encoding="utf-8",
     )
+    _commit_portable_documents(path, "test__model")
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="invalid content or metadata"):
@@ -272,6 +319,7 @@ def test_load_rejects_faiss_document_count_mismatch(tmp_path):
         ),
         encoding="utf-8",
     )
+    _commit_portable_documents(path, "test__model")
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
     with pytest.raises(ValueError, match="2 vectors for 1 documents"):
@@ -294,6 +342,27 @@ def test_load_rejects_top_level_document_count_mismatch(tmp_path):
         loaded.load()
 
 
+def test_load_rejects_same_count_torn_document_write(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+
+    documents_path = path / "l2" / "documents_test__model.pkl"
+    with documents_path.open("rb") as handle:
+        documents = pickle.load(handle)
+    documents[0].page_content = "def unrelated():\n    return -1"
+    with documents_path.open("wb") as handle:
+        pickle.dump(documents, handle)
+
+    loaded = _make_store(embedding_model="test/model", store_path=str(path))
+    with pytest.raises(
+        ValueError,
+        match="committed documents vector artifact does not match",
+    ):
+        loaded.load()
+
+
 def test_zero_top_level_count_does_not_resurrect_stale_level_files(tmp_path):
     path = tmp_path / "vs"
     store = _make_store(embedding_model="test/model")
@@ -303,6 +372,8 @@ def test_zero_top_level_count_does_not_resurrect_stale_level_files(tmp_path):
     config_path = path / "config_test__model.json"
     config = json.loads(config_path.read_text(encoding="utf-8"))
     config["l2_documents"] = 0
+    config.pop("persistence_schema")
+    config.pop("level_artifacts")
     config_path.write_text(json.dumps(config), encoding="utf-8")
 
     loaded = _make_store(embedding_model="test/model", store_path=str(path))
@@ -323,7 +394,7 @@ def test_failed_swap_preserves_the_serving_index(tmp_path):
     replacement.save(str(replacement_path))
     (replacement_path / "l2" / "documents_test__model.pkl").unlink()
 
-    with pytest.raises(ValueError, match="document store"):
+    with pytest.raises(ValueError, match="vector artifact file"):
         current.swap_index(str(replacement_path))
 
     assert current.l2_index.ntotal == 2

--- a/test/index/test_vector_store_ivf.py
+++ b/test/index/test_vector_store_ivf.py
@@ -253,6 +253,107 @@ def test_load_rejects_invalid_portable_json_documents(tmp_path):
         loaded.load()
 
 
+def test_load_rejects_faiss_document_count_mismatch(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+
+    documents_path = path / "l2" / "documents_test__model.pkl"
+    documents_path.unlink()
+    documents_path.with_suffix(".json").write_text(
+        json.dumps(
+            [
+                {
+                    "page_content": "def f0(): pass",
+                    "metadata": {"name": "f0", "file": "m0.py"},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = _make_store(embedding_model="test/model", store_path=str(path))
+    with pytest.raises(ValueError, match="2 vectors for 1 documents"):
+        loaded.load()
+
+
+def test_load_rejects_top_level_document_count_mismatch(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+
+    config_path = path / "config_test__model.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["l2_documents"] = 3
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    loaded = _make_store(embedding_model="test/model", store_path=str(path))
+    with pytest.raises(ValueError, match="config expects 3 documents, loaded 2"):
+        loaded.load()
+
+
+def test_zero_top_level_count_does_not_resurrect_stale_level_files(tmp_path):
+    path = tmp_path / "vs"
+    store = _make_store(embedding_model="test/model")
+    store.add_code_chunks(_chunks(2))
+    store.save(str(path))
+
+    config_path = path / "config_test__model.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["l2_documents"] = 0
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    loaded = _make_store(embedding_model="test/model", store_path=str(path))
+    loaded.load()
+
+    assert loaded.l2_index.ntotal == 0
+    assert loaded.l2_documents == []
+
+
+def test_failed_swap_preserves_the_serving_index(tmp_path):
+    current = _make_store(embedding_model="test/model")
+    current_chunks = _chunks(2)
+    current.add_code_chunks(current_chunks)
+
+    replacement_path = tmp_path / "replacement"
+    replacement = _make_store(embedding_model="test/model")
+    replacement.add_code_chunks(_chunks(1))
+    replacement.save(str(replacement_path))
+    (replacement_path / "l2" / "documents_test__model.pkl").unlink()
+
+    with pytest.raises(ValueError, match="document store"):
+        current.swap_index(str(replacement_path))
+
+    assert current.l2_index.ntotal == 2
+    assert len(current.l2_documents) == 2
+    results = current.search(current_chunks[0]["content"], top_k=1)
+    assert results[0].node_name == current_chunks[0]["name"]
+
+
+def test_successful_swap_replaces_all_levels(tmp_path):
+    current = _make_store(embedding_model="test/model")
+    current.add_code_chunks(_chunks(2), level="l0")
+    current.add_code_chunks(_chunks(2), level="l2")
+
+    replacement_path = tmp_path / "replacement"
+    replacement = _make_store(embedding_model="test/model")
+    replacement_chunk = _chunks(1)[0]
+    replacement_chunk["name"] = "replacement"
+    replacement_chunk["content"] = "def replacement():\n    return 42"
+    replacement.add_code_chunks([replacement_chunk], level="l2")
+    replacement.save(str(replacement_path))
+
+    current.swap_index(str(replacement_path))
+
+    assert current.l0_index.ntotal == 0
+    assert current.l0_documents == []
+    assert current.l2_index.ntotal == 1
+    results = current.search(replacement_chunk["content"], top_k=1)
+    assert results[0].node_name == "replacement"
+
+
 def test_load_rejects_faiss_dimension_mismatch(tmp_path):
     path = tmp_path / "vs"
     model = "test/model"


### PR DESCRIPTION
## Summary
Reject incomplete, modified, or unpublished vector generations before changing a live store or converting one into a portable artifact. Saves publish file pairs atomically under a top-level commit record, manifests bind that exact generation, and portable staging validates every committed level before rewriting trusted local pickles to inert JSON.

Supersedes #458, which GitHub closed automatically when its merged stack base was deleted.

## Changes
- Atomically publish FAISS, documents, level config, and top-level config files
- Keep an interrupted-save marker until a complete generation is committed
- Record and validate exact file size and SHA-256 for each non-empty level
- Bind manifest entries to the exact top-level vector commit record
- Validate manifest and level generation identity before runtime loading and artifact staging
- Load both levels transactionally before replacing live in-memory state
- Reject count, dimension, index type, metric, cardinality, and fingerprint mismatches
- Rewrite portable persistence records after verified pickle-to-JSON conversion
- Retain read compatibility for legacy vector artifacts

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- targeted vector and artifact integrity tests: 36 passed
- expanded index/compiler/artifact tier: 377 passed; the unrelated publish preflight test passed in isolation and is addressed structurally by #449
- pre-commit on every changed file: passed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published