### PR TITLE
feat(storage): add durable index job leases

### DIFF
--- a/codenib/storage/__init__.py
+++ b/codenib/storage/__init__.py
@@ -6,10 +6,18 @@
 
 from .cas import BlobInfo, LocalCAS
 from .models import (
+    INDEX_JOB_REQUEST_CONTRACT,
     ArtifactMember,
+    IndexJobCompletion,
+    IndexJobRecord,
+    IndexJobRequest,
+    IndexJobRequestedMode,
+    IndexJobStatus,
+    IndexJobViewRecord,
     ObjectRecord,
     PublishConflict,
     PublishedSnapshot,
+    RefJobLease,
     RefState,
     RepositoryIdentity,
     SnapshotView,
@@ -21,7 +29,7 @@ from .models import (
     ViewGeneration,
     ViewProfile,
 )
-from .protocols import IndexCatalog, ObjectStore
+from .protocols import IndexCatalog, JobCatalog, ObjectStore
 from .sqlite_catalog import (
     DEFAULT_NAMESPACE_ID,
     CatalogConflictError,
@@ -39,13 +47,22 @@ __all__ = [
     "CatalogNotFoundError",
     "CatalogValidationError",
     "DEFAULT_NAMESPACE_ID",
+    "INDEX_JOB_REQUEST_CONTRACT",
     "IndexCatalog",
+    "IndexJobCompletion",
+    "IndexJobRecord",
+    "IndexJobRequest",
+    "IndexJobRequestedMode",
+    "IndexJobStatus",
+    "IndexJobViewRecord",
+    "JobCatalog",
     "LocalCAS",
     "ObjectRecord",
     "ObjectStore",
     "PublishConflict",
     "PublishedSnapshot",
     "RefState",
+    "RefJobLease",
     "RepositoryIdentity",
     "SQLiteCatalog",
     "SnapshotView",

--- a/codenib/storage/models.py
+++ b/codenib/storage/models.py
@@ -11,10 +11,32 @@ import json
 import math
 import re
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, Mapping
 
 _DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z", re.ASCII)
+_CATALOG_INT64_MAX = 9_223_372_036_854_775_807
+INDEX_JOB_REQUEST_CONTRACT = "codenib.index-job-request.v1"
+_SECRET_FIELD_NAMES = frozenset(
+    {
+        "access_key",
+        "access_token",
+        "api_key",
+        "apikey",
+        "authorization",
+        "client_secret",
+        "cookie",
+        "credential",
+        "credentials",
+        "password",
+        "passwd",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "token",
+    }
+)
 
 
 class StorageError(RuntimeError):
@@ -115,6 +137,23 @@ def _optional_text(value: str | None, field: str) -> str | None:
     return normalized or None
 
 
+def _bounded_text(value: str, field: str, *, max_length: int) -> str:
+    normalized = _required_text(value, field)
+    if "\x00" in normalized:
+        raise StorageValidationError(f"{field} must not contain NUL")
+    if len(normalized) > max_length:
+        raise StorageValidationError(f"{field} must not exceed {max_length} characters")
+    return normalized
+
+
+def _optional_bounded_text(
+    value: str | None, field: str, *, max_length: int
+) -> str | None:
+    if value is None:
+        return None
+    return _bounded_text(value, field, max_length=max_length)
+
+
 def _canonical_relative_path(value: str, field: str) -> str:
     path = _required_text(value, field)
     if "\\" in path or "\x00" in path:
@@ -125,6 +164,62 @@ def _canonical_relative_path(value: str, field: str) -> str:
     if path != normalized.as_posix() or path in {".", ""}:
         raise StorageValidationError(f"{field} is not canonical")
     return normalized.as_posix()
+
+
+def _nonnegative_integer(value: int, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise StorageValidationError(f"{field} must be an integer")
+    if value < 0:
+        raise StorageValidationError(f"{field} must not be negative")
+    return value
+
+
+def _optional_nonnegative_integer(value: int | None, field: str) -> int | None:
+    if value is None:
+        return None
+    return _nonnegative_integer(value, field)
+
+
+def _canonical_json_object(value: str, field: str) -> tuple[str, dict[str, Any]]:
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise StorageValidationError(f"{field} must be valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise StorageValidationError(f"{field} must be a JSON object")
+    return canonical_json(parsed), parsed
+
+
+def _reject_secret_fields(value: Any, *, path: str = "request") -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            normalized = key.lower().replace("-", "_")
+            if normalized in _SECRET_FIELD_NAMES:
+                raise StorageValidationError(
+                    f"index job request must not contain secret field: {path}.{key}"
+                )
+            _reject_secret_fields(child, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_secret_fields(child, path=f"{path}[{index}]")
+
+
+class IndexJobStatus(str, Enum):
+    """Persisted lifecycle states for an index job."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class IndexJobCompletion(str, Enum):
+    """M1 lease-release outcomes; success is reserved for M2 publication."""
+
+    REQUEUE = "requeue"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 @dataclass(frozen=True, slots=True)
@@ -488,6 +583,390 @@ class PublishedSnapshot:
         )
 
 
+class IndexJobRequestedMode(str, Enum):
+    """Requested builder behavior before capability fallback is resolved."""
+
+    AUTO = "auto"
+    FULL = "full"
+    INCREMENTAL = "incremental"
+
+
+@dataclass(frozen=True, slots=True)
+class IndexJobViewRecord:
+    """Immutable requested profile, mode, and requirement for one job view."""
+
+    job_id: str
+    view_type: str
+    profile_id: str
+    requested_mode: IndexJobRequestedMode
+    required: bool
+
+    def __post_init__(self) -> None:
+        try:
+            mode = IndexJobRequestedMode(self.requested_mode)
+        except ValueError as exc:
+            raise StorageValidationError(
+                f"invalid requested index mode: {self.requested_mode}"
+            ) from exc
+        if not isinstance(self.required, bool):
+            raise StorageValidationError("index job view required must be boolean")
+        object.__setattr__(
+            self, "job_id", _bounded_text(self.job_id, "job ID", max_length=80)
+        )
+        object.__setattr__(
+            self,
+            "view_type",
+            _bounded_text(self.view_type, "view type", max_length=128),
+        )
+        object.__setattr__(
+            self,
+            "profile_id",
+            _bounded_text(self.profile_id, "profile ID", max_length=96),
+        )
+        object.__setattr__(self, "requested_mode", mode)
+
+    @property
+    def request(self) -> dict[str, Any]:
+        return {
+            "profile_id": self.profile_id,
+            "requested_mode": self.requested_mode.value,
+            "required": self.required,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class IndexJobRequest:
+    """Canonical, secret-free request scoped by an idempotency key."""
+
+    repository_id: str
+    source_revision_id: str
+    ref_name: str
+    idempotency_key: str
+    expected_ref_generation: int
+    max_attempts: int
+    request_json: str
+
+    def __post_init__(self) -> None:
+        repository = _bounded_text(self.repository_id, "repository ID", max_length=96)
+        source = _bounded_text(
+            self.source_revision_id, "source revision ID", max_length=96
+        )
+        ref_name = _bounded_text(self.ref_name, "ref name", max_length=512)
+        idempotency_key = _bounded_text(
+            self.idempotency_key, "idempotency key", max_length=256
+        )
+        expected = _nonnegative_integer(
+            self.expected_ref_generation, "expected ref generation"
+        )
+        if expected > _CATALOG_INT64_MAX:
+            raise StorageValidationError(
+                "expected ref generation exceeds catalog int64 range"
+            )
+        max_attempts = _nonnegative_integer(self.max_attempts, "maximum attempts")
+        if max_attempts < 1 or max_attempts > 1_000:
+            raise StorageValidationError("maximum attempts must be between 1 and 1000")
+        request_json, request = _canonical_json_object(
+            self.request_json, "index job request"
+        )
+        if len(request_json) > 65_536:
+            raise StorageValidationError(
+                "index job request must not exceed 65536 characters"
+            )
+        _reject_secret_fields(request)
+        if set(request) != {"contract", "views"}:
+            raise StorageValidationError(
+                "index job request must contain exactly contract and views"
+            )
+        if request.get("contract") != INDEX_JOB_REQUEST_CONTRACT:
+            raise StorageValidationError(
+                "index job request contract must be " f"{INDEX_JOB_REQUEST_CONTRACT!r}"
+            )
+        views = request.get("views")
+        if not isinstance(views, dict) or not views:
+            raise StorageValidationError(
+                "index job request views must be a non-empty JSON object"
+            )
+        if len(views) > 64:
+            raise StorageValidationError("index job request must not exceed 64 views")
+        for view_type, view_request in views.items():
+            if not isinstance(view_request, dict) or set(view_request) != {
+                "profile_id",
+                "requested_mode",
+                "required",
+            }:
+                raise StorageValidationError(
+                    "index job view request must contain exactly profile_id, "
+                    f"requested_mode, and required: {view_type}"
+                )
+            normalized_view = IndexJobViewRecord(
+                job_id="job_" + "0" * 64,
+                view_type=view_type,
+                profile_id=view_request.get("profile_id"),
+                requested_mode=view_request.get("requested_mode"),
+                required=view_request.get("required"),
+            )
+            if (
+                normalized_view.view_type != view_type
+                or normalized_view.profile_id != view_request["profile_id"]
+                or normalized_view.requested_mode.value
+                != view_request["requested_mode"]
+            ):
+                raise StorageValidationError(
+                    f"index job view request strings must be canonical: {view_type}"
+                )
+        object.__setattr__(self, "repository_id", repository)
+        object.__setattr__(self, "source_revision_id", source)
+        object.__setattr__(self, "ref_name", ref_name)
+        object.__setattr__(self, "idempotency_key", idempotency_key)
+        object.__setattr__(self, "expected_ref_generation", expected)
+        object.__setattr__(self, "max_attempts", max_attempts)
+        object.__setattr__(self, "request_json", request_json)
+
+    @classmethod
+    def create(
+        cls,
+        repository_id: str,
+        source_revision_id: str,
+        idempotency_key: str,
+        request: Mapping[str, Any],
+        *,
+        ref_name: str = "main",
+        expected_ref_generation: int = 0,
+        max_attempts: int = 3,
+    ) -> IndexJobRequest:
+        return cls(
+            repository_id=repository_id,
+            source_revision_id=source_revision_id,
+            ref_name=ref_name,
+            idempotency_key=idempotency_key,
+            expected_ref_generation=expected_ref_generation,
+            max_attempts=max_attempts,
+            request_json=canonical_json(request),
+        )
+
+    @property
+    def request(self) -> dict[str, Any]:
+        return json.loads(self.request_json)
+
+    @property
+    def contract(self) -> str:
+        return str(self.request["contract"])
+
+    @property
+    def view_requests(self) -> tuple[IndexJobViewRecord, ...]:
+        return tuple(
+            IndexJobViewRecord(
+                job_id=self.job_id,
+                view_type=view_type,
+                profile_id=view_request["profile_id"],
+                requested_mode=view_request["requested_mode"],
+                required=view_request["required"],
+            )
+            for view_type, view_request in sorted(self.request["views"].items())
+        )
+
+    @property
+    def job_id(self) -> str:
+        return content_id(
+            "job",
+            {
+                "repository_id": self.repository_id,
+                "idempotency_key": self.idempotency_key,
+            },
+        )
+
+    @property
+    def request_digest(self) -> str:
+        return content_id(
+            "jobreq",
+            {
+                "repository_id": self.repository_id,
+                "source_revision_id": self.source_revision_id,
+                "ref_name": self.ref_name,
+                "expected_ref_generation": self.expected_ref_generation,
+                "max_attempts": self.max_attempts,
+                "request": self.request,
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class IndexJobRecord:
+    """Backend-neutral persisted state for one index job."""
+
+    job_id: str
+    repository_id: str
+    source_revision_id: str
+    ref_name: str
+    idempotency_key: str
+    expected_ref_generation: int
+    max_attempts: int
+    request_json: str
+    request_digest: str
+    status: IndexJobStatus
+    cancel_requested: bool
+    attempt_count: int
+    result_snapshot_id: str | None
+    error_code: str | None
+    error_message: str | None
+    created_at_ms: int
+    updated_at_ms: int
+    started_at_ms: int | None
+    finished_at_ms: int | None
+
+    def __post_init__(self) -> None:
+        request = IndexJobRequest(
+            repository_id=self.repository_id,
+            source_revision_id=self.source_revision_id,
+            ref_name=self.ref_name,
+            idempotency_key=self.idempotency_key,
+            expected_ref_generation=self.expected_ref_generation,
+            max_attempts=self.max_attempts,
+            request_json=self.request_json,
+        )
+        try:
+            status = IndexJobStatus(self.status)
+        except ValueError as exc:
+            raise StorageValidationError(
+                f"invalid index job status: {self.status}"
+            ) from exc
+        if self.job_id != request.job_id:
+            raise StorageValidationError(
+                "job ID does not match its idempotency identity"
+            )
+        if self.request_digest != request.request_digest:
+            raise StorageValidationError(
+                "job request digest does not match its request"
+            )
+        snapshot = _optional_bounded_text(
+            self.result_snapshot_id, "result snapshot ID", max_length=96
+        )
+        error_code = _optional_bounded_text(
+            self.error_code, "job error code", max_length=128
+        )
+        error_message = _optional_bounded_text(
+            self.error_message, "job error message", max_length=4_096
+        )
+        if error_message is not None and error_code is None:
+            raise StorageValidationError("job error message requires an error code")
+        terminal = status in {
+            IndexJobStatus.SUCCEEDED,
+            IndexJobStatus.FAILED,
+            IndexJobStatus.CANCELLED,
+        }
+        if terminal != (self.finished_at_ms is not None):
+            raise StorageValidationError("terminal index jobs require a finish time")
+        if status is IndexJobStatus.SUCCEEDED and snapshot is None:
+            raise StorageValidationError(
+                "successful index jobs require a result snapshot"
+            )
+        if status is not IndexJobStatus.SUCCEEDED and snapshot is not None:
+            raise StorageValidationError(
+                "only successful index jobs may have a result snapshot"
+            )
+        if status is IndexJobStatus.FAILED and error_code is None:
+            raise StorageValidationError("failed index jobs require an error code")
+        if status is IndexJobStatus.SUCCEEDED and error_code is not None:
+            raise StorageValidationError("successful index jobs cannot have an error")
+        if status is IndexJobStatus.RUNNING and self.started_at_ms is None:
+            raise StorageValidationError("running index jobs require a start time")
+        if status is IndexJobStatus.CANCELLED and not self.cancel_requested:
+            raise StorageValidationError("cancelled index jobs require cancellation")
+        if not isinstance(self.cancel_requested, bool):
+            raise StorageValidationError("cancel requested must be boolean")
+
+        object.__setattr__(self, "job_id", request.job_id)
+        object.__setattr__(self, "repository_id", request.repository_id)
+        object.__setattr__(self, "source_revision_id", request.source_revision_id)
+        object.__setattr__(self, "ref_name", request.ref_name)
+        object.__setattr__(self, "idempotency_key", request.idempotency_key)
+        object.__setattr__(
+            self, "expected_ref_generation", request.expected_ref_generation
+        )
+        object.__setattr__(self, "max_attempts", request.max_attempts)
+        object.__setattr__(self, "request_json", request.request_json)
+        object.__setattr__(self, "request_digest", request.request_digest)
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "result_snapshot_id", snapshot)
+        object.__setattr__(self, "error_code", error_code)
+        object.__setattr__(self, "error_message", error_message)
+        object.__setattr__(
+            self,
+            "attempt_count",
+            _nonnegative_integer(self.attempt_count, "job attempt count"),
+        )
+        if self.attempt_count > self.max_attempts:
+            raise StorageValidationError("job attempts exceed the configured maximum")
+        for field in ("created_at_ms", "updated_at_ms"):
+            object.__setattr__(
+                self, field, _nonnegative_integer(getattr(self, field), field)
+            )
+        for field in ("started_at_ms", "finished_at_ms"):
+            object.__setattr__(
+                self,
+                field,
+                _optional_nonnegative_integer(getattr(self, field), field),
+            )
+        if self.updated_at_ms < self.created_at_ms:
+            raise StorageValidationError("job update time precedes creation")
+        if self.started_at_ms is not None and (
+            self.started_at_ms < self.created_at_ms
+            or self.updated_at_ms < self.started_at_ms
+        ):
+            raise StorageValidationError("job start time is out of order")
+        if self.finished_at_ms is not None:
+            finish_floor = self.started_at_ms or self.created_at_ms
+            if (
+                self.finished_at_ms < finish_floor
+                or self.updated_at_ms < self.finished_at_ms
+            ):
+                raise StorageValidationError("job finish time is out of order")
+
+    @property
+    def request(self) -> dict[str, Any]:
+        return json.loads(self.request_json)
+
+
+@dataclass(frozen=True, slots=True)
+class RefJobLease:
+    """Active, fenced ownership of the single publisher slot for a ref."""
+
+    repository_id: str
+    ref_name: str
+    job_id: str
+    owner_id: str
+    fencing_token: int
+    acquired_at_ms: int
+    heartbeat_at_ms: int
+    lease_expires_at_ms: int
+
+    def __post_init__(self) -> None:
+        token = _nonnegative_integer(self.fencing_token, "lease fencing token")
+        if token < 1:
+            raise StorageValidationError("lease fencing token must be positive")
+        object.__setattr__(
+            self,
+            "repository_id",
+            _bounded_text(self.repository_id, "repository ID", max_length=96),
+        )
+        object.__setattr__(
+            self, "ref_name", _bounded_text(self.ref_name, "ref name", max_length=512)
+        )
+        object.__setattr__(
+            self, "job_id", _bounded_text(self.job_id, "job ID", max_length=80)
+        )
+        object.__setattr__(
+            self, "owner_id", _bounded_text(self.owner_id, "owner ID", max_length=256)
+        )
+        object.__setattr__(self, "fencing_token", token)
+        for field in ("acquired_at_ms", "heartbeat_at_ms", "lease_expires_at_ms"):
+            object.__setattr__(
+                self, field, _nonnegative_integer(getattr(self, field), field)
+            )
+        if not self.acquired_at_ms <= self.heartbeat_at_ms < self.lease_expires_at_ms:
+            raise StorageValidationError("lease timestamps are not ordered")
+
+
 @dataclass(frozen=True, slots=True)
 class RefState:
     """A generation-counted repository ref resolved to one snapshot."""
@@ -513,11 +992,19 @@ class RefState:
 
 __all__ = [
     "ArtifactMember",
+    "INDEX_JOB_REQUEST_CONTRACT",
+    "IndexJobCompletion",
+    "IndexJobRecord",
+    "IndexJobRequest",
+    "IndexJobRequestedMode",
+    "IndexJobStatus",
+    "IndexJobViewRecord",
     "ObjectRecord",
     "PublishConflict",
     "PublishedSnapshot",
     "RefState",
     "RepositoryIdentity",
+    "RefJobLease",
     "SnapshotView",
     "SourceRevision",
     "StorageError",

--- a/codenib/storage/protocols.py
+++ b/codenib/storage/protocols.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, BinaryIO, Mapping, Protocol, Sequence, runtime_checkable
 
 from .cas import BlobInfo
+from .models import IndexJobCompletion, IndexJobRecord, IndexJobViewRecord, RefJobLease
 
 
 @runtime_checkable
@@ -107,4 +108,55 @@ class IndexCatalog(Protocol):
     def get_manifest_summary(self, snapshot_id: str) -> dict[str, Any]: ...
 
 
-__all__ = ["IndexCatalog", "ObjectStore"]
+@runtime_checkable
+class JobCatalog(Protocol):
+    """Durable index-job coordination, separate from snapshot publication."""
+
+    def create_job(
+        self,
+        repository_id: str,
+        source_revision_id: str,
+        idempotency_key: str,
+        request: Mapping[str, Any],
+        *,
+        ref_name: str = "main",
+        expected_ref_generation: int = 0,
+        max_attempts: int = 3,
+    ) -> IndexJobRecord: ...
+
+    def get_job(self, job_id: str) -> IndexJobRecord: ...
+
+    def get_job_views(self, job_id: str) -> tuple[IndexJobViewRecord, ...]: ...
+
+    def acquire_job_lease(
+        self,
+        job_id: str,
+        *,
+        owner_id: str,
+        lease_duration_ms: int,
+    ) -> RefJobLease: ...
+
+    def renew_job_lease(
+        self,
+        job_id: str,
+        *,
+        owner_id: str,
+        fencing_token: int,
+        lease_duration_ms: int,
+    ) -> RefJobLease: ...
+
+    def request_job_cancel(self, job_id: str) -> IndexJobRecord: ...
+
+    def finish_job_attempt(
+        self,
+        job_id: str,
+        *,
+        owner_id: str,
+        fencing_token: int,
+        outcome: IndexJobCompletion,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> IndexJobRecord: ...
+
+
+__all__ = ["IndexCatalog", "JobCatalog", "ObjectStore"]

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -23,10 +23,17 @@ from pathlib import Path
 from typing import Any, Iterator, Mapping, Sequence
 
 from .models import (
+    IndexJobCompletion,
+    IndexJobRecord,
+    IndexJobRequest,
+    IndexJobStatus,
+    IndexJobViewRecord,
     ObjectRecord,
     PublishConflict,
+    RefJobLease,
     SourceRevision,
     StorageError,
+    StorageIntegrityError,
     StorageNotFound,
     StorageValidationError,
     canonical_json,
@@ -34,7 +41,7 @@ from .models import (
     normalize_digest,
 )
 
-LATEST_SCHEMA_VERSION = 1
+LATEST_SCHEMA_VERSION = 2
 DEFAULT_NAMESPACE_ID = "ns_default"
 DEFAULT_NAMESPACE_NAME = "default"
 
@@ -42,6 +49,8 @@ CatalogError = StorageError
 CatalogConflictError = PublishConflict
 CatalogNotFoundError = StorageNotFound
 CatalogValidationError = StorageValidationError
+
+_DB_NOW_MS_SQL = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)"
 
 
 def _now() -> str:
@@ -52,6 +61,29 @@ def _required_text(value: str, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise CatalogValidationError(f"{field} must not be empty")
     return value.strip()
+
+
+def _bounded_text(value: str, field: str, *, max_length: int) -> str:
+    normalized = _required_text(value, field)
+    if "\x00" in normalized:
+        raise CatalogValidationError(f"{field} must not contain NUL")
+    if len(normalized) > max_length:
+        raise CatalogValidationError(f"{field} must not exceed {max_length} characters")
+    return normalized
+
+
+def _optional_bounded_text(
+    value: str | None, field: str, *, max_length: int
+) -> str | None:
+    if value is None:
+        return None
+    return _bounded_text(value, field, max_length=max_length)
+
+
+def _positive_integer(value: int, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise CatalogValidationError(f"{field} must be a positive integer")
+    return value
 
 
 _SCHEMA_V1 = (
@@ -344,7 +376,416 @@ _SCHEMA_V1 = (
     """,
 )
 
-_MIGRATIONS: dict[int, tuple[str, ...]] = {1: _SCHEMA_V1}
+_SCHEMA_V2 = (
+    """
+    CREATE UNIQUE INDEX snapshots_source_identity_idx
+        ON snapshots(snapshot_id, source_revision_id, repository_id)
+    """,
+    """
+    CREATE TABLE index_jobs (
+        job_id TEXT PRIMARY KEY,
+        repository_id TEXT NOT NULL,
+        source_revision_id TEXT NOT NULL,
+        ref_name TEXT NOT NULL CHECK (
+            length(ref_name) BETWEEN 1 AND 512 AND instr(ref_name, char(0)) = 0
+        ),
+        idempotency_key TEXT NOT NULL CHECK (
+            length(idempotency_key) BETWEEN 1 AND 256
+            AND instr(idempotency_key, char(0)) = 0
+        ),
+        expected_ref_generation INTEGER NOT NULL CHECK (
+            expected_ref_generation BETWEEN 0 AND 9223372036854775807
+        ),
+        max_attempts INTEGER NOT NULL CHECK (max_attempts BETWEEN 1 AND 1000),
+        request_contract TEXT NOT NULL CHECK (
+            length(request_contract) BETWEEN 1 AND 128
+            AND instr(request_contract, char(0)) = 0
+        ),
+        request_json TEXT NOT NULL CHECK (
+            length(request_json) BETWEEN 1 AND 65536
+            AND instr(request_json, char(0)) = 0
+            AND json_valid(request_json)
+        ),
+        request_digest TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (
+            status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')
+        ),
+        cancel_requested INTEGER NOT NULL DEFAULT 0
+            CHECK (cancel_requested IN (0, 1)),
+        attempt_count INTEGER NOT NULL DEFAULT 0
+            CHECK (attempt_count BETWEEN 0 AND max_attempts),
+        result_snapshot_id TEXT,
+        error_code TEXT CHECK (
+            error_code IS NULL OR (
+                length(error_code) BETWEEN 1 AND 128
+                AND instr(error_code, char(0)) = 0
+            )
+        ),
+        error_message TEXT CHECK (
+            error_message IS NULL OR (
+                length(error_message) BETWEEN 1 AND 4096
+                AND instr(error_message, char(0)) = 0
+            )
+        ),
+        created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+        updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+        started_at_ms INTEGER CHECK (started_at_ms IS NULL OR started_at_ms >= 0),
+        finished_at_ms INTEGER CHECK (finished_at_ms IS NULL OR finished_at_ms >= 0),
+        UNIQUE (repository_id, idempotency_key),
+        UNIQUE (job_id, repository_id, ref_name),
+        FOREIGN KEY (repository_id) REFERENCES repositories(repository_id)
+            ON DELETE RESTRICT,
+        FOREIGN KEY (source_revision_id, repository_id)
+            REFERENCES source_revisions(source_revision_id, repository_id)
+            ON DELETE RESTRICT,
+        FOREIGN KEY (result_snapshot_id, source_revision_id, repository_id)
+            REFERENCES snapshots(snapshot_id, source_revision_id, repository_id)
+            ON DELETE RESTRICT,
+        CHECK (error_message IS NULL OR error_code IS NOT NULL),
+        CHECK (status != 'running' OR started_at_ms IS NOT NULL),
+        CHECK (status != 'cancelled' OR cancel_requested = 1),
+        CHECK (started_at_ms IS NULL OR started_at_ms >= created_at_ms),
+        CHECK (
+            finished_at_ms IS NULL
+            OR finished_at_ms >= COALESCE(started_at_ms, created_at_ms)
+        ),
+        CHECK (started_at_ms IS NULL OR updated_at_ms >= started_at_ms),
+        CHECK (finished_at_ms IS NULL OR updated_at_ms >= finished_at_ms),
+        CHECK (
+            (status IN ('queued', 'running')
+                AND finished_at_ms IS NULL AND result_snapshot_id IS NULL)
+            OR
+            (status = 'succeeded'
+                AND finished_at_ms IS NOT NULL
+                AND result_snapshot_id IS NOT NULL
+                AND error_code IS NULL AND error_message IS NULL)
+            OR
+            (status = 'failed'
+                AND finished_at_ms IS NOT NULL
+                AND result_snapshot_id IS NULL AND error_code IS NOT NULL)
+            OR
+            (status = 'cancelled'
+                AND finished_at_ms IS NOT NULL AND result_snapshot_id IS NULL)
+        )
+    )
+    """,
+    """
+    CREATE TABLE index_job_views (
+        job_id TEXT NOT NULL,
+        view_type TEXT NOT NULL CHECK (
+            length(view_type) BETWEEN 1 AND 128
+            AND instr(view_type, char(0)) = 0
+        ),
+        profile_id TEXT NOT NULL,
+        requested_mode TEXT NOT NULL
+            CHECK (requested_mode IN ('auto', 'full', 'incremental')),
+        required INTEGER NOT NULL CHECK (required IN (0, 1)),
+        PRIMARY KEY (job_id, view_type),
+        FOREIGN KEY (job_id) REFERENCES index_jobs(job_id) ON DELETE CASCADE,
+        FOREIGN KEY (profile_id, view_type)
+            REFERENCES view_profiles(profile_id, view_type) ON DELETE RESTRICT
+    )
+    """,
+    """
+    CREATE TABLE ref_job_leases (
+        repository_id TEXT NOT NULL,
+        ref_name TEXT NOT NULL CHECK (
+            length(ref_name) BETWEEN 1 AND 512 AND instr(ref_name, char(0)) = 0
+        ),
+        job_id TEXT,
+        owner_id TEXT CHECK (
+            owner_id IS NULL OR (
+                length(owner_id) BETWEEN 1 AND 256
+                AND instr(owner_id, char(0)) = 0
+            )
+        ),
+        fencing_token INTEGER NOT NULL DEFAULT 0 CHECK (fencing_token >= 0),
+        acquired_at_ms INTEGER CHECK (
+            acquired_at_ms IS NULL OR acquired_at_ms >= 0
+        ),
+        heartbeat_at_ms INTEGER CHECK (
+            heartbeat_at_ms IS NULL OR heartbeat_at_ms >= 0
+        ),
+        lease_expires_at_ms INTEGER CHECK (
+            lease_expires_at_ms IS NULL OR lease_expires_at_ms >= 0
+        ),
+        updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= 0),
+        PRIMARY KEY (repository_id, ref_name),
+        UNIQUE (job_id),
+        FOREIGN KEY (repository_id) REFERENCES repositories(repository_id)
+            ON DELETE RESTRICT,
+        FOREIGN KEY (job_id, repository_id, ref_name)
+            REFERENCES index_jobs(job_id, repository_id, ref_name)
+            ON DELETE RESTRICT,
+        CHECK (
+            (job_id IS NULL AND owner_id IS NULL
+                AND acquired_at_ms IS NULL AND heartbeat_at_ms IS NULL
+                AND lease_expires_at_ms IS NULL)
+            OR
+            (job_id IS NOT NULL AND owner_id IS NOT NULL
+                AND acquired_at_ms IS NOT NULL AND heartbeat_at_ms IS NOT NULL
+                AND lease_expires_at_ms IS NOT NULL
+                AND acquired_at_ms <= heartbeat_at_ms
+                AND heartbeat_at_ms < lease_expires_at_ms)
+        )
+    )
+    """,
+    """
+    CREATE INDEX index_jobs_queue_idx
+        ON index_jobs(status, repository_id, ref_name, created_at_ms)
+    """,
+    """
+    CREATE INDEX ref_job_leases_expiry_idx
+        ON ref_job_leases(lease_expires_at_ms)
+        WHERE job_id IS NOT NULL
+    """,
+    """
+    CREATE TRIGGER index_jobs_reject_duplicate_inserts
+    BEFORE INSERT ON index_jobs
+    WHEN EXISTS (
+        SELECT 1 FROM index_jobs AS existing
+        WHERE existing.job_id = NEW.job_id
+            OR (
+                existing.repository_id = NEW.repository_id
+                AND existing.idempotency_key = NEW.idempotency_key
+            )
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'duplicate index job insert is forbidden');
+    END
+    """,
+    """
+    CREATE TRIGGER index_job_request_is_immutable
+    BEFORE UPDATE ON index_jobs
+    WHEN
+        NEW.job_id IS NOT OLD.job_id
+        OR NEW.repository_id IS NOT OLD.repository_id
+        OR NEW.source_revision_id IS NOT OLD.source_revision_id
+        OR NEW.ref_name IS NOT OLD.ref_name
+        OR NEW.idempotency_key IS NOT OLD.idempotency_key
+        OR NEW.expected_ref_generation IS NOT OLD.expected_ref_generation
+        OR NEW.max_attempts IS NOT OLD.max_attempts
+        OR NEW.request_contract IS NOT OLD.request_contract
+        OR NEW.request_json IS NOT OLD.request_json
+        OR NEW.request_digest IS NOT OLD.request_digest
+        OR NEW.created_at_ms IS NOT OLD.created_at_ms
+    BEGIN
+        SELECT RAISE(ABORT, 'index job request is immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER terminal_index_jobs_are_immutable
+    BEFORE UPDATE ON index_jobs
+    WHEN OLD.status IN ('succeeded', 'failed', 'cancelled')
+    BEGIN
+        SELECT RAISE(ABORT, 'terminal index jobs are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER index_job_status_transitions_are_valid
+    BEFORE UPDATE ON index_jobs
+    WHEN NOT (
+        (OLD.status = 'queued' AND NEW.status IN ('queued', 'cancelled'))
+        OR
+        (
+            OLD.status = 'queued' AND NEW.status = 'running'
+            AND EXISTS (
+                SELECT 1 FROM ref_job_leases AS lease
+                WHERE lease.repository_id = NEW.repository_id
+                    AND lease.ref_name = NEW.ref_name
+                    AND lease.job_id = NEW.job_id
+                    AND lease.owner_id IS NOT NULL
+            )
+        )
+        OR
+        (OLD.status = 'running'
+            AND NEW.status IN (
+                'running', 'queued', 'succeeded', 'failed', 'cancelled'
+            ))
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'invalid index job status transition');
+    END
+    """,
+    """
+    CREATE TRIGGER m1_index_jobs_cannot_insert_succeeded
+    BEFORE INSERT ON index_jobs
+    WHEN NEW.status = 'succeeded'
+    BEGIN
+        SELECT RAISE(ABORT, 'M1 cannot persist successful index jobs');
+    END
+    """,
+    """
+    CREATE TRIGGER m1_index_jobs_cannot_update_succeeded
+    BEFORE UPDATE ON index_jobs
+    WHEN NEW.status = 'succeeded'
+    BEGIN
+        SELECT RAISE(ABORT, 'M1 cannot persist successful index jobs');
+    END
+    """,
+    """
+    CREATE TRIGGER m1_index_jobs_must_start_queued
+    BEFORE INSERT ON index_jobs
+    WHEN NEW.status != 'queued'
+    BEGIN
+        SELECT RAISE(ABORT, 'M1 index jobs must start queued');
+    END
+    """,
+    """
+    CREATE TRIGGER index_job_views_are_immutable
+    BEFORE UPDATE ON index_job_views
+    BEGIN
+        SELECT RAISE(ABORT, 'index job view requests are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER index_job_views_cannot_be_deleted
+    BEFORE DELETE ON index_job_views
+    BEGIN
+        SELECT RAISE(ABORT, 'index job view requests are immutable');
+    END
+    """,
+    """
+    CREATE TRIGGER index_job_views_reject_duplicate_inserts
+    BEFORE INSERT ON index_job_views
+    WHEN EXISTS (
+        SELECT 1 FROM index_job_views AS existing
+        WHERE existing.job_id = NEW.job_id
+            AND existing.view_type = NEW.view_type
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'duplicate index job view insert is forbidden');
+    END
+    """,
+    """
+    CREATE TRIGGER index_job_view_request_must_match
+    BEFORE INSERT ON index_job_views
+    WHEN NOT EXISTS (
+        SELECT 1
+        FROM index_jobs AS job,
+             json_each(job.request_json, '$.views') AS requested
+        WHERE job.job_id = NEW.job_id
+            AND requested.key = NEW.view_type
+            AND json_type(requested.value) = 'object'
+            AND (
+                SELECT COUNT(*) FROM json_each(requested.value)
+            ) = 3
+            AND json_type(requested.value, '$.profile_id') = 'text'
+            AND json_extract(requested.value, '$.profile_id') = NEW.profile_id
+            AND json_type(requested.value, '$.requested_mode') = 'text'
+            AND json_extract(
+                requested.value, '$.requested_mode'
+            ) = NEW.requested_mode
+            AND json_type(requested.value, '$.required') = CASE NEW.required
+                WHEN 1 THEN 'true'
+                ELSE 'false'
+            END
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'index job view does not match canonical request');
+    END
+    """,
+    """
+    CREATE TRIGGER ref_job_leases_reject_duplicate_inserts
+    BEFORE INSERT ON ref_job_leases
+    WHEN EXISTS (
+        SELECT 1 FROM ref_job_leases AS existing
+        WHERE (
+                existing.repository_id = NEW.repository_id
+                AND existing.ref_name = NEW.ref_name
+            )
+            OR (
+                NEW.job_id IS NOT NULL
+                AND existing.job_id = NEW.job_id
+            )
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'duplicate ref job lease insert is forbidden');
+    END
+    """,
+    """
+    CREATE TRIGGER ref_job_lease_insert_fencing
+    BEFORE INSERT ON ref_job_leases
+    WHEN
+        (NEW.job_id IS NOT NULL AND NEW.fencing_token != 1)
+        OR (NEW.job_id IS NULL AND NEW.fencing_token != 0)
+        OR (
+            NEW.job_id IS NOT NULL
+            AND (SELECT status FROM index_jobs WHERE job_id = NEW.job_id) != 'queued'
+        )
+    BEGIN
+        SELECT RAISE(ABORT, 'initial ref job lease fencing token is invalid');
+    END
+    """,
+    """
+    CREATE TRIGGER ref_job_lease_updates_are_fenced
+    BEFORE UPDATE ON ref_job_leases
+    WHEN NOT (
+        NEW.repository_id IS OLD.repository_id
+        AND NEW.ref_name IS OLD.ref_name
+        AND NEW.updated_at_ms >= OLD.updated_at_ms
+        AND (
+            (
+                OLD.job_id IS NOT NULL AND NEW.job_id IS NOT NULL
+                AND NEW.fencing_token = OLD.fencing_token
+                AND NEW.job_id IS OLD.job_id
+                AND NEW.owner_id IS OLD.owner_id
+                AND NEW.acquired_at_ms IS OLD.acquired_at_ms
+                AND NEW.heartbeat_at_ms >= OLD.heartbeat_at_ms
+                AND NEW.lease_expires_at_ms > OLD.lease_expires_at_ms
+                AND OLD.lease_expires_at_ms > CAST(
+                    (julianday('now') - 2440587.5) * 86400000 AS INTEGER
+                )
+                AND (
+                    SELECT status FROM index_jobs WHERE job_id = NEW.job_id
+                ) = 'running'
+            )
+            OR
+            (
+                OLD.job_id IS NOT NULL AND NEW.job_id IS NULL
+                AND NEW.fencing_token = OLD.fencing_token
+                AND (
+                    SELECT status FROM index_jobs WHERE job_id = OLD.job_id
+                ) != 'running'
+            )
+            OR
+            (
+                OLD.job_id IS NULL AND NEW.job_id IS NOT NULL
+                AND NEW.fencing_token = OLD.fencing_token + 1
+                AND (
+                    SELECT status FROM index_jobs WHERE job_id = NEW.job_id
+                ) = 'queued'
+            )
+            OR
+            (
+                OLD.job_id IS NOT NULL AND NEW.job_id IS NOT NULL
+                AND NEW.fencing_token = OLD.fencing_token + 1
+                AND OLD.lease_expires_at_ms <= CAST(
+                    (julianday('now') - 2440587.5) * 86400000 AS INTEGER
+                )
+                AND (
+                    SELECT status FROM index_jobs WHERE job_id = OLD.job_id
+                ) != 'running'
+                AND (
+                    SELECT status FROM index_jobs WHERE job_id = NEW.job_id
+                ) = 'queued'
+            )
+        )
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'ref job lease fencing transition is invalid');
+    END
+    """,
+    """
+    CREATE TRIGGER ref_job_lease_slots_are_persistent
+    BEFORE DELETE ON ref_job_leases
+    BEGIN
+        SELECT RAISE(ABORT, 'ref job lease slots are persistent');
+    END
+    """,
+)
+
+_MIGRATIONS: dict[int, tuple[str, ...]] = {1: _SCHEMA_V1, 2: _SCHEMA_V2}
 
 
 class SQLiteCatalog:
@@ -377,6 +818,17 @@ class SQLiteCatalog:
         self._connection.row_factory = sqlite3.Row
         try:
             self._connection.execute("PRAGMA foreign_keys = ON")
+            self._connection.execute("PRAGMA recursive_triggers = ON")
+            if self._connection.execute("PRAGMA recursive_triggers").fetchone()[0] != 1:
+                raise CatalogError("SQLite recursive triggers could not be enabled")
+            try:
+                json1_available = self._connection.execute(
+                    "SELECT json_valid('{}')"
+                ).fetchone()[0]
+            except sqlite3.DatabaseError as exc:
+                raise CatalogError("SQLite JSON1 support is required") from exc
+            if json1_available != 1:
+                raise CatalogError("SQLite JSON1 support is required")
             self._connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms:d}")
             self._connection.execute("PRAGMA journal_mode = WAL")
             self._connection.execute("PRAGMA synchronous = FULL")
@@ -482,6 +934,7 @@ class SQLiteCatalog:
             "objects": "digest",
             "view_generations": "view_generation_id",
             "snapshots": "snapshot_id",
+            "index_jobs": "job_id",
         }
         if allowed.get(table) != key:
             raise AssertionError("unsafe catalog lookup")
@@ -492,6 +945,720 @@ class SQLiteCatalog:
             label = table.replace("_", " ").rstrip("s")
             raise CatalogNotFoundError(f"{label} not found: {value}")
         return row
+
+    def _db_now_ms(self) -> int:
+        row = self._connection.execute(f"SELECT {_DB_NOW_MS_SQL} AS now_ms").fetchone()
+        return int(row["now_ms"])
+
+    @staticmethod
+    def _job_from_row(row: sqlite3.Row) -> IndexJobRecord:
+        record = IndexJobRecord(
+            job_id=row["job_id"],
+            repository_id=row["repository_id"],
+            source_revision_id=row["source_revision_id"],
+            ref_name=row["ref_name"],
+            idempotency_key=row["idempotency_key"],
+            expected_ref_generation=int(row["expected_ref_generation"]),
+            max_attempts=int(row["max_attempts"]),
+            request_json=row["request_json"],
+            request_digest=row["request_digest"],
+            status=IndexJobStatus(row["status"]),
+            cancel_requested=bool(row["cancel_requested"]),
+            attempt_count=int(row["attempt_count"]),
+            result_snapshot_id=row["result_snapshot_id"],
+            error_code=row["error_code"],
+            error_message=row["error_message"],
+            created_at_ms=int(row["created_at_ms"]),
+            updated_at_ms=int(row["updated_at_ms"]),
+            started_at_ms=(
+                int(row["started_at_ms"]) if row["started_at_ms"] is not None else None
+            ),
+            finished_at_ms=(
+                int(row["finished_at_ms"])
+                if row["finished_at_ms"] is not None
+                else None
+            ),
+        )
+        if row["request_contract"] != record.request["contract"]:
+            raise StorageIntegrityError(
+                f"job request contract column is inconsistent: {record.job_id}"
+            )
+        return record
+
+    @staticmethod
+    def _job_view_from_row(row: sqlite3.Row) -> IndexJobViewRecord:
+        return IndexJobViewRecord(
+            job_id=row["job_id"],
+            view_type=row["view_type"],
+            profile_id=row["profile_id"],
+            requested_mode=row["requested_mode"],
+            required=bool(row["required"]),
+        )
+
+    @staticmethod
+    def _lease_from_row(row: sqlite3.Row) -> RefJobLease:
+        return RefJobLease(
+            repository_id=row["repository_id"],
+            ref_name=row["ref_name"],
+            job_id=row["job_id"],
+            owner_id=row["owner_id"],
+            fencing_token=int(row["fencing_token"]),
+            acquired_at_ms=int(row["acquired_at_ms"]),
+            heartbeat_at_ms=int(row["heartbeat_at_ms"]),
+            lease_expires_at_ms=int(row["lease_expires_at_ms"]),
+        )
+
+    def _job_views(self, job: IndexJobRecord) -> tuple[IndexJobViewRecord, ...]:
+        rows = self._connection.execute(
+            """
+            SELECT job_id, view_type, profile_id, requested_mode, required
+            FROM index_job_views WHERE job_id = ? ORDER BY view_type
+            """,
+            (job.job_id,),
+        ).fetchall()
+        actual = tuple(self._job_view_from_row(row) for row in rows)
+        expected = IndexJobRequest(
+            repository_id=job.repository_id,
+            source_revision_id=job.source_revision_id,
+            ref_name=job.ref_name,
+            idempotency_key=job.idempotency_key,
+            expected_ref_generation=job.expected_ref_generation,
+            max_attempts=job.max_attempts,
+            request_json=job.request_json,
+        ).view_requests
+        if actual != expected:
+            raise StorageIntegrityError(
+                f"job view rows do not match canonical request: {job.job_id}"
+            )
+        return actual
+
+    def create_job(
+        self,
+        repository_id: str,
+        source_revision_id: str,
+        idempotency_key: str,
+        request: Mapping[str, Any],
+        *,
+        ref_name: str = "main",
+        expected_ref_generation: int = 0,
+        max_attempts: int = 3,
+    ) -> IndexJobRecord:
+        """Create or return one canonical idempotent index-job request."""
+        job_request = IndexJobRequest.create(
+            repository_id,
+            source_revision_id,
+            idempotency_key,
+            request,
+            ref_name=ref_name,
+            expected_ref_generation=expected_ref_generation,
+            max_attempts=max_attempts,
+        )
+        with self._transaction():
+            self._require_record(
+                "repositories", "repository_id", job_request.repository_id
+            )
+            row = self._connection.execute(
+                """
+                SELECT * FROM index_jobs
+                WHERE repository_id = ? AND idempotency_key = ?
+                """,
+                (job_request.repository_id, job_request.idempotency_key),
+            ).fetchone()
+            if row is not None:
+                job = self._job_from_row(row)
+                if (
+                    job.job_id != job_request.job_id
+                    or job.request_digest != job_request.request_digest
+                ):
+                    raise CatalogConflictError(
+                        "idempotency key is already bound to another "
+                        "index-job request"
+                    )
+                self._job_views(job)
+                return job
+
+            source = self._require_record(
+                "source_revisions",
+                "source_revision_id",
+                job_request.source_revision_id,
+            )
+            if source["repository_id"] != job_request.repository_id:
+                raise CatalogValidationError(
+                    "index job source revision belongs to another repository"
+                )
+            for view in job_request.view_requests:
+                profile = self._require_record(
+                    "view_profiles", "profile_id", view.profile_id
+                )
+                if profile["view_type"] != view.view_type:
+                    raise CatalogValidationError(
+                        f"job view does not match its profile: {view.view_type}"
+                    )
+
+            now_ms = self._db_now_ms()
+            self._connection.execute(
+                """
+                    INSERT INTO index_jobs(
+                        job_id, repository_id, source_revision_id, ref_name,
+                        idempotency_key, expected_ref_generation, max_attempts,
+                        request_contract, request_json, request_digest, status,
+                        cancel_requested, attempt_count, result_snapshot_id,
+                        error_code, error_message, created_at_ms, updated_at_ms,
+                        started_at_ms, finished_at_ms
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', 0, 0,
+                        NULL, NULL, NULL, ?, ?, NULL, NULL
+                    )
+                    """,
+                (
+                    job_request.job_id,
+                    job_request.repository_id,
+                    job_request.source_revision_id,
+                    job_request.ref_name,
+                    job_request.idempotency_key,
+                    job_request.expected_ref_generation,
+                    job_request.max_attempts,
+                    job_request.contract,
+                    job_request.request_json,
+                    job_request.request_digest,
+                    now_ms,
+                    now_ms,
+                ),
+            )
+            self._connection.executemany(
+                """
+                    INSERT INTO index_job_views(
+                        job_id, view_type, profile_id, requested_mode, required
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                [
+                    (
+                        view.job_id,
+                        view.view_type,
+                        view.profile_id,
+                        view.requested_mode.value,
+                        int(view.required),
+                    )
+                    for view in job_request.view_requests
+                ],
+            )
+            row = self._require_record("index_jobs", "job_id", job_request.job_id)
+            job = self._job_from_row(row)
+            self._job_views(job)
+            return job
+
+    def get_job(self, job_id: str) -> IndexJobRecord:
+        """Return one persisted index job after validating its canonical request."""
+        normalized = _bounded_text(job_id, "job ID", max_length=80)
+        with self._transaction(immediate=False):
+            job = self._job_from_row(
+                self._require_record("index_jobs", "job_id", normalized)
+            )
+            self._job_views(job)
+            return job
+
+    def get_job_views(self, job_id: str) -> tuple[IndexJobViewRecord, ...]:
+        """Return the immutable requested view mapping for one index job."""
+        normalized = _bounded_text(job_id, "job ID", max_length=80)
+        with self._transaction(immediate=False):
+            job = self._job_from_row(
+                self._require_record("index_jobs", "job_id", normalized)
+            )
+            return self._job_views(job)
+
+    def _retire_expired_holder(self, job_id: str, now_ms: int) -> IndexJobStatus:
+        job = self._job_from_row(self._require_record("index_jobs", "job_id", job_id))
+        self._job_views(job)
+        if job.status is not IndexJobStatus.RUNNING:
+            return job.status
+        if job.cancel_requested:
+            status = IndexJobStatus.CANCELLED
+            error_code = "cancelled"
+            error_message = "lease expired after cancellation was requested"
+            finished_at_ms: int | None = now_ms
+        elif job.attempt_count >= job.max_attempts:
+            status = IndexJobStatus.FAILED
+            error_code = "attempts_exhausted"
+            error_message = "lease expired on the final permitted attempt"
+            finished_at_ms = now_ms
+        else:
+            status = IndexJobStatus.QUEUED
+            error_code = "lease_expired"
+            error_message = "previous worker lease expired; job was requeued"
+            finished_at_ms = None
+        cursor = self._connection.execute(
+            """
+            UPDATE index_jobs
+            SET status = ?, error_code = ?, error_message = ?,
+                finished_at_ms = ?, updated_at_ms = ?
+            WHERE job_id = ? AND status = 'running'
+            """,
+            (
+                status.value,
+                error_code,
+                error_message,
+                finished_at_ms,
+                now_ms,
+                job.job_id,
+            ),
+        )
+        if cursor.rowcount != 1:
+            raise CatalogConflictError("expired index job changed during takeover")
+        return status
+
+    def _release_job_slot(
+        self,
+        job: IndexJobRecord,
+        *,
+        fencing_token: int,
+        now_ms: int,
+    ) -> None:
+        cursor = self._connection.execute(
+            """
+            UPDATE ref_job_leases
+            SET job_id = NULL, owner_id = NULL,
+                acquired_at_ms = NULL, heartbeat_at_ms = NULL,
+                lease_expires_at_ms = NULL, updated_at_ms = ?
+            WHERE repository_id = ? AND ref_name = ?
+                AND job_id = ? AND fencing_token = ?
+            """,
+            (
+                now_ms,
+                job.repository_id,
+                job.ref_name,
+                job.job_id,
+                fencing_token,
+            ),
+        )
+        if cursor.rowcount != 1:
+            raise CatalogConflictError("index job lease changed before release")
+
+    def acquire_job_lease(
+        self,
+        job_id: str,
+        *,
+        owner_id: str,
+        lease_duration_ms: int,
+    ) -> RefJobLease:
+        """Acquire or take over the single fenced publisher slot for a ref."""
+        normalized_job = _bounded_text(job_id, "job ID", max_length=80)
+        owner = _bounded_text(owner_id, "owner ID", max_length=256)
+        duration = _positive_integer(lease_duration_ms, "lease duration")
+        if duration > 2_147_483_647:
+            raise CatalogValidationError("lease duration is too large")
+
+        lease: RefJobLease | None = None
+        blocked_reason: str | None = None
+        with self._transaction():
+            job = self._job_from_row(
+                self._require_record("index_jobs", "job_id", normalized_job)
+            )
+            self._job_views(job)
+            if job.status not in {IndexJobStatus.QUEUED, IndexJobStatus.RUNNING}:
+                raise CatalogConflictError(
+                    f"terminal index job cannot be acquired: {job.status.value}"
+                )
+            if job.status is IndexJobStatus.QUEUED and job.cancel_requested:
+                raise StorageIntegrityError("queued index job has a cancellation flag")
+            if job.status is IndexJobStatus.QUEUED and (
+                job.attempt_count >= job.max_attempts
+            ):
+                raise CatalogConflictError("index job has exhausted its attempts")
+
+            now_ms = self._db_now_ms()
+            expires_at_ms = now_ms + duration
+            slot = self._connection.execute(
+                """
+                SELECT * FROM ref_job_leases
+                WHERE repository_id = ? AND ref_name = ?
+                """,
+                (job.repository_id, job.ref_name),
+            ).fetchone()
+            if (
+                slot is not None
+                and slot["job_id"] is not None
+                and int(slot["lease_expires_at_ms"]) > now_ms
+            ):
+                if (
+                    slot["job_id"] == job.job_id
+                    and slot["owner_id"] == owner
+                    and job.status is IndexJobStatus.RUNNING
+                ):
+                    return self._lease_from_row(slot)
+                raise CatalogConflictError(
+                    "repository ref already has an active index-job lease"
+                )
+
+            if slot is None:
+                token = 1
+                cursor = self._connection.execute(
+                    """
+                    INSERT INTO ref_job_leases(
+                        repository_id, ref_name, job_id, owner_id, fencing_token,
+                        acquired_at_ms, heartbeat_at_ms, lease_expires_at_ms,
+                        updated_at_ms
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        job.repository_id,
+                        job.ref_name,
+                        job.job_id,
+                        owner,
+                        token,
+                        now_ms,
+                        now_ms,
+                        expires_at_ms,
+                        now_ms,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise CatalogConflictError("ref job lease slot was not created")
+            elif slot["job_id"] is None:
+                token = int(slot["fencing_token"]) + 1
+                cursor = self._connection.execute(
+                    """
+                    UPDATE ref_job_leases
+                    SET job_id = ?, owner_id = ?, fencing_token = ?,
+                        acquired_at_ms = ?, heartbeat_at_ms = ?,
+                        lease_expires_at_ms = ?, updated_at_ms = ?
+                    WHERE repository_id = ? AND ref_name = ? AND job_id IS NULL
+                    """,
+                    (
+                        job.job_id,
+                        owner,
+                        token,
+                        now_ms,
+                        now_ms,
+                        expires_at_ms,
+                        now_ms,
+                        job.repository_id,
+                        job.ref_name,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise CatalogConflictError("empty ref job slot changed")
+            else:
+                old_job_id = str(slot["job_id"])
+                retired_status = self._retire_expired_holder(old_job_id, now_ms)
+                token = int(slot["fencing_token"]) + 1
+                if old_job_id == job.job_id and retired_status in {
+                    IndexJobStatus.FAILED,
+                    IndexJobStatus.CANCELLED,
+                }:
+                    current = self._job_from_row(
+                        self._require_record("index_jobs", "job_id", job.job_id)
+                    )
+                    self._release_job_slot(
+                        current,
+                        fencing_token=int(slot["fencing_token"]),
+                        now_ms=now_ms,
+                    )
+                    blocked_reason = (
+                        "expired lease made the index job terminal: "
+                        f"{retired_status.value}"
+                    )
+                else:
+                    cursor = self._connection.execute(
+                        """
+                        UPDATE ref_job_leases
+                        SET job_id = ?, owner_id = ?, fencing_token = ?,
+                            acquired_at_ms = ?, heartbeat_at_ms = ?,
+                            lease_expires_at_ms = ?, updated_at_ms = ?
+                        WHERE repository_id = ? AND ref_name = ?
+                            AND job_id = ? AND fencing_token = ?
+                            AND lease_expires_at_ms <= ?
+                        """,
+                        (
+                            job.job_id,
+                            owner,
+                            token,
+                            now_ms,
+                            now_ms,
+                            expires_at_ms,
+                            now_ms,
+                            job.repository_id,
+                            job.ref_name,
+                            old_job_id,
+                            int(slot["fencing_token"]),
+                            now_ms,
+                        ),
+                    )
+                    if cursor.rowcount != 1:
+                        raise CatalogConflictError(
+                            "expired ref job slot changed during takeover"
+                        )
+
+            if blocked_reason is None:
+                job = self._job_from_row(
+                    self._require_record("index_jobs", "job_id", job.job_id)
+                )
+                if job.status is not IndexJobStatus.QUEUED:
+                    raise StorageIntegrityError(
+                        "an acquirable index job must be queued before its attempt"
+                    )
+                cursor = self._connection.execute(
+                    """
+                    UPDATE index_jobs
+                    SET status = 'running', attempt_count = attempt_count + 1,
+                        started_at_ms = COALESCE(started_at_ms, ?),
+                        updated_at_ms = ?, error_code = NULL, error_message = NULL
+                    WHERE job_id = ? AND status = 'queued'
+                        AND attempt_count < max_attempts
+                    """,
+                    (now_ms, now_ms, job.job_id),
+                )
+                if cursor.rowcount != 1:
+                    raise CatalogConflictError(
+                        "index job could not start a new attempt"
+                    )
+                lease_row = self._connection.execute(
+                    """
+                    SELECT * FROM ref_job_leases
+                    WHERE repository_id = ? AND ref_name = ?
+                    """,
+                    (job.repository_id, job.ref_name),
+                ).fetchone()
+                if lease_row is None:
+                    raise StorageIntegrityError("acquired index job lease disappeared")
+                lease = self._lease_from_row(lease_row)
+
+        if blocked_reason is not None:
+            raise CatalogConflictError(blocked_reason)
+        if lease is None:
+            raise AssertionError("successful lease acquisition produced no lease")
+        return lease
+
+    def renew_job_lease(
+        self,
+        job_id: str,
+        *,
+        owner_id: str,
+        fencing_token: int,
+        lease_duration_ms: int,
+    ) -> RefJobLease:
+        """Extend an unexpired lease without changing its fencing token."""
+        normalized_job = _bounded_text(job_id, "job ID", max_length=80)
+        owner = _bounded_text(owner_id, "owner ID", max_length=256)
+        token = _positive_integer(fencing_token, "fencing token")
+        duration = _positive_integer(lease_duration_ms, "lease duration")
+        if duration > 2_147_483_647:
+            raise CatalogValidationError("lease duration is too large")
+
+        with self._transaction():
+            job = self._job_from_row(
+                self._require_record("index_jobs", "job_id", normalized_job)
+            )
+            self._job_views(job)
+            if job.status is not IndexJobStatus.RUNNING:
+                raise CatalogConflictError(
+                    "index job lease can only be renewed while running"
+                )
+            cursor = self._connection.execute(
+                f"""
+                UPDATE ref_job_leases
+                SET heartbeat_at_ms = MAX(heartbeat_at_ms, {_DB_NOW_MS_SQL}),
+                    lease_expires_at_ms = MAX(
+                        lease_expires_at_ms + 1, {_DB_NOW_MS_SQL} + ?
+                    ),
+                    updated_at_ms = MAX(updated_at_ms, {_DB_NOW_MS_SQL})
+                WHERE repository_id = ? AND ref_name = ? AND job_id = ?
+                    AND owner_id = ? AND fencing_token = ?
+                    AND lease_expires_at_ms > {_DB_NOW_MS_SQL}
+                """,
+                (
+                    duration,
+                    job.repository_id,
+                    job.ref_name,
+                    job.job_id,
+                    owner,
+                    token,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise CatalogConflictError("index job lease expired before renewal")
+            renewed = self._connection.execute(
+                """
+                SELECT * FROM ref_job_leases
+                WHERE repository_id = ? AND ref_name = ? AND job_id = ?
+                    AND owner_id = ? AND fencing_token = ?
+                """,
+                (job.repository_id, job.ref_name, job.job_id, owner, token),
+            ).fetchone()
+            if renewed is None:
+                raise StorageIntegrityError("renewed index job lease disappeared")
+            return self._lease_from_row(renewed)
+
+    def request_job_cancel(self, job_id: str) -> IndexJobRecord:
+        """Cancel a queued job or request cooperative cancellation while running."""
+        normalized = _bounded_text(job_id, "job ID", max_length=80)
+        with self._transaction():
+            job = self._job_from_row(
+                self._require_record("index_jobs", "job_id", normalized)
+            )
+            self._job_views(job)
+            if job.status in {
+                IndexJobStatus.SUCCEEDED,
+                IndexJobStatus.FAILED,
+                IndexJobStatus.CANCELLED,
+            }:
+                return job
+            if job.cancel_requested:
+                return job
+            now_ms = self._db_now_ms()
+            if job.status is IndexJobStatus.QUEUED:
+                active_slot = self._connection.execute(
+                    "SELECT 1 FROM ref_job_leases WHERE job_id = ?",
+                    (job.job_id,),
+                ).fetchone()
+                if active_slot is not None:
+                    raise StorageIntegrityError(
+                        "queued index job holds an active lease"
+                    )
+                self._connection.execute(
+                    """
+                    UPDATE index_jobs
+                    SET status = 'cancelled', cancel_requested = 1,
+                        error_code = 'cancelled', error_message = NULL,
+                        finished_at_ms = ?, updated_at_ms = ?
+                    WHERE job_id = ? AND status = 'queued'
+                    """,
+                    (now_ms, now_ms, job.job_id),
+                )
+            else:
+                self._connection.execute(
+                    """
+                    UPDATE index_jobs
+                    SET cancel_requested = 1, updated_at_ms = ?
+                    WHERE job_id = ? AND status = 'running'
+                    """,
+                    (now_ms, job.job_id),
+                )
+            return self._job_from_row(
+                self._require_record("index_jobs", "job_id", job.job_id)
+            )
+
+    def finish_job_attempt(
+        self,
+        job_id: str,
+        *,
+        owner_id: str,
+        fencing_token: int,
+        outcome: IndexJobCompletion,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> IndexJobRecord:
+        """Finish a fenced M1 attempt as failed, cancelled, or requeued."""
+        normalized_job = _bounded_text(job_id, "job ID", max_length=80)
+        owner = _bounded_text(owner_id, "owner ID", max_length=256)
+        token = _positive_integer(fencing_token, "fencing token")
+        try:
+            normalized_outcome = IndexJobCompletion(outcome)
+        except ValueError as exc:
+            raise CatalogValidationError(
+                f"unsupported M1 job completion: {outcome}"
+            ) from exc
+        code = _optional_bounded_text(error_code, "job error code", max_length=128)
+        message = _optional_bounded_text(
+            error_message, "job error message", max_length=4_096
+        )
+        if message is not None and code is None:
+            raise CatalogValidationError("job error message requires an error code")
+        if (
+            normalized_outcome
+            in {
+                IndexJobCompletion.REQUEUE,
+                IndexJobCompletion.FAILED,
+            }
+            and code is None
+        ):
+            raise CatalogValidationError(
+                f"{normalized_outcome.value} completion requires an error code"
+            )
+        if normalized_outcome is IndexJobCompletion.CANCELLED and code is None:
+            code = "cancelled"
+
+        with self._transaction():
+            job = self._job_from_row(
+                self._require_record("index_jobs", "job_id", normalized_job)
+            )
+            self._job_views(job)
+            if job.status is not IndexJobStatus.RUNNING:
+                raise CatalogConflictError(
+                    "index job mutation requires its current unexpired fenced lease"
+                )
+            if (
+                normalized_outcome is IndexJobCompletion.CANCELLED
+                and not job.cancel_requested
+            ):
+                raise CatalogConflictError(
+                    "running index job must receive cancellation before acknowledging it"
+                )
+            if (
+                normalized_outcome is IndexJobCompletion.REQUEUE
+                and job.cancel_requested
+            ):
+                raise CatalogConflictError(
+                    "cancelled index job attempt cannot be requeued"
+                )
+            if (
+                normalized_outcome is IndexJobCompletion.REQUEUE
+                and job.attempt_count >= job.max_attempts
+            ):
+                raise CatalogConflictError(
+                    "final index job attempt must fail instead of requeueing"
+                )
+
+            if normalized_outcome is IndexJobCompletion.REQUEUE:
+                status = IndexJobStatus.QUEUED
+                is_terminal = 0
+            elif normalized_outcome is IndexJobCompletion.FAILED:
+                status = IndexJobStatus.FAILED
+                is_terminal = 1
+            else:
+                status = IndexJobStatus.CANCELLED
+                is_terminal = 1
+            cursor = self._connection.execute(
+                f"""
+                UPDATE index_jobs
+                SET status = ?, error_code = ?, error_message = ?,
+                    finished_at_ms = CASE ?
+                        WHEN 1 THEN {_DB_NOW_MS_SQL}
+                        ELSE NULL
+                    END,
+                    updated_at_ms = MAX(updated_at_ms, {_DB_NOW_MS_SQL})
+                WHERE job_id = ? AND status = 'running'
+                    AND EXISTS (
+                        SELECT 1 FROM ref_job_leases AS lease
+                        WHERE lease.repository_id = index_jobs.repository_id
+                            AND lease.ref_name = index_jobs.ref_name
+                            AND lease.job_id = index_jobs.job_id
+                            AND lease.owner_id = ?
+                            AND lease.fencing_token = ?
+                            AND lease.lease_expires_at_ms > {_DB_NOW_MS_SQL}
+                    )
+                """,
+                (
+                    status.value,
+                    code,
+                    message,
+                    is_terminal,
+                    job.job_id,
+                    owner,
+                    token,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise CatalogConflictError(
+                    "index job mutation requires its current unexpired fenced lease"
+                )
+            self._release_job_slot(
+                job,
+                fencing_token=token,
+                now_ms=self._db_now_ms(),
+            )
+            return self._job_from_row(
+                self._require_record("index_jobs", "job_id", job.job_id)
+            )
 
     def create_namespace(self, name: str) -> str:
         """Create an idempotent logical namespace and return its stable ID."""

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -176,8 +176,25 @@ Status: in progress.
   equivalent `RepoManifest` v1.1.
 
 The SQLite/CAS foundation through refs and atomic snapshot sealing is
-implemented.  Initial job/lease records plus legacy manifest import/export are
-the remaining M1 deliverables.
+implemented.  Schema v2 now adds canonical idempotent job requests, immutable
+per-view request mappings, bounded retry state, and database-clock fenced
+per-ref leases.  Catalog reads revalidate the normalized view rows against the
+canonical request; the M2 publication transaction must repeat that gate before
+associating outputs.  An explicit acquire may atomically retire an expired
+holder while taking over its slot; this slice adds no background reaper and is
+not wired to the compiler or Web workers.  Legacy manifest import/export
+remains the outstanding M1 deliverable.
+
+Schema v2 deliberately retains complete job aggregates.  Duplicate-insert
+guards reject `REPLACE` of jobs, requested views, and persistent lease slots
+even from ordinary SQLite connections whose connection-local recursive trigger
+setting is disabled.  Catalog connections additionally enable recursive
+triggers; direct deletion of requested view rows and cascading deletion of
+their parent job remain blocked.  A future retention/GC milestone must add an
+explicit aggregate-deletion migration and policy rather than bypassing these
+audit guards.  Schema v2 also rejects successful job rows; M2 must remove that
+temporary gate only inside the migration which introduces atomic
+`publish_job_snapshot` completion.
 
 ### M2: Immutable generation publication
 
@@ -198,8 +215,9 @@ Status: pending.
 
 Status: pending.
 
-- Add idempotent index jobs, progress/events, heartbeats, leases, cancellation,
-  and one-publisher-per-repository/ref enforcement.
+- Wire the M1 idempotent jobs, heartbeats, cancellation, and fenced per-ref
+  leases into workers; add progress/events without weakening the catalog state
+  machine.
 - Expose the #266 status and update APIs with accurate incremental versus
   rebuild behavior.
 - Load a complete new bundle and swap it RCU-style; pin old bundles for in-flight

--- a/test/storage/test_contracts.py
+++ b/test/storage/test_contracts.py
@@ -14,7 +14,7 @@ from codenib.storage.models import (
     ViewGeneration,
     ViewProfile,
 )
-from codenib.storage.protocols import IndexCatalog, ObjectStore
+from codenib.storage.protocols import IndexCatalog, JobCatalog, ObjectStore
 from codenib.storage.sqlite_catalog import DEFAULT_NAMESPACE_ID, SQLiteCatalog
 
 
@@ -24,6 +24,7 @@ def test_embedded_backends_implement_storage_protocols(tmp_path) -> None:
     try:
         assert isinstance(object_store, ObjectStore)
         assert isinstance(catalog, IndexCatalog)
+        assert isinstance(catalog, JobCatalog)
     finally:
         catalog.close()
 

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -73,6 +73,9 @@ def test_initializes_pragmas_default_namespace_and_idempotent_reopen(tmp_path):
             == LATEST_SCHEMA_VERSION
         )
         assert catalog._connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert (
+            catalog._connection.execute("PRAGMA recursive_triggers").fetchone()[0] == 1
+        )
         assert catalog._connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
         assert catalog._connection.execute("PRAGMA busy_timeout").fetchone()[0] == 1_234
         assert catalog._connection.execute("PRAGMA synchronous").fetchone()[0] == 2
@@ -85,7 +88,7 @@ def test_initializes_pragmas_default_namespace_and_idempotent_reopen(tmp_path):
         migration_count = reopened._connection.execute(
             "SELECT COUNT(*) FROM schema_migrations"
         ).fetchone()[0]
-        assert migration_count == 1
+        assert migration_count == LATEST_SCHEMA_VERSION
 
 
 def test_reopen_rejects_mismatched_schema_version_records(tmp_path):

--- a/test/storage/test_sqlite_jobs.py
+++ b/test/storage/test_sqlite_jobs.py
@@ -1,0 +1,1285 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for durable SQLite index jobs and fenced ref leases."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from codenib.storage import sqlite_catalog as sqlite_catalog_module
+from codenib.storage.models import (
+    INDEX_JOB_REQUEST_CONTRACT,
+    IndexJobCompletion,
+    IndexJobRecord,
+    IndexJobRequest,
+    IndexJobRequestedMode,
+    IndexJobStatus,
+    StorageIntegrityError,
+    StorageValidationError,
+)
+from codenib.storage.sqlite_catalog import (
+    LATEST_SCHEMA_VERSION,
+    CatalogConflictError,
+    CatalogNotFoundError,
+    SQLiteCatalog,
+)
+
+
+def _request(
+    profile_id: str,
+    *,
+    view_type: str = "bm25",
+    mode: str = "auto",
+    required: bool = True,
+) -> dict[str, object]:
+    return {
+        "contract": INDEX_JOB_REQUEST_CONTRACT,
+        "views": {
+            view_type: {
+                "profile_id": profile_id,
+                "requested_mode": mode,
+                "required": required,
+            }
+        },
+    }
+
+
+def _repository(catalog: SQLiteCatalog, key: str = "owner/repo") -> tuple[str, str]:
+    repository_id = catalog.create_repository(key)
+    source_revision_id = catalog.create_source_revision(
+        repository_id,
+        commit_sha="a" * 40,
+        tree_sha="b" * 64,
+    )
+    return repository_id, source_revision_id
+
+
+def _job_setup(
+    catalog: SQLiteCatalog,
+    *,
+    key: str = "owner/repo",
+    idempotency_key: str = "request-1",
+    max_attempts: int = 3,
+) -> IndexJobRecord:
+    repository_id, source_revision_id = _repository(catalog, key)
+    profile_id = catalog.create_view_profile("bm25", {"tokenizer": "unicode61"})
+    return catalog.create_job(
+        repository_id,
+        source_revision_id,
+        idempotency_key,
+        _request(profile_id),
+        expected_ref_generation=0,
+        max_attempts=max_attempts,
+    )
+
+
+def _publish_snapshot(
+    catalog: SQLiteCatalog,
+    job: IndexJobRecord,
+    *,
+    source_revision_id: str | None = None,
+    suffix: str = "d",
+    ref_name: str = "published",
+) -> str:
+    source = source_revision_id or job.source_revision_id
+    profile_id = job.request["views"]["bm25"]["profile_id"]
+    digest = catalog.register_object(
+        suffix * 64,
+        storage_key=f"sha256/{suffix * 2}/{suffix * 62}",
+        byte_size=1,
+    )
+    view_id = catalog.stage_view_generation(
+        job.repository_id,
+        source,
+        profile_id,
+        "bm25",
+        digest,
+        schema_version="1",
+    )
+    return catalog.publish_snapshot(
+        job.repository_id,
+        source,
+        [view_id],
+        ref_name=ref_name,
+        expected_generation=0,
+    )["snapshot_id"]
+
+
+def test_job_request_identity_is_canonical_and_idempotency_scoped_to_repo() -> None:
+    repository_id = "repo_" + "a" * 64
+    source_revision_id = "src_" + "b" * 64
+    profile_id = "profile_" + "c" * 64
+    first = IndexJobRequest.create(
+        repository_id,
+        source_revision_id,
+        "client-request",
+        _request(profile_id),
+        ref_name="main",
+        expected_ref_generation=4,
+        max_attempts=5,
+    )
+    reordered = IndexJobRequest.create(
+        repository_id,
+        source_revision_id,
+        "client-request",
+        {
+            "views": {
+                "bm25": {
+                    "required": True,
+                    "requested_mode": "auto",
+                    "profile_id": profile_id,
+                }
+            },
+            "contract": INDEX_JOB_REQUEST_CONTRACT,
+        },
+        ref_name="main",
+        expected_ref_generation=4,
+        max_attempts=5,
+    )
+    other_ref = IndexJobRequest.create(
+        repository_id,
+        source_revision_id,
+        "client-request",
+        _request(profile_id),
+        ref_name="release",
+        expected_ref_generation=4,
+        max_attempts=5,
+    )
+
+    assert first.job_id == reordered.job_id == other_ref.job_id
+    assert first.request_digest == reordered.request_digest
+    assert first.request_digest != other_ref.request_digest
+    assert first.view_requests[0].requested_mode is IndexJobRequestedMode.AUTO
+
+
+def test_job_request_rejects_secrets_unbounded_text_and_invalid_shape() -> None:
+    base = {
+        "repository_id": "repo_" + "a" * 64,
+        "source_revision_id": "src_" + "b" * 64,
+        "idempotency_key": "request",
+    }
+    profile_id = "profile_" + "c" * 64
+    secret_request = _request(profile_id)
+    secret_request["views"]["bm25"]["api_key"] = "must-not-persist"  # type: ignore[index]
+
+    with pytest.raises(StorageValidationError, match="secret field"):
+        IndexJobRequest.create(**base, request=secret_request)
+    with pytest.raises(StorageValidationError, match="NUL"):
+        IndexJobRequest.create(
+            repository_id=base["repository_id"],
+            source_revision_id=base["source_revision_id"],
+            idempotency_key="bad\x00key",
+            request=_request(profile_id),
+        )
+    with pytest.raises(StorageValidationError, match="maximum attempts"):
+        IndexJobRequest.create(**base, request=_request(profile_id), max_attempts=0)
+    with pytest.raises(StorageValidationError, match="int64"):
+        IndexJobRequest.create(
+            **base,
+            request=_request(profile_id),
+            expected_ref_generation=9_223_372_036_854_775_808,
+        )
+    with pytest.raises(StorageValidationError, match="must be canonical"):
+        IndexJobRequest.create(**base, request=_request(f" {profile_id} "))
+    with pytest.raises(StorageValidationError, match="must be canonical"):
+        IndexJobRequest.create(
+            **base,
+            request=_request(profile_id, view_type=" bm25 "),
+        )
+    with pytest.raises(StorageValidationError, match="contain exactly"):
+        IndexJobRequest.create(
+            **base,
+            request={"contract": INDEX_JOB_REQUEST_CONTRACT, "views": {}, "extra": 1},
+        )
+
+
+def test_job_record_canonicalizes_identity_fields_and_orders_timestamps() -> None:
+    request = IndexJobRequest.create(
+        "repo_" + "a" * 64,
+        "src_" + "b" * 64,
+        "request",
+        _request("profile_" + "c" * 64),
+    )
+    record = IndexJobRecord(
+        job_id=request.job_id,
+        repository_id=f" {request.repository_id} ",
+        source_revision_id=f" {request.source_revision_id} ",
+        ref_name=" main ",
+        idempotency_key=" request ",
+        expected_ref_generation=0,
+        max_attempts=3,
+        request_json=request.request_json,
+        request_digest=request.request_digest,
+        status=IndexJobStatus.QUEUED,
+        cancel_requested=False,
+        attempt_count=0,
+        result_snapshot_id=None,
+        error_code=None,
+        error_message=None,
+        created_at_ms=10,
+        updated_at_ms=10,
+        started_at_ms=None,
+        finished_at_ms=None,
+    )
+
+    assert record.repository_id == request.repository_id
+    assert record.ref_name == "main"
+    assert record.idempotency_key == "request"
+    with pytest.raises(StorageValidationError, match="start time"):
+        IndexJobRecord(
+            **{
+                field: getattr(record, field)
+                for field in record.__dataclass_fields__
+                if field
+                not in {"status", "attempt_count", "updated_at_ms", "started_at_ms"}
+            },
+            status=IndexJobStatus.RUNNING,
+            attempt_count=1,
+            updated_at_ms=11,
+            started_at_ms=9,
+        )
+
+
+def test_forward_migrates_v1_catalog_without_losing_existing_rows(
+    tmp_path, monkeypatch
+) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 1)
+    with SQLiteCatalog(path) as catalog:
+        repository_id, _ = _repository(catalog)
+        assert catalog.schema_version == 1
+
+    monkeypatch.setattr(
+        sqlite_catalog_module, "LATEST_SCHEMA_VERSION", LATEST_SCHEMA_VERSION
+    )
+    with SQLiteCatalog(path) as catalog:
+        assert catalog.schema_version == 2
+        assert catalog.create_repository("owner/repo") == repository_id
+        assert (
+            catalog._connection.execute(
+                "SELECT COUNT(*) FROM schema_migrations"
+            ).fetchone()[0]
+            == 2
+        )
+        tables = {
+            row[0]
+            for row in catalog._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert {"index_jobs", "index_job_views", "ref_job_leases"} <= tables
+
+
+def test_failed_v2_migration_rolls_back_as_one_transaction(
+    tmp_path, monkeypatch
+) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 1)
+    with SQLiteCatalog(path):
+        pass
+
+    original_migrations = sqlite_catalog_module._MIGRATIONS
+    broken = dict(original_migrations)
+    broken[2] = (
+        "CREATE TABLE migration_must_rollback(value TEXT)",
+        "THIS IS NOT VALID SQL",
+    )
+    monkeypatch.setattr(sqlite_catalog_module, "_MIGRATIONS", broken)
+    monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 2)
+    with pytest.raises(sqlite3.OperationalError):
+        SQLiteCatalog(path)
+
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert (
+            connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
+            == 1
+        )
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE name = 'migration_must_rollback'"
+            ).fetchone()[0]
+            == 0
+        )
+    finally:
+        connection.close()
+
+
+def test_create_job_is_idempotent_and_conflicts_on_any_request_change(tmp_path) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id = _repository(catalog)
+        profile_id = catalog.create_view_profile("bm25", {})
+        request = _request(profile_id)
+        first = catalog.create_job(
+            repository_id,
+            source_revision_id,
+            "request-1",
+            request,
+            ref_name="main",
+            expected_ref_generation=2,
+            max_attempts=4,
+        )
+        same = catalog.create_job(
+            repository_id,
+            source_revision_id,
+            "request-1",
+            {
+                "views": request["views"],
+                "contract": INDEX_JOB_REQUEST_CONTRACT,
+            },
+            ref_name="main",
+            expected_ref_generation=2,
+            max_attempts=4,
+        )
+
+        assert same == first
+        assert catalog.get_job_views(first.job_id)[0].profile_id == profile_id
+        with pytest.raises(StorageValidationError, match="must be canonical"):
+            catalog.create_job(
+                repository_id,
+                source_revision_id,
+                "request-1",
+                _request(f" {profile_id} "),
+                ref_name="main",
+                expected_ref_generation=2,
+                max_attempts=4,
+            )
+        for changed in (
+            {"ref_name": "other"},
+            {"expected_ref_generation": 3},
+            {"max_attempts": 5},
+            {"request": _request(profile_id, mode="full")},
+        ):
+            kwargs = {
+                "ref_name": "main",
+                "expected_ref_generation": 2,
+                "max_attempts": 4,
+                "request": request,
+            }
+            kwargs.update(changed)
+            with pytest.raises(CatalogConflictError, match="idempotency key"):
+                catalog.create_job(
+                    repository_id,
+                    source_revision_id,
+                    "request-1",
+                    **kwargs,
+                )
+
+        other_repository, other_source = _repository(catalog, "owner/other")
+        other = catalog.create_job(
+            other_repository,
+            other_source,
+            "request-1",
+            request,
+        )
+        assert other.job_id != first.job_id
+        int64_job = catalog.create_job(
+            repository_id,
+            source_revision_id,
+            "int64-maximum",
+            request,
+            expected_ref_generation=9_223_372_036_854_775_807,
+        )
+        assert int64_job.expected_ref_generation == 9_223_372_036_854_775_807
+        with pytest.raises(StorageValidationError, match="int64"):
+            catalog.create_job(
+                repository_id,
+                source_revision_id,
+                "int64-overflow",
+                request,
+                expected_ref_generation=9_223_372_036_854_775_808,
+            )
+
+
+def test_job_views_and_contract_are_revalidated_against_canonical_request(
+    tmp_path,
+) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        job = _job_setup(catalog)
+        with pytest.raises(sqlite3.IntegrityError, match="view requests are immutable"):
+            catalog._connection.execute(
+                "UPDATE index_job_views SET required = 0 WHERE job_id = ?",
+                (job.job_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="view requests are immutable"):
+            catalog._connection.execute(
+                "DELETE FROM index_job_views WHERE job_id = ?", (job.job_id,)
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="duplicate index job view"):
+            catalog._connection.execute(
+                """
+                INSERT OR REPLACE INTO index_job_views(
+                    job_id, view_type, profile_id, requested_mode, required
+                )
+                SELECT job_id, view_type, profile_id, requested_mode, required
+                FROM index_job_views WHERE job_id = ?
+                """,
+                (job.job_id,),
+            )
+        vector_profile = catalog.create_view_profile("vector", {})
+        with pytest.raises(sqlite3.IntegrityError, match="canonical request"):
+            catalog._connection.execute(
+                """
+                INSERT INTO index_job_views(
+                    job_id, view_type, profile_id, requested_mode, required
+                ) VALUES (?, 'vector', ?, 'full', 1)
+                """,
+                (job.job_id, vector_profile),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="view requests are immutable"):
+            catalog._connection.execute(
+                "DELETE FROM index_jobs WHERE job_id = ?", (job.job_id,)
+            )
+
+        catalog._connection.execute("DROP TRIGGER index_job_views_are_immutable")
+        catalog._connection.execute("DROP TRIGGER index_job_views_cannot_be_deleted")
+        catalog._connection.execute(
+            "DELETE FROM index_job_views WHERE job_id = ?", (job.job_id,)
+        )
+        with pytest.raises(StorageIntegrityError, match="canonical request"):
+            catalog.get_job(job.job_id)
+
+    with SQLiteCatalog(tmp_path / "contract.sqlite3") as catalog:
+        job = _job_setup(catalog)
+        catalog._connection.execute("DROP TRIGGER index_job_request_is_immutable")
+        catalog._connection.execute(
+            "UPDATE index_jobs SET request_contract = 'corrupt.v1' WHERE job_id = ?",
+            (job.job_id,),
+        )
+        with pytest.raises(StorageIntegrityError, match="contract column"):
+            catalog.get_job(job.job_id)
+
+
+def test_two_connections_compete_for_one_ref_slot(tmp_path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        first = _job_setup(catalog, idempotency_key="first")
+        second = catalog.create_job(
+            first.repository_id,
+            first.source_revision_id,
+            "second",
+            first.request,
+        )
+
+    barrier = threading.Barrier(2)
+
+    def acquire(job_id: str, owner_id: str) -> tuple[str, object]:
+        with SQLiteCatalog(path) as catalog:
+            barrier.wait(timeout=5)
+            try:
+                return (
+                    "acquired",
+                    catalog.acquire_job_lease(
+                        job_id,
+                        owner_id=owner_id,
+                        lease_duration_ms=60_000,
+                    ),
+                )
+            except CatalogConflictError as exc:
+                return "conflict", str(exc)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda args: acquire(*args),
+                ((first.job_id, "worker-1"), (second.job_id, "worker-2")),
+            )
+        )
+
+    assert sorted(result[0] for result in results) == ["acquired", "conflict"]
+    with SQLiteCatalog(path) as catalog:
+        running = catalog._connection.execute(
+            "SELECT COUNT(*) FROM index_jobs WHERE status = 'running'"
+        ).fetchone()[0]
+        assert running == 1
+
+
+def test_acquire_retry_is_idempotent_but_other_owners_are_fenced(tmp_path) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        job = _job_setup(catalog)
+        queued = catalog.create_job(
+            job.repository_id,
+            job.source_revision_id,
+            "queued-replacement",
+            job.request,
+        )
+        first = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker-1", lease_duration_ms=60_000
+        )
+        retried = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker-1", lease_duration_ms=1
+        )
+
+        assert retried == first
+        assert catalog.get_job(job.job_id).attempt_count == 1
+        with pytest.raises(sqlite3.IntegrityError, match="duplicate ref job lease"):
+            catalog._connection.execute(
+                """
+                INSERT OR REPLACE INTO ref_job_leases(
+                    repository_id, ref_name, job_id, owner_id, fencing_token,
+                    acquired_at_ms, heartbeat_at_ms, lease_expires_at_ms,
+                    updated_at_ms
+                )
+                SELECT repository_id, ref_name, ?, 'replacement-owner', fencing_token,
+                    acquired_at_ms, heartbeat_at_ms, lease_expires_at_ms,
+                    updated_at_ms
+                FROM ref_job_leases
+                WHERE repository_id = ? AND ref_name = ?
+                """,
+                (queued.job_id, job.repository_id, job.ref_name),
+            )
+        unchanged = catalog._connection.execute(
+            """
+            SELECT owner_id, fencing_token FROM ref_job_leases
+            WHERE repository_id = ? AND ref_name = ?
+            """,
+            (job.repository_id, job.ref_name),
+        ).fetchone()
+        assert (unchanged["owner_id"], unchanged["fencing_token"]) == (
+            "worker-1",
+            first.fencing_token,
+        )
+        with pytest.raises(CatalogConflictError, match="active"):
+            catalog.acquire_job_lease(
+                job.job_id,
+                owner_id="worker-2",
+                lease_duration_ms=60_000,
+            )
+
+
+@pytest.mark.parametrize(
+    "enable_foreign_keys",
+    [False, True],
+    ids=["foreign-keys-off", "foreign-keys-on"],
+)
+def test_duplicate_insert_guards_block_replace_from_plain_connections(
+    tmp_path,
+    enable_foreign_keys: bool,
+) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        job = _job_setup(catalog)
+        first_lease = catalog.acquire_job_lease(
+            job.job_id,
+            owner_id="worker",
+            lease_duration_ms=30_000,
+        )
+        running = catalog.get_job(job.job_id)
+        requested_view = catalog.get_job_views(job.job_id)[0]
+
+    def open_plain_connection() -> sqlite3.Connection:
+        connection = sqlite3.connect(path, isolation_level=None)
+        assert connection.execute("PRAGMA recursive_triggers").fetchone()[0] == 0
+        assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+        if enable_foreign_keys:
+            connection.execute("PRAGMA foreign_keys = ON")
+            assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        return connection
+
+    connection = open_plain_connection()
+    try:
+        with pytest.raises(sqlite3.IntegrityError, match="duplicate index job"):
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO index_jobs(
+                    job_id, repository_id, source_revision_id, ref_name,
+                    idempotency_key, expected_ref_generation, max_attempts,
+                    request_contract, request_json, request_digest, status,
+                    cancel_requested, attempt_count, result_snapshot_id,
+                    error_code, error_message, created_at_ms, updated_at_ms,
+                    started_at_ms, finished_at_ms
+                )
+                SELECT
+                    job_id, repository_id, source_revision_id, ref_name,
+                    idempotency_key, expected_ref_generation, max_attempts,
+                    request_contract, '{"contract":"tampered.v1","views":{}}',
+                    'tampered-request-digest', 'queued', 0, 0, NULL,
+                    NULL, NULL, created_at_ms, updated_at_ms, NULL, NULL
+                FROM index_jobs WHERE job_id = ?
+                """,
+                (job.job_id,),
+            )
+        alternate_job_id = "job_" + "f" * 64
+        assert alternate_job_id != job.job_id
+        with pytest.raises(sqlite3.IntegrityError, match="duplicate index job"):
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO index_jobs(
+                    job_id, repository_id, source_revision_id, ref_name,
+                    idempotency_key, expected_ref_generation, max_attempts,
+                    request_contract, request_json, request_digest, status,
+                    cancel_requested, attempt_count, result_snapshot_id,
+                    error_code, error_message, created_at_ms, updated_at_ms,
+                    started_at_ms, finished_at_ms
+                )
+                SELECT
+                    ?, repository_id, source_revision_id, ref_name,
+                    idempotency_key, expected_ref_generation, max_attempts,
+                    request_contract, request_json, request_digest, 'queued',
+                    0, 0, NULL, NULL, NULL, created_at_ms, updated_at_ms,
+                    NULL, NULL
+                FROM index_jobs WHERE job_id = ?
+                """,
+                (alternate_job_id, job.job_id),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="duplicate index job view"):
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO index_job_views(
+                    job_id, view_type, profile_id, requested_mode, required
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    requested_view.job_id,
+                    requested_view.view_type,
+                    requested_view.profile_id,
+                    requested_view.requested_mode.value,
+                    int(requested_view.required),
+                ),
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO index_job_views(
+                    job_id, view_type, profile_id, requested_mode, required
+                ) VALUES (?, ?, ?, 'full', 0)
+                """,
+                (
+                    requested_view.job_id,
+                    requested_view.view_type,
+                    requested_view.profile_id,
+                ),
+            )
+
+        persisted_job = connection.execute(
+            """
+            SELECT status, attempt_count, request_json, request_digest
+            FROM index_jobs WHERE job_id = ?
+            """,
+            (job.job_id,),
+        ).fetchone()
+        assert persisted_job == (
+            "running",
+            1,
+            running.request_json,
+            running.request_digest,
+        )
+        persisted_view = connection.execute(
+            """
+            SELECT profile_id, requested_mode, required
+            FROM index_job_views WHERE job_id = ? AND view_type = ?
+            """,
+            (requested_view.job_id, requested_view.view_type),
+        ).fetchone()
+        assert persisted_view == (
+            requested_view.profile_id,
+            requested_view.requested_mode.value,
+            int(requested_view.required),
+        )
+    finally:
+        connection.close()
+
+    with SQLiteCatalog(path) as catalog:
+        requeued = catalog.finish_job_attempt(
+            job.job_id,
+            owner_id="worker",
+            fencing_token=first_lease.fencing_token,
+            outcome=IndexJobCompletion.REQUEUE,
+            error_code="retry",
+        )
+        assert requeued.status is IndexJobStatus.QUEUED
+
+    connection = open_plain_connection()
+    try:
+        with pytest.raises(sqlite3.IntegrityError, match="duplicate ref job lease"):
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO ref_job_leases(
+                    repository_id, ref_name, job_id, owner_id, fencing_token,
+                    acquired_at_ms, heartbeat_at_ms, lease_expires_at_ms,
+                    updated_at_ms
+                ) VALUES (?, ?, NULL, NULL, 0, NULL, NULL, NULL, 0)
+                """,
+                (job.repository_id, job.ref_name),
+            )
+        persisted_slot = connection.execute(
+            """
+            SELECT job_id, owner_id, fencing_token FROM ref_job_leases
+            WHERE repository_id = ? AND ref_name = ?
+            """,
+            (job.repository_id, job.ref_name),
+        ).fetchone()
+        assert persisted_slot == (None, None, first_lease.fencing_token)
+    finally:
+        connection.close()
+
+    with SQLiteCatalog(path) as catalog:
+        reacquired = catalog.acquire_job_lease(
+            job.job_id,
+            owner_id="worker",
+            lease_duration_ms=30_000,
+        )
+        assert reacquired.fencing_token == first_lease.fencing_token + 1
+        with pytest.raises(CatalogConflictError, match="fenced lease"):
+            catalog.finish_job_attempt(
+                job.job_id,
+                owner_id="worker",
+                fencing_token=first_lease.fencing_token,
+                outcome=IndexJobCompletion.FAILED,
+                error_code="stale_worker",
+            )
+        assert catalog.get_job(job.job_id).status is IndexJobStatus.RUNNING
+
+
+def test_plain_connection_cannot_move_lease_via_job_unique_identity(
+    tmp_path,
+) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        job = _job_setup(catalog)
+        first_lease = catalog.acquire_job_lease(
+            job.job_id,
+            owner_id="worker",
+            lease_duration_ms=20,
+        )
+
+    connection = sqlite3.connect(path, isolation_level=None)
+    try:
+        assert connection.execute("PRAGMA recursive_triggers").fetchone()[0] == 0
+        assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+        connection.execute(
+            """
+            UPDATE index_jobs
+            SET status = 'queued', error_code = 'raw_half_state'
+            WHERE job_id = ?
+            """,
+            (job.job_id,),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="duplicate ref job lease"):
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO ref_job_leases(
+                    repository_id, ref_name, job_id, owner_id, fencing_token,
+                    acquired_at_ms, heartbeat_at_ms, lease_expires_at_ms,
+                    updated_at_ms
+                )
+                SELECT repository_id, 'hijacked', job_id, 'hijacker',
+                    fencing_token, acquired_at_ms, heartbeat_at_ms,
+                    lease_expires_at_ms, updated_at_ms
+                FROM ref_job_leases
+                WHERE repository_id = ? AND ref_name = ?
+                """,
+                (job.repository_id, job.ref_name),
+            )
+        persisted_slot = connection.execute(
+            """
+            SELECT ref_name, job_id, owner_id, fencing_token
+            FROM ref_job_leases WHERE repository_id = ?
+            """,
+            (job.repository_id,),
+        ).fetchall()
+        assert persisted_slot == [
+            (
+                job.ref_name,
+                job.job_id,
+                "worker",
+                first_lease.fencing_token,
+            )
+        ]
+    finally:
+        connection.close()
+
+    time.sleep(0.05)
+    with SQLiteCatalog(path) as catalog:
+        recovered = catalog.acquire_job_lease(
+            job.job_id,
+            owner_id="recovery-worker",
+            lease_duration_ms=30_000,
+        )
+        assert recovered.ref_name == job.ref_name
+        assert recovered.fencing_token == first_lease.fencing_token + 1
+        assert catalog.get_job(job.job_id).attempt_count == 2
+        assert (
+            catalog._connection.execute(
+                """
+                SELECT COUNT(*) FROM ref_job_leases
+                WHERE repository_id = ? AND ref_name = 'hijacked'
+                """,
+                (job.repository_id,),
+            ).fetchone()[0]
+            == 0
+        )
+
+
+def test_renew_requeue_restart_and_fencing_token_are_durable(tmp_path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        job = _job_setup(catalog)
+        lease = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker-1", lease_duration_ms=30_000
+        )
+        renewed = catalog.renew_job_lease(
+            job.job_id,
+            owner_id="worker-1",
+            fencing_token=lease.fencing_token,
+            lease_duration_ms=60_000,
+        )
+        requeued = catalog.finish_job_attempt(
+            job.job_id,
+            owner_id="worker-1",
+            fencing_token=lease.fencing_token,
+            outcome=IndexJobCompletion.REQUEUE,
+            error_code="transient_io",
+            error_message="retry the immutable build",
+        )
+
+        assert renewed.fencing_token == lease.fencing_token
+        assert renewed.acquired_at_ms == lease.acquired_at_ms
+        assert renewed.heartbeat_at_ms >= lease.heartbeat_at_ms
+        assert renewed.lease_expires_at_ms > lease.lease_expires_at_ms
+        assert requeued.status is IndexJobStatus.QUEUED
+        assert requeued.error_code == "transient_io"
+        slot = catalog._connection.execute(
+            "SELECT * FROM ref_job_leases WHERE repository_id = ? AND ref_name = 'main'",
+            (job.repository_id,),
+        ).fetchone()
+        assert slot["job_id"] is None
+        assert slot["fencing_token"] == lease.fencing_token
+
+    with SQLiteCatalog(path) as catalog:
+        next_lease = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker-2", lease_duration_ms=30_000
+        )
+        restarted = catalog.get_job(job.job_id)
+        assert next_lease.fencing_token == lease.fencing_token + 1
+        assert restarted.attempt_count == 2
+        assert restarted.error_code is None
+
+
+def test_high_frequency_one_millisecond_renewal_has_one_conflict_boundary(
+    tmp_path,
+) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        job = _job_setup(catalog)
+        lease = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker", lease_duration_ms=10
+        )
+        renewed_count = 0
+        for _ in range(50):
+            try:
+                lease = catalog.renew_job_lease(
+                    job.job_id,
+                    owner_id="worker",
+                    fencing_token=lease.fencing_token,
+                    lease_duration_ms=1,
+                )
+            except CatalogConflictError:
+                break
+            renewed_count += 1
+
+        assert renewed_count >= 1
+        time.sleep(0.08)
+        with pytest.raises(CatalogConflictError, match="expired"):
+            catalog.renew_job_lease(
+                job.job_id,
+                owner_id="worker",
+                fencing_token=lease.fencing_token,
+                lease_duration_ms=1,
+            )
+
+
+def test_expired_lease_cannot_mutate_and_takeover_atomically_requeues(tmp_path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as first_catalog:
+        first = _job_setup(first_catalog, idempotency_key="first")
+        second = first_catalog.create_job(
+            first.repository_id,
+            first.source_revision_id,
+            "second",
+            first.request,
+        )
+        stale = first_catalog.acquire_job_lease(
+            first.job_id, owner_id="worker-1", lease_duration_ms=1
+        )
+
+    time.sleep(0.02)
+    with SQLiteCatalog(path) as catalog:
+        with pytest.raises(sqlite3.IntegrityError, match="fencing transition"):
+            catalog._connection.execute(
+                """
+                UPDATE ref_job_leases
+                SET heartbeat_at_ms = heartbeat_at_ms,
+                    lease_expires_at_ms = lease_expires_at_ms + 10000,
+                    updated_at_ms = updated_at_ms
+                WHERE job_id = ?
+                """,
+                (first.job_id,),
+            )
+        with pytest.raises(CatalogConflictError, match="expired"):
+            catalog.renew_job_lease(
+                first.job_id,
+                owner_id="worker-1",
+                fencing_token=stale.fencing_token,
+                lease_duration_ms=10_000,
+            )
+        with pytest.raises(CatalogConflictError, match="unexpired"):
+            catalog.finish_job_attempt(
+                first.job_id,
+                owner_id="worker-1",
+                fencing_token=stale.fencing_token,
+                outcome=IndexJobCompletion.FAILED,
+                error_code="stale_worker",
+            )
+
+        current = catalog.acquire_job_lease(
+            second.job_id, owner_id="worker-2", lease_duration_ms=30_000
+        )
+        retired = catalog.get_job(first.job_id)
+        assert current.fencing_token == stale.fencing_token + 1
+        assert retired.status is IndexJobStatus.QUEUED
+        assert retired.error_code == "lease_expired"
+
+
+@pytest.mark.parametrize("raw_status", ["queued", "failed", "cancelled"])
+def test_expired_nonrunning_half_state_is_reclaimed_without_fencing_aba(
+    tmp_path,
+    raw_status: str,
+) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        first = _job_setup(catalog, idempotency_key="first")
+        second = catalog.create_job(
+            first.repository_id,
+            first.source_revision_id,
+            "second",
+            first.request,
+        )
+        stale = catalog.acquire_job_lease(
+            first.job_id, owner_id="worker-1", lease_duration_ms=100
+        )
+        now_ms = catalog._db_now_ms()
+        if raw_status == "queued":
+            catalog._connection.execute(
+                """
+                UPDATE index_jobs
+                SET status = 'queued', error_code = 'raw_half_state',
+                    updated_at_ms = ?
+                WHERE job_id = ?
+                """,
+                (now_ms, first.job_id),
+            )
+        else:
+            catalog._connection.execute(
+                """
+                UPDATE index_jobs
+                SET status = ?, cancel_requested = ?,
+                    error_code = 'raw_half_state', finished_at_ms = ?,
+                    updated_at_ms = ?
+                WHERE job_id = ?
+                """,
+                (
+                    raw_status,
+                    int(raw_status == "cancelled"),
+                    now_ms,
+                    now_ms,
+                    first.job_id,
+                ),
+            )
+        with pytest.raises(CatalogConflictError, match="active"):
+            catalog.acquire_job_lease(
+                second.job_id,
+                owner_id="worker-2",
+                lease_duration_ms=30_000,
+            )
+
+    time.sleep(0.12)
+    with SQLiteCatalog(path) as catalog:
+        current = catalog.acquire_job_lease(
+            second.job_id, owner_id="worker-2", lease_duration_ms=30_000
+        )
+        assert current.fencing_token == stale.fencing_token + 1
+        assert catalog.get_job(first.job_id).status.value == raw_status
+        with pytest.raises(CatalogConflictError, match="fenced lease"):
+            catalog.finish_job_attempt(
+                second.job_id,
+                owner_id="worker-1",
+                fencing_token=stale.fencing_token,
+                outcome=IndexJobCompletion.FAILED,
+                error_code="stale_worker",
+            )
+        assert catalog.get_job(second.job_id).status is IndexJobStatus.RUNNING
+
+
+def test_queued_and_running_cancellation_have_distinct_semantics(tmp_path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        queued = _job_setup(catalog, idempotency_key="queued")
+        cancelled = catalog.request_job_cancel(queued.job_id)
+        assert cancelled.status is IndexJobStatus.CANCELLED
+        assert cancelled.cancel_requested
+        assert catalog.request_job_cancel(queued.job_id) == cancelled
+        with pytest.raises(CatalogConflictError, match="terminal"):
+            catalog.acquire_job_lease(
+                queued.job_id, owner_id="worker", lease_duration_ms=30_000
+            )
+
+        running = catalog.create_job(
+            queued.repository_id,
+            queued.source_revision_id,
+            "running",
+            queued.request,
+            ref_name="other",
+        )
+        lease = catalog.acquire_job_lease(
+            running.job_id, owner_id="worker", lease_duration_ms=30_000
+        )
+
+    with SQLiteCatalog(path) as requester:
+        requested = requester.request_job_cancel(running.job_id)
+        assert requested.status is IndexJobStatus.RUNNING
+        assert requested.cancel_requested
+
+    with SQLiteCatalog(path) as catalog:
+        with pytest.raises(CatalogConflictError, match="cannot be requeued"):
+            catalog.finish_job_attempt(
+                running.job_id,
+                owner_id="worker",
+                fencing_token=lease.fencing_token,
+                outcome=IndexJobCompletion.REQUEUE,
+                error_code="retry",
+            )
+        finished = catalog.finish_job_attempt(
+            running.job_id,
+            owner_id="worker",
+            fencing_token=lease.fencing_token,
+            outcome=IndexJobCompletion.CANCELLED,
+        )
+        assert finished.status is IndexJobStatus.CANCELLED
+        assert finished.finished_at_ms is not None
+
+
+def test_final_attempt_cannot_requeue_and_failed_jobs_are_terminal(tmp_path) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        job = _job_setup(catalog, max_attempts=1)
+        lease = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker", lease_duration_ms=30_000
+        )
+        with pytest.raises(CatalogConflictError, match="must fail"):
+            catalog.finish_job_attempt(
+                job.job_id,
+                owner_id="worker",
+                fencing_token=lease.fencing_token,
+                outcome=IndexJobCompletion.REQUEUE,
+                error_code="retry",
+            )
+        failed = catalog.finish_job_attempt(
+            job.job_id,
+            owner_id="worker",
+            fencing_token=lease.fencing_token,
+            outcome=IndexJobCompletion.FAILED,
+            error_code="builder_failed",
+            error_message="bounded diagnostic",
+        )
+        assert failed.status is IndexJobStatus.FAILED
+        with pytest.raises(CatalogConflictError, match="terminal"):
+            catalog.acquire_job_lease(
+                job.job_id, owner_id="other", lease_duration_ms=30_000
+            )
+        with pytest.raises(
+            sqlite3.IntegrityError, match="terminal.*immutable|status transition"
+        ):
+            catalog._connection.execute(
+                "UPDATE index_jobs SET status = 'queued' WHERE job_id = ?",
+                (job.job_id,),
+            )
+
+
+def test_m1_rejects_success_and_result_snapshot_binds_full_source_identity(
+    tmp_path,
+) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        job = _job_setup(catalog)
+        correct_snapshot = _publish_snapshot(catalog, job)
+        catalog.acquire_job_lease(
+            job.job_id, owner_id="worker", lease_duration_ms=30_000
+        )
+        now_ms = catalog._db_now_ms()
+
+        with pytest.raises(sqlite3.IntegrityError, match="M1"):
+            catalog._connection.execute(
+                """
+                UPDATE index_jobs
+                SET status = 'succeeded', result_snapshot_id = ?,
+                    finished_at_ms = ?, updated_at_ms = ?
+                WHERE job_id = ?
+                """,
+                (correct_snapshot, now_ms, now_ms, job.job_id),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="M1"):
+            catalog._connection.execute(
+                """
+                INSERT INTO index_jobs(
+                    job_id, repository_id, source_revision_id, ref_name,
+                    idempotency_key, expected_ref_generation, max_attempts,
+                    request_contract, request_json, request_digest, status,
+                    cancel_requested, attempt_count, result_snapshot_id,
+                    error_code, error_message, created_at_ms, updated_at_ms,
+                    started_at_ms, finished_at_ms
+                )
+                SELECT
+                    'job_inserted_success', repository_id, source_revision_id,
+                    ref_name, 'inserted-success', expected_ref_generation,
+                    max_attempts, request_contract, request_json, request_digest,
+                    'succeeded', 0, attempt_count, ?, NULL, NULL,
+                    created_at_ms, ?, started_at_ms, ?
+                FROM index_jobs WHERE job_id = ?
+                """,
+                (correct_snapshot, now_ms, now_ms, job.job_id),
+            )
+
+        other_source = catalog.create_source_revision(
+            job.repository_id,
+            commit_sha="c" * 40,
+            tree_sha="e" * 64,
+        )
+        wrong_snapshot = _publish_snapshot(
+            catalog,
+            job,
+            source_revision_id=other_source,
+            suffix="e",
+            ref_name="other-published",
+        )
+        catalog._connection.execute(
+            "DROP TRIGGER m1_index_jobs_cannot_update_succeeded"
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="FOREIGN KEY"):
+            catalog._connection.execute(
+                """
+                UPDATE index_jobs
+                SET status = 'succeeded', result_snapshot_id = ?,
+                    finished_at_ms = ?, updated_at_ms = ?
+                WHERE job_id = ?
+                """,
+                (wrong_snapshot, now_ms, now_ms, job.job_id),
+            )
+        assert catalog.get_job(job.job_id).status is IndexJobStatus.RUNNING
+
+
+def test_job_finish_and_slot_release_roll_back_together(tmp_path) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        job = _job_setup(catalog)
+        lease = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker", lease_duration_ms=30_000
+        )
+        catalog._connection.execute("""
+            CREATE TRIGGER fail_job_slot_release
+            BEFORE UPDATE ON ref_job_leases
+            WHEN NEW.job_id IS NULL
+            BEGIN
+                SELECT RAISE(ABORT, 'simulated slot release failure');
+            END
+            """)
+
+        with pytest.raises(sqlite3.IntegrityError, match="simulated slot"):
+            catalog.finish_job_attempt(
+                job.job_id,
+                owner_id="worker",
+                fencing_token=lease.fencing_token,
+                outcome=IndexJobCompletion.FAILED,
+                error_code="builder_failed",
+            )
+
+        still_running = catalog.get_job(job.job_id)
+        assert still_running.status is IndexJobStatus.RUNNING
+        assert still_running.error_code is None
+        assert (
+            catalog._connection.execute(
+                "SELECT job_id FROM ref_job_leases WHERE repository_id = ?",
+                (job.repository_id,),
+            ).fetchone()["job_id"]
+            == job.job_id
+        )
+
+
+def test_db_clock_drives_job_and_lease_times_despite_python_clock_skew(
+    tmp_path, monkeypatch
+) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id = _repository(catalog)
+        profile_id = catalog.create_view_profile("bm25", {})
+        before_ms = catalog._db_now_ms()
+        monkeypatch.setattr(
+            sqlite_catalog_module,
+            "_now",
+            lambda: "1900-01-01T00:00:00+00:00",
+        )
+        job = catalog.create_job(
+            repository_id,
+            source_revision_id,
+            "clock-skew",
+            _request(profile_id),
+        )
+        lease = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker", lease_duration_ms=10_000
+        )
+        after_ms = catalog._db_now_ms()
+
+        assert before_ms <= job.created_at_ms <= after_ms
+        assert before_ms <= lease.acquired_at_ms <= after_ms
+        assert lease.lease_expires_at_ms > lease.heartbeat_at_ms
+
+
+def test_direct_sql_cannot_skip_job_or_lease_state_machine(tmp_path) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        job = _job_setup(catalog)
+        with pytest.raises(sqlite3.IntegrityError, match="status transition"):
+            catalog._connection.execute(
+                """
+                UPDATE index_jobs
+                SET status = 'running', attempt_count = 1,
+                    started_at_ms = updated_at_ms
+                WHERE job_id = ?
+                """,
+                (job.job_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="status transition"):
+            catalog._connection.execute(
+                """
+                UPDATE index_jobs
+                SET status = 'failed', error_code = 'unsafe',
+                    finished_at_ms = updated_at_ms
+                WHERE job_id = ?
+                """,
+                (job.job_id,),
+            )
+        lease = catalog.acquire_job_lease(
+            job.job_id, owner_id="worker", lease_duration_ms=30_000
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="fencing transition"):
+            catalog._connection.execute(
+                """
+                UPDATE ref_job_leases
+                SET owner_id = 'thief', fencing_token = fencing_token + 1,
+                    acquired_at_ms = heartbeat_at_ms,
+                    heartbeat_at_ms = heartbeat_at_ms,
+                    lease_expires_at_ms = lease_expires_at_ms + 1
+                WHERE job_id = ?
+                """,
+                (job.job_id,),
+            )
+        assert catalog.get_job(job.job_id).status is IndexJobStatus.RUNNING
+        assert lease.fencing_token == 1
+
+
+def test_missing_job_uses_catalog_not_found_error(tmp_path) -> None:
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        with pytest.raises(CatalogNotFoundError, match="index job"):
+            catalog.get_job("job_" + "f" * 64)


### PR DESCRIPTION
## Summary

Add the M1 durable index-job state machine and per-ref fenced lease slot to the embedded catalog. This records canonical idempotent requests and safe retry, cancellation, expiry, and failure transitions without wiring workers or snapshot publication yet.

Part of #199 and #266.

## Changes

- add backend-neutral job, requested-view, completion, and lease records plus the `JobCatalog` protocol
- migrate SQLite catalogs to schema v2 with immutable job requests, database-clock leases, fencing tokens, bounded attempts, and cancellation state
- reserve successful completion for the M2 atomic snapshot/ref publication transaction
- protect job, view, and lease identities from `INSERT OR REPLACE`, including ordinary SQLite connections with foreign keys and recursive triggers disabled
- document M1 retention and the M2/M3 ownership boundaries

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest -q test/storage` — 80 passed
- local unit tier excluding the unavailable Docker binary test — 3,491 passed, 11 skipped
- Black, isort, flake8, namespace, diff, and Python 3.10 grammar checks
- independent adversarial review of default SQLite connections, primary and secondary unique-key replacement, fencing ABA, expiry, takeover, rollback, and cross-source publication guards

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
