### PR TITLE
fix(release): derive upgrade smoke contract

### DIFF
--- a/scripts/smoke_release_upgrade.py
+++ b/scripts/smoke_release_upgrade.py
@@ -75,6 +75,46 @@ def _load_bm25(manifest_path: Path) -> dict[str, object]:
     return bm25
 
 
+def _installed_bm25_identity(
+    python: Path,
+    *,
+    root: Path,
+    env: dict[str, str],
+) -> dict[str, object]:
+    result = _run(
+        [
+            python,
+            "-c",
+            (
+                "import json\n"
+                "from codenib.compiler.index_builders import BM25IndexBuilder\n"
+                "print(json.dumps(BM25IndexBuilder().artifact_identity()))\n"
+            ),
+        ],
+        cwd=root,
+        env=env,
+    )
+    identity = json.loads(result.stdout)
+    if not isinstance(identity, dict):
+        raise RuntimeError(f"installed BM25 builder has no identity: {identity!r}")
+    return identity
+
+
+def _assert_builder_contract(
+    actual: object,
+    expected: dict[str, object],
+) -> None:
+    if not isinstance(actual, dict):
+        raise RuntimeError(f"upgraded BM25 view has no config: {actual!r}")
+    mismatches = {
+        key: {"expected": value, "actual": actual.get(key)}
+        for key, value in expected.items()
+        if actual.get(key) != value
+    }
+    if mismatches:
+        raise RuntimeError(f"unexpected BM25 builder contract: {mismatches!r}")
+
+
 def smoke(wheel: Path, *, expected_version: str, root: Path) -> None:
     repository = root / "upgrade-repository"
     repository.mkdir(parents=True)
@@ -135,6 +175,11 @@ def smoke(wheel: Path, *, expected_version: str, root: Path) -> None:
     version = _run([codenib, "--version"], cwd=root, env=environment).stdout.strip()
     if version != f"codenib {expected_version}":
         raise RuntimeError(f"unexpected upgraded version: {version!r}")
+    expected_bm25_identity = _installed_bm25_identity(
+        python,
+        root=root,
+        env=environment,
+    )
 
     _run(
         [codenib, "index", repository, "--preset", "fast"],
@@ -144,13 +189,7 @@ def smoke(wheel: Path, *, expected_version: str, root: Path) -> None:
     upgraded = _load_bm25(manifest_path)
     if upgraded.get("built_at") == baseline.get("built_at"):
         raise RuntimeError("0.2 reused the incompatible 0.1 BM25 view")
-    upgraded_config = upgraded.get("config")
-    if not isinstance(upgraded_config, dict):
-        raise RuntimeError(f"upgraded BM25 view has no config: {upgraded!r}")
-    if upgraded_config.get("builder_schema") != 6:
-        raise RuntimeError(f"unexpected BM25 builder schema: {upgraded_config!r}")
-    if upgraded_config.get("repository_filter_policy") != 3:
-        raise RuntimeError(f"unexpected repository filter policy: {upgraded_config!r}")
+    _assert_builder_contract(upgraded.get("config"), expected_bm25_identity)
 
     _run(
         [codenib, "index", repository, "--preset", "fast"],

--- a/test/scripts/test_smoke_release_upgrade.py
+++ b/test/scripts/test_smoke_release_upgrade.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from scripts.smoke_release_upgrade import _assert_builder_contract
+
+
+def test_upgrade_smoke_accepts_current_builder_identity_with_build_metadata():
+    expected = {
+        "builder_schema": 8,
+        "repository_filter_policy": 3,
+        "languages": ["python"],
+    }
+    actual = {
+        **expected,
+        "artifact_file_fingerprints": {"documents.json": {"sha256": "abc"}},
+        "chunk_count": 1,
+    }
+
+    _assert_builder_contract(actual, expected)
+
+
+def test_upgrade_smoke_rejects_stale_builder_contract():
+    with pytest.raises(RuntimeError, match="unexpected BM25 builder contract"):
+        _assert_builder_contract(
+            {"builder_schema": 7, "repository_filter_policy": 3},
+            {"builder_schema": 8, "repository_filter_policy": 3},
+        )


### PR DESCRIPTION
## Summary
Fix the release upgrade smoke after the BM25 builder schema advanced. The smoke now derives the expected compatibility contract from the upgraded wheel instead of duplicating schema and repository-policy constants.

## Changes
- Query the installed wheel for the current BM25 builder identity after upgrade
- Compare the rebuilt manifest against the complete installed builder contract
- Keep build-only manifest metadata outside the compatibility assertion
- Add focused tests for current and stale contracts

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest test/scripts/test_smoke_release_upgrade.py -q --tb=short`: 2 passed
- Replayed the failed release artifact through the full `0.1.0 -> 0.2.0` upgrade smoke: passed
- `pre-commit run --files scripts/smoke_release_upgrade.py test/scripts/test_smoke_release_upgrade.py`: passed

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published