### PR TITLE
refactor(artifacts): share portable view normalization

### DIFF
--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -19,7 +19,7 @@ from .github import (
     resolve_github_context_artifact,
 )
 from .mcp_config import MCP_CONFIG_HOSTS, render_artifact_mcp_config
-from .portable_views import normalize_owned_query_view
+from .portable_views import SourceTrust, normalize_owned_query_view
 from .runtime import (
     ContextArtifactBinding,
     VerifiedContextArtifact,
@@ -36,6 +36,7 @@ __all__ = [
     "GitHubArtifactFetchResult",
     "GitHubArtifactRecord",
     "MCP_CONFIG_HOSTS",
+    "SourceTrust",
     "VerifiedContextArtifact",
     "bind_context_artifact",
     "extract_context_artifact_archive",

--- a/codenib/artifacts/__init__.py
+++ b/codenib/artifacts/__init__.py
@@ -19,6 +19,7 @@ from .github import (
     resolve_github_context_artifact,
 )
 from .mcp_config import MCP_CONFIG_HOSTS, render_artifact_mcp_config
+from .portable_views import normalize_owned_query_view
 from .runtime import (
     ContextArtifactBinding,
     VerifiedContextArtifact,
@@ -39,6 +40,7 @@ __all__ = [
     "bind_context_artifact",
     "extract_context_artifact_archive",
     "fetch_github_context_artifact",
+    "normalize_owned_query_view",
     "resolve_github_context_artifact",
     "render_artifact_mcp_config",
     "stage_context_artifact",

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -299,6 +299,7 @@ def stage_context_artifact(
                 repo_path=repo_path,
                 view_type=view,
                 view_config=entry.config,
+                source_trust="trusted-local",
             )
             entry_data = entry.to_dict()
             entry_data["path"] = relative

--- a/codenib/artifacts/context.py
+++ b/codenib/artifacts/context.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Mapping, Sequence
 
-from .. import compat_pickle
 from .._atomic_directory import (
     capture_directory_ownership,
     discard_owned_directory,
@@ -24,22 +23,16 @@ from .._atomic_directory import (
     publish_staged_directory,
 )
 from .._version import package_version
-from ..compiler.artifact_fingerprints import (
-    bm25_artifact_file_fingerprints,
-    require_bm25_manifest_artifact,
-)
+from ..compiler.artifact_fingerprints import require_bm25_manifest_artifact
 from ..compiler.checkout_identity import validate_checkout_identity
 from ..compiler.manifest import MANIFEST_FILENAME, RepoManifest
 from ..compiler.snapshot_store import normalize_repo
 from ..index.embedding.artifact_integrity import (
-    VECTOR_PERSISTENCE_SCHEMA,
     require_complete_vector_view,
     validate_vector_config_artifact,
-    validate_vector_generation_artifacts,
-    vector_config_artifact_record,
-    vector_level_artifact_records,
 )
 from ..provider_routes import resolve_embedding_artifact_route
+from .portable_views import normalize_owned_query_view
 from .security import assert_no_credential_fields, assert_publishable_tree, file_sha256
 
 CONTEXT_ARTIFACT_SCHEMA = "codenib.context-artifact.v1"
@@ -164,190 +157,6 @@ def _copy_view(source: Path, stage: Path, view: str) -> str:
     target = destination / source.name
     shutil.copy2(source, target)
     return target.relative_to(stage).as_posix()
-
-
-def _normalize_copied_view(
-    stage: Path,
-    *,
-    repo_path: Path,
-    view: str,
-    relative: str,
-    view_config: Mapping[str, Any],
-) -> dict[str, Any]:
-    """Rewrite view-local machine paths and return identity adjustments."""
-
-    target = stage.joinpath(*PurePosixPath(relative).parts)
-    if view == "vector":
-        route = resolve_embedding_artifact_route(view_config)
-        return _normalize_vector_view(
-            target,
-            repo_path,
-            embedding_model=route.model,
-        )
-    if view != "bm25":
-        raise ValueError(
-            f"view {view!r} is not yet supported by portable context artifacts; "
-            "select bm25 and/or vector"
-        )
-    root = target if target.is_dir() else target.parent
-    metadata_path = root / "bm25_metadata.json"
-    if not metadata_path.is_file():
-        raise ValueError("portable BM25 view is missing bm25_metadata.json")
-    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    if not isinstance(metadata, dict):
-        raise ValueError("portable BM25 metadata must be a JSON object")
-    metadata["project_root"] = "source"
-    metadata_path.write_bytes(_json_bytes(metadata))
-    return {"artifact_file_fingerprints": bm25_artifact_file_fingerprints(root)}
-
-
-def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str:
-    raw = str(value or "")
-    if not raw:
-        return ""
-    path = Path(raw).expanduser()
-    if path.is_absolute():
-        try:
-            path = path.resolve().relative_to(repo_path)
-        except ValueError as exc:
-            raise ValueError(f"{source} points outside the repository: {raw}") from exc
-    normalized = PurePosixPath(path.as_posix())
-    if normalized.is_absolute() or ".." in normalized.parts:
-        raise ValueError(f"{source} is not repository-relative: {raw}")
-    return normalized.as_posix()
-
-
-def _convert_vector_documents(path: Path, repo_path: Path) -> Path:
-    """Convert a trusted local document pickle to portable, inert JSON."""
-
-    with path.open("rb") as handle:
-        documents = compat_pickle.load(handle)
-    if not isinstance(documents, list):
-        raise ValueError(f"portable vector documents must be a list: {path.name}")
-    payload: list[dict[str, Any]] = []
-    for index, document in enumerate(documents):
-        page_content = getattr(document, "page_content", None)
-        if not isinstance(page_content, str):
-            raise ValueError(
-                f"portable vector document {index} has invalid content: {path.name}"
-            )
-        metadata = getattr(document, "metadata", None)
-        if not isinstance(metadata, dict):
-            raise ValueError(
-                f"portable vector document {index} has invalid metadata: {path.name}"
-            )
-        normalized_metadata = dict(metadata)
-        normalized_metadata["file"] = _portable_source_path(
-            metadata.get("file"),
-            repo_path,
-            source=f"vector document {index} file",
-        )
-        payload.append(
-            {
-                "page_content": page_content,
-                "metadata": normalized_metadata,
-            }
-        )
-
-    output = path.with_suffix(".json")
-    output.write_bytes(_json_bytes(payload))
-    path.unlink()
-    return output
-
-
-def _refresh_vector_persistence_records(target: Path) -> None:
-    """Commit the portable JSON/index pairs in copied vector configs."""
-
-    for config_path in sorted(target.glob("config_*.json")):
-        config = json.loads(config_path.read_text(encoding="utf-8"))
-        if not isinstance(config, dict):
-            raise ValueError(f"portable vector config must be an object: {config_path}")
-        embedding_model = config.get("embedding_model")
-        if not isinstance(embedding_model, str) or not embedding_model:
-            continue
-        model_suffix = embedding_model.replace("/", "__")
-        level_artifacts: dict[str, dict[str, dict[str, Any]]] = {}
-        has_level_counts = False
-        for level in ("l0", "l2"):
-            count = config.get(f"{level}_documents")
-            if count is None:
-                continue
-            has_level_counts = True
-            if not isinstance(count, int) or isinstance(count, bool) or count < 0:
-                raise ValueError(
-                    f"portable vector config has invalid {level} count: {count!r}"
-                )
-            if count == 0:
-                continue
-            level_path = target / level
-            documents_path = level_path / f"documents_{model_suffix}.json"
-            level_artifacts[level] = vector_level_artifact_records(
-                level_path,
-                model_suffix,
-                documents_file=documents_path.name,
-            )
-        if has_level_counts:
-            config["persistence_schema"] = VECTOR_PERSISTENCE_SCHEMA
-            config["level_artifacts"] = level_artifacts
-            config_path.write_bytes(_json_bytes(config))
-
-
-def _normalize_vector_view(
-    target: Path,
-    repo_path: Path,
-    *,
-    embedding_model: str,
-) -> dict[str, Any]:
-    if not target.is_dir():
-        raise ValueError("portable vector view must be a directory")
-    require_complete_vector_view(target)
-    interrupted = sorted(target.glob(".config_*.json.save-in-progress"))
-    if interrupted:
-        raise ValueError(
-            "portable vector view contains an interrupted save marker: "
-            f"{interrupted[0].name}"
-        )
-
-    model_suffix = embedding_model.replace("/", "__")
-    # Validate the source generation before replacing its trusted local pickle
-    # with portable JSON. Recomputing records first would bless torn level files.
-    validate_vector_generation_artifacts(target, model_suffix)
-
-    # Query serving does not need the mutable state used to build the next
-    # commit. Excluding it keeps the downloadable artifact smaller and avoids
-    # publishing build-machine paths from incremental caches.
-    for name in (
-        "chunk_store.json",
-        "chunk_store.pkl",
-        "embeddings_cache.json",
-        "embeddings_cache.npz",
-        "embeddings_cache.pkl",
-        "incremental_state.json",
-    ):
-        (target / name).unlink(missing_ok=True)
-
-    document_files = sorted(target.glob("l[02]/documents_*.pkl"))
-    if not document_files:
-        raise ValueError(
-            "portable vector view requires the current documents_*.pkl format; "
-            "rebuild the vector view"
-        )
-    for path in document_files:
-        _convert_vector_documents(path, repo_path)
-
-    # The current document files supersede legacy LangChain docstore pickles.
-    # Leaving both formats would retain duplicate absolute source paths.
-    for legacy in target.glob("l[02]/index_*.pkl"):
-        legacy.unlink()
-    _refresh_vector_persistence_records(target)
-    return {
-        "artifact_scope": "query-serving",
-        "portable_document_format": "codenib.vector-documents.v1",
-        "persistence_config_fingerprint": vector_config_artifact_record(
-            target,
-            model_suffix,
-        ),
-    }
 
 
 def _inventory(root: Path) -> list[dict[str, Any]]:
@@ -485,11 +294,10 @@ def stage_context_artifact(
                 # could bless a torn or tampered source with fresh hashes.
                 require_bm25_manifest_artifact(entry)
             relative = _copy_view(source, stage, view)
-            adjustments = _normalize_copied_view(
-                stage,
+            adjustments = normalize_owned_query_view(
+                stage.joinpath(*PurePosixPath(relative).parts),
                 repo_path=repo_path,
-                view=view,
-                relative=relative,
+                view_type=view,
                 view_config=entry.config,
             )
             entry_data = entry.to_dict()

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -6,9 +6,11 @@
 
 from __future__ import annotations
 
+import importlib
 import json
+import re
 from pathlib import Path, PurePosixPath
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 
 from .. import compat_pickle
 from ..compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
@@ -16,11 +18,12 @@ from ..index.embedding.artifact_integrity import (
     VECTOR_PERSISTENCE_SCHEMA,
     VECTOR_VIEW_UPDATE_MARKER,
     require_complete_vector_view,
+    validate_vector_config_artifact,
     validate_vector_generation_artifacts,
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
-from ..provider_routes import resolve_embedding_artifact_route
+from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
 
 _VECTOR_LEVELS = ("l0", "l2")
 _REMOVABLE_MUTABLE_VECTOR_FILES = frozenset(
@@ -38,6 +41,9 @@ _MUTABLE_VECTOR_PREFIXES = (
     "embeddings_cache.",
     "incremental_state.",
 )
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_PICKLE_SUFFIXES = frozenset({".pkl", ".pickle"})
+SourceTrust = Literal["portable-inert", "trusted-local"]
 
 
 def _json_bytes(value: Any) -> bytes:
@@ -105,14 +111,37 @@ def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str
     raw = str(value or "")
     if not raw:
         return ""
+    if any(ord(character) < 32 or ord(character) == 127 for character in raw):
+        raise ValueError(
+            f"{source} is not a portable repository-relative path: {raw!r}"
+        )
+
     path = Path(raw).expanduser()
     if path.is_absolute():
         try:
             path = path.resolve().relative_to(repo_path)
-        except ValueError as exc:
+        except (OSError, RuntimeError, ValueError) as exc:
             raise ValueError(f"{source} points outside the repository: {raw}") from exc
-    normalized = PurePosixPath(path.as_posix())
-    if normalized.is_absolute() or ".." in normalized.parts:
+        raw = path.as_posix()
+    else:
+        native = path.as_posix()
+        if native != raw:
+            raw_parts = raw.replace("\\", "/").split("/")
+            if any(part in {"", ".", ".."} for part in raw_parts):
+                raise ValueError(f"{source} is not repository-relative: {raw}")
+            raw = native
+        elif "\\" in raw or raw.startswith("//") or _WINDOWS_DRIVE_RE.match(raw):
+            raise ValueError(
+                f"{source} is not a portable repository-relative path: {raw!r}"
+            )
+
+    raw_parts = raw.split("/")
+    normalized = PurePosixPath(raw)
+    if (
+        normalized.is_absolute()
+        or any(part in {"", ".", ".."} for part in raw_parts)
+        or raw != normalized.as_posix()
+    ):
         raise ValueError(f"{source} is not repository-relative: {raw}")
     return normalized.as_posix()
 
@@ -160,6 +189,23 @@ def _normalize_pickle_documents(
     # Validate serializability before any file in the owned view is changed.
     _json_bytes(payload)
     return payload
+
+
+def _pickle_paths(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path.suffix.casefold() in _PICKLE_SUFFIXES
+    )
+
+
+def _reject_inert_pickles(root: Path) -> None:
+    pickles = _pickle_paths(root)
+    if pickles:
+        raise ValueError(
+            "portable-inert query view must not contain pickle: "
+            f"{pickles[0].relative_to(root)}"
+        )
 
 
 def _normalize_json_documents(
@@ -215,20 +261,228 @@ def _is_mutable_vector_state(path: Path) -> bool:
     )
 
 
+def _validate_vector_model_policy(
+    root: Path,
+    *,
+    model_suffix: str,
+    source_trust: SourceTrust,
+) -> None:
+    """Reject ambiguous multi-model trees and untrusted serialized objects."""
+
+    allowed_model_artifacts = {
+        root / f"config_{model_suffix}.json",
+    }
+    for level in _VECTOR_LEVELS:
+        allowed_model_artifacts.update(
+            {
+                root / level / f"config_{model_suffix}.json",
+                root / level / f"documents_{model_suffix}.json",
+                root / level / f"documents_{model_suffix}.pkl",
+                root / level / f"index_{model_suffix}.faiss",
+                root / level / f"index_{model_suffix}.pkl",
+            }
+        )
+    unexpected_model_artifacts = sorted(
+        path
+        for path in root.rglob("*")
+        if path.name.casefold().startswith(("config_", "documents_", "index_"))
+        and path not in allowed_model_artifacts
+    )
+    if unexpected_model_artifacts:
+        raise ValueError(
+            "portable vector view contains an unknown or other-model artifact: "
+            f"{unexpected_model_artifacts[0].relative_to(root)}"
+        )
+
+    pickles = _pickle_paths(root)
+    if source_trust == "portable-inert":
+        _reject_inert_pickles(root)
+        return
+
+    allowed_pickles = {
+        root / level / f"documents_{model_suffix}.pkl" for level in _VECTOR_LEVELS
+    }
+    allowed_pickles.update(
+        root / level / f"index_{model_suffix}.pkl" for level in _VECTOR_LEVELS
+    )
+    allowed_pickles.update(
+        root / name for name in _REMOVABLE_MUTABLE_VECTOR_FILES if name.endswith(".pkl")
+    )
+    unexpected = [path for path in pickles if path not in allowed_pickles]
+    if unexpected:
+        raise ValueError(
+            "trusted-local vector view contains an unexpected pickle: "
+            f"{unexpected[0].relative_to(root)}"
+        )
+
+
+def _validate_vector_semantics(
+    config: Mapping[str, Any],
+    view_config: Mapping[str, Any],
+) -> tuple[str, int]:
+    """Close the manifest-route to persisted-config compatibility contract."""
+
+    route = resolve_embedding_artifact_route(view_config)
+    required_checks: tuple[tuple[str, object], ...] = (
+        ("embedding_model", route.model),
+        ("dimension", route.dimension),
+    )
+    for key, expected in required_checks:
+        if config.get(key) != expected:
+            raise ValueError(
+                f"portable vector persistence {key} does not match its view route"
+            )
+    if "embedding_dimension" in config and config["embedding_dimension"] != (
+        route.dimension
+    ):
+        raise ValueError(
+            "portable vector persistence embedding_dimension does not match its "
+            "view route"
+        )
+    try:
+        provider = normalize_provider(str(config.get("embedding_provider", "")))
+    except ValueError as exc:
+        raise ValueError(
+            "portable vector persistence has an invalid embedding provider"
+        ) from exc
+    if provider != route.provider:
+        raise ValueError(
+            "portable vector persistence embedding provider does not match "
+            "its view route"
+        )
+
+    expected_metric = view_config.get("index_metric")
+    persisted_metric = config.get("index_metric")
+    if expected_metric is not None and persisted_metric != expected_metric:
+        raise ValueError(
+            "portable vector persistence index metric does not match its view config"
+        )
+
+    persisted_identity = config.get("artifact")
+    if persisted_identity is not None:
+        if not isinstance(persisted_identity, Mapping):
+            raise ValueError("portable vector persistence artifact identity is invalid")
+        persisted_route = resolve_embedding_artifact_route(persisted_identity)
+        if persisted_route.public_identity() != route.public_identity():
+            raise ValueError(
+                "portable vector persistence route identity does not match its view "
+                "route"
+            )
+        persisted_identity_metric = persisted_identity.get("index_metric")
+        if (
+            expected_metric is not None
+            and persisted_identity_metric is not None
+            and persisted_identity_metric != expected_metric
+        ):
+            raise ValueError(
+                "portable vector persistence identity metric does not match its "
+                "view config"
+            )
+    elif "embedding_kwargs" in config:
+        # Legacy configs sometimes expose the semantic options directly. When
+        # present, absence is not treated as a wildcard.
+        persisted_route = resolve_embedding_artifact_route(config)
+        if persisted_route.public_identity() != route.public_identity():
+            raise ValueError(
+                "portable vector persistence options do not match its view route"
+            )
+
+    if route.dimension is None:
+        raise ValueError("portable vector route is missing its embedding dimension")
+    return route.model.replace("/", "__"), route.dimension
+
+
+def _faiss_shape(path: Path) -> tuple[int, int]:
+    """Read only the persisted index shape, importing FAISS on demand."""
+
+    try:
+        faiss = importlib.import_module("faiss")
+        index = faiss.read_index(str(path))
+        dimension = int(index.d)
+        total = int(index.ntotal)
+    except Exception as exc:
+        raise ValueError(f"portable vector FAISS index is unreadable: {path}") from exc
+    return dimension, total
+
+
+def _validate_level_semantics(
+    path: Path,
+    *,
+    level: str,
+    model: str,
+    provider: str,
+    dimension: int,
+    metric: object,
+    count: int,
+) -> None:
+    if not path.exists():
+        return
+    config = _load_json_object(path, label=f"portable vector {level} config")
+    checks: tuple[tuple[str, object], ...] = (
+        ("embedding_model", model),
+        ("dimension", dimension),
+        ("index_metric", metric),
+        ("level", level),
+        ("num_documents", count),
+    )
+    for key, expected in checks:
+        if key in config and expected is not None and config[key] != expected:
+            raise ValueError(
+                f"portable vector {level} persistence {key} does not match"
+            )
+    if "embedding_provider" in config:
+        try:
+            persisted_provider = normalize_provider(str(config["embedding_provider"]))
+        except ValueError as exc:
+            raise ValueError(
+                f"portable vector {level} persistence provider is invalid"
+            ) from exc
+        if persisted_provider != provider:
+            raise ValueError(
+                f"portable vector {level} persistence provider does not match"
+            )
+
+
 def _validate_vector_layout(
     root: Path,
     repo_path: Path,
     *,
     model_suffix: str,
     config: Mapping[str, Any],
-) -> tuple[str, dict[Path, list[dict[str, Any]]]]:
+    expected_model: str,
+    expected_provider: str,
+    expected_dimension: int,
+    expected_metric: object,
+    source_trust: SourceTrust,
+) -> tuple[
+    str,
+    dict[Path, list[dict[str, Any]]],
+    dict[str, int],
+    set[Path],
+]:
     expected_documents: set[Path] = set()
     selected: dict[Path, list[dict[str, Any]]] = {}
     formats: set[str] = set()
+    counts_present = [f"{level}_documents" in config for level in _VECTOR_LEVELS]
+    if any(counts_present) and not all(counts_present):
+        raise ValueError("portable vector config has partial level counts")
+    legacy_counts = not any(counts_present)
+    if legacy_counts and (
+        config.get("persistence_schema") is not None
+        or config.get("level_artifacts") is not None
+    ):
+        raise ValueError(
+            "portable vector config with persistence records requires level counts"
+        )
+
+    derived_counts: dict[str, int] = {}
+    stale_paths: set[Path] = set()
 
     for level in _VECTOR_LEVELS:
-        count = config.get(f"{level}_documents")
-        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        count = config.get(f"{level}_documents") if not legacy_counts else None
+        if count is not None and (
+            not isinstance(count, int) or isinstance(count, bool) or count < 0
+        ):
             raise ValueError(
                 f"portable vector config has invalid {level} count: {count!r}"
             )
@@ -237,37 +491,94 @@ def _validate_vector_layout(
         json_path = level_path / f"documents_{model_suffix}.json"
         present = [path for path in (pickle_path, json_path) if path.is_file()]
         expected_documents.update(present)
+        index_path = level_path / f"index_{model_suffix}.faiss"
 
         if count == 0:
-            if present:
-                raise ValueError(
-                    f"portable vector view contains documents for empty {level} level"
+            # A zero count is authoritative. Older writers left uncommitted
+            # current-model level files behind; this caller-owned copy may prune
+            # those exact names, but never unknown or other-model artifacts.
+            stale_paths.update(
+                path
+                for path in (
+                    pickle_path,
+                    json_path,
+                    index_path,
+                    level_path / f"index_{model_suffix}.pkl",
+                    level_path / f"config_{model_suffix}.json",
                 )
+                if path.is_file()
+            )
+            derived_counts[level] = 0
             continue
         if len(present) > 1:
             raise ValueError(
                 f"portable vector view mixes pickle and JSON documents in {level}"
             )
-        if not present:
+        if not present and (count is not None and count > 0):
             raise ValueError(
                 f"portable vector view is missing documents for non-empty {level}"
             )
-        index_path = level_path / f"index_{model_suffix}.faiss"
+        if not present and count is None:
+            if (
+                index_path.exists()
+                or (level_path / f"config_{model_suffix}.json").exists()
+            ):
+                raise ValueError(f"portable legacy vector {level} level is incomplete")
+            derived_counts[level] = 0
+            continue
         if index_path.is_symlink() or not index_path.is_file():
             raise ValueError(f"portable vector view is missing its index: {index_path}")
 
         path = present[0]
         document_format = path.suffix.removeprefix(".")
-        formats.add(document_format)
         if document_format == "pkl":
+            if source_trust != "trusted-local":
+                raise ValueError(
+                    "portable-inert vector view must not deserialize documents"
+                )
             payload = _normalize_pickle_documents(path, repo_path)
         else:
             payload = _normalize_json_documents(path, repo_path)
-        if len(payload) != count:
+        if count is not None and len(payload) != count:
             raise ValueError(
                 f"portable vector {level} count differs from {path.name}: "
                 f"expected {count}, found {len(payload)}"
             )
+        count = len(payload)
+        dimension, total = _faiss_shape(index_path)
+        if dimension != expected_dimension:
+            raise ValueError(
+                f"portable vector FAISS dimension mismatch in {level}: "
+                f"expected {expected_dimension}, found {dimension}"
+            )
+        if total != count:
+            raise ValueError(
+                f"portable vector FAISS count mismatch in {level}: "
+                f"expected {count}, found {total}"
+            )
+        _validate_level_semantics(
+            level_path / f"config_{model_suffix}.json",
+            level=level,
+            model=expected_model,
+            provider=expected_provider,
+            dimension=expected_dimension,
+            metric=expected_metric,
+            count=count,
+        )
+        derived_counts[level] = count
+        if legacy_counts and count == 0:
+            stale_paths.update(
+                candidate
+                for candidate in (
+                    path,
+                    index_path,
+                    level_path / f"index_{model_suffix}.pkl",
+                    level_path / f"config_{model_suffix}.json",
+                )
+                if candidate.is_file()
+            )
+            continue
+        formats.add(document_format)
         selected[path] = payload
 
     if not selected:
@@ -278,7 +589,7 @@ def _validate_vector_layout(
     candidates = {
         path
         for path in root.rglob("documents_*")
-        if path.suffix.lower() in {".json", ".pkl"}
+        if path.suffix.casefold() in {".json", ".pkl", ".pickle"}
     }
     unexpected_documents = sorted(candidates - expected_documents)
     if unexpected_documents:
@@ -288,6 +599,9 @@ def _validate_vector_layout(
         )
 
     allowed_pickles = {path for path in selected if path.suffix.lower() == ".pkl"}
+    allowed_pickles.update(
+        path for path in stale_paths if path.suffix.casefold() in _PICKLE_SUFFIXES
+    )
     allowed_pickles.update(
         path for path in root.glob("l[02]/index_*.pkl") if path.is_file()
     )
@@ -299,7 +613,7 @@ def _validate_vector_layout(
     residual_pickles = sorted(
         path
         for path in root.rglob("*")
-        if path.suffix.lower() == ".pkl" and path not in allowed_pickles
+        if path.suffix.casefold() in _PICKLE_SUFFIXES and path not in allowed_pickles
     )
     if residual_pickles:
         raise ValueError(
@@ -320,7 +634,7 @@ def _validate_vector_layout(
             f"{residual_mutable[0].relative_to(root)}"
         )
 
-    return next(iter(formats)), selected
+    return next(iter(formats)), selected, derived_counts, stale_paths
 
 
 def _refresh_vector_persistence_records(
@@ -353,7 +667,7 @@ def _refresh_vector_persistence_records(
 
 def _assert_normalized_vector_tree(root: Path) -> None:
     for path in sorted(root.rglob("*")):
-        if path.suffix.lower() == ".pkl":
+        if path.suffix.casefold() in _PICKLE_SUFFIXES:
             raise ValueError(
                 "portable vector normalization left a pickle behind: "
                 f"{path.relative_to(root)}"
@@ -370,6 +684,7 @@ def _normalize_vector_view(
     repo_path: Path,
     *,
     view_config: Mapping[str, Any],
+    source_trust: SourceTrust,
 ) -> dict[str, Any]:
     require_complete_vector_view(root)
     interrupted = sorted(root.glob(".config_*.json.save-in-progress"))
@@ -381,19 +696,40 @@ def _normalize_vector_view(
 
     route = resolve_embedding_artifact_route(view_config)
     model_suffix = route.model.replace("/", "__")
+    _validate_vector_model_policy(
+        root,
+        model_suffix=model_suffix,
+        source_trust=source_trust,
+    )
+    expected_config = view_config.get("persistence_config_fingerprint")
+    if expected_config is not None:
+        validate_vector_config_artifact(
+            root,
+            model_suffix,
+            expected_config,
+        )
     # Validate the committed source generation before replacing any trusted-local
     # pickle or refreshing records. Otherwise normalization could bless torn files.
     validate_vector_generation_artifacts(root, model_suffix)
     config_path = root / f"config_{model_suffix}.json"
     config = _load_json_object(config_path, label="portable vector config")
-    if config.get("embedding_model") != route.model:
+    semantic_suffix, expected_dimension = _validate_vector_semantics(
+        config,
+        view_config,
+    )
+    if semantic_suffix != model_suffix:
         raise ValueError("portable vector config embedding model does not match")
 
-    document_format, documents = _validate_vector_layout(
+    document_format, documents, counts, stale_paths = _validate_vector_layout(
         root,
         repo_path,
         model_suffix=model_suffix,
         config=config,
+        expected_model=route.model,
+        expected_provider=route.provider,
+        expected_dimension=expected_dimension,
+        expected_metric=view_config.get("index_metric"),
+        source_trust=source_trust,
     )
 
     for path, payload in documents.items():
@@ -401,6 +737,18 @@ def _normalize_vector_view(
         output.write_bytes(_json_bytes(payload))
         if document_format == "pkl":
             path.unlink()
+
+    for path in sorted(stale_paths):
+        path.unlink(missing_ok=True)
+    for level in _VECTOR_LEVELS:
+        level_path = root / level
+        try:
+            level_path.rmdir()
+        except OSError:
+            pass
+
+    config.update({f"{level}_documents": counts[level] for level in _VECTOR_LEVELS})
+    config_path.write_bytes(_json_bytes(config))
 
     # Query serving does not need build-time incremental state. These exact
     # machine-local files are safe to discard from the owned copy; unfamiliar
@@ -429,20 +777,27 @@ def normalize_owned_query_view(
     repo_path: Path,
     view_type: str,
     view_config: Mapping[str, Any],
+    source_trust: SourceTrust = "portable-inert",
 ) -> dict[str, Any]:
     """Normalize one copied view and return its portable identity adjustments.
 
-    ``root`` must be a caller-owned copy that can be safely rewritten. Local
-    vector pickles are deserialized only on that explicit trust boundary;
-    already-portable JSON document stores are parsed as inert data.
+    ``root`` must be a caller-owned copy that can be safely rewritten.
+    ``source_trust`` defaults to inert portable data; only ``trusted-local`` may
+    deserialize the exact legacy vector pickle names owned by this program.
     """
 
+    if not isinstance(source_trust, str) or source_trust not in {
+        "portable-inert",
+        "trusted-local",
+    }:
+        raise ValueError(f"invalid portable query view source trust: {source_trust!r}")
     normalized_root, repository = _owned_view_root(root, repo_path)
     if view_type == "vector":
         return _normalize_vector_view(
             normalized_root,
             repository,
             view_config=view_config,
+            source_trust=source_trust,
         )
     if view_type != "bm25":
         raise ValueError(
@@ -450,6 +805,7 @@ def normalize_owned_query_view(
             "select bm25 and/or vector"
         )
 
+    _reject_inert_pickles(normalized_root)
     metadata_path = normalized_root / "bm25_metadata.json"
     metadata = _load_json_object(metadata_path, label="portable BM25 metadata")
     metadata["project_root"] = "source"
@@ -459,4 +815,4 @@ def normalize_owned_query_view(
     }
 
 
-__all__ = ["normalize_owned_query_view"]
+__all__ = ["SourceTrust", "normalize_owned_query_view"]

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -23,6 +23,9 @@ from ..index.embedding.artifact_integrity import (
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
+from ..index.embedding.model_policy import (
+    resolve_embedding_load_policy_from_options,
+)
 from ..provider_routes import normalize_provider, resolve_embedding_artifact_route
 
 _VECTOR_LEVELS = ("l0", "l2")
@@ -319,13 +322,22 @@ def _validate_vector_model_policy(
 def _validate_vector_semantics(
     config: Mapping[str, Any],
     view_config: Mapping[str, Any],
-) -> tuple[str, int]:
+) -> tuple[str, int, str | None, str, str]:
     """Close the manifest-route to persisted-config compatibility contract."""
 
     route = resolve_embedding_artifact_route(view_config)
+    expected_revision = (
+        resolve_embedding_load_policy_from_options(
+            route.model,
+            route.compatibility_options,
+        ).revision
+        if route.provider == "huggingface"
+        else None
+    )
     required_checks: tuple[tuple[str, object], ...] = (
         ("embedding_model", route.model),
         ("dimension", route.dimension),
+        ("embedding_revision", expected_revision),
     )
     for key, expected in required_checks:
         if config.get(key) != expected:
@@ -351,14 +363,39 @@ def _validate_vector_semantics(
             "its view route"
         )
 
-    expected_metric = view_config.get("index_metric")
+    expected_metric = view_config.get("index_metric", "ip")
+    if expected_metric not in {"ip", "l2"}:
+        raise ValueError(
+            f"portable vector view has unsupported index metric: {expected_metric!r}"
+        )
     persisted_metric = config.get("index_metric")
-    if expected_metric is not None and persisted_metric != expected_metric:
+    if persisted_metric != expected_metric:
         raise ValueError(
             "portable vector persistence index metric does not match its view config"
         )
 
+    expected_index_type = view_config.get("index_type", "flat")
+    if expected_index_type not in {"flat", "ivf"}:
+        raise ValueError(
+            "portable vector view has unsupported index type: "
+            f"{expected_index_type!r}"
+        )
+    if config.get("index_type") != expected_index_type:
+        raise ValueError(
+            "portable vector persistence index type does not match its view config"
+        )
+
     persisted_identity = config.get("artifact")
+    builder_schema = view_config.get("builder_schema")
+    identity_required = (
+        view_config.get("embedding_fingerprint") is not None
+        or (
+            isinstance(builder_schema, int)
+            and not isinstance(builder_schema, bool)
+            and builder_schema >= 3
+        )
+        or bool(route.compatibility_options)
+    )
     if persisted_identity is not None:
         if not isinstance(persisted_identity, Mapping):
             raise ValueError("portable vector persistence artifact identity is invalid")
@@ -368,16 +405,38 @@ def _validate_vector_semantics(
                 "portable vector persistence route identity does not match its view "
                 "route"
             )
-        persisted_identity_metric = persisted_identity.get("index_metric")
+        expected_fingerprint = view_config.get("embedding_fingerprint")
         if (
-            expected_metric is not None
-            and persisted_identity_metric is not None
-            and persisted_identity_metric != expected_metric
+            expected_fingerprint is not None
+            and persisted_identity.get("embedding_fingerprint") != expected_fingerprint
         ):
+            raise ValueError(
+                "portable vector persistence embedding fingerprint does not match "
+                "its view config"
+            )
+        persisted_revision = (
+            resolve_embedding_load_policy_from_options(
+                persisted_route.model,
+                persisted_route.compatibility_options,
+            ).revision
+            if persisted_route.provider == "huggingface"
+            else None
+        )
+        if persisted_revision != expected_revision:
+            raise ValueError(
+                "portable vector persistence artifact revision does not match its "
+                "view config"
+            )
+        persisted_identity_metric = persisted_identity.get("index_metric")
+        if persisted_identity_metric != expected_metric:
             raise ValueError(
                 "portable vector persistence identity metric does not match its "
                 "view config"
             )
+    elif identity_required:
+        raise ValueError(
+            "portable vector persistence is missing its embedding artifact identity"
+        )
     elif "embedding_kwargs" in config:
         # Legacy configs sometimes expose the semantic options directly. When
         # present, absence is not treated as a wildcard.
@@ -389,20 +448,43 @@ def _validate_vector_semantics(
 
     if route.dimension is None:
         raise ValueError("portable vector route is missing its embedding dimension")
-    return route.model.replace("/", "__"), route.dimension
+    return (
+        route.model.replace("/", "__"),
+        route.dimension,
+        expected_revision,
+        expected_metric,
+        expected_index_type,
+    )
 
 
-def _faiss_shape(path: Path) -> tuple[int, int]:
-    """Read only the persisted index shape, importing FAISS on demand."""
+def _faiss_contract(path: Path) -> tuple[int, int, str, str]:
+    """Read the persisted index contract, importing FAISS on demand."""
 
     try:
         faiss = importlib.import_module("faiss")
         index = faiss.read_index(str(path))
         dimension = int(index.d)
         total = int(index.ntotal)
+        metric_type = int(index.metric_type)
+        if metric_type == int(faiss.METRIC_INNER_PRODUCT):
+            metric = "ip"
+        elif metric_type == int(faiss.METRIC_L2):
+            metric = "l2"
+        else:
+            raise ValueError(
+                f"portable vector FAISS index has unsupported metric: {metric_type}"
+            )
+        if isinstance(index, faiss.IndexIVF):
+            index_type = "ivf"
+        elif isinstance(index, faiss.IndexFlat):
+            index_type = "flat"
+        else:
+            raise ValueError(
+                f"portable vector FAISS index has unsupported type: {type(index).__name__}"
+            )
     except Exception as exc:
         raise ValueError(f"portable vector FAISS index is unreadable: {path}") from exc
-    return dimension, total
+    return dimension, total, metric, index_type
 
 
 def _validate_level_semantics(
@@ -411,8 +493,10 @@ def _validate_level_semantics(
     level: str,
     model: str,
     provider: str,
+    revision: str | None,
     dimension: int,
     metric: object,
+    index_type: str,
     count: int,
 ) -> None:
     if not path.exists():
@@ -420,27 +504,28 @@ def _validate_level_semantics(
     config = _load_json_object(path, label=f"portable vector {level} config")
     checks: tuple[tuple[str, object], ...] = (
         ("embedding_model", model),
+        ("embedding_revision", revision),
         ("dimension", dimension),
         ("index_metric", metric),
+        ("index_type", index_type),
         ("level", level),
         ("num_documents", count),
     )
     for key, expected in checks:
-        if key in config and expected is not None and config[key] != expected:
+        if config.get(key) != expected:
             raise ValueError(
                 f"portable vector {level} persistence {key} does not match"
             )
-    if "embedding_provider" in config:
-        try:
-            persisted_provider = normalize_provider(str(config["embedding_provider"]))
-        except ValueError as exc:
-            raise ValueError(
-                f"portable vector {level} persistence provider is invalid"
-            ) from exc
-        if persisted_provider != provider:
-            raise ValueError(
-                f"portable vector {level} persistence provider does not match"
-            )
+    try:
+        persisted_provider = normalize_provider(
+            str(config.get("embedding_provider", ""))
+        )
+    except ValueError as exc:
+        raise ValueError(
+            f"portable vector {level} persistence provider is invalid"
+        ) from exc
+    if persisted_provider != provider:
+        raise ValueError(f"portable vector {level} persistence provider does not match")
 
 
 def _validate_vector_layout(
@@ -451,8 +536,10 @@ def _validate_vector_layout(
     config: Mapping[str, Any],
     expected_model: str,
     expected_provider: str,
+    expected_revision: str | None,
     expected_dimension: int,
-    expected_metric: object,
+    expected_metric: str,
+    expected_index_type: str,
     source_trust: SourceTrust,
 ) -> tuple[
     str,
@@ -545,7 +632,7 @@ def _validate_vector_layout(
                 f"expected {count}, found {len(payload)}"
             )
         count = len(payload)
-        dimension, total = _faiss_shape(index_path)
+        dimension, total, metric, index_type = _faiss_contract(index_path)
         if dimension != expected_dimension:
             raise ValueError(
                 f"portable vector FAISS dimension mismatch in {level}: "
@@ -556,15 +643,16 @@ def _validate_vector_layout(
                 f"portable vector FAISS count mismatch in {level}: "
                 f"expected {count}, found {total}"
             )
-        _validate_level_semantics(
-            level_path / f"config_{model_suffix}.json",
-            level=level,
-            model=expected_model,
-            provider=expected_provider,
-            dimension=expected_dimension,
-            metric=expected_metric,
-            count=count,
-        )
+        if metric != expected_metric:
+            raise ValueError(
+                f"portable vector FAISS metric mismatch in {level}: "
+                f"expected {expected_metric}, found {metric}"
+            )
+        if index_type != expected_index_type:
+            raise ValueError(
+                f"portable vector FAISS index type mismatch in {level}: "
+                f"expected {expected_index_type}, found {index_type}"
+            )
         derived_counts[level] = count
         if legacy_counts and count == 0:
             stale_paths.update(
@@ -578,6 +666,17 @@ def _validate_vector_layout(
                 if candidate.is_file()
             )
             continue
+        _validate_level_semantics(
+            level_path / f"config_{model_suffix}.json",
+            level=level,
+            model=expected_model,
+            provider=expected_provider,
+            revision=expected_revision,
+            dimension=expected_dimension,
+            metric=expected_metric,
+            index_type=expected_index_type,
+            count=count,
+        )
         formats.add(document_format)
         selected[path] = payload
 
@@ -665,6 +764,36 @@ def _refresh_vector_persistence_records(
     config_path.write_bytes(_json_bytes(config))
 
 
+def _validate_view_document_count(
+    view_config: Mapping[str, Any],
+    counts: Mapping[str, int],
+) -> None:
+    if "document_count" not in view_config:
+        return
+    raw = view_config["document_count"]
+    if not isinstance(raw, Mapping):
+        raise ValueError("portable vector document_count must be a mapping")
+    expected = {
+        level: count for level in _VECTOR_LEVELS if (count := counts[level]) > 0
+    }
+    if set(raw) != set(expected):
+        raise ValueError(
+            "portable vector document_count must contain exactly the non-empty "
+            "levels"
+        )
+    for level, count in raw.items():
+        if (
+            not isinstance(level, str)
+            or not isinstance(count, int)
+            or isinstance(count, bool)
+            or count <= 0
+            or count != expected[level]
+        ):
+            raise ValueError(
+                "portable vector document_count does not match persisted levels"
+            )
+
+
 def _assert_normalized_vector_tree(root: Path) -> None:
     for path in sorted(root.rglob("*")):
         if path.suffix.casefold() in _PICKLE_SUFFIXES:
@@ -713,10 +842,13 @@ def _normalize_vector_view(
     validate_vector_generation_artifacts(root, model_suffix)
     config_path = root / f"config_{model_suffix}.json"
     config = _load_json_object(config_path, label="portable vector config")
-    semantic_suffix, expected_dimension = _validate_vector_semantics(
-        config,
-        view_config,
-    )
+    (
+        semantic_suffix,
+        expected_dimension,
+        expected_revision,
+        expected_metric,
+        expected_index_type,
+    ) = _validate_vector_semantics(config, view_config)
     if semantic_suffix != model_suffix:
         raise ValueError("portable vector config embedding model does not match")
 
@@ -727,10 +859,13 @@ def _normalize_vector_view(
         config=config,
         expected_model=route.model,
         expected_provider=route.provider,
+        expected_revision=expected_revision,
         expected_dimension=expected_dimension,
-        expected_metric=view_config.get("index_metric"),
+        expected_metric=expected_metric,
+        expected_index_type=expected_index_type,
         source_trust=source_trust,
     )
+    _validate_view_document_count(view_config, counts)
 
     for path, payload in documents.items():
         output = path.with_suffix(".json")

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -1,0 +1,462 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Normalize owned query views into portable, query-only artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+
+from .. import compat_pickle
+from ..compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
+from ..index.embedding.artifact_integrity import (
+    VECTOR_PERSISTENCE_SCHEMA,
+    VECTOR_VIEW_UPDATE_MARKER,
+    require_complete_vector_view,
+    validate_vector_generation_artifacts,
+    vector_config_artifact_record,
+    vector_level_artifact_records,
+)
+from ..provider_routes import resolve_embedding_artifact_route
+
+_VECTOR_LEVELS = ("l0", "l2")
+_REMOVABLE_MUTABLE_VECTOR_FILES = frozenset(
+    {
+        "chunk_store.json",
+        "chunk_store.pkl",
+        "embeddings_cache.json",
+        "embeddings_cache.npz",
+        "embeddings_cache.pkl",
+        "incremental_state.json",
+    }
+)
+_MUTABLE_VECTOR_PREFIXES = (
+    "chunk_store.",
+    "embeddings_cache.",
+    "incremental_state.",
+)
+
+
+def _json_bytes(value: Any) -> bytes:
+    return (
+        json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def _load_json(path: Path, *, label: str) -> Any:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"{label} is not a regular file: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} is invalid JSON: {path}") from exc
+
+
+def _load_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    value = _load_json(path, label=label)
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object: {path}")
+    return value
+
+
+def _owned_view_root(root: Path, repo_path: Path) -> tuple[Path, Path]:
+    candidate = root.expanduser()
+    if candidate.is_symlink():
+        raise ValueError(f"portable query view root must not be a symlink: {candidate}")
+    resolved = candidate.resolve()
+    if not resolved.is_dir():
+        raise ValueError(f"portable query view must be a directory: {resolved}")
+
+    repository = repo_path.expanduser().resolve()
+    if not repository.is_dir():
+        raise ValueError(f"repository directory does not exist: {repository}")
+    if (
+        resolved == repository
+        or resolved in repository.parents
+        or repository in resolved.parents
+    ):
+        raise ValueError(
+            "portable query view must not overlap the source repository: " f"{resolved}"
+        )
+
+    for path in sorted(resolved.rglob("*")):
+        relative = path.relative_to(resolved)
+        if path.is_symlink():
+            raise ValueError(f"portable query view contains a symlink: {relative}")
+        if not path.is_dir() and not path.is_file():
+            raise ValueError(
+                f"portable query view contains a non-regular entry: {relative}"
+            )
+    return resolved, repository
+
+
+def _portable_source_path(value: object, repo_path: Path, *, source: str) -> str:
+    raw = str(value or "")
+    if not raw:
+        return ""
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        try:
+            path = path.resolve().relative_to(repo_path)
+        except ValueError as exc:
+            raise ValueError(f"{source} points outside the repository: {raw}") from exc
+    normalized = PurePosixPath(path.as_posix())
+    if normalized.is_absolute() or ".." in normalized.parts:
+        raise ValueError(f"{source} is not repository-relative: {raw}")
+    return normalized.as_posix()
+
+
+def _normalize_pickle_documents(
+    path: Path,
+    repo_path: Path,
+) -> list[dict[str, Any]]:
+    """Load documents from an explicitly trusted, machine-local pickle."""
+
+    try:
+        with path.open("rb") as handle:
+            documents = compat_pickle.load(handle)
+    except Exception as exc:
+        raise ValueError(
+            f"trusted-local vector documents pickle is invalid: {path.name}"
+        ) from exc
+    if not isinstance(documents, list):
+        raise ValueError(f"portable vector documents must be a list: {path.name}")
+
+    payload: list[dict[str, Any]] = []
+    for index, document in enumerate(documents):
+        page_content = getattr(document, "page_content", None)
+        if not isinstance(page_content, str):
+            raise ValueError(
+                f"portable vector document {index} has invalid content: {path.name}"
+            )
+        metadata = getattr(document, "metadata", None)
+        if not isinstance(metadata, dict):
+            raise ValueError(
+                f"portable vector document {index} has invalid metadata: {path.name}"
+            )
+        normalized_metadata = dict(metadata)
+        normalized_metadata["file"] = _portable_source_path(
+            metadata.get("file"),
+            repo_path,
+            source=f"vector document {index} file",
+        )
+        payload.append(
+            {
+                "page_content": page_content,
+                "metadata": normalized_metadata,
+            }
+        )
+    # Validate serializability before any file in the owned view is changed.
+    _json_bytes(payload)
+    return payload
+
+
+def _normalize_json_documents(
+    path: Path,
+    repo_path: Path,
+) -> list[dict[str, Any]]:
+    documents = _load_json(path, label="portable vector documents")
+    if not isinstance(documents, list):
+        raise ValueError(f"portable vector documents must be a JSON list: {path}")
+
+    payload: list[dict[str, Any]] = []
+    for index, document in enumerate(documents):
+        if not isinstance(document, dict) or set(document) != {
+            "page_content",
+            "metadata",
+        }:
+            raise ValueError(
+                f"portable vector document {index} has invalid shape: {path.name}"
+            )
+        page_content = document["page_content"]
+        metadata = document["metadata"]
+        if not isinstance(page_content, str) or not isinstance(metadata, dict):
+            raise ValueError(
+                "portable vector document "
+                f"{index} has invalid content or metadata: {path.name}"
+            )
+        raw_file = metadata.get("file")
+        if raw_file is not None and not isinstance(raw_file, str):
+            raise ValueError(
+                f"portable vector document {index} has invalid file: {path.name}"
+            )
+        normalized_metadata = dict(metadata)
+        normalized_metadata["file"] = _portable_source_path(
+            raw_file,
+            repo_path,
+            source=f"vector document {index} file",
+        )
+        payload.append(
+            {
+                "page_content": page_content,
+                "metadata": normalized_metadata,
+            }
+        )
+    return payload
+
+
+def _is_mutable_vector_state(path: Path) -> bool:
+    name = path.name.lower()
+    return (
+        name == VECTOR_VIEW_UPDATE_MARKER
+        or name.endswith(".save-in-progress")
+        or name.startswith(_MUTABLE_VECTOR_PREFIXES)
+    )
+
+
+def _validate_vector_layout(
+    root: Path,
+    repo_path: Path,
+    *,
+    model_suffix: str,
+    config: Mapping[str, Any],
+) -> tuple[str, dict[Path, list[dict[str, Any]]]]:
+    expected_documents: set[Path] = set()
+    selected: dict[Path, list[dict[str, Any]]] = {}
+    formats: set[str] = set()
+
+    for level in _VECTOR_LEVELS:
+        count = config.get(f"{level}_documents")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError(
+                f"portable vector config has invalid {level} count: {count!r}"
+            )
+        level_path = root / level
+        pickle_path = level_path / f"documents_{model_suffix}.pkl"
+        json_path = level_path / f"documents_{model_suffix}.json"
+        present = [path for path in (pickle_path, json_path) if path.is_file()]
+        expected_documents.update(present)
+
+        if count == 0:
+            if present:
+                raise ValueError(
+                    f"portable vector view contains documents for empty {level} level"
+                )
+            continue
+        if len(present) > 1:
+            raise ValueError(
+                f"portable vector view mixes pickle and JSON documents in {level}"
+            )
+        if not present:
+            raise ValueError(
+                f"portable vector view is missing documents for non-empty {level}"
+            )
+        index_path = level_path / f"index_{model_suffix}.faiss"
+        if index_path.is_symlink() or not index_path.is_file():
+            raise ValueError(f"portable vector view is missing its index: {index_path}")
+
+        path = present[0]
+        document_format = path.suffix.removeprefix(".")
+        formats.add(document_format)
+        if document_format == "pkl":
+            payload = _normalize_pickle_documents(path, repo_path)
+        else:
+            payload = _normalize_json_documents(path, repo_path)
+        if len(payload) != count:
+            raise ValueError(
+                f"portable vector {level} count differs from {path.name}: "
+                f"expected {count}, found {len(payload)}"
+            )
+        selected[path] = payload
+
+    if not selected:
+        raise ValueError("portable vector view has no non-empty document store")
+    if len(formats) != 1:
+        raise ValueError("portable vector view mixes pickle and JSON documents")
+
+    candidates = {
+        path
+        for path in root.rglob("documents_*")
+        if path.suffix.lower() in {".json", ".pkl"}
+    }
+    unexpected_documents = sorted(candidates - expected_documents)
+    if unexpected_documents:
+        raise ValueError(
+            "portable vector view contains an unexpected document store: "
+            f"{unexpected_documents[0].relative_to(root)}"
+        )
+
+    allowed_pickles = {path for path in selected if path.suffix.lower() == ".pkl"}
+    allowed_pickles.update(
+        path for path in root.glob("l[02]/index_*.pkl") if path.is_file()
+    )
+    allowed_pickles.update(
+        root / name
+        for name in _REMOVABLE_MUTABLE_VECTOR_FILES
+        if name.endswith(".pkl") and (root / name).is_file()
+    )
+    residual_pickles = sorted(
+        path
+        for path in root.rglob("*")
+        if path.suffix.lower() == ".pkl" and path not in allowed_pickles
+    )
+    if residual_pickles:
+        raise ValueError(
+            "portable vector view contains an unexpected pickle: "
+            f"{residual_pickles[0].relative_to(root)}"
+        )
+
+    removable_mutable = {root / name for name in _REMOVABLE_MUTABLE_VECTOR_FILES}
+    residual_mutable = sorted(
+        path
+        for path in root.rglob("*")
+        if _is_mutable_vector_state(path)
+        and (path not in removable_mutable or not path.is_file())
+    )
+    if residual_mutable:
+        raise ValueError(
+            "portable vector view contains unexpected mutable state: "
+            f"{residual_mutable[0].relative_to(root)}"
+        )
+
+    return next(iter(formats)), selected
+
+
+def _refresh_vector_persistence_records(
+    root: Path,
+    *,
+    model_suffix: str,
+) -> None:
+    config_path = root / f"config_{model_suffix}.json"
+    config = _load_json_object(config_path, label="portable vector config")
+    level_artifacts: dict[str, dict[str, dict[str, Any]]] = {}
+    for level in _VECTOR_LEVELS:
+        count = config.get(f"{level}_documents")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError(
+                f"portable vector config has invalid {level} count: {count!r}"
+            )
+        if count == 0:
+            continue
+        level_path = root / level
+        documents_path = level_path / f"documents_{model_suffix}.json"
+        level_artifacts[level] = vector_level_artifact_records(
+            level_path,
+            model_suffix,
+            documents_file=documents_path.name,
+        )
+    config["persistence_schema"] = VECTOR_PERSISTENCE_SCHEMA
+    config["level_artifacts"] = level_artifacts
+    config_path.write_bytes(_json_bytes(config))
+
+
+def _assert_normalized_vector_tree(root: Path) -> None:
+    for path in sorted(root.rglob("*")):
+        if path.suffix.lower() == ".pkl":
+            raise ValueError(
+                "portable vector normalization left a pickle behind: "
+                f"{path.relative_to(root)}"
+            )
+        if _is_mutable_vector_state(path):
+            raise ValueError(
+                "portable vector normalization left mutable state behind: "
+                f"{path.relative_to(root)}"
+            )
+
+
+def _normalize_vector_view(
+    root: Path,
+    repo_path: Path,
+    *,
+    view_config: Mapping[str, Any],
+) -> dict[str, Any]:
+    require_complete_vector_view(root)
+    interrupted = sorted(root.glob(".config_*.json.save-in-progress"))
+    if interrupted:
+        raise ValueError(
+            "portable vector view contains an interrupted save marker: "
+            f"{interrupted[0].name}"
+        )
+
+    route = resolve_embedding_artifact_route(view_config)
+    model_suffix = route.model.replace("/", "__")
+    # Validate the committed source generation before replacing any trusted-local
+    # pickle or refreshing records. Otherwise normalization could bless torn files.
+    validate_vector_generation_artifacts(root, model_suffix)
+    config_path = root / f"config_{model_suffix}.json"
+    config = _load_json_object(config_path, label="portable vector config")
+    if config.get("embedding_model") != route.model:
+        raise ValueError("portable vector config embedding model does not match")
+
+    document_format, documents = _validate_vector_layout(
+        root,
+        repo_path,
+        model_suffix=model_suffix,
+        config=config,
+    )
+
+    for path, payload in documents.items():
+        output = path.with_suffix(".json")
+        output.write_bytes(_json_bytes(payload))
+        if document_format == "pkl":
+            path.unlink()
+
+    # Query serving does not need build-time incremental state. These exact
+    # machine-local files are safe to discard from the owned copy; unfamiliar
+    # mutable state was rejected before mutation.
+    for name in _REMOVABLE_MUTABLE_VECTOR_FILES:
+        (root / name).unlink(missing_ok=True)
+    for legacy in root.glob("l[02]/index_*.pkl"):
+        legacy.unlink()
+
+    _refresh_vector_persistence_records(root, model_suffix=model_suffix)
+    _assert_normalized_vector_tree(root)
+    validate_vector_generation_artifacts(root, model_suffix)
+    return {
+        "artifact_scope": "query-serving",
+        "portable_document_format": "codenib.vector-documents.v1",
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            root,
+            model_suffix,
+        ),
+    }
+
+
+def normalize_owned_query_view(
+    root: Path,
+    *,
+    repo_path: Path,
+    view_type: str,
+    view_config: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Normalize one copied view and return its portable identity adjustments.
+
+    ``root`` must be a caller-owned copy that can be safely rewritten. Local
+    vector pickles are deserialized only on that explicit trust boundary;
+    already-portable JSON document stores are parsed as inert data.
+    """
+
+    normalized_root, repository = _owned_view_root(root, repo_path)
+    if view_type == "vector":
+        return _normalize_vector_view(
+            normalized_root,
+            repository,
+            view_config=view_config,
+        )
+    if view_type != "bm25":
+        raise ValueError(
+            f"view {view_type!r} is not yet supported by portable query views; "
+            "select bm25 and/or vector"
+        )
+
+    metadata_path = normalized_root / "bm25_metadata.json"
+    metadata = _load_json_object(metadata_path, label="portable BM25 metadata")
+    metadata["project_root"] = "source"
+    metadata_path.write_bytes(_json_bytes(metadata))
+    return {
+        "artifact_file_fingerprints": bm25_artifact_file_fingerprints(normalized_root)
+    }
+
+
+__all__ = ["normalize_owned_query_view"]

--- a/codenib/artifacts/portable_views.py
+++ b/codenib/artifacts/portable_views.py
@@ -457,7 +457,7 @@ def _validate_vector_semantics(
     )
 
 
-def _faiss_contract(path: Path) -> tuple[int, int, str, str]:
+def _faiss_contract(path: Path) -> tuple[int, int, str, str, bool]:
     """Read the persisted index contract, importing FAISS on demand."""
 
     try:
@@ -465,26 +465,23 @@ def _faiss_contract(path: Path) -> tuple[int, int, str, str]:
         index = faiss.read_index(str(path))
         dimension = int(index.d)
         total = int(index.ntotal)
+        is_trained = bool(index.is_trained)
         metric_type = int(index.metric_type)
         if metric_type == int(faiss.METRIC_INNER_PRODUCT):
             metric = "ip"
         elif metric_type == int(faiss.METRIC_L2):
             metric = "l2"
         else:
-            raise ValueError(
-                f"portable vector FAISS index has unsupported metric: {metric_type}"
-            )
+            metric = f"unsupported:{metric_type}"
         if isinstance(index, faiss.IndexIVF):
             index_type = "ivf"
         elif isinstance(index, faiss.IndexFlat):
             index_type = "flat"
         else:
-            raise ValueError(
-                f"portable vector FAISS index has unsupported type: {type(index).__name__}"
-            )
+            index_type = f"unsupported:{type(index).__name__}"
     except Exception as exc:
         raise ValueError(f"portable vector FAISS index is unreadable: {path}") from exc
-    return dimension, total, metric, index_type
+    return dimension, total, metric, index_type, is_trained
 
 
 def _validate_level_semantics(
@@ -632,7 +629,7 @@ def _validate_vector_layout(
                 f"expected {count}, found {len(payload)}"
             )
         count = len(payload)
-        dimension, total, metric, index_type = _faiss_contract(index_path)
+        dimension, total, metric, index_type, is_trained = _faiss_contract(index_path)
         if dimension != expected_dimension:
             raise ValueError(
                 f"portable vector FAISS dimension mismatch in {level}: "
@@ -642,16 +639,6 @@ def _validate_vector_layout(
             raise ValueError(
                 f"portable vector FAISS count mismatch in {level}: "
                 f"expected {count}, found {total}"
-            )
-        if metric != expected_metric:
-            raise ValueError(
-                f"portable vector FAISS metric mismatch in {level}: "
-                f"expected {expected_metric}, found {metric}"
-            )
-        if index_type != expected_index_type:
-            raise ValueError(
-                f"portable vector FAISS index type mismatch in {level}: "
-                f"expected {expected_index_type}, found {index_type}"
             )
         derived_counts[level] = count
         if legacy_counts and count == 0:
@@ -666,6 +653,20 @@ def _validate_vector_layout(
                 if candidate.is_file()
             )
             continue
+        if metric != expected_metric:
+            raise ValueError(
+                f"portable vector FAISS metric mismatch in {level}: "
+                f"expected {expected_metric}, found {metric}"
+            )
+        if index_type != expected_index_type:
+            raise ValueError(
+                f"portable vector FAISS index type mismatch in {level}: "
+                f"expected {expected_index_type}, found {index_type}"
+            )
+        if index_type == "ivf" and not is_trained:
+            raise ValueError(
+                f"portable vector active IVF index is untrained in {level}"
+            )
         _validate_level_semantics(
             level_path / f"config_{model_suffix}.json",
             level=level,

--- a/test/artifacts/test_context_artifact.py
+++ b/test/artifacts/test_context_artifact.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import hashlib
+import importlib
 import json
 import os
 import pickle
@@ -17,6 +18,7 @@ from codenib.artifacts import (
     CONTEXT_ARTIFACT_MANIFEST,
     CONTEXT_ARTIFACT_SCHEMA,
     stage_context_artifact,
+    verify_context_artifact,
 )
 from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
 from codenib.compiler.manifest import IndexEntry, RepoManifest
@@ -27,6 +29,15 @@ from codenib.index.embedding.artifact_integrity import (
     vector_level_artifact_records,
 )
 from codenib.source_fingerprint import fingerprint_repository
+
+
+def _write_faiss(path: Path, *, count: int = 1, dimension: int = 4) -> None:
+    faiss = importlib.import_module("faiss")
+    numpy = importlib.import_module("numpy")
+    index = faiss.IndexFlatIP(dimension)
+    if count:
+        index.add(numpy.zeros((count, dimension), dtype="float32"))
+    faiss.write_index(index, str(path))
 
 
 def _fixture_manifest(
@@ -117,7 +128,7 @@ def _fixture_vector_manifest(root: Path) -> tuple[Path, Path, Path]:
             ],
             handle,
         )
-    (level / "index_test__model.faiss").write_bytes(b"serving-index")
+    _write_faiss(level / "index_test__model.faiss")
     (level / "index_test__model.pkl").write_bytes(
         pickle.dumps({"legacy_path": str(source)})
     )
@@ -487,6 +498,29 @@ def test_context_artifact_keeps_only_portable_vector_serving_state(
     )
     assert not list(output.rglob("*.pkl"))
     assert str(repo).encode() not in b"".join(_tree(output).values())
+    verified = verify_context_artifact(
+        output,
+        expected_repository="example/vector-project",
+        expected_commit="b" * 40,
+    )
+    assert verified.views == ("vector",)
+
+
+@pytest.mark.parametrize("name", ["cache.PKL", "cache.pickle", "cache.PICKLE"])
+def test_context_artifact_rejects_pickle_in_any_view_case_insensitively(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    repo, manifest_path, bm25 = _fixture_manifest(tmp_path)
+    (bm25 / name).write_bytes(b"unsafe")
+
+    with pytest.raises(ValueError, match="must not contain pickle"):
+        stage_context_artifact(
+            repo,
+            manifest_path,
+            tmp_path / "publish" / "context",
+            repository="example/project",
+        )
 
 
 def test_context_artifact_rejects_interrupted_vector_save(tmp_path: Path) -> None:

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -4,8 +4,12 @@
 
 from __future__ import annotations
 
+import importlib
 import json
+import os
 import pickle
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -41,10 +45,19 @@ def _tree(root: Path) -> dict[str, bytes]:
 
 def _repository(root: Path) -> tuple[Path, Path]:
     repo = root / "repo"
-    repo.mkdir()
+    repo.mkdir(parents=True)
     source = repo / "sample.py"
     source.write_text("VALUE = 1\n", encoding="utf-8")
     return repo, source
+
+
+def _write_faiss(path: Path, *, count: int = 1, dimension: int = 4) -> None:
+    faiss = importlib.import_module("faiss")
+    numpy = importlib.import_module("numpy")
+    index = faiss.IndexFlatIP(dimension)
+    if count:
+        index.add(numpy.zeros((count, dimension), dtype="float32"))
+    faiss.write_index(index, str(path))
 
 
 def _vector_view(
@@ -86,7 +99,7 @@ def _vector_view(
             ),
             encoding="utf-8",
         )
-    (level / f"index_{_MODEL_SUFFIX}.faiss").write_bytes(b"serving-index")
+    _write_faiss(level / f"index_{_MODEL_SUFFIX}.faiss")
     config = {
         "embedding_model": "test/model",
         "embedding_provider": "huggingface",
@@ -109,6 +122,25 @@ def _vector_view(
         encoding="utf-8",
     )
     return vector
+
+
+def _refresh_level_record(vector: Path, level: str = "l2") -> None:
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    documents = next(
+        path
+        for path in (
+            vector / level / f"documents_{_MODEL_SUFFIX}.json",
+            vector / level / f"documents_{_MODEL_SUFFIX}.pkl",
+        )
+        if path.is_file()
+    )
+    config["level_artifacts"][level] = vector_level_artifact_records(
+        vector / level,
+        _MODEL_SUFFIX,
+        documents_file=documents.name,
+    )
+    config_path.write_text(json.dumps(config), encoding="utf-8")
 
 
 def test_normalize_bm25_rewrites_project_root_and_refreshes_fingerprints(
@@ -159,6 +191,7 @@ def test_normalize_vector_converts_trusted_pickle_and_strips_build_state(
         repo_path=repo,
         view_type="vector",
         view_config=_VECTOR_CONFIG,
+        source_trust="trusted-local",
     )
 
     documents_path = level / f"documents_{_MODEL_SUFFIX}.json"
@@ -195,11 +228,224 @@ def test_normalize_committed_json_vector_is_idempotent(tmp_path: Path) -> None:
         vector,
         repo_path=repo,
         view_type="vector",
-        view_config=_VECTOR_CONFIG,
+        view_config={**_VECTOR_CONFIG, **first_adjustments},
     )
 
     assert _tree(vector) == first_tree
     assert second_adjustments == first_adjustments
+
+
+def test_normalize_portable_json_is_idempotent_in_a_different_checkout(
+    tmp_path: Path,
+) -> None:
+    first_repo, _source = _repository(tmp_path / "first")
+    vector = _vector_view(tmp_path, first_repo, document_format="json")
+    first_adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=first_repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    first_tree = _tree(vector)
+    second_repo, _second_source = _repository(tmp_path / "second")
+
+    normalize_owned_query_view(
+        vector,
+        repo_path=second_repo,
+        view_type="vector",
+        view_config={**_VECTOR_CONFIG, **first_adjustments},
+    )
+
+    assert _tree(vector) == first_tree
+
+
+def test_normalize_upgrades_fully_legacy_vector_config(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    for field in (
+        "l0_documents",
+        "l2_documents",
+        "persistence_schema",
+        "level_artifacts",
+    ):
+        config.pop(field)
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+        source_trust="trusted-local",
+    )
+
+    upgraded = json.loads(config_path.read_text(encoding="utf-8"))
+    assert upgraded["l0_documents"] == 0
+    assert upgraded["l2_documents"] == 1
+    assert upgraded["persistence_schema"] == VECTOR_PERSISTENCE_SCHEMA
+    assert set(upgraded["level_artifacts"]) == {"l2"}
+    assert not list(vector.rglob("*.pkl"))
+
+
+def test_normalize_prunes_derived_empty_legacy_level(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    for field in (
+        "l0_documents",
+        "l2_documents",
+        "persistence_schema",
+        "level_artifacts",
+    ):
+        config.pop(field)
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    empty = vector / "l0"
+    empty.mkdir()
+    (empty / f"documents_{_MODEL_SUFFIX}.json").write_text("[]\n", encoding="utf-8")
+    _write_faiss(empty / f"index_{_MODEL_SUFFIX}.faiss", count=0)
+    (empty / f"config_{_MODEL_SUFFIX}.json").write_text("{}\n", encoding="utf-8")
+
+    normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+
+    upgraded = json.loads(config_path.read_text(encoding="utf-8"))
+    assert upgraded["l0_documents"] == 0
+    assert not empty.exists()
+
+
+def test_normalize_preserves_format_when_later_legacy_level_is_empty(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    active = vector / "l0"
+    (vector / "l2").rename(active)
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    for field in (
+        "l0_documents",
+        "l2_documents",
+        "persistence_schema",
+        "level_artifacts",
+    ):
+        config.pop(field)
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    empty = vector / "l2"
+    empty.mkdir()
+    (empty / f"documents_{_MODEL_SUFFIX}.json").write_text("[]\n", encoding="utf-8")
+    _write_faiss(empty / f"index_{_MODEL_SUFFIX}.faiss", count=0)
+    (empty / f"config_{_MODEL_SUFFIX}.json").write_text("{}\n", encoding="utf-8")
+
+    normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+
+    upgraded = json.loads(config_path.read_text(encoding="utf-8"))
+    assert upgraded["l0_documents"] == 1
+    assert upgraded["l2_documents"] == 0
+    assert set(upgraded["level_artifacts"]) == {"l0"}
+    assert active.is_dir()
+    assert not empty.exists()
+
+
+def test_normalize_rejects_partial_legacy_level_counts(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config.pop("l0_documents")
+    config.pop("persistence_schema")
+    config.pop("level_artifacts")
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="partial level counts"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_prunes_current_model_files_for_zero_count(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    stale = vector / "l0"
+    stale.mkdir()
+    (stale / f"documents_{_MODEL_SUFFIX}.json").write_text("[]\n", encoding="utf-8")
+    _write_faiss(stale / f"index_{_MODEL_SUFFIX}.faiss", count=0)
+    (stale / f"index_{_MODEL_SUFFIX}.pkl").write_bytes(b"stale")
+    (stale / f"config_{_MODEL_SUFFIX}.json").write_text("{}\n", encoding="utf-8")
+
+    normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+        source_trust="trusted-local",
+    )
+
+    assert not stale.exists()
+
+
+def test_normalize_rejects_other_model_artifacts(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    other = vector / "l0" / "documents_other__model.json"
+    other.parent.mkdir()
+    other.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown or other-model"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_inert_pickle_rejects_before_loading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    called = False
+
+    def fail_if_called(_handle):
+        nonlocal called
+        called = True
+        raise AssertionError("pickle loader must not run")
+
+    monkeypatch.setattr(
+        "codenib.artifacts.portable_views.compat_pickle.load", fail_if_called
+    )
+    with pytest.raises(ValueError, match="portable-inert.*pickle"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+    assert called is False
+
+
+def test_portable_views_do_not_import_faiss_eagerly() -> None:
+    script = (
+        "import sys; import codenib.artifacts.portable_views; "
+        "assert 'faiss' not in sys.modules"
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)
 
 
 def test_normalize_vector_rejects_mixed_document_formats(tmp_path: Path) -> None:
@@ -214,6 +460,7 @@ def test_normalize_vector_rejects_mixed_document_formats(tmp_path: Path) -> None
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            source_trust="trusted-local",
         )
 
     assert json_path.is_file()
@@ -235,6 +482,7 @@ def test_normalize_vector_rejects_missing_committed_documents(tmp_path: Path) ->
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            source_trust="trusted-local",
         )
 
 
@@ -268,6 +516,7 @@ def test_normalize_vector_rejects_residual_pickle(tmp_path: Path) -> None:
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+            source_trust="trusted-local",
         )
 
     assert residual.is_file()
@@ -317,6 +566,319 @@ def test_normalize_vector_rejects_document_paths_outside_repository(
             repo_path=repo,
             view_type="vector",
             view_config=_VECTOR_CONFIG,
+        )
+
+
+@pytest.mark.parametrize("absolute", [False, True])
+def test_normalize_vector_accepts_native_document_paths(
+    tmp_path: Path,
+    absolute: bool,
+) -> None:
+    repo, source = _repository(tmp_path)
+    if absolute:
+        source_path = str(source)
+        expected = "sample.py"
+    else:
+        nested = repo / "nested" / "sample.py"
+        nested.parent.mkdir()
+        nested.write_text("VALUE = 2\n", encoding="utf-8")
+        source_path = str(Path("nested") / "sample.py")
+        expected = "nested/sample.py"
+    payload = json.dumps(
+        [{"page_content": "VALUE = 1", "metadata": {"file": source_path}}]
+    ).encode("utf-8")
+    vector = _vector_view(
+        tmp_path,
+        repo,
+        document_format="json",
+        document_bytes=payload,
+    )
+
+    normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+
+    documents = json.loads(
+        (vector / "l2" / f"documents_{_MODEL_SUFFIX}.json").read_text(encoding="utf-8")
+    )
+    assert documents[0]["metadata"]["file"] == expected
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows syntax is native on Windows")
+@pytest.mark.parametrize(
+    "source_path",
+    ["C:\\repo\\sample.py", "\\\\server\\share\\sample.py", "dir\\sample.py"],
+)
+def test_normalize_vector_rejects_foreign_windows_document_paths(
+    tmp_path: Path,
+    source_path: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    payload = json.dumps(
+        [{"page_content": "VALUE = 1", "metadata": {"file": source_path}}]
+    ).encode("utf-8")
+    vector = _vector_view(
+        tmp_path,
+        repo,
+        document_format="json",
+        document_bytes=payload,
+    )
+
+    with pytest.raises(ValueError, match="portable"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+@pytest.mark.parametrize(
+    "source_path",
+    [
+        "C:sample.py",
+        "//server/share/sample.py",
+        "sample.py\x00tail",
+        "sample.py\x1ftail",
+        ".",
+        "./sample.py",
+        "dir/../sample.py",
+        "/sample.py",
+        "dir//sample.py",
+    ],
+)
+def test_normalize_vector_rejects_nonportable_document_paths(
+    tmp_path: Path,
+    source_path: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    payload = json.dumps(
+        [{"page_content": "VALUE = 1", "metadata": {"file": source_path}}]
+    ).encode("utf-8")
+    vector = _vector_view(
+        tmp_path,
+        repo,
+        document_format="json",
+        document_bytes=payload,
+    )
+
+    with pytest.raises(ValueError, match="portable|repository-relative|outside"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("embedding_model", "other/model", "embedding_model"),
+        ("embedding_provider", "openai", "embedding provider"),
+        ("dimension", 8, "dimension"),
+        ("index_metric", "l2", "index metric"),
+    ],
+)
+def test_normalize_rejects_persistence_semantic_drift(
+    tmp_path: Path,
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config[field] = value
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_rejects_level_config_semantic_drift(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    level_config = vector / "l2" / f"config_{_MODEL_SUFFIX}.json"
+    level_config.write_text(
+        json.dumps(
+            {
+                "embedding_model": "test/model",
+                "embedding_provider": "huggingface",
+                "dimension": 4,
+                "index_metric": "l2",
+                "level": "l2",
+                "num_documents": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="l2 persistence index_metric"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_rejects_persisted_route_identity_drift(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["artifact"] = {**_VECTOR_CONFIG, "embedding_kwargs": {}}
+    config["artifact"]["embedding_dimension"] = 8
+    config["artifact"]["dimension"] = 8
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="route identity"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_rejects_persisted_embedding_options_drift(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["artifact"] = {
+        **_VECTOR_CONFIG,
+        "embedding_kwargs": {"encode_kwargs": {"normalize_embeddings": False}},
+    }
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    view_config = {
+        **_VECTOR_CONFIG,
+        "embedding_kwargs": {"encode_kwargs": {"normalize_embeddings": True}},
+    }
+
+    with pytest.raises(ValueError, match="route identity"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+def test_normalize_rejects_persisted_embedding_fingerprint_drift(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["artifact"] = {
+        **_VECTOR_CONFIG,
+        "embedding_fingerprint": "sha256:" + "0" * 64,
+    }
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="embedding fingerprint mismatch"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_rejects_persistence_commit_fingerprint_drift(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    expected = vector_config_artifact_record(vector, _MODEL_SUFFIX)
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config_path.write_bytes(config_path.read_bytes() + b"\n")
+
+    with pytest.raises(ValueError, match="manifest fingerprint"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config={
+                **_VECTOR_CONFIG,
+                "persistence_config_fingerprint": expected,
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("dimension", "count", "message"),
+    [(8, 1, "FAISS dimension mismatch"), (4, 2, "FAISS count mismatch")],
+)
+def test_normalize_rejects_faiss_shape_drift(
+    tmp_path: Path,
+    dimension: int,
+    count: int,
+    message: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    _write_faiss(
+        vector / "l2" / f"index_{_MODEL_SUFFIX}.faiss",
+        dimension=dimension,
+        count=count,
+    )
+    _refresh_level_record(vector)
+
+    with pytest.raises(ValueError, match=message):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+@pytest.mark.parametrize("name", ["cache.PKL", "cache.pickle", "cache.PICKLE"])
+def test_normalize_bm25_rejects_pickle_case_insensitively(
+    tmp_path: Path,
+    name: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    bm25 = tmp_path / "state" / "bm25"
+    bm25.mkdir(parents=True)
+    (bm25 / "documents.json").write_text("[]\n", encoding="utf-8")
+    (bm25 / "bm25_metadata.json").write_text("{}\n", encoding="utf-8")
+    (bm25 / name).write_bytes(b"unsafe")
+
+    with pytest.raises(ValueError, match="must not contain pickle"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )
+
+
+def test_normalize_rejects_invalid_source_trust(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    bm25 = tmp_path / "state" / "bm25"
+    bm25.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="invalid.*source trust"):
+        normalize_owned_query_view(
+            bm25,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+            source_trust="implicit-local",  # type: ignore[arg-type]
         )
 
 

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import pickle
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codenib.artifacts import normalize_owned_query_view
+from codenib.compiler.artifact_fingerprints import bm25_artifact_file_fingerprints
+from codenib.index.embedding.artifact_integrity import (
+    VECTOR_PERSISTENCE_SCHEMA,
+    vector_config_artifact_record,
+    vector_level_artifact_records,
+)
+
+_VECTOR_CONFIG = {
+    "builder_schema": 2,
+    "embedding_model": "test/model",
+    "embedding_provider": "huggingface",
+    "embedding_dimension": 4,
+    "dimension": 4,
+    "embedding_kwargs": {},
+    "index_metric": "ip",
+}
+_MODEL_SUFFIX = "test__model"
+
+
+def _tree(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def _repository(root: Path) -> tuple[Path, Path]:
+    repo = root / "repo"
+    repo.mkdir()
+    source = repo / "sample.py"
+    source.write_text("VALUE = 1\n", encoding="utf-8")
+    return repo, source
+
+
+def _vector_view(
+    root: Path,
+    repo: Path,
+    *,
+    document_format: str,
+    document_bytes: bytes | None = None,
+) -> Path:
+    vector = root / "state" / "vector"
+    level = vector / "l2"
+    level.mkdir(parents=True)
+    documents_path = level / f"documents_{_MODEL_SUFFIX}.{document_format}"
+    if document_bytes is not None:
+        documents_path.write_bytes(document_bytes)
+    elif document_format == "pkl":
+        with documents_path.open("wb") as handle:
+            pickle.dump(
+                [
+                    SimpleNamespace(
+                        page_content="VALUE = 1",
+                        metadata={
+                            "file": str(repo / "sample.py"),
+                            "node_id": "sample.py",
+                        },
+                    )
+                ],
+                handle,
+            )
+    else:
+        documents_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "page_content": "VALUE = 1",
+                        "metadata": {"file": "sample.py", "node_id": "sample.py"},
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+    (level / f"index_{_MODEL_SUFFIX}.faiss").write_bytes(b"serving-index")
+    config = {
+        "embedding_model": "test/model",
+        "embedding_provider": "huggingface",
+        "dimension": 4,
+        "index_type": "flat",
+        "index_metric": "ip",
+        "l0_documents": 0,
+        "l2_documents": 1,
+        "persistence_schema": VECTOR_PERSISTENCE_SCHEMA,
+        "level_artifacts": {
+            "l2": vector_level_artifact_records(
+                level,
+                _MODEL_SUFFIX,
+                documents_file=documents_path.name,
+            )
+        },
+    }
+    (vector / f"config_{_MODEL_SUFFIX}.json").write_text(
+        json.dumps(config),
+        encoding="utf-8",
+    )
+    return vector
+
+
+def test_normalize_bm25_rewrites_project_root_and_refreshes_fingerprints(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    bm25 = tmp_path / "state" / "bm25"
+    bm25.mkdir(parents=True)
+    (bm25 / "documents.json").write_text("[]\n", encoding="utf-8")
+    (bm25 / "bm25_metadata.json").write_text(
+        json.dumps({"project_root": str(repo), "max_k": 128}),
+        encoding="utf-8",
+    )
+
+    adjustments = normalize_owned_query_view(
+        bm25,
+        repo_path=repo,
+        view_type="bm25",
+        view_config={},
+    )
+
+    metadata = json.loads((bm25 / "bm25_metadata.json").read_text(encoding="utf-8"))
+    assert metadata["project_root"] == "source"
+    assert adjustments == {
+        "artifact_file_fingerprints": bm25_artifact_file_fingerprints(bm25)
+    }
+
+
+def test_normalize_vector_converts_trusted_pickle_and_strips_build_state(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    level = vector / "l2"
+    (level / f"index_{_MODEL_SUFFIX}.pkl").write_bytes(b"legacy-docstore")
+    for name in (
+        "chunk_store.json",
+        "chunk_store.pkl",
+        "embeddings_cache.json",
+        "embeddings_cache.npz",
+        "embeddings_cache.pkl",
+        "incremental_state.json",
+    ):
+        (vector / name).write_bytes(b"machine-local")
+
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+
+    documents_path = level / f"documents_{_MODEL_SUFFIX}.json"
+    documents = json.loads(documents_path.read_text(encoding="utf-8"))
+    assert documents[0]["metadata"]["file"] == "sample.py"
+    assert not list(vector.rglob("*.pkl"))
+    assert not any(
+        path.name.startswith(
+            ("chunk_store.", "embeddings_cache.", "incremental_state.")
+        )
+        for path in vector.rglob("*")
+    )
+    config = json.loads(
+        (vector / f"config_{_MODEL_SUFFIX}.json").read_text(encoding="utf-8")
+    )
+    assert config["level_artifacts"]["l2"]["documents"]["file"] == (documents_path.name)
+    assert adjustments["persistence_config_fingerprint"] == (
+        vector_config_artifact_record(vector, _MODEL_SUFFIX)
+    )
+
+
+def test_normalize_committed_json_vector_is_idempotent(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+
+    first_adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+    first_tree = _tree(vector)
+    second_adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=_VECTOR_CONFIG,
+    )
+
+    assert _tree(vector) == first_tree
+    assert second_adjustments == first_adjustments
+
+
+def test_normalize_vector_rejects_mixed_document_formats(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="pkl")
+    json_path = vector / "l2" / f"documents_{_MODEL_SUFFIX}.json"
+    json_path.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="mixes pickle and JSON"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+    assert json_path.is_file()
+    assert (vector / "l2" / f"documents_{_MODEL_SUFFIX}.pkl").is_file()
+
+
+def test_normalize_vector_rejects_missing_committed_documents(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    documents = vector / "l2" / f"documents_{_MODEL_SUFFIX}.json"
+    documents.unlink()
+
+    with pytest.raises(
+        ValueError,
+        match="invalid vector artifact file|committed documents|missing documents",
+    ):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_vector_rejects_malformed_committed_json(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(
+        tmp_path,
+        repo,
+        document_format="json",
+        document_bytes=b'[{"page_content": "unterminated"',
+    )
+
+    with pytest.raises(ValueError, match="invalid JSON"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_vector_rejects_residual_pickle(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    residual = vector / "unexamined.pkl"
+    residual.write_bytes(b"must-not-publish")
+
+    with pytest.raises(ValueError, match="unexpected pickle"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+    assert residual.is_file()
+
+
+def test_normalize_vector_rejects_unowned_mutable_state(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    residual = vector / "l2" / "embeddings_cache.json"
+    residual.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unexpected mutable state"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+    assert residual.is_file()
+
+
+@pytest.mark.parametrize("source_path", ["../outside.py", "/outside/sample.py"])
+def test_normalize_vector_rejects_document_paths_outside_repository(
+    tmp_path: Path,
+    source_path: str,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    payload = json.dumps(
+        [
+            {
+                "page_content": "VALUE = 1",
+                "metadata": {"file": source_path},
+            }
+        ]
+    ).encode("utf-8")
+    vector = _vector_view(
+        tmp_path,
+        repo,
+        document_format="json",
+        document_bytes=payload,
+    )
+
+    with pytest.raises(ValueError, match="outside the repository|repository-relative"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=_VECTOR_CONFIG,
+        )
+
+
+def test_normalize_owned_view_rejects_repository_overlap(tmp_path: Path) -> None:
+    repo, _source = _repository(tmp_path)
+    view = repo / "copied-view"
+    view.mkdir()
+
+    with pytest.raises(ValueError, match="must not overlap"):
+        normalize_owned_query_view(
+            view,
+            repo_path=repo,
+            view_type="bm25",
+            view_config={},
+        )

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -60,6 +60,7 @@ def _write_faiss(
     dimension: int = 4,
     metric: str = "ip",
     index_type: str = "flat",
+    trained: bool = True,
 ) -> None:
     faiss = importlib.import_module("faiss")
     numpy = importlib.import_module("numpy")
@@ -78,8 +79,12 @@ def _write_faiss(
             count, dimension
         )
         if index_type == "ivf":
-            index.train(vectors)
-        index.add(vectors)
+            if trained:
+                index.train(vectors)
+            else:
+                index.ntotal = count
+        if index_type != "ivf" or trained:
+            index.add(vectors)
     faiss.write_index(index, str(path))
 
 
@@ -415,7 +420,15 @@ def test_normalize_upgrades_fully_legacy_vector_config(tmp_path: Path) -> None:
     assert not list(vector.rglob("*.pkl"))
 
 
-def test_normalize_prunes_derived_empty_legacy_level(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("stale_index_type", "stale_metric"),
+    [("ivf", "ip"), ("flat", "l2")],
+)
+def test_normalize_prunes_semantically_mismatched_derived_empty_legacy_level(
+    tmp_path: Path,
+    stale_index_type: str,
+    stale_metric: str,
+) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="json")
     config_path = vector / f"config_{_MODEL_SUFFIX}.json"
@@ -431,7 +444,12 @@ def test_normalize_prunes_derived_empty_legacy_level(tmp_path: Path) -> None:
     empty = vector / "l0"
     empty.mkdir()
     (empty / f"documents_{_MODEL_SUFFIX}.json").write_text("[]\n", encoding="utf-8")
-    _write_faiss(empty / f"index_{_MODEL_SUFFIX}.faiss", count=0)
+    _write_faiss(
+        empty / f"index_{_MODEL_SUFFIX}.faiss",
+        count=0,
+        index_type=stale_index_type,
+        metric=stale_metric,
+    )
     (empty / f"config_{_MODEL_SUFFIX}.json").write_text("{}\n", encoding="utf-8")
 
     normalize_owned_query_view(
@@ -799,6 +817,56 @@ def test_normalize_schema6_rejects_faiss_index_type_drift(tmp_path: Path) -> Non
     _refresh_view_fingerprint(vector, view_config)
 
     with pytest.raises(ValueError, match="FAISS index type mismatch"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+def test_normalize_rejects_untrained_active_ivf_before_runtime_first_search(
+    tmp_path: Path,
+) -> None:
+    from codenib.index.embedding.vector_store import CodeVectorStore
+
+    class _Embedding:
+        def embed_query(self, _text: str) -> list[float]:
+            return [0.0] * 4
+
+        def embed_documents(self, texts: list[str]) -> list[list[float]]:
+            return [[0.0] * 4 for _text in texts]
+
+    repo, vector, view_config = _production_vector_view(
+        tmp_path,
+        index_type="ivf",
+    )
+    _write_faiss(
+        vector / "l2" / f"index_{_MODEL_SUFFIX}.faiss",
+        count=1,
+        index_type="ivf",
+        trained=False,
+    )
+    _refresh_level_record(vector)
+    _refresh_view_fingerprint(vector, view_config)
+    store = CodeVectorStore(
+        embedding_model="test/model",
+        embedding_provider="huggingface",
+        dimension=4,
+        index_type="ivf",
+        index_metric="ip",
+        store_path=str(vector),
+        embedding=_Embedding(),
+        artifact_metadata=view_config,
+        revision=_REVISION,
+        trust_remote_code=False,
+    )
+    store.load()
+    assert store.l2_index.is_trained is False
+    with pytest.raises(RuntimeError, match="is_trained"):
+        store.search("VALUE", top_k=1)
+
+    with pytest.raises(ValueError, match="active IVF index is untrained"):
         normalize_owned_query_view(
             vector,
             repo_path=repo,

--- a/test/artifacts/test_portable_views.py
+++ b/test/artifacts/test_portable_views.py
@@ -22,6 +22,7 @@ from codenib.index.embedding.artifact_integrity import (
     vector_config_artifact_record,
     vector_level_artifact_records,
 )
+from codenib.provider_routes import resolve_inference_route
 
 _VECTOR_CONFIG = {
     "builder_schema": 2,
@@ -33,6 +34,7 @@ _VECTOR_CONFIG = {
     "index_metric": "ip",
 }
 _MODEL_SUFFIX = "test__model"
+_REVISION = "a" * 40
 
 
 def _tree(root: Path) -> dict[str, bytes]:
@@ -51,12 +53,33 @@ def _repository(root: Path) -> tuple[Path, Path]:
     return repo, source
 
 
-def _write_faiss(path: Path, *, count: int = 1, dimension: int = 4) -> None:
+def _write_faiss(
+    path: Path,
+    *,
+    count: int = 1,
+    dimension: int = 4,
+    metric: str = "ip",
+    index_type: str = "flat",
+) -> None:
     faiss = importlib.import_module("faiss")
     numpy = importlib.import_module("numpy")
-    index = faiss.IndexFlatIP(dimension)
+    if metric == "ip":
+        quantizer = faiss.IndexFlatIP(dimension)
+        metric_type = faiss.METRIC_INNER_PRODUCT
+    else:
+        quantizer = faiss.IndexFlatL2(dimension)
+        metric_type = faiss.METRIC_L2
+    if index_type == "ivf":
+        index = faiss.IndexIVFFlat(quantizer, dimension, max(1, count), metric_type)
+    else:
+        index = quantizer
     if count:
-        index.add(numpy.zeros((count, dimension), dtype="float32"))
+        vectors = numpy.arange(count * dimension, dtype="float32").reshape(
+            count, dimension
+        )
+        if index_type == "ivf":
+            index.train(vectors)
+        index.add(vectors)
     faiss.write_index(index, str(path))
 
 
@@ -141,6 +164,109 @@ def _refresh_level_record(vector: Path, level: str = "l2") -> None:
         documents_file=documents.name,
     )
     config_path.write_text(json.dumps(config), encoding="utf-8")
+
+
+def _schema6_identity(
+    *,
+    metric: str = "ip",
+    revision: str = _REVISION,
+) -> dict[str, object]:
+    options = {"revision": revision, "trust_remote_code": False}
+    route = resolve_inference_route(
+        operation="embeddings",
+        provider="huggingface",
+        model="test/model",
+        dimension=4,
+        compatibility_options=options,
+    )
+    return {
+        "builder_schema": 6,
+        "embedding_model": route.model,
+        "embedding_provider": route.provider,
+        "embedding_dimension": 4,
+        "dimension": 4,
+        "embedding_endpoint": route.endpoint,
+        "embedding_kwargs": route.compatibility_options,
+        "embedding_route": route.public_identity(),
+        "embedding_fingerprint": route.compatibility_fingerprint,
+        "index_metric": metric,
+        "levels": ["l2"],
+    }
+
+
+def _production_vector_view(
+    root: Path,
+    *,
+    index_type: str = "flat",
+    metric: str = "ip",
+) -> tuple[Path, Path, dict[str, object]]:
+    repo, _source = _repository(root)
+    vector = _vector_view(root, repo, document_format="json")
+    level = vector / "l2"
+    _write_faiss(
+        level / f"index_{_MODEL_SUFFIX}.faiss",
+        metric=metric,
+        index_type=index_type,
+    )
+    identity = _schema6_identity(metric=metric)
+    (level / f"config_{_MODEL_SUFFIX}.json").write_text(
+        json.dumps(
+            {
+                "embedding_model": "test/model",
+                "embedding_provider": "huggingface",
+                "embedding_revision": _REVISION,
+                "dimension": 4,
+                "index_type": index_type,
+                "index_metric": metric,
+                "level": "l2",
+                "num_documents": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    documents = level / f"documents_{_MODEL_SUFFIX}.json"
+    config = {
+        "embedding_model": "test/model",
+        "embedding_provider": "huggingface",
+        "embedding_revision": _REVISION,
+        "dimension": 4,
+        "index_type": index_type,
+        "index_metric": metric,
+        "l0_documents": 0,
+        "l2_documents": 1,
+        "persistence_schema": VECTOR_PERSISTENCE_SCHEMA,
+        "level_artifacts": {
+            "l2": vector_level_artifact_records(
+                level,
+                _MODEL_SUFFIX,
+                documents_file=documents.name,
+            )
+        },
+        "artifact": identity,
+    }
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    view_config = {
+        **identity,
+        "document_count": {"l2": 1},
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            vector,
+            _MODEL_SUFFIX,
+        ),
+    }
+    if index_type != "flat":
+        view_config["index_type"] = index_type
+    return repo, vector, view_config
+
+
+def _refresh_view_fingerprint(
+    vector: Path,
+    view_config: dict[str, object],
+) -> None:
+    view_config["persistence_config_fingerprint"] = vector_config_artifact_record(
+        vector,
+        _MODEL_SUFFIX,
+    )
 
 
 def test_normalize_bm25_rewrites_project_root_and_refreshes_fingerprints(
@@ -448,6 +574,264 @@ def test_portable_views_do_not_import_faiss_eagerly() -> None:
     subprocess.run([sys.executable, "-c", script], check=True)
 
 
+@pytest.mark.parametrize("index_type", ["flat", "ivf"])
+def test_normalize_schema6_view_loads_with_runtime_contract(
+    tmp_path: Path,
+    index_type: str,
+) -> None:
+    from codenib.index.embedding.vector_store import CodeVectorStore
+
+    class _Embedding:
+        def embed_query(self, _text: str) -> list[float]:
+            return [0.0] * 4
+
+        def embed_documents(self, texts: list[str]) -> list[list[float]]:
+            return [[0.0] * 4 for _text in texts]
+
+    repo, vector, view_config = _production_vector_view(
+        tmp_path,
+        index_type=index_type,
+    )
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=view_config,
+    )
+    portable_config = {**view_config, **adjustments}
+    store = CodeVectorStore(
+        embedding_model="test/model",
+        embedding_provider="huggingface",
+        dimension=4,
+        index_type=index_type,
+        index_metric="ip",
+        store_path=str(vector),
+        embedding=_Embedding(),
+        artifact_metadata=portable_config,
+        revision=_REVISION,
+        trust_remote_code=False,
+    )
+
+    store.load()
+
+    assert len(store.l2_documents) == 1
+    assert int(store.l2_index.ntotal) == 1
+    assert store.artifact_metadata["embedding_fingerprint"] == (
+        view_config["embedding_fingerprint"]
+    )
+
+
+def test_normalize_schema6_rejects_top_revision_drift(tmp_path: Path) -> None:
+    repo, vector, view_config = _production_vector_view(tmp_path)
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["embedding_revision"] = "b" * 40
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    _refresh_view_fingerprint(vector, view_config)
+
+    with pytest.raises(ValueError, match="embedding_revision"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+def test_normalize_schema6_rejects_level_revision_drift(tmp_path: Path) -> None:
+    repo, vector, view_config = _production_vector_view(tmp_path)
+    config_path = vector / "l2" / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["embedding_revision"] = "b" * 40
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="l2 persistence embedding_revision"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+def test_normalize_schema6_requires_persisted_artifact_identity(
+    tmp_path: Path,
+) -> None:
+    repo, vector, view_config = _production_vector_view(tmp_path)
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config.pop("artifact")
+    config["embedding_kwargs"] = view_config["embedding_kwargs"]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    _refresh_view_fingerprint(vector, view_config)
+
+    with pytest.raises(ValueError, match="missing.*artifact identity"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+def test_normalize_schema6_rejects_persisted_artifact_revision_drift(
+    tmp_path: Path,
+) -> None:
+    repo, vector, view_config = _production_vector_view(tmp_path)
+    config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    config["artifact"] = _schema6_identity(revision="b" * 40)
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    _refresh_view_fingerprint(vector, view_config)
+
+    with pytest.raises(ValueError, match="route identity|artifact revision"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+def test_normalize_openai_compatible_bundled_model_has_no_hf_revision(
+    tmp_path: Path,
+) -> None:
+    repo, _source = _repository(tmp_path)
+    vector = _vector_view(tmp_path, repo, document_format="json")
+    model = "nomic-ai/CodeRankEmbed"
+    model_suffix = model.replace("/", "__")
+    level = vector / "l2"
+    documents = level / f"documents_{_MODEL_SUFFIX}.json"
+    index = level / f"index_{_MODEL_SUFFIX}.faiss"
+    documents = documents.rename(level / f"documents_{model_suffix}.json")
+    index.rename(level / f"index_{model_suffix}.faiss")
+
+    route = resolve_inference_route(
+        operation="embeddings",
+        provider="openai",
+        model=model,
+        endpoint="https://embeddings.example.test/v1",
+        dimension=4,
+        compatibility_options={"dimensions": 4},
+        environ={},
+    )
+    identity = {
+        "builder_schema": 6,
+        "embedding_model": route.model,
+        "embedding_provider": route.provider,
+        "embedding_dimension": route.dimension,
+        "dimension": route.dimension,
+        "embedding_endpoint": route.endpoint,
+        "embedding_kwargs": route.compatibility_options,
+        "embedding_route": route.public_identity(),
+        "embedding_fingerprint": route.compatibility_fingerprint,
+        "index_metric": "ip",
+        "levels": ["l2"],
+    }
+    old_config_path = vector / f"config_{_MODEL_SUFFIX}.json"
+    config_path = vector / f"config_{model_suffix}.json"
+    config = json.loads(old_config_path.read_text(encoding="utf-8"))
+    config.update(
+        {
+            "embedding_model": model,
+            "embedding_provider": "openai",
+            "embedding_revision": None,
+            "level_artifacts": {
+                "l2": vector_level_artifact_records(
+                    level,
+                    model_suffix,
+                    documents_file=documents.name,
+                )
+            },
+            "artifact": identity,
+        }
+    )
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    old_config_path.unlink()
+    view_config = {
+        **identity,
+        "document_count": {"l2": 1},
+        "persistence_config_fingerprint": vector_config_artifact_record(
+            vector,
+            model_suffix,
+        ),
+    }
+
+    adjustments = normalize_owned_query_view(
+        vector,
+        repo_path=repo,
+        view_type="vector",
+        view_config=view_config,
+    )
+
+    normalized = json.loads(config_path.read_text(encoding="utf-8"))
+    assert normalized["embedding_revision"] is None
+    assert adjustments["persistence_config_fingerprint"] == (
+        vector_config_artifact_record(vector, model_suffix)
+    )
+
+
+def test_normalize_schema6_rejects_faiss_metric_drift(tmp_path: Path) -> None:
+    repo, vector, view_config = _production_vector_view(tmp_path)
+    _write_faiss(
+        vector / "l2" / f"index_{_MODEL_SUFFIX}.faiss",
+        metric="l2",
+    )
+    _refresh_level_record(vector)
+    _refresh_view_fingerprint(vector, view_config)
+
+    with pytest.raises(ValueError, match="FAISS metric mismatch"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+def test_normalize_schema6_rejects_faiss_index_type_drift(tmp_path: Path) -> None:
+    repo, vector, view_config = _production_vector_view(tmp_path)
+    _write_faiss(
+        vector / "l2" / f"index_{_MODEL_SUFFIX}.faiss",
+        index_type="ivf",
+    )
+    _refresh_level_record(vector)
+    _refresh_view_fingerprint(vector, view_config)
+
+    with pytest.raises(ValueError, match="FAISS index type mismatch"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
+@pytest.mark.parametrize(
+    "document_count",
+    [
+        {"l2": 2},
+        {"l0": 0, "l2": 1},
+        {"other": 1, "l2": 1},
+        [1],
+    ],
+)
+def test_normalize_rejects_noncanonical_view_document_count(
+    tmp_path: Path,
+    document_count: object,
+) -> None:
+    repo, vector, view_config = _production_vector_view(tmp_path)
+    view_config["document_count"] = document_count
+
+    with pytest.raises(ValueError, match="document_count"):
+        normalize_owned_query_view(
+            vector,
+            repo_path=repo,
+            view_type="vector",
+            view_config=view_config,
+        )
+
+
 def test_normalize_vector_rejects_mixed_document_formats(tmp_path: Path) -> None:
     repo, _source = _repository(tmp_path)
     vector = _vector_view(tmp_path, repo, document_format="pkl")
@@ -681,6 +1065,7 @@ def test_normalize_vector_rejects_nonportable_document_paths(
         ("embedding_provider", "openai", "embedding provider"),
         ("dimension", 8, "dimension"),
         ("index_metric", "l2", "index metric"),
+        ("index_type", "ivf", "index type"),
     ],
 )
 def test_normalize_rejects_persistence_semantic_drift(
@@ -715,6 +1100,7 @@ def test_normalize_rejects_level_config_semantic_drift(tmp_path: Path) -> None:
                 "embedding_model": "test/model",
                 "embedding_provider": "huggingface",
                 "dimension": 4,
+                "index_type": "flat",
                 "index_metric": "l2",
                 "level": "l2",
                 "num_documents": 1,


### PR DESCRIPTION
## Summary

Replace #539 with a clean implementation on the current atomic-publication and snapshot-storage foundation. This extracts one shared portable query-view normalizer for context artifacts and the M1 SQLite/CAS adapter while closing the remaining cross-platform and vector-runtime compatibility gaps tracked by #199.

## Changes

- Extract owned BM25/vector normalization into `codenib.artifacts.portable_views` without weakening #540's destination/stage ownership validation.
- Make trusted-local pickle conversion explicit while keeping portable JSON generations inert and re-importable.
- Normalize native absolute and relative source paths before rejecting foreign path syntax.
- Preserve active document formats when pruning a later empty legacy vector level.
- Bind vector publication to persisted route, provider, model, provider-scoped revision, dimension, metric, index type, artifact fingerprints, and authoritative document counts.
- Reject non-empty untrained IVF indexes before publication while keeping stale empty legacy levels prunable.
- Add focused BM25/vector, Windows-path, OpenAI-compatible route, FAISS, legacy-upgrade, pickle, and lazy-import regressions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `8 passed`: remaining P2 and untrained-IVF regressions.
- `370 passed`: artifact, storage, atomic-publication, and lazy-import suites.
- `39 passed`: related vector-store suites.
- `3729 passed, 10 skipped, 190 deselected`: unit tier with only the locally unavailable Docker sandbox file ignored; the unfiltered run's sole failure was the existing missing `/usr/bin/docker` environment baseline.
- Black, isort, flake8, diff check, namespace checks, Python 3.10 compile/import, and lazy-FAISS smoke passed.
- Current-main merge-tree is clean.
- Independent final-head review found no P0/P1 blocker.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
