### PR TITLE
fix(mcp): bound query-seeded LSP routes

### DIFF
--- a/codenib/agent/lsp_graph.py
+++ b/codenib/agent/lsp_graph.py
@@ -13,6 +13,7 @@ about SWE-bench scoring, answer formats, or experiment feedback gates.
 from __future__ import annotations
 
 import re
+import time
 from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence
 
@@ -128,6 +129,10 @@ _ENDPOINT_TERMS = {
     "validate",
 }
 _QUERY_SEED_MIN_OVERLAP = 2
+_QUERY_SEED_SCAN_BUDGET = 10_000
+_QUERY_SEED_MATCH_BUDGET = 256
+_QUERY_SEED_CANDIDATE_BUDGET = 512
+_QUERY_SEED_TIMEOUT_SECONDS = 0.1
 _ROUTE_SEED_NODE_TYPES = frozenset(
     {NODE_TYPE_CLASS, NODE_TYPE_FIELD, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD}
 )
@@ -693,12 +698,19 @@ def _query_seed_candidates(
     *,
     query_terms: set[str],
     limit: int,
+    deadline: float,
 ) -> list[dict[str, Any]]:
     if not query_terms:
         return []
 
     candidates: list[dict[str, Any]] = []
+    scanned = 0
     for name in getattr(graph, "name_to_vertex", {}) or {}:
+        if scanned >= _QUERY_SEED_SCAN_BUDGET:
+            break
+        if scanned and time.monotonic() >= deadline:
+            break
+        scanned += 1
         info = graph.get_node_info_by_name(name) or {}
         node_type = str(info.get("type") or "")
         if node_type and node_type not in _ROUTE_SEED_NODE_TYPES:
@@ -721,6 +733,8 @@ def _query_seed_candidates(
             graph, candidate, query_terms=query_terms
         ) + 6.0 * len(overlap)
         candidates.append(candidate)
+        if len(candidates) >= _QUERY_SEED_MATCH_BUDGET:
+            break
 
     candidates.sort(
         key=lambda item: (
@@ -731,19 +745,13 @@ def _query_seed_candidates(
     return candidates[:limit]
 
 
-def _route_neighbors(graph: Any, name: str) -> list[tuple[str, str]]:
-    neighbors: list[tuple[str, str]] = []
+def _route_neighbors(graph: Any, name: str) -> Iterable[tuple[str, str]]:
     if hasattr(graph, "get_successors"):
-        neighbors.extend(
-            (neighbor, "successor")
-            for neighbor in _graph_names_for_ids(graph, graph.get_successors(name))
-        )
+        for neighbor in _graph_names_for_ids(graph, graph.get_successors(name)):
+            yield neighbor, "successor"
     if hasattr(graph, "get_predecessors"):
-        neighbors.extend(
-            (neighbor, "predecessor")
-            for neighbor in _graph_names_for_ids(graph, graph.get_predecessors(name))
-        )
-    return neighbors
+        for neighbor in _graph_names_for_ids(graph, graph.get_predecessors(name)):
+            yield neighbor, "predecessor"
 
 
 def _include_neighbor(
@@ -792,7 +800,11 @@ def _append_route_seed(
     source: str,
     query_terms: set[str],
     include_neighbors: bool,
+    candidate_budget: Optional[int] = None,
+    deadline: Optional[float] = None,
 ) -> None:
+    if candidate_budget is not None and len(candidates) >= candidate_budget:
+        return
     role = _role(graph, name, query_terms=query_terms)
     candidate = {
         "name": name,
@@ -807,6 +819,10 @@ def _append_route_seed(
     if not include_neighbors:
         return
     for neighbor, direction in _route_neighbors(graph, name):
+        if candidate_budget is not None and len(candidates) >= candidate_budget:
+            break
+        if deadline is not None and time.monotonic() >= deadline:
+            break
         neighbor_role = _role(graph, neighbor, query_terms=query_terms)
         if not _include_neighbor(
             graph, neighbor, role=neighbor_role, query_terms=query_terms
@@ -858,9 +874,19 @@ def lsp_route(
             )
 
     if not candidates:
+        query_seed_deadline = time.monotonic() + _QUERY_SEED_TIMEOUT_SECONDS
         for rank, candidate in enumerate(
-            _query_seed_candidates(graph, query_terms=query_terms, limit=limit)
+            _query_seed_candidates(
+                graph,
+                query_terms=query_terms,
+                limit=limit,
+                deadline=query_seed_deadline,
+            )
         ):
+            if len(candidates) >= _QUERY_SEED_CANDIDATE_BUDGET:
+                break
+            if rank and time.monotonic() >= query_seed_deadline:
+                break
             _append_route_seed(
                 graph,
                 candidates,
@@ -870,6 +896,8 @@ def lsp_route(
                 source="query_seed",
                 query_terms=query_terms,
                 include_neighbors=include_neighbors,
+                candidate_budget=_QUERY_SEED_CANDIDATE_BUDGET,
+                deadline=query_seed_deadline,
             )
 
     source_rank = {"direct_seed": 0, "query_seed": 0, "neighbor": 1}

--- a/codenib/mcp/README.md
+++ b/codenib/mcp/README.md
@@ -177,7 +177,10 @@ entry budget before normalization.
   `include_declaration` defaults to `true` and `top_k` to 40.
 - `lsp_route`: provide `symbols`, with optional `query`, `top_k` (default 12),
   and `include_neighbors` (default `true`) to rank endpoint, bridge/factory,
-  provider/value, and type anchors.
+  provider/value, and type anchors. If no reliable symbol is known, pass
+  `symbols=[]` with a non-blank query for a bounded, best-effort graph scan.
+  That fallback examines at most 10,000 graph nodes, retains at most 256 query
+  matches and 512 expanded candidates, and stops after 100 milliseconds.
 
 ### `read_source`
 Reads source only when server startup verified the checkout against the direct

--- a/codenib/mcp/server.py
+++ b/codenib/mcp/server.py
@@ -70,7 +70,7 @@ _LspSymbol = Annotated[str, Field(max_length=MAX_LSP_SYMBOL_CHARS)]
 _LspQuery = Annotated[str, Field(max_length=MAX_LSP_QUERY_CHARS)]
 _RouteSymbols = Annotated[
     list[_LspSymbol],
-    Field(min_length=1, max_length=MAX_ROUTE_SYMBOLS),
+    Field(max_length=MAX_ROUTE_SYMBOLS),
 ]
 _SourcePath = Annotated[str, Field(min_length=1, max_length=MAX_SOURCE_PATH_CHARS)]
 
@@ -348,8 +348,9 @@ async def lsp_references(
     name="lsp_route",
     description=(
         "Return compact route anchors from CodeNib's static symbol graph for "
-        "one or more symbol seeds. Use this when multiple symbols need a route "
-        "map across endpoint, bridge/factory, provider/value, or type anchors. "
+        "symbol seeds, or use a query alone when no reliable symbol is known. "
+        "Use this for a route map across endpoint, bridge/factory, "
+        "provider/value, or type anchors. "
         "Results are locations only; call read_source before finalizing."
     ),
 )

--- a/codenib/mcp/tools/lsp.py
+++ b/codenib/mcp/tools/lsp.py
@@ -185,9 +185,14 @@ def lsp_route_impl(
     """Return graph-backed route anchors for one or more symbol seeds."""
     top_k = bounded_integer(top_k, name="top_k", maximum=MAX_TOOL_RESULTS)
     seeds = _coerce_symbols(symbols)
-    query = bounded_text(query, name="query", maximum=MAX_LSP_QUERY_CHARS)
-    if not seeds:
-        raise ValueError("symbols must contain at least one non-empty seed.")
+    requested_query = bounded_text(
+        query,
+        name="query",
+        maximum=MAX_LSP_QUERY_CHARS,
+    )
+    normalized_query = requested_query.strip()
+    if not seeds and not normalized_query:
+        return []
     graph = _symbol_graph(ctx)
     if graph is None:
         return {"error": "symbol_graph index not available"}
@@ -196,7 +201,7 @@ def lsp_route_impl(
 
     results = StaticLSPProvider(graph).route(
         symbols=seeds,
-        query=query or None,
+        query=normalized_query or None,
         top_k=top_k,
         include_neighbors=bool(include_neighbors),
     )

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -122,13 +122,18 @@ Only tools whose backing views are fresh and available can return results.
 | `dependency_subgraph` | `symbol_graph` | call graph | Caller impact, callee dependencies, or a one-hop neighborhood |
 | `lsp_definition` | `symbol_graph` | location | Static go-to-definition-shaped lookup |
 | `lsp_references` | `symbol_graph` | locations | Static find-references-shaped lookup |
-| `lsp_route` | `symbol_graph` | locations | Compact route anchors among related symbols |
+| `lsp_route` | `symbol_graph` | locations | Compact route anchors from symbol seeds or a bounded query fallback |
 | `read_source` | verified checkout | source window | Read an exact 1-based span after retrieval or navigation |
 | `get_manifest` | manifest | repository | Repository identity, languages, view states, and capabilities |
 
 All source locations returned by MCP use 1-based line numbers. Search tools
 reject blank query text, cap it at 16,000 characters, and accept `top_k` values
 from 1 through 100.
+
+Call `lsp_route` with `symbols=[]` and a non-blank query when no reliable symbol
+is known. This best-effort fallback examines at most 10,000 graph nodes, retains
+at most 256 query matches and 512 expanded candidates, and stops after 100
+milliseconds.
 
 `search_context` accepts `query`, `top_k` (1-100), `budget`
 (`fast`, `balanced`, or `thorough`), dense `level` (`l0` or `l2`), and

--- a/test/agent/test_lsp_graph.py
+++ b/test/agent/test_lsp_graph.py
@@ -287,6 +287,111 @@ def test_lsp_route_can_fallback_to_query_seed_candidates():
     assert route[0].content == "route provider: query match config, default"
 
 
+class _QueryBudgetGraph:
+    def __init__(self, names):
+        self.names = list(names)
+        self.name_to_vertex = {name: index for index, name in enumerate(self.names)}
+        self.seen_names = []
+        self.successors = {}
+
+    def get_node_info_by_name(self, name):
+        self.seen_names.append(name)
+        if name not in self.name_to_vertex:
+            return None
+        return {
+            "name": name,
+            "unified_name": name,
+            "type": "function",
+            "file": "routes.py",
+            "start_line": self.name_to_vertex[name],
+            "end_line": self.name_to_vertex[name] + 1,
+        }
+
+    def get_successors(self, name):
+        return self.successors.get(name, [])
+
+    def get_predecessors(self, name):
+        return []
+
+    def get_node_info_by_id(self, vertex_id):
+        if not 0 <= vertex_id < len(self.names):
+            return None
+        return self.get_node_info_by_name(self.names[vertex_id])
+
+
+def test_lsp_route_query_fallback_stops_at_scan_budget(monkeypatch):
+    graph = _QueryBudgetGraph(["NoiseOne", "NoiseTwo", "NoiseThree", "TargetRoute"])
+    monkeypatch.setattr(lsp_graph, "_QUERY_SEED_SCAN_BUDGET", 3)
+    monkeypatch.setattr(lsp_graph.time, "monotonic", lambda: 0.0)
+
+    route = lsp_graph.lsp_route(
+        graph,
+        symbols=[],
+        query="target route",
+        top_k=4,
+        include_neighbors=False,
+    )
+
+    assert route == []
+    assert "TargetRoute" not in graph.seen_names
+
+
+def test_lsp_route_query_fallback_stops_at_match_budget(monkeypatch):
+    graph = _QueryBudgetGraph(["TargetRouteOne", "TargetRouteTwo", "TargetRouteThree"])
+    monkeypatch.setattr(lsp_graph, "_QUERY_SEED_MATCH_BUDGET", 2)
+
+    route = lsp_graph.lsp_route(
+        graph,
+        symbols=[],
+        query="target route",
+        top_k=4,
+        include_neighbors=False,
+    )
+
+    assert [node.node_name for node in route] == ["TargetRouteOne", "TargetRouteTwo"]
+    assert "TargetRouteThree" not in graph.seen_names
+
+
+def test_lsp_route_query_fallback_bounds_expanded_candidates(monkeypatch):
+    graph = _QueryBudgetGraph(
+        ["TargetRoute", "EndpointOne", "EndpointTwo", "EndpointThree"]
+    )
+    graph.successors["TargetRoute"] = [1, 2, 3]
+    monkeypatch.setattr(lsp_graph, "_QUERY_SEED_CANDIDATE_BUDGET", 3)
+
+    route = lsp_graph.lsp_route(
+        graph,
+        symbols=[],
+        query="target route",
+        top_k=4,
+        include_neighbors=True,
+    )
+
+    assert [node.node_name for node in route] == [
+        "TargetRoute",
+        "EndpointOne",
+        "EndpointTwo",
+    ]
+
+
+def test_lsp_route_query_fallback_stops_at_deadline(monkeypatch):
+    graph = _QueryBudgetGraph(["NoiseOne", "TargetRoute"])
+    clock = iter([0.0, 2.0])
+    monkeypatch.setattr(lsp_graph, "_QUERY_SEED_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(lsp_graph.time, "monotonic", lambda: next(clock))
+
+    route = lsp_graph.lsp_route(
+        graph,
+        symbols=[],
+        query="target route",
+        top_k=4,
+        include_neighbors=False,
+    )
+
+    assert route == []
+    assert "TargetRoute" not in graph.seen_names
+
+
 def test_lsp_skills_load_and_execute_against_expand_context(tmp_path):
     (tmp_path / "caller.py").write_text(
         "def run():\n    return load_config()\n", encoding="utf-8"

--- a/test/mcp/test_mcp_server.py
+++ b/test/mcp/test_mcp_server.py
@@ -100,7 +100,7 @@ def test_search_tool_schemas_publish_bounded_inputs() -> None:
     assert dependency["max_nodes"]["maximum"] == 100
 
     route_symbols = tools["lsp_route"].input_schema["properties"]["symbols"]
-    assert route_symbols["minItems"] == 1
+    assert "minItems" not in route_symbols
     assert route_symbols["maxItems"] == 32
     assert route_symbols["items"]["maxLength"] == 1024
     assert tools["lsp_route"].input_schema["properties"]["query"]["maxLength"] == 16000
@@ -317,10 +317,45 @@ def test_lsp_tools_validate_result_and_seed_bounds():
 
     with pytest.raises(ValueError, match="top_k must be between"):
         lsp_references_impl(ctx, symbol="load_config", top_k=101)
-    with pytest.raises(ValueError, match="at least one non-empty seed"):
-        lsp_route_impl(ctx, symbols=[])
     with pytest.raises(ValueError, match="at most 32 entries"):
         lsp_route_impl(ctx, symbols=[f"symbol_{index}" for index in range(33)])
+
+
+def test_lsp_route_uses_query_fallback_without_symbol_seeds():
+    from codenib.graph.code_graph import CodeGraph
+
+    graph = CodeGraph()
+    graph._add_vertex(
+        "src/cache.py:CachePathResolver.resolve()",
+        {
+            "type": "method",
+            "file": "src/cache.py",
+            "start_line": 4,
+            "end_line": 12,
+            "unified_name": "CachePathResolver.resolve()",
+        },
+    )
+
+    result = lsp_route_impl(
+        MagicMock(symbol_graph=graph),
+        symbols=[],
+        query="  resolve cached path  ",
+        top_k=5,
+    )
+
+    assert isinstance(result, list)
+    assert [node["node_name"] for node in result] == ["CachePathResolver.resolve()"]
+    assert result[0]["file"] == "src/cache.py"
+    assert result[0]["start_line"] == 5
+
+
+def test_lsp_route_skips_provider_without_symbols_or_query():
+    ctx = MagicMock(symbol_graph=None)
+    with patch("codenib.agent.lsp_provider.StaticLSPProvider") as provider:
+        result = lsp_route_impl(ctx, symbols=[], query="   ")
+
+    assert result == []
+    provider.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Expose the shared query-seeded `lsp_route` fallback through MCP without allowing an untrusted query to trigger an unbounded graph scan. Closes #505 and supersedes the stacked draft #506 now that #520 is on `main`.

## Changes

- allow `symbols=[]` with a non-blank, bounded query while preserving #520's 32-slot, per-symbol, aggregate-symbol, query, and result limits
- normalize query whitespace and keep empty symbols plus a blank query as a provider-free no-op
- bound query fallback work to 10,000 scanned nodes, 256 query matches, 512 expanded candidates, and a 100 millisecond monotonic deadline
- preserve existing seeded route behavior and neighbor ranking
- publish the query-only contract and add real-graph plus scan, match, candidate, deadline, schema, and no-op regressions

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/mcp test/mcp_server test/agent/test_lsp_graph.py test/agent/test_lsp_provider.py test/agent/test_runner_lsp_route_context.py test/eval/test_lsp_agent_ab.py test/eval/test_lsp_agent_study.py test/eval/test_lsp_agent_study_runner.py test/eval/test_lsp_baseline.py test/eval/test_lsp_latency.py test/eval/test_lsp_provider_cli.py test/eval/test_lsp_provider_validation.py test/eval/test_lsp_replay_benchmark.py test/scripts/test_aggregate_lsp_replay.py test/scripts/test_lsp_graph_smoke.py --tb=short` (`242 passed, 14 skipped`)
- Black 24.8.0, isort 5.13.2, and flake8 7.1.1 with flake8-bugbear on all changed Python files
- `mkdocs build --strict`
- `python scripts/check_public_docs.py`
- `python scripts/check_namespace.py`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
