### PR TITLE
fix(mcp): validate direct search bounds

### DIFF
--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -83,6 +83,8 @@ also remain available. All forms accept
 
 All source locations returned by MCP use 1-based line numbers. Internal indexes
 remain 0-based; the MCP adapters perform the conversion once at the boundary.
+All search tools reject blank queries and query text longer than 16,000
+characters. They accept integer `top_k` values from 1 through 100.
 
 ### `search_context`
 Plans and executes ranked retrieval without asking the agent to choose an index.
@@ -113,7 +115,7 @@ expanding a response without bound.
 Vector-embedding similarity search.
 
 - `query` (str): natural-language or code query.
-- `top_k` (int, default 10): max results.
+- `top_k` (int, default 10): max results, from 1 through 100.
 - `level` (str, default `"l2"`): hierarchy level — `"l0"` (files), `"l2"`
   (functions/methods).
 - `score_threshold` (float, default 0.0): minimum similarity; `0` disables the filter.
@@ -125,14 +127,15 @@ returns `{"error": ...}` so callers can recover gracefully.
 ### `search_bm25`
 BM25 keyword retrieval over indexed symbols.
 
-- `query` (str), `top_k` (int, default 20), `filter_test` (bool, default `False`) —
+- `query` (str), `top_k` (int, default 20, from 1 through 100),
+  `filter_test` (bool, default `False`) —
   when `True`, excludes results from test files.
 
 ### `search_regex`
 Grep-like regex over CodeGraph nodes.
 
 - `pattern` (str): Python `re` pattern.
-- `top_k` (int, default 20).
+- `top_k` (int, default 20): from 1 through 100.
 - `file_glob` (str, default `""`): restrict by file path (e.g. `*.py`).
 - `node_type` (str, default `""`): filter by type (`function`, `class`, `method`,
   `file`, …).
@@ -144,7 +147,7 @@ file-level (`type="file"`).
 
 - `query` (str): plain substring, regex (`regex:foo`), or atoms like `case:yes` /
   `lang:python`.
-- `top_k` (int, default 20).
+- `top_k` (int, default 20): from 1 through 100.
 - `file_filter` (str, default `""`): glob/regex appended as `file:<expr>`.
 
 ### `dependency_subgraph`

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -35,6 +35,7 @@ from .tools._validation import (
     MAX_GRAPH_DEPTH,
     MAX_LSP_POSITION,
     MAX_ROUTE_SYMBOLS,
+    MAX_SEARCH_QUERY_CHARS,
     MAX_SOURCE_PATH_CHARS,
     MAX_TOOL_RESULTS,
 )
@@ -50,6 +51,10 @@ logger = logging.getLogger(__name__)
 # Global context is set once at startup before the event loop runs tools.
 _ctx: Optional[ServerContext] = None
 _SearchText = Annotated[str, Field(min_length=1)]
+_SearchQuery = Annotated[
+    str,
+    Field(min_length=1, max_length=MAX_SEARCH_QUERY_CHARS),
+]
 _SearchTopK = Annotated[int, Field(ge=1, le=MAX_TOOL_RESULTS)]
 _SearchLevel = Literal["l0", "l2"]
 _FiniteScore = Annotated[float, Field(allow_inf_nan=False)]
@@ -104,7 +109,7 @@ mcp = MCPServer(
     ),
 )
 async def search_context(
-    query: _SearchText,
+    query: _SearchQuery,
     top_k: _SearchTopK = 10,
     budget: str = "balanced",
     level: _SearchLevel = "l2",
@@ -133,7 +138,7 @@ async def search_context(
     ),
 )
 async def semantic_search(
-    query: _SearchText,
+    query: _SearchQuery,
     top_k: _SearchTopK = 10,
     level: _SearchLevel = "l2",
     score_threshold: _FiniteScore = 0.0,
@@ -165,7 +170,7 @@ async def semantic_search(
     ),
 )
 async def search_bm25(
-    query: _SearchText,
+    query: _SearchQuery,
     top_k: _SearchTopK = 20,
     filter_test: bool = False,
 ) -> list[dict[str, Any]]:
@@ -187,7 +192,7 @@ async def search_bm25(
     ),
 )
 async def search_regex(
-    pattern: _SearchText,
+    pattern: _SearchQuery,
     top_k: _SearchTopK = 20,
     file_glob: str = "",
     node_type: str = "",
@@ -219,7 +224,7 @@ async def search_regex(
     ),
 )
 async def search_zoekt(
-    query: _SearchText,
+    query: _SearchQuery,
     top_k: _SearchTopK = 20,
     file_filter: str = "",
 ) -> list[dict[str, Any]]:

--- a/codenib/mcp/tools/_validation.py
+++ b/codenib/mcp/tools/_validation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 MAX_TOOL_RESULTS = 100
+MAX_SEARCH_QUERY_CHARS = 16_000
 MAX_GRAPH_DEPTH = 8
 MAX_ROUTE_SYMBOLS = 32
 MAX_LSP_POSITION = 2**31 - 1
@@ -17,9 +18,16 @@ MAX_SOURCE_WINDOW_LINES = 200
 MAX_SOURCE_CONTENT_CHARS = 16_000
 
 
-def required_text(value: Any, *, name: str) -> str:
+def required_text(
+    value: Any,
+    *,
+    name: str,
+    maximum: int | None = None,
+) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{name} must not be empty.")
+    if maximum is not None and len(value) > maximum:
+        raise ValueError(f"{name} must not exceed {maximum} characters.")
     return value.strip()
 
 

--- a/codenib/mcp/tools/search.py
+++ b/codenib/mcp/tools/search.py
@@ -16,7 +16,12 @@ from ...agent.boundary import to_agent_repr
 from ...context_delivery import project_evidence_payloads
 from ...types import NodeInfo
 from ..context import ServerContext
-from ._validation import MAX_TOOL_RESULTS, bounded_integer, required_text
+from ._validation import (
+    MAX_SEARCH_QUERY_CHARS,
+    MAX_TOOL_RESULTS,
+    bounded_integer,
+    required_text,
+)
 
 
 def _node_to_dict(node: NodeInfo) -> Dict[str, Any]:
@@ -40,7 +45,11 @@ def search_context_impl(
     filter_test: bool = False,
 ) -> Dict[str, Any]:
     """Plan and execute ranked retrieval over the available repository views."""
-    normalized_query = required_text(query, name="query")
+    normalized_query = required_text(
+        query,
+        name="query",
+        maximum=MAX_SEARCH_QUERY_CHARS,
+    )
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     normalized_level = (level or "l2").strip().lower()
     if normalized_level not in {"l0", "l2"}:
@@ -181,7 +190,11 @@ async def search_semantic(
         List of NodeInfo dicts with scores and content. On missing index,
         returns ``{"error": ...}`` so callers can handle gracefully.
     """
-    normalized_query = required_text(query, name="query")
+    normalized_query = required_text(
+        query,
+        name="query",
+        maximum=MAX_SEARCH_QUERY_CHARS,
+    )
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     normalized_level = (level or "l2").strip().lower()
     if normalized_level not in {"l0", "l2"}:
@@ -237,7 +250,11 @@ def search_bm25_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content, score.
     """
-    normalized_query = required_text(query, name="query")
+    normalized_query = required_text(
+        query,
+        name="query",
+        maximum=MAX_SEARCH_QUERY_CHARS,
+    )
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     if ctx.bm25 is None:
         raise RuntimeError(
@@ -282,7 +299,11 @@ def search_regex_impl(
         List of dicts with keys: node_name, type, file, start_line,
         end_line, content.
     """
-    required_text(pattern, name="pattern")
+    required_text(
+        pattern,
+        name="pattern",
+        maximum=MAX_SEARCH_QUERY_CHARS,
+    )
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     if ctx.regex_index is None:
         raise RuntimeError(
@@ -343,7 +364,11 @@ def search_zoekt_impl(
         (``"file"``), ``file``, ``start_line``, ``end_line``, ``content``,
         ``score``, ``node_id`` (language hint, when reported).
     """
-    normalized_query = required_text(query, name="query")
+    normalized_query = required_text(
+        query,
+        name="query",
+        maximum=MAX_SEARCH_QUERY_CHARS,
+    )
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     if ctx.zoekt is None:
         raise RuntimeError(

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -126,7 +126,9 @@ Only tools whose backing views are fresh and available can return results.
 | `read_source` | verified checkout | source window | Read an exact 1-based span after retrieval or navigation |
 | `get_manifest` | manifest | repository | Repository identity, languages, view states, and capabilities |
 
-All source locations returned by MCP use 1-based line numbers.
+All source locations returned by MCP use 1-based line numbers. Search tools
+reject blank query text, cap it at 16,000 characters, and accept `top_k` values
+from 1 through 100.
 
 `search_context` accepts `query`, `top_k` (1-100), `budget`
 (`fast`, `balanced`, or `thorough`), dense `level` (`l0` or `l2`), and

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -81,6 +81,7 @@ def test_search_tool_schemas_publish_bounded_inputs() -> None:
         schema = tools[name].input_schema
         text_field = "pattern" if name == "search_regex" else "query"
         assert schema["properties"][text_field]["minLength"] == 1
+        assert schema["properties"][text_field]["maxLength"] == 16_000
         assert schema["properties"]["top_k"] == {
             "default": 10 if name in {"search_context", "search_semantic"} else 20,
             "maximum": 100,

--- a/test/mcp/test_search_semantic.py
+++ b/test/mcp/test_search_semantic.py
@@ -15,6 +15,7 @@ import pytest
 
 from codenib.compiler.manifest import RepoManifest
 from codenib.mcp.context import ServerContext
+from codenib.mcp.tools._validation import MAX_SEARCH_QUERY_CHARS
 from codenib.mcp.tools.search import search_semantic
 from codenib.types import NodeInfo
 
@@ -126,6 +127,18 @@ def test_search_semantic_empty_results(mock_context):
 
     assert results == []
     assert isinstance(results, list)
+
+
+def test_search_semantic_rejects_oversized_query_before_provider(mock_context):
+    with pytest.raises(ValueError, match="must not exceed 16000 characters"):
+        asyncio.run(
+            search_semantic(
+                mock_context,
+                query="x" * (MAX_SEARCH_QUERY_CHARS + 1),
+            )
+        )
+
+    mock_context.vector.search_with_content.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/test/mcp_server/test_tools_search.py
+++ b/test/mcp_server/test_tools_search.py
@@ -16,6 +16,7 @@ import pytest
 from codenib.compiler.manifest import RepoManifest
 from codenib.index.trigram import ZoektUnavailableError
 from codenib.index.trigram.zoekt_searcher import _file_match_to_node
+from codenib.mcp.tools._validation import MAX_SEARCH_QUERY_CHARS
 from codenib.mcp.tools.search import (
     search_bm25_impl,
     search_context_impl,
@@ -79,6 +80,27 @@ def _sample_nodes() -> list[NodeInfo]:
             score=0.0,
         ),
     ]
+
+
+@pytest.mark.parametrize(
+    ("impl", "context_key", "query_key"),
+    [
+        (search_context_impl, "bm25", "query"),
+        (search_bm25_impl, "bm25", "query"),
+        (search_regex_impl, "regex_index", "pattern"),
+        (search_zoekt_impl, "zoekt", "query"),
+    ],
+)
+def test_search_rejects_oversized_input_before_provider(
+    impl, context_key, query_key
+) -> None:
+    provider = MagicMock()
+    ctx = _make_ctx(**{context_key: provider})
+
+    with pytest.raises(ValueError, match="must not exceed 16000 characters"):
+        impl(ctx, **{query_key: "x" * (MAX_SEARCH_QUERY_CHARS + 1)})
+
+    provider.search.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Rebuild the search-input budget fix on the current `main` so every public MCP search entry point rejects oversized query text without regressing the existing evidence projection, finite-score, level, or shared `top_k` contracts. This supersedes the conflicted implementation in #496.

Closes #495.

## Changes

- enforce a shared 16,000-character search-text budget before index or graph work
- expose the same limit in all five public MCP search schemas
- preserve the current `main` validation and evidence-delivery behavior
- add runtime and schema regressions for oversized and boundary-sized queries

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- MCP unit tests (`141 passed, 7 skipped, 7 deselected`)
- search/planning tests (`24 passed`)
- evidence-projection tests (`5 passed`)
- Black, isort, flake8+bugbear, py_compile, and `git diff --check`
- merge-tree against current `origin/main`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
