### PR TITLE
feat(facts): add immutable FactBatch model

### DIFF
--- a/codenib/facts/__init__.py
+++ b/codenib/facts/__init__.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provider-neutral, per-file semantic fact contracts."""
+
+from .adapters import fact_batch_from_scip_occurrences, fact_batches_from_code_graph
+from .model import (
+    CAPABILITY_DEFINITIONS,
+    CAPABILITY_DIAGNOSTICS,
+    CAPABILITY_EDGES,
+    CAPABILITY_OCCURRENCES,
+    COMPLETENESS_COMPLETE,
+    COMPLETENESS_FAILED,
+    COMPLETENESS_PARTIAL,
+    COMPLETENESS_SYNTACTIC,
+    FACT_BATCH_SCHEMA_VERSION,
+    PROVENANCE_CLANGD,
+    PROVENANCE_FRAMEWORK,
+    PROVENANCE_HEURISTIC,
+    PROVENANCE_LSP,
+    PROVENANCE_SCIP,
+    PROVENANCE_SYNTACTIC,
+    DiagnosticFact,
+    EdgeFact,
+    FactBatch,
+    OccurrenceFact,
+    SourceRange,
+    SymbolFact,
+    merge_fact_batches,
+    sha256_digest,
+)
+
+__all__ = [
+    "CAPABILITY_DEFINITIONS",
+    "CAPABILITY_DIAGNOSTICS",
+    "CAPABILITY_EDGES",
+    "CAPABILITY_OCCURRENCES",
+    "COMPLETENESS_COMPLETE",
+    "COMPLETENESS_FAILED",
+    "COMPLETENESS_PARTIAL",
+    "COMPLETENESS_SYNTACTIC",
+    "DiagnosticFact",
+    "EdgeFact",
+    "FACT_BATCH_SCHEMA_VERSION",
+    "FactBatch",
+    "OccurrenceFact",
+    "PROVENANCE_CLANGD",
+    "PROVENANCE_FRAMEWORK",
+    "PROVENANCE_HEURISTIC",
+    "PROVENANCE_LSP",
+    "PROVENANCE_SCIP",
+    "PROVENANCE_SYNTACTIC",
+    "SourceRange",
+    "SymbolFact",
+    "fact_batch_from_scip_occurrences",
+    "fact_batches_from_code_graph",
+    "merge_fact_batches",
+    "sha256_digest",
+]

--- a/codenib/facts/adapters.py
+++ b/codenib/facts/adapters.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility adapters from current CodeNib semantic products."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ..types import (
+    EDGE_TYPE_CONTAIN,
+    NODE_TYPE_FILE,
+    NODE_TYPE_SYMBOL,
+    is_symbol_node,
+    node_has_definition,
+)
+from .model import (
+    CAPABILITY_DEFINITIONS,
+    CAPABILITY_EDGES,
+    CAPABILITY_OCCURRENCES,
+    COMPLETENESS_PARTIAL,
+    PROVENANCE_SCIP,
+    EdgeFact,
+    FactBatch,
+    OccurrenceFact,
+    SourceRange,
+    SymbolFact,
+)
+
+
+def _normalize_path(value: str | Path) -> str:
+    normalized = str(value).replace("\\", "/")
+    return normalized[2:] if normalized.startswith("./") else normalized
+
+
+def _definition_symbol_id(
+    file_path: str,
+    moniker: str,
+    source_range: SourceRange,
+) -> str:
+    scoped = f"{file_path}::{moniker}" if moniker.startswith("local ") else moniker
+    return (
+        f"{scoped}@{source_range.start_line}:{source_range.start_character}-"
+        f"{source_range.end_line}:{source_range.end_character}"
+    )
+
+
+def fact_batch_from_scip_occurrences(
+    occurrence_index: Any,
+    *,
+    file_path: str,
+    language: str,
+    content_digest: str,
+    profile_digest: str,
+    provider: str = "scip_occurrence_index",
+) -> FactBatch:
+    """Project one file from ``SCIPOccurrenceIndex`` into ``FactBatch v1``.
+
+    The current occurrence index does not retain symbol kinds, enclosing
+    ranges, or caller attribution, so the adapter reports partial completeness
+    and intentionally emits no inferred edges.
+    """
+
+    normalized_path = _normalize_path(file_path)
+    occurrences: list[OccurrenceFact] = []
+    symbols: dict[str, SymbolFact] = {}
+    for occurrence in getattr(occurrence_index, "occurrences", ()):
+        if _normalize_path(occurrence.file_path) != normalized_path:
+            continue
+        source_range = SourceRange(
+            start_line=occurrence.start_line,
+            start_character=occurrence.start_character,
+            end_line=occurrence.end_line,
+            end_character=occurrence.end_character,
+        )
+        occurrence_fact = OccurrenceFact(
+            symbol_moniker=occurrence.symbol,
+            source_range=source_range,
+            roles=occurrence.symbol_roles,
+        )
+        occurrences.append(occurrence_fact)
+        if not occurrence_fact.is_definition:
+            continue
+        symbol_id = _definition_symbol_id(
+            normalized_path,
+            occurrence.symbol,
+            source_range,
+        )
+        symbols[symbol_id] = SymbolFact(
+            symbol_id=symbol_id,
+            moniker=occurrence.symbol,
+            display_name=occurrence.symbol,
+            kind=NODE_TYPE_SYMBOL,
+            definition_range=source_range,
+            selection_range=source_range,
+        )
+
+    return FactBatch(
+        file_path=normalized_path,
+        language=language,
+        content_digest=content_digest,
+        profile_digest=profile_digest,
+        provider=provider,
+        completeness=COMPLETENESS_PARTIAL,
+        position_encoding=str(
+            getattr(occurrence_index, "position_encoding", None) or "UTF8"
+        ),
+        capabilities=(CAPABILITY_DEFINITIONS, CAPABILITY_OCCURRENCES),
+        symbols=tuple(symbols.values()),
+        occurrences=tuple(occurrences),
+    )
+
+
+def _language_for_file(language: str | Mapping[str, str], file_path: str) -> str:
+    if isinstance(language, str):
+        return language
+    value = language.get(file_path)
+    if value is None:
+        raise KeyError(f"language is unavailable for {file_path!r}")
+    return value
+
+
+def _graph_vertices(graph: Any) -> list[dict[str, Any]]:
+    return [dict(vertex.attributes()) for vertex in graph.graph.vs]
+
+
+def _graph_definition_range(attributes: Mapping[str, Any]) -> SourceRange:
+    start_line = attributes["start_line"]
+    end_line = attributes["end_line"]
+    return SourceRange(
+        start_line=start_line,
+        start_character=0,
+        end_line=end_line + 1,
+        end_character=0,
+    )
+
+
+def _graph_selection_range(
+    attributes: Mapping[str, Any],
+) -> SourceRange | None:
+    line = attributes.get("selection_line")
+    if isinstance(line, bool) or not isinstance(line, int) or line < 0:
+        return None
+    return SourceRange(
+        start_line=line,
+        start_character=0,
+        end_line=line + 1,
+        end_character=0,
+    )
+
+
+def _edge_anchor(attributes: Mapping[str, Any]) -> SourceRange | None:
+    line = attributes.get("anchor_line")
+    if isinstance(line, bool) or not isinstance(line, int) or line < 0:
+        return None
+    return SourceRange(
+        start_line=line,
+        start_character=0,
+        end_line=line + 1,
+        end_character=0,
+    )
+
+
+def fact_batches_from_code_graph(
+    graph: Any,
+    *,
+    language: str | Mapping[str, str],
+    content_digests: Mapping[str, str],
+    profile_digest: str,
+    provider: str = "legacy_code_graph",
+    edge_provenance: str = PROVENANCE_SCIP,
+    position_encoding: str = "UTF8",
+) -> tuple[FactBatch, ...]:
+    """Project the current materialized graph into per-file compatibility facts.
+
+    This is a dual-write bridge, not a replacement decoder. Existing graph
+    ranges are line-based and inclusive, so their definition facts become
+    half-open full-line ranges. Exact SCIP occurrences can then be merged from
+    :func:`fact_batch_from_scip_occurrences`.
+    """
+
+    normalized_digests: dict[str, str] = {}
+    for raw_path, digest in content_digests.items():
+        file_path = _normalize_path(raw_path)
+        if file_path in normalized_digests:
+            raise ValueError(f"duplicate normalized content digest path {file_path!r}")
+        normalized_digests[file_path] = digest
+
+    vertices = _graph_vertices(graph)
+    names = [str(attributes.get("name") or "") for attributes in vertices]
+    symbol_by_file: dict[str, list[SymbolFact]] = {
+        file_path: [] for file_path in normalized_digests
+    }
+    occurrence_by_file: dict[str, list[OccurrenceFact]] = {
+        file_path: [] for file_path in normalized_digests
+    }
+    edge_by_file: dict[str, list[EdgeFact]] = {
+        file_path: [] for file_path in normalized_digests
+    }
+
+    parent_symbols: dict[int, str] = {}
+    for edge in graph.graph.es:
+        attributes = edge.attributes()
+        if attributes.get("type") != EDGE_TYPE_CONTAIN:
+            continue
+        source = vertices[edge.source]
+        target = vertices[edge.target]
+        if is_symbol_node(source.get("type")) and is_symbol_node(target.get("type")):
+            parent_symbols[edge.target] = names[edge.source]
+
+    for index, attributes in enumerate(vertices):
+        if not is_symbol_node(attributes.get("type")) or not node_has_definition(
+            attributes
+        ):
+            continue
+        raw_file = attributes.get("file")
+        if not isinstance(raw_file, str):
+            continue
+        file_path = _normalize_path(raw_file)
+        if file_path not in normalized_digests:
+            continue
+        definition_range = _graph_definition_range(attributes)
+        symbol_id = names[index]
+        moniker = str(attributes.get("unified_name") or symbol_id)
+        symbol_by_file[file_path].append(
+            SymbolFact(
+                symbol_id=symbol_id,
+                moniker=moniker,
+                display_name=moniker,
+                kind=str(attributes.get("type") or NODE_TYPE_SYMBOL),
+                definition_range=definition_range,
+                selection_range=_graph_selection_range(attributes),
+                enclosing_symbol_id=parent_symbols.get(index),
+            )
+        )
+        occurrence_by_file[file_path].append(
+            OccurrenceFact(
+                symbol_moniker=moniker,
+                source_range=definition_range,
+                roles=1,
+            )
+        )
+
+    for edge in graph.graph.es:
+        attributes = edge.attributes()
+        kind = attributes.get("type")
+        if not isinstance(kind, str) or not kind:
+            continue
+        source = vertices[edge.source]
+        target = vertices[edge.target]
+        if not is_symbol_node(target.get("type")):
+            continue
+
+        if kind == EDGE_TYPE_CONTAIN:
+            raw_file = target.get("file")
+        else:
+            raw_file = attributes.get("anchor_file") or source.get("file")
+            if raw_file is None and source.get("type") == NODE_TYPE_FILE:
+                raw_file = names[edge.source]
+        if not isinstance(raw_file, str):
+            continue
+        file_path = _normalize_path(raw_file)
+        if file_path not in normalized_digests:
+            continue
+
+        source_symbol_id = (
+            names[edge.source] if is_symbol_node(source.get("type")) else None
+        )
+        edge_by_file[file_path].append(
+            EdgeFact(
+                kind=kind,
+                provenance=edge_provenance,
+                source_symbol_id=source_symbol_id,
+                target_symbol_id=names[edge.target],
+                anchor_range=_edge_anchor(attributes),
+                confidence=1.0,
+                resolver="legacy_code_graph",
+            )
+        )
+
+    batches = []
+    for file_path, content_digest in sorted(normalized_digests.items()):
+        batches.append(
+            FactBatch(
+                file_path=file_path,
+                language=_language_for_file(language, file_path),
+                content_digest=content_digest,
+                profile_digest=profile_digest,
+                provider=provider,
+                completeness=COMPLETENESS_PARTIAL,
+                position_encoding=position_encoding,
+                capabilities=(
+                    CAPABILITY_DEFINITIONS,
+                    CAPABILITY_OCCURRENCES,
+                    CAPABILITY_EDGES,
+                ),
+                symbols=tuple(symbol_by_file[file_path]),
+                occurrences=tuple(occurrence_by_file[file_path]),
+                edges=tuple(edge_by_file[file_path]),
+            )
+        )
+    return tuple(batches)
+
+
+__all__ = [
+    "fact_batch_from_scip_occurrences",
+    "fact_batches_from_code_graph",
+]

--- a/codenib/facts/model.py
+++ b/codenib/facts/model.py
@@ -1,0 +1,666 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Immutable, provider-neutral semantic facts for one repository file.
+
+The contract deliberately sits before graph materialization and storage. SCIP,
+clangd, generic LSP, and lower-confidence syntactic analyzers can emit the same
+shape while resolvers add edges without mutating the provider's original
+batch. Positions are zero-based, half-open, and interpreted using the batch's
+``position_encoding``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Mapping, Sequence
+
+FACT_BATCH_SCHEMA_VERSION = 1
+
+CAPABILITY_DEFINITIONS = "definitions"
+CAPABILITY_OCCURRENCES = "occurrences"
+CAPABILITY_EDGES = "edges"
+CAPABILITY_DIAGNOSTICS = "diagnostics"
+FACT_CAPABILITIES = frozenset(
+    {
+        CAPABILITY_DEFINITIONS,
+        CAPABILITY_OCCURRENCES,
+        CAPABILITY_EDGES,
+        CAPABILITY_DIAGNOSTICS,
+    }
+)
+
+COMPLETENESS_COMPLETE = "complete"
+COMPLETENESS_PARTIAL = "partial"
+COMPLETENESS_SYNTACTIC = "syntactic"
+COMPLETENESS_FAILED = "failed"
+FACT_COMPLETENESS = frozenset(
+    {
+        COMPLETENESS_COMPLETE,
+        COMPLETENESS_PARTIAL,
+        COMPLETENESS_SYNTACTIC,
+        COMPLETENESS_FAILED,
+    }
+)
+
+PROVENANCE_SCIP = "scip"
+PROVENANCE_LSP = "lsp"
+PROVENANCE_CLANGD = "clangd"
+PROVENANCE_SYNTACTIC = "syntactic"
+PROVENANCE_FRAMEWORK = "framework"
+PROVENANCE_HEURISTIC = "heuristic"
+FACT_PROVENANCES = frozenset(
+    {
+        PROVENANCE_SCIP,
+        PROVENANCE_LSP,
+        PROVENANCE_CLANGD,
+        PROVENANCE_SYNTACTIC,
+        PROVENANCE_FRAMEWORK,
+        PROVENANCE_HEURISTIC,
+    }
+)
+
+_DIAGNOSTIC_SEVERITIES = frozenset({"debug", "info", "warning", "error"})
+_MAX_DIAGNOSTIC_CODE_CHARS = 256
+_MAX_DIAGNOSTIC_MESSAGE_CHARS = 4096
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _required_text(value: Any, *, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+    if value != value.strip():
+        raise ValueError(f"{name} must not have surrounding whitespace")
+    if "\x00" in value:
+        raise ValueError(f"{name} must not contain NUL bytes")
+    return value
+
+
+def _zero_based_integer(value: Any, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _canonical_file_path(value: Any) -> str:
+    text = _required_text(value, name="file_path")
+    if "\\" in text:
+        raise ValueError("file_path must be a repository-relative POSIX path")
+    path = PurePosixPath(text)
+    if (
+        path.is_absolute()
+        or path.as_posix() != text
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise ValueError("file_path must be a repository-relative POSIX path")
+    return text
+
+
+def _sha256(value: Any, *, name: str) -> str:
+    text = _required_text(value, name=name)
+    if not _SHA256_RE.fullmatch(text):
+        raise ValueError(f"{name} must use canonical sha256:<64 lowercase hex>")
+    return text
+
+
+def sha256_digest(value: bytes | str) -> str:
+    """Return the canonical digest spelling used by ``FactBatch``."""
+
+    payload = value.encode("utf-8") if isinstance(value, str) else bytes(value)
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+@dataclass(frozen=True, slots=True)
+class SourceRange:
+    """Zero-based half-open source range."""
+
+    start_line: int
+    start_character: int
+    end_line: int
+    end_character: int
+
+    def __post_init__(self) -> None:
+        for name in (
+            "start_line",
+            "start_character",
+            "end_line",
+            "end_character",
+        ):
+            _zero_based_integer(getattr(self, name), name=name)
+        if (self.end_line, self.end_character) < (
+            self.start_line,
+            self.start_character,
+        ):
+            raise ValueError("source range end must not precede its start")
+
+    @property
+    def sort_key(self) -> tuple[int, int, int, int]:
+        return (
+            self.start_line,
+            self.start_character,
+            self.end_line,
+            self.end_character,
+        )
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "start_line": self.start_line,
+            "start_character": self.start_character,
+            "end_line": self.end_line,
+            "end_character": self.end_character,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> SourceRange:
+        return cls(
+            start_line=payload.get("start_line"),
+            start_character=payload.get("start_character"),
+            end_line=payload.get("end_line"),
+            end_character=payload.get("end_character"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolFact:
+    """One observed symbol definition."""
+
+    symbol_id: str
+    moniker: str
+    display_name: str
+    kind: str
+    definition_range: SourceRange
+    selection_range: SourceRange | None = None
+    enclosing_symbol_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _required_text(self.symbol_id, name="symbol_id")
+        _required_text(self.moniker, name="moniker")
+        _required_text(self.display_name, name="display_name")
+        _required_text(self.kind, name="kind")
+        if self.enclosing_symbol_id is not None:
+            _required_text(self.enclosing_symbol_id, name="enclosing_symbol_id")
+
+    @property
+    def sort_key(self) -> tuple[Any, ...]:
+        return self.symbol_id, self.definition_range.sort_key
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "symbol_id": self.symbol_id,
+            "moniker": self.moniker,
+            "display_name": self.display_name,
+            "kind": self.kind,
+            "definition_range": self.definition_range.to_dict(),
+        }
+        if self.selection_range is not None:
+            payload["selection_range"] = self.selection_range.to_dict()
+        if self.enclosing_symbol_id is not None:
+            payload["enclosing_symbol_id"] = self.enclosing_symbol_id
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> SymbolFact:
+        selection = payload.get("selection_range")
+        return cls(
+            symbol_id=payload.get("symbol_id"),
+            moniker=payload.get("moniker"),
+            display_name=payload.get("display_name"),
+            kind=payload.get("kind"),
+            definition_range=SourceRange.from_dict(payload["definition_range"]),
+            selection_range=(
+                SourceRange.from_dict(selection)
+                if isinstance(selection, Mapping)
+                else None
+            ),
+            enclosing_symbol_id=payload.get("enclosing_symbol_id"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OccurrenceFact:
+    """One exact symbol occurrence; the moniker may remain unresolved."""
+
+    symbol_moniker: str
+    source_range: SourceRange
+    roles: int = 0
+    enclosing_range: SourceRange | None = None
+
+    def __post_init__(self) -> None:
+        _required_text(self.symbol_moniker, name="symbol_moniker")
+        _zero_based_integer(self.roles, name="roles")
+
+    @property
+    def is_definition(self) -> bool:
+        return bool(self.roles & 1)
+
+    @property
+    def sort_key(self) -> tuple[Any, ...]:
+        return self.source_range.sort_key, self.symbol_moniker, self.roles
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "symbol_moniker": self.symbol_moniker,
+            "source_range": self.source_range.to_dict(),
+            "roles": self.roles,
+        }
+        if self.enclosing_range is not None:
+            payload["enclosing_range"] = self.enclosing_range.to_dict()
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> OccurrenceFact:
+        enclosing = payload.get("enclosing_range")
+        return cls(
+            symbol_moniker=payload.get("symbol_moniker"),
+            source_range=SourceRange.from_dict(payload["source_range"]),
+            roles=payload.get("roles", 0),
+            enclosing_range=(
+                SourceRange.from_dict(enclosing)
+                if isinstance(enclosing, Mapping)
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeFact:
+    """One resolved or unresolved semantic relationship."""
+
+    kind: str
+    provenance: str
+    target_symbol_id: str | None = None
+    target_moniker: str | None = None
+    source_symbol_id: str | None = None
+    anchor_range: SourceRange | None = None
+    confidence: float = 1.0
+    resolver: str | None = None
+
+    def __post_init__(self) -> None:
+        _required_text(self.kind, name="edge kind")
+        if self.provenance not in FACT_PROVENANCES:
+            raise ValueError(
+                f"unsupported edge provenance {self.provenance!r}; "
+                f"supported: {sorted(FACT_PROVENANCES)}"
+            )
+        targets = int(self.target_symbol_id is not None) + int(
+            self.target_moniker is not None
+        )
+        if targets != 1:
+            raise ValueError(
+                "exactly one of target_symbol_id or target_moniker is required"
+            )
+        if self.target_symbol_id is not None:
+            _required_text(self.target_symbol_id, name="target_symbol_id")
+        if self.target_moniker is not None:
+            _required_text(self.target_moniker, name="target_moniker")
+        if self.source_symbol_id is not None:
+            _required_text(self.source_symbol_id, name="source_symbol_id")
+        if isinstance(self.confidence, bool) or not isinstance(
+            self.confidence, (int, float)
+        ):
+            raise ValueError("confidence must be a finite number between 0 and 1")
+        if not math.isfinite(float(self.confidence)) or not 0 <= self.confidence <= 1:
+            raise ValueError("confidence must be a finite number between 0 and 1")
+        if self.resolver is not None:
+            _required_text(self.resolver, name="resolver")
+        if self.provenance in {PROVENANCE_FRAMEWORK, PROVENANCE_HEURISTIC} and (
+            self.resolver is None
+        ):
+            raise ValueError(
+                "framework and heuristic edges must name the resolver that "
+                "synthesized them"
+            )
+
+    @property
+    def sort_key(self) -> tuple[Any, ...]:
+        anchor = self.anchor_range.sort_key if self.anchor_range else (-1, -1, -1, -1)
+        return (
+            self.source_symbol_id or "",
+            self.kind,
+            self.target_symbol_id or "",
+            self.target_moniker or "",
+            anchor,
+            self.provenance,
+            float(self.confidence),
+            self.resolver or "",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "kind": self.kind,
+            "provenance": self.provenance,
+            "confidence": float(self.confidence),
+        }
+        for name in (
+            "target_symbol_id",
+            "target_moniker",
+            "source_symbol_id",
+            "resolver",
+        ):
+            value = getattr(self, name)
+            if value is not None:
+                payload[name] = value
+        if self.anchor_range is not None:
+            payload["anchor_range"] = self.anchor_range.to_dict()
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> EdgeFact:
+        anchor = payload.get("anchor_range")
+        return cls(
+            kind=payload.get("kind"),
+            provenance=payload.get("provenance"),
+            target_symbol_id=payload.get("target_symbol_id"),
+            target_moniker=payload.get("target_moniker"),
+            source_symbol_id=payload.get("source_symbol_id"),
+            anchor_range=(
+                SourceRange.from_dict(anchor) if isinstance(anchor, Mapping) else None
+            ),
+            confidence=payload.get("confidence", 1.0),
+            resolver=payload.get("resolver"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticFact:
+    """Bounded analyzer diagnostic retained with its source batch."""
+
+    severity: str
+    code: str
+    message: str
+    source_range: SourceRange | None = None
+
+    def __post_init__(self) -> None:
+        if self.severity not in _DIAGNOSTIC_SEVERITIES:
+            raise ValueError(
+                f"unsupported diagnostic severity {self.severity!r}; "
+                f"supported: {sorted(_DIAGNOSTIC_SEVERITIES)}"
+            )
+        code = _required_text(self.code, name="diagnostic code")
+        message = _required_text(self.message, name="diagnostic message")
+        if len(code) > _MAX_DIAGNOSTIC_CODE_CHARS:
+            raise ValueError(
+                "diagnostic code must be at most "
+                f"{_MAX_DIAGNOSTIC_CODE_CHARS} characters"
+            )
+        if len(message) > _MAX_DIAGNOSTIC_MESSAGE_CHARS:
+            raise ValueError(
+                "diagnostic message must be at most "
+                f"{_MAX_DIAGNOSTIC_MESSAGE_CHARS} characters"
+            )
+
+    @property
+    def sort_key(self) -> tuple[Any, ...]:
+        source = self.source_range.sort_key if self.source_range else (-1, -1, -1, -1)
+        return self.severity, self.code, source, self.message
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.source_range is not None:
+            payload["source_range"] = self.source_range.to_dict()
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> DiagnosticFact:
+        source = payload.get("source_range")
+        return cls(
+            severity=payload.get("severity"),
+            code=payload.get("code"),
+            message=payload.get("message"),
+            source_range=(
+                SourceRange.from_dict(source) if isinstance(source, Mapping) else None
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FactBatch:
+    """Deterministically ordered semantic facts for exactly one source file."""
+
+    file_path: str
+    language: str
+    content_digest: str
+    profile_digest: str
+    provider: str
+    completeness: str
+    position_encoding: str = "UTF8"
+    capabilities: tuple[str, ...] = ()
+    symbols: tuple[SymbolFact, ...] = ()
+    occurrences: tuple[OccurrenceFact, ...] = ()
+    edges: tuple[EdgeFact, ...] = ()
+    diagnostics: tuple[DiagnosticFact, ...] = ()
+    schema_version: int = FACT_BATCH_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "file_path", _canonical_file_path(self.file_path))
+        _required_text(self.language, name="language")
+        object.__setattr__(
+            self,
+            "content_digest",
+            _sha256(self.content_digest, name="content_digest"),
+        )
+        object.__setattr__(
+            self,
+            "profile_digest",
+            _sha256(self.profile_digest, name="profile_digest"),
+        )
+        _required_text(self.provider, name="provider")
+        _required_text(self.position_encoding, name="position_encoding")
+        if self.completeness not in FACT_COMPLETENESS:
+            raise ValueError(
+                f"unsupported completeness {self.completeness!r}; "
+                f"supported: {sorted(FACT_COMPLETENESS)}"
+            )
+        if (
+            isinstance(self.schema_version, bool)
+            or not isinstance(self.schema_version, int)
+            or self.schema_version != FACT_BATCH_SCHEMA_VERSION
+        ):
+            raise ValueError(
+                f"FactBatch schema_version={self.schema_version!r}, "
+                f"expected {FACT_BATCH_SCHEMA_VERSION}"
+            )
+
+        capabilities = tuple(sorted(set(self.capabilities)))
+        if any(capability not in FACT_CAPABILITIES for capability in capabilities):
+            unknown = sorted(set(capabilities) - FACT_CAPABILITIES)
+            raise ValueError(f"unsupported fact capabilities: {unknown}")
+        object.__setattr__(self, "capabilities", capabilities)
+        object.__setattr__(
+            self, "symbols", tuple(sorted(self.symbols, key=lambda item: item.sort_key))
+        )
+        object.__setattr__(
+            self,
+            "occurrences",
+            tuple(sorted(set(self.occurrences), key=lambda item: item.sort_key)),
+        )
+        object.__setattr__(
+            self,
+            "edges",
+            tuple(sorted(set(self.edges), key=lambda item: item.sort_key)),
+        )
+        object.__setattr__(
+            self,
+            "diagnostics",
+            tuple(sorted(set(self.diagnostics), key=lambda item: item.sort_key)),
+        )
+        symbol_ids = [symbol.symbol_id for symbol in self.symbols]
+        if len(symbol_ids) != len(set(symbol_ids)):
+            raise ValueError("FactBatch symbol_id values must be unique per file")
+        if self.completeness == COMPLETENESS_FAILED and (
+            self.symbols or self.occurrences or self.edges
+        ):
+            raise ValueError("failed FactBatch values must not contain semantic facts")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "file_path": self.file_path,
+            "language": self.language,
+            "content_digest": self.content_digest,
+            "profile_digest": self.profile_digest,
+            "provider": self.provider,
+            "completeness": self.completeness,
+            "position_encoding": self.position_encoding,
+            "capabilities": list(self.capabilities),
+            "symbols": [symbol.to_dict() for symbol in self.symbols],
+            "occurrences": [item.to_dict() for item in self.occurrences],
+            "edges": [edge.to_dict() for edge in self.edges],
+            "diagnostics": [item.to_dict() for item in self.diagnostics],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> FactBatch:
+        return cls(
+            schema_version=payload.get("schema_version"),
+            file_path=payload.get("file_path"),
+            language=payload.get("language"),
+            content_digest=payload.get("content_digest"),
+            profile_digest=payload.get("profile_digest"),
+            provider=payload.get("provider"),
+            completeness=payload.get("completeness"),
+            position_encoding=payload.get("position_encoding", "UTF8"),
+            capabilities=tuple(payload.get("capabilities") or ()),
+            symbols=tuple(
+                SymbolFact.from_dict(item) for item in payload.get("symbols") or ()
+            ),
+            occurrences=tuple(
+                OccurrenceFact.from_dict(item)
+                for item in payload.get("occurrences") or ()
+            ),
+            edges=tuple(
+                EdgeFact.from_dict(item) for item in payload.get("edges") or ()
+            ),
+            diagnostics=tuple(
+                DiagnosticFact.from_dict(item)
+                for item in payload.get("diagnostics") or ()
+            ),
+        )
+
+    def canonical_json(self) -> str:
+        return json.dumps(
+            self.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+
+    def digest(self) -> str:
+        return sha256_digest(self.canonical_json())
+
+    def semantic_dict(self) -> dict[str, Any]:
+        """Return observable facts without build-route identity fields."""
+
+        payload = self.to_dict()
+        payload.pop("profile_digest")
+        payload.pop("provider")
+        return payload
+
+    def semantic_digest(self) -> str:
+        return sha256_digest(
+            json.dumps(
+                self.semantic_dict(),
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            )
+        )
+
+
+def merge_fact_batches(
+    batches: Sequence[FactBatch],
+    *,
+    provider: str,
+    profile_digest: str,
+    completeness: str = COMPLETENESS_PARTIAL,
+) -> FactBatch:
+    """Merge compatible provider batches without losing their provenance."""
+
+    values = tuple(batches)
+    if not values:
+        raise ValueError("at least one FactBatch is required")
+    first = values[0]
+    compatibility = (
+        first.file_path,
+        first.language,
+        first.content_digest,
+        first.position_encoding,
+    )
+    for batch in values[1:]:
+        candidate = (
+            batch.file_path,
+            batch.language,
+            batch.content_digest,
+            batch.position_encoding,
+        )
+        if candidate != compatibility:
+            raise ValueError(
+                "FactBatch values must share file, language, content digest, "
+                "and position encoding"
+            )
+
+    symbols: dict[str, SymbolFact] = {}
+    for batch in values:
+        for symbol in batch.symbols:
+            existing = symbols.get(symbol.symbol_id)
+            if existing is not None and existing != symbol:
+                raise ValueError(
+                    f"conflicting facts for symbol_id {symbol.symbol_id!r}"
+                )
+            symbols[symbol.symbol_id] = symbol
+    return FactBatch(
+        file_path=first.file_path,
+        language=first.language,
+        content_digest=first.content_digest,
+        profile_digest=profile_digest,
+        provider=provider,
+        completeness=completeness,
+        position_encoding=first.position_encoding,
+        capabilities=tuple(
+            capability for batch in values for capability in batch.capabilities
+        ),
+        symbols=tuple(symbols.values()),
+        occurrences=tuple(item for batch in values for item in batch.occurrences),
+        edges=tuple(edge for batch in values for edge in batch.edges),
+        diagnostics=tuple(item for batch in values for item in batch.diagnostics),
+    )
+
+
+__all__ = [
+    "CAPABILITY_DEFINITIONS",
+    "CAPABILITY_DIAGNOSTICS",
+    "CAPABILITY_EDGES",
+    "CAPABILITY_OCCURRENCES",
+    "COMPLETENESS_COMPLETE",
+    "COMPLETENESS_FAILED",
+    "COMPLETENESS_PARTIAL",
+    "COMPLETENESS_SYNTACTIC",
+    "DiagnosticFact",
+    "EdgeFact",
+    "FACT_BATCH_SCHEMA_VERSION",
+    "FACT_CAPABILITIES",
+    "FACT_COMPLETENESS",
+    "FACT_PROVENANCES",
+    "FactBatch",
+    "OccurrenceFact",
+    "PROVENANCE_CLANGD",
+    "PROVENANCE_FRAMEWORK",
+    "PROVENANCE_HEURISTIC",
+    "PROVENANCE_LSP",
+    "PROVENANCE_SCIP",
+    "PROVENANCE_SYNTACTIC",
+    "SourceRange",
+    "SymbolFact",
+    "merge_fact_batches",
+    "sha256_digest",
+]

--- a/test/facts/test_adapters.py
+++ b/test/facts/test_adapters.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for compatibility adapters into ``FactBatch v1``."""
+
+from __future__ import annotations
+
+from codenib.facts import (
+    CAPABILITY_DEFINITIONS,
+    CAPABILITY_EDGES,
+    CAPABILITY_OCCURRENCES,
+    PROVENANCE_SCIP,
+    fact_batch_from_scip_occurrences,
+    fact_batches_from_code_graph,
+    merge_fact_batches,
+    sha256_digest,
+)
+from codenib.graph.code_graph import CodeGraph
+from codenib.scip_interface.lsp_occurrence_index import (
+    SCIPOccurrence,
+    SCIPOccurrenceIndex,
+)
+from codenib.types import (
+    EDGE_TYPE_CONTAIN,
+    EDGE_TYPE_REFERENCE,
+    NODE_TYPE_FILE,
+    NODE_TYPE_FUNCTION,
+)
+
+
+def test_scip_occurrence_adapter_keeps_exact_ranges_and_unresolved_monikers() -> None:
+    index = SCIPOccurrenceIndex(
+        [
+            SCIPOccurrence(
+                "src/main.py",
+                2,
+                4,
+                2,
+                7,
+                "scip-python python project 1 pkg/run().",
+                1,
+            ),
+            SCIPOccurrence(
+                "src/main.py",
+                8,
+                10,
+                8,
+                13,
+                "scip-python python project 1 pkg/run().",
+                0,
+            ),
+            SCIPOccurrence(
+                "src/other.py",
+                0,
+                0,
+                0,
+                3,
+                "other",
+                1,
+            ),
+        ],
+        position_encoding="UTF8",
+    )
+
+    batch = fact_batch_from_scip_occurrences(
+        index,
+        file_path="src/main.py",
+        language="python",
+        content_digest=sha256_digest("source"),
+        profile_digest=sha256_digest("profile"),
+    )
+
+    assert batch.capabilities == (
+        CAPABILITY_DEFINITIONS,
+        CAPABILITY_OCCURRENCES,
+    )
+    assert len(batch.symbols) == 1
+    assert len(batch.occurrences) == 2
+    assert batch.occurrences[0].source_range.sort_key == (2, 4, 2, 7)
+    assert batch.occurrences[1].is_definition is False
+    assert batch.edges == ()
+
+
+def _legacy_graph() -> CodeGraph:
+    graph = CodeGraph()
+    graph._add_vertex("src/caller.py", {"type": NODE_TYPE_FILE})
+    graph._add_vertex("src/target.py", {"type": NODE_TYPE_FILE})
+    graph._add_vertex(
+        "caller-id",
+        {
+            "type": NODE_TYPE_FUNCTION,
+            "file": "src/caller.py",
+            "start_line": 1,
+            "end_line": 4,
+            "unified_name": "src/caller.py:caller()",
+            "has_definition": True,
+        },
+    )
+    graph._add_vertex(
+        "target-id",
+        {
+            "type": NODE_TYPE_FUNCTION,
+            "file": "src/target.py",
+            "start_line": 6,
+            "end_line": 8,
+            "unified_name": "src/target.py:target()",
+            "has_definition": True,
+        },
+    )
+    graph._add_edge("src/caller.py", "caller-id", EDGE_TYPE_CONTAIN)
+    graph._add_edge("src/target.py", "target-id", EDGE_TYPE_CONTAIN)
+    graph._add_edge(
+        "caller-id",
+        "target-id",
+        EDGE_TYPE_REFERENCE,
+        anchor_file="src/caller.py",
+        anchor_line=3,
+    )
+    return graph
+
+
+def test_legacy_graph_adapter_preserves_resolved_edges_and_line_conversion() -> None:
+    profile_digest = sha256_digest("legacy graph profile")
+    batches = fact_batches_from_code_graph(
+        _legacy_graph(),
+        language="python",
+        content_digests={
+            "src/caller.py": sha256_digest("caller source"),
+            "src/target.py": sha256_digest("target source"),
+        },
+        profile_digest=profile_digest,
+        edge_provenance=PROVENANCE_SCIP,
+    )
+
+    assert [batch.file_path for batch in batches] == [
+        "src/caller.py",
+        "src/target.py",
+    ]
+    caller = batches[0]
+    assert caller.capabilities == (
+        CAPABILITY_DEFINITIONS,
+        CAPABILITY_EDGES,
+        CAPABILITY_OCCURRENCES,
+    )
+    assert caller.symbols[0].definition_range.sort_key == (1, 0, 5, 0)
+    reference = next(edge for edge in caller.edges if edge.kind == EDGE_TYPE_REFERENCE)
+    assert reference.source_symbol_id == "caller-id"
+    assert reference.target_symbol_id == "target-id"
+    assert reference.target_moniker is None
+    assert reference.anchor_range.sort_key == (3, 0, 4, 0)
+    assert reference.provenance == PROVENANCE_SCIP
+    assert reference.resolver == "legacy_code_graph"
+
+
+def test_graph_and_scip_batches_can_form_a_dual_write_projection() -> None:
+    content_digest = sha256_digest("caller source")
+    graph_batch = fact_batches_from_code_graph(
+        _legacy_graph(),
+        language="python",
+        content_digests={"src/caller.py": content_digest},
+        profile_digest=sha256_digest("graph"),
+    )[0]
+    occurrence_batch = fact_batch_from_scip_occurrences(
+        SCIPOccurrenceIndex(
+            [
+                SCIPOccurrence(
+                    "src/caller.py",
+                    1,
+                    4,
+                    1,
+                    10,
+                    "scip-python python project 1 pkg/caller().",
+                    1,
+                )
+            ]
+        ),
+        file_path="src/caller.py",
+        language="python",
+        content_digest=content_digest,
+        profile_digest=sha256_digest("occurrences"),
+    )
+
+    combined = merge_fact_batches(
+        (graph_batch, occurrence_batch),
+        provider="legacy+scip",
+        profile_digest=sha256_digest("combined"),
+    )
+
+    assert len(combined.symbols) == 2
+    assert len(combined.occurrences) == 2
+    assert any(edge.kind == EDGE_TYPE_REFERENCE for edge in combined.edges)

--- a/test/facts/test_model.py
+++ b/test/facts/test_model.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for immutable per-file semantic facts."""
+
+from __future__ import annotations
+
+import pytest
+
+from codenib.facts import (
+    CAPABILITY_DEFINITIONS,
+    CAPABILITY_EDGES,
+    CAPABILITY_OCCURRENCES,
+    COMPLETENESS_FAILED,
+    COMPLETENESS_PARTIAL,
+    PROVENANCE_HEURISTIC,
+    PROVENANCE_SCIP,
+    DiagnosticFact,
+    EdgeFact,
+    FactBatch,
+    OccurrenceFact,
+    SourceRange,
+    SymbolFact,
+    merge_fact_batches,
+    sha256_digest,
+)
+from codenib.types import EDGE_TYPE_REFERENCE, NODE_TYPE_FUNCTION
+
+_CONTENT_DIGEST = sha256_digest("def run(): pass\n")
+_PROFILE_DIGEST = sha256_digest("scip-profile-v1")
+
+
+def _range(line: int, start: int = 0, end: int = 3) -> SourceRange:
+    return SourceRange(line, start, line, end)
+
+
+def _symbol(symbol_id: str, line: int) -> SymbolFact:
+    return SymbolFact(
+        symbol_id=symbol_id,
+        moniker=f"scip python project 1 pkg/{symbol_id}().",
+        display_name=symbol_id,
+        kind=NODE_TYPE_FUNCTION,
+        definition_range=_range(line),
+    )
+
+
+def _batch(*, reverse: bool = False) -> FactBatch:
+    symbols = (_symbol("alpha", 1), _symbol("beta", 5))
+    occurrences = (
+        OccurrenceFact(symbol_moniker="beta", source_range=_range(8), roles=0),
+        OccurrenceFact(symbol_moniker="alpha", source_range=_range(1), roles=1),
+    )
+    edges = (
+        EdgeFact(
+            kind=EDGE_TYPE_REFERENCE,
+            provenance=PROVENANCE_SCIP,
+            source_symbol_id="alpha",
+            target_moniker="beta",
+            anchor_range=_range(3),
+        ),
+    )
+    return FactBatch(
+        file_path="src/main.py",
+        language="python",
+        content_digest=_CONTENT_DIGEST,
+        profile_digest=_PROFILE_DIGEST,
+        provider="scip-python",
+        completeness=COMPLETENESS_PARTIAL,
+        capabilities=(
+            CAPABILITY_OCCURRENCES,
+            CAPABILITY_DEFINITIONS,
+            CAPABILITY_EDGES,
+        ),
+        symbols=tuple(reversed(symbols)) if reverse else symbols,
+        occurrences=tuple(reversed(occurrences)) if reverse else occurrences,
+        edges=edges,
+    )
+
+
+def test_fact_batch_is_deterministic_and_round_trips() -> None:
+    forward = _batch()
+    reverse = _batch(reverse=True)
+
+    assert forward == reverse
+    assert forward.digest() == reverse.digest()
+    assert forward.capabilities == (
+        CAPABILITY_DEFINITIONS,
+        CAPABILITY_EDGES,
+        CAPABILITY_OCCURRENCES,
+    )
+    assert FactBatch.from_dict(forward.to_dict()) == forward
+    assert forward.to_dict()["schema_version"] == 1
+
+
+def test_fact_batch_rejects_ambiguous_or_noncanonical_identity() -> None:
+    with pytest.raises(ValueError, match="repository-relative POSIX"):
+        FactBatch(
+            file_path="../src/main.py",
+            language="python",
+            content_digest=_CONTENT_DIGEST,
+            profile_digest=_PROFILE_DIGEST,
+            provider="test",
+            completeness=COMPLETENESS_PARTIAL,
+        )
+    with pytest.raises(ValueError, match="canonical sha256"):
+        FactBatch(
+            file_path="src/main.py",
+            language="python",
+            content_digest="sha256:not-a-digest",
+            profile_digest=_PROFILE_DIGEST,
+            provider="test",
+            completeness=COMPLETENESS_PARTIAL,
+        )
+    with pytest.raises(ValueError, match="symbol_id values must be unique"):
+        FactBatch(
+            file_path="src/main.py",
+            language="python",
+            content_digest=_CONTENT_DIGEST,
+            profile_digest=_PROFILE_DIGEST,
+            provider="test",
+            completeness=COMPLETENESS_PARTIAL,
+            symbols=(_symbol("duplicate", 1), _symbol("duplicate", 2)),
+        )
+    with pytest.raises(ValueError, match="schema_version"):
+        FactBatch(
+            file_path="src/main.py",
+            language="python",
+            content_digest=_CONTENT_DIGEST,
+            profile_digest=_PROFILE_DIGEST,
+            provider="test",
+            completeness=COMPLETENESS_PARTIAL,
+            schema_version=True,
+        )
+
+
+def test_failed_fact_batch_cannot_publish_semantic_facts() -> None:
+    with pytest.raises(ValueError, match="must not contain semantic facts"):
+        FactBatch(
+            file_path="src/main.py",
+            language="python",
+            content_digest=_CONTENT_DIGEST,
+            profile_digest=_PROFILE_DIGEST,
+            provider="test",
+            completeness=COMPLETENESS_FAILED,
+            symbols=(_symbol("run", 1),),
+        )
+
+
+def test_edge_fact_requires_one_target_and_bounded_confidence() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        EdgeFact(
+            kind=EDGE_TYPE_REFERENCE,
+            provenance=PROVENANCE_SCIP,
+            target_symbol_id="resolved",
+            target_moniker="unresolved",
+        )
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        EdgeFact(
+            kind=EDGE_TYPE_REFERENCE,
+            provenance=PROVENANCE_SCIP,
+            target_moniker="target",
+            confidence=1.1,
+        )
+    with pytest.raises(ValueError, match="must name the resolver"):
+        EdgeFact(
+            kind=EDGE_TYPE_REFERENCE,
+            provenance=PROVENANCE_HEURISTIC,
+            target_moniker="target",
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("code", "x" * 257, "diagnostic code must be at most 256"),
+        ("message", "x" * 4097, "diagnostic message must be at most 4096"),
+    ),
+)
+def test_diagnostic_fact_bounds_untrusted_provider_text(
+    field: str, value: str, message: str
+) -> None:
+    values = {"severity": "warning", "code": "W001", "message": "bounded"}
+    values[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        DiagnosticFact(**values)
+
+
+def test_merge_fact_batches_unions_provider_facts() -> None:
+    first = FactBatch(
+        file_path="src/main.py",
+        language="python",
+        content_digest=_CONTENT_DIGEST,
+        profile_digest=sha256_digest("definitions"),
+        provider="definitions",
+        completeness=COMPLETENESS_PARTIAL,
+        capabilities=(CAPABILITY_DEFINITIONS,),
+        symbols=(_symbol("run", 1),),
+    )
+    occurrence = OccurrenceFact("run", _range(1), roles=1)
+    second = FactBatch(
+        file_path="src/main.py",
+        language="python",
+        content_digest=_CONTENT_DIGEST,
+        profile_digest=sha256_digest("occurrences"),
+        provider="occurrences",
+        completeness=COMPLETENESS_PARTIAL,
+        capabilities=(CAPABILITY_OCCURRENCES,),
+        occurrences=(occurrence, occurrence),
+    )
+
+    merged = merge_fact_batches(
+        (first, second),
+        provider="combined",
+        profile_digest=_PROFILE_DIGEST,
+    )
+
+    assert merged.provider == "combined"
+    assert merged.capabilities == (
+        CAPABILITY_DEFINITIONS,
+        CAPABILITY_OCCURRENCES,
+    )
+    assert merged.symbols == first.symbols
+    assert merged.occurrences == (occurrence,)
+
+
+def test_merge_rejects_cross_content_contamination() -> None:
+    incompatible = FactBatch(
+        file_path="src/main.py",
+        language="python",
+        content_digest=sha256_digest("different source"),
+        profile_digest=_PROFILE_DIGEST,
+        provider="other",
+        completeness=COMPLETENESS_PARTIAL,
+    )
+
+    with pytest.raises(ValueError, match="must share file"):
+        merge_fact_batches(
+            (_batch(), incompatible),
+            provider="combined",
+            profile_digest=_PROFILE_DIGEST,
+        )


### PR DESCRIPTION
## Summary

Define the provider-neutral, immutable FactBatch v1 contract before introducing any native wire transport or runtime selection.

Closes #563.
Part of #560.
Depends on merged #559 / #562.

## Changes

- add deterministic source-range, symbol, occurrence, edge, diagnostic, and FactBatch values
- bind batches to canonical repository paths and SHA-256 content/profile identity
- validate capabilities, completeness, provenance, confidence, schema version, and safe provider merges
- adapt SCIP occurrence indexes and legacy CodeGraph values into the same per-file contract
- add pure unit coverage for ordering, round trips, digests, identity rejection, merge isolation, and graph/range parity
- intentionally exclude the C++ buffer ABI (#564) and runtime promotion gate (#565)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `python -m pytest -q test/facts` — 11 passed
- unit tier with two known environment-specific baseline nodes precisely deselected — 3844 passed, 10 skipped
- `pre-commit run --files <5 changed files>`
- `python -m mkdocs build --strict`

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published