### PR TITLE
perf(core): add graph-free FactQueryIndex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ endef
 .PHONY: active-scip-tools active-lsp-tools active-scip-env active-system-deps-ubuntu
 .PHONY: go-tool scip-go-tool rust-tool scip-python-tool scip-typescript-tool scip-clang-tool
 .PHONY: node-workspace-tools zoekt-tool python-lsp-tool ty-tool typescript-lsp-tool gopls-tool clangd-tool
-.PHONY: core-system-deps-ubuntu core-python-deps core-build core-test fact-buffer-profile
+.PHONY: core-system-deps-ubuntu core-python-deps core-build core-test fact-buffer-profile fact-query-profile
 .PHONY: scip-cold-start-tools scip-cold-start-tools-all scip-cold-start-env scip-cold-start-system-deps-ubuntu
 .PHONY: scip-candidates scip-candidates-all scip-candidate-env scip-candidate-system-deps-ubuntu
 .PHONY: scip-jvm-compat-system-deps-ubuntu
@@ -412,13 +412,16 @@ core-test: core-build
 	./build/core/scip_decode_test
 	./build/core/graph_layers_test
 	./build/core/fact_batch_buffer_test
+	./build/core/fact_query_index_test
 	PYTHONPATH="build/core:$$PYTHONPATH" python -m pytest -q \
 		test/scip/test_scip_core.py \
 		test/scip/test_scip_core_registry.py \
 		test/scip/test_fact_batch_buffer.py \
+		test/scip/test_fact_query_index.py \
 		test/facts/test_model.py \
 		test/facts/test_adapters.py \
-		test/scripts/test_profile_fact_batch_buffer.py
+		test/scripts/test_profile_fact_batch_buffer.py \
+		test/scripts/test_profile_fact_query_index.py
 
 fact-buffer-profile: core-build
 	@test -n "$(FACT_BUFFER_PROFILE_INDEX)" || { echo "Set FACT_BUFFER_PROFILE_INDEX=/path/to/index.decoded" >&2; exit 1; }
@@ -429,6 +432,16 @@ fact-buffer-profile: core-build
 		$(if $(FACT_BUFFER_PROFILE_PROJECT_ROOT),--project-root "$(FACT_BUFFER_PROFILE_PROJECT_ROOT)",) \
 		$(if $(FACT_BUFFER_PROFILE_OUTPUT),--output-json "$(FACT_BUFFER_PROFILE_OUTPUT)",) \
 		$(FACT_BUFFER_PROFILE_EXTRA_ARGS)
+
+fact-query-profile: core-build
+	@test -n "$(FACT_QUERY_PROFILE_INDEX)" || { echo "Set FACT_QUERY_PROFILE_INDEX=/path/to/index.decoded" >&2; exit 1; }
+	@test -n "$(FACT_QUERY_PROFILE_LANGUAGE)" || { echo "Set FACT_QUERY_PROFILE_LANGUAGE=<language>" >&2; exit 1; }
+	PYTHONPATH="build/core:$$PYTHONPATH" python scripts/profiling/profile_fact_query_index.py \
+		--index "$(FACT_QUERY_PROFILE_INDEX)" \
+		--language "$(FACT_QUERY_PROFILE_LANGUAGE)" \
+		$(if $(FACT_QUERY_PROFILE_PROJECT_ROOT),--project-root "$(FACT_QUERY_PROFILE_PROJECT_ROOT)",) \
+		$(if $(FACT_QUERY_PROFILE_OUTPUT),--output-json "$(FACT_QUERY_PROFILE_OUTPUT)",) \
+		$(FACT_QUERY_PROFILE_EXTRA_ARGS)
 
 scip-cold-start-tools: scip-java-tool gradle-tool sbt-tool scip-dotnet-tool scip-ruby-tool scip-php-info
 	@$(MAKE) --no-print-directory scip-cold-start-env

--- a/codenib/agent/lsp_graph.py
+++ b/codenib/agent/lsp_graph.py
@@ -214,10 +214,16 @@ def _unified_index(graph: Any) -> dict[str, list[str]]:
 
 def resolve_symbol_candidates(graph: Any, symbol: str, limit: int = 8) -> list[str]:
     """Return canonical node names that match a user-facing symbol seed."""
-    names = getattr(graph, "name_to_vertex", {}) or {}
     seed = (symbol or "").strip().strip("`'\"")
     if not seed:
         return []
+    direct_resolver = getattr(graph, "resolve_symbol_candidates", None)
+    if callable(direct_resolver):
+        return _dedupe_names(
+            (str(name) for name in direct_resolver(seed, limit)), limit
+        )
+
+    names = getattr(graph, "name_to_vertex", {}) or {}
     if seed in names:
         return [seed]
 
@@ -416,6 +422,9 @@ def lsp_definition(
     limit = max(1, int(top_k or 8))
     if symbol:
         return _definitions_for_symbol(graph, symbol, limit)
+    capabilities = getattr(graph, "capabilities", None)
+    if isinstance(capabilities, dict) and capabilities.get("position_queries") is False:
+        raise ValueError("query index does not support position queries")
     if not file_path or line is None:
         raise ValueError("lsp_definition requires either symbol or file_path + line")
     if not hasattr(graph, "query_range"):
@@ -594,21 +603,31 @@ def lsp_references(
                 )
             )
 
-        vid = getattr(graph, "name_to_vertex", {}).get(name)
-        if vid is None or not hasattr(graph, "graph"):
-            continue
-        for eid in graph.graph.incident(vid, mode="in"):
-            edge = graph.graph.es[eid]
-            attrs = edge.attributes()
-            if attrs.get("type") != EDGE_TYPE_REFERENCE:
+        direct_references = getattr(graph, "iter_incoming_references", None)
+        if callable(direct_references):
+            references = direct_references(name)
+        else:
+            vid = getattr(graph, "name_to_vertex", {}).get(name)
+            if vid is None or not hasattr(graph, "graph"):
                 continue
+            references = (
+                {
+                    "source_vid": edge.source,
+                    "file": edge.attributes().get("anchor_file"),
+                    "line": edge.attributes().get("anchor_line"),
+                }
+                for eid in graph.graph.incident(vid, mode="in")
+                if (edge := graph.graph.es[eid]).attributes().get("type")
+                == EDGE_TYPE_REFERENCE
+            )
+        for reference in references:
             nodes.append(
                 _compact_reference(
                     graph,
                     target_name=name,
-                    source_vid=edge.source,
-                    file_path=attrs.get("anchor_file"),
-                    line=attrs.get("anchor_line"),
+                    source_vid=reference.get("source_vid"),
+                    file_path=reference.get("file"),
+                    line=reference.get("line"),
                 )
             )
     return _dedupe_nodes(nodes, limit)
@@ -856,6 +875,10 @@ def lsp_route(
     neighborhood. This function intentionally avoids benchmark instance names or
     scorer-specific answer ordering.
     """
+    capabilities = getattr(graph, "capabilities", None)
+    if isinstance(capabilities, dict) and capabilities.get("route_queries") is False:
+        raise ValueError("query index does not support route queries")
+
     limit = max(1, int(top_k or 12))
     query_terms = _query_terms(query)
     candidates: list[dict[str, Any]] = []

--- a/codenib/scip_interface/scip_decode_core.py
+++ b/codenib/scip_interface/scip_decode_core.py
@@ -21,10 +21,10 @@ import hashlib
 import os
 import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from ..graph.code_graph import CodeGraph
-from ..languages import core_decoder_languages
+from ..languages import core_decoder_languages, normalize_language
 from ..log_utils import get_logger
 from .fact_batch_buffer import FactBatchBufferView, validate_compiled_contract
 
@@ -54,6 +54,20 @@ _FACT_BUFFER_ENV = "CODENIB_CORE_FACT_BUFFER"
 _FACT_BUFFER_OFF = frozenset({"0", "false", "no", "off", "disabled"})
 _FACT_BUFFER_ON = frozenset({"", "1", "true", "yes", "on", "auto"})
 _FACT_BUFFER_REQUIRED = frozenset({"required", "strict"})
+
+_FACT_QUERY_ENV = "CODENIB_NATIVE_FACT_QUERY_INDEX"
+_FACT_QUERY_OFF = frozenset({"0", "false", "no", "off", "disabled"})
+_FACT_QUERY_AUTO = frozenset({"", "1", "true", "yes", "on", "auto"})
+_FACT_QUERY_REQUIRED = frozenset({"required", "strict"})
+_FACT_QUERY_PROMOTED_LANGUAGES = frozenset({"python", "rust"})
+_FACT_QUERY_ABI_VERSION = 1
+_FACT_QUERY_FORMAT = "fact-query-index-v1"
+_FACT_QUERY_CAPABILITIES = {
+    "definition_by_symbol": True,
+    "references_by_symbol": True,
+    "position_queries": False,
+    "route_queries": False,
+}
 
 
 def _ensure_available() -> None:
@@ -164,6 +178,39 @@ def _fact_buffer_profile_digest(language: str) -> str:
     return f"sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
+def _fact_query_mode() -> str:
+    value = os.environ.get(_FACT_QUERY_ENV, "auto").strip().lower()
+    if value in _FACT_QUERY_OFF:
+        return "off"
+    if value in _FACT_QUERY_AUTO:
+        return "auto"
+    if value in _FACT_QUERY_REQUIRED:
+        return "required"
+    raise ValueError(
+        f"{_FACT_QUERY_ENV} must be auto, required, or 0/off; got {value!r}"
+    )
+
+
+def _validate_fact_query_contract(contract: Mapping[str, Any]) -> None:
+    abi_version = contract.get("abi_version")
+    if type(abi_version) is not int or abi_version != _FACT_QUERY_ABI_VERSION:
+        raise RuntimeError(
+            "compiled FactQueryIndex contract mismatch: "
+            f"expected ABI {_FACT_QUERY_ABI_VERSION}, got {abi_version!r}"
+        )
+    if contract.get("format") != _FACT_QUERY_FORMAT:
+        raise RuntimeError(
+            "compiled FactQueryIndex contract mismatch: "
+            f"expected format {_FACT_QUERY_FORMAT!r}"
+        )
+    if contract.get("requires_anchored_references") is not True:
+        raise RuntimeError(
+            "compiled FactQueryIndex must fail closed on unanchored references"
+        )
+    if contract.get("capabilities") != _FACT_QUERY_CAPABILITIES:
+        raise RuntimeError("compiled FactQueryIndex capabilities do not match v1")
+
+
 class SCIPDecoderCore:
     """Decoder facade that runs the C++ core/ pipeline and returns a CodeGraph.
 
@@ -192,6 +239,10 @@ class SCIPDecoderCore:
         self.fact_buffer_view: FactBatchBufferView | None = None
         self.transport_backend = "uninitialized"
         self.transport_fallback_error: str | None = None
+        self.query_index: Any | None = None
+        self.query_backend = "uninitialized"
+        self.query_fallback_error: str | None = None
+        self.query_timings: Dict[str, float | int] = {}
 
     def _decode_fact_buffer(self) -> tuple[CodeGraph, dict[str, float | int]]:
         if not hasattr(_cpp, "decode_scip_fact_buffer") or not hasattr(
@@ -261,6 +312,112 @@ class SCIPDecoderCore:
             "node_count": len(result["vertices"]),
             "edge_count": len(result["edges"]),
         }
+
+    def _decode_native_fact_query_index(
+        self,
+    ) -> tuple[Any, dict[str, float | int]]:
+        if not hasattr(_cpp, "decode_scip_fact_query_index") or not hasattr(
+            _cpp, "fact_query_index_contract"
+        ):
+            raise RuntimeError("compiled core does not expose FactQueryIndex v1")
+        _validate_fact_query_contract(_cpp.fact_query_index_contract())
+
+        started = time.perf_counter()
+        payload = _cpp.decode_scip_fact_query_index(
+            index_file=self.index_file_path,
+            project_root=self.project_root,
+            language=self.language,
+        )
+        binding_seconds = time.perf_counter() - started
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("native FactQueryIndex returned a non-mapping payload")
+        if payload.get("format") != _FACT_QUERY_FORMAT:
+            raise RuntimeError("native FactQueryIndex returned an unknown format")
+        if payload.get("graph_materialized") is not False:
+            raise RuntimeError(
+                "native FactQueryIndex unexpectedly materialized a graph"
+            )
+
+        index = payload.get("index")
+        if index is None or getattr(index, "fact_query_index", None) is not True:
+            raise RuntimeError("native FactQueryIndex payload is missing its index")
+        if getattr(index, "materializes_graph", None) is not False:
+            raise RuntimeError(
+                "native FactQueryIndex does not guarantee graph-free use"
+            )
+        if getattr(index, "capabilities", None) != _FACT_QUERY_CAPABILITIES:
+            raise RuntimeError("native FactQueryIndex capabilities do not match v1")
+
+        native_decode = int(payload.get("native_decode_ns") or 0) / 1_000_000_000
+        native_index = int(payload.get("native_index_ns") or 0) / 1_000_000_000
+        timings: dict[str, float | int] = {
+            "core_decode": binding_seconds,
+            "native_decode": native_decode,
+            "native_fact_query_index": native_index,
+            "boundary_transport_residual": max(
+                0.0, binding_seconds - native_decode - native_index
+            ),
+            "node_count": int(getattr(index, "record_count", 0)),
+            "edge_count": int(getattr(index, "edge_count", 0)),
+            "definition_symbol_count": int(getattr(index, "symbol_count", 0)),
+            "reference_count": int(getattr(index, "reference_count", 0)),
+        }
+        for name, nanoseconds in (payload.get("decode_profile_ns") or {}).items():
+            if name in {"worker_count", "document_count"}:
+                timings[f"native_{name}"] = int(nanoseconds)
+            else:
+                timings[f"native_{name}"] = int(nanoseconds) / 1_000_000_000
+        return index, timings
+
+    def decode_query_index(self) -> Any:
+        """Return a graph-free symbol index or a compatible CodeGraph fallback.
+
+        This capability-specific API never changes :meth:`decode`. ``auto``
+        selects native indexing only for benchmark-promoted languages;
+        ``required`` attempts it for every core language and fails closed.
+        """
+
+        total_started = time.perf_counter()
+        self.query_index = None
+        self.query_backend = "uninitialized"
+        self.query_fallback_error = None
+        self.query_timings = {}
+        mode = _fact_query_mode()
+        canonical_language = normalize_language(self.language) or self.language
+
+        if mode == "off" or (
+            mode == "auto" and canonical_language not in _FACT_QUERY_PROMOTED_LANGUAGES
+        ):
+            index = self.decode()
+            timings = dict(self.timings)
+            self.query_backend = (
+                "code-graph-disabled" if mode == "off" else "code-graph-not-promoted"
+            )
+        else:
+            try:
+                index, timings = self._decode_native_fact_query_index()
+                self.query_backend = "fact-query-index-v1"
+            except MemoryError:
+                raise
+            except Exception as exc:
+                if mode == "required":
+                    raise
+                self.query_fallback_error = f"{type(exc).__name__}: {exc}"
+                logger.warning(
+                    "FactQueryIndex unavailable; falling back to the complete "
+                    f"CodeGraph: {self.query_fallback_error}"
+                )
+                index = self.decode()
+                timings = dict(self.timings)
+                self.query_backend = "code-graph-fallback"
+
+        self.query_index = index
+        timings["fact_query_index_enabled"] = int(
+            self.query_backend == "fact-query-index-v1"
+        )
+        timings["query_total"] = time.perf_counter() - total_started
+        self.query_timings = timings
+        return index
 
     def _enrich_graph(self, graph: CodeGraph) -> None:
         if self.language not in {"ts", "typescript", "js", "javascript"}:

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -49,6 +49,7 @@ pkg_check_modules(RE2 REQUIRED re2)
 add_library(codenib_core STATIC
     code_graph.cpp
     fact_batch_buffer.cpp
+    fact_query_index.cpp
     graph_layers.cpp
     scip_decoder_registry.cpp
     scip_decode_common.cpp
@@ -93,6 +94,12 @@ add_executable(fact_batch_buffer_test
 
 target_link_libraries(fact_batch_buffer_test PRIVATE codenib_core)
 
+add_executable(fact_query_index_test
+    tests/fact_query_index_test.cpp
+)
+
+target_link_libraries(fact_query_index_test PRIVATE codenib_core)
+
 add_executable(scip_decode_repo
     tests/scip_decode_repo.cpp
 )
@@ -112,6 +119,9 @@ if(CODENIB_ENABLE_O3)
     endif()
     if(TARGET fact_batch_buffer_test)
         target_compile_options(fact_batch_buffer_test PRIVATE -O3)
+    endif()
+    if(TARGET fact_query_index_test)
+        target_compile_options(fact_query_index_test PRIVATE -O3)
     endif()
 endif()
 
@@ -188,5 +198,10 @@ if(CODENIB_ENABLE_DEBUG)
     if(TARGET fact_batch_buffer_test)
         target_compile_definitions(fact_batch_buffer_test PRIVATE CODENIB_DEBUG=1)
         target_compile_options(fact_batch_buffer_test PRIVATE ${_codenib_debug_flags})
+    endif()
+
+    if(TARGET fact_query_index_test)
+        target_compile_definitions(fact_query_index_test PRIVATE CODENIB_DEBUG=1)
+        target_compile_options(fact_query_index_test PRIVATE ${_codenib_debug_flags})
     endif()
 endif()

--- a/core/README.md
+++ b/core/README.md
@@ -90,6 +90,29 @@ make fact-buffer-profile \
   FACT_BUFFER_PROFILE_EXTRA_ARGS='--include-semantic-consumer'
 ```
 
+## FactQueryIndex v1
+
+`decode_scip_fact_query_index(...)` owns immutable `DecodedRecords` and builds
+integer symbol/reference postings without constructing `CodeGraph` or igraph.
+Its v1 capabilities are intentionally limited to canonical/display/bare symbol
+resolution, definition metadata, and anchored incoming references. Position
+and route queries report unsupported; a malformed endpoint, definition range,
+duplicate name, or unanchored reference rejects the whole candidate.
+
+The existing `SCIPDecoderCore.decode()` behavior does not change. Call
+`decode_query_index()` for this capability-specific route. Its
+`CODENIB_NATIVE_FACT_QUERY_INDEX=auto` default selects the native index only
+for Python and Rust, which passed the 20% query-ready gate; `off` always
+returns the complete graph and `required` attempts native indexing for any
+core language without fallback. Reproduce the gate with:
+
+```bash
+make fact-query-profile \
+  FACT_QUERY_PROFILE_INDEX=/path/to/index.decoded \
+  FACT_QUERY_PROFILE_LANGUAGE=python \
+  FACT_QUERY_PROFILE_OUTPUT=/tmp/fact-query-report.json
+```
+
 ## Use Through Python
 
 Application code should select the core decoder through `LSIndexer`, which

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -23,6 +23,7 @@
 // ecount worth of tuples/dicts.
 
 #include "fact_batch_buffer.h"
+#include "fact_query_index.h"
 #include "graph_layers.h"
 #include "scip_decode.h"
 
@@ -59,6 +60,24 @@ py::dict vertex_to_dict(const CodeGraph::VertexData &v) {
   d["has_definition"] =
       v.has_definition.has_value() ? py::cast(*v.has_definition) : py::none();
   return d;
+}
+
+py::dict fact_query_capabilities() {
+  py::dict result;
+  result["definition_by_symbol"] = true;
+  result["references_by_symbol"] = true;
+  result["position_queries"] = false;
+  result["route_queries"] = false;
+  return result;
+}
+
+py::dict
+reference_to_dict(const codenib::core::FactQueryIndex::Reference &reference) {
+  py::dict result;
+  result["source_vid"] = reference.source;
+  result["file"] = reference.anchor_file;
+  result["line"] = reference.anchor_line;
+  return result;
 }
 
 py::dict decode_scip(const std::string &index_file,
@@ -284,6 +303,52 @@ py::dict fact_batch_buffer_contract() {
   return result;
 }
 
+py::dict decode_scip_fact_query_index(const std::string &index_file,
+                                      std::optional<std::string> project_root,
+                                      const std::string &language) {
+  auto decoder =
+      codenib::core::make_scip_decoder(language, index_file, project_root);
+
+  using clock = std::chrono::steady_clock;
+  clock::time_point decode_started;
+  clock::time_point decode_finished;
+  clock::time_point index_finished;
+  codenib::core::SCIPDecodeProfile decode_profile;
+  std::shared_ptr<codenib::core::FactQueryIndex> index;
+  {
+    py::gil_scoped_release release;
+    decode_started = clock::now();
+    auto records = std::make_shared<codenib::core::SCIPDecodedRecords>(
+        decoder->decode_records());
+    decode_finished = clock::now();
+    decode_profile = decoder->last_profile();
+    index = std::make_shared<codenib::core::FactQueryIndex>(records);
+    index_finished = clock::now();
+  }
+
+  auto elapsed_ns = [](clock::time_point start, clock::time_point end) {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+        .count();
+  };
+  py::dict result;
+  result["format"] = codenib::core::FACT_QUERY_INDEX_FORMAT;
+  result["index"] = std::move(index);
+  result["native_decode_ns"] = elapsed_ns(decode_started, decode_finished);
+  result["native_index_ns"] = elapsed_ns(decode_finished, index_finished);
+  result["decode_profile_ns"] = decode_profile_to_dict(decode_profile);
+  result["graph_materialized"] = false;
+  return result;
+}
+
+py::dict fact_query_index_contract() {
+  py::dict result;
+  result["abi_version"] = codenib::core::FACT_QUERY_INDEX_ABI_VERSION;
+  result["format"] = codenib::core::FACT_QUERY_INDEX_FORMAT;
+  result["requires_anchored_references"] = true;
+  result["capabilities"] = fact_query_capabilities();
+  return result;
+}
+
 codenib::core::LayerBuckets
 classify_edge_layers_py(const std::vector<std::string> &edge_types) {
   py::gil_scoped_release release;
@@ -301,6 +366,67 @@ PYBIND11_MODULE(codenib_core, m) {
       .def("__len__", [](const FactBatchOwnedBuffer &buffer) {
         return buffer.bytes().size();
       });
+
+  py::class_<codenib::core::FactQueryIndex,
+             std::shared_ptr<codenib::core::FactQueryIndex>>(
+      m, "_NativeFactQueryIndex")
+      .def_property_readonly(
+          "fact_query_index",
+          [](const codenib::core::FactQueryIndex &) { return true; })
+      .def_property_readonly(
+          "materializes_graph",
+          [](const codenib::core::FactQueryIndex &) { return false; })
+      .def_property_readonly("capabilities",
+                             [](const codenib::core::FactQueryIndex &) {
+                               return fact_query_capabilities();
+                             })
+      .def_property_readonly("project_root",
+                             [](const codenib::core::FactQueryIndex &index) {
+                               return index.project_root().empty()
+                                          ? py::object(py::none())
+                                          : py::object(
+                                                py::cast(index.project_root()));
+                             })
+      .def_property_readonly("record_count",
+                             &codenib::core::FactQueryIndex::record_count)
+      .def_property_readonly("edge_count",
+                             &codenib::core::FactQueryIndex::edge_count)
+      .def_property_readonly("symbol_count",
+                             &codenib::core::FactQueryIndex::symbol_count)
+      .def_property_readonly("reference_count",
+                             &codenib::core::FactQueryIndex::reference_count)
+      .def("has_symbol", &codenib::core::FactQueryIndex::has_symbol)
+      .def("get_node_info_by_name",
+           [](const codenib::core::FactQueryIndex &index,
+              const std::string &name) -> py::object {
+             const auto vertex = index.get_node_info_by_name(name);
+             if (!vertex.has_value())
+               return py::none();
+             return vertex_to_dict(*vertex);
+           })
+      .def("get_node_info_by_id",
+           [](const codenib::core::FactQueryIndex &index,
+              CodeGraph::VertexId id) -> py::object {
+             const auto vertex = index.get_node_info_by_id(id);
+             if (!vertex.has_value())
+               return py::none();
+             return vertex_to_dict(*vertex);
+           })
+      .def("resolve_symbol_candidates",
+           &codenib::core::FactQueryIndex::resolve_symbol_candidates,
+           py::arg("symbol"), py::arg("limit") = 8)
+      .def(
+          "iter_incoming_references",
+          [](const codenib::core::FactQueryIndex &index,
+             const std::string &target_name) {
+            py::list result;
+            for (const auto &reference :
+                 index.incoming_references(target_name)) {
+              result.append(reference_to_dict(reference));
+            }
+            return result;
+          },
+          py::arg("target_name"));
 
   m.def("decode_scip", &decode_scip, py::arg("index_file"),
         py::arg("project_root") = std::optional<std::string>(std::nullopt),
@@ -351,6 +477,22 @@ buffer exporters instead of copying every table into Python bytes.
 
   m.def("fact_batch_buffer_contract", &fact_batch_buffer_contract,
         R"pbdoc(Return the compiled FactBatchBuffer ABI contract.)pbdoc");
+
+  m.def("decode_scip_fact_query_index", &decode_scip_fact_query_index,
+        py::arg("index_file"),
+        py::arg("project_root") = std::optional<std::string>(std::nullopt),
+        py::arg("language") = std::string("python"),
+        R"pbdoc(
+Decode a SCIP index into a graph-free FactQueryIndex v1.
+
+The returned index owns immutable decoded records and integer postings. It
+supports symbol-based definitions and anchored references only; position and
+route queries remain unavailable and no CodeGraph or igraph is materialized.
+)pbdoc");
+
+  m.def(
+      "fact_query_index_contract", &fact_query_index_contract,
+      R"pbdoc(Return the compiled FactQueryIndex ABI and capabilities.)pbdoc");
 
   m.def("canonical_scip_decoder_languages",
         &codenib::core::canonical_scip_decoder_languages,

--- a/core/fact_query_index.cpp
+++ b/core/fact_query_index.cpp
@@ -1,0 +1,354 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "fact_query_index.h"
+
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+
+namespace codenib::core {
+namespace {
+
+bool is_symbol_type(const std::string &type) {
+  return type == NODE_TYPE_SYMBOL || type == NODE_TYPE_CLASS ||
+         type == NODE_TYPE_FUNCTION || type == NODE_TYPE_METHOD ||
+         type == NODE_TYPE_FIELD;
+}
+
+bool has_definition(const CodeGraph::VertexData &vertex) {
+  if (vertex.has_definition.has_value())
+    return *vertex.has_definition;
+  return is_symbol_type(vertex.type) && vertex.file.has_value() &&
+         vertex.start_line.has_value() && vertex.end_line.has_value();
+}
+
+bool has_suffix(const std::string &value, const std::string &suffix) {
+  return value.size() >= suffix.size() &&
+         value.compare(value.size() - suffix.size(), suffix.size(), suffix) ==
+             0;
+}
+
+} // namespace
+
+FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records)
+    : records_(std::move(records)) {
+  if (!records_)
+    throw std::invalid_argument("FactQueryIndex records must not be null");
+
+  record_by_name_.reserve(records_->vertices.size());
+  definition_by_name_.reserve(records_->vertices.size());
+  aliases_.reserve(records_->vertices.size() * 2);
+  lsp_aliases_.reserve(records_->vertices.size() * 2);
+  alias_order_.reserve(records_->vertices.size() * 2);
+
+  auto add_alias = [&](const std::string &alias, CodeGraph::VertexId id) {
+    if (alias.empty())
+      return;
+    auto [entry, inserted] = aliases_.try_emplace(alias);
+    if (inserted)
+      alias_order_.push_back(alias);
+    entry->second.push_back(id);
+  };
+
+  for (std::size_t index = 0; index < records_->vertices.size(); ++index) {
+    const auto id = static_cast<CodeGraph::VertexId>(index);
+    const auto &vertex = records_->vertices[index];
+    if (vertex.name.empty())
+      throw std::invalid_argument(
+          "FactQueryIndex vertex name must not be empty");
+    if (!record_by_name_.emplace(vertex.name, id).second)
+      throw std::invalid_argument(
+          "FactQueryIndex requires globally unique vertex names");
+
+    if (has_definition(vertex)) {
+      if (!is_symbol_type(vertex.type) || !vertex.file.has_value() ||
+          vertex.file->empty() || !vertex.start_line.has_value() ||
+          !vertex.end_line.has_value() || *vertex.start_line < 0 ||
+          *vertex.end_line < *vertex.start_line ||
+          (vertex.selection_line.has_value() && *vertex.selection_line < 0)) {
+        throw std::invalid_argument(
+            "FactQueryIndex definition row has an invalid source range");
+      }
+      definition_by_name_.emplace(vertex.name, id);
+    }
+
+    if (vertex.unified_name.has_value() && !vertex.unified_name->empty()) {
+      add_alias(*vertex.unified_name, id);
+      add_alias(graph_bare_symbol(*vertex.unified_name), id);
+      lsp_aliases_[*vertex.unified_name].push_back(id);
+      lsp_aliases_[bare_symbol(*vertex.unified_name)].push_back(id);
+    }
+  }
+
+  incoming_reference_indexes_.reserve(definition_by_name_.size());
+  std::vector<std::vector<std::size_t>> reference_indexes_by_source(
+      records_->vertices.size());
+  for (std::size_t index = 0; index < records_->edges.size(); ++index) {
+    const auto &edge = records_->edges[index];
+    if (edge.source < 0 || edge.target < 0 ||
+        static_cast<std::size_t>(edge.source) >= records_->vertices.size() ||
+        static_cast<std::size_t>(edge.target) >= records_->vertices.size()) {
+      throw std::out_of_range("FactQueryIndex edge endpoint is out of range");
+    }
+    if (edge.type != EDGE_TYPE_REFERENCE)
+      continue;
+    if (!edge.anchor_file.has_value() || edge.anchor_file->empty() ||
+        !edge.anchor_line.has_value() || *edge.anchor_line < 0) {
+      throw std::invalid_argument(
+          "FactQueryIndex requires every reference to have a source anchor");
+    }
+    reference_indexes_by_source[static_cast<std::size_t>(edge.source)]
+        .push_back(index);
+    ++reference_count_;
+  }
+
+  // igraph's incoming iterator groups rows by source id and prepends edge ids
+  // within one source adjacency list. Build the same order in O(E), without
+  // constructing igraph or sorting every target posting independently.
+  for (const auto &source_postings : reference_indexes_by_source) {
+    for (auto posting = source_postings.rbegin();
+         posting != source_postings.rend(); ++posting) {
+      const auto target = records_->edges[*posting].target;
+      incoming_reference_indexes_[target].push_back(*posting);
+    }
+  }
+}
+
+bool FactQueryIndex::has_symbol(const std::string &name) const {
+  return record_by_name_.find(name) != record_by_name_.end();
+}
+
+std::optional<CodeGraph::VertexData>
+FactQueryIndex::get_node_info_by_name(const std::string &name) const {
+  const auto found = record_by_name_.find(name);
+  if (found == record_by_name_.end())
+    return std::nullopt;
+  return get_node_info_by_id(found->second);
+}
+
+std::optional<CodeGraph::VertexData>
+FactQueryIndex::get_node_info_by_id(CodeGraph::VertexId id) const {
+  if (id < 0 || static_cast<std::size_t>(id) >= records_->vertices.size())
+    return std::nullopt;
+  return records_->vertices[static_cast<std::size_t>(id)];
+}
+
+std::string FactQueryIndex::trim_symbol(std::string value) {
+  auto is_space = [](unsigned char character) {
+    return std::isspace(character) != 0;
+  };
+  value.erase(value.begin(),
+              std::find_if_not(value.begin(), value.end(), is_space));
+  value.erase(std::find_if_not(value.rbegin(), value.rend(), is_space).base(),
+              value.end());
+  auto is_quote = [](char character) {
+    return character == '`' || character == '\'' || character == '"';
+  };
+  while (!value.empty() && is_quote(value.front()))
+    value.erase(value.begin());
+  while (!value.empty() && is_quote(value.back()))
+    value.pop_back();
+  return value;
+}
+
+std::string FactQueryIndex::bare_symbol(const std::string &value) {
+  const auto start = value.find_last_of(":.#");
+  std::string result = value.substr(start == std::string::npos ? 0 : start + 1);
+  while (!result.empty() &&
+         (result.back() == '(' || result.back() == ')' ||
+          std::isspace(static_cast<unsigned char>(result.back())))) {
+    result.pop_back();
+  }
+  result.erase(result.begin(),
+               std::find_if_not(result.begin(), result.end(),
+                                [](unsigned char character) {
+                                  return std::isspace(character) != 0;
+                                }));
+  return result;
+}
+
+std::string FactQueryIndex::graph_bare_symbol(const std::string &value) {
+  const auto colon = value.find_last_of(':');
+  std::string result = value.substr(colon == std::string::npos ? 0 : colon + 1);
+  const auto dot = result.find_last_of('.');
+  if (dot != std::string::npos)
+    result.erase(0, dot + 1);
+  while (!result.empty() &&
+         (result.back() == '(' || result.back() == ')' ||
+          std::isspace(static_cast<unsigned char>(result.back())))) {
+    result.pop_back();
+  }
+  result.erase(result.begin(),
+               std::find_if_not(result.begin(), result.end(),
+                                [](unsigned char character) {
+                                  return std::isspace(character) != 0;
+                                }));
+  return result;
+}
+
+std::string FactQueryIndex::lowercase(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char character) {
+                   return static_cast<char>(std::tolower(character));
+                 });
+  return value;
+}
+
+void FactQueryIndex::append_candidate(std::vector<CodeGraph::VertexId> &output,
+                                      CodeGraph::VertexId id,
+                                      std::size_t limit) const {
+  if (output.size() >= limit ||
+      std::find(output.begin(), output.end(), id) != output.end()) {
+    return;
+  }
+  output.push_back(id);
+}
+
+std::vector<std::string>
+FactQueryIndex::resolve_symbol_candidates(const std::string &raw_symbol,
+                                          std::size_t limit) const {
+  if (limit == 0)
+    return {};
+  const std::string symbol = trim_symbol(raw_symbol);
+  if (symbol.empty())
+    return {};
+
+  std::vector<CodeGraph::VertexId> candidates;
+  const auto exact = record_by_name_.find(symbol);
+  if (exact != record_by_name_.end()) {
+    candidates.push_back(exact->second);
+  } else {
+    constexpr std::size_t graph_resolution_limit = 8;
+    const std::string graph_bare = graph_bare_symbol(symbol);
+    for (const auto &key : {symbol, symbol + "()", graph_bare}) {
+      const auto found = aliases_.find(key);
+      if (found == aliases_.end())
+        continue;
+      for (const auto id : found->second)
+        append_candidate(candidates, id, graph_resolution_limit);
+      if (!candidates.empty())
+        break;
+    }
+
+    if (candidates.empty() && !graph_bare.empty()) {
+      const std::string needle = lowercase(graph_bare);
+      for (const auto &alias : alias_order_) {
+        if (lowercase(alias).find(needle) == std::string::npos)
+          continue;
+        for (const auto id : aliases_.at(alias))
+          append_candidate(candidates, id, graph_resolution_limit);
+        if (candidates.size() >= graph_resolution_limit)
+          break;
+      }
+    }
+
+    if (candidates.empty()) {
+      const std::string suffix = "." + symbol;
+      std::string base = symbol;
+      if (const auto dot = base.find_last_of('.'); dot != std::string::npos)
+        base.erase(0, dot + 1);
+      if (const auto colon = base.find_last_of(':'); colon != std::string::npos)
+        base.erase(0, colon + 1);
+      for (std::size_t index = 0; index < records_->vertices.size(); ++index) {
+        const auto &name = records_->vertices[index].name;
+        std::string leaf = name;
+        if (const auto dot = leaf.find_last_of('.'); dot != std::string::npos)
+          leaf.erase(0, dot + 1);
+        if (has_suffix(name, suffix) || leaf == base)
+          append_candidate(candidates, static_cast<CodeGraph::VertexId>(index),
+                           graph_resolution_limit);
+        if (candidates.size() >= graph_resolution_limit)
+          break;
+      }
+    }
+
+    const bool graph_resolved = !candidates.empty();
+    if (candidates.empty()) {
+      const std::string bare = bare_symbol(symbol);
+      const std::string suffix = "." + symbol;
+      for (std::size_t index = 0; index < records_->vertices.size(); ++index) {
+        const auto &name = records_->vertices[index].name;
+        if (has_suffix(name, suffix) || bare_symbol(name) == bare)
+          append_candidate(candidates, static_cast<CodeGraph::VertexId>(index),
+                           limit);
+        if (candidates.size() >= limit)
+          break;
+      }
+      if (candidates.empty() && !bare.empty()) {
+        const std::string needle = lowercase(bare);
+        for (std::size_t index = 0; index < records_->vertices.size();
+             ++index) {
+          if (lowercase(records_->vertices[index].name).find(needle) !=
+              std::string::npos) {
+            append_candidate(candidates,
+                             static_cast<CodeGraph::VertexId>(index), limit);
+          }
+          if (candidates.size() >= limit)
+            break;
+        }
+      }
+    }
+
+    // CodeGraph.resolve_symbol returns display labels for ambiguous matches;
+    // lsp_graph maps each display back to every canonical name sharing it
+    // before applying the caller's final limit.
+    if (graph_resolved && candidates.size() > 1) {
+      std::vector<CodeGraph::VertexId> expanded;
+      for (const auto id : candidates) {
+        const auto &vertex = records_->vertices[static_cast<std::size_t>(id)];
+        const std::string &display = vertex.unified_name.has_value()
+                                         ? *vertex.unified_name
+                                         : vertex.name;
+        const auto canonical_display = record_by_name_.find(display);
+        if (canonical_display != record_by_name_.end()) {
+          append_candidate(expanded, canonical_display->second, limit);
+          continue;
+        }
+        for (const auto &key :
+             {display, display + "()", bare_symbol(display)}) {
+          const auto found = lsp_aliases_.find(key);
+          if (found == lsp_aliases_.end())
+            continue;
+          for (const auto candidate : found->second)
+            append_candidate(expanded, candidate, limit);
+        }
+        if (expanded.size() >= limit)
+          break;
+      }
+      candidates = std::move(expanded);
+    }
+  }
+
+  std::vector<std::string> result;
+  result.reserve(candidates.size());
+  for (const auto id : candidates)
+    result.push_back(records_->vertices[static_cast<std::size_t>(id)].name);
+  return result;
+}
+
+std::vector<FactQueryIndex::Reference>
+FactQueryIndex::incoming_references(const std::string &target_name) const {
+  const auto target = record_by_name_.find(target_name);
+  if (target == record_by_name_.end())
+    return {};
+  const auto postings = incoming_reference_indexes_.find(target->second);
+  if (postings == incoming_reference_indexes_.end())
+    return {};
+
+  std::vector<Reference> result;
+  result.reserve(postings->second.size());
+  for (const auto index : postings->second) {
+    const auto &edge = records_->edges[index];
+    result.push_back(
+        Reference{edge.source, *edge.anchor_file, *edge.anchor_line});
+  }
+  return result;
+}
+
+} // namespace codenib::core

--- a/core/fact_query_index.h
+++ b/core/fact_query_index.h
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "decoded_records.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace codenib::core {
+
+inline constexpr std::uint32_t FACT_QUERY_INDEX_ABI_VERSION = 1;
+inline constexpr char FACT_QUERY_INDEX_FORMAT[] = "fact-query-index-v1";
+
+// Graph-free read index for the symbol-based definition/reference subset of
+// the LSP-shaped API. The index owns one immutable DecodedRecords allocation
+// and stores only vertex ids and edge indexes as postings. Position and route
+// queries are deliberately outside the v1 capability contract.
+class FactQueryIndex {
+public:
+  struct Reference {
+    CodeGraph::VertexId source;
+    std::string anchor_file;
+    int anchor_line{0};
+  };
+
+  explicit FactQueryIndex(std::shared_ptr<const DecodedRecords> records);
+
+  bool has_symbol(const std::string &name) const;
+  std::optional<CodeGraph::VertexData>
+  get_node_info_by_name(const std::string &name) const;
+  std::optional<CodeGraph::VertexData>
+  get_node_info_by_id(CodeGraph::VertexId id) const;
+  std::vector<std::string>
+  resolve_symbol_candidates(const std::string &symbol,
+                            std::size_t limit = 8) const;
+  std::vector<Reference>
+  incoming_references(const std::string &target_name) const;
+
+  const std::string &project_root() const { return records_->project_root; }
+  std::size_t record_count() const { return records_->vertices.size(); }
+  std::size_t edge_count() const { return records_->edges.size(); }
+  std::size_t symbol_count() const { return definition_by_name_.size(); }
+  std::size_t reference_count() const { return reference_count_; }
+
+private:
+  static std::string trim_symbol(std::string value);
+  static std::string bare_symbol(const std::string &value);
+  static std::string graph_bare_symbol(const std::string &value);
+  static std::string lowercase(std::string value);
+  void append_candidate(std::vector<CodeGraph::VertexId> &output,
+                        CodeGraph::VertexId id, std::size_t limit) const;
+
+  std::shared_ptr<const DecodedRecords> records_;
+  std::unordered_map<std::string, CodeGraph::VertexId> record_by_name_;
+  std::unordered_map<std::string, CodeGraph::VertexId> definition_by_name_;
+  std::unordered_map<std::string, std::vector<CodeGraph::VertexId>> aliases_;
+  std::unordered_map<std::string, std::vector<CodeGraph::VertexId>>
+      lsp_aliases_;
+  std::vector<std::string> alias_order_;
+  std::unordered_map<CodeGraph::VertexId, std::vector<std::size_t>>
+      incoming_reference_indexes_;
+  std::size_t reference_count_{0};
+};
+
+} // namespace codenib::core

--- a/core/tests/fact_query_index_test.cpp
+++ b/core/tests/fact_query_index_test.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "fact_query_index.h"
+
+#include <cassert>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using codenib::core::CodeGraph;
+using codenib::core::DecodedRecords;
+using codenib::core::FactQueryIndex;
+
+namespace {
+
+CodeGraph::VertexData definition(const std::string &name,
+                                 const std::string &display, int line) {
+  CodeGraph::VertexData vertex;
+  vertex.name = name;
+  vertex.type = codenib::core::NODE_TYPE_FUNCTION;
+  vertex.file = "src/main.py";
+  vertex.start_line = line;
+  vertex.end_line = line + 2;
+  vertex.selection_line = line;
+  vertex.unified_name = display;
+  vertex.has_definition = true;
+  return vertex;
+}
+
+CodeGraph::VertexData reference_only(const std::string &name,
+                                     const std::string &display) {
+  CodeGraph::VertexData vertex;
+  vertex.name = name;
+  vertex.type = codenib::core::NODE_TYPE_SYMBOL;
+  vertex.file = "src/main.py";
+  vertex.unified_name = display;
+  vertex.has_definition = false;
+  return vertex;
+}
+
+std::shared_ptr<DecodedRecords> make_records() {
+  auto records = std::make_shared<DecodedRecords>();
+  records->project_root = "/workspace/project";
+  records->vertices = {
+      definition("canonical-target", "src/main.py:Widget.target()", 2),
+      definition("canonical-caller", "src/main.py:caller()", 8),
+      definition("canonical-run-one", "src/one.py:run()", 12),
+      definition("canonical-run-two", "src/two.py:run()", 20),
+      reference_only("external-target", "dependency.py:external()"),
+      definition("canonical-shared-one", "src/shared.py:shared()", 24),
+      definition("canonical-shared-two", "src/shared.py:shared()", 28),
+  };
+  records->edges = {
+      {1, 0, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 8},
+      {1, 0, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 10},
+      {1, 4, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 11},
+      {1, 0, codenib::core::EDGE_TYPE_CONTAIN, std::nullopt, std::nullopt},
+  };
+  return records;
+}
+
+void assert_symbol_resolution_and_postings() {
+  FactQueryIndex index(make_records());
+  assert(index.project_root() == "/workspace/project");
+  assert(index.record_count() == 7);
+  assert(index.edge_count() == 4);
+  assert(index.symbol_count() == 6);
+  assert(index.reference_count() == 3);
+  assert(index.has_symbol("canonical-target"));
+  assert(index.has_symbol("external-target"));
+  assert(!index.has_symbol("missing"));
+
+  assert((index.resolve_symbol_candidates("canonical-target") ==
+          std::vector<std::string>{"canonical-target"}));
+  assert((index.resolve_symbol_candidates("src/main.py:Widget.target()") ==
+          std::vector<std::string>{"canonical-target"}));
+  assert((index.resolve_symbol_candidates("target") ==
+          std::vector<std::string>{"canonical-target"}));
+  assert((index.resolve_symbol_candidates("`target`") ==
+          std::vector<std::string>{"canonical-target"}));
+  assert((index.resolve_symbol_candidates("run") ==
+          std::vector<std::string>{"canonical-run-one", "canonical-run-two"}));
+  assert((index.resolve_symbol_candidates("shared") ==
+          std::vector<std::string>{"canonical-shared-one",
+                                   "canonical-shared-two"}));
+  assert(index.resolve_symbol_candidates("run", 1).size() == 1);
+  assert(index.resolve_symbol_candidates("missing").empty());
+
+  const auto target = index.get_node_info_by_name("canonical-target");
+  assert(target.has_value());
+  assert(target->selection_line == 2);
+  assert(!index.get_node_info_by_name("missing").has_value());
+  assert(index.get_node_info_by_id(4)->has_definition == false);
+  assert(!index.get_node_info_by_id(99).has_value());
+
+  const auto references = index.incoming_references("canonical-target");
+  assert(references.size() == 2);
+  assert(references[0].source == 1);
+  assert(references[0].anchor_file == "src/main.py");
+  assert(references[0].anchor_line == 10);
+  assert(references[1].anchor_line == 8);
+  assert(index.incoming_references("missing").empty());
+}
+
+void assert_invalid_records_fail_closed() {
+  try {
+    (void)FactQueryIndex(nullptr);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+
+  auto duplicate = make_records();
+  duplicate->vertices.push_back(duplicate->vertices.front());
+  try {
+    (void)FactQueryIndex(duplicate);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+
+  auto invalid_endpoint = make_records();
+  invalid_endpoint->edges.push_back(
+      {99, 0, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", 1});
+  try {
+    (void)FactQueryIndex(invalid_endpoint);
+    assert(false);
+  } catch (const std::out_of_range &) {
+  }
+
+  auto unanchored = make_records();
+  unanchored->edges.push_back(
+      {1, 0, codenib::core::EDGE_TYPE_REFERENCE, std::nullopt, std::nullopt});
+  try {
+    (void)FactQueryIndex(unanchored);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+
+  auto invalid_definition = make_records();
+  invalid_definition->vertices[0].start_line = 8;
+  invalid_definition->vertices[0].end_line = 2;
+  try {
+    (void)FactQueryIndex(invalid_definition);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+}
+
+} // namespace
+
+int main() {
+  assert_symbol_resolution_and_postings();
+  assert_invalid_records_fail_closed();
+  std::cout << "fact_query_index_test: OK\n";
+  return 0;
+}

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -115,6 +115,36 @@ make fact-buffer-profile \
   FACT_BUFFER_PROFILE_EXTRA_ARGS='--iterations 7 --warmups 2 --include-semantic-consumer'
 ```
 
+## FactQueryIndex v1
+
+`SCIPDecoderCore.decode_query_index()` can stop at a graph-free native index
+for symbol definition and reference consumers. The index owns the decoded
+records and integer postings, resolves canonical, display, and bare names, and
+returns only fully anchored references. Its capability metadata explicitly
+marks position and route queries unavailable. Invalid endpoints, definition
+ranges, duplicate names, and unanchored references fail closed before any
+public result is returned.
+
+This API is separate from `decode()`, whose graph behavior is unchanged.
+`CODENIB_NATIVE_FACT_QUERY_INDEX=auto` selects native indexing only for Python
+and Rust; other languages receive the complete compatible graph. Use `off` to
+force that graph or `required` to attempt the native path without fallback.
+The promotion gate starts from an existing `index.decoded` artifact and
+measures both decode-to-query-ready startup and an identical symbol workload.
+Reproduce it with:
+
+```bash
+make fact-query-profile \
+  FACT_QUERY_PROFILE_INDEX=/path/to/index.decoded \
+  FACT_QUERY_PROFILE_LANGUAGE=python \
+  FACT_QUERY_PROFILE_PROJECT_ROOT=/path/to/repository \
+  FACT_QUERY_PROFILE_OUTPUT=/tmp/fact-query-report.json \
+  FACT_QUERY_PROFILE_EXTRA_ARGS='--iterations 15 --warmups 5'
+```
+
+Pass `--external-index-seconds` through `FACT_QUERY_PROFILE_EXTRA_ARGS` when a
+separate cold-start analysis should include unchanged SCIP generation time.
+
 ## Verify
 
 ```bash
@@ -132,6 +162,8 @@ skip report.
 - `code_graph.{h,cpp}` implements the C++ graph container.
 - `decoded_records.h` defines the provider-neutral pre-graph boundary.
 - `fact_batch_buffer.{h,cpp}` defines the v1 native buffer ABI and encoder.
+- `fact_query_index.{h,cpp}` implements graph-free symbol and reference
+  postings.
 - `graph_layers.{h,cpp}` classifies normalized edge types into reusable graph
   layers.
 - `scip_decode_base.{h,cpp}` and `scip_decode_common.{h,cpp}` provide shared

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -688,6 +688,38 @@ the report with `make fact-buffer-profile` and add
 facts. FactQuery indexing (#561) and clangd parsing (#555) remain separate
 promotion and review decisions.
 
+FactQueryIndex v1 promotion status
+([#561](https://github.com/sysevol-ai/CodeNib/issues/561)): the graph-free index
+owns `DecodedRecords` plus integer postings and exposes only symbol definitions
+and fully anchored references. Position and route capabilities remain false;
+invalid endpoints, definition ranges, duplicate names, and unanchored
+references fail the candidate before it can return a partial result. The
+existing `decode()` graph API is unchanged. `decode_query_index()` defaults to
+`auto`, with compatible graph fallback; `required` fails closed.
+
+The 2026-08-10 query-ready gate starts from a saved `index.decoded`, alternates
+complete-CodeGraph and FactQueryIndex arms, includes an identical workload of
+100 definition/reference symbol pairs, and requires exact results and public
+errors across canonical, display, bare, quoted, ambiguous, and missing seeds:
+
+| SCIP subject | Parity seeds | CodeGraph | FactQueryIndex | Index build | Improvement | Result |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| CodeNib Python, 41.6 MB | 1,143 | 0.4006s | 0.2991s | 0.0171s | +25.3% | promote auto |
+| Ruff Rust, 130.5 MB | 1,109 | 2.4401s | 1.7280s | 0.1377s | +29.2% | promote auto |
+
+The Python report used 15 measured iterations after five warmups; Rust used
+seven after three. Cyclic garbage collection was collected before each arm and
+disabled inside timed regions, and both reports retain every raw sample and
+arm order. The artifact SHA-256 values are
+`96e2c407c421d7eb72b2fd834c812c6b688b3634973f2fcdc865cb78bfe87227` and
+`ab55627fb2f379bff19b3fe8123cb94b4d019732711b16c0ddaf5179898c8778`.
+This is a persisted-artifact query-readiness decision, not a claim that
+unchanged external SCIP generation becomes faster. Use
+`make fact-query-profile` and optionally pass `--external-index-seconds` for a
+separate cold-start decision. Auto promotion is therefore restricted to
+Python and Rust; every other core language stays on CodeGraph until it clears
+the same 20% gate. clangd parsing (#555) remains a separate decision.
+
 ### Phase 6: Multi-Graph Python Surface
 
 Mixed-language repositories need a Python-side graph aggregation path before a

--- a/scripts/profiling/profile_fact_query_index.py
+++ b/scripts/profiling/profile_fact_query_index.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark graph-free FactQueryIndex v1 against query-ready CodeGraph.
+
+Both arms decode the same SCIP artifact and execute the same deterministic
+symbol definition/reference workload. The candidate must preserve public
+results and errors, own no graph, and clear the configured end-to-end gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CORE_BUILD = _PROJECT_ROOT / "build/core"
+for candidate in (_CORE_BUILD, _PROJECT_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+from scripts.profiling.profile_fact_batch_buffer import (  # noqa: E402
+    DEFAULT_ITERATIONS,
+    DEFAULT_THRESHOLD,
+    DEFAULT_WARMUPS,
+    acceleration_decision,
+    summarize_samples,
+)
+
+DEFAULT_QUERY_WORKLOAD_SIZE = 100
+DEFAULT_PARITY_SAMPLE_LIMIT = 300
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _timed(call: Callable[[], Any]) -> tuple[Any, float]:
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    started = time.perf_counter()
+    try:
+        result = call()
+        elapsed = time.perf_counter() - started
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+        else:
+            gc.disable()
+    return result, elapsed
+
+
+def _run_arm(call: Callable[[], Any]) -> tuple[Any, float]:
+    gc.collect()
+    return _timed(call)
+
+
+def _even_sample(values: Sequence[str], limit: int) -> list[str]:
+    if limit < 1:
+        raise ValueError("sample limit must be positive")
+    if len(values) <= limit:
+        return list(values)
+    stride = max(1, len(values) // limit)
+    return list(values[::stride][:limit])
+
+
+def _definition_symbols(graph: Any) -> list[str]:
+    from codenib.types import node_has_definition
+
+    return [
+        name
+        for name in graph.name_to_vertex
+        if node_has_definition(graph.get_node_info_by_name(name) or {})
+    ]
+
+
+def _reference_count(graph: Any) -> int:
+    from codenib.types import EDGE_TYPE_REFERENCE
+
+    return sum(
+        edge.attributes().get("type") == EDGE_TYPE_REFERENCE for edge in graph.graph.es
+    )
+
+
+def _query_workload(index: Any, symbols: Sequence[str]) -> None:
+    from codenib.agent.lsp_graph import lsp_definition, lsp_references
+
+    for symbol in symbols:
+        lsp_definition(index, symbol=symbol, top_k=10_000)
+        lsp_references(index, symbol=symbol, top_k=10_000)
+
+
+def _parity_seeds(graph: Any, symbols: Sequence[str]) -> list[str]:
+    seeds: list[str] = []
+    for symbol in symbols:
+        info = graph.get_node_info_by_name(symbol) or {}
+        display = str(info.get("unified_name") or symbol)
+        bare = display.split(":")[-1].split(".")[-1].split("#")[-1]
+        bare = bare.rstrip("()").strip()
+        seeds.extend((symbol, display, bare, f"`{bare}`"))
+    seeds.append("definitely-missing-fact-query-symbol")
+    return list(dict.fromkeys(seed for seed in seeds if seed))
+
+
+def _query_outcome(call: Callable[[], Any]) -> tuple[Any, ...]:
+    try:
+        return "ok", call()
+    except Exception as exc:  # noqa: BLE001 - parity includes public failures
+        return "error", type(exc).__name__, str(exc)
+
+
+def _assert_query_parity(
+    graph: Any,
+    index: Any,
+    *,
+    seeds: Sequence[str],
+    expected_symbol_count: int,
+    expected_reference_count: int,
+) -> None:
+    from codenib.agent.lsp_graph import lsp_definition, lsp_references
+
+    if getattr(index, "materializes_graph", None) is not False or hasattr(
+        index, "graph"
+    ):
+        raise AssertionError("candidate materialized a graph")
+    expected_capabilities = {
+        "definition_by_symbol": True,
+        "references_by_symbol": True,
+        "position_queries": False,
+        "route_queries": False,
+    }
+    if getattr(index, "capabilities", None) != expected_capabilities:
+        raise AssertionError("candidate capabilities differ from v1")
+    if index.symbol_count != expected_symbol_count:
+        raise AssertionError(
+            f"definition symbol count differs: {expected_symbol_count} != "
+            f"{index.symbol_count}"
+        )
+    if index.reference_count != expected_reference_count:
+        raise AssertionError(
+            f"reference count differs: {expected_reference_count} != "
+            f"{index.reference_count}"
+        )
+
+    for symbol in seeds:
+        expected = _query_outcome(
+            lambda symbol=symbol: lsp_definition(graph, symbol=symbol, top_k=10_000)
+        )
+        actual = _query_outcome(
+            lambda symbol=symbol: lsp_definition(index, symbol=symbol, top_k=10_000)
+        )
+        if actual != expected:
+            raise AssertionError(f"definition result differs for {symbol!r}")
+
+        for include_declaration in (False, True):
+            expected = _query_outcome(
+                lambda symbol=symbol, include_declaration=include_declaration: (
+                    lsp_references(
+                        graph,
+                        symbol=symbol,
+                        include_declaration=include_declaration,
+                        top_k=10_000,
+                    )
+                )
+            )
+            actual = _query_outcome(
+                lambda symbol=symbol, include_declaration=include_declaration: (
+                    lsp_references(
+                        index,
+                        symbol=symbol,
+                        include_declaration=include_declaration,
+                        top_k=10_000,
+                    )
+                )
+            )
+            if actual != expected:
+                raise AssertionError(
+                    f"reference result differs for {symbol!r} "
+                    f"(include_declaration={include_declaration})"
+                )
+
+
+def _append_sample(samples: dict[str, list[float]], name: str, value: float) -> None:
+    samples.setdefault(name, []).append(float(value))
+
+
+def profile_fact_query_index(
+    *,
+    index_path: Path,
+    language: str,
+    project_root: Path | None = None,
+    iterations: int = DEFAULT_ITERATIONS,
+    warmups: int = DEFAULT_WARMUPS,
+    threshold: float = DEFAULT_THRESHOLD,
+    external_index_seconds: float | None = None,
+    query_workload_size: int = DEFAULT_QUERY_WORKLOAD_SIZE,
+    parity_sample_limit: int = DEFAULT_PARITY_SAMPLE_LIMIT,
+) -> dict[str, Any]:
+    """Run alternating graph/native arms and return a reproducible report."""
+
+    if iterations < 1 or warmups < 0:
+        raise ValueError("iterations must be positive and warmups non-negative")
+    if query_workload_size < 1 or parity_sample_limit < 1:
+        raise ValueError("query and parity sample sizes must be positive")
+    index_path = index_path.resolve()
+    if not index_path.is_file():
+        raise FileNotFoundError(index_path)
+    root = str(project_root.resolve()) if project_root is not None else None
+
+    import codenib_core
+
+    from codenib.scip_interface.scip_decode_core import _build_code_graph
+
+    if not hasattr(codenib_core, "decode_scip_fact_query_index"):
+        raise RuntimeError("compiled core does not expose FactQueryIndex v1")
+    contract = codenib_core.fact_query_index_contract()
+
+    def legacy_arm() -> tuple[Any, dict[str, float]]:
+        payload, binding = _timed(
+            lambda: codenib_core.decode_scip(
+                index_file=str(index_path), project_root=root, language=language
+            )
+        )
+        graph, materialize = _timed(
+            lambda: _build_code_graph(
+                payload["vertices"], payload["edges"], project_root=root
+            )
+        )
+        _, query = _timed(lambda: _query_workload(graph, workload_symbols))
+        return graph, {
+            "binding": binding,
+            "graph_materialize": materialize,
+            "query_workload": query,
+        }
+
+    # Establish deterministic workload and parity seeds outside measured arms.
+    baseline_payload = codenib_core.decode_scip(
+        index_file=str(index_path), project_root=root, language=language
+    )
+    baseline_graph = _build_code_graph(
+        baseline_payload["vertices"], baseline_payload["edges"], project_root=root
+    )
+    all_symbols = _definition_symbols(baseline_graph)
+    if not all_symbols:
+        raise ValueError("benchmark index has no definition symbols")
+    expected_references = _reference_count(baseline_graph)
+    workload_symbols = _even_sample(all_symbols, query_workload_size)
+    parity_symbols = _even_sample(all_symbols, parity_sample_limit)
+    parity_seeds = _parity_seeds(baseline_graph, parity_symbols)
+
+    def native_arm() -> tuple[Any, dict[str, float]]:
+        payload, binding = _timed(
+            lambda: codenib_core.decode_scip_fact_query_index(
+                index_file=str(index_path), project_root=root, language=language
+            )
+        )
+        if payload.get("graph_materialized") is not False:
+            raise AssertionError("candidate payload reports graph materialization")
+        index = payload["index"]
+        _, query = _timed(lambda: _query_workload(index, workload_symbols))
+        native_decode = payload["native_decode_ns"] / 1_000_000_000
+        native_index = payload["native_index_ns"] / 1_000_000_000
+        profile = payload.get("decode_profile_ns") or {}
+        stage_values = {
+            name: value / 1_000_000_000
+            for name, value in profile.items()
+            if name not in {"worker_count", "document_count"}
+        }
+        return index, {
+            "binding": binding,
+            "native_decode": native_decode,
+            "native_index": native_index,
+            "boundary_residual": max(0.0, binding - native_decode - native_index),
+            "query_workload": query,
+            **{f"native_stage_{name}": value for name, value in stage_values.items()},
+        }
+
+    for _ in range(warmups):
+        _run_arm(legacy_arm)
+        _run_arm(native_arm)
+
+    legacy_samples: dict[str, list[float]] = {}
+    native_samples: dict[str, list[float]] = {}
+    first_arm_by_iteration: list[str] = []
+    last_graph = baseline_graph
+    last_index = None
+    for iteration in range(iterations):
+        if iteration % 2 == 0:
+            first_arm_by_iteration.append("legacy")
+            (last_graph, legacy_timing), legacy_total = _run_arm(legacy_arm)
+            (last_index, native_timing), native_total = _run_arm(native_arm)
+        else:
+            first_arm_by_iteration.append("native")
+            (last_index, native_timing), native_total = _run_arm(native_arm)
+            (last_graph, legacy_timing), legacy_total = _run_arm(legacy_arm)
+        legacy_timing["total"] = legacy_total
+        native_timing["total"] = native_total
+        for name, value in legacy_timing.items():
+            _append_sample(legacy_samples, name, value)
+        for name, value in native_timing.items():
+            _append_sample(native_samples, name, value)
+
+    parity = True
+    parity_error = None
+    try:
+        _assert_query_parity(
+            last_graph,
+            last_index,
+            seeds=parity_seeds,
+            expected_symbol_count=len(all_symbols),
+            expected_reference_count=expected_references,
+        )
+    except AssertionError as exc:
+        parity = False
+        parity_error = str(exc)
+
+    legacy_summary = {
+        name: summarize_samples(values) for name, values in legacy_samples.items()
+    }
+    native_summary = {
+        name: summarize_samples(values) for name, values in native_samples.items()
+    }
+    decision = acceleration_decision(
+        legacy_local_seconds=legacy_summary["total"]["median_seconds"],
+        candidate_local_seconds=native_summary["total"]["median_seconds"],
+        threshold=threshold,
+        external_index_seconds=external_index_seconds,
+        parity=parity,
+        candidate_name="native-fact-query-index",
+    )
+
+    return {
+        "schema_version": 1,
+        "benchmark": "native_fact_query_index_v1",
+        "timer": "time.perf_counter",
+        "subject": {
+            "index_path": str(index_path),
+            "index_bytes": index_path.stat().st_size,
+            "index_sha256": _sha256(index_path),
+            "language": language,
+            "project_root": root,
+            "definition_symbols": len(all_symbols),
+            "references": expected_references,
+        },
+        "configuration": {
+            "iterations": iterations,
+            "warmups": warmups,
+            "threshold": threshold,
+            "alternating_arm_order": True,
+            "first_arm_by_iteration": first_arm_by_iteration,
+            "query_workload_size": len(workload_symbols),
+            "parity_sample_size": len(parity_symbols),
+            "parity_seed_count": len(parity_seeds),
+            "cyclic_gc_collected_before_each_arm": True,
+            "cyclic_gc_disabled_during_timed_regions": True,
+            "fact_query_index_contract": contract,
+        },
+        "capabilities": dict(contract["capabilities"]),
+        "parity": {"passed": parity, "error": parity_error},
+        "raw_samples": {
+            "legacy_code_graph": legacy_samples,
+            "native_fact_query_index": native_samples,
+        },
+        "legacy_code_graph": legacy_summary,
+        "native_fact_query_index": native_summary,
+        "decision": decision,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--index", type=Path, required=True)
+    parser.add_argument("--language", required=True)
+    parser.add_argument("--project-root", type=Path)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    parser.add_argument("--external-index-seconds", type=float)
+    parser.add_argument(
+        "--query-workload-size", type=int, default=DEFAULT_QUERY_WORKLOAD_SIZE
+    )
+    parser.add_argument(
+        "--parity-sample-limit", type=int, default=DEFAULT_PARITY_SAMPLE_LIMIT
+    )
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = profile_fact_query_index(
+        index_path=args.index,
+        language=args.language,
+        project_root=args.project_root,
+        iterations=args.iterations,
+        warmups=args.warmups,
+        threshold=args.threshold,
+        external_index_seconds=args.external_index_seconds,
+        query_workload_size=args.query_workload_size,
+        parity_sample_limit=args.parity_sample_limit,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(rendered)
+    return 0 if report["parity"]["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/scip/test_fact_query_index.py
+++ b/test/scip/test_fact_query_index.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph-free native FactQueryIndex parity and selection tests."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+if importlib.util.find_spec("codenib_core") is None:
+    pytest.skip(
+        "codenib_core pybind module not built; run make core-build",
+        allow_module_level=True,
+    )
+
+import codenib_core  # noqa: E402
+
+from codenib.agent.lsp_graph import (  # noqa: E402
+    lsp_definition,
+    lsp_references,
+    lsp_route,
+)
+from codenib.graph.code_graph import CodeGraph  # noqa: E402
+from codenib.scip_interface import scip_decode_core as scip_core  # noqa: E402
+from codenib.scip_interface.scip_decode_core import (  # noqa: E402
+    SCIPDecoderCore,
+    _build_code_graph,
+    _validate_fact_query_contract,
+)
+from codenib.types import node_has_definition  # noqa: E402
+
+_FIXTURE = (
+    Path(__file__).resolve().parent / "fixtures/typescript_schema_v5/index.decoded"
+)
+
+
+def _legacy_graph() -> CodeGraph:
+    payload = codenib_core.decode_scip(
+        index_file=str(_FIXTURE), project_root=None, language="typescript"
+    )
+    return _build_code_graph(payload["vertices"], payload["edges"], project_root=None)
+
+
+def _native_index():
+    payload = codenib_core.decode_scip_fact_query_index(
+        index_file=str(_FIXTURE), project_root=None, language="typescript"
+    )
+    assert payload["graph_materialized"] is False
+    return payload["index"]
+
+
+def _outcome(call: Callable[[], Any]) -> tuple[Any, ...]:
+    try:
+        return "ok", call()
+    except Exception as exc:  # noqa: BLE001 - public failure parity is required
+        return "error", type(exc).__name__, str(exc)
+
+
+def _symbol_seeds(graph: CodeGraph) -> list[str]:
+    seeds: list[str] = []
+    for name in graph.name_to_vertex:
+        info = graph.get_node_info_by_name(name) or {}
+        if not node_has_definition(info):
+            continue
+        display = str(info.get("unified_name") or name)
+        bare = display.split(":")[-1].split(".")[-1].split("#")[-1]
+        bare = bare.rstrip("()")
+        seeds.extend((name, display, bare, f"`{bare}`"))
+    seeds.append("definitely-missing-fact-query-symbol")
+    return list(dict.fromkeys(seed for seed in seeds if seed))
+
+
+def test_compiled_contract_and_capabilities_are_explicit() -> None:
+    contract = codenib_core.fact_query_index_contract()
+    _validate_fact_query_contract(contract)
+    index = _native_index()
+
+    assert contract == {
+        "abi_version": 1,
+        "format": "fact-query-index-v1",
+        "requires_anchored_references": True,
+        "capabilities": {
+            "definition_by_symbol": True,
+            "references_by_symbol": True,
+            "position_queries": False,
+            "route_queries": False,
+        },
+    }
+    assert index.fact_query_index is True
+    assert index.materializes_graph is False
+    assert index.capabilities == contract["capabilities"]
+    assert index.project_root is None
+    assert not hasattr(index, "graph")
+
+
+def test_contract_rejects_boolean_abi_version() -> None:
+    contract = dict(codenib_core.fact_query_index_contract())
+    contract["abi_version"] = True
+
+    with pytest.raises(RuntimeError, match="contract mismatch"):
+        _validate_fact_query_contract(contract)
+
+
+@pytest.mark.parametrize("include_declaration", (False, True))
+def test_symbol_definition_reference_results_and_errors_match_code_graph(
+    include_declaration: bool,
+) -> None:
+    graph = _legacy_graph()
+    index = _native_index()
+
+    assert index.record_count == graph.graph.vcount()
+    assert index.edge_count == graph.graph.ecount()
+    assert index.symbol_count == sum(
+        node_has_definition(graph.get_node_info_by_name(name) or {})
+        for name in graph.name_to_vertex
+    )
+    assert index.reference_count == sum(
+        edge.attributes().get("type") == "reference" for edge in graph.graph.es
+    )
+
+    for seed in _symbol_seeds(graph):
+        expected_definition = _outcome(
+            lambda seed=seed: lsp_definition(graph, symbol=seed, top_k=10_000)
+        )
+        actual_definition = _outcome(
+            lambda seed=seed: lsp_definition(index, symbol=seed, top_k=10_000)
+        )
+        assert actual_definition == expected_definition, seed
+
+        expected_references = _outcome(
+            lambda seed=seed: lsp_references(
+                graph,
+                symbol=seed,
+                include_declaration=include_declaration,
+                top_k=10_000,
+            )
+        )
+        actual_references = _outcome(
+            lambda seed=seed: lsp_references(
+                index,
+                symbol=seed,
+                include_declaration=include_declaration,
+                top_k=10_000,
+            )
+        )
+        assert actual_references == expected_references, seed
+
+
+def test_position_and_route_queries_fail_instead_of_returning_partial_rows() -> None:
+    index = _native_index()
+
+    with pytest.raises(ValueError, match="does not support position queries"):
+        lsp_definition(index, file_path="src/types.ts", line=0, character=0)
+    with pytest.raises(ValueError, match="does not support position queries"):
+        lsp_references(index, file_path="src/types.ts", line=0, character=0)
+    with pytest.raises(ValueError, match="does not support route queries"):
+        lsp_route(index, symbols=["DefaultRunner"])
+
+
+def test_query_selector_defaults_to_graph_for_unpromoted_languages(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("CODENIB_NATIVE_FACT_QUERY_INDEX", raising=False)
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "off")
+    decoder = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+
+    index = decoder.decode_query_index()
+
+    assert isinstance(index, CodeGraph)
+    assert decoder.query_backend == "code-graph-not-promoted"
+    assert decoder.query_timings["fact_query_index_enabled"] == 0
+
+
+def test_query_selector_promoted_auto_and_required_are_graph_free(monkeypatch) -> None:
+    monkeypatch.setattr(
+        scip_core, "_FACT_QUERY_PROMOTED_LANGUAGES", frozenset({"typescript"})
+    )
+    monkeypatch.setenv("CODENIB_NATIVE_FACT_QUERY_INDEX", "auto")
+    decoder = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+
+    index = decoder.decode_query_index()
+
+    assert index.fact_query_index is True
+    assert decoder.code_graph is None
+    assert decoder.query_backend == "fact-query-index-v1"
+    assert decoder.query_fallback_error is None
+    assert decoder.query_timings["fact_query_index_enabled"] == 1
+
+    monkeypatch.setenv("CODENIB_NATIVE_FACT_QUERY_INDEX", "required")
+    required = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+    assert required.decode_query_index().fact_query_index is True
+
+
+def test_query_selector_off_preserves_complete_graph(monkeypatch) -> None:
+    monkeypatch.setenv("CODENIB_NATIVE_FACT_QUERY_INDEX", "off")
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "off")
+    decoder = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+
+    index = decoder.decode_query_index()
+
+    assert isinstance(index, CodeGraph)
+    assert decoder.query_backend == "code-graph-disabled"
+    assert decoder.code_graph is index
+
+
+def test_query_selector_auto_falls_back_but_required_fails(monkeypatch) -> None:
+    def fail_query_index(**_kwargs):
+        raise RuntimeError("injected FactQueryIndex failure")
+
+    monkeypatch.setattr(codenib_core, "decode_scip_fact_query_index", fail_query_index)
+    monkeypatch.setattr(
+        scip_core, "_FACT_QUERY_PROMOTED_LANGUAGES", frozenset({"typescript"})
+    )
+    monkeypatch.setenv("CODENIB_CORE_FACT_BUFFER", "off")
+    monkeypatch.setenv("CODENIB_NATIVE_FACT_QUERY_INDEX", "auto")
+    decoder = SCIPDecoderCore(str(_FIXTURE), language="typescript")
+
+    assert isinstance(decoder.decode_query_index(), CodeGraph)
+    assert decoder.query_backend == "code-graph-fallback"
+    assert "injected FactQueryIndex failure" in decoder.query_fallback_error
+
+    monkeypatch.setenv("CODENIB_NATIVE_FACT_QUERY_INDEX", "required")
+    with pytest.raises(RuntimeError, match="injected FactQueryIndex failure"):
+        SCIPDecoderCore(str(_FIXTURE), language="typescript").decode_query_index()
+
+
+def test_query_selector_does_not_mask_memory_exhaustion(monkeypatch) -> None:
+    def exhaust_memory(**_kwargs):
+        raise MemoryError("injected allocation failure")
+
+    monkeypatch.setattr(codenib_core, "decode_scip_fact_query_index", exhaust_memory)
+    monkeypatch.setattr(
+        scip_core, "_FACT_QUERY_PROMOTED_LANGUAGES", frozenset({"typescript"})
+    )
+    monkeypatch.setenv("CODENIB_NATIVE_FACT_QUERY_INDEX", "auto")
+
+    with pytest.raises(MemoryError, match="injected allocation failure"):
+        SCIPDecoderCore(str(_FIXTURE), language="typescript").decode_query_index()
+
+
+def test_query_selector_rejects_unknown_mode(monkeypatch) -> None:
+    monkeypatch.setenv("CODENIB_NATIVE_FACT_QUERY_INDEX", "sometimes")
+
+    with pytest.raises(ValueError, match="CODENIB_NATIVE_FACT_QUERY_INDEX must be"):
+        SCIPDecoderCore(str(_FIXTURE), language="typescript").decode_query_index()

--- a/test/scripts/test_profile_fact_query_index.py
+++ b/test/scripts/test_profile_fact_query_index.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the reproducible FactQueryIndex promotion profiler."""
+
+from __future__ import annotations
+
+import gc
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+if importlib.util.find_spec("codenib_core") is None:
+    pytest.skip(
+        "codenib_core pybind module not built; run make core-build",
+        allow_module_level=True,
+    )
+
+import codenib_core  # noqa: E402
+
+from scripts.profiling.profile_fact_query_index import (  # noqa: E402
+    _even_sample,
+    _timed,
+    main,
+    profile_fact_query_index,
+)
+
+_FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "scip/fixtures/typescript_schema_v5/index.decoded"
+)
+
+
+def test_profiler_records_graph_free_parity_raw_samples_and_arm_order() -> None:
+    report = profile_fact_query_index(
+        index_path=_FIXTURE,
+        language="typescript",
+        iterations=2,
+        warmups=0,
+        query_workload_size=4,
+        parity_sample_limit=4,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "native_fact_query_index_v1"
+    assert report["parity"] == {"passed": True, "error": None}
+    assert report["capabilities"]["position_queries"] is False
+    assert report["configuration"]["fact_query_index_contract"] == (
+        codenib_core.fact_query_index_contract()
+    )
+    assert report["configuration"]["first_arm_by_iteration"] == [
+        "legacy",
+        "native",
+    ]
+    assert len(report["raw_samples"]["legacy_code_graph"]["total"]) == 2
+    assert len(report["raw_samples"]["native_fact_query_index"]["total"]) == 2
+    assert report["native_fact_query_index"]["native_index"]["samples"] == 2
+    assert report["decision"]["parity"] is True
+
+
+def test_profiler_can_apply_cold_start_gate() -> None:
+    report = profile_fact_query_index(
+        index_path=_FIXTURE,
+        language="typescript",
+        iterations=1,
+        warmups=0,
+        external_index_seconds=10.0,
+        query_workload_size=2,
+        parity_sample_limit=2,
+    )
+
+    assert report["decision"]["gate"] == "cold_start_end_to_end"
+    assert report["decision"]["external_index_seconds"] == 10.0
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    (
+        ({"iterations": 0}, "iterations must be positive"),
+        ({"warmups": -1}, "iterations must be positive"),
+        ({"query_workload_size": 0}, "sample sizes must be positive"),
+        ({"parity_sample_limit": 0}, "sample sizes must be positive"),
+    ),
+)
+def test_profiler_rejects_invalid_configuration(kwargs, message) -> None:
+    configuration = {
+        "index_path": _FIXTURE,
+        "language": "typescript",
+        "iterations": 1,
+        "warmups": 0,
+    }
+    configuration.update(kwargs)
+    with pytest.raises(ValueError, match=message):
+        profile_fact_query_index(**configuration)
+
+
+def test_timed_restores_enabled_gc_after_success_and_failure() -> None:
+    gc.enable()
+    _, elapsed = _timed(lambda: "ok")
+    assert elapsed >= 0
+    assert gc.isenabled() is True
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _timed(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert gc.isenabled() is True
+
+
+def test_timed_preserves_disabled_gc_state() -> None:
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        _timed(lambda: None)
+        assert gc.isenabled() is False
+    finally:
+        if was_enabled:
+            gc.enable()
+
+
+def test_even_sample_is_deterministic_and_validated() -> None:
+    assert _even_sample(["a", "b", "c", "d", "e"], 2) == ["a", "c"]
+    with pytest.raises(ValueError, match="positive"):
+        _even_sample(["a"], 0)
+
+
+def test_cli_writes_reproducible_json(tmp_path, capsys) -> None:
+    output = tmp_path / "fact-query.json"
+    result = main(
+        [
+            "--index",
+            str(_FIXTURE),
+            "--language",
+            "typescript",
+            "--iterations",
+            "1",
+            "--warmups",
+            "0",
+            "--query-workload-size",
+            "2",
+            "--parity-sample-limit",
+            "2",
+            "--output-json",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    expected = json.loads(capsys.readouterr().out)
+    assert json.loads(output.read_text(encoding="utf-8")) == expected


### PR DESCRIPTION
## Summary

Adds FactQueryIndex v1, a provider-neutral native symbol index that answers definition and anchored-reference queries directly from immutable decoded SCIP records without materializing CodeGraph or igraph.

Closes #561. Parent tracker: #554. Dependencies #559 and #560 are merged and closed.

## Changes

- Build canonical/display/bare symbol aliases and incoming-reference integer postings in C++, preserving CodeGraph result and error semantics.
- Expose an explicit ABI/capability contract and fail closed on malformed endpoints, definitions, duplicate names, unanchored references, position queries, and route queries.
- Add a separate `SCIPDecoderCore.decode_query_index()` selector with `off|auto|required` behavior; existing `decode()` remains unchanged.
- Promote auto mode only for Python and Rust after exact parity and a greater-than-20% query-ready gate.
- Add alternating-arm profiling with raw samples, hashes, arm order, stage timings, and optional external SCIP generation time.
- Document the capability boundary and durable promotion evidence.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- [x] `./build/core/fact_query_index_test`
- [x] Focused Python parity/profiler tier: 21 passed
- [x] `make core-test`: 79 passed, 4 skipped, plus all C++ test executables
- [x] Expanded local unit tier: 3906 passed, 8 skipped, 200 deselected; two known baseline checks were explicitly deselected
- [x] `python -m mkdocs build --strict`
- [x] `python scripts/check_public_docs.py`
- [x] CodeNib Python: 25.3% median improvement, 1,143 parity seeds, artifact SHA-256 `96e2c407c421d7eb72b2fd834c812c6b688b3634973f2fcdc865cb78bfe87227`
- [x] Ruff Rust: 29.2% median improvement, 1,109 parity seeds, artifact SHA-256 `ab55627fb2f379bff19b3fe8123cb94b4d019732711b16c0ddaf5179898c8778`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published