### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -51,7 +51,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up codenib conda env
-      uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
+      uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
       with:
         activate-environment: codenib-test
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -51,7 +51,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up codenib conda env
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
       with:
         activate-environment: codenib-test
         python-version: ${{ inputs.python-version }}

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up codenib conda env
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           activate-environment: codenib-test
           python-version: "3.12"

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up codenib conda env
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
         with:
           activate-environment: codenib-test
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up codenib conda env
-        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
         with:
           activate-environment: codenib-test
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up codenib conda env
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
         with:
           activate-environment: codenib-test
           python-version: "3.12"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
           python-version: "3.12"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Sync labels from labels.yml
-        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.yml
           delete-other-labels: ${{ github.event_name == 'workflow_dispatch' && inputs.delete_unused }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Sync labels from labels.yml
-        uses: EndBug/label-sync@v2
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2
         with:
           config-file: .github/labels.yml
           delete-other-labels: ${{ github.event_name == 'workflow_dispatch' && inputs.delete_unused }}

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -38,7 +38,7 @@ jobs:
           path: dist
 
       - name: Publish distributions
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -38,7 +38,7 @@ jobs:
           path: dist
 
       - name: Publish distributions
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           path: dist
 
       - name: Publish distributions
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   publish-mcp-registry:
     name: Publish to MCP Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           path: dist
 
       - name: Publish distributions
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 
   publish-mcp-registry:
     name: Publish to MCP Registry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,9 @@ clang-format for C/C++.
 - Before merging, confirm the PR is not draft, is mergeable, has no failing
   required checks, and has all dependent changes merged or explicitly accounted
   for. Treat cancelled checks as incomplete, not green.
+- Pin every external GitHub Action in workflows and composite actions to a
+  full 40-character commit SHA, with the exact release tag retained in a
+  trailing comment. Local actions under `./` do not need a commit pin.
 
 ## Testing Guidance
 

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -15,6 +15,8 @@ import yaml
 from scripts.classify_ci_changes import classify_refs, classify_serial_changes
 
 ROOT = Path(__file__).resolve().parents[1]
+_ACTION_SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
+_USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
 
 
 def _workflow(path: str) -> dict:
@@ -24,6 +26,26 @@ def _workflow(path: str) -> dict:
 def _workflow_triggers(document: dict):
     # PyYAML follows YAML 1.1 and parses the unquoted key `on` as True.
     return document.get("on", document.get(True))
+
+
+def test_external_github_actions_are_pinned_to_full_commit_shas() -> None:
+    action_files = sorted((ROOT / ".github" / "workflows").glob("*.y*ml"))
+    action_files.extend(sorted((ROOT / ".github" / "actions").rglob("action.y*ml")))
+    offenders: list[str] = []
+
+    for path in action_files:
+        text = path.read_text(encoding="utf-8")
+        for reference in _USES_RE.findall(text):
+            if reference.startswith(("./", "docker://")):
+                continue
+            if "@" not in reference:
+                offenders.append(f"{path.relative_to(ROOT)}: {reference}")
+                continue
+            revision = reference.rsplit("@", 1)[1]
+            if _ACTION_SHA_RE.fullmatch(revision) is None:
+                offenders.append(f"{path.relative_to(ROOT)}: {reference}")
+
+    assert offenders == []
 
 
 def _pyproject(

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -16,7 +16,6 @@ from scripts.classify_ci_changes import classify_refs, classify_serial_changes
 
 ROOT = Path(__file__).resolve().parents[1]
 _ACTION_SHA_RE = re.compile(r"[0-9a-f]{40}\Z")
-_USES_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)", re.MULTILINE)
 
 
 def _workflow(path: str) -> dict:
@@ -29,13 +28,23 @@ def _workflow_triggers(document: dict):
 
 
 def test_external_github_actions_are_pinned_to_full_commit_shas() -> None:
-    action_files = sorted((ROOT / ".github" / "workflows").glob("*.y*ml"))
-    action_files.extend(sorted((ROOT / ".github" / "actions").rglob("action.y*ml")))
     offenders: list[str] = []
+    step_groups: list[tuple[Path, list[dict]]] = []
 
-    for path in action_files:
-        text = path.read_text(encoding="utf-8")
-        for reference in _USES_RE.findall(text):
+    for path in sorted((ROOT / ".github" / "workflows").glob("*.y*ml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job in document.get("jobs", {}).values():
+            step_groups.append((path, job.get("steps", [])))
+
+    for path in sorted((ROOT / ".github" / "actions").rglob("action.y*ml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        step_groups.append((path, document.get("runs", {}).get("steps", [])))
+
+    for path, steps in step_groups:
+        for step in steps:
+            reference = str(step.get("uses", ""))
+            if not reference:
+                continue
             if reference.startswith(("./", "docker://")):
                 continue
             if "@" not in reference:


### PR DESCRIPTION
## Summary

Restore hosted CI, Docs, release publishing, environment setup, and label synchronization after the repository effective Actions policy began requiring every third-party action to use a full commit SHA. The floating refs currently fail during job setup before checkout.

Progresses the compensating-control work in #509 without closing the remaining runner-group blocker.

## Changes

- Pin setup-miniconda v3, setup-uv v8.3.2, gh-action-pypi-publish release/v1, and label-sync v2 to their current official commit SHAs.
- Cover both workflow files and the shared setup-env composite action.
- Add a repository-wide unit contract that rejects future floating external action references while allowing local and Docker actions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- CI policy, release artifact, and publish action tests: 45 passed
- All 14 workflow and composite action YAML files parse successfully
- Black, isort, flake8 with bugbear, and git diff check passed
- Each pinned SHA was resolved against the corresponding official GitHub repository

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published