### PR TITLE
fix(storage): bind atomic directory publication

### DIFF
--- a/codenib/_atomic_directory.py
+++ b/codenib/_atomic_directory.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import stat
 import tempfile
@@ -15,7 +16,14 @@ from typing import Callable
 
 _FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _EXPECTED_DESTINATION_UNSET = object()
+_EXPECTED_OWNERSHIP_UNSET = object()
 _MAX_SAFE_REMOVAL_DEPTH = 256
+_MAX_OWNERSHIP_ENTRIES = 100_000
+_MAX_OWNERSHIP_BYTES = 64 << 30
+_MAX_OWNERSHIP_METADATA_BYTES = 16 << 20
+_MAX_OWNERSHIP_PATH_BYTES = 4_096
+_MAX_OWNERSHIP_COMPONENT_BYTES = 255
+_OWNERSHIP_COPY_BYTES = 1 << 20
 _SAFE_REMOVAL_DIRECTORY_FDS = (
     hasattr(os, "O_DIRECTORY")
     and hasattr(os, "O_NOFOLLOW")
@@ -26,6 +34,14 @@ _SAFE_REMOVAL_DIRECTORY_FDS = (
     and os.unlink in os.supports_dir_fd
     and os.rmdir in os.supports_dir_fd
 )
+_SAFE_OWNERSHIP_DIRECTORY_FDS = (
+    hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and os.open in os.supports_dir_fd
+    and os.stat in os.supports_dir_fd
+    and os.stat in os.supports_follow_symlinks
+    and os.scandir in os.supports_fd
+)
 
 
 @dataclass(slots=True)
@@ -33,11 +49,27 @@ class _RemovalState:
     destructive_started: bool = False
 
 
+@dataclass(slots=True)
+class _OwnershipBudget:
+    entries: int = 0
+    byte_count: int = 0
+    metadata_bytes: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _TreeOwnership:
+    root_identity: tuple[int, ...]
+    digest: str
+    entries: int
+    byte_count: int
+    metadata_bytes: int
+
+
 class _PreviousOutputIdentityLost(RuntimeError):
     """The moved previous tree can no longer be trusted for rollback."""
 
 
-def _lexical_child_of_resolved_parent(path: Path) -> Path:
+def lexical_directory_path(path: Path) -> Path:
     """Resolve the parent without ever following the final path component."""
 
     candidate = path.expanduser()
@@ -130,6 +162,375 @@ def _path_is_mount_point(
     return os.path.ismount(path) or lexical in observed_mount_points
 
 
+def _ownership_binding_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    """Bind path and descriptor observations without cache-sensitive times."""
+
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size if stat.S_ISREG(metadata.st_mode) else 0,
+        getattr(metadata, "st_file_attributes", 0),
+    )
+
+
+def _ownership_version_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    """Detect mutation between observations made through one open descriptor."""
+
+    return (
+        *_ownership_binding_identity(metadata),
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+        metadata.st_nlink,
+    )
+
+
+def _ownership_hash_field(hasher, value: bytes) -> None:
+    hasher.update(len(value).to_bytes(8, "big"))
+    hasher.update(value)
+
+
+def _ownership_relative_path(parts: tuple[bytes, ...]) -> bytes:
+    if len(parts) > _MAX_SAFE_REMOVAL_DEPTH:
+        raise RuntimeError("directory ownership path exceeds its depth limit")
+    relative = b"/".join(parts)
+    if len(relative) > _MAX_OWNERSHIP_PATH_BYTES:
+        raise RuntimeError("directory ownership path exceeds its byte limit")
+    return relative
+
+
+def _reserve_ownership_record(
+    budget: _OwnershipBudget,
+    *,
+    relative: bytes,
+) -> None:
+    budget.entries += 1
+    if budget.entries > _MAX_OWNERSHIP_ENTRIES:
+        raise RuntimeError("directory ownership scan exceeds its entry limit")
+    # Charge the largest record before descending so nested wide directories
+    # cannot accumulate more work than the global budget before unwinding.
+    budget.metadata_bytes += 8 + len(relative) + 1 + 4 + 8 + 32
+    if budget.metadata_bytes > _MAX_OWNERSHIP_METADATA_BYTES:
+        raise RuntimeError("directory ownership scan exceeds its metadata limit")
+
+
+def _hash_owned_regular_file(
+    parent_descriptor: int,
+    name: str,
+    path: Path,
+    metadata: os.stat_result,
+    *,
+    root_device: int,
+    budget: _OwnershipBudget,
+) -> tuple[int, str]:
+    flags = os.O_RDONLY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NONBLOCK", 0)
+    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != root_device
+            or _ownership_binding_identity(opened)
+            != _ownership_binding_identity(metadata)
+        ):
+            raise RuntimeError(f"directory ownership file changed: {path}")
+        size = opened.st_size
+        if size < 0 or budget.byte_count + size > _MAX_OWNERSHIP_BYTES:
+            raise RuntimeError("directory ownership scan exceeds its byte limit")
+        digest = hashlib.sha256()
+        remaining = size
+        while remaining:
+            chunk = os.read(descriptor, min(remaining, _OWNERSHIP_COPY_BYTES))
+            if not chunk:
+                raise RuntimeError(f"directory ownership file was truncated: {path}")
+            digest.update(chunk)
+            remaining -= len(chunk)
+        if os.read(descriptor, 1):
+            raise RuntimeError(f"directory ownership file grew while read: {path}")
+        after = os.fstat(descriptor)
+        if _ownership_version_identity(after) != _ownership_version_identity(opened):
+            raise RuntimeError(f"directory ownership file changed: {path}")
+        path_after = os.stat(
+            name,
+            dir_fd=parent_descriptor,
+            follow_symlinks=False,
+        )
+        if _ownership_binding_identity(path_after) != _ownership_binding_identity(
+            opened
+        ):
+            raise RuntimeError(f"directory ownership file changed: {path}")
+    finally:
+        os.close(descriptor)
+    budget.byte_count += size
+    return size, digest.hexdigest()
+
+
+def _scan_owned_directory(
+    descriptor: int,
+    path: Path,
+    parts: tuple[bytes, ...],
+    *,
+    root_device: int,
+    mount_points: frozenset[str],
+    budget: _OwnershipBudget,
+    depth: int,
+    required_root_file: bytes | None = None,
+    allow_empty_root: bool = False,
+) -> bytes:
+    if depth > _MAX_SAFE_REMOVAL_DEPTH:
+        raise RuntimeError("directory ownership scan exceeds its depth limit")
+    before = os.fstat(descriptor)
+    if not stat.S_ISDIR(before.st_mode) or before.st_dev != root_device:
+        raise RuntimeError(f"directory ownership root changed: {path}")
+
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    scan_descriptor = os.open(".", flags, dir_fd=descriptor)
+    names: list[tuple[bytes, str]] = []
+    try:
+        with os.scandir(scan_descriptor) as entries:
+            for entry in entries:
+                raw_name = os.fsencode(entry.name)
+                if not raw_name or len(raw_name) > _MAX_OWNERSHIP_COMPONENT_BYTES:
+                    raise RuntimeError(
+                        "directory ownership component exceeds its byte limit"
+                    )
+                relative = _ownership_relative_path(parts + (raw_name,))
+                _reserve_ownership_record(budget, relative=relative)
+                names.append((raw_name, entry.name))
+    finally:
+        os.close(scan_descriptor)
+    names.sort(key=lambda item: item[0])
+    if (
+        required_root_file is not None
+        and not (allow_empty_root and not names)
+        and not any(raw_name == required_root_file for raw_name, _name in names)
+    ):
+        raise RuntimeError("directory ownership root is missing its required marker")
+
+    hasher = hashlib.sha256()
+    hasher.update(b"codenib.atomic-directory.v1\x00")
+    hasher.update(stat.S_IMODE(before.st_mode).to_bytes(4, "big"))
+    for raw_name, name in names:
+        child_parts = parts + (raw_name,)
+        relative = _ownership_relative_path(child_parts)
+        child_path = path / name
+        metadata = os.stat(
+            name,
+            dir_fd=descriptor,
+            follow_symlinks=False,
+        )
+        if metadata.st_dev != root_device or _path_is_mount_point(
+            child_path,
+            mount_points=mount_points,
+        ):
+            raise RuntimeError(
+                f"directory ownership scan refuses mounted content: {child_path}"
+            )
+        if _is_link_or_reparse(metadata):
+            raise RuntimeError(
+                f"directory ownership scan refuses linked content: {child_path}"
+            )
+
+        entry_hasher = hashlib.sha256()
+        if stat.S_ISDIR(metadata.st_mode):
+            child_descriptor = os.open(name, flags, dir_fd=descriptor)
+            try:
+                opened = os.fstat(child_descriptor)
+                if _ownership_binding_identity(opened) != _ownership_binding_identity(
+                    metadata
+                ):
+                    raise RuntimeError(
+                        f"directory ownership directory changed: {child_path}"
+                    )
+                child_digest = _scan_owned_directory(
+                    child_descriptor,
+                    child_path,
+                    child_parts,
+                    root_device=root_device,
+                    mount_points=mount_points,
+                    budget=budget,
+                    depth=depth + 1,
+                )
+                after = os.fstat(child_descriptor)
+                if _ownership_version_identity(after) != _ownership_version_identity(
+                    opened
+                ):
+                    raise RuntimeError(
+                        f"directory ownership directory changed: {child_path}"
+                    )
+            finally:
+                os.close(child_descriptor)
+            path_after = os.stat(
+                name,
+                dir_fd=descriptor,
+                follow_symlinks=False,
+            )
+            if _ownership_binding_identity(path_after) != _ownership_binding_identity(
+                metadata
+            ):
+                raise RuntimeError(
+                    f"directory ownership directory changed: {child_path}"
+                )
+            entry_hasher.update(b"D")
+            _ownership_hash_field(entry_hasher, relative)
+            entry_hasher.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
+            entry_hasher.update(child_digest)
+        elif stat.S_ISREG(metadata.st_mode):
+            size, digest = _hash_owned_regular_file(
+                descriptor,
+                name,
+                child_path,
+                metadata,
+                root_device=root_device,
+                budget=budget,
+            )
+            digest_bytes = bytes.fromhex(digest)
+            entry_hasher.update(b"F")
+            _ownership_hash_field(entry_hasher, relative)
+            entry_hasher.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
+            entry_hasher.update(size.to_bytes(8, "big"))
+            entry_hasher.update(digest_bytes)
+        else:
+            raise RuntimeError(
+                f"directory ownership scan refuses special content: {child_path}"
+            )
+        if raw_name == required_root_file and not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError("directory ownership root marker is not a regular file")
+        hasher.update(entry_hasher.digest())
+
+    after = os.fstat(descriptor)
+    if _ownership_version_identity(after) != _ownership_version_identity(before):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    return hasher.digest()
+
+
+def capture_directory_ownership(
+    path: Path,
+    *,
+    required_root_file: str | None = None,
+    allow_empty_root: bool = False,
+) -> _TreeOwnership:
+    """Return a bounded content token for one stable, real directory tree."""
+
+    required_root_file_bytes: bytes | None = None
+    if required_root_file is not None:
+        if (
+            not required_root_file
+            or required_root_file in {".", ".."}
+            or "/" in required_root_file
+            or "\\" in required_root_file
+        ):
+            raise ValueError("directory ownership marker must be one file name")
+        required_root_file_bytes = os.fsencode(required_root_file)
+        if len(required_root_file_bytes) > _MAX_OWNERSHIP_COMPONENT_BYTES:
+            raise ValueError("directory ownership marker exceeds its byte limit")
+
+    metadata = _directory_or_missing(path, label="directory ownership root")
+    if metadata is None:
+        raise RuntimeError(f"directory ownership root disappeared: {path}")
+    if _path_is_mount_point(path):
+        raise RuntimeError(f"directory ownership root is mounted: {path}")
+    if not _SAFE_OWNERSHIP_DIRECTORY_FDS:
+        # A path-only fallback cannot safely traverse a non-empty tree.  It can
+        # still bind the empty sentinel used for a first publication: a raced
+        # entry is checked again after the sentinel is moved and cleanup uses
+        # rmdir rather than recursive deletion on the same platforms.
+        with os.scandir(path) as entries:
+            if next(iter(entries), None) is not None:
+                raise RuntimeError(
+                    "safe directory ownership requires no-follow directory-fd "
+                    "support for non-empty trees"
+                )
+        after = _directory_or_missing(path, label="directory ownership root")
+        if after is None or _ownership_binding_identity(
+            after
+        ) != _ownership_binding_identity(metadata):
+            raise RuntimeError(f"directory ownership root changed: {path}")
+        digest = hashlib.sha256()
+        digest.update(b"codenib.atomic-directory.v1\x00")
+        digest.update(stat.S_IMODE(metadata.st_mode).to_bytes(4, "big"))
+        return _TreeOwnership(
+            root_identity=_directory_inode_identity(metadata),
+            digest=digest.hexdigest(),
+            entries=0,
+            byte_count=0,
+            metadata_bytes=0,
+        )
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        if _ownership_binding_identity(opened) != _ownership_binding_identity(metadata):
+            raise RuntimeError(f"directory ownership root changed: {path}")
+        budget = _OwnershipBudget()
+        digest = _scan_owned_directory(
+            descriptor,
+            path,
+            (),
+            root_device=opened.st_dev,
+            mount_points=_linux_mount_points(),
+            budget=budget,
+            depth=0,
+            required_root_file=required_root_file_bytes,
+            allow_empty_root=allow_empty_root,
+        )
+        after = os.fstat(descriptor)
+        if _ownership_version_identity(after) != _ownership_version_identity(opened):
+            raise RuntimeError(f"directory ownership root changed: {path}")
+    finally:
+        os.close(descriptor)
+    path_after = _directory_or_missing(path, label="directory ownership root")
+    if path_after is None or _ownership_binding_identity(
+        path_after
+    ) != _ownership_binding_identity(metadata):
+        raise RuntimeError(f"directory ownership root changed: {path}")
+    return _TreeOwnership(
+        root_identity=_directory_inode_identity(opened),
+        digest=digest.hex(),
+        entries=budget.entries,
+        byte_count=budget.byte_count,
+        metadata_bytes=budget.metadata_bytes,
+    )
+
+
+def _require_tree_ownership(
+    path: Path,
+    expected: _TreeOwnership,
+    *,
+    label: str,
+) -> None:
+    try:
+        observed = capture_directory_ownership(path)
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise RuntimeError(f"{label} changed during directory publication") from exc
+    if observed != expected:
+        raise RuntimeError(f"{label} changed during directory publication")
+
+
+def discard_owned_directory(path: Path, ownership: _TreeOwnership) -> None:
+    """Best-effort cleanup that never follows a substituted root path."""
+
+    try:
+        metadata = _directory_or_missing(path, label="owned temporary directory")
+    except (OSError, ValueError):
+        return
+    if (
+        metadata is None
+        or _directory_inode_identity(metadata) != ownership.root_identity
+    ):
+        return
+    try:
+        _remove_owned_directory(path, ownership.root_identity)
+    except (OSError, RuntimeError, ValueError):
+        # Temporary cleanup must not reacquire or remove a replacement path.
+        # A partially removed owned tree is left for explicit orphan GC.
+        return
+
+
 def _require_safe_tree(
     path: Path,
     *,
@@ -203,7 +604,7 @@ def _remove_tree_at(
     descriptor = os.open(name, flags, dir_fd=parent_descriptor)
     try:
         opened = os.fstat(descriptor)
-        if _directory_identity(opened) != _directory_identity(metadata):
+        if _directory_inode_identity(opened) != _directory_inode_identity(metadata):
             raise RuntimeError(f"directory cleanup target changed: {path}")
         if opened.st_dev != root_device or _path_is_mount_point(
             path,
@@ -283,7 +684,7 @@ def _remove_owned_directory(
     if removal_state is None:
         removal_state = _RemovalState()
     metadata = _directory_or_missing(path, label="directory cleanup target")
-    if metadata is None or _directory_identity(metadata) != expected_identity:
+    if metadata is None or _directory_inode_identity(metadata) != expected_identity:
         raise RuntimeError(f"directory cleanup target changed: {path}")
     root_device = metadata.st_dev
     if not _SAFE_REMOVAL_DIRECTORY_FDS:
@@ -298,7 +699,7 @@ def _remove_owned_directory(
         )
         if (
             final_metadata is None
-            or _directory_identity(final_metadata) != expected_identity
+            or _directory_inode_identity(final_metadata) != expected_identity
         ):
             raise RuntimeError(f"directory cleanup target changed: {path}")
         removal_state.destructive_started = True
@@ -379,7 +780,7 @@ def _recover_invalid_publication(
             raise _PreviousOutputIdentityLost(message) from exc
         if (
             backup_metadata is None
-            or _directory_identity(backup_metadata) != expected_backup_identity
+            or _directory_inode_identity(backup_metadata) != expected_backup_identity
         ):
             raise _PreviousOutputIdentityLost(message)
 
@@ -439,6 +840,11 @@ def publish_staged_directory(
         _EXPECTED_DESTINATION_UNSET
     ),
     expected_stage_identity: tuple[int, ...] | None = None,
+    expected_stage_root_ownership: _TreeOwnership | None = None,
+    expected_destination_ownership: _TreeOwnership | None | object = (
+        _EXPECTED_OWNERSHIP_UNSET
+    ),
+    validate_staged_directory: Callable[[Path], None] | None = None,
     validate_moved_destination: Callable[[Path], None] | None = None,
     validate_published_destination: Callable[[Path], None] | None = None,
 ) -> None:
@@ -449,21 +855,26 @@ def publish_staged_directory(
     destination is restored and *stage* remains available to caller cleanup.
 
     The destination-to-backup rename is the old tree's ownership linearization
-    point. ``validate_moved_destination`` runs against that exact moved tree
-    both before and after stage publication. ``validate_published_destination``
-    binds the new tree's complete ownership token before cleanup. All cleanup
-    preflight runs before deletion. An untrusted published tree is quarantined
-    before the previous root is considered for restoration. During cleanup,
-    the already-verified new tree stays active if the moved old root loses its
-    captured identity. Once destructive cleanup starts, publication is also
-    committed and failures preserve whatever remains at the backup path.
+    point. Callers that observed the destination before building a stage must
+    pass that opaque ``expected_destination_ownership`` token; the helper
+    rejects any completed pre-linearization change. ``validate_staged_directory``
+    reruns the caller's artifact-specific verifier inside the publication
+    boundary. ``validate_moved_destination`` runs against the exact moved old
+    tree both before and after stage publication, while
+    ``validate_published_destination`` verifies the new tree before cleanup.
+    All cleanup preflight runs before deletion. An untrusted published tree is
+    quarantined before the previous root is considered for restoration. During
+    cleanup, the already-verified new tree stays active if the moved old root
+    loses its captured identity. Once destructive cleanup starts, publication
+    is also committed and failures preserve whatever remains at the backup
+    path.
     """
 
     # Only parents are resolved.  Resolving the final destination component
     # would turn ``destination -> victim`` into ``victim`` and let a raced
     # symlink redirect the replacement into an unrelated directory.
-    stage = _lexical_child_of_resolved_parent(stage)
-    destination = _lexical_child_of_resolved_parent(destination)
+    stage = lexical_directory_path(stage)
+    destination = lexical_directory_path(destination)
     if stage == destination:
         raise ValueError("staged and destination directories must differ")
     if stage.parent != destination.parent:
@@ -477,11 +888,37 @@ def publish_staged_directory(
         and observed_stage_identity != expected_stage_identity
     ):
         raise RuntimeError("staged directory changed before directory publication")
-    required_stage_identity = expected_stage_identity or observed_stage_identity
+    required_stage_inode_identity = _directory_inode_identity(stage_metadata)
+    if (
+        expected_stage_root_ownership is not None
+        and required_stage_inode_identity != expected_stage_root_ownership.root_identity
+    ):
+        raise RuntimeError("staged directory root changed before publication")
+    expected_stage_ownership = None
+    if validate_staged_directory is not None:
+        if _SAFE_OWNERSHIP_DIRECTORY_FDS:
+            expected_stage_ownership = capture_directory_ownership(stage)
+        validate_staged_directory(stage)
+        if expected_stage_ownership is not None:
+            _require_tree_ownership(
+                stage,
+                expected_stage_ownership,
+                label="staged directory",
+            )
+    elif validate_published_destination is None:
+        expected_stage_ownership = capture_directory_ownership(stage)
     destination_metadata = _directory_or_missing(
         destination,
         label="destination",
     )
+    if expected_destination_ownership is not _EXPECTED_OWNERSHIP_UNSET:
+        observed_ownership = (
+            None
+            if destination_metadata is None
+            else capture_directory_ownership(destination)
+        )
+        if observed_ownership != expected_destination_ownership:
+            raise RuntimeError("destination changed before directory publication")
     if expected_destination_identity is not _EXPECTED_DESTINATION_UNSET:
         observed_identity = (
             None
@@ -506,6 +943,25 @@ def publish_staged_directory(
 
     if destination_metadata is None:
         raise RuntimeError("destination sentinel disappeared during publication")
+    required_destination_inode_identity = _directory_inode_identity(
+        destination_metadata
+    )
+    try:
+        if destination_was_missing:
+            moved_destination_ownership = capture_directory_ownership(destination)
+        elif expected_destination_ownership is not _EXPECTED_OWNERSHIP_UNSET:
+            moved_destination_ownership = expected_destination_ownership
+        elif validate_moved_destination is None:
+            moved_destination_ownership = capture_directory_ownership(destination)
+        else:
+            moved_destination_ownership = None
+    except BaseException:
+        if destination_was_missing:
+            try:
+                destination.rmdir()
+            except OSError:
+                pass
+        raise
     try:
         backup = Path(
             tempfile.mkdtemp(
@@ -519,6 +975,26 @@ def publish_staged_directory(
             destination.rmdir()
         raise
 
+    if expected_stage_ownership is not None:
+        try:
+            _require_tree_ownership(
+                stage,
+                expected_stage_ownership,
+                label="staged directory",
+            )
+        except Exception as exc:
+            if destination_was_missing:
+                destination.rmdir()
+            raise RuntimeError(
+                "staged directory changed before destination publication"
+            ) from exc
+        except BaseException:
+            if destination_was_missing:
+                try:
+                    destination.rmdir()
+                except OSError:
+                    pass
+            raise
     try:
         stage_before_destination_rename = _directory_or_missing(
             stage,
@@ -532,8 +1008,8 @@ def publish_staged_directory(
         ) from exc
     if (
         stage_before_destination_rename is None
-        or _directory_identity(stage_before_destination_rename)
-        != required_stage_identity
+        or _directory_inode_identity(stage_before_destination_rename)
+        != required_stage_inode_identity
     ):
         if destination_was_missing:
             destination.rmdir()
@@ -542,8 +1018,50 @@ def publish_staged_directory(
     try:
         os.replace(destination, backup)
     except BaseException:
-        if destination_was_missing:
-            destination.rmdir()
+        try:
+            backup_after_error = _directory_or_missing(
+                backup,
+                label="moved destination after interrupted rename",
+            )
+            destination_after_error = _directory_or_missing(
+                destination,
+                label="destination after interrupted rename",
+            )
+        except (OSError, ValueError) as inspection_error:
+            raise RuntimeError(
+                "destination rename was interrupted and its publication state "
+                f"could not be inspected; the previous output may remain at {backup}"
+            ) from inspection_error
+        rename_completed = (
+            backup_after_error is not None
+            and _directory_inode_identity(backup_after_error)
+            == required_destination_inode_identity
+            and destination_after_error is None
+        )
+        if rename_completed:
+            try:
+                _restore_previous_directory(
+                    backup,
+                    destination,
+                    destination_was_missing=destination_was_missing,
+                )
+            except OSError as restore_error:
+                raise RuntimeError(
+                    "destination rename was interrupted after completion and the "
+                    f"previous output could not be restored; inspect {backup} and "
+                    f"{destination}"
+                ) from restore_error
+        elif destination_was_missing and (
+            destination_after_error is not None
+            and _directory_inode_identity(destination_after_error)
+            == required_destination_inode_identity
+        ):
+            try:
+                destination.rmdir()
+            except OSError:
+                # Preserve raced content at a destination that was initially
+                # absent; it must never be recursively cleaned here.
+                pass
         raise
     try:
         moved_metadata = _directory_or_missing(
@@ -551,17 +1069,76 @@ def publish_staged_directory(
             label="moved destination",
         )
     except (OSError, ValueError) as exc:
-        os.replace(backup, destination)
+        try:
+            _restore_previous_directory(
+                backup,
+                destination,
+                destination_was_missing=destination_was_missing,
+            )
+        except OSError as restore_error:
+            raise RuntimeError(
+                "destination changed at the publication boundary and the previous "
+                f"output could not be restored; it remains at {backup}"
+            ) from restore_error
         raise RuntimeError("destination changed at the publication boundary") from exc
+    except BaseException:
+        try:
+            _restore_previous_directory(
+                backup,
+                destination,
+                destination_was_missing=destination_was_missing,
+            )
+        except OSError as restore_error:
+            raise RuntimeError(
+                "destination boundary inspection was interrupted and the previous "
+                f"output could not be restored; it remains at {backup}"
+            ) from restore_error
+        raise
     if moved_metadata is None:
         raise RuntimeError("destination disappeared at the publication boundary")
-    if _directory_identity(moved_metadata) != _directory_identity(destination_metadata):
+    if _directory_inode_identity(moved_metadata) != required_destination_inode_identity:
         _restore_previous_directory(
             backup,
             destination,
             destination_was_missing=destination_was_missing,
         )
         raise RuntimeError("destination changed at the publication boundary")
+
+    if moved_destination_ownership is not None:
+        try:
+            _require_tree_ownership(
+                backup,
+                moved_destination_ownership,
+                label="moved destination",
+            )
+        except Exception as ownership_error:
+            try:
+                _restore_previous_directory(
+                    backup,
+                    destination,
+                    destination_was_missing=destination_was_missing,
+                )
+            except OSError as restore_error:
+                raise RuntimeError(
+                    "destination changed at the publication boundary; raced "
+                    f"content remains at {destination}"
+                ) from restore_error
+            raise RuntimeError(
+                "destination changed at the publication boundary"
+            ) from ownership_error
+        except BaseException:
+            try:
+                _restore_previous_directory(
+                    backup,
+                    destination,
+                    destination_was_missing=destination_was_missing,
+                )
+            except OSError as restore_error:
+                raise RuntimeError(
+                    "destination ownership scan was interrupted and the previous "
+                    f"output could not be restored; it remains at {backup}"
+                ) from restore_error
+            raise
 
     if validate_moved_destination is not None and not destination_was_missing:
         try:
@@ -580,6 +1157,20 @@ def publish_staged_directory(
                 ) from restore_error
             raise
 
+    if expected_stage_ownership is not None:
+        try:
+            _require_tree_ownership(
+                stage,
+                expected_stage_ownership,
+                label="staged directory",
+            )
+        except BaseException:
+            _restore_previous_directory(
+                backup,
+                destination,
+                destination_was_missing=destination_was_missing,
+            )
+            raise
     try:
         stage_before_publish = _directory_or_missing(
             stage,
@@ -592,9 +1183,23 @@ def publish_staged_directory(
             destination_was_missing=destination_was_missing,
         )
         raise RuntimeError("staged directory changed before final publication") from exc
+    except BaseException:
+        try:
+            _restore_previous_directory(
+                backup,
+                destination,
+                destination_was_missing=destination_was_missing,
+            )
+        except OSError as restore_error:
+            raise RuntimeError(
+                "staged directory inspection was interrupted and the previous "
+                f"output could not be restored; it remains at {backup}"
+            ) from restore_error
+        raise
     if (
         stage_before_publish is None
-        or _directory_identity(stage_before_publish) != required_stage_identity
+        or _directory_inode_identity(stage_before_publish)
+        != required_stage_inode_identity
     ):
         _restore_previous_directory(
             backup,
@@ -626,16 +1231,31 @@ def publish_staged_directory(
         )
         if published_metadata is None:
             raise RuntimeError("staged directory disappeared during publication")
-        if _directory_identity(published_metadata) != required_stage_identity:
+        if (
+            _directory_inode_identity(published_metadata)
+            != required_stage_inode_identity
+        ):
             raise RuntimeError("staged directory changed at the publication boundary")
+        if expected_stage_ownership is not None:
+            _require_tree_ownership(
+                destination,
+                expected_stage_ownership,
+                label="published staged directory",
+            )
         if validate_published_destination is not None:
             validate_published_destination(destination)
+        if expected_stage_ownership is not None:
+            _require_tree_ownership(
+                destination,
+                expected_stage_ownership,
+                label="published staged directory",
+            )
     except Exception as boundary_error:
         quarantine = _recover_invalid_publication(
             backup,
             destination,
             destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_identity(moved_metadata),
+            expected_backup_identity=_directory_inode_identity(moved_metadata),
             published_output_trusted=False,
         )
         quarantine_message = (
@@ -650,10 +1270,37 @@ def publish_staged_directory(
             backup,
             destination,
             destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_identity(moved_metadata),
+            expected_backup_identity=_directory_inode_identity(moved_metadata),
             published_output_trusted=False,
         )
         raise
+    if moved_destination_ownership is not None:
+        try:
+            _require_tree_ownership(
+                backup,
+                moved_destination_ownership,
+                label="previous destination",
+            )
+        except Exception as cleanup_error:
+            try:
+                quarantine = _recover_invalid_publication(
+                    backup,
+                    destination,
+                    destination_was_missing=destination_was_missing,
+                    expected_backup_identity=_directory_inode_identity(moved_metadata),
+                    published_output_trusted=True,
+                )
+            except _PreviousOutputIdentityLost as recovery_error:
+                raise recovery_error from cleanup_error
+            quarantine_message = (
+                f" at {quarantine}"
+                if quarantine is not None
+                else " because it vanished"
+            )
+            raise RuntimeError(
+                "previous destination failed safe cleanup validation; newly "
+                f"published output was quarantined{quarantine_message}"
+            ) from cleanup_error
     if validate_moved_destination is not None and not destination_was_missing:
         try:
             validate_moved_destination(backup)
@@ -663,7 +1310,7 @@ def publish_staged_directory(
                     backup,
                     destination,
                     destination_was_missing=destination_was_missing,
-                    expected_backup_identity=_directory_identity(moved_metadata),
+                    expected_backup_identity=_directory_inode_identity(moved_metadata),
                     published_output_trusted=True,
                 )
             except _PreviousOutputIdentityLost as recovery_error:
@@ -682,7 +1329,7 @@ def publish_staged_directory(
     try:
         _remove_owned_directory(
             backup,
-            _directory_identity(moved_metadata),
+            _directory_inode_identity(moved_metadata),
             removal_state=removal_state,
         )
     except Exception as cleanup_error:
@@ -695,7 +1342,7 @@ def publish_staged_directory(
             backup,
             destination,
             destination_was_missing=destination_was_missing,
-            expected_backup_identity=_directory_identity(moved_metadata),
+            expected_backup_identity=_directory_inode_identity(moved_metadata),
             published_output_trusted=True,
         )
         quarantine_message = (
@@ -707,4 +1354,9 @@ def publish_staged_directory(
         ) from cleanup_error
 
 
-__all__ = ["publish_staged_directory"]
+__all__ = [
+    "capture_directory_ownership",
+    "discard_owned_directory",
+    "lexical_directory_path",
+    "publish_staged_directory",
+]

--- a/codenib/artifacts/archive.py
+++ b/codenib/artifacts/archive.py
@@ -6,13 +6,17 @@
 
 from __future__ import annotations
 
-import shutil
 import stat
 import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
 
-from .._atomic_directory import publish_staged_directory
+from .._atomic_directory import (
+    capture_directory_ownership,
+    discard_owned_directory,
+    lexical_directory_path,
+    publish_staged_directory,
+)
 from .context import CONTEXT_ARTIFACT_MANIFEST
 from .runtime import VerifiedContextArtifact, verify_context_artifact
 
@@ -150,28 +154,39 @@ def extract_context_artifact_archive(
     archive_path = archive_candidate.resolve()
     if not archive_path.is_file():
         raise ValueError(f"context artifact archive does not exist: {archive_path}")
-    output_candidate = Path(output_dir).expanduser()
-    if output_candidate.is_symlink():
+    output = lexical_directory_path(Path(output_dir))
+    if output.is_symlink():
         raise ValueError(
-            f"context artifact output must not be a symbolic link: {output_candidate}"
+            f"context artifact output must not be a symbolic link: {output}"
         )
-    output = output_candidate.resolve()
     if output.exists() and not output.is_dir():
         raise ValueError(f"context artifact output is not a directory: {output}")
-    if output.exists() and any(output.iterdir()):
-        if not (output / CONTEXT_ARTIFACT_MANIFEST).is_file():
-            raise ValueError(
-                "refusing to replace a non-empty directory that is not a "
-                f"CodeNib context artifact: {output}"
+    try:
+        expected_output_ownership = (
+            capture_directory_ownership(
+                output,
+                required_root_file=CONTEXT_ARTIFACT_MANIFEST,
+                allow_empty_root=True,
             )
+            if output.exists()
+            else None
+        )
+    except RuntimeError as exc:
+        raise ValueError(
+            "refusing to replace a non-empty directory that is not a "
+            f"CodeNib context artifact: {output}"
+        ) from exc
 
     output.parent.mkdir(parents=True, exist_ok=True)
-    stage = Path(
-        tempfile.mkdtemp(
-            prefix=f".{output.name}.extract-",
-            dir=str(output.parent),
+    stage = lexical_directory_path(
+        Path(
+            tempfile.mkdtemp(
+                prefix=f".{output.name}.extract-",
+                dir=str(output.parent),
+            )
         )
-    ).resolve()
+    )
+    stage_root_ownership = capture_directory_ownership(stage)
     try:
         with zipfile.ZipFile(archive_path) as archive:
             members = _validated_members(
@@ -181,21 +196,32 @@ def extract_context_artifact_archive(
             )
             for info, relative in members:
                 _extract_member(archive, info, relative, stage)
-        verify_context_artifact(
+
+        def validate_artifact(candidate: Path) -> None:
+            verify_context_artifact(
+                candidate,
+                expected_repository=expected_repository,
+                expected_commit=expected_commit,
+                max_files=max_files,
+                max_bytes=max_bytes,
+            )
+
+        validate_artifact(stage)
+        publish_staged_directory(
             stage,
-            expected_repository=expected_repository,
-            expected_commit=expected_commit,
-            max_files=max_files,
-            max_bytes=max_bytes,
+            output,
+            expected_stage_root_ownership=stage_root_ownership,
+            expected_destination_ownership=expected_output_ownership,
+            validate_staged_directory=validate_artifact,
+            validate_published_destination=validate_artifact,
         )
-        publish_staged_directory(stage, output)
     except zipfile.BadZipFile as exc:
-        shutil.rmtree(stage, ignore_errors=True)
+        discard_owned_directory(stage, stage_root_ownership)
         raise ValueError(
             f"context artifact archive is not a valid ZIP: {archive_path}"
         ) from exc
     except BaseException:
-        shutil.rmtree(stage, ignore_errors=True)
+        discard_owned_directory(stage, stage_root_ownership)
         raise
 
     return verify_context_artifact(

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -17,7 +17,12 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping, Sequence
 
 from .. import compat_pickle
-from .._atomic_directory import publish_staged_directory
+from .._atomic_directory import (
+    capture_directory_ownership,
+    discard_owned_directory,
+    lexical_directory_path,
+    publish_staged_directory,
+)
 from .._version import package_version
 from ..compiler.artifact_fingerprints import (
     bm25_artifact_file_fingerprints,
@@ -96,8 +101,16 @@ def _repository_slug(repo_path: Path, explicit: str | None) -> str:
     return normalize_repo(origin or repo_path.name)
 
 
-def _validated_output(repo_path: Path, manifest_root: Path, output_dir: Path) -> Path:
-    output = output_dir.expanduser().resolve()
+def _validated_output(
+    repo_path: Path,
+    manifest_root: Path,
+    output_dir: Path,
+) -> tuple[Path, object | None]:
+    output = lexical_directory_path(output_dir)
+    if output.is_symlink():
+        raise ValueError(
+            f"context artifact output must not be a symbolic link: {output}"
+        )
     for source, label in (
         (repo_path.resolve(), "repository"),
         (manifest_root.resolve(), "index root"),
@@ -106,13 +119,22 @@ def _validated_output(repo_path: Path, manifest_root: Path, output_dir: Path) ->
             raise ValueError(f"context artifact output overlaps the {label}: {output}")
     if output.exists() and not output.is_dir():
         raise ValueError(f"context artifact output is not a directory: {output}")
-    if output.exists() and any(output.iterdir()):
-        if not (output / CONTEXT_ARTIFACT_MANIFEST).is_file():
-            raise ValueError(
-                "refusing to replace a non-empty directory that is not a CodeNib "
-                f"context artifact: {output}"
+    try:
+        expected_ownership = (
+            capture_directory_ownership(
+                output,
+                required_root_file=CONTEXT_ARTIFACT_MANIFEST,
+                allow_empty_root=True,
             )
-    return output
+            if output.exists()
+            else None
+        )
+    except RuntimeError as exc:
+        raise ValueError(
+            "refusing to replace a non-empty directory that is not a CodeNib "
+            f"context artifact: {output}"
+        ) from exc
+    return output, expected_ownership
 
 
 def _view_source(entry_path: str, manifest_root: Path, *, view: str) -> Path:
@@ -402,7 +424,11 @@ def stage_context_artifact(
     if not manifest_path.is_file():
         raise ValueError(f"repository manifest does not exist: {manifest_path}")
     manifest_root = manifest_path.parent
-    output_dir = _validated_output(repo_path, manifest_root, output_dir)
+    output_dir, expected_output_ownership = _validated_output(
+        repo_path,
+        manifest_root,
+        output_dir,
+    )
     environment = os.environ if environ is None else environ
     manifest = RepoManifest.load(manifest_path)
     if validate_checkout:
@@ -421,12 +447,15 @@ def stage_context_artifact(
     slug = _repository_slug(repo_path, repository)
 
     output_dir.parent.mkdir(parents=True, exist_ok=True)
-    stage = Path(
-        tempfile.mkdtemp(
-            prefix=f".{output_dir.name}.tmp-",
-            dir=str(output_dir.parent),
+    stage = lexical_directory_path(
+        Path(
+            tempfile.mkdtemp(
+                prefix=f".{output_dir.name}.tmp-",
+                dir=str(output_dir.parent),
+            )
         )
-    ).resolve()
+    )
+    stage_root_ownership = capture_directory_ownership(stage)
     try:
         portable = manifest.to_dict()
         portable["repo"]["path"] = "source"
@@ -518,9 +547,40 @@ def stage_context_artifact(
             label="context artifact",
         )
 
-        publish_staged_directory(stage, output_dir)
+        expected_metadata_bytes = _json_bytes(metadata)
+
+        def validate_artifact(candidate: Path) -> None:
+            assert_publishable_tree(
+                candidate,
+                forbidden_paths=(repo_path, manifest_root),
+                environ=environment,
+                label="context artifact",
+            )
+            candidate_metadata = candidate / CONTEXT_ARTIFACT_MANIFEST
+            actual_files = [
+                record
+                for record in _inventory(candidate)
+                if record["path"] != CONTEXT_ARTIFACT_MANIFEST
+            ]
+            if (
+                not candidate_metadata.is_file()
+                or candidate_metadata.read_bytes() != expected_metadata_bytes
+                or actual_files != files
+            ):
+                raise ValueError(
+                    "published context artifact differs from its staged identity"
+                )
+
+        publish_staged_directory(
+            stage,
+            output_dir,
+            expected_stage_root_ownership=stage_root_ownership,
+            expected_destination_ownership=expected_output_ownership,
+            validate_staged_directory=validate_artifact,
+            validate_published_destination=validate_artifact,
+        )
     except BaseException:
-        shutil.rmtree(stage, ignore_errors=True)
+        discard_owned_directory(stage, stage_root_ownership)
         raise
 
     byte_count = sum(int(item["bytes"]) for item in files)

--- a/codenib/storage/view_bundle.py
+++ b/codenib/storage/view_bundle.py
@@ -438,7 +438,7 @@ def materialize_view_bundle(
     output = _output_path(output)
     _reject_overlap(output, archive, label="view bundle archive and output")
     _reject_forbidden_roots(output, forbidden_roots, label="view bundle output")
-    _validate_materialization_target(
+    expected_ownership = _validate_materialization_target(
         output,
         max_files=max_files,
         max_bytes=max_bytes,
@@ -511,12 +511,6 @@ def materialize_view_bundle(
                 raise StorageIntegrityError(
                     "view bundle materialization stage changed before publication"
                 )
-        expected_ownership = _validate_materialization_target(
-            output,
-            max_files=max_files,
-            max_bytes=max_bytes,
-            max_metadata_bytes=max_metadata_bytes,
-        )
 
         def validate_moved_destination(moved: Path) -> None:
             try:
@@ -2826,7 +2820,7 @@ def _remove_owned_stage(stage: Path, expected_identity: tuple[int, ...]) -> None
             pass
         return
     try:
-        _remove_owned_directory(cleanup, _directory_identity(moved_metadata))
+        _remove_owned_directory(cleanup, _directory_inode_identity(moved_metadata))
     except (OSError, RuntimeError, ValueError):
         # Cleanup is best effort.  The owned tree remains quarantined under a
         # unique sibling name rather than following a changed path.

--- a/codenib/web/static_export.py
+++ b/codenib/web/static_export.py
@@ -17,7 +17,12 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping
 from urllib.parse import quote, unquote, urlsplit
 
-from .._atomic_directory import publish_staged_directory
+from .._atomic_directory import (
+    capture_directory_ownership,
+    discard_owned_directory,
+    lexical_directory_path,
+    publish_staged_directory,
+)
 from .._version import package_version
 from ..artifacts.security import assert_publishable_tree, file_sha256
 from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
@@ -691,7 +696,7 @@ def _generation_summary(pages: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
 def _file_inventory(root: Path) -> list[dict[str, Any]]:
     files = []
     for path in sorted(root.rglob("*")):
-        if not path.is_file() or path.name == STATIC_EXPORT_MANIFEST:
+        if not path.is_file() or path == root / STATIC_EXPORT_MANIFEST:
             continue
         size, digest = file_sha256(path)
         files.append(
@@ -708,10 +713,14 @@ def _validated_output(
     repo_path: Path,
     manifest_root: Path,
     output_dir: Path,
-) -> Path:
+) -> tuple[Path, object | None]:
     repo_path = repo_path.resolve()
     manifest_root = manifest_root.resolve()
-    output_dir = output_dir.expanduser().resolve()
+    output_dir = lexical_directory_path(output_dir)
+    if output_dir.is_symlink():
+        raise ValueError(
+            f"static export output must not be a symbolic link: {output_dir}"
+        )
     for source, label in (
         (repo_path, "target repository"),
         (manifest_root, "index root"),
@@ -722,13 +731,22 @@ def _validated_output(
             raise ValueError(f"static export output must not contain the {label}")
     if output_dir.exists() and not output_dir.is_dir():
         raise ValueError(f"static export output is not a directory: {output_dir}")
-    if output_dir.exists() and any(output_dir.iterdir()):
-        if not (output_dir / STATIC_EXPORT_MANIFEST).is_file():
-            raise ValueError(
-                "refusing to replace a non-empty directory that is not a CodeNib "
-                f"static export: {output_dir}"
+    try:
+        expected_ownership = (
+            capture_directory_ownership(
+                output_dir,
+                required_root_file=STATIC_EXPORT_MANIFEST,
+                allow_empty_root=True,
             )
-    return output_dir
+            if output_dir.exists()
+            else None
+        )
+    except RuntimeError as exc:
+        raise ValueError(
+            "refusing to replace a non-empty directory that is not a CodeNib "
+            f"static export: {output_dir}"
+        ) from exc
+    return output_dir, expected_ownership
 
 
 def export_static_wiki(
@@ -744,7 +762,11 @@ def export_static_wiki(
 
     repo_path = repo_path.expanduser().resolve()
     manifest_path = manifest_path.expanduser().resolve()
-    output_dir = _validated_output(repo_path, manifest_path.parent, output_dir)
+    output_dir, expected_output_ownership = _validated_output(
+        repo_path,
+        manifest_path.parent,
+        output_dir,
+    )
     base_path = normalize_base_path(base_path)
     frontend = _prebuilt_frontend(frontend_dir)
     environment = os.environ if environ is None else environ
@@ -794,12 +816,15 @@ def export_static_wiki(
     repo_info["source_url"] = _github_repository_url(repo_path)
 
     output_dir.parent.mkdir(parents=True, exist_ok=True)
-    stage = Path(
-        tempfile.mkdtemp(
-            prefix=f".{output_dir.name}.tmp-",
-            dir=str(output_dir.parent),
+    stage = lexical_directory_path(
+        Path(
+            tempfile.mkdtemp(
+                prefix=f".{output_dir.name}.tmp-",
+                dir=str(output_dir.parent),
+            )
         )
-    ).resolve()
+    )
+    stage_root_ownership = capture_directory_ownership(stage)
     try:
         _copy_frontend(frontend, stage, base_path=base_path)
         _write_bytes(stage, "runtime-config.js", _runtime_config(base_path))
@@ -873,10 +898,36 @@ def export_static_wiki(
             label="static export",
         )
 
-        publish_staged_directory(stage, output_dir)
+        expected_manifest_bytes = _json_bytes(export_manifest)
+
+        def validate_export(candidate: Path) -> None:
+            assert_publishable_tree(
+                candidate,
+                forbidden_paths=(repo_path, manifest_path.parent),
+                environ=environment,
+                label="static export",
+            )
+            candidate_manifest = candidate / STATIC_EXPORT_MANIFEST
+            if (
+                not candidate_manifest.is_file()
+                or candidate_manifest.read_bytes() != expected_manifest_bytes
+                or _file_inventory(candidate) != export_manifest["files"]
+            ):
+                raise ValueError(
+                    "published static export differs from its staged identity"
+                )
+
+        publish_staged_directory(
+            stage,
+            output_dir,
+            expected_stage_root_ownership=stage_root_ownership,
+            expected_destination_ownership=expected_output_ownership,
+            validate_staged_directory=validate_export,
+            validate_published_destination=validate_export,
+        )
         manifest_file = output_dir / manifest_file.relative_to(stage)
-    except Exception:
-        shutil.rmtree(stage, ignore_errors=True)
+    except BaseException:
+        discard_owned_directory(stage, stage_root_ownership)
         raise
 
     return StaticExportResult(

--- a/docs/storage_backend_roadmap.md
+++ b/docs/storage_backend_roadmap.md
@@ -199,6 +199,16 @@ original destination-to-`.previous-*` rename is the only old-file handoff; after
 publication, builders only revalidate that path against the still-open previous
 descriptor and never reserve, rename, or unlink it. Controlled M5 GC is
 responsible for reclaiming verified old files and missing-destination sentinels.
+Generic staged-directory publication now uses the same ownership boundary:
+callers capture a bounded, no-follow receipt for the authorized old root before
+building, bind the original temporary-root inode, and run their semantic
+validator inside an exact tree-token sandwich before and after the atomic
+rename.  The token covers the raw relative entry set, exact portable modes,
+regular-file sizes and SHA-256 bytes under the view-bundle file, byte, metadata,
+path, component, and depth limits.  This avoids relying on directory timestamps,
+which are not reliable on every supported filesystem.  Existing non-empty trees
+fail closed on platforms without safe directory-fd traversal; a first publish
+may proceed only with caller validation and an ownership-checked empty sentinel.
 Schema v2 now adds
 canonical idempotent job requests, immutable
 per-view request mappings, bounded retry state, and database-clock fenced

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -306,6 +306,114 @@ def test_context_artifact_restores_previous_output_on_publish_failure(
     assert not list(output.parent.glob(".context.previous-*"))
 
 
+def test_context_artifact_preserves_output_changed_during_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, manifest_path, _view_path = _fixture_manifest(tmp_path)
+    output = tmp_path / "publish" / "context"
+    stage_context_artifact(
+        repo,
+        manifest_path,
+        output,
+        repository="example/project",
+    )
+    previous = _tree(output)
+
+    from codenib.artifacts import context as context_module
+
+    real_copy = context_module._copy_view
+    mutated = False
+
+    def mutate_old_output(*args, **kwargs):
+        nonlocal mutated
+        if not mutated:
+            mutated = True
+            nested = output / "late"
+            nested.mkdir()
+            (nested / "preserve.txt").write_text("preserve", encoding="utf-8")
+        return real_copy(*args, **kwargs)
+
+    monkeypatch.setattr(context_module, "_copy_view", mutate_old_output)
+
+    with pytest.raises(RuntimeError, match="changed before directory publication"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            output,
+            repository="example/project",
+        )
+
+    for relative, content in previous.items():
+        assert (output / relative).read_bytes() == content
+    assert (output / "late" / "preserve.txt").read_text(encoding="utf-8") == (
+        "preserve"
+    )
+
+
+def test_context_artifact_rejects_output_symlink(tmp_path: Path) -> None:
+    repo, manifest_path, _view_path = _fixture_manifest(tmp_path)
+    victim = tmp_path / "victim"
+    stage_context_artifact(
+        repo,
+        manifest_path,
+        victim,
+        repository="example/project",
+    )
+    previous = _tree(victim)
+    output = tmp_path / "output"
+    output.symlink_to(victim, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            output,
+            repository="example/project",
+        )
+
+    assert output.is_symlink()
+    assert _tree(victim) == previous
+
+
+def test_context_artifact_does_not_follow_swapped_stage_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, manifest_path, _view_path = _fixture_manifest(tmp_path)
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "keep.txt").write_text("keep", encoding="utf-8")
+    stolen = tmp_path / "stolen-stage"
+
+    from codenib.artifacts import context as context_module
+
+    real_mkdtemp = context_module.tempfile.mkdtemp
+    swapped: Path | None = None
+
+    def swap_stage(*args, **kwargs):
+        nonlocal swapped
+        created = Path(real_mkdtemp(*args, **kwargs))
+        created.rename(stolen)
+        created.symlink_to(victim, target_is_directory=True)
+        swapped = created
+        return str(created)
+
+    monkeypatch.setattr(context_module.tempfile, "mkdtemp", swap_stage)
+
+    with pytest.raises(ValueError, match="link"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "output",
+            repository="example/project",
+        )
+
+    assert swapped is not None and swapped.is_symlink()
+    assert stolen.is_dir()
+    assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
 def test_context_artifact_default_ignores_nonportable_current_views(
     tmp_path: Path,
 ) -> None:

--- a/test/artifacts/test_runtime.py
+++ b/test/artifacts/test_runtime.py
@@ -498,6 +498,94 @@ def test_extract_archive_restores_previous_output_on_publish_failure(
     assert not list(output.parent.glob(".extracted.previous-*"))
 
 
+def test_extract_archive_preserves_output_changed_during_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    output = tmp_path / "extracted"
+    extract_context_artifact_archive(archive, output)
+    previous_metadata = (output / CONTEXT_ARTIFACT_MANIFEST).read_bytes()
+
+    from codenib.artifacts import archive as archive_module
+
+    real_extract = archive_module._extract_member
+    mutated = False
+
+    def mutate_old_output(*args, **kwargs):
+        nonlocal mutated
+        if not mutated:
+            mutated = True
+            nested = output / "late"
+            nested.mkdir()
+            (nested / "preserve.txt").write_text("preserve", encoding="utf-8")
+        return real_extract(*args, **kwargs)
+
+    monkeypatch.setattr(archive_module, "_extract_member", mutate_old_output)
+
+    with pytest.raises(RuntimeError, match="changed before directory publication"):
+        extract_context_artifact_archive(archive, output)
+
+    assert (output / CONTEXT_ARTIFACT_MANIFEST).read_bytes() == previous_metadata
+    assert (output / "late" / "preserve.txt").read_text(encoding="utf-8") == (
+        "preserve"
+    )
+
+
+def test_extract_archive_rejects_output_symlink(tmp_path: Path) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    victim = tmp_path / "victim"
+    extract_context_artifact_archive(archive, victim)
+    previous = (victim / CONTEXT_ARTIFACT_MANIFEST).read_bytes()
+    output = tmp_path / "output"
+    output.symlink_to(victim, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        extract_context_artifact_archive(archive, output)
+
+    assert output.is_symlink()
+    assert (victim / CONTEXT_ARTIFACT_MANIFEST).read_bytes() == previous
+
+
+def test_extract_archive_does_not_follow_swapped_stage_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _repo, artifact, _commit = _bm25_artifact(tmp_path)
+    archive = tmp_path / "artifact.zip"
+    _zip_tree(artifact, archive)
+    victim = tmp_path / "victim"
+    victim.mkdir()
+    (victim / "keep.txt").write_text("keep", encoding="utf-8")
+    stolen = tmp_path / "stolen-stage"
+
+    from codenib.artifacts import archive as archive_module
+
+    real_mkdtemp = archive_module.tempfile.mkdtemp
+    swapped: Path | None = None
+
+    def swap_stage(*args, **kwargs):
+        nonlocal swapped
+        created = Path(real_mkdtemp(*args, **kwargs))
+        created.rename(stolen)
+        created.symlink_to(victim, target_is_directory=True)
+        swapped = created
+        return str(created)
+
+    monkeypatch.setattr(archive_module.tempfile, "mkdtemp", swap_stage)
+
+    with pytest.raises(ValueError, match="link"):
+        extract_context_artifact_archive(archive, tmp_path / "output")
+
+    assert swapped is not None and swapped.is_symlink()
+    assert stolen.is_dir()
+    assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
 def test_extract_archive_rejects_traversal_and_symlink(tmp_path: Path) -> None:
     traversal = tmp_path / "traversal.zip"
     with zipfile.ZipFile(traversal, "w") as archive:

--- a/test/storage/test_view_bundle.py
+++ b/test/storage/test_view_bundle.py
@@ -1352,6 +1352,7 @@ def test_materialization_failure_preserves_previous_bundle(
 
     assert _tree(output) == previous
     assert not list(tmp_path.glob(".runtime.materialize-*"))
+    assert not [path for path in tmp_path.iterdir() if ".cleanup-" in path.name]
 
 
 def test_materialization_rejects_late_destination_mutation_without_deleting_it(
@@ -1386,6 +1387,55 @@ def test_materialization_rejects_late_destination_mutation_without_deleting_it(
         encoding="utf-8"
     ) == "preserve"
     assert (output / "payload" / "documents.json").read_bytes() == b"[]\n"
+
+
+def test_materialization_rejects_concurrent_valid_generation_without_deleting_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(tmp_path)
+    documents = source / "documents.json"
+    first_archive = tmp_path / "first.zip"
+    build_view_bundle(source, first_archive, view_type="bm25")
+    output = tmp_path / "runtime"
+    materialize_view_bundle(first_archive, output)
+
+    documents.write_bytes(b"[1]\n")
+    second_archive = tmp_path / "second.zip"
+    build_view_bundle(source, second_archive, view_type="bm25")
+    documents.write_bytes(b"[2]\n")
+    concurrent_archive = tmp_path / "concurrent.zip"
+    build_view_bundle(source, concurrent_archive, view_type="bm25")
+    concurrent = tmp_path / "concurrent"
+    materialize_view_bundle(concurrent_archive, concurrent)
+
+    original_verify = bundle_module._verify_archive_handle
+    stolen = tmp_path / "stolen-original"
+    swapped = False
+
+    def verify_then_publish_concurrent(*args: object, **kwargs: object):
+        nonlocal swapped
+        result = original_verify(*args, **kwargs)
+        os.replace(output, stolen)
+        os.replace(concurrent, output)
+        swapped = True
+        return result
+
+    monkeypatch.setattr(
+        bundle_module,
+        "_verify_archive_handle",
+        verify_then_publish_concurrent,
+    )
+    with pytest.raises(RuntimeError, match="destination changed before"):
+        materialize_view_bundle(second_archive, output)
+
+    assert swapped
+    assert (output / "payload" / "documents.json").read_bytes() == b"[2]\n"
+    assert (stolen / "payload" / "documents.json").read_bytes() == b"[]\n"
+    assert not concurrent.exists()
+    assert not list(tmp_path.glob(".runtime.materialize-*"))
+    assert not list(tmp_path.glob(".runtime.previous-*"))
+    assert not [path for path in tmp_path.iterdir() if ".cleanup-" in path.name]
 
 
 def test_materialization_boundary_revalidates_same_size_payload_digest(

--- a/test/test_atomic_directory.py
+++ b/test/test_atomic_directory.py
@@ -12,7 +12,10 @@ from types import SimpleNamespace
 import pytest
 
 import codenib._atomic_directory as atomic_module
-from codenib._atomic_directory import publish_staged_directory
+from codenib._atomic_directory import (
+    capture_directory_ownership,
+    publish_staged_directory,
+)
 
 
 def test_publish_staged_directory_replaces_existing_tree(tmp_path: Path) -> None:
@@ -168,6 +171,11 @@ def test_publish_staged_directory_preserves_late_destination_entry(
         (destination / "late.txt").write_text("late", encoding="utf-8")
         return real_mkdtemp(*args, **kwargs)
 
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_identity",
+        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
+    )
     monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
 
     with pytest.raises(RuntimeError, match="changed at the publication boundary"):
@@ -175,6 +183,511 @@ def test_publish_staged_directory_preserves_late_destination_entry(
 
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert (destination / "late.txt").read_text(encoding="utf-8") == "late"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_preserves_nested_late_destination_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    nested = destination / "nested"
+    nested.mkdir(parents=True)
+    (nested / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    real_mkdtemp = atomic_module.tempfile.mkdtemp
+
+    def mutate_then_allocate(*args, **kwargs):
+        (nested / "late.txt").write_text("late", encoding="utf-8")
+        return real_mkdtemp(*args, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_identity",
+        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
+    )
+    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+
+    with pytest.raises(RuntimeError, match="changed at the publication boundary"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "nested" / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (destination / "nested" / "late.txt").read_text(encoding="utf-8") == ("late")
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_rejects_nested_stage_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    nested = stage / "nested"
+    nested.mkdir(parents=True)
+    (nested / "new.txt").write_text("new", encoding="utf-8")
+    real_mkdtemp = atomic_module.tempfile.mkdtemp
+
+    def mutate_then_allocate(*args, **kwargs):
+        (nested / "late.txt").write_text("late", encoding="utf-8")
+        return real_mkdtemp(*args, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_identity",
+        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
+    )
+    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+
+    with pytest.raises(RuntimeError, match="before destination publication"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "nested" / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (stage / "nested" / "late.txt").read_text(encoding="utf-8") == "late"
+
+
+def test_publish_staged_directory_rejects_same_size_destination_rewrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    previous = destination / "old.txt"
+    previous.write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    real_mkdtemp = atomic_module.tempfile.mkdtemp
+
+    def mutate_then_allocate(*args, **kwargs):
+        previous.write_text("NEW", encoding="utf-8")
+        return real_mkdtemp(*args, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_identity",
+        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
+    )
+    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+
+    with pytest.raises(RuntimeError, match="changed at the publication boundary"):
+        publish_staged_directory(stage, destination)
+
+    assert previous.read_text(encoding="utf-8") == "NEW"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_publish_staged_directory_preserves_raced_missing_target_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    real_mkdtemp = atomic_module.tempfile.mkdtemp
+
+    def mutate_then_allocate(*args, **kwargs):
+        (destination / "late.txt").write_text("late", encoding="utf-8")
+        return real_mkdtemp(*args, **kwargs)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_identity",
+        lambda metadata: (metadata.st_dev, metadata.st_ino, metadata.st_mode),
+    )
+    monkeypatch.setattr(atomic_module.tempfile, "mkdtemp", mutate_then_allocate)
+
+    with pytest.raises(RuntimeError, match="raced content remains"):
+        publish_staged_directory(
+            stage,
+            destination,
+            expected_destination_identity=None,
+            validate_moved_destination=lambda _path: None,
+            validate_published_destination=lambda _path: None,
+        )
+
+    assert (destination / "late.txt").read_text(encoding="utf-8") == "late"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+@pytest.mark.parametrize(
+    ("constant", "limit", "files", "error"),
+    [
+        ("_MAX_OWNERSHIP_ENTRIES", 1, {"a": "1", "b": "2"}, "entry limit"),
+        ("_MAX_OWNERSHIP_BYTES", 2, {"a": "123"}, "byte limit"),
+        ("_MAX_OWNERSHIP_METADATA_BYTES", 1, {"a": "1"}, "metadata"),
+        ("_MAX_OWNERSHIP_COMPONENT_BYTES", 1, {"aa": "1"}, "component"),
+    ],
+)
+def test_publish_staged_directory_bounds_builtin_ownership_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    constant: str,
+    limit: int,
+    files: dict[str, str],
+    error: str,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    for name, content in files.items():
+        (stage / name).write_text(content, encoding="utf-8")
+    monkeypatch.setattr(atomic_module, constant, limit)
+
+    with pytest.raises(RuntimeError, match=error):
+        publish_staged_directory(stage, destination)
+
+    assert not destination.exists()
+    for name, content in files.items():
+        assert (stage / name).read_text(encoding="utf-8") == content
+
+
+def test_directory_ownership_is_independent_of_entry_order(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    for name in ("a", "b", "c"):
+        (first / name).write_text(name, encoding="utf-8")
+    for name in ("c", "b", "a"):
+        (second / name).write_text(name, encoding="utf-8")
+
+    first_token = capture_directory_ownership(first)
+    second_token = capture_directory_ownership(second)
+    assert (
+        first_token.digest,
+        first_token.entries,
+        first_token.byte_count,
+        first_token.metadata_bytes,
+    ) == (
+        second_token.digest,
+        second_token.entries,
+        second_token.byte_count,
+        second_token.metadata_bytes,
+    )
+
+
+@pytest.mark.parametrize(
+    ("constant", "limit", "error"),
+    [
+        ("_MAX_SAFE_REMOVAL_DEPTH", 1, "depth limit"),
+        ("_MAX_OWNERSHIP_PATH_BYTES", 3, "path exceeds"),
+    ],
+)
+def test_directory_ownership_bounds_derived_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    constant: str,
+    limit: int,
+    error: str,
+) -> None:
+    root = tmp_path / "root"
+    nested = root / "aa" / "bb"
+    nested.mkdir(parents=True)
+    (nested / "value").write_text("value", encoding="utf-8")
+    monkeypatch.setattr(atomic_module, constant, limit)
+
+    with pytest.raises(RuntimeError, match=error):
+        capture_directory_ownership(root)
+
+
+def test_directory_ownership_reserves_parent_entries_before_child_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    child = root / "child"
+    child.mkdir(parents=True)
+    (child / "one").write_text("one", encoding="utf-8")
+    (child / "two").write_text("two", encoding="utf-8")
+    monkeypatch.setattr(atomic_module, "_MAX_OWNERSHIP_ENTRIES", 2)
+
+    with pytest.raises(RuntimeError, match="entry limit"):
+        capture_directory_ownership(root)
+
+
+def test_directory_ownership_binds_required_root_marker(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "payload").write_text("payload", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="required marker"):
+        capture_directory_ownership(
+            root,
+            required_root_file="manifest.json",
+            allow_empty_root=True,
+        )
+
+    (root / "manifest.json").mkdir()
+    with pytest.raises(RuntimeError, match="marker is not a regular file"):
+        capture_directory_ownership(
+            root,
+            required_root_file="manifest.json",
+            allow_empty_root=True,
+        )
+
+
+def test_directory_ownership_detects_same_size_rewrite_across_tokens(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    payload = root / "payload"
+    payload.write_bytes(b"original")
+    real_read = atomic_module.os.read
+    mutated = False
+
+    def rewrite_after_read(descriptor: int, size: int) -> bytes:
+        nonlocal mutated
+        result = real_read(descriptor, size)
+        if result and not mutated:
+            mutated = True
+            payload.write_bytes(b"modified")
+        return result
+
+    expected = capture_directory_ownership(root)
+    monkeypatch.setattr(atomic_module.os, "read", rewrite_after_read)
+
+    try:
+        raced = capture_directory_ownership(root)
+    except RuntimeError as exc:
+        assert "file changed" in str(exc)
+    else:
+        observed = capture_directory_ownership(root)
+        assert raced != observed
+        assert expected != observed
+
+
+def test_expected_destination_ownership_rejects_identical_root_swap(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    expected = capture_directory_ownership(destination)
+    stolen = tmp_path / "stolen"
+    destination.rename(stolen)
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="changed before directory publication"):
+        publish_staged_directory(
+            stage,
+            destination,
+            expected_destination_ownership=expected,
+        )
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stolen / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_expected_stage_root_preserves_substituted_cleanup_path(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    expected = capture_directory_ownership(stage)
+    stolen = tmp_path / "stolen-stage"
+    stage.rename(stolen)
+    stage.mkdir()
+    (stage / "foreign.txt").write_text("preserve", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="root changed before publication"):
+        publish_staged_directory(
+            stage,
+            destination,
+            expected_stage_root_ownership=expected,
+        )
+    atomic_module.discard_owned_directory(stage, expected)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert stolen.is_dir()
+    assert (stage / "foreign.txt").read_text(encoding="utf-8") == "preserve"
+
+
+def test_publish_staged_directory_restores_old_tree_on_scan_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    real_require = atomic_module._require_tree_ownership
+
+    def interrupt_moved_tree(path, expected, *, label):
+        if label == "moved destination":
+            raise KeyboardInterrupt("injected ownership interruption")
+        return real_require(path, expected, label=label)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_require_tree_ownership",
+        interrupt_moved_tree,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="ownership interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_publish_restores_old_tree_when_moved_lstat_is_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    real_directory_or_missing = atomic_module._directory_or_missing
+
+    def interrupt_moved_lstat(path: Path, *, label: str):
+        if label == "moved destination":
+            raise KeyboardInterrupt("injected moved lstat interruption")
+        return real_directory_or_missing(path, label=label)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_or_missing",
+        interrupt_moved_lstat,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="moved lstat interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_publish_restores_old_tree_when_rename_completes_then_interrupts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    real_replace = atomic_module.os.replace
+
+    def interrupt_after_old_rename(source, target):
+        result = real_replace(source, target)
+        if Path(source) == destination and Path(target).name.startswith(
+            ".published.previous-"
+        ):
+            raise KeyboardInterrupt("injected post-rename interruption")
+        return result
+
+    monkeypatch.setattr(atomic_module.os, "replace", interrupt_after_old_rename)
+
+    with pytest.raises(KeyboardInterrupt, match="post-rename interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_publish_restores_old_tree_when_final_stage_lstat_is_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    real_directory_or_missing = atomic_module._directory_or_missing
+    staged_calls = 0
+
+    def interrupt_final_stage_lstat(path: Path, *, label: str):
+        nonlocal staged_calls
+        if label == "staged directory":
+            staged_calls += 1
+            if staged_calls == 3:
+                raise KeyboardInterrupt("injected final stage lstat interruption")
+        return real_directory_or_missing(path, label=label)
+
+    monkeypatch.setattr(
+        atomic_module,
+        "_directory_or_missing",
+        interrupt_final_stage_lstat,
+    )
+
+    with pytest.raises(KeyboardInterrupt, match="final stage lstat interruption"):
+        publish_staged_directory(stage, destination)
+
+    assert staged_calls == 3
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.previous-*"))
+
+
+def test_first_publication_works_without_safe_ownership_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
+
+    publish_staged_directory(
+        stage,
+        destination,
+        expected_destination_ownership=None,
+        validate_staged_directory=lambda _path: None,
+        validate_published_destination=lambda _path: None,
+    )
+
+    assert (destination / "new.txt").read_text(encoding="utf-8") == "new"
+
+
+def test_existing_publication_fails_closed_without_safe_ownership_fds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    monkeypatch.setattr(atomic_module, "_SAFE_OWNERSHIP_DIRECTORY_FDS", False)
+
+    with pytest.raises(RuntimeError, match="non-empty trees"):
+        publish_staged_directory(
+            stage,
+            destination,
+            validate_staged_directory=lambda _path: None,
+            validate_published_destination=lambda _path: None,
+        )
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
 
 
@@ -207,6 +720,40 @@ def test_publish_staged_directory_quarantines_failed_published_identity(
     assert (quarantines[0] / "late.txt").read_text(encoding="utf-8") == "late"
     assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
     assert not stage.exists()
+
+
+def test_published_callback_cannot_bypass_exact_tree_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "published"
+    destination.mkdir()
+    (destination / "old.txt").write_text("old", encoding="utf-8")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    (stage / "new.txt").write_text("new", encoding="utf-8")
+    real_replace = os.replace
+
+    def add_empty_directory_after_publish(source, target):
+        result = real_replace(source, target)
+        if Path(source) == stage and Path(target) == destination:
+            (destination / "late-empty").mkdir()
+        return result
+
+    monkeypatch.setattr(atomic_module.os, "replace", add_empty_directory_after_publish)
+
+    with pytest.raises(RuntimeError, match="quarantined"):
+        publish_staged_directory(
+            stage,
+            destination,
+            validate_staged_directory=lambda _path: None,
+            validate_published_destination=lambda _path: None,
+        )
+
+    assert (destination / "old.txt").read_text(encoding="utf-8") == "old"
+    quarantines = list(tmp_path.glob(".published.quarantine-*"))
+    assert len(quarantines) == 1
+    assert (quarantines[0] / "late-empty").is_dir()
 
 
 def test_published_boundary_quarantines_new_before_lost_backup_check(
@@ -295,7 +842,7 @@ def test_published_callback_quarantines_new_before_lost_backup_check(
     assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
 
 
-def test_publish_staged_directory_rolls_back_before_mounted_tree_cleanup(
+def test_publish_staged_directory_rejects_mounted_tree_before_publication(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -316,15 +863,14 @@ def test_publish_staged_directory_rolls_back_before_mounted_tree_cleanup(
 
     monkeypatch.setattr(atomic_module, "_path_is_mount_point", fake_mount_check)
 
-    with pytest.raises(RuntimeError, match="safe cleanup validation"):
+    with pytest.raises(RuntimeError, match="ownership scan refuses mounted"):
         publish_staged_directory(stage, destination)
 
     assert (destination / "mounted" / "external.txt").read_text(
         encoding="utf-8"
     ) == "preserve"
-    quarantines = list(tmp_path.glob(".published.quarantine-*"))
-    assert len(quarantines) == 1
-    assert (quarantines[0] / "new.txt").read_text(encoding="utf-8") == "new"
+    assert (stage / "new.txt").read_text(encoding="utf-8") == "new"
+    assert not list(tmp_path.glob(".published.quarantine-*"))
 
 
 def test_publish_staged_directory_fails_closed_without_safe_cleanup_fds(

--- a/test/web/test_static_export.py
+++ b/test/web/test_static_export.py
@@ -269,6 +269,128 @@ def test_static_export_is_deterministic_and_publishable(
     assert "href='#heading'" in index
 
 
+def test_static_export_preserves_output_changed_during_build(
+    export_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = export_setup
+    monkeypatch.setattr(
+        "codenib.web.static_export._github_repository_url",
+        lambda _repo: "https://github.com/owner/demo",
+    )
+    export_static_wiki(
+        setup.repo,
+        setup.manifest_path,
+        setup.output,
+        frontend_dir=setup.frontend,
+    )
+    previous = _tree_bytes(setup.output)
+
+    from codenib.web import static_export as static_export_module
+
+    real_copy = static_export_module._copy_frontend
+    mutated = False
+
+    def mutate_old_output(*args, **kwargs):
+        nonlocal mutated
+        if not mutated:
+            mutated = True
+            nested = setup.output / "late"
+            nested.mkdir()
+            (nested / "preserve.txt").write_text("preserve", encoding="utf-8")
+        return real_copy(*args, **kwargs)
+
+    monkeypatch.setattr(static_export_module, "_copy_frontend", mutate_old_output)
+
+    with pytest.raises(RuntimeError, match="changed before directory publication"):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            setup.output,
+            frontend_dir=setup.frontend,
+        )
+
+    for relative, content in previous.items():
+        assert (setup.output / relative).read_bytes() == content
+    assert (setup.output / "late" / "preserve.txt").read_text(encoding="utf-8") == (
+        "preserve"
+    )
+
+
+def test_static_export_rejects_output_symlink(
+    export_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = export_setup
+    monkeypatch.setattr(
+        "codenib.web.static_export._github_repository_url",
+        lambda _repo: "https://github.com/owner/demo",
+    )
+    victim = setup.output
+    export_static_wiki(
+        setup.repo,
+        setup.manifest_path,
+        victim,
+        frontend_dir=setup.frontend,
+    )
+    previous = _tree_bytes(victim)
+    output = setup.output.parent / "output-link"
+    output.symlink_to(victim, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert output.is_symlink()
+    assert _tree_bytes(victim) == previous
+
+
+def test_static_export_does_not_follow_swapped_stage_symlink(
+    export_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    setup = export_setup
+    monkeypatch.setattr(
+        "codenib.web.static_export._github_repository_url",
+        lambda _repo: "https://github.com/owner/demo",
+    )
+    victim = setup.output.parent / "victim"
+    victim.mkdir()
+    (victim / "keep.txt").write_text("keep", encoding="utf-8")
+    stolen = setup.output.parent / "stolen-stage"
+
+    from codenib.web import static_export as static_export_module
+
+    real_mkdtemp = static_export_module.tempfile.mkdtemp
+    swapped: Path | None = None
+
+    def swap_stage(*args, **kwargs):
+        nonlocal swapped
+        created = Path(real_mkdtemp(*args, **kwargs))
+        created.rename(stolen)
+        created.symlink_to(victim, target_is_directory=True)
+        swapped = created
+        return str(created)
+
+    monkeypatch.setattr(static_export_module.tempfile, "mkdtemp", swap_stage)
+
+    with pytest.raises(ValueError, match="link"):
+        export_static_wiki(
+            setup.repo,
+            setup.manifest_path,
+            setup.output,
+            frontend_dir=setup.frontend,
+        )
+
+    assert swapped is not None and swapped.is_symlink()
+    assert stolen.is_dir()
+    assert (victim / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
 def test_publishability_rejects_json_escaped_windows_path(tmp_path: Path) -> None:
     root = tmp_path / "site"
     root.mkdir()


### PR DESCRIPTION
## Summary

Fix atomic directory publication on filesystems where directory size and timestamps do not expose completed direct or nested writes. This restores the self-hosted Full CI gate introduced by #537 and advances the publication-safety work tracked in #199.

## Changes

- Replace root-directory stat checks with bounded, deterministic, no-follow whole-tree ownership receipts.
- Bind destination ownership before long-running builds and revalidate the exact moved generation at the publication boundary.
- Bind staged output to its original root and exact contents around caller-specific semantic validation.
- Restore previous output across path substitution and asynchronous interruption windows without deleting foreign trees.
- Apply the publication contract to context artifacts, repository archives, static exports, and view-bundle materialization.
- Document the new publication and compatibility gate in the storage backend roadmap.
- Add adversarial coverage for Lustre/coarse timestamps, nested and same-size writes, valid A/B/C generation races, symlink and stage swaps, cleanup ownership, and interrupted renames.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `282 passed`: storage, atomic-directory, artifact, and static-export suites.
- `42 passed`: atomic-directory suite with pytest temporary state on the same Lustre workspace used by the self-hosted runner.
- `3612 passed, 11 skipped, 181 deselected`: unit tier excluding the unavailable local Docker sandbox fixture; the unfiltered run reached the same missing `/usr/bin/docker` environment baseline after 2235 passing tests.
- Strict MkDocs build passed.
- Black, isort, flake8, diff check, Python 3.10 compilation, and namespace checks passed.
- Two independent final-head reviews found no remaining P0/P1 blocker.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
