### PR TITLE
fix(storage): make snapshot publication idempotent

### DIFF
--- a/codenib/storage/protocols.py
+++ b/codenib/storage/protocols.py
@@ -97,7 +97,16 @@ class IndexCatalog(Protocol):
         *,
         ref_name: str = "main",
         expected_generation: int = 0,
-    ) -> dict[str, Any]: ...
+    ) -> dict[str, Any]:
+        """Publish a desired snapshot or return its unchanged current ref.
+
+        Implementations return ``changed=False`` without advancing the ref when
+        it already targets the fully validated desired snapshot.  Otherwise,
+        ``expected_generation`` is a compare-and-swap precondition and a
+        successful advance returns ``changed=True``.
+        """
+
+        ...
 
     def resolve_ref(
         self,

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -31,6 +31,7 @@ from .models import (
     ObjectRecord,
     PublishConflict,
     RefJobLease,
+    RepositoryIdentity,
     SourceRevision,
     StorageError,
     StorageIntegrityError,
@@ -41,7 +42,7 @@ from .models import (
     normalize_digest,
 )
 
-LATEST_SCHEMA_VERSION = 2
+LATEST_SCHEMA_VERSION = 3
 DEFAULT_NAMESPACE_ID = "ns_default"
 DEFAULT_NAMESPACE_NAME = "default"
 
@@ -51,6 +52,7 @@ CatalogNotFoundError = StorageNotFound
 CatalogValidationError = StorageValidationError
 
 _DB_NOW_MS_SQL = "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)"
+_SQLITE_INT64_MAX = 9_223_372_036_854_775_807
 
 
 def _now() -> str:
@@ -83,6 +85,37 @@ def _optional_bounded_text(
 def _positive_integer(value: int, field: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise CatalogValidationError(f"{field} must be a positive integer")
+    return value
+
+
+def _persisted_positive_int64(value: object, field: str) -> int:
+    """Reject SQLite numeric coercions when reading an identity counter."""
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 1
+        or value > _SQLITE_INT64_MAX
+    ):
+        raise CatalogConflictError(f"{field} must be a positive 64-bit integer")
+    return value
+
+
+def _persisted_utc_timestamp(value: object, field: str) -> str:
+    """Require the exact UTC ISO-8601 representation emitted by ``_now``."""
+    if not isinstance(value, str):
+        raise CatalogConflictError(f"{field} must be a canonical UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise CatalogConflictError(
+            f"{field} must be a canonical UTC timestamp"
+        ) from exc
+    if (
+        parsed.tzinfo is None
+        or parsed.utcoffset() != timezone.utc.utcoffset(parsed)
+        or parsed.isoformat() != value
+    ):
+        raise CatalogConflictError(f"{field} must be a canonical UTC timestamp")
     return value
 
 
@@ -785,7 +818,37 @@ _SCHEMA_V2 = (
     """,
 )
 
-_MIGRATIONS: dict[int, tuple[str, ...]] = {1: _SCHEMA_V1, 2: _SCHEMA_V2}
+_SCHEMA_V3 = (
+    """
+    CREATE TRIGGER objects_reject_duplicate_inserts
+    BEFORE INSERT ON objects
+    WHEN EXISTS (
+        SELECT 1 FROM objects AS existing
+        WHERE existing.digest = NEW.digest
+            OR existing.storage_key = NEW.storage_key
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'duplicate object insert is forbidden');
+    END
+    """,
+    """
+    CREATE TRIGGER referenced_objects_cannot_be_deleted
+    BEFORE DELETE ON objects
+    WHEN EXISTS (
+        SELECT 1 FROM view_generations AS generation
+        WHERE generation.object_digest = OLD.digest
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'referenced objects cannot be deleted');
+    END
+    """,
+)
+
+_MIGRATIONS: dict[int, tuple[str, ...]] = {
+    1: _SCHEMA_V1,
+    2: _SCHEMA_V2,
+    3: _SCHEMA_V3,
+}
 
 
 class SQLiteCatalog:
@@ -2010,6 +2073,10 @@ class SQLiteCatalog:
             raise CatalogValidationError("expected generation must be an integer")
         if expected_generation < 0:
             raise CatalogValidationError("expected generation must not be negative")
+        if expected_generation > _SQLITE_INT64_MAX:
+            raise CatalogValidationError(
+                "expected generation must fit in a signed 64-bit integer"
+            )
         if isinstance(view_generation_ids, (str, bytes)):
             raise CatalogValidationError("view generation IDs must be a sequence")
         view_ids = [
@@ -2021,7 +2088,9 @@ class SQLiteCatalog:
             raise CatalogValidationError("duplicate view generation IDs")
 
         with self._transaction():
-            self._require_record("repositories", "repository_id", repository)
+            repository_row = self._require_record(
+                "repositories", "repository_id", repository
+            )
             source_row = self._require_record(
                 "source_revisions", "source_revision_id", source
             )
@@ -2029,6 +2098,7 @@ class SQLiteCatalog:
                 raise CatalogValidationError(
                     "snapshot source revision belongs to another repository"
                 )
+            self._validate_repository_source_identity(repository_row, source_row)
 
             placeholders = ",".join("?" for _ in view_ids)
             rows = self._connection.execute(
@@ -2081,17 +2151,20 @@ class SQLiteCatalog:
                 """,
                 (repository, normalized_ref),
             ).fetchone()
-            current_generation = (
-                int(current_ref["generation"]) if current_ref is not None else 0
-            )
-            if current_ref is not None and (
-                current_generation < 1
-                or not isinstance(current_ref["updated_at"], str)
-                or not current_ref["updated_at"].strip()
-            ):
-                raise CatalogConflictError(
-                    f"ref {normalized_ref!r} has invalid publication metadata"
-                )
+            if current_ref is None:
+                current_generation = 0
+            else:
+                try:
+                    current_generation = _persisted_positive_int64(
+                        current_ref["generation"], "ref generation"
+                    )
+                    _persisted_utc_timestamp(
+                        current_ref["updated_at"], "ref updated_at"
+                    )
+                except CatalogConflictError as exc:
+                    raise CatalogConflictError(
+                        f"ref {normalized_ref!r} has invalid publication metadata"
+                    ) from exc
 
             existing_snapshot = self._connection.execute(
                 "SELECT * FROM snapshots WHERE snapshot_id = ?", (snapshot_id,)
@@ -2159,6 +2232,24 @@ class SQLiteCatalog:
                 )
                 if seal.rowcount != 1:
                     raise CatalogConflictError("snapshot could not be sealed")
+                existing_snapshot = self._connection.execute(
+                    "SELECT * FROM snapshots WHERE snapshot_id = ?", (snapshot_id,)
+                ).fetchone()
+                rows = self._connection.execute(
+                    f"""
+                    SELECT * FROM view_generations
+                    WHERE view_generation_id IN ({placeholders})
+                    """,
+                    view_ids,
+                ).fetchall()
+                self._validate_ready_snapshot(
+                    existing_snapshot,
+                    repository_id=repository,
+                    source_revision_id=source,
+                    content_digest=content_digest,
+                    members=members,
+                    view_rows=rows,
+                )
             else:
                 self._validate_ready_snapshot(
                     existing_snapshot,
@@ -2169,6 +2260,8 @@ class SQLiteCatalog:
                     view_rows=rows,
                 )
 
+            if current_generation == _SQLITE_INT64_MAX:
+                raise CatalogConflictError("ref generation cannot be incremented")
             next_generation = current_generation + 1
             if current_ref is None:
                 self._connection.execute(
@@ -2215,8 +2308,60 @@ class SQLiteCatalog:
             "changed": True,
         }
 
+    def _validate_repository_source_identity(
+        self, repository_row: sqlite3.Row, source_row: sqlite3.Row
+    ) -> None:
+        """Recompute the content identities that bind a publication source."""
+        namespace_row = self._require_record(
+            "namespaces", "namespace_id", repository_row["namespace_id"]
+        )
+        try:
+            namespace_name = _required_text(namespace_row["name"], "namespace name")
+            expected_namespace_id = (
+                DEFAULT_NAMESPACE_ID
+                if namespace_name == DEFAULT_NAMESPACE_NAME
+                else content_id("ns", {"name": namespace_name})
+            )
+            repository_identity = RepositoryIdentity(
+                namespace_id=repository_row["namespace_id"],
+                repository_key=repository_row["repository_key"],
+            )
+            source_identity = SourceRevision(
+                repository_id=source_row["repository_id"],
+                source_kind=source_row["source_kind"],
+                commit_sha=source_row["commit_sha"],
+                tree_sha=source_row["tree_sha"],
+                source_fingerprint=source_row["source_fingerprint"],
+            )
+        except (TypeError, CatalogValidationError) as exc:
+            raise CatalogConflictError(
+                "repository or source revision identity conflicts"
+            ) from exc
+        expected_source_id = source_identity.source_revision_id
+        if (
+            namespace_row["namespace_id"] != expected_namespace_id
+            or repository_row["repository_id"] != repository_identity.repository_id
+            or source_row["repository_id"] != repository_row["repository_id"]
+            or source_row["source_revision_id"] != expected_source_id
+            or source_row["identity_digest"] != expected_source_id.removeprefix("src_")
+        ):
+            raise CatalogConflictError(
+                "repository or source revision identity conflicts"
+            )
+
     def _validate_view_generation_input(self, row: sqlite3.Row) -> None:
         """Validate the immutable profile, object, and generation identities."""
+        status = row["status"]
+        ready_at = row["ready_at"]
+        if status == "staged":
+            if ready_at is not None:
+                raise CatalogConflictError(
+                    "staged view generation has invalid readiness metadata"
+                )
+        elif status == "ready":
+            _persisted_utc_timestamp(ready_at, "view generation ready_at")
+        else:
+            raise CatalogConflictError("view generation has invalid readiness state")
         profile_row = self._require_record(
             "view_profiles", "profile_id", row["profile_id"]
         )
@@ -2317,15 +2462,16 @@ class SQLiteCatalog:
             if snapshot is not None
             else None
         )
-        if (
-            actual_snapshot != expected_snapshot
-            or snapshot is None
-            or not isinstance(snapshot["published_at"], str)
-            or not snapshot["published_at"].strip()
-        ):
+        if actual_snapshot != expected_snapshot or snapshot is None:
             raise CatalogConflictError(
                 "existing snapshot identity or seal state conflicts"
             )
+        try:
+            _persisted_utc_timestamp(snapshot["published_at"], "snapshot published_at")
+        except CatalogConflictError as exc:
+            raise CatalogConflictError(
+                "existing snapshot identity or seal state conflicts"
+            ) from exc
 
         persisted_members = self._connection.execute(
             """
@@ -2337,13 +2483,19 @@ class SQLiteCatalog:
         actual_members = [
             (row["view_type"], row["view_generation_id"]) for row in persisted_members
         ]
-        if actual_members != list(members) or any(
-            row["status"] != "ready"
-            or not isinstance(row["ready_at"], str)
-            or not row["ready_at"].strip()
-            for row in view_rows
-        ):
+        if actual_members != list(members):
             raise CatalogConflictError("existing ready snapshot membership conflicts")
+        for row in view_rows:
+            if row["status"] != "ready":
+                raise CatalogConflictError(
+                    "existing ready snapshot membership conflicts"
+                )
+            try:
+                _persisted_utc_timestamp(row["ready_at"], "view generation ready_at")
+            except CatalogConflictError as exc:
+                raise CatalogConflictError(
+                    "existing ready snapshot membership conflicts"
+                ) from exc
 
     def resolve_ref(self, repository_id: str, ref_name: str = "main") -> dict[str, Any]:
         """Resolve a named ref and return its pinned manifest summary."""
@@ -2361,13 +2513,24 @@ class SQLiteCatalog:
                 raise CatalogNotFoundError(
                     f"ref not found: {repository}:{normalized_ref}"
                 )
+            try:
+                generation = _persisted_positive_int64(
+                    row["generation"], "ref generation"
+                )
+                updated_at = _persisted_utc_timestamp(
+                    row["updated_at"], "ref updated_at"
+                )
+            except CatalogConflictError as exc:
+                raise CatalogConflictError(
+                    f"ref {normalized_ref!r} has invalid publication metadata"
+                ) from exc
             manifest = self._manifest_summary(row["snapshot_id"])
             return {
                 "repository_id": repository,
                 "ref_name": normalized_ref,
                 "snapshot_id": row["snapshot_id"],
-                "generation": int(row["generation"]),
-                "updated_at": row["updated_at"],
+                "generation": generation,
+                "updated_at": updated_at,
                 "manifest": manifest,
             }
 
@@ -2383,9 +2546,14 @@ class SQLiteCatalog:
             raise CatalogValidationError(
                 f"snapshot is not ready for publication: {snapshot_id}"
             )
+        _persisted_utc_timestamp(snapshot["published_at"], "snapshot published_at")
+        repository = self._require_record(
+            "repositories", "repository_id", snapshot["repository_id"]
+        )
         source = self._require_record(
             "source_revisions", "source_revision_id", snapshot["source_revision_id"]
         )
+        self._validate_repository_source_identity(repository, source)
         view_rows = self._connection.execute(
             """
             SELECT
@@ -2394,6 +2562,8 @@ class SQLiteCatalog:
                 vg.schema_version,
                 vg.metadata_json,
                 vg.object_digest,
+                vg.status,
+                vg.ready_at,
                 vp.profile_id,
                 vp.name AS profile_name,
                 vp.config_json AS profile_config_json,
@@ -2410,6 +2580,12 @@ class SQLiteCatalog:
             """,
             (snapshot_id,),
         ).fetchall()
+        for row in view_rows:
+            if row["status"] != "ready":
+                raise CatalogConflictError(
+                    "ready snapshot contains a non-ready view generation"
+                )
+            _persisted_utc_timestamp(row["ready_at"], "view generation ready_at")
         views = {
             row["view_type"]: {
                 "view_generation_id": row["view_generation_id"],

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -1993,10 +1993,13 @@ class SQLiteCatalog:
         ref_name: str = "main",
         expected_generation: int = 0,
     ) -> dict[str, Any]:
-        """Atomically publish views and advance a ref with compare-and-swap.
+        """Publish the desired snapshot and advance a ref when necessary.
 
-        A missing ref has generation zero.  On any validation or CAS failure,
-        the snapshot insertion and every staged-to-ready transition roll back.
+        A missing ref has generation zero.  A retry whose ref already targets
+        the fully validated desired snapshot is idempotent even when it carries
+        the generation expected before the first publication.  On any
+        validation or CAS failure, the snapshot insertion and every
+        staged-to-ready transition roll back.
         """
         repository = _required_text(repository_id, "repository ID")
         source = _required_text(source_revision_id, "source revision ID")
@@ -2058,21 +2061,7 @@ class SQLiteCatalog:
                     )
                 view_types.add(row["view_type"])
 
-            current_ref = self._connection.execute(
-                """
-                SELECT generation FROM refs
-                WHERE repository_id = ? AND ref_name = ?
-                """,
-                (repository, normalized_ref),
-            ).fetchone()
-            current_generation = (
-                int(current_ref["generation"]) if current_ref is not None else 0
-            )
-            if current_generation != expected_generation:
-                raise CatalogConflictError(
-                    f"ref {normalized_ref!r} generation is {current_generation}; "
-                    f"expected {expected_generation}"
-                )
+                self._validate_view_generation_input(row)
 
             members = sorted(
                 (row["view_type"], row["view_generation_id"]) for row in rows
@@ -2084,10 +2073,55 @@ class SQLiteCatalog:
             }
             snapshot_id = content_id("snapshot", snapshot_identity)
             content_digest = snapshot_id.removeprefix("snapshot_")
-            published_at = _now()
+
+            current_ref = self._connection.execute(
+                """
+                SELECT snapshot_id, generation, updated_at FROM refs
+                WHERE repository_id = ? AND ref_name = ?
+                """,
+                (repository, normalized_ref),
+            ).fetchone()
+            current_generation = (
+                int(current_ref["generation"]) if current_ref is not None else 0
+            )
+            if current_ref is not None and (
+                current_generation < 1
+                or not isinstance(current_ref["updated_at"], str)
+                or not current_ref["updated_at"].strip()
+            ):
+                raise CatalogConflictError(
+                    f"ref {normalized_ref!r} has invalid publication metadata"
+                )
+
             existing_snapshot = self._connection.execute(
                 "SELECT * FROM snapshots WHERE snapshot_id = ?", (snapshot_id,)
             ).fetchone()
+            if current_ref is not None and current_ref["snapshot_id"] == snapshot_id:
+                self._validate_ready_snapshot(
+                    existing_snapshot,
+                    repository_id=repository,
+                    source_revision_id=source,
+                    content_digest=content_digest,
+                    members=members,
+                    view_rows=rows,
+                )
+                result = {
+                    "snapshot_id": snapshot_id,
+                    "repository_id": repository,
+                    "ref_name": normalized_ref,
+                    "generation": current_generation,
+                    "updated_at": current_ref["updated_at"],
+                    "changed": False,
+                }
+                return result
+
+            if current_generation != expected_generation:
+                raise CatalogConflictError(
+                    f"ref {normalized_ref!r} generation is {current_generation}; "
+                    f"expected {expected_generation}"
+                )
+
+            published_at = _now()
             if existing_snapshot is None:
                 self._connection.execute(
                     """
@@ -2126,44 +2160,16 @@ class SQLiteCatalog:
                 if seal.rowcount != 1:
                     raise CatalogConflictError("snapshot could not be sealed")
             else:
-                expected_snapshot = (
-                    repository,
-                    source,
-                    content_digest,
-                    "ready",
+                self._validate_ready_snapshot(
+                    existing_snapshot,
+                    repository_id=repository,
+                    source_revision_id=source,
+                    content_digest=content_digest,
+                    members=members,
+                    view_rows=rows,
                 )
-                actual_snapshot = tuple(
-                    existing_snapshot[key]
-                    for key in (
-                        "repository_id",
-                        "source_revision_id",
-                        "content_digest",
-                        "status",
-                    )
-                )
-                if actual_snapshot != expected_snapshot:
-                    raise CatalogConflictError(
-                        "existing snapshot identity or seal state conflicts"
-                    )
-                existing_members = self._connection.execute(
-                    """
-                    SELECT view_type, view_generation_id FROM snapshot_views
-                    WHERE snapshot_id = ? ORDER BY view_type
-                    """,
-                    (snapshot_id,),
-                ).fetchall()
-                actual_members = [
-                    (row["view_type"], row["view_generation_id"])
-                    for row in existing_members
-                ]
-                if actual_members != members or any(
-                    row["status"] != "ready" for row in rows
-                ):
-                    raise CatalogConflictError(
-                        "existing ready snapshot membership conflicts"
-                    )
 
-            next_generation = expected_generation + 1
+            next_generation = current_generation + 1
             if current_ref is None:
                 self._connection.execute(
                     """
@@ -2205,7 +2211,139 @@ class SQLiteCatalog:
             "repository_id": repository,
             "ref_name": normalized_ref,
             "generation": next_generation,
+            "updated_at": published_at,
+            "changed": True,
         }
+
+    def _validate_view_generation_input(self, row: sqlite3.Row) -> None:
+        """Validate the immutable profile, object, and generation identities."""
+        profile_row = self._require_record(
+            "view_profiles", "profile_id", row["profile_id"]
+        )
+        if profile_row["view_type"] != row["view_type"]:
+            raise CatalogValidationError("view type does not match the view profile")
+        try:
+            profile_config = json.loads(profile_row["config_json"])
+            if not isinstance(profile_config, dict):
+                raise CatalogValidationError(
+                    "view profile config must be a JSON object"
+                )
+            canonical_profile_config = canonical_json(profile_config)
+        except (TypeError, json.JSONDecodeError, CatalogValidationError) as exc:
+            raise CatalogConflictError("view profile identity conflicts") from exc
+        expected_profile_id = content_id(
+            "profile",
+            {
+                "view_type": profile_row["view_type"],
+                "name": profile_row["name"],
+                "config": profile_config,
+            },
+        )
+        if (
+            profile_row["profile_id"] != expected_profile_id
+            or profile_row["profile_digest"]
+            != expected_profile_id.removeprefix("profile_")
+            or profile_row["config_json"] != canonical_profile_config
+        ):
+            raise CatalogConflictError("view profile identity conflicts")
+
+        object_row = self._require_record("objects", "digest", row["object_digest"])
+        try:
+            object_record = ObjectRecord(
+                digest=object_row["digest"],
+                storage_key=object_row["storage_key"],
+                byte_size=object_row["byte_size"],
+                media_type=object_row["media_type"],
+            )
+        except CatalogValidationError as exc:
+            raise CatalogConflictError("registered object metadata conflicts") from exc
+        if object_record.digest != row["object_digest"]:
+            raise CatalogConflictError("registered object identity conflicts")
+
+        try:
+            metadata = json.loads(row["metadata_json"])
+            if not isinstance(metadata, dict):
+                raise CatalogValidationError(
+                    "view generation metadata must be a JSON object"
+                )
+            canonical_metadata = canonical_json(metadata)
+        except (TypeError, json.JSONDecodeError, CatalogValidationError) as exc:
+            raise CatalogConflictError("view generation identity conflicts") from exc
+        expected_view_generation_id = content_id(
+            "view",
+            {
+                "repository_id": row["repository_id"],
+                "source_revision_id": row["source_revision_id"],
+                "profile_id": row["profile_id"],
+                "view_type": row["view_type"],
+                "object_digest": row["object_digest"],
+                "schema_version": row["schema_version"],
+                "metadata": metadata,
+            },
+        )
+        if (
+            row["view_generation_id"] != expected_view_generation_id
+            or row["metadata_json"] != canonical_metadata
+        ):
+            raise CatalogConflictError("view generation identity conflicts")
+
+    def _validate_ready_snapshot(
+        self,
+        snapshot: sqlite3.Row | None,
+        *,
+        repository_id: str,
+        source_revision_id: str,
+        content_digest: str,
+        members: Sequence[tuple[str, str]],
+        view_rows: Sequence[sqlite3.Row],
+    ) -> None:
+        """Fail closed unless a persisted snapshot exactly matches its identity."""
+        expected_snapshot = (
+            repository_id,
+            source_revision_id,
+            content_digest,
+            "ready",
+        )
+        actual_snapshot = (
+            tuple(
+                snapshot[key]
+                for key in (
+                    "repository_id",
+                    "source_revision_id",
+                    "content_digest",
+                    "status",
+                )
+            )
+            if snapshot is not None
+            else None
+        )
+        if (
+            actual_snapshot != expected_snapshot
+            or snapshot is None
+            or not isinstance(snapshot["published_at"], str)
+            or not snapshot["published_at"].strip()
+        ):
+            raise CatalogConflictError(
+                "existing snapshot identity or seal state conflicts"
+            )
+
+        persisted_members = self._connection.execute(
+            """
+            SELECT view_type, view_generation_id FROM snapshot_views
+            WHERE snapshot_id = ? ORDER BY view_type
+            """,
+            (snapshot["snapshot_id"],),
+        ).fetchall()
+        actual_members = [
+            (row["view_type"], row["view_generation_id"]) for row in persisted_members
+        ]
+        if actual_members != list(members) or any(
+            row["status"] != "ready"
+            or not isinstance(row["ready_at"], str)
+            or not row["ready_at"].strip()
+            for row in view_rows
+        ):
+            raise CatalogConflictError("existing ready snapshot membership conflicts")
 
     def resolve_ref(self, repository_id: str, ref_name: str = "main") -> dict[str, Any]:
         """Resolve a named ref and return its pinned manifest summary."""

--- a/codenib/storage/sqlite_catalog.py
+++ b/codenib/storage/sqlite_catalog.py
@@ -842,6 +842,111 @@ _SCHEMA_V3 = (
         SELECT RAISE(ABORT, 'referenced objects cannot be deleted');
     END
     """,
+    """
+    CREATE TRIGGER view_generations_reject_duplicate_inserts
+    BEFORE INSERT ON view_generations
+    WHEN EXISTS (
+        SELECT 1 FROM view_generations AS existing
+        WHERE existing.view_generation_id = NEW.view_generation_id
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'duplicate view generation insert is forbidden');
+    END
+    """,
+    """
+    CREATE TRIGGER referenced_view_generations_cannot_be_deleted
+    BEFORE DELETE ON view_generations
+    WHEN EXISTS (
+        SELECT 1 FROM snapshot_views AS member
+        WHERE member.view_generation_id = OLD.view_generation_id
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'referenced view generations cannot be deleted');
+    END
+    """,
+    """
+    CREATE TRIGGER snapshots_reject_duplicate_inserts
+    BEFORE INSERT ON snapshots
+    WHEN EXISTS (
+        SELECT 1 FROM snapshots AS existing
+        WHERE existing.snapshot_id = NEW.snapshot_id
+            OR (
+                existing.repository_id = NEW.repository_id
+                AND existing.content_digest = NEW.content_digest
+            )
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'duplicate snapshot insert is forbidden');
+    END
+    """,
+    """
+    CREATE TRIGGER referenced_snapshots_cannot_be_deleted
+    BEFORE DELETE ON snapshots
+    WHEN EXISTS (
+        SELECT 1 FROM refs AS ref
+        WHERE ref.snapshot_id = OLD.snapshot_id
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'referenced snapshots cannot be deleted');
+    END
+    """,
+    """
+    CREATE TRIGGER refs_reject_duplicate_inserts
+    BEFORE INSERT ON refs
+    WHEN EXISTS (
+        SELECT 1 FROM refs AS existing
+        WHERE existing.repository_id = NEW.repository_id
+            AND existing.ref_name = NEW.ref_name
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'duplicate ref insert is forbidden');
+    END
+    """,
+    """
+    CREATE TRIGGER refs_cannot_be_deleted
+    BEFORE DELETE ON refs
+    BEGIN
+        SELECT RAISE(ABORT, 'refs cannot be deleted');
+    END
+    """,
+    """
+    CREATE TRIGGER ref_identity_is_immutable
+    BEFORE UPDATE ON refs
+    WHEN
+        NEW.repository_id IS NOT OLD.repository_id
+        OR NEW.ref_name IS NOT OLD.ref_name
+    BEGIN
+        SELECT RAISE(ABORT, 'ref identity is immutable');
+    END
+    """,
+    "DROP TRIGGER refs_require_ready_snapshot_on_insert",
+    "DROP TRIGGER refs_require_ready_snapshot_on_update",
+    """
+    CREATE TRIGGER refs_require_ready_snapshot_on_insert
+    BEFORE INSERT ON refs
+    WHEN NOT EXISTS (
+        SELECT 1 FROM snapshots AS snapshot
+        WHERE snapshot.snapshot_id = NEW.snapshot_id
+            AND snapshot.repository_id = NEW.repository_id
+            AND snapshot.status = 'ready'
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'refs may only target ready snapshots in their repository');
+    END
+    """,
+    """
+    CREATE TRIGGER refs_require_ready_snapshot_on_update
+    BEFORE UPDATE ON refs
+    WHEN NOT EXISTS (
+        SELECT 1 FROM snapshots AS snapshot
+        WHERE snapshot.snapshot_id = NEW.snapshot_id
+            AND snapshot.repository_id = NEW.repository_id
+            AND snapshot.status = 'ready'
+    )
+    BEGIN
+        SELECT RAISE(ABORT, 'refs may only target ready snapshots in their repository');
+    END
+    """,
 )
 
 _MIGRATIONS: dict[int, tuple[str, ...]] = {
@@ -1999,29 +2104,34 @@ class SQLiteCatalog:
                     "view type does not match the view profile"
                 )
             self._require_record("objects", "digest", digest)
-            self._connection.execute(
-                """
-                INSERT OR IGNORE INTO view_generations(
-                    view_generation_id, repository_id, source_revision_id,
-                    profile_id, view_type, object_digest, schema_version,
-                    metadata_json, status, created_at, ready_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'staged', ?, NULL)
-                """,
-                (
-                    view_generation_id,
-                    repository,
-                    source,
-                    profile,
-                    normalized_view_type,
-                    digest,
-                    normalized_schema_version,
-                    metadata_json,
-                    _now(),
-                ),
-            )
-            row = self._require_record(
-                "view_generations", "view_generation_id", view_generation_id
-            )
+            row = self._connection.execute(
+                "SELECT * FROM view_generations WHERE view_generation_id = ?",
+                (view_generation_id,),
+            ).fetchone()
+            if row is None:
+                self._connection.execute(
+                    """
+                    INSERT INTO view_generations(
+                        view_generation_id, repository_id, source_revision_id,
+                        profile_id, view_type, object_digest, schema_version,
+                        metadata_json, status, created_at, ready_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'staged', ?, NULL)
+                    """,
+                    (
+                        view_generation_id,
+                        repository,
+                        source,
+                        profile,
+                        normalized_view_type,
+                        digest,
+                        normalized_schema_version,
+                        metadata_json,
+                        _now(),
+                    ),
+                )
+                row = self._require_record(
+                    "view_generations", "view_generation_id", view_generation_id
+                )
             expected = (
                 repository,
                 source,
@@ -2340,10 +2450,17 @@ class SQLiteCatalog:
         expected_source_id = source_identity.source_revision_id
         if (
             namespace_row["namespace_id"] != expected_namespace_id
+            or namespace_row["name"] != namespace_name
             or repository_row["repository_id"] != repository_identity.repository_id
+            or repository_row["namespace_id"] != repository_identity.namespace_id
+            or repository_row["repository_key"] != repository_identity.repository_key
             or source_row["repository_id"] != repository_row["repository_id"]
             or source_row["source_revision_id"] != expected_source_id
             or source_row["identity_digest"] != expected_source_id.removeprefix("src_")
+            or source_row["source_kind"] != source_identity.source_kind
+            or source_row["commit_sha"] != source_identity.commit_sha
+            or source_row["tree_sha"] != source_identity.tree_sha
+            or source_row["source_fingerprint"] != source_identity.source_fingerprint
         ):
             raise CatalogConflictError(
                 "repository or source revision identity conflicts"
@@ -2525,6 +2642,10 @@ class SQLiteCatalog:
                     f"ref {normalized_ref!r} has invalid publication metadata"
                 ) from exc
             manifest = self._manifest_summary(row["snapshot_id"])
+            if manifest["repository_id"] != repository:
+                raise CatalogConflictError(
+                    f"ref {normalized_ref!r} targets another repository"
+                )
             return {
                 "repository_id": repository,
                 "ref_name": normalized_ref,
@@ -2554,11 +2675,63 @@ class SQLiteCatalog:
             "source_revisions", "source_revision_id", snapshot["source_revision_id"]
         )
         self._validate_repository_source_identity(repository, source)
+        raw_member_rows = self._connection.execute(
+            """
+            SELECT view_type, view_generation_id
+            FROM snapshot_views
+            WHERE snapshot_id = ?
+            ORDER BY view_type
+            """,
+            (snapshot_id,),
+        ).fetchall()
+        raw_members: list[tuple[str, str]] = []
+        for member in raw_member_rows:
+            try:
+                view_type = _required_text(member["view_type"], "snapshot view type")
+                generation_id = _required_text(
+                    member["view_generation_id"], "snapshot view generation ID"
+                )
+            except (TypeError, CatalogValidationError) as exc:
+                raise CatalogConflictError(
+                    "snapshot membership is not canonical"
+                ) from exc
+            if (
+                member["view_type"] != view_type
+                or member["view_generation_id"] != generation_id
+            ):
+                raise CatalogConflictError("snapshot membership is not canonical")
+            raw_members.append((view_type, generation_id))
+        if (
+            not raw_members
+            or len({view_type for view_type, _ in raw_members}) != len(raw_members)
+            or len({generation_id for _, generation_id in raw_members})
+            != len(raw_members)
+        ):
+            raise CatalogConflictError("snapshot membership is incomplete")
+
+        expected_snapshot_id = content_id(
+            "snapshot",
+            {
+                "repository_id": snapshot["repository_id"],
+                "source_revision_id": snapshot["source_revision_id"],
+                "views": raw_members,
+            },
+        )
+        if snapshot["snapshot_id"] != expected_snapshot_id or snapshot[
+            "content_digest"
+        ] != expected_snapshot_id.removeprefix("snapshot_"):
+            raise CatalogConflictError("snapshot content identity conflicts")
+
         view_rows = self._connection.execute(
             """
             SELECT
-                sv.view_type,
+                sv.view_type AS snapshot_view_type,
+                sv.view_generation_id AS selected_view_generation_id,
                 vg.view_generation_id,
+                vg.repository_id,
+                vg.source_revision_id,
+                vg.profile_id,
+                vg.view_type,
                 vg.schema_version,
                 vg.metadata_json,
                 vg.object_digest,
@@ -2580,14 +2753,31 @@ class SQLiteCatalog:
             """,
             (snapshot_id,),
         ).fetchall()
+        joined_members = [
+            (row["snapshot_view_type"], row["selected_view_generation_id"])
+            for row in view_rows
+        ]
+        if joined_members != raw_members:
+            raise CatalogConflictError(
+                "snapshot membership dependencies are missing or inconsistent"
+            )
         for row in view_rows:
+            if (
+                row["selected_view_generation_id"] != row["view_generation_id"]
+                or row["snapshot_view_type"] != row["view_type"]
+                or row["repository_id"] != snapshot["repository_id"]
+                or row["source_revision_id"] != snapshot["source_revision_id"]
+            ):
+                raise CatalogConflictError(
+                    "snapshot membership dependencies are inconsistent"
+                )
+            self._validate_view_generation_input(row)
             if row["status"] != "ready":
                 raise CatalogConflictError(
                     "ready snapshot contains a non-ready view generation"
                 )
-            _persisted_utc_timestamp(row["ready_at"], "view generation ready_at")
         views = {
-            row["view_type"]: {
+            row["snapshot_view_type"]: {
                 "view_generation_id": row["view_generation_id"],
                 "schema_version": row["schema_version"],
                 "metadata": json.loads(row["metadata_json"]),

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -230,6 +230,14 @@ audit guards.  Schema v2 also rejects successful job rows; M2 must remove that
 temporary gate only inside the migration which introduces atomic
 `publish_job_snapshot` completion.
 
+Schema v3 closes the equivalent receipt-replacement gap for immutable objects:
+duplicate digest or storage-key inserts are rejected even when a raw SQLite
+client disables foreign keys and recursive triggers.  Referenced objects cannot
+be deleted, while unreferenced rows remain deletable for the future explicit GC
+policy.  Snapshot publication also recomputes repository/source content
+identities, requires exact staged/ready timestamp pairing, validates canonical
+UTC publication timestamps, and refuses non-integer persisted ref generations.
+
 ### M2: Immutable generation publication
 
 Status: pending.

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -230,13 +230,17 @@ audit guards.  Schema v2 also rejects successful job rows; M2 must remove that
 temporary gate only inside the migration which introduces atomic
 `publish_job_snapshot` completion.
 
-Schema v3 closes the equivalent receipt-replacement gap for immutable objects:
-duplicate digest or storage-key inserts are rejected even when a raw SQLite
-client disables foreign keys and recursive triggers.  Referenced objects cannot
-be deleted, while unreferenced rows remain deletable for the future explicit GC
-policy.  Snapshot publication also recomputes repository/source content
-identities, requires exact staged/ready timestamp pairing, validates canonical
-UTC publication timestamps, and refuses non-integer persisted ref generations.
+Schema v3 closes the equivalent replacement gap across the published aggregate
+even when a raw SQLite client disables foreign keys and recursive triggers.
+Duplicate objects, generations, snapshots, and refs are rejected before
+`REPLACE` can erase their dependency rows; referenced objects, generations, and
+snapshots cannot be deleted, and refs are persistent.  Unreferenced object rows
+remain deletable for the future explicit GC policy.  Ref gates require a ready
+snapshot in the same repository, while manifest reads compare raw membership
+with fully joined dependencies and recompute every content identity.  Snapshot
+publication also requires exact staged/ready timestamp pairing, canonical UTC
+publication timestamps, canonical repository/source fields, and positive
+integer persisted ref generations.
 
 ### M2: Immutable generation publication
 

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -525,6 +525,8 @@ def test_idempotent_retry_revalidates_input_dependencies(
     }
     connection = sqlite3.connect(path)
     connection.execute("PRAGMA foreign_keys = OFF")
+    if table == "objects":
+        connection.execute("DROP TRIGGER referenced_objects_cannot_be_deleted")
     connection.execute(
         f"DELETE FROM {table} WHERE {key_column} = ?", (identifiers[table],)
     )
@@ -539,6 +541,297 @@ def test_idempotent_retry_revalidates_input_dependencies(
                 [view_id],
                 expected_generation=0,
             )
+
+
+@pytest.mark.parametrize("dependency", ("repository", "source", "source_digest"))
+def test_publish_recomputes_repository_and_source_content_identities(
+    tmp_path, dependency
+):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        mutations = {
+            "repository": (
+                "repositories_are_immutable",
+                "UPDATE repositories SET repository_key = 'owner/tampered' "
+                "WHERE repository_id = ?",
+                repository_id,
+            ),
+            "source": (
+                "source_revisions_are_immutable",
+                "UPDATE source_revisions SET commit_sha = ? "
+                "WHERE source_revision_id = ?",
+                ("b" * 40, source_revision_id),
+            ),
+            "source_digest": (
+                "source_revisions_are_immutable",
+                "UPDATE source_revisions SET identity_digest = ? "
+                "WHERE source_revision_id = ?",
+                ("b" * 64, source_revision_id),
+            ),
+        }
+        trigger, statement, parameters = mutations[dependency]
+        catalog._connection.execute(f"DROP TRIGGER {trigger}")
+        if isinstance(parameters, tuple):
+            catalog._connection.execute(statement, parameters)
+        else:
+            catalog._connection.execute(statement, (parameters,))
+
+        with pytest.raises(
+            CatalogConflictError, match="repository or source revision identity"
+        ):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+
+
+@pytest.mark.parametrize("dependency", ("repository", "source"))
+def test_publish_rejects_raw_replace_of_repository_or_source_identity(
+    tmp_path, dependency
+):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    if dependency == "repository":
+        row = connection.execute(
+            "SELECT namespace_id, created_at FROM repositories "
+            "WHERE repository_id = ?",
+            (repository_id,),
+        ).fetchone()
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO repositories(
+                repository_id, namespace_id, repository_key, created_at
+            ) VALUES (?, ?, 'owner/tampered', ?)
+            """,
+            (repository_id, row[0], row[1]),
+        )
+    else:
+        row = connection.execute(
+            "SELECT * FROM source_revisions WHERE source_revision_id = ?",
+            (source_revision_id,),
+        ).fetchone()
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO source_revisions(
+                source_revision_id, repository_id, source_kind, commit_sha,
+                tree_sha, source_fingerprint, identity_digest, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                row[0],
+                row[1],
+                row[2],
+                "b" * 40,
+                row[4],
+                row[5],
+                row[6],
+                row[7],
+            ),
+        )
+    connection.commit()
+    connection.close()
+
+    with SQLiteCatalog(path) as catalog:
+        with pytest.raises(
+            CatalogConflictError, match="repository or source revision identity"
+        ):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+
+
+def test_raw_connection_cannot_replace_or_delete_referenced_object(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        _, _, _, object_digest, _ = _setup_staged_view(catalog)
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    original = connection.execute(
+        "SELECT digest, storage_key, byte_size, media_type FROM objects"
+    ).fetchone()
+    assert original is not None
+    with pytest.raises(sqlite3.IntegrityError, match="duplicate object insert"):
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO objects(
+                digest, storage_key, byte_size, media_type, created_at
+            ) VALUES (?, 'sha256/changed/object', 99, 'application/evil', 'now')
+            """,
+            (object_digest,),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="duplicate object insert"):
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO objects(
+                digest, storage_key, byte_size, media_type, created_at
+            ) VALUES (?, ?, 99, 'application/evil', 'now')
+            """,
+            ("b" * 64, original[1]),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="referenced objects"):
+        connection.execute("DELETE FROM objects WHERE digest = ?", (object_digest,))
+    connection.rollback()
+    assert (
+        connection.execute(
+            "SELECT digest, storage_key, byte_size, media_type FROM objects"
+        ).fetchone()
+        == original
+    )
+    connection.close()
+
+
+def test_raw_connection_can_delete_unreferenced_object_for_future_gc(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        digest = _object(catalog, "a")
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    connection.execute("DELETE FROM objects WHERE digest = ?", (digest,))
+    connection.commit()
+    assert connection.execute("SELECT COUNT(*) FROM objects").fetchone()[0] == 0
+    connection.close()
+
+
+@pytest.mark.parametrize(
+    "timestamp", ("now", "2026-01-01T00:00:00", "2026-01-01T01:00:00+01:00")
+)
+def test_idempotent_publish_rejects_noncanonical_publication_timestamps(
+    tmp_path, timestamp
+):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+        catalog._connection.execute(
+            "UPDATE refs SET updated_at = ? WHERE repository_id = ?",
+            (timestamp, repository_id),
+        )
+
+        with pytest.raises(CatalogConflictError, match="publication metadata"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+        with pytest.raises(CatalogConflictError, match="publication metadata"):
+            catalog.resolve_ref(repository_id)
+        assert published["changed"] is True
+
+
+def test_publish_rejects_real_ref_generation_without_integer_coercion(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+        catalog._connection.execute(
+            "UPDATE refs SET generation = 1.5 WHERE repository_id = ?",
+            (repository_id,),
+        )
+
+        with pytest.raises(CatalogConflictError, match="publication metadata"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=1,
+            )
+        with pytest.raises(CatalogConflictError, match="publication metadata"):
+            catalog.resolve_ref(repository_id)
+
+
+def test_new_publish_rejects_invalid_staged_readiness_and_rolls_back(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        catalog._connection.execute("PRAGMA ignore_check_constraints = ON")
+        catalog._connection.execute(
+            "UPDATE view_generations SET ready_at = 'now' "
+            "WHERE view_generation_id = ?",
+            (view_id,),
+        )
+
+        with pytest.raises(CatalogConflictError, match="readiness metadata"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+
+        assert (
+            catalog._connection.execute("SELECT COUNT(*) FROM snapshots").fetchone()[0]
+            == 0
+        )
+        assert (
+            catalog._connection.execute(
+                "SELECT status FROM view_generations WHERE view_generation_id = ?",
+                (view_id,),
+            ).fetchone()["status"]
+            == "staged"
+        )
+
+
+@pytest.mark.parametrize("target", ("snapshot", "view"))
+def test_publish_rejects_noncanonical_ready_timestamps_on_all_reuse_paths(
+    tmp_path, target
+):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+        if target == "snapshot":
+            catalog._connection.execute("DROP TRIGGER snapshot_seal_is_the_only_update")
+            catalog._connection.execute(
+                "UPDATE snapshots SET published_at = 'now' WHERE snapshot_id = ?",
+                (published["snapshot_id"],),
+            )
+            message = "seal state conflicts"
+        else:
+            catalog._connection.execute(
+                "DROP TRIGGER ready_view_generations_are_immutable"
+            )
+            catalog._connection.execute(
+                "UPDATE view_generations SET ready_at = 'now' "
+                "WHERE view_generation_id = ?",
+                (view_id,),
+            )
+            message = "ready_at"
+
+        for ref_name in ("main", "stable"):
+            with pytest.raises(CatalogConflictError, match=message):
+                catalog.publish_snapshot(
+                    repository_id,
+                    source_revision_id,
+                    [view_id],
+                    ref_name=ref_name,
+                    expected_generation=0,
+                )
 
 
 @pytest.mark.parametrize(
@@ -575,7 +868,7 @@ def test_idempotent_retry_revalidates_input_dependencies(
             WHERE view_generation_id = ?
             """,
             "view",
-            "membership conflicts",
+            "ready_at",
         ),
     ),
 )

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 
 import pytest
 
@@ -61,6 +63,21 @@ def _stage(
         schema_version="1",
         metadata={"document_count": 4},
     )
+
+
+def _setup_staged_view(catalog: SQLiteCatalog, suffix: str = "a"):
+    repository_id = catalog.create_repository("owner/repo")
+    source_revision_id = _source(catalog, repository_id)
+    profile_id = catalog.create_view_profile("bm25", {})
+    object_digest = _object(catalog, suffix)
+    view_id = _stage(
+        catalog,
+        repository_id,
+        source_revision_id,
+        profile_id,
+        object_digest,
+    )
+    return repository_id, source_revision_id, profile_id, object_digest, view_id
 
 
 def test_initializes_pragmas_default_namespace_and_idempotent_reopen(tmp_path):
@@ -408,8 +425,10 @@ def test_publish_resolves_complete_pinned_manifest(tmp_path):
         direct = catalog.get_manifest_summary(published["snapshot_id"])
 
         assert published["generation"] == 1
+        assert published["changed"] is True
         assert resolved["snapshot_id"] == published["snapshot_id"]
         assert resolved["generation"] == 1
+        assert published["updated_at"] == resolved["updated_at"]
         assert resolved["manifest"] == direct
         assert direct["status"] == "ready"
         assert direct["source"]["source_revision_id"] == source_revision_id
@@ -432,6 +451,286 @@ def test_publish_resolves_complete_pinned_manifest(tmp_path):
             "SELECT DISTINCT status FROM view_generations"
         ).fetchall()
         assert [row["status"] for row in statuses] == ["ready"]
+
+
+def test_publish_retry_for_current_snapshot_is_desired_state_idempotent(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+
+        first = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+        retry_with_current_generation = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=1,
+        )
+        retry_with_original_generation = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+
+        assert first["changed"] is True
+        for retry in (retry_with_current_generation, retry_with_original_generation):
+            assert retry == {
+                "snapshot_id": first["snapshot_id"],
+                "repository_id": repository_id,
+                "ref_name": "main",
+                "generation": 1,
+                "updated_at": first["updated_at"],
+                "changed": False,
+            }
+        assert catalog.resolve_ref(repository_id)["generation"] == 1
+
+
+@pytest.mark.parametrize(
+    ("table", "key_column", "dependency"),
+    (
+        ("repositories", "repository_id", "repository"),
+        ("source_revisions", "source_revision_id", "source"),
+        ("view_profiles", "profile_id", "profile"),
+        ("objects", "digest", "object"),
+    ),
+)
+def test_idempotent_retry_revalidates_input_dependencies(
+    tmp_path, table, key_column, dependency
+):
+    path = tmp_path / f"{dependency}.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        (
+            repository_id,
+            source_revision_id,
+            profile_id,
+            object_digest,
+            view_id,
+        ) = _setup_staged_view(catalog)
+        catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+
+    identifiers = {
+        "repositories": repository_id,
+        "source_revisions": source_revision_id,
+        "view_profiles": profile_id,
+        "objects": object_digest,
+    }
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute(
+        f"DELETE FROM {table} WHERE {key_column} = ?", (identifiers[table],)
+    )
+    connection.commit()
+    connection.close()
+
+    with SQLiteCatalog(path) as catalog:
+        with pytest.raises(CatalogNotFoundError, match="not found"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+
+
+@pytest.mark.parametrize(
+    ("trigger", "corruption", "target", "message"),
+    (
+        (
+            "ready_snapshot_views_cannot_be_deleted",
+            "DELETE FROM snapshot_views WHERE view_generation_id = ?",
+            "view",
+            "membership conflicts",
+        ),
+        (
+            "snapshot_seal_is_the_only_update",
+            """
+            UPDATE snapshots SET status = 'building', published_at = NULL
+            WHERE snapshot_id = ?
+            """,
+            "snapshot",
+            "seal state conflicts",
+        ),
+        (
+            "ready_view_generations_are_immutable",
+            """
+            UPDATE view_generations SET status = 'staged', ready_at = NULL
+            WHERE view_generation_id = ?
+            """,
+            "view",
+            "membership conflicts",
+        ),
+        (
+            "ready_view_generations_are_immutable",
+            """
+            UPDATE view_generations SET ready_at = ''
+            WHERE view_generation_id = ?
+            """,
+            "view",
+            "membership conflicts",
+        ),
+    ),
+)
+def test_idempotent_retry_rejects_corrupt_ready_state(
+    tmp_path, trigger, corruption, target, message
+):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+        catalog._connection.execute(f"DROP TRIGGER {trigger}")
+        target_id = published["snapshot_id"] if target == "snapshot" else view_id
+        catalog._connection.execute(corruption, (target_id,))
+
+        with pytest.raises(CatalogConflictError, match=message):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+
+
+@pytest.mark.parametrize("identity_column", ("profile_id", "object_digest"))
+def test_idempotent_retry_rejects_generation_dependency_mismatch(
+    tmp_path, identity_column
+):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+        replacements = {
+            "profile_id": catalog.create_view_profile(
+                "bm25", {"variant": "tampered"}, name="tampered"
+            ),
+            "object_digest": _object(catalog, "b"),
+        }
+        catalog._connection.execute(
+            "DROP TRIGGER staged_view_generation_identity_is_immutable"
+        )
+        catalog._connection.execute("DROP TRIGGER ready_view_generations_are_immutable")
+        catalog._connection.execute(
+            f"""
+            UPDATE view_generations SET {identity_column} = ?
+            WHERE view_generation_id = ?
+            """,
+            (replacements[identity_column], view_id),
+        )
+
+        with pytest.raises(CatalogConflictError, match="generation identity conflicts"):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+
+
+def test_two_connections_converge_on_the_same_desired_snapshot(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+
+    barrier = Barrier(2)
+
+    def publish():
+        with SQLiteCatalog(path, busy_timeout_ms=5_000) as catalog:
+            barrier.wait()
+            return catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(publish) for _ in range(2)]
+        results = [future.result() for future in futures]
+
+    assert sorted(result["changed"] for result in results) == [False, True]
+    assert {result["generation"] for result in results} == {1}
+    assert {result["snapshot_id"] for result in results} == {results[0]["snapshot_id"]}
+    assert {result["updated_at"] for result in results} == {results[0]["updated_at"]}
+    with SQLiteCatalog(path) as catalog:
+        assert catalog.resolve_ref(repository_id)["generation"] == 1
+
+
+def test_two_connections_keep_cas_for_different_desired_snapshots(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_id, source_revision_id, profile_id, _, first_view = (
+            _setup_staged_view(catalog)
+        )
+        second_view = _stage(
+            catalog,
+            repository_id,
+            source_revision_id,
+            profile_id,
+            _object(catalog, "b"),
+        )
+        views = (first_view, second_view)
+
+    barrier = Barrier(2)
+
+    def publish(view_id):
+        with SQLiteCatalog(path, busy_timeout_ms=5_000) as catalog:
+            barrier.wait()
+            try:
+                result = catalog.publish_snapshot(
+                    repository_id,
+                    source_revision_id,
+                    [view_id],
+                    expected_generation=0,
+                )
+            except CatalogConflictError:
+                return view_id, None
+            return view_id, result
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(publish, view_id) for view_id in views]
+        outcomes = [future.result() for future in futures]
+
+    successes = [
+        (view_id, result) for view_id, result in outcomes if result is not None
+    ]
+    conflicts = [(view_id, result) for view_id, result in outcomes if result is None]
+    assert len(successes) == 1
+    assert len(conflicts) == 1
+    winning_view, published = successes[0]
+    losing_view, _ = conflicts[0]
+    assert published["changed"] is True
+    assert published["generation"] == 1
+
+    with SQLiteCatalog(path) as catalog:
+        resolved = catalog.resolve_ref(repository_id)
+        statuses = {
+            row["view_generation_id"]: row["status"]
+            for row in catalog._connection.execute(
+                """
+                SELECT view_generation_id, status FROM view_generations
+                WHERE view_generation_id IN (?, ?)
+                """,
+                views,
+            ).fetchall()
+        }
+        assert resolved["snapshot_id"] == published["snapshot_id"]
+        assert statuses == {winning_view: "ready", losing_view: "staged"}
 
 
 def test_stale_cas_rolls_back_and_keeps_old_ref(tmp_path):
@@ -528,6 +827,8 @@ def test_ready_generation_can_be_reused_in_a_later_snapshot(tmp_path):
             expected_generation=0,
         )
         assert alias["snapshot_id"] == first["snapshot_id"]
+        assert alias["changed"] is True
+        assert alias["generation"] == 1
         vector = _stage(
             catalog,
             repository_id,

--- a/test/storage/test_sqlite_catalog.py
+++ b/test/storage/test_sqlite_catalog.py
@@ -706,6 +706,422 @@ def test_raw_connection_can_delete_unreferenced_object_for_future_gc(tmp_path):
     connection.close()
 
 
+def test_raw_connection_cannot_replace_or_delete_published_aggregate(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    replacements = (
+        (
+            "duplicate view generation insert",
+            """
+            INSERT OR REPLACE INTO view_generations(
+                view_generation_id, repository_id, source_revision_id,
+                profile_id, view_type, object_digest, schema_version,
+                metadata_json, status, created_at, ready_at
+            ) SELECT
+                view_generation_id, repository_id, source_revision_id,
+                profile_id, view_type, object_digest, schema_version,
+                metadata_json, status, created_at, ready_at
+            FROM view_generations WHERE view_generation_id = ?
+            """,
+            (view_id,),
+        ),
+        (
+            "duplicate snapshot insert",
+            """
+            INSERT OR REPLACE INTO snapshots(
+                snapshot_id, repository_id, source_revision_id,
+                content_digest, status, published_at
+            ) SELECT
+                snapshot_id, repository_id, source_revision_id,
+                content_digest, status, published_at
+            FROM snapshots WHERE snapshot_id = ?
+            """,
+            (published["snapshot_id"],),
+        ),
+        (
+            "duplicate snapshot insert",
+            """
+            INSERT OR REPLACE INTO snapshots(
+                snapshot_id, repository_id, source_revision_id,
+                content_digest, status, published_at
+            ) SELECT
+                'snapshot_replacement', repository_id, source_revision_id,
+                content_digest, status, published_at
+            FROM snapshots WHERE snapshot_id = ?
+            """,
+            (published["snapshot_id"],),
+        ),
+        (
+            "duplicate ref insert",
+            """
+            INSERT OR REPLACE INTO refs(
+                repository_id, ref_name, snapshot_id, generation, updated_at
+            ) SELECT
+                repository_id, ref_name, snapshot_id, generation, updated_at
+            FROM refs WHERE repository_id = ? AND ref_name = 'main'
+            """,
+            (repository_id,),
+        ),
+    )
+    for message, statement, parameters in replacements:
+        with pytest.raises(sqlite3.IntegrityError, match=message):
+            connection.execute(statement, parameters)
+    with pytest.raises(sqlite3.IntegrityError, match="ref identity is immutable"):
+        connection.execute(
+            "UPDATE refs SET ref_name = 'renamed' "
+            "WHERE repository_id = ? AND ref_name = 'main'",
+            (repository_id,),
+        )
+
+    deletions = (
+        (
+            "referenced view generations",
+            "DELETE FROM view_generations WHERE view_generation_id = ?",
+            view_id,
+        ),
+        (
+            "referenced snapshots",
+            "DELETE FROM snapshots WHERE snapshot_id = ?",
+            published["snapshot_id"],
+        ),
+        (
+            "refs cannot be deleted",
+            "DELETE FROM refs WHERE repository_id = ? AND ref_name = 'main'",
+            repository_id,
+        ),
+    )
+    for message, statement, identifier in deletions:
+        with pytest.raises(sqlite3.IntegrityError, match=message):
+            connection.execute(statement, (identifier,))
+    connection.rollback()
+    assert (
+        connection.execute("SELECT COUNT(*) FROM view_generations").fetchone()[0] == 1
+    )
+    assert connection.execute("SELECT COUNT(*) FROM snapshots").fetchone()[0] == 1
+    assert connection.execute("SELECT COUNT(*) FROM refs").fetchone()[0] == 1
+    connection.close()
+
+
+def test_concurrent_stage_calls_converge_without_replace(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_id = catalog.create_repository("owner/repo")
+        source_revision_id = _source(catalog, repository_id)
+        profile_id = catalog.create_view_profile("bm25", {})
+        object_digest = _object(catalog, "a")
+
+    barrier = Barrier(2)
+
+    def stage():
+        with SQLiteCatalog(path) as catalog:
+            barrier.wait()
+            return _stage(
+                catalog,
+                repository_id,
+                source_revision_id,
+                profile_id,
+                object_digest,
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(stage) for _ in range(2)]
+        results = [future.result() for future in futures]
+
+    assert results[0] == results[1]
+    with SQLiteCatalog(path) as catalog:
+        assert (
+            catalog._connection.execute(
+                "SELECT COUNT(*) FROM view_generations"
+            ).fetchone()[0]
+            == 1
+        )
+
+
+def test_ref_database_gates_reject_cross_repository_targets(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_one, source_one, _, _, view_one = _setup_staged_view(catalog, "a")
+        snapshot_one = catalog.publish_snapshot(
+            repository_one,
+            source_one,
+            [view_one],
+            expected_generation=0,
+        )
+        repository_two = catalog.create_repository("owner/two")
+        source_two = _source(catalog, repository_two, "b")
+        profile_two = catalog.create_view_profile("vector", {})
+        view_two = _stage(
+            catalog,
+            repository_two,
+            source_two,
+            profile_two,
+            _object(catalog, "b"),
+            view_type="vector",
+        )
+        catalog.publish_snapshot(
+            repository_two,
+            source_two,
+            [view_two],
+            expected_generation=0,
+        )
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    updated_at = connection.execute(
+        "SELECT updated_at FROM refs WHERE repository_id = ?",
+        (repository_one,),
+    ).fetchone()[0]
+    with pytest.raises(sqlite3.IntegrityError, match="their repository"):
+        connection.execute(
+            """
+            INSERT INTO refs(
+                repository_id, ref_name, snapshot_id, generation, updated_at
+            ) VALUES (?, 'cross', ?, 1, ?)
+            """,
+            (repository_two, snapshot_one["snapshot_id"], updated_at),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="their repository"):
+        connection.execute(
+            "UPDATE refs SET snapshot_id = ? "
+            "WHERE repository_id = ? AND ref_name = 'main'",
+            (snapshot_one["snapshot_id"], repository_two),
+        )
+    connection.rollback()
+    connection.close()
+
+
+def test_resolve_ref_rejects_cross_repository_target_after_trigger_bypass(tmp_path):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_one, source_one, _, _, view_one = _setup_staged_view(catalog, "a")
+        snapshot_one = catalog.publish_snapshot(
+            repository_one,
+            source_one,
+            [view_one],
+            expected_generation=0,
+        )
+        repository_two = catalog.create_repository("owner/two")
+        source_two = _source(catalog, repository_two, "b")
+        profile_two = catalog.create_view_profile("vector", {})
+        view_two = _stage(
+            catalog,
+            repository_two,
+            source_two,
+            profile_two,
+            _object(catalog, "b"),
+            view_type="vector",
+        )
+        catalog.publish_snapshot(
+            repository_two,
+            source_two,
+            [view_two],
+            expected_generation=0,
+        )
+        catalog._connection.execute(
+            "DROP TRIGGER refs_require_ready_snapshot_on_update"
+        )
+        catalog._connection.execute("PRAGMA foreign_keys = OFF")
+        catalog._connection.execute(
+            "UPDATE refs SET snapshot_id = ? "
+            "WHERE repository_id = ? AND ref_name = 'main'",
+            (snapshot_one["snapshot_id"], repository_two),
+        )
+        catalog._connection.execute("PRAGMA foreign_keys = ON")
+
+        with pytest.raises(CatalogConflictError, match="another repository"):
+            catalog.resolve_ref(repository_two)
+
+
+@pytest.mark.parametrize("column", ("commit_sha", "tree_sha"))
+def test_publish_rejects_noncanonical_uppercase_source_fields(tmp_path, column):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    row = connection.execute(
+        "SELECT * FROM source_revisions WHERE source_revision_id = ?",
+        (source_revision_id,),
+    ).fetchone()
+    values = list(row)
+    values[3 if column == "commit_sha" else 4] = values[
+        3 if column == "commit_sha" else 4
+    ].upper()
+    connection.execute(
+        """
+        INSERT OR REPLACE INTO source_revisions(
+            source_revision_id, repository_id, source_kind, commit_sha,
+            tree_sha, source_fingerprint, identity_digest, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        values,
+    )
+    connection.commit()
+    connection.close()
+
+    with SQLiteCatalog(path) as catalog:
+        with pytest.raises(
+            CatalogConflictError, match="repository or source revision identity"
+        ):
+            catalog.publish_snapshot(
+                repository_id,
+                source_revision_id,
+                [view_id],
+                expected_generation=0,
+            )
+        with pytest.raises(
+            CatalogConflictError, match="repository or source revision identity"
+        ):
+            catalog.get_manifest_summary(published["snapshot_id"])
+
+
+@pytest.mark.parametrize("missing", ("profile", "generation", "object", "member"))
+def test_manifest_summary_rejects_missing_membership_dependencies(tmp_path, missing):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_id, source_revision_id, profile_id, object_digest, view_id = (
+            _setup_staged_view(catalog)
+        )
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    operations = {
+        "profile": ("DELETE FROM view_profiles WHERE profile_id = ?", profile_id),
+        "generation": (
+            "DROP TRIGGER referenced_view_generations_cannot_be_deleted",
+            None,
+        ),
+        "object": ("DROP TRIGGER referenced_objects_cannot_be_deleted", None),
+        "member": ("DROP TRIGGER ready_snapshot_views_cannot_be_deleted", None),
+    }
+    statement, identifier = operations[missing]
+    connection.execute(statement, () if identifier is None else (identifier,))
+    if missing == "generation":
+        connection.execute(
+            "DELETE FROM view_generations WHERE view_generation_id = ?", (view_id,)
+        )
+    elif missing == "object":
+        connection.execute("DELETE FROM objects WHERE digest = ?", (object_digest,))
+    elif missing == "member":
+        connection.execute(
+            "DELETE FROM snapshot_views WHERE snapshot_id = ?",
+            (published["snapshot_id"],),
+        )
+    connection.commit()
+    connection.close()
+
+    with SQLiteCatalog(path) as catalog:
+        with pytest.raises(CatalogConflictError, match="membership"):
+            catalog.get_manifest_summary(published["snapshot_id"])
+        with pytest.raises(CatalogConflictError, match="membership"):
+            catalog.resolve_ref(repository_id)
+
+
+@pytest.mark.parametrize("dependency", ("profile", "generation"))
+def test_manifest_summary_recomputes_joined_dependency_identities(tmp_path, dependency):
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        repository_id, source_revision_id, profile_id, _, view_id = _setup_staged_view(
+            catalog
+        )
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    if dependency == "profile":
+        row = connection.execute(
+            "SELECT * FROM view_profiles WHERE profile_id = ?", (profile_id,)
+        ).fetchone()
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO view_profiles(
+                profile_id, view_type, name, config_json,
+                profile_digest, created_at
+            ) VALUES (?, ?, 'tampered', ?, ?, ?)
+            """,
+            (row[0], row[1], row[3], row[4], row[5]),
+        )
+        message = "profile identity"
+    else:
+        connection.execute("DROP TRIGGER view_generations_reject_duplicate_inserts")
+        row = connection.execute(
+            "SELECT * FROM view_generations WHERE view_generation_id = ?", (view_id,)
+        ).fetchone()
+        values = list(row)
+        values[7] = '{"tampered":true}'
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO view_generations(
+                view_generation_id, repository_id, source_revision_id,
+                profile_id, view_type, object_digest, schema_version,
+                metadata_json, status, created_at, ready_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            values,
+        )
+        message = "generation identity"
+    connection.commit()
+    connection.close()
+
+    with SQLiteCatalog(path) as catalog:
+        with pytest.raises(CatalogConflictError, match=message):
+            catalog.get_manifest_summary(published["snapshot_id"])
+
+
+def test_manifest_summary_rejects_membership_and_snapshot_identity_drift(tmp_path):
+    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+        repository_id, source_revision_id, _, _, view_id = _setup_staged_view(catalog)
+        published = catalog.publish_snapshot(
+            repository_id,
+            source_revision_id,
+            [view_id],
+            expected_generation=0,
+        )
+        catalog._connection.execute("DROP TRIGGER snapshot_views_are_immutable")
+        catalog._connection.execute("PRAGMA foreign_keys = OFF")
+        catalog._connection.execute(
+            "UPDATE snapshot_views SET view_type = 'vector' " "WHERE snapshot_id = ?",
+            (published["snapshot_id"],),
+        )
+        catalog._connection.execute("PRAGMA foreign_keys = ON")
+
+        with pytest.raises(CatalogConflictError, match="snapshot content identity"):
+            catalog.get_manifest_summary(published["snapshot_id"])
+
+
 @pytest.mark.parametrize(
     "timestamp", ("now", "2026-01-01T00:00:00", "2026-01-01T01:00:00+01:00")
 )

--- a/test/storage/test_sqlite_jobs.py
+++ b/test/storage/test_sqlite_jobs.py
@@ -260,13 +260,13 @@ def test_forward_migrates_v1_catalog_without_losing_existing_rows(
         sqlite_catalog_module, "LATEST_SCHEMA_VERSION", LATEST_SCHEMA_VERSION
     )
     with SQLiteCatalog(path) as catalog:
-        assert catalog.schema_version == 2
+        assert catalog.schema_version == LATEST_SCHEMA_VERSION
         assert catalog.create_repository("owner/repo") == repository_id
         assert (
             catalog._connection.execute(
                 "SELECT COUNT(*) FROM schema_migrations"
             ).fetchone()[0]
-            == 2
+            == LATEST_SCHEMA_VERSION
         )
         tables = {
             row[0]
@@ -309,6 +309,77 @@ def test_failed_v2_migration_rolls_back_as_one_transaction(
             ).fetchone()[0]
             == 0
         )
+    finally:
+        connection.close()
+
+
+def test_forward_migrates_v2_object_guards_for_existing_rows(
+    tmp_path, monkeypatch
+) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 2)
+    with SQLiteCatalog(path) as catalog:
+        digest = catalog.register_object(
+            "a" * 64,
+            storage_key="sha256/aa/object",
+            byte_size=1,
+        )
+        assert catalog.schema_version == 2
+
+    monkeypatch.setattr(
+        sqlite_catalog_module, "LATEST_SCHEMA_VERSION", LATEST_SCHEMA_VERSION
+    )
+    with SQLiteCatalog(path) as catalog:
+        assert catalog.schema_version == LATEST_SCHEMA_VERSION
+        assert (
+            catalog._connection.execute(
+                "SELECT byte_size FROM objects WHERE digest = ?", (digest,)
+            ).fetchone()["byte_size"]
+            == 1
+        )
+
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("PRAGMA recursive_triggers = OFF")
+    with pytest.raises(sqlite3.IntegrityError, match="duplicate object insert"):
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO objects(
+                digest, storage_key, byte_size, media_type, created_at
+            ) VALUES (?, 'sha256/replaced', 2, 'application/evil', 'now')
+            """,
+            (digest,),
+        )
+    connection.close()
+
+
+def test_failed_v3_migration_rolls_back_object_guards(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 2)
+    with SQLiteCatalog(path):
+        pass
+
+    broken = dict(sqlite_catalog_module._MIGRATIONS)
+    broken[3] = (
+        sqlite_catalog_module._MIGRATIONS[3][0],
+        "THIS IS NOT VALID SQL",
+    )
+    monkeypatch.setattr(sqlite_catalog_module, "_MIGRATIONS", broken)
+    monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 3)
+    with pytest.raises(sqlite3.OperationalError):
+        SQLiteCatalog(path)
+
+    connection = sqlite3.connect(path)
+    try:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert (
+            connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
+            == 2
+        )
+        assert connection.execute("""
+            SELECT COUNT(*) FROM sqlite_master
+            WHERE type = 'trigger' AND name = 'objects_reject_duplicate_inserts'
+            """).fetchone()[0] == 0
     finally:
         connection.close()
 

--- a/test/storage/test_sqlite_jobs.py
+++ b/test/storage/test_sqlite_jobs.py
@@ -337,6 +337,25 @@ def test_forward_migrates_v2_object_guards_for_existing_rows(
             ).fetchone()["byte_size"]
             == 1
         )
+        triggers = {
+            row[0]
+            for row in catalog._connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+            )
+        }
+        assert {
+            "objects_reject_duplicate_inserts",
+            "referenced_objects_cannot_be_deleted",
+            "view_generations_reject_duplicate_inserts",
+            "referenced_view_generations_cannot_be_deleted",
+            "snapshots_reject_duplicate_inserts",
+            "referenced_snapshots_cannot_be_deleted",
+            "refs_reject_duplicate_inserts",
+            "refs_cannot_be_deleted",
+            "ref_identity_is_immutable",
+            "refs_require_ready_snapshot_on_insert",
+            "refs_require_ready_snapshot_on_update",
+        } <= triggers
 
     connection = sqlite3.connect(path)
     connection.execute("PRAGMA foreign_keys = OFF")
@@ -360,10 +379,7 @@ def test_failed_v3_migration_rolls_back_object_guards(tmp_path, monkeypatch) -> 
         pass
 
     broken = dict(sqlite_catalog_module._MIGRATIONS)
-    broken[3] = (
-        sqlite_catalog_module._MIGRATIONS[3][0],
-        "THIS IS NOT VALID SQL",
-    )
+    broken[3] = sqlite_catalog_module._MIGRATIONS[3] + ("THIS IS NOT VALID SQL",)
     monkeypatch.setattr(sqlite_catalog_module, "_MIGRATIONS", broken)
     monkeypatch.setattr(sqlite_catalog_module, "LATEST_SCHEMA_VERSION", 3)
     with pytest.raises(sqlite3.OperationalError):
@@ -376,10 +392,18 @@ def test_failed_v3_migration_rolls_back_object_guards(tmp_path, monkeypatch) -> 
             connection.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()[0]
             == 2
         )
-        assert connection.execute("""
-            SELECT COUNT(*) FROM sqlite_master
-            WHERE type = 'trigger' AND name = 'objects_reject_duplicate_inserts'
-            """).fetchone()[0] == 0
+        triggers = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+            )
+        }
+        assert "objects_reject_duplicate_inserts" not in triggers
+        assert "view_generations_reject_duplicate_inserts" not in triggers
+        assert "snapshots_reject_duplicate_inserts" not in triggers
+        assert "refs_reject_duplicate_inserts" not in triggers
+        assert "refs_require_ready_snapshot_on_insert" in triggers
+        assert "refs_require_ready_snapshot_on_update" in triggers
     finally:
         connection.close()
 


### PR DESCRIPTION
## Summary

Make snapshot publication a desired-state operation: retries that already target the exact validated snapshot return the existing ref generation instead of creating a second publication. This advances the hybrid storage backend work tracked in #199.

Independent final-head review passed after the publication, raw-SQLite, migration, and manifest-integrity gates were replayed.

## Changes

- Compute and validate the intended snapshot before ref CAS, returning `changed: false` for an exact already-published target while preserving CAS conflicts for different desired state.
- Add schema v3 guards against raw SQLite replacement or destructive mutation of objects, generations, snapshots, and refs, including same-repository ready-snapshot ref binding.
- Recompute namespace, repository, source, profile, generation, and snapshot identities; require canonical UTC publication timestamps and positive int64 ref generations.
- Reconcile raw snapshot membership with fully joined generation/profile/object dependencies so missing or drifted rows fail closed.
- Replace generation `INSERT OR IGNORE` with transactionally serialized select-then-insert semantics and cover concurrent convergence.
- Document the strengthened M1 catalog and publication gates in the durable storage roadmap.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pytest test/storage -q -x --tb=short` — 200 passed
- `black --check` and `isort --profile black --check-only` on changed Python files
- `flake8` on changed Python files
- `python scripts/check_namespace.py`
- Python 3.10 compile/import and in-memory schema-v3 migration smoke
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD` matched the current HEAD tree

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
