### PR TITLE
ci: restore pull request control labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -114,6 +114,12 @@
   description: 1 week+
 
 # ── GitHub-native / special ──────────────────────────────────────────
+- name: full-ci
+  color: "0e8a16"
+  description: Run the hosted unit gate while a pull request is draft
+- name: skip-tests
+  color: "e4e669"
+  description: Skip the hosted pull-request unit gate
 - name: good first issue
   color: "7057ff"
   description: Good for newcomers

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import ast
+import re
 import subprocess
 from pathlib import Path
 
@@ -257,6 +258,18 @@ def test_draft_ci_defers_hosted_unit_tests_until_review() -> None:
     assert "ready_for_review" in workflow
     assert "github.event.pull_request.draft" in workflow
     assert "contains(github.event.pull_request.labels.*.name, 'full-ci')" in workflow
+
+
+def test_pull_request_ci_control_labels_are_synced() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    labels = yaml.safe_load((ROOT / ".github/labels.yml").read_text(encoding="utf-8"))
+    configured = {str(label["name"]) for label in labels}
+    referenced = set(
+        re.findall(r"pull_request\.labels\.\*\.name,\s*'([^']+)'", workflow)
+    )
+
+    assert referenced == {"full-ci", "skip-tests"}
+    assert referenced <= configured
 
 
 def test_default_make_target_excludes_external_and_billed_tiers() -> None:


### PR DESCRIPTION
## Summary

Restore the two pull-request control labels referenced by the hosted CI workflow to the synced label source of truth.

## Changes

- Add `full-ci`, which runs the hosted unit gate while a pull request is still draft.
- Add `skip-tests`, which explicitly skips that pull-request unit gate.
- Add a CI policy contract requiring every pull-request label referenced by `ci.yml` to exist in `.github/labels.yml`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `test/test_ci_policy.py`: 16 passed.
- Black, isort, flake8, and `git diff --check`: passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
