### PR TITLE
fix(compiler): serialize cache updates

### DIFF
--- a/codenib/compiler/index_compiler.py
+++ b/codenib/compiler/index_compiler.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, List, Optional
 
+from filelock import FileLock
+
 from ..paths import REPO_INDEX_DIRNAME
 from ..source_fingerprint import (
     SourceFingerprint,
@@ -40,6 +42,8 @@ from .manifest import MANIFEST_FILENAME, IndexEntry, RepoManifest
 from .resources import IndexStatus
 
 logger = logging.getLogger(__name__)
+
+_COMPILER_LOCK_FILENAME = ".index-compiler.lock"
 
 
 @dataclass(slots=True)
@@ -101,12 +105,18 @@ class IndexCompiler:
         Returns:
             The completed ``RepoManifest``.
         """
-        return self._compile(
-            repo_path,
-            index_types=index_types,
-            cache_dir=cache_dir,
-            existing_manifest=None,
-        )
+        repo_path = os.path.abspath(repo_path)
+        cache = self._resolve_cache_dir(repo_path, cache_dir)
+        os.makedirs(cache, exist_ok=True)
+        with FileLock(os.path.join(cache, _COMPILER_LOCK_FILENAME)):
+            existing = self._load_existing_manifest(cache)
+            return self._compile(
+                repo_path,
+                index_types=index_types,
+                cache_dir=cache,
+                existing_manifest=existing,
+                force_rebuild=True,
+            )
 
     def update_repo(
         self,
@@ -127,15 +137,35 @@ class IndexCompiler:
         Returns the existing manifest untouched when HEAD has not moved.
         """
         repo_path = os.path.abspath(repo_path)
-        cache = cache_dir or os.path.join(repo_path, self._config.cache_dir_name)
+        cache = self._resolve_cache_dir(repo_path, cache_dir)
+        os.makedirs(cache, exist_ok=True)
+        with FileLock(os.path.join(cache, _COMPILER_LOCK_FILENAME)):
+            return self._update_repo_locked(
+                repo_path,
+                index_types=index_types,
+                cache=cache,
+            )
+
+    def _update_repo_locked(
+        self,
+        repo_path: str,
+        *,
+        index_types: Optional[List[str]],
+        cache: str,
+    ) -> RepoManifest:
+        """Update a repository while holding its cache-level compiler lock."""
         manifest_path = os.path.join(cache, MANIFEST_FILENAME)
 
         if not os.path.isfile(manifest_path):
             logger.info(
                 "No manifest at %s; falling back to a full build", manifest_path
             )
-            return self.compile_repo(
-                repo_path, index_types=index_types, cache_dir=cache_dir
+            return self._compile(
+                repo_path,
+                index_types=index_types,
+                cache_dir=cache,
+                existing_manifest=None,
+                force_rebuild=True,
             )
 
         try:
@@ -144,8 +174,12 @@ class IndexCompiler:
             logger.warning(
                 "Manifest at %s unusable (%s); rebuilding", manifest_path, exc
             )
-            return self.compile_repo(
-                repo_path, index_types=index_types, cache_dir=cache_dir
+            return self._compile(
+                repo_path,
+                index_types=index_types,
+                cache_dir=cache,
+                existing_manifest=None,
+                force_rebuild=True,
             )
 
         types_to_update = index_types or self._config.index_types
@@ -184,10 +218,30 @@ class IndexCompiler:
         return self._compile(
             repo_path,
             index_types=index_types,
-            cache_dir=cache_dir,
+            cache_dir=cache,
             existing_manifest=existing,
             source=source,
+            force_rebuild=False,
         )
+
+    def _resolve_cache_dir(self, repo_path: str, cache_dir: Optional[str]) -> str:
+        cache = cache_dir or os.path.join(repo_path, self._config.cache_dir_name)
+        return os.path.abspath(cache)
+
+    @staticmethod
+    def _load_existing_manifest(cache: str) -> Optional[RepoManifest]:
+        manifest_path = os.path.join(cache, MANIFEST_FILENAME)
+        if not os.path.isfile(manifest_path):
+            return None
+        try:
+            return RepoManifest.load(manifest_path)
+        except Exception as exc:  # noqa: BLE001 - explicit rebuild repairs it
+            logger.warning(
+                "Manifest at %s unusable (%s); rebuilding requested views",
+                manifest_path,
+                exc,
+            )
+            return None
 
     def _compile(
         self,
@@ -197,6 +251,7 @@ class IndexCompiler:
         cache_dir: Optional[str],
         existing_manifest: Optional[RepoManifest],
         source: Optional[SourceFingerprint] = None,
+        force_rebuild: bool,
     ) -> RepoManifest:
         """Build requested views while preserving independent manifest entries."""
         repo_path = os.path.abspath(repo_path)
@@ -245,6 +300,12 @@ class IndexCompiler:
             builder = self._builders.get(idx_type)
             if builder is None:
                 logger.warning("No builder registered for '%s', skipping", idx_type)
+                existing_entry = manifest.indexes.get(idx_type)
+                if force_rebuild and existing_entry is not None:
+                    existing_entry.status = "failed"
+                    existing_entry.metadata["error"] = (
+                        f"No builder registered for {idx_type!r}"
+                    )
                 requested_succeeded = False
                 continue
 
@@ -253,7 +314,8 @@ class IndexCompiler:
             )
             current_entry = manifest.indexes.get(idx_type)
             if (
-                current_entry is not None
+                not force_rebuild
+                and current_entry is not None
                 and current_entry.status == "fresh"
                 and self._entry_matches_builder(
                     current_entry,
@@ -280,7 +342,8 @@ class IndexCompiler:
             incremental_from = (
                 previous_commit
                 if (
-                    previous_commit
+                    not force_rebuild
+                    and previous_commit
                     and head_commit
                     and previous_commit != head_commit
                     and not source_is_dirty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
 ]
 dependencies = [
     "fastapi>=0.100.0",
+    "filelock>=3.0.0",
     "pydantic>=2.0.0",
     "pyyaml>=6.0",
     "rank_bm25>=0.2.2",
@@ -136,7 +137,6 @@ test = [
     "datasets>=4.0.0",
     "einops>=0.8.0",
     "faiss-cpu>=1.7.0",
-    "filelock>=3.0.0",
     "igraph>=0.11.6",
     "litellm>=1.93.0",
     "matplotlib>=3.4.0",

--- a/test/compiler/test_index_compiler.py
+++ b/test/compiler/test_index_compiler.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
@@ -1004,6 +1006,80 @@ class TestIndexCompiler:
 
         assert "bm25" in manifest.indexes
         assert "vector" not in manifest.indexes
+
+    def test_partial_rebuild_preserves_unrequested_views(self, tmp_path):
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", _mock_builder("bm25"))
+        registry.register("vector", _mock_builder("vector"))
+
+        compiler = IndexCompiler(registry)
+        cache_dir = str(tmp_path / "cache")
+        compiler.compile_repo(str(tmp_path), cache_dir=cache_dir, index_types=["bm25"])
+        manifest = compiler.compile_repo(
+            str(tmp_path), cache_dir=cache_dir, index_types=["vector"]
+        )
+
+        assert set(manifest.indexes) == {"bm25", "vector"}
+
+    def test_rebuild_does_not_keep_requested_view_fresh_without_builder(self, tmp_path):
+        initial_registry = IndexBuilderRegistry()
+        initial_registry.register("bm25", _mock_builder("bm25"))
+        cache_dir = str(tmp_path / "cache")
+        IndexCompiler(initial_registry).compile_repo(
+            str(tmp_path), cache_dir=cache_dir, index_types=["bm25"]
+        )
+
+        manifest = IndexCompiler(IndexBuilderRegistry()).compile_repo(
+            str(tmp_path), cache_dir=cache_dir, index_types=["bm25"]
+        )
+
+        assert manifest.indexes["bm25"].status == "failed"
+        assert "No builder registered" in manifest.indexes["bm25"].metadata["error"]
+
+    def test_compiles_for_same_cache_are_serialized(self, tmp_path):
+        state_lock = threading.Lock()
+        second_entered = threading.Event()
+        active = 0
+        max_active = 0
+        entries = 0
+
+        class TrackingBuilder:
+            def build(self, scope: str, **kwargs) -> IndexStatus:
+                nonlocal active, entries, max_active
+                with state_lock:
+                    active += 1
+                    entries += 1
+                    max_active = max(max_active, active)
+                    if entries == 2:
+                        second_entered.set()
+                second_entered.wait(timeout=0.25)
+                with state_lock:
+                    active -= 1
+                output_dir = kwargs["output_dir"]
+                os.makedirs(output_dir, exist_ok=True)
+                return IndexStatus(
+                    index_type="bm25",
+                    state=IndexState.FRESH,
+                    last_built=time.time(),
+                    age_seconds=0.0,
+                    scope=scope,
+                    path=output_dir,
+                )
+
+        registry = IndexBuilderRegistry()
+        registry.register("bm25", TrackingBuilder())
+        compiler = IndexCompiler(registry, IndexCompilerConfig(index_types=["bm25"]))
+        cache_dir = str(tmp_path / "cache")
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(compiler.compile_repo, str(tmp_path), cache_dir=cache_dir)
+                for _ in range(2)
+            ]
+            for future in futures:
+                future.result()
+
+        assert max_active == 1
 
     def test_build_duration_recorded(self, tmp_path):
         registry = IndexBuilderRegistry()

--- a/uv.lock
+++ b/uv.lock
@@ -576,6 +576,7 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "filelock" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rank-bm25" },
@@ -647,7 +648,6 @@ test = [
     { name = "datasets" },
     { name = "einops" },
     { name = "faiss-cpu" },
-    { name = "filelock" },
     { name = "igraph" },
     { name = "litellm" },
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -697,7 +697,7 @@ requires-dist = [
     { name = "faiss-cpu", marker = "extra == 'semantic-remote'", specifier = ">=1.7.0" },
     { name = "faiss-cpu", marker = "extra == 'test'", specifier = ">=1.7.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
-    { name = "filelock", marker = "extra == 'test'", specifier = ">=3.0.0" },
+    { name = "filelock", specifier = ">=3.0.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=4.0.1" },
     { name = "flake8-bugbear", marker = "extra == 'dev'", specifier = ">=24.4.0" },
     { name = "igraph", marker = "extra == 'full'", specifier = ">=0.11.6" },


### PR DESCRIPTION
## Summary
Prevent concurrent index builds from mutating the same repository cache, and keep independently managed views in the manifest when only selected views are rebuilt.

## Changes
- Acquire a cross-process cache lock around manifest reads, view builds, and manifest publication.
- Preserve unrequested manifest entries during explicit rebuilds while still forcing requested builders to run.
- Mark a requested existing view failed when its builder is unavailable.
- Move `filelock` into the core runtime dependencies and add concurrency/rebuild regressions.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes

`pytest -q test/compiler/test_index_compiler.py test/test_cli.py test/test_cli_entrypoints.py test/test_cli_remote_embeddings.py --tb=short` (130 passed)

`pytest -m "not slow and not integration and not integration_serial and not integration_serial_consumer" -x --tb=short` (2831 passed, 10 skipped)

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published