### PR TITLE
fix(wiki): restore grounded source-linked repository pages

### DIFF
--- a/codenib/web/repo_registry.py
+++ b/codenib/web/repo_registry.py
@@ -397,21 +397,30 @@ class RepoRegistry:
     def _load_vector_store(self, vec_entry: Any) -> "CodeVectorStore":
         """Load a manifest vector view with the configured embedding backend."""
         artifact_config = dict(vec_entry.config or {})
-        if not artifact_config.get("embedding_route") and not artifact_config.get(
-            "embedding_provider"
-        ):
+        legacy_route = not artifact_config.get("embedding_route")
+        legacy_fallbacks = []
+        if legacy_route and not artifact_config.get("embedding_provider"):
             # Pre-provider manifests from build_qa_index.py intentionally relied
             # on the QA runtime route. Keep that narrow compatibility path while
             # requiring all newly built artifacts to persist their provider.
             artifact_config["embedding_provider"] = self._config.embedding_provider
+            legacy_fallbacks.append(f"provider={self._config.embedding_provider}")
             if self._config.embedding_base_url:
                 artifact_config["embedding_endpoint"] = self._config.embedding_base_url
+        if (
+            legacy_route
+            and "dimension" not in artifact_config
+            and "embedding_dimension" not in artifact_config
+        ):
+            artifact_config["embedding_dimension"] = self._config.embedding_dimension
+            legacy_fallbacks.append(f"dimension={self._config.embedding_dimension}")
+        if legacy_fallbacks:
             logger.warning(
-                "Vector artifact at %s has no embedding provider; using the "
-                "configured legacy route %s. Rebuild the manifest to persist "
-                "its compatibility identity.",
+                "Vector artifact at %s is missing legacy route identity; "
+                "using configured compatibility fallback(s): %s. Rebuild "
+                "the manifest to persist its compatibility identity.",
                 vec_entry.path,
-                self._config.embedding_provider,
+                ", ".join(legacy_fallbacks),
             )
         route = resolve_embedding_artifact_route(artifact_config)
         configured_endpoint = normalize_endpoint(self._config.embedding_base_url)
@@ -472,15 +481,24 @@ class RepoRegistry:
 
         bm25_index: Optional["BM25CodeIndexer"] = None
         vector_store: Optional["CodeVectorStore"] = None
+        index_types = set(self._config.index_types())
 
         bm25_entry = manifest.indexes.get("bm25")
-        if bm25_entry is not None and manifest.index_is_current("bm25"):
+        if (
+            "bm25" in index_types
+            and bm25_entry is not None
+            and manifest.index_is_current("bm25")
+        ):
             require_bm25_manifest_artifact(bm25_entry)
             bm25_index = BM25CodeIndexer()
             bm25_index.load_index(bm25_entry.path)
 
         vec_entry = manifest.indexes.get("vector")
-        if vec_entry is not None and manifest.index_is_current("vector"):
+        if (
+            "vector" in index_types
+            and vec_entry is not None
+            and manifest.index_is_current("vector")
+        ):
             vector_store = self._load_vector_store(vec_entry)
 
         bundle.vector_store = vector_store

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -36,6 +36,16 @@ _DOCUMENT_REFERENCE_RE = re.compile(
 _SAFE_BASE_PATH_RE = re.compile(r"^/[A-Za-z0-9._~!$&()*+,;=:@%/-]*$")
 _SAFE_PAGE_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
+# Page graphs remain interactive on a serverless export, so every source-bearing
+# graph item needs a self-contained preview. Keep each preview small enough that
+# one broad class span or generated line cannot dominate the published JSON.
+_GRAPH_SOURCE_MAX_LINES = 160
+_GRAPH_SOURCE_MAX_BYTES = 64 * 1024
+_GRAPH_SOURCE_PAGE_MAX_BYTES = 1024 * 1024
+_GRAPH_SOURCE_MAX_ANCHORS = 64
+_GRAPH_NODE_CONTEXT_LINES = 3
+_GRAPH_ANCHOR_CONTEXT_LINES = 6
+
 
 @dataclass(frozen=True, slots=True)
 class StaticExportResult:
@@ -217,6 +227,260 @@ def _page_graph(bundle: Any, page: Mapping[str, Any]) -> dict[str, Any]:
         )
     except Exception:  # noqa: BLE001 - an optional graph must not block the Wiki
         return _unavailable_page_graph("The indexed dependency view was unavailable.")
+
+
+def _positive_line(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return None
+    return value
+
+
+def _graph_source_range(
+    value: Mapping[str, Any], *, context: int
+) -> tuple[int, int] | None:
+    line = _positive_line(value.get("line"))
+    if line is None:
+        return None
+    end = _positive_line(value.get("end_line")) or line
+    end = max(line, end)
+    first = max(1, line - context)
+    last = min(end + context, first + _GRAPH_SOURCE_MAX_LINES - 1)
+    return first, last
+
+
+def _bounded_graph_source(
+    builder: Any,
+    file: Any,
+    first: int,
+    last: int,
+    required_line: int,
+    cache: dict[tuple[str, int, int, int], dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    if not isinstance(file, str):
+        return None
+    try:
+        relative = _source_path(file)
+    except ValueError:
+        return None
+    if not relative:
+        return None
+
+    first = max(1, first)
+    last = min(max(first, last), first + _GRAPH_SOURCE_MAX_LINES - 1)
+    required_line = max(first, min(required_line, last))
+    key = (relative, first, last, required_line)
+    if key in cache:
+        return cache[key]
+
+    try:
+        raw = builder.source(relative, first, last)
+    except (OSError, TypeError, ValueError):
+        raw = None
+    if not isinstance(raw, Mapping):
+        cache[key] = None
+        return None
+
+    raw_file = raw.get("file", relative)
+    if not isinstance(raw_file, str):
+        cache[key] = None
+        return None
+    try:
+        returned_file = _source_path(raw_file)
+    except ValueError:
+        cache[key] = None
+        return None
+    if returned_file != relative:
+        cache[key] = None
+        return None
+
+    content = raw.get("content")
+    if not isinstance(content, str) or not content:
+        cache[key] = None
+        return None
+
+    returned_start = _positive_line(raw.get("start_line"))
+    returned_end = _positive_line(raw.get("end_line"))
+    if returned_start != first or (
+        returned_end is not None and returned_end < returned_start
+    ):
+        cache[key] = None
+        return None
+    lines = content.splitlines(keepends=True)[:_GRAPH_SOURCE_MAX_LINES]
+    if returned_end is not None:
+        lines = lines[: returned_end - returned_start + 1]
+    if not lines:
+        cache[key] = None
+        return None
+
+    target_index = required_line - returned_start
+    if target_index < 0 or target_index >= len(lines):
+        cache[key] = None
+        return None
+
+    # A generated line before the highlighted symbol can be larger than the
+    # entire preview budget. Trim whole lines around the requested target
+    # instead of slicing bytes from the beginning and silently dropping the
+    # highlighted source location.
+    line_sizes = [len(line.encode("utf-8")) for line in lines]
+    low = 0
+    high = len(lines)
+    total_bytes = sum(line_sizes)
+    while total_bytes > _GRAPH_SOURCE_MAX_BYTES and high - low > 1:
+        before = target_index - low
+        after = high - target_index - 1
+        if before >= after and low < target_index:
+            total_bytes -= line_sizes[low]
+            low += 1
+        elif high - 1 > target_index:
+            high -= 1
+            total_bytes -= line_sizes[high]
+        else:
+            break
+    if total_bytes > _GRAPH_SOURCE_MAX_BYTES:
+        cache[key] = None
+        return None
+
+    lines = lines[low:high]
+    result_start = returned_start + low
+    result_end = result_start + len(lines) - 1
+    if not (result_start <= required_line <= result_end):
+        cache[key] = None
+        return None
+
+    result = {
+        "file": relative,
+        "start_line": result_start,
+        "end_line": result_end,
+        "content": "".join(lines),
+    }
+    cache[key] = result
+    return result
+
+
+def _embed_page_graph_sources(
+    builder: Any,
+    graph: dict[str, Any],
+    *,
+    cache: dict[tuple[str, int, int, int], dict[str, Any] | None] | None = None,
+) -> dict[str, Any]:
+    """Attach bounded source previews to a precomputed page graph.
+
+    Static clients have no ``/source`` endpoint. Nodes, hierarchy-only symbol
+    scopes, and exact edge anchors therefore carry the same source-slice shape
+    as the live endpoint. The cache avoids re-reading a range when it is
+    referenced more than once within a page. Export uses a fresh cache per page
+    so large repositories cannot retain every preview in memory at once.
+    """
+
+    source_cache = cache if cache is not None else {}
+    view_node_ids: set[str] = set()
+    attached_bytes = 0
+    processed_anchors = 0
+
+    def attach(value: dict[str, Any], source: dict[str, Any]) -> bool:
+        nonlocal attached_bytes
+        size = len(_json_bytes(source))
+        if attached_bytes + size > _GRAPH_SOURCE_PAGE_MAX_BYTES:
+            return False
+        value["source"] = source
+        attached_bytes += size
+        return True
+
+    for value in graph.get("nodes") or ():
+        if not isinstance(value, dict):
+            continue
+        value["source"] = None
+        node_id = value.get("id")
+        if isinstance(node_id, str):
+            view_node_ids.add(node_id)
+        source_range = _graph_source_range(value, context=_GRAPH_NODE_CONTEXT_LINES)
+        if source_range is None:
+            continue
+        required_line = _positive_line(value.get("line"))
+        if required_line is None:
+            continue
+        source = _bounded_graph_source(
+            builder,
+            value.get("file"),
+            *source_range,
+            required_line,
+            source_cache,
+        )
+        if source is None:
+            continue
+        attach(value, source)
+
+    hierarchy = graph.get("hierarchy")
+    hierarchy_nodes = hierarchy.get("nodes") if isinstance(hierarchy, dict) else ()
+    for value in hierarchy_nodes or ():
+        if not isinstance(value, dict) or value.get("kind") != "symbol":
+            continue
+        node_id = value.get("node_id")
+        # A projected view symbol already resolves through data.nodes in every
+        # frontend consumer. Embedding it again under hierarchy would duplicate
+        # the full source string in JSON; only hierarchy-only ancestor scopes
+        # need their own preview.
+        if isinstance(node_id, str) and node_id in view_node_ids:
+            continue
+        value["source"] = None
+        source_range = _graph_source_range(value, context=_GRAPH_NODE_CONTEXT_LINES)
+        if source_range is None:
+            continue
+        required_line = _positive_line(value.get("line"))
+        if required_line is None:
+            continue
+        source = _bounded_graph_source(
+            builder,
+            value.get("file"),
+            *source_range,
+            required_line,
+            source_cache,
+        )
+        if source is not None:
+            attach(value, source)
+
+    for edge in graph.get("edges") or ():
+        if not isinstance(edge, dict):
+            continue
+        for anchor in edge.get("anchors") or ():
+            if not isinstance(anchor, dict):
+                continue
+            anchor["source"] = None
+            source_range = _graph_source_range(
+                anchor, context=_GRAPH_ANCHOR_CONTEXT_LINES
+            )
+            if source_range is None:
+                continue
+            file = anchor.get("file")
+            if not isinstance(file, str):
+                continue
+            try:
+                relative = _source_path(file)
+            except ValueError:
+                continue
+            if not relative:
+                continue
+            required_line = _positive_line(anchor.get("line"))
+            if required_line is None:
+                continue
+            if processed_anchors >= _GRAPH_SOURCE_MAX_ANCHORS:
+                continue
+            # Malformed ranges and unsafe paths are not source candidates and
+            # must not consume the bounded attachment quota. Valid candidates
+            # still count even when the file is missing, keeping graph scans
+            # bounded for stale artifacts.
+            processed_anchors += 1
+            source = _bounded_graph_source(
+                builder,
+                relative,
+                *source_range,
+                required_line,
+                source_cache,
+            )
+            if source is not None:
+                attach(anchor, source)
+
+    return graph
 
 
 def _prebuilt_frontend(explicit: str | os.PathLike[str] | None) -> Path:
@@ -507,7 +771,10 @@ def export_static_wiki(
             raise ValueError(f"Wiki page tree references a missing page: {page_id}")
         normalized = _normalize_page(builder, page)
         pages.append(normalized)
-        graphs[page_id] = _page_graph(bundle, normalized)
+        graphs[page_id] = _embed_page_graph_sources(
+            builder,
+            _page_graph(bundle, normalized),
+        )
 
     repo_info = _model_dict(bundle.info())
     capabilities = {name: False for name in dict(repo_info.get("capabilities") or {})}

--- a/codenib/wiki/agent_wiki.py
+++ b/codenib/wiki/agent_wiki.py
@@ -84,7 +84,7 @@ _MAX_CONTEXT_CHARS = 14000
 # A quoted body should carry an idea, not reproduce a file.
 _MAX_EXCERPT_LINES = 14
 _OUTLINE_PROMPT_VERSION = "13"
-_PAGE_PROMPT_VERSION = "102"
+_PAGE_PROMPT_VERSION = "106"
 _MAX_PLAN_REPAIRS = 3
 _MAX_STYLE_REPAIRS = 2
 # The overview is asked for a section per outline area, and a repository
@@ -606,6 +606,77 @@ def _supported_thesis(
     return statement, ids
 
 
+def _supported_framing_statements(
+    statements: Sequence[Any],
+    raw_ids: Sequence[Any],
+    evidence: Sequence[EvidenceItem],
+    relations: Sequence[RelationItem],
+) -> tuple[list[str], list[str]]:
+    """Admit reader-facing framing with the same source checks as claims.
+
+    Purpose text, scan-table rows, and section leads are model-authored facts,
+    even though they are not part of ``sections[].claims``.  Treating an
+    existing evidence id as sufficient let invented identifiers and marketing
+    language bypass the claim admission path.
+    """
+
+    evidence_by_id = {item.id: item for item in evidence}
+    relations_by_id = {item.id: item for item in relations}
+    ids = [
+        str(item)
+        for item in raw_ids
+        if str(item) in evidence_by_id or str(item) in relations_by_id
+    ]
+    cited_evidence = [evidence_by_id[item] for item in ids if item in evidence_by_id]
+    cited_relations = [relations_by_id[item] for item in ids if item in relations_by_id]
+    if not cited_evidence:
+        return [], []
+
+    admitted: list[str] = []
+    for raw in statements:
+        statement = re.sub(r"\s+", " ", str(raw or "")).strip()
+        if not statement:
+            continue
+        statement = _normalize_callable_command_labels(statement, cited_evidence)
+        if not _claim_has_local_support(
+            statement, cited_evidence
+        ) or _method_owner_generalizations(statement, cited_evidence):
+            continue
+        candidate = (
+            _format_supported_literals(statement).rstrip(".")
+            + "."
+            + "".join(f" [{item}]" for item in ids)
+        )
+        report = grounding_report(candidate, cited_evidence, cited_relations)
+        if any(
+            report[key]
+            for key in (
+                "unknown_citations",
+                "unknown_files",
+                "unsupported_identifiers",
+                "promotional_phrases",
+            )
+        ):
+            continue
+        admitted.append(statement)
+    return admitted, ids
+
+
+def _substantially_repeats(candidate: str, existing: str) -> bool:
+    """Mirror the published-page redundancy rule before rendering prose."""
+
+    candidate_terms = _redundancy_terms(candidate)
+    existing_terms = _redundancy_terms(existing)
+    smaller = min(len(candidate_terms), len(existing_terms))
+    if smaller < 5:
+        return False
+    candidate_subject = _leading_code_subject(candidate)
+    existing_subject = _leading_code_subject(existing)
+    if candidate_subject and existing_subject and candidate_subject != existing_subject:
+        return False
+    return len(candidate_terms & existing_terms) / smaller >= 0.7
+
+
 def _hard_plan_warnings(warnings: Sequence[str]) -> List[str]:
     """Return diagnostics that represent unsupported or incomplete facts."""
 
@@ -1074,17 +1145,18 @@ def _renderable_plan(
     # Framing and the scan table are grounded like any claim: a statement or row
     # that cites nothing admissible is dropped rather than rendered unsupported.
     purpose = rendered.get("purpose") or {}
-    purpose_ids = [
-        str(item) for item in (purpose.get("evidence") or []) if str(item) in allowed
-    ]
-    purpose_statements = [
-        sentence
-        for sentence in (
-            re.sub(r"\s+", " ", str(raw or "")).strip()
-            for raw in (purpose.get("statements") or [])
-        )
-        if sentence
-    ]
+    purpose_statements, purpose_ids = _supported_framing_statements(
+        purpose.get("statements") or [],
+        purpose.get("evidence") or [],
+        evidence,
+        relations,
+    )
+    if intro:
+        purpose_statements = [
+            statement
+            for statement in purpose_statements
+            if not _substantially_repeats(statement, intro)
+        ]
     if purpose_statements and purpose_ids:
         rendered["purpose"] = {
             "statements": purpose_statements[:3],
@@ -1097,8 +1169,13 @@ def _renderable_plan(
     for row in rendered.get("map") or []:
         concern = re.sub(r"\s+", " ", str(row.get("concern") or "")).strip()
         entity = re.sub(r"\s+", " ", str(row.get("entity") or "")).strip()
-        ids = [str(item) for item in row.get("evidence") or [] if str(item) in allowed]
-        if not concern or not entity or not ids:
+        admitted, ids = _supported_framing_statements(
+            [f"{concern}: {entity}"],
+            row.get("evidence") or [],
+            evidence,
+            relations,
+        )
+        if not concern or not entity or not admitted or not ids:
             continue
         rendered_map.append({"concern": concern, "entity": entity, "evidence": ids})
     # A two-row table is not worth the chrome; below that, prose carries it.
@@ -1289,6 +1366,31 @@ def _renderable_plan(
         if deduplicated_claims:
             rendered_section = copy.deepcopy(section)
             rendered_section["claims"] = deduplicated_claims
+            lead = rendered_section.get("lead") or {}
+            lead_statements, lead_ids = _supported_framing_statements(
+                lead.get("statements") or [],
+                lead.get("evidence") or [],
+                evidence,
+                relations,
+            )
+            claim_statements = [
+                str(claim.get("statement") or "") for claim in deduplicated_claims
+            ]
+            distinct_leads: list[str] = []
+            for statement in lead_statements:
+                if any(
+                    _substantially_repeats(statement, other)
+                    for other in (*claim_statements, *distinct_leads)
+                ):
+                    continue
+                distinct_leads.append(statement)
+            if distinct_leads and lead_ids:
+                rendered_section["lead"] = {
+                    "statements": distinct_leads,
+                    "evidence": lead_ids,
+                }
+            else:
+                rendered_section.pop("lead", None)
             rendered_sections.append(rendered_section)
     rendered["sections"] = rendered_sections
     return rendered
@@ -1345,6 +1447,7 @@ def _fact_plan_markdown(
 
     # Mermaid node ids must be opaque; the labels carry the real names.
     flow_block = ""
+    flow_title = "How it fits together"
     flow = plan.get("flow") or {}
     if flow.get("steps"):
         node_ids: dict[str, str] = {}
@@ -1378,17 +1481,18 @@ def _fact_plan_markdown(
             for item in step.get("evidence") or []:
                 if item not in caption_ids:
                     caption_ids.append(str(item))
-        caption = str(flow.get("title") or "").strip()
-        if caption and caption_ids:
+        flow_title = str(flow.get("title") or "").strip() or flow_title
+        if caption_ids:
             # The fence is stripped before the prose checks run, so the caption
             # is where this block states its sources.
             lines.append("")
             lines.append(
-                caption.rstrip(".")
-                + ". "
+                flow_title.rstrip(".")
+                + ". The diagram traces the admitted source-to-target handoffs "
+                "between the named components. "
                 + " ".join(f"[{item}]" for item in caption_ids)
             )
-        flow_block = "\n".join(lines)
+            flow_block = "\n".join(lines)
 
     see_also_block = ""
     refs = plan.get("see_also") or []
@@ -1397,9 +1501,11 @@ def _fact_plan_markdown(
         for ref in refs:
             page = str(ref.get("page") or "").strip()
             title = str(ref.get("title") or page).strip()
-            why = str(ref.get("why") or "").strip()
             link = f"[{title}](?p={page})"
-            parts.append(f"- {link}" + (f" — {why}" if why else ""))
+            # This is navigation chrome, not a source-backed fact.  Rendering
+            # the model-authored explanation made the list both factual and
+            # uncited, so keep only outline-resolved page links here.
+            parts.append(f"- {link}")
         see_also_block = "\n".join(parts)
 
     evidence_by_id = {item.id: item for item in evidence}
@@ -1419,15 +1525,13 @@ def _fact_plan_markdown(
         if len(lines) < 2:
             return ""
         language = _lang(item.file)
-        span = ""
-        if item.start_line is not None:
-            span = f":{item.start_line}"
-            if item.end_line is not None and item.end_line != item.start_line:
-                span += f"-{item.end_line}"
-        why = re.sub(r"\s+", " ", str(spec.get("why") or "")).strip()
-        caption = f"`{item.file}{span}`" + (f" — {why.rstrip('.')}." if why else "")
+        # The evidence ledger already owns the file and line span.  Repeating
+        # it as prose made every deterministic excerpt violate the page's own
+        # reference-narration rule; the model-authored ``why`` was also an
+        # unadmitted factual path.  A neutral linked caption preserves source
+        # access without making another claim.
         return "\n".join(
-            [f"```{language}", *lines, "```", "", f"{caption} [{item.id}]"]
+            [f"```{language}", *lines, "```", "", f"Source excerpt. [{item.id}]"]
         )
 
     rendered_sections: List[tuple[str, List[str]]] = []
@@ -1479,7 +1583,7 @@ def _fact_plan_markdown(
     if map_block:
         blocks.extend(("## At a glance", map_block))
     if flow_block:
-        blocks.extend((f"## {flow.get('title') or 'How it fits together'}", flow_block))
+        blocks.extend((f"## {flow_title}", flow_block))
     for title, parts in rendered_sections:
         blocks.append(f"## {title}")
         blocks.extend(parts)
@@ -3181,6 +3285,25 @@ class AgentWiki:
                     ),
                     reverse=True,
                 )
+                # Dense, sparse, and symbol-table routes can spell the same
+                # definition differently.  Apply the per-file quota to unique
+                # source spans; otherwise two aliases of one method consume
+                # both slots and hide the next relevant method in that file.
+                unique_matches: List[tuple[Any, tuple[str, ...]]] = []
+                match_index: Dict[tuple[str, Any, Any, str], int] = {}
+                for node, route_names in matches:
+                    source_key = self._source_span_key(node)
+                    prior_index = match_index.get(source_key)
+                    if prior_index is None:
+                        match_index[source_key] = len(unique_matches)
+                        unique_matches.append((node, tuple(route_names)))
+                        continue
+                    prior_node, prior_routes = unique_matches[prior_index]
+                    unique_matches[prior_index] = (
+                        prior_node,
+                        tuple(dict.fromkeys((*prior_routes, *route_names))),
+                    )
+                matches = unique_matches
                 if overview:
                     per_file_limit = 2 if file in overview_topic_files else 1
                 elif parent_page and not parent_has_core_files:
@@ -3410,11 +3533,30 @@ class AgentWiki:
         kind = str(self._node_attr(node, "type") or "").lower()
         return 2 if kind in {"class", "interface", "module"} else 1
 
-    def _source_span_key(self, node: Any) -> tuple[str, Any, Any]:
+    def _source_span_key(self, node: Any) -> tuple[str, Any, Any, str]:
+        start = self._node_attr(node, "start_line")
+        end = self._node_attr(node, "end_line")
+        # Missing, reversed, and 0/0 spans cannot identify a definition.  The
+        # latter is the no-line-data signature used by older indexes.  Keep
+        # route aliases collapsed in that case, but include the canonical
+        # symbol so distinct definitions in one file do not share a quota key.
+        reliable = (
+            isinstance(start, int)
+            and not isinstance(start, bool)
+            and isinstance(end, int)
+            and not isinstance(end, bool)
+            and start >= 0
+            and end >= start
+            and (start, end) != (0, 0)
+        )
+        raw_symbol = (
+            self._node_attr(node, "node_name") or self._node_attr(node, "name") or ""
+        )
         return (
             self._norm_hint_path(self._rel(self._node_attr(node, "file")) or ""),
-            self._node_attr(node, "start_line"),
-            self._node_attr(node, "end_line"),
+            start,
+            end,
+            "" if reliable else _canonical_symbol(str(raw_symbol)),
         )
 
     def _outline_anchor_rank(
@@ -3568,6 +3710,15 @@ class AgentWiki:
                 continue
             start = self._node_attr(node, "start_line")
             end = self._node_attr(node, "end_line")
+            has_complete_span = (
+                isinstance(start, int)
+                and not isinstance(start, bool)
+                and isinstance(end, int)
+                and not isinstance(end, bool)
+                and start >= 0
+                and end >= start
+                and (start != 0 or end != 0)
+            )
             # A 0/0 span is the "no line data" signature of an index whose
             # document metadata carries no spans (``_compute_symbols`` coerces
             # a missing span to 0). Emitting it would cite line 1 of the file
@@ -3577,11 +3728,13 @@ class AgentWiki:
             if start == 0 and end == 0:
                 start = end = None
             start_line = (start + 1) if isinstance(start, int) else None
-            end_line = (end + 1) if isinstance(end, int) else start_line
-            content = self._node_attr(node, "content") or ""
-            if not content:
+            end_line = (end + 1) if has_complete_span else start_line
+            content = ""
+            if has_complete_span and start_line is not None and end_line is not None:
                 source = self._wb.source(file, start_line, end_line)
                 content = (source or {}).get("content", "") if source else ""
+            if not content:
+                content = self._node_attr(node, "content") or ""
             content = _prepare_evidence_content(file, content)
             if not content:
                 continue
@@ -3919,16 +4072,12 @@ class AgentWiki:
                 title = str(page.get("title") or "").strip()
                 if not title:
                     continue
-                summary = re.sub(r"\s+", " ", str(page.get("summary") or "")).strip()[
-                    :160
-                ]
                 marker = " (this page)" if page_id == current_id else ""
                 indent = "  " * depth
-                # The id is what a cross-reference has to name, so hand it over.
-                lines.append(
-                    f"{indent}- [{page_id}] {title}{marker}"
-                    + (f": {summary}" if summary else "")
-                )
+                # Outline summaries are generated hints, not source evidence.
+                # Give the planner only the stable identity it needs for a
+                # cross-reference so those hints cannot leak into page facts.
+                lines.append(f"{indent}- [{page_id}] {title}{marker}")
                 walk(page.get("children") or [], depth + 1)
 
         # Read the resolved outline only. Generating one here would make page
@@ -4609,13 +4758,14 @@ class AgentWiki:
                     repaired = True
         markdown = _link_evidence_markers(markdown)
         blocking_plan_warnings = _blocking_plan_warnings(plan_warnings)
-        # Publish on the grounding floor, not on a spotless report. Coverage,
-        # unresolved identifiers, marketing words and composition notes are all
-        # still computed and returned -- they describe the page, and surfacing
-        # them is the point. Gating on every one of them made "degraded" fire on
-        # pages whose only fault was a shape the checker could not spell.
+        # Keep the generation label aligned with the public audit.  A readable
+        # grounding floor remains useful as a diagnostic, but it must not call
+        # a page generated when strict citations or structural integrity fail.
         publishable = bool(
-            report.get("grounded", report["valid"]) and not blocking_plan_warnings
+            report["valid"]
+            and report.get("grounded", True)
+            and quality["valid"]
+            and not blocking_plan_warnings
         )
         generated = publishable and not model_failed and not model_planning_failed
         if generated:

--- a/codenib/wiki/builder.py
+++ b/codenib/wiki/builder.py
@@ -826,21 +826,38 @@ class WikiBuilder:
         self, file: str, start: Optional[int] = None, end: Optional[int] = None
     ) -> Optional[dict]:
         repo_dir = self._entry.repo_dir
-        # Prevent path traversal; only serve files under repo_dir.
-        safe = os.path.normpath(file).lstrip("/")
-        abs_path = os.path.normpath(os.path.join(repo_dir, safe))
-        if not abs_path.startswith(os.path.abspath(repo_dir)) or not os.path.isfile(
-            abs_path
-        ):
+        root = os.path.realpath(repo_dir)
+        if os.path.isabs(file):
             return None
-        with open(abs_path, "r", encoding="utf-8", errors="replace") as fh:
-            all_lines = fh.readlines()
+        relative = os.path.normpath(file.replace("\\", os.sep))
+        if relative in ("", ".", "..") or relative.startswith(".." + os.sep):
+            return None
+        abs_path = os.path.realpath(os.path.join(root, relative))
+        try:
+            if os.path.commonpath((root, abs_path)) != root:
+                return None
+        except ValueError:
+            return None
+        if not os.path.isfile(abs_path):
+            return None
+        # Resolve the target only for the containment check. Graph identities
+        # are keyed by the normalized repository path that was indexed, which
+        # may intentionally be a symlink to another contained source file.
+        safe = relative.replace(os.sep, "/")
         if start is not None and end is not None:
-            chunk = all_lines[max(0, start - 1) : end]  # 1-based inclusive
             first = max(1, start)
+            last = max(first - 1, end)
         else:
-            chunk = all_lines[:400]
             first = 1
+            last = 400
+        chunk = []
+        with open(abs_path, "r", encoding="utf-8", errors="replace") as fh:
+            for line_number, line in enumerate(fh, start=1):
+                if line_number < first:
+                    continue
+                if line_number > last:
+                    break
+                chunk.append(line)
         return {
             "file": safe,
             "start_line": first,

--- a/codenib/wiki/evidence.py
+++ b/codenib/wiki/evidence.py
@@ -29,6 +29,88 @@ _CODE_RE = re.compile(r"`([^`\n]+)`")
 # Publication floor: at least half a page's blocks must carry their source.
 _MIN_CITATION_COVERAGE = 0.5
 _TABLE_DIVIDER_RE = re.compile(r"^\s*\|[\s:|-]+\|\s*$")
+_INTERNAL_WIKI_NAV_ITEM_RE = re.compile(
+    r"^\s*[-*]\s+\[[^\]\n]+\]\(\?p=[^)\s]+\)\s*$",
+)
+
+
+def is_internal_wiki_navigation(block: str) -> bool:
+    """Whether a block is only a list of internal Wiki page links."""
+
+    lines = [line for line in block.splitlines() if line.strip()]
+    return bool(lines) and all(
+        _INTERNAL_WIKI_NAV_ITEM_RE.fullmatch(line) for line in lines
+    )
+
+
+def _corpus_contains_exact(corpus: str, value: str) -> bool:
+    """Match one complete code-like value instead of an arbitrary substring."""
+
+    value = (value or "").strip()
+    if not value:
+        return False
+    return bool(
+        re.search(
+            rf"(?<![\w.]){re.escape(value)}(?![\w.])",
+            corpus,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _corpus_contains_leaf(corpus: str, value: str) -> bool:
+    """Match a complete leaf name, including after attribute punctuation."""
+
+    value = (value or "").strip()
+    if not value:
+        return False
+    return bool(
+        re.search(
+            rf"(?<!\w){re.escape(value)}(?!\w)",
+            corpus,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _owner_and_leaf(value: str) -> tuple[str, str]:
+    """Split the last attribute separator from a qualified identifier."""
+
+    separators = list(re.finditer(r"\.|::", value or ""))
+    if not separators:
+        return "", (value or "").strip()
+    separator = separators[-1]
+    return value[: separator.start()].strip(), value[separator.end() :].strip()
+
+
+def _qualified_identifier_supported(
+    value: str,
+    *,
+    evidence_corpora: Sequence[str],
+    relation_endpoints: Sequence[str],
+) -> bool:
+    """Require a qualified name's owner and leaf to share one source.
+
+    Evidence often stores ``Owner.member`` as separate symbol and source-code
+    fields, so an item may support the two halves without containing the joined
+    display name.  Do not, however, combine an owner from one item with a leaf
+    from another.  Relations are already canonical symbol identities and only
+    support the qualified name when one complete endpoint names it.
+    """
+
+    owner, leaf = _owner_and_leaf(value)
+    if not owner or not leaf:
+        return False
+    if any(_corpus_contains_exact(endpoint, value) for endpoint in relation_endpoints):
+        return True
+    return any(
+        _corpus_contains_exact(corpus, value)
+        or (
+            _corpus_contains_exact(corpus, owner)
+            and _corpus_contains_leaf(corpus, leaf)
+        )
+        for corpus in evidence_corpora
+    )
 
 
 def _block_is_cited(block: str) -> bool:
@@ -741,69 +823,123 @@ def grounding_report(
     unknown_citations = sorted(cited - allowed_ids)
 
     without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    prose_blocks = []
     blocks = []
     for raw in re.split(r"\n\s*\n", without_fences):
         block = raw.strip()
         if not block or block.startswith("#"):
             continue
+        # Related-page links are navigation metadata, not factual prose. Keep
+        # this narrow: any description beside a link, or any ordinary list,
+        # remains part of the grounding denominator.
+        if is_internal_wiki_navigation(block):
+            continue
+        prose_blocks.append(block)
         plain = re.sub(r"^[-*]\s+", "", block, flags=re.MULTILINE)
         if len(re.sub(r"[`*_[\]()#>-]", "", plain).strip()) >= 40:
             blocks.append(block)
     cited_blocks = sum(1 for block in blocks if _block_is_cited(block))
     coverage = cited_blocks / len(blocks) if blocks else 0.0
 
-    corpus = "\n".join(
-        [part for item in evidence for part in (item.file, item.symbol, item.content)]
-        + [
-            part
-            for item in relations
-            for part in (item.source, item.target, *item.anchors)
-        ]
-    ).lower()
+    evidence_corpora = [
+        "\n".join((item.file, item.symbol, item.content)) for item in evidence
+    ]
+    relation_endpoints = [
+        endpoint for item in relations for endpoint in (item.source, item.target)
+    ]
+    support_corpora = [
+        *evidence_corpora,
+        *relation_endpoints,
+        *(anchor for item in relations for anchor in item.anchors),
+    ]
+
+    def any_exact(value: str) -> bool:
+        return any(_corpus_contains_exact(corpus, value) for corpus in support_corpora)
+
+    def any_leaf(value: str) -> bool:
+        return any(_corpus_contains_leaf(corpus, value) for corpus in support_corpora)
+
+    known_files = {item.file.lower().lstrip("./") for item in evidence}
     unsupported_identifiers = []
     for identifier in _CODE_RE.findall(without_fences):
         normalized = identifier.strip()
         source_name = re.sub(r":\d+(?:-\d+)?$", "", normalized)
-        call_name_match = re.match(r"([A-Za-z_][\w.]*)\s*\(", source_name)
+        call_name_match = re.fullmatch(
+            r"([A-Za-z_]\w*(?:(?:\.|::)[A-Za-z_]\w*)*)\s*\([^`\n]*\)",
+            source_name,
+        )
         call_name = call_name_match.group(1) if call_name_match else ""
-        call_leaf = call_name.rsplit(".", 1)[-1]
+        call_owner, call_leaf = _owner_and_leaf(call_name)
+        call_supported = bool(
+            call_name
+            and (
+                (not call_owner and any_leaf(call_leaf))
+                or _qualified_identifier_supported(
+                    call_name,
+                    evidence_corpora=evidence_corpora,
+                    relation_endpoints=relation_endpoints,
+                )
+            )
+        )
         # `path/to/file.rs:Symbol` is a display form; the corpus holds the path
         # and the symbol separately, never joined. Accept it only when both
         # halves are known.
         qualified = ""
         if ":" in source_name and not source_name.endswith(":"):
             head, _, tail = source_name.rpartition(":")
-            if head and tail and head.lower() in corpus and tail.lower() in corpus:
+            tail = re.sub(r"\([^`\n]*\)$", "", tail).strip()
+            matching_evidence = [
+                corpus
+                for item, corpus in zip(evidence, evidence_corpora, strict=True)
+                if item.file.lower().lstrip("./") == head.lower().lstrip("./")
+            ]
+            if tail and any(
+                _corpus_contains_exact(corpus, tail)
+                or (
+                    not _owner_and_leaf(tail)[0] and _corpus_contains_leaf(corpus, tail)
+                )
+                or _qualified_identifier_supported(
+                    tail,
+                    evidence_corpora=[corpus],
+                    relation_endpoints=(),
+                )
+                for corpus in matching_evidence
+            ):
                 qualified = source_name
         # Attribute access, e.g. `PreparedRequest.url`. Calls already resolve by
-        # leaf name; do the same for attributes, but require the owner too.
+        # their complete owner; do the same for attributes.
         attribute = ""
-        if not call_name and "." in source_name:
-            owner, _, leaf = source_name.rpartition(".")
-            if owner and leaf and owner.lower() in corpus and leaf.lower() in corpus:
+        if not call_name and re.search(r"\.|::", source_name):
+            if _qualified_identifier_supported(
+                source_name,
+                evidence_corpora=evidence_corpora,
+                relation_endpoints=relation_endpoints,
+            ):
                 attribute = source_name
+        bare_member = bool(
+            re.fullmatch(r"[A-Za-z_]\w*", source_name) and any_leaf(source_name)
+        )
         if (
             not normalized
             or normalized.lower() in _COMMON_CODE_TERMS
             # A URI scheme (`mailto:`, `https:`) is not a code identifier.
             or re.fullmatch(r"[A-Za-z][A-Za-z0-9+.\-]*:", normalized)
-            or normalized.lower() in corpus
-            or source_name.lower() in corpus
+            or any_exact(normalized)
+            or any_exact(source_name)
+            or bare_member
             or qualified
             or attribute
-            or (call_name and call_name.lower() in corpus)
-            or (call_leaf and call_leaf.lower() in corpus)
+            or call_supported
         ):
             continue
         unsupported_identifiers.append(normalized)
 
-    known_files = {item.file.lower() for item in evidence}
     unknown_files = sorted(
         {
             path
             for path in _PATH_RE.findall(without_fences)
             if path.lower().lstrip("./") not in known_files
-            and path.lower() not in corpus
+            and not any_exact(path)
             and not any(file.endswith("/" + path.lower()) for file in known_files)
         }
     )
@@ -811,7 +947,7 @@ def grounding_report(
     # Marketing words the page wrote itself are a defect; the same words inside
     # a block it is quoting from cited source are not.
     authored = "\n\n".join(
-        block for block in blocks if not _quotes_cited_evidence(block, evidence)
+        block for block in prose_blocks if not _quotes_cited_evidence(block, evidence)
     )
     promotional = promotional_phrases(authored)
     valid = (

--- a/codenib/wiki/quality.py
+++ b/codenib/wiki/quality.py
@@ -16,6 +16,7 @@ from .evidence import (
     evidence_matches_claim,
     infer_claim_role,
     is_interaction_claim,
+    is_internal_wiki_navigation,
     promotional_phrases,
     relation_endpoints_named,
     relation_matches_claim,
@@ -44,10 +45,46 @@ _REFERENCE_NARRATION = re.compile(
     r"cs|kt|kts|swift|scala):\d+(?:-\d+)?`",
     re.IGNORECASE,
 )
+_FRAMING_SECTION_TITLES = frozenset({"purpose and scope", "at a glance"})
+
+
+def _without_internal_wiki_navigation(markdown: str) -> str:
+    """Remove navigation-only blocks before measuring explanatory prose."""
+
+    blocks = re.split(r"\n\s*\n", markdown)
+
+    def is_section_heading(block: str) -> bool:
+        return bool(re.fullmatch(r"\s*#{2,6}\s+.+?\s*", block))
+
+    explanatory_blocks: list[str] = []
+    for index, block in enumerate(blocks):
+        if is_internal_wiki_navigation(block.strip()):
+            continue
+        if is_section_heading(block):
+            section_body: list[str] = []
+            for candidate in blocks[index + 1 :]:
+                if is_section_heading(candidate):
+                    break
+                if candidate.strip():
+                    section_body.append(candidate)
+            # A heading whose entire body is internal navigation is chrome too.
+            # Inspect the full section so a navigation list before real prose
+            # cannot accidentally erase that prose's heading.
+            if section_body and all(
+                is_internal_wiki_navigation(candidate.strip())
+                for candidate in section_body
+            ):
+                continue
+        explanatory_blocks.append(block)
+    return "\n\n".join(explanatory_blocks)
 
 
 def _prose_sentences(markdown: str) -> list[str]:
-    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    without_fences = re.sub(
+        r"```[\s\S]*?```",
+        "",
+        _without_internal_wiki_navigation(markdown),
+    )
     without_headings = re.sub(
         r"^#{1,6}\s+.*$",
         "",
@@ -131,7 +168,11 @@ def leading_code_subject(text: str) -> str:
 def duplicate_prose_blocks(markdown: str) -> List[List[int]]:
     """Find paragraph pairs where one largely restates the other."""
 
-    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    without_fences = re.sub(
+        r"```[\s\S]*?```",
+        "",
+        _without_internal_wiki_navigation(markdown),
+    )
     terms = []
     subjects = []
     for raw in re.split(r"\n\s*\n", without_fences):
@@ -186,7 +227,11 @@ def section_evidence_report(markdown: str) -> dict[str, Any]:
             sections_without_new_evidence.append(title)
         if intro_evidence and evidence and evidence.issubset(intro_evidence):
             intro_only_sections.append(title)
-        seen.update(evidence)
+        # These overview panels frame the page for scanning. Their citations
+        # still belong in the report, but they must not make a later detail
+        # section look source-stale merely because it expands the same facts.
+        if title.casefold() not in _FRAMING_SECTION_TITLES:
+            seen.update(evidence)
 
     return {
         "intro_evidence": sorted(intro_evidence),
@@ -200,7 +245,11 @@ def section_evidence_report(markdown: str) -> dict[str, Any]:
 def section_narrative_report(markdown: str) -> dict[str, Any]:
     """Find sections that substantially restate the intro or an earlier section."""
 
-    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    without_fences = re.sub(
+        r"```[\s\S]*?```",
+        "",
+        _without_internal_wiki_navigation(markdown),
+    )
     section_matches = list(
         re.finditer(r"^##\s+(.+?)\s*$", without_fences, flags=re.MULTILINE)
     )
@@ -267,7 +316,11 @@ def narrative_density_report(markdown: str) -> dict[str, Any]:
 def section_synthesis_report(markdown: str) -> dict[str, Any]:
     """Find pages dominated by sections that only inventory local operations."""
 
-    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    without_fences = re.sub(
+        r"```[\s\S]*?```",
+        "",
+        _without_internal_wiki_navigation(markdown),
+    )
     section_matches = list(
         re.finditer(r"^##\s+(.+?)\s*$", without_fences, flags=re.MULTILINE)
     )
@@ -567,7 +620,11 @@ def page_quality_report(
 ) -> dict[str, Any]:
     """Measure whether a page represents its supported fact plan."""
 
-    without_fences = re.sub(r"```[\s\S]*?```", "", markdown)
+    without_fences = re.sub(
+        r"```[\s\S]*?```",
+        "",
+        _without_internal_wiki_navigation(markdown),
+    )
     rendered_sections = len(
         re.findall(r"^#{2,6}\s+\S", without_fences, flags=re.MULTILINE)
     )

--- a/test/web/test_repo_registry.py
+++ b/test/web/test_repo_registry.py
@@ -125,9 +125,10 @@ def test_repo_views_reject_bm25_that_no_longer_matches_manifest(tmp_path):
     manifest = RepoManifest(indexes={"bm25": entry})
     documents.write_text(documents.read_text().replace("alpha", "omega"))
     bundle = SimpleNamespace(manifest=manifest, bm25=None, vector_store=None)
+    registry = SimpleNamespace(_config=SimpleNamespace(index_types=lambda: ("bm25",)))
 
     with pytest.raises(ValueError, match="manifest fingerprints"):
-        RepoRegistry._load_repo_views(object(), bundle)
+        RepoRegistry._load_repo_views(registry, bundle)
 
     assert bundle.bm25 is None
 
@@ -212,6 +213,35 @@ def test_bundle_accepts_legacy_graph_beside_current_vector_view(tmp_path):
 def test_config_index_types_for_mode():
     assert QAConfig(mode="sparse").index_types() == ["bm25"]
     assert QAConfig(mode="hybrid").index_types() == ["bm25", "vector"]
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_vector_loads"),
+    [("sparse", 0), ("hybrid", 1)],
+)
+def test_repo_views_respect_configured_index_mode(
+    monkeypatch,
+    mode,
+    expected_vector_loads,
+):
+    vector_entry = SimpleNamespace(path="/tmp/vector")
+    manifest = SimpleNamespace(
+        indexes={"vector": vector_entry},
+        index_is_current=lambda index_type: index_type == "vector",
+    )
+    bundle = SimpleNamespace(manifest=manifest)
+    registry = RepoRegistry(QAConfig(mode=mode))
+    loaded = []
+    monkeypatch.setattr(
+        registry,
+        "_load_vector_store",
+        lambda entry: loaded.append(entry) or "vector-store",
+    )
+
+    registry._load_repo_views(bundle)
+
+    assert loaded == [vector_entry] * expected_vector_loads
+    assert bundle.vector_store == ("vector-store" if expected_vector_loads else None)
 
 
 def test_config_paths(tmp_path):
@@ -434,7 +464,7 @@ def test_vector_store_restores_manifest_embedding_identity(monkeypatch):
     assert created[0].kwargs["revision"] == "immutable-model-revision"
 
 
-def test_vector_store_supports_legacy_prebuilt_provider_fallback(monkeypatch):
+def test_vector_store_supports_legacy_prebuilt_route_fallback(monkeypatch):
     created = []
 
     class FakeVectorStore:
@@ -450,12 +480,16 @@ def test_vector_store_supports_legacy_prebuilt_provider_fallback(monkeypatch):
         "codenib.web.repo_registry._vector_store_type",
         lambda: FakeVectorStore,
     )
-    registry = RepoRegistry(QAConfig(embedding_provider="huggingface"))
+    registry = RepoRegistry(
+        QAConfig(
+            embedding_provider="huggingface",
+            embedding_dimension=768,
+        )
+    )
     entry = SimpleNamespace(
         path="/tmp/legacy-prebuilt",
         config={
             "embedding_model": "nomic-ai/CodeRankEmbed",
-            "embedding_dimension": 768,
         },
     )
 
@@ -464,6 +498,64 @@ def test_vector_store_supports_legacy_prebuilt_provider_fallback(monkeypatch):
     assert created[0].kwargs["embedding_provider"] == "huggingface"
     assert created[0].kwargs["embedding_model"] == "nomic-ai/CodeRankEmbed"
     assert created[0].kwargs["dimension"] == 768
+
+
+def test_vector_store_fills_legacy_dimension_with_persisted_provider(monkeypatch):
+    created = []
+
+    class FakeVectorStore:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.embedding = object()
+            created.append(self)
+
+        def load(self, _path):
+            pass
+
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: FakeVectorStore,
+    )
+    registry = RepoRegistry(
+        QAConfig(
+            embedding_provider="huggingface",
+            embedding_dimension=768,
+        )
+    )
+    entry = SimpleNamespace(
+        path="/tmp/legacy-prebuilt",
+        config={
+            "embedding_model": "nomic-ai/CodeRankEmbed",
+            "embedding_provider": "huggingface",
+        },
+    )
+
+    registry._load_vector_store(entry)
+
+    assert created[0].kwargs["dimension"] == 768
+
+
+def test_vector_store_rejects_invalid_persisted_legacy_dimension(monkeypatch):
+    monkeypatch.setattr(
+        "codenib.web.repo_registry._vector_store_type",
+        lambda: pytest.fail("invalid route must fail before loading the store"),
+    )
+    registry = RepoRegistry(
+        QAConfig(
+            embedding_provider="huggingface",
+            embedding_dimension=768,
+        )
+    )
+    entry = SimpleNamespace(
+        path="/tmp/legacy-prebuilt",
+        config={
+            "embedding_model": "nomic-ai/CodeRankEmbed",
+            "embedding_dimension": 0,
+        },
+    )
+
+    with pytest.raises(ValueError, match="dimension must be a positive integer"):
+        registry._load_vector_store(entry)
 
 
 def test_vector_store_cache_separates_model_revisions(monkeypatch):

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -14,7 +14,10 @@ from codenib.artifacts.security import assert_publishable_tree
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
 from codenib.web.static_export import (
+    _GRAPH_SOURCE_MAX_ANCHORS,
+    _GRAPH_SOURCE_PAGE_MAX_BYTES,
     STATIC_EXPORT_MANIFEST,
+    _embed_page_graph_sources,
     _load_static_bundle,
     export_static_wiki,
     normalize_base_path,
@@ -60,12 +63,16 @@ class _Builder:
         return self.pages.get(page_id)
 
     def source(self, file, start, end):
-        assert (file, start, end) == ("src/runtime.py", 1, 2)
+        assert file == "src/runtime.py"
+        lines = ["def run():\n", "    return 'ready'\n"]
+        first = max(1, start or 1)
+        last = max(first, end or len(lines))
+        content = "".join(lines[first - 1 : last])
         return {
             "file": file,
-            "start_line": start,
-            "end_line": end,
-            "content": "def run():\n    return 'ready'\n",
+            "start_line": first,
+            "end_line": first + len(content.splitlines()) - 1,
+            "content": content,
         }
 
 
@@ -317,8 +324,42 @@ def test_static_export_advertises_only_precomputed_page_graphs(
         "codenib.web.static_export._page_graph",
         lambda _bundle, _page: {
             "available": True,
-            "nodes": [{"id": "run"}],
-            "edges": [],
+            "nodes": [
+                {
+                    "id": "run",
+                    "file": "src/runtime.py",
+                    "line": 1,
+                    "end_line": 2,
+                }
+            ],
+            "hierarchy": {
+                "root": "root",
+                "nodes": [
+                    {
+                        "id": "symbol-run",
+                        "kind": "symbol",
+                        "node_id": "run",
+                        "file": "src/runtime.py",
+                        "line": 1,
+                        "end_line": 2,
+                    },
+                    {
+                        "id": "symbol-scope",
+                        "kind": "symbol",
+                        "node_id": "src/runtime.py:Runtime",
+                        "file": "src/runtime.py",
+                        "line": 1,
+                        "end_line": 2,
+                    },
+                ],
+            },
+            "edges": [
+                {
+                    "source": "run",
+                    "target": "run",
+                    "anchors": [{"file": "src/runtime.py", "line": 2}],
+                }
+            ],
             "mermaid": "",
         },
     )
@@ -344,6 +385,215 @@ def test_static_export_advertises_only_precomputed_page_graphs(
         ).read_text()
     )
     assert graph["available"] is True
+    assert graph["nodes"][0]["source"]["content"].startswith("def run")
+    assert "source" not in graph["hierarchy"]["nodes"][0]
+    assert graph["hierarchy"]["nodes"][1]["source"]["content"].startswith("def run")
+    assert graph["edges"][0]["anchors"][0]["source"]["content"].endswith(
+        "return 'ready'\n"
+    )
+
+
+def test_page_graph_source_previews_are_bounded_cached_and_path_safe() -> None:
+    class SourceBuilder:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def source(self, file, start, end):
+            self.calls.append((file, start, end))
+            return {
+                "file": file,
+                "start_line": start,
+                "end_line": end,
+                "content": "".join(
+                    f"line {line} {'x' * 2_000}\n" for line in range(start, end + 1)
+                ),
+            }
+
+    builder = SourceBuilder()
+    graph = {
+        "available": True,
+        "nodes": [
+            {
+                "id": "wide",
+                "file": "src/runtime.py",
+                "line": 10,
+                "end_line": 10_000,
+            },
+            {
+                "id": "unsafe",
+                "file": "../secret.py",
+                "line": 1,
+                "end_line": 2,
+            },
+        ],
+        "hierarchy": {
+            "nodes": [
+                {
+                    "id": "mapped",
+                    "kind": "symbol",
+                    "node_id": "wide",
+                    "file": "src/runtime.py",
+                    "line": 10,
+                    "end_line": 10_000,
+                },
+                {
+                    "id": "scope",
+                    "kind": "symbol",
+                    "node_id": "canonical-scope",
+                    "file": "src/runtime.py",
+                    "line": 30,
+                    "end_line": 35,
+                },
+            ]
+        },
+        "edges": [
+            {
+                "anchors": [
+                    {"file": "src/runtime.py", "line": 30},
+                    {"file": "src/runtime.py", "line": 30},
+                    {"file": "/tmp/secret.py", "line": 1},
+                    *[
+                        {"file": "src/runtime.py", "line": 100 + index * 20}
+                        for index in range(100)
+                    ],
+                ]
+            }
+        ],
+    }
+
+    enriched = _embed_page_graph_sources(builder, graph)
+
+    wide = enriched["nodes"][0]["source"]
+    assert len(wide["content"].encode("utf-8")) <= 64 * 1024
+    assert len(wide["content"].splitlines()) <= 160
+    assert builder.calls[0] == ("src/runtime.py", 7, 166)
+    assert enriched["nodes"][1]["source"] is None
+    hierarchy = enriched["hierarchy"]["nodes"]
+    assert "source" not in hierarchy[0]
+    assert "source" in hierarchy[1]
+    anchors = enriched["edges"][0]["anchors"]
+    assert anchors[0]["source"] == anchors[1]["source"]
+    assert anchors[2]["source"] is None
+    assert builder.calls.count(("src/runtime.py", 24, 36)) == 1
+    attached_anchors = [
+        anchor for anchor in anchors if anchor.get("source") is not None
+    ]
+    assert len(attached_anchors) < 50  # the per-page byte budget stops first
+    assert any(
+        anchor.get("source") is None
+        for anchor in anchors
+        if anchor.get("file") == "src/runtime.py"
+    )
+    assert len(builder.calls) <= _GRAPH_SOURCE_MAX_ANCHORS + 2
+    attached_sources = [
+        value["source"]
+        for value in [*enriched["nodes"], *hierarchy, *anchors]
+        if value.get("source") is not None
+    ]
+    assert (
+        sum(len(json.dumps(source).encode("utf-8")) for source in attached_sources)
+        <= _GRAPH_SOURCE_PAGE_MAX_BYTES
+    )
+
+
+def test_page_graph_source_preview_rejects_mismatched_returned_range() -> None:
+    class MismatchedBuilder:
+        def source(self, file, start, end):
+            return {
+                "file": file,
+                "start_line": start + 1,
+                "end_line": end + 1,
+                "content": "wrong range\n",
+            }
+
+    graph = {
+        "nodes": [
+            {
+                "id": "run",
+                "file": "src/runtime.py",
+                "line": 10,
+                "end_line": 12,
+            }
+        ],
+        "hierarchy": {"nodes": []},
+        "edges": [],
+    }
+
+    _embed_page_graph_sources(MismatchedBuilder(), graph)
+
+    assert graph["nodes"][0]["source"] is None
+
+
+def test_invalid_anchors_do_not_exhaust_source_preview_quota() -> None:
+    class SourceBuilder:
+        def source(self, file, start, end):
+            return {
+                "file": file,
+                "start_line": start,
+                "end_line": end,
+                "content": "source\n",
+            }
+
+    graph = {
+        "nodes": [],
+        "hierarchy": {"nodes": []},
+        "edges": [
+            {
+                "anchors": [
+                    *[
+                        {"file": "../outside.py", "line": index + 1}
+                        for index in range(_GRAPH_SOURCE_MAX_ANCHORS)
+                    ],
+                    {"file": "src/runtime.py", "line": 10},
+                ]
+            }
+        ],
+    }
+
+    _embed_page_graph_sources(SourceBuilder(), graph)
+
+    assert all(anchor["source"] is None for anchor in graph["edges"][0]["anchors"][:-1])
+    assert "source" in graph["edges"][0]["anchors"][-1]
+
+
+def test_page_graph_source_preview_keeps_the_highlighted_line_when_trimmed() -> None:
+    class SourceBuilder:
+        def source(self, file, start, end):
+            lines = []
+            for line in range(start, end + 1):
+                if line == 8:
+                    lines.append("generated = '" + ("x" * (70 * 1024)) + "'\n")
+                elif line == 10:
+                    lines.append("TARGET = build_runtime()\n")
+                else:
+                    lines.append(f"line_{line} = {line}\n")
+            return {
+                "file": file,
+                "start_line": start,
+                "end_line": end,
+                "content": "".join(lines),
+            }
+
+    graph = {
+        "nodes": [
+            {
+                "id": "runtime",
+                "file": "src/runtime.py",
+                "line": 10,
+                "end_line": 12,
+            }
+        ],
+        "hierarchy": {"nodes": []},
+        "edges": [],
+    }
+
+    _embed_page_graph_sources(SourceBuilder(), graph)
+
+    source = graph["nodes"][0]["source"]
+    assert source is not None
+    assert source["start_line"] <= 10 <= source["end_line"]
+    assert "TARGET = build_runtime()" in source["content"]
+    assert len(source["content"].encode("utf-8")) <= 64 * 1024
 
 
 def test_static_export_does_not_replace_an_unrelated_directory(export_setup) -> None:

--- a/test/wiki/test_agent_wiki.py
+++ b/test/wiki/test_agent_wiki.py
@@ -32,6 +32,7 @@ from codenib.wiki.agent_wiki import (
 )
 from codenib.wiki.builder import Symbol
 from codenib.wiki.evidence import EvidenceItem, RelationItem, candidate_key
+from codenib.wiki.quality import prose_integrity_report
 
 
 class _FakeVectorStore:
@@ -774,6 +775,223 @@ def test_fact_plan_renderer_drops_unsupported_claims():
     assert "## Indexing" in markdown
     assert "## Invented" not in markdown
     assert "`MagicIndex`" not in markdown
+
+
+def test_fact_plan_renderer_admits_only_source_backed_framing():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/models.py",
+            start_line=1,
+            end_line=8,
+            symbol="PreparedRequest.prepare_url",
+            kind="method",
+            content=(
+                "class PreparedRequest:\n"
+                "    def prepare_url(self, url):\n"
+                "        # Normalize HTTP request URLs before parsing.\n"
+                "        self.url = url\n"
+                "        return self.url"
+            ),
+        ),
+        EvidenceItem(
+            id="E2",
+            file="src/sessions.py",
+            start_line=1,
+            end_line=6,
+            symbol="Session.merge_environment_settings",
+            kind="method",
+            content=(
+                "def merge_environment_settings(self, proxies):\n"
+                "    # Merge environment settings with proxy defaults.\n"
+                "    return merge_setting(proxies, self.proxies)"
+            ),
+        ),
+        EvidenceItem(
+            id="E3",
+            file="src/adapters.py",
+            start_line=1,
+            end_line=6,
+            symbol="HTTPAdapter.send",
+            kind="method",
+            content=(
+                "class HTTPAdapter:\n"
+                "    def send(self, prepared_request):\n"
+                "        # Send the prepared request through the adapter.\n"
+                "        return prepared_request"
+            ),
+        ),
+    ]
+    plan = {
+        "purpose": {
+            "statements": [
+                "`PreparedRequest.prepare_url()` normalizes HTTP request URLs",
+                "The user-friendly `RequestEncodingMixin` handles every body",
+            ],
+            "evidence": ["E1"],
+        },
+        "map": [
+            {
+                "concern": "HTTP request URL normalization",
+                "entity": "`PreparedRequest.prepare_url()`",
+                "evidence": ["E1"],
+            },
+            {
+                "concern": "Environment settings and proxy defaults",
+                "entity": "`Session.merge_environment_settings()`",
+                "evidence": ["E2"],
+            },
+            {
+                "concern": "Prepared request adapter sending",
+                "entity": "`HTTPAdapter.send()`",
+                "evidence": ["E3"],
+            },
+            {
+                "concern": "Universal request routing",
+                "entity": "`MagicGateway.route()`",
+                "evidence": ["E1"],
+            },
+        ],
+        "sections": [
+            {
+                "title": "URL preparation",
+                "lead": {
+                    "statements": [
+                        "The prepared request stores its normalized URL",
+                        "The `Authorization` helper retries every request",
+                    ],
+                    "evidence": ["E1"],
+                },
+                "claims": [
+                    {
+                        "role": "responsibility",
+                        "statement": (
+                            "`PreparedRequest.prepare_url()` normalizes HTTP "
+                            "request URLs before parsing"
+                        ),
+                        "evidence": ["E1"],
+                    }
+                ],
+            }
+        ],
+    }
+
+    rendered = _renderable_plan(plan, evidence, [])
+    markdown = _fact_plan_markdown(rendered, evidence, [])
+
+    assert rendered["purpose"]["statements"] == [
+        "`PreparedRequest.prepare_url()` normalizes HTTP request URLs"
+    ]
+    assert len(rendered["map"]) == 3
+    assert rendered["sections"][0]["lead"]["statements"] == [
+        "The prepared request stores its normalized URL"
+    ]
+    assert "RequestEncodingMixin" not in markdown
+    assert "MagicGateway" not in markdown
+    assert "Authorization" not in markdown
+    assert "user-friendly" not in markdown
+
+
+def test_fact_plan_excerpt_caption_is_neutral_source_metadata():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/codec.py",
+            start_line=1,
+            end_line=8,
+            symbol="encode_payload",
+            kind="function",
+            content=(
+                "def encode_payload(value):\n"
+                "    payload = value.encode('utf-8')\n"
+                "    return payload"
+            ),
+        )
+    ]
+    markdown = _fact_plan_markdown(
+        {
+            "sections": [
+                {
+                    "title": "Payload encoding",
+                    "excerpt": {
+                        "evidence": "E1",
+                        "why": "The function shows how values become bytes",
+                    },
+                    "claims": [
+                        {
+                            "role": "contract",
+                            "statement": (
+                                "`encode_payload()` encodes a value as UTF-8 bytes"
+                            ),
+                            "evidence": ["E1"],
+                        }
+                    ],
+                }
+            ]
+        },
+        evidence,
+        [],
+    )
+
+    integrity = prose_integrity_report(markdown)
+
+    assert "Source excerpt. [E1]" in markdown
+    assert "`src/codec.py:1-8`" not in markdown
+    assert "shows how values become bytes" not in markdown
+    assert integrity["reference_narration_sentences"] == []
+    assert integrity["prose_integrity_valid"] is True
+
+
+def test_fact_plan_renderer_drops_a_lead_that_repeats_its_claim():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="src/sessions.py",
+            start_line=1,
+            end_line=8,
+            symbol="Session.merge_environment_settings",
+            kind="method",
+            content=(
+                "def merge_environment_settings(self, proxies, verify):\n"
+                "    # Collect environment settings and combine session defaults.\n"
+                "    proxies = merge_setting(proxies, self.proxies)\n"
+                "    verify = merge_setting(verify, self.verify)\n"
+                "    return proxies, verify"
+            ),
+        )
+    ]
+    markdown = _fact_plan_markdown(
+        {
+            "sections": [
+                {
+                    "title": "Environment settings",
+                    "lead": {
+                        "statements": [
+                            "`Session.merge_environment_settings()` collects "
+                            "environment settings and combines session defaults"
+                        ],
+                        "evidence": ["E1"],
+                    },
+                    "claims": [
+                        {
+                            "role": "responsibility",
+                            "statement": (
+                                "`Session.merge_environment_settings()` calls "
+                                "`merge_setting()` to combine environment "
+                                "settings with session defaults"
+                            ),
+                            "evidence": ["E1"],
+                        }
+                    ],
+                }
+            ]
+        },
+        evidence,
+        [],
+    )
+
+    assert markdown.count("combines session defaults") == 0
+    assert markdown.count("combine environment settings with session defaults") == 1
 
 
 def test_fact_plan_rejects_behavior_not_supported_by_the_cited_body():
@@ -4008,6 +4226,109 @@ def test_readme_evidence_drops_chrome_and_keeps_complete_paragraphs():
     assert prepared.endswith((".", "!", "?"))
 
 
+def test_evidence_items_prefer_the_current_source_span(tmp_path):
+    source = tmp_path / "src" / "core.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "class Router:\n"
+        "    def dispatch(self, headers):\n"
+        "        return headers['Authorization']\n",
+        encoding="utf-8",
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        )
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    evidence = wiki._evidence_items(
+        [
+            {
+                "file": "src/core.py",
+                "node_name": "Router.dispatch",
+                "type": "method",
+                "start_line": 0,
+                "end_line": 2,
+                "content": "class Router:\n    pass  # stale index excerpt",
+            }
+        ]
+    )
+
+    assert len(evidence) == 1
+    assert "Authorization" in evidence[0].content
+    assert "stale index excerpt" not in evidence[0].content
+
+
+def test_evidence_items_keep_indexed_content_for_an_incomplete_span(tmp_path):
+    source = tmp_path / "src" / "legacy.py"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "def live_implementation():\n"
+        "    return 'only the first source line would have been read'\n",
+        encoding="utf-8",
+    )
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        )
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    evidence = wiki._evidence_items(
+        [
+            {
+                "file": "src/legacy.py",
+                "node_name": "legacy",
+                "type": "function",
+                "start_line": 0,
+                "content": (
+                    "def legacy():\n"
+                    "    indexed_body_is_complete()\n"
+                    "    return 'ready'"
+                ),
+            }
+        ]
+    )
+
+    assert len(evidence) == 1
+    assert evidence[0].start_line == 1
+    assert evidence[0].end_line == 1
+    assert "indexed_body_is_complete" in evidence[0].content
+    assert "live_implementation" not in evidence[0].content
+
+
+def test_wiki_context_exposes_page_identity_without_generated_summaries(tmp_path):
+    wiki = AgentWiki(
+        SimpleNamespace(
+            entry=SimpleNamespace(repo_dir=str(tmp_path), language="python")
+        ),
+        model="fake-model",
+    )
+    wiki._outline = {
+        "pages": [
+            {
+                "id": "routing",
+                "title": "Request Routing",
+                "summary": "The invented MagicGateway controls every request",
+            }
+        ]
+    }
+
+    context = wiki._wiki_context("overview")
+
+    assert context == "- [routing] Request Routing"
+    assert "MagicGateway" not in context
+
+
 class _FakeBM25:
     def __init__(self, nodes):
         self.nodes = nodes
@@ -4465,6 +4786,145 @@ def test_parent_without_core_files_selects_two_anchors_per_child(tmp_path):
         "RerankAgent",
         "RerankAgent.__init__",
     ]
+
+
+def test_parent_anchor_quota_counts_unique_spans_across_routes(tmp_path):
+    dense_nodes = [
+        {
+            "file": "src/models.py",
+            "node_name": "PreparedRequest.prepare_url",
+            "type": "method",
+            "start_line": 10,
+            "end_line": 30,
+            "content": "def prepare_url(self): pass",
+        },
+        {
+            "file": "src/models.py",
+            "node_name": "PreparedRequest.prepare_body",
+            "type": "method",
+            "start_line": 32,
+            "end_line": 52,
+            "content": "def prepare_body(self): pass",
+        },
+        {
+            "file": "src/sessions.py",
+            "node_name": "Session.prepare_request",
+            "type": "method",
+            "start_line": 60,
+            "end_line": 80,
+            "content": "def prepare_request(self): pass",
+        },
+        {
+            "file": "src/sessions.py",
+            "node_name": "Session.merge_environment_settings",
+            "type": "method",
+            "start_line": 82,
+            "end_line": 102,
+            "content": "def merge_environment_settings(self): pass",
+        },
+    ]
+    sparse_aliases = [
+        {
+            **dense_nodes[0],
+            "node_name": "src/models.py:PreparedRequest.prepare_url()",
+        },
+        {
+            **dense_nodes[2],
+            "node_name": "src/sessions.py:Session.prepare_request()",
+        },
+    ]
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir=str(tmp_path), language="python"),
+        vector_store=_FakeVectorStore(dense_nodes),
+        bm25=_FakeBM25(sparse_aliases),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    result = wiki._retrieve(
+        {
+            "id": "request-preparation",
+            "title": "Request Preparation",
+            "summary": "Preparing URL, body, and session settings",
+            "keywords": ["prepare", "request", "settings"],
+            "files": ["src/models.py", "src/sessions.py"],
+            "children": [
+                {
+                    "id": "url-preparation",
+                    "title": "URL Preparation",
+                    "files": ["src/models.py"],
+                },
+                {
+                    "id": "session-settings",
+                    "title": "Session Settings",
+                    "files": ["src/sessions.py"],
+                },
+            ],
+        },
+        top_k=8,
+    )
+
+    assert {
+        (node["file"], node["start_line"], node["end_line"]) for node in result
+    } == {
+        ("src/models.py", 10, 30),
+        ("src/models.py", 32, 52),
+        ("src/sessions.py", 60, 80),
+        ("src/sessions.py", 82, 102),
+    }
+
+
+def test_parent_anchor_quota_keeps_distinct_symbols_without_spans(tmp_path):
+    dense_nodes = [
+        {
+            "file": "src/models.py",
+            "node_name": symbol,
+            "type": "method",
+            "start_line": 0,
+            "end_line": 0,
+            "content": content,
+        }
+        for symbol, content in (
+            ("PreparedRequest.prepare_url", "def prepare_url(self): pass"),
+            ("PreparedRequest.prepare_body", "def prepare_body(self): pass"),
+            ("PreparedRequest.prepare_headers", "def prepare_headers(self): pass"),
+        )
+    ]
+    sparse_alias = {
+        **dense_nodes[0],
+        "node_name": "src/models.py:PreparedRequest.prepare_url()",
+    }
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(repo_dir=str(tmp_path), language="python"),
+        vector_store=_FakeVectorStore(dense_nodes),
+        bm25=_FakeBM25([sparse_alias]),
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+    )
+    wiki = AgentWiki(bundle, model="fake-model")
+
+    result = wiki._retrieve(
+        {
+            "id": "request-preparation",
+            "title": "Request Preparation",
+            "summary": "Preparing URL, body, and headers",
+            "keywords": ["prepare", "request"],
+            "files": ["src/models.py"],
+            "children": [
+                {
+                    "id": "prepared-request-fields",
+                    "title": "Prepared Request Fields",
+                    "files": ["src/models.py"],
+                }
+            ],
+        },
+        top_k=8,
+    )
+
+    assert {node["node_name"] for node in result} == {
+        "PreparedRequest.prepare_url",
+        "PreparedRequest.prepare_body",
+        "PreparedRequest.prepare_headers",
+    }
 
 
 def test_parent_with_one_shared_file_keeps_multiple_broad_symbols(tmp_path):
@@ -5354,6 +5814,86 @@ def test_generation_separates_soft_composition_and_semantic_diagnostics(tmp_path
     assert guarded["generation"]["plan_warnings"] == [semantic_warning]
 
 
+def test_generation_mode_requires_the_strict_page_quality_gate(tmp_path, monkeypatch):
+    import codenib.wiki.agent_wiki as agent_wiki_module
+
+    node = {
+        "file": "src/core.py",
+        "node_name": "Router",
+        "type": "class",
+        "start_line": 0,
+        "end_line": 5,
+        "content": (
+            "class Router:\n"
+            "    def handle(self, repository_request):\n"
+            "        return repository_request"
+        ),
+    }
+    bundle = SimpleNamespace(
+        entry=SimpleNamespace(
+            repo="owner/repo",
+            repo_dir=str(tmp_path),
+            instance_id="owner__repo-1",
+            commit_short="abc123",
+            language="python",
+        ),
+        vector_store=_FakeVectorStore([node]),
+        bm25=None,
+        manifest=SimpleNamespace(languages=["python"], indexes={}),
+        code_graph=lambda: None,
+    )
+    wiki = AgentWiki(bundle, model="fake-model", llm=SimpleNamespace())
+    wiki._fact_plan = lambda *_args: (
+        {
+            "thesis": {
+                "statement": "The `Router` handles repository requests",
+                "evidence": ["E1"],
+            },
+            "sections": [
+                {
+                    "title": "Request handling",
+                    "claims": [
+                        {
+                            "role": "contract",
+                            "statement": (
+                                "`Router.handle()` returns the repository request"
+                            ),
+                            "evidence": ["E1"],
+                        }
+                    ],
+                }
+            ],
+        },
+        [],
+    )
+    real_report = agent_wiki_module._page_quality_report
+
+    def force_quality_failure(*args, **kwargs):
+        report = real_report(*args, **kwargs)
+        return {**report, "valid": False}
+
+    monkeypatch.setattr(
+        agent_wiki_module,
+        "_page_quality_report",
+        force_quality_failure,
+    )
+
+    page = wiki._generate_page(
+        {
+            "id": "routing",
+            "title": "Request Routing",
+            "summary": "Repository request handling",
+            "keywords": ["router", "request"],
+            "files": ["src/core.py"],
+        }
+    )
+
+    assert page["grounding"]["valid"] is True
+    assert page["quality"]["valid"] is False
+    assert page["generation"]["mode"] == "degraded"
+    assert page["generation"]["reason"] == "quality_guard"
+
+
 def test_page_reports_model_unavailable_when_fact_planning_falls_back(tmp_path):
     class LLM:
         cache_identity = "fake"
@@ -5564,7 +6104,7 @@ def test_flow_keeps_only_its_connected_path():
             file="a.py",
             start_line=1,
             end_line=3,
-            symbol="Session.send",
+            symbol="Session.dispatch",
             kind="method",
             content="def send(self):\n    prepare()",
         ),
@@ -5617,6 +6157,117 @@ def test_flow_keeps_only_its_connected_path():
     steps = _renderable_plan(plan, evidence, [])["flow"]["steps"]
     assert len(steps) == 2
     assert all("unrelated" not in str(s) for s in steps)
+
+
+def test_fact_plan_flow_fallback_caption_is_auditable_and_not_thin():
+    evidence = [
+        EvidenceItem(
+            id="E1",
+            file="a.py",
+            start_line=1,
+            end_line=6,
+            symbol="Session.send",
+            kind="method",
+            content="def dispatch(self):\n    return adapter.send()",
+        ),
+        EvidenceItem(
+            id="E2",
+            file="b.py",
+            start_line=1,
+            end_line=6,
+            symbol="Adapter.send",
+            kind="method",
+            content="def send(self):\n    return response.build()",
+        ),
+        EvidenceItem(
+            id="E3",
+            file="c.py",
+            start_line=1,
+            end_line=6,
+            symbol="Response.build",
+            kind="method",
+            content="def build(self):\n    return Response()",
+        ),
+    ]
+    relations = [
+        RelationItem(
+            id="R1",
+            source="a.py:Session.dispatch()",
+            target="b.py:Adapter.send()",
+            anchors=("a.py:2",),
+        ),
+        RelationItem(
+            id="R2",
+            source="b.py:Adapter.send()",
+            target="c.py:Response.build()",
+            anchors=("b.py:2",),
+        ),
+    ]
+    plan = {
+        "flow": {
+            "title": "",
+            "steps": [
+                {
+                    "from": "`Session.dispatch()`",
+                    "to": "`Adapter.send()`",
+                    "evidence": ["R1"],
+                },
+                {
+                    "from": "`Adapter.send()`",
+                    "to": "`Response.build()`",
+                    "evidence": ["R2"],
+                },
+            ],
+        },
+        "sections": [
+            {
+                "title": "Dispatch",
+                "claims": [
+                    {
+                        "role": "flow",
+                        "statement": "`Session.dispatch()` calls `Adapter.send()`",
+                        "evidence": ["R1"],
+                    }
+                ],
+            },
+            {
+                "title": "Transport",
+                "claims": [
+                    {
+                        "role": "flow",
+                        "statement": "`Adapter.send()` calls `Response.build()`",
+                        "evidence": ["R2"],
+                    }
+                ],
+            },
+            {
+                "title": "Response",
+                "claims": [
+                    {
+                        "role": "contract",
+                        "statement": "`Response.build()` returns a response",
+                        "evidence": ["E3"],
+                    }
+                ],
+            },
+        ],
+    }
+    rendered = _renderable_plan(plan, evidence, relations)
+    markdown = _fact_plan_markdown(rendered, evidence, relations)
+    quality = _page_quality_report(
+        markdown,
+        rendered,
+        require_dense_sections=True,
+        relations=relations,
+        evidence_items=evidence,
+    )
+
+    assert "## How it fits together" in markdown
+    assert (
+        "How it fits together. The diagram traces the admitted "
+        "source-to-target handoffs between the named components. [R1] [R2]" in markdown
+    )
+    assert "How it fits together" not in quality["thin_sections"]
 
 
 def test_flow_drops_names_that_exist_without_a_proven_relation():

--- a/test/wiki/test_builder.py
+++ b/test/wiki/test_builder.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -238,8 +239,68 @@ def test_symbol_content_is_hydrated_from_source(repo_dir):
 def test_source_traversal_guard(repo_dir):
     wb = WikiBuilder(_make_bundle(repo_dir))
     assert wb.source("../../../etc/passwd") is None
+    sibling = Path(repo_dir).with_name(Path(repo_dir).name + "-private")
+    sibling.mkdir()
+    (sibling / "secret.py").write_text("SECRET = True\n", encoding="utf-8")
+    assert wb.source(f"../{sibling.name}/secret.py") is None
     ok = wb.source("pkg/mod/a.py", 1, 3)
     assert ok is not None and ok["content"].count("\n") == 3
+
+
+def test_source_preserves_a_contained_symlink_path(repo_dir):
+    link = Path(repo_dir) / "pkg/mod/alias.py"
+    link.symlink_to("a.py")
+    wb = WikiBuilder(_make_bundle(repo_dir))
+
+    source = wb.source("pkg/mod/alias.py", 1, 3)
+
+    assert source is not None
+    assert source["file"] == "pkg/mod/alias.py"
+    assert source["content"].count("\n") == 3
+
+
+def test_source_reads_only_the_requested_line_window(repo_dir, monkeypatch):
+    wb = WikiBuilder(_make_bundle(repo_dir))
+    source_path = Path(repo_dir) / "pkg/mod/a.py"
+    real_open = open
+
+    class GuardedReader:
+        def __init__(self, handle):
+            self.handle = handle
+            self.lines_read = 0
+
+        def __enter__(self):
+            self.handle.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self.handle.__exit__(*args)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            self.lines_read += 1
+            if self.lines_read > 4:
+                raise AssertionError("source reader consumed past the requested window")
+            return next(self.handle)
+
+        def readlines(self):
+            raise AssertionError("source reader loaded the complete file")
+
+    def guarded_open(file, *args, **kwargs):
+        handle = real_open(file, *args, **kwargs)
+        if Path(file) == source_path:
+            return GuardedReader(handle)
+        return handle
+
+    monkeypatch.setattr("builtins.open", guarded_open)
+
+    result = wb.source("pkg/mod/a.py", 1, 3)
+
+    assert result is not None
+    assert result["start_line"] == 1
+    assert result["end_line"] == 3
 
 
 def test_overview_links_modules(repo_dir):

--- a/test/wiki/test_evidence.py
+++ b/test/wiki/test_evidence.py
@@ -680,6 +680,23 @@ def test_promotional_words_the_page_wrote_itself_still_flag():
     assert grounding_report(authored, [src], [])["promotional_phrases"]
 
 
+def test_short_promotional_claim_is_not_hidden_below_citation_block_threshold():
+    src = EvidenceItem(
+        id="E1",
+        file="site.go",
+        start_line=1,
+        end_line=3,
+        symbol="Build",
+        kind="function",
+        content="func Build() error { return nil }",
+    )
+
+    report = grounding_report("Fast and flexible. [E1]", [src], [])
+
+    assert report["citation_coverage"] == 0.0
+    assert report["promotional_phrases"] == ["fast", "flexible"]
+
+
 def _doc(content, file="src/models.py", symbol="PreparedRequest.prepare_url"):
     from codenib.wiki.evidence import EvidenceItem
 
@@ -712,6 +729,135 @@ def test_attribute_access_resolves_from_owner_and_leaf():
     )
     md = "`PreparedRequest.url` holds the encoded target after preparation. [E1]"
     assert grounding_report(md, [item], [])["unsupported_identifiers"] == []
+
+
+def test_bare_member_name_resolves_from_a_qualified_symbol():
+    from codenib.wiki.evidence import grounding_report
+
+    item = _doc(
+        "class PreparedRequest:\n    pass",
+        symbol="PreparedRequest.url",
+    )
+    md = "The bare `url` member holds the encoded request target. [E1]"
+
+    assert grounding_report(md, [item], [])["unsupported_identifiers"] == []
+
+
+def test_identifier_support_uses_exact_names_not_substrings():
+    from codenib.wiki.evidence import grounding_report
+
+    item = _doc(
+        "class AuthorizationError(Exception):\n    pass",
+        symbol="AuthorizationError",
+    )
+    md = "The `Authorization` value is attached to every request. [E1]"
+
+    assert grounding_report(md, [item], [])["unsupported_identifiers"] == [
+        "Authorization"
+    ]
+
+
+def test_qualified_call_requires_a_supported_owner():
+    from codenib.wiki.evidence import EvidenceItem, grounding_report
+
+    item = EvidenceItem(
+        id="E1",
+        file="src/models.py",
+        start_line=1,
+        end_line=9,
+        symbol="PreparedRequest",
+        kind="class",
+        content=(
+            "class PreparedRequest:\n"
+            "    def prepare_url(self, url):\n"
+            "        self.url = url"
+        ),
+    )
+
+    valid = "`PreparedRequest.prepare_url()` stores the request URL. [E1]"
+    invented = "`requests.api.prepare_url()` stores the request URL. [E1]"
+
+    assert grounding_report(valid, [item], [])["unsupported_identifiers"] == []
+    assert grounding_report(invented, [item], [])["unsupported_identifiers"] == [
+        "requests.api.prepare_url()"
+    ]
+
+
+def test_qualified_call_does_not_join_owner_and_leaf_across_evidence_items():
+    from codenib.wiki.evidence import EvidenceItem, grounding_report
+
+    owner = EvidenceItem(
+        id="E1",
+        file="src/models.py",
+        start_line=1,
+        end_line=2,
+        symbol="PreparedRequest",
+        kind="class",
+        content="class PreparedRequest:\n    pass",
+    )
+    leaf = EvidenceItem(
+        id="E2",
+        file="src/helpers.py",
+        start_line=1,
+        end_line=2,
+        symbol="prepare_url",
+        kind="function",
+        content="def prepare_url(url):\n    return url",
+    )
+    markdown = "`PreparedRequest.prepare_url()` stores the request URL. [E1][E2]"
+
+    assert grounding_report(markdown, [owner, leaf], [])["unsupported_identifiers"] == [
+        "PreparedRequest.prepare_url()"
+    ]
+
+
+def test_qualified_call_requires_one_complete_relation_endpoint():
+    from codenib.wiki.evidence import RelationItem, grounding_report
+
+    split = RelationItem(
+        id="R1",
+        source="src/models.py:PreparedRequest",
+        target="src/helpers.py:prepare_url()",
+    )
+    complete = RelationItem(
+        id="R1",
+        source="src/models.py:PreparedRequest.prepare_url()",
+        target="src/adapters.py:HTTPAdapter.send()",
+    )
+    markdown = "`PreparedRequest.prepare_url()` stores the request URL. [R1]"
+
+    assert grounding_report(markdown, [], [split])["unsupported_identifiers"] == [
+        "PreparedRequest.prepare_url()"
+    ]
+    assert grounding_report(markdown, [], [complete])["unsupported_identifiers"] == []
+
+
+def test_path_qualified_symbol_does_not_join_across_evidence_items():
+    from codenib.wiki.evidence import EvidenceItem, grounding_report
+
+    path_item = EvidenceItem(
+        id="E1",
+        file="src/models.py",
+        start_line=1,
+        end_line=2,
+        symbol="PreparedRequest",
+        kind="class",
+        content="class PreparedRequest:\n    pass",
+    )
+    symbol_item = EvidenceItem(
+        id="E2",
+        file="src/helpers.py",
+        start_line=1,
+        end_line=2,
+        symbol="prepare_url",
+        kind="function",
+        content="def prepare_url(url):\n    return url",
+    )
+    markdown = "`src/models.py:prepare_url` stores the request URL. [E1][E2]"
+
+    assert grounding_report(markdown, [path_item, symbol_item], [])[
+        "unsupported_identifiers"
+    ] == ["src/models.py:prepare_url"]
 
 
 def test_uri_scheme_is_not_an_identifier():
@@ -771,6 +917,29 @@ def test_grounding_floor_rejects_a_page_citing_evidence_that_does_not_exist():
     report = grounding_report(md, [item], [])
     assert report["grounded"] is False
     assert report["unknown_citations"] == ["E9"]
+
+
+def test_bare_internal_wiki_navigation_is_not_a_factual_block():
+    from codenib.wiki.evidence import grounding_report
+
+    item = _doc("def prepare_url(self):\n    return None")
+    claim = "`prepare_url` encodes the target host before transmission. [E1]"
+    navigation = (
+        "- [Request preparation details](?p=request-preparation)\n"
+        "- [Transport adapter lifecycle](?p=transport-adapters)"
+    )
+    factual_list = (
+        "- Request preparation normalizes the target host.\n"
+        "- Transport adapters receive the normalized request."
+    )
+
+    nav_report = grounding_report(f"{claim}\n\n{navigation}", [item], [])
+    factual_report = grounding_report(f"{claim}\n\n{factual_list}", [item], [])
+
+    assert nav_report["valid"] is True
+    assert nav_report["citation_coverage"] == 1.0
+    assert factual_report["valid"] is False
+    assert factual_report["citation_coverage"] == 0.5
 
 
 def test_flow_needs_at_least_two_steps():

--- a/test/wiki/test_quality.py
+++ b/test/wiki/test_quality.py
@@ -109,6 +109,83 @@ def test_section_evidence_report_detects_section_source_reuse():
     assert report["sections_without_new_evidence"] == ["Serve"]
 
 
+def test_framing_sections_do_not_consume_detail_evidence_novelty():
+    markdown = (
+        "# Overview\n\n"
+        "The repository accepts source checkouts. [E1]\n\n"
+        "## Purpose and scope\n\n"
+        "The compiler creates the repository index. [E2]\n\n"
+        "## At a glance\n\n"
+        "The runtime loads the index for queries. [E3]\n\n"
+        "## Compilation details\n\n"
+        "Compilation writes the index consumed by the runtime. [E2] [E3]"
+    )
+
+    report = section_evidence_report(markdown)
+
+    assert report["evidence_by_section"]["Purpose and scope"] == ["E2"]
+    assert report["evidence_by_section"]["At a glance"] == ["E3"]
+    assert report["new_evidence_by_section"]["Compilation details"] == ["E2", "E3"]
+    assert report["sections_without_new_evidence"] == []
+
+
+def test_internal_related_pages_do_not_count_as_repeated_prose():
+    markdown = (
+        "# Request Preparation\n\n"
+        "The request pipeline prepares URLs, bodies, headers, and connection "
+        "pool attributes. [E1]\n\n"
+        "## Boundaries with Other Preparation Stages\n\n"
+        "URL preparation, body encoding, header preparation, and connection "
+        "pool selection are separate lifecycle stages. [E1]\n\n"
+        "## Related pages\n\n"
+        "- [URL and Parameter Encoding](?p=url-and-parameter-encoding)\n"
+        "- [Body and File Encoding](?p=body-and-file-encoding)\n"
+        "- [Connection Pool Management](?p=connection-pool-management)"
+    )
+
+    narrative = section_narrative_report(markdown)
+
+    assert duplicate_prose_blocks(markdown) == []
+    assert narrative["redundant_sections"] == []
+    assert "Related pages" not in narrative["section_similarity"]
+
+
+def test_internal_related_pages_do_not_dilute_section_synthesis_gate():
+    technical = (
+        "## Parse catalog\n\n"
+        "`Alpha.parse()` returns parsed values. "
+        "`Alpha.load()` loads input values.\n\n"
+        "## Render catalog\n\n"
+        "`Beta.render()` generates rendered output. "
+        "`Beta.save()` saves rendered output.\n\n"
+        "## Lifecycle\n\n"
+        "The runtime coordinates parsing before delivery. "
+        "It records state for later consumers."
+    )
+    with_navigation = (
+        technical + "\n\n## Related pages\n\n"
+        "- [Parser internals](?p=parser-internals)\n"
+        "- [Rendering internals](?p=rendering-internals)"
+    )
+
+    assert section_synthesis_report(technical)["section_synthesis_valid"] is False
+    assert section_synthesis_report(with_navigation)["section_synthesis_valid"] is False
+
+
+def test_navigation_before_real_prose_preserves_the_section_heading():
+    markdown = (
+        "# Overview\n\n"
+        "The repository prepares source context for requests. [E1]\n\n"
+        "## Navigation and behavior\n\n"
+        "- [Request pipeline](?p=request-pipeline)\n\n"
+        "The runtime then dispatches the prepared request to an adapter. [E2]"
+    )
+
+    report = section_narrative_report(markdown)
+
+    assert "Navigation and behavior" in report["section_similarity"]
+
+
 def test_page_audit_adds_narrative_validity_to_legacy_quality():
     old_gate = audit_page(_page(repeated_prose=True))
     improved = audit_page(_page(repeated_prose=False))

--- a/web/app/[repoId]/page.tsx
+++ b/web/app/[repoId]/page.tsx
@@ -493,6 +493,7 @@ export default function WikiPageView({ repoId }: { repoId: string }) {
                           variant="wiki"
                           onFocus={hasGraph ? (label) => openGraph(label) : undefined}
                           repoFullName={repo?.repo}
+                          sourceUrl={repo?.source_url}
                           commit={repo?.base_commit}
                         />
                       </Suspense>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3588,6 +3588,63 @@ a.codepanel-name:hover {
   gap: 5px;
   padding: 2px 10px 9px 10px;
 }
+.hier-scope {
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  overflow: hidden;
+  background: var(--code-bg);
+}
+.hier-scope-head {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+}
+.hier-scope-toggle {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  flex: 1 1 auto;
+  padding: 6px 9px;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+.hier-scope-toggle:hover {
+  background: var(--accent-soft);
+}
+.hier-scope-toggle .hier-symbol-line {
+  margin-inline-start: 0;
+}
+.hier-scope-source,
+.hier-scope-focus {
+  flex: 0 0 auto;
+  padding: 5px 9px;
+  border: 0;
+  border-left: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+}
+.hier-scope-source:not(:disabled):hover,
+.hier-scope-focus:not(:disabled):hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.hier-scope-source:disabled,
+.hier-scope-focus:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+.hier-scope > .hier-children {
+  padding-top: 5px;
+  border-top: 1px solid var(--border-subtle);
+}
 .hier-symbol {
   display: flex;
   align-items: baseline;

--- a/web/components/CodeGraph.tsx
+++ b/web/components/CodeGraph.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useRef, useState } from "react";
 import cytoscape, { type Core, type ElementDefinition, type NodeSingular } from "cytoscape";
-import { fetchEdgeLabel, type CallSite, type CodemapResponse } from "@/lib/api";
+import {
+  fetchEdgeLabel,
+  type CallSite,
+  type CodemapResponse,
+  type SourceSlice,
+} from "@/lib/api";
 
 export interface EdgeClickInfo {
   anchors: CallSite[];
@@ -27,6 +32,7 @@ export interface GraphNodeInfo {
   endLine: number | null; // 1-based end of the definition, so the peek shows just this symbol
   kind: string;
   external: boolean; // defined outside this repo — no source to open
+  source?: SourceSlice | null; // embedded by static Wiki exports
 }
 
 type CMNode = CodemapResponse["nodes"][number];
@@ -379,6 +385,7 @@ function buildElements(
             root: n.is_root ? 1 : 0,
             external: n.external ? 1 : 0,
             declaration: n.declaration ? 1 : 0,
+            source: n.source,
             treeDepth: n.depth ?? fileDepth,
           },
         });
@@ -461,7 +468,11 @@ function buildElements(
     // Collect anchors for ALL edges (incl. file-level aggregates) so the on-hover
     // label has call-site evidence. The click-peek still only uses them for
     // symbol edges (see the `anchors` field below).
-    if (e.anchors) a.anchors.push(...e.anchors);
+    if (e.anchors) {
+      a.anchors.push(
+        ...e.anchors.filter((anchor) => anchor.source !== null),
+      );
+    }
     a.crossFile = a.crossFile || !!e.cross_file;
     if (symbolEdge) {
       a.srcShort = shortById.get(e.source) || "";
@@ -1629,6 +1640,7 @@ export default function CodeGraph({
       }
       focusedRef.current = d.id;
       focusNode(evt.target);
+      if (d.source === null && d.external !== 1) return;
       onNodeClickRef.current?.({
         label: d.flabel,
         short: d.short,
@@ -1637,6 +1649,7 @@ export default function CodeGraph({
         endLine: d.endLine ?? null,
         kind: d.kind,
         external: d.external === 1,
+        source: d.source,
       });
     });
 
@@ -1776,6 +1789,7 @@ export default function CodeGraph({
   };
 
   const openSymbol = (node: CMNode) => {
+    if (node.source === null && !node.external) return;
     onNodeClickRef.current?.({
       label: node.label,
       short: node.short,
@@ -1784,6 +1798,7 @@ export default function CodeGraph({
       endLine: node.end_line ?? null,
       kind: node.kind,
       external: node.external === true,
+      source: node.source,
     });
   };
 

--- a/web/components/GraphView.tsx
+++ b/web/components/GraphView.tsx
@@ -12,6 +12,7 @@ import {
   type CallSite,
   type CodemapResponse,
 } from "@/lib/api";
+import { isStaticRuntime } from "@/lib/runtime";
 
 // Cytoscape loads only when a graph is shown, so the wiki
 // narrative paints first and the graph fills in a beat later.
@@ -29,9 +30,17 @@ function GraphLoading() {
 // definition. Both resolve to a (file, line) the /source endpoint can open.
 type PeekSource = ({ kind: "edge" } & EdgeClickInfo) | { kind: "node"; node: GraphNodeInfo };
 
-function githubFileUrl(repoFullName: string | undefined, commit: string | undefined, file: string): string | null {
-  if (!repoFullName || !file) return null;
-  return `https://github.com/${repoFullName}/blob/${commit || "HEAD"}/${file}`;
+function githubFileUrl(
+  repoFullName: string | undefined,
+  sourceUrl: string | null | undefined,
+  commit: string | undefined,
+  file: string,
+  line?: number | null,
+): string | null {
+  if ((!repoFullName && !sourceUrl) || !file) return null;
+  const root = (sourceUrl || `https://github.com/${repoFullName}`).replace(/\/+$/, "");
+  const anchor = line ? `#L${line}` : "";
+  return `${root}/blob/${commit || "HEAD"}/${file}${anchor}`;
 }
 
 function compactSymbol(label: string): string {
@@ -50,6 +59,7 @@ function SourcePeek({
   onClose,
   onFocus,
   repoFullName,
+  sourceUrl,
   commit,
 }: {
   repoId: string;
@@ -57,6 +67,7 @@ function SourcePeek({
   onClose: () => void;
   onFocus?: (label: string) => void;
   repoFullName?: string;
+  sourceUrl?: string | null;
   commit?: string;
 }) {
   const peekRef = useRef<HTMLDivElement>(null);
@@ -77,6 +88,7 @@ function SourcePeek({
   const [edgeLabel, setEdgeLabel] = useState<"idle" | "loading" | string>("idle");
 
   const site = sites[Math.min(idx, sites.length - 1)] || sites[0];
+  const embedded = isNode ? source.node.source : site?.source;
   const rel = repoRelative(site.file);
   const line = site.line ?? 1;
   const isExternal = source.kind === "node" && !!source.node.external;
@@ -89,7 +101,9 @@ function SourcePeek({
       ? `${compactSymbol(source.srcLabel)} -> ${compactSymbol(source.tgtLabel)}`
       : compactSymbol(source.node.short);
   const sourceMeta = source.kind === "edge" ? "Exact reference" : source.node.kind;
-  const fileUrl = isExternal ? null : githubFileUrl(repoFullName, commit, rel);
+  const fileUrl = isExternal
+    ? null
+    : githubFileUrl(repoFullName, sourceUrl, commit, rel, line);
 
   useEffect(() => {
     const id = requestAnimationFrame(() => {
@@ -101,6 +115,10 @@ function SourcePeek({
   useEffect(() => {
     if (source.kind !== "edge") {
       setEdgeLabel("idle");
+      return;
+    }
+    if (isStaticRuntime()) {
+      setEdgeLabel("");
       return;
     }
     let cancelled = false;
@@ -121,7 +139,9 @@ function SourcePeek({
           end_line: source.tgtEnd ?? null,
           label: source.tgtLabel,
         },
-        anchors: source.anchors,
+        // Static page graphs may carry bounded source previews on each anchor.
+        // The edge-label endpoint only needs provenance, not the embedded code.
+        anchors: source.anchors.map(({ file, line }) => ({ file, line })),
         commit,
       },
       { signal: ctrl.signal }
@@ -138,6 +158,17 @@ function SourcePeek({
     if (isExternal || hasNoSingleFile) return; // nothing single to fetch
     let cancelled = false;
     setState("loading");
+    if (embedded === null) {
+      setCode("");
+      setState("err");
+      return;
+    }
+    if (embedded?.content && repoRelative(embedded.file) === rel) {
+      setCode(embedded.content);
+      setStart(embedded.start_line || 1);
+      setState("ok");
+      return;
+    }
     // Node peeks use the indexed symbol span, plus a little context around it.
     // Edge peeks remain point locations with context above and below.
     const PAD = 3;
@@ -155,7 +186,17 @@ function SourcePeek({
     return () => {
       cancelled = true;
     };
-  }, [repoId, rel, line, isNode, nodeEnd, isExternal, hasNoSingleFile, commit]);
+  }, [
+    repoId,
+    rel,
+    line,
+    isNode,
+    nodeEnd,
+    isExternal,
+    hasNoSingleFile,
+    commit,
+    embedded,
+  ]);
 
   return (
     <div className="callsite-peek" ref={peekRef}>
@@ -265,6 +306,7 @@ export default function GraphView({
   variant = "explore",
   onFocus,
   repoFullName,
+  sourceUrl,
   commit,
 }: {
   repoId: string;
@@ -274,6 +316,7 @@ export default function GraphView({
   variant?: "wiki" | "explore" | "modules";
   onFocus?: (label: string) => void;
   repoFullName?: string;
+  sourceUrl?: string | null;
   commit?: string;
 }) {
   const [peek, setPeek] = useState<PeekSource | null>(null);
@@ -294,6 +337,17 @@ export default function GraphView({
       ? onFocus
       : (label: string) => setFocusReq((p) => ({ label, nonce: (p?.nonce ?? 0) + 1 }));
 
+  const openNodeSource = (node: GraphNodeInfo) => {
+    if (!node.external && node.source === null) return;
+    setPeek({ kind: "node", node });
+  };
+
+  const openEdgeSource = (info: EdgeClickInfo) => {
+    const anchors = info.anchors.filter((anchor) => anchor.source !== null);
+    if (!anchors.length) return;
+    setPeek({ kind: "edge", ...info, anchors });
+  };
+
   return (
     <>
       {variant === "wiki" ? (
@@ -302,14 +356,15 @@ export default function GraphView({
         hasHierarchy ? (
           <HierarchyMap
             data={data}
-            onNodeClick={(node) => setPeek({ kind: "node", node })}
-            onEdgeClick={(info) => setPeek({ kind: "edge", ...info })}
+            onNodeClick={openNodeSource}
+            onSourceClick={openNodeSource}
+            onEdgeClick={openEdgeSource}
           />
         ) : (
           <SystemMap
             data={data}
-            onNodeClick={(node) => setPeek({ kind: "node", node })}
-            onEdgeClick={(info) => setPeek({ kind: "edge", ...info })}
+            onNodeClick={openNodeSource}
+            onEdgeClick={openEdgeSource}
           />
         )
       ) : (
@@ -319,8 +374,8 @@ export default function GraphView({
             variant={variant}
             focusRequest={focusReq}
             repoId={repoId}
-            onNodeClick={(node) => setPeek({ kind: "node", node })}
-            onEdgeClick={(info) => setPeek({ kind: "edge", ...info })}
+            onNodeClick={openNodeSource}
+            onEdgeClick={openEdgeSource}
           />
         </Suspense>
       )}
@@ -332,6 +387,7 @@ export default function GraphView({
           onClose={() => setPeek(null)}
           onFocus={peekFocus}
           repoFullName={repoFullName}
+          sourceUrl={sourceUrl}
           commit={commit}
         />
       )}

--- a/web/components/HierarchyMap.test.tsx
+++ b/web/components/HierarchyMap.test.tsx
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CodemapResponse } from "@/lib/api";
+import HierarchyMap, {
+  hierarchyNodeToInfo,
+  toggleHierarchyOpen,
+} from "./HierarchyMap";
+
+function hierarchyData(scopeOpen: boolean): CodemapResponse {
+  return {
+    available: true,
+    root: "src/model.py:Widget.run()",
+    root_label: "src/model.py:Widget.run()",
+    nodes: [
+      {
+        id: "n0",
+        name: "src/model.py:Widget.run()",
+        label: "src/model.py:Widget.run()",
+        short: "model.py:Widget.run()",
+        file: "src/model.py",
+        line: 12,
+        end_line: 18,
+        kind: "method",
+        depth: 0,
+        is_root: true,
+      },
+      {
+        id: "n1",
+        name: "src/helper.py:helper()",
+        label: "src/helper.py:helper()",
+        short: "helper.py:helper()",
+        file: "src/helper.py",
+        line: 4,
+        end_line: 7,
+        kind: "function",
+        depth: 1,
+        is_root: false,
+      },
+    ],
+    edges: [
+      {
+        source: "n0",
+        target: "n1",
+        anchors: [{ file: "src/model.py", line: 15 }],
+        source_hierarchy: "hier::symbol::n0",
+        target_hierarchy: "hier::symbol::n1",
+      },
+    ],
+    hierarchy: {
+      root: "hier::root",
+      nodes: [
+        {
+          id: "hier::root",
+          parent: null,
+          kind: "root",
+          label: "root",
+          depth: 0,
+          child_count: 2,
+          symbol_count: 3,
+          doi: 1,
+          open_by_default: true,
+        },
+        {
+          id: "hier::file::src/model.py",
+          parent: "hier::root",
+          kind: "file",
+          label: "model.py",
+          file: "src/model.py",
+          depth: 1,
+          child_count: 1,
+          symbol_count: 2,
+          doi: 1,
+          open_by_default: true,
+        },
+        {
+          id: "hier::symbol::src/model.py:Widget",
+          parent: "hier::file::src/model.py",
+          kind: "symbol",
+          label: "Widget",
+          path: "src/model.py:Widget",
+          file: "src/model.py",
+          node_id: "src/model.py:Widget",
+          line: 8,
+          end_line: 24,
+          source: {
+            file: "src/model.py",
+            start_line: 8,
+            end_line: 24,
+            content: "class Widget:\n    pass",
+          },
+          depth: 2,
+          child_count: 1,
+          symbol_count: 2,
+          doi: 1,
+          open_by_default: scopeOpen,
+        },
+        {
+          id: "hier::symbol::n0",
+          parent: "hier::symbol::src/model.py:Widget",
+          kind: "symbol",
+          label: "Widget.run()",
+          path: "src/model.py:Widget.run()",
+          file: "src/model.py",
+          node_id: "n0",
+          line: 12,
+          end_line: 18,
+          depth: 3,
+          child_count: 0,
+          symbol_count: 1,
+          doi: 1,
+        },
+        {
+          id: "hier::file::src/helper.py",
+          parent: "hier::root",
+          kind: "file",
+          label: "helper.py",
+          file: "src/helper.py",
+          depth: 1,
+          child_count: 1,
+          symbol_count: 1,
+          doi: 0.5,
+          open_by_default: true,
+        },
+        {
+          id: "hier::symbol::n1",
+          parent: "hier::file::src/helper.py",
+          kind: "symbol",
+          label: "helper()",
+          path: "src/helper.py:helper()",
+          file: "src/helper.py",
+          node_id: "n1",
+          line: 4,
+          end_line: 7,
+          depth: 2,
+          child_count: 0,
+          symbol_count: 1,
+          doi: 0.5,
+        },
+      ],
+    },
+    mermaid: "",
+  };
+}
+
+describe("HierarchyMap symbol scopes", () => {
+  it("opens and closes a scope without mutating the previous state", () => {
+    const closed = new Set(["hier::root"]);
+    const opened = toggleHierarchyOpen(
+      closed,
+      "hier::symbol::src/model.py:Widget",
+    );
+
+    expect(closed).toEqual(new Set(["hier::root"]));
+    expect(opened).toContain("hier::symbol::src/model.py:Widget");
+    expect(
+      toggleHierarchyOpen(opened, "hier::symbol::src/model.py:Widget"),
+    ).not.toContain("hier::symbol::src/model.py:Widget");
+  });
+
+  it("renders an open parent scope, its child symbol, and an enabled source action", () => {
+    const data = hierarchyData(true);
+    const html = renderToStaticMarkup(
+      <HierarchyMap
+        data={data}
+        onNodeClick={vi.fn()}
+        onSourceClick={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('class="hier-scope-toggle" aria-expanded="true"');
+    expect(html).toContain("Widget.run()");
+    const sourceButton = html.match(
+      /<button[^>]*class="hier-scope-source"[^>]*aria-label="View source for Widget"[^>]*>/,
+    )?.[0];
+    expect(sourceButton).toBeDefined();
+    expect(sourceButton).not.toContain("disabled");
+    expect(sourceButton).toContain("src/model.py:Widget");
+
+    const parentScope = data.hierarchy?.nodes.find(
+      (node) => node.id === "hier::symbol::src/model.py:Widget",
+    );
+    expect(parentScope && hierarchyNodeToInfo(parentScope)?.source?.content).toBe(
+      "class Widget:\n    pass",
+    );
+  });
+
+  it("does not label a focus-only consumer action as source", () => {
+    const html = renderToStaticMarkup(
+      <HierarchyMap data={hierarchyData(true)} onNodeClick={vi.fn()} />,
+    );
+
+    expect(html).not.toContain('class="hier-scope-source"');
+    const focusButton = html.match(
+      /<button[^>]*class="hier-scope-focus"[^>]*aria-label="Focus on Widget"[^>]*>/,
+    )?.[0];
+    expect(focusButton).toBeDefined();
+    expect(focusButton).not.toContain("disabled");
+  });
+
+  it("disables static source actions whose previews were dropped", () => {
+    const data = hierarchyData(false);
+    const parent = data.hierarchy?.nodes.find(
+      (node) => node.id === "hier::symbol::src/model.py:Widget",
+    );
+    if (parent) parent.source = null;
+    data.edges[0].anchors = [
+      { file: "src/model.py", line: 15, source: null },
+    ];
+
+    const html = renderToStaticMarkup(
+      <HierarchyMap
+        data={data}
+        onNodeClick={vi.fn()}
+        onSourceClick={vi.fn()}
+        onEdgeClick={vi.fn()}
+      />,
+    );
+
+    const sourceButton = html.match(
+      /<button[^>]*class="hier-scope-source"[^>]*aria-label="View source for Widget"[^>]*>/,
+    )?.[0];
+    expect(sourceButton).toContain("disabled");
+    const relationship = html.match(
+      /<button[^>]*class="hier-link"[^>]*title="Widget -&gt; helper\(\)"[^>]*>/,
+    )?.[0];
+    expect(relationship).toContain("disabled");
+  });
+
+  it("rolls a child edge up to its nearest closed symbol scope", () => {
+    const html = renderToStaticMarkup(
+      <HierarchyMap
+        data={hierarchyData(false)}
+        onNodeClick={vi.fn()}
+        onEdgeClick={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('title="Widget -&gt; helper()"');
+    expect(html).not.toContain('title="Widget.run() -&gt; helper()"');
+  });
+});

--- a/web/components/HierarchyMap.tsx
+++ b/web/components/HierarchyMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { EdgeClickInfo, GraphNodeInfo } from "@/components/CodeGraph";
 import type { CallSite, CodemapHierarchyNode, CodemapResponse } from "@/lib/api";
@@ -19,6 +19,20 @@ interface RolledEdge {
 
 const CONTAINER_KINDS = new Set(["root", "directory", "file"]);
 
+function isContainer(
+  node: CodemapHierarchyNode | undefined,
+  childrenOf: Map<string, CodemapHierarchyNode[]>,
+): boolean {
+  return !!node && (CONTAINER_KINDS.has(node.kind) || childrenOf.has(node.id));
+}
+
+export function toggleHierarchyOpen(previous: Set<string>, id: string): Set<string> {
+  const next = new Set(previous);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+}
+
 function nodeToInfo(node: CMNode): GraphNodeInfo {
   return {
     label: node.label,
@@ -28,6 +42,26 @@ function nodeToInfo(node: CMNode): GraphNodeInfo {
     endLine: node.end_line ?? null,
     kind: node.kind,
     external: node.external === true,
+    source: node.source,
+  };
+}
+
+/** Ancestor scopes are projected from the repo hierarchy, not the small page
+ * view, so their ``node_id`` is a canonical graph id rather than ``n0``/``n1``.
+ * They still carry an exact source span and are valid source-preview targets. */
+export function hierarchyNodeToInfo(
+  node: CodemapHierarchyNode,
+): GraphNodeInfo | null {
+  if (!node.file || node.line == null) return null;
+  return {
+    label: node.path || node.node_id || node.label,
+    short: node.label,
+    file: node.file,
+    line: node.line,
+    endLine: node.end_line ?? null,
+    kind: node.kind,
+    external: node.external === true,
+    source: node.source,
   };
 }
 
@@ -40,10 +74,15 @@ function nodeToInfo(node: CMNode): GraphNodeInfo {
 export default function HierarchyMap({
   data,
   onNodeClick,
+  onSourceClick,
   onEdgeClick,
 }: {
   data: CodemapResponse;
   onNodeClick?: (node: GraphNodeInfo) => void;
+  /** Explicit source-preview action for parent scopes. Some consumers use
+   *  onNodeClick for graph focus instead, so the two meanings cannot share a
+   *  button labelled "source". */
+  onSourceClick?: (node: GraphNodeInfo) => void;
   onEdgeClick?: (info: EdgeClickInfo) => void;
 }) {
   const hierarchy = data.hierarchy;
@@ -66,13 +105,16 @@ export default function HierarchyMap({
     }
     const rootId = hierarchy?.root ?? "";
     const defaultOpen = new Set<string>(
-      nodes.filter((n) => n.open_by_default && CONTAINER_KINDS.has(n.kind)).map((n) => n.id)
+      nodes
+        .filter((n) => n.open_by_default && isContainer(n, childrenOf))
+        .map((n) => n.id)
     );
     if (rootId) defaultOpen.add(rootId);
     return { byId, childrenOf, root: rootId, defaultOpen };
   }, [hierarchy]);
 
   const [open, setOpen] = useState<Set<string>>(defaultOpen);
+  useEffect(() => setOpen(defaultOpen), [defaultOpen]);
 
   const viewNodeById = useMemo(
     () => new Map(data.nodes.map((n) => [n.id, n])),
@@ -88,12 +130,7 @@ export default function HierarchyMap({
   }, [hierarchy]);
 
   const toggle = (id: string) =>
-    setOpen((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+    setOpen((previous) => toggleHierarchyOpen(previous, id));
 
   /** Deepest ancestor-or-self the reader can currently see. */
   const nearestVisible = (hid: string | undefined): string | null => {
@@ -109,7 +146,7 @@ export default function HierarchyMap({
     for (const id of chain) {
       visible = id;
       // A closed container is the boundary: nothing beneath it is on screen.
-      if (CONTAINER_KINDS.has(byId.get(id)?.kind ?? "") && !open.has(id)) break;
+      if (isContainer(byId.get(id), childrenOf) && !open.has(id)) break;
     }
     return visible;
   };
@@ -145,7 +182,11 @@ export default function HierarchyMap({
       link.weight += edge.weight ?? edge.anchors?.length ?? 1;
       // Keep every descendant's call site, or collapsing a container would
       // silently change what clicking its edge opens.
-      if (edge.anchors) link.anchors.push(...edge.anchors);
+      if (edge.anchors) {
+        link.anchors.push(
+          ...edge.anchors.filter((anchor) => anchor.source !== null),
+        );
+      }
     }
     return [...acc.values()].sort((a, b) => b.weight - a.weight).slice(0, 12);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -156,14 +197,83 @@ export default function HierarchyMap({
   const renderNode = (node: CodemapHierarchyNode, depth: number) => {
     if (node.kind === "symbol") {
       const viewNode = node.node_id ? viewNodeById.get(node.node_id) : undefined;
+      const sourceInfo = viewNode ? nodeToInfo(viewNode) : hierarchyNodeToInfo(node);
+      const kids = childrenOf.get(node.id) ?? [];
+      const sourceAvailable =
+        !!sourceInfo && (sourceInfo.external || sourceInfo.source !== null);
+
+      if (kids.length > 0) {
+        const isOpen = open.has(node.id);
+        return (
+          <div
+            key={node.id}
+            className={`hier-scope${isOpen ? " is-open" : ""}`}
+            style={{ marginInlineStart: depth > 1 ? 10 : 0 }}
+          >
+            <div className="hier-scope-head">
+              <button
+                type="button"
+                className="hier-scope-toggle"
+                aria-expanded={isOpen}
+                onClick={() => toggle(node.id)}
+              >
+                <span className="hier-chevron" aria-hidden="true">
+                  {isOpen ? "-" : "+"}
+                </span>
+                <span className="hier-symbol-name">{node.label}</span>
+                {node.line != null && (
+                  <span className="hier-symbol-line mono">:{node.line}</span>
+                )}
+                <span className="hier-meta">
+                  {node.symbol_count} symbol{node.symbol_count === 1 ? "" : "s"}
+                </span>
+              </button>
+              {onSourceClick ? (
+                <button
+                  type="button"
+                  className="hier-scope-source"
+                  disabled={!sourceAvailable}
+                  onClick={() => sourceInfo && onSourceClick(sourceInfo)}
+                  title={`View source for ${sourceInfo?.label ?? node.label}`}
+                  aria-label={`View source for ${node.label}`}
+                >
+                  source
+                </button>
+              ) : onNodeClick ? (
+                <button
+                  type="button"
+                  className="hier-scope-focus"
+                  disabled={!sourceInfo}
+                  onClick={() => sourceInfo && onNodeClick(sourceInfo)}
+                  title={`Focus on ${sourceInfo?.label ?? node.label}`}
+                  aria-label={`Focus on ${node.label}`}
+                >
+                  focus
+                </button>
+              ) : null}
+            </div>
+            {isOpen && (
+              <div className="hier-children">
+                {kids.map((child) => renderNode(child, depth + 1))}
+              </div>
+            )}
+          </div>
+        );
+      }
+
+      const nodeAction = onSourceClick ?? onNodeClick;
+      const nodeActionAvailable =
+        !!sourceInfo &&
+        !!nodeAction &&
+        (!onSourceClick || sourceInfo.external || sourceInfo.source !== null);
       return (
         <button
           key={node.id}
           type="button"
           className={`hier-symbol${viewNode?.declaration ? " is-derived" : ""}`}
-          title={viewNode?.label ?? node.label}
-          disabled={!viewNode || !onNodeClick}
-          onClick={() => viewNode && onNodeClick?.(nodeToInfo(viewNode))}
+          title={sourceInfo?.label ?? node.label}
+          disabled={!nodeActionAvailable}
+          onClick={() => sourceInfo && nodeAction?.(sourceInfo)}
         >
           <span className="hier-symbol-name">{node.label}</span>
           {node.line != null && (

--- a/web/components/SystemMap.test.tsx
+++ b/web/components/SystemMap.test.tsx
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CodemapResponse } from "@/lib/api";
+import SystemMap from "./SystemMap";
+
+function systemData(source: null | undefined): CodemapResponse {
+  return {
+    available: true,
+    root: "src/api.py:start()",
+    root_label: "src/api.py:start()",
+    nodes: [
+      {
+        id: "n0",
+        name: "src/api.py:start()",
+        label: "src/api.py:start()",
+        short: "api.py:start()",
+        file: "src/api.py",
+        line: 1,
+        end_line: 3,
+        kind: "function",
+        depth: 0,
+        is_root: true,
+        ...(source === null ? { source } : {}),
+      },
+      {
+        id: "n1",
+        name: "src/store.py:save()",
+        label: "src/store.py:save()",
+        short: "store.py:save()",
+        file: "src/store.py",
+        line: 4,
+        end_line: 6,
+        kind: "function",
+        depth: 1,
+        is_root: false,
+        ...(source === null ? { source } : {}),
+      },
+    ],
+    edges: [
+      {
+        source: "n0",
+        target: "n1",
+        anchors: [
+          {
+            file: "src/api.py",
+            line: 2,
+            ...(source === null ? { source } : {}),
+          },
+        ],
+      },
+    ],
+    mermaid: "",
+  };
+}
+
+describe("SystemMap static source actions", () => {
+  it("disables nodes and relationships with explicitly unavailable previews", () => {
+    const html = renderToStaticMarkup(
+      <SystemMap
+        data={systemData(null)}
+        onNodeClick={vi.fn()}
+        onEdgeClick={vi.fn()}
+      />,
+    );
+
+    const symbols =
+      html.match(/<button[^>]*class="system-symbol[^>]*>/g) ?? [];
+    expect(symbols).toHaveLength(2);
+    expect(symbols.every((button) => button.includes("disabled"))).toBe(true);
+    const relationship = html.match(
+      /<button[^>]*class="system-link"[^>]*>/,
+    )?.[0];
+    expect(relationship).toContain("disabled");
+  });
+
+  it("keeps live payloads without embedded source previews actionable", () => {
+    const html = renderToStaticMarkup(
+      <SystemMap
+        data={systemData(undefined)}
+        onNodeClick={vi.fn()}
+        onEdgeClick={vi.fn()}
+      />,
+    );
+
+    const symbols =
+      html.match(/<button[^>]*class="system-symbol[^>]*>/g) ?? [];
+    expect(symbols).toHaveLength(2);
+    expect(symbols.every((button) => !button.includes("disabled"))).toBe(true);
+    const relationship = html.match(
+      /<button[^>]*class="system-link"[^>]*>/,
+    )?.[0];
+    expect(relationship).not.toContain("disabled");
+  });
+});

--- a/web/components/SystemMap.tsx
+++ b/web/components/SystemMap.tsx
@@ -163,6 +163,7 @@ function nodeToInfo(node: CMNode): GraphNodeInfo {
     endLine: node.end_line ?? null,
     kind: node.kind,
     external: node.external === true,
+    source: node.source,
   };
 }
 
@@ -263,7 +264,11 @@ function buildSystem(data: CodemapResponse): {
       links.set(key, link);
     }
     link.weight += weight;
-    if (edge.anchors) link.anchors.push(...edge.anchors);
+    if (edge.anchors) {
+      link.anchors.push(
+        ...edge.anchors.filter((anchor) => anchor.source !== null),
+      );
+    }
     if (internal) continue;
     // Stage ordering reads flow *between* components; counting a component's
     // internal traffic as both its own inbound and outbound would flatten it.
@@ -391,6 +396,10 @@ export default function SystemMap({
                         key={node.id}
                         type="button"
                         className={`system-symbol ${node.is_root ? "root" : ""}`}
+                        disabled={
+                          !onNodeClick ||
+                          (!node.external && node.source === null)
+                        }
                         onClick={() => onNodeClick?.(nodeToInfo(node))}
                         title={`${node.label}${node.file ? ` (${repoRelative(node.file)}:${node.line ?? "?"})` : ""}`}
                       >

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -235,11 +235,16 @@ export interface CodemapNode {
   // but held out of the importance ranking so a wall of typedefs cannot pass
   // itself off as the repo's core.
   declaration?: boolean;
+  /** Precomputed source preview used by static Wiki exports. Live runtimes
+   *  normally omit this and resolve the same slice through /source. */
+  source?: SourceSlice | null;
 }
 
 export interface CallSite {
   file: string;
   line: number | null;
+  /** Bounded exact call-site context embedded by the static Wiki exporter. */
+  source?: SourceSlice | null;
 }
 
 export interface CodemapEdge {
@@ -275,6 +280,8 @@ export interface CodemapHierarchyNode {
   importance?: number;
   open_by_default?: boolean;
   external?: boolean;
+  /** Source for projected parent scopes that are not standalone view nodes. */
+  source?: SourceSlice | null;
 }
 
 export interface CodemapHierarchy {


### PR DESCRIPTION
## Summary

Restore source-linked Wiki generation and subsystem exploration on top of the current main branch. This is a clean, four-commit replacement for #455 that preserves the grounded Wiki feature set while closing its five unresolved review blockers.

## Changes

- Embed repository-contained source previews for static page graph nodes, hierarchy scopes, and exact call sites under per-slice, per-page, and anchor-count budgets.
- Mark previews unavailable when the 1 MiB page budget is exhausted, and prevent static node or edge actions from opening a source request that cannot succeed.
- Keep expandable hierarchy scopes focusable, with distinct toggle, focus, and source actions.
- Preserve normalized requested paths for contained symlinks after verifying their resolved targets stay inside the repository.
- Trim oversized previews around the requested target line and reject slices that cannot retain it.
- Hydrate Wiki evidence from repository source only for complete valid spans, preserving indexed content for legacy records without an end line.
- Honor the configured sparse or hybrid retrieval mode while retaining manifest fingerprint checks and legacy vector-route compatibility.
- Enforce purpose, claim, flow, excerpt, related-page, citation, and narrative quality gates against admitted evidence.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Python Web and Wiki suites: 471 passed.
- Frontend Vitest suite on Node 24: 27 passed.
- The repository's Node/SSR harness directly checks Hierarchy focus/source markup and System Map null-versus-omitted preview actions. Cytoscape browser event dispatch is not exposed by that harness, so the matching CodeGraph null guard and direct focus callback are additionally covered by the TypeScript production build and independent code review.
- Frontend TypeScript check and production Vite build completed successfully.
- Black, isort (Black profile), flake8, and diff checks passed.
- CI classifier reports no serial-chain paths changed.
- Fresh merge-tree against `b639f848b04d6031678ef8d3e4e3aa8636446a25` completed without conflicts.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
