### PR TITLE
perf(core): gate FactBatchBuffer runtime promotion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ LARGE_SCIP_PROFILE_CACHE_ROOT ?= $(CODENIB_TEMP_DIR)/large-scip-repos
 LARGE_SCIP_PROFILE_OUTPUT_DIR ?= $(CODENIB_TEMP_DIR)/large-scip-profile
 LARGE_SCIP_PROFILE_TIMEOUT ?= 1800
 LARGE_SCIP_PROFILE_EXTRA_ARGS ?=
+FACT_BUFFER_PROFILE_INDEX ?=
+FACT_BUFFER_PROFILE_LANGUAGE ?=
+FACT_BUFFER_PROFILE_PROJECT_ROOT ?=
+FACT_BUFFER_PROFILE_OUTPUT ?=
+FACT_BUFFER_PROFILE_EXTRA_ARGS ?=
 PROJECT_LANGUAGE ?=
 PROJECT_ROOT ?=
 hash := \#
@@ -184,7 +189,7 @@ endef
 .PHONY: active-scip-tools active-lsp-tools active-scip-env active-system-deps-ubuntu
 .PHONY: go-tool scip-go-tool rust-tool scip-python-tool scip-typescript-tool scip-clang-tool
 .PHONY: node-workspace-tools zoekt-tool python-lsp-tool ty-tool typescript-lsp-tool gopls-tool clangd-tool
-.PHONY: core-system-deps-ubuntu core-python-deps core-build core-test
+.PHONY: core-system-deps-ubuntu core-python-deps core-build core-test fact-buffer-profile
 .PHONY: scip-cold-start-tools scip-cold-start-tools-all scip-cold-start-env scip-cold-start-system-deps-ubuntu
 .PHONY: scip-candidates scip-candidates-all scip-candidate-env scip-candidate-system-deps-ubuntu
 .PHONY: scip-jvm-compat-system-deps-ubuntu
@@ -412,7 +417,18 @@ core-test: core-build
 		test/scip/test_scip_core_registry.py \
 		test/scip/test_fact_batch_buffer.py \
 		test/facts/test_model.py \
-		test/facts/test_adapters.py
+		test/facts/test_adapters.py \
+		test/scripts/test_profile_fact_batch_buffer.py
+
+fact-buffer-profile: core-build
+	@test -n "$(FACT_BUFFER_PROFILE_INDEX)" || { echo "Set FACT_BUFFER_PROFILE_INDEX=/path/to/index.decoded" >&2; exit 1; }
+	@test -n "$(FACT_BUFFER_PROFILE_LANGUAGE)" || { echo "Set FACT_BUFFER_PROFILE_LANGUAGE=<language>" >&2; exit 1; }
+	PYTHONPATH="build/core:$$PYTHONPATH" python scripts/profiling/profile_fact_batch_buffer.py \
+		--index "$(FACT_BUFFER_PROFILE_INDEX)" \
+		--language "$(FACT_BUFFER_PROFILE_LANGUAGE)" \
+		$(if $(FACT_BUFFER_PROFILE_PROJECT_ROOT),--project-root "$(FACT_BUFFER_PROFILE_PROJECT_ROOT)",) \
+		$(if $(FACT_BUFFER_PROFILE_OUTPUT),--output-json "$(FACT_BUFFER_PROFILE_OUTPUT)",) \
+		$(FACT_BUFFER_PROFILE_EXTRA_ARGS)
 
 scip-cold-start-tools: scip-java-tool gradle-tool sbt-tool scip-dotnet-tool scip-ruby-tool scip-php-info
 	@$(MAKE) --no-print-directory scip-cold-start-env

--- a/codenib/scip_interface/scip_decode_core.py
+++ b/codenib/scip_interface/scip_decode_core.py
@@ -17,6 +17,8 @@ and fall back to the serial decoder).
 """
 from __future__ import annotations
 
+import hashlib
+import os
 import time
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -24,6 +26,7 @@ from typing import Dict, List, Optional
 from ..graph.code_graph import CodeGraph
 from ..languages import core_decoder_languages
 from ..log_utils import get_logger
+from .fact_batch_buffer import FactBatchBufferView, validate_compiled_contract
 
 logger = get_logger(__name__)
 
@@ -46,6 +49,11 @@ else:
 # "js" are configured in LanguageSpec.core_decoder_aliases.
 SUPPORTED_LANGUAGES = core_decoder_languages(include_aliases=False)
 ACCEPTED_LANGUAGES = core_decoder_languages(include_aliases=True)
+
+_FACT_BUFFER_ENV = "CODENIB_CORE_FACT_BUFFER"
+_FACT_BUFFER_OFF = frozenset({"0", "false", "no", "off", "disabled"})
+_FACT_BUFFER_ON = frozenset({"", "1", "true", "yes", "on", "auto"})
+_FACT_BUFFER_REQUIRED = frozenset({"required", "strict"})
 
 
 def _ensure_available() -> None:
@@ -134,6 +142,28 @@ def _build_code_graph(
     return code_graph
 
 
+def _fact_buffer_mode() -> str:
+    # The v1 transport remains opt-in until a measured end-to-end benchmark
+    # clears the acceleration gate. It is useful as a semantic batch boundary,
+    # but graph-compatible and eager logical-object consumers remain slower
+    # than legacy transport on representative repositories.
+    value = os.environ.get(_FACT_BUFFER_ENV, "off").strip().lower()
+    if value in _FACT_BUFFER_OFF:
+        return "off"
+    if value in _FACT_BUFFER_ON:
+        return "auto"
+    if value in _FACT_BUFFER_REQUIRED:
+        return "required"
+    raise ValueError(
+        f"{_FACT_BUFFER_ENV} must be auto, required, or 0/off; got {value!r}"
+    )
+
+
+def _fact_buffer_profile_digest(language: str) -> str:
+    payload = f"codenib-core-fact-buffer-v1:{language}".encode("utf-8")
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
 class SCIPDecoderCore:
     """Decoder facade that runs the C++ core/ pipeline and returns a CodeGraph.
 
@@ -157,45 +187,129 @@ class SCIPDecoderCore:
                 f"Unknown language {language!r}. " f"Supported: {SUPPORTED_LANGUAGES}."
             )
         _ensure_available()
-        self.timings: Dict[str, float] = {}
+        self.timings: Dict[str, float | int] = {}
         self.code_graph: Optional[CodeGraph] = None
+        self.fact_buffer_view: FactBatchBufferView | None = None
+        self.transport_backend = "uninitialized"
+        self.transport_fallback_error: str | None = None
 
-    def decode(self) -> CodeGraph:
-        t_total = time.perf_counter()
+    def _decode_fact_buffer(self) -> tuple[CodeGraph, dict[str, float | int]]:
+        if not hasattr(_cpp, "decode_scip_fact_buffer") or not hasattr(
+            _cpp, "fact_batch_buffer_contract"
+        ):
+            raise RuntimeError("compiled core does not expose FactBatchBuffer v1")
+        validate_compiled_contract(_cpp.fact_batch_buffer_contract())
+        started = time.perf_counter()
+        payload = _cpp.decode_scip_fact_buffer(
+            index_file=self.index_file_path,
+            profile_digest=_fact_buffer_profile_digest(self.language),
+            project_root=self.project_root,
+            language=self.language,
+            copy_buffers=False,
+        )
+        binding_seconds = time.perf_counter() - started
+        view = FactBatchBufferView(payload)
+        started = time.perf_counter()
+        graph = view.materialize_code_graph(project_root=self.project_root)
+        # Preserve the established facade contract: an omitted project root is
+        # represented as None even when the native envelope stores an empty
+        # effective root string.
+        graph.project_root = self.project_root
+        materialize_seconds = time.perf_counter() - started
+        native_decode = (view.meta.native_decode_ns or 0) / 1_000_000_000
+        native_encode = (view.meta.native_encode_ns or 0) / 1_000_000_000
+        self.fact_buffer_view = view
+        timings: dict[str, float | int] = {
+            "core_decode": binding_seconds,
+            "native_decode": native_decode,
+            "native_fact_buffer_encode": native_encode,
+            "boundary_transport_residual": max(
+                0.0, binding_seconds - native_decode - native_encode
+            ),
+            "build_code_graph": materialize_seconds,
+            "node_count": view.meta.graph_vertex_count,
+            "edge_count": view.meta.graph_edge_count,
+            "fact_batch_count": view.meta.batch_count,
+            "fact_symbol_count": view.meta.symbol_count,
+            "fact_edge_count": view.meta.edge_count,
+        }
+        for name, nanoseconds in (view.meta.decode_profile_ns or {}).items():
+            if name in {"worker_count", "document_count"}:
+                timings[f"native_{name}"] = nanoseconds
+            else:
+                timings[f"native_{name}"] = nanoseconds / 1_000_000_000
+        return graph, timings
 
-        t0 = time.perf_counter()
-        # This binding intentionally returns the low-level flat transport.
-        # Build and enrich through this facade before exposing a CodeGraph.
+    def _decode_legacy(self) -> tuple[CodeGraph, dict[str, float | int]]:
+        started = time.perf_counter()
         result = _cpp.decode_scip(
             index_file=self.index_file_path,
             project_root=self.project_root,
             language=self.language,
         )
-        t_core = time.perf_counter() - t0
-
-        t0 = time.perf_counter()
+        binding_seconds = time.perf_counter() - started
+        started = time.perf_counter()
         graph = _build_code_graph(
             result["vertices"],
             result["edges"],
             project_root=self.project_root,
         )
-        if self.language in {"ts", "typescript", "js", "javascript"}:
-            from .typescript_semantics import enrich_typescript_import_edges
-
-            decoded_content = Path(self.index_file_path).read_text(encoding="utf-8")
-            enrich_typescript_import_edges(
-                graph, decoded_content, project_root=self.project_root
-            )
-        t_build = time.perf_counter() - t0
-
-        self.code_graph = graph
-        self.timings = {
-            "core_decode": t_core,
-            "build_code_graph": t_build,
+        materialize_seconds = time.perf_counter() - started
+        return graph, {
+            "core_decode": binding_seconds,
+            "build_code_graph": materialize_seconds,
             "node_count": len(result["vertices"]),
             "edge_count": len(result["edges"]),
-            "total": time.perf_counter() - t_total,
         }
+
+    def _enrich_graph(self, graph: CodeGraph) -> None:
+        if self.language not in {"ts", "typescript", "js", "javascript"}:
+            return
+        from .typescript_semantics import enrich_typescript_import_edges
+
+        decoded_content = Path(self.index_file_path).read_text(encoding="utf-8")
+        enrich_typescript_import_edges(
+            graph, decoded_content, project_root=self.project_root
+        )
+
+    def decode(self) -> CodeGraph:
+        t_total = time.perf_counter()
+        self.fact_buffer_view = None
+        self.transport_backend = "uninitialized"
+        self.transport_fallback_error = None
+        mode = _fact_buffer_mode()
+        if mode == "off":
+            graph, timings = self._decode_legacy()
+            self.transport_backend = "legacy-disabled"
+        else:
+            try:
+                graph, timings = self._decode_fact_buffer()
+                self.transport_backend = "fact-buffer-v1"
+            except MemoryError:
+                raise
+            except Exception as exc:
+                if mode == "required":
+                    raise
+                self.transport_fallback_error = f"{type(exc).__name__}: {exc}"
+                logger.warning(
+                    "FactBatchBuffer transport unavailable; falling back to the "
+                    f"legacy core transport: {self.transport_fallback_error}"
+                )
+                graph, timings = self._decode_legacy()
+                self.transport_backend = "legacy-fallback"
+
+        enrichment_started = time.perf_counter()
+        self._enrich_graph(graph)
+        enrichment_seconds = time.perf_counter() - enrichment_started
+        timings["source_enrichment"] = enrichment_seconds
+        # build_code_graph historically included TypeScript source enrichment.
+        # Keep that aggregate timing stable while exposing the new substage.
+        timings["build_code_graph"] += enrichment_seconds
+
+        self.code_graph = graph
+        timings["fact_buffer_enabled"] = int(self.transport_backend == "fact-buffer-v1")
+        timings["total"] = time.perf_counter() - t_total
+        self.timings = timings
         return graph
 
     def save_graph(self, output_path: str) -> None:

--- a/core/README.md
+++ b/core/README.md
@@ -77,6 +77,19 @@ fixed envelope immediately and the complete selected projection before
 returning a materialized consumer result. The zero-copy mode keeps native
 storage alive through read-only buffer owners.
 
+The graph-compatible runtime remains experimental and defaults to the legacy
+transport because the candidate did not clear the 20% end-to-end promotion
+gate. `CODENIB_CORE_FACT_BUFFER=auto` enables the ownership-safe zero-copy
+candidate with compatible fallback; `required` fails closed for ABI and parity
+testing. Reproduce both graph and eager logical-fact arms with:
+
+```bash
+make fact-buffer-profile \
+  FACT_BUFFER_PROFILE_INDEX=/path/to/index.decoded \
+  FACT_BUFFER_PROFILE_LANGUAGE=python \
+  FACT_BUFFER_PROFILE_EXTRA_ARGS='--include-semantic-consumer'
+```
+
 ## Use Through Python
 
 Application code should select the core decoder through `LSIndexer`, which

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -98,6 +98,23 @@ envelope immediately, then checks the selected projection's flags, string
 references, identities, ranges, and graph endpoints before constructing its
 consumer result. Zero-copy exports are read-only and retain their native owner.
 
+The established decode path still defaults to the legacy transport. Set
+`CODENIB_CORE_FACT_BUFFER=auto` to try the ownership-safe zero-copy buffer path
+with compatible fallback, or `required` to fail closed when its ABI or
+materialization fails. Neither the graph-compatible arm nor the eager logical
+`FactBatch` arm passed the 20% end-to-end promotion gate recorded in the
+internal multi-language roadmap, so this setting is not promoted by default.
+Reproduce the alternating-arm measurement with:
+
+```bash
+make fact-buffer-profile \
+  FACT_BUFFER_PROFILE_INDEX=/path/to/index.decoded \
+  FACT_BUFFER_PROFILE_LANGUAGE=python \
+  FACT_BUFFER_PROFILE_PROJECT_ROOT=/path/to/repository \
+  FACT_BUFFER_PROFILE_OUTPUT=/tmp/fact-buffer-report.json \
+  FACT_BUFFER_PROFILE_EXTRA_ARGS='--iterations 7 --warmups 2 --include-semantic-consumer'
+```
+
 ## Verify
 
 ```bash

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -651,12 +651,42 @@ decode/build gate before recommending any new C++ decoder work. This is the
 preferred path for proving that a serial-only active language has outgrown its
 current Python decoder.
 
-Provider-neutral native boundary status ([#559](https://github.com/sysevol-ai/CodeNib/issues/559)):
-the core decodes SCIP into flat `DecodedRecords` before igraph or Python object
+Provider-neutral native boundary status: issue
+[#559](https://github.com/sysevol-ai/CodeNib/issues/559) landed through PR #562.
+The core decodes SCIP into flat `DecodedRecords` before igraph or Python object
 materialization. The established `decode()` path materializes those rows into
 the same graph, while capability-specific consumers can stop at
-`decode_records()`. FactBatch encoding (#560), FactQuery indexing (#561), and
-clangd parsing (#555) remain separate promotion and review decisions.
+`decode_records()`. The immutable `FactBatch v1` model landed through #563/PR
+#566, and the versioned native `FactBatchBuffer v1` ABI, exact graph projection,
+validation, and read-only ownership contract landed through #564/PR #567.
+
+FactBatchBuffer runtime promotion status
+([#565](https://github.com/sysevol-ai/CodeNib/issues/565)): the candidate uses
+ownership-safe zero-copy buffers but remains opt-in. The 2026-08-10 local gate
+alternated arm order, required graph and semantic parity, and compared median
+end-to-end time against a 20% threshold:
+
+| SCIP subject | Consumer | Legacy | FactBatchBuffer | Improvement | Result |
+| --- | --- | ---: | ---: | ---: | --- |
+| CodeNib Python, 41.6 MB | graph-compatible | 0.3775s | 0.3937s | -4.3% | keep experimental |
+| CodeNib Python, 41.6 MB | logical FactBatch | 0.6271s | 0.6772s | -8.0% | keep experimental |
+| Ruff Rust, 130.5 MB | graph-compatible | 1.9756s | 2.0352s | -3.0% | keep experimental |
+| Ruff Rust, 130.5 MB | logical FactBatch | 3.2654s | 3.2031s | +1.9% | below gate |
+
+All four parity gates passed. Cyclic garbage collection was disabled inside
+timed regions and collected before each arm; each generated JSON retains every
+raw sample and the alternating arm order. The CodeNib report used 11 iterations
+after two warmups; Ruff used seven after two warmups. Their index SHA-256 values
+were `96e2c407c421d7eb72b2fd834c812c6b688b3634973f2fcdc865cb78bfe87227`
+and `ab55627fb2f379bff19b3fe8123cb94b4d019732711b16c0ddaf5179898c8778`.
+Adding unchanged external SCIP generation time can only dilute the sole 1.9%
+local improvement, so neither cold-start gate can reach 20%. Keep
+`CODENIB_CORE_FACT_BUFFER` at its default `off`; use `auto` for compatible
+fallback experiments and `required` for fail-closed ABI/parity gates. Reproduce
+the report with `make fact-buffer-profile` and add
+`FACT_BUFFER_PROFILE_EXTRA_ARGS='--include-semantic-consumer'` for logical
+facts. FactQuery indexing (#561) and clangd parsing (#555) remain separate
+promotion and review decisions.
 
 ### Phase 6: Multi-Graph Python Surface
 

--- a/scripts/profiling/profile_fact_batch_buffer.py
+++ b/scripts/profiling/profile_fact_batch_buffer.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark legacy pybind objects against FactBatchBuffer v1.
+
+The benchmark deliberately alternates arm order. It reports native SCIP decode
+stages, FactBatch encoding, boundary-copy residual, Python validation, and
+igraph materialization separately, then applies an explicit end-to-end
+promotion threshold. An optional external-index duration folds the unchanged
+SCIP tool cost into the same Amdahl-style decision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import math
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CORE_BUILD = _PROJECT_ROOT / "build/core"
+for candidate in (_CORE_BUILD, _PROJECT_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+DEFAULT_THRESHOLD = 0.20
+DEFAULT_ITERATIONS = 5
+DEFAULT_WARMUPS = 1
+REPORT_SCHEMA_VERSION = 1
+
+
+def summarize_samples(values: Sequence[float]) -> dict[str, float | int]:
+    """Return stable distribution fields for a non-empty timing sample."""
+
+    if not values:
+        raise ValueError("at least one timing sample is required")
+    ordered = sorted(float(value) for value in values)
+    if any(not math.isfinite(value) or value < 0 for value in ordered):
+        raise ValueError("timing samples must be finite and non-negative")
+    p95_index = max(0, min(len(ordered) - 1, int(0.95 * len(ordered) - 1e-12)))
+    return {
+        "samples": len(ordered),
+        "min_seconds": ordered[0],
+        "median_seconds": statistics.median(ordered),
+        "p95_seconds": ordered[p95_index],
+        "max_seconds": ordered[-1],
+    }
+
+
+def acceleration_decision(
+    *,
+    legacy_local_seconds: float,
+    candidate_local_seconds: float,
+    threshold: float = DEFAULT_THRESHOLD,
+    external_index_seconds: float | None = None,
+    parity: bool = True,
+    candidate_name: str = "fact-buffer",
+) -> dict[str, Any]:
+    """Apply the promotion gate to local and optional cold-start timings."""
+
+    if not math.isfinite(threshold) or not 0 < threshold < 1:
+        raise ValueError("threshold must be between 0 and 1")
+    for name, value in (
+        ("legacy_local_seconds", legacy_local_seconds),
+        ("candidate_local_seconds", candidate_local_seconds),
+    ):
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError(f"{name} must be finite and positive")
+    if external_index_seconds is not None and (
+        not math.isfinite(external_index_seconds) or external_index_seconds < 0
+    ):
+        raise ValueError("external_index_seconds must be finite and non-negative")
+    if not candidate_name or not candidate_name.strip():
+        raise ValueError("candidate_name must be non-empty")
+
+    local_improvement = (
+        legacy_local_seconds - candidate_local_seconds
+    ) / legacy_local_seconds
+    result: dict[str, Any] = {
+        "threshold": threshold,
+        "parity": parity,
+        "legacy_local_seconds": legacy_local_seconds,
+        "candidate_local_seconds": candidate_local_seconds,
+        "local_improvement_fraction": local_improvement,
+    }
+    gate_improvement = local_improvement
+    gate_name = "local_decode_end_to_end"
+    if external_index_seconds is not None:
+        legacy_cold = external_index_seconds + legacy_local_seconds
+        candidate_cold = external_index_seconds + candidate_local_seconds
+        cold_improvement = (legacy_cold - candidate_cold) / legacy_cold
+        result.update(
+            {
+                "external_index_seconds": external_index_seconds,
+                "legacy_cold_start_seconds": legacy_cold,
+                "candidate_cold_start_seconds": candidate_cold,
+                "cold_start_improvement_fraction": cold_improvement,
+            }
+        )
+        gate_improvement = cold_improvement
+        gate_name = "cold_start_end_to_end"
+    promoted = parity and gate_improvement >= threshold
+    result.update(
+        {
+            "gate": gate_name,
+            "gate_improvement_fraction": gate_improvement,
+            "promoted": promoted,
+            "recommendation": (
+                f"promote-{candidate_name}" if promoted else "keep-experimental"
+            ),
+            "reason": (
+                "semantic parity and end-to-end threshold passed"
+                if promoted
+                else (
+                    "semantic parity failed"
+                    if not parity
+                    else "end-to-end improvement is below threshold"
+                )
+            ),
+        }
+    )
+    return result
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _timed(call: Callable[[], Any]) -> tuple[Any, float]:
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    started = time.perf_counter()
+    try:
+        result = call()
+        elapsed = time.perf_counter() - started
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+        else:
+            gc.disable()
+    return result, elapsed
+
+
+def _run_arm(call: Callable[[], Any]) -> Any:
+    """Collect cyclic garbage outside the timed region, then run one arm."""
+
+    gc.collect()
+    return call()
+
+
+def _assert_graph_parity(reference: Any, candidate: Any) -> None:
+    vertex_fields = (
+        "name",
+        "type",
+        "file",
+        "start_line",
+        "end_line",
+        "selection_line",
+        "unified_name",
+        "symbol_kind",
+        "has_definition",
+    )
+    edge_fields = ("type", "anchor_file", "anchor_line")
+    if reference.project_root != candidate.project_root:
+        raise AssertionError(
+            f"project root differs: {reference.project_root!r} != "
+            f"{candidate.project_root!r}"
+        )
+    if reference.graph.vcount() != candidate.graph.vcount():
+        raise AssertionError(
+            f"vertex count differs: {reference.graph.vcount()} != "
+            f"{candidate.graph.vcount()}"
+        )
+    if reference.graph.ecount() != candidate.graph.ecount():
+        raise AssertionError(
+            f"edge count differs: {reference.graph.ecount()} != "
+            f"{candidate.graph.ecount()}"
+        )
+    for index, (left, right) in enumerate(
+        zip(reference.graph.vs, candidate.graph.vs, strict=True)
+    ):
+        left_row = tuple(left.attributes().get(name) for name in vertex_fields)
+        right_row = tuple(right.attributes().get(name) for name in vertex_fields)
+        if left_row != right_row:
+            raise AssertionError(
+                f"vertex {index} differs: {left_row!r} != {right_row!r}"
+            )
+    for index, (left, right) in enumerate(
+        zip(reference.graph.es, candidate.graph.es, strict=True)
+    ):
+        left_row = (
+            left.source,
+            left.target,
+            *(left.attributes().get(name) for name in edge_fields),
+        )
+        right_row = (
+            right.source,
+            right.target,
+            *(right.attributes().get(name) for name in edge_fields),
+        )
+        if left_row != right_row:
+            raise AssertionError(f"edge {index} differs: {left_row!r} != {right_row!r}")
+    if reference.name_to_vertex != candidate.name_to_vertex:
+        raise AssertionError("name_to_vertex indexes differ")
+    if reference.symbol_ranges != candidate.symbol_ranges:
+        raise AssertionError("symbol_ranges indexes differ")
+
+
+def _fact_file_paths(graph: Any) -> set[str]:
+    attributes = [vertex.attributes() for vertex in graph.graph.vs]
+    file_paths = {str(item["file"]) for item in attributes if item.get("file")}
+    file_paths.update(
+        str(item["name"]) for item in attributes if item.get("type") == "file"
+    )
+    file_paths.update(
+        str(edge.attributes()["anchor_file"])
+        for edge in graph.graph.es
+        if edge.attributes().get("anchor_file")
+    )
+    return file_paths
+
+
+def _append_sample(samples: dict[str, list[float]], name: str, value: float) -> None:
+    samples.setdefault(name, []).append(float(value))
+
+
+def profile_fact_batch_buffer(
+    *,
+    index_path: Path,
+    language: str,
+    project_root: Path | None = None,
+    iterations: int = DEFAULT_ITERATIONS,
+    warmups: int = DEFAULT_WARMUPS,
+    threshold: float = DEFAULT_THRESHOLD,
+    external_index_seconds: float | None = None,
+    include_semantic_consumer: bool = False,
+) -> dict[str, Any]:
+    """Run alternating legacy/buffer arms and return a JSON-ready report."""
+
+    if iterations < 1 or warmups < 0:
+        raise ValueError("iterations must be positive and warmups non-negative")
+    index_path = index_path.resolve()
+    if not index_path.is_file():
+        raise FileNotFoundError(index_path)
+    root = str(project_root.resolve()) if project_root is not None else None
+
+    import codenib_core
+
+    from codenib.scip_interface.fact_batch_buffer import (
+        FactBatchBufferView,
+        validate_compiled_contract,
+    )
+    from codenib.scip_interface.scip_decode_core import _build_code_graph
+
+    validate_compiled_contract(codenib_core.fact_batch_buffer_contract())
+    profile_digest = (
+        "sha256:"
+        + hashlib.sha256(f"fact-buffer-profile:{language}".encode("utf-8")).hexdigest()
+    )
+
+    def legacy_arm() -> tuple[Any, dict[str, float]]:
+        result, binding = _timed(
+            lambda: codenib_core.decode_scip(
+                index_file=str(index_path), project_root=root, language=language
+            )
+        )
+        graph, materialize = _timed(
+            lambda: _build_code_graph(
+                result["vertices"], result["edges"], project_root=root
+            )
+        )
+        return graph, {
+            "binding": binding,
+            "materialize": materialize,
+            "total": binding + materialize,
+        }
+
+    def buffer_arm() -> tuple[Any, dict[str, float], int]:
+        payload, binding = _timed(
+            lambda: codenib_core.decode_scip_fact_buffer(
+                index_file=str(index_path),
+                profile_digest=profile_digest,
+                project_root=root,
+                language=language,
+                copy_buffers=False,
+            )
+        )
+        view, validation = _timed(lambda: FactBatchBufferView(payload))
+
+        def materialize_graph():
+            graph = view.materialize_code_graph(project_root=root)
+            graph.project_root = root
+            return graph
+
+        graph, materialize = _timed(materialize_graph)
+        native_decode = (view.meta.native_decode_ns or 0) / 1_000_000_000
+        native_encode = (view.meta.native_encode_ns or 0) / 1_000_000_000
+        stage_values = {
+            name: value / 1_000_000_000
+            for name, value in (view.meta.decode_profile_ns or {}).items()
+            if name not in {"worker_count", "document_count"}
+        }
+        timings = {
+            "binding": binding,
+            "native_decode_outer": native_decode,
+            "native_encode": native_encode,
+            "boundary_transport_residual": max(
+                0.0, binding - native_decode - native_encode
+            ),
+            "validation": validation,
+            "materialize": materialize,
+            "total": binding + validation + materialize,
+            **{f"native_stage_{name}": value for name, value in stage_values.items()},
+        }
+        buffer_bytes = sum(
+            len(payload[name])
+            for name in (
+                "meta",
+                "batches",
+                "symbols",
+                "occurrences",
+                "edges",
+                "diagnostics",
+                "graph_vertices",
+                "graph_edges",
+                "arena",
+            )
+        )
+        return graph, timings, buffer_bytes
+
+    for _ in range(warmups):
+        _run_arm(legacy_arm)
+        _run_arm(buffer_arm)
+
+    legacy_samples: dict[str, list[float]] = {}
+    buffer_samples: dict[str, list[float]] = {}
+    parity = True
+    parity_error = None
+    buffer_sizes: list[int] = []
+    semantic_file_paths: set[str] = set()
+    for iteration in range(iterations):
+        if iteration % 2 == 0:
+            legacy_graph, legacy_timing = _run_arm(legacy_arm)
+            buffer_graph, buffer_timing, buffer_size = _run_arm(buffer_arm)
+        else:
+            buffer_graph, buffer_timing, buffer_size = _run_arm(buffer_arm)
+            legacy_graph, legacy_timing = _run_arm(legacy_arm)
+        if parity:
+            try:
+                _assert_graph_parity(legacy_graph, buffer_graph)
+            except AssertionError as exc:
+                parity = False
+                parity_error = str(exc)
+        for name, value in legacy_timing.items():
+            _append_sample(legacy_samples, name, value)
+        for name, value in buffer_timing.items():
+            _append_sample(buffer_samples, name, value)
+        buffer_sizes.append(buffer_size)
+        if include_semantic_consumer and not semantic_file_paths:
+            semantic_file_paths = _fact_file_paths(legacy_graph)
+        del legacy_graph, buffer_graph
+
+    legacy_summary = {
+        name: summarize_samples(values) for name, values in legacy_samples.items()
+    }
+    buffer_summary = {
+        name: summarize_samples(values) for name, values in buffer_samples.items()
+    }
+    decision = acceleration_decision(
+        legacy_local_seconds=legacy_summary["total"]["median_seconds"],
+        candidate_local_seconds=buffer_summary["total"]["median_seconds"],
+        threshold=threshold,
+        external_index_seconds=external_index_seconds,
+        parity=parity,
+    )
+    report = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "benchmark": "fact_batch_buffer_v1",
+        "subject": {
+            "index_path": str(index_path),
+            "index_bytes": index_path.stat().st_size,
+            "index_sha256": _sha256(index_path),
+            "language": language,
+            "project_root": root,
+        },
+        "configuration": {
+            "iterations": iterations,
+            "warmups": warmups,
+            "threshold": threshold,
+            "alternating_arm_order": True,
+            "copy_buffers": False,
+            "include_semantic_consumer": include_semantic_consumer,
+            "promotion_metric": "median_total_seconds",
+            "timer": "time.perf_counter",
+            "garbage_collection": "disabled-during-timing; collected-before-arms",
+            "first_arm_by_iteration": [
+                "legacy" if iteration % 2 == 0 else "fact_buffer"
+                for iteration in range(iterations)
+            ],
+            "fact_batch_buffer_contract": dict(
+                codenib_core.fact_batch_buffer_contract()
+            ),
+        },
+        "parity": {"passed": parity, "error": parity_error},
+        "raw_samples": {
+            "legacy": legacy_samples,
+            "fact_buffer": buffer_samples,
+        },
+        "legacy": legacy_summary,
+        "fact_buffer": {
+            **buffer_summary,
+            "wire_bytes": {
+                "min": min(buffer_sizes),
+                "median": statistics.median(buffer_sizes),
+                "max": max(buffer_sizes),
+            },
+        },
+        "decision": decision,
+    }
+
+    if include_semantic_consumer:
+        from codenib.facts import fact_batches_from_code_graph, sha256_digest
+
+        content_digests = {
+            path: sha256_digest(f"benchmark:{path}") for path in semantic_file_paths
+        }
+
+        def legacy_fact_arm() -> tuple[Any, dict[str, float]]:
+            graph, graph_timing = legacy_arm()
+            facts, adapt = _timed(
+                lambda: fact_batches_from_code_graph(
+                    graph,
+                    language=language,
+                    content_digests=content_digests,
+                    profile_digest=profile_digest,
+                    provider="scip-core",
+                )
+            )
+            return facts, {
+                "graph_ready": graph_timing["total"],
+                "fact_materialize": adapt,
+                "total": graph_timing["total"] + adapt,
+            }
+
+        def native_fact_arm() -> tuple[Any, dict[str, float]]:
+            payload, binding = _timed(
+                lambda: codenib_core.decode_scip_fact_buffer(
+                    index_file=str(index_path),
+                    profile_digest=profile_digest,
+                    project_root=root,
+                    language=language,
+                    content_digests=content_digests,
+                    include_graph_compat=False,
+                    copy_buffers=False,
+                )
+            )
+            view, validation = _timed(lambda: FactBatchBufferView(payload))
+            facts, materialize = _timed(
+                lambda: view.to_fact_batches(content_digests=content_digests)
+            )
+            native_decode = (view.meta.native_decode_ns or 0) / 1_000_000_000
+            native_encode = (view.meta.native_encode_ns or 0) / 1_000_000_000
+            return facts, {
+                "binding": binding,
+                "native_decode": native_decode,
+                "native_encode": native_encode,
+                "boundary_residual": max(0.0, binding - native_decode - native_encode),
+                "validation": validation,
+                "fact_materialize": materialize,
+                "total": binding + validation + materialize,
+            }
+
+        for _ in range(warmups):
+            _run_arm(legacy_fact_arm)
+            _run_arm(native_fact_arm)
+
+        legacy_fact_samples: dict[str, list[float]] = {}
+        native_fact_samples: dict[str, list[float]] = {}
+        semantic_parity = True
+        semantic_error = None
+        semantic_batch_count = 0
+        for iteration in range(iterations):
+            if iteration % 2 == 0:
+                legacy_facts, legacy_fact_timing = _run_arm(legacy_fact_arm)
+                native_facts, native_fact_timing = _run_arm(native_fact_arm)
+            else:
+                native_facts, native_fact_timing = _run_arm(native_fact_arm)
+                legacy_facts, legacy_fact_timing = _run_arm(legacy_fact_arm)
+            if semantic_parity and native_facts != legacy_facts:
+                semantic_parity = False
+                semantic_error = "logical FactBatch tuples differ"
+            semantic_batch_count = len(legacy_facts)
+            for name, value in legacy_fact_timing.items():
+                _append_sample(legacy_fact_samples, name, value)
+            for name, value in native_fact_timing.items():
+                _append_sample(native_fact_samples, name, value)
+            del legacy_facts, native_facts
+
+        legacy_fact_summary = {
+            name: summarize_samples(values)
+            for name, values in legacy_fact_samples.items()
+        }
+        native_fact_summary = {
+            name: summarize_samples(values)
+            for name, values in native_fact_samples.items()
+        }
+        semantic_decision = acceleration_decision(
+            legacy_local_seconds=legacy_fact_summary["total"]["median_seconds"],
+            candidate_local_seconds=native_fact_summary["total"]["median_seconds"],
+            threshold=threshold,
+            external_index_seconds=external_index_seconds,
+            parity=semantic_parity,
+            candidate_name="native-fact-batches",
+        )
+        report["semantic_fact_consumer"] = {
+            "content_digest_source": "synthetic-path-digests-for-timing",
+            "batch_count": semantic_batch_count,
+            "parity": {"passed": semantic_parity, "error": semantic_error},
+            "raw_samples": {
+                "legacy_graph_adapter": legacy_fact_samples,
+                "native_fact_buffer": native_fact_samples,
+            },
+            "legacy_graph_adapter": legacy_fact_summary,
+            "native_fact_buffer": native_fact_summary,
+            "decision": semantic_decision,
+        }
+
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--index", type=Path, required=True)
+    parser.add_argument("--language", required=True)
+    parser.add_argument("--project-root", type=Path)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    parser.add_argument("--external-index-seconds", type=float)
+    parser.add_argument("--include-semantic-consumer", action="store_true")
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = profile_fact_batch_buffer(
+        index_path=args.index,
+        language=args.language,
+        project_root=args.project_root,
+        iterations=args.iterations,
+        warmups=args.warmups,
+        threshold=args.threshold,
+        external_index_seconds=args.external_index_seconds,
+        include_semantic_consumer=args.include_semantic_consumer,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(rendered)
+    parity_passed = report["parity"]["passed"]
+    semantic = report.get("semantic_fact_consumer")
+    if semantic is not None:
+        parity_passed = parity_passed and semantic["parity"]["passed"]
+    return 0 if parity_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scip/test_fact_batch_buffer.py
+++ b/test/scip/test_fact_batch_buffer.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Native FactBatchBuffer ABI, parity, and ownership tests."""
+"""Native FactBatchBuffer ABI, parity, ownership, and fallback tests."""
 
 from __future__ import annotations
 
@@ -27,7 +27,13 @@ from codenib.scip_interface.fact_batch_buffer import (  # noqa: E402
     FactBatchBufferView,
     validate_compiled_contract,
 )
-from codenib.scip_interface.scip_decode_core import _build_code_graph  # noqa: E402
+from codenib.scip_interface.scip_decode_core import (  # noqa: E402
+    SCIPDecoderCore,
+    _build_code_graph,
+)
+from scripts.profiling.profile_fact_batch_buffer import (  # noqa: E402
+    profile_fact_batch_buffer,
+)
 
 _FIXTURE = (
     Path(__file__).resolve().parent / "fixtures/typescript_schema_v5/index.decoded"
@@ -41,7 +47,9 @@ def _legacy_graph():
         project_root=None,
         language="typescript",
     )
-    return _build_code_graph(result["vertices"], result["edges"])
+    return _build_code_graph(
+        result["vertices"], result["edges"], project_root=result["project_root"]
+    )
 
 
 def _content_digests(graph) -> dict[str, str]:
@@ -116,6 +124,7 @@ def test_compiled_contract_and_graph_projection_are_exact() -> None:
     assert _edge_rows(actual) == _edge_rows(expected)
     assert actual.name_to_vertex == expected.name_to_vertex
     assert actual.symbol_ranges == expected.symbol_ranges
+    assert actual.project_root == expected.project_root
 
 
 def test_compiled_contract_rejects_boolean_version() -> None:
@@ -188,6 +197,29 @@ def test_writable_buffers_are_rejected_before_validation() -> None:
 
     with pytest.raises(FactBatchBufferError, match="arena must be read-only"):
         FactBatchBufferView(payload)
+
+
+def test_fact_buffer_profiler_can_gate_logical_fact_consumer() -> None:
+    report = profile_fact_batch_buffer(
+        index_path=_FIXTURE,
+        language="typescript",
+        iterations=1,
+        warmups=0,
+        include_semantic_consumer=True,
+    )
+
+    semantic = report["semantic_fact_consumer"]
+    assert report["schema_version"] == 1
+    assert report["configuration"]["copy_buffers"] is False
+    assert report["configuration"]["fact_batch_buffer_contract"] == (
+        codenib_core.fact_batch_buffer_contract()
+    )
+    assert report["configuration"]["first_arm_by_iteration"] == ["legacy"]
+    assert len(report["raw_samples"]["legacy"]["total"]) == 1
+    assert len(semantic["raw_samples"]["native_fact_buffer"]["total"]) == 1
+    assert semantic["parity"] == {"passed": True, "error": None}
+    assert semantic["batch_count"] > 0
+    assert semantic["native_fact_buffer"]["fact_materialize"]["samples"] == 1
 
 
 def test_missing_content_digest_blocks_logical_fact_materialization() -> None:
@@ -281,3 +313,73 @@ def test_graph_corruption_is_rejected_before_a_graph_is_returned(
     view = FactBatchBufferView(payload)
     with pytest.raises(FactBatchBufferError, match=message):
         view.materialize_code_graph()
+
+
+def test_decoder_kill_switch_preserves_legacy_compatibility(monkeypatch) -> None:
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "auto")
+    native = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+    native_graph = native.decode()
+    assert native.transport_backend == "fact-buffer-v1"
+    assert native.fact_buffer_view is not None
+
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "off")
+    legacy = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+    legacy_graph = legacy.decode()
+    assert legacy.transport_backend == "legacy-disabled"
+    assert legacy.fact_buffer_view is None
+    assert _vertex_rows(native_graph) == _vertex_rows(legacy_graph)
+    assert _edge_rows(native_graph) == _edge_rows(legacy_graph)
+    assert native_graph.project_root == legacy_graph.project_root
+
+
+def test_decoder_defaults_to_legacy_until_promotion_gate_passes(monkeypatch) -> None:
+    monkeypatch.delenv("CODENIB_CORE_FACT_BUFFER", raising=False)
+
+    decoder = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+    graph = decoder.decode()
+
+    assert graph.graph.vcount() > 0
+    assert decoder.transport_backend == "legacy-disabled"
+    assert decoder.fact_buffer_view is None
+    assert decoder.timings["fact_buffer_enabled"] == 0
+
+
+def test_decoder_auto_falls_back_but_required_mode_fails(monkeypatch) -> None:
+    def fail_buffer(**_kwargs):
+        raise RuntimeError("injected native buffer failure")
+
+    monkeypatch.setattr(codenib_core, "decode_scip_fact_buffer", fail_buffer)
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "auto")
+    decoder = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+    fallback_graph = decoder.decode()
+    assert fallback_graph.graph.vcount() > 0
+    assert decoder.transport_backend == "legacy-fallback"
+    assert "injected native buffer failure" in decoder.transport_fallback_error
+
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "off")
+    legacy_graph = SCIPDecoderCore(str(_FIXTURE), language="typescript").decode()
+    assert _vertex_rows(fallback_graph) == _vertex_rows(legacy_graph)
+    assert _edge_rows(fallback_graph) == _edge_rows(legacy_graph)
+    assert fallback_graph.project_root == legacy_graph.project_root
+
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "required")
+    with pytest.raises(RuntimeError, match="injected native buffer failure"):
+        SCIPDecoderCore(str(_FIXTURE), language="typescript").decode()
+
+
+def test_decoder_rejects_unknown_transport_mode(monkeypatch) -> None:
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "sometimes")
+
+    with pytest.raises(ValueError, match="CODENIB_CORE_FACT_BUFFER must be"):
+        SCIPDecoderCore(str(_FIXTURE), language="typescript").decode()
+
+
+def test_decoder_auto_does_not_mask_memory_exhaustion(monkeypatch) -> None:
+    def exhaust_memory(**_kwargs):
+        raise MemoryError("injected allocation failure")
+
+    monkeypatch.setattr(codenib_core, "decode_scip_fact_buffer", exhaust_memory)
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "auto")
+
+    with pytest.raises(MemoryError, match="injected allocation failure"):
+        SCIPDecoderCore(str(_FIXTURE), language="typescript").decode()

--- a/test/scripts/test_profile_fact_batch_buffer.py
+++ b/test/scripts/test_profile_fact_batch_buffer.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the FactBatchBuffer promotion gate."""
+
+from __future__ import annotations
+
+import gc
+
+import pytest
+
+from scripts.profiling.profile_fact_batch_buffer import (
+    _timed,
+    acceleration_decision,
+    summarize_samples,
+)
+
+
+def test_summarize_samples_reports_nearest_rank_p95():
+    summary = summarize_samples([4.0, 1.0, 3.0, 2.0])
+
+    assert summary == {
+        "samples": 4,
+        "min_seconds": 1.0,
+        "median_seconds": 2.5,
+        "p95_seconds": 4.0,
+        "max_seconds": 4.0,
+    }
+
+
+def test_timed_disables_and_restores_cyclic_gc_on_failure():
+    was_enabled = gc.isenabled()
+    gc.enable()
+
+    def fail():
+        assert gc.isenabled() is False
+        raise RuntimeError("stop")
+
+    try:
+        with pytest.raises(RuntimeError, match="stop"):
+            _timed(fail)
+        assert gc.isenabled() is True
+    finally:
+        if not was_enabled:
+            gc.disable()
+
+
+def test_timed_preserves_an_already_disabled_gc_state():
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        observed, elapsed = _timed(gc.isenabled)
+        assert observed is False
+        assert elapsed >= 0
+        assert gc.isenabled() is False
+    finally:
+        if was_enabled:
+            gc.enable()
+
+
+@pytest.mark.parametrize("values", [[], [1.0, -0.1], [float("nan")], [float("inf")]])
+def test_summarize_samples_rejects_invalid_values(values):
+    with pytest.raises(ValueError):
+        summarize_samples(values)
+
+
+def test_acceleration_decision_promotes_local_path_at_threshold():
+    decision = acceleration_decision(
+        legacy_local_seconds=1.0,
+        candidate_local_seconds=0.75,
+        threshold=0.20,
+    )
+
+    assert decision["gate"] == "local_decode_end_to_end"
+    assert decision["gate_improvement_fraction"] == pytest.approx(0.25)
+    assert decision["promoted"] is True
+    assert decision["recommendation"] == "promote-fact-buffer"
+
+
+def test_acceleration_decision_applies_cold_start_amdahl_gate():
+    decision = acceleration_decision(
+        legacy_local_seconds=1.0,
+        candidate_local_seconds=0.5,
+        external_index_seconds=9.0,
+        threshold=0.20,
+    )
+
+    assert decision["local_improvement_fraction"] == pytest.approx(0.5)
+    assert decision["cold_start_improvement_fraction"] == pytest.approx(0.05)
+    assert decision["gate"] == "cold_start_end_to_end"
+    assert decision["promoted"] is False
+    assert decision["recommendation"] == "keep-experimental"
+
+
+def test_acceleration_decision_requires_semantic_parity():
+    decision = acceleration_decision(
+        legacy_local_seconds=1.0,
+        candidate_local_seconds=0.5,
+        parity=False,
+    )
+
+    assert decision["promoted"] is False
+    assert decision["reason"] == "semantic parity failed"
+
+
+def test_acceleration_decision_names_promoted_candidate():
+    decision = acceleration_decision(
+        legacy_local_seconds=1.0,
+        candidate_local_seconds=0.5,
+        candidate_name="native-fact-batches",
+    )
+
+    assert decision["recommendation"] == "promote-native-fact-batches"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"legacy_local_seconds": 0.0, "candidate_local_seconds": 1.0}, "positive"),
+        ({"legacy_local_seconds": 1.0, "candidate_local_seconds": 0.0}, "positive"),
+        (
+            {
+                "legacy_local_seconds": 1.0,
+                "candidate_local_seconds": 0.5,
+                "threshold": 1.0,
+            },
+            "threshold",
+        ),
+        (
+            {
+                "legacy_local_seconds": 1.0,
+                "candidate_local_seconds": 0.5,
+                "external_index_seconds": -1.0,
+            },
+            "non-negative",
+        ),
+        (
+            {
+                "legacy_local_seconds": float("nan"),
+                "candidate_local_seconds": 0.5,
+            },
+            "finite and positive",
+        ),
+        (
+            {
+                "legacy_local_seconds": 1.0,
+                "candidate_local_seconds": 0.5,
+                "external_index_seconds": float("inf"),
+            },
+            "finite and non-negative",
+        ),
+    ],
+)
+def test_acceleration_decision_rejects_invalid_inputs(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        acceleration_decision(**kwargs)


### PR DESCRIPTION
## Summary

Gate the FactBatchBuffer v1 runtime promotion tracked by #565 after the transport dependency in #564/#567. The established decoder remains the default because representative graph and eager logical-fact consumers do not meet the 20 percent end-to-end threshold.

## Changes

- Add off, auto fallback, and fail-closed required transport modes while preserving the default legacy route.
- Use ownership-safe read-only zero-copy native buffers for the candidate route.
- Preserve graph, project-root, range, anchor, and TypeScript enrichment parity across candidate and fallback paths.
- Add an alternating-arm profiler that separates native decode, encoding, boundary, validation, and materialization costs.
- Stabilize timing by collecting cyclic garbage before arms and disabling it inside timed regions; retain raw samples and arm order in schema-versioned JSON.
- Record the negative promotion decision and reproduction commands in core docs and the SCIP roadmap.

Measured median end-to-end results with all parity gates passing:

| Subject | Consumer | Legacy | Candidate | Improvement |
| --- | --- | ---: | ---: | ---: |
| CodeNib Python, 41.6 MB | graph | 0.3775s | 0.3937s | -4.3% |
| CodeNib Python, 41.6 MB | logical facts | 0.6271s | 0.6772s | -8.0% |
| Ruff Rust, 130.5 MB | graph | 1.9756s | 2.0352s | -3.0% |
| Ruff Rust, 130.5 MB | logical facts | 3.2654s | 3.2031s | +1.9% |

Closes #565
Part of #560

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- make core-test: 58 passed, 4 skipped, plus three native C++ executables.
- Unit tier with the two documented environment-baseline deselections: 3885 passed, 8 skipped, 200 deselected.
- make fact-buffer-profile smoke with graph and semantic parity.
- 11-iteration CodeNib and 7-iteration Ruff promotion runs after two warmups.
- pre-commit on all changed files.
- python -m mkdocs build --strict.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published