### PR TITLE
fix(mcp): enforce LSP request bounds

### DIFF
--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -162,6 +162,11 @@ Each node's optional `line` is 1-based.
 ### `lsp_definition` / `lsp_references` / `lsp_route`
 Static LSP-shaped navigation over the loaded `symbol_graph`. These tools return
 compact locations only; clients should read source before finalizing.
+All three tools require `top_k` from 1 through 100. File paths are limited to
+4,096 characters, each symbol field or route entry to 1,024 characters, and a
+route query to 16,000 characters. `lsp_route` accepts at most 32 supplied symbol
+entries and 16,000 aggregate symbol characters; blank entries still consume the
+entry budget before normalization.
 
 - `lsp_definition`: provide either `symbol`, or `file_path` + 1-based `line`
   with optional 0-based `character`; `top_k` defaults to 8.

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -34,6 +34,8 @@ from .prompts import CODENIB_GUIDE
 from .tools._validation import (
     MAX_GRAPH_DEPTH,
     MAX_LSP_POSITION,
+    MAX_LSP_QUERY_CHARS,
+    MAX_LSP_SYMBOL_CHARS,
     MAX_ROUTE_SYMBOLS,
     MAX_SOURCE_PATH_CHARS,
     MAX_TOOL_RESULTS,
@@ -57,8 +59,11 @@ _GraphDirection = Literal["impact", "dependencies", "both"]
 _GraphDepth = Annotated[int, Field(ge=1, le=MAX_GRAPH_DEPTH)]
 _PositiveLine = Annotated[int, Field(ge=1, le=MAX_LSP_POSITION)]
 _Character = Annotated[int, Field(ge=0, le=MAX_LSP_POSITION)]
+_LspFilePath = Annotated[str, Field(max_length=MAX_SOURCE_PATH_CHARS)]
+_LspSymbol = Annotated[str, Field(max_length=MAX_LSP_SYMBOL_CHARS)]
+_LspQuery = Annotated[str, Field(max_length=MAX_LSP_QUERY_CHARS)]
 _RouteSymbols = Annotated[
-    list[str],
+    list[_LspSymbol],
     Field(min_length=1, max_length=MAX_ROUTE_SYMBOLS),
 ]
 _SourcePath = Annotated[str, Field(min_length=1, max_length=MAX_SOURCE_PATH_CHARS)]
@@ -270,10 +275,10 @@ async def dependency_subgraph(
     ),
 )
 async def lsp_definition(
-    file_path: str = "",
+    file_path: _LspFilePath = "",
     line: _PositiveLine | None = None,
     character: _Character | None = None,
-    symbol: str = "",
+    symbol: _LspSymbol = "",
     top_k: _SearchTopK = 8,
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Graph-backed definition lookup over the static symbol graph."""
@@ -299,10 +304,10 @@ async def lsp_definition(
     ),
 )
 async def lsp_references(
-    file_path: str = "",
+    file_path: _LspFilePath = "",
     line: _PositiveLine | None = None,
     character: _Character | None = None,
-    symbol: str = "",
+    symbol: _LspSymbol = "",
     include_declaration: bool = True,
     top_k: _SearchTopK = 40,
 ) -> list[dict[str, Any]] | dict[str, str]:
@@ -332,7 +337,7 @@ async def lsp_references(
 )
 async def lsp_route(
     symbols: _RouteSymbols,
-    query: str = "",
+    query: _LspQuery = "",
     top_k: _SearchTopK = 12,
     include_neighbors: bool = True,
 ) -> list[dict[str, Any]] | dict[str, str]:

--- a/codenib/mcp/tools/_validation.py
+++ b/codenib/mcp/tools/_validation.py
@@ -12,6 +12,9 @@ MAX_TOOL_RESULTS = 100
 MAX_GRAPH_DEPTH = 8
 MAX_ROUTE_SYMBOLS = 32
 MAX_LSP_POSITION = 2**31 - 1
+MAX_LSP_SYMBOL_CHARS = 1_024
+MAX_LSP_QUERY_CHARS = 16_000
+MAX_LSP_ROUTE_TEXT_CHARS = 16_000
 MAX_SOURCE_PATH_CHARS = 4_096
 MAX_SOURCE_WINDOW_LINES = 200
 MAX_SOURCE_CONTENT_CHARS = 16_000
@@ -21,6 +24,14 @@ def required_text(value: Any, *, name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{name} must not be empty.")
     return value.strip()
+
+
+def bounded_text(value: Any, *, name: str, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string.")
+    if len(value) > maximum:
+        raise ValueError(f"{name} must not exceed {maximum} characters.")
+    return value
 
 
 def bounded_integer(

--- a/codenib/mcp/tools/lsp.py
+++ b/codenib/mcp/tools/lsp.py
@@ -10,16 +10,51 @@ from typing import Any, Sequence
 
 from ._validation import (
     MAX_LSP_POSITION,
+    MAX_LSP_QUERY_CHARS,
+    MAX_LSP_ROUTE_TEXT_CHARS,
+    MAX_LSP_SYMBOL_CHARS,
     MAX_ROUTE_SYMBOLS,
+    MAX_SOURCE_PATH_CHARS,
     MAX_TOOL_RESULTS,
     bounded_integer,
+    bounded_text,
 )
 
 
 def _coerce_symbols(symbols: Sequence[str] | str) -> list[str]:
     if isinstance(symbols, str):
-        return [s.strip() for s in symbols.split(",") if s.strip()]
-    return [str(s).strip() for s in symbols or [] if str(s).strip()]
+        route_text = bounded_text(
+            symbols,
+            name="symbols",
+            maximum=MAX_LSP_ROUTE_TEXT_CHARS,
+        )
+        values: Sequence[str] = route_text.split(",")
+    elif isinstance(symbols, Sequence):
+        values = symbols
+    else:
+        raise ValueError("symbols must be a string or sequence of strings.")
+
+    if len(values) > MAX_ROUTE_SYMBOLS:
+        raise ValueError(f"symbols must contain at most {MAX_ROUTE_SYMBOLS} entries.")
+
+    normalized: list[str] = []
+    total_chars = 0
+    for value in values:
+        symbol = bounded_text(
+            value,
+            name="each symbol",
+            maximum=MAX_LSP_SYMBOL_CHARS,
+        )
+        total_chars += len(symbol)
+        if total_chars > MAX_LSP_ROUTE_TEXT_CHARS:
+            raise ValueError(
+                "symbols must not exceed "
+                f"{MAX_LSP_ROUTE_TEXT_CHARS} total characters."
+            )
+        normalized_symbol = symbol.strip()
+        if normalized_symbol:
+            normalized.append(normalized_symbol)
+    return normalized
 
 
 def _node_to_dict(node: Any) -> dict[str, Any]:
@@ -48,6 +83,16 @@ def lsp_definition_impl(
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Return graph-backed definition locations."""
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
+    file_path = bounded_text(
+        file_path,
+        name="file_path",
+        maximum=MAX_SOURCE_PATH_CHARS,
+    )
+    symbol = bounded_text(
+        symbol,
+        name="symbol",
+        maximum=MAX_LSP_SYMBOL_CHARS,
+    )
     if line is not None:
         bounded_integer(line, name="line", maximum=MAX_LSP_POSITION)
     if character is not None:
@@ -89,6 +134,16 @@ def lsp_references_impl(
 ) -> list[dict[str, Any]] | dict[str, str]:
     """Return graph-backed reference locations."""
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
+    file_path = bounded_text(
+        file_path,
+        name="file_path",
+        maximum=MAX_SOURCE_PATH_CHARS,
+    )
+    symbol = bounded_text(
+        symbol,
+        name="symbol",
+        maximum=MAX_LSP_SYMBOL_CHARS,
+    )
     if line is not None:
         bounded_integer(line, name="line", maximum=MAX_LSP_POSITION)
     if character is not None:
@@ -130,10 +185,9 @@ def lsp_route_impl(
     """Return graph-backed route anchors for one or more symbol seeds."""
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     seeds = _coerce_symbols(symbols)
+    query = bounded_text(query, name="query", maximum=MAX_LSP_QUERY_CHARS)
     if not seeds:
         raise ValueError("symbols must contain at least one non-empty seed.")
-    if len(seeds) > MAX_ROUTE_SYMBOLS:
-        raise ValueError(f"symbols must contain at most {MAX_ROUTE_SYMBOLS} seeds.")
     graph = _symbol_graph(ctx)
     if graph is None:
         return {"error": "symbol_graph index not available"}

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -101,6 +101,12 @@ def test_search_tool_schemas_publish_bounded_inputs() -> None:
     route_symbols = tools["lsp_route"].input_schema["properties"]["symbols"]
     assert route_symbols["minItems"] == 1
     assert route_symbols["maxItems"] == 32
+    assert route_symbols["items"]["maxLength"] == 1024
+    assert tools["lsp_route"].input_schema["properties"]["query"]["maxLength"] == 16000
+    for name in ("lsp_definition", "lsp_references"):
+        properties = tools[name].input_schema["properties"]
+        assert properties["file_path"]["maxLength"] == 4096
+        assert properties["symbol"]["maxLength"] == 1024
     assert (
         tools["lsp_definition"].input_schema["properties"]["line"]["anyOf"][0][
             "minimum"
@@ -312,8 +318,76 @@ def test_lsp_tools_validate_result_and_seed_bounds():
         lsp_references_impl(ctx, symbol="load_config", top_k=101)
     with pytest.raises(ValueError, match="at least one non-empty seed"):
         lsp_route_impl(ctx, symbols=[])
-    with pytest.raises(ValueError, match="at most 32 seeds"):
+    with pytest.raises(ValueError, match="at most 32 entries"):
         lsp_route_impl(ctx, symbols=[f"symbol_{index}" for index in range(33)])
+
+
+@pytest.mark.parametrize(
+    "symbols",
+    [
+        [""] * 33,
+        ",".join([""] * 33),
+    ],
+)
+def test_lsp_route_counts_blank_entries_against_request_budget(symbols):
+    ctx = MagicMock(symbol_graph=MagicMock())
+    with patch("codenib.agent.lsp_provider.StaticLSPProvider") as provider:
+        with pytest.raises(ValueError, match="at most 32 entries"):
+            lsp_route_impl(ctx, symbols=symbols)
+
+    provider.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("impl", "kwargs", "error"),
+    [
+        (
+            lsp_definition_impl,
+            {"symbol": "s" * 1_025},
+            "symbol must not exceed 1024 characters",
+        ),
+        (
+            lsp_references_impl,
+            {"file_path": "p" * 4_097, "line": 1},
+            "file_path must not exceed 4096 characters",
+        ),
+        (
+            lsp_route_impl,
+            {"symbols": ["s" * 1_025]},
+            "each symbol must not exceed 1024 characters",
+        ),
+        (
+            lsp_route_impl,
+            {"symbols": ["symbol"], "query": "q" * 16_001},
+            "query must not exceed 16000 characters",
+        ),
+        (
+            lsp_route_impl,
+            {"symbols": ["s" * 1_000] * 17},
+            "symbols must not exceed 16000 total characters",
+        ),
+    ],
+)
+def test_lsp_tools_reject_oversized_text_before_provider(impl, kwargs, error):
+    ctx = MagicMock(symbol_graph=MagicMock())
+    with patch("codenib.agent.lsp_provider.StaticLSPProvider") as provider:
+        with pytest.raises(ValueError, match=error):
+            impl(ctx, **kwargs)
+
+    provider.assert_not_called()
+
+
+def test_lsp_route_accepts_exact_text_and_entry_budgets():
+    ctx = MagicMock(symbol_graph=MagicMock())
+    symbols = ["s" * 500] * 32
+    with patch(
+        "codenib.agent.lsp_provider.StaticLSPProvider.route",
+        return_value=[],
+    ) as route:
+        assert lsp_route_impl(ctx, symbols=symbols, query="q" * 16_000) == []
+
+    assert route.call_args.kwargs["symbols"] == symbols
+    assert route.call_args.kwargs["query"] == "q" * 16_000
 
 
 def test_server_status_resource(mock_manifest: Path):


### PR DESCRIPTION
## Summary

Rebuild the MCP LSP request-budget fix on the current `main`, preserving the shared line, character, result, and route validators while closing empty-slot and aggregate-text bypasses. This supersedes the conflicted implementation in #498 and provides the explicit base for the query-fallback follow-up.

Closes #497.

## Changes

- bound paths, symbols, queries, positions, result counts, and aggregate route text
- count the original 32 route input slots before filtering blank values
- keep the current shared integer and LSP position validators intact
- synchronize MCP schemas and public MCP documentation with the runtime budgets
- add empty-slot, comma-slot, aggregate-text, and boundary regressions

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- MCP tests (`116 passed`)
- static LSP provider tests (`12 passed`)
- Black, isort, flake8+bugbear, and `git diff --check`
- merge-tree against current `origin/main`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
