### PR TITLE
feat(core): add FactBatchBuffer v1 transport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,9 +406,13 @@ core-build: core-python-deps
 core-test: core-build
 	./build/core/scip_decode_test
 	./build/core/graph_layers_test
+	./build/core/fact_batch_buffer_test
 	PYTHONPATH="build/core:$$PYTHONPATH" python -m pytest -q \
 		test/scip/test_scip_core.py \
-		test/scip/test_scip_core_registry.py
+		test/scip/test_scip_core_registry.py \
+		test/scip/test_fact_batch_buffer.py \
+		test/facts/test_model.py \
+		test/facts/test_adapters.py
 
 scip-cold-start-tools: scip-java-tool gradle-tool sbt-tool scip-dotnet-tool scip-ruby-tool scip-php-info
 	@$(MAKE) --no-print-directory scip-cold-start-env

--- a/codenib/scip_interface/fact_batch_buffer.py
+++ b/codenib/scip_interface/fact_batch_buffer.py
@@ -1,0 +1,813 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validated reader for the native ``FactBatchBuffer v1`` wire format.
+
+The native extension returns a constant number of byte tables. This module
+validates the complete envelope before exposing either a column-oriented
+``CodeGraph`` materialization or the higher-level immutable ``FactBatch``
+objects. The fixed envelope is checked immediately and every selected consumer
+projection is checked completely before it is returned. Normal graph decoding
+therefore avoids the former per-vertex dict and per-edge tuple transport;
+logical fact objects are created only when a caller explicitly asks for them.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Mapping
+
+from ..facts import (
+    CAPABILITY_DEFINITIONS,
+    CAPABILITY_DIAGNOSTICS,
+    CAPABILITY_EDGES,
+    CAPABILITY_OCCURRENCES,
+    COMPLETENESS_COMPLETE,
+    COMPLETENESS_FAILED,
+    COMPLETENESS_PARTIAL,
+    COMPLETENESS_SYNTACTIC,
+    PROVENANCE_CLANGD,
+    PROVENANCE_FRAMEWORK,
+    PROVENANCE_HEURISTIC,
+    PROVENANCE_LSP,
+    PROVENANCE_SCIP,
+    PROVENANCE_SYNTACTIC,
+    DiagnosticFact,
+    EdgeFact,
+    FactBatch,
+    OccurrenceFact,
+    SourceRange,
+    SymbolFact,
+)
+from ..graph.code_graph import CodeGraph
+
+FACT_BATCH_BUFFER_ABI_VERSION = 1
+FACT_BATCH_SCHEMA_VERSION = 1
+FACT_BATCH_BUFFER_NONE = 0xFFFFFFFF
+
+FACT_BATCH_META_SIZE = 64
+FACT_BATCH_ROW_SIZE = 56
+FACT_SYMBOL_ROW_SIZE = 80
+FACT_OCCURRENCE_ROW_SIZE = 48
+FACT_EDGE_ROW_SIZE = 72
+FACT_DIAGNOSTIC_ROW_SIZE = 40
+FACT_GRAPH_VERTEX_ROW_SIZE = 56
+FACT_GRAPH_EDGE_ROW_SIZE = 32
+
+FACT_BUFFER_FLAG_GRAPH_COMPAT = 1 << 0
+FACT_BUFFER_FLAG_CONTENT_DIGESTS_COMPLETE = 1 << 1
+
+_META = struct.Struct("<4sHH12IQ")
+_BATCH = struct.Struct("<12IBBHI")
+_SYMBOL = struct.Struct("<20I")
+_OCCURRENCE = struct.Struct("<12I")
+_EDGE = struct.Struct("<IBBHd14I")
+_DIAGNOSTIC = struct.Struct("<IBBH8I")
+_GRAPH_VERTEX = struct.Struct("<14I")
+_GRAPH_EDGE = struct.Struct("<8I")
+
+_COMPLETENESS = {
+    1: COMPLETENESS_COMPLETE,
+    2: COMPLETENESS_PARTIAL,
+    3: COMPLETENESS_SYNTACTIC,
+    4: COMPLETENESS_FAILED,
+}
+_CAPABILITIES = {
+    1 << 0: CAPABILITY_DEFINITIONS,
+    1 << 1: CAPABILITY_OCCURRENCES,
+    1 << 2: CAPABILITY_EDGES,
+    1 << 3: CAPABILITY_DIAGNOSTICS,
+}
+_PROVENANCES = {
+    1: PROVENANCE_SCIP,
+    2: PROVENANCE_LSP,
+    3: PROVENANCE_CLANGD,
+    4: PROVENANCE_SYNTACTIC,
+    5: PROVENANCE_FRAMEWORK,
+    6: PROVENANCE_HEURISTIC,
+}
+_DIAGNOSTIC_SEVERITIES = {1: "debug", 2: "info", 3: "warning", 4: "error"}
+
+
+class FactBatchBufferError(ValueError):
+    """Raised when a native buffer fails its complete wire-contract check."""
+
+
+@dataclass(frozen=True, slots=True)
+class FactBatchBufferMeta:
+    flags: int
+    batch_count: int
+    symbol_count: int
+    occurrence_count: int
+    edge_count: int
+    diagnostic_count: int
+    graph_vertex_count: int
+    graph_edge_count: int
+    arena_size: int
+    project_root: str
+    native_decode_ns: int | None = None
+    native_encode_ns: int | None = None
+    decode_profile_ns: Mapping[str, int] | None = None
+    encode_profile_ns: Mapping[str, int] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _BatchInfo:
+    file_path: str
+    language: str
+    content_digest: str | None
+    profile_digest: str
+    provider: str
+    position_encoding: str
+    completeness: str
+    capabilities: tuple[str, ...]
+
+
+def _byte_view(value: Any, *, name: str) -> memoryview:
+    try:
+        view = memoryview(value)
+    except TypeError as exc:
+        raise FactBatchBufferError(f"{name} must be bytes-like") from exc
+    if not view.contiguous:
+        raise FactBatchBufferError(f"{name} must be contiguous")
+    if not view.readonly:
+        raise FactBatchBufferError(f"{name} must be read-only")
+    return view.cast("B")
+
+
+def _nonnegative_timing(value: Any, *, name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise FactBatchBufferError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _normalized_path(value: str) -> str:
+    normalized = value.replace("\\", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    path = PurePosixPath(normalized)
+    if (
+        not normalized
+        or path.is_absolute()
+        or path.as_posix() != normalized
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise FactBatchBufferError(
+            f"non-canonical repository-relative file path {value!r}"
+        )
+    return normalized
+
+
+class FactBatchBufferView:
+    """Validated, zero-copy view over one native FactBatchBuffer envelope."""
+
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        if not isinstance(payload, Mapping):
+            raise FactBatchBufferError("FactBatchBuffer payload must be a mapping")
+        self._meta_buffer = _byte_view(payload.get("meta"), name="meta")
+        self._batches = _byte_view(payload.get("batches"), name="batches")
+        self._symbols = _byte_view(payload.get("symbols"), name="symbols")
+        self._occurrences = _byte_view(payload.get("occurrences"), name="occurrences")
+        self._edges = _byte_view(payload.get("edges"), name="edges")
+        self._diagnostics = _byte_view(payload.get("diagnostics"), name="diagnostics")
+        self._graph_vertices = _byte_view(
+            payload.get("graph_vertices"), name="graph_vertices"
+        )
+        self._graph_edges = _byte_view(payload.get("graph_edges"), name="graph_edges")
+        self._arena = _byte_view(payload.get("arena"), name="arena")
+        self._strings: dict[tuple[int, int], str] = {}
+        self.meta = self._decode_meta(payload)
+        self._validate_table_sizes()
+
+    def _decode_meta(self, payload: Mapping[str, Any]) -> FactBatchBufferMeta:
+        if len(self._meta_buffer) != FACT_BATCH_META_SIZE:
+            raise FactBatchBufferError(
+                f"meta has {len(self._meta_buffer)} bytes; expected "
+                f"{FACT_BATCH_META_SIZE}"
+            )
+        values = _META.unpack(self._meta_buffer)
+        magic, abi_version, schema_version = values[:3]
+        if magic != b"CNFB":
+            raise FactBatchBufferError(f"unsupported FactBatchBuffer magic {magic!r}")
+        if abi_version != FACT_BATCH_BUFFER_ABI_VERSION:
+            raise FactBatchBufferError(
+                f"FactBatchBuffer ABI {abi_version} != expected "
+                f"{FACT_BATCH_BUFFER_ABI_VERSION}"
+            )
+        if schema_version != FACT_BATCH_SCHEMA_VERSION:
+            raise FactBatchBufferError(
+                f"FactBatch schema {schema_version} != expected "
+                f"{FACT_BATCH_SCHEMA_VERSION}"
+            )
+        (
+            flags,
+            batch_count,
+            symbol_count,
+            occurrence_count,
+            edge_count,
+            diagnostic_count,
+            graph_vertex_count,
+            graph_edge_count,
+            arena_size,
+            project_root_offset,
+            project_root_length,
+            reserved,
+        ) = values[3:15]
+        if reserved != 0 or values[15] != 0:
+            raise FactBatchBufferError(
+                "FactBatchBuffer reserved meta fields are nonzero"
+            )
+        if arena_size != len(self._arena):
+            raise FactBatchBufferError(
+                f"arena has {len(self._arena)} bytes; meta declares {arena_size}"
+            )
+        project_root = self._string(
+            project_root_offset,
+            project_root_length,
+            label="project_root",
+        )
+        if project_root is None:
+            raise FactBatchBufferError("project_root string reference is absent")
+        profiles: dict[str, Mapping[str, int] | None] = {}
+        for profile_name in ("decode_profile_ns", "encode_profile_ns"):
+            raw_profile = payload.get(profile_name)
+            profile = None
+            if raw_profile is not None:
+                if not isinstance(raw_profile, Mapping):
+                    raise FactBatchBufferError(f"{profile_name} must be a mapping")
+                profile = {
+                    str(name): _nonnegative_timing(value, name=f"{profile_name}.{name}")
+                    for name, value in raw_profile.items()
+                }
+                if any(value is None for value in profile.values()):
+                    raise FactBatchBufferError(f"{profile_name} values must be present")
+            profiles[profile_name] = profile
+        return FactBatchBufferMeta(
+            flags=flags,
+            batch_count=batch_count,
+            symbol_count=symbol_count,
+            occurrence_count=occurrence_count,
+            edge_count=edge_count,
+            diagnostic_count=diagnostic_count,
+            graph_vertex_count=graph_vertex_count,
+            graph_edge_count=graph_edge_count,
+            arena_size=arena_size,
+            project_root=project_root,
+            native_decode_ns=_nonnegative_timing(
+                payload.get("native_decode_ns"), name="native_decode_ns"
+            ),
+            native_encode_ns=_nonnegative_timing(
+                payload.get("native_encode_ns"), name="native_encode_ns"
+            ),
+            decode_profile_ns=profiles["decode_profile_ns"],
+            encode_profile_ns=profiles["encode_profile_ns"],
+        )
+
+    def _validate_table_sizes(self) -> None:
+        supported_flags = (
+            FACT_BUFFER_FLAG_GRAPH_COMPAT | FACT_BUFFER_FLAG_CONTENT_DIGESTS_COMPLETE
+        )
+        if self.meta.flags & ~supported_flags:
+            raise FactBatchBufferError(
+                f"FactBatchBuffer has unsupported flags {self.meta.flags:#x}"
+            )
+        tables = (
+            ("batches", self._batches, self.meta.batch_count, FACT_BATCH_ROW_SIZE),
+            ("symbols", self._symbols, self.meta.symbol_count, FACT_SYMBOL_ROW_SIZE),
+            (
+                "occurrences",
+                self._occurrences,
+                self.meta.occurrence_count,
+                FACT_OCCURRENCE_ROW_SIZE,
+            ),
+            ("edges", self._edges, self.meta.edge_count, FACT_EDGE_ROW_SIZE),
+            (
+                "diagnostics",
+                self._diagnostics,
+                self.meta.diagnostic_count,
+                FACT_DIAGNOSTIC_ROW_SIZE,
+            ),
+            (
+                "graph_vertices",
+                self._graph_vertices,
+                self.meta.graph_vertex_count,
+                FACT_GRAPH_VERTEX_ROW_SIZE,
+            ),
+            (
+                "graph_edges",
+                self._graph_edges,
+                self.meta.graph_edge_count,
+                FACT_GRAPH_EDGE_ROW_SIZE,
+            ),
+        )
+        for name, table, count, row_size in tables:
+            expected = count * row_size
+            if len(table) != expected:
+                raise FactBatchBufferError(
+                    f"{name} has {len(table)} bytes; expected {expected} "
+                    f"for {count} rows"
+                )
+        if not self.has_graph_compat and (
+            self.meta.graph_vertex_count or self.meta.graph_edge_count
+        ):
+            raise FactBatchBufferError(
+                "FactBatchBuffer declares graph rows without graph compatibility"
+            )
+
+    @property
+    def has_graph_compat(self) -> bool:
+        """Whether exact legacy graph compatibility tables are present."""
+
+        return bool(self.meta.flags & FACT_BUFFER_FLAG_GRAPH_COMPAT)
+
+    def _string(
+        self,
+        offset: int,
+        length: int,
+        *,
+        required: bool = False,
+        label: str = "string",
+    ) -> str | None:
+        if offset == FACT_BATCH_BUFFER_NONE:
+            if length != 0:
+                raise FactBatchBufferError(
+                    f"absent {label} has nonzero length {length}"
+                )
+            if required:
+                raise FactBatchBufferError(f"required {label} is absent")
+            return None
+        end = offset + length
+        if end < offset or end > len(self._arena):
+            raise FactBatchBufferError(
+                f"{label} range ({offset}, {length}) exceeds the string arena"
+            )
+        key = (offset, length)
+        cached = self._strings.get(key)
+        if cached is not None:
+            return cached
+        try:
+            value = self._arena[offset:end].tobytes().decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise FactBatchBufferError(f"{label} is not valid UTF-8") from exc
+        if "\x00" in value:
+            raise FactBatchBufferError(f"{label} contains a NUL byte")
+        if required and not value:
+            raise FactBatchBufferError(f"required {label} is empty")
+        self._strings[key] = value
+        return value
+
+    @staticmethod
+    def _optional_line(value: int) -> int | None:
+        return None if value == FACT_BATCH_BUFFER_NONE else value
+
+    @staticmethod
+    def _range(values: tuple[int, int, int, int], *, label: str) -> SourceRange | None:
+        absent = [value == FACT_BATCH_BUFFER_NONE for value in values]
+        if all(absent):
+            return None
+        if any(absent):
+            raise FactBatchBufferError(f"{label} is only partially present")
+        try:
+            return SourceRange(*values)
+        except (TypeError, ValueError) as exc:
+            raise FactBatchBufferError(f"invalid {label}: {exc}") from exc
+
+    def materialize_code_graph(self, *, project_root: str | None = None) -> CodeGraph:
+        """Build the current graph contract directly from packed columns."""
+
+        if not self.has_graph_compat:
+            raise FactBatchBufferError(
+                "FactBatchBuffer does not include graph compatibility tables"
+            )
+
+        names: list[str] = []
+        types: list[str] = []
+        files: list[str | None] = []
+        start_lines: list[int | None] = []
+        end_lines: list[int | None] = []
+        selection_lines: list[int | None] = []
+        unified_names: list[str | None] = []
+        symbol_kinds: list[str | None] = []
+        has_definitions: list[bool | None] = []
+
+        for index in range(self.meta.graph_vertex_count):
+            row = _GRAPH_VERTEX.unpack_from(
+                self._graph_vertices, index * FACT_GRAPH_VERTEX_ROW_SIZE
+            )
+            names.append(
+                self._string(row[0], row[1], required=True, label="vertex name")
+            )
+            types.append(
+                self._string(row[2], row[3], required=True, label="vertex type")
+            )
+            files.append(self._string(row[4], row[5], label="vertex file"))
+            unified_names.append(
+                self._string(row[6], row[7], label="vertex unified_name")
+            )
+            symbol_kinds.append(
+                self._string(row[8], row[9], label="vertex symbol_kind")
+            )
+            start_lines.append(self._optional_line(row[10]))
+            end_lines.append(self._optional_line(row[11]))
+            selection_lines.append(self._optional_line(row[12]))
+            flags = row[13]
+            if flags & ~0b11:
+                raise FactBatchBufferError(
+                    f"graph vertex {index} has unsupported flags {flags:#x}"
+                )
+            has_definitions.append(bool(flags & 0b10) if flags & 0b1 else None)
+
+        if len(names) != len(set(names)):
+            raise FactBatchBufferError(
+                "FactBatchBuffer graph vertex names must be globally unique"
+            )
+
+        graph = CodeGraph(
+            self.meta.project_root if project_root is None else str(project_root)
+        )
+        if names:
+            graph.graph.add_vertices(
+                len(names),
+                attributes={
+                    "name": names,
+                    "type": types,
+                    "file": files,
+                    "start_line": start_lines,
+                    "end_line": end_lines,
+                    "selection_line": selection_lines,
+                    "unified_name": unified_names,
+                    "symbol_kind": symbol_kinds,
+                    "has_definition": has_definitions,
+                },
+            )
+        graph.name_to_vertex.update({name: index for index, name in enumerate(names)})
+        graph.symbol_ranges.update(
+            {
+                name: (start, end)
+                for name, start, end in zip(names, start_lines, end_lines, strict=True)
+                if start is not None and end is not None
+            }
+        )
+
+        pairs: list[tuple[int, int]] = []
+        edge_types: list[str] = []
+        anchor_files: list[str | None] = []
+        anchor_lines: list[int | None] = []
+        for index in range(self.meta.graph_edge_count):
+            row = _GRAPH_EDGE.unpack_from(
+                self._graph_edges, index * FACT_GRAPH_EDGE_ROW_SIZE
+            )
+            source, target = row[:2]
+            if source >= len(names) or target >= len(names):
+                raise FactBatchBufferError(
+                    f"graph edge {index} endpoint ({source}, {target}) is out of range"
+                )
+            if row[7] != 0:
+                raise FactBatchBufferError(
+                    f"graph edge {index} has nonzero reserved flags"
+                )
+            pairs.append((source, target))
+            edge_types.append(
+                self._string(row[2], row[3], required=True, label="edge type")
+            )
+            anchor_files.append(self._string(row[4], row[5], label="edge anchor_file"))
+            anchor_lines.append(self._optional_line(row[6]))
+        if pairs:
+            graph.graph.add_edges(
+                pairs,
+                attributes={
+                    "type": edge_types,
+                    "anchor_file": anchor_files,
+                    "anchor_line": anchor_lines,
+                },
+            )
+        return graph
+
+    def _batch_infos(self) -> tuple[_BatchInfo, ...]:
+        batches = []
+        supported_capability_mask = sum(_CAPABILITIES)
+        for index in range(self.meta.batch_count):
+            row = _BATCH.unpack_from(self._batches, index * FACT_BATCH_ROW_SIZE)
+            completeness = _COMPLETENESS.get(row[12])
+            if completeness is None:
+                raise FactBatchBufferError(
+                    f"batch {index} has unsupported completeness {row[12]}"
+                )
+            capability_mask = row[13]
+            if capability_mask & ~supported_capability_mask:
+                raise FactBatchBufferError(
+                    f"batch {index} has unsupported capabilities {capability_mask:#x}"
+                )
+            if row[14] != 0 or row[15] != 0:
+                raise FactBatchBufferError(f"batch {index} reserved fields are nonzero")
+            batches.append(
+                _BatchInfo(
+                    file_path=_normalized_path(
+                        self._string(
+                            row[0], row[1], required=True, label="batch file_path"
+                        )
+                    ),
+                    language=self._string(
+                        row[2], row[3], required=True, label="batch language"
+                    ),
+                    content_digest=self._string(
+                        row[4], row[5], label="batch content_digest"
+                    ),
+                    profile_digest=self._string(
+                        row[6], row[7], required=True, label="batch profile_digest"
+                    ),
+                    provider=self._string(
+                        row[8], row[9], required=True, label="batch provider"
+                    ),
+                    position_encoding=self._string(
+                        row[10],
+                        row[11],
+                        required=True,
+                        label="batch position_encoding",
+                    ),
+                    completeness=completeness,
+                    capabilities=tuple(
+                        name
+                        for bit, name in _CAPABILITIES.items()
+                        if capability_mask & bit
+                    ),
+                )
+            )
+        paths = [batch.file_path for batch in batches]
+        if paths != sorted(paths) or len(paths) != len(set(paths)):
+            raise FactBatchBufferError(
+                "FactBatchBuffer batch paths must be unique and sorted"
+            )
+        digests_complete = all(batch.content_digest is not None for batch in batches)
+        declared_complete = bool(
+            self.meta.flags & FACT_BUFFER_FLAG_CONTENT_DIGESTS_COMPLETE
+        )
+        if declared_complete != digests_complete:
+            raise FactBatchBufferError(
+                "FactBatchBuffer content-digest flag does not match batch rows"
+            )
+        return tuple(batches)
+
+    @staticmethod
+    def _check_batch_index(index: int, batch_count: int, *, table: str) -> None:
+        if index >= batch_count:
+            raise FactBatchBufferError(
+                f"{table} row references out-of-range batch {index}"
+            )
+
+    def to_fact_batches(
+        self, *, content_digests: Mapping[str, str] | None = None
+    ) -> tuple[FactBatch, ...]:
+        """Materialize logical facts; source digests must be authoritative."""
+
+        try:
+            return self._to_fact_batches(content_digests=content_digests)
+        except FactBatchBufferError:
+            raise
+        except (TypeError, ValueError) as exc:
+            raise FactBatchBufferError(f"invalid semantic facts: {exc}") from exc
+
+    def _to_fact_batches(
+        self, *, content_digests: Mapping[str, str] | None = None
+    ) -> tuple[FactBatch, ...]:
+        """Implement materialization behind the stable wire-error boundary."""
+
+        infos = self._batch_infos()
+        overrides = {
+            _normalized_path(str(path)): str(digest)
+            for path, digest in (content_digests or {}).items()
+        }
+        symbols: list[list[SymbolFact]] = [[] for _ in infos]
+        occurrences: list[list[OccurrenceFact]] = [[] for _ in infos]
+        edges: list[list[EdgeFact]] = [[] for _ in infos]
+        diagnostics: list[list[DiagnosticFact]] = [[] for _ in infos]
+
+        for index in range(self.meta.symbol_count):
+            row = _SYMBOL.unpack_from(self._symbols, index * FACT_SYMBOL_ROW_SIZE)
+            batch_index, flags = row[:2]
+            self._check_batch_index(batch_index, len(infos), table="symbol")
+            if flags & ~0b111 or not flags & 0b1:
+                raise FactBatchBufferError(
+                    f"symbol row {index} has invalid definition flags {flags:#x}"
+                )
+            definition = self._range(tuple(row[10:14]), label="definition_range")
+            if definition is None:
+                raise FactBatchBufferError(f"symbol row {index} lacks a definition")
+            selection = self._range(tuple(row[14:18]), label="selection_range")
+            enclosing = self._string(
+                row[18], row[19], label="symbol enclosing_symbol_id"
+            )
+            if bool(flags & 0b10) != (selection is not None):
+                raise FactBatchBufferError(
+                    f"symbol row {index} selection flag does not match its range"
+                )
+            if bool(flags & 0b100) != (enclosing is not None):
+                raise FactBatchBufferError(
+                    f"symbol row {index} enclosing flag does not match its value"
+                )
+            symbols[batch_index].append(
+                SymbolFact(
+                    symbol_id=self._string(
+                        row[2], row[3], required=True, label="symbol_id"
+                    ),
+                    moniker=self._string(
+                        row[4], row[5], required=True, label="symbol moniker"
+                    ),
+                    display_name=self._string(
+                        row[6], row[7], required=True, label="symbol display_name"
+                    ),
+                    kind=self._string(
+                        row[8], row[9], required=True, label="symbol kind"
+                    ),
+                    definition_range=definition,
+                    selection_range=selection,
+                    enclosing_symbol_id=enclosing,
+                )
+            )
+
+        for index in range(self.meta.occurrence_count):
+            row = _OCCURRENCE.unpack_from(
+                self._occurrences, index * FACT_OCCURRENCE_ROW_SIZE
+            )
+            batch_index, roles = row[:2]
+            self._check_batch_index(batch_index, len(infos), table="occurrence")
+            source = self._range(tuple(row[4:8]), label="occurrence source_range")
+            if source is None:
+                raise FactBatchBufferError(
+                    f"occurrence row {index} lacks a source range"
+                )
+            occurrences[batch_index].append(
+                OccurrenceFact(
+                    symbol_moniker=self._string(
+                        row[2],
+                        row[3],
+                        required=True,
+                        label="occurrence symbol_moniker",
+                    ),
+                    source_range=source,
+                    roles=roles,
+                    enclosing_range=self._range(
+                        tuple(row[8:12]), label="occurrence enclosing_range"
+                    ),
+                )
+            )
+
+        for index in range(self.meta.edge_count):
+            row = _EDGE.unpack_from(self._edges, index * FACT_EDGE_ROW_SIZE)
+            batch_index, provenance_code, flags, reserved = row[:4]
+            self._check_batch_index(batch_index, len(infos), table="edge")
+            if reserved != 0 or flags & ~0b11111:
+                raise FactBatchBufferError(
+                    f"edge row {index} has unsupported reserved fields"
+                )
+            provenance = _PROVENANCES.get(provenance_code)
+            if provenance is None:
+                raise FactBatchBufferError(
+                    f"edge row {index} has unsupported provenance {provenance_code}"
+                )
+            confidence = row[4]
+            if not math.isfinite(confidence) or not 0 <= confidence <= 1:
+                raise FactBatchBufferError(
+                    f"edge row {index} has invalid confidence {confidence!r}"
+                )
+            source_symbol_id = self._string(
+                row[7], row[8], label="edge source_symbol_id"
+            )
+            target_symbol_id = self._string(
+                row[9], row[10], label="edge target_symbol_id"
+            )
+            target_moniker = self._string(row[11], row[12], label="edge target_moniker")
+            resolver = self._string(row[13], row[14], label="edge resolver")
+            anchor_range = self._range(tuple(row[15:19]), label="edge anchor_range")
+            expected_flags = (
+                int(source_symbol_id is not None)
+                | int(target_symbol_id is not None) << 1
+                | int(target_moniker is not None) << 2
+                | int(anchor_range is not None) << 3
+                | int(resolver is not None) << 4
+            )
+            if flags != expected_flags:
+                raise FactBatchBufferError(
+                    f"edge row {index} flags do not match optional fields"
+                )
+            edges[batch_index].append(
+                EdgeFact(
+                    kind=self._string(row[5], row[6], required=True, label="edge kind"),
+                    provenance=provenance,
+                    source_symbol_id=source_symbol_id,
+                    target_symbol_id=target_symbol_id,
+                    target_moniker=target_moniker,
+                    resolver=resolver,
+                    anchor_range=anchor_range,
+                    confidence=confidence,
+                )
+            )
+
+        for index in range(self.meta.diagnostic_count):
+            row = _DIAGNOSTIC.unpack_from(
+                self._diagnostics, index * FACT_DIAGNOSTIC_ROW_SIZE
+            )
+            batch_index, severity_code, flags, reserved = row[:4]
+            self._check_batch_index(batch_index, len(infos), table="diagnostic")
+            severity = _DIAGNOSTIC_SEVERITIES.get(severity_code)
+            if severity is None or reserved != 0 or flags & ~0b1:
+                raise FactBatchBufferError(
+                    f"diagnostic row {index} has unsupported enum or flags"
+                )
+            source_range = self._range(
+                tuple(row[8:12]), label="diagnostic source_range"
+            )
+            if bool(flags & 0b1) != (source_range is not None):
+                raise FactBatchBufferError(
+                    f"diagnostic row {index} range flag does not match its value"
+                )
+            diagnostics[batch_index].append(
+                DiagnosticFact(
+                    severity=severity,
+                    code=self._string(
+                        row[4], row[5], required=True, label="diagnostic code"
+                    ),
+                    message=self._string(
+                        row[6], row[7], required=True, label="diagnostic message"
+                    ),
+                    source_range=source_range,
+                )
+            )
+
+        result = []
+        for index, info in enumerate(infos):
+            content_digest = overrides.get(info.file_path, info.content_digest)
+            if content_digest is None:
+                raise FactBatchBufferError(
+                    f"authoritative content digest is required for {info.file_path!r}"
+                )
+            result.append(
+                FactBatch(
+                    file_path=info.file_path,
+                    language=info.language,
+                    content_digest=content_digest,
+                    profile_digest=info.profile_digest,
+                    provider=info.provider,
+                    completeness=info.completeness,
+                    position_encoding=info.position_encoding,
+                    capabilities=info.capabilities,
+                    symbols=tuple(symbols[index]),
+                    occurrences=tuple(occurrences[index]),
+                    edges=tuple(edges[index]),
+                    diagnostics=tuple(diagnostics[index]),
+                )
+            )
+        return tuple(result)
+
+
+def expected_contract() -> dict[str, int]:
+    """Return the Python-side constants a compiled extension must match."""
+
+    return {
+        "abi_version": FACT_BATCH_BUFFER_ABI_VERSION,
+        "schema_version": FACT_BATCH_SCHEMA_VERSION,
+        "meta_size": FACT_BATCH_META_SIZE,
+        "batch_row_size": FACT_BATCH_ROW_SIZE,
+        "symbol_row_size": FACT_SYMBOL_ROW_SIZE,
+        "occurrence_row_size": FACT_OCCURRENCE_ROW_SIZE,
+        "edge_row_size": FACT_EDGE_ROW_SIZE,
+        "diagnostic_row_size": FACT_DIAGNOSTIC_ROW_SIZE,
+        "graph_vertex_row_size": FACT_GRAPH_VERTEX_ROW_SIZE,
+        "graph_edge_row_size": FACT_GRAPH_EDGE_ROW_SIZE,
+    }
+
+
+def validate_compiled_contract(raw: Mapping[str, Any]) -> None:
+    """Reject a stale extension before any native buffer is consumed."""
+
+    if not isinstance(raw, Mapping):
+        raise FactBatchBufferError(
+            "compiled FactBatchBuffer contract must be a mapping"
+        )
+    expected = expected_contract()
+    actual = {name: raw.get(name) for name in expected}
+    if actual != expected or any(
+        isinstance(value, bool) or not isinstance(value, int)
+        for value in actual.values()
+    ):
+        raise FactBatchBufferError(
+            f"compiled FactBatchBuffer contract mismatch: {actual}; "
+            f"expected {expected}"
+        )
+
+
+__all__ = [
+    "FACT_BATCH_BUFFER_ABI_VERSION",
+    "FACT_BATCH_SCHEMA_VERSION",
+    "FactBatchBufferError",
+    "FactBatchBufferMeta",
+    "FactBatchBufferView",
+    "expected_contract",
+    "validate_compiled_contract",
+]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -48,6 +48,7 @@ pkg_check_modules(RE2 REQUIRED re2)
 
 add_library(codenib_core STATIC
     code_graph.cpp
+    fact_batch_buffer.cpp
     graph_layers.cpp
     scip_decoder_registry.cpp
     scip_decode_common.cpp
@@ -86,6 +87,12 @@ add_executable(graph_layers_test
 
 target_link_libraries(graph_layers_test PRIVATE codenib_core)
 
+add_executable(fact_batch_buffer_test
+    tests/fact_batch_buffer_test.cpp
+)
+
+target_link_libraries(fact_batch_buffer_test PRIVATE codenib_core)
+
 add_executable(scip_decode_repo
     tests/scip_decode_repo.cpp
 )
@@ -102,6 +109,9 @@ if(CODENIB_ENABLE_O3)
     endif()
     if(TARGET graph_layers_test)
         target_compile_options(graph_layers_test PRIVATE -O3)
+    endif()
+    if(TARGET fact_batch_buffer_test)
+        target_compile_options(fact_batch_buffer_test PRIVATE -O3)
     endif()
 endif()
 
@@ -173,5 +183,10 @@ if(CODENIB_ENABLE_DEBUG)
     if(TARGET graph_layers_test)
         target_compile_definitions(graph_layers_test PRIVATE CODENIB_DEBUG=1)
         target_compile_options(graph_layers_test PRIVATE ${_codenib_debug_flags})
+    endif()
+
+    if(TARGET fact_batch_buffer_test)
+        target_compile_definitions(fact_batch_buffer_test PRIVATE CODENIB_DEBUG=1)
+        target_compile_options(fact_batch_buffer_test PRIVATE ${_codenib_debug_flags})
     endif()
 endif()

--- a/core/README.md
+++ b/core/README.md
@@ -15,6 +15,8 @@ core decoder continue to use the serial Python path.
 
 - `code_graph.{h,cpp}` — C++ graph container.
 - `decoded_records.h` — provider-neutral rows before graph materialization.
+- `fact_batch_buffer.{h,cpp}` — versioned flat semantic and graph-compatibility
+  tables for the native/Python boundary.
 - `graph_layers.{h,cpp}` — shared normalized edge-layer classification.
 - `scip_decode_base.{h,cpp}` — common loading, document scheduling, merge, and
   post-processing behavior.
@@ -23,7 +25,8 @@ core decoder continue to use the serial Python path.
 - `scip_decode_<language>.{h,cpp}` — language-specific decoder policy.
 - `scip_decoder_registry.{h,cpp}` — canonical decoder names and aliases.
 - `bindings/pybind_module.cpp` — Python bindings for `decode_scip(...)`,
-  `classify_edge_layers(...)`, and registry inspection.
+  `decode_scip_fact_buffer(...)`, `classify_edge_layers(...)`, and registry
+  inspection.
 
 `codenib_core.decode_scip(...)` is a low-level flat transport API. It does not
 apply source-aware post-decode layers, including TypeScript import enrichment,
@@ -63,6 +66,16 @@ path materializes those rows into the same `CodeGraph`; `decode_records()` lets
 future capability-specific consumers stop before igraph. The record merge owns
 the established first-definition and edge-deduplication policy, and
 language-specific postprocessing runs before either consumer observes rows.
+
+## FactBatchBuffer v1
+
+`decode_scip_fact_buffer(...)` encodes `DecodedRecords` into fixed-width,
+little-endian tables plus one shared UTF-8 arena. Consumers may request the
+provider-neutral per-file `FactBatch` projection, the exact legacy graph
+projection, or omit the graph tables entirely. The Python view validates the
+fixed envelope immediately and the complete selected projection before
+returning a materialized consumer result. The zero-copy mode keeps native
+storage alive through read-only buffer owners.
 
 ## Use Through Python
 

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Pybind11 bindings for codenib::core SCIP decoders.
+// Pybind11 bindings for codenib::core semantic decoders and transports.
 //
 // Exposes a low-level function `decode_scip(index_file, project_root,
 // language)` that returns a transport with two flat Python lists:
@@ -22,15 +22,19 @@
 // serialization cost across the C++/Python boundary is just one igraph vcount +
 // ecount worth of tuples/dicts.
 
+#include "fact_batch_buffer.h"
 #include "graph_layers.h"
 #include "scip_decode.h"
 
+#include <chrono>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace py = pybind11;
@@ -101,6 +105,185 @@ py::dict decode_scip(const std::string &index_file,
   return result;
 }
 
+py::bytes bytes_from_vector(const std::vector<std::uint8_t> &buffer) {
+  if (buffer.empty())
+    return py::bytes();
+  return py::bytes(reinterpret_cast<const char *>(buffer.data()),
+                   buffer.size());
+}
+
+enum class FactBufferTable {
+  Meta,
+  Batches,
+  Symbols,
+  Occurrences,
+  Edges,
+  Diagnostics,
+  GraphVertices,
+  GraphEdges,
+  Arena,
+};
+
+class FactBatchOwnedBuffer {
+public:
+  FactBatchOwnedBuffer(std::shared_ptr<codenib::core::FactBatchBuffers> owner,
+                       FactBufferTable table)
+      : owner_(std::move(owner)), table_(table) {}
+
+  const std::vector<std::uint8_t> &bytes() const {
+    switch (table_) {
+    case FactBufferTable::Meta:
+      return owner_->meta;
+    case FactBufferTable::Batches:
+      return owner_->batches;
+    case FactBufferTable::Symbols:
+      return owner_->symbols;
+    case FactBufferTable::Occurrences:
+      return owner_->occurrences;
+    case FactBufferTable::Edges:
+      return owner_->edges;
+    case FactBufferTable::Diagnostics:
+      return owner_->diagnostics;
+    case FactBufferTable::GraphVertices:
+      return owner_->graph_vertices;
+    case FactBufferTable::GraphEdges:
+      return owner_->graph_edges;
+    case FactBufferTable::Arena:
+      return owner_->arena;
+    }
+    throw std::logic_error("unknown FactBatchBuffer table");
+  }
+
+  py::buffer_info buffer_info() const {
+    const auto &buffer = bytes();
+    return py::buffer_info(buffer.data(),
+                           static_cast<py::ssize_t>(buffer.size()), true);
+  }
+
+private:
+  std::shared_ptr<codenib::core::FactBatchBuffers> owner_;
+  FactBufferTable table_;
+};
+
+void add_fact_buffers(py::dict &result, codenib::core::FactBatchBuffers buffers,
+                      bool copy_buffers) {
+  if (copy_buffers) {
+    result["meta"] = bytes_from_vector(buffers.meta);
+    result["batches"] = bytes_from_vector(buffers.batches);
+    result["symbols"] = bytes_from_vector(buffers.symbols);
+    result["occurrences"] = bytes_from_vector(buffers.occurrences);
+    result["edges"] = bytes_from_vector(buffers.edges);
+    result["diagnostics"] = bytes_from_vector(buffers.diagnostics);
+    result["graph_vertices"] = bytes_from_vector(buffers.graph_vertices);
+    result["graph_edges"] = bytes_from_vector(buffers.graph_edges);
+    result["arena"] = bytes_from_vector(buffers.arena);
+    return;
+  }
+
+  auto owner =
+      std::make_shared<codenib::core::FactBatchBuffers>(std::move(buffers));
+  auto add = [&](const char *name, FactBufferTable table) {
+    result[name] = py::cast(FactBatchOwnedBuffer(owner, table));
+  };
+  add("meta", FactBufferTable::Meta);
+  add("batches", FactBufferTable::Batches);
+  add("symbols", FactBufferTable::Symbols);
+  add("occurrences", FactBufferTable::Occurrences);
+  add("edges", FactBufferTable::Edges);
+  add("diagnostics", FactBufferTable::Diagnostics);
+  add("graph_vertices", FactBufferTable::GraphVertices);
+  add("graph_edges", FactBufferTable::GraphEdges);
+  add("arena", FactBufferTable::Arena);
+}
+
+py::dict
+decode_profile_to_dict(const codenib::core::SCIPDecodeProfile &profile) {
+  py::dict result;
+  result["load_metadata"] = profile.load_metadata_ns;
+  result["file_read"] = profile.file_read_ns;
+  result["extract_blocks"] = profile.extract_blocks_ns;
+  result["prescan"] = profile.prescan_ns;
+  result["process_documents"] = profile.process_documents_ns;
+  result["merge_subgraphs"] = profile.merge_subgraphs_ns;
+  result["materialize_graph"] = profile.materialize_graph_ns;
+  result["total"] = profile.total_ns;
+  result["worker_count"] = profile.worker_count;
+  result["document_count"] = profile.document_count;
+  return result;
+}
+
+py::dict fact_encode_profile_to_dict(
+    const codenib::core::FactBatchEncodeProfile &profile) {
+  py::dict result;
+  result["validate_options"] = profile.validate_options_ns;
+  result["collect_indexes"] = profile.collect_indexes_ns;
+  result["collect_facts"] = profile.collect_facts_ns;
+  result["encode_semantic"] = profile.encode_semantic_ns;
+  result["encode_graph"] = profile.encode_graph_ns;
+  result["finalize"] = profile.finalize_ns;
+  result["total"] = profile.total_ns;
+  return result;
+}
+
+py::dict decode_scip_fact_buffer(
+    const std::string &index_file, const std::string &profile_digest,
+    std::optional<std::string> project_root, const std::string &language,
+    const std::unordered_map<std::string, std::string> &content_digests,
+    bool include_graph_compat, bool copy_buffers) {
+  auto decoder =
+      codenib::core::make_scip_decoder(language, index_file, project_root);
+  codenib::core::FactBatchBufferOptions options;
+  options.language = language;
+  options.profile_digest = profile_digest;
+  options.content_digests = content_digests;
+  options.include_graph_compat = include_graph_compat;
+
+  using clock = std::chrono::steady_clock;
+  clock::time_point decode_started;
+  clock::time_point decode_finished;
+  clock::time_point encode_finished;
+  codenib::core::SCIPDecodeProfile decode_profile;
+  codenib::core::FactBatchBuffers buffers;
+  {
+    py::gil_scoped_release release;
+    decode_started = clock::now();
+    codenib::core::SCIPDecodedRecords records = decoder->decode_records();
+    decode_finished = clock::now();
+    decode_profile = decoder->last_profile();
+    buffers = codenib::core::encode_fact_batch_buffer(
+        records.vertices, records.edges, records.project_root, options);
+    encode_finished = clock::now();
+  }
+
+  auto elapsed_ns = [](clock::time_point start, clock::time_point end) {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+        .count();
+  };
+  py::dict result;
+  const auto encode_profile = buffers.profile;
+  add_fact_buffers(result, std::move(buffers), copy_buffers);
+  result["native_decode_ns"] = elapsed_ns(decode_started, decode_finished);
+  result["native_encode_ns"] = elapsed_ns(decode_finished, encode_finished);
+  result["decode_profile_ns"] = decode_profile_to_dict(decode_profile);
+  result["encode_profile_ns"] = fact_encode_profile_to_dict(encode_profile);
+  return result;
+}
+
+py::dict fact_batch_buffer_contract() {
+  py::dict result;
+  result["abi_version"] = codenib::core::FACT_BATCH_BUFFER_ABI_VERSION;
+  result["schema_version"] = codenib::core::FACT_BATCH_SCHEMA_VERSION;
+  result["meta_size"] = codenib::core::FACT_BATCH_META_SIZE;
+  result["batch_row_size"] = codenib::core::FACT_BATCH_ROW_SIZE;
+  result["symbol_row_size"] = codenib::core::FACT_SYMBOL_ROW_SIZE;
+  result["occurrence_row_size"] = codenib::core::FACT_OCCURRENCE_ROW_SIZE;
+  result["edge_row_size"] = codenib::core::FACT_EDGE_ROW_SIZE;
+  result["diagnostic_row_size"] = codenib::core::FACT_DIAGNOSTIC_ROW_SIZE;
+  result["graph_vertex_row_size"] = codenib::core::FACT_GRAPH_VERTEX_ROW_SIZE;
+  result["graph_edge_row_size"] = codenib::core::FACT_GRAPH_EDGE_ROW_SIZE;
+  return result;
+}
+
 codenib::core::LayerBuckets
 classify_edge_layers_py(const std::vector<std::string> &edge_types) {
   py::gil_scoped_release release;
@@ -110,8 +293,14 @@ classify_edge_layers_py(const std::vector<std::string> &edge_types) {
 } // namespace
 
 PYBIND11_MODULE(codenib_core, m) {
-  m.doc() =
-      "codenib::core SCIP decoders (Python / Go / Rust / Ruby / TypeScript).";
+  m.doc() = "CodeNib native semantic decoders and transports.";
+
+  py::class_<FactBatchOwnedBuffer>(m, "_FactBatchOwnedBuffer",
+                                   py::buffer_protocol())
+      .def_buffer(&FactBatchOwnedBuffer::buffer_info)
+      .def("__len__", [](const FactBatchOwnedBuffer &buffer) {
+        return buffer.bytes().size();
+      });
 
   m.def("decode_scip", &decode_scip, py::arg("index_file"),
         py::arg("project_root") = std::optional<std::string>(std::nullopt),
@@ -140,6 +329,28 @@ Returns:
            anchor_file_or_None, anchor_line_or_None)
       - "project_root": the effective project_root used.
 )pbdoc");
+
+  m.def("decode_scip_fact_buffer", &decode_scip_fact_buffer,
+        py::arg("index_file"), py::arg("profile_digest"),
+        py::arg("project_root") = std::optional<std::string>(std::nullopt),
+        py::arg("language") = std::string("python"),
+        py::arg("content_digests") =
+            std::unordered_map<std::string, std::string>{},
+        py::arg("include_graph_compat") = true, py::arg("copy_buffers") = true,
+        R"pbdoc(
+Decode a SCIP index into FactBatchBuffer v1 byte tables.
+
+The return value contains a constant number of Python bytes objects rather
+than one dict/tuple per vertex or edge. ``graph_vertices`` and ``graph_edges``
+are an exact compatibility projection for the existing CodeGraph schema;
+the semantic tables remain grouped by file for FactBatch consumers. Set
+``include_graph_compat=False`` for consumers that do not materialize the
+legacy graph. Set ``copy_buffers=False`` to return ownership-safe read-only
+buffer exporters instead of copying every table into Python bytes.
+)pbdoc");
+
+  m.def("fact_batch_buffer_contract", &fact_batch_buffer_contract,
+        R"pbdoc(Return the compiled FactBatchBuffer ABI contract.)pbdoc");
 
   m.def("canonical_scip_decoder_languages",
         &codenib::core::canonical_scip_decoder_languages,

--- a/core/fact_batch_buffer.cpp
+++ b/core/fact_batch_buffer.cpp
@@ -1,0 +1,590 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "fact_batch_buffer.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string_view>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+
+namespace codenib::core {
+namespace {
+
+struct StringRef {
+  std::uint32_t offset{FACT_BATCH_BUFFER_NONE};
+  std::uint32_t length{0};
+};
+
+struct SourceRange {
+  std::uint32_t start_line{FACT_BATCH_BUFFER_NONE};
+  std::uint32_t start_character{FACT_BATCH_BUFFER_NONE};
+  std::uint32_t end_line{FACT_BATCH_BUFFER_NONE};
+  std::uint32_t end_character{FACT_BATCH_BUFFER_NONE};
+
+  auto key() const {
+    return std::make_tuple(start_line, start_character, end_line,
+                           end_character);
+  }
+};
+
+class StringArena {
+public:
+  StringRef add(std::string_view value) {
+    auto found = refs_.find(value);
+    if (found != refs_.end())
+      return found->second;
+    if (value.size() > std::numeric_limits<std::uint32_t>::max())
+      throw std::overflow_error("FactBatchBuffer string exceeds u32 length");
+    if (bytes_.size() >
+        std::numeric_limits<std::uint32_t>::max() - value.size())
+      throw std::overflow_error(
+          "FactBatchBuffer string arena exceeds u32 size");
+    StringRef ref{static_cast<std::uint32_t>(bytes_.size()),
+                  static_cast<std::uint32_t>(value.size())};
+    bytes_.insert(bytes_.end(), value.begin(), value.end());
+    refs_.emplace(value, ref);
+    return ref;
+  }
+
+  StringRef add(const std::string &value) {
+    return add(std::string_view(value));
+  }
+
+  StringRef add(const std::optional<std::string> &value) {
+    return value.has_value() ? add(std::string_view(*value)) : StringRef{};
+  }
+
+  StringRef add(const std::optional<std::string_view> &value) {
+    return value.has_value() ? add(*value) : StringRef{};
+  }
+
+  std::vector<std::uint8_t> take() { return std::move(bytes_); }
+
+private:
+  std::vector<std::uint8_t> bytes_;
+  std::unordered_map<std::string_view, StringRef> refs_;
+};
+
+void append_u8(std::vector<std::uint8_t> &out, std::uint8_t value) {
+  out.push_back(value);
+}
+
+void append_u16(std::vector<std::uint8_t> &out, std::uint16_t value) {
+  out.push_back(static_cast<std::uint8_t>(value & 0xffU));
+  out.push_back(static_cast<std::uint8_t>((value >> 8U) & 0xffU));
+}
+
+void append_u32(std::vector<std::uint8_t> &out, std::uint32_t value) {
+  for (unsigned shift = 0; shift < 32; shift += 8)
+    out.push_back(static_cast<std::uint8_t>((value >> shift) & 0xffU));
+}
+
+void append_u64(std::vector<std::uint8_t> &out, std::uint64_t value) {
+  for (unsigned shift = 0; shift < 64; shift += 8)
+    out.push_back(static_cast<std::uint8_t>((value >> shift) & 0xffU));
+}
+
+void append_f64(std::vector<std::uint8_t> &out, double value) {
+  static_assert(sizeof(double) == sizeof(std::uint64_t));
+  std::uint64_t bits = 0;
+  std::memcpy(&bits, &value, sizeof(bits));
+  append_u64(out, bits);
+}
+
+void append_ref(std::vector<std::uint8_t> &out, StringRef ref) {
+  append_u32(out, ref.offset);
+  append_u32(out, ref.length);
+}
+
+void append_range(std::vector<std::uint8_t> &out, const SourceRange &range) {
+  append_u32(out, range.start_line);
+  append_u32(out, range.start_character);
+  append_u32(out, range.end_line);
+  append_u32(out, range.end_character);
+}
+
+std::uint32_t checked_count(std::size_t value, std::string_view label) {
+  if (value > std::numeric_limits<std::uint32_t>::max())
+    throw std::overflow_error(std::string(label) + " exceeds u32 count");
+  return static_cast<std::uint32_t>(value);
+}
+
+std::uint32_t checked_line(int value, std::string_view label) {
+  if (value < 0)
+    throw std::invalid_argument(std::string(label) + " must be non-negative");
+  return static_cast<std::uint32_t>(value);
+}
+
+SourceRange line_range(const std::optional<int> &start,
+                       const std::optional<int> &end) {
+  if (!start.has_value() || !end.has_value())
+    return {};
+  const auto end_line = checked_line(*end, "range end_line");
+  if (end_line == std::numeric_limits<std::uint32_t>::max())
+    throw std::overflow_error("range end_line cannot be made half-open");
+  return {checked_line(*start, "range start_line"), 0, end_line + 1, 0};
+}
+
+SourceRange selection_range(const std::optional<int> &line) {
+  if (!line.has_value())
+    return {};
+  const auto value = checked_line(*line, "selection_line");
+  if (value == std::numeric_limits<std::uint32_t>::max())
+    throw std::overflow_error("selection_line cannot be made half-open");
+  return {value, 0, value + 1, 0};
+}
+
+SourceRange anchor_range(const std::optional<int> &line) {
+  return selection_range(line);
+}
+
+bool has_range(const SourceRange &range) {
+  return range.start_line != FACT_BATCH_BUFFER_NONE;
+}
+
+bool is_symbol_type(const std::string &type) {
+  return type == NODE_TYPE_SYMBOL || type == NODE_TYPE_CLASS ||
+         type == NODE_TYPE_FUNCTION || type == NODE_TYPE_METHOD ||
+         type == NODE_TYPE_FIELD;
+}
+
+bool has_definition(const CodeGraph::VertexData &vertex) {
+  if (vertex.has_definition.has_value())
+    return *vertex.has_definition;
+  return is_symbol_type(vertex.type) && vertex.file.has_value() &&
+         vertex.start_line.has_value() && vertex.end_line.has_value();
+}
+
+std::string normalize_path(std::string value) {
+  std::replace(value.begin(), value.end(), '\\', '/');
+  if (value.rfind("./", 0) == 0)
+    value.erase(0, 2);
+  if (value.empty() || value.front() == '/')
+    throw std::invalid_argument(
+        "FactBatchBuffer file paths must be repository-relative POSIX paths");
+  std::size_t begin = 0;
+  while (begin <= value.size()) {
+    const auto end = value.find('/', begin);
+    const auto part = value.substr(begin, end - begin);
+    if (part.empty() || part == "." || part == "..")
+      throw std::invalid_argument(
+          "FactBatchBuffer file paths must be canonical POSIX paths");
+    if (end == std::string::npos)
+      break;
+    begin = end + 1;
+  }
+  return value;
+}
+
+bool is_canonical_digest(const std::string &value) {
+  if (value.size() != 71 || value.rfind("sha256:", 0) != 0)
+    return false;
+  return std::all_of(value.begin() + 7, value.end(), [](char ch) {
+    return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f');
+  });
+}
+
+void require_text(const std::string &value, std::string_view label) {
+  if (value.empty() || value.find('\0') != std::string::npos)
+    throw std::invalid_argument(std::string(label) + " must not be empty");
+}
+
+struct SymbolRecord {
+  std::uint32_t batch_index;
+  std::string_view symbol_id;
+  std::string_view moniker;
+  std::string_view display_name;
+  std::string_view kind;
+  SourceRange definition;
+  SourceRange selection;
+  std::optional<std::string_view> enclosing_symbol_id;
+
+  auto key() const {
+    return std::make_tuple(batch_index, symbol_id, definition.key());
+  }
+};
+
+struct OccurrenceRecord {
+  std::uint32_t batch_index;
+  std::string_view moniker;
+  SourceRange source;
+  std::uint32_t roles;
+  SourceRange enclosing;
+
+  auto key() const {
+    return std::make_tuple(batch_index, source.key(), moniker, roles,
+                           enclosing.key());
+  }
+};
+
+struct EdgeRecord {
+  std::uint32_t batch_index;
+  std::string_view kind;
+  std::optional<std::string_view> source_symbol_id;
+  std::optional<std::string_view> target_symbol_id;
+  std::optional<std::string_view> target_moniker;
+  SourceRange anchor;
+  std::uint8_t provenance{FACT_PROVENANCE_SCIP};
+  double confidence{1.0};
+  std::optional<std::string_view> resolver;
+
+  auto key() const {
+    return std::make_tuple(batch_index, source_symbol_id, kind,
+                           target_symbol_id, target_moniker, anchor.key(),
+                           provenance, confidence, resolver);
+  }
+};
+
+template <typename Record> void sort_unique(std::vector<Record> &records) {
+  std::sort(records.begin(), records.end(),
+            [](const Record &left, const Record &right) {
+              return left.key() < right.key();
+            });
+  records.erase(std::unique(records.begin(), records.end(),
+                            [](const Record &left, const Record &right) {
+                              return left.key() == right.key();
+                            }),
+                records.end());
+}
+
+void require_row_size(const std::vector<std::uint8_t> &out, std::size_t before,
+                      std::size_t expected, std::string_view label) {
+  if (out.size() - before != expected)
+    throw std::logic_error(std::string(label) + " encoder row-size mismatch");
+}
+
+} // namespace
+
+FactBatchBuffers
+encode_fact_batch_buffer(const std::vector<CodeGraph::VertexData> &vertices,
+                         const std::vector<CodeGraph::EdgeData> &graph_edges,
+                         const std::string &project_root,
+                         const FactBatchBufferOptions &options) {
+  using clock = std::chrono::steady_clock;
+  const auto started = clock::now();
+  require_text(options.language, "language");
+  require_text(options.provider, "provider");
+  require_text(options.position_encoding, "position_encoding");
+  if (!is_canonical_digest(options.profile_digest))
+    throw std::invalid_argument(
+        "profile_digest must use canonical sha256:<64 lowercase hex>");
+
+  std::unordered_map<std::string, std::string> content_digests;
+  for (const auto &[raw_path, digest] : options.content_digests) {
+    const auto path = normalize_path(raw_path);
+    if (!is_canonical_digest(digest))
+      throw std::invalid_argument(
+          "content digests must use canonical sha256:<64 lowercase hex>");
+    if (!content_digests.emplace(path, digest).second)
+      throw std::invalid_argument("duplicate normalized content digest path");
+  }
+  const auto validated = clock::now();
+
+  std::set<std::string> file_paths;
+  for (const auto &vertex : vertices) {
+    if (vertex.type == NODE_TYPE_FILE)
+      file_paths.insert(normalize_path(vertex.name));
+    if (vertex.file.has_value())
+      file_paths.insert(normalize_path(*vertex.file));
+  }
+  for (const auto &edge : graph_edges)
+    if (edge.anchor_file.has_value())
+      file_paths.insert(normalize_path(*edge.anchor_file));
+
+  std::vector<std::string> files(file_paths.begin(), file_paths.end());
+  std::unordered_map<std::string, std::uint32_t> batch_by_file;
+  for (std::size_t index = 0; index < files.size(); ++index)
+    batch_by_file.emplace(files[index], checked_count(index, "batch index"));
+
+  std::unordered_map<std::size_t, std::size_t> parent_symbols;
+  for (const auto &edge : graph_edges) {
+    const auto source = static_cast<std::size_t>(edge.source);
+    const auto target = static_cast<std::size_t>(edge.target);
+    if (source >= vertices.size() || target >= vertices.size())
+      throw std::out_of_range(
+          "CodeGraph edge endpoint is outside vertex table");
+    if (edge.type == EDGE_TYPE_CONTAIN &&
+        is_symbol_type(vertices[source].type) &&
+        is_symbol_type(vertices[target].type))
+      parent_symbols[target] = source;
+  }
+  const auto indexes_collected = clock::now();
+
+  std::vector<SymbolRecord> symbols;
+  std::vector<OccurrenceRecord> occurrences;
+  for (std::size_t index = 0; index < vertices.size(); ++index) {
+    const auto &vertex = vertices[index];
+    if (!is_symbol_type(vertex.type) || !has_definition(vertex) ||
+        !vertex.file.has_value())
+      continue;
+    const auto file = normalize_path(*vertex.file);
+    const auto batch = batch_by_file.at(file);
+    const auto definition = line_range(vertex.start_line, vertex.end_line);
+    const auto selection = selection_range(vertex.selection_line);
+    const std::string_view moniker =
+        vertex.unified_name.has_value() ? std::string_view(*vertex.unified_name)
+                                        : std::string_view(vertex.name);
+    auto parent = parent_symbols.find(index);
+    std::optional<std::string_view> enclosing;
+    if (parent != parent_symbols.end())
+      enclosing = vertices[parent->second].name;
+    symbols.push_back(SymbolRecord{batch, vertex.name, moniker, moniker,
+                                   vertex.type, definition, selection,
+                                   enclosing});
+    occurrences.push_back(
+        OccurrenceRecord{batch, moniker, definition, 1U, SourceRange{}});
+  }
+  sort_unique(symbols);
+  sort_unique(occurrences);
+
+  std::vector<EdgeRecord> fact_edges;
+  for (const auto &edge : graph_edges) {
+    const auto source_index = static_cast<std::size_t>(edge.source);
+    const auto target_index = static_cast<std::size_t>(edge.target);
+    const auto &source = vertices[source_index];
+    const auto &target = vertices[target_index];
+    if (!is_symbol_type(target.type))
+      continue;
+
+    std::optional<std::string> raw_file;
+    if (edge.type == EDGE_TYPE_CONTAIN) {
+      raw_file = target.file;
+    } else if (edge.anchor_file.has_value()) {
+      raw_file = edge.anchor_file;
+    } else if (source.file.has_value()) {
+      raw_file = source.file;
+    } else if (source.type == NODE_TYPE_FILE) {
+      raw_file = source.name;
+    }
+    if (!raw_file.has_value())
+      continue;
+    const auto file = normalize_path(*raw_file);
+    auto batch = batch_by_file.find(file);
+    if (batch == batch_by_file.end())
+      continue;
+
+    std::optional<std::string_view> source_symbol;
+    if (is_symbol_type(source.type))
+      source_symbol = source.name;
+    fact_edges.push_back(EdgeRecord{
+        batch->second,
+        edge.type,
+        source_symbol,
+        target.name,
+        std::nullopt,
+        anchor_range(edge.anchor_line),
+        FACT_PROVENANCE_SCIP,
+        1.0,
+        std::string_view("legacy_code_graph"),
+    });
+  }
+  sort_unique(fact_edges);
+  const auto facts_collected = clock::now();
+
+  FactBatchBuffers result;
+  StringArena arena;
+
+  for (const auto &file : files) {
+    const auto before = result.batches.size();
+    append_ref(result.batches, arena.add(file));
+    append_ref(result.batches, arena.add(options.language));
+    auto digest = content_digests.find(file);
+    append_ref(result.batches, digest == content_digests.end()
+                                   ? StringRef{}
+                                   : arena.add(digest->second));
+    append_ref(result.batches, arena.add(options.profile_digest));
+    append_ref(result.batches, arena.add(options.provider));
+    append_ref(result.batches, arena.add(options.position_encoding));
+    append_u8(result.batches, FACT_COMPLETENESS_PARTIAL);
+    append_u8(result.batches, FACT_CAPABILITY_DEFINITIONS |
+                                  FACT_CAPABILITY_OCCURRENCES |
+                                  FACT_CAPABILITY_EDGES);
+    append_u16(result.batches, 0);
+    append_u32(result.batches, 0);
+    require_row_size(result.batches, before, FACT_BATCH_ROW_SIZE, "batch");
+  }
+
+  for (const auto &symbol : symbols) {
+    const auto before = result.symbols.size();
+    append_u32(result.symbols, symbol.batch_index);
+    std::uint32_t flags = 1U;
+    if (has_range(symbol.selection))
+      flags |= 1U << 1;
+    if (symbol.enclosing_symbol_id.has_value())
+      flags |= 1U << 2;
+    append_u32(result.symbols, flags);
+    append_ref(result.symbols, arena.add(symbol.symbol_id));
+    append_ref(result.symbols, arena.add(symbol.moniker));
+    append_ref(result.symbols, arena.add(symbol.display_name));
+    append_ref(result.symbols, arena.add(symbol.kind));
+    append_range(result.symbols, symbol.definition);
+    append_range(result.symbols, symbol.selection);
+    append_ref(result.symbols, arena.add(symbol.enclosing_symbol_id));
+    require_row_size(result.symbols, before, FACT_SYMBOL_ROW_SIZE, "symbol");
+  }
+
+  for (const auto &occurrence : occurrences) {
+    const auto before = result.occurrences.size();
+    append_u32(result.occurrences, occurrence.batch_index);
+    append_u32(result.occurrences, occurrence.roles);
+    append_ref(result.occurrences, arena.add(occurrence.moniker));
+    append_range(result.occurrences, occurrence.source);
+    append_range(result.occurrences, occurrence.enclosing);
+    require_row_size(result.occurrences, before, FACT_OCCURRENCE_ROW_SIZE,
+                     "occurrence");
+  }
+
+  for (const auto &edge : fact_edges) {
+    const auto before = result.edges.size();
+    append_u32(result.edges, edge.batch_index);
+    append_u8(result.edges, edge.provenance);
+    std::uint8_t flags = 0;
+    if (edge.source_symbol_id.has_value())
+      flags |= 1U << 0;
+    if (edge.target_symbol_id.has_value())
+      flags |= 1U << 1;
+    if (edge.target_moniker.has_value())
+      flags |= 1U << 2;
+    if (has_range(edge.anchor))
+      flags |= 1U << 3;
+    if (edge.resolver.has_value())
+      flags |= 1U << 4;
+    append_u8(result.edges, flags);
+    append_u16(result.edges, 0);
+    append_f64(result.edges, edge.confidence);
+    append_ref(result.edges, arena.add(edge.kind));
+    append_ref(result.edges, arena.add(edge.source_symbol_id));
+    append_ref(result.edges, arena.add(edge.target_symbol_id));
+    append_ref(result.edges, arena.add(edge.target_moniker));
+    append_ref(result.edges, arena.add(edge.resolver));
+    append_range(result.edges, edge.anchor);
+    require_row_size(result.edges, before, FACT_EDGE_ROW_SIZE, "edge");
+  }
+  const auto semantic_encoded = clock::now();
+
+  if (options.include_graph_compat) {
+    for (const auto &vertex : vertices) {
+      const auto before = result.graph_vertices.size();
+      append_ref(result.graph_vertices, arena.add(vertex.name));
+      append_ref(result.graph_vertices, arena.add(vertex.type));
+      append_ref(result.graph_vertices, arena.add(vertex.file));
+      append_ref(result.graph_vertices, arena.add(vertex.unified_name));
+      append_ref(result.graph_vertices, arena.add(vertex.symbol_kind));
+      append_u32(result.graph_vertices,
+                 vertex.start_line.has_value()
+                     ? checked_line(*vertex.start_line, "vertex start_line")
+                     : FACT_BATCH_BUFFER_NONE);
+      append_u32(result.graph_vertices,
+                 vertex.end_line.has_value()
+                     ? checked_line(*vertex.end_line, "vertex end_line")
+                     : FACT_BATCH_BUFFER_NONE);
+      append_u32(
+          result.graph_vertices,
+          vertex.selection_line.has_value()
+              ? checked_line(*vertex.selection_line, "vertex selection_line")
+              : FACT_BATCH_BUFFER_NONE);
+      std::uint32_t flags = 0;
+      if (vertex.has_definition.has_value()) {
+        flags |= 1U;
+        if (*vertex.has_definition)
+          flags |= 1U << 1;
+      }
+      append_u32(result.graph_vertices, flags);
+      require_row_size(result.graph_vertices, before,
+                       FACT_GRAPH_VERTEX_ROW_SIZE, "graph vertex");
+    }
+
+    for (const auto &edge : graph_edges) {
+      const auto before = result.graph_edges.size();
+      append_u32(result.graph_edges,
+                 checked_count(static_cast<std::size_t>(edge.source),
+                               "graph edge source"));
+      append_u32(result.graph_edges,
+                 checked_count(static_cast<std::size_t>(edge.target),
+                               "graph edge target"));
+      append_ref(result.graph_edges, arena.add(edge.type));
+      append_ref(result.graph_edges, arena.add(edge.anchor_file));
+      append_u32(result.graph_edges,
+                 edge.anchor_line.has_value()
+                     ? checked_line(*edge.anchor_line, "edge anchor_line")
+                     : FACT_BATCH_BUFFER_NONE);
+      append_u32(result.graph_edges, 0);
+      require_row_size(result.graph_edges, before, FACT_GRAPH_EDGE_ROW_SIZE,
+                       "graph edge");
+    }
+  }
+  const auto graph_encoded = clock::now();
+
+  const auto project_root_ref = arena.add(project_root);
+  result.arena = arena.take();
+
+  std::uint32_t flags =
+      options.include_graph_compat ? FACT_BUFFER_FLAG_GRAPH_COMPAT : 0U;
+  if (content_digests.size() >= files.size() &&
+      std::all_of(files.begin(), files.end(), [&](const std::string &file) {
+        return content_digests.find(file) != content_digests.end();
+      }))
+    flags |= FACT_BUFFER_FLAG_CONTENT_DIGESTS_COMPLETE;
+
+  result.meta.insert(result.meta.end(), {'C', 'N', 'F', 'B'});
+  append_u16(result.meta, FACT_BATCH_BUFFER_ABI_VERSION);
+  append_u16(result.meta, FACT_BATCH_SCHEMA_VERSION);
+  append_u32(result.meta, flags);
+  append_u32(result.meta, checked_count(files.size(), "batch count"));
+  append_u32(result.meta, checked_count(symbols.size(), "symbol count"));
+  append_u32(result.meta,
+             checked_count(occurrences.size(), "occurrence count"));
+  append_u32(result.meta, checked_count(fact_edges.size(), "fact edge count"));
+  append_u32(result.meta, 0); // diagnostics are reserved in v1
+  append_u32(result.meta, options.include_graph_compat
+                              ? checked_count(vertices.size(), "vertex count")
+                              : 0U);
+  append_u32(result.meta,
+             options.include_graph_compat
+                 ? checked_count(graph_edges.size(), "graph edge count")
+                 : 0U);
+  append_u32(result.meta, checked_count(result.arena.size(), "arena size"));
+  append_ref(result.meta, project_root_ref);
+  append_u32(result.meta, 0);
+  append_u64(result.meta, 0);
+  if (result.meta.size() != FACT_BATCH_META_SIZE)
+    throw std::logic_error("FactBatchBuffer meta-size mismatch");
+
+  const auto finished = clock::now();
+  auto elapsed_ns = [](auto begin, auto end) {
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)
+            .count());
+  };
+  result.profile = FactBatchEncodeProfile{
+      elapsed_ns(started, validated),
+      elapsed_ns(validated, indexes_collected),
+      elapsed_ns(indexes_collected, facts_collected),
+      elapsed_ns(facts_collected, semantic_encoded),
+      elapsed_ns(semantic_encoded, graph_encoded),
+      elapsed_ns(graph_encoded, finished),
+      elapsed_ns(started, finished),
+  };
+
+  return result;
+}
+
+FactBatchBuffers
+encode_fact_batch_buffer(const CodeGraph &graph,
+                         const FactBatchBufferOptions &options) {
+  return encode_fact_batch_buffer(graph.vertices(), graph.edges(),
+                                  graph.project_root(), options);
+}
+
+} // namespace codenib::core

--- a/core/fact_batch_buffer.h
+++ b/core/fact_batch_buffer.h
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "code_graph.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace codenib::core {
+
+// FactBatchBuffer is the stable native/Python wire contract. All integer
+// fields are little-endian. Strings are (offset, length) pairs into ``arena``;
+// FACT_BATCH_BUFFER_NONE marks an absent string/range component.
+constexpr std::uint16_t FACT_BATCH_BUFFER_ABI_VERSION = 1;
+constexpr std::uint16_t FACT_BATCH_SCHEMA_VERSION = 1;
+constexpr std::uint32_t FACT_BATCH_BUFFER_NONE = 0xffffffffU;
+
+constexpr std::size_t FACT_BATCH_META_SIZE = 64;
+constexpr std::size_t FACT_BATCH_ROW_SIZE = 56;
+constexpr std::size_t FACT_SYMBOL_ROW_SIZE = 80;
+constexpr std::size_t FACT_OCCURRENCE_ROW_SIZE = 48;
+constexpr std::size_t FACT_EDGE_ROW_SIZE = 72;
+constexpr std::size_t FACT_DIAGNOSTIC_ROW_SIZE = 40;
+constexpr std::size_t FACT_GRAPH_VERTEX_ROW_SIZE = 56;
+constexpr std::size_t FACT_GRAPH_EDGE_ROW_SIZE = 32;
+
+constexpr std::uint32_t FACT_BUFFER_FLAG_GRAPH_COMPAT = 1U << 0;
+constexpr std::uint32_t FACT_BUFFER_FLAG_CONTENT_DIGESTS_COMPLETE = 1U << 1;
+
+constexpr std::uint8_t FACT_COMPLETENESS_COMPLETE = 1;
+constexpr std::uint8_t FACT_COMPLETENESS_PARTIAL = 2;
+constexpr std::uint8_t FACT_COMPLETENESS_SYNTACTIC = 3;
+constexpr std::uint8_t FACT_COMPLETENESS_FAILED = 4;
+
+constexpr std::uint8_t FACT_CAPABILITY_DEFINITIONS = 1U << 0;
+constexpr std::uint8_t FACT_CAPABILITY_OCCURRENCES = 1U << 1;
+constexpr std::uint8_t FACT_CAPABILITY_EDGES = 1U << 2;
+constexpr std::uint8_t FACT_CAPABILITY_DIAGNOSTICS = 1U << 3;
+
+constexpr std::uint8_t FACT_PROVENANCE_SCIP = 1;
+constexpr std::uint8_t FACT_PROVENANCE_LSP = 2;
+constexpr std::uint8_t FACT_PROVENANCE_CLANGD = 3;
+constexpr std::uint8_t FACT_PROVENANCE_SYNTACTIC = 4;
+constexpr std::uint8_t FACT_PROVENANCE_FRAMEWORK = 5;
+constexpr std::uint8_t FACT_PROVENANCE_HEURISTIC = 6;
+
+struct FactBatchBufferOptions {
+  std::string language;
+  std::string provider{"scip-core"};
+  std::string profile_digest;
+  std::string position_encoding{"UTF8"};
+  std::unordered_map<std::string, std::string> content_digests;
+  bool include_graph_compat{true};
+};
+
+struct FactBatchEncodeProfile {
+  std::uint64_t validate_options_ns{0};
+  std::uint64_t collect_indexes_ns{0};
+  std::uint64_t collect_facts_ns{0};
+  std::uint64_t encode_semantic_ns{0};
+  std::uint64_t encode_graph_ns{0};
+  std::uint64_t finalize_ns{0};
+  std::uint64_t total_ns{0};
+};
+
+struct FactBatchBuffers {
+  std::vector<std::uint8_t> meta;
+  std::vector<std::uint8_t> batches;
+  std::vector<std::uint8_t> symbols;
+  std::vector<std::uint8_t> occurrences;
+  std::vector<std::uint8_t> edges;
+  std::vector<std::uint8_t> diagnostics;
+
+  // Exact compatibility projection of the existing CodeGraph. Python uses
+  // these two tables for graph materialization without an intermediate
+  // list[dict] / list[tuple] transport. They do not alter persisted schema.
+  std::vector<std::uint8_t> graph_vertices;
+  std::vector<std::uint8_t> graph_edges;
+
+  std::vector<std::uint8_t> arena;
+  FactBatchEncodeProfile profile;
+};
+
+FactBatchBuffers
+encode_fact_batch_buffer(const CodeGraph &graph,
+                         const FactBatchBufferOptions &options);
+
+FactBatchBuffers
+encode_fact_batch_buffer(const std::vector<CodeGraph::VertexData> &vertices,
+                         const std::vector<CodeGraph::EdgeData> &edges,
+                         const std::string &project_root,
+                         const FactBatchBufferOptions &options);
+
+} // namespace codenib::core

--- a/core/tests/fact_batch_buffer_test.cpp
+++ b/core/tests/fact_batch_buffer_test.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fact_batch_buffer.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using codenib::core::CodeGraph;
+using codenib::core::FactBatchBufferOptions;
+using codenib::core::FactBatchBuffers;
+
+namespace {
+
+std::uint16_t read_u16(const std::vector<std::uint8_t> &buffer,
+                       std::size_t offset) {
+  return static_cast<std::uint16_t>(buffer.at(offset)) |
+         static_cast<std::uint16_t>(buffer.at(offset + 1)) << 8U;
+}
+
+std::uint32_t read_u32(const std::vector<std::uint8_t> &buffer,
+                       std::size_t offset) {
+  std::uint32_t value = 0;
+  for (unsigned shift = 0; shift < 32; shift += 8)
+    value |= static_cast<std::uint32_t>(buffer.at(offset + shift / 8U))
+             << shift;
+  return value;
+}
+
+CodeGraph make_graph() {
+  CodeGraph graph("/workspace/project");
+  graph.batch_upsert_nodes({
+      CodeGraph::VertexData{".", "root", std::nullopt, std::nullopt,
+                            std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, std::nullopt},
+      CodeGraph::VertexData{
+          "src", codenib::core::NODE_TYPE_DIRECTORY, std::nullopt, std::nullopt,
+          std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
+      CodeGraph::VertexData{"src/main.py", codenib::core::NODE_TYPE_FILE,
+                            std::string("src/main.py"), std::nullopt,
+                            std::nullopt, std::nullopt, std::nullopt,
+                            std::nullopt, std::nullopt},
+      CodeGraph::VertexData{
+          "src/main.py:run()", codenib::core::NODE_TYPE_FUNCTION,
+          std::string("src/main.py"), 0, 2, 0, std::string("src/main.py:run"),
+          std::string("function"), true},
+      CodeGraph::VertexData{
+          "python-stdlib:print", codenib::core::NODE_TYPE_FUNCTION,
+          std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+          std::string("python-stdlib:print"), std::string("function"), false},
+  });
+  graph.batch_add_edges({
+      {".", "src", codenib::core::EDGE_TYPE_CONTAIN, std::nullopt,
+       std::nullopt},
+      {"src", "src/main.py", codenib::core::EDGE_TYPE_CONTAIN, std::nullopt,
+       std::nullopt},
+      {"src/main.py", "src/main.py:run()", codenib::core::EDGE_TYPE_CONTAIN,
+       std::nullopt, std::nullopt},
+      {"src/main.py:run()", "python-stdlib:print",
+       codenib::core::EDGE_TYPE_REFERENCE, std::string("src/main.py"), 1},
+  });
+  return graph;
+}
+
+void assert_same(const FactBatchBuffers &left, const FactBatchBuffers &right) {
+  assert(left.meta == right.meta);
+  assert(left.batches == right.batches);
+  assert(left.symbols == right.symbols);
+  assert(left.occurrences == right.occurrences);
+  assert(left.edges == right.edges);
+  assert(left.diagnostics == right.diagnostics);
+  assert(left.graph_vertices == right.graph_vertices);
+  assert(left.graph_edges == right.graph_edges);
+  assert(left.arena == right.arena);
+}
+
+} // namespace
+
+int main() {
+  auto graph = make_graph();
+  FactBatchBufferOptions options;
+  options.language = "python";
+  options.profile_digest = "sha256:" + std::string(64, 'a');
+  options.content_digests.emplace("src/main.py",
+                                  "sha256:" + std::string(64, 'b'));
+
+  const auto encoded = codenib::core::encode_fact_batch_buffer(graph, options);
+  const auto repeated = codenib::core::encode_fact_batch_buffer(graph, options);
+  assert_same(encoded, repeated);
+
+  assert(encoded.meta.size() == codenib::core::FACT_BATCH_META_SIZE);
+  assert(encoded.meta[0] == 'C' && encoded.meta[1] == 'N' &&
+         encoded.meta[2] == 'F' && encoded.meta[3] == 'B');
+  assert(read_u16(encoded.meta, 4) ==
+         codenib::core::FACT_BATCH_BUFFER_ABI_VERSION);
+  assert(read_u16(encoded.meta, 6) == codenib::core::FACT_BATCH_SCHEMA_VERSION);
+  assert(read_u32(encoded.meta, 12) == 1); // batches
+  assert(read_u32(encoded.meta, 16) == 1); // definition symbols
+  assert(read_u32(encoded.meta, 20) == 1); // definition occurrences
+  assert(read_u32(encoded.meta, 24) == 2); // contain + reference facts
+  assert(read_u32(encoded.meta, 28) == 0); // diagnostics
+  assert(read_u32(encoded.meta, 32) == 5); // compatibility vertices
+  assert(read_u32(encoded.meta, 36) == 4); // compatibility edges
+  assert(read_u32(encoded.meta, 40) == encoded.arena.size());
+
+  assert(encoded.batches.size() == codenib::core::FACT_BATCH_ROW_SIZE);
+  assert(encoded.symbols.size() == codenib::core::FACT_SYMBOL_ROW_SIZE);
+  assert(encoded.occurrences.size() == codenib::core::FACT_OCCURRENCE_ROW_SIZE);
+  assert(encoded.edges.size() == 2 * codenib::core::FACT_EDGE_ROW_SIZE);
+  assert(encoded.diagnostics.empty());
+  assert(encoded.graph_vertices.size() ==
+         5 * codenib::core::FACT_GRAPH_VERTEX_ROW_SIZE);
+  assert(encoded.graph_edges.size() ==
+         4 * codenib::core::FACT_GRAPH_EDGE_ROW_SIZE);
+
+  const auto flags = read_u32(encoded.meta, 8);
+  assert((flags & codenib::core::FACT_BUFFER_FLAG_GRAPH_COMPAT) != 0);
+  assert((flags & codenib::core::FACT_BUFFER_FLAG_CONTENT_DIGESTS_COMPLETE) !=
+         0);
+
+  FactBatchBufferOptions missing_digest = options;
+  missing_digest.content_digests.clear();
+  const auto partial =
+      codenib::core::encode_fact_batch_buffer(graph, missing_digest);
+  assert((read_u32(partial.meta, 8) &
+          codenib::core::FACT_BUFFER_FLAG_CONTENT_DIGESTS_COMPLETE) == 0);
+
+  return 0;
+}

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -72,6 +72,7 @@ and returns no graph. Non-SCIP backends such as C/C++ ignore
 `decoder_backend` because they do not use a SCIP decoder.
 
 The pybind module also exposes lower-level `decode_scip(...)`,
+`decode_scip_fact_buffer(...)`, `fact_batch_buffer_contract(...)`,
 `classify_edge_layers(...)`, and decoder-registry inspection functions. These
 are primarily integration surfaces; application code should normally use
 `LSIndexer` so filtering, occurrence indexes, range indexes, and persistence
@@ -85,6 +86,17 @@ materializes the same graph, so persisted schema and public graph behavior do
 not change. `decode_records()` is the reusable boundary for later consumers:
 it owns deterministic vertex order, indexed edges, project identity, and
 language-specific postprocessing without constructing a `CodeGraph`.
+
+## FactBatchBuffer v1
+
+The optional buffer transport consumes `DecodedRecords` directly and crosses
+the pybind boundary as a constant number of fixed-width little-endian tables
+plus one shared UTF-8 arena. It can expose provider-neutral per-file semantic
+facts, preserve the exact legacy vertex/edge/range projection, or omit graph
+compatibility tables for fact-only consumers. Python validates the fixed
+envelope immediately, then checks the selected projection's flags, string
+references, identities, ranges, and graph endpoints before constructing its
+consumer result. Zero-copy exports are read-only and retain their native owner.
 
 ## Verify
 
@@ -102,6 +114,7 @@ skip report.
 
 - `code_graph.{h,cpp}` implements the C++ graph container.
 - `decoded_records.h` defines the provider-neutral pre-graph boundary.
+- `fact_batch_buffer.{h,cpp}` defines the v1 native buffer ABI and encoder.
 - `graph_layers.{h,cpp}` classifies normalized edge types into reusable graph
   layers.
 - `scip_decode_base.{h,cpp}` and `scip_decode_common.{h,cpp}` provide shared

--- a/test/scip/test_fact_batch_buffer.py
+++ b/test/scip/test_fact_batch_buffer.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native FactBatchBuffer ABI, parity, and ownership tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import struct
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+if importlib.util.find_spec("codenib_core") is None:
+    pytest.skip(
+        "codenib_core pybind module not built; run make core-build",
+        allow_module_level=True,
+    )
+
+import codenib_core  # noqa: E402
+
+from codenib.facts import fact_batches_from_code_graph, sha256_digest  # noqa: E402
+from codenib.scip_interface.fact_batch_buffer import (  # noqa: E402
+    FactBatchBufferError,
+    FactBatchBufferView,
+    validate_compiled_contract,
+)
+from codenib.scip_interface.scip_decode_core import _build_code_graph  # noqa: E402
+
+_FIXTURE = (
+    Path(__file__).resolve().parent / "fixtures/typescript_schema_v5/index.decoded"
+)
+_PROFILE_DIGEST = sha256_digest("native-fact-buffer-test-profile")
+
+
+def _legacy_graph():
+    result = codenib_core.decode_scip(
+        index_file=str(_FIXTURE),
+        project_root=None,
+        language="typescript",
+    )
+    return _build_code_graph(result["vertices"], result["edges"])
+
+
+def _content_digests(graph) -> dict[str, str]:
+    return {
+        attributes["name"]: sha256_digest(f"fixture:{attributes['name']}")
+        for vertex in graph.graph.vs
+        if (attributes := vertex.attributes()).get("type") == "file"
+    }
+
+
+def _payload(
+    *,
+    content_digests: dict[str, str] | None = None,
+    include_graph_compat: bool = True,
+    copy_buffers: bool = True,
+) -> dict[str, Any]:
+    return codenib_core.decode_scip_fact_buffer(
+        index_file=str(_FIXTURE),
+        profile_digest=_PROFILE_DIGEST,
+        project_root=None,
+        language="typescript",
+        content_digests=content_digests or {},
+        include_graph_compat=include_graph_compat,
+        copy_buffers=copy_buffers,
+    )
+
+
+def _replace_u32(payload: dict[str, Any], table: str, offset: int, value: int) -> None:
+    data = bytearray(payload[table])
+    struct.pack_into("<I", data, offset, value)
+    payload[table] = bytes(data)
+
+
+def _vertex_rows(graph) -> list[tuple[Any, ...]]:
+    fields = (
+        "name",
+        "type",
+        "file",
+        "start_line",
+        "end_line",
+        "selection_line",
+        "unified_name",
+        "symbol_kind",
+        "has_definition",
+    )
+    return [
+        tuple(vertex.attributes().get(field) for field in fields)
+        for vertex in graph.graph.vs
+    ]
+
+
+def _edge_rows(graph) -> list[tuple[Any, ...]]:
+    return [
+        (
+            edge.source,
+            edge.target,
+            edge.attributes().get("type"),
+            edge.attributes().get("anchor_file"),
+            edge.attributes().get("anchor_line"),
+        )
+        for edge in graph.graph.es
+    ]
+
+
+def test_compiled_contract_and_graph_projection_are_exact() -> None:
+    validate_compiled_contract(codenib_core.fact_batch_buffer_contract())
+    expected = _legacy_graph()
+    view = FactBatchBufferView(_payload())
+    actual = view.materialize_code_graph()
+
+    assert _vertex_rows(actual) == _vertex_rows(expected)
+    assert _edge_rows(actual) == _edge_rows(expected)
+    assert actual.name_to_vertex == expected.name_to_vertex
+    assert actual.symbol_ranges == expected.symbol_ranges
+
+
+def test_compiled_contract_rejects_boolean_version() -> None:
+    contract = dict(codenib_core.fact_batch_buffer_contract())
+    contract["abi_version"] = True
+
+    with pytest.raises(FactBatchBufferError, match="contract mismatch"):
+        validate_compiled_contract(contract)
+
+
+def test_semantic_tables_match_the_legacy_graph_adapter() -> None:
+    graph = _legacy_graph()
+    content_digests = _content_digests(graph)
+    view = FactBatchBufferView(_payload(content_digests=content_digests))
+
+    actual = view.to_fact_batches()
+    expected = fact_batches_from_code_graph(
+        graph,
+        language="typescript",
+        content_digests=content_digests,
+        profile_digest=_PROFILE_DIGEST,
+        provider="scip-core",
+    )
+
+    assert actual == expected
+
+
+def test_fact_only_direct_decode_skips_graph_materialization() -> None:
+    graph = _legacy_graph()
+    content_digests = _content_digests(graph)
+    view = FactBatchBufferView(
+        _payload(
+            content_digests=content_digests,
+            include_graph_compat=False,
+            copy_buffers=False,
+        )
+    )
+
+    assert view.has_graph_compat is False
+    assert view.meta.graph_vertex_count == 0
+    assert view.meta.graph_edge_count == 0
+    assert view.meta.decode_profile_ns["materialize_graph"] == 0
+    assert view.to_fact_batches() == fact_batches_from_code_graph(
+        graph,
+        language="typescript",
+        content_digests=content_digests,
+        profile_digest=_PROFILE_DIGEST,
+        provider="scip-core",
+    )
+    with pytest.raises(FactBatchBufferError, match="does not include graph"):
+        view.materialize_code_graph()
+
+
+def test_owned_buffers_are_read_only_and_keep_native_storage_alive() -> None:
+    payload = _payload(include_graph_compat=False, copy_buffers=False)
+    meta = memoryview(payload["meta"])
+    view = FactBatchBufferView(payload)
+
+    assert meta.readonly is True
+    assert bytes(meta[:4]) == b"CNFB"
+    del payload
+    assert view.meta.batch_count > 0
+    with pytest.raises(TypeError):
+        meta[0] = 0
+
+
+def test_writable_buffers_are_rejected_before_validation() -> None:
+    payload = _payload()
+    payload["arena"] = bytearray(payload["arena"])
+
+    with pytest.raises(FactBatchBufferError, match="arena must be read-only"):
+        FactBatchBufferView(payload)
+
+
+def test_missing_content_digest_blocks_logical_fact_materialization() -> None:
+    view = FactBatchBufferView(_payload())
+
+    with pytest.raises(FactBatchBufferError, match="content digest is required"):
+        view.to_fact_batches()
+
+
+@pytest.mark.parametrize("corruption", ("abi", "arena"))
+def test_wire_corruption_is_rejected(corruption: str) -> None:
+    payload = _payload()
+    if corruption == "abi":
+        meta = bytearray(payload["meta"])
+        meta[4] = 99
+        payload["meta"] = bytes(meta)
+        message = "ABI 99"
+    else:
+        payload["arena"] = payload["arena"][:-1]
+        message = "meta declares"
+
+    with pytest.raises(FactBatchBufferError, match=message):
+        FactBatchBufferView(payload)
+
+
+@pytest.mark.parametrize("corruption", ("table_size", "meta_flags"))
+def test_envelope_corruption_is_rejected_during_view_creation(corruption: str) -> None:
+    payload = _payload()
+    if corruption == "table_size":
+        payload["symbols"] = payload["symbols"][:-1]
+        message = "symbols has"
+    else:
+        _replace_u32(payload, "meta", 8, 1 << 31)
+        message = "unsupported flags"
+
+    with pytest.raises(FactBatchBufferError, match=message):
+        FactBatchBufferView(payload)
+
+
+@pytest.mark.parametrize("corruption", ("symbol_flags", "edge_flags", "digest_flag"))
+def test_semantic_corruption_is_rejected_before_batches_are_returned(
+    corruption: str,
+) -> None:
+    graph = _legacy_graph()
+    payload = _payload(content_digests=_content_digests(graph))
+    if corruption == "symbol_flags":
+        _replace_u32(payload, "symbols", 4, 0)
+        message = "invalid definition flags"
+    elif corruption == "edge_flags":
+        data = bytearray(payload["edges"])
+        data[5] = 0
+        payload["edges"] = bytes(data)
+        message = "flags do not match optional fields"
+    else:
+        _replace_u32(payload, "meta", 8, 1)
+        message = "content-digest flag does not match"
+
+    view = FactBatchBufferView(payload)
+    with pytest.raises(FactBatchBufferError, match=message):
+        view.to_fact_batches()
+
+
+def test_invalid_semantic_identity_uses_the_wire_error_boundary() -> None:
+    graph = _legacy_graph()
+    payload = _payload(content_digests=_content_digests(graph))
+    data = bytearray(payload["edges"])
+    data[5] &= ~(1 << 1)
+    struct.pack_into("<II", data, 32, 0xFFFFFFFF, 0)
+    payload["edges"] = bytes(data)
+
+    view = FactBatchBufferView(payload)
+    with pytest.raises(FactBatchBufferError, match="exactly one .* target"):
+        view.to_fact_batches()
+
+
+@pytest.mark.parametrize("corruption", ("edge_endpoint", "duplicate_vertex"))
+def test_graph_corruption_is_rejected_before_a_graph_is_returned(
+    corruption: str,
+) -> None:
+    payload = _payload()
+    if corruption == "edge_endpoint":
+        _replace_u32(payload, "graph_edges", 0, 0xFFFFFFFF)
+        message = "endpoint"
+    else:
+        data = bytearray(payload["graph_vertices"])
+        row_size = codenib_core.fact_batch_buffer_contract()["graph_vertex_row_size"]
+        data[row_size : row_size + 8] = data[:8]
+        payload["graph_vertices"] = bytes(data)
+        message = "globally unique"
+
+    view = FactBatchBufferView(payload)
+    with pytest.raises(FactBatchBufferError, match=message):
+        view.materialize_code_graph()


### PR DESCRIPTION
## Summary

Add the versioned FactBatchBuffer v1 native/Python transport tracked by #564. This is the transport milestone under #560 and depends on the already merged FactBatch model in #563/#566.

## Changes

- Encode DecodedRecords directly into fixed-width little-endian semantic and graph-compatibility tables plus one UTF-8 arena.
- Expose copied bytes or ownership-safe read-only native buffers through pybind.
- Validate the fixed envelope and each selected projection before returning FactBatch or CodeGraph results.
- Add exact graph parity, semantic parity, corruption, ABI, ownership, and fact-only tests.
- Document the low-level transport without changing the default decoder route or promotion policy.

Closes #564
Part of #560

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- make core-test: 35 passed, 4 skipped, plus three native C++ executables.
- Unit tier with the two documented environment-baseline deselections: 3862 passed, 8 skipped, 200 deselected.
- pre-commit on all changed files.
- python -m mkdocs build --strict.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published