### PR TITLE
test(storage): make lease boundary check deterministic

### DIFF
--- a/test/storage/test_sqlite_jobs.py
+++ b/test/storage/test_sqlite_jobs.py
@@ -864,29 +864,39 @@ def test_renew_requeue_restart_and_fencing_token_are_durable(tmp_path) -> None:
         assert restarted.error_code is None
 
 
-def test_high_frequency_one_millisecond_renewal_has_one_conflict_boundary(
-    tmp_path,
-) -> None:
-    with SQLiteCatalog(tmp_path / "catalog.sqlite3") as catalog:
+def test_one_millisecond_renewal_uses_strict_db_clock_boundary(tmp_path) -> None:
+    path = tmp_path / "catalog.sqlite3"
+    with SQLiteCatalog(path) as catalog:
+        # Keep every lease check on SQLite's clock while making the exact
+        # millisecond boundary deterministic.  A wall-clock loop can be
+        # descheduled past a short lease before its first renewal under xdist.
+        clock = {"raw_ms": 0}
+        catalog._connection.create_function(
+            "julianday",
+            1,
+            lambda _value: 2440587.5 + clock["raw_ms"] / 86_400_000,
+        )
+        assert catalog._db_now_ms() == 0
+
         job = _job_setup(catalog)
         lease = catalog.acquire_job_lease(
-            job.job_id, owner_id="worker", lease_duration_ms=10
+            job.job_id, owner_id="worker", lease_duration_ms=1
         )
-        renewed_count = 0
-        for _ in range(50):
-            try:
-                lease = catalog.renew_job_lease(
-                    job.job_id,
-                    owner_id="worker",
-                    fencing_token=lease.fencing_token,
-                    lease_duration_ms=1,
-                )
-            except CatalogConflictError:
-                break
-            renewed_count += 1
+        assert lease.heartbeat_at_ms == 0
+        assert lease.lease_expires_at_ms == 1
+        assert catalog._db_now_ms() == lease.lease_expires_at_ms - 1
 
-        assert renewed_count >= 1
-        time.sleep(0.08)
+        lease = catalog.renew_job_lease(
+            job.job_id,
+            owner_id="worker",
+            fencing_token=lease.fencing_token,
+            lease_duration_ms=1,
+        )
+        assert lease.heartbeat_at_ms == 0
+        assert lease.lease_expires_at_ms == 2
+
+        clock["raw_ms"] = 2
+        assert catalog._db_now_ms() == lease.lease_expires_at_ms
         with pytest.raises(CatalogConflictError, match="expired"):
             catalog.renew_job_lease(
                 job.job_id,
@@ -894,6 +904,18 @@ def test_high_frequency_one_millisecond_renewal_has_one_conflict_boundary(
                 fencing_token=lease.fencing_token,
                 lease_duration_ms=1,
             )
+
+    # The test clock is connection-local and cannot leak into a restarted
+    # catalog or alter the persisted lease while the failed renewal rolls back.
+    with SQLiteCatalog(path) as restarted:
+        assert restarted._db_now_ms() > lease.lease_expires_at_ms
+        persisted = restarted._connection.execute(
+            "SELECT * FROM ref_job_leases WHERE job_id = ?",
+            (job.job_id,),
+        ).fetchone()
+        assert persisted is not None
+        assert persisted["heartbeat_at_ms"] == lease.heartbeat_at_ms
+        assert persisted["lease_expires_at_ms"] == lease.lease_expires_at_ms
 
 
 def test_expired_lease_cannot_mutate_and_takeover_atomically_requeues(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Remove the operating-system scheduling assumption from the one-millisecond SQLite lease renewal boundary test added in #536. The production lease implementation remains unchanged: an unexpired lease renews and an exactly expired lease conflicts according to the database clock.

## Changes

- Replace the 10 ms wall-clock loop with a connection-local SQLite clock controlled at exact millisecond boundaries.
- Prove renewal succeeds at `expires_at_ms - 1` and conflicts at `expires_at_ms`.
- Reopen the catalog to prove the test clock is connection-local and the rejected renewal does not mutate the persisted lease.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- Target test passed 100 consecutive repetitions.
- `25 passed`: SQLite job tests, both sequentially and with pytest-xdist.
- `159 passed`: storage suite, both sequentially and with pytest-xdist.
- Target test passed on Python 3.10 and Python 3.12.
- Black, isort, flake8, namespace, and diff checks passed.
- Independent final-head review found no blocker.
- The same main SHA failed the old assertion once and passed on rerun under the 64-worker self-hosted runner, confirming the original test was scheduler-sensitive.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
