### PR TITLE
fix(web): update DOMPurify to 3.4.13

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2913,9 +2913,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/web/package.json
+++ b/web/package.json
@@ -37,7 +37,7 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
     "postcss": "8.5.23",
     "sharp": "0.35.3"
   }


### PR DESCRIPTION
## Summary

Update the production DOMPurify override to the first release that fixes GHSA-55q2-fjhq-7xh7. The newly published advisory currently makes the Web dependency verification fail on `main` and on otherwise unrelated Web PRs.

## Changes

- pin DOMPurify 3.4.13 in the frontend override
- refresh the lockfile integrity record without changing Mermaid or other dependencies

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Tests

## Testing

- [x] Tests pass locally
- [ ] Added new tests for the changes

- `npm audit --omit=dev --audit-level=moderate` (`0 vulnerabilities`)
- `npm test` (`20 passed`)
- `npm run build`
- `npm ci --ignore-scripts`
- `git diff --check`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
