### PR TITLE
test: enforce integration failure contracts

### DIFF
--- a/test/graph/test_traverse_graph.py
+++ b/test/graph/test_traverse_graph.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test script for traverse_graph functionality using the httpie CLI repository."""
+"""Integration contracts for graph traversal over a pinned HTTPie checkout."""
 
 import subprocess
 from pathlib import Path
@@ -19,269 +19,164 @@ from codenib.types import (
     NODE_TYPE_FILE,
     NODE_TYPE_FUNCTION,
     NODE_TYPE_METHOD,
-    NODE_TYPE_SYMBOL,
 )
 
 pytestmark = pytest.mark.integration
 
 HTTPIE_REPO_URL = "https://github.com/httpie/cli.git"
 HTTPIE_REPO_PATH = Path("/tmp/httpie-cli")
+# Keep the standalone diagnostic aligned with test/conftest.py's fixture pin.
+HTTPIE_REPO_REF = "3.2.4"
+
+
+def _run_git(repo_path: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo_path), *args], check=True)
 
 
 def ensure_httpie_repo() -> Path:
-    """Clone the httpie/cli repository if needed and return its path."""
-    if not HTTPIE_REPO_PATH.exists():
+    """Return the same pinned HTTPie revision used by the pytest fixture."""
+    tag_ref = f"refs/tags/{HTTPIE_REPO_REF}"
+    if not (HTTPIE_REPO_PATH / ".git").is_dir():
+        if HTTPIE_REPO_PATH.exists():
+            raise RuntimeError(f"Not a git checkout: {HTTPIE_REPO_PATH}")
         subprocess.run(
-            ["git", "clone", "--depth", "1", HTTPIE_REPO_URL, str(HTTPIE_REPO_PATH)],
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                HTTPIE_REPO_REF,
+                HTTPIE_REPO_URL,
+                str(HTTPIE_REPO_PATH),
+            ],
             check=True,
+        )
+    else:
+        tag_exists = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(HTTPIE_REPO_PATH),
+                "rev-parse",
+                "--verify",
+                f"{tag_ref}^{{commit}}",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if tag_exists.returncode != 0:
+            _run_git(
+                HTTPIE_REPO_PATH,
+                "fetch",
+                "--depth",
+                "1",
+                "origin",
+                f"{tag_ref}:{tag_ref}",
+            )
+
+    _run_git(HTTPIE_REPO_PATH, "checkout", "--detach", tag_ref)
+    head = subprocess.check_output(
+        ["git", "-C", str(HTTPIE_REPO_PATH), "rev-parse", "HEAD"], text=True
+    ).strip()
+    pinned = subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(HTTPIE_REPO_PATH),
+            "rev-parse",
+            f"{tag_ref}^{{commit}}",
+        ],
+        text=True,
+    ).strip()
+    if head != pinned:
+        raise RuntimeError(
+            f"Expected HTTPie {HTTPIE_REPO_REF} at {pinned}, found {head}"
         )
     return HTTPIE_REPO_PATH
 
 
-def test_transgraph_simple(httpie_cli_repo=None, tmp_path_factory=None):
-    """Test traverse functions with the httpie CLI repository."""
+def _nodes_by_type(graph, node_type):
+    return [
+        vertex.attributes()
+        for vertex in graph.graph.vs
+        if vertex.attributes().get("type") == node_type
+    ]
 
-    repo_path = httpie_cli_repo or ensure_httpie_repo()
-    if tmp_path_factory:
-        output_path = tmp_path_factory.mktemp("httpie_cli_transgraph")
-    else:
-        output_path = Path("/tmp") / "httpie_cli_transgraph"
-        output_path.mkdir(parents=True, exist_ok=True)
 
-    print(f"Testing with repository: {repo_path}")
-    print(f"Output directory: {output_path}")
+def run_traverse_graph_smoke(repo_path: Path, output_path: Path) -> None:
+    """Index HTTPie and assert containment plus bidirectional traversal."""
+    assert repo_path.is_dir(), f"Test repository not found: {repo_path}"
 
-    # Ensure the test repo exists
-    if not repo_path.exists():
-        print(f"Error: Test repository not found at {repo_path}")
-        return False
-
-    # Setup codegraph
-    repo_indexer = LSIndexer(repo_path, output_dir=output_path)
-
-    print("\n" + "=" * 50)
-    print("GENERATING SCIP INDEX")
-    print("=" * 50)
-
-    # Run the indexing pipeline
-    graph = repo_indexer.run_pipeline(
+    graph = LSIndexer(repo_path, output_dir=output_path).run_pipeline(
         project_name="httpie_cli_test", skip_level="graph"
     )
+    assert graph is not None, "LSIndexer did not produce a graph"
 
-    if not graph:
-        print("Failed to generate graph!")
-        return False
+    file_names = {node["name"] for node in _nodes_by_type(graph, NODE_TYPE_FILE)}
+    assert "httpie/core.py" in file_names
+    assert _nodes_by_type(graph, NODE_TYPE_CLASS)
+    assert _nodes_by_type(graph, NODE_TYPE_FUNCTION)
+    assert _nodes_by_type(graph, NODE_TYPE_METHOD)
+    assert _nodes_by_type(graph, NODE_TYPE_FIELD)
 
-    print("Graph generated successfully!")
+    root_file = "httpie/core.py"
+    target_function = "httpie/core.py:raw_main()"
+    downstream = traverse_tree_structure(
+        graph,
+        root_file,
+        direction="downstream",
+        hops=2,
+        node_type_filter=[NODE_TYPE_CLASS, NODE_TYPE_FUNCTION, NODE_TYPE_METHOD],
+    )
+    assert downstream.startswith(root_file)
+    assert target_function in downstream
+    assert EDGE_TYPE_CONTAIN in downstream
 
-    # Print basic graph info
-    print(f"\n--- Basic Graph Information ---")
-    graph.print_graph_basic_info()
+    searcher = RepoDependencySearcher(graph)
+    contain_nodes, contain_edges = searcher.get_neighbors(
+        root_file,
+        direction="forward",
+        etype_filter=[EDGE_TYPE_CONTAIN],
+    )
+    assert target_function in contain_nodes
+    assert contain_edges
+    assert all(edge[3]["type"] == EDGE_TYPE_CONTAIN for edge in contain_edges)
 
-    # Test traverse functionality
-    print("\n" + "=" * 50)
-    print("TESTING TRAVERSE FUNCTIONS")
-    print("=" * 50)
+    parent_nodes, parent_edges = searcher.get_neighbors(
+        target_function,
+        direction="backward",
+        ntype_filter=[NODE_TYPE_FILE],
+        etype_filter=[EDGE_TYPE_CONTAIN],
+    )
+    assert root_file in parent_nodes
+    assert any(
+        edge[0] == root_file and edge[1] == target_function for edge in parent_edges
+    )
 
-    dependency_searcher = RepoDependencySearcher(graph)
-
-    def nodes_by_type(ntype):
-        return [
-            v.attributes()
-            for v in graph.graph.vs
-            if "type" in v.attributes() and v["type"] == ntype
-        ]
-
-    # Get sample nodes
-    print("\n--- Getting sample nodes ---")
-    file_nodes = nodes_by_type(NODE_TYPE_FILE)
-    symbol_nodes = nodes_by_type(NODE_TYPE_SYMBOL)
-
-    print(f"Found {len(file_nodes)} file nodes")
-    print(f"Found {len(symbol_nodes)} symbol nodes")
-
-    if file_nodes:
-        print(f"Sample file nodes:")
-        for i, node in enumerate(file_nodes[:5]):
-            print(f"  {i+1}. {node['name']}")
-
-    if symbol_nodes:
-        print(f"Sample symbol nodes:")
-        for i, node in enumerate(symbol_nodes[:10]):
-            print(f"  {i+1}. {node['name']} (type: {node.get('type', 'unknown')})")
-
-    # Test specific symbol types
-    print("\n--- Testing specific symbol types ---")
-    class_nodes = nodes_by_type(NODE_TYPE_CLASS)
-    function_nodes = nodes_by_type(NODE_TYPE_FUNCTION)
-    method_nodes = nodes_by_type(NODE_TYPE_METHOD)
-    field_nodes = nodes_by_type(NODE_TYPE_FIELD)
-
-    print(f"Found {len(class_nodes)} class nodes")
-    print(f"Found {len(function_nodes)} function nodes")
-    print(f"Found {len(method_nodes)} method nodes")
-    print(f"Found {len(field_nodes)} field nodes")
-
-    if class_nodes:
-        print("Sample class nodes:")
-        for i, node in enumerate(class_nodes[:3]):
-            print(f"  {i+1}. {node['name']}")
-
-    if field_nodes:
-        print("Sample field nodes:")
-        for i, node in enumerate(field_nodes[:3]):
-            print(f"  {i+1}. {node['name']}")
-
-    # Test traverse_tree_structure
-    if file_nodes:
-        print(f"\n--- Testing traverse_tree_structure ---")
-
-        preferred_file = "httpie/core.py"
-        available_files = {node["name"] for node in file_nodes}
-        if preferred_file in available_files:
-            main_file = preferred_file
-        else:
-            main_file = file_nodes[0]["name"]
-
-        if main_file:
-
-            # Test downstream traversal
-            tree_result_downstream = traverse_tree_structure(
-                graph,
-                main_file,
-                direction="downstream",
-                hops=2,
-                node_type_filter=[
-                    NODE_TYPE_FILE,
-                    NODE_TYPE_CLASS,
-                    NODE_TYPE_FUNCTION,
-                    NODE_TYPE_METHOD,
-                ],
-                # edge_type_filter=[EDGE_TYPE_CONTAIN]
-            )
-            print("Tree structure (downstream, 2 hops):")
-            print(tree_result_downstream)
-
-            # Test with unlimited hops
-            tree_result_unlimited = traverse_tree_structure(
-                graph,
-                main_file,
-                direction="downstream",
-                hops=-1,  # Unlimited
-                node_type_filter=[
-                    NODE_TYPE_FILE,
-                    NODE_TYPE_CLASS,
-                    NODE_TYPE_FUNCTION,
-                    NODE_TYPE_METHOD,
-                ],
-            )
-            print(f"\nTree structure (downstream, unlimited hops):")
-            print(tree_result_unlimited)
-
-    # Test with a symbol node if available
-    if symbol_nodes:
-        print(f"\n--- Testing with Symbol Node ---")
-
-        target_symbol = next(
-            (node["name"] for node in symbol_nodes if "raw_main" in node["name"]),
-            symbol_nodes[0]["name"],
-        )
-
-        print(f"Symbol: {target_symbol}")
-
-        # Test upstream traversal
-        tree_result_upstream = traverse_tree_structure(
-            graph,
-            target_symbol,
-            direction="upstream",
-            hops=2,
-            node_type_filter=[NODE_TYPE_FILE, NODE_TYPE_SYMBOL],
-        )
-        print("Tree structure (upstream from symbol, 2 hops):")
-        print(tree_result_upstream)
-
-    # Basic node structure check (replaces RepoEntitySearcher coverage)
-    print(f"\n--- Node Attribute Inspection ---")
-    if file_nodes:
-        sample_file = file_nodes[0]
-        print(f"Sample file node: {sample_file}")
-
-    # Test RepoDependencySearcher functionality
-    print(f"\n--- Testing RepoDependencySearcher ---")
-
-    if file_nodes:
-        test_file = file_nodes[0]["name"]
-
-        # Get forward neighbors (what this file contains)
-        forward_nodes, forward_edges = dependency_searcher.get_neighbors(
-            test_file, direction="forward", ntype_filter=[NODE_TYPE_SYMBOL]
-        )
-        print(f"Forward neighbors of {test_file!r}: {len(forward_nodes)} nodes")
-        if forward_nodes:
-            print("Forward neighbors:")
-            for node in forward_nodes[:5]:
-                print(f"  - {node}")
-
-        print(f"Forward edges: {len(forward_edges)}")
-        if forward_edges:
-            print("Forward edges:")
-            for edge in forward_edges[:5]:
-                print(f"  - {edge[0]} -> {edge[1]} ({edge[3]['type']})")
-
-    # Test with symbol nodes
-    if symbol_nodes:
-        test_symbol = symbol_nodes[0]["name"]
-
-        # Get backward neighbors (what contains this symbol)
-        backward_nodes, backward_edges = dependency_searcher.get_neighbors(
-            test_symbol, direction="backward", ntype_filter=[NODE_TYPE_FILE]
-        )
-        print(f"\nBackward neighbors of {test_symbol!r}: {len(backward_nodes)} nodes")
-        if backward_nodes:
-            print("Backward neighbors:")
-            for node in backward_nodes:
-                print(f"  - {node}")
-
-        print(f"Backward edges: {len(backward_edges)}")
-        if backward_edges:
-            print("Backward edges:")
-            for edge in backward_edges:
-                print(f"  - {edge[0]} -> {edge[1]} ({edge[3]['type']})")
-
-    # Test edge filtering
-    print(f"\n--- Testing Edge Filtering ---")
-    if file_nodes:
-        test_file = file_nodes[0]["name"]
-        contain_nodes, contain_edges = dependency_searcher.get_neighbors(
-            test_file, direction="forward", etype_filter=[EDGE_TYPE_CONTAIN]
-        )
-        print(f"Nodes connected via {EDGE_TYPE_CONTAIN!r} edges: {len(contain_nodes)}")
-        if contain_nodes:
-            for node in contain_nodes[:3]:
-                print(f"  - {node}")
-
-    print(f"\n--- Test Summary ---")
-    print(f"✅ Graph indexing: SUCCESS")
-    print(f"✅ Entity searching: SUCCESS")
-    print(f"✅ Dependency searching: SUCCESS")
-    print(f"✅ Tree traversal: SUCCESS")
-    print(f"✅ Node filtering: SUCCESS")
-    print(f"✅ Edge filtering: SUCCESS")
-
-    return True
+    upstream = traverse_tree_structure(
+        graph,
+        target_function,
+        direction="upstream",
+        hops=1,
+        node_type_filter=[NODE_TYPE_FILE],
+        edge_type_filter=[EDGE_TYPE_CONTAIN],
+    )
+    assert upstream.startswith(target_function)
+    assert root_file in upstream
 
 
-# Example usage
+def test_transgraph_simple(httpie_cli_repo, tmp_path_factory):
+    """Index a pinned checkout and verify traversal contracts end to end."""
+    output_path = tmp_path_factory.mktemp("httpie_cli_transgraph")
+    run_traverse_graph_smoke(httpie_cli_repo, output_path)
+
+
 if __name__ == "__main__":
-    print("Starting httpie CLI repository traverse test...")
     setup_detailed_logging(
         log_dir="logs", run_name="httpie_cli_test", mode="both", level="scip_debug"
     )
-    success = test_transgraph_simple()
-
-    if success:
-        print("\n🎉 All tests completed successfully!")
-
-    else:
-        print("\n❌ Some tests failed!")
-        exit(1)
+    standalone_output = Path("/tmp") / "httpie_cli_transgraph"
+    standalone_output.mkdir(parents=True, exist_ok=True)
+    run_traverse_graph_smoke(ensure_httpie_repo(), standalone_output)
+    print("All tests completed successfully.")

--- a/test/index/test_dense_compatibility.py
+++ b/test/index/test_dense_compatibility.py
@@ -4,9 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test to check if all dense chunk node_ids exist in BM25 graph nodes."""
-
-import warnings
+"""Check that dense chunks can be joined to BM25 documents by node ID."""
 
 import pytest
 
@@ -31,21 +29,6 @@ def test_dense_compatibility(httpie_cli_repo, tmp_path_factory):
     if not graph:
         pytest.fail("Failed to create BM25 graph")
 
-    # target_file = "httpie/cookies.py"
-    # target_nodes = []
-    # for vertex in graph.graph.vs:
-    #     attrs = vertex.attributes()
-    #     if vertex["name"] == target_file or attrs.get("file") == target_file:
-    #         target_nodes.append(
-    #             {
-    #                 "name": vertex["name"],
-    #                 "type": attrs.get("type"),
-    #                 "start_line": attrs.get("start_line"),
-    #                 "end_line": attrs.get("end_line"),
-    #             }
-    #         )
-    # print(f"Graph nodes for {target_file}: {target_nodes}")
-
     bm25_indexer = BM25CodeIndexer(code_graph=graph)
     bm25_node_ids = {
         doc.metadata.get("node_id")
@@ -61,24 +44,10 @@ def test_dense_compatibility(httpie_cli_repo, tmp_path_factory):
 
     dense_node_ids = {chunk.node_id for chunk in chunks if chunk.node_id}
 
-    compatible_ids = dense_node_ids.intersection(bm25_node_ids)
     missing_ids = dense_node_ids - bm25_node_ids
-    extra_bm25_ids = bm25_node_ids - dense_node_ids
-
-    compatibility_rate = (
-        len(compatible_ids) / len(dense_node_ids) * 100 if dense_node_ids else 0
-    )
-
+    assert dense_node_ids, "Dense chunking produced no addressable chunks"
+    assert bm25_node_ids, "BM25 indexing produced no addressable documents"
     assert not missing_ids, (
-        "Found dense node IDs missing in BM25: "
-        f"{sorted(missing_ids)} (compatibility={compatibility_rate:.1f}%)"
+        f"{len(missing_ids)}/{len(dense_node_ids)} dense node IDs are missing "
+        f"from BM25; sample={sorted(missing_ids)[:10]}"
     )
-
-    # Report extra BM25 IDs as context rather than failing the test. Some indices
-    # may contain auxiliary nodes that dense chunking intentionally omits.
-    if extra_bm25_ids:
-        warnings.warn(
-            f"BM25 contains node IDs without dense chunks: {sorted(extra_bm25_ids)}",
-            UserWarning,
-            stacklevel=1,
-        )


### PR DESCRIPTION
## Summary
Rebuild #452 on current `main` so integration smoke tests fail on real regressions while retaining the newer explicit Vertex ADC and provider-failure contract already merged on `main`.

## Changes
- Replace print-and-return HTTPie graph diagnostics with assertions for indexing, containment edges, and bidirectional traversal.
- Pin the standalone HTTPie checkout to the same `3.2.4` tag as the pytest fixture and verify its resolved commit before indexing.
- Express dense/BM25 identity compatibility as non-empty dense and BM25 sets plus a bounded missing-ID diagnostic.
- Leave the current explicit Vertex credential fixture, revision-pinned models, and uncaught provider failures unchanged.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- Targeted unit contracts: 35 passed.
- Targeted HTTPie integration contracts: 2 passed.
- Full integration tier: 36 passed, 14 skipped.
- Related serial graph/BM25 contracts: 4 passed.
- Credential-free Vertex path: 2 expected skips under the explicit ADC policy.
- Fresh standalone HTTPie clone resolved tag `3.2.4` to `2105caa49bae87c5809c274e407619a0de2639d1`.
- Black, isort, flake8+bugbear, diff checks, and current-main merge-tree passed.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
