### PR TITLE
feat(storage): add embedded catalog foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@ For the current multi-language SCIP cold-start and acceleration program, use
 whenever a backend is promoted, a C++ acceleration gate changes, or a related
 issue/PR is closed.
 
+For the hybrid storage backend program, use
+`docs/storage_backend_roadmap.md` as the durable objective record. Update it
+whenever a storage milestone changes status, a publication or compatibility
+gate changes, or a related issue/PR is reconciled.
+
 ## Dev Commands
 
 ```bash

--- a/codenib/storage/__init__.py
+++ b/codenib/storage/__init__.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Transactional catalog and immutable artifact storage contracts."""
+
+from .cas import BlobInfo, LocalCAS
+from .models import (
+    ArtifactMember,
+    ObjectRecord,
+    PublishConflict,
+    PublishedSnapshot,
+    RefState,
+    RepositoryIdentity,
+    SnapshotView,
+    SourceRevision,
+    StorageError,
+    StorageIntegrityError,
+    StorageNotFound,
+    StorageValidationError,
+    ViewGeneration,
+    ViewProfile,
+)
+from .protocols import IndexCatalog, ObjectStore
+from .sqlite_catalog import (
+    DEFAULT_NAMESPACE_ID,
+    CatalogConflictError,
+    CatalogError,
+    CatalogNotFoundError,
+    CatalogValidationError,
+    SQLiteCatalog,
+)
+
+__all__ = [
+    "ArtifactMember",
+    "BlobInfo",
+    "CatalogConflictError",
+    "CatalogError",
+    "CatalogNotFoundError",
+    "CatalogValidationError",
+    "DEFAULT_NAMESPACE_ID",
+    "IndexCatalog",
+    "LocalCAS",
+    "ObjectRecord",
+    "ObjectStore",
+    "PublishConflict",
+    "PublishedSnapshot",
+    "RefState",
+    "RepositoryIdentity",
+    "SQLiteCatalog",
+    "SnapshotView",
+    "SourceRevision",
+    "StorageError",
+    "StorageIntegrityError",
+    "StorageNotFound",
+    "StorageValidationError",
+    "ViewGeneration",
+    "ViewProfile",
+]

--- a/codenib/storage/cas.py
+++ b/codenib/storage/cas.py
@@ -1,0 +1,817 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Crash-safe local content-addressed storage."""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import re
+import secrets
+import stat
+import tempfile
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Iterator
+
+from .models import StorageIntegrityError, StorageValidationError
+
+_DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_COPY_BUFFER_SIZE = 1024 * 1024
+_SAFE_DIRECTORY_FDS = (
+    hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and os.open in os.supports_dir_fd
+    and os.stat in os.supports_dir_fd
+    and os.stat in os.supports_follow_symlinks
+    and os.mkdir in os.supports_dir_fd
+    and os.unlink in os.supports_dir_fd
+)
+_LINK_UNSUPPORTED_ERRNOS = {
+    value
+    for value in (
+        getattr(errno, "ENOSYS", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "EPERM", None),
+        getattr(errno, "EXDEV", None),
+    )
+    if value is not None
+}
+_PUBLISH_LOCKS = tuple(threading.Lock() for _ in range(64))
+
+
+@dataclass(frozen=True, slots=True)
+class BlobInfo:
+    """Identity and location of one immutable CAS object."""
+
+    digest: str
+    byte_size: int
+    storage_key: str
+
+
+class LocalCAS:
+    """A SHA-256 content-addressed store backed by regular local files.
+
+    Objects are stored below ``sha256/<first two hex digits>/<remaining hex>``.
+    A digest is always the bare, lowercase, 64-character hexadecimal value.
+
+    On platforms with ``dir_fd``, ``O_DIRECTORY``, and ``O_NOFOLLOW`` support,
+    every internal path component is opened relative to its verified parent.
+    Other platforms retain explicit lstat/fstat checks, but cannot eliminate a
+    concurrent directory-replacement race as completely as the anchored path.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        requested_root = Path(root).expanduser()
+        try:
+            requested_metadata = requested_root.lstat()
+        except FileNotFoundError:
+            pass
+        else:
+            if not stat.S_ISDIR(requested_metadata.st_mode):
+                raise StorageValidationError(
+                    f"path is not a real directory: {requested_root}"
+                )
+        self.root = requested_root.resolve()
+        _ensure_directory(self.root)
+        self._sha256_root = self.root / "sha256"
+        with _open_directory_path(self.root, label="CAS root") as root_descriptor:
+            with _open_or_create_child_directory(
+                root_descriptor,
+                self.root,
+                "sha256",
+                label="CAS SHA-256 root",
+            ):
+                pass
+
+    def put_bytes(self, data: bytes) -> BlobInfo:
+        """Store *data*, deduplicating an already-valid immutable object."""
+
+        if not isinstance(data, bytes):
+            raise TypeError("CAS payload must be bytes")
+        digest = hashlib.sha256(data).hexdigest()
+        info = self._blob_info(digest, len(data))
+        with self._open_shard(digest, create=True) as (
+            shard_descriptor,
+            shard_path,
+        ):
+            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
+                # A concurrent publisher may have linked this entry but not
+                # yet flushed the shard.  A successful deduplicated put is a
+                # durability receipt too, so it must not return before the
+                # canonical directory entry is persistent.
+                _fsync_directory_handle(shard_descriptor, shard_path)
+                return info
+
+            descriptor, temporary_name = _create_temporary_file(
+                shard_descriptor,
+                shard_path,
+                digest[2:],
+            )
+            try:
+                with os.fdopen(descriptor, "wb") as handle:
+                    handle.write(data)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                self._publish_temporary_at(
+                    shard_descriptor,
+                    shard_path,
+                    temporary_name,
+                    info,
+                )
+                return info
+            finally:
+                _unlink_at(shard_descriptor, shard_path, temporary_name)
+                _fsync_directory_handle(shard_descriptor, shard_path)
+
+    def put_file(self, source: str | Path) -> BlobInfo:
+        """Store a stable snapshot of a regular file.
+
+        The source is read twice.  The first pass establishes its digest and
+        destination; the second writes the destination-directory temporary.
+        Identity and metadata checks around both passes reject a source that is
+        replaced or modified while it is being stored.
+        """
+
+        source_path = Path(source)
+        digest, byte_size, source_signature = _hash_stable_file(source_path)
+        info = self._blob_info(digest, byte_size)
+        with self._open_shard(digest, create=True) as (
+            shard_descriptor,
+            shard_path,
+        ):
+            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
+                _fsync_directory_handle(shard_descriptor, shard_path)
+                return info
+
+            descriptor, temporary_name = _create_temporary_file(
+                shard_descriptor,
+                shard_path,
+                digest[2:],
+            )
+            try:
+                with os.fdopen(descriptor, "wb") as target:
+                    copied_digest, copied_size = _copy_stable_file(
+                        source_path,
+                        target,
+                        expected_signature=source_signature,
+                    )
+                    target.flush()
+                    os.fsync(target.fileno())
+                if copied_digest != digest or copied_size != byte_size:
+                    raise OSError(f"source changed while being stored: {source_path}")
+                self._publish_temporary_at(
+                    shard_descriptor,
+                    shard_path,
+                    temporary_name,
+                    info,
+                )
+                return info
+            finally:
+                _unlink_at(shard_descriptor, shard_path, temporary_name)
+                _fsync_directory_handle(shard_descriptor, shard_path)
+
+    def has(self, digest: str) -> bool:
+        """Return whether a regular object exists for *digest*.
+
+        This is an existence check, not a full-content read.  Use :meth:`verify`
+        before trusting an object at a publication boundary.
+        """
+
+        try:
+            handle = self.open(digest)
+        except FileNotFoundError:
+            return False
+        handle.close()
+        return True
+
+    def open(self, digest: str) -> BinaryIO:
+        """Open a CAS object for binary reading without following symlinks."""
+
+        digest = _validate_digest(digest)
+        with self._open_shard(digest) as (shard_descriptor, shard_path):
+            return _open_regular_at(
+                shard_descriptor,
+                shard_path,
+                digest[2:],
+                label="CAS object",
+            )
+
+    def read_bytes(self, digest: str) -> bytes:
+        """Read an object and reject content that does not match its key."""
+
+        chunks: list[bytes] = []
+        observed_digest, byte_size = self._consume_object(digest, chunks=chunks)
+        if observed_digest != digest:
+            raise StorageIntegrityError(f"CAS object digest mismatch for {digest}")
+        # ``byte_size`` is consumed to keep the full-read and verify paths
+        # symmetrical; joining the recorded chunks cannot change its value.
+        payload = b"".join(chunks)
+        if len(payload) != byte_size:
+            raise StorageIntegrityError(
+                f"CAS object size changed while reading {digest}"
+            )
+        return payload
+
+    def verify(self, digest: str) -> BlobInfo:
+        """Fully verify an object and return its canonical metadata."""
+
+        observed_digest, byte_size = self._consume_object(digest)
+        if observed_digest != digest:
+            raise StorageIntegrityError(f"CAS object digest mismatch for {digest}")
+        return self._blob_info(digest, byte_size)
+
+    def materialize(self, digest: str, destination: str | Path) -> Path:
+        """Atomically copy a verified object to a regular destination path."""
+
+        digest = _validate_digest(digest)
+        source = self._object_path(digest)
+        destination_path = Path(destination)
+        _ensure_directory(destination_path.parent)
+        _validate_materialization_target(destination_path)
+
+        if _same_lexical_path(source, destination_path):
+            self.verify(digest)
+            return destination_path
+
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=str(destination_path.parent),
+            prefix=f".{destination_path.name}.",
+            suffix=".tmp",
+        )
+        temporary = Path(temporary_name)
+        try:
+            observed = hashlib.sha256()
+            byte_size = 0
+            with os.fdopen(descriptor, "wb") as target, self.open(digest) as stored:
+                source_signature = _object_signature(os.fstat(stored.fileno()))
+                while block := stored.read(_COPY_BUFFER_SIZE):
+                    observed.update(block)
+                    byte_size += len(block)
+                    target.write(block)
+                if _object_signature(os.fstat(stored.fileno())) != source_signature:
+                    raise StorageIntegrityError(
+                        f"CAS object changed while reading {digest}"
+                    )
+                target.flush()
+                os.fsync(target.fileno())
+
+            if observed.hexdigest() != digest:
+                raise StorageIntegrityError(f"CAS object digest mismatch for {digest}")
+
+            # Check again immediately before replacement so a destination that
+            # became a symlink or special file is never silently accepted.
+            _validate_materialization_target(destination_path)
+            os.replace(temporary, destination_path)
+            _fsync_directory(destination_path.parent)
+            return destination_path
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def _object_path(self, digest: str) -> Path:
+        digest = _validate_digest(digest)
+        parent = self._sha256_root / digest[:2]
+        return parent / digest[2:]
+
+    @contextmanager
+    def _open_shard(
+        self,
+        digest: str,
+        *,
+        create: bool = False,
+    ) -> Iterator[tuple[int | None, Path]]:
+        digest = _validate_digest(digest)
+        with _open_directory_path(self.root, label="CAS root") as root_descriptor:
+            with _open_child_directory(
+                root_descriptor,
+                self.root,
+                "sha256",
+                label="CAS SHA-256 root",
+            ) as (sha256_descriptor, sha256_path):
+                open_child = (
+                    _open_or_create_child_directory if create else _open_child_directory
+                )
+                with open_child(
+                    sha256_descriptor,
+                    sha256_path,
+                    digest[:2],
+                    label="CAS digest shard",
+                ) as shard:
+                    yield shard
+
+    @staticmethod
+    def _blob_info(digest: str, byte_size: int) -> BlobInfo:
+        digest = _validate_digest(digest)
+        return BlobInfo(
+            digest=digest,
+            byte_size=byte_size,
+            storage_key=f"sha256/{digest[:2]}/{digest[2:]}",
+        )
+
+    def _verify_existing_at(
+        self,
+        shard_descriptor: int | None,
+        shard_path: Path,
+        expected: BlobInfo,
+    ) -> BlobInfo | None:
+        path = shard_path / expected.digest[2:]
+        try:
+            with _open_regular_at(
+                shard_descriptor,
+                shard_path,
+                expected.digest[2:],
+                label="existing CAS object",
+            ) as handle:
+                signature = _object_signature(os.fstat(handle.fileno()))
+                observed = hashlib.sha256()
+                byte_size = 0
+                while block := handle.read(_COPY_BUFFER_SIZE):
+                    observed.update(block)
+                    byte_size += len(block)
+                if _object_signature(os.fstat(handle.fileno())) != signature:
+                    raise StorageIntegrityError(
+                        f"existing CAS object changed while read: {path}"
+                    )
+        except FileNotFoundError:
+            return None
+
+        if byte_size != expected.byte_size or observed.hexdigest() != expected.digest:
+            raise StorageIntegrityError(
+                f"existing CAS object failed integrity validation: {path}"
+            )
+        return expected
+
+    def _publish_temporary_at(
+        self,
+        shard_descriptor: int | None,
+        shard_path: Path,
+        temporary_name: str,
+        info: BlobInfo,
+    ) -> None:
+        destination_name = info.digest[2:]
+        # Another writer may have completed while this writer populated its
+        # temporary.  A valid winner is reused; an invalid one is never healed
+        # silently because that could hide corruption of a published object.
+        if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
+            return
+
+        try:
+            _link_at(
+                shard_descriptor,
+                shard_path,
+                temporary_name,
+                destination_name,
+            )
+            return
+        except FileExistsError:
+            # A concurrent publisher won the no-replace link operation.
+            if self._verify_existing_at(shard_descriptor, shard_path, info) is None:
+                raise StorageIntegrityError(
+                    f"CAS object disappeared during publication: {info.digest}"
+                ) from None
+            return
+        except OSError as exc:
+            if exc.errno not in _LINK_UNSUPPORTED_ERRNOS:
+                raise
+
+        # Hard links may be unavailable on some filesystems.  Serialize local
+        # writers before the atomic-replace fallback; cross-process writers can
+        # still race here, but they can only publish identical verified bytes.
+        lock = _PUBLISH_LOCKS[int(info.digest[:2], 16) % len(_PUBLISH_LOCKS)]
+        with lock:
+            if self._verify_existing_at(shard_descriptor, shard_path, info) is not None:
+                return
+            _replace_at(
+                shard_descriptor,
+                shard_path,
+                temporary_name,
+                destination_name,
+            )
+
+    def _consume_object(
+        self,
+        digest: str,
+        *,
+        chunks: list[bytes] | None = None,
+    ) -> tuple[str, int]:
+        digest = _validate_digest(digest)
+        observed = hashlib.sha256()
+        byte_size = 0
+        with self.open(digest) as handle:
+            signature = _object_signature(os.fstat(handle.fileno()))
+            while block := handle.read(_COPY_BUFFER_SIZE):
+                observed.update(block)
+                byte_size += len(block)
+                if chunks is not None:
+                    chunks.append(block)
+            if _object_signature(os.fstat(handle.fileno())) != signature:
+                raise StorageIntegrityError(
+                    f"CAS object changed while reading {digest}"
+                )
+        return observed.hexdigest(), byte_size
+
+
+@contextmanager
+def _open_directory_path(path: Path, *, label: str) -> Iterator[int | None]:
+    metadata = path.lstat()
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise StorageIntegrityError(f"{label} is not a real directory: {path}")
+
+    if not _SAFE_DIRECTORY_FDS:
+        # The visible component is still rejected when it is a link.  Without
+        # anchored directory descriptors, however, another process can replace
+        # it between this check and a later child operation.
+        yield None
+        return
+
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise StorageIntegrityError(f"{label} is not a directory: {path}")
+        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+            raise StorageIntegrityError(f"{label} changed while opening: {path}")
+        yield descriptor
+    finally:
+        os.close(descriptor)
+
+
+@contextmanager
+def _open_child_directory(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    name: str,
+    *,
+    label: str,
+) -> Iterator[tuple[int | None, Path]]:
+    path = parent_path / name
+    if parent_descriptor is None:
+        with _open_directory_path(path, label=label) as descriptor:
+            yield descriptor, path
+        return
+
+    metadata = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise StorageIntegrityError(f"{label} is not a real directory: {path}")
+
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISDIR(opened.st_mode):
+            raise StorageIntegrityError(f"{label} is not a directory: {path}")
+        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+            raise StorageIntegrityError(f"{label} changed while opening: {path}")
+        yield descriptor, path
+    finally:
+        os.close(descriptor)
+
+
+@contextmanager
+def _open_or_create_child_directory(
+    parent_descriptor: int | None,
+    parent_path: Path,
+    name: str,
+    *,
+    label: str,
+) -> Iterator[tuple[int | None, Path]]:
+    created = False
+    try:
+        if parent_descriptor is None:
+            (parent_path / name).mkdir()
+        else:
+            os.mkdir(name, mode=0o755, dir_fd=parent_descriptor)
+        created = True
+    except FileExistsError:
+        pass
+
+    if created:
+        # Persist the directory entry in its parent before an object published
+        # inside the new shard can be reported durable.
+        _fsync_directory_handle(parent_descriptor, parent_path)
+
+    with _open_child_directory(
+        parent_descriptor,
+        parent_path,
+        name,
+        label=label,
+    ) as child:
+        yield child
+
+
+def _open_regular_at(
+    directory_descriptor: int | None,
+    directory_path: Path,
+    name: str,
+    *,
+    label: str,
+) -> BinaryIO:
+    if directory_descriptor is None:
+        return _open_regular_file(directory_path / name, label=label)
+
+    metadata = os.stat(name, dir_fd=directory_descriptor, follow_symlinks=False)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise StorageIntegrityError(
+            f"{label} is not a regular file: {directory_path / name}"
+        )
+
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    descriptor = os.open(name, flags, dir_fd=directory_descriptor)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise StorageIntegrityError(
+                f"{label} is not a regular file: {directory_path / name}"
+            )
+        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+            raise StorageIntegrityError(
+                f"{label} changed while opening: {directory_path / name}"
+            )
+        return os.fdopen(descriptor, "rb")
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _create_temporary_file(
+    directory_descriptor: int | None,
+    directory_path: Path,
+    object_name: str,
+) -> tuple[int, str]:
+    if directory_descriptor is None:
+        descriptor, temporary_path = tempfile.mkstemp(
+            dir=str(directory_path),
+            prefix=f".{object_name}.",
+            suffix=".tmp",
+        )
+        return descriptor, Path(temporary_path).name
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    for _attempt in range(100):
+        name = f".{object_name}.{secrets.token_hex(8)}.tmp"
+        try:
+            descriptor = os.open(
+                name,
+                flags,
+                0o600,
+                dir_fd=directory_descriptor,
+            )
+        except FileExistsError:
+            continue
+        return descriptor, name
+    raise FileExistsError(f"could not allocate CAS temporary in {directory_path}")
+
+
+def _link_at(
+    directory_descriptor: int | None,
+    directory_path: Path,
+    source_name: str,
+    destination_name: str,
+) -> None:
+    if directory_descriptor is not None and os.link in os.supports_dir_fd:
+        os.link(
+            source_name,
+            destination_name,
+            src_dir_fd=directory_descriptor,
+            dst_dir_fd=directory_descriptor,
+            follow_symlinks=False,
+        )
+        return
+    os.link(directory_path / source_name, directory_path / destination_name)
+
+
+def _replace_at(
+    directory_descriptor: int | None,
+    directory_path: Path,
+    source_name: str,
+    destination_name: str,
+) -> None:
+    if directory_descriptor is not None:
+        os.replace(
+            source_name,
+            destination_name,
+            src_dir_fd=directory_descriptor,
+            dst_dir_fd=directory_descriptor,
+        )
+        return
+    os.replace(directory_path / source_name, directory_path / destination_name)
+
+
+def _unlink_at(
+    directory_descriptor: int | None,
+    directory_path: Path,
+    name: str,
+) -> None:
+    try:
+        if directory_descriptor is None:
+            (directory_path / name).unlink()
+        else:
+            os.unlink(name, dir_fd=directory_descriptor)
+    except FileNotFoundError:
+        pass
+
+
+def _validate_digest(digest: str) -> str:
+    if not isinstance(digest, str) or _DIGEST_RE.fullmatch(digest) is None:
+        raise StorageValidationError(
+            "digest must be 64 lowercase hexadecimal characters"
+        )
+    return digest
+
+
+def _ensure_directory(path: Path) -> None:
+    missing: list[Path] = []
+    current = path
+    while True:
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            missing.append(current)
+            parent = current.parent
+            if parent == current:
+                raise StorageValidationError(
+                    f"directory hierarchy has no existing root: {path}"
+                ) from None
+            current = parent
+            continue
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise StorageValidationError(f"path is not a real directory: {current}")
+        break
+
+    for directory in reversed(missing):
+        try:
+            directory.mkdir()
+        except FileExistsError:
+            # A concurrent creator is acceptable only if it published the same
+            # kind of real directory.  We fsync its entry below as well.
+            pass
+        metadata = directory.lstat()
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise StorageValidationError(f"path is not a real directory: {directory}")
+        _fsync_directory(directory.parent)
+
+
+def _open_regular_file(path: Path, *, label: str) -> BinaryIO:
+    metadata = path.lstat()
+    if not stat.S_ISREG(metadata.st_mode):
+        raise StorageIntegrityError(f"{label} is not a regular file: {path}")
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise StorageIntegrityError(f"{label} is not a regular file: {path}")
+        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+            raise StorageIntegrityError(f"{label} changed while opening: {path}")
+        return os.fdopen(descriptor, "rb")
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _hash_stable_file(path: Path) -> tuple[str, int, tuple[int, ...]]:
+    observed = hashlib.sha256()
+    byte_size = 0
+    with _open_regular_file(path, label="CAS source") as source:
+        signature = _file_signature(os.fstat(source.fileno()))
+        while block := source.read(_COPY_BUFFER_SIZE):
+            observed.update(block)
+            byte_size += len(block)
+        if _file_signature(os.fstat(source.fileno())) != signature:
+            raise OSError(f"source changed while being hashed: {path}")
+    _require_path_signature(path, signature, label="CAS source")
+    if byte_size != signature[3]:
+        raise OSError(f"source size changed while being hashed: {path}")
+    return observed.hexdigest(), byte_size, signature
+
+
+def _copy_stable_file(
+    path: Path,
+    target: BinaryIO,
+    *,
+    expected_signature: tuple[int, ...],
+) -> tuple[str, int]:
+    observed = hashlib.sha256()
+    byte_size = 0
+    with _open_regular_file(path, label="CAS source") as source:
+        signature = _file_signature(os.fstat(source.fileno()))
+        if signature != expected_signature:
+            raise OSError(f"source changed before it could be stored: {path}")
+        while block := source.read(_COPY_BUFFER_SIZE):
+            observed.update(block)
+            byte_size += len(block)
+            target.write(block)
+        if _file_signature(os.fstat(source.fileno())) != signature:
+            raise OSError(f"source changed while being stored: {path}")
+    _require_path_signature(path, signature, label="CAS source")
+    return observed.hexdigest(), byte_size
+
+
+def _file_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _object_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    """Metadata expected to remain stable while immutable bytes are read.
+
+    Link-count changes update ctime on POSIX.  A successful no-replace publish
+    briefly gives the object both its temporary and canonical names, so ctime
+    is deliberately excluded here.  The full SHA-256 check still detects any
+    content change.
+    """
+
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+    )
+
+
+def _require_path_signature(
+    path: Path,
+    expected: tuple[int, ...],
+    *,
+    label: str,
+) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as exc:
+        raise OSError(f"{label} disappeared while being read: {path}") from exc
+    if not stat.S_ISREG(metadata.st_mode) or _file_signature(metadata) != expected:
+        raise OSError(f"{label} changed while being read: {path}")
+
+
+def _validate_materialization_target(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    if not stat.S_ISREG(metadata.st_mode):
+        raise StorageValidationError(
+            f"materialization target is not a regular file: {path}"
+        )
+
+
+def _same_lexical_path(left: Path, right: Path) -> bool:
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(
+        os.path.abspath(right)
+    )
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        # Some supported platforms cannot open a directory descriptor.  File
+        # content is still flushed before its atomic replacement there.
+        return
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_directory_handle(descriptor: int | None, path: Path) -> None:
+    if descriptor is None:
+        _fsync_directory(path)
+    else:
+        os.fsync(descriptor)
+
+
+__all__ = ["BlobInfo", "LocalCAS"]

--- a/codenib/storage/models.py
+++ b/codenib/storage/models.py
@@ -1,0 +1,532 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-neutral identities for immutable index storage."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Mapping
+
+_DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+
+
+class StorageError(RuntimeError):
+    """Base class for storage contract failures."""
+
+
+class StorageIntegrityError(StorageError):
+    """Stored bytes or metadata do not match their immutable identity."""
+
+
+class PublishConflict(StorageError):
+    """A compare-and-swap publication precondition no longer holds."""
+
+
+class StorageNotFound(StorageError):
+    """A requested catalog or object-store record does not exist."""
+
+
+class StorageValidationError(StorageError, ValueError):
+    """Input cannot form a valid storage identity."""
+
+
+def canonical_json(value: Mapping[str, Any]) -> str:
+    """Return the deterministic JSON representation used by content IDs."""
+
+    if not isinstance(value, Mapping):
+        raise StorageValidationError("canonical JSON payload must be an object")
+    try:
+        return json.dumps(
+            _normalize_json_value(value),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise StorageValidationError(f"payload is not canonical JSON: {exc}") from exc
+
+
+def _normalize_json_value(value: Any) -> Any:
+    """Normalize JSON-compatible values without lossy object-key coercion."""
+
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise StorageValidationError(
+                    "canonical JSON object keys must be strings"
+                )
+            normalized[key] = _normalize_json_value(child)
+        return normalized
+    if isinstance(value, (list, tuple)):
+        return [_normalize_json_value(child) for child in value]
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise StorageValidationError("canonical JSON numbers must be finite")
+        return value
+    raise StorageValidationError(
+        f"canonical JSON does not support {type(value).__name__} values"
+    )
+
+
+def content_id(prefix: str, value: Mapping[str, Any]) -> str:
+    """Return a namespaced SHA-256 identity for a canonical JSON object."""
+
+    normalized_prefix = _required_text(prefix, "content ID prefix")
+    digest = hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+    return f"{normalized_prefix}_{digest}"
+
+
+def normalize_digest(value: str) -> str:
+    """Normalize an optional ``sha256:`` prefix to a bare lowercase digest."""
+
+    normalized = _required_text(value, "digest").lower()
+    if normalized.startswith("sha256:"):
+        normalized = normalized[7:]
+    if _DIGEST_RE.fullmatch(normalized) is None:
+        raise StorageValidationError(
+            "digest must be 64 lowercase hexadecimal characters"
+        )
+    return normalized
+
+
+def _required_text(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise StorageValidationError(f"{field} must not be empty")
+    return value.strip()
+
+
+def _optional_text(value: str | None, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise StorageValidationError(f"{field} must be text or null")
+    normalized = value.strip()
+    return normalized or None
+
+
+def _canonical_relative_path(value: str, field: str) -> str:
+    path = _required_text(value, field)
+    if "\\" in path or "\x00" in path:
+        raise StorageValidationError(f"{field} must use safe POSIX separators")
+    normalized = PurePosixPath(path)
+    if normalized.is_absolute() or ".." in normalized.parts:
+        raise StorageValidationError(f"{field} must be relative and contained")
+    if path != normalized.as_posix() or path in {".", ""}:
+        raise StorageValidationError(f"{field} is not canonical")
+    return normalized.as_posix()
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryIdentity:
+    """A repository key scoped to a non-null logical namespace."""
+
+    namespace_id: str
+    repository_key: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "namespace_id", _required_text(self.namespace_id, "namespace ID")
+        )
+        object.__setattr__(
+            self,
+            "repository_key",
+            _required_text(self.repository_key, "repository key"),
+        )
+
+    @property
+    def repository_id(self) -> str:
+        return content_id(
+            "repo",
+            {
+                "namespace_id": self.namespace_id,
+                "repository_key": self.repository_key,
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRevision:
+    """A clean Git tree or a dirty-worktree source identity."""
+
+    repository_id: str
+    source_kind: str
+    commit_sha: str | None
+    tree_sha: str | None
+    source_fingerprint: str
+
+    def __post_init__(self) -> None:
+        repository = _required_text(self.repository_id, "repository ID")
+        kind = _required_text(self.source_kind, "source kind").lower()
+        commit = _optional_text(self.commit_sha, "source commit")
+        tree = _optional_text(self.tree_sha, "source tree")
+        commit = commit.lower() if commit else None
+        tree = tree.lower() if tree else None
+        fingerprint = _required_text(self.source_fingerprint, "source fingerprint")
+        if kind not in {"clean", "dirty"}:
+            raise StorageValidationError("source kind must be 'clean' or 'dirty'")
+        if kind == "clean":
+            if not commit or not tree:
+                raise StorageValidationError(
+                    "clean source requires both commit and tree identity"
+                )
+            expected = f"git-tree:{tree}"
+            if fingerprint != expected:
+                raise StorageValidationError(
+                    "clean source fingerprint must match its Git tree"
+                )
+        elif tree is not None:
+            raise StorageValidationError(
+                "dirty source identity must not include a base tree"
+            )
+
+        object.__setattr__(self, "repository_id", repository)
+        object.__setattr__(self, "source_kind", kind)
+        object.__setattr__(self, "commit_sha", commit)
+        object.__setattr__(self, "tree_sha", tree)
+        object.__setattr__(self, "source_fingerprint", fingerprint)
+
+    @classmethod
+    def clean(
+        cls,
+        repository_id: str,
+        *,
+        commit_sha: str,
+        tree_sha: str,
+    ) -> SourceRevision:
+        tree = _required_text(tree_sha, "clean source tree").lower()
+        return cls(
+            repository_id=repository_id,
+            source_kind="clean",
+            commit_sha=commit_sha,
+            tree_sha=tree,
+            source_fingerprint=f"git-tree:{tree}",
+        )
+
+    @classmethod
+    def dirty(
+        cls,
+        repository_id: str,
+        *,
+        source_fingerprint: str,
+        commit_sha: str | None = None,
+    ) -> SourceRevision:
+        return cls(
+            repository_id=repository_id,
+            source_kind="dirty",
+            commit_sha=commit_sha,
+            tree_sha=None,
+            source_fingerprint=source_fingerprint,
+        )
+
+    @property
+    def source_revision_id(self) -> str:
+        return content_id(
+            "src",
+            {
+                "repository_id": self.repository_id,
+                "source_kind": self.source_kind,
+                "commit_sha": self.commit_sha,
+                "tree_sha": self.tree_sha,
+                "source_fingerprint": self.source_fingerprint,
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ViewProfile:
+    """Canonical compatibility identity for one persisted view type."""
+
+    view_type: str
+    name: str
+    config_json: str
+
+    def __post_init__(self) -> None:
+        view_type = _required_text(self.view_type, "view type")
+        name = _required_text(self.name, "profile name")
+        try:
+            parsed = json.loads(self.config_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise StorageValidationError("profile config must be valid JSON") from exc
+        if not isinstance(parsed, dict):
+            raise StorageValidationError("profile config must be a JSON object")
+        config_json = canonical_json(parsed)
+        object.__setattr__(self, "view_type", view_type)
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "config_json", config_json)
+
+    @classmethod
+    def create(
+        cls,
+        view_type: str,
+        config: Mapping[str, Any] | None = None,
+        *,
+        name: str = "default",
+    ) -> ViewProfile:
+        return cls(
+            view_type=view_type,
+            name=name,
+            config_json=canonical_json(config or {}),
+        )
+
+    @property
+    def config(self) -> dict[str, Any]:
+        return json.loads(self.config_json)
+
+    @property
+    def profile_id(self) -> str:
+        return content_id(
+            "profile",
+            {
+                "view_type": self.view_type,
+                "name": self.name,
+                "config": self.config,
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectRecord:
+    """Catalog metadata for one immutable object-store payload."""
+
+    digest: str
+    byte_size: int
+    storage_key: str
+    media_type: str = "application/octet-stream"
+
+    def __post_init__(self) -> None:
+        if isinstance(self.byte_size, bool) or not isinstance(self.byte_size, int):
+            raise StorageValidationError("object byte size must be an integer")
+        if self.byte_size < 0:
+            raise StorageValidationError("object byte size must not be negative")
+        object.__setattr__(self, "digest", normalize_digest(self.digest))
+        object.__setattr__(
+            self,
+            "storage_key",
+            _canonical_relative_path(self.storage_key, "storage key"),
+        )
+        object.__setattr__(
+            self, "media_type", _required_text(self.media_type, "media type")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactMember:
+    """One relative-path member of a multi-file immutable artifact."""
+
+    path: str
+    digest: str
+    byte_size: int
+    mode: int = 0o644
+
+    def __post_init__(self) -> None:
+        path = _canonical_relative_path(self.path, "artifact member path")
+        if isinstance(self.byte_size, bool) or not isinstance(self.byte_size, int):
+            raise StorageValidationError("artifact member size must be an integer")
+        if self.byte_size < 0:
+            raise StorageValidationError("artifact member size must not be negative")
+        if isinstance(self.mode, bool) or not isinstance(self.mode, int):
+            raise StorageValidationError("artifact member mode must be an integer")
+        if self.mode < 0 or self.mode > 0o777:
+            raise StorageValidationError("artifact member mode is out of range")
+        object.__setattr__(self, "path", path)
+        object.__setattr__(self, "digest", normalize_digest(self.digest))
+
+
+@dataclass(frozen=True, slots=True)
+class ViewGeneration:
+    """One immutable view output for a source revision and profile."""
+
+    repository_id: str
+    source_revision_id: str
+    profile: ViewProfile
+    object_digest: str
+    schema_version: str
+    metadata_json: str = "{}"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "repository_id", _required_text(self.repository_id, "repository ID")
+        )
+        object.__setattr__(
+            self,
+            "source_revision_id",
+            _required_text(self.source_revision_id, "source revision ID"),
+        )
+        if not isinstance(self.profile, ViewProfile):
+            raise StorageValidationError(
+                "view generation profile must be a ViewProfile"
+            )
+        object.__setattr__(self, "object_digest", normalize_digest(self.object_digest))
+        object.__setattr__(
+            self,
+            "schema_version",
+            _required_text(self.schema_version, "schema version"),
+        )
+        try:
+            metadata = json.loads(self.metadata_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise StorageValidationError("view metadata must be valid JSON") from exc
+        if not isinstance(metadata, dict):
+            raise StorageValidationError("view metadata must be a JSON object")
+        object.__setattr__(self, "metadata_json", canonical_json(metadata))
+
+    @classmethod
+    def create(
+        cls,
+        source: SourceRevision,
+        profile: ViewProfile,
+        object_record: ObjectRecord,
+        *,
+        schema_version: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> ViewGeneration:
+        return cls(
+            repository_id=source.repository_id,
+            source_revision_id=source.source_revision_id,
+            profile=profile,
+            object_digest=object_record.digest,
+            schema_version=schema_version,
+            metadata_json=canonical_json(metadata or {}),
+        )
+
+    @property
+    def profile_id(self) -> str:
+        return self.profile.profile_id
+
+    @property
+    def view_type(self) -> str:
+        return self.profile.view_type
+
+    @property
+    def view_generation_id(self) -> str:
+        return content_id(
+            "view",
+            {
+                "repository_id": self.repository_id,
+                "source_revision_id": self.source_revision_id,
+                "profile_id": self.profile_id,
+                "view_type": self.view_type,
+                "object_digest": self.object_digest,
+                "schema_version": self.schema_version,
+                "metadata": json.loads(self.metadata_json),
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotView:
+    """A view generation selected into a published snapshot."""
+
+    generation: ViewGeneration
+
+    @property
+    def view_type(self) -> str:
+        return self.generation.view_type
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedSnapshot:
+    """An immutable, source-consistent set of independently profiled views."""
+
+    repository_id: str
+    source_revision_id: str
+    views: tuple[SnapshotView, ...]
+
+    def __post_init__(self) -> None:
+        repository = _required_text(self.repository_id, "repository ID")
+        source = _required_text(self.source_revision_id, "source revision ID")
+        views = tuple(self.views)
+        if not views:
+            raise StorageValidationError("a snapshot requires at least one view")
+        seen: set[str] = set()
+        for snapshot_view in views:
+            generation = snapshot_view.generation
+            if generation.repository_id != repository:
+                raise StorageValidationError(
+                    "all snapshot views must belong to the same repository"
+                )
+            if generation.source_revision_id != source:
+                raise StorageValidationError(
+                    "all snapshot views must share the snapshot source identity"
+                )
+            if generation.view_type in seen:
+                raise StorageValidationError(
+                    f"snapshot has duplicate view type: {generation.view_type}"
+                )
+            seen.add(generation.view_type)
+        object.__setattr__(self, "repository_id", repository)
+        object.__setattr__(self, "source_revision_id", source)
+        object.__setattr__(
+            self,
+            "views",
+            tuple(sorted(views, key=lambda item: item.view_type)),
+        )
+
+    @property
+    def snapshot_id(self) -> str:
+        return content_id(
+            "snapshot",
+            {
+                "repository_id": self.repository_id,
+                "source_revision_id": self.source_revision_id,
+                "views": [
+                    [view.view_type, view.generation.view_generation_id]
+                    for view in self.views
+                ],
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefState:
+    """A generation-counted repository ref resolved to one snapshot."""
+
+    repository_id: str
+    ref_name: str
+    snapshot_id: str
+    generation: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.generation, bool) or not isinstance(self.generation, int):
+            raise StorageValidationError("ref generation must be an integer")
+        if self.generation < 1:
+            raise StorageValidationError("ref generation must be positive")
+        object.__setattr__(
+            self, "repository_id", _required_text(self.repository_id, "repository ID")
+        )
+        object.__setattr__(self, "ref_name", _required_text(self.ref_name, "ref name"))
+        object.__setattr__(
+            self, "snapshot_id", _required_text(self.snapshot_id, "snapshot ID")
+        )
+
+
+__all__ = [
+    "ArtifactMember",
+    "ObjectRecord",
+    "PublishConflict",
+    "PublishedSnapshot",
+    "RefState",
+    "RepositoryIdentity",
+    "SnapshotView",
+    "SourceRevision",
+    "StorageError",
+    "StorageIntegrityError",
+    "StorageNotFound",
+    "StorageValidationError",
+    "ViewGeneration",
+    "ViewProfile",
+    "canonical_json",
+    "content_id",
+    "normalize_digest",
+]

--- a/codenib/storage/protocols.py
+++ b/codenib/storage/protocols.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal replaceable interfaces for catalog and object-store backends."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, BinaryIO, Mapping, Protocol, Sequence, runtime_checkable
+
+from .cas import BlobInfo
+
+
+@runtime_checkable
+class ObjectStore(Protocol):
+    """Immutable byte-object operations required by artifact publication."""
+
+    def put_bytes(self, data: bytes) -> BlobInfo: ...
+
+    def put_file(self, source: str | Path) -> BlobInfo: ...
+
+    def has(self, digest: str) -> bool: ...
+
+    def open(self, digest: str) -> BinaryIO: ...
+
+    def read_bytes(self, digest: str) -> bytes: ...
+
+    def verify(self, digest: str) -> BlobInfo: ...
+
+    def materialize(self, digest: str, destination: str | Path) -> Path: ...
+
+
+@runtime_checkable
+class IndexCatalog(Protocol):
+    """Transactional identities and publication, excluding query engines.
+
+    Object registration is a metadata operation, not a byte upload.  A
+    coordinator must first obtain and verify the corresponding ``ObjectStore``
+    receipt and must compare digest, size, and storage key before publication.
+    """
+
+    def create_namespace(self, name: str) -> str: ...
+
+    def create_repository(
+        self,
+        repository_key: str,
+        *,
+        namespace_id: str,
+    ) -> str: ...
+
+    def create_source_revision(
+        self,
+        repository_id: str,
+        *,
+        commit_sha: str | None = None,
+        tree_sha: str | None = None,
+        dirty: bool = False,
+        source_fingerprint: str | None = None,
+    ) -> str: ...
+
+    def create_view_profile(
+        self,
+        view_type: str,
+        config: Mapping[str, Any] | None = None,
+        *,
+        name: str = "default",
+    ) -> str: ...
+
+    def register_object(
+        self,
+        digest: str,
+        *,
+        storage_key: str,
+        byte_size: int,
+        media_type: str = "application/octet-stream",
+    ) -> str: ...
+
+    def stage_view_generation(
+        self,
+        repository_id: str,
+        source_revision_id: str,
+        profile_id: str,
+        view_type: str,
+        object_digest: str,
+        *,
+        schema_version: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> str: ...
+
+    def publish_snapshot(
+        self,
+        repository_id: str,
+        source_revision_id: str,
+        view_generation_ids: Sequence[str],
+        *,
+        ref_name: str = "main",
+        expected_generation: int = 0,
+    ) -> dict[str, Any]: ...
+
+    def resolve_ref(
+        self,
+        repository_id: str,
+        ref_name: str = "main",
+    ) -> dict[str, Any]: ...
+
+    def get_manifest_summary(self, snapshot_id: str) -> dict[str, Any]: ...
+
+
+__all__ = ["IndexCatalog", "ObjectStore"]

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -1,0 +1,1152 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQLite control-plane catalog for immutable index generations.
+
+The catalog deliberately stores metadata, not index payloads.  Payloads live in
+an artifact store and are registered here by their SHA-256 digest.  Published
+snapshots and ready view generations are immutable; the only mutable serving
+pointer is a named ref, advanced with compare-and-swap semantics.
+
+This module uses only primitive Python values so higher-level storage protocols
+can adapt it without coupling the SQLite implementation to application models.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Sequence
+
+from .models import (
+    ObjectRecord,
+    PublishConflict,
+    SourceRevision,
+    StorageError,
+    StorageNotFound,
+    StorageValidationError,
+    canonical_json,
+    content_id,
+    normalize_digest,
+)
+
+LATEST_SCHEMA_VERSION = 1
+DEFAULT_NAMESPACE_ID = "ns_default"
+DEFAULT_NAMESPACE_NAME = "default"
+
+CatalogError = StorageError
+CatalogConflictError = PublishConflict
+CatalogNotFoundError = StorageNotFound
+CatalogValidationError = StorageValidationError
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _required_text(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CatalogValidationError(f"{field} must not be empty")
+    return value.strip()
+
+
+_SCHEMA_V1 = (
+    """
+    CREATE TABLE namespaces (
+        namespace_id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        created_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE repositories (
+        repository_id TEXT PRIMARY KEY,
+        namespace_id TEXT NOT NULL,
+        repository_key TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (namespace_id, repository_key),
+        FOREIGN KEY (namespace_id) REFERENCES namespaces(namespace_id)
+            ON DELETE RESTRICT
+    )
+    """,
+    """
+    CREATE TABLE source_revisions (
+        source_revision_id TEXT PRIMARY KEY,
+        repository_id TEXT NOT NULL,
+        source_kind TEXT NOT NULL CHECK (source_kind IN ('clean', 'dirty')),
+        commit_sha TEXT,
+        tree_sha TEXT,
+        source_fingerprint TEXT NOT NULL,
+        identity_digest TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (repository_id, identity_digest),
+        UNIQUE (source_revision_id, repository_id),
+        CHECK (
+            (source_kind = 'clean'
+                AND commit_sha IS NOT NULL AND length(commit_sha) > 0
+                AND tree_sha IS NOT NULL AND length(tree_sha) > 0)
+            OR
+            (source_kind = 'dirty' AND length(source_fingerprint) > 0)
+        ),
+        FOREIGN KEY (repository_id) REFERENCES repositories(repository_id)
+            ON DELETE RESTRICT
+    )
+    """,
+    """
+    CREATE TABLE view_profiles (
+        profile_id TEXT PRIMARY KEY,
+        view_type TEXT NOT NULL,
+        name TEXT NOT NULL,
+        config_json TEXT NOT NULL,
+        profile_digest TEXT NOT NULL UNIQUE,
+        created_at TEXT NOT NULL,
+        UNIQUE (profile_id, view_type)
+    )
+    """,
+    """
+    CREATE TABLE objects (
+        digest TEXT PRIMARY KEY,
+        storage_key TEXT NOT NULL,
+        byte_size INTEGER NOT NULL CHECK (byte_size >= 0),
+        media_type TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (storage_key)
+    )
+    """,
+    """
+    CREATE TABLE view_generations (
+        view_generation_id TEXT PRIMARY KEY,
+        repository_id TEXT NOT NULL,
+        source_revision_id TEXT NOT NULL,
+        profile_id TEXT NOT NULL,
+        view_type TEXT NOT NULL,
+        object_digest TEXT NOT NULL,
+        schema_version TEXT NOT NULL,
+        metadata_json TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('staged', 'ready')),
+        created_at TEXT NOT NULL,
+        ready_at TEXT,
+        UNIQUE (view_generation_id, view_type),
+        FOREIGN KEY (repository_id) REFERENCES repositories(repository_id)
+            ON DELETE RESTRICT,
+        FOREIGN KEY (source_revision_id, repository_id)
+            REFERENCES source_revisions(source_revision_id, repository_id)
+            ON DELETE RESTRICT,
+        FOREIGN KEY (profile_id, view_type)
+            REFERENCES view_profiles(profile_id, view_type) ON DELETE RESTRICT,
+        FOREIGN KEY (object_digest) REFERENCES objects(digest)
+            ON DELETE RESTRICT,
+        CHECK (
+            (status = 'staged' AND ready_at IS NULL)
+            OR (status = 'ready' AND ready_at IS NOT NULL)
+        )
+    )
+    """,
+    """
+    CREATE TABLE snapshots (
+        snapshot_id TEXT PRIMARY KEY,
+        repository_id TEXT NOT NULL,
+        source_revision_id TEXT NOT NULL,
+        content_digest TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('building', 'ready')),
+        published_at TEXT,
+        UNIQUE (repository_id, content_digest),
+        UNIQUE (snapshot_id, repository_id),
+        FOREIGN KEY (repository_id) REFERENCES repositories(repository_id)
+            ON DELETE RESTRICT,
+        FOREIGN KEY (source_revision_id, repository_id)
+            REFERENCES source_revisions(source_revision_id, repository_id)
+            ON DELETE RESTRICT,
+        CHECK (
+            (status = 'building' AND published_at IS NULL)
+            OR (status = 'ready' AND published_at IS NOT NULL)
+        )
+    )
+    """,
+    """
+    CREATE TABLE snapshot_views (
+        snapshot_id TEXT NOT NULL,
+        view_type TEXT NOT NULL,
+        view_generation_id TEXT NOT NULL,
+        PRIMARY KEY (snapshot_id, view_type),
+        UNIQUE (snapshot_id, view_generation_id),
+        FOREIGN KEY (snapshot_id) REFERENCES snapshots(snapshot_id)
+            ON DELETE CASCADE,
+        FOREIGN KEY (view_generation_id, view_type)
+            REFERENCES view_generations(view_generation_id, view_type)
+            ON DELETE RESTRICT
+    )
+    """,
+    """
+    CREATE TABLE refs (
+        repository_id TEXT NOT NULL,
+        ref_name TEXT NOT NULL,
+        snapshot_id TEXT NOT NULL,
+        generation INTEGER NOT NULL CHECK (generation > 0),
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (repository_id, ref_name),
+        FOREIGN KEY (repository_id) REFERENCES repositories(repository_id)
+            ON DELETE RESTRICT,
+        FOREIGN KEY (snapshot_id, repository_id)
+            REFERENCES snapshots(snapshot_id, repository_id) ON DELETE RESTRICT
+    )
+    """,
+    """
+    CREATE INDEX source_revisions_repository_idx
+        ON source_revisions(repository_id)
+    """,
+    """
+    CREATE INDEX view_generations_source_idx
+        ON view_generations(repository_id, source_revision_id, profile_id)
+    """,
+    """
+    CREATE INDEX refs_snapshot_idx ON refs(snapshot_id)
+    """,
+    """
+    CREATE TRIGGER objects_are_immutable
+    BEFORE UPDATE ON objects
+    BEGIN
+        SELECT RAISE(ABORT, 'registered objects are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER namespaces_are_immutable
+    BEFORE UPDATE ON namespaces
+    BEGIN
+        SELECT RAISE(ABORT, 'namespace identities are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER repositories_are_immutable
+    BEFORE UPDATE ON repositories
+    BEGIN
+        SELECT RAISE(ABORT, 'repository identities are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER source_revisions_are_immutable
+    BEFORE UPDATE ON source_revisions
+    BEGIN
+        SELECT RAISE(ABORT, 'source revisions are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER view_profiles_are_immutable
+    BEFORE UPDATE ON view_profiles
+    BEGIN
+        SELECT RAISE(ABORT, 'view profiles are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER staged_view_generation_identity_is_immutable
+    BEFORE UPDATE ON view_generations
+    WHEN
+        NEW.view_generation_id IS NOT OLD.view_generation_id
+        OR NEW.repository_id IS NOT OLD.repository_id
+        OR NEW.source_revision_id IS NOT OLD.source_revision_id
+        OR NEW.profile_id IS NOT OLD.profile_id
+        OR NEW.view_type IS NOT OLD.view_type
+        OR NEW.object_digest IS NOT OLD.object_digest
+        OR NEW.schema_version IS NOT OLD.schema_version
+        OR NEW.metadata_json IS NOT OLD.metadata_json
+        OR NEW.created_at IS NOT OLD.created_at
+    BEGIN
+        SELECT RAISE(ABORT, 'view generation identity is immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER ready_view_generations_are_immutable
+    BEFORE UPDATE ON view_generations
+    WHEN OLD.status = 'ready'
+    BEGIN
+        SELECT RAISE(ABORT, 'ready view generations are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER snapshot_seal_is_the_only_update
+    BEFORE UPDATE ON snapshots
+    WHEN NOT (
+        OLD.status = 'building'
+        AND OLD.published_at IS NULL
+        AND NEW.status = 'ready'
+        AND NEW.published_at IS NOT NULL
+        AND NEW.snapshot_id IS OLD.snapshot_id
+        AND NEW.repository_id IS OLD.repository_id
+        AND NEW.source_revision_id IS OLD.source_revision_id
+        AND NEW.content_digest IS OLD.content_digest
+        AND EXISTS (
+            SELECT 1 FROM snapshot_views
+            WHERE snapshot_id = OLD.snapshot_id
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM snapshot_views AS sv
+            JOIN view_generations AS vg
+                ON vg.view_generation_id = sv.view_generation_id
+            WHERE sv.snapshot_id = OLD.snapshot_id
+                AND (
+                    vg.status != 'ready'
+                    OR vg.repository_id != OLD.repository_id
+                    OR vg.source_revision_id != OLD.source_revision_id
+                )
+        )
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'only an immutable snapshot seal is allowed');
+    END
+    """,
+    """
+    CREATE TRIGGER snapshot_views_are_immutable
+    BEFORE UPDATE ON snapshot_views
+    BEGIN
+        SELECT RAISE(ABORT, 'published snapshot views are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER ready_snapshot_views_cannot_be_inserted
+    BEFORE INSERT ON snapshot_views
+    WHEN (SELECT status FROM snapshots WHERE snapshot_id = NEW.snapshot_id) = 'ready'
+    BEGIN
+        SELECT RAISE(ABORT, 'ready snapshot views are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER ready_snapshot_views_cannot_be_deleted
+    BEFORE DELETE ON snapshot_views
+    WHEN (SELECT status FROM snapshots WHERE snapshot_id = OLD.snapshot_id) = 'ready'
+    BEGIN
+        SELECT RAISE(ABORT, 'ready snapshot views are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER refs_require_ready_snapshot_on_insert
+    BEFORE INSERT ON refs
+    WHEN (
+        SELECT status FROM snapshots WHERE snapshot_id = NEW.snapshot_id
+    ) IS NOT 'ready'
+    BEGIN
+        SELECT RAISE(ABORT, 'refs may only target ready snapshots');
+    END
+    """,
+    """
+    CREATE TRIGGER refs_require_ready_snapshot_on_update
+    BEFORE UPDATE ON refs
+    WHEN (
+        SELECT status FROM snapshots WHERE snapshot_id = NEW.snapshot_id
+    ) IS NOT 'ready'
+    BEGIN
+        SELECT RAISE(ABORT, 'refs may only target ready snapshots');
+    END
+    """,
+)
+
+_MIGRATIONS: dict[int, tuple[str, ...]] = {1: _SCHEMA_V1}
+
+
+class SQLiteCatalog:
+    """Transactional SQLite catalog for immutable index snapshots."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        busy_timeout_ms: int = 5_000,
+    ) -> None:
+        if (
+            isinstance(busy_timeout_ms, bool)
+            or not isinstance(busy_timeout_ms, int)
+            or busy_timeout_ms < 0
+        ):
+            raise ValueError("busy_timeout_ms must be a non-negative integer")
+
+        raw_path = str(path)
+        if raw_path != ":memory:":
+            resolved = Path(path).expanduser().resolve()
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+            raw_path = str(resolved)
+        self.path = raw_path
+        self._connection = sqlite3.connect(
+            raw_path,
+            timeout=busy_timeout_ms / 1_000,
+            isolation_level=None,
+        )
+        self._connection.row_factory = sqlite3.Row
+        try:
+            self._connection.execute("PRAGMA foreign_keys = ON")
+            self._connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms:d}")
+            self._connection.execute("PRAGMA journal_mode = WAL")
+            self._connection.execute("PRAGMA synchronous = FULL")
+            self._migrate()
+        except BaseException:
+            self._connection.close()
+            raise
+
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        self._connection.close()
+
+    def __enter__(self) -> SQLiteCatalog:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    @property
+    def schema_version(self) -> int:
+        """Return the latest successfully applied schema migration."""
+        row = self._connection.execute(
+            "SELECT COALESCE(MAX(version), 0) AS version FROM schema_migrations"
+        ).fetchone()
+        return int(row["version"])
+
+    @contextmanager
+    def _transaction(self, *, immediate: bool = True) -> Iterator[None]:
+        if self._connection.in_transaction:
+            raise CatalogError("nested catalog transactions are not supported")
+        self._connection.execute("BEGIN IMMEDIATE" if immediate else "BEGIN")
+        try:
+            yield
+            self._connection.commit()
+        except BaseException:
+            if self._connection.in_transaction:
+                self._connection.rollback()
+            raise
+
+    def _migrate(self) -> None:
+        with self._transaction():
+            self._connection.execute("""
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    applied_at TEXT NOT NULL
+                )
+                """)
+            rows = self._connection.execute(
+                "SELECT version FROM schema_migrations ORDER BY version"
+            ).fetchall()
+            applied = [int(row["version"]) for row in rows]
+            if applied != list(range(1, len(applied) + 1)):
+                raise CatalogError(f"non-contiguous schema migrations: {applied!r}")
+            current_version = applied[-1] if applied else 0
+            user_version = int(
+                self._connection.execute("PRAGMA user_version").fetchone()[0]
+            )
+            if current_version > LATEST_SCHEMA_VERSION:
+                raise CatalogError(
+                    "catalog schema is newer than this CodeNib version: "
+                    f"{current_version} > {LATEST_SCHEMA_VERSION}"
+                )
+            if user_version > LATEST_SCHEMA_VERSION:
+                raise CatalogError(
+                    "catalog user_version is newer than this CodeNib version: "
+                    f"{user_version} > {LATEST_SCHEMA_VERSION}"
+                )
+            if user_version != current_version:
+                raise CatalogError(
+                    "catalog user_version does not match schema_migrations: "
+                    f"{user_version} != {current_version}"
+                )
+
+            for version in range(current_version + 1, LATEST_SCHEMA_VERSION + 1):
+                statements = _MIGRATIONS.get(version)
+                if statements is None:
+                    raise CatalogError(f"missing catalog migration {version}")
+                for statement in statements:
+                    self._connection.execute(statement)
+                if version == 1:
+                    self._connection.execute(
+                        """
+                        INSERT INTO namespaces(namespace_id, name, created_at)
+                        VALUES (?, ?, ?)
+                        """,
+                        (DEFAULT_NAMESPACE_ID, DEFAULT_NAMESPACE_NAME, _now()),
+                    )
+                self._connection.execute(
+                    """
+                    INSERT INTO schema_migrations(version, applied_at)
+                    VALUES (?, ?)
+                    """,
+                    (version, _now()),
+                )
+                self._connection.execute(f"PRAGMA user_version = {version:d}")
+
+    def _require_record(self, table: str, key: str, value: str) -> sqlite3.Row:
+        allowed = {
+            "namespaces": "namespace_id",
+            "repositories": "repository_id",
+            "source_revisions": "source_revision_id",
+            "view_profiles": "profile_id",
+            "objects": "digest",
+            "view_generations": "view_generation_id",
+            "snapshots": "snapshot_id",
+        }
+        if allowed.get(table) != key:
+            raise AssertionError("unsafe catalog lookup")
+        row = self._connection.execute(
+            f"SELECT * FROM {table} WHERE {key} = ?", (value,)
+        ).fetchone()
+        if row is None:
+            label = table.replace("_", " ").rstrip("s")
+            raise CatalogNotFoundError(f"{label} not found: {value}")
+        return row
+
+    def create_namespace(self, name: str) -> str:
+        """Create an idempotent logical namespace and return its stable ID."""
+        normalized = _required_text(name, "namespace name")
+        if normalized == DEFAULT_NAMESPACE_NAME:
+            namespace_id = DEFAULT_NAMESPACE_ID
+        else:
+            namespace_id = content_id("ns", {"name": normalized})
+        with self._transaction():
+            self._connection.execute(
+                """
+                INSERT OR IGNORE INTO namespaces(namespace_id, name, created_at)
+                VALUES (?, ?, ?)
+                """,
+                (namespace_id, normalized, _now()),
+            )
+            row = self._connection.execute(
+                "SELECT namespace_id FROM namespaces WHERE name = ?", (normalized,)
+            ).fetchone()
+            if row is None or row["namespace_id"] != namespace_id:
+                raise CatalogConflictError(
+                    f"namespace identity conflicts with existing name: {normalized}"
+                )
+        return namespace_id
+
+    def create_repository(
+        self,
+        repository_key: str,
+        *,
+        namespace_id: str = DEFAULT_NAMESPACE_ID,
+    ) -> str:
+        """Create an idempotent repository identity in a non-null namespace."""
+        key = _required_text(repository_key, "repository key")
+        namespace = _required_text(namespace_id, "namespace ID")
+        repository_id = content_id(
+            "repo", {"namespace_id": namespace, "repository_key": key}
+        )
+        with self._transaction():
+            self._require_record("namespaces", "namespace_id", namespace)
+            self._connection.execute(
+                """
+                INSERT OR IGNORE INTO repositories(
+                    repository_id, namespace_id, repository_key, created_at
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (repository_id, namespace, key, _now()),
+            )
+            row = self._connection.execute(
+                """
+                SELECT repository_id FROM repositories
+                WHERE namespace_id = ? AND repository_key = ?
+                """,
+                (namespace, key),
+            ).fetchone()
+            if row is None or row["repository_id"] != repository_id:
+                raise CatalogConflictError(
+                    f"repository identity conflicts with existing key: {key}"
+                )
+        return repository_id
+
+    def create_source_revision(
+        self,
+        repository_id: str,
+        *,
+        commit_sha: str | None = None,
+        tree_sha: str | None = None,
+        dirty: bool = False,
+        source_fingerprint: str | None = None,
+    ) -> str:
+        """Create a stable clean or dirty source identity.
+
+        Clean identities require both a commit and tree and use the tree as the
+        canonical source fingerprint.  Dirty identities require an explicit
+        content fingerprint, may bind a base commit, and never include a base
+        tree as a second identity for the same dirty contents.
+        """
+        repository = _required_text(repository_id, "repository ID")
+        if dirty:
+            revision = SourceRevision(
+                repository_id=repository,
+                source_kind="dirty",
+                commit_sha=commit_sha,
+                tree_sha=tree_sha,
+                source_fingerprint=source_fingerprint or "",
+            )
+        else:
+            revision = SourceRevision.clean(
+                repository,
+                commit_sha=commit_sha or "",
+                tree_sha=tree_sha or "",
+            )
+
+        identity = {
+            "repository_id": revision.repository_id,
+            "source_kind": revision.source_kind,
+            "commit_sha": revision.commit_sha,
+            "tree_sha": revision.tree_sha,
+            "source_fingerprint": revision.source_fingerprint,
+        }
+        source_revision_id = revision.source_revision_id
+        if source_revision_id != content_id("src", identity):
+            raise AssertionError("source revision identity implementations diverged")
+        identity_digest = source_revision_id.removeprefix("src_")
+        with self._transaction():
+            self._require_record("repositories", "repository_id", repository)
+            self._connection.execute(
+                """
+                INSERT OR IGNORE INTO source_revisions(
+                    source_revision_id, repository_id, source_kind, commit_sha,
+                    tree_sha, source_fingerprint, identity_digest, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    source_revision_id,
+                    repository,
+                    revision.source_kind,
+                    revision.commit_sha,
+                    revision.tree_sha,
+                    revision.source_fingerprint,
+                    identity_digest,
+                    _now(),
+                ),
+            )
+            row = self._connection.execute(
+                """
+                SELECT source_revision_id FROM source_revisions
+                WHERE repository_id = ? AND identity_digest = ?
+                """,
+                (repository, identity_digest),
+            ).fetchone()
+            if row is None or row["source_revision_id"] != source_revision_id:
+                raise CatalogConflictError("source revision identity conflict")
+        return source_revision_id
+
+    def create_view_profile(
+        self,
+        view_type: str,
+        config: Mapping[str, Any] | None = None,
+        *,
+        name: str = "default",
+    ) -> str:
+        """Create an idempotent, view-specific canonical JSON profile."""
+        normalized_view_type = _required_text(view_type, "view type")
+        normalized_name = _required_text(name, "profile name")
+        config_json = canonical_json(config or {})
+        identity = {
+            "view_type": normalized_view_type,
+            "name": normalized_name,
+            "config": json.loads(config_json),
+        }
+        profile_id = content_id("profile", identity)
+        profile_digest = profile_id.removeprefix("profile_")
+        with self._transaction():
+            self._connection.execute(
+                """
+                INSERT OR IGNORE INTO view_profiles(
+                    profile_id, view_type, name, config_json, profile_digest, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    profile_id,
+                    normalized_view_type,
+                    normalized_name,
+                    config_json,
+                    profile_digest,
+                    _now(),
+                ),
+            )
+            row = self._connection.execute(
+                "SELECT profile_id FROM view_profiles WHERE profile_digest = ?",
+                (profile_digest,),
+            ).fetchone()
+            if row is None or row["profile_id"] != profile_id:
+                raise CatalogConflictError("view profile identity conflict")
+        return profile_id
+
+    def register_object(
+        self,
+        digest: str,
+        *,
+        storage_key: str,
+        byte_size: int,
+        media_type: str = "application/octet-stream",
+    ) -> str:
+        """Register metadata for an already-durable, independently verified object.
+
+        This low-level catalog has no object-store handle.  Publication
+        coordinators must call ``ObjectStore.verify`` and match its digest,
+        size, and storage key before registering or publishing the receipt.
+        """
+        record = ObjectRecord(
+            digest=digest,
+            storage_key=storage_key,
+            byte_size=byte_size,
+            media_type=media_type,
+        )
+        normalized_digest = record.digest
+        normalized_storage_key = record.storage_key
+        normalized_media_type = record.media_type
+
+        with self._transaction():
+            row = self._connection.execute(
+                "SELECT * FROM objects WHERE digest = ?", (normalized_digest,)
+            ).fetchone()
+            if row is None:
+                self._connection.execute(
+                    """
+                    INSERT INTO objects(
+                        digest, storage_key, byte_size, media_type, created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        normalized_digest,
+                        normalized_storage_key,
+                        record.byte_size,
+                        normalized_media_type,
+                        _now(),
+                    ),
+                )
+            elif (
+                row["storage_key"] != normalized_storage_key
+                or row["byte_size"] != record.byte_size
+                or row["media_type"] != normalized_media_type
+            ):
+                raise CatalogConflictError(
+                    f"object metadata is immutable: {normalized_digest}"
+                )
+        return normalized_digest
+
+    def stage_view_generation(
+        self,
+        repository_id: str,
+        source_revision_id: str,
+        profile_id: str,
+        view_type: str,
+        object_digest: str,
+        *,
+        schema_version: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> str:
+        """Stage an immutable view generation backed by a registered object."""
+        repository = _required_text(repository_id, "repository ID")
+        source = _required_text(source_revision_id, "source revision ID")
+        profile = _required_text(profile_id, "profile ID")
+        normalized_view_type = _required_text(view_type, "view type")
+        digest = normalize_digest(object_digest)
+        normalized_schema_version = _required_text(
+            schema_version, "view schema version"
+        )
+        metadata_json = canonical_json(metadata or {})
+        identity = {
+            "repository_id": repository,
+            "source_revision_id": source,
+            "profile_id": profile,
+            "view_type": normalized_view_type,
+            "object_digest": digest,
+            "schema_version": normalized_schema_version,
+            "metadata": json.loads(metadata_json),
+        }
+        view_generation_id = content_id("view", identity)
+
+        with self._transaction():
+            self._require_record("repositories", "repository_id", repository)
+            source_row = self._require_record(
+                "source_revisions", "source_revision_id", source
+            )
+            if source_row["repository_id"] != repository:
+                raise CatalogValidationError(
+                    "view source revision belongs to another repository"
+                )
+            profile_row = self._require_record("view_profiles", "profile_id", profile)
+            if profile_row["view_type"] != normalized_view_type:
+                raise CatalogValidationError(
+                    "view type does not match the view profile"
+                )
+            self._require_record("objects", "digest", digest)
+            self._connection.execute(
+                """
+                INSERT OR IGNORE INTO view_generations(
+                    view_generation_id, repository_id, source_revision_id,
+                    profile_id, view_type, object_digest, schema_version,
+                    metadata_json, status, created_at, ready_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'staged', ?, NULL)
+                """,
+                (
+                    view_generation_id,
+                    repository,
+                    source,
+                    profile,
+                    normalized_view_type,
+                    digest,
+                    normalized_schema_version,
+                    metadata_json,
+                    _now(),
+                ),
+            )
+            row = self._require_record(
+                "view_generations", "view_generation_id", view_generation_id
+            )
+            expected = (
+                repository,
+                source,
+                profile,
+                normalized_view_type,
+                digest,
+                normalized_schema_version,
+                metadata_json,
+            )
+            actual = tuple(
+                row[key]
+                for key in (
+                    "repository_id",
+                    "source_revision_id",
+                    "profile_id",
+                    "view_type",
+                    "object_digest",
+                    "schema_version",
+                    "metadata_json",
+                )
+            )
+            if actual != expected:
+                raise CatalogConflictError("view generation identity conflict")
+        return view_generation_id
+
+    def publish_snapshot(
+        self,
+        repository_id: str,
+        source_revision_id: str,
+        view_generation_ids: Sequence[str],
+        *,
+        ref_name: str = "main",
+        expected_generation: int = 0,
+    ) -> dict[str, Any]:
+        """Atomically publish views and advance a ref with compare-and-swap.
+
+        A missing ref has generation zero.  On any validation or CAS failure,
+        the snapshot insertion and every staged-to-ready transition roll back.
+        """
+        repository = _required_text(repository_id, "repository ID")
+        source = _required_text(source_revision_id, "source revision ID")
+        normalized_ref = _required_text(ref_name, "ref name")
+        if isinstance(expected_generation, bool) or not isinstance(
+            expected_generation, int
+        ):
+            raise CatalogValidationError("expected generation must be an integer")
+        if expected_generation < 0:
+            raise CatalogValidationError("expected generation must not be negative")
+        if isinstance(view_generation_ids, (str, bytes)):
+            raise CatalogValidationError("view generation IDs must be a sequence")
+        view_ids = [
+            _required_text(value, "view generation ID") for value in view_generation_ids
+        ]
+        if not view_ids:
+            raise CatalogValidationError("a snapshot requires at least one view")
+        if len(set(view_ids)) != len(view_ids):
+            raise CatalogValidationError("duplicate view generation IDs")
+
+        with self._transaction():
+            self._require_record("repositories", "repository_id", repository)
+            source_row = self._require_record(
+                "source_revisions", "source_revision_id", source
+            )
+            if source_row["repository_id"] != repository:
+                raise CatalogValidationError(
+                    "snapshot source revision belongs to another repository"
+                )
+
+            placeholders = ",".join("?" for _ in view_ids)
+            rows = self._connection.execute(
+                f"""
+                SELECT * FROM view_generations
+                WHERE view_generation_id IN ({placeholders})
+                """,
+                view_ids,
+            ).fetchall()
+            if len(rows) != len(view_ids):
+                found = {row["view_generation_id"] for row in rows}
+                missing = sorted(set(view_ids) - found)
+                raise CatalogNotFoundError(
+                    f"view generation not found: {', '.join(missing)}"
+                )
+
+            view_types: set[str] = set()
+            for row in rows:
+                if row["repository_id"] != repository:
+                    raise CatalogValidationError(
+                        "snapshot view belongs to another repository"
+                    )
+                if row["source_revision_id"] != source:
+                    raise CatalogValidationError(
+                        "all snapshot views must share the snapshot source identity"
+                    )
+                if row["view_type"] in view_types:
+                    raise CatalogValidationError(
+                        f"snapshot has duplicate view type: {row['view_type']}"
+                    )
+                view_types.add(row["view_type"])
+
+            current_ref = self._connection.execute(
+                """
+                SELECT generation FROM refs
+                WHERE repository_id = ? AND ref_name = ?
+                """,
+                (repository, normalized_ref),
+            ).fetchone()
+            current_generation = (
+                int(current_ref["generation"]) if current_ref is not None else 0
+            )
+            if current_generation != expected_generation:
+                raise CatalogConflictError(
+                    f"ref {normalized_ref!r} generation is {current_generation}; "
+                    f"expected {expected_generation}"
+                )
+
+            members = sorted(
+                (row["view_type"], row["view_generation_id"]) for row in rows
+            )
+            snapshot_identity = {
+                "repository_id": repository,
+                "source_revision_id": source,
+                "views": members,
+            }
+            snapshot_id = content_id("snapshot", snapshot_identity)
+            content_digest = snapshot_id.removeprefix("snapshot_")
+            published_at = _now()
+            existing_snapshot = self._connection.execute(
+                "SELECT * FROM snapshots WHERE snapshot_id = ?", (snapshot_id,)
+            ).fetchone()
+            if existing_snapshot is None:
+                self._connection.execute(
+                    """
+                    INSERT INTO snapshots(
+                        snapshot_id, repository_id, source_revision_id,
+                        content_digest, status, published_at
+                    ) VALUES (?, ?, ?, ?, 'building', NULL)
+                    """,
+                    (snapshot_id, repository, source, content_digest),
+                )
+                for view_type, view_generation_id in members:
+                    self._connection.execute(
+                        """
+                        INSERT INTO snapshot_views(
+                            snapshot_id, view_type, view_generation_id
+                        ) VALUES (?, ?, ?)
+                        """,
+                        (snapshot_id, view_type, view_generation_id),
+                    )
+                    self._connection.execute(
+                        """
+                        UPDATE view_generations
+                        SET status = 'ready', ready_at = ?
+                        WHERE view_generation_id = ? AND status = 'staged'
+                        """,
+                        (published_at, view_generation_id),
+                    )
+                seal = self._connection.execute(
+                    """
+                    UPDATE snapshots
+                    SET status = 'ready', published_at = ?
+                    WHERE snapshot_id = ? AND status = 'building'
+                    """,
+                    (published_at, snapshot_id),
+                )
+                if seal.rowcount != 1:
+                    raise CatalogConflictError("snapshot could not be sealed")
+            else:
+                expected_snapshot = (
+                    repository,
+                    source,
+                    content_digest,
+                    "ready",
+                )
+                actual_snapshot = tuple(
+                    existing_snapshot[key]
+                    for key in (
+                        "repository_id",
+                        "source_revision_id",
+                        "content_digest",
+                        "status",
+                    )
+                )
+                if actual_snapshot != expected_snapshot:
+                    raise CatalogConflictError(
+                        "existing snapshot identity or seal state conflicts"
+                    )
+                existing_members = self._connection.execute(
+                    """
+                    SELECT view_type, view_generation_id FROM snapshot_views
+                    WHERE snapshot_id = ? ORDER BY view_type
+                    """,
+                    (snapshot_id,),
+                ).fetchall()
+                actual_members = [
+                    (row["view_type"], row["view_generation_id"])
+                    for row in existing_members
+                ]
+                if actual_members != members or any(
+                    row["status"] != "ready" for row in rows
+                ):
+                    raise CatalogConflictError(
+                        "existing ready snapshot membership conflicts"
+                    )
+
+            next_generation = expected_generation + 1
+            if current_ref is None:
+                self._connection.execute(
+                    """
+                    INSERT INTO refs(
+                        repository_id, ref_name, snapshot_id, generation, updated_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        repository,
+                        normalized_ref,
+                        snapshot_id,
+                        next_generation,
+                        published_at,
+                    ),
+                )
+            else:
+                cursor = self._connection.execute(
+                    """
+                    UPDATE refs
+                    SET snapshot_id = ?, generation = ?, updated_at = ?
+                    WHERE repository_id = ? AND ref_name = ? AND generation = ?
+                    """,
+                    (
+                        snapshot_id,
+                        next_generation,
+                        published_at,
+                        repository,
+                        normalized_ref,
+                        expected_generation,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise CatalogConflictError(
+                        f"ref {normalized_ref!r} changed during publication"
+                    )
+
+        return {
+            "snapshot_id": snapshot_id,
+            "repository_id": repository,
+            "ref_name": normalized_ref,
+            "generation": next_generation,
+        }
+
+    def resolve_ref(self, repository_id: str, ref_name: str = "main") -> dict[str, Any]:
+        """Resolve a named ref and return its pinned manifest summary."""
+        repository = _required_text(repository_id, "repository ID")
+        normalized_ref = _required_text(ref_name, "ref name")
+        with self._transaction(immediate=False):
+            row = self._connection.execute(
+                """
+                SELECT snapshot_id, generation, updated_at FROM refs
+                WHERE repository_id = ? AND ref_name = ?
+                """,
+                (repository, normalized_ref),
+            ).fetchone()
+            if row is None:
+                raise CatalogNotFoundError(
+                    f"ref not found: {repository}:{normalized_ref}"
+                )
+            manifest = self._manifest_summary(row["snapshot_id"])
+            return {
+                "repository_id": repository,
+                "ref_name": normalized_ref,
+                "snapshot_id": row["snapshot_id"],
+                "generation": int(row["generation"]),
+                "updated_at": row["updated_at"],
+                "manifest": manifest,
+            }
+
+    def get_manifest_summary(self, snapshot_id: str) -> dict[str, Any]:
+        """Return the immutable summary for a published, ready snapshot."""
+        normalized_snapshot = _required_text(snapshot_id, "snapshot ID")
+        with self._transaction(immediate=False):
+            return self._manifest_summary(normalized_snapshot)
+
+    def _manifest_summary(self, snapshot_id: str) -> dict[str, Any]:
+        snapshot = self._require_record("snapshots", "snapshot_id", snapshot_id)
+        if snapshot["status"] != "ready":
+            raise CatalogValidationError(
+                f"snapshot is not ready for publication: {snapshot_id}"
+            )
+        source = self._require_record(
+            "source_revisions", "source_revision_id", snapshot["source_revision_id"]
+        )
+        view_rows = self._connection.execute(
+            """
+            SELECT
+                sv.view_type,
+                vg.view_generation_id,
+                vg.schema_version,
+                vg.metadata_json,
+                vg.object_digest,
+                vp.profile_id,
+                vp.name AS profile_name,
+                vp.config_json AS profile_config_json,
+                o.storage_key,
+                o.byte_size,
+                o.media_type
+            FROM snapshot_views AS sv
+            JOIN view_generations AS vg
+                ON vg.view_generation_id = sv.view_generation_id
+            JOIN view_profiles AS vp ON vp.profile_id = vg.profile_id
+            JOIN objects AS o ON o.digest = vg.object_digest
+            WHERE sv.snapshot_id = ?
+            ORDER BY sv.view_type
+            """,
+            (snapshot_id,),
+        ).fetchall()
+        views = {
+            row["view_type"]: {
+                "view_generation_id": row["view_generation_id"],
+                "schema_version": row["schema_version"],
+                "metadata": json.loads(row["metadata_json"]),
+                "profile": {
+                    "profile_id": row["profile_id"],
+                    "name": row["profile_name"],
+                    "config": json.loads(row["profile_config_json"]),
+                },
+                "object": {
+                    "digest": row["object_digest"],
+                    "storage_key": row["storage_key"],
+                    "byte_size": int(row["byte_size"]),
+                    "media_type": row["media_type"],
+                },
+            }
+            for row in view_rows
+        }
+        return {
+            "snapshot_id": snapshot["snapshot_id"],
+            "repository_id": snapshot["repository_id"],
+            "status": snapshot["status"],
+            "published_at": snapshot["published_at"],
+            "source": {
+                "source_revision_id": source["source_revision_id"],
+                "kind": source["source_kind"],
+                "commit_sha": source["commit_sha"],
+                "tree_sha": source["tree_sha"],
+                "source_fingerprint": source["source_fingerprint"],
+            },
+            "views": views,
+        }
+
+
+__all__ = [
+    "CatalogConflictError",
+    "CatalogError",
+    "CatalogNotFoundError",
+    "CatalogValidationError",
+    "DEFAULT_NAMESPACE_ID",
+    "DEFAULT_NAMESPACE_NAME",
+    "LATEST_SCHEMA_VERSION",
+    "SQLiteCatalog",
+]

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -1,0 +1,258 @@
+# Hybrid Storage Backend Roadmap
+
+## Objective
+
+CodeNib will publish repository context through a transactional catalog and
+immutable, content-addressed artifacts without replacing the query engines
+that make the artifacts useful.  The embedded deployment uses SQLite in WAL
+mode plus a local filesystem object store.  A server deployment may replace
+those two implementations with PostgreSQL and an S3-compatible object store
+without changing compiler or retrieval contracts.
+
+The program is complete only when repository updates, concurrent readers,
+multi-version queries, overlays, garbage collection, and server-backed
+storage all preserve the existing `RepoManifest`, MCP, BM25, FAISS, graph, and
+portable artifact behavior.
+
+## Architectural Boundaries
+
+The storage system has three independent layers:
+
+1. **Transactional catalog** — repositories, source revisions, profiles,
+   immutable view generations, published snapshots, refs, jobs, leases, and
+   authorization metadata.  SQLite is the embedded implementation;
+   PostgreSQL is the future multi-worker implementation.
+2. **Content-addressed object store** — large immutable payloads such as BM25
+   documents, FAISS indexes and document mappings, graph payloads, and
+   portable context artifacts.  The embedded implementation uses regular
+   files; the server implementation uses object storage.
+3. **Materialized query views** — BM25, FAISS, and igraph remain the execution
+   formats used by a pinned snapshot.  They are read models, not the catalog
+   or the source of versioning semantics.
+
+DuckDB may be used for offline analysis, but not as the online job/ref
+catalog.  A graph database is not part of the design.  `pgvector` or another
+shared ANN backend remains optional and must be justified by a serving
+benchmark; it cannot replace portable vector artifacts.
+
+## Invariants
+
+- A builder never modifies an artifact reachable from a published ref.
+- A request resolves `ref -> snapshot_id` once and pins that snapshot for its
+  entire lifetime.
+- A snapshot never silently combines views from different source identities.
+  Missing or stale views degrade independently and explicitly.
+- A failed build cannot move a ref or make the previous snapshot unreadable.
+- Source identity preserves both Git commit/tree identity and the existing
+  dirty-worktree `source_fingerprint` contract.
+- Artifact compatibility includes builder schema, language/toolchain context,
+  graph schema, and embedding provider/model/revision/dimension/metric.
+- Large payloads do not live in SQL rows.  The catalog stores their digest,
+  size, media type, schema, trust class, and storage key.
+- Content digests do not grant access.  Every artifact lookup is authorized
+  through its namespace, repository, and reachable snapshot.
+- The embedded deployment creates a non-null default namespace.  Future RLS
+  and cache isolation must not depend on nullable tenant identifiers.
+- Legacy `RepoManifest` v1.1 remains importable and exportable while consumers
+  migrate.  Optional views continue to fail independently.
+
+## Identity Model
+
+```text
+SourceRevision
+  clean: repository + commit + tree
+  dirty: repository + commit + source_fingerprint
+
+ViewProfile
+  canonical digest of view type + builder/schema/toolchain/model configuration
+
+ViewGeneration
+  immutable output for one SourceRevision + ViewProfile
+
+PublishedSnapshot
+  atomic set of compatible ViewGenerations for one SourceRevision
+
+Ref
+  compare-and-swap pointer to one PublishedSnapshot
+```
+
+Per-file analysis reuse cannot be keyed by a raw Git blob hash alone.  Paths,
+package/module identity, build flags, dependencies, decoder/toolchain versions,
+and the analysis profile may affect facts for identical bytes.  The safe
+identity is a digest of the source blob plus semantic context and profile, or
+the digest of the normalized facts themselves.
+
+`ViewProfile` stays generic because each view has different compatibility
+axes, but its builder adapter must emit a versioned, secret-free compatibility
+object and reject omissions.  The top level must identify the profile contract,
+builder and artifact schemas.  Vector profiles additionally bind provider,
+model/revision (or an immutable compatibility fingerprint), dimension, metric,
+normalization, and options; graph profiles bind graph schema, route, language
+analyzers/grammars/toolchains, and build flags; BM25 profiles bind tokenizer,
+chunker, filter, and language schemas.  A legacy import uses an explicit
+`legacy` contract instead of guessed defaults.  No builder may reuse or publish
+a generation through this catalog until positive and negative tests show that
+every semantic compatibility axis changes the profile identity and that a
+missing required axis fails closed.
+
+## Publication Protocol
+
+1. Create or reuse an idempotent index job and obtain its lease.
+2. Build each requested view in a job-owned staging generation.
+3. Write immutable objects, validate their SHA-256 digests and compatibility,
+   and record short-lived orphan candidates if publication has not completed.
+4. In one catalog transaction, register objects and ready generations, create
+   the snapshot manifest, compare-and-swap the ref generation, and mark the job
+   successful.
+5. Load and validate the new runtime bundle before atomically swapping the
+   process pointer.  Requests already using the previous bundle keep it pinned.
+6. Reclaim unreachable snapshots and objects only after leases, explicit pins,
+   overlay heads, running jobs, retention rules, and a grace period are honored.
+
+The database transaction is never committed before required objects are
+durably available.
+
+## Graph Versioning Pivot
+
+The current global igraph materializes cross-file references as resolved
+vertex-to-vertex edges.  Updating one file can therefore mutate inbound edges
+associated with unchanged files.  Per-file content reuse and natural snapshot
+isolation require a different canonical representation:
+
+- immutable per-file symbols and intra-file edges;
+- unresolved cross-file references
+  `(src_local_symbol, target_moniker, anchor)`;
+- a definitions index mapping monikers to local symbols in active file units;
+- bounded query-time resolution and a discardable hot-edge cache keyed by the
+  complete snapshot or manifest digest.
+
+The new facts will be dual-written beside the legacy materialized graph.  The
+legacy graph remains the serving authority until range, neighborhood,
+dependency, incoming/outgoing, and incremental replay parity gates pass.
+
+## Overlay Semantics
+
+An overlay pins a base snapshot and publishes immutable overlay generations.
+Overlay entries are path operations, not a set union:
+
+```text
+overlay_files(path, operation = upsert | delete, analysis_unit_id?)
+```
+
+An upsert shadows the base path and a delete is a tombstone.  Each overlay head
+is updated with compare-and-swap, is scoped to its owner/namespace, and has an
+explicit TTL unless pinned.
+
+## Milestones
+
+### M0: Contract and acceptance matrix
+
+Status: complete.
+
+- Record the architecture, identities, publication protocol, graph pivot, and
+  compatibility invariants in this roadmap.
+- Define the first `IndexCatalog`/`ObjectStore` contracts without routing existing
+  consumers through them.
+- Add unit-level conformance tests for digest validation, schema migration,
+  ref compare-and-swap, and crash-safe publication boundaries.
+- Reconcile the plan with issues #199, #266, and #431.
+
+The backend boundary, identity rules, publication ordering, graph pivot, and
+compatibility gates are now durable here.  The initial protocols and
+failure-injection/conformance tests establish the acceptance surface without
+routing production builders or readers through an unfinished backend.
+
+### M1: Embedded catalog and object store
+
+Status: in progress.
+
+- Implement a versioned SQLite schema with WAL, foreign keys, explicit
+  transactions, and forward-only migrations.
+- Implement a filesystem SHA-256 object store with atomic writes and verified
+  materialization.
+- Store namespaces, repositories, source revisions, profiles, objects,
+  generations, snapshots, snapshot views, refs, and initial job/lease records.
+- Import one existing cache/manifest as a ready snapshot and export an
+  equivalent `RepoManifest` v1.1.
+
+The SQLite/CAS foundation through refs and atomic snapshot sealing is
+implemented.  Initial job/lease records plus legacy manifest import/export are
+the remaining M1 deliverables.
+
+### M2: Immutable generation publication
+
+Status: pending.
+
+- Make every builder write to a unique staging generation.
+- Add per-view profile adapters that fail closed on incomplete compatibility
+  inputs and prove every semantic axis participates in the profile identity.
+- Publish whole-view BM25, FAISS, and graph artifacts through the catalog and
+  object store without changing their ranking/query semantics.
+- Add the publication coordinator that verifies each object-store receipt and
+  matches digest, size, and storage key before catalog registration; catalog
+  metadata alone must never make missing bytes publishable.
+- Move refs only after object and compatibility validation.
+- Prove interrupted and failed builds leave the previous snapshot usable.
+
+### M3: Jobs and runtime hot switching
+
+Status: pending.
+
+- Add idempotent index jobs, progress/events, heartbeats, leases, cancellation,
+  and one-publisher-per-repository/ref enforcement.
+- Expose the #266 status and update APIs with accurate incremental versus
+  rebuild behavior.
+- Load a complete new bundle and swap it RCU-style; pin old bundles for in-flight
+  requests.
+- Keep read-only/prebuilt paths safe through copy-on-write or explicit refusal.
+
+### M4: Cross-file reference de-materialization
+
+Status: pending.
+
+- Preserve definitions and unresolved target monikers in Python and C++ decode
+  paths while continuing to emit the legacy graph.
+- Add snapshot-aware definition/reference resolution and bounded hot caches.
+- Establish parity gates for every public graph query and supported language.
+- Remove eager incoming-edge reconnection only after parity is demonstrated.
+
+### M5: Per-file versions, retention, and overlays
+
+Status: pending.
+
+- Store path/mode/blob identity and content-addressed analysis units per source
+  revision.
+- Reuse unchanged analysis units across commits without cross-version edge
+  contamination.
+- Add snapshot leases, pins, retention policy, mark-and-sweep GC, and crash
+  recovery.
+- Add path-aware overlay upsert/delete generations and owner isolation.
+
+### M6: PostgreSQL and object-storage deployment
+
+Status: pending and demand-gated.
+
+- Implement the same catalog semantics with PostgreSQL transactions, row
+  locking/`SKIP LOCKED`, leases, and namespace-scoped authorization.
+- Implement S3/MinIO object publication, verification, materialization cache,
+  and deletion recovery.
+- Validate multi-worker contention, backup/restore, migration, quotas, audit,
+  and failure injection before making the server backend supported.
+
+### M7: Managed semantic and optional shared ANN
+
+Status: pending and benchmark-gated.
+
+- Keep managed embeddings keyed by namespace, immutable embedding fingerprint,
+  and strong input digest.
+- Preserve local, BYO, managed, no-model, and artifact-only routes.
+- Add a shared ANN read model only if measured workload demonstrates that local
+  FAISS materialization is the limiting cost.
+- Keep artifact export and local fallback as compatibility gates.
+
+## Completion Gate
+
+The program is complete when all milestones are implemented, locally and
+remotely verified at their required test tiers, documented, and reconciled
+with their issues and PRs.  Passing one backend test, landing the catalog
+schema, or publishing a single snapshot is not completion of the objective.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ repo_name: sysevol-ai/CodeNib
 exclude_docs: |
   experiments/
   product_roadmap.md
+  storage_backend_roadmap.md
   agent_runner_architecture_goal.md
   agent_compile_design.md
   scip_multilanguage_roadmap.md

--- a/test/storage/test_cas.py
+++ b/test/storage/test_cas.py
@@ -1,0 +1,455 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+import codenib.storage.cas as cas_module
+from codenib.storage.cas import LocalCAS
+from codenib.storage.models import StorageIntegrityError, StorageValidationError
+
+
+def test_put_bytes_uses_canonical_key_and_deduplicates(tmp_path: Path) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"immutable artifact"
+    digest = hashlib.sha256(payload).hexdigest()
+
+    first = store.put_bytes(payload)
+    stored = store.root / first.storage_key
+    first_metadata = stored.stat()
+    second = store.put_bytes(payload)
+
+    assert first == second
+    assert first.digest == digest
+    assert first.byte_size == len(payload)
+    assert first.storage_key == f"sha256/{digest[:2]}/{digest[2:]}"
+    assert stored.stat().st_ino == first_metadata.st_ino
+    assert store.has(digest)
+    assert store.verify(digest) == first
+    assert store.read_bytes(digest) == payload
+    with store.open(digest) as handle:
+        assert handle.read() == payload
+
+
+def test_put_file_stores_regular_file(tmp_path: Path) -> None:
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"file artifact" * 100)
+    store = LocalCAS(tmp_path / "objects")
+
+    info = store.put_file(source)
+
+    assert info.byte_size == source.stat().st_size
+    assert store.read_bytes(info.digest) == source.read_bytes()
+
+
+def test_existing_corrupt_object_is_rejected_instead_of_replaced(
+    tmp_path: Path,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"correct"
+    info = store.put_bytes(payload)
+    stored = store.root / info.storage_key
+    original_inode = stored.stat().st_ino
+    stored.write_bytes(b"corrupt")
+
+    with pytest.raises(StorageIntegrityError, match="digest mismatch"):
+        store.verify(info.digest)
+    with pytest.raises(StorageIntegrityError, match="digest mismatch"):
+        store.read_bytes(info.digest)
+    with pytest.raises(StorageIntegrityError, match="failed integrity"):
+        store.put_bytes(payload)
+
+    assert stored.stat().st_ino == original_inode
+    assert stored.read_bytes() == b"corrupt"
+
+
+@pytest.mark.parametrize(
+    "digest",
+    [
+        "",
+        "0" * 63,
+        "0" * 65,
+        "A" * 64,
+        "g" * 64,
+        "sha256:" + "0" * 64,
+        "../" + "0" * 61,
+        "0" * 64 + "\n",
+    ],
+)
+def test_digest_syntax_is_strict(tmp_path: Path, digest: str) -> None:
+    store = LocalCAS(tmp_path / "objects")
+
+    with pytest.raises(StorageValidationError, match="64 lowercase hexadecimal"):
+        store.has(digest)
+    with pytest.raises(StorageValidationError, match="64 lowercase hexadecimal"):
+        store.verify(digest)
+    with pytest.raises(StorageValidationError, match="64 lowercase hexadecimal"):
+        store.materialize(digest, tmp_path / "out")
+
+
+def test_existing_special_object_is_rejected(tmp_path: Path) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"special"
+    digest = hashlib.sha256(payload).hexdigest()
+    parent = store.root / "sha256" / digest[:2]
+    parent.mkdir()
+    stored = parent / digest[2:]
+    stored.symlink_to(tmp_path / "missing")
+
+    with pytest.raises(StorageIntegrityError, match="not a regular file"):
+        store.has(digest)
+    with pytest.raises(StorageIntegrityError, match="not a regular file"):
+        store.put_bytes(payload)
+
+
+def test_failed_put_cleans_temporary_without_publishing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"not published"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+
+    def fail_link(*_args, **_kwargs):
+        raise OSError("injected publish failure")
+
+    monkeypatch.setattr("codenib.storage.cas._link_at", fail_link)
+
+    with pytest.raises(OSError, match="injected publish failure"):
+        store.put_bytes(payload)
+
+    assert not destination.exists()
+    assert list(destination.parent.glob("*.tmp")) == []
+
+
+def test_materialize_atomically_replaces_regular_file(tmp_path: Path) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"published view"
+    info = store.put_bytes(payload)
+    destination = tmp_path / "runtime" / "view.bin"
+    destination.parent.mkdir()
+    destination.write_bytes(b"previous view")
+
+    result = store.materialize(info.digest, destination)
+
+    assert result == destination
+    assert destination.read_bytes() == payload
+    assert list(destination.parent.glob("*.tmp")) == []
+
+
+def test_materialize_failure_preserves_previous_file_and_cleans_temporary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    info = store.put_bytes(b"new view")
+    destination = tmp_path / "view.bin"
+    destination.write_bytes(b"old view")
+
+    def fail_replace(source: str | os.PathLike[str], target: str | os.PathLike[str]):
+        raise OSError("injected materialization failure")
+
+    monkeypatch.setattr("codenib.storage.cas.os.replace", fail_replace)
+
+    with pytest.raises(OSError, match="injected materialization failure"):
+        store.materialize(info.digest, destination)
+
+    assert destination.read_bytes() == b"old view"
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_materialize_rejects_symlink_and_special_target(tmp_path: Path) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    info = store.put_bytes(b"view")
+    real_target = tmp_path / "real.bin"
+    real_target.write_bytes(b"keep")
+    symlink = tmp_path / "link.bin"
+    symlink.symlink_to(real_target)
+
+    with pytest.raises(StorageValidationError, match="not a regular file"):
+        store.materialize(info.digest, symlink)
+    with pytest.raises(StorageValidationError, match="not a regular file"):
+        store.materialize(info.digest, tmp_path)
+
+    assert real_target.read_bytes() == b"keep"
+
+
+def test_put_file_rejects_source_changed_between_passes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"first version")
+    real_create_temporary = cas_module._create_temporary_file
+
+    def mutate_then_create(*args, **kwargs):
+        source.write_bytes(b"second version with a different size")
+        return real_create_temporary(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "codenib.storage.cas._create_temporary_file",
+        mutate_then_create,
+    )
+
+    with pytest.raises(OSError, match="source changed"):
+        store.put_file(source)
+
+    assert list((store.root / "sha256").rglob("*.tmp")) == []
+
+
+@pytest.mark.parametrize("swapped_component", ["sha256", "shard"])
+def test_reads_reject_symlinked_internal_directory(
+    tmp_path: Path,
+    swapped_component: str,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"valid bytes outside the CAS root"
+    digest = hashlib.sha256(payload).hexdigest()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    if swapped_component == "sha256":
+        external_shard = outside / digest[:2]
+        external_shard.mkdir()
+        (external_shard / digest[2:]).write_bytes(payload)
+        (store.root / "sha256").rmdir()
+        (store.root / "sha256").symlink_to(outside, target_is_directory=True)
+    else:
+        (outside / digest[2:]).write_bytes(payload)
+        (store.root / "sha256" / digest[:2]).symlink_to(
+            outside,
+            target_is_directory=True,
+        )
+
+    with pytest.raises(StorageIntegrityError, match="not a real directory"):
+        store.has(digest)
+    with pytest.raises(StorageIntegrityError, match="not a real directory"):
+        store.open(digest)
+    with pytest.raises(StorageIntegrityError, match="not a real directory"):
+        store.verify(digest)
+    destination = tmp_path / "materialized.bin"
+    with pytest.raises(StorageIntegrityError, match="not a real directory"):
+        store.materialize(digest, destination)
+    assert not destination.exists()
+
+
+def test_new_digest_shard_fsyncs_sha256_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    fsynced: list[Path] = []
+    real_fsync = cas_module._fsync_directory_handle
+
+    def record_fsync(descriptor: int | None, path: Path) -> None:
+        fsynced.append(path)
+        real_fsync(descriptor, path)
+
+    monkeypatch.setattr(cas_module, "_fsync_directory_handle", record_fsync)
+
+    info = store.put_bytes(b"first object in its digest shard")
+
+    assert store.root / "sha256" in fsynced
+    assert (store.root / info.storage_key).is_file()
+
+
+def test_relative_root_remains_stable_after_working_directory_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    store = LocalCAS(Path("relative-objects"))
+    info = store.put_bytes(b"stable root")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    monkeypatch.chdir(elsewhere)
+
+    assert store.root == (tmp_path / "relative-objects").resolve()
+    assert store.read_bytes(info.digest) == b"stable root"
+    assert store.put_bytes(b"another object").byte_size == len(b"another object")
+
+
+def test_new_root_fsyncs_each_created_parent_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    root = existing / "level-one" / "level-two" / "objects"
+    fsynced: list[Path] = []
+
+    monkeypatch.setattr(
+        cas_module,
+        "_fsync_directory",
+        lambda path: fsynced.append(path),
+    )
+    monkeypatch.setattr(
+        cas_module,
+        "_fsync_directory_handle",
+        lambda _descriptor, _path: None,
+    )
+
+    store = LocalCAS(root)
+
+    assert store.root == root
+    assert fsynced == [
+        existing,
+        existing / "level-one",
+        existing / "level-one" / "level-two",
+    ]
+
+
+def test_constructor_rejects_symlink_and_special_root(tmp_path: Path) -> None:
+    real_root = tmp_path / "real-root"
+    real_root.mkdir()
+    symlink_root = tmp_path / "symlink-root"
+    symlink_root.symlink_to(real_root, target_is_directory=True)
+    file_root = tmp_path / "file-root"
+    file_root.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(StorageValidationError, match="not a real directory"):
+        LocalCAS(symlink_root)
+    with pytest.raises(StorageValidationError, match="not a real directory"):
+        LocalCAS(file_root)
+
+
+def test_concurrent_same_digest_put_publishes_without_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"concurrent immutable object"
+    digest = hashlib.sha256(payload).hexdigest()
+    destination = store.root / "sha256" / digest[:2] / digest[2:]
+    gate = threading.Barrier(2)
+    local = threading.local()
+    real_verify = LocalCAS._verify_existing_at
+
+    def synchronize_publish_check(self, *args, **kwargs):
+        result = real_verify(self, *args, **kwargs)
+        count = getattr(local, "count", 0) + 1
+        local.count = count
+        if count == 2 and result is None:
+            gate.wait(timeout=5)
+        return result
+
+    successful_inodes: list[int] = []
+    real_link = cas_module._link_at
+
+    def record_link(*args, **kwargs):
+        real_link(*args, **kwargs)
+        successful_inodes.append(destination.stat().st_ino)
+
+    monkeypatch.setattr(LocalCAS, "_verify_existing_at", synchronize_publish_check)
+    monkeypatch.setattr(cas_module, "_link_at", record_link)
+
+    errors: list[BaseException] = []
+
+    def put() -> None:
+        try:
+            store.put_bytes(payload)
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=put) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert len(successful_inodes) == 1
+    assert destination.stat().st_ino == successful_inodes[0]
+    assert store.read_bytes(digest) == payload
+
+
+def test_deduplicated_put_flushes_concurrent_publish_before_return(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    payload = b"concurrent durability receipt"
+    digest = hashlib.sha256(payload).hexdigest()
+    shard = store.root / "sha256" / digest[:2]
+    linked = threading.Event()
+    release_first_writer = threading.Event()
+    dedupe_flushed = threading.Event()
+    real_link = cas_module._link_at
+    real_fsync = cas_module._fsync_directory_handle
+
+    def link_then_pause(*args, **kwargs) -> None:
+        real_link(*args, **kwargs)
+        linked.set()
+        if not release_first_writer.wait(timeout=5):
+            raise TimeoutError("first CAS publisher was not released")
+
+    def record_fsync(descriptor: int | None, path: Path) -> None:
+        if linked.is_set() and path == shard:
+            dedupe_flushed.set()
+        real_fsync(descriptor, path)
+
+    monkeypatch.setattr(cas_module, "_link_at", link_then_pause)
+    monkeypatch.setattr(cas_module, "_fsync_directory_handle", record_fsync)
+    errors: list[BaseException] = []
+
+    def put() -> None:
+        try:
+            store.put_bytes(payload)
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first = threading.Thread(target=put)
+    first.start()
+    assert linked.wait(timeout=5)
+    second = threading.Thread(target=put)
+    second.start()
+    second.join(timeout=5)
+
+    try:
+        assert not second.is_alive()
+        assert dedupe_flushed.is_set()
+        assert errors == []
+    finally:
+        release_first_writer.set()
+        first.join(timeout=5)
+
+    assert not first.is_alive()
+    assert errors == []
+    assert store.read_bytes(digest) == payload
+
+
+def test_put_falls_back_to_atomic_replace_without_hard_link_support(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalCAS(tmp_path / "objects")
+    replacements: list[str] = []
+    real_replace = cas_module._replace_at
+
+    def unsupported_link(*_args, **_kwargs) -> None:
+        raise OSError(errno.EOPNOTSUPP, "hard links unavailable")
+
+    def record_replace(*args, **kwargs) -> None:
+        real_replace(*args, **kwargs)
+        replacements.append("replaced")
+
+    monkeypatch.setattr(cas_module, "_link_at", unsupported_link)
+    monkeypatch.setattr(cas_module, "_replace_at", record_replace)
+
+    info = store.put_bytes(b"fallback publication")
+
+    assert replacements == ["replaced"]
+    assert store.read_bytes(info.digest) == b"fallback publication"
+    assert list((store.root / "sha256").rglob("*.tmp")) == []

--- a/test/storage/test_contracts.py
+++ b/test/storage/test_contracts.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from codenib.storage.cas import LocalCAS
+from codenib.storage.models import (
+    ObjectRecord,
+    PublishedSnapshot,
+    RepositoryIdentity,
+    SnapshotView,
+    SourceRevision,
+    ViewGeneration,
+    ViewProfile,
+)
+from codenib.storage.protocols import IndexCatalog, ObjectStore
+from codenib.storage.sqlite_catalog import DEFAULT_NAMESPACE_ID, SQLiteCatalog
+
+
+def test_embedded_backends_implement_storage_protocols(tmp_path) -> None:
+    object_store = LocalCAS(tmp_path / "objects")
+    catalog = SQLiteCatalog(tmp_path / "catalog.sqlite3")
+    try:
+        assert isinstance(object_store, ObjectStore)
+        assert isinstance(catalog, IndexCatalog)
+    finally:
+        catalog.close()
+
+
+def test_domain_and_sqlite_content_identities_match(tmp_path) -> None:
+    object_store = LocalCAS(tmp_path / "objects")
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository = RepositoryIdentity(DEFAULT_NAMESPACE_ID, "owner/repo")
+        repository_id = catalog.create_repository("owner/repo")
+        assert repository_id == repository.repository_id
+
+        source = SourceRevision.clean(
+            repository_id,
+            commit_sha="a" * 40,
+            tree_sha="b" * 64,
+        )
+        source_revision_id = catalog.create_source_revision(
+            repository_id,
+            commit_sha="a" * 40,
+            tree_sha="b" * 64,
+        )
+        assert source_revision_id == source.source_revision_id
+
+        profile = ViewProfile.create("bm25", {"max_k": 128})
+        profile_id = catalog.create_view_profile("bm25", {"max_k": 128})
+        assert profile_id == profile.profile_id
+
+        blob = object_store.put_bytes(b"immutable BM25 artifact")
+        object_record = ObjectRecord(
+            digest=blob.digest,
+            byte_size=blob.byte_size,
+            storage_key=blob.storage_key,
+        )
+        catalog.register_object(
+            blob.digest,
+            storage_key=blob.storage_key,
+            byte_size=blob.byte_size,
+        )
+
+        generation = ViewGeneration.create(
+            source,
+            profile,
+            object_record,
+            schema_version="1",
+            metadata={"document_count": 4},
+        )
+        generation_id = catalog.stage_view_generation(
+            repository_id,
+            source_revision_id,
+            profile_id,
+            "bm25",
+            blob.digest,
+            schema_version="1",
+            metadata={"document_count": 4},
+        )
+        assert generation_id == generation.view_generation_id
+
+        snapshot = PublishedSnapshot(
+            repository_id,
+            source_revision_id,
+            (SnapshotView(generation),),
+        )
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [generation_id],
+            expected_generation=0,
+        )
+        assert published["snapshot_id"] == snapshot.snapshot_id

--- a/test/storage/test_models.py
+++ b/test/storage/test_models.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from codenib.storage.models import (
+    ArtifactMember,
+    ObjectRecord,
+    PublishedSnapshot,
+    RepositoryIdentity,
+    SnapshotView,
+    SourceRevision,
+    StorageValidationError,
+    ViewGeneration,
+    ViewProfile,
+    canonical_json,
+)
+
+
+def _object(suffix: str) -> ObjectRecord:
+    return ObjectRecord(
+        digest=suffix * 64,
+        byte_size=12,
+        storage_key=f"sha256/{suffix * 2}/{suffix * 62}",
+    )
+
+
+def test_canonical_json_and_profile_identity_ignore_mapping_order() -> None:
+    first = {"languages": ["python"], "options": {"b": 2, "a": 1}}
+    second = {"options": {"a": 1, "b": 2}, "languages": ["python"]}
+
+    assert canonical_json(first) == canonical_json(second)
+    assert (
+        ViewProfile.create("vector", first).profile_id
+        == ViewProfile.create("vector", second).profile_id
+    )
+    assert (
+        ViewProfile.create("vector", first).profile_id
+        != ViewProfile.create("bm25", first).profile_id
+    )
+
+
+def test_canonical_json_rejects_non_object_and_non_finite_value() -> None:
+    with pytest.raises(StorageValidationError, match="must be an object"):
+        canonical_json([])  # type: ignore[arg-type]
+    with pytest.raises(StorageValidationError, match="canonical JSON"):
+        canonical_json({"score": float("nan")})
+    with pytest.raises(StorageValidationError, match="keys must be strings"):
+        canonical_json({1: "numeric key"})  # type: ignore[dict-item]
+    with pytest.raises(StorageValidationError, match="keys must be strings"):
+        canonical_json({"nested": [{1: "numeric key"}]})  # type: ignore[dict-item]
+
+
+def test_repository_requires_non_empty_namespace() -> None:
+    with pytest.raises(StorageValidationError, match="namespace ID"):
+        RepositoryIdentity("", "owner/repo")
+
+    identity = RepositoryIdentity("default", "owner/repo")
+    assert (
+        identity.repository_id
+        == RepositoryIdentity("default", "owner/repo").repository_id
+    )
+
+
+def test_clean_and_dirty_source_identities_are_distinct_and_deterministic() -> None:
+    repository_id = RepositoryIdentity("default", "owner/repo").repository_id
+    clean = SourceRevision.clean(
+        repository_id,
+        commit_sha="A" * 40,
+        tree_sha="B" * 64,
+    )
+    same_clean = SourceRevision.clean(
+        repository_id,
+        commit_sha="a" * 40,
+        tree_sha="b" * 64,
+    )
+    dirty = SourceRevision.dirty(
+        repository_id,
+        commit_sha="a" * 40,
+        source_fingerprint="sha256:dirty-tree",
+    )
+    dirty_without_commit = SourceRevision.dirty(
+        repository_id,
+        commit_sha="   ",
+        source_fingerprint="sha256:dirty-tree",
+    )
+
+    assert clean.source_revision_id == same_clean.source_revision_id
+    assert clean.source_revision_id != dirty.source_revision_id
+    assert dirty_without_commit.commit_sha is None
+    with pytest.raises(StorageValidationError, match="commit and tree"):
+        SourceRevision(
+            repository_id,
+            "clean",
+            "a" * 40,
+            None,
+            "git-tree:missing",
+        )
+    with pytest.raises(StorageValidationError, match="source fingerprint"):
+        SourceRevision.dirty(repository_id, source_fingerprint="")
+    with pytest.raises(StorageValidationError, match="must not include a base tree"):
+        SourceRevision(
+            repository_id,
+            "dirty",
+            "a" * 40,
+            "b" * 64,
+            "sha256:dirty-tree",
+        )
+
+
+def test_snapshot_accepts_independent_profiles_for_one_source() -> None:
+    repository_id = RepositoryIdentity("default", "owner/repo").repository_id
+    source = SourceRevision.clean(
+        repository_id,
+        commit_sha="a" * 40,
+        tree_sha="b" * 64,
+    )
+    bm25 = ViewGeneration.create(
+        source,
+        ViewProfile.create("bm25", {"max_k": 128}),
+        _object("a"),
+        schema_version="1",
+    )
+    vector = ViewGeneration.create(
+        source,
+        ViewProfile.create("vector", {"model": "test"}),
+        _object("b"),
+        schema_version="2",
+    )
+
+    snapshot = PublishedSnapshot(
+        repository_id,
+        source.source_revision_id,
+        (SnapshotView(vector), SnapshotView(bm25)),
+    )
+
+    assert [view.view_type for view in snapshot.views] == ["bm25", "vector"]
+    assert (
+        snapshot.snapshot_id
+        == PublishedSnapshot(
+            repository_id,
+            source.source_revision_id,
+            (SnapshotView(bm25), SnapshotView(vector)),
+        ).snapshot_id
+    )
+
+
+def test_snapshot_rejects_cross_source_and_duplicate_view_type() -> None:
+    repository_id = RepositoryIdentity("default", "owner/repo").repository_id
+    source_one = SourceRevision.clean(
+        repository_id,
+        commit_sha="a" * 40,
+        tree_sha="a" * 64,
+    )
+    source_two = SourceRevision.clean(
+        repository_id,
+        commit_sha="b" * 40,
+        tree_sha="b" * 64,
+    )
+    profile = ViewProfile.create("bm25", {})
+    first = ViewGeneration.create(source_one, profile, _object("a"), schema_version="1")
+    second_source = ViewGeneration.create(
+        source_two, profile, _object("b"), schema_version="1"
+    )
+    duplicate = ViewGeneration.create(
+        source_one, profile, _object("c"), schema_version="1"
+    )
+
+    with pytest.raises(StorageValidationError, match="source identity"):
+        PublishedSnapshot(
+            repository_id,
+            source_one.source_revision_id,
+            (SnapshotView(first), SnapshotView(second_source)),
+        )
+    with pytest.raises(StorageValidationError, match="duplicate view type"):
+        PublishedSnapshot(
+            repository_id,
+            source_one.source_revision_id,
+            (SnapshotView(first), SnapshotView(duplicate)),
+        )
+
+
+def test_artifact_member_is_contained_and_models_are_frozen() -> None:
+    member = ArtifactMember("l2/index.faiss", "a" * 64, 10)
+    assert member.path == "l2/index.faiss"
+
+    with pytest.raises(StorageValidationError, match="relative and contained"):
+        ArtifactMember("../outside", "a" * 64, 10)
+    with pytest.raises(StorageValidationError, match="canonical"):
+        ArtifactMember("./index.faiss", "a" * 64, 10)
+    with pytest.raises(StorageValidationError, match="POSIX"):
+        ArtifactMember("l2\\index.faiss", "a" * 64, 10)
+    with pytest.raises(FrozenInstanceError):
+        member.path = "changed"  # type: ignore[misc]
+
+
+def test_object_storage_key_is_canonical_and_contained() -> None:
+    record = _object("a")
+    assert record.storage_key == f"sha256/{'a' * 2}/{'a' * 62}"
+
+    with pytest.raises(StorageValidationError, match="relative and contained"):
+        ObjectRecord("a" * 64, 1, "../../outside")
+    with pytest.raises(StorageValidationError, match="canonical"):
+        ObjectRecord("a" * 64, 1, "sha256/./object")
+
+
+def test_generation_derives_view_identity_from_profile() -> None:
+    repository_id = RepositoryIdentity("default", "owner/repo").repository_id
+    source = SourceRevision.clean(
+        repository_id,
+        commit_sha="a" * 40,
+        tree_sha="b" * 64,
+    )
+    profile = ViewProfile.create("bm25", {})
+    generation = ViewGeneration.create(
+        source,
+        profile,
+        _object("a"),
+        schema_version="1",
+    )
+
+    assert generation.profile is profile
+    assert generation.profile_id == profile.profile_id
+    assert generation.view_type == "bm25"
+    with pytest.raises(StorageValidationError, match="must be a ViewProfile"):
+        ViewGeneration(
+            repository_id,
+            source.source_revision_id,
+            "profile_not_a_profile",  # type: ignore[arg-type]
+            "a" * 64,
+            "1",
+        )

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -1,0 +1,863 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the SQLite immutable-generation catalog."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from codenib.storage.cas import LocalCAS
+from codenib.storage.sqlite_catalog import (
+    DEFAULT_NAMESPACE_ID,
+    LATEST_SCHEMA_VERSION,
+    CatalogConflictError,
+    CatalogError,
+    CatalogNotFoundError,
+    CatalogValidationError,
+    SQLiteCatalog,
+)
+
+
+def _source(catalog: SQLiteCatalog, repository_id: str, suffix: str = "a") -> str:
+    return catalog.create_source_revision(
+        repository_id,
+        commit_sha=suffix * 40,
+        tree_sha=suffix * 64,
+    )
+
+
+def _object(
+    catalog: SQLiteCatalog,
+    suffix: str,
+    *,
+    byte_size: int = 12,
+) -> str:
+    return catalog.register_object(
+        suffix * 64,
+        storage_key=f"sha256/{suffix * 2}/{suffix * 62}",
+        byte_size=byte_size,
+    )
+
+
+def _stage(
+    catalog: SQLiteCatalog,
+    repository_id: str,
+    source_revision_id: str,
+    profile_id: str,
+    object_digest: str,
+    *,
+    view_type: str = "bm25",
+) -> str:
+    return catalog.stage_view_generation(
+        repository_id,
+        source_revision_id,
+        profile_id,
+        view_type,
+        object_digest,
+        schema_version="1",
+        metadata={"document_count": 4},
+    )
+
+
+def test_initializes_pragmas_default_namespace_and_idempotent_reopen(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+
+    with SQLiteCatalog(path, busy_timeout_ms=1_234) as catalog:
+        assert catalog.schema_version == LATEST_SCHEMA_VERSION
+        assert (
+            catalog._connection.execute("PRAGMA user_version").fetchone()[0]
+            == LATEST_SCHEMA_VERSION
+        )
+        assert catalog._connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert catalog._connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert catalog._connection.execute("PRAGMA busy_timeout").fetchone()[0] == 1_234
+        assert catalog._connection.execute("PRAGMA synchronous").fetchone()[0] == 2
+        repository_id = catalog.create_repository("sysevol-ai/CodeNib")
+
+    with SQLiteCatalog(path) as reopened:
+        assert reopened.schema_version == LATEST_SCHEMA_VERSION
+        assert reopened.create_namespace("default") == DEFAULT_NAMESPACE_ID
+        assert reopened.create_repository("sysevol-ai/CodeNib") == repository_id
+        migration_count = reopened._connection.execute(
+            "SELECT COUNT(*) FROM schema_migrations"
+        ).fetchone()[0]
+        assert migration_count == 1
+
+
+def test_reopen_rejects_mismatched_schema_version_records(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path):
+        pass
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA user_version = 0")
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(CatalogError, match="does not match schema_migrations"):
+        SQLiteCatalog(path)
+
+
+def test_reopen_rejects_catalog_newer_than_implementation(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path):
+        pass
+    future_version = LATEST_SCHEMA_VERSION + 1
+    connection = sqlite3.connect(path)
+    connection.execute(
+        "INSERT INTO schema_migrations(version, applied_at) VALUES (?, 'future')",
+        (future_version,),
+    )
+    connection.execute(f"PRAGMA user_version = {future_version}")
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(CatalogError, match="newer than this CodeNib version"):
+        SQLiteCatalog(path)
+
+
+def test_repository_requires_an_existing_non_null_namespace(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        namespace_id = catalog.create_namespace("team-one")
+        repository_id = catalog.create_repository(
+            "owner/repo", namespace_id=namespace_id
+        )
+        repository = catalog._connection.execute(
+            "SELECT namespace_id FROM repositories WHERE repository_id = ?",
+            (repository_id,),
+        ).fetchone()
+
+        assert repository["namespace_id"] == namespace_id
+        with pytest.raises(CatalogNotFoundError, match="namespace"):
+            catalog.create_repository("owner/missing", namespace_id="ns_missing")
+        with pytest.raises(CatalogValidationError, match="namespace ID"):
+            catalog.create_repository("owner/null", namespace_id="")
+
+
+def test_namespace_and_repository_content_identities_are_immutable(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        namespace_id = catalog.create_namespace("team-one")
+        repository_id = catalog.create_repository(
+            "owner/repo", namespace_id=namespace_id
+        )
+
+        with pytest.raises(sqlite3.IntegrityError, match="namespace.*immutable"):
+            catalog._connection.execute(
+                "UPDATE namespaces SET name = 'renamed' WHERE namespace_id = ?",
+                (namespace_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="repository.*immutable"):
+            catalog._connection.execute(
+                """
+                UPDATE repositories SET repository_key = 'owner/renamed'
+                WHERE repository_id = ?
+                """,
+                (repository_id,),
+            )
+
+
+def test_commit_failure_rolls_back_and_leaves_connection_reusable(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        catalog._connection.execute("PRAGMA defer_foreign_keys = ON")
+
+        with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+            with catalog._transaction():
+                catalog._connection.execute("""
+                    INSERT INTO repositories(
+                        repository_id, namespace_id, repository_key, created_at
+                    ) VALUES ('invalid-repo', 'missing-namespace', 'invalid', 'now')
+                    """)
+
+        assert catalog._connection.in_transaction is False
+        assert (
+            catalog._connection.execute(
+                "SELECT COUNT(*) FROM repositories WHERE repository_id = 'invalid-repo'"
+            ).fetchone()[0]
+            == 0
+        )
+        assert catalog.create_repository("owner/valid").startswith("repo_")
+
+
+def test_clean_dirty_source_and_profile_identities_are_canonical(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+
+        clean_one = catalog.create_source_revision(
+            repository_id,
+            commit_sha="A" * 40,
+            tree_sha="B" * 64,
+        )
+        clean_two = catalog.create_source_revision(
+            repository_id,
+            commit_sha="a" * 40,
+            tree_sha="b" * 64,
+            source_fingerprint="ignored-for-clean-git-sources",
+        )
+        dirty_one = catalog.create_source_revision(
+            repository_id,
+            commit_sha="a" * 40,
+            dirty=True,
+            source_fingerprint="sha256:working-copy-one",
+        )
+        dirty_two = catalog.create_source_revision(
+            repository_id,
+            commit_sha="A" * 40,
+            dirty=True,
+            source_fingerprint="sha256:working-copy-one",
+        )
+        dirty_other = catalog.create_source_revision(
+            repository_id,
+            commit_sha="a" * 40,
+            dirty=True,
+            source_fingerprint="sha256:working-copy-two",
+        )
+
+        assert clean_one == clean_two
+        assert dirty_one == dirty_two
+        assert clean_one != dirty_one
+        assert dirty_one != dirty_other
+        with pytest.raises(CatalogValidationError, match="clean source tree"):
+            catalog.create_source_revision(repository_id, commit_sha="a" * 40)
+        with pytest.raises(CatalogValidationError, match="source fingerprint"):
+            catalog.create_source_revision(repository_id, dirty=True)
+        with pytest.raises(
+            CatalogValidationError, match="must not include a base tree"
+        ):
+            catalog.create_source_revision(
+                repository_id,
+                commit_sha="a" * 40,
+                tree_sha="b" * 64,
+                dirty=True,
+                source_fingerprint="sha256:working-copy-one",
+            )
+
+        profile_one = catalog.create_view_profile(
+            "bm25",
+            {"languages": ["python"], "options": {"b": 2, "a": 1}},
+            name="default",
+        )
+        profile_two = catalog.create_view_profile(
+            "bm25",
+            {"options": {"a": 1, "b": 2}, "languages": ["python"]},
+            name="default",
+        )
+        profile_other = catalog.create_view_profile(
+            "vector",
+            {"options": {"a": 1, "b": 2}, "languages": ["python"]},
+            name="default",
+        )
+
+        assert profile_one == profile_two
+        assert profile_one != profile_other
+        with pytest.raises(CatalogValidationError, match="keys must be strings"):
+            catalog.create_view_profile(
+                "bm25",
+                {"nested": [{1: "numeric key"}]},  # type: ignore[dict-item]
+            )
+
+
+def test_registered_objects_are_idempotent_but_immutable(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        digest = catalog.register_object(
+            "A" * 64,
+            storage_key="sha256/aa/object",
+            byte_size=10,
+            media_type="application/x-codenib-bm25",
+        )
+
+        assert digest == "a" * 64
+        assert (
+            catalog.register_object(
+                f"sha256:{'a' * 64}",
+                storage_key="sha256/aa/object",
+                byte_size=10,
+                media_type="application/x-codenib-bm25",
+            )
+            == digest
+        )
+        with pytest.raises(CatalogConflictError, match="immutable"):
+            catalog.register_object(
+                digest,
+                storage_key="sha256/aa/replaced",
+                byte_size=10,
+                media_type="application/x-codenib-bm25",
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            catalog._connection.execute(
+                "UPDATE objects SET storage_key = 'mutated' WHERE digest = ?",
+                (digest,),
+            )
+        with pytest.raises(CatalogValidationError, match="relative and contained"):
+            catalog.register_object(
+                "b" * 64,
+                storage_key="../../outside",
+                byte_size=10,
+            )
+        with pytest.raises(CatalogValidationError, match="canonical"):
+            catalog.register_object(
+                "c" * 64,
+                storage_key="sha256/./object",
+                byte_size=10,
+            )
+
+
+def test_register_object_accepts_local_cas_blob_identity(tmp_path):
+    blob = LocalCAS(tmp_path / "objects").put_bytes(b"compiled bm25 generation")
+
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        digest = catalog.register_object(
+            blob.digest,
+            storage_key=blob.storage_key,
+            byte_size=blob.byte_size,
+        )
+        stored = catalog._connection.execute(
+            "SELECT digest, storage_key, byte_size FROM objects WHERE digest = ?",
+            (digest,),
+        ).fetchone()
+
+        assert dict(stored) == {
+            "digest": blob.digest,
+            "storage_key": blob.storage_key,
+            "byte_size": blob.byte_size,
+        }
+
+
+def test_stage_requires_registered_object_and_matching_repository(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_one = catalog.create_repository("owner/one")
+        repository_two = catalog.create_repository("owner/two")
+        source_one = _source(catalog, repository_one)
+        profile_id = catalog.create_view_profile("bm25", {})
+
+        with pytest.raises(CatalogNotFoundError, match="object"):
+            _stage(
+                catalog,
+                repository_one,
+                source_one,
+                profile_id,
+                "f" * 64,
+            )
+
+        digest = _object(catalog, "a")
+        with pytest.raises(CatalogValidationError, match="another repository"):
+            _stage(catalog, repository_two, source_one, profile_id, digest)
+        with pytest.raises(CatalogValidationError, match="does not match"):
+            _stage(
+                catalog,
+                repository_one,
+                source_one,
+                profile_id,
+                digest,
+                view_type="vector",
+            )
+        with pytest.raises(CatalogValidationError, match="keys must be strings"):
+            catalog.stage_view_generation(
+                repository_one,
+                source_one,
+                profile_id,
+                "bm25",
+                digest,
+                schema_version="1",
+                metadata={"nested": [{1: "numeric key"}]},  # type: ignore[dict-item]
+            )
+
+
+def test_publish_resolves_complete_pinned_manifest(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+        source_revision_id = _source(catalog, repository_id)
+        bm25_profile = catalog.create_view_profile(
+            "bm25",
+            {"languages": ["python"], "max_k": 128},
+            name="python-sparse",
+        )
+        vector_profile = catalog.create_view_profile(
+            "vector",
+            {"languages": ["python"], "model": "test-embedding"},
+            name="python-dense",
+        )
+        bm25 = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            bm25_profile,
+            _object(catalog, "a", byte_size=20),
+        )
+        vector = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            vector_profile,
+            _object(catalog, "b", byte_size=30),
+            view_type="vector",
+        )
+
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [vector, bm25],
+            expected_generation=0,
+        )
+        resolved = catalog.resolve_ref(repository_id)
+        direct = catalog.get_manifest_summary(published["snapshot_id"])
+
+        assert published["generation"] == 1
+        assert resolved["snapshot_id"] == published["snapshot_id"]
+        assert resolved["generation"] == 1
+        assert resolved["manifest"] == direct
+        assert direct["status"] == "ready"
+        assert direct["source"]["source_revision_id"] == source_revision_id
+        assert direct["source"]["kind"] == "clean"
+        assert direct["views"]["bm25"]["profile"] == {
+            "profile_id": bm25_profile,
+            "name": "python-sparse",
+            "config": {"languages": ["python"], "max_k": 128},
+        }
+        assert direct["views"]["vector"]["profile"] == {
+            "profile_id": vector_profile,
+            "name": "python-dense",
+            "config": {"languages": ["python"], "model": "test-embedding"},
+        }
+        assert list(direct["views"]) == ["bm25", "vector"]
+        assert direct["views"]["bm25"]["object"]["byte_size"] == 20
+        assert direct["views"]["vector"]["object"]["byte_size"] == 30
+
+        statuses = catalog._connection.execute(
+            "SELECT DISTINCT status FROM view_generations"
+        ).fetchall()
+        assert [row["status"] for row in statuses] == ["ready"]
+
+
+def test_stale_cas_rolls_back_and_keeps_old_ref(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+        source_revision_id = _source(catalog, repository_id)
+        profile_id = catalog.create_view_profile("bm25", {})
+        old_view = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            profile_id,
+            _object(catalog, "a"),
+        )
+        first = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [old_view],
+            expected_generation=0,
+        )
+        replacement_view = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            profile_id,
+            _object(catalog, "b"),
+        )
+
+        with pytest.raises(CatalogConflictError, match="generation is 1"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [replacement_view],
+                expected_generation=0,
+            )
+
+        resolved = catalog.resolve_ref(repository_id)
+        replacement_status = catalog._connection.execute(
+            """
+            SELECT status FROM view_generations WHERE view_generation_id = ?
+            """,
+            (replacement_view,),
+        ).fetchone()["status"]
+        snapshot_count = catalog._connection.execute(
+            "SELECT COUNT(*) FROM snapshots"
+        ).fetchone()[0]
+        building_count = catalog._connection.execute(
+            "SELECT COUNT(*) FROM snapshots WHERE status = 'building'"
+        ).fetchone()[0]
+        assert resolved["snapshot_id"] == first["snapshot_id"]
+        assert resolved["generation"] == 1
+        assert replacement_status == "staged"
+        assert snapshot_count == 1
+        assert building_count == 0
+
+        second = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [replacement_view],
+            expected_generation=1,
+        )
+        assert second["generation"] == 2
+        assert (
+            catalog.resolve_ref(repository_id)["snapshot_id"] == second["snapshot_id"]
+        )
+
+
+def test_ready_generation_can_be_reused_in_a_later_snapshot(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+        source_revision_id = _source(catalog, repository_id)
+        bm25_profile = catalog.create_view_profile("bm25", {"max_k": 128})
+        vector_profile = catalog.create_view_profile(
+            "vector", {"model": "test-embedding"}
+        )
+        bm25 = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            bm25_profile,
+            _object(catalog, "a"),
+        )
+        first = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [bm25],
+            expected_generation=0,
+        )
+        alias = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [bm25],
+            ref_name="stable",
+            expected_generation=0,
+        )
+        assert alias["snapshot_id"] == first["snapshot_id"]
+        vector = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            vector_profile,
+            _object(catalog, "b"),
+            view_type="vector",
+        )
+
+        second = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [bm25, vector],
+            expected_generation=1,
+        )
+        manifest = catalog.get_manifest_summary(second["snapshot_id"])
+
+        assert second["generation"] == 2
+        assert manifest["views"]["bm25"]["view_generation_id"] == bm25
+        assert manifest["views"]["vector"]["view_generation_id"] == vector
+
+
+def test_ready_snapshot_membership_stays_immutable_after_ref_moves(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+        source_revision_id = _source(catalog, repository_id)
+        bm25_profile = catalog.create_view_profile("bm25", {})
+        old_view = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            bm25_profile,
+            _object(catalog, "a"),
+        )
+        old_snapshot = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [old_view],
+            expected_generation=0,
+        )
+        replacement_view = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            bm25_profile,
+            _object(catalog, "b"),
+        )
+        catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [replacement_view],
+            expected_generation=1,
+        )
+        vector_profile = catalog.create_view_profile("vector", {})
+        vector_view = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            vector_profile,
+            _object(catalog, "c"),
+            view_type="vector",
+        )
+
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            catalog._connection.execute(
+                """
+                INSERT INTO snapshot_views(snapshot_id, view_type, view_generation_id)
+                VALUES (?, 'vector', ?)
+                """,
+                (old_snapshot["snapshot_id"], vector_view),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            catalog._connection.execute(
+                """
+                DELETE FROM snapshot_views
+                WHERE snapshot_id = ? AND view_generation_id = ?
+                """,
+                (old_snapshot["snapshot_id"], old_view),
+            )
+
+        catalog._connection.execute(
+            "DELETE FROM snapshots WHERE snapshot_id = ?",
+            (old_snapshot["snapshot_id"],),
+        )
+        assert (
+            catalog._connection.execute(
+                "SELECT COUNT(*) FROM snapshot_views WHERE snapshot_id = ?",
+                (old_snapshot["snapshot_id"],),
+            ).fetchone()[0]
+            == 0
+        )
+
+
+def test_direct_sql_cannot_seal_invalid_or_expose_building_snapshots(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_one = catalog.create_repository("owner/one")
+        source_one = _source(catalog, repository_one, "a")
+        profile_id = catalog.create_view_profile("bm25", {})
+        ready_view = _stage(
+            catalog,
+            repository_one,
+            source_one,
+            profile_id,
+            _object(catalog, "a"),
+        )
+        catalog.publish_snapshot(
+            repository_one,
+            source_one,
+            [ready_view],
+            expected_generation=0,
+        )
+
+        repository_two = catalog.create_repository("owner/two")
+        source_two = _source(catalog, repository_two, "b")
+        staged_view = _stage(
+            catalog,
+            repository_two,
+            source_two,
+            profile_id,
+            _object(catalog, "b"),
+        )
+
+        catalog._connection.execute(
+            """
+            INSERT INTO snapshots(
+                snapshot_id, repository_id, source_revision_id,
+                content_digest, status, published_at
+            ) VALUES ('cross-source', ?, ?, 'cross', 'building', NULL)
+            """,
+            (repository_two, source_two),
+        )
+        catalog._connection.execute(
+            """
+            INSERT INTO snapshot_views(snapshot_id, view_type, view_generation_id)
+            VALUES ('cross-source', 'bm25', ?)
+            """,
+            (ready_view,),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
+            catalog._connection.execute("""
+                UPDATE snapshots SET status = 'ready', published_at = 'now'
+                WHERE snapshot_id = 'cross-source'
+                """)
+
+        catalog._connection.execute(
+            """
+            INSERT INTO snapshots(
+                snapshot_id, repository_id, source_revision_id,
+                content_digest, status, published_at
+            ) VALUES ('staged-view', ?, ?, 'staged', 'building', NULL)
+            """,
+            (repository_two, source_two),
+        )
+        catalog._connection.execute(
+            """
+            INSERT INTO snapshot_views(snapshot_id, view_type, view_generation_id)
+            VALUES ('staged-view', 'bm25', ?)
+            """,
+            (staged_view,),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
+            catalog._connection.execute("""
+                UPDATE snapshots SET status = 'ready', published_at = 'now'
+                WHERE snapshot_id = 'staged-view'
+                """)
+
+        catalog._connection.execute(
+            """
+            INSERT INTO snapshots(
+                snapshot_id, repository_id, source_revision_id,
+                content_digest, status, published_at
+            ) VALUES ('empty', ?, ?, 'empty', 'building', NULL)
+            """,
+            (repository_two, source_two),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="snapshot seal"):
+            catalog._connection.execute("""
+                UPDATE snapshots SET status = 'ready', published_at = 'now'
+                WHERE snapshot_id = 'empty'
+                """)
+        with pytest.raises(CatalogValidationError, match="not ready"):
+            catalog.get_manifest_summary("empty")
+
+        with pytest.raises(sqlite3.IntegrityError, match="ready snapshots"):
+            catalog._connection.execute(
+                """
+                INSERT INTO refs(
+                    repository_id, ref_name, snapshot_id, generation, updated_at
+                ) VALUES (?, 'unsafe', 'empty', 1, 'now')
+                """,
+                (repository_two,),
+            )
+
+        catalog._connection.execute(
+            """
+            INSERT INTO snapshots(
+                snapshot_id, repository_id, source_revision_id,
+                content_digest, status, published_at
+            ) VALUES ('update-target', ?, ?, 'target', 'building', NULL)
+            """,
+            (repository_one, source_one),
+        )
+        with pytest.raises(CatalogValidationError, match="not ready"):
+            catalog.get_manifest_summary("update-target")
+        with pytest.raises(sqlite3.IntegrityError, match="ready snapshots"):
+            catalog._connection.execute(
+                """
+                UPDATE refs SET snapshot_id = 'update-target', generation = 2
+                WHERE repository_id = ? AND ref_name = 'main'
+                """,
+                (repository_one,),
+            )
+
+
+def test_late_ref_failure_rolls_back_building_snapshot_and_view_seal(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+        source_revision_id = _source(catalog, repository_id)
+        profile_id = catalog.create_view_profile("bm25", {})
+        view_id = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            profile_id,
+            _object(catalog, "a"),
+        )
+        catalog._connection.execute("""
+            CREATE TRIGGER fail_ref_publication
+            BEFORE INSERT ON refs
+            BEGIN
+                SELECT RAISE(ABORT, 'simulated ref failure');
+            END
+            """)
+
+        with pytest.raises(sqlite3.IntegrityError, match="simulated ref failure"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+
+        assert (
+            catalog._connection.execute("SELECT COUNT(*) FROM snapshots").fetchone()[0]
+            == 0
+        )
+        assert (
+            catalog._connection.execute(
+                "SELECT status FROM view_generations WHERE view_generation_id = ?",
+                (view_id,),
+            ).fetchone()["status"]
+            == "staged"
+        )
+        with pytest.raises(CatalogNotFoundError, match="ref not found"):
+            catalog.resolve_ref(repository_id)
+
+
+def test_cross_source_view_is_rejected_and_old_ref_is_unchanged(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+        source_one = _source(catalog, repository_id, "a")
+        source_two = _source(catalog, repository_id, "b")
+        profile_id = catalog.create_view_profile("bm25", {})
+        first_view = _stage(
+            catalog,
+            repository_id,
+            source_one,
+            profile_id,
+            _object(catalog, "a"),
+        )
+        first = catalog.publish_snapshot(
+            repository_id,
+            source_one,
+            [first_view],
+            expected_generation=0,
+        )
+        other_source_view = _stage(
+            catalog,
+            repository_id,
+            source_two,
+            profile_id,
+            _object(catalog, "b"),
+        )
+
+        with pytest.raises(CatalogValidationError, match="source identity"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_one,
+                [other_source_view],
+                expected_generation=1,
+            )
+
+        resolved = catalog.resolve_ref(repository_id)
+        staged_status = catalog._connection.execute(
+            """
+            SELECT status FROM view_generations WHERE view_generation_id = ?
+            """,
+            (other_source_view,),
+        ).fetchone()["status"]
+        assert resolved["snapshot_id"] == first["snapshot_id"]
+        assert resolved["generation"] == 1
+        assert staged_status == "staged"
+
+
+def test_ready_generation_cannot_be_mutated_or_deleted(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+        source_revision_id = _source(catalog, repository_id)
+        profile_id = catalog.create_view_profile("bm25", {})
+        view_id = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            profile_id,
+            _object(catalog, "a"),
+        )
+        catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            catalog._connection.execute(
+                """
+                UPDATE view_generations SET metadata_json = '{}'
+                WHERE view_generation_id = ?
+                """,
+                (view_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            catalog._connection.execute(
+                "DELETE FROM view_generations WHERE view_generation_id = ?",
+                (view_id,),
+            )


### PR DESCRIPTION
## Summary

Establish the durable M0 architecture contract and the first M1 foundation for the hybrid storage program: SQLite WAL as the embedded transactional catalog and a local filesystem CAS for immutable payloads. Existing compiler, RepoManifest, MCP, BM25, FAISS, and graph readers are intentionally not routed through the new backend yet.

Progresses #199, #266, and #431 without closing them.

## Changes

- Add the M0-M7 hybrid storage roadmap and durable repository guidance.
- Add backend-neutral repository, source, profile, generation, snapshot, ref, and artifact identities.
- Add ObjectStore and IndexCatalog protocols without abstracting query engines.
- Add a crash-safe SHA-256 LocalCAS with anchored path traversal, atomic no-replace publication, verified materialization, corruption rejection, and concurrent durability receipts.
- Add a forward-migrated SQLite WAL catalog with immutable generations, atomic snapshot sealing, ref compare-and-swap, direct-SQL invariant triggers, and per-view profiles.
- Add failure-injection and conformance coverage for migration, identity collisions, rollback, corruption, path escape, concurrent publication, and crash durability boundaries.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- test/storage: 55 passed
- Related manifest, snapshot, and artifact contracts: 95 passed
- Unit tier excluding the local Docker-only file: 3466 passed, 11 skipped, 181 deselected
- Black, isort, flake8 with bugbear, namespace check, and git diff check passed
- MkDocs strict build passed
- The excluded Docker test requires /usr/bin/docker, which is absent in this environment; hosted CI remains the authoritative full unit gate

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published