### PR TITLE
ci(core): enforce native clangd gates

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -351,8 +351,8 @@ jobs:
         run: pytest -m "integration_serial" -x -v --tb=short --timeout=900 --durations=20
 
   # =============================================================
-  # Job 3b — SCIP core  (builds core/ pybind + parity-checks the C++
-  # decoder against the serial graphs persisted by integration-serial.
+  # Job 3b — Native core (builds core/ pybind + runs the maintained C++,
+  # SCIP, Fact, and clangd gates, including serial graph parity)
   # Depends on integration-serial having run first to populate
   # $CODENIB_SCIP_CACHE with graph_ref.pkl per language.)
   # =============================================================
@@ -394,17 +394,18 @@ jobs:
           install-clangd: "true"
           install-bear: "true"
 
-      - name: Install C++ build deps (re2, cmake)
+      - name: Install C++ build deps
         shell: bash -l {0}
         timeout-minutes: 5
         # libigraph is vendored via FetchContent in core/CMakeLists.txt
-        # (see comment there) so we only need re2 + cmake from the system.
+        # (see comment there) so only re2, zlib, and build tools are system deps.
         run: |
           set -eu
           NEED=()
           command -v pkg-config >/dev/null 2>&1 || NEED+=(pkg-config)
           command -v cmake      >/dev/null 2>&1 || NEED+=(cmake)
           pkg-config --exists re2    2>/dev/null || NEED+=(libre2-dev)
+          pkg-config --exists zlib   2>/dev/null || NEED+=(zlib1g-dev)
           if [ ${#NEED[@]} -eq 0 ]; then
             echo "[deps] all present — skipping apt"
             exit 0
@@ -415,7 +416,7 @@ jobs:
 
       - name: Install pybind11
         shell: bash -l {0}
-        run: python -m pip install pybind11
+        run: make core-python-deps
 
       - name: Cache build/core
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -439,7 +440,7 @@ jobs:
             -DPython_EXECUTABLE="$(which python)"
           cmake --build build/core -j "$(nproc)"
 
-      - name: Run SCIP core parity tests
+      - name: Run maintained core gate
         shell: bash -l {0}
         env:
           PYTHONPATH: ${{ github.workspace }}/build/core
@@ -459,7 +460,7 @@ jobs:
           else
             echo "[ld] system libstdc++.so.6 not found via gcc; running without LD_PRELOAD"
           fi
-          pytest test/scip/test_scip_core.py -v --tb=short
+          make core-test
 
   # =============================================================
   # Job 5 — Graph cache consumer tests (~5 min)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ COMPOSER_DOCKER_IMAGE ?= composer:2
 SCIP_JDK_PACKAGE ?= openjdk-21-jdk
 SCIP_JDK_COMPAT_PACKAGES ?= openjdk-11-jdk
 ACTIVE_SCIP_SYSTEM_PACKAGES ?= bear build-essential clang clangd cmake curl git gzip nodejs npm pkg-config python3-dev python3-venv tar unzip $(SCIP_JDK_PACKAGE)
-CORE_SYSTEM_PACKAGES ?= build-essential cmake git libre2-dev pkg-config python3-dev python3-venv
+CORE_SYSTEM_PACKAGES ?= build-essential cmake git libre2-dev pkg-config python3-dev python3-venv zlib1g-dev
 SCIP_CANDIDATE_SYSTEM_PACKAGES ?= build-essential curl git gzip libyaml-dev ruby-dev ruby-full tar unzip zlib1g-dev
 SCIP_PHP_SYSTEM_PACKAGES ?= php-cli composer git unzip
 JDTLS_VERSION ?= 1.58.0
@@ -413,6 +413,7 @@ core-test: core-build
 	./build/core/graph_layers_test
 	./build/core/fact_batch_buffer_test
 	./build/core/fact_query_index_test
+	PYTHONPATH="build/core:$$PYTHONPATH" python -c 'import sys; import codenib_core as core; required = ("decode_clangd_fact_query_index", "clangd_fact_query_contract"); missing = [name for name in required if not hasattr(core, name)]; missing and sys.exit(f"codenib_core missing required bindings: {missing}")'
 	PYTHONPATH="build/core:$$PYTHONPATH" python -m pytest -q \
 		test/scip/test_scip_core.py \
 		test/scip/test_scip_core_registry.py \

--- a/core/README.md
+++ b/core/README.md
@@ -59,6 +59,11 @@ The resulting library and Python extension are placed in `build/core`.
 c-igraph is fetched by CMake and linked privately to avoid symbol clashes with
 the Python `igraph` wheel.
 
+`make core-test` is also the maintained native gate used by trusted full CI.
+It runs every C++ test executable, verifies that the built extension exports
+the required clangd query ABI, and then runs the SCIP, Fact, clangd, and
+profiling-contract Python tests with `build/core` first on `PYTHONPATH`.
+
 Some parity tests use generated SCIP integration fixtures and are skipped when
 those caches are absent. Always inspect the skip report from `make core-test`.
 

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -107,7 +107,7 @@ preflight ─ unit ─ integration ─ integration-serial ─┬─ scip-core �
 | **unit** | `preflight` | self-hosted | `not slow and not integration and not integration_serial and not integration_serial_consumer` | 20 min |
 | **integration** | `preflight`, `unit` | self-hosted | `integration and not slow` | 30 min |
 | **integration-serial** | `preflight`, `integration` | self-hosted | `integration_serial` | 45 min |
-| **scip-core** | `preflight`, `integration-serial` | self-hosted | `test/scip/test_scip_core.py` (C++ decoder parity) | 30 min |
+| **scip-core** | `preflight`, `integration-serial` | self-hosted | `make core-test` (C++ executables plus SCIP/Fact/clangd parity) | 30 min |
 | **graph-consumer** | `preflight`, `integration-serial` | self-hosted | `integration_serial_consumer` | 15 min |
 | **slow** | `preflight`, `unit`, `integration`, `integration-serial`, `scip-core`, `graph-consumer` | self-hosted | `slow` | 60 min |
 
@@ -246,13 +246,14 @@ pytest -m "integration_serial" -x -v --tb=short --timeout=900 --durations=20
 
 ### scip-core
 
-Builds the `core/` C++ pybind module and **parity-checks the C++ decoder against
-the Python implementation** using the serial graphs persisted by
-`integration-serial`. Gated on both `should-run` and `run-serial`. Key steps:
+Builds the `core/` C++ pybind module and runs the maintained C++, SCIP, Fact,
+and clangd gate, including decoder parity against the serial graphs persisted
+by `integration-serial`. Gated on both `should-run` and `run-serial`. Key
+steps:
 
 - Checks out with `submodules: recursive` (libigraph is vendored via
-  `FetchContent` in `core/CMakeLists.txt`; only `re2` + `cmake` come from the
-  system).
+  `FetchContent` in `core/CMakeLists.txt`; `re2`, zlib, and build tools come
+  from the system).
 - Installs `pybind11`, caches `build/core`, then builds:
 
   ```bash
@@ -263,12 +264,17 @@ the Python implementation** using the serial graphs persisted by
   cmake --build build/core -j "$(nproc)"
   ```
 
-- Runs the parity tests with `PYTHONPATH=build/core` and an `LD_PRELOAD` of the
-  system `libstdc++.so.6` (to match the GCC that compiled the pybind `.so`):
+- Runs the maintained native gate with an `LD_PRELOAD` of the system
+  `libstdc++.so.6` (to match the GCC that compiled the pybind `.so`):
 
   ```bash
-  pytest test/scip/test_scip_core.py -v --tb=short
+  make core-test
   ```
+
+  This incrementally reuses the configured build, runs all C++ executables,
+  verifies the required clangd bindings are present, and executes the SCIP,
+  Fact, clangd, and profiler-contract Python tests with `build/core` first on
+  `PYTHONPATH`. The same `make core-test` command is the local reproduction.
 
 ### graph-consumer
 

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -190,10 +190,13 @@ make core-test
 ```
 
 This runs the C++ smoke tests, graph-layer checks, registry consistency checks,
-and the serial/core parity fixtures available in the checkout. Some
-integration-cache parity cases are skipped when their generated SCIP fixtures
-are not present, so a successful local run should be read together with its
-skip report.
+Fact transport/query tests, native clangd result/error and fallback tests, and
+the serial/core parity fixtures available in the checkout. Before pytest it
+also requires the built extension to export the native clangd decode and
+contract bindings, so an absent or stale extension cannot turn that gate into
+a skip. Some integration-cache parity cases are skipped when their generated
+SCIP fixtures are not present, so a successful local run should be read
+together with its skip report.
 
 ## Components
 

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -757,6 +757,20 @@ receipts (#548), serving integration (#549), mixed/RSS/concurrency matrices
 (#550), native position (#553), native route (#552), and durable FactBatch
 storage (#551) remain separate review and promotion gates.
 
+Native core CI enforcement status
+([#547](https://github.com/sysevol-ai/CodeNib/issues/547)): the trusted
+`scip-core` job now declares zlib development headers alongside RE2 and CMake,
+preserves the vendored-igraph and system-libstdc++ loader contracts, and calls
+the maintained `make core-test` gate instead of one SCIP-only pytest file. The
+gate runs all four C++ executables plus SCIP, Fact, native clangd, fallback, and
+profiler-contract Python tests. It first asserts that the built extension
+exports `decode_clangd_fact_query_index` and `clangd_fact_query_contract`, so a
+missing or stale extension cannot silently skip the clangd module. CI-policy
+tests pin the dependency probe, Make target, binding guard, and test inventory.
+The same `make core-test` command is the documented local reproduction; slow,
+billed, and external clangd-generation benchmarks remain outside this
+deterministic job.
+
 ### Phase 6: Multi-Graph Python Surface
 
 Mixed-language repositories need a Python-side graph aggregation path before a

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -27,8 +27,8 @@ the heavier deps, and pick the right tier: anything that *mutates* a shared
 repo must be `integration_serial`, never plain `integration` — the
 `integration` job runs parallel under pytest-xdist and a mutating test breaks
 it. The CI jobs key off exactly these markers (`unit`, `integration`,
-`integration-serial`, `graph-consumer`, `slow`; `scip-core` runs
-`test/scip/test_scip_core.py` directly) — see
+`integration-serial`, `graph-consumer`, `slow`; `scip-core` runs the C++
+executables and SCIP/Fact/clangd Python gates through `make core-test`) — see
 [`docs/ci_cd.md`](../docs/ci_cd.md) for the job chain.
 
 ## Fixtures & caches

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -283,6 +283,42 @@ def test_trusted_full_ci_is_separate_from_pull_request_ci() -> None:
         assert full_ci["jobs"][name]["runs-on"] == "self-hosted"
 
 
+def test_full_ci_enforces_the_maintained_native_core_gate() -> None:
+    workflow = _workflow(".github/workflows/ci-full.yml")
+    steps = workflow["jobs"]["scip-core"]["steps"]
+    dependency_step = next(
+        step for step in steps if step.get("name") == "Install C++ build deps"
+    )
+    gate_step = next(
+        step for step in steps if step.get("name") == "Run maintained core gate"
+    )
+    dependency_run = str(dependency_step["run"])
+    gate_run = str(gate_step["run"])
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    core_target = makefile.split("\ncore-test:", 1)[1].split("\n\n", 1)[0]
+
+    assert "pkg-config --exists zlib" in dependency_run
+    assert "zlib1g-dev" in dependency_run
+    core_packages = next(
+        line
+        for line in makefile.splitlines()
+        if line.startswith("CORE_SYSTEM_PACKAGES")
+    )
+    assert "zlib1g-dev" in core_packages
+    assert "make core-test" in gate_run
+    assert "pytest test/scip/test_scip_core.py" not in gate_run
+    assert "LD_PRELOAD" in gate_run
+    assert "decode_clangd_fact_query_index" in core_target
+    for command in (
+        "./build/core/scip_decode_test",
+        "./build/core/graph_layers_test",
+        "./build/core/fact_batch_buffer_test",
+        "./build/core/fact_query_index_test",
+        "test/ls_index/test_clangd_fact_query.py",
+    ):
+        assert command in core_target
+
+
 def test_draft_ci_defers_hosted_unit_tests_until_review() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Make the trusted native core job enforce the complete maintained C++/SCIP/Fact/clangd gate instead of one SCIP-only pytest file, with zlib declared for clean Ubuntu builds.

Closes #547.

## Changes

- Add `zlib1g-dev` to the reusable core Ubuntu dependency set and probe `pkg-config zlib` in `scip-core` before building.
- Preserve the Release CMake configuration, build cache, vendored-igraph linkage, and system `libstdc++` preload, then run `make core-test` as the single test inventory.
- Fail before pytest if a missing or stale extension does not export `decode_clangd_fact_query_index` and `clangd_fact_query_contract`.
- Add CI-policy coverage that pins zlib, the Make entry point, all four C++ executables, and the native clangd Python gate.
- Update core, CI, test-contract, and multi-language roadmap documentation with the one-command local reproduction.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes
- `make core-test`: all four C++ executables passed; 88 Python tests passed and 4 integration-cache fixtures skipped.
- `pytest -q test/test_ci_policy.py --tb=short`: 18 passed.
- Pre-commit hooks: all passed.
- `python -m mkdocs build --strict`: passed.
- `python scripts/check_public_docs.py`: passed.
- The trusted main `scip-core` run will be monitored after merge because `ci-full.yml` intentionally does not execute privileged self-hosted jobs on pull requests.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
