### PR TITLE
perf(cpp): add native clangd symbol queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ endef
 .PHONY: active-scip-tools active-lsp-tools active-scip-env active-system-deps-ubuntu
 .PHONY: go-tool scip-go-tool rust-tool scip-python-tool scip-typescript-tool scip-clang-tool
 .PHONY: node-workspace-tools zoekt-tool python-lsp-tool ty-tool typescript-lsp-tool gopls-tool clangd-tool
-.PHONY: core-system-deps-ubuntu core-python-deps core-build core-test fact-buffer-profile fact-query-profile
+.PHONY: core-system-deps-ubuntu core-python-deps core-build core-test fact-buffer-profile fact-query-profile clangd-fact-query-profile
 .PHONY: scip-cold-start-tools scip-cold-start-tools-all scip-cold-start-env scip-cold-start-system-deps-ubuntu
 .PHONY: scip-candidates scip-candidates-all scip-candidate-env scip-candidate-system-deps-ubuntu
 .PHONY: scip-jvm-compat-system-deps-ubuntu
@@ -421,7 +421,8 @@ core-test: core-build
 		test/facts/test_model.py \
 		test/facts/test_adapters.py \
 		test/scripts/test_profile_fact_batch_buffer.py \
-		test/scripts/test_profile_fact_query_index.py
+		test/scripts/test_profile_fact_query_index.py \
+		test/ls_index/test_clangd_fact_query.py
 
 fact-buffer-profile: core-build
 	@test -n "$(FACT_BUFFER_PROFILE_INDEX)" || { echo "Set FACT_BUFFER_PROFILE_INDEX=/path/to/index.decoded" >&2; exit 1; }
@@ -442,6 +443,15 @@ fact-query-profile: core-build
 		$(if $(FACT_QUERY_PROFILE_PROJECT_ROOT),--project-root "$(FACT_QUERY_PROFILE_PROJECT_ROOT)",) \
 		$(if $(FACT_QUERY_PROFILE_OUTPUT),--output-json "$(FACT_QUERY_PROFILE_OUTPUT)",) \
 		$(FACT_QUERY_PROFILE_EXTRA_ARGS)
+
+clangd-fact-query-profile: core-build
+	@test -n "$(CLANGD_FACT_QUERY_PROFILE_INDEX_DIR)" || { echo "Set CLANGD_FACT_QUERY_PROFILE_INDEX_DIR=/path/to/.cache/clangd/index" >&2; exit 1; }
+	@test -n "$(CLANGD_FACT_QUERY_PROFILE_PROJECT_ROOT)" || { echo "Set CLANGD_FACT_QUERY_PROFILE_PROJECT_ROOT=/path/to/repository" >&2; exit 1; }
+	PYTHONPATH="build/core:$$PYTHONPATH" python scripts/profiling/profile_clangd_fact_query_index.py \
+		--idx-directory "$(CLANGD_FACT_QUERY_PROFILE_INDEX_DIR)" \
+		--project-root "$(CLANGD_FACT_QUERY_PROFILE_PROJECT_ROOT)" \
+		$(if $(CLANGD_FACT_QUERY_PROFILE_OUTPUT),--output-json "$(CLANGD_FACT_QUERY_PROFILE_OUTPUT)",) \
+		$(CLANGD_FACT_QUERY_PROFILE_EXTRA_ARGS)
 
 scip-cold-start-tools: scip-java-tool gradle-tool sbt-tool scip-dotnet-tool scip-ruby-tool scip-php-info
 	@$(MAKE) --no-print-directory scip-cold-start-env

--- a/codenib/ls_index/__init__.py
+++ b/codenib/ls_index/__init__.py
@@ -4,7 +4,7 @@
 
 """Language-server indexers and decoders."""
 
-from .clangd_decode import ClangdGraphDecoder
+from .clangd_decode import ClangdGraphDecoder, ClangdHybridQueryProvider
 from .clangd_indexer import ClangdIndexer
 from .lsp_graph_decode import GenericLSPGraphDecoder
 from .lsp_indexer import GenericLSPIndexer
@@ -12,6 +12,7 @@ from .lsp_indexer import GenericLSPIndexer
 __all__ = [
     "ClangdIndexer",
     "ClangdGraphDecoder",
+    "ClangdHybridQueryProvider",
     "GenericLSPIndexer",
     "GenericLSPGraphDecoder",
 ]

--- a/codenib/ls_index/clangd_decode.py
+++ b/codenib/ls_index/clangd_decode.py
@@ -23,10 +23,12 @@ Two-pass approach for graph building:
 """
 
 import logging
+import os
 import struct
+import time
 import zlib
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Tuple
 
 from ..code_chunking import CppCodeChunker
 from ..graph.code_graph import CodeGraph
@@ -72,6 +74,63 @@ RELATION_OVERRIDDEN_BY = 1
 
 # Zero SymbolID (8 bytes = 16 hex chars)
 ZERO_SYMBOL_ID = "0" * 16
+
+_NATIVE_QUERY_ENV = "CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX"
+_NATIVE_QUERY_OFF = frozenset({"0", "false", "no", "off", "disabled"})
+_NATIVE_QUERY_AUTO = frozenset({"", "1", "true", "yes", "on", "auto"})
+_NATIVE_QUERY_REQUIRED = frozenset({"required", "strict"})
+_NATIVE_QUERY_PROMOTED = True
+_NATIVE_QUERY_ABI_VERSION = 1
+_NATIVE_QUERY_FORMAT = "clangd-riff-fact-query-v1"
+_NATIVE_QUERY_CAPABILITIES = {
+    "definition_by_symbol": True,
+    "references_by_symbol": True,
+    "position_queries": False,
+    "route_queries": False,
+}
+
+
+def native_clangd_query_mode() -> str:
+    """Return the configured native clangd symbol-query selection mode."""
+
+    value = os.environ.get(_NATIVE_QUERY_ENV, "auto").strip().lower()
+    if value in _NATIVE_QUERY_OFF:
+        return "off"
+    if value in _NATIVE_QUERY_AUTO:
+        return "auto"
+    if value in _NATIVE_QUERY_REQUIRED:
+        return "required"
+    raise ValueError(
+        f"{_NATIVE_QUERY_ENV} must be auto, required, or 0/off; got {value!r}"
+    )
+
+
+def native_clangd_query_promoted() -> bool:
+    """Whether the checked symbol-only benchmark currently clears the gate."""
+
+    return _NATIVE_QUERY_PROMOTED
+
+
+def _validate_native_query_contract(contract: Mapping[str, Any]) -> None:
+    abi_version = contract.get("abi_version")
+    if type(abi_version) is not int or abi_version != _NATIVE_QUERY_ABI_VERSION:
+        raise RuntimeError(
+            "compiled clangd FactQueryIndex contract mismatch: "
+            f"expected ABI {_NATIVE_QUERY_ABI_VERSION}, got {abi_version!r}"
+        )
+    if contract.get("format") != _NATIVE_QUERY_FORMAT:
+        raise RuntimeError(
+            "compiled clangd FactQueryIndex contract mismatch: "
+            f"expected format {_NATIVE_QUERY_FORMAT!r}"
+        )
+    if contract.get("stable_filename_order") is not True:
+        raise RuntimeError("compiled clangd reader does not guarantee stable order")
+    if contract.get("preserves_unanchored_relations") is not True:
+        raise RuntimeError("compiled clangd reader drops legacy relation rows")
+    if contract.get("capabilities") != _NATIVE_QUERY_CAPABILITIES:
+        raise RuntimeError(
+            "compiled clangd FactQueryIndex capabilities do not match v1"
+        )
 
 
 # ===================================================================
@@ -346,6 +405,63 @@ def parse_idx_file(filepath: str) -> dict:
 # ===================================================================
 
 
+class ClangdHybridQueryProvider:
+    """Serve symbol queries natively and lazily fall back for full-graph work.
+
+    The baseline native index advertises no position or route capability.
+    Those requests therefore materialize the established Python CodeGraph
+    exactly once. Production MCP injection and content-bound generation
+    receipts remain separate follow-up decisions.
+    """
+
+    def __init__(self, decoder: "ClangdGraphDecoder", query_index: Any):
+        from ..agent.lsp_provider import StaticLSPProvider
+
+        self.decoder = decoder
+        self.graph = query_index
+        self.provider_backend = decoder.query_backend
+        self._symbol_provider = StaticLSPProvider(query_index)
+        self._graph_provider = None
+        self.graph_materialization_count = 0
+        self.last_fallback_reason = None
+        self.provider = self._symbol_provider.provider
+        self.snapshot_id = self._symbol_provider.snapshot_id
+
+    def _full_graph_provider(self, reason: str):
+        from ..agent.lsp_provider import StaticLSPProvider
+
+        self.last_fallback_reason = reason
+        if self._graph_provider is None:
+            graph = self.decoder.materialize_code_graph()
+            self._graph_provider = StaticLSPProvider(graph)
+            self.graph_materialization_count += 1
+        return self._graph_provider
+
+    def can_serve(self, capability: str):
+        # The hybrid can serve every established capability: native for symbol
+        # definition/reference calls and the complete graph for everything else.
+        return self._symbol_provider.can_serve(capability)
+
+    def definition(self, **arguments):
+        if arguments.get("symbol"):
+            return self._symbol_provider.definition(**arguments)
+        return self._full_graph_provider(
+            "native_clangd_position_query_requires_complete_graph"
+        ).definition(**arguments)
+
+    def references(self, **arguments):
+        if arguments.get("symbol"):
+            return self._symbol_provider.references(**arguments)
+        return self._full_graph_provider(
+            "native_clangd_position_query_requires_complete_graph"
+        ).references(**arguments)
+
+    def route(self, **arguments):
+        return self._full_graph_provider(
+            "native_clangd_route_query_requires_complete_graph"
+        ).route(**arguments)
+
+
 class ClangdGraphDecoder:
     """
     Decoder that builds a CodeGraph from clangd .idx files.
@@ -388,6 +504,12 @@ class ClangdGraphDecoder:
         # Code chunker for range detection
         self._chunker = CppCodeChunker()
         self._chunks_cache = {}
+        self._graph_materialized = False
+        self._range_indexes_built = False
+        self.query_index = None
+        self.query_backend = "not-decoded"
+        self.query_fallback_error = None
+        self.query_profile: dict[str, float | int] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -395,6 +517,8 @@ class ClangdGraphDecoder:
 
     def decode(self) -> CodeGraph:
         """Main entry point. Parse all .idx files and build CodeGraph."""
+        if self._graph_materialized:
+            return self.code_graph
         logger.info(f"Starting clangd idx decode from {self.idx_directory}")
 
         # Pass 1: collect all data
@@ -406,8 +530,139 @@ class ClangdGraphDecoder:
         # Pass 2: build the graph
         self.code_graph.add_root_node(ROOT_NODE)
         self._build_graph()
+        self._graph_materialized = True
 
         return self.code_graph
+
+    def materialize_code_graph(self) -> CodeGraph:
+        """Build and range-index the established graph at most once."""
+
+        graph = self.decode()
+        if not self._range_indexes_built:
+            graph.build_range_indexes()
+            self._range_indexes_built = True
+        return graph
+
+    def _decode_native_query_index(self):
+        try:
+            import codenib_core
+        except ImportError as exc:
+            raise RuntimeError(
+                "compiled codenib_core extension is unavailable"
+            ) from exc
+
+        decode = getattr(codenib_core, "decode_clangd_fact_query_index", None)
+        contract_reader = getattr(codenib_core, "clangd_fact_query_contract", None)
+        if not callable(decode) or not callable(contract_reader):
+            raise RuntimeError("compiled core does not expose clangd FactQueryIndex v1")
+        _validate_native_query_contract(contract_reader())
+
+        started = time.perf_counter()
+        payload = decode(
+            idx_directory=str(self.idx_directory),
+            project_root=str(self.project_root),
+        )
+        binding_seconds = time.perf_counter() - started
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("native clangd query decoder returned non-mapping data")
+        if payload.get("format") != _NATIVE_QUERY_FORMAT:
+            raise RuntimeError("native clangd query decoder returned unknown format")
+        if payload.get("graph_materialized") is not False:
+            raise RuntimeError("native clangd query decoder materialized a graph")
+
+        index = payload.get("index")
+        if index is None or getattr(index, "fact_query_index", None) is not True:
+            raise RuntimeError("native clangd query payload is missing its index")
+        if getattr(index, "materializes_graph", None) is not False:
+            raise RuntimeError(
+                "native clangd query index does not guarantee graph-free use"
+            )
+        if getattr(index, "capabilities", None) != _NATIVE_QUERY_CAPABILITIES:
+            raise RuntimeError("native clangd query index capabilities do not match v1")
+        if getattr(index, "requires_anchored_references", None) is not False:
+            raise RuntimeError(
+                "native clangd query index cannot preserve relation references"
+            )
+
+        native_decode = int(payload.get("native_decode_ns") or 0) / 1_000_000_000
+        native_index = int(payload.get("native_index_ns") or 0) / 1_000_000_000
+        profile: dict[str, float | int] = {
+            "binding": binding_seconds,
+            "native_decode": native_decode,
+            "native_index": native_index,
+            "boundary_residual": max(
+                0.0, binding_seconds - native_decode - native_index
+            ),
+            "record_count": int(getattr(index, "record_count", 0)),
+            "definition_count": int(getattr(index, "symbol_count", 0)),
+            "reference_count": int(getattr(index, "reference_count", 0)),
+        }
+        count_fields = {
+            "file_count",
+            "raw_symbol_count",
+            "raw_reference_count",
+            "definition_count",
+            "reference_count",
+            "decoded_record_count",
+            "index_bytes",
+        }
+        for name, value in (payload.get("decode_profile_ns") or {}).items():
+            profile[f"native_{name}"] = (
+                int(value) if name in count_fields else int(value) / 1_000_000_000
+            )
+        return index, profile
+
+    def decode_query_index(self):
+        """Return the gated symbol index or the complete compatible graph."""
+
+        if self.query_index is not None:
+            return self.query_index
+        total_started = time.perf_counter()
+        mode = native_clangd_query_mode()
+        if mode == "off" or (mode == "auto" and not _NATIVE_QUERY_PROMOTED):
+            self.query_index = self.materialize_code_graph()
+            self.query_backend = (
+                "legacy-query-disabled"
+                if mode == "off"
+                else "legacy-query-not-promoted"
+            )
+            self.query_profile = {
+                "fact_query_native": 0,
+                "query_total": time.perf_counter() - total_started,
+            }
+            return self.query_index
+
+        try:
+            self.query_index, self.query_profile = self._decode_native_query_index()
+            self.query_backend = "native-clangd-fact-query-v1"
+            self.query_profile["fact_query_native"] = 1
+        except MemoryError:
+            raise
+        except Exception as exc:
+            if mode == "required":
+                raise
+            self.query_fallback_error = f"{type(exc).__name__}: {exc}"
+            logger.warning(
+                "Native clangd FactQueryIndex unavailable; falling back to "
+                "ClangdGraphDecoder: %s",
+                self.query_fallback_error,
+            )
+            self.query_index = self.materialize_code_graph()
+            self.query_backend = "legacy-query-fallback"
+            self.query_profile = {"fact_query_native": 0}
+
+        self.query_profile["query_total"] = time.perf_counter() - total_started
+        return self.query_index
+
+    def decode_query_provider(self):
+        """Return native symbol queries with lazy position/route fallback."""
+
+        from ..agent.lsp_provider import StaticLSPProvider
+
+        index = self.decode_query_index()
+        if getattr(index, "fact_query_index", False):
+            return ClangdHybridQueryProvider(self, index)
+        return StaticLSPProvider(index)
 
     def save_graph(self, output_path: str):
         """Save the code graph to a file."""

--- a/codenib/ls_index/clangd_indexer.py
+++ b/codenib/ls_index/clangd_indexer.py
@@ -262,6 +262,68 @@ class ClangdIndexer:
             logger.error(f"Error processing .idx files: {e}")
             return None
 
+    def process_query_index(self):
+        """Build the gated symbol-query view from an existing clangd index.
+
+        This capability-scoped entry point leaves process_index and graph
+        persistence unchanged. It never invokes clangd index generation.
+        """
+
+        self._select_existing_idx_directory()
+        if not self.idx_directory.exists() or not any(self.idx_directory.glob("*.idx")):
+            raise FileNotFoundError(
+                f"No clangd .idx files found in {self.idx_directory}"
+            )
+        decoder_class = self._get_decoder_class()
+        with self.profiler.section("process_query_index.decode"):
+            decoder = decoder_class(
+                idx_directory=str(self.idx_directory),
+                project_root=str(self.project_root),
+            )
+            return decoder.decode_query_index()
+
+    def process_query_provider(self):
+        """Return native symbol queries with lazy complete-graph fallback."""
+
+        self._select_existing_idx_directory()
+        if not self.idx_directory.exists() or not any(self.idx_directory.glob("*.idx")):
+            raise FileNotFoundError(
+                f"No clangd .idx files found in {self.idx_directory}"
+            )
+        decoder_class = self._get_decoder_class()
+        decoder = decoder_class(
+            idx_directory=str(self.idx_directory),
+            project_root=str(self.project_root),
+        )
+        return decoder.decode_query_provider()
+
+    def _select_existing_idx_directory(self) -> Optional[Path]:
+        """Select a project-local clangd generation without building one."""
+
+        candidates = [
+            self.idx_directory,
+            self.project_root / ".cache" / "clangd" / "index",
+            self.project_root / "build" / ".cache" / "clangd" / "index",
+        ]
+        comp_db = discover_compilation_database(
+            self.project_root,
+            extra_candidates=(self.output_dir / "compile_commands.json",),
+        )
+        if comp_db is not None:
+            candidates.extend(self._build_candidate_idx_dirs(comp_db))
+
+        observed = set()
+        for candidate in candidates:
+            normalized = candidate.expanduser().absolute()
+            key = str(normalized)
+            if key in observed:
+                continue
+            observed.add(key)
+            if normalized.is_dir() and any(normalized.glob("*.idx")):
+                self.idx_directory = normalized
+                return normalized
+        return None
+
     def run_pipeline(
         self,
         output_file: Optional[str] = None,

--- a/codenib/ls_router.py
+++ b/codenib/ls_router.py
@@ -241,6 +241,26 @@ class LSIndexer:
     ) -> Union[CodeGraph, None]:
         return self._delegate.process_index(output_file=output_file)
 
+    def process_query_index(self) -> Any:
+        """Build a backend-specific capability-scoped query index."""
+
+        method = getattr(self._delegate, "process_query_index", None)
+        if not callable(method):
+            raise RuntimeError(
+                f"{self.language} indexer does not expose a query-index path"
+            )
+        return method()
+
+    def process_query_provider(self) -> Any:
+        """Build a backend-specific provider with compatible fallbacks."""
+
+        method = getattr(self._delegate, "process_query_provider", None)
+        if not callable(method):
+            raise RuntimeError(
+                f"{self.language} indexer does not expose a query-provider path"
+            )
+        return method()
+
     def run_pipeline(
         self,
         output_file: Optional[str] = None,

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -45,8 +45,10 @@ FetchContent_MakeAvailable(igraph)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(RE2 REQUIRED re2)
+find_package(ZLIB REQUIRED)
 
 add_library(codenib_core STATIC
+    clangd_fact_query.cpp
     code_graph.cpp
     fact_batch_buffer.cpp
     fact_query_index.cpp
@@ -74,6 +76,7 @@ target_link_libraries(codenib_core
     PUBLIC
         igraph
         ${RE2_LIBRARIES}
+        ZLIB::ZLIB
 )
 
 add_executable(scip_decode_test

--- a/core/README.md
+++ b/core/README.md
@@ -17,6 +17,8 @@ core decoder continue to use the serial Python path.
 - `decoded_records.h` — provider-neutral rows before graph materialization.
 - `fact_batch_buffer.{h,cpp}` — versioned flat semantic and graph-compatibility
   tables for the native/Python boundary.
+- `clangd_fact_query.{h,cpp}` — deterministic clangd RIFF shard decoding into
+  provider-neutral records for graph-free symbol queries.
 - `graph_layers.{h,cpp}` — shared normalized edge-layer classification.
 - `scip_decode_base.{h,cpp}` — common loading, document scheduling, merge, and
   post-processing behavior.
@@ -42,6 +44,7 @@ Requirements:
 - a C++17 compiler
 - `pkg-config`
 - RE2 development headers
+- zlib development headers
 - pybind11 in the active Python environment
 
 From the repository root:
@@ -112,6 +115,40 @@ make fact-query-profile \
   FACT_QUERY_PROFILE_LANGUAGE=python \
   FACT_QUERY_PROFILE_OUTPUT=/tmp/fact-query-report.json
 ```
+
+## Native clangd Symbol Queries
+
+For C and C++ projects with an existing project-local clangd index,
+`decode_clangd_fact_query_index(...)` reads the direct `*.idx` children in
+stable filename order, decodes them into `DecodedRecords`, and builds the same
+`FactQueryIndex` without constructing `CodeGraph`, igraph, or Python record
+dictionaries. The v1 slice covers definition and reference lookup by symbol.
+clangd relation rows may be unanchored, so this provider explicitly opts into
+that record policy while still rejecting partial or invalid anchors.
+
+Use `LSIndexer.process_query_index()` for the capability-specific index or
+`process_query_provider()` for hybrid behavior. The provider keeps successful
+symbol queries on the native index and lazily constructs the complete graph
+once when a position or route query is requested. Existing `process_index()`,
+graph persistence, incremental processing, and quality gates are unchanged.
+
+`CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX=auto` is the default and falls back to
+the compatible graph if native decoding fails. Set it to `off` to force the
+graph or `required` to fail closed. Reproduce the alternating query-ready gate
+from an already generated `.idx` directory with:
+
+```bash
+make clangd-fact-query-profile \
+  CLANGD_FACT_QUERY_PROFILE_INDEX_DIR=/path/to/.cache/clangd/index \
+  CLANGD_FACT_QUERY_PROFILE_PROJECT_ROOT=/path/to/repository \
+  CLANGD_FACT_QUERY_PROFILE_OUTPUT=/tmp/clangd-fact-query.json \
+  CLANGD_FACT_QUERY_PROFILE_EXTRA_ARGS='--iterations 15 --warmups 5'
+```
+
+This baseline makes no claim about clangd index generation time. Native
+position and route queries, serving integration, content receipts, and a
+hardened clangd artifact compatibility/resource contract remain separate
+promotion gates.
 
 ## Use Through Python
 

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -22,6 +22,7 @@
 // serialization cost across the C++/Python boundary is just one igraph vcount +
 // ecount worth of tuples/dicts.
 
+#include "clangd_fact_query.h"
 #include "fact_batch_buffer.h"
 #include "fact_query_index.h"
 #include "graph_layers.h"
@@ -75,8 +76,12 @@ py::dict
 reference_to_dict(const codenib::core::FactQueryIndex::Reference &reference) {
   py::dict result;
   result["source_vid"] = reference.source;
-  result["file"] = reference.anchor_file;
-  result["line"] = reference.anchor_line;
+  result["file"] = reference.anchor_file.has_value()
+                       ? py::object(py::cast(*reference.anchor_file))
+                       : py::object(py::none());
+  result["line"] = reference.anchor_line.has_value()
+                       ? py::object(py::cast(*reference.anchor_line))
+                       : py::object(py::none());
   return result;
 }
 
@@ -231,6 +236,26 @@ decode_profile_to_dict(const codenib::core::SCIPDecodeProfile &profile) {
   return result;
 }
 
+py::dict clangd_decode_profile_to_dict(
+    const codenib::core::ClangdFactDecodeProfile &profile) {
+  py::dict result;
+  result["discover_files"] = profile.discover_files_ns;
+  result["read_files"] = profile.read_files_ns;
+  result["parse_files"] = profile.parse_files_ns;
+  result["merge_records"] = profile.merge_records_ns;
+  result["build_query_records"] = profile.build_query_records_ns;
+  result["materialize_graph"] = 0;
+  result["total"] = profile.total_ns;
+  result["file_count"] = profile.file_count;
+  result["raw_symbol_count"] = profile.raw_symbol_count;
+  result["raw_reference_count"] = profile.raw_reference_count;
+  result["definition_count"] = profile.definition_count;
+  result["reference_count"] = profile.reference_count;
+  result["decoded_record_count"] = profile.decoded_record_count;
+  result["index_bytes"] = profile.index_bytes;
+  return result;
+}
+
 py::dict fact_encode_profile_to_dict(
     const codenib::core::FactBatchEncodeProfile &profile) {
   py::dict result;
@@ -349,6 +374,49 @@ py::dict fact_query_index_contract() {
   return result;
 }
 
+py::dict decode_clangd_fact_query_index(const std::string &idx_directory,
+                                        const std::string &project_root) {
+  using clock = std::chrono::steady_clock;
+  clock::time_point decode_started;
+  clock::time_point decode_finished;
+  clock::time_point index_finished;
+  codenib::core::ClangdQueryRecords decoded;
+  std::shared_ptr<codenib::core::FactQueryIndex> index;
+  {
+    py::gil_scoped_release release;
+    decode_started = clock::now();
+    decoded =
+        codenib::core::decode_clangd_query_records(idx_directory, project_root);
+    decode_finished = clock::now();
+    index =
+        std::make_shared<codenib::core::FactQueryIndex>(decoded.records, false);
+    index_finished = clock::now();
+  }
+
+  auto elapsed_ns = [](clock::time_point start, clock::time_point end) {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+        .count();
+  };
+  py::dict result;
+  result["format"] = codenib::core::CLANGD_FACT_QUERY_FORMAT;
+  result["index"] = std::move(index);
+  result["native_decode_ns"] = elapsed_ns(decode_started, decode_finished);
+  result["native_index_ns"] = elapsed_ns(decode_finished, index_finished);
+  result["decode_profile_ns"] = clangd_decode_profile_to_dict(decoded.profile);
+  result["graph_materialized"] = false;
+  return result;
+}
+
+py::dict clangd_fact_query_contract() {
+  py::dict result;
+  result["abi_version"] = codenib::core::CLANGD_FACT_QUERY_ABI_VERSION;
+  result["format"] = codenib::core::CLANGD_FACT_QUERY_FORMAT;
+  result["stable_filename_order"] = true;
+  result["preserves_unanchored_relations"] = true;
+  result["capabilities"] = fact_query_capabilities();
+  return result;
+}
+
 codenib::core::LayerBuckets
 classify_edge_layers_py(const std::vector<std::string> &edge_types) {
   py::gil_scoped_release release;
@@ -395,6 +463,9 @@ PYBIND11_MODULE(codenib_core, m) {
                              &codenib::core::FactQueryIndex::symbol_count)
       .def_property_readonly("reference_count",
                              &codenib::core::FactQueryIndex::reference_count)
+      .def_property_readonly(
+          "requires_anchored_references",
+          &codenib::core::FactQueryIndex::requires_anchored_references)
       .def("has_symbol", &codenib::core::FactQueryIndex::has_symbol)
       .def("get_node_info_by_name",
            [](const codenib::core::FactQueryIndex &index,
@@ -493,6 +564,20 @@ route queries remain unavailable and no CodeGraph or igraph is materialized.
   m.def(
       "fact_query_index_contract", &fact_query_index_contract,
       R"pbdoc(Return the compiled FactQueryIndex ABI and capabilities.)pbdoc");
+
+  m.def("decode_clangd_fact_query_index", &decode_clangd_fact_query_index,
+        py::arg("idx_directory"), py::arg("project_root"),
+        R"pbdoc(
+Decode an existing project-local clangd .idx directory into FactQueryIndex v1.
+
+Direct .idx children are read in stable filename order into provider-neutral
+decoded records. The returned index supports symbol definitions and references
+without Python record dictionaries, CodeGraph, or igraph. Position and route
+queries remain outside this baseline capability.
+)pbdoc");
+
+  m.def("clangd_fact_query_contract", &clangd_fact_query_contract,
+        R"pbdoc(Return the baseline native clangd query ABI contract.)pbdoc");
 
   m.def("canonical_scip_decoder_languages",
         &codenib::core::canonical_scip_decoder_languages,

--- a/core/clangd_fact_query.cpp
+++ b/core/clangd_fact_query.cpp
@@ -1,0 +1,823 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "clangd_fact_query.h"
+
+#include <zlib.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace codenib::core {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+constexpr std::uint8_t REF_KIND_DEFINITION = 0x2;
+constexpr std::uint8_t REF_KIND_REFERENCE = 0x4;
+constexpr std::uint8_t REF_KIND_SPELLED = 0x8;
+
+constexpr std::uint8_t KIND_MACRO = 4;
+constexpr std::uint8_t KIND_STRUCT = 6;
+constexpr std::uint8_t KIND_CLASS = 7;
+constexpr std::uint8_t KIND_FUNCTION = 12;
+constexpr std::uint8_t KIND_FIELD = 14;
+constexpr std::uint8_t KIND_INSTANCE_METHOD = 16;
+constexpr std::uint8_t KIND_CLASS_METHOD = 17;
+constexpr std::uint8_t KIND_STATIC_METHOD = 18;
+constexpr std::uint8_t KIND_CONSTRUCTOR = 22;
+constexpr std::uint8_t KIND_DESTRUCTOR = 23;
+
+constexpr std::uint8_t RELATION_BASE_OF = 0;
+constexpr std::uint8_t RELATION_OVERRIDDEN_BY = 1;
+
+std::uint64_t elapsed_ns(Clock::time_point start, Clock::time_point end) {
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+          .count());
+}
+
+struct ByteView {
+  const std::uint8_t *data{nullptr};
+  std::size_t size{0};
+};
+
+class Reader {
+public:
+  explicit Reader(ByteView view)
+      : current_(view.data), end_(view.data + view.size) {}
+
+  bool empty() const { return current_ == end_; }
+  std::size_t remaining() const {
+    return static_cast<std::size_t>(end_ - current_);
+  }
+
+  std::uint8_t read_u8() {
+    require(1, "truncated clangd byte");
+    return *current_++;
+  }
+
+  std::uint64_t read_varint() {
+    std::uint64_t result = 0;
+    unsigned shift = 0;
+    for (unsigned count = 0; count < 10; ++count) {
+      const auto byte = read_u8();
+      const auto payload = static_cast<std::uint64_t>(byte & 0x7fU);
+      if (shift >= 64 ||
+          payload > (std::numeric_limits<std::uint64_t>::max() >> shift)) {
+        throw std::runtime_error("clangd varint overflows uint64");
+      }
+      result |= payload << shift;
+      if ((byte & 0x80U) == 0)
+        return result;
+      shift += 7;
+    }
+    throw std::runtime_error("clangd varint exceeds 10 bytes");
+  }
+
+  std::string read_symbol_id() {
+    require(8, "truncated clangd SymbolID");
+    std::string result(reinterpret_cast<const char *>(current_), 8);
+    current_ += 8;
+    return result;
+  }
+
+private:
+  void require(std::size_t count, const char *message) const {
+    if (count > remaining())
+      throw std::runtime_error(message);
+  }
+
+  const std::uint8_t *current_;
+  const std::uint8_t *end_;
+};
+
+std::uint32_t read_u32_le(const std::uint8_t *data) {
+  return static_cast<std::uint32_t>(data[0]) |
+         (static_cast<std::uint32_t>(data[1]) << 8U) |
+         (static_cast<std::uint32_t>(data[2]) << 16U) |
+         (static_cast<std::uint32_t>(data[3]) << 24U);
+}
+
+std::vector<std::uint8_t> read_file(const std::filesystem::path &path) {
+  std::ifstream stream(path, std::ios::binary | std::ios::ate);
+  if (!stream)
+    throw std::runtime_error("cannot open clangd index: " + path.string());
+  const auto end = stream.tellg();
+  if (end < 0)
+    throw std::runtime_error("cannot size clangd index: " + path.string());
+  const auto size = static_cast<std::uint64_t>(end);
+  if (size > std::numeric_limits<std::size_t>::max() ||
+      size > static_cast<std::uint64_t>(
+                 std::numeric_limits<std::streamsize>::max())) {
+    throw std::runtime_error("clangd index is too large for this platform: " +
+                             path.string());
+  }
+  std::vector<std::uint8_t> data(static_cast<std::size_t>(size));
+  stream.seekg(0, std::ios::beg);
+  if (!data.empty() &&
+      !stream.read(reinterpret_cast<char *>(data.data()),
+                   static_cast<std::streamsize>(data.size()))) {
+    throw std::runtime_error("cannot read clangd index: " + path.string());
+  }
+  return data;
+}
+
+std::unordered_map<std::string, ByteView>
+read_riff(const std::vector<std::uint8_t> &data) {
+  if (data.size() < 12)
+    throw std::runtime_error("truncated clangd RIFF header");
+  if (!std::equal(data.begin(), data.begin() + 4, "RIFF"))
+    throw std::runtime_error("not a RIFF file");
+  if (!std::equal(data.begin() + 8, data.begin() + 12, "CdIx"))
+    throw std::runtime_error("not a clangd CdIx index");
+
+  const auto declared =
+      static_cast<std::uint64_t>(read_u32_le(data.data() + 4));
+  const auto end64 = declared + 8ULL;
+  if (declared < 4 || end64 > data.size())
+    throw std::runtime_error("invalid clangd RIFF length");
+  const auto end = static_cast<std::size_t>(end64);
+
+  std::unordered_map<std::string, ByteView> chunks;
+  std::size_t offset = 12;
+  while (offset < end) {
+    if (end - offset < 8)
+      throw std::runtime_error("truncated RIFF chunk header");
+    const std::string id(reinterpret_cast<const char *>(data.data() + offset),
+                         4);
+    const auto length =
+        static_cast<std::uint64_t>(read_u32_le(data.data() + offset + 4));
+    offset += 8;
+    if (length > end - offset)
+      throw std::runtime_error("truncated RIFF chunk payload");
+    chunks[id] =
+        ByteView{data.data() + offset, static_cast<std::size_t>(length)};
+    offset += static_cast<std::size_t>(length);
+    if ((length & 1U) != 0) {
+      if (offset >= end)
+        throw std::runtime_error("missing RIFF padding byte");
+      ++offset;
+    }
+  }
+  if (offset != end)
+    throw std::runtime_error("invalid RIFF chunk alignment");
+  return chunks;
+}
+
+std::vector<std::string> decode_string_table(ByteView view) {
+  if (view.size < 4)
+    throw std::runtime_error("truncated clangd string table");
+  const auto expected = static_cast<std::uint64_t>(read_u32_le(view.data));
+  const auto *payload = view.data + 4;
+  const auto payload_size = view.size - 4;
+
+  std::vector<std::uint8_t> raw;
+  if (expected == 0) {
+    raw.assign(payload, payload + payload_size);
+  } else {
+    if (expected > std::numeric_limits<std::size_t>::max() ||
+        expected > std::numeric_limits<uLongf>::max() ||
+        payload_size > std::numeric_limits<uLong>::max()) {
+      throw std::runtime_error("clangd string table exceeds platform limits");
+    }
+    raw.resize(static_cast<std::size_t>(expected));
+    uLongf output_size = static_cast<uLongf>(raw.size());
+    const int status =
+        uncompress(reinterpret_cast<Bytef *>(raw.data()), &output_size,
+                   reinterpret_cast<const Bytef *>(payload),
+                   static_cast<uLong>(payload_size));
+    if (status != Z_OK || output_size != raw.size())
+      throw std::runtime_error("cannot decompress clangd string table");
+  }
+
+  std::vector<std::string> strings;
+  std::size_t start = 0;
+  for (std::size_t index = 0; index < raw.size(); ++index) {
+    if (raw[index] != 0)
+      continue;
+    strings.emplace_back(reinterpret_cast<const char *>(raw.data() + start),
+                         index - start);
+    start = index + 1;
+  }
+  if (start < raw.size()) {
+    strings.emplace_back(reinterpret_cast<const char *>(raw.data() + start),
+                         raw.size() - start);
+  }
+  return strings;
+}
+
+const std::string &string_at(const std::vector<std::string> &strings,
+                             std::uint64_t index) {
+  if (index >= strings.size())
+    throw std::runtime_error("clangd string index is out of range");
+  return strings[static_cast<std::size_t>(index)];
+}
+
+int checked_line(std::uint64_t value) {
+  if (value > static_cast<std::uint64_t>(std::numeric_limits<int>::max()))
+    throw std::runtime_error("clangd source line exceeds int range");
+  return static_cast<int>(value);
+}
+
+struct Location {
+  std::string file;
+  int start_line{0};
+  int start_col{0};
+  int end_line{0};
+  int end_col{0};
+};
+
+Location decode_location(Reader &reader,
+                         const std::vector<std::string> &strings) {
+  Location location;
+  location.file = string_at(strings, reader.read_varint());
+  location.start_line = checked_line(reader.read_varint());
+  location.start_col = checked_line(reader.read_varint());
+  location.end_line = checked_line(reader.read_varint());
+  location.end_col = checked_line(reader.read_varint());
+  return location;
+}
+
+struct SymbolRecord {
+  std::string id;
+  std::uint8_t kind{0};
+  std::string name;
+  std::string scope;
+  std::optional<Location> definition;
+  std::optional<Location> canonical_declaration;
+};
+
+struct ReferenceRecord {
+  std::uint8_t kind{0};
+  Location location;
+  std::string container;
+};
+
+struct ReferenceGroup {
+  std::string symbol_id;
+  std::vector<ReferenceRecord> refs;
+};
+
+struct RelationRecord {
+  std::string subject;
+  std::uint8_t predicate{0};
+  std::string object;
+};
+
+struct ParsedFile {
+  std::vector<SymbolRecord> symbols;
+  std::vector<ReferenceGroup> refs;
+  std::vector<RelationRecord> relations;
+};
+
+std::vector<SymbolRecord>
+decode_symbols(ByteView view, const std::vector<std::string> &strings) {
+  Reader reader(view);
+  std::vector<SymbolRecord> symbols;
+  while (!reader.empty()) {
+    SymbolRecord symbol;
+    symbol.id = reader.read_symbol_id();
+    symbol.kind = reader.read_u8();
+    (void)reader.read_u8(); // SymbolLanguage
+    symbol.name = string_at(strings, reader.read_varint());
+    symbol.scope = string_at(strings, reader.read_varint());
+    (void)string_at(strings,
+                    reader.read_varint()); // TemplateSpecializationArgs
+    symbol.definition = decode_location(reader, strings);
+    symbol.canonical_declaration =
+        decode_location(reader, strings);           // CanonicalDeclaration
+    (void)reader.read_varint();                     // References count
+    (void)reader.read_u8();                         // Flags
+    (void)string_at(strings, reader.read_varint()); // Signature
+    (void)string_at(strings,
+                    reader.read_varint());          // CompletionSnippetSuffix
+    (void)string_at(strings, reader.read_varint()); // Documentation
+    (void)string_at(strings, reader.read_varint()); // ReturnType
+    (void)string_at(strings, reader.read_varint()); // Type
+    const auto headers = reader.read_varint();
+    for (std::uint64_t index = 0; index < headers; ++index) {
+      (void)string_at(strings, reader.read_varint());
+      (void)reader.read_varint();
+    }
+    symbols.push_back(std::move(symbol));
+  }
+  return symbols;
+}
+
+std::vector<ReferenceGroup>
+decode_refs(ByteView view, const std::vector<std::string> &strings) {
+  Reader reader(view);
+  std::vector<ReferenceGroup> groups;
+  while (!reader.empty()) {
+    ReferenceGroup group;
+    group.symbol_id = reader.read_symbol_id();
+    const auto count = reader.read_varint();
+    if (count > std::numeric_limits<std::size_t>::max())
+      throw std::runtime_error("clangd reference count exceeds size_t");
+    group.refs.reserve(static_cast<std::size_t>(count));
+    for (std::uint64_t index = 0; index < count; ++index) {
+      ReferenceRecord reference;
+      reference.kind = reader.read_u8();
+      reference.location = decode_location(reader, strings);
+      reference.container = reader.read_symbol_id();
+      group.refs.push_back(std::move(reference));
+    }
+    groups.push_back(std::move(group));
+  }
+  return groups;
+}
+
+std::vector<RelationRecord> decode_relations(ByteView view) {
+  Reader reader(view);
+  std::vector<RelationRecord> relations;
+  while (!reader.empty()) {
+    RelationRecord relation;
+    relation.subject = reader.read_symbol_id();
+    relation.predicate = reader.read_u8();
+    relation.object = reader.read_symbol_id();
+    relations.push_back(std::move(relation));
+  }
+  return relations;
+}
+
+ParsedFile parse_idx(const std::vector<std::uint8_t> &data) {
+  const auto chunks = read_riff(data);
+  const auto string_chunk = chunks.find("stri");
+  if (string_chunk == chunks.end())
+    throw std::runtime_error("missing required clangd RIFF chunk: stri");
+  const auto strings = decode_string_table(string_chunk->second);
+
+  ParsedFile parsed;
+  if (const auto symbols = chunks.find("symb"); symbols != chunks.end())
+    parsed.symbols = decode_symbols(symbols->second, strings);
+  if (const auto refs = chunks.find("refs"); refs != chunks.end())
+    parsed.refs = decode_refs(refs->second, strings);
+  if (const auto relations = chunks.find("rela"); relations != chunks.end())
+    parsed.relations = decode_relations(relations->second);
+  return parsed;
+}
+
+bool has_file(const std::optional<Location> &location) {
+  return location.has_value() && !location->file.empty();
+}
+
+struct CollectedRecords {
+  std::vector<SymbolRecord> symbols;
+  std::unordered_map<std::string, std::size_t> symbol_indexes;
+  std::unordered_map<std::string, std::vector<ReferenceRecord>> refs;
+  std::vector<std::string> ref_order;
+  std::vector<RelationRecord> relations;
+};
+
+void merge_file(CollectedRecords &collected, ParsedFile parsed) {
+  for (auto &symbol : parsed.symbols) {
+    const auto found = collected.symbol_indexes.find(symbol.id);
+    if (found == collected.symbol_indexes.end()) {
+      const auto index = collected.symbols.size();
+      collected.symbol_indexes.emplace(symbol.id, index);
+      collected.symbols.push_back(std::move(symbol));
+      continue;
+    }
+    auto &existing = collected.symbols[found->second];
+    if (!has_file(existing.definition) && has_file(symbol.definition))
+      existing = std::move(symbol);
+  }
+
+  for (auto &group : parsed.refs) {
+    auto found = collected.refs.find(group.symbol_id);
+    if (found == collected.refs.end()) {
+      collected.ref_order.push_back(group.symbol_id);
+      found = collected.refs
+                  .emplace(group.symbol_id, std::vector<ReferenceRecord>{})
+                  .first;
+    }
+    auto &destination = found->second;
+    destination.insert(destination.end(),
+                       std::make_move_iterator(group.refs.begin()),
+                       std::make_move_iterator(group.refs.end()));
+  }
+  collected.relations.insert(collected.relations.end(),
+                             std::make_move_iterator(parsed.relations.begin()),
+                             std::make_move_iterator(parsed.relations.end()));
+}
+
+const char *node_type(std::uint8_t kind) {
+  if (kind == KIND_STRUCT || kind == KIND_CLASS)
+    return NODE_TYPE_CLASS;
+  if (kind == KIND_FUNCTION)
+    return NODE_TYPE_FUNCTION;
+  if (kind == KIND_INSTANCE_METHOD || kind == KIND_CLASS_METHOD ||
+      kind == KIND_STATIC_METHOD || kind == KIND_CONSTRUCTOR ||
+      kind == KIND_DESTRUCTOR) {
+    return NODE_TYPE_METHOD;
+  }
+  if (kind == KIND_FIELD)
+    return NODE_TYPE_FIELD;
+  return NODE_TYPE_SYMBOL;
+}
+
+std::string symbol_hex(const std::string &id) {
+  static constexpr std::array<char, 16> digits = {'0', '1', '2', '3', '4', '5',
+                                                  '6', '7', '8', '9', 'a', 'b',
+                                                  'c', 'd', 'e', 'f'};
+  std::string result(id.size() * 2, '0');
+  for (std::size_t index = 0; index < id.size(); ++index) {
+    const auto byte = static_cast<unsigned char>(id[index]);
+    result[index * 2] = digits[byte >> 4U];
+    result[index * 2 + 1] = digits[byte & 0x0fU];
+  }
+  return result;
+}
+
+std::filesystem::path normalized_absolute(const std::string &value) {
+  std::error_code error;
+  auto path = std::filesystem::absolute(std::filesystem::path(value), error);
+  if (error)
+    path = std::filesystem::path(value);
+  return path.lexically_normal();
+}
+
+struct IndexFile {
+  std::filesystem::path path;
+  std::string name;
+  std::uint64_t bytes{0};
+};
+
+std::vector<IndexFile>
+discover_index_files(const std::filesystem::path &directory) {
+  if (!std::filesystem::is_directory(directory))
+    throw std::runtime_error("clangd index directory does not exist: " +
+                             directory.string());
+  std::vector<IndexFile> files;
+  for (const auto &entry : std::filesystem::directory_iterator(directory)) {
+    if (!entry.is_regular_file() || entry.path().extension() != ".idx")
+      continue;
+    std::error_code size_error;
+    const auto bytes = entry.file_size(size_error);
+    if (size_error)
+      throw std::runtime_error("cannot size clangd index: " +
+                               entry.path().string());
+    files.push_back(IndexFile{entry.path(),
+                              entry.path().filename().generic_string(),
+                              static_cast<std::uint64_t>(bytes)});
+  }
+  std::sort(files.begin(), files.end(),
+            [](const IndexFile &left, const IndexFile &right) {
+              return left.name < right.name;
+            });
+  if (files.empty())
+    throw std::runtime_error("clangd index directory has no .idx files: " +
+                             directory.string());
+  return files;
+}
+
+bool path_has_prefix(const std::filesystem::path &path,
+                     const std::filesystem::path &prefix) {
+  auto path_part = path.begin();
+  for (auto prefix_part = prefix.begin(); prefix_part != prefix.end();
+       ++prefix_part, ++path_part) {
+    if (path_part == path.end() || *path_part != *prefix_part)
+      return false;
+  }
+  return true;
+}
+
+std::string relative_file(std::string uri,
+                          const std::filesystem::path &project_root) {
+  if (uri.rfind("file://", 0) == 0)
+    uri.erase(0, 7);
+  auto path = std::filesystem::path(uri).lexically_normal();
+  if (path_has_prefix(path, project_root)) {
+    const auto relative = path.lexically_relative(project_root);
+    if (!relative.empty())
+      return relative.generic_string();
+  }
+  return path.generic_string();
+}
+
+std::optional<Location>
+resolve_definition(const SymbolRecord &symbol,
+                   const std::vector<ReferenceRecord> *refs) {
+  if (refs != nullptr) {
+    for (const auto &reference : *refs) {
+      if ((reference.kind & REF_KIND_DEFINITION) != 0 &&
+          (reference.kind & REF_KIND_SPELLED) != 0) {
+        return reference.location;
+      }
+    }
+    for (const auto &reference : *refs) {
+      if ((reference.kind & REF_KIND_DEFINITION) != 0)
+        return reference.location;
+    }
+  }
+  if (has_file(symbol.definition))
+    return symbol.definition;
+  return std::nullopt;
+}
+
+void replace_scope_separators(std::string &value) {
+  std::size_t position = 0;
+  while ((position = value.find("::", position)) != std::string::npos) {
+    value.replace(position, 2, ".");
+    ++position;
+  }
+}
+
+std::shared_ptr<DecodedRecords>
+build_query_records(const CollectedRecords &collected,
+                    const std::filesystem::path &project_root) {
+  auto records = std::make_shared<DecodedRecords>();
+  records->project_root = project_root.generic_string();
+  records->vertices.reserve(collected.symbols.size());
+
+  std::unordered_map<std::string, CodeGraph::VertexId> record_indexes;
+  record_indexes.reserve(collected.symbols.size());
+  auto upsert_structural = [&](const std::string &name, const char *type) {
+    const auto found = record_indexes.find(name);
+    if (found != record_indexes.end()) {
+      records->vertices[static_cast<std::size_t>(found->second)].type = type;
+      return;
+    }
+    const auto id = static_cast<CodeGraph::VertexId>(records->vertices.size());
+    CodeGraph::VertexData vertex;
+    vertex.name = name;
+    vertex.type = type;
+    records->vertices.push_back(std::move(vertex));
+    record_indexes.emplace(name, id);
+  };
+  auto ensure_placeholder = [&](const std::string &name) {
+    if (record_indexes.find(name) != record_indexes.end())
+      return;
+    const auto id = static_cast<CodeGraph::VertexId>(records->vertices.size());
+    CodeGraph::VertexData vertex;
+    vertex.name = name;
+    records->vertices.push_back(std::move(vertex));
+    record_indexes.emplace(name, id);
+  };
+
+  upsert_structural(ROOT_NODE, "root");
+  std::unordered_set<std::string> observed_files;
+  std::unordered_set<std::string> observed_directories;
+  std::vector<std::pair<std::string, std::string>> structural_edge_names;
+  std::unordered_map<std::string, CodeGraph::VertexId> vertex_by_symbol;
+  vertex_by_symbol.reserve(collected.symbols.size());
+  for (const auto &symbol : collected.symbols) {
+    if (symbol.kind == KIND_MACRO)
+      continue;
+    std::string qualified = symbol.scope + symbol.name;
+    if (qualified.empty())
+      continue;
+    const auto ref_it = collected.refs.find(symbol.id);
+    const auto definition = resolve_definition(
+        symbol, ref_it == collected.refs.end() ? nullptr : &ref_it->second);
+    if (!definition.has_value() || definition->file.empty())
+      continue;
+    const std::string file = relative_file(definition->file, project_root);
+    if (std::filesystem::path(file).is_absolute() ||
+        file.find("third_party/") != std::string::npos) {
+      continue;
+    }
+
+    if (observed_files.insert(file).second) {
+      auto directory = std::filesystem::path(file).parent_path();
+      while (!directory.empty() && directory != directory.parent_path() &&
+             directory != std::filesystem::path(".")) {
+        const auto name = directory.generic_string();
+        if (observed_directories.insert(name).second) {
+          upsert_structural(name, NODE_TYPE_DIRECTORY);
+          auto parent = directory.parent_path().generic_string();
+          if (parent.empty() || parent == ".")
+            parent = ROOT_NODE;
+          ensure_placeholder(parent);
+          structural_edge_names.emplace_back(parent, name);
+        }
+        directory = directory.parent_path();
+      }
+      upsert_structural(file, NODE_TYPE_FILE);
+      auto parent = std::filesystem::path(file).parent_path().generic_string();
+      if (parent.empty() || parent == ".")
+        parent = ROOT_NODE;
+      ensure_placeholder(parent);
+      structural_edge_names.emplace_back(parent, file);
+    }
+
+    CodeGraph::VertexData vertex;
+    vertex.name = symbol_hex(symbol.id);
+    vertex.type = node_type(symbol.kind);
+    vertex.file = file;
+    vertex.start_line = definition->start_line;
+    vertex.end_line = definition->start_line;
+    vertex.selection_line = definition->start_line;
+    replace_scope_separators(qualified);
+    if (vertex.type == NODE_TYPE_FUNCTION || vertex.type == NODE_TYPE_METHOD)
+      qualified += "()";
+    vertex.unified_name = file + ":" + qualified;
+    vertex.has_definition = true;
+
+    const auto existing = record_indexes.find(vertex.name);
+    CodeGraph::VertexId id;
+    if (existing == record_indexes.end()) {
+      id = static_cast<CodeGraph::VertexId>(records->vertices.size());
+      record_indexes.emplace(vertex.name, id);
+      records->vertices.push_back(std::move(vertex));
+    } else {
+      id = existing->second;
+      records->vertices[static_cast<std::size_t>(id)] = std::move(vertex);
+    }
+    vertex_by_symbol.emplace(symbol.id, id);
+  }
+
+  std::unordered_map<std::string, std::vector<CodeGraph::VertexId>>
+      resolution_groups;
+  std::vector<std::string> resolution_display_order;
+  for (std::size_t index = 0; index < records->vertices.size(); ++index) {
+    const auto &vertex = records->vertices[index];
+    if (!vertex.unified_name.has_value() || vertex.unified_name->empty())
+      continue;
+    const auto id = static_cast<CodeGraph::VertexId>(index);
+    auto [group, inserted] =
+        resolution_groups.try_emplace(*vertex.unified_name);
+    if (inserted)
+      resolution_display_order.push_back(*vertex.unified_name);
+    group->second.push_back(id);
+  }
+  records->query_resolution_order.reserve(records->vertices.size());
+  std::vector<bool> resolution_seen(records->vertices.size(), false);
+  for (const auto &display : resolution_display_order) {
+    for (const auto id : resolution_groups.at(display)) {
+      records->query_resolution_order.push_back(id);
+      resolution_seen[static_cast<std::size_t>(id)] = true;
+    }
+  }
+  for (std::size_t index = 0; index < records->vertices.size(); ++index) {
+    if (!resolution_seen[index]) {
+      records->query_resolution_order.push_back(
+          static_cast<CodeGraph::VertexId>(index));
+    }
+  }
+
+  for (const auto &[source_name, target_name] : structural_edge_names) {
+    const auto source = record_indexes.find(source_name);
+    const auto target = record_indexes.find(target_name);
+    if (source == record_indexes.end() || target == record_indexes.end())
+      continue;
+    records->edges.push_back(CodeGraph::EdgeData{source->second, target->second,
+                                                 EDGE_TYPE_CONTAIN,
+                                                 std::nullopt, std::nullopt});
+  }
+
+  std::unordered_set<std::string> contained_symbols;
+  contained_symbols.reserve(vertex_by_symbol.size());
+  for (const auto &target_symbol : collected.ref_order) {
+    const auto target = vertex_by_symbol.find(target_symbol);
+    if (target == vertex_by_symbol.end())
+      continue;
+    const auto ref_group = collected.refs.find(target_symbol);
+    if (ref_group == collected.refs.end())
+      continue;
+    for (const auto &reference : ref_group->second) {
+      if ((reference.kind & REF_KIND_DEFINITION) == 0 ||
+          reference.container == std::string(8, '\0')) {
+        continue;
+      }
+      const auto source = vertex_by_symbol.find(reference.container);
+      if (source == vertex_by_symbol.end())
+        continue;
+      records->edges.push_back(
+          CodeGraph::EdgeData{source->second, target->second, EDGE_TYPE_CONTAIN,
+                              std::nullopt, std::nullopt});
+      contained_symbols.insert(target_symbol);
+      break;
+    }
+  }
+
+  for (const auto &symbol : collected.symbols) {
+    if (symbol.kind == KIND_MACRO ||
+        contained_symbols.find(symbol.id) != contained_symbols.end()) {
+      continue;
+    }
+    const auto target = vertex_by_symbol.find(symbol.id);
+    if (target == vertex_by_symbol.end())
+      continue;
+    const auto &vertex =
+        records->vertices[static_cast<std::size_t>(target->second)];
+    if (!vertex.file.has_value())
+      continue;
+    const auto source = record_indexes.find(*vertex.file);
+    if (source == record_indexes.end())
+      continue;
+    records->edges.push_back(CodeGraph::EdgeData{source->second, target->second,
+                                                 EDGE_TYPE_CONTAIN,
+                                                 std::nullopt, std::nullopt});
+  }
+
+  for (const auto &target_symbol : collected.ref_order) {
+    const auto target = vertex_by_symbol.find(target_symbol);
+    if (target == vertex_by_symbol.end())
+      continue;
+    const auto ref_group = collected.refs.find(target_symbol);
+    if (ref_group == collected.refs.end())
+      continue;
+    for (const auto &reference : ref_group->second) {
+      if ((reference.kind & REF_KIND_REFERENCE) == 0 ||
+          reference.container == std::string(8, '\0')) {
+        continue;
+      }
+      const auto source = vertex_by_symbol.find(reference.container);
+      if (source == vertex_by_symbol.end())
+        continue;
+      CodeGraph::EdgeData edge;
+      edge.source = source->second;
+      edge.target = target->second;
+      edge.type = EDGE_TYPE_REFERENCE;
+      if (!reference.location.file.empty())
+        edge.anchor_file = relative_file(reference.location.file, project_root);
+      edge.anchor_line = reference.location.start_line;
+      records->edges.push_back(std::move(edge));
+    }
+  }
+
+  for (const auto &relation : collected.relations) {
+    const auto subject = vertex_by_symbol.find(relation.subject);
+    const auto object = vertex_by_symbol.find(relation.object);
+    if (subject == vertex_by_symbol.end() || object == vertex_by_symbol.end())
+      continue;
+    if (relation.predicate != RELATION_BASE_OF &&
+        relation.predicate != RELATION_OVERRIDDEN_BY) {
+      continue;
+    }
+    records->edges.push_back(
+        CodeGraph::EdgeData{object->second, subject->second,
+                            EDGE_TYPE_REFERENCE, std::nullopt, std::nullopt});
+  }
+  return records;
+}
+
+} // namespace
+
+ClangdQueryRecords
+decode_clangd_query_records(const std::string &idx_directory,
+                            const std::string &project_root) {
+  const auto total_started = Clock::now();
+  ClangdFactDecodeProfile profile;
+
+  const auto discover_started = Clock::now();
+  const auto files = discover_index_files(normalized_absolute(idx_directory));
+  const auto root = normalized_absolute(project_root);
+  profile.file_count = files.size();
+  for (const auto &file : files)
+    profile.index_bytes += file.bytes;
+  profile.discover_files_ns = elapsed_ns(discover_started, Clock::now());
+
+  CollectedRecords collected;
+  for (const auto &file : files) {
+    const auto read_started = Clock::now();
+    auto data = read_file(file.path);
+    profile.read_files_ns += elapsed_ns(read_started, Clock::now());
+
+    const auto parse_started = Clock::now();
+    auto parsed = parse_idx(data);
+    profile.parse_files_ns += elapsed_ns(parse_started, Clock::now());
+    profile.raw_symbol_count += parsed.symbols.size();
+    for (const auto &group : parsed.refs)
+      profile.raw_reference_count += group.refs.size();
+
+    const auto merge_started = Clock::now();
+    merge_file(collected, std::move(parsed));
+    profile.merge_records_ns += elapsed_ns(merge_started, Clock::now());
+  }
+
+  const auto build_started = Clock::now();
+  auto records = build_query_records(collected, root);
+  profile.build_query_records_ns = elapsed_ns(build_started, Clock::now());
+  profile.decoded_record_count = records->vertices.size();
+  for (const auto &vertex : records->vertices) {
+    if (vertex.has_definition.value_or(false))
+      ++profile.definition_count;
+  }
+  for (const auto &edge : records->edges) {
+    if (edge.type == EDGE_TYPE_REFERENCE)
+      ++profile.reference_count;
+  }
+  profile.total_ns = elapsed_ns(total_started, Clock::now());
+  return ClangdQueryRecords{std::move(records), profile};
+}
+
+} // namespace codenib::core

--- a/core/clangd_fact_query.h
+++ b/core/clangd_fact_query.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "decoded_records.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace codenib::core {
+
+inline constexpr std::uint32_t CLANGD_FACT_QUERY_ABI_VERSION = 1;
+inline constexpr char CLANGD_FACT_QUERY_FORMAT[] = "clangd-riff-fact-query-v1";
+
+// Timings cover the baseline query-ready path from an existing project-local
+// clangd index. External clangd generation is deliberately outside this
+// contract and must be reported separately by callers.
+struct ClangdFactDecodeProfile {
+  std::uint64_t discover_files_ns{0};
+  std::uint64_t read_files_ns{0};
+  std::uint64_t parse_files_ns{0};
+  std::uint64_t merge_records_ns{0};
+  std::uint64_t build_query_records_ns{0};
+  std::uint64_t total_ns{0};
+  std::size_t file_count{0};
+  std::size_t raw_symbol_count{0};
+  std::size_t raw_reference_count{0};
+  std::size_t definition_count{0};
+  std::size_t reference_count{0};
+  std::size_t decoded_record_count{0};
+  std::uint64_t index_bytes{0};
+};
+
+struct ClangdQueryRecords {
+  std::shared_ptr<DecodedRecords> records;
+  ClangdFactDecodeProfile profile;
+};
+
+// Decode every direct *.idx child in stable filename order. Any read or parse
+// failure rejects the complete native candidate so Python auto mode can use
+// the established ClangdGraphDecoder without publishing partial rows.
+ClangdQueryRecords decode_clangd_query_records(const std::string &idx_directory,
+                                               const std::string &project_root);
+
+} // namespace codenib::core

--- a/core/decoded_records.h
+++ b/core/decoded_records.h
@@ -19,6 +19,11 @@ namespace codenib::core {
 struct DecodedRecords {
   std::vector<CodeGraph::VertexData> vertices;
   std::vector<CodeGraph::EdgeData> edges;
+  // Optional permutation used only while building user-facing symbol aliases.
+  // Providers whose legacy lookup groups equal display names can preserve that
+  // ordering without changing vertex ids or reference adjacency semantics.
+  // Empty means natural vertex order.
+  std::vector<CodeGraph::VertexId> query_resolution_order;
   std::string project_root;
 };
 

--- a/core/fact_query_index.cpp
+++ b/core/fact_query_index.cpp
@@ -36,8 +36,10 @@ bool has_suffix(const std::string &value, const std::string &suffix) {
 
 } // namespace
 
-FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records)
-    : records_(std::move(records)) {
+FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
+                               bool require_anchored_references)
+    : records_(std::move(records)),
+      require_anchored_references_(require_anchored_references) {
   if (!records_)
     throw std::invalid_argument("FactQueryIndex records must not be null");
 
@@ -77,12 +79,38 @@ FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records)
       }
       definition_by_name_.emplace(vertex.name, id);
     }
+  }
 
-    if (vertex.unified_name.has_value() && !vertex.unified_name->empty()) {
-      add_alias(*vertex.unified_name, id);
-      add_alias(graph_bare_symbol(*vertex.unified_name), id);
-      lsp_aliases_[*vertex.unified_name].push_back(id);
-      lsp_aliases_[bare_symbol(*vertex.unified_name)].push_back(id);
+  auto add_vertex_aliases = [&](CodeGraph::VertexId id) {
+    if (id < 0 || static_cast<std::size_t>(id) >= records_->vertices.size())
+      throw std::out_of_range(
+          "FactQueryIndex query resolution vertex is out of range");
+    const auto &vertex = records_->vertices[static_cast<std::size_t>(id)];
+    if (!vertex.unified_name.has_value() || vertex.unified_name->empty())
+      return;
+    add_alias(*vertex.unified_name, id);
+    add_alias(graph_bare_symbol(*vertex.unified_name), id);
+    lsp_aliases_[*vertex.unified_name].push_back(id);
+    lsp_aliases_[bare_symbol(*vertex.unified_name)].push_back(id);
+  };
+  if (records_->query_resolution_order.empty()) {
+    for (std::size_t index = 0; index < records_->vertices.size(); ++index)
+      add_vertex_aliases(static_cast<CodeGraph::VertexId>(index));
+  } else {
+    if (records_->query_resolution_order.size() != records_->vertices.size())
+      throw std::invalid_argument(
+          "FactQueryIndex query resolution order must cover every vertex");
+    std::vector<bool> observed(records_->vertices.size(), false);
+    for (const auto id : records_->query_resolution_order) {
+      if (id < 0 || static_cast<std::size_t>(id) >= observed.size())
+        throw std::out_of_range(
+            "FactQueryIndex query resolution vertex is out of range");
+      const auto index = static_cast<std::size_t>(id);
+      if (observed[index])
+        throw std::invalid_argument(
+            "FactQueryIndex query resolution order contains a duplicate");
+      observed[index] = true;
+      add_vertex_aliases(id);
     }
   }
 
@@ -98,10 +126,14 @@ FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records)
     }
     if (edge.type != EDGE_TYPE_REFERENCE)
       continue;
-    if (!edge.anchor_file.has_value() || edge.anchor_file->empty() ||
-        !edge.anchor_line.has_value() || *edge.anchor_line < 0) {
+    const bool has_file =
+        edge.anchor_file.has_value() && !edge.anchor_file->empty();
+    const bool has_line =
+        edge.anchor_line.has_value() && *edge.anchor_line >= 0;
+    if (has_file != has_line ||
+        (require_anchored_references_ && (!has_file || !has_line))) {
       throw std::invalid_argument(
-          "FactQueryIndex requires every reference to have a source anchor");
+          "FactQueryIndex reference has an invalid source anchor");
     }
     reference_indexes_by_source[static_cast<std::size_t>(edge.source)]
         .push_back(index);
@@ -346,7 +378,7 @@ FactQueryIndex::incoming_references(const std::string &target_name) const {
   for (const auto index : postings->second) {
     const auto &edge = records_->edges[index];
     result.push_back(
-        Reference{edge.source, *edge.anchor_file, *edge.anchor_line});
+        Reference{edge.source, edge.anchor_file, edge.anchor_line});
   }
   return result;
 }

--- a/core/fact_query_index.h
+++ b/core/fact_query_index.h
@@ -29,11 +29,12 @@ class FactQueryIndex {
 public:
   struct Reference {
     CodeGraph::VertexId source;
-    std::string anchor_file;
-    int anchor_line{0};
+    std::optional<std::string> anchor_file;
+    std::optional<int> anchor_line;
   };
 
-  explicit FactQueryIndex(std::shared_ptr<const DecodedRecords> records);
+  explicit FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
+                          bool require_anchored_references = true);
 
   bool has_symbol(const std::string &name) const;
   std::optional<CodeGraph::VertexData>
@@ -51,6 +52,9 @@ public:
   std::size_t edge_count() const { return records_->edges.size(); }
   std::size_t symbol_count() const { return definition_by_name_.size(); }
   std::size_t reference_count() const { return reference_count_; }
+  bool requires_anchored_references() const {
+    return require_anchored_references_;
+  }
 
 private:
   static std::string trim_symbol(std::string value);
@@ -70,6 +74,7 @@ private:
   std::unordered_map<CodeGraph::VertexId, std::vector<std::size_t>>
       incoming_reference_indexes_;
   std::size_t reference_count_{0};
+  bool require_anchored_references_{true};
 };
 
 } // namespace codenib::core

--- a/core/tests/fact_query_index_test.cpp
+++ b/core/tests/fact_query_index_test.cpp
@@ -105,6 +105,12 @@ void assert_symbol_resolution_and_postings() {
   assert(references[0].anchor_line == 10);
   assert(references[1].anchor_line == 8);
   assert(index.incoming_references("missing").empty());
+
+  auto custom_order = make_records();
+  custom_order->query_resolution_order = {0, 1, 3, 2, 4, 5, 6};
+  FactQueryIndex reordered(custom_order);
+  assert((reordered.resolve_symbol_candidates("run") ==
+          std::vector<std::string>{"canonical-run-two", "canonical-run-one"}));
 }
 
 void assert_invalid_records_fail_closed() {
@@ -145,6 +151,33 @@ void assert_invalid_records_fail_closed() {
   invalid_definition->vertices[0].end_line = 2;
   try {
     (void)FactQueryIndex(invalid_definition);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+
+  auto relation = make_records();
+  relation->edges.push_back(
+      {1, 0, codenib::core::EDGE_TYPE_REFERENCE, std::nullopt, std::nullopt});
+  FactQueryIndex permissive(relation, false);
+  assert(!permissive.requires_anchored_references());
+  const auto references = permissive.incoming_references("canonical-target");
+  assert(references.size() == 3);
+  assert(!references.front().anchor_file.has_value());
+  assert(!references.front().anchor_line.has_value());
+
+  auto partial_anchor = make_records();
+  partial_anchor->edges.push_back(
+      {1, 0, codenib::core::EDGE_TYPE_REFERENCE, "src/main.py", std::nullopt});
+  try {
+    (void)FactQueryIndex(partial_anchor, false);
+    assert(false);
+  } catch (const std::invalid_argument &) {
+  }
+
+  auto duplicate_resolution = make_records();
+  duplicate_resolution->query_resolution_order = {0, 1, 2, 3, 4, 5, 5};
+  try {
+    (void)FactQueryIndex(duplicate_resolution);
     assert(false);
   } catch (const std::invalid_argument &) {
   }

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -31,6 +31,7 @@ Requirements:
 - a C++17 compiler
 - `pkg-config`
 - RE2 development headers
+- zlib development headers
 - pybind11 in the active Python environment
 
 On Ubuntu:
@@ -73,6 +74,7 @@ and returns no graph. Non-SCIP backends such as C/C++ ignore
 
 The pybind module also exposes lower-level `decode_scip(...)`,
 `decode_scip_fact_buffer(...)`, `fact_batch_buffer_contract(...)`,
+`decode_clangd_fact_query_index(...)`, `clangd_fact_query_contract()`,
 `classify_edge_layers(...)`, and decoder-registry inspection functions. These
 are primarily integration surfaces; application code should normally use
 `LSIndexer` so filtering, occurrence indexes, range indexes, and persistence
@@ -145,6 +147,42 @@ make fact-query-profile \
 Pass `--external-index-seconds` through `FACT_QUERY_PROFILE_EXTRA_ARGS` when a
 separate cold-start analysis should include unchanged SCIP generation time.
 
+## Native clangd Symbol Queries
+
+The C/C++ query-specific path starts from an existing project-local clangd
+`.idx` directory. `decode_clangd_fact_query_index(...)` reads direct shards in
+stable filename order and decodes RIFF string, symbol, reference, and relation
+rows directly into provider-neutral `DecodedRecords`. `FactQueryIndex` then
+builds integer postings without a `CodeGraph`, igraph, or intermediate Python
+record dictionaries. Its explicit contract advertises symbol definition and
+reference support while position and route capabilities remain false.
+
+Call `LSIndexer.process_query_index()` to obtain the capability-specific index,
+or `process_query_provider()` for a hybrid provider. Successful symbol queries
+stay graph-free. The first position or route request lazily materializes the
+complete compatible graph, and later unsupported requests reuse it. The normal
+`process_index()` path, persistence format, incremental checks, range indexes,
+and graph quality behavior are unchanged.
+
+`CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX=auto` is promoted by default after the
+persisted-artifact query-ready gate passed on both the generated C++ fixture
+and `fmt`. It falls back to the complete graph on a native candidate failure;
+`off` always selects that graph and `required` fails closed. Reproduce the
+gate with:
+
+```bash
+make clangd-fact-query-profile \
+  CLANGD_FACT_QUERY_PROFILE_INDEX_DIR=/path/to/.cache/clangd/index \
+  CLANGD_FACT_QUERY_PROFILE_PROJECT_ROOT=/path/to/repository \
+  CLANGD_FACT_QUERY_PROFILE_OUTPUT=/tmp/clangd-fact-query.json \
+  CLANGD_FACT_QUERY_PROFILE_EXTRA_ARGS='--iterations 15 --warmups 5'
+```
+
+This result measures an already generated `.idx` directory through identical
+definition/reference work. It does not claim faster clangd generation. Native
+position/route lookup, serving integration, content receipts, and systematic
+format-version/resource hardening remain independent follow-up gates.
+
 ## Verify
 
 ```bash
@@ -164,6 +202,8 @@ skip report.
 - `fact_batch_buffer.{h,cpp}` defines the v1 native buffer ABI and encoder.
 - `fact_query_index.{h,cpp}` implements graph-free symbol and reference
   postings.
+- `clangd_fact_query.{h,cpp}` decodes clangd RIFF shards into provider-neutral
+  records for the query-specific path.
 - `graph_layers.{h,cpp}` classifies normalized edge types into reusable graph
   layers.
 - `scip_decode_base.{h,cpp}` and `scip_decode_common.{h,cpp}` provide shared

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -720,6 +720,43 @@ separate cold-start decision. Auto promotion is therefore restricted to
 Python and Rust; every other core language stays on CodeGraph until it clears
 the same 20% gate. clangd parsing (#555) remains a separate decision.
 
+Native clangd FactQueryIndex promotion status
+([#555](https://github.com/sysevol-ai/CodeNib/issues/555)): the baseline C/C++
+slice reads the direct `*.idx` children of an existing project-local clangd
+index in stable filename order, decodes RIFF records directly into
+`DecodedRecords`, and builds `FactQueryIndex` without Python record dictionaries,
+igraph, or `CodeGraph`. Its v1 contract exposes only definition and reference
+lookup by symbol. A hybrid provider keeps those successful calls graph-free
+and materializes the complete established graph exactly once for position or
+route fallback. Existing graph decode, persistence, incremental checks, and
+quality behavior remain unchanged. `auto` falls back on native candidate
+errors, `off` forces the complete graph, and `required` fails closed.
+
+The 2026-08-10 gate started from unchanged `.idx` shards, alternated complete
+graph and native arms for 15 measured iterations after five warmups, disabled
+cyclic garbage collection inside timed regions, used the same deterministic
+definition/reference workload, and exhaustively compared public results and
+errors for canonical, display, bare, quoted, ambiguous, and missing seeds:
+
+| clangd subject | Graph shape | Parity seeds | CodeGraph | Native index | Improvement | Result |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| `cpp_simple`, 0.9 MB | 33 vertices / 80 edges | 95 | 0.1162s | 0.0166s | +85.7% | promote auto |
+| `fmt`, 2.3 MB | 9,375 vertices / 36,614 edges | 25,101 | 1.2135s | 0.0974s | +92.0% | promote auto |
+
+Both parity gates passed: `cpp_simple` contained 26 definitions and 48
+references, while `fmt` contained 9,319 definitions and 27,240 references.
+The native graph-materialization stage was zero in every measured sample. The
+stable shard-set SHA-256 values were
+`ed4f34dc789611aa0f23cb1cfa6ad19a15d5bc36c43c7ac38adb1f0c42c70de4` and
+`b42e63b7afa75e2e45642779ff27ecf99505e1a4ea187a9c65d5c069884e6140`.
+Reproduce the report with `make clangd-fact-query-profile`.
+
+This promotion does not include or accelerate clangd index generation. RIFF
+version/resource hardening (#546), zlib CI enforcement (#547), content
+receipts (#548), serving integration (#549), mixed/RSS/concurrency matrices
+(#550), native position (#553), native route (#552), and durable FactBatch
+storage (#551) remain separate review and promotion gates.
+
 ### Phase 6: Multi-Graph Python Surface
 
 Mixed-language repositories need a Python-side graph aggregation path before a

--- a/scripts/profiling/profile_clangd_fact_query_index.py
+++ b/scripts/profiling/profile_clangd_fact_query_index.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark native clangd symbol queries against the complete CodeGraph.
+
+Both arms start from the same existing project-local .idx directory and run
+the same deterministic definition/reference workload. clangd index generation,
+position queries, routes, persistence, and serving integration are outside this
+baseline gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CORE_BUILD = _PROJECT_ROOT / "build/core"
+for candidate in (_CORE_BUILD, _PROJECT_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+from scripts.profiling.profile_fact_batch_buffer import (  # noqa: E402
+    DEFAULT_ITERATIONS,
+    DEFAULT_THRESHOLD,
+    DEFAULT_WARMUPS,
+    acceleration_decision,
+    summarize_samples,
+)
+from scripts.profiling.profile_fact_query_index import (  # noqa: E402
+    DEFAULT_PARITY_SAMPLE_LIMIT,
+    DEFAULT_QUERY_WORKLOAD_SIZE,
+    _assert_query_parity,
+    _definition_symbols,
+    _even_sample,
+    _parity_seeds,
+    _query_workload,
+    _reference_count,
+    _run_arm,
+    _timed,
+)
+
+
+def _idx_digest(idx_directory: Path) -> tuple[str, int, int]:
+    digest = hashlib.sha256()
+    total_bytes = 0
+    files = sorted(idx_directory.glob("*.idx"), key=lambda path: path.name)
+    for path in files:
+        name = path.name.encode("utf-8")
+        digest.update(len(name).to_bytes(8, "little"))
+        digest.update(name)
+        with path.open("rb") as handle:
+            for block in iter(lambda: handle.read(1024 * 1024), b""):
+                total_bytes += len(block)
+                digest.update(block)
+    return f"sha256:{digest.hexdigest()}", total_bytes, len(files)
+
+
+def _append_sample(samples: dict[str, list[float]], name: str, value: float) -> None:
+    samples.setdefault(name, []).append(float(value))
+
+
+def profile_clangd_fact_query_index(
+    *,
+    idx_directory: Path,
+    project_root: Path,
+    iterations: int = DEFAULT_ITERATIONS,
+    warmups: int = DEFAULT_WARMUPS,
+    threshold: float = DEFAULT_THRESHOLD,
+    external_index_seconds: float | None = None,
+    query_workload_size: int = DEFAULT_QUERY_WORKLOAD_SIZE,
+    parity_sample_limit: int = DEFAULT_PARITY_SAMPLE_LIMIT,
+) -> dict[str, Any]:
+    """Run alternating graph/native arms and return a reproducible report."""
+
+    if iterations < 1 or warmups < 0:
+        raise ValueError("iterations must be positive and warmups non-negative")
+    if query_workload_size < 1 or parity_sample_limit < 1:
+        raise ValueError("query and parity sample sizes must be positive")
+    idx_directory = idx_directory.resolve()
+    project_root = project_root.resolve()
+    if not idx_directory.is_dir():
+        raise FileNotFoundError(idx_directory)
+    if not project_root.is_dir():
+        raise FileNotFoundError(project_root)
+    if not any(idx_directory.glob("*.idx")):
+        raise ValueError(f"no .idx files in {idx_directory}")
+
+    import codenib_core
+
+    from codenib.ls_index.clangd_decode import ClangdGraphDecoder
+
+    if not hasattr(codenib_core, "decode_clangd_fact_query_index"):
+        raise RuntimeError("compiled core does not expose clangd FactQueryIndex v1")
+    contract = codenib_core.clangd_fact_query_contract()
+    initial_digest = _idx_digest(idx_directory)
+
+    def legacy_arm() -> tuple[Any, dict[str, float]]:
+        decoder = ClangdGraphDecoder(
+            idx_directory=str(idx_directory), project_root=str(project_root)
+        )
+        graph, startup = _timed(decoder.materialize_code_graph)
+        _, query = _timed(lambda: _query_workload(graph, workload_symbols))
+        return graph, {
+            "startup": startup,
+            "query_workload": query,
+        }
+
+    baseline_decoder = ClangdGraphDecoder(
+        idx_directory=str(idx_directory), project_root=str(project_root)
+    )
+    baseline_graph = baseline_decoder.materialize_code_graph()
+    all_symbols = _definition_symbols(baseline_graph)
+    if not all_symbols:
+        raise ValueError("benchmark index has no definition symbols")
+    expected_references = _reference_count(baseline_graph)
+    workload_symbols = _even_sample(all_symbols, query_workload_size)
+    parity_symbols = _even_sample(all_symbols, parity_sample_limit)
+    parity_seeds = _parity_seeds(baseline_graph, parity_symbols)
+
+    def native_arm() -> tuple[Any, dict[str, float]]:
+        payload, startup = _timed(
+            lambda: codenib_core.decode_clangd_fact_query_index(
+                idx_directory=str(idx_directory), project_root=str(project_root)
+            )
+        )
+        if payload.get("graph_materialized") is not False:
+            raise AssertionError("candidate payload reports graph materialization")
+        index = payload["index"]
+        _, query = _timed(lambda: _query_workload(index, workload_symbols))
+        native_decode = payload["native_decode_ns"] / 1_000_000_000
+        native_index = payload["native_index_ns"] / 1_000_000_000
+        count_fields = {
+            "file_count",
+            "raw_symbol_count",
+            "raw_reference_count",
+            "definition_count",
+            "reference_count",
+            "decoded_record_count",
+            "index_bytes",
+        }
+        stages = {
+            name: value / 1_000_000_000
+            for name, value in (payload.get("decode_profile_ns") or {}).items()
+            if name not in count_fields
+        }
+        return index, {
+            "startup": startup,
+            "native_decode": native_decode,
+            "native_index": native_index,
+            "boundary_residual": max(0.0, startup - native_decode - native_index),
+            "query_workload": query,
+            **{f"native_stage_{name}": value for name, value in stages.items()},
+        }
+
+    for _ in range(warmups):
+        _run_arm(legacy_arm)
+        _run_arm(native_arm)
+
+    legacy_samples: dict[str, list[float]] = {}
+    native_samples: dict[str, list[float]] = {}
+    first_arm_by_iteration: list[str] = []
+    last_graph = baseline_graph
+    last_index = None
+    for iteration in range(iterations):
+        if iteration % 2 == 0:
+            first_arm_by_iteration.append("legacy")
+            (last_graph, legacy_timing), legacy_total = _run_arm(legacy_arm)
+            (last_index, native_timing), native_total = _run_arm(native_arm)
+        else:
+            first_arm_by_iteration.append("native")
+            (last_index, native_timing), native_total = _run_arm(native_arm)
+            (last_graph, legacy_timing), legacy_total = _run_arm(legacy_arm)
+        legacy_timing["total"] = legacy_total
+        native_timing["total"] = native_total
+        for name, value in legacy_timing.items():
+            _append_sample(legacy_samples, name, value)
+        for name, value in native_timing.items():
+            _append_sample(native_samples, name, value)
+
+    parity = True
+    parity_error = None
+    try:
+        _assert_query_parity(
+            last_graph,
+            last_index,
+            seeds=parity_seeds,
+            expected_symbol_count=len(all_symbols),
+            expected_reference_count=expected_references,
+        )
+    except AssertionError as exc:
+        parity = False
+        parity_error = str(exc)
+
+    final_digest = _idx_digest(idx_directory)
+    if final_digest != initial_digest:
+        raise RuntimeError("clangd index changed during benchmark")
+    legacy_summary = {
+        name: summarize_samples(values) for name, values in legacy_samples.items()
+    }
+    native_summary = {
+        name: summarize_samples(values) for name, values in native_samples.items()
+    }
+    decision = acceleration_decision(
+        legacy_local_seconds=legacy_summary["total"]["median_seconds"],
+        candidate_local_seconds=native_summary["total"]["median_seconds"],
+        threshold=threshold,
+        external_index_seconds=external_index_seconds,
+        parity=parity,
+        candidate_name="native-clangd-fact-query-index",
+    )
+    idx_sha256, idx_bytes, idx_files = initial_digest
+    return {
+        "schema_version": 1,
+        "benchmark": "native_clangd_fact_query_index_v1",
+        "timer": "time.perf_counter",
+        "subject": {
+            "idx_directory": str(idx_directory),
+            "idx_files": idx_files,
+            "idx_bytes": idx_bytes,
+            "idx_sha256": idx_sha256,
+            "language": "cpp",
+            "project_root": str(project_root),
+            "definition_symbols": len(all_symbols),
+            "references": expected_references,
+        },
+        "configuration": {
+            "iterations": iterations,
+            "warmups": warmups,
+            "threshold": threshold,
+            "alternating_arm_order": True,
+            "first_arm_by_iteration": first_arm_by_iteration,
+            "query_workload_size": len(workload_symbols),
+            "parity_sample_size": len(parity_symbols),
+            "parity_seed_count": len(parity_seeds),
+            "cyclic_gc_collected_before_each_arm": True,
+            "cyclic_gc_disabled_during_timed_regions": True,
+            "external_index_seconds": external_index_seconds,
+            "clangd_fact_query_contract": contract,
+        },
+        "capabilities": dict(contract["capabilities"]),
+        "parity": {"passed": parity, "error": parity_error},
+        "raw_samples": {
+            "legacy_clangd_graph": legacy_samples,
+            "native_clangd_fact_query_index": native_samples,
+        },
+        "legacy_clangd_graph": legacy_summary,
+        "native_clangd_fact_query_index": native_summary,
+        "decision": decision,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--idx-directory", type=Path, required=True)
+    parser.add_argument("--project-root", type=Path, required=True)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    parser.add_argument("--external-index-seconds", type=float)
+    parser.add_argument(
+        "--query-workload-size", type=int, default=DEFAULT_QUERY_WORKLOAD_SIZE
+    )
+    parser.add_argument(
+        "--parity-sample-limit", type=int, default=DEFAULT_PARITY_SAMPLE_LIMIT
+    )
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = profile_clangd_fact_query_index(
+        idx_directory=args.idx_directory,
+        project_root=args.project_root,
+        iterations=args.iterations,
+        warmups=args.warmups,
+        threshold=args.threshold,
+        external_index_seconds=args.external_index_seconds,
+        query_workload_size=args.query_workload_size,
+        parity_sample_limit=args.parity_sample_limit,
+    )
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(rendered)
+    return 0 if report["parity"]["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/ls_index/test_clangd_fact_query.py
+++ b/test/ls_index/test_clangd_fact_query.py
@@ -1,0 +1,586 @@
+# SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Baseline native clangd symbol-query parity, fallback, and benchmark tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import struct
+import zlib
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+if importlib.util.find_spec("codenib_core") is None:
+    pytest.skip(
+        "codenib_core pybind module not built; run make core-build",
+        allow_module_level=True,
+    )
+
+import codenib_core  # noqa: E402
+
+from codenib.agent.lsp_graph import lsp_definition, lsp_references  # noqa: E402
+from codenib.agent.lsp_provider import StaticLSPProvider  # noqa: E402
+from codenib.graph.code_graph import CodeGraph  # noqa: E402
+from codenib.ls_index import clangd_decode  # noqa: E402
+from codenib.ls_index.clangd_decode import ClangdGraphDecoder  # noqa: E402
+from codenib.ls_index.clangd_decode import (
+    ClangdHybridQueryProvider,
+    _validate_native_query_contract,
+)
+from codenib.ls_router import LSIndexer  # noqa: E402
+from codenib.types import EDGE_TYPE_REFERENCE, node_has_definition  # noqa: E402
+from scripts.profiling.profile_clangd_fact_query_index import (  # noqa: E402
+    main as profile_main,
+)
+from scripts.profiling.profile_clangd_fact_query_index import (  # noqa: E402
+    profile_clangd_fact_query_index,
+)
+
+
+def _varint(value: int) -> bytes:
+    encoded = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            encoded.append(byte | 0x80)
+        else:
+            encoded.append(byte)
+            return bytes(encoded)
+
+
+def _location(
+    file_index: int,
+    line: int,
+    column: int = 0,
+    *,
+    end_column: int | None = None,
+) -> bytes:
+    resolved_end_column = column + 1 if end_column is None else end_column
+    return b"".join(
+        _varint(value)
+        for value in (file_index, line, column, line, resolved_end_column)
+    )
+
+
+def _symbol(
+    symbol_id: bytes,
+    *,
+    kind: int,
+    name_index: int,
+    scope_index: int,
+    file_index: int,
+    line: int,
+    column: int = 0,
+    end_column: int | None = None,
+) -> bytes:
+    return b"".join(
+        (
+            symbol_id,
+            bytes((kind, 2)),
+            _varint(name_index),
+            _varint(scope_index),
+            _varint(0),
+            _location(file_index, line, column, end_column=end_column),
+            _location(file_index, line, column, end_column=end_column),
+            _varint(0),
+            b"\x00",
+            _varint(0),
+            _varint(0),
+            _varint(0),
+            _varint(0),
+            _varint(0),
+            _varint(0),
+        )
+    )
+
+
+def _ref_group(symbol_id: bytes, rows: list[tuple[int, bytes, bytes]]) -> bytes:
+    payload = bytearray(symbol_id + _varint(len(rows)))
+    for kind, location, container in rows:
+        payload.extend(bytes((kind,)))
+        payload.extend(location)
+        payload.extend(container)
+    return bytes(payload)
+
+
+def _relation(subject: bytes, predicate: int, object_id: bytes) -> bytes:
+    return subject + bytes((predicate,)) + object_id
+
+
+def _riff_chunk(name: bytes, payload: bytes) -> bytes:
+    result = name + struct.pack("<I", len(payload)) + payload
+    return result + (b"\x00" if len(payload) % 2 else b"")
+
+
+def _riff_bytes(chunks: list[tuple[bytes, bytes]]) -> bytes:
+    body = b"CdIx" + b"".join(_riff_chunk(name, payload) for name, payload in chunks)
+    return b"RIFF" + struct.pack("<I", len(body)) + body
+
+
+def _empty_idx() -> bytes:
+    return _riff_bytes(
+        [
+            (b"meta", struct.pack("<I", 18)),
+            (b"stri", struct.pack("<I", 0) + b"\x00"),
+        ]
+    )
+
+
+@pytest.fixture()
+def clangd_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "repo"
+    source = root / "src" / "main.cpp"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        "int target() { return 1; }\n"
+        "int caller() { return target(); }\n"
+        "int target();\n"
+        "Thing value;\n",
+        encoding="utf-8",
+    )
+    idx_directory = root / ".cache" / "clangd" / "index"
+    idx_directory.mkdir(parents=True)
+
+    caller_id = bytes.fromhex("0102030405060708")
+    target_id = bytes.fromhex("1112131415161718")
+    method_one_id = bytes.fromhex("2122232425262728")
+    method_two_id = bytes.fromhex("3132333435363738")
+    function_id = bytes.fromhex("4142434445464748")
+    method_three_id = bytes.fromhex("5152535455565758")
+    directory_collision_id = bytes.fromhex("6162636465666768")
+    zero_id = b"\x00" * 8
+    strings = [
+        "",
+        source.as_uri(),
+        "caller",
+        "target",
+        "demo::",
+        "Thing",
+        "Thing::",
+        "src",
+    ]
+    raw_strings = b"\x00".join(value.encode("utf-8") for value in strings) + b"\x00"
+    string_table = struct.pack("<I", len(raw_strings)) + zlib.compress(raw_strings)
+    symbols = b"".join(
+        (
+            _symbol(
+                caller_id,
+                kind=12,
+                name_index=2,
+                scope_index=4,
+                file_index=1,
+                line=1,
+                column=4,
+                end_column=10,
+            ),
+            _symbol(
+                target_id,
+                kind=12,
+                name_index=3,
+                scope_index=4,
+                file_index=1,
+                line=0,
+                column=4,
+                end_column=10,
+            ),
+            _symbol(
+                method_one_id,
+                kind=22,
+                name_index=5,
+                scope_index=6,
+                file_index=1,
+                line=3,
+            ),
+            _symbol(
+                method_two_id,
+                kind=22,
+                name_index=5,
+                scope_index=6,
+                file_index=1,
+                line=3,
+            ),
+            _symbol(
+                function_id,
+                kind=12,
+                name_index=5,
+                scope_index=0,
+                file_index=1,
+                line=3,
+            ),
+            _symbol(
+                method_three_id,
+                kind=22,
+                name_index=5,
+                scope_index=6,
+                file_index=1,
+                line=3,
+            ),
+            _symbol(
+                directory_collision_id,
+                kind=12,
+                name_index=7,
+                scope_index=0,
+                file_index=1,
+                line=0,
+            ),
+        )
+    )
+    refs = b"".join(
+        (
+            _ref_group(
+                caller_id,
+                [(0x2 | 0x8, _location(1, 1, 4, end_column=10), zero_id)],
+            ),
+            _ref_group(
+                target_id,
+                [
+                    (0x2 | 0x8, _location(1, 0, 4, end_column=10), zero_id),
+                    (
+                        0x4 | 0x8,
+                        _location(1, 1, 22, end_column=28),
+                        caller_id,
+                    ),
+                    (
+                        0x4 | 0x8,
+                        _location(1, 1, 22, end_column=28),
+                        caller_id,
+                    ),
+                    (0x1 | 0x8, _location(1, 2, 4, end_column=10), zero_id),
+                ],
+            ),
+            _ref_group(
+                method_one_id,
+                [(0x4 | 0x8, _location(1, 3, 0, end_column=5), caller_id)],
+            ),
+            _ref_group(
+                method_two_id,
+                [(0x4 | 0x8, _location(1, 3, 0, end_column=5), caller_id)],
+            ),
+        )
+    )
+    relations = _relation(target_id, 0, caller_id)
+    (idx_directory / "main.cpp.TEST.idx").write_bytes(
+        _riff_bytes(
+            [
+                (b"meta", struct.pack("<I", 18)),
+                (b"stri", string_table),
+                (b"symb", symbols),
+                (b"refs", refs),
+                (b"rela", relations),
+            ]
+        )
+    )
+    return root, idx_directory
+
+
+def _definition_symbols(graph: CodeGraph) -> list[str]:
+    return [
+        name
+        for name in graph.name_to_vertex
+        if node_has_definition(graph.get_node_info_by_name(name) or {})
+    ]
+
+
+def _seeds(graph: CodeGraph) -> list[str]:
+    seeds: list[str] = []
+    for name in _definition_symbols(graph):
+        info = graph.get_node_info_by_name(name) or {}
+        display = str(info.get("unified_name") or name)
+        bare = display.split(":")[-1].split(".")[-1].rstrip("()")
+        seeds.extend((name, display, bare, f"`{bare}`"))
+    seeds.append("definitely-missing-native-clangd-symbol")
+    return list(dict.fromkeys(seed for seed in seeds if seed))
+
+
+def _outcome(call: Callable[[], Any]) -> tuple[Any, ...]:
+    try:
+        return "ok", call()
+    except Exception as exc:  # noqa: BLE001 - public error parity is required
+        return "error", type(exc).__name__, str(exc)
+
+
+def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
+    root, idx_directory = clangd_fixture
+    contract = codenib_core.clangd_fact_query_contract()
+    _validate_native_query_contract(contract)
+
+    payload = codenib_core.decode_clangd_fact_query_index(
+        idx_directory=str(idx_directory), project_root=str(root)
+    )
+    index = payload["index"]
+
+    assert contract == {
+        "abi_version": 1,
+        "format": "clangd-riff-fact-query-v1",
+        "stable_filename_order": True,
+        "preserves_unanchored_relations": True,
+        "capabilities": {
+            "definition_by_symbol": True,
+            "references_by_symbol": True,
+            "position_queries": False,
+            "route_queries": False,
+        },
+    }
+    assert payload["graph_materialized"] is False
+    assert payload["decode_profile_ns"]["materialize_graph"] == 0
+    assert index.fact_query_index is True
+    assert index.materializes_graph is False
+    assert index.requires_anchored_references is False
+    assert not hasattr(index, "graph")
+
+
+def test_symbol_results_errors_counts_and_relations_match_graph(
+    clangd_fixture,
+) -> None:
+    root, idx_directory = clangd_fixture
+    graph = ClangdGraphDecoder(str(idx_directory), str(root)).materialize_code_graph()
+    payload = codenib_core.decode_clangd_fact_query_index(
+        idx_directory=str(idx_directory), project_root=str(root)
+    )
+    index = payload["index"]
+    expected_references = sum(
+        edge.attributes().get("type") == EDGE_TYPE_REFERENCE for edge in graph.graph.es
+    )
+
+    assert index.record_count == graph.graph.vcount()
+    assert index.edge_count == graph.graph.ecount()
+    assert index.symbol_count == len(_definition_symbols(graph)) == 7
+    assert index.reference_count == expected_references == 5
+
+    for seed in _seeds(graph):
+        assert _outcome(
+            lambda seed=seed: lsp_definition(graph, symbol=seed, top_k=100)
+        ) == _outcome(lambda seed=seed: lsp_definition(index, symbol=seed, top_k=100))
+        for include_declaration in (False, True):
+            assert _outcome(
+                lambda seed=seed, include_declaration=include_declaration: (
+                    lsp_references(
+                        graph,
+                        symbol=seed,
+                        include_declaration=include_declaration,
+                        top_k=100,
+                    )
+                )
+            ) == _outcome(
+                lambda seed=seed, include_declaration=include_declaration: (
+                    lsp_references(
+                        index,
+                        symbol=seed,
+                        include_declaration=include_declaration,
+                        top_k=100,
+                    )
+                )
+            )
+
+    target = bytes.fromhex("1112131415161718").hex()
+    assert any(
+        node.file is None
+        for node in lsp_references(
+            index, symbol=target, include_declaration=False, top_k=100
+        )
+    )
+
+
+def test_native_file_discovery_is_stable_by_filename(
+    clangd_fixture, tmp_path: Path
+) -> None:
+    root, idx_directory = clangd_fixture
+    original = next(idx_directory.glob("*.idx")).read_bytes()
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "z.idx").write_bytes(original)
+    (first / "a.idx").write_bytes(_empty_idx())
+    (second / "a.idx").write_bytes(_empty_idx())
+    (second / "z.idx").write_bytes(original)
+
+    left = codenib_core.decode_clangd_fact_query_index(
+        idx_directory=str(first), project_root=str(root)
+    )["index"]
+    right = codenib_core.decode_clangd_fact_query_index(
+        idx_directory=str(second), project_root=str(root)
+    )["index"]
+
+    assert left.record_count == right.record_count
+    assert left.edge_count == right.edge_count
+    for seed in ("target", "Thing", "definitely-missing-native-clangd-symbol"):
+        assert _outcome(
+            lambda seed=seed: lsp_references(left, symbol=seed, top_k=100)
+        ) == _outcome(lambda seed=seed: lsp_references(right, symbol=seed, top_k=100))
+
+
+def test_selector_auto_off_required_and_failure_modes(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    monkeypatch.delenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", raising=False)
+    monkeypatch.setattr(clangd_decode, "_NATIVE_QUERY_PROMOTED", True)
+    automatic = ClangdGraphDecoder(str(idx_directory), str(root))
+
+    index = automatic.decode_query_index()
+
+    assert index.fact_query_index is True
+    assert automatic.query_backend == "native-clangd-fact-query-v1"
+    assert automatic._graph_materialized is False
+    assert automatic.query_profile["fact_query_native"] == 1
+
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "off")
+    disabled = ClangdGraphDecoder(str(idx_directory), str(root))
+    assert isinstance(disabled.decode_query_index(), CodeGraph)
+    assert disabled.query_backend == "legacy-query-disabled"
+    assert disabled._graph_materialized is True
+
+    def fail(**_kwargs):
+        raise RuntimeError("injected native clangd failure")
+
+    monkeypatch.setattr(codenib_core, "decode_clangd_fact_query_index", fail)
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "auto")
+    fallback = ClangdGraphDecoder(str(idx_directory), str(root))
+    assert isinstance(fallback.decode_query_index(), CodeGraph)
+    assert fallback.query_backend == "legacy-query-fallback"
+    assert "injected native clangd failure" in fallback.query_fallback_error
+
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "required")
+    with pytest.raises(RuntimeError, match="injected native clangd failure"):
+        ClangdGraphDecoder(str(idx_directory), str(root)).decode_query_index()
+
+
+def test_selector_does_not_mask_memory_exhaustion_or_unknown_mode(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+
+    def exhaust(**_kwargs):
+        raise MemoryError("injected allocation failure")
+
+    monkeypatch.setattr(codenib_core, "decode_clangd_fact_query_index", exhaust)
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "auto")
+    with pytest.raises(MemoryError, match="injected allocation failure"):
+        ClangdGraphDecoder(str(idx_directory), str(root)).decode_query_index()
+
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "sometimes")
+    with pytest.raises(
+        ValueError, match="CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX must be"
+    ):
+        ClangdGraphDecoder(str(idx_directory), str(root)).decode_query_index()
+
+
+def test_hybrid_uses_native_symbols_then_materializes_graph_once(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    monkeypatch.delenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", raising=False)
+    graph = ClangdGraphDecoder(str(idx_directory), str(root)).materialize_code_graph()
+    legacy = StaticLSPProvider(graph)
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    provider = decoder.decode_query_provider()
+    target = bytes.fromhex("1112131415161718").hex()
+
+    assert isinstance(provider, ClangdHybridQueryProvider)
+    assert [node.model_dump() for node in provider.definition(symbol=target)] == [
+        node.model_dump() for node in legacy.definition(symbol=target)
+    ]
+    assert decoder._graph_materialized is False
+
+    position_arguments = {
+        "file_path": "src/main.cpp",
+        "line": 1,
+        "character": 22,
+        "top_k": 100,
+    }
+    assert [
+        node.model_dump() for node in provider.definition(**position_arguments)
+    ] == [node.model_dump() for node in legacy.definition(**position_arguments)]
+    assert decoder._graph_materialized is True
+    assert provider.graph_materialization_count == 1
+
+    route_arguments = {
+        "symbols": [target],
+        "query": "target caller",
+        "top_k": 10,
+        "include_neighbors": True,
+    }
+    assert [node.model_dump() for node in provider.route(**route_arguments)] == [
+        node.model_dump() for node in legacy.route(**route_arguments)
+    ]
+    assert provider.graph_materialization_count == 1
+
+
+def test_ls_indexer_exposes_query_index_and_provider(
+    clangd_fixture, tmp_path: Path, monkeypatch
+) -> None:
+    root, _idx_directory = clangd_fixture
+    monkeypatch.delenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", raising=False)
+    indexer = LSIndexer(root, output_dir=tmp_path / "output", language="cpp")
+
+    index = indexer.process_query_index()
+    provider = indexer.process_query_provider()
+
+    assert index.fact_query_index is True
+    assert isinstance(provider, ClangdHybridQueryProvider)
+    assert provider.decoder._graph_materialized is False
+
+
+def test_profiler_records_parity_samples_order_and_contract(
+    clangd_fixture,
+) -> None:
+    root, idx_directory = clangd_fixture
+
+    report = profile_clangd_fact_query_index(
+        idx_directory=idx_directory,
+        project_root=root,
+        iterations=2,
+        warmups=0,
+        query_workload_size=4,
+        parity_sample_limit=7,
+    )
+
+    assert report["schema_version"] == 1
+    assert report["benchmark"] == "native_clangd_fact_query_index_v1"
+    assert report["parity"] == {"passed": True, "error": None}
+    assert report["configuration"]["first_arm_by_iteration"] == [
+        "legacy",
+        "native",
+    ]
+    assert report["configuration"]["clangd_fact_query_contract"] == (
+        codenib_core.clangd_fact_query_contract()
+    )
+    assert len(report["raw_samples"]["legacy_clangd_graph"]["total"]) == 2
+    assert len(report["raw_samples"]["native_clangd_fact_query_index"]["total"]) == 2
+    assert report["decision"]["parity"] is True
+
+
+def test_profiler_cli_writes_json(clangd_fixture, tmp_path: Path, capsys) -> None:
+    root, idx_directory = clangd_fixture
+    output = tmp_path / "clangd-query.json"
+
+    result = profile_main(
+        [
+            "--idx-directory",
+            str(idx_directory),
+            "--project-root",
+            str(root),
+            "--iterations",
+            "1",
+            "--warmups",
+            "0",
+            "--query-workload-size",
+            "2",
+            "--parity-sample-limit",
+            "2",
+            "--output-json",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    assert json.loads(output.read_text(encoding="utf-8")) == json.loads(
+        capsys.readouterr().out
+    )


### PR DESCRIPTION
## Summary

Land the baseline native clangd symbol-query vertical slice from an existing project-local `.idx` directory. The new capability-specific path reaches definition/reference query readiness without materializing CodeGraph, while unsupported position and route calls retain exact behavior through a lazy complete-graph fallback.

Closes #555.

## Changes

- Decode direct clangd RIFF shards in stable filename order into provider-neutral `DecodedRecords`, then build `FactQueryIndex` without Python record dictionaries or igraph.
- Add explicit `auto|off|required` selection, strict ABI/capability validation, graph-free success metadata, and one-time hybrid graph fallback.
- Preserve the established graph decode, persistence, incremental, range-index, and quality paths.
- Add synthetic exhaustive result/error parity coverage, real `cpp_simple` and `fmt` parity gates, an alternating-arm profiler, a Make target, and roadmap documentation.
- Keep RIFF hardening, CI/zlib enforcement, receipts, serving, mixed-load/resource gates, native position/route, and durable publication in their existing follow-up issues.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `make core-test`: 88 passed, 4 fixture-dependent skips; all four C++ test executables passed.
- LSP/provider/router/index-quality/incremental targeted tier: 130 passed.
- Non-slow/non-integration unit tier: 3,915 passed, 8 skipped, with two known unrelated baseline tests explicitly deselected (plus 198 marker deselections).
- Pre-commit hooks: all passed.
- `mkdocs build --strict` and public-doc boundary check: passed.
- `cpp_simple`: 95 parity seeds; 116.18 ms to 16.58 ms, 85.7% improvement.
- `fmt`: 25,101 parity seeds; 1.2135 s to 97.36 ms, 92.0% improvement.
- Both benchmark arms used 15 measured alternating iterations after five warmups; native graph materialization remained zero.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
