### PR TITLE
refactor(core): decode SCIP into flat records

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -14,6 +14,7 @@ core decoder continue to use the serial Python path.
 ## Components
 
 - `code_graph.{h,cpp}` — C++ graph container.
+- `decoded_records.h` — provider-neutral rows before graph materialization.
 - `graph_layers.{h,cpp}` — shared normalized edge-layer classification.
 - `scip_decode_base.{h,cpp}` — common loading, document scheduling, merge, and
   post-processing behavior.
@@ -54,6 +55,14 @@ the Python `igraph` wheel.
 
 Some parity tests use generated SCIP integration fixtures and are skipped when
 those caches are absent. Always inspect the skip report from `make core-test`.
+
+## Pre-Graph Decode Boundary
+
+`SCIPDecoderBase` first produces `DecodedRecords`. The established `decode()`
+path materializes those rows into the same `CodeGraph`; `decode_records()` lets
+future capability-specific consumers stop before igraph. The record merge owns
+the established first-definition and edge-deduplication policy, and
+language-specific postprocessing runs before either consumer observes rows.
 
 ## Use Through Python
 

--- a/core/code_graph.cpp
+++ b/core/code_graph.cpp
@@ -584,6 +584,41 @@ void CodeGraph::batch_add_edges(
   igraph_vector_int_destroy(&edge_vector);
 }
 
+void CodeGraph::batch_add_indexed_edges(const std::vector<EdgeData> &edges) {
+  if (edges.empty()) {
+    return;
+  }
+
+  const auto vertex_count = igraph_vcount(&graph_);
+  igraph_vector_int_t edge_vector;
+  if (igraph_vector_int_init(&edge_vector,
+                             static_cast<igraph_integer_t>(edges.size() * 2)) !=
+      IGRAPH_SUCCESS) {
+    throw std::runtime_error("Failed to allocate indexed edge vector");
+  }
+
+  for (std::size_t index = 0; index < edges.size(); ++index) {
+    const auto &edge = edges[index];
+    if (edge.source < 0 || edge.target < 0 || edge.source >= vertex_count ||
+        edge.target >= vertex_count) {
+      igraph_vector_int_destroy(&edge_vector);
+      throw std::out_of_range("Indexed edge endpoint is outside vertex table");
+    }
+    VECTOR(edge_vector)[index * 2] = edge.source;
+    VECTOR(edge_vector)[index * 2 + 1] = edge.target;
+  }
+
+  const auto previous_count = static_cast<std::size_t>(igraph_ecount(&graph_));
+  if (igraph_add_edges(&graph_, &edge_vector, nullptr) != IGRAPH_SUCCESS) {
+    igraph_vector_int_destroy(&edge_vector);
+    throw std::runtime_error("Failed to batch add indexed edges");
+  }
+  igraph_vector_int_destroy(&edge_vector);
+
+  edges_.resize(previous_count + edges.size());
+  std::copy(edges.begin(), edges.end(), edges_.begin() + previous_count);
+}
+
 std::optional<CodeGraph::VertexData>
 CodeGraph::get_node_info_by_name(const std::string &node_name) const {
   auto it = name_to_vertex_.find(node_name);

--- a/core/code_graph.h
+++ b/core/code_graph.h
@@ -128,6 +128,11 @@ public:
           std::tuple<std::string, std::string, std::string,
                      std::optional<std::string>, std::optional<int>>> &edges);
 
+  // Append an already validated and deduplicated indexed edge table. This is
+  // the fast materialization path for DecodedRecords: vertex ids must
+  // refer to the current vertex table and rows must already be in final order.
+  void batch_add_indexed_edges(const std::vector<EdgeData> &edges);
+
   std::optional<VertexData>
   get_node_info_by_name(const std::string &node_name) const;
   std::optional<VertexData> get_node_info_by_id(VertexId vertex_id) const;

--- a/core/decoded_records.h
+++ b/core/decoded_records.h
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "code_graph.h"
+
+#include <string>
+#include <vector>
+
+namespace codenib::core {
+
+// Provider-neutral semantic rows before an igraph instance or Python objects
+// are built. Vertex ids in ``edges`` index ``vertices``. Each adapter owns its
+// merge, filtering, and deterministic-order policy before publishing rows.
+struct DecodedRecords {
+  std::vector<CodeGraph::VertexData> vertices;
+  std::vector<CodeGraph::EdgeData> edges;
+  std::string project_root;
+};
+
+} // namespace codenib::core

--- a/core/scip_decode_base.cpp
+++ b/core/scip_decode_base.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -24,6 +25,11 @@ namespace {
 bool debug_logging_enabled() {
   static const bool enabled = std::getenv("CODENIB_SCIP_DEBUG") != nullptr;
   return enabled;
+}
+
+bool profile_logging_enabled() {
+  const char *value = std::getenv("CODENIB_CORE_PROFILE");
+  return value != nullptr && std::string_view(value) == "1";
 }
 
 void log_debug(const std::string &message) {
@@ -176,9 +182,8 @@ SCIPDecoderBase::SCIPDecoderBase(std::string index_file_path,
       project_root_(std::move(project_root)),
       code_graph_(project_root_ ? *project_root_ : std::string{}) {}
 
-CodeGraph SCIPDecoderBase::decode() {
-  using clock = std::chrono::high_resolution_clock;
-  using ms = std::chrono::milliseconds;
+SCIPDecodedRecords SCIPDecoderBase::decode_records_impl() {
+  using clock = std::chrono::steady_clock;
   auto t0 = clock::now();
 
   load_metadata();
@@ -225,29 +230,77 @@ CodeGraph SCIPDecoderBase::decode() {
   }
   auto t_procs = clock::now();
 
-  code_graph_.add_root_node(ROOT_NODE);
-  merge_subgraphs(subgraphs);
-  postprocess();
+  SCIPDecodedRecords records = merge_subgraphs(subgraphs);
+  postprocess_records(records);
   auto t_merge = clock::now();
 
-  auto as_ms = [](auto a, auto b) {
-    return std::chrono::duration_cast<ms>(b - a).count();
+  auto as_ns = [](auto a, auto b) {
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(b - a).count());
   };
-  std::cout << "\n=== C++ decode profile ===\n"
-            << "load_metadata:   " << as_ms(t0, t_meta) << " ms\n"
-            << "file_read:       " << as_ms(t_meta, t_read) << " ms\n"
-            << "extract_blocks:  " << as_ms(t_read, t_extract) << " ms\n"
-            << "prescan:         " << as_ms(t_extract, t_prescan) << " ms\n"
-            << "process_docs:    " << as_ms(t_prescan, t_procs)
-            << " ms  (threads=" << max_threads << ", docs=" << num_blocks
-            << ")\n"
-            << "merge_subgraphs: " << as_ms(t_procs, t_merge) << " ms\n"
-            << "total_wall:      " << as_ms(t0, t_merge) << " ms\n"
-            << "==========================\n";
+  last_profile_ = SCIPDecodeProfile{};
+  last_profile_.load_metadata_ns = as_ns(t0, t_meta);
+  last_profile_.file_read_ns = as_ns(t_meta, t_read);
+  last_profile_.extract_blocks_ns = as_ns(t_read, t_extract);
+  last_profile_.prescan_ns = as_ns(t_extract, t_prescan);
+  last_profile_.process_documents_ns = as_ns(t_prescan, t_procs);
+  last_profile_.merge_subgraphs_ns = as_ns(t_procs, t_merge);
+  last_profile_.total_ns = as_ns(t0, t_merge);
+  last_profile_.worker_count = max_threads;
+  last_profile_.document_count = num_blocks;
+  return records;
+}
+
+SCIPDecodedRecords SCIPDecoderBase::decode_records() {
+  SCIPDecodedRecords records = decode_records_impl();
+  log_profile();
+  return records;
+}
+
+CodeGraph SCIPDecoderBase::decode() {
+  using clock = std::chrono::steady_clock;
+  SCIPDecodedRecords records = decode_records_impl();
+  const auto materialize_started = clock::now();
+  code_graph_.batch_upsert_nodes(records.vertices);
+  code_graph_.batch_add_indexed_edges(records.edges);
+  const auto materialize_finished = clock::now();
+  const auto materialize_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          materialize_finished - materialize_started)
+          .count());
+  last_profile_.materialize_graph_ns = materialize_ns;
+  last_profile_.total_ns += materialize_ns;
+  log_profile();
   return std::move(code_graph_);
 }
 
-void SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) {
+void SCIPDecoderBase::log_profile() const {
+  if (profile_logging_enabled()) {
+    auto ms = [](std::uint64_t ns) {
+      return static_cast<double>(ns) / 1'000'000.0;
+    };
+    std::cout << "\n=== C++ decode profile ===\n"
+              << "load_metadata:   " << ms(last_profile_.load_metadata_ns)
+              << " ms\n"
+              << "file_read:       " << ms(last_profile_.file_read_ns)
+              << " ms\n"
+              << "extract_blocks:  " << ms(last_profile_.extract_blocks_ns)
+              << " ms\n"
+              << "prescan:         " << ms(last_profile_.prescan_ns) << " ms\n"
+              << "process_docs:    " << ms(last_profile_.process_documents_ns)
+              << " ms  (threads=" << last_profile_.worker_count
+              << ", docs=" << last_profile_.document_count << ")\n"
+              << "merge_subgraphs: " << ms(last_profile_.merge_subgraphs_ns)
+              << " ms\n"
+              << "materialize_graph: " << ms(last_profile_.materialize_graph_ns)
+              << " ms\n"
+              << "total_wall:      " << ms(last_profile_.total_ns) << " ms\n"
+              << "==========================\n";
+  }
+}
+
+SCIPDecodedRecords
+SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) const {
   // Reproduce serial semantics:
   //   - First occurrence of a name takes its attrs (including unified_name).
   //   - Later DEFINITION overwrites all attrs (matches serial
@@ -257,9 +310,7 @@ void SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) {
   //   - Later REFERENCE leaves existing attrs alone (matches serial
   //     add_symbol_reference's "only create if missing").
   std::unordered_map<std::string, Subgraph::Node> merged_nodes;
-  std::vector<std::tuple<std::string, std::string, std::string,
-                         std::optional<std::string>, std::optional<int>>>
-      all_edges;
+  std::vector<Subgraph::Edge> all_edges;
 
   std::size_t estimated = 0;
   for (const auto &sg : subgraphs)
@@ -310,19 +361,96 @@ void SCIPDecoderBase::merge_subgraphs(const std::vector<Subgraph> &subgraphs) {
       // else: subsequent ref on existing node — leave attrs alone.
     }
     for (const auto &e : sg.edges) {
-      all_edges.emplace_back(e.source, e.target, e.type, e.anchor_file,
-                             e.anchor_line);
+      all_edges.push_back(e);
     }
   }
 
-  std::vector<CodeGraph::VertexData> flat_nodes;
-  flat_nodes.reserve(merged_nodes.size());
+  SCIPDecodedRecords records;
+  records.project_root = project_root_.value_or(std::string{});
+  records.vertices.reserve(merged_nodes.size() + 1);
+  CodeGraph::VertexData root;
+  root.name = ROOT_NODE;
+  root.type = "root";
+  records.vertices.push_back(std::move(root));
   for (auto &[name, node] : merged_nodes) {
-    flat_nodes.emplace_back(std::move(node.data));
+    if (name != ROOT_NODE)
+      records.vertices.emplace_back(std::move(node.data));
   }
 
-  code_graph_.batch_upsert_nodes(flat_nodes);
-  code_graph_.batch_add_edges(all_edges);
+  std::unordered_map<std::string, CodeGraph::VertexId> vertex_ids;
+  vertex_ids.reserve(records.vertices.size());
+  for (std::size_t index = 0; index < records.vertices.size(); ++index) {
+    vertex_ids.emplace(records.vertices[index].name,
+                       static_cast<CodeGraph::VertexId>(index));
+  }
+
+  struct StructuralKey {
+    CodeGraph::VertexId source;
+    CodeGraph::VertexId target;
+    bool operator==(const StructuralKey &other) const {
+      return source == other.source && target == other.target;
+    }
+  };
+  struct StructuralHash {
+    std::size_t operator()(const StructuralKey &key) const {
+      return std::hash<CodeGraph::VertexId>{}(key.source) ^
+             (std::hash<CodeGraph::VertexId>{}(key.target) << 1U);
+    }
+  };
+  struct AnchoredKey {
+    CodeGraph::VertexId source;
+    CodeGraph::VertexId target;
+    std::string type;
+    std::optional<std::string> anchor_file;
+    std::optional<int> anchor_line;
+    bool operator==(const AnchoredKey &other) const {
+      return source == other.source && target == other.target &&
+             type == other.type && anchor_file == other.anchor_file &&
+             anchor_line == other.anchor_line;
+    }
+  };
+  struct AnchoredHash {
+    std::size_t operator()(const AnchoredKey &key) const {
+      std::size_t hash = std::hash<CodeGraph::VertexId>{}(key.source);
+      hash ^= std::hash<CodeGraph::VertexId>{}(key.target) << 1U;
+      hash ^= std::hash<std::string>{}(key.type) << 2U;
+      if (key.anchor_file.has_value())
+        hash ^= std::hash<std::string>{}(*key.anchor_file) << 3U;
+      if (key.anchor_line.has_value())
+        hash ^= std::hash<int>{}(*key.anchor_line) << 4U;
+      return hash;
+    }
+  };
+
+  std::unordered_set<StructuralKey, StructuralHash> structural_edges;
+  std::unordered_set<AnchoredKey, AnchoredHash> anchored_edges;
+  structural_edges.reserve(all_edges.size());
+  anchored_edges.reserve(all_edges.size());
+  records.edges.reserve(all_edges.size());
+  for (const auto &edge : all_edges) {
+    const auto source = vertex_ids.find(edge.source);
+    const auto target = vertex_ids.find(edge.target);
+    if (source == vertex_ids.end() || target == vertex_ids.end())
+      continue;
+    const bool structural =
+        !edge.anchor_file.has_value() && !edge.anchor_line.has_value();
+    if (structural) {
+      if (!structural_edges
+               .insert(StructuralKey{source->second, target->second})
+               .second)
+        continue;
+    } else if (!anchored_edges
+                    .insert(AnchoredKey{source->second, target->second,
+                                        edge.type, edge.anchor_file,
+                                        edge.anchor_line})
+                    .second) {
+      continue;
+    }
+    records.edges.push_back(CodeGraph::EdgeData{source->second, target->second,
+                                                edge.type, edge.anchor_file,
+                                                edge.anchor_line});
+  }
+  return records;
 }
 
 } // namespace codenib::core

--- a/core/scip_decode_base.h
+++ b/core/scip_decode_base.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "code_graph.h"
+#include "decoded_records.h"
 #include "scip_decode_common.h"
 
 #include <chrono>
@@ -16,6 +17,24 @@
 #include <vector>
 
 namespace codenib::core {
+
+struct SCIPDecodeProfile {
+  std::uint64_t load_metadata_ns{0};
+  std::uint64_t file_read_ns{0};
+  std::uint64_t extract_blocks_ns{0};
+  std::uint64_t prescan_ns{0};
+  std::uint64_t process_documents_ns{0};
+  std::uint64_t merge_subgraphs_ns{0};
+  std::uint64_t materialize_graph_ns{0};
+  std::uint64_t total_ns{0};
+  std::size_t worker_count{0};
+  std::size_t document_count{0};
+};
+
+// Compatibility name for SCIP decoder APIs. Query/storage consumers use the
+// provider-neutral DecodedRecords contract; clangd can emit the same boundary
+// without pretending to be a SCIP backend.
+using SCIPDecodedRecords = DecodedRecords;
 
 // Common orchestration for SCIP decoders across languages. Subclasses
 // implement `process_document` (language-specific symbol parsing + subgraph
@@ -33,6 +52,8 @@ public:
   virtual ~SCIPDecoderBase() = default;
 
   CodeGraph decode();
+  SCIPDecodedRecords decode_records();
+  const SCIPDecodeProfile &last_profile() const { return last_profile_; }
 
 protected:
   virtual Subgraph
@@ -48,15 +69,21 @@ protected:
   // Optional per-decoder setup (parent-process only): read go.mod, Cargo.toml.
   virtual void load_metadata() {}
 
-  // Optional post-pass after merge_subgraphs. Default no-op. Python overrides
-  // to run `_fix_unified_names` over the fully-built graph.
-  virtual void postprocess() {}
+  // Optional post-pass after record merge. Default no-op. Python overrides to
+  // run `_fix_unified_names` without requiring an igraph materialization.
+  virtual void postprocess_records(SCIPDecodedRecords &) {}
 
-  void merge_subgraphs(const std::vector<Subgraph> &subgraphs);
+  SCIPDecodedRecords
+  merge_subgraphs(const std::vector<Subgraph> &subgraphs) const;
 
   std::string index_file_path_;
   std::optional<std::string> project_root_;
   CodeGraph code_graph_;
+  SCIPDecodeProfile last_profile_;
+
+private:
+  SCIPDecodedRecords decode_records_impl();
+  void log_profile() const;
 };
 
 // Shared helpers — brace-matching block extractor and integer-list regex.

--- a/core/scip_decode_python.cpp
+++ b/core/scip_decode_python.cpp
@@ -51,12 +51,12 @@ SCIPPythonDecoder::process_document(const std::string &document_block) const {
   return builder.build();
 }
 
-void SCIPPythonDecoder::postprocess() {
+void SCIPPythonDecoder::postprocess_records(SCIPDecodedRecords &records) {
   // Mirror Python _fix_unified_names post-pass:
   //   - file / directory → unified_name = name
   //   - symbol with ':' in name and a file attribute →
   //     unified_name = `{file}:{symbol_part_after_colon}`
-  for (auto &v : code_graph_.mutable_vertices()) {
+  for (auto &v : records.vertices) {
     if (v.type == NODE_TYPE_FILE || v.type == NODE_TYPE_DIRECTORY) {
       v.unified_name = v.name;
       continue;

--- a/core/scip_decode_python.h
+++ b/core/scip_decode_python.h
@@ -16,7 +16,7 @@ public:
 
 protected:
   Subgraph process_document(const std::string &document_block) const override;
-  void postprocess() override;
+  void postprocess_records(SCIPDecodedRecords &records) override;
 
 private:
   void process_occurrence(const std::string &occurrence_block,

--- a/core/tests/scip_decode_test.cpp
+++ b/core/tests/scip_decode_test.cpp
@@ -180,8 +180,27 @@ int main(int argc, char **argv) {
   write_python_source(temp_project.path());
   const auto index_path = write_test_index(temp_project.path());
 
+  SCIPGraphDecoder records_decoder(index_path.string(),
+                                   temp_project.path().string());
+  const auto records = records_decoder.decode_records();
+  assert(records_decoder.last_profile().materialize_graph_ns == 0);
+  assert(!records.vertices.empty());
+  assert(records.vertices.front().name == ROOT_NODE);
+  assert(!records.edges.empty());
+
   SCIPGraphDecoder decoder(index_path.string(), temp_project.path().string());
   CodeGraph graph = decoder.decode();
+  assert(records.vertices.size() == graph.vertices().size());
+  assert(records.edges.size() == graph.edges().size());
+
+  CodeGraph invalid_graph;
+  invalid_graph.batch_upsert_nodes({records.vertices.front()});
+  try {
+    invalid_graph.batch_add_indexed_edges(
+        {{0, 1, "contain", std::nullopt, std::nullopt}});
+    assert(false && "out-of-range indexed edges must throw");
+  } catch (const std::out_of_range &) {
+  }
 
   const auto root_info = graph.get_node_info_by_name(ROOT_NODE);
   assert(root_info.has_value());

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -77,6 +77,15 @@ are primarily integration surfaces; application code should normally use
 `LSIndexer` so filtering, occurrence indexes, range indexes, and persistence
 remain consistent with the serial path.
 
+## Pre-Graph Decode Boundary
+
+The C++ decoder now merges each SCIP index into provider-neutral
+`DecodedRecords` before constructing igraph. The normal `decode()` API then
+materializes the same graph, so persisted schema and public graph behavior do
+not change. `decode_records()` is the reusable boundary for later consumers:
+it owns deterministic vertex order, indexed edges, project identity, and
+language-specific postprocessing without constructing a `CodeGraph`.
+
 ## Verify
 
 ```bash
@@ -92,6 +101,7 @@ skip report.
 ## Components
 
 - `code_graph.{h,cpp}` implements the C++ graph container.
+- `decoded_records.h` defines the provider-neutral pre-graph boundary.
 - `graph_layers.{h,cpp}` classifies normalized edge types into reusable graph
   layers.
 - `scip_decode_base.{h,cpp}` and `scip_decode_common.{h,cpp}` provide shared

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -651,6 +651,13 @@ decode/build gate before recommending any new C++ decoder work. This is the
 preferred path for proving that a serial-only active language has outgrown its
 current Python decoder.
 
+Provider-neutral native boundary status ([#559](https://github.com/sysevol-ai/CodeNib/issues/559)):
+the core decodes SCIP into flat `DecodedRecords` before igraph or Python object
+materialization. The established `decode()` path materializes those rows into
+the same graph, while capability-specific consumers can stop at
+`decode_records()`. FactBatch encoding (#560), FactQuery indexing (#561), and
+clangd parsing (#555) remain separate promotion and review decisions.
+
 ### Phase 6: Multi-Graph Python Surface
 
 Mixed-language repositories need a Python-side graph aggregation path before a


### PR DESCRIPTION
## Summary

Separate provider-neutral decoded SCIP records from graph materialization so later transports and indexes can consume one stable decode boundary.

Closes #559.

## Changes

- add DecodedRecords as the flat C++ decode result
- make SCIPDecoderBase decode records before optionally materializing CodeGraph
- preserve merge behavior and Python post-processing at the records boundary
- add structured decode profiling without unconditional stdout output
- validate indexed-edge endpoints and cover records/graph parity
- document the #559 boundary and defer FactBatch and query indexing to #560 and #561

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `pre-commit run --files <11 changed files>`
- `make core-test` — 7 passed, 4 skipped
- `python -m mkdocs build --strict`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published