### PR TITLE
docs(web): publish interactive request budgets

### DIFF
--- a/docs/web_demo.md
+++ b/docs/web_demo.md
@@ -207,6 +207,21 @@ The backend exposes (all under `/api`):
 | `POST /api/repos/{id}/edge-label` | Short LLM phrase for how a graph edge's source uses its target (opt-in via `edge_labels`; returns `disabled` when off) |
 | `POST /api/chat` | Ask: answer + citations |
 
+Interactive requests are bounded before repository or model work:
+
+| Boundary | Public budget |
+|---|---|
+| Ask (`POST /api/chat`) | 128 messages; 65,536 characters per message; 262,144 characters across the conversation; 512 characters for `repo_id` |
+| Edge label (`POST /api/repos/{id}/edge-label`) | 4,096 characters per file path; 1,024 characters per display label; 128 characters for the commit; 32 call-site anchors with positive line numbers |
+| Direct FastAPI request body | 8 MiB, enforced while streaming even without `Content-Length` |
+| Installed same-origin proxy | 8 MiB request body and 32 MiB upstream response body |
+
+The browser sends only the first three edge-label anchors because prompt
+generation consumes at most that sample. The installed proxy rejects
+transfer-encoded request bodies and malformed, negative, or oversized
+`Content-Length` values instead of buffering them. Validation errors omit the
+rejected input so oversized prompts are not reflected back to clients.
+
 The `/commits` endpoint and the `commit` parameter are served from per-commit
 graph snapshots — see [Per-commit graph snapshots](#per-commit-graph-snapshots)
 below.

--- a/test/web/test_app_runtime.py
+++ b/test/web/test_app_runtime.py
@@ -9,7 +9,26 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
+from fastapi.testclient import TestClient
+
 import codenib.web.app as web_app
+
+
+def test_oversized_chat_request_is_rejected_before_runtime_lookup(monkeypatch):
+    def unexpected_registry_lookup():
+        raise AssertionError("invalid chat payload reached the repository runtime")
+
+    monkeypatch.setattr(web_app, "_registry", unexpected_registry_lookup)
+
+    response = TestClient(web_app.app).post(
+        "/api/chat",
+        json={
+            "repo_id": "missing",
+            "messages": [{"role": "user", "content": "bounded"} for _ in range(129)],
+        },
+    )
+
+    assert response.status_code == 422
 
 
 def test_wiki_generation_runs_off_event_loop(monkeypatch):

--- a/test/web/test_schemas.py
+++ b/test/web/test_schemas.py
@@ -39,6 +39,23 @@ def test_chat_request_bounds_each_message() -> None:
         )
 
 
+def test_chat_request_preserves_bounded_follow_up_history() -> None:
+    request = ChatRequest(
+        repo_id="repo",
+        messages=[
+            {"role": "user", "content": "Where is indexing configured?"},
+            {"role": "assistant", "content": "See codenib/compiler."},
+            {"role": "user", "content": "What calls it?"},
+        ],
+    )
+
+    assert [message.role for message in request.messages] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+
+
 def test_edge_label_request_bounds_locations_and_anchor_count() -> None:
     endpoint = EdgeEndpoint(file="src/runtime.py", line=1)
 
@@ -49,6 +66,27 @@ def test_edge_label_request_bounds_locations_and_anchor_count() -> None:
             source=endpoint,
             target=endpoint,
             anchors=[{"file": "src/runtime.py", "line": 1}] * 33,
+        )
+
+
+def test_edge_label_request_bounds_text_fields() -> None:
+    endpoint = EdgeEndpoint(file="src/runtime.py", line=1)
+
+    with pytest.raises(ValidationError, match="at most 4096"):
+        EdgeEndpoint(file="f" * 4097, line=1)
+    with pytest.raises(ValidationError, match="at most 1024"):
+        EdgeEndpoint(file="src/runtime.py", line=1, label="n" * 1025)
+    with pytest.raises(ValidationError, match="at most 128"):
+        EdgeLabelRequest(
+            source=endpoint,
+            target=endpoint,
+            commit="c" * 129,
+        )
+    with pytest.raises(ValidationError, match="at most 4096"):
+        EdgeLabelRequest(
+            source=endpoint,
+            target=endpoint,
+            anchors=[{"file": "a" * 4097, "line": 1}],
         )
 
 


### PR DESCRIPTION
## Summary

Publish the interactive Web request budgets already enforced by the hardened boundaries in #449 and add the remaining route/schema regressions for #501. This closes the documentation and verification gap without reviving the older, conflicting implementation in #502.

Closes #501.

## Changes

- document the Ask, edge-label, direct FastAPI, and installed proxy request budgets
- verify bounded multi-turn histories and every edge-label text-field limit
- prove oversized chat histories fail at schema validation before runtime lookup
- record the three-anchor browser/prompt sample separately from the bounded API payload

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest -q test/web/test_schemas.py test/web/test_request_limits.py test/web/test_static_server.py test/web/test_app_runtime.py --tb=short` (`46 passed`)
- `vitest run lib/api.test.ts` under Node 24 (`1 passed`)
- `mkdocs build --strict`
- `python scripts/check_public_docs.py`
- Black, isort, flake8+bugbear, and `git diff --check`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
