### PR TITLE
fix(index): contain BM25 source reads

### DIFF
--- a/codenib/index/sparse_idx/bm25_index.py
+++ b/codenib/index/sparse_idx/bm25_index.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import stat
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, List, Optional
 
@@ -21,6 +22,325 @@ if TYPE_CHECKING:
     from ...graph.code_graph import CodeGraph
 
 logger = get_logger(__name__)
+
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_SECURE_SOURCE_DIRECTORY_FDS = (
+    os.name == "posix"
+    and hasattr(os, "O_DIRECTORY")
+    and hasattr(os, "O_NOFOLLOW")
+    and hasattr(os, "O_NONBLOCK")
+    and os.open in getattr(os, "supports_dir_fd", ())
+)
+
+
+def _is_link_or_reparse(metadata: os.stat_result) -> bool:
+    """Return whether metadata represents a link-like filesystem entry."""
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        getattr(metadata, "st_file_attributes", 0) & _FILE_ATTRIBUTE_REPARSE_POINT
+    )
+
+
+def _path_components(path: str) -> Optional[tuple[str, ...]]:
+    """Split a native path without normalizing away parent traversal."""
+    normalized = path
+    if os.altsep:
+        normalized = normalized.replace(os.altsep, os.sep)
+    _drive, tail = os.path.splitdrive(normalized)
+    parts = tuple(part for part in tail.split(os.sep) if part not in {"", "."})
+    if not parts or any(part == ".." for part in parts):
+        return None
+    return parts
+
+
+def _contained_source_path(
+    project_root: object,
+    file_path: object,
+) -> Optional[tuple[str, str, tuple[str, ...]]]:
+    """Resolve a lexical source path beneath a canonical repository root."""
+    try:
+        root_value = os.fspath(project_root)
+        source_value = os.fspath(file_path)
+    except TypeError:
+        return None
+    if (
+        not isinstance(root_value, str)
+        or not isinstance(source_value, str)
+        or not source_value
+        or "\x00" in root_value
+        or "\x00" in source_value
+        or _path_components(source_value) is None
+    ):
+        return None
+
+    try:
+        # The configured root is trusted and may itself be reached through a
+        # stable developer-facing alias. Canonicalize that anchor once, but do
+        # not resolve source components: links below the root must be rejected.
+        root = os.path.realpath(os.path.abspath(root_value))
+        if os.path.isabs(source_value):
+            candidate = os.path.abspath(source_value)
+        else:
+            drive, _tail = os.path.splitdrive(source_value)
+            if drive:
+                # ``C:relative.py`` is drive-relative on Windows and therefore
+                # cannot be safely anchored beneath the configured root.
+                return None
+            candidate = os.path.abspath(os.path.join(root, source_value))
+
+        common = os.path.commonpath((root, candidate))
+        if os.path.normcase(common) != os.path.normcase(root):
+            return None
+        relative = os.path.relpath(candidate, root)
+        parts = _path_components(relative)
+        if parts is None:
+            return None
+        return root, os.path.join(root, *parts), parts
+    except (OSError, ValueError):
+        # Different Windows drives, malformed paths, and unavailable roots are
+        # all unreadable through the contained source boundary.
+        return None
+
+
+def _regular_source_flags(*, nofollow: bool) -> int:
+    flags = os.O_RDONLY
+    for name in ("O_NONBLOCK", "O_CLOEXEC", "O_BINARY"):
+        flags |= getattr(os, name, 0)
+    if nofollow:
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+    return flags
+
+
+def _open_regular_file_beneath(root: str, parts: tuple[str, ...]) -> Optional[int]:
+    """Open one regular file through descriptor-relative POSIX traversal."""
+    directory_fd: Optional[int] = None
+    source_fd: Optional[int] = None
+    directory_flags = (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | os.O_NONBLOCK
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        directory_fd = os.open(root, directory_flags)
+        root_metadata = os.fstat(directory_fd)
+        if _is_link_or_reparse(root_metadata) or not stat.S_ISDIR(
+            root_metadata.st_mode
+        ):
+            return None
+        for part in parts[:-1]:
+            child_fd: Optional[int] = None
+            try:
+                child_fd = os.open(part, directory_flags, dir_fd=directory_fd)
+                child_metadata = os.fstat(child_fd)
+                if _is_link_or_reparse(child_metadata) or not stat.S_ISDIR(
+                    child_metadata.st_mode
+                ):
+                    return None
+                previous_fd = directory_fd
+                directory_fd = child_fd
+                child_fd = None
+                os.close(previous_fd)
+            finally:
+                if child_fd is not None:
+                    os.close(child_fd)
+
+        source_fd = os.open(
+            parts[-1],
+            _regular_source_flags(nofollow=True),
+            dir_fd=directory_fd,
+        )
+        opened = os.fstat(source_fd)
+        if _is_link_or_reparse(opened) or not stat.S_ISREG(opened.st_mode):
+            return None
+        descriptor = source_fd
+        source_fd = None
+        return descriptor
+    except (NotImplementedError, OSError, ValueError):
+        return None
+    finally:
+        if source_fd is not None:
+            os.close(source_fd)
+        if directory_fd is not None:
+            os.close(directory_fd)
+
+
+def _static_regular_source(
+    root: str,
+    parts: tuple[str, ...],
+) -> Optional[tuple[str, os.stat_result, tuple[tuple[int, int, int], ...]]]:
+    """Validate a contained, link-free path on platforms without safe dir FDs."""
+    try:
+        metadata = os.lstat(root)
+        identity = _file_identity(metadata)
+        if (
+            _is_link_or_reparse(metadata)
+            or not stat.S_ISDIR(metadata.st_mode)
+            or identity is None
+        ):
+            return None
+        identities = [identity]
+        current = root
+        for part in parts[:-1]:
+            current = os.path.join(current, part)
+            metadata = os.lstat(current)
+            identity = _file_identity(metadata)
+            if (
+                _is_link_or_reparse(metadata)
+                or not stat.S_ISDIR(metadata.st_mode)
+                or identity is None
+            ):
+                return None
+            identities.append(identity)
+        source = os.path.join(current, parts[-1])
+        metadata = os.lstat(source)
+        identity = _file_identity(metadata)
+        if (
+            _is_link_or_reparse(metadata)
+            or not stat.S_ISREG(metadata.st_mode)
+            or identity is None
+        ):
+            return None
+        identities.append(identity)
+        return source, metadata, tuple(identities)
+    except (OSError, ValueError):
+        return None
+
+
+def _file_identity(metadata: os.stat_result) -> Optional[tuple[int, int, int]]:
+    """Return a usable path identity, or ``None`` for inode-less metadata."""
+    device = getattr(metadata, "st_dev", None)
+    inode = getattr(metadata, "st_ino", None)
+    if (
+        not isinstance(device, int)
+        or isinstance(device, bool)
+        or device < 0
+        or not isinstance(inode, int)
+        or isinstance(inode, bool)
+        or inode <= 0
+    ):
+        return None
+    return device, inode, stat.S_IFMT(metadata.st_mode)
+
+
+def _read_open_descriptor(descriptor: int) -> Optional[str]:
+    try:
+        with os.fdopen(
+            descriptor,
+            "r",
+            encoding="utf-8",
+            errors="replace",
+        ) as source:
+            descriptor = -1
+            return source.read()
+    except (OSError, ValueError):
+        return None
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _read_static_contained_source(
+    root: str,
+    parts: tuple[str, ...],
+) -> Optional[str]:
+    """Read after a portable component check and bind the opened file identity."""
+    validated = _static_regular_source(root, parts)
+    if validated is None:
+        return None
+    source_path, expected, expected_path_identities = validated
+    expected_identity = _file_identity(expected)
+    if expected_identity is None:
+        return None
+
+    descriptor: Optional[int] = None
+    try:
+        descriptor = os.open(source_path, _regular_source_flags(nofollow=True))
+        opened = os.fstat(descriptor)
+        opened_identity = _file_identity(opened)
+        if (
+            _is_link_or_reparse(opened)
+            or not stat.S_ISREG(opened.st_mode)
+            or opened_identity is None
+            or opened_identity != expected_identity
+        ):
+            return None
+        owned_descriptor = descriptor
+        descriptor = None
+        content = _read_open_descriptor(owned_descriptor)
+    except (NotImplementedError, OSError, ValueError):
+        return None
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+    # Windows and other fallback platforms cannot make every component lookup
+    # descriptor-relative. Recheck the static path after reading so a final or
+    # intermediate link swap fails closed instead of returning source bytes.
+    current = _static_regular_source(root, parts)
+    if content is None or current is None or current[2] != expected_path_identities:
+        return None
+    return content
+
+
+def _read_legacy_source(file_path: object) -> Optional[str]:
+    """Preserve direct-path reads for old indexes that have no project root.
+
+    Without a trusted root there is no meaningful containment boundary. Older
+    graph artifacts commonly store absolute source paths, so keep following a
+    final link in this compatibility branch while still refusing non-files and
+    using non-blocking flags where the platform provides them.
+    """
+    try:
+        source_path = os.fspath(file_path)
+    except TypeError:
+        return None
+    if not isinstance(source_path, str) or not source_path or "\x00" in source_path:
+        return None
+
+    descriptor: Optional[int] = None
+    try:
+        descriptor = os.open(source_path, _regular_source_flags(nofollow=False))
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            return None
+        owned_descriptor = descriptor
+        descriptor = None
+        content = _read_open_descriptor(owned_descriptor)
+        return content
+    except (NotImplementedError, OSError, ValueError):
+        return None
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def _read_source_text(project_root: object, file_path: object) -> Optional[str]:
+    """Read source through containment when a repository root is available."""
+    if project_root is None:
+        return _read_legacy_source(file_path)
+
+    contained = _contained_source_path(project_root, file_path)
+    if contained is None:
+        return None
+    root, _source_path, parts = contained
+    if _SECURE_SOURCE_DIRECTORY_FDS:
+        descriptor = _open_regular_file_beneath(root, parts)
+        if descriptor is None:
+            return None
+        return _read_open_descriptor(descriptor)
+    return _read_static_contained_source(root, parts)
+
+
+def _split_source_lines(source_text: str) -> List[str]:
+    """Split only on normalized LF while retaining TextIO ``readlines`` shape."""
+    if not source_text:
+        return []
+    segments = source_text.split("\n")
+    lines = [segment + "\n" for segment in segments[:-1]]
+    if segments[-1]:
+        lines.append(segments[-1])
+    return lines
 
 
 @dataclass(slots=True)
@@ -434,62 +754,42 @@ class BM25CodeIndexer:
             # Handle code content if requested
             content = None
             if return_code_content and file_path:
-                # Construct full file path using project_root if available
-                full_file_path = file_path
-                if self.project_root and not os.path.isabs(file_path):
-                    full_file_path = os.path.join(self.project_root, file_path)
-
-                try:
-                    with open(
-                        full_file_path, "r", encoding="utf-8", errors="replace"
-                    ) as f:
-                        if node_type == NODE_TYPE_FILE:
-                            # For file nodes, return entire file content
-                            code_content = f.read()
-                            if wrap_with_ln:
-                                lines = code_content.split("\n")
-                                content = wrap_code_snippet(code_content, 1, len(lines))
-                            else:
-                                content = code_content
+                source_text = _read_source_text(self.project_root, file_path)
+                if source_text is not None:
+                    if node_type == NODE_TYPE_FILE:
+                        # For file nodes, return entire file content.
+                        code_content = source_text
+                        if wrap_with_ln:
+                            lines = code_content.split("\n")
+                            content = wrap_code_snippet(code_content, 1, len(lines))
                         else:
-                            # For symbol nodes, extract specific lines
-                            if start_line is not None and end_line is not None:
-                                lines = f.readlines()
-                                # start_line and end_line are already 0-based and inclusive
-                                start_idx = max(0, start_line)
-                                end_idx = min(
-                                    len(lines), end_line + 1
-                                )  # +1 for slice end exclusivity
+                            content = code_content
+                    elif start_line is not None and end_line is not None:
+                        # Symbol ranges remain 0-based and inclusive.
+                        lines = _split_source_lines(source_text)
+                        start_idx = max(0, start_line)
+                        end_idx = min(
+                            len(lines), end_line + 1
+                        )  # +1 for slice end exclusivity
+                        extracted_lines = lines[start_idx:end_idx]
 
-                                extracted_lines = lines[start_idx:end_idx]
+                        # Strip trailing blank lines to avoid extra whitespace.
+                        original_end_idx = len(extracted_lines)
+                        while extracted_lines and extracted_lines[-1].strip() == "":
+                            extracted_lines.pop()
 
-                                # Strip trailing blank lines to avoid extra whitespace.
-                                original_end_idx = len(extracted_lines)
-                                while (
-                                    extracted_lines
-                                    and extracted_lines[-1].strip() == ""
-                                ):
-                                    extracted_lines.pop()
-
-                                code_content = "".join(extracted_lines)
-
-                                if wrap_with_ln:
-                                    # Calculate the actual end line after removing empty lines
-                                    lines_removed = original_end_idx - len(
-                                        extracted_lines
-                                    )
-                                    actual_end_line = end_line - lines_removed
-                                    # Convert to 1-based for display purposes
-                                    content = wrap_code_snippet(
-                                        code_content,
-                                        start_line + 1,
-                                        actual_end_line + 1,
-                                    )
-                                else:
-                                    content = code_content
-                except (IOError, UnicodeDecodeError):
-                    # If file reading fails, content remains None
-                    pass
+                        code_content = "".join(extracted_lines)
+                        if wrap_with_ln:
+                            # Calculate the actual end line after removing empty lines.
+                            lines_removed = original_end_idx - len(extracted_lines)
+                            actual_end_line = end_line - lines_removed
+                            content = wrap_code_snippet(
+                                code_content,
+                                start_line + 1,
+                                actual_end_line + 1,
+                            )
+                        else:
+                            content = code_content
 
             # Create NodeInfo object (LangChain BM25Retriever doesn't provide scores)
             result = NodeInfo(
@@ -574,21 +874,18 @@ class BM25CodeIndexer:
             if declared_name.rsplit(".", 1)[-1] == symbol:
                 continue
 
-            full_path = file_path
-            if self.project_root and not os.path.isabs(file_path):
-                full_path = os.path.join(self.project_root, file_path)
-            if full_path not in files:
-                try:
-                    with open(
-                        full_path,
-                        "r",
-                        encoding="utf-8",
-                        errors="replace",
-                    ) as source:
-                        files[full_path] = source.readlines()
-                except OSError:
-                    files[full_path] = []
-            lines = files[full_path]
+            try:
+                source_key = os.fspath(file_path)
+            except TypeError:
+                continue
+            if not isinstance(source_key, str):
+                continue
+            if source_key not in files:
+                source_text = _read_source_text(self.project_root, source_key)
+                files[source_key] = (
+                    _split_source_lines(source_text) if source_text is not None else []
+                )
+            lines = files[source_key]
             if not lines:
                 continue
 

--- a/test/index/sparse_idx/test_bm25_safe_source.py
+++ b/test/index/sparse_idx/test_bm25_safe_source.py
@@ -1,0 +1,586 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from codenib.code_chunking.base import CodeChunk
+from codenib.index.sparse_idx import bm25_index as bm25_module
+from codenib.index.sparse_idx.bm25_index import BM25CodeIndexer
+from codenib.types import NODE_TYPE_FILE
+
+
+class _ZeroIdentityMetadata:
+    st_dev = 0
+    st_ino = 0
+
+    def __init__(self, wrapped: os.stat_result) -> None:
+        self._wrapped = wrapped
+
+    def __getattr__(self, name: str):
+        return getattr(self._wrapped, name)
+
+
+_NON_LF_LINE_BREAKS = [
+    pytest.param("\v", id="vertical-tab"),
+    pytest.param("\f", id="form-feed"),
+    pytest.param("\x85", id="next-line"),
+    pytest.param("\u2028", id="line-separator"),
+    pytest.param("\u2029", id="paragraph-separator"),
+]
+
+
+def _indexer(
+    project_root: Path | None,
+    file_path: str,
+    *,
+    start_line: int = 0,
+    end_line: int = 0,
+    node_type: str = "function",
+) -> BM25CodeIndexer:
+    indexer = BM25CodeIndexer(
+        chunks=[
+            CodeChunk(
+                content="def safe_source_marker(): pass",
+                start_line=start_line,
+                end_line=end_line,
+                chunk_type="function",
+                name="safe_source_marker",
+                file="pkg/source.py",
+                node_id="pkg/source.py:safe_source_marker()",
+            )
+        ],
+        project_root=str(project_root) if project_root is not None else None,
+    )
+    indexer.documents[0].metadata.update(
+        {
+            "file": file_path,
+            "start_line": start_line,
+            "end_line": end_line,
+            "type": node_type,
+        }
+    )
+    return indexer
+
+
+def _content(indexer: BM25CodeIndexer, *, wrap_with_ln: bool = False) -> str | None:
+    result = indexer.search(
+        "safe_source_marker",
+        top_k=1,
+        return_code_content=True,
+        wrap_with_ln=wrap_with_ln,
+    )[0]
+    return result.content
+
+
+def _symlink_or_skip(link: Path, target: Path, *, directory: bool = False) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=directory)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation is unavailable: {exc}")
+
+
+def test_relative_regular_source_preserves_inclusive_symbol_range(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "pkg" / "source.py"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"zero\r\none\r\ntwo\r\nthree\r\n")
+
+    indexer = _indexer(
+        repo,
+        "pkg/source.py",
+        start_line=1,
+        end_line=2,
+    )
+
+    assert _content(indexer) == "one\ntwo\n"
+    wrapped = _content(indexer, wrap_with_ln=True)
+    assert wrapped is not None
+    assert "2 | one" in wrapped
+    assert "3 | two" in wrapped
+
+
+@pytest.mark.parametrize(
+    ("source_text", "expected"),
+    [
+        ("", []),
+        ("one", ["one"]),
+        ("one\n", ["one\n"]),
+        ("one\ntwo", ["one\n", "two"]),
+        ("one\n\n", ["one\n", "\n"]),
+    ],
+)
+def test_source_line_splitter_preserves_textio_trailing_newline_shape(
+    source_text: str,
+    expected: list[str],
+) -> None:
+    assert bm25_module._split_source_lines(source_text) == expected
+
+
+@pytest.mark.parametrize("embedded_break", _NON_LF_LINE_BREAKS)
+def test_symbol_range_does_not_treat_non_lf_characters_as_lines(
+    tmp_path: Path,
+    embedded_break: str,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "source.py"
+    repo.mkdir()
+    first_line = f"prefix{embedded_break}safe_source_marker = 1\n"
+    source.write_text(first_line + "second\n", encoding="utf-8")
+    indexer = _indexer(repo, "source.py", start_line=0, end_line=0)
+
+    assert _content(indexer) == first_line
+
+
+def test_regular_file_node_still_returns_the_entire_source(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "source.py"
+    repo.mkdir()
+    source.write_text("first\nsecond\n", encoding="utf-8")
+
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "first\nsecond\n"
+
+
+def test_absolute_source_beneath_root_is_accepted(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "pkg" / "source.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("contained absolute source\n", encoding="utf-8")
+
+    indexer = _indexer(repo, str(source), node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "contained absolute source\n"
+
+
+@pytest.mark.parametrize("outside_path", ["absolute", "parent"])
+def test_source_outside_root_is_rejected(tmp_path: Path, outside_path: str) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside secret\n", encoding="utf-8")
+    file_path = str(outside) if outside_path == "absolute" else "../outside.py"
+
+    indexer = _indexer(repo, file_path, node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+
+
+def test_identifier_occurrence_scan_uses_the_same_source_boundary(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside_call()\n", encoding="utf-8")
+    indexer = _indexer(repo, "../outside.py")
+
+    assert indexer.search_identifier_occurrences("outside_call") == []
+
+
+@pytest.mark.parametrize("embedded_break", _NON_LF_LINE_BREAKS)
+def test_identifier_range_does_not_treat_non_lf_characters_as_lines(
+    tmp_path: Path,
+    embedded_break: str,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "source.py"
+    repo.mkdir()
+    first_line = f"prefix{embedded_break}outside_call()\n"
+    source.write_text(first_line + "second\n", encoding="utf-8")
+    indexer = _indexer(repo, "source.py", start_line=0, end_line=0)
+
+    results = indexer.search_identifier_occurrences(
+        "outside_call",
+        wrap_with_ln=False,
+    )
+
+    assert [result.content for result in results] == [first_line]
+
+
+@pytest.mark.skipif(os.name != "nt", reason="drive-relative paths are Windows-only")
+def test_source_on_a_different_windows_drive_is_rejected(tmp_path: Path) -> None:
+    root_drive, _tail = os.path.splitdrive(str(tmp_path))
+    other_drive = "Z:" if root_drive.upper() != "Z:" else "Y:"
+
+    assert (
+        bm25_module._contained_source_path(
+            tmp_path,
+            other_drive + r"\outside.py",
+        )
+        is None
+    )
+
+
+def test_final_source_symlink_is_rejected(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "real.py"
+    target.write_text("contained alias target\n", encoding="utf-8")
+    _symlink_or_skip(repo / "source.py", target)
+
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+
+
+def test_intermediate_source_symlink_is_rejected(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    repo.mkdir()
+    outside.mkdir()
+    (outside / "source.py").write_text("outside secret\n", encoding="utf-8")
+    _symlink_or_skip(repo / "pkg", outside, directory=True)
+
+    indexer = _indexer(repo, "pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+
+
+def test_static_fallback_reads_an_ordinary_contained_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "pkg" / "source.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("portable source\n", encoding="utf-8")
+    monkeypatch.setattr(bm25_module, "_SECURE_SOURCE_DIRECTORY_FDS", False)
+
+    indexer = _indexer(repo, "pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "portable source\n"
+
+
+@pytest.mark.parametrize("zero_component", ["root", "intermediate", "final"])
+def test_static_fallback_does_not_open_a_zero_identity_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    zero_component: str,
+) -> None:
+    repo = tmp_path / "repo"
+    package = repo / "pkg"
+    source = package / "source.py"
+    package.mkdir(parents=True)
+    source.write_text("safe source\n", encoding="utf-8")
+    targets = {
+        "root": repo,
+        "intermediate": package,
+        "final": source,
+    }
+    zero_path = os.path.normcase(os.path.abspath(targets[zero_component]))
+    real_lstat = os.lstat
+
+    def zero_identity_lstat(path: str | os.PathLike[str]) -> os.stat_result:
+        metadata = real_lstat(path)
+        if os.path.normcase(os.path.abspath(path)) == zero_path:
+            return _ZeroIdentityMetadata(metadata)  # type: ignore[return-value]
+        return metadata
+
+    def forbidden_open(*_args, **_kwargs):
+        raise AssertionError("zero-identity source paths must fail before open")
+
+    monkeypatch.setattr(bm25_module, "_SECURE_SOURCE_DIRECTORY_FDS", False)
+    monkeypatch.setattr(bm25_module.os, "lstat", zero_identity_lstat)
+    monkeypatch.setattr(bm25_module.os, "open", forbidden_open)
+    indexer = _indexer(repo, "pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+
+
+def test_static_fallback_zero_identity_swap_and_restore_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    package = repo / "pkg"
+    source = package / "source.py"
+    package.mkdir(parents=True)
+    source.write_text("SAFE\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "source.py").write_text("OUTSIDE\n", encoding="utf-8")
+    moved_package = repo / "saved-pkg"
+    real_lstat = os.lstat
+    real_fstat = os.fstat
+    real_open = os.open
+    real_read = bm25_module._read_open_descriptor
+    open_attempted = False
+    restore_attempted = False
+
+    def zero_identity_lstat(path: str | os.PathLike[str]) -> os.stat_result:
+        return _ZeroIdentityMetadata(real_lstat(path))  # type: ignore[return-value]
+
+    def zero_identity_fstat(descriptor: int) -> os.stat_result:
+        return _ZeroIdentityMetadata(real_fstat(descriptor))  # type: ignore[return-value]
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal open_attempted
+        open_attempted = True
+        package.rename(moved_package)
+        _symlink_or_skip(package, outside, directory=True)
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    def restoring_read(descriptor: int) -> str | None:
+        nonlocal restore_attempted
+        try:
+            return real_read(descriptor)
+        finally:
+            package.unlink()
+            moved_package.rename(package)
+            restore_attempted = True
+
+    monkeypatch.setattr(bm25_module, "_SECURE_SOURCE_DIRECTORY_FDS", False)
+    monkeypatch.setattr(bm25_module.os, "lstat", zero_identity_lstat)
+    monkeypatch.setattr(bm25_module.os, "fstat", zero_identity_fstat)
+    monkeypatch.setattr(bm25_module.os, "open", swapping_open)
+    monkeypatch.setattr(bm25_module, "_read_open_descriptor", restoring_read)
+    indexer = _indexer(repo, "pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+    assert not open_attempted
+    assert not restore_attempted
+
+
+def test_static_fallback_zero_fstat_identity_is_not_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "source.py"
+    repo.mkdir()
+    source.write_text("safe source\n", encoding="utf-8")
+    real_fstat = os.fstat
+    read_attempted = False
+
+    def zero_identity_fstat(descriptor: int) -> os.stat_result:
+        return _ZeroIdentityMetadata(real_fstat(descriptor))  # type: ignore[return-value]
+
+    def forbidden_read(_descriptor: int) -> str | None:
+        nonlocal read_attempted
+        read_attempted = True
+        raise AssertionError("zero-identity source descriptors must not be read")
+
+    monkeypatch.setattr(bm25_module, "_SECURE_SOURCE_DIRECTORY_FDS", False)
+    monkeypatch.setattr(bm25_module.os, "fstat", zero_identity_fstat)
+    monkeypatch.setattr(bm25_module, "_read_open_descriptor", forbidden_read)
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+    assert not read_attempted
+
+
+def test_static_fallback_rejects_a_final_symlink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside secret\n", encoding="utf-8")
+    _symlink_or_skip(repo / "source.py", outside)
+    monkeypatch.setattr(bm25_module, "_SECURE_SOURCE_DIRECTORY_FDS", False)
+
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+
+
+def test_static_fallback_rejects_a_reparse_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "source.py"
+    repo.mkdir()
+    source.write_text("reparse source\n", encoding="utf-8")
+    real_lstat = os.lstat
+
+    class _ReparseMetadata:
+        st_file_attributes = bm25_module._FILE_ATTRIBUTE_REPARSE_POINT
+
+        def __init__(self, wrapped: os.stat_result) -> None:
+            self._wrapped = wrapped
+
+        def __getattr__(self, name: str):
+            return getattr(self._wrapped, name)
+
+    def reparse_lstat(path: str | os.PathLike[str]) -> os.stat_result:
+        metadata = real_lstat(path)
+        if os.path.normcase(os.path.abspath(path)) == os.path.normcase(str(source)):
+            return _ReparseMetadata(metadata)  # type: ignore[return-value]
+        return metadata
+
+    monkeypatch.setattr(bm25_module, "_SECURE_SOURCE_DIRECTORY_FDS", False)
+    monkeypatch.setattr(bm25_module.os, "lstat", reparse_lstat)
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+
+
+def test_static_fallback_rejects_an_intermediate_link_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    package = repo / "pkg"
+    package.mkdir(parents=True)
+    source = package / "source.py"
+    source.write_text("safe source\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "source.py").write_text("outside secret\n", encoding="utf-8")
+    real_open = os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if not swapped and dir_fd is None and os.fspath(path) == str(source):
+            package.rename(repo / "old-pkg")
+            _symlink_or_skip(package, outside, directory=True)
+            swapped = True
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(bm25_module, "_SECURE_SOURCE_DIRECTORY_FDS", False)
+    monkeypatch.setattr(bm25_module.os, "open", swapping_open)
+    indexer = _indexer(repo, "pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+    assert swapped
+
+
+@pytest.mark.skipif(
+    not bm25_module._SECURE_SOURCE_DIRECTORY_FDS,
+    reason="descriptor-relative swap coverage requires POSIX safe-open flags",
+)
+def test_final_component_swap_to_symlink_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "source.py"
+    repo.mkdir()
+    source.write_text("safe source\n", encoding="utf-8")
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside secret\n", encoding="utf-8")
+    real_open = os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if not swapped and dir_fd is not None and os.fspath(path) == "source.py":
+            source.unlink()
+            _symlink_or_skip(source, outside)
+            swapped = True
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(bm25_module.os, "open", swapping_open)
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+    assert swapped
+
+
+@pytest.mark.skipif(
+    not bm25_module._SECURE_SOURCE_DIRECTORY_FDS,
+    reason="descriptor-relative swap coverage requires POSIX safe-open flags",
+)
+def test_intermediate_component_swap_to_symlink_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    package = repo / "pkg"
+    package.mkdir(parents=True)
+    (package / "source.py").write_text("safe source\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "source.py").write_text("outside secret\n", encoding="utf-8")
+    real_open = os.open
+    swapped = False
+
+    def swapping_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if not swapped and dir_fd is not None and os.fspath(path) == "pkg":
+            package.rename(repo / "old-pkg")
+            _symlink_or_skip(package, outside, directory=True)
+            swapped = True
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(bm25_module.os, "open", swapping_open)
+    indexer = _indexer(repo, "pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None
+    assert swapped
+
+
+def test_index_without_project_root_keeps_absolute_path_compatibility(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "legacy.py"
+    source.write_text("legacy absolute source\n", encoding="utf-8")
+    indexer = _indexer(None, str(source), node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "legacy absolute source\n"
+
+
+@pytest.mark.skipif(
+    not bm25_module._SECURE_SOURCE_DIRECTORY_FDS,
+    reason="descriptor leak coverage requires POSIX safe-open flags",
+)
+def test_successful_source_read_closes_every_opened_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    source = repo / "pkg" / "source.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("safe source\n", encoding="utf-8")
+    real_open = os.open
+    opened: list[int] = []
+
+    def tracking_open(path, flags, mode=0o777, *, dir_fd=None):
+        if dir_fd is None:
+            descriptor = real_open(path, flags, mode)
+        else:
+            descriptor = real_open(path, flags, mode, dir_fd=dir_fd)
+        opened.append(descriptor)
+        return descriptor
+
+    monkeypatch.setattr(bm25_module.os, "open", tracking_open)
+    indexer = _indexer(repo, "pkg/source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) == "safe source\n"
+    assert opened
+    for descriptor in set(opened):
+        with pytest.raises(OSError) as exc_info:
+            os.fstat(descriptor)
+        assert exc_info.value.errno == errno.EBADF
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO requires POSIX")
+@pytest.mark.timeout(2)
+def test_non_regular_source_is_rejected_without_blocking(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    os.mkfifo(repo / "source.py")
+    indexer = _indexer(repo, "source.py", node_type=NODE_TYPE_FILE)
+
+    assert _content(indexer) is None


### PR DESCRIPTION
## Summary

Harden BM25 runtime source reads so a manifest-backed index cannot escape its configured checkout through absolute paths, traversal, links, special files, unstable identities, or path replacement races. This is an independent safety prerequisite for the RepoManifest storage bridge in #199.

## Changes

- Resolve manifest file references lexically beneath the configured project root.
- Use anchored no-follow descriptor traversal on supported POSIX platforms and a fail-closed identity sandwich elsewhere.
- Reject symlinks, reparse points, FIFO/device inputs, cross-root paths, and inode-less fallback identities before reading.
- Route symbol content and identifier occurrence reads through the same boundary.
- Preserve TextIO and tree-sitter LF-only line semantics for code ranges.
- Add deterministic race, fallback, descriptor cleanup, and non-LF separator regressions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- 103 passed, 1 skipped across BM25 safe-source, identifier/span, and MCP source/search tests on Python 3.10.
- Independent final review: PASS with no P0/P1 findings.
- Black, isort, flake8, py_compile, and git diff checks passed.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Related: #199