### PR TITLE
feat(guardian): stabilize iterative review experiments

### DIFF
--- a/codenib/clients/execution/codex.py
+++ b/codenib/clients/execution/codex.py
@@ -133,14 +133,35 @@ class CodexExecutor:
         executable: str = "codex",
         process_runner: ProcessRunner | None = None,
         max_output_bytes: int = 8 * 1024**2,
+        enabled_features: Sequence[str] = (),
+        disabled_features: Sequence[str] = (),
     ) -> None:
         if not executable or "\x00" in executable:
             raise ValueError("executable must be a non-empty, NUL-free string")
         if max_output_bytes <= 0:
             raise ValueError("max_output_bytes must be positive")
+        for name, features in (
+            ("enabled_features", enabled_features),
+            ("disabled_features", disabled_features),
+        ):
+            if isinstance(features, (str, bytes)) or any(
+                not isinstance(feature, str) or not feature or "\x00" in feature
+                for feature in features
+            ):
+                raise ValueError(f"{name} must contain non-empty, NUL-free strings")
+        enabled = tuple(enabled_features)
+        disabled = tuple(disabled_features)
+        overlap = sorted(set(enabled) & set(disabled))
+        if overlap:
+            raise ValueError(
+                "Codex features cannot be both enabled and disabled: "
+                + ", ".join(overlap)
+            )
         self._executable = executable
         self._process_runner = process_runner or LocalProcessRunner()
         self._max_output_bytes = max_output_bytes
+        self._enabled_features = enabled
+        self._disabled_features = disabled
 
     def _unsupported_policy(self, request: AgentRunRequest) -> AgentRunResult | None:
         if request.policy.network is NetworkAccess.DISABLED:
@@ -169,6 +190,10 @@ class CodexExecutor:
             "--cd",
             str(request.workspace),
         ]
+        for feature in self._enabled_features:
+            command.extend(("--enable", feature))
+        for feature in self._disabled_features:
+            command.extend(("--disable", feature))
         if request.policy.isolation is ExecutionIsolation.EXTERNAL:
             command.append("--dangerously-bypass-approvals-and-sandbox")
         else:

--- a/codenib/clients/guardian/__init__.py
+++ b/codenib/clients/guardian/__init__.py
@@ -6,6 +6,7 @@
 
 from .agent import GuardianAgent
 from .artifacts import render_markdown
+from .memory import GuardianMemoryStore
 from .types import (
     ContextMessage,
     Evidence,
@@ -13,10 +14,14 @@ from .types import (
     FindingStatus,
     GuardianConfig,
     GuardianFinding,
+    GuardianMemory,
     GuardianRequest,
     GuardianResult,
     LocalSpecification,
+    RememberedEvidence,
+    RememberedSpecification,
     ReviewStatus,
+    SpecificationAssessment,
 )
 
 __all__ = [
@@ -27,9 +32,14 @@ __all__ = [
     "GuardianAgent",
     "GuardianConfig",
     "GuardianFinding",
+    "GuardianMemory",
+    "GuardianMemoryStore",
     "GuardianRequest",
     "GuardianResult",
     "LocalSpecification",
+    "RememberedEvidence",
+    "RememberedSpecification",
     "ReviewStatus",
+    "SpecificationAssessment",
     "render_markdown",
 ]

--- a/codenib/clients/guardian/agent.py
+++ b/codenib/clients/guardian/agent.py
@@ -112,6 +112,7 @@ class GuardianAgent:
             candidates=candidates,
             findings=findings,
             backlog=backlog,
+            assessments=assessed,
             summary=summary,
             rollouts=rollouts,
             errors=all_errors,

--- a/codenib/clients/guardian/memory.py
+++ b/codenib/clients/guardian/memory.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Controller-owned persistence for Guardian's local-specification memory."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .types import (
+    Evidence,
+    EvidenceAuthority,
+    FindingStatus,
+    GuardianMemory,
+    GuardianResult,
+    RememberedEvidence,
+    RememberedSpecification,
+    SpecificationAssessment,
+)
+
+_SCHEMA_VERSION = 1
+_MEMORY_ID = re.compile(r"^spec:[0-9a-f]{16}$")
+
+
+def _specification_id(statement: str, condition: str) -> str:
+    value = f"{statement.strip().casefold()}\0{condition.strip().casefold()}"
+    return f"spec:{hashlib.sha256(value.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _blob_sha256(workspace: Path, path: str) -> str:
+    relative = PurePosixPath(path)
+    if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+        return ""
+    target = workspace.joinpath(*relative.parts)
+    try:
+        resolved = target.resolve(strict=True)
+        if not resolved.is_relative_to(workspace) or not resolved.is_file():
+            return ""
+        return hashlib.sha256(resolved.read_bytes()).hexdigest()
+    except (OSError, RuntimeError):
+        return ""
+
+
+def _evidence_to_dict(value: RememberedEvidence) -> dict[str, object]:
+    evidence = value.evidence
+    return {
+        "path": evidence.path,
+        "line_start": evidence.line_start,
+        "line_end": evidence.line_end,
+        "description": evidence.description,
+        "authority": evidence.authority.value,
+        "snapshot": value.snapshot,
+        "blob_sha256": value.blob_sha256,
+    }
+
+
+def _assessment_to_dict(value: SpecificationAssessment) -> dict[str, object]:
+    return {
+        "snapshot": value.snapshot,
+        "status": value.status.value,
+        "patch_assessment": value.patch_assessment,
+        "recommendation": value.recommendation,
+        "confidence": value.confidence,
+    }
+
+
+def _memory_to_dict(memory: GuardianMemory) -> dict[str, object]:
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "observed_snapshots": list(memory.observed_snapshots),
+        "specifications": [
+            {
+                "memory_id": specification.memory_id,
+                "statement": specification.statement,
+                "condition": specification.condition,
+                "evidence": [
+                    _evidence_to_dict(evidence) for evidence in specification.evidence
+                ],
+                "assessments": [
+                    _assessment_to_dict(assessment)
+                    for assessment in specification.assessments
+                ],
+            }
+            for specification in memory.specifications
+        ],
+    }
+
+
+def _load_evidence(raw: object) -> RememberedEvidence:
+    if not isinstance(raw, dict):
+        raise ValueError("remembered evidence must be an object")
+    authority = EvidenceAuthority(str(raw.get("authority", "repository")))
+    return RememberedEvidence(
+        evidence=Evidence(
+            path=str(raw["path"]),
+            line_start=int(raw["line_start"]),
+            line_end=int(raw["line_end"]),
+            description=str(raw["description"]),
+            authority=authority,
+        ),
+        snapshot=str(raw["snapshot"]),
+        blob_sha256=str(raw["blob_sha256"]),
+    )
+
+
+def _load_assessment(raw: object) -> SpecificationAssessment:
+    if not isinstance(raw, dict):
+        raise ValueError("specification assessment must be an object")
+    return SpecificationAssessment(
+        snapshot=str(raw["snapshot"]),
+        status=FindingStatus(str(raw["status"])),
+        patch_assessment=str(raw.get("patch_assessment", "")),
+        recommendation=str(raw.get("recommendation", "")),
+        confidence=float(raw.get("confidence", 0.0)),
+    )
+
+
+def _memory_from_dict(raw: object) -> GuardianMemory:
+    if not isinstance(raw, dict) or raw.get("schema_version") != _SCHEMA_VERSION:
+        raise ValueError("unsupported Guardian memory schema")
+    snapshots = raw.get("observed_snapshots", [])
+    specifications = raw.get("specifications", [])
+    if not isinstance(snapshots, list) or not isinstance(specifications, list):
+        raise ValueError("Guardian memory collections must be arrays")
+    values: list[RememberedSpecification] = []
+    for item in specifications:
+        if not isinstance(item, dict):
+            raise ValueError("remembered specification must be an object")
+        memory_id = str(item.get("memory_id", ""))
+        if not _MEMORY_ID.fullmatch(memory_id):
+            raise ValueError("remembered specification has an invalid id")
+        evidence = item.get("evidence", [])
+        assessments = item.get("assessments", [])
+        if not isinstance(evidence, list) or not isinstance(assessments, list):
+            raise ValueError("remembered specification history must be arrays")
+        values.append(
+            RememberedSpecification(
+                memory_id=memory_id,
+                statement=str(item["statement"]),
+                condition=str(item.get("condition", "")),
+                evidence=tuple(_load_evidence(value) for value in evidence),
+                assessments=tuple(_load_assessment(value) for value in assessments),
+            )
+        )
+    return GuardianMemory(
+        specifications=tuple(values),
+        observed_snapshots=tuple(str(value) for value in snapshots),
+    )
+
+
+class GuardianMemoryStore:
+    """Single-writer event journal with an atomic materialized memory view."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root).expanduser().resolve()
+        self.state_path = self.root / "memory.json"
+        self.events_path = self.root / "events.jsonl"
+
+    def load(self, workspace: Path | None = None) -> GuardianMemory:
+        if not self.state_path.exists():
+            return GuardianMemory()
+        try:
+            memory = _memory_from_dict(
+                json.loads(self.state_path.read_text(encoding="utf-8"))
+            )
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"Guardian memory cannot be loaded: {exc}") from exc
+        if workspace is None:
+            return memory
+        workspace = Path(workspace).resolve()
+        return replace(
+            memory,
+            specifications=tuple(
+                replace(
+                    specification,
+                    evidence=tuple(
+                        replace(
+                            remembered,
+                            fresh=(
+                                bool(remembered.blob_sha256)
+                                and _blob_sha256(workspace, remembered.evidence.path)
+                                == remembered.blob_sha256
+                            ),
+                        )
+                        for remembered in specification.evidence
+                    ),
+                )
+                for specification in memory.specifications
+            ),
+        )
+
+    def update(self, result: GuardianResult, workspace: Path) -> GuardianMemory:
+        """Merge one successful review into memory and append an audit event."""
+
+        memory = self.load()
+        by_id = {
+            specification.memory_id: specification
+            for specification in memory.specifications
+        }
+        by_statement = {
+            specification.statement.strip().casefold(): specification.memory_id
+            for specification in memory.specifications
+        }
+        candidate_conditions = {
+            candidate.statement.strip().casefold(): candidate.condition
+            for candidate in result.candidates
+        }
+        changed: list[str] = []
+        assessed = result.assessments or result.findings + result.backlog
+        for finding in assessed:
+            statement_key = finding.statement.strip().casefold()
+            condition = finding.condition or candidate_conditions.get(statement_key, "")
+            supplied_id = (
+                finding.memory_id if _MEMORY_ID.fullmatch(finding.memory_id) else ""
+            )
+            memory_id = (
+                supplied_id
+                if supplied_id in by_id
+                else by_statement.get(statement_key)
+                or _specification_id(finding.statement, condition)
+            )
+            previous = by_id.get(memory_id)
+            remembered_evidence = tuple(
+                RememberedEvidence(
+                    evidence=evidence,
+                    snapshot=result.candidate_commit,
+                    blob_sha256=_blob_sha256(workspace, evidence.path),
+                    fresh=True,
+                )
+                for evidence in finding.evidence
+            )
+            assessment = SpecificationAssessment(
+                snapshot=result.candidate_commit,
+                status=finding.status,
+                patch_assessment=finding.patch_assessment,
+                recommendation=finding.recommendation,
+                confidence=finding.confidence,
+            )
+            evidence_history = previous.evidence if previous else ()
+            assessment_history = previous.assessments if previous else ()
+            value = RememberedSpecification(
+                memory_id=memory_id,
+                statement=finding.statement,
+                condition=condition or (previous.condition if previous else ""),
+                evidence=evidence_history + remembered_evidence,
+                assessments=assessment_history + (assessment,),
+            )
+            by_id[memory_id] = value
+            by_statement[statement_key] = memory_id
+            changed.append(memory_id)
+
+        snapshots = memory.observed_snapshots
+        if result.candidate_commit not in snapshots:
+            snapshots += (result.candidate_commit,)
+        updated = GuardianMemory(
+            specifications=tuple(
+                sorted(by_id.values(), key=lambda value: value.memory_id)
+            ),
+            observed_snapshots=snapshots,
+        )
+        self.root.mkdir(parents=True, exist_ok=True)
+        serialized = _memory_to_dict(updated)
+        specification_rows = serialized["specifications"]
+        if not isinstance(specification_rows, list):
+            raise RuntimeError("serialized Guardian specifications must be a list")
+        event: dict[str, Any] = {
+            "schema_version": _SCHEMA_VERSION,
+            "sequence": len(snapshots),
+            "base_commit": result.base_commit,
+            "candidate_commit": result.candidate_commit,
+            "updates": [
+                next(
+                    value
+                    for value in specification_rows
+                    if isinstance(value, dict)
+                    if value["memory_id"] == memory_id
+                )
+                for memory_id in changed
+            ],
+        }
+        with self.events_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary = self.state_path.with_suffix(".json.tmp")
+        temporary.write_text(
+            json.dumps(serialized, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary, self.state_path)
+        return updated
+
+
+__all__ = ["GuardianMemoryStore"]

--- a/codenib/clients/guardian/memory.py
+++ b/codenib/clients/guardian/memory.py
@@ -30,8 +30,12 @@ _MEMORY_ID = re.compile(r"^spec:[0-9a-f]{16}$")
 
 
 def _specification_id(statement: str, condition: str) -> str:
-    value = f"{statement.strip().casefold()}\0{condition.strip().casefold()}"
+    value = "\0".join(_specification_key(statement, condition))
     return f"spec:{hashlib.sha256(value.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _specification_key(statement: str, condition: str) -> tuple[str, str]:
+    return statement.strip().casefold(), condition.strip().casefold()
 
 
 def _blob_sha256(workspace: Path, path: str) -> str:
@@ -204,8 +208,11 @@ class GuardianMemoryStore:
             specification.memory_id: specification
             for specification in memory.specifications
         }
-        by_statement = {
-            specification.statement.strip().casefold(): specification.memory_id
+        by_key = {
+            _specification_key(
+                specification.statement,
+                specification.condition,
+            ): specification.memory_id
             for specification in memory.specifications
         }
         candidate_conditions = {
@@ -217,13 +224,21 @@ class GuardianMemoryStore:
         for finding in assessed:
             statement_key = finding.statement.strip().casefold()
             condition = finding.condition or candidate_conditions.get(statement_key, "")
+            specification_key = _specification_key(finding.statement, condition)
             supplied_id = (
                 finding.memory_id if _MEMORY_ID.fullmatch(finding.memory_id) else ""
             )
-            memory_id = (
+            supplied = by_id.get(supplied_id)
+            matched_supplied_id = (
                 supplied_id
-                if supplied_id in by_id
-                else by_statement.get(statement_key)
+                if supplied is not None
+                and _specification_key(supplied.statement, supplied.condition)
+                == specification_key
+                else ""
+            )
+            memory_id = (
+                matched_supplied_id
+                or by_key.get(specification_key)
                 or _specification_id(finding.statement, condition)
             )
             previous = by_id.get(memory_id)
@@ -247,13 +262,13 @@ class GuardianMemoryStore:
             assessment_history = previous.assessments if previous else ()
             value = RememberedSpecification(
                 memory_id=memory_id,
-                statement=finding.statement,
-                condition=condition or (previous.condition if previous else ""),
+                statement=previous.statement if previous else finding.statement,
+                condition=previous.condition if previous else condition,
                 evidence=evidence_history + remembered_evidence,
                 assessments=assessment_history + (assessment,),
             )
             by_id[memory_id] = value
-            by_statement[statement_key] = memory_id
+            by_key[specification_key] = memory_id
             changed.append(memory_id)
 
         snapshots = memory.observed_snapshots

--- a/codenib/clients/guardian/normalization.py
+++ b/codenib/clients/guardian/normalization.py
@@ -98,6 +98,7 @@ def parse_candidates(text: str, *, explorer: str) -> tuple[LocalSpecification, .
                 confidence=_confidence(row.get("confidence")),
                 uncertainty=str(row.get("uncertainty", "")).strip(),
                 explorer=explorer,
+                memory_id=str(row.get("memory_id", "")).strip(),
             )
         )
     return tuple(values)
@@ -130,6 +131,8 @@ def parse_findings(
                 patch_assessment=str(row.get("patch_assessment", "")).strip(),
                 recommendation=str(row.get("recommendation", "")).strip(),
                 confidence=_confidence(row.get("confidence")),
+                condition=str(row.get("condition", "")).strip(),
+                memory_id=str(row.get("memory_id", "")).strip(),
             )
         )
     return str(value.get("summary", "")).strip(), tuple(findings)

--- a/codenib/clients/guardian/prompts.py
+++ b/codenib/clients/guardian/prompts.py
@@ -39,6 +39,46 @@ def _context(request: GuardianRequest) -> str:
     return json.dumps(rows, indent=2)
 
 
+def _memory(request: GuardianRequest) -> str:
+    if not request.memory.specifications:
+        return (
+            "Guardian has no prior local-specification memory for this review stream."
+        )
+    rows = []
+    for specification in request.memory.specifications:
+        latest = specification.assessments[-1] if specification.assessments else None
+        rows.append(
+            {
+                "memory_id": specification.memory_id,
+                "statement": specification.statement,
+                "condition": specification.condition,
+                "last_assessment": (
+                    {
+                        "snapshot": latest.snapshot,
+                        "status": latest.status.value,
+                        "patch_assessment": latest.patch_assessment,
+                        "confidence": latest.confidence,
+                    }
+                    if latest
+                    else None
+                ),
+                "evidence": [
+                    {
+                        "path": remembered.evidence.path,
+                        "line_start": remembered.evidence.line_start,
+                        "line_end": remembered.evidence.line_end,
+                        "description": remembered.evidence.description,
+                        "authority": remembered.evidence.authority.value,
+                        "observed_snapshot": remembered.snapshot,
+                        "fresh_in_candidate": remembered.fresh,
+                    }
+                    for remembered in specification.evidence[-5:]
+                ],
+            }
+        )
+    return json.dumps(rows, indent=2)
+
+
 def _patch_context(request: GuardianRequest) -> str:
     if request.change_patch:
         return (
@@ -80,10 +120,17 @@ Participant context follows. It can identify intended areas or uncertainty, but 
 not authoritative evidence and may be wrong:
 {_context(request)}
 
+Guardian memory follows. It is a fallible record of earlier evidence and assessments,
+not authoritative truth. Revalidate relevant entries in the current repository,
+especially evidence marked stale. Preserve a specification's `memory_id` when you
+reassess the same property, and challenge gaps that earlier reviews left unresolved:
+{_memory(request)}
+
 Return only one JSON object with this shape:
 {{
-  "candidates": [
+    "candidates": [
     {{
+      "memory_id": "existing spec id when reassessing one, otherwise empty",
       "statement": "falsifiable property that must hold",
       "condition": "specific triggering condition or path",
       "evidence": [
@@ -104,7 +151,11 @@ Return only one JSON object with this shape:
 
 Every candidate needs concrete evidence. Prefer a small set of important, distinct
 specifications over generic review advice. A solver message must use authority `solver`
-and cannot by itself justify a requirement.
+and cannot by itself justify a requirement. Before returning, reopen every cited path
+and confirm that it is an existing repository-relative file and that the inclusive line
+range contains the fact described. Never put a command, observation label, URL, or
+invented filename in `path`. Runtime evidence must still cite the repository source or
+test file exercised and describe the observed command result in `description`.
 """
 
 
@@ -118,6 +169,7 @@ def aggregation_prompt(
         rows.append(
             {
                 "explorer": candidate.explorer,
+                "memory_id": candidate.memory_id,
                 "statement": candidate.statement,
                 "condition": candidate.condition,
                 "evidence": [
@@ -150,13 +202,24 @@ Use repository tools. {_patch_context(request)}
 Explorer candidates:
 {json.dumps(rows, indent=2)}
 
+Guardian memory from earlier snapshots follows. Treat it as a set of hypotheses with
+provenance, not as normative authority. Revalidate relevant entries against the current
+snapshot. For every remembered specification you materially reassess, return its exact
+`memory_id`; use `satisfied` when current evidence establishes that the candidate now
+meets it, and `retracted` only when the earlier property itself is unsupported or no
+longer applicable. Evidence marked stale must not justify an assessment without being
+reopened:
+{_memory(request)}
+
 Return only one JSON object:
 {{
   "summary": "brief review conclusion",
   "findings": [
     {{
+      "memory_id": "existing spec id when reassessing one, otherwise empty",
       "statement": "admitted local specification",
-      "status": "violated|uncertain|satisfied",
+      "condition": "specific triggering condition or execution path",
+      "status": "violated|uncertain|satisfied|retracted",
       "evidence": [{{"path": "...", "line_start": 1, "line_end": 1,
         "description": "...", "authority": "repository|test|runtime|task|solver"}}],
       "patch_assessment": "specific candidate behavior",
@@ -169,7 +232,10 @@ Return only one JSON object:
 Admit at most {max_findings} violated findings. A violated finding requires non-solver
 evidence, confidence >= 0.70, and a concrete mismatch in the candidate. Put plausible
 but unverified or incompletely assessed items under status `uncertain`. Include satisfied
-items only when they materially explain why a candidate was rejected.
+items only when they materially explain why a candidate was rejected. Reopen every
+cited path before returning and verify that the repository-relative file and inclusive
+line range exist. Do not emit synthetic paths for commands or runtime observations;
+anchor those claims to the repository source or test that was exercised.
 """
 
 

--- a/codenib/clients/guardian/types.py
+++ b/codenib/clients/guardian/types.py
@@ -73,12 +73,57 @@ class LocalSpecification:
     confidence: float
     uncertainty: str = ""
     explorer: str = ""
+    memory_id: str = ""
 
 
 class FindingStatus(str, Enum):
     VIOLATED = "violated"
     UNCERTAIN = "uncertain"
     SATISFIED = "satisfied"
+    RETRACTED = "retracted"
+
+
+@dataclass(frozen=True, slots=True)
+class RememberedEvidence:
+    """Repository evidence as it was observed in an immutable snapshot."""
+
+    evidence: Evidence
+    snapshot: str
+    blob_sha256: str
+    fresh: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class SpecificationAssessment:
+    """A local specification's assessment for one repository snapshot."""
+
+    snapshot: str
+    status: FindingStatus
+    patch_assessment: str
+    recommendation: str
+    confidence: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "status", FindingStatus(self.status))
+
+
+@dataclass(frozen=True, slots=True)
+class RememberedSpecification:
+    """A specification whose evidence and assessments persist across reviews."""
+
+    memory_id: str
+    statement: str
+    condition: str
+    evidence: tuple[RememberedEvidence, ...] = ()
+    assessments: tuple[SpecificationAssessment, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class GuardianMemory:
+    """Controller-owned, read-only memory supplied to one Guardian review."""
+
+    specifications: tuple[RememberedSpecification, ...] = ()
+    observed_snapshots: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,6 +134,8 @@ class GuardianFinding:
     patch_assessment: str
     recommendation: str
     confidence: float
+    condition: str = ""
+    memory_id: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "status", FindingStatus(self.status))
@@ -101,6 +148,7 @@ class GuardianRequest:
     candidate_commit: str
     context: tuple[ContextMessage, ...] = ()
     change_patch: str = ""
+    memory: GuardianMemory = field(default_factory=GuardianMemory)
 
     def __post_init__(self) -> None:
         workspace = Path(self.workspace).expanduser().resolve()
@@ -113,6 +161,8 @@ class GuardianRequest:
             object.__setattr__(self, name, revision)
         object.__setattr__(self, "workspace", workspace)
         object.__setattr__(self, "context", tuple(self.context))
+        if not isinstance(self.memory, GuardianMemory):
+            raise TypeError("memory must be GuardianMemory")
         if not isinstance(self.change_patch, str):
             raise TypeError("change_patch must be a string")
         if len(self.change_patch.encode("utf-8")) > 2 * 1024**2:
@@ -171,6 +221,7 @@ class GuardianResult:
     candidates: tuple[LocalSpecification, ...] = ()
     findings: tuple[GuardianFinding, ...] = ()
     backlog: tuple[GuardianFinding, ...] = ()
+    assessments: tuple[GuardianFinding, ...] = field(default=(), repr=False)
     summary: str = ""
     rollouts: tuple[AgentRunResult, ...] = field(default=(), repr=False)
     errors: tuple[str, ...] = ()
@@ -204,6 +255,7 @@ class GuardianResult:
             "candidates": [specification(value) for value in self.candidates],
             "findings": [finding(value) for value in self.findings],
             "backlog": [finding(value) for value in self.backlog],
+            "assessments": [finding(value) for value in self.assessments],
             "candidate_count": len(self.candidates),
             "errors": list(self.errors),
             "usage": {
@@ -224,8 +276,12 @@ __all__ = [
     "FindingStatus",
     "GuardianConfig",
     "GuardianFinding",
+    "GuardianMemory",
     "GuardianRequest",
     "GuardianResult",
     "LocalSpecification",
+    "RememberedEvidence",
+    "RememberedSpecification",
     "ReviewStatus",
+    "SpecificationAssessment",
 ]

--- a/codenib/sandbox/docker.py
+++ b/codenib/sandbox/docker.py
@@ -733,36 +733,6 @@ class DockerSandboxProvider:
             raise SandboxPolicyError(
                 "Git symlinks are unsupported in revision-pinned sandboxes"
             )
-        archive_attributes = subprocess.run(
-            self._git_command(
-                [
-                    "-c",
-                    "core.hooksPath=/dev/null",
-                    "-C",
-                    str(source),
-                    "grep",
-                    "--quiet",
-                    "--extended-regexp",
-                    r"export-(ignore|subst)",
-                    revision,
-                    "--",
-                    ".gitattributes",
-                    ":(glob)**/.gitattributes",
-                ]
-            ),
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=_safe_git_environment(),
-        )
-        if archive_attributes.returncode == 0:
-            raise SandboxPolicyError(
-                "export-ignore/export-subst attributes are unsupported in exact "
-                "revision snapshots"
-            )
-        if archive_attributes.returncode != 1:
-            raise SandboxPolicyError("source archive attributes cannot be inspected")
         info_attributes = common_dir / "info" / "attributes"
         try:
             info_attributes_stat = info_attributes.lstat()
@@ -777,19 +747,95 @@ class DockerSandboxProvider:
                 raise SandboxPolicyError(
                     "Git info attributes must be a regular, non-symlink file"
                 )
-            try:
-                if info_attributes_stat.st_size > 1024**2:
-                    raise SandboxPolicyError("Git info attributes file is too large")
-                info_text = info_attributes.read_text(
-                    encoding="utf-8", errors="replace"
+            if info_attributes_stat.st_size > 1024**2:
+                raise SandboxPolicyError("Git info attributes file is too large")
+        tree_paths = subprocess.run(
+            self._git_command(
+                [
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "-C",
+                    str(source),
+                    "ls-tree",
+                    "-rzt",
+                    "--full-tree",
+                    "--name-only",
+                    revision,
+                ]
+            ),
+            check=False,
+            capture_output=True,
+            timeout=30,
+            env=_safe_git_environment(),
+        )
+        if tree_paths.returncode != 0:
+            raise SandboxPolicyError("source Git paths cannot be inspected safely")
+        # Use a private index so attribute matching is revision-scoped without
+        # relying on the caller's mutable index or requiring newer Git's
+        # ``check-attr --source`` option.
+        with tempfile.TemporaryDirectory(prefix="codenib-git-index-") as temp_dir:
+            attribute_env = _safe_git_environment()
+            attribute_env["GIT_INDEX_FILE"] = str(Path(temp_dir) / "index")
+            read_tree = subprocess.run(
+                self._git_command(
+                    [
+                        "-c",
+                        "core.hooksPath=/dev/null",
+                        "-C",
+                        str(source),
+                        "read-tree",
+                        revision,
+                    ]
+                ),
+                check=False,
+                capture_output=True,
+                timeout=30,
+                env=attribute_env,
+            )
+            if read_tree.returncode != 0:
+                raise SandboxPolicyError(
+                    "source archive attributes cannot be inspected"
                 )
-            except OSError as exc:
+            archive_attributes = subprocess.run(
+                self._git_command(
+                    [
+                        "-c",
+                        "core.hooksPath=/dev/null",
+                        "-C",
+                        str(source),
+                        "check-attr",
+                        "-z",
+                        "--stdin",
+                        "--cached",
+                        "export-ignore",
+                        "export-subst",
+                    ]
+                ),
+                check=False,
+                input=tree_paths.stdout,
+                capture_output=True,
+                timeout=30,
+                env=attribute_env,
+            )
+        if archive_attributes.returncode != 0:
+            raise SandboxPolicyError("source archive attributes cannot be inspected")
+        attribute_fields = archive_attributes.stdout.split(b"\0")
+        if attribute_fields[-1:] == [b""]:
+            attribute_fields.pop()
+        if len(attribute_fields) % 3:
+            raise SandboxPolicyError("source archive attributes are malformed")
+        for _, attribute, value in zip(
+            attribute_fields[0::3],
+            attribute_fields[1::3],
+            attribute_fields[2::3],
+            strict=True,
+        ):
+            if attribute not in {b"export-ignore", b"export-subst"}:
+                raise SandboxPolicyError("source archive attributes are malformed")
+            if value not in {b"unspecified", b"unset"}:
                 raise SandboxPolicyError(
-                    "Git info attributes file cannot be inspected"
-                ) from exc
-            if re.search(r"export-(?:ignore|subst)", info_text):
-                raise SandboxPolicyError(
-                    "Git info export attributes are unsupported in exact snapshots"
+                    "effective export-ignore/export-subst attributes are unsupported "
+                    "in exact revision snapshots"
                 )
         self._validate_host_mount_path(common_dir)
         return common_dir

--- a/scripts/guardian/deepswe/README.md
+++ b/scripts/guardian/deepswe/README.md
@@ -44,6 +44,20 @@ Guardian performs at most three review cycles by default. Configure this with
 its unresolved findings; subsequent solver edits can be acknowledged by the
 checkpoint command but cannot launch another Guardian review.
 
+Across those cycles, the host controller maintains a local-specification ledger
+outside the solver repository and Guardian rollout sandboxes. Each remembered
+specification retains snapshot-addressed evidence and per-snapshot assessments;
+evidence is marked stale when its repository blob changes. Explorers and the
+aggregator receive this ledger as fallible context and must revalidate it. The
+live ledger stays in host-private storage while the solver runs, then is exported
+to `agent_logs/guardian_memory/` with its append-only `events.jsonl` journal for
+experiment analysis.
+
+Configure the inference allocation independently with
+`--guardian-explorer-model` and `--guardian-aggregator-model`. The legacy
+`--guardian-model` option remains a shared fallback for both roles. When none
+of these options is provided, both roles continue to use the solver model.
+
 Generated trial data belongs under `data/deepswe_outputs/`; generated
 `dashboard/data.json` is ignored and can be recreated by the exporter.
 Set `CODENIB_DEEPSWE_ROOT` to use a DeepSWE checkout outside the default

--- a/scripts/guardian/deepswe/ablation.py
+++ b/scripts/guardian/deepswe/ablation.py
@@ -148,6 +148,15 @@ def _guardian_run_status(logs_dir: Path) -> dict[str, Any] | None:
     summary["exit_reasons"] = [
         str(status.get("exit_reason") or "") for status in statuses
     ]
+    summary["analysis_warnings"] = [
+        str(error)
+        for status in statuses
+        for error in (
+            status.get("analysis_warnings")
+            if isinstance(status.get("analysis_warnings"), list)
+            else []
+        )
+    ]
     summary["degraded"] = any(bool(status.get("degraded")) for status in statuses)
 
     health = {str(status.get("analysis_status") or "") for status in statuses}
@@ -320,7 +329,9 @@ def _build_pier_command(
                 "--ak",
                 "solver=codex",
                 "--ak",
-                f"guardian_model={args.guardian_model}",
+                f"guardian_explorer_model={args.guardian_explorer_model}",
+                "--ak",
+                f"guardian_aggregator_model={args.guardian_aggregator_model}",
                 "--ak",
                 f"guardian_explorer_count={args.guardian_explorer_count}",
                 "--ak",
@@ -432,6 +443,12 @@ def _run_trial(
             getattr(args, "context_injection_sha256", "") or ""
         ),
         "guardian_model": args.guardian_model if baseline == "guardian" else "",
+        "guardian_explorer_model": (
+            args.guardian_explorer_model if baseline == "guardian" else ""
+        ),
+        "guardian_aggregator_model": (
+            args.guardian_aggregator_model if baseline == "guardian" else ""
+        ),
         "guardian_explorer_count": (
             args.guardian_explorer_count if baseline == "guardian" else None
         ),
@@ -524,7 +541,24 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=("solo", "guardian"),
         help="Select which experiment arms to run",
     )
-    parser.add_argument("--guardian-model", default=None)
+    parser.add_argument(
+        "--guardian-model",
+        default=None,
+        help=(
+            "Backward-compatible shared fallback for both Guardian roles; "
+            "role-specific options take precedence"
+        ),
+    )
+    parser.add_argument(
+        "--guardian-explorer-model",
+        default=None,
+        help="Model used by independent local-specification explorers",
+    )
+    parser.add_argument(
+        "--guardian-aggregator-model",
+        default=None,
+        help="Model used to aggregate and admit explorer candidates",
+    )
     parser.add_argument(
         "--guardian-explorer-count",
         type=int,
@@ -570,8 +604,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         )
     if args.guardian_max_cycles < 1:
         raise ValueError("--guardian-max-cycles must be positive")
-    if args.guardian_model is None:
-        args.guardian_model = f"codex:{args.model}"
+    shared_guardian_model = args.guardian_model or f"codex:{args.model}"
+    args.guardian_explorer_model = args.guardian_explorer_model or shared_guardian_model
+    args.guardian_aggregator_model = (
+        args.guardian_aggregator_model or shared_guardian_model
+    )
+    args.guardian_model = (
+        shared_guardian_model
+        if args.guardian_explorer_model == args.guardian_aggregator_model
+        else ""
+    )
     return args
 
 

--- a/scripts/guardian/deepswe/harness/agent.py
+++ b/scripts/guardian/deepswe/harness/agent.py
@@ -34,6 +34,8 @@ import importlib
 import logging
 import re
 import shlex
+import shutil
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -106,7 +108,9 @@ class GuardianCodingAgent(BaseInstalledAgent):
         # Guardian kwargs (from --ak)
         solver: str = "codex",
         guardian_repo: str = "/app",
-        guardian_model: str = "codex:gpt-5.6-luna",
+        guardian_model: str | None = None,
+        guardian_explorer_model: str | None = None,
+        guardian_aggregator_model: str | None = None,
         guardian_explorer_count: int = 2,
         guardian_max_findings: int = 5,
         guardian_max_cycles: int = 3,
@@ -132,7 +136,11 @@ class GuardianCodingAgent(BaseInstalledAgent):
 
         self._solver_name = solver
         self._guardian_repo = guardian_repo
-        self._guardian_model = guardian_model
+        shared_guardian_model = guardian_model or "codex:gpt-5.6-luna"
+        self._guardian_explorer_model = guardian_explorer_model or shared_guardian_model
+        self._guardian_aggregator_model = (
+            guardian_aggregator_model or shared_guardian_model
+        )
         self._guardian_explorer_count = int(guardian_explorer_count)
         self._guardian_max_findings = int(guardian_max_findings)
         self._guardian_max_cycles = int(guardian_max_cycles)
@@ -300,7 +308,16 @@ class GuardianCodingAgent(BaseInstalledAgent):
             return path
 
         default = Path.home() / ".codex" / "auth.json"
-        if self._guardian_model.startswith("codex:") and default.is_file():
+        if (
+            any(
+                model.startswith("codex:")
+                for model in (
+                    self._guardian_explorer_model,
+                    self._guardian_aggregator_model,
+                )
+            )
+            and default.is_file()
+        ):
             return default
 
         return None
@@ -356,10 +373,9 @@ class GuardianCodingAgent(BaseInstalledAgent):
         augmented = f"{guardian_preamble}\n\n---\n\n{instruction}"
         auth_path = self._resolve_codex_auth_json_path()
         auth_json = auth_path.read_bytes() if auth_path is not None else None
-        model = self._guardian_model.removeprefix("codex:")
         config = GuardianConfig(
-            explorer_model=model,
-            aggregator_model=model,
+            explorer_model=self._guardian_explorer_model.removeprefix("codex:"),
+            aggregator_model=self._guardian_aggregator_model.removeprefix("codex:"),
             explorer_count=self._guardian_explorer_count,
             rollout_timeout_seconds=self._guardian_rollout_timeout,
             max_findings=self._guardian_max_findings,
@@ -373,23 +389,31 @@ class GuardianCodingAgent(BaseInstalledAgent):
             docker_host=self._guardian_docker_host,
             platform=self._guardian_platform,
         )
-        controller = GuardianHostController(
-            exchange_root=self._guardian_host_exchange_dir,
-            episodes_root=self._guardian_host_exchange_dir.parent / "guardian_episodes",
-            config=config,
-            reviewer_factory=reviewer_factory,
-            initial_base_commit=self._guardian_baseline_commit,
-            max_cycles=self._guardian_max_cycles,
-            poll_interval_seconds=self._guardian_poll_interval,
-        )
-        stop = asyncio.Event()
-        controller_task = asyncio.create_task(controller.serve(stop))
-        try:
-            await self._inner.run(augmented, environment, context)
-        finally:
-            stop.set()
-            await controller_task
-            await self._write_codex_token_summary(environment)
+        with tempfile.TemporaryDirectory(prefix="guardian-memory-") as memory_dir:
+            controller = GuardianHostController(
+                exchange_root=self._guardian_host_exchange_dir,
+                episodes_root=(
+                    self._guardian_host_exchange_dir.parent / "guardian_episodes"
+                ),
+                memory_root=Path(memory_dir),
+                config=config,
+                reviewer_factory=reviewer_factory,
+                initial_base_commit=self._guardian_baseline_commit,
+                max_cycles=self._guardian_max_cycles,
+                poll_interval_seconds=self._guardian_poll_interval,
+            )
+            stop = asyncio.Event()
+            controller_task = asyncio.create_task(controller.serve(stop))
+            try:
+                await self._inner.run(augmented, environment, context)
+            finally:
+                stop.set()
+                await controller_task
+                exported_memory = (
+                    self._guardian_host_exchange_dir.parent / "guardian_memory"
+                )
+                shutil.copytree(memory_dir, exported_memory, dirs_exist_ok=True)
+                await self._write_codex_token_summary(environment)
 
     async def _write_codex_token_summary(self, environment: BaseEnvironment) -> None:
         """Parse codex turn.completed events and write token totals to codex_tokens.json."""

--- a/scripts/guardian/deepswe/harness/checkpoint.py
+++ b/scripts/guardian/deepswe/harness/checkpoint.py
@@ -267,7 +267,13 @@ def main() -> int:
                 "Guardian checkpoint: "
                 + ("report ready" if submitted else "report incomplete")
             )
-            print(f"model: {status.get('llm_model', '')}")
+            explorer_model = status.get("explorer_model")
+            aggregator_model = status.get("aggregator_model")
+            if explorer_model or aggregator_model:
+                print(f"explorer model: {explorer_model or 'unknown'}")
+                print(f"aggregator model: {aggregator_model or 'unknown'}")
+            else:
+                print(f"model: {status.get('llm_model', '')}")
             print(f"backend: {status.get('llm_backend', '')}")
             print(f"findings: {status.get('findings', 0)}")
             print(f"backlog: {status.get('backlog', 0)}")
@@ -293,6 +299,19 @@ def main() -> int:
                     "not be treated as a complete clean review.",
                     file=sys.stderr,
                 )
+            analysis_warnings = status.get("analysis_warnings")
+            if isinstance(analysis_warnings, list) and analysis_warnings:
+                print(
+                    f"Guardian analysis warnings: {len(analysis_warnings)}",
+                    file=sys.stderr,
+                )
+                for warning in analysis_warnings[:3]:
+                    print(f"- {warning}", file=sys.stderr)
+                if len(analysis_warnings) > 3:
+                    print(
+                        f"- ... and {len(analysis_warnings) - 3} more",
+                        file=sys.stderr,
+                    )
             tokens = status.get("llm_tokens")
             if isinstance(tokens, dict):
                 print(f"tokens: {tokens.get('total', 0)}")

--- a/scripts/guardian/deepswe/harness/controller.py
+++ b/scripts/guardian/deepswe/harness/controller.py
@@ -20,6 +20,7 @@ from codenib.clients.guardian import (
     ContextMessage,
     GuardianAgent,
     GuardianConfig,
+    GuardianMemoryStore,
     GuardianRequest,
     GuardianResult,
     ReviewStatus,
@@ -77,23 +78,33 @@ def _write_result(
     path: Path,
     result: GuardianResult,
     *,
-    model: str,
+    explorer_model: str,
+    aggregator_model: str,
+    explorer_count: int,
     cycle_index: int,
     max_cycles: int,
+    memory_specifications: int,
+    memory_snapshots: int,
 ) -> None:
     terminal = result.status is not ReviewStatus.FAILED and cycle_index >= max_cycles
+    exit_reason = (
+        "ReviewFailed" if result.status is ReviewStatus.FAILED else "ReviewCompleted"
+    )
     _write_text_atomic(path / "findings.md", render_markdown(result))
     _write_json_atomic(path / "findings.json", result.to_dict())
     rollout_dir = path / "rollouts"
     rollout_dir.mkdir(parents=True, exist_ok=True)
     for index, rollout in enumerate(result.rollouts, 1):
         prefix = rollout_dir / f"rollout_{index:02d}"
+        is_explorer = index <= explorer_count
         _write_text_atomic(prefix.with_suffix(".jsonl"), rollout.raw_output)
         _write_text_atomic(prefix.with_suffix(".stderr.txt"), rollout.stderr)
         _write_json_atomic(
             prefix.with_suffix(".metadata.json"),
             {
                 "status": rollout.status.value,
+                "role": "explorer" if is_explorer else "aggregator",
+                "model": explorer_model if is_explorer else aggregator_model,
                 "exit_code": rollout.exit_code,
                 "duration_seconds": rollout.duration_seconds,
                 "error": (
@@ -125,16 +136,21 @@ def _write_result(
             "candidate_count": len(result.candidates),
             "degraded": result.status is not ReviewStatus.COMPLETE,
             "analysis_status": result.status.value,
-            "exit_reason": "ReviewCompleted",
+            "exit_reason": exit_reason,
             "review_performed": True,
             "cycle_index": cycle_index,
             "max_cycles": max_cycles,
             "terminal": terminal,
             "termination_reason": "max_cycles_reached" if terminal else "",
-            "llm_model": model,
+            "llm_model": aggregator_model,
+            "explorer_model": explorer_model,
+            "aggregator_model": aggregator_model,
             "llm_backend": "codex-cli+codenib-sandbox",
             "llm_transport_history": ["codex-cli+codenib-sandbox"],
             "llm_tokens": _tokens(result),
+            "analysis_warnings": list(result.errors),
+            "memory_specifications": memory_specifications,
+            "memory_snapshots": memory_snapshots,
             "running": False,
             "error": (
                 ""
@@ -150,7 +166,8 @@ def _write_limit_response(
     *,
     request_id: str,
     base_commit: str,
-    model: str,
+    explorer_model: str,
+    aggregator_model: str,
     completed_cycles: int,
     max_cycles: int,
 ) -> None:
@@ -179,9 +196,65 @@ def _write_limit_response(
             "max_cycles": max_cycles,
             "terminal": True,
             "termination_reason": "max_cycles_reached",
-            "llm_model": model,
+            "llm_model": aggregator_model,
+            "explorer_model": explorer_model,
+            "aggregator_model": aggregator_model,
             "llm_backend": "codex-cli+codenib-sandbox",
             "llm_tokens": {"prompt": 0, "cached_input": 0, "completion": 0, "total": 0},
+            "analysis_warnings": [],
+            "running": False,
+            "error": "",
+        },
+    )
+
+
+def _write_superseded_response(
+    path: Path,
+    *,
+    request_id: str,
+    base_commit: str,
+    expected_base_commit: str,
+    explorer_model: str,
+    aggregator_model: str,
+    completed_cycles: int,
+    max_cycles: int,
+) -> None:
+    _write_text_atomic(
+        path / "findings.md",
+        "# Repository Guardian Superseded Review\n\n"
+        f"Candidate `{request_id}` was not reviewed because its base "
+        f"`{base_commit}` is no longer Guardian's current review head "
+        f"`{expected_base_commit}`.\n",
+    )
+    _write_json_atomic(
+        path / "status.json",
+        {
+            "commit": request_id,
+            "base_commit": base_commit,
+            "expected_base_commit": expected_base_commit,
+            "findings": 0,
+            "backlog": 0,
+            "high_confidence_backlog": 0,
+            "candidate_count": 0,
+            "degraded": False,
+            "analysis_status": "not_run",
+            "exit_reason": "ReviewSuperseded",
+            "review_performed": False,
+            "cycle_index": completed_cycles,
+            "max_cycles": max_cycles,
+            "terminal": False,
+            "termination_reason": "stale_base_commit",
+            "llm_model": aggregator_model,
+            "explorer_model": explorer_model,
+            "aggregator_model": aggregator_model,
+            "llm_backend": "codex-cli+codenib-sandbox",
+            "llm_tokens": {
+                "prompt": 0,
+                "cached_input": 0,
+                "completion": 0,
+                "total": 0,
+            },
+            "analysis_warnings": [],
             "running": False,
             "error": "",
         },
@@ -193,7 +266,8 @@ def _write_failure(
     *,
     request_id: str,
     error: str,
-    model: str,
+    explorer_model: str,
+    aggregator_model: str,
     cycle_index: int,
     max_cycles: int,
 ) -> None:
@@ -218,9 +292,12 @@ def _write_failure(
             "max_cycles": max_cycles,
             "terminal": False,
             "termination_reason": "",
-            "llm_model": model,
+            "llm_model": aggregator_model,
+            "explorer_model": explorer_model,
+            "aggregator_model": aggregator_model,
             "llm_backend": "codex-cli+codenib-sandbox",
             "llm_tokens": {"prompt": 0, "cached_input": 0, "completion": 0, "total": 0},
+            "analysis_warnings": [],
             "running": False,
             "error": error,
         },
@@ -284,6 +361,7 @@ class GuardianHostController:
         config: GuardianConfig,
         reviewer_factory: ReviewerFactory,
         initial_base_commit: str | None = None,
+        memory_root: Path | None = None,
         max_cycles: int = 3,
         poll_interval_seconds: float = 1.0,
     ) -> None:
@@ -295,6 +373,9 @@ class GuardianHostController:
         self.episodes_root = episodes_root
         self.config = config
         self.reviewer_factory = reviewer_factory
+        self.memory_store = GuardianMemoryStore(
+            memory_root or self.episodes_root.parent / "guardian_state"
+        )
         self._expected_base_commit = initial_base_commit
         self.max_cycles = max_cycles
         self._completed_cycles = 0
@@ -333,22 +414,31 @@ class GuardianHostController:
         if (response / "status.json").exists():
             return
         response.mkdir(parents=True, exist_ok=True)
+        publish_latest = True
         try:
             request, bundle = load_exchange_request(self.exchange_root, manifest)
             if (
                 self._expected_base_commit is not None
                 and request.base_commit != self._expected_base_commit
             ):
-                raise ValueError(
-                    "request base does not match the controller-owned review head: "
-                    f"expected {self._expected_base_commit}, got {request.base_commit}"
+                _write_superseded_response(
+                    response,
+                    request_id=request_id,
+                    base_commit=request.base_commit,
+                    expected_base_commit=self._expected_base_commit,
+                    explorer_model=self.config.explorer_model,
+                    aggregator_model=self.config.aggregator_model,
+                    completed_cycles=self._completed_cycles,
+                    max_cycles=self.max_cycles,
                 )
-            if self._completed_cycles >= self.max_cycles:
+                publish_latest = False
+            elif self._completed_cycles >= self.max_cycles:
                 _write_limit_response(
                     response,
                     request_id=request_id,
                     base_commit=request.base_commit,
-                    model=self.config.aggregator_model,
+                    explorer_model=self.config.explorer_model,
+                    aggregator_model=self.config.aggregator_model,
                     completed_cycles=self._completed_cycles,
                     max_cycles=self.max_cycles,
                 )
@@ -363,20 +453,22 @@ class GuardianHostController:
                 response,
                 request_id=request_id,
                 error=f"{type(exc).__name__}: {exc}",
-                model=self.config.aggregator_model,
+                explorer_model=self.config.explorer_model,
+                aggregator_model=self.config.aggregator_model,
                 cycle_index=self._completed_cycles + 1,
                 max_cycles=self.max_cycles,
             )
         episode = self.episodes_root / request_id
         _copy_report(response, episode)
-        latest = self.exchange_root / "latest"
-        latest.mkdir(parents=True, exist_ok=True)
-        for stale in latest.iterdir():
-            if stale.is_dir():
-                shutil.rmtree(stale)
-            else:
-                stale.unlink()
-        _copy_report(response, latest)
+        if publish_latest:
+            latest = self.exchange_root / "latest"
+            latest.mkdir(parents=True, exist_ok=True)
+            for stale in latest.iterdir():
+                if stale.is_dir():
+                    shutil.rmtree(stale)
+                else:
+                    stale.unlink()
+            _copy_report(response, latest)
 
     async def _review_request(
         self,
@@ -397,6 +489,7 @@ class GuardianHostController:
             )
             patch = _git_patch(workspace, request.base_commit, request.candidate_commit)
             reviewer = self.reviewer_factory(workspace)
+            memory = self.memory_store.load(workspace)
             result = await reviewer.review(
                 GuardianRequest(
                     workspace=workspace,
@@ -404,14 +497,22 @@ class GuardianHostController:
                     candidate_commit=request.candidate_commit,
                     context=_context(self.exchange_root, workspace),
                     change_patch=patch,
+                    memory=memory,
                 )
             )
+            updated_memory = memory
+            if result.status is not ReviewStatus.FAILED:
+                updated_memory = self.memory_store.update(result, workspace)
             _write_result(
                 response,
                 result,
-                model=self.config.aggregator_model,
+                explorer_model=self.config.explorer_model,
+                aggregator_model=self.config.aggregator_model,
+                explorer_count=self.config.explorer_count,
                 cycle_index=cycle_index,
                 max_cycles=self.max_cycles,
+                memory_specifications=len(updated_memory.specifications),
+                memory_snapshots=len(updated_memory.observed_snapshots),
             )
             if result.status is not ReviewStatus.FAILED:
                 self._expected_base_commit = request.candidate_commit
@@ -420,10 +521,46 @@ class GuardianHostController:
     async def process_pending(self) -> int:
         self._prepare()
         processed = 0
-        for manifest in sorted((self.exchange_root / "requests").glob("*.json")):
-            response = self.exchange_root / "responses" / manifest.stem / "status.json"
-            if response.exists():
-                continue
+        while True:
+            pending = [
+                manifest
+                for manifest in (self.exchange_root / "requests").glob("*.json")
+                if not (
+                    self.exchange_root / "responses" / manifest.stem / "status.json"
+                ).exists()
+            ]
+            if not pending:
+                break
+
+            ordered = sorted(
+                pending,
+                key=lambda path: (path.lstat().st_mtime_ns, path.name),
+            )
+            eligible: list[Path] = []
+            malformed: list[Path] = []
+            for manifest in ordered:
+                try:
+                    if manifest.is_symlink():
+                        raise ValueError("request manifest must not be a symlink")
+                    request = ReviewExchangeRequest.from_dict(
+                        json.loads(manifest.read_text(encoding="utf-8"))
+                    )
+                except (OSError, json.JSONDecodeError, ValueError):
+                    malformed.append(manifest)
+                    continue
+                if (
+                    self._expected_base_commit is None
+                    or request.base_commit == self._expected_base_commit
+                ):
+                    eligible.append(manifest)
+
+            # A malformed request must not block later valid work. Otherwise,
+            # follow the commit chain from the controller-owned review head.
+            # Requests left behind after the chain advances are handled as
+            # superseded rather than operational failures.
+            manifest = (
+                eligible[0] if eligible else malformed[0] if malformed else ordered[0]
+            )
             await self.process_manifest(manifest)
             processed += 1
         return processed
@@ -491,6 +628,8 @@ def sandbox_reviewer_factory(
                 executable=codex_executable,
                 process_runner=runner,
                 max_output_bytes=limits.output_bytes,
+                enabled_features=("unified_exec",),
+                disabled_features=("code_mode", "code_mode_host"),
             ),
         )
 

--- a/test/clients/test_execution.py
+++ b/test/clients/test_execution.py
@@ -241,6 +241,43 @@ def test_codex_executor_translates_workspace_write_policy(tmp_path: Path) -> Non
     assert "--model" not in command
 
 
+def test_codex_executor_applies_explicit_feature_policy(tmp_path: Path) -> None:
+    output = _jsonl(
+        {
+            "type": "item.completed",
+            "item": {"type": "agent_message", "text": "done"},
+        }
+    )
+    runner = FakeProcessRunner(_process_result(output))
+    executor = CodexExecutor(
+        process_runner=runner,
+        enabled_features=("unified_exec",),
+        disabled_features=("code_mode", "code_mode_host"),
+    )
+
+    result = asyncio.run(executor.run(_request(tmp_path)))
+
+    assert result.succeeded
+    command = runner.requests[0].argv
+    assert command.count("--enable") == 1
+    assert command[command.index("--enable") + 1] == "unified_exec"
+    assert command.count("--disable") == 2
+    disabled = {
+        command[index + 1]
+        for index, value in enumerate(command)
+        if value == "--disable"
+    }
+    assert disabled == {"code_mode", "code_mode_host"}
+
+
+def test_codex_executor_rejects_conflicting_feature_policy() -> None:
+    with pytest.raises(ValueError, match="both enabled and disabled"):
+        CodexExecutor(
+            enabled_features=("unified_exec",),
+            disabled_features=("unified_exec",),
+        )
+
+
 def test_codex_executor_delegates_sandboxing_only_when_explicit(tmp_path: Path) -> None:
     output = _jsonl(
         {

--- a/test/clients/test_guardian.py
+++ b/test/clients/test_guardian.py
@@ -22,10 +22,16 @@ from codenib.clients.execution import (
 )
 from codenib.clients.guardian import (
     ContextMessage,
+    Evidence,
+    FindingStatus,
     GuardianAgent,
     GuardianConfig,
+    GuardianMemory,
     GuardianRequest,
+    RememberedEvidence,
+    RememberedSpecification,
     ReviewStatus,
+    SpecificationAssessment,
     render_markdown,
 )
 
@@ -196,6 +202,12 @@ def test_guardian_discovers_aggregates_and_filters_delivery(tmp_path: Path) -> N
         "strong",
     ]
     assert all(
+        "reopen every cited path" in " ".join(request.instruction.lower().split())
+        for request in executor.requests
+    )
+    assert "invented filename" in executor.requests[0].instruction
+    assert "synthetic paths" in executor.requests[-1].instruction
+    assert all(
         request.policy.filesystem.value == "read-only" for request in executor.requests
     )
     markdown = render_markdown(result)
@@ -337,3 +349,75 @@ def test_guardian_rejects_aggregate_findings_with_invalid_lines(
     assert not result.findings
     assert not result.backlog
     assert any("aggregator finding" in error for error in result.errors)
+
+
+def test_guardian_prompts_treat_memory_as_fallible_and_preserve_ids(
+    tmp_path: Path,
+) -> None:
+    request = _request(tmp_path)
+    remembered = RememberedSpecification(
+        memory_id="spec:0123456789abcdef",
+        statement="Copies preserve mode",
+        condition="when state is copied",
+        evidence=(
+            RememberedEvidence(
+                evidence=Evidence(
+                    path="tests/test_contract.py",
+                    line_start=10,
+                    line_end=14,
+                    description="the public-path contract",
+                ),
+                snapshot=request.base_commit,
+                blob_sha256="0" * 64,
+                fresh=False,
+            ),
+        ),
+        assessments=(
+            SpecificationAssessment(
+                snapshot=request.base_commit,
+                status=FindingStatus.VIOLATED,
+                patch_assessment="an earlier snapshot omitted the field",
+                recommendation="preserve the field",
+                confidence=0.9,
+            ),
+        ),
+    )
+    executor = ScriptedExecutor(
+        [
+            _result(json.dumps({"candidates": [_candidate("Copies preserve mode")]})),
+            _result(
+                json.dumps(
+                    {
+                        "summary": "The remembered property is now satisfied.",
+                        "findings": [
+                            {
+                                **_finding("Copies preserve mode", "satisfied"),
+                                "memory_id": remembered.memory_id,
+                                "condition": remembered.condition,
+                            }
+                        ],
+                    }
+                )
+            ),
+        ]
+    )
+    agent = GuardianAgent(
+        GuardianConfig(
+            explorer_model="cheap",
+            aggregator_model="strong",
+            explorer_count=1,
+        ),
+        executor=executor,
+    )
+
+    result = asyncio.run(
+        agent.review(replace(request, memory=GuardianMemory((remembered,), ())))
+    )
+
+    assert result.assessments[0].memory_id == remembered.memory_id
+    assert all(remembered.memory_id in call.instruction for call in executor.requests)
+    assert "not authoritative truth" in executor.requests[0].instruction
+    assert "hypotheses with provenance" in " ".join(
+        executor.requests[1].instruction.split()
+    )
+    assert '"fresh_in_candidate": false' in executor.requests[0].instruction.lower()

--- a/test/clients/test_guardian_memory.py
+++ b/test/clients/test_guardian_memory.py
@@ -31,10 +31,16 @@ def _result(snapshot: str, finding: GuardianFinding) -> GuardianResult:
     )
 
 
-def _finding(status: FindingStatus, *, memory_id: str = "") -> GuardianFinding:
+def _finding(
+    status: FindingStatus,
+    *,
+    memory_id: str = "",
+    statement: str = "Prediction preserves the fitted feature layout.",
+    condition: str = "when preprocessing expands raw input columns",
+) -> GuardianFinding:
     return GuardianFinding(
-        statement="Prediction preserves the fitted feature layout.",
-        condition="when preprocessing expands raw input columns",
+        statement=statement,
+        condition=condition,
         status=status,
         evidence=(
             Evidence(
@@ -107,3 +113,82 @@ def test_memory_fails_closed_when_materialized_state_is_invalid(
 
     with pytest.raises(ValueError, match="cannot be loaded"):
         store.load(tmp_path)
+
+
+def test_memory_ignores_existing_id_for_a_different_specification(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repository"
+    workspace.mkdir()
+    (workspace / "feature.py").write_text("enabled = True\n", encoding="utf-8")
+    store = GuardianMemoryStore(tmp_path / "state")
+    first = store.update(
+        _result("b" * 40, _finding(FindingStatus.VIOLATED)),
+        workspace,
+    )
+    original = first.specifications[0]
+
+    rewritten = _finding(
+        FindingStatus.VIOLATED,
+        memory_id=original.memory_id,
+        statement="Prediction preserves the fitted output labels.",
+        condition="when preprocessing expands target columns",
+    )
+    updated = store.update(_result("c" * 40, rewritten), workspace)
+
+    assert len(updated.specifications) == 2
+    by_id = {
+        specification.memory_id: specification
+        for specification in updated.specifications
+    }
+    persisted_original = by_id[original.memory_id]
+    assert persisted_original.statement == original.statement
+    assert persisted_original.condition == original.condition
+    assert persisted_original.assessments == original.assessments
+    added = next(
+        specification
+        for specification in updated.specifications
+        if specification.memory_id != original.memory_id
+    )
+    assert added.statement == rewritten.statement
+    assert added.condition == rewritten.condition
+
+
+def test_memory_keeps_equal_statements_with_distinct_conditions(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "repository"
+    workspace.mkdir()
+    (workspace / "feature.py").write_text("enabled = True\n", encoding="utf-8")
+    store = GuardianMemoryStore(tmp_path / "state")
+    statement = "Prediction preserves the fitted feature layout."
+
+    store.update(
+        _result(
+            "b" * 40,
+            _finding(
+                FindingStatus.VIOLATED,
+                statement=statement,
+                condition="when preprocessing expands raw input columns",
+            ),
+        ),
+        workspace,
+    )
+    updated = store.update(
+        _result(
+            "c" * 40,
+            _finding(
+                FindingStatus.VIOLATED,
+                statement=statement,
+                condition="when preprocessing drops raw input columns",
+            ),
+        ),
+        workspace,
+    )
+
+    assert len(updated.specifications) == 2
+    assert {value.condition for value in updated.specifications} == {
+        "when preprocessing expands raw input columns",
+        "when preprocessing drops raw input columns",
+    }
+    assert len({value.memory_id for value in updated.specifications}) == 2

--- a/test/clients/test_guardian_memory.py
+++ b/test/clients/test_guardian_memory.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for controller-owned Guardian memory persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codenib.clients.guardian import (
+    Evidence,
+    FindingStatus,
+    GuardianFinding,
+    GuardianMemoryStore,
+    GuardianResult,
+    ReviewStatus,
+)
+
+
+def _result(snapshot: str, finding: GuardianFinding) -> GuardianResult:
+    return GuardianResult(
+        base_commit="a" * 40,
+        candidate_commit=snapshot,
+        status=ReviewStatus.COMPLETE,
+        findings=(finding,) if finding.status is FindingStatus.VIOLATED else (),
+        assessments=(finding,),
+    )
+
+
+def _finding(status: FindingStatus, *, memory_id: str = "") -> GuardianFinding:
+    return GuardianFinding(
+        statement="Prediction preserves the fitted feature layout.",
+        condition="when preprocessing expands raw input columns",
+        status=status,
+        evidence=(
+            Evidence(
+                path="feature.py",
+                line_start=1,
+                line_end=1,
+                description="the prediction path applies the recorded layout",
+            ),
+        ),
+        patch_assessment="the current snapshot was assessed",
+        recommendation="apply the recorded layout",
+        confidence=0.9,
+        memory_id=memory_id,
+    )
+
+
+def test_memory_persists_assessments_and_revalidates_evidence(tmp_path: Path) -> None:
+    workspace = tmp_path / "repository"
+    workspace.mkdir()
+    source = workspace / "feature.py"
+    source.write_text("enabled = True\n", encoding="utf-8")
+    store = GuardianMemoryStore(tmp_path / "state")
+
+    first = store.update(_result("b" * 40, _finding(FindingStatus.VIOLATED)), workspace)
+
+    assert first.observed_snapshots == ("b" * 40,)
+    assert len(first.specifications) == 1
+    remembered = store.load(workspace).specifications[0]
+    assert remembered.evidence[0].fresh is True
+    assert remembered.assessments[0].status is FindingStatus.VIOLATED
+
+    source.write_text("enabled = False\n", encoding="utf-8")
+    assert store.load(workspace).specifications[0].evidence[0].fresh is False
+
+    second_finding = _finding(
+        FindingStatus.SATISFIED,
+        memory_id=remembered.memory_id,
+    )
+    second = store.update(_result("c" * 40, second_finding), workspace)
+
+    assert len(second.specifications) == 1
+    assert [
+        assessment.status for assessment in second.specifications[0].assessments
+    ] == [
+        FindingStatus.VIOLATED,
+        FindingStatus.SATISFIED,
+    ]
+    assert second.observed_snapshots == ("b" * 40, "c" * 40)
+    events = [
+        json.loads(line)
+        for line in store.events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [event["sequence"] for event in events] == [1, 2]
+    assert events[0]["updates"][0]["memory_id"] == remembered.memory_id
+
+    retracted = _finding(
+        FindingStatus.RETRACTED,
+        memory_id=remembered.memory_id,
+    )
+    third = store.update(_result("d" * 40, retracted), workspace)
+    assert third.specifications[0].assessments[-1].status is FindingStatus.RETRACTED
+
+
+def test_memory_fails_closed_when_materialized_state_is_invalid(
+    tmp_path: Path,
+) -> None:
+    store = GuardianMemoryStore(tmp_path / "state")
+    store.root.mkdir()
+    store.state_path.write_text('{"schema_version": 999}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cannot be loaded"):
+        store.load(tmp_path)

--- a/test/guardian/deepswe/test_ablation.py
+++ b/test/guardian/deepswe/test_ablation.py
@@ -22,6 +22,10 @@ def test_local_specification_rollout_controls_are_forwarded(tmp_path):
             "fixture-task",
             "--guardian-explorer-count",
             "3",
+            "--guardian-explorer-model",
+            "codex:gpt-5.6-luna",
+            "--guardian-aggregator-model",
+            "codex:gpt-5.6-sol",
             "--guardian-max-findings",
             "4",
             "--guardian-max-cycles",
@@ -39,6 +43,8 @@ def test_local_specification_rollout_controls_are_forwarded(tmp_path):
     )
 
     assert "guardian_explorer_count=3" in command
+    assert "guardian_explorer_model=codex:gpt-5.6-luna" in command
+    assert "guardian_aggregator_model=codex:gpt-5.6-sol" in command
     assert "guardian_max_findings=4" in command
     assert "guardian_max_cycles=2" in command
     assert "guardian_rollout_timeout=123.0" in command
@@ -64,9 +70,36 @@ def test_reframed_guardian_defaults_are_explicit(tmp_path):
     )
 
     assert "guardian_explorer_count=2" in command
+    assert "guardian_explorer_model=codex:gpt-5.6-terra" in command
+    assert "guardian_aggregator_model=codex:gpt-5.6-terra" in command
     assert "guardian_max_findings=5" in command
     assert "guardian_max_cycles=3" in command
     assert "guardian_rollout_timeout=600.0" in command
+
+
+def test_legacy_guardian_model_remains_a_shared_fallback(tmp_path):
+    args = ablation.parse_args(
+        [
+            "--model",
+            "gpt-5.6-terra",
+            "--reasoning-effort",
+            "medium",
+            "--tasks",
+            "fixture-task",
+            "--guardian-model",
+            "codex:gpt-5.6-luna",
+        ]
+    )
+
+    command = ablation._build_pier_command(
+        args,
+        task="fixture-task",
+        baseline="guardian",
+        logs_dir=Path(tmp_path),
+    )
+
+    assert "guardian_explorer_model=codex:gpt-5.6-luna" in command
+    assert "guardian_aggregator_model=codex:gpt-5.6-luna" in command
 
 
 def test_baseline_selection_can_run_only_guardian(tmp_path, monkeypatch):
@@ -188,6 +221,7 @@ def test_guardian_run_status_aggregates_every_cycle(tmp_path):
             "degraded": True,
             "analysis_status": "degraded",
             "exit_reason": "ReportSubmitted",
+            "analysis_warnings": ["explorer_1 used an invalid evidence path"],
             "llm_tokens": {
                 "prompt": 100,
                 "cached_input": 60,
@@ -222,6 +256,7 @@ def test_guardian_run_status_aggregates_every_cycle(tmp_path):
     assert status["backlog"] == 0
     assert status["cycle_count"] == 2
     assert status["exit_reasons"] == ["ReportSubmitted", "ReportSubmitted"]
+    assert status["analysis_warnings"] == ["explorer_1 used an invalid evidence path"]
     assert status["degraded"] is True
     assert status["analysis_status"] == "degraded"
     assert status["llm_tokens"] == {

--- a/test/guardian/deepswe/test_checkpoint.py
+++ b/test/guardian/deepswe/test_checkpoint.py
@@ -65,8 +65,13 @@ def test_guardian_checkpoint_prints_fresh_report(tmp_path):
                 "analysis_status": "degraded",
                 "exit_reason": "ReportSubmitted",
                 "llm_model": "codex:gpt-5.6-luna",
+                "explorer_model": "gpt-5.6-luna",
+                "aggregator_model": "gpt-5.6-sol",
                 "llm_backend": "codex-sdk",
                 "llm_tokens": {"total": 123},
+                "analysis_warnings": [
+                    "explorer_1 candidate evidence path does not resolve"
+                ],
                 "error": "",
             }
         ),
@@ -96,6 +101,8 @@ def test_guardian_checkpoint_prints_fresh_report(tmp_path):
     )
 
     assert "Guardian checkpoint: report ready" in result.stdout
+    assert "explorer model: gpt-5.6-luna" in result.stdout
+    assert "aggregator model: gpt-5.6-sol" in result.stdout
     assert "backend: codex-sdk" in result.stdout
     assert "backlog: 1" in result.stdout
     assert "high-confidence backlog: 1" in result.stdout
@@ -103,6 +110,8 @@ def test_guardian_checkpoint_prints_fresh_report(tmp_path):
     assert "tokens: 123" in result.stdout
     assert "Risk found." in result.stdout
     assert "must not be treated as a complete clean review" in result.stderr
+    assert "Guardian analysis warnings: 1" in result.stderr
+    assert "evidence path does not resolve" in result.stderr
 
 
 def test_guardian_checkpoint_times_out_on_stale_report(tmp_path):

--- a/test/guardian/deepswe/test_controller.py
+++ b/test/guardian/deepswe/test_controller.py
@@ -13,6 +13,7 @@ import subprocess
 from pathlib import Path
 
 from codenib.clients.guardian import GuardianConfig, GuardianResult, ReviewStatus
+from scripts.guardian.deepswe.harness import controller as controller_module
 from scripts.guardian.deepswe.harness.controller import GuardianHostController
 
 
@@ -103,17 +104,53 @@ def _publish_next(repo: Path, exchange: Path, base: str) -> str:
 
 
 class FakeReviewer:
-    def __init__(self, requests: list) -> None:
+    def __init__(
+        self,
+        requests: list,
+        *,
+        status: ReviewStatus = ReviewStatus.COMPLETE,
+        errors: tuple[str, ...] = (),
+    ) -> None:
         self.requests = requests
+        self.status = status
+        self.errors = errors
 
     async def review(self, request):
         self.requests.append(request)
         return GuardianResult(
             base_commit=request.base_commit,
             candidate_commit=request.candidate_commit,
-            status=ReviewStatus.COMPLETE,
+            status=self.status,
             summary="No admitted violation.",
+            errors=self.errors,
         )
+
+
+def test_sandbox_reviewer_uses_stable_codex_tool_execution(
+    tmp_path: Path, monkeypatch
+) -> None:
+    executor_options = {}
+
+    class FakeExecutor:
+        def __init__(self, **kwargs) -> None:
+            executor_options.update(kwargs)
+
+    monkeypatch.setattr(controller_module, "CodexExecutor", FakeExecutor)
+    factory = controller_module.sandbox_reviewer_factory(
+        config=GuardianConfig(explorer_model="luna", aggregator_model="terra"),
+        image="fixture:latest",
+        codex_executable="/usr/local/bin/codex-guardian",
+        auth_json=None,
+    )
+
+    reviewer = factory(tmp_path)
+
+    assert reviewer.executor is not None
+    assert executor_options["enabled_features"] == ("unified_exec",)
+    assert executor_options["disabled_features"] == (
+        "code_mode",
+        "code_mode_host",
+    )
 
 
 def test_host_controller_reviews_materialized_snapshot(tmp_path: Path) -> None:
@@ -142,9 +179,13 @@ def test_host_controller_reviews_materialized_snapshot(tmp_path: Path) -> None:
     )
     assert status["analysis_status"] == "complete"
     assert status["llm_backend"] == "codex-cli+codenib-sandbox"
+    assert status["explorer_model"] == "luna"
+    assert status["aggregator_model"] == "terra"
     assert status["cycle_index"] == 1
     assert status["max_cycles"] == 3
     assert status["terminal"] is False
+    assert status["memory_specifications"] == 0
+    assert status["memory_snapshots"] == 1
     assert (exchange / "latest" / "findings.md").is_file()
     assert (tmp_path / "episodes" / candidate / "status.json").is_file()
 
@@ -171,6 +212,117 @@ def test_host_controller_reports_invalid_bundle_without_review(tmp_path: Path) -
     )
     assert status["analysis_status"] == "failed"
     assert "checksum" in status["error"]
+
+
+def test_host_controller_exposes_degraded_analysis_warnings(tmp_path: Path) -> None:
+    exchange, base, candidate = _publish(tmp_path)
+    validation_error = "explorer_1 candidate 2 evidence path does not resolve"
+    controller = GuardianHostController(
+        exchange_root=exchange,
+        episodes_root=tmp_path / "episodes",
+        config=GuardianConfig(explorer_model="luna", aggregator_model="terra"),
+        reviewer_factory=lambda _workspace: FakeReviewer(
+            [],
+            status=ReviewStatus.DEGRADED,
+            errors=(validation_error,),
+        ),
+        initial_base_commit=base,
+    )
+
+    assert asyncio.run(controller.process_pending()) == 1
+    status = json.loads(
+        (exchange / "responses" / candidate / "status.json").read_text()
+    )
+    assert status["analysis_status"] == "degraded"
+    assert status["exit_reason"] == "ReviewCompleted"
+    assert status["error"] == ""
+    assert status["analysis_warnings"] == [validation_error]
+
+
+def test_host_controller_labels_failed_review_truthfully(tmp_path: Path) -> None:
+    exchange, base, candidate = _publish(tmp_path)
+    controller = GuardianHostController(
+        exchange_root=exchange,
+        episodes_root=tmp_path / "episodes",
+        config=GuardianConfig(explorer_model="luna", aggregator_model="terra"),
+        reviewer_factory=lambda _workspace: FakeReviewer(
+            [],
+            status=ReviewStatus.FAILED,
+            errors=("explorers unavailable",),
+        ),
+        initial_base_commit=base,
+    )
+
+    assert asyncio.run(controller.process_pending()) == 1
+    status = json.loads(
+        (exchange / "responses" / candidate / "status.json").read_text()
+    )
+    assert status["analysis_status"] == "failed"
+    assert status["exit_reason"] == "ReviewFailed"
+    assert status["review_performed"] is True
+    assert status["error"] == "explorers unavailable"
+    assert status["analysis_warnings"] == ["explorers unavailable"]
+
+
+def test_host_controller_processes_pending_requests_in_commit_order(
+    tmp_path: Path,
+) -> None:
+    exchange, base, candidate = _publish(tmp_path)
+    revised = _publish_next(tmp_path / "solver", exchange, candidate)
+    # Make filesystem order disagree with commit order. The controller must
+    # still start with the request rooted at its current review head.
+    first_manifest = exchange / "requests" / f"{candidate}.json"
+    second_manifest = exchange / "requests" / f"{revised}.json"
+    first_manifest.touch()
+    second_manifest.touch()
+    second_mtime = second_manifest.stat().st_mtime_ns
+    first_manifest.touch()
+    assert first_manifest.stat().st_mtime_ns >= second_mtime
+
+    requests = []
+    controller = GuardianHostController(
+        exchange_root=exchange,
+        episodes_root=tmp_path / "episodes",
+        config=GuardianConfig(explorer_model="luna", aggregator_model="terra"),
+        reviewer_factory=lambda _workspace: FakeReviewer(requests),
+        initial_base_commit=base,
+    )
+
+    assert asyncio.run(controller.process_pending()) == 2
+    assert [request.candidate_commit for request in requests] == [candidate, revised]
+    assert requests[0].memory.observed_snapshots == ()
+    assert requests[1].memory.observed_snapshots == (candidate,)
+    memory = json.loads((tmp_path / "guardian_state" / "memory.json").read_text())
+    assert memory["observed_snapshots"] == [candidate, revised]
+    assert (tmp_path / "guardian_state" / "events.jsonl").read_text().count("\n") == 2
+
+
+def test_host_controller_marks_stale_request_superseded_without_replacing_latest(
+    tmp_path: Path,
+) -> None:
+    exchange, base, candidate = _publish(tmp_path)
+    requests = []
+    controller = GuardianHostController(
+        exchange_root=exchange,
+        episodes_root=tmp_path / "episodes",
+        config=GuardianConfig(explorer_model="luna", aggregator_model="terra"),
+        reviewer_factory=lambda _workspace: FakeReviewer(requests),
+        initial_base_commit=base,
+    )
+    assert asyncio.run(controller.process_pending()) == 1
+
+    stale = _publish_next(tmp_path / "solver", exchange, base)
+    assert asyncio.run(controller.process_pending()) == 1
+
+    assert len(requests) == 1
+    stale_status = json.loads(
+        (exchange / "responses" / stale / "status.json").read_text()
+    )
+    assert stale_status["analysis_status"] == "not_run"
+    assert stale_status["exit_reason"] == "ReviewSuperseded"
+    assert stale_status["termination_reason"] == "stale_base_commit"
+    latest_status = json.loads((exchange / "latest" / "status.json").read_text())
+    assert latest_status["commit"] == candidate
 
 
 def test_host_controller_stops_before_review_beyond_cycle_limit(tmp_path: Path) -> None:

--- a/test/sandbox/test_docker.py
+++ b/test/sandbox/test_docker.py
@@ -505,13 +505,14 @@ def test_revision_snapshot_rejects_tracked_symlinks(monkeypatch, tmp_path):
         )
 
 
-def test_revision_snapshot_rejects_archive_mutating_attributes(monkeypatch, tmp_path):
+def test_revision_snapshot_allows_unmatched_archive_attribute(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
     )
     source, _ = _git_repo(tmp_path)
     (source / ".gitattributes").write_text(
-        "tracked.txt export-ignore\n", encoding="utf-8"
+        "IPython/.git_commit_info.ini export-subst\n",
+        encoding="utf-8",
     )
     subprocess.run(["git", "-C", str(source), "add", ".gitattributes"], check=True)
     subprocess.run(
@@ -535,8 +536,52 @@ def test_revision_snapshot_rejects_archive_mutating_attributes(monkeypatch, tmp_
         capture_output=True,
         text=True,
     ).stdout.strip()
+    session = _provider(tmp_path, RecordingCLI()).create(
+        SandboxSpec(
+            source_dir=source,
+            source_revision=revision,
+            image=IMAGE,
+            platform="linux/amd64",
+        )
+    )
+    session.close()
 
-    with pytest.raises(SandboxPolicyError, match="export-ignore"):
+
+@pytest.mark.parametrize("attribute", ["export-ignore", "export-subst"])
+def test_revision_snapshot_rejects_effective_archive_attribute(
+    monkeypatch, tmp_path, attribute
+):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, _ = _git_repo(tmp_path)
+    (source / ".gitattributes").write_text(
+        f"tracked.txt {attribute}\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", str(source), "add", ".gitattributes"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CodeNib Test",
+            "-c",
+            "user.email=test@example.com",
+            "-C",
+            str(source),
+            "commit",
+            "-qm",
+            "add effective archive attribute",
+        ],
+        check=True,
+    )
+    revision = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    with pytest.raises(SandboxPolicyError, match="effective export"):
         _provider(tmp_path, RecordingCLI()).create(
             SandboxSpec(
                 source_dir=source,
@@ -545,6 +590,121 @@ def test_revision_snapshot_rejects_archive_mutating_attributes(monkeypatch, tmp_
                 platform="linux/amd64",
             )
         )
+
+
+def test_revision_snapshot_checks_attributes_from_pinned_revision(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, revision = _git_repo(tmp_path)
+    (source / ".gitattributes").write_text(
+        "tracked.txt export-ignore\n", encoding="utf-8"
+    )
+
+    session = _provider(tmp_path, RecordingCLI()).create(
+        SandboxSpec(
+            source_dir=source,
+            source_revision=revision,
+            image=IMAGE,
+            platform="linux/amd64",
+        )
+    )
+    session.close()
+
+
+def test_revision_snapshot_rejects_effective_directory_archive_attribute(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, _ = _git_repo(tmp_path)
+    nested = source / "generated"
+    nested.mkdir()
+    (nested / "artifact.txt").write_text("generated\n", encoding="utf-8")
+    (source / ".gitattributes").write_text(
+        "generated export-ignore\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", str(source), "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=CodeNib Test",
+            "-c",
+            "user.email=test@example.com",
+            "-C",
+            str(source),
+            "commit",
+            "-qm",
+            "add directory archive attribute",
+        ],
+        check=True,
+    )
+    revision = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    with pytest.raises(SandboxPolicyError, match="effective export"):
+        _provider(tmp_path, RecordingCLI()).create(
+            SandboxSpec(
+                source_dir=source,
+                source_revision=revision,
+                image=IMAGE,
+                platform="linux/amd64",
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("pattern", "rejected"),
+    [
+        ("missing.txt export-ignore\n", False),
+        ("tracked.txt export-ignore\n", True),
+    ],
+)
+def test_revision_snapshot_checks_effective_info_attributes(
+    monkeypatch, tmp_path, pattern, rejected
+):
+    monkeypatch.setattr(
+        "codenib.sandbox.docker.shutil.which", lambda _: "/usr/bin/docker"
+    )
+    source, revision = _git_repo(tmp_path)
+    info_attributes = Path(
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(source),
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-path",
+                "info/attributes",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    info_attributes.write_text(pattern, encoding="utf-8")
+    spec = SandboxSpec(
+        source_dir=source,
+        source_revision=revision,
+        image=IMAGE,
+        platform="linux/amd64",
+    )
+
+    if rejected:
+        with pytest.raises(SandboxPolicyError, match="effective export"):
+            _provider(tmp_path, RecordingCLI()).create(spec)
+    else:
+        session = _provider(tmp_path, RecordingCLI()).create(spec)
+        session.close()
 
 
 def test_revision_snapshot_requires_repository_top_level(monkeypatch, tmp_path):

--- a/test/sandbox/test_docker_integration.py
+++ b/test/sandbox/test_docker_integration.py
@@ -43,6 +43,10 @@ def test_rootless_docker_session_end_to_end(tmp_path):
     _git(repo, "config", "user.name", "CodeNib Test")
     _git(repo, "config", "user.email", "test@codenib.invalid")
     (repo / ".gitignore").write_text(".env/\n", encoding="utf-8")
+    (repo / ".gitattributes").write_text(
+        "IPython/.git_commit_info.ini export-subst\n",
+        encoding="utf-8",
+    )
     (repo / "hello.txt").write_text("before\n", encoding="utf-8")
     (repo / ".env").mkdir()
     (repo / ".env" / "ignored-secret.txt").write_text(
@@ -52,7 +56,14 @@ def test_rootless_docker_session_end_to_end(tmp_path):
     executable = repo / "scripts" / "run.sh"
     executable.write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
     executable.chmod(0o755)
-    _git(repo, "add", ".gitignore", "hello.txt", "scripts/run.sh")
+    _git(
+        repo,
+        "add",
+        ".gitattributes",
+        ".gitignore",
+        "hello.txt",
+        "scripts/run.sh",
+    )
     _git(repo, "commit", "-qm", "fixture")
     revision = _git(repo, "rev-parse", "HEAD")
 
@@ -72,6 +83,7 @@ def test_rootless_docker_session_end_to_end(tmp_path):
 
     with provider.create(spec) as session:
         assert session.metadata.source_fingerprint == fingerprint_repository(repo).value
+        assert session.read_file("hello.txt") == b"before\n"
         result = session.execute(
             ExecRequest(argv=("/bin/sh", "-lc", "printf 'after\\n' > hello.txt"))
         )


### PR DESCRIPTION
## Summary

Stabilize iterative Guardian experiments and preserve local-specification understanding across solver revision cycles.

## Changes

- validate only effective `export-ignore` and `export-subst` attributes when materializing exact Git revision snapshots
- add explicit Codex feature controls so Guardian uses unified execution without unavailable Code Mode hosts
- configure explorer and aggregator models independently while preserving the legacy shared-model fallback
- persist a host-owned, snapshot-aware local-specification ledger with append-only audit events
- process checkpoint requests along the controller-owned commit chain and report degraded, failed, and superseded reviews truthfully
- export Guardian memory with run artifacts and add focused unit and real-run coverage

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `pytest` focused Guardian/execution/sandbox suite: 81 passed, 2 deselected
- `flake8` on all changed Python files
- `isort --profile black --check-only` on all changed Python files
- `black --check`: all 29 changed Python files unchanged (the local process required timeout termination after reporting completion)
- 20 real DeepSWE Guardian trials completed without launcher or Code Mode host errors
- the broader unit tier progressed through the changed client and Guardian surfaces; two existing process-runner tests are excluded because one terminates the surrounding test process group

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
