### PR TITLE
fix(cpp): harden clangd RIFF decoding

### DIFF
--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -253,6 +253,9 @@ py::dict clangd_decode_profile_to_dict(
   result["reference_count"] = profile.reference_count;
   result["decoded_record_count"] = profile.decoded_record_count;
   result["index_bytes"] = profile.index_bytes;
+  result["decompressed_string_bytes"] = profile.decompressed_string_bytes;
+  result["materialized_string_bytes"] = profile.materialized_string_bytes;
+  result["string_entry_count"] = profile.string_entry_count;
   return result;
 }
 
@@ -408,9 +411,32 @@ py::dict decode_clangd_fact_query_index(const std::string &idx_directory,
 }
 
 py::dict clangd_fact_query_contract() {
+  const codenib::core::ClangdFactDecodeLimits limits;
+  py::dict resource_limits;
+  resource_limits["max_index_files"] = limits.max_index_files;
+  resource_limits["max_chunks_per_file"] = limits.max_chunks_per_file;
+  resource_limits["max_index_file_bytes"] = limits.max_index_file_bytes;
+  resource_limits["max_aggregate_index_bytes"] =
+      limits.max_aggregate_index_bytes;
+  resource_limits["max_string_table_bytes"] = limits.max_string_table_bytes;
+  resource_limits["max_aggregate_string_table_bytes"] =
+      limits.max_aggregate_string_table_bytes;
+  resource_limits["max_string_entries_per_file"] =
+      limits.max_string_entries_per_file;
+  resource_limits["max_aggregate_string_entries"] =
+      limits.max_aggregate_string_entries;
+  resource_limits["max_materialized_string_bytes_per_file"] =
+      limits.max_materialized_string_bytes_per_file;
+  resource_limits["max_aggregate_materialized_string_bytes"] =
+      limits.max_aggregate_materialized_string_bytes;
+  resource_limits["max_records_per_file"] = limits.max_records_per_file;
+  resource_limits["max_aggregate_records"] = limits.max_aggregate_records;
+
   py::dict result;
   result["abi_version"] = codenib::core::CLANGD_FACT_QUERY_ABI_VERSION;
   result["format"] = codenib::core::CLANGD_FACT_QUERY_FORMAT;
+  result["supported_versions"] = codenib::core::CLANGD_SUPPORTED_RIFF_VERSIONS;
+  result["resource_limits"] = std::move(resource_limits);
   result["stable_filename_order"] = true;
   result["preserves_unanchored_relations"] = true;
   result["capabilities"] = fact_query_capabilities();

--- a/core/clangd_fact_query.cpp
+++ b/core/clangd_fact_query.cpp
@@ -16,9 +16,11 @@
 #include <fstream>
 #include <iterator>
 #include <limits>
+#include <new>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -47,6 +49,97 @@ constexpr std::uint8_t KIND_DESTRUCTOR = 23;
 constexpr std::uint8_t RELATION_BASE_OF = 0;
 constexpr std::uint8_t RELATION_OVERRIDDEN_BY = 1;
 
+bool is_supported_version(std::uint32_t version) {
+  return std::find(CLANGD_SUPPORTED_RIFF_VERSIONS.begin(),
+                   CLANGD_SUPPORTED_RIFF_VERSIONS.end(),
+                   version) != CLANGD_SUPPORTED_RIFF_VERSIONS.end();
+}
+
+bool is_known_chunk(std::string_view id) {
+  return id == "meta" || id == "srcs" || id == "stri" || id == "symb" ||
+         id == "refs" || id == "rela" || id == "cmdl";
+}
+
+template <typename Value>
+void consume_budget(Value amount, Value &used, Value limit,
+                    std::string_view label) {
+  if (used > limit || amount > limit - used) {
+    throw std::runtime_error("clangd " + std::string(label) +
+                             " exceeds safety limit " + std::to_string(limit));
+  }
+  used += amount;
+}
+
+struct DecodeBudget {
+  explicit DecodeBudget(const ClangdFactDecodeLimits &limits)
+      : limits(limits) {}
+
+  const ClangdFactDecodeLimits &limits;
+  std::uint64_t string_table_bytes{0};
+  std::uint64_t materialized_string_bytes{0};
+  std::size_t string_entries{0};
+  std::size_t records{0};
+};
+
+struct FileBudget {
+  explicit FileBudget(DecodeBudget &aggregate) : aggregate(aggregate) {}
+
+  void consume_string_bytes(std::uint64_t amount) {
+    if (amount > aggregate.limits.max_string_table_bytes) {
+      throw std::runtime_error(
+          "clangd string table exceeds per-file safety limit " +
+          std::to_string(aggregate.limits.max_string_table_bytes));
+    }
+    consume_budget(amount, aggregate.string_table_bytes,
+                   aggregate.limits.max_aggregate_string_table_bytes,
+                   "aggregate decompressed string bytes");
+  }
+
+  void consume_string_entries(std::size_t amount) {
+    if (amount > aggregate.limits.max_string_entries_per_file) {
+      throw std::runtime_error(
+          "clangd string table exceeds per-file entry limit " +
+          std::to_string(aggregate.limits.max_string_entries_per_file));
+    }
+    consume_budget(amount, aggregate.string_entries,
+                   aggregate.limits.max_aggregate_string_entries,
+                   "aggregate string entries");
+  }
+
+  void consume_materialized_string_bytes(std::uint64_t amount) {
+    if (file_materialized_string_bytes >
+            aggregate.limits.max_materialized_string_bytes_per_file ||
+        amount > aggregate.limits.max_materialized_string_bytes_per_file -
+                     file_materialized_string_bytes) {
+      throw std::runtime_error(
+          "clangd copied strings exceed per-file safety limit " +
+          std::to_string(
+              aggregate.limits.max_materialized_string_bytes_per_file));
+    }
+    file_materialized_string_bytes += amount;
+    consume_budget(amount, aggregate.materialized_string_bytes,
+                   aggregate.limits.max_aggregate_materialized_string_bytes,
+                   "aggregate copied string bytes");
+  }
+
+  void consume_records(std::size_t amount, std::string_view kind) {
+    if (file_records > aggregate.limits.max_records_per_file ||
+        amount > aggregate.limits.max_records_per_file - file_records) {
+      throw std::runtime_error(
+          "clangd " + std::string(kind) + " exceeds per-file record limit " +
+          std::to_string(aggregate.limits.max_records_per_file));
+    }
+    file_records += amount;
+    consume_budget(amount, aggregate.records,
+                   aggregate.limits.max_aggregate_records,
+                   "aggregate decoded records");
+  }
+
+  DecodeBudget &aggregate;
+  std::size_t file_records{0};
+  std::uint64_t file_materialized_string_bytes{0};
+};
+
 std::uint64_t elapsed_ns(Clock::time_point start, Clock::time_point end) {
   return static_cast<std::uint64_t>(
       std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
@@ -60,52 +153,47 @@ struct ByteView {
 
 class Reader {
 public:
-  explicit Reader(ByteView view)
-      : current_(view.data), end_(view.data + view.size) {}
+  explicit Reader(ByteView view) : view_(view) {}
 
-  bool empty() const { return current_ == end_; }
-  std::size_t remaining() const {
-    return static_cast<std::size_t>(end_ - current_);
-  }
+  bool empty() const { return offset_ >= view_.size; }
+  std::size_t remaining() const { return view_.size - offset_; }
 
   std::uint8_t read_u8() {
-    require(1, "truncated clangd byte");
-    return *current_++;
+    require(1, "uint8");
+    return view_.data[offset_++];
   }
 
   std::uint64_t read_varint() {
-    std::uint64_t result = 0;
-    unsigned shift = 0;
-    for (unsigned count = 0; count < 10; ++count) {
+    std::uint64_t value = 0;
+    unsigned int shift = 0;
+    for (unsigned int count = 0; count < 10; ++count) {
       const auto byte = read_u8();
-      const auto payload = static_cast<std::uint64_t>(byte & 0x7fU);
-      if (shift >= 64 ||
-          payload > (std::numeric_limits<std::uint64_t>::max() >> shift)) {
+      if (shift == 63 && (byte & 0x7eU) != 0)
         throw std::runtime_error("clangd varint overflows uint64");
-      }
-      result |= payload << shift;
+      value |= static_cast<std::uint64_t>(byte & 0x7fU) << shift;
       if ((byte & 0x80U) == 0)
-        return result;
+        return value;
       shift += 7;
     }
     throw std::runtime_error("clangd varint exceeds 10 bytes");
   }
 
   std::string read_symbol_id() {
-    require(8, "truncated clangd SymbolID");
-    std::string result(reinterpret_cast<const char *>(current_), 8);
-    current_ += 8;
+    require(8, "SymbolID");
+    std::string result(reinterpret_cast<const char *>(view_.data + offset_), 8);
+    offset_ += 8;
     return result;
   }
 
 private:
-  void require(std::size_t count, const char *message) const {
-    if (count > remaining())
-      throw std::runtime_error(message);
+  void require(std::size_t count, const char *what) const {
+    if (count > remaining()) {
+      throw std::runtime_error(std::string("truncated clangd ") + what);
+    }
   }
 
-  const std::uint8_t *current_;
-  const std::uint8_t *end_;
+  ByteView view_;
+  std::size_t offset_{0};
 };
 
 std::uint32_t read_u32_le(const std::uint8_t *data) {
@@ -115,61 +203,77 @@ std::uint32_t read_u32_le(const std::uint8_t *data) {
          (static_cast<std::uint32_t>(data[3]) << 24U);
 }
 
-std::vector<std::uint8_t> read_file(const std::filesystem::path &path) {
-  std::ifstream stream(path, std::ios::binary | std::ios::ate);
-  if (!stream)
+std::vector<std::uint8_t> read_file(const std::filesystem::path &path,
+                                    const ClangdFactDecodeLimits &limits) {
+  std::ifstream input(path, std::ios::binary | std::ios::ate);
+  if (!input)
     throw std::runtime_error("cannot open clangd index: " + path.string());
-  const auto end = stream.tellg();
+  const auto end = input.tellg();
   if (end < 0)
     throw std::runtime_error("cannot size clangd index: " + path.string());
   const auto size = static_cast<std::uint64_t>(end);
+  if (size > limits.max_index_file_bytes) {
+    throw std::runtime_error("clangd index exceeds per-file safety limit " +
+                             std::to_string(limits.max_index_file_bytes) +
+                             ": " + path.string());
+  }
   if (size > std::numeric_limits<std::size_t>::max() ||
       size > static_cast<std::uint64_t>(
                  std::numeric_limits<std::streamsize>::max())) {
-    throw std::runtime_error("clangd index is too large for this platform: " +
-                             path.string());
+    throw std::runtime_error("clangd index is too large: " + path.string());
   }
   std::vector<std::uint8_t> data(static_cast<std::size_t>(size));
-  stream.seekg(0, std::ios::beg);
-  if (!data.empty() &&
-      !stream.read(reinterpret_cast<char *>(data.data()),
-                   static_cast<std::streamsize>(data.size()))) {
+  input.seekg(0, std::ios::beg);
+  if (!data.empty() && !input.read(reinterpret_cast<char *>(data.data()),
+                                   static_cast<std::streamsize>(data.size()))) {
     throw std::runtime_error("cannot read clangd index: " + path.string());
   }
   return data;
 }
 
 std::unordered_map<std::string, ByteView>
-read_riff(const std::vector<std::uint8_t> &data) {
-  if (data.size() < 12)
-    throw std::runtime_error("truncated clangd RIFF header");
-  if (!std::equal(data.begin(), data.begin() + 4, "RIFF"))
+read_riff(const std::vector<std::uint8_t> &data,
+          const ClangdFactDecodeLimits &limits) {
+  if (data.size() < 12 ||
+      std::string(reinterpret_cast<const char *>(data.data()), 4) != "RIFF") {
     throw std::runtime_error("not a RIFF file");
-  if (!std::equal(data.begin() + 8, data.begin() + 12, "CdIx"))
+  }
+  const auto total_len = static_cast<std::size_t>(read_u32_le(data.data() + 4));
+  if (total_len < 4)
+    throw std::runtime_error("invalid RIFF length");
+  if (total_len != data.size() - 8)
+    throw std::runtime_error("RIFF length does not match file size");
+  if (std::string(reinterpret_cast<const char *>(data.data() + 8), 4) !=
+      "CdIx") {
     throw std::runtime_error("not a clangd CdIx index");
+  }
 
-  const auto declared =
-      static_cast<std::uint64_t>(read_u32_le(data.data() + 4));
-  const auto end64 = declared + 8ULL;
-  if (declared < 4 || end64 > data.size())
-    throw std::runtime_error("invalid clangd RIFF length");
-  const auto end = static_cast<std::size_t>(end64);
-
+  const std::size_t end = 8 + total_len;
+  std::size_t chunk_count = 0;
   std::unordered_map<std::string, ByteView> chunks;
   std::size_t offset = 12;
   while (offset < end) {
+    if (chunk_count >= limits.max_chunks_per_file) {
+      throw std::runtime_error("clangd RIFF chunk count exceeds safety limit " +
+                               std::to_string(limits.max_chunks_per_file));
+    }
+    ++chunk_count;
     if (end - offset < 8)
       throw std::runtime_error("truncated RIFF chunk header");
     const std::string id(reinterpret_cast<const char *>(data.data() + offset),
                          4);
     const auto length =
-        static_cast<std::uint64_t>(read_u32_le(data.data() + offset + 4));
+        static_cast<std::size_t>(read_u32_le(data.data() + offset + 4));
     offset += 8;
     if (length > end - offset)
       throw std::runtime_error("truncated RIFF chunk payload");
-    chunks[id] =
-        ByteView{data.data() + offset, static_cast<std::size_t>(length)};
-    offset += static_cast<std::size_t>(length);
+    if (is_known_chunk(id)) {
+      const auto inserted =
+          chunks.emplace(id, ByteView{data.data() + offset, length}).second;
+      if (!inserted)
+        throw std::runtime_error("duplicate clangd RIFF chunk: " + id);
+    }
+    offset += length;
     if ((length & 1U) != 0) {
       if (offset >= end)
         throw std::runtime_error("missing RIFF padding byte");
@@ -177,37 +281,54 @@ read_riff(const std::vector<std::uint8_t> &data) {
     }
   }
   if (offset != end)
-    throw std::runtime_error("invalid RIFF chunk alignment");
+    throw std::runtime_error("RIFF chunk alignment exceeds declared length");
   return chunks;
 }
 
-std::vector<std::string> decode_string_table(ByteView view) {
+std::vector<std::string> decode_string_table(ByteView view,
+                                             FileBudget &budget) {
   if (view.size < 4)
     throw std::runtime_error("truncated clangd string table");
-  const auto expected = static_cast<std::uint64_t>(read_u32_le(view.data));
+  const auto expected = static_cast<std::size_t>(read_u32_le(view.data));
   const auto *payload = view.data + 4;
   const auto payload_size = view.size - 4;
+  const auto decoded_size = expected == 0 ? payload_size : expected;
+  budget.consume_string_bytes(static_cast<std::uint64_t>(decoded_size));
 
   std::vector<std::uint8_t> raw;
   if (expected == 0) {
     raw.assign(payload, payload + payload_size);
   } else {
-    if (expected > std::numeric_limits<std::size_t>::max() ||
-        expected > std::numeric_limits<uLongf>::max() ||
-        payload_size > std::numeric_limits<uLong>::max()) {
-      throw std::runtime_error("clangd string table exceeds platform limits");
+    raw.resize(expected);
+    if (payload_size > std::numeric_limits<uInt>::max() ||
+        raw.size() > std::numeric_limits<uInt>::max()) {
+      throw std::runtime_error("clangd zlib input exceeds platform limit");
     }
-    raw.resize(static_cast<std::size_t>(expected));
-    uLongf output_size = static_cast<uLongf>(raw.size());
-    const int status =
-        uncompress(reinterpret_cast<Bytef *>(raw.data()), &output_size,
-                   reinterpret_cast<const Bytef *>(payload),
-                   static_cast<uLong>(payload_size));
-    if (status != Z_OK || output_size != raw.size())
+    z_stream stream{};
+    stream.next_in =
+        const_cast<Bytef *>(reinterpret_cast<const Bytef *>(payload));
+    stream.avail_in = static_cast<uInt>(payload_size);
+    stream.next_out = reinterpret_cast<Bytef *>(raw.data());
+    stream.avail_out = static_cast<uInt>(raw.size());
+    const int init_status = inflateInit(&stream);
+    if (init_status != Z_OK)
+      throw std::runtime_error("cannot initialize clangd string decompressor");
+    const int status = inflate(&stream, Z_FINISH);
+    const bool complete = status == Z_STREAM_END && stream.avail_in == 0 &&
+                          stream.total_out == raw.size();
+    (void)inflateEnd(&stream);
+    if (!complete)
       throw std::runtime_error("cannot decompress clangd string table");
   }
 
+  std::size_t string_count = static_cast<std::size_t>(
+      std::count(raw.begin(), raw.end(), static_cast<std::uint8_t>(0)));
+  if (!raw.empty() && raw.back() != 0)
+    ++string_count;
+  budget.consume_string_entries(string_count);
+
   std::vector<std::string> strings;
+  strings.reserve(string_count);
   std::size_t start = 0;
   for (std::size_t index = 0; index < raw.size(); ++index) {
     if (raw[index] != 0)
@@ -230,6 +351,14 @@ const std::string &string_at(const std::vector<std::string> &strings,
   return strings[static_cast<std::size_t>(index)];
 }
 
+std::string copy_string_at(const std::vector<std::string> &strings,
+                           std::uint64_t index, FileBudget &budget) {
+  const auto &value = string_at(strings, index);
+  budget.consume_materialized_string_bytes(
+      static_cast<std::uint64_t>(value.size()));
+  return value;
+}
+
 int checked_line(std::uint64_t value) {
   if (value > static_cast<std::uint64_t>(std::numeric_limits<int>::max()))
     throw std::runtime_error("clangd source line exceeds int range");
@@ -245,9 +374,11 @@ struct Location {
 };
 
 Location decode_location(Reader &reader,
-                         const std::vector<std::string> &strings) {
+                         const std::vector<std::string> &strings,
+                         FileBudget &budget) {
+  const auto file_index = reader.read_varint();
   Location location;
-  location.file = string_at(strings, reader.read_varint());
+  location.file = copy_string_at(strings, file_index, budget);
   location.start_line = checked_line(reader.read_varint());
   location.start_col = checked_line(reader.read_varint());
   location.end_line = checked_line(reader.read_varint());
@@ -288,21 +419,25 @@ struct ParsedFile {
 };
 
 std::vector<SymbolRecord>
-decode_symbols(ByteView view, const std::vector<std::string> &strings) {
+decode_symbols(ByteView view, const std::vector<std::string> &strings,
+               FileBudget &budget) {
   Reader reader(view);
   std::vector<SymbolRecord> symbols;
   while (!reader.empty()) {
+    if (reader.remaining() < 8)
+      throw std::runtime_error("truncated clangd symbol record");
+    budget.consume_records(1, "symbol records");
     SymbolRecord symbol;
     symbol.id = reader.read_symbol_id();
     symbol.kind = reader.read_u8();
     (void)reader.read_u8(); // SymbolLanguage
-    symbol.name = string_at(strings, reader.read_varint());
-    symbol.scope = string_at(strings, reader.read_varint());
+    symbol.name = copy_string_at(strings, reader.read_varint(), budget);
+    symbol.scope = copy_string_at(strings, reader.read_varint(), budget);
     (void)string_at(strings,
                     reader.read_varint()); // TemplateSpecializationArgs
-    symbol.definition = decode_location(reader, strings);
+    symbol.definition = decode_location(reader, strings, budget);
     symbol.canonical_declaration =
-        decode_location(reader, strings);           // CanonicalDeclaration
+        decode_location(reader, strings, budget);   // CanonicalDeclaration
     (void)reader.read_varint();                     // References count
     (void)reader.read_u8();                         // Flags
     (void)string_at(strings, reader.read_varint()); // Signature
@@ -312,6 +447,12 @@ decode_symbols(ByteView view, const std::vector<std::string> &strings) {
     (void)string_at(strings, reader.read_varint()); // ReturnType
     (void)string_at(strings, reader.read_varint()); // Type
     const auto headers = reader.read_varint();
+    if (headers > reader.remaining() / 2)
+      throw std::runtime_error("invalid clangd include-header count");
+    if (headers > std::numeric_limits<std::size_t>::max())
+      throw std::runtime_error("clangd include-header count exceeds size_t");
+    budget.consume_records(static_cast<std::size_t>(headers),
+                           "include-header records");
     for (std::uint64_t index = 0; index < headers; ++index) {
       (void)string_at(strings, reader.read_varint());
       (void)reader.read_varint();
@@ -321,21 +462,29 @@ decode_symbols(ByteView view, const std::vector<std::string> &strings) {
   return symbols;
 }
 
-std::vector<ReferenceGroup>
-decode_refs(ByteView view, const std::vector<std::string> &strings) {
+std::vector<ReferenceGroup> decode_refs(ByteView view,
+                                        const std::vector<std::string> &strings,
+                                        FileBudget &budget) {
   Reader reader(view);
   std::vector<ReferenceGroup> groups;
   while (!reader.empty()) {
+    if (reader.remaining() < 8)
+      throw std::runtime_error("truncated clangd reference group");
+    budget.consume_records(1, "reference groups");
     ReferenceGroup group;
     group.symbol_id = reader.read_symbol_id();
     const auto count = reader.read_varint();
+    if (count > reader.remaining() / 14)
+      throw std::runtime_error("invalid clangd reference count");
     if (count > std::numeric_limits<std::size_t>::max())
       throw std::runtime_error("clangd reference count exceeds size_t");
+    budget.consume_records(static_cast<std::size_t>(count),
+                           "reference records");
     group.refs.reserve(static_cast<std::size_t>(count));
     for (std::uint64_t index = 0; index < count; ++index) {
       ReferenceRecord reference;
       reference.kind = reader.read_u8();
-      reference.location = decode_location(reader, strings);
+      reference.location = decode_location(reader, strings, budget);
       reference.container = reader.read_symbol_id();
       group.refs.push_back(std::move(reference));
     }
@@ -344,10 +493,14 @@ decode_refs(ByteView view, const std::vector<std::string> &strings) {
   return groups;
 }
 
-std::vector<RelationRecord> decode_relations(ByteView view) {
+std::vector<RelationRecord> decode_relations(ByteView view,
+                                             FileBudget &budget) {
   Reader reader(view);
   std::vector<RelationRecord> relations;
   while (!reader.empty()) {
+    if (reader.remaining() < 17)
+      throw std::runtime_error("truncated clangd relation record");
+    budget.consume_records(1, "relation records");
     RelationRecord relation;
     relation.subject = reader.read_symbol_id();
     relation.predicate = reader.read_u8();
@@ -357,20 +510,34 @@ std::vector<RelationRecord> decode_relations(ByteView view) {
   return relations;
 }
 
-ParsedFile parse_idx(const std::vector<std::uint8_t> &data) {
-  const auto chunks = read_riff(data);
+ParsedFile parse_idx(const std::vector<std::uint8_t> &data,
+                     DecodeBudget &aggregate_budget) {
+  const auto chunks = read_riff(data, aggregate_budget.limits);
+  const auto metadata = chunks.find("meta");
+  if (metadata == chunks.end())
+    throw std::runtime_error("missing required clangd RIFF chunk: meta");
+  if (metadata->second.size != sizeof(std::uint32_t))
+    throw std::runtime_error("invalid clangd meta chunk length");
+  const auto version = read_u32_le(metadata->second.data);
+  if (!is_supported_version(version)) {
+    throw std::runtime_error("unsupported clangd RIFF version " +
+                             std::to_string(version) +
+                             "; supported versions are 18, 19, 20");
+  }
+
   const auto string_chunk = chunks.find("stri");
   if (string_chunk == chunks.end())
     throw std::runtime_error("missing required clangd RIFF chunk: stri");
-  const auto strings = decode_string_table(string_chunk->second);
+  FileBudget file_budget(aggregate_budget);
+  const auto strings = decode_string_table(string_chunk->second, file_budget);
 
   ParsedFile parsed;
   if (const auto symbols = chunks.find("symb"); symbols != chunks.end())
-    parsed.symbols = decode_symbols(symbols->second, strings);
+    parsed.symbols = decode_symbols(symbols->second, strings, file_budget);
   if (const auto refs = chunks.find("refs"); refs != chunks.end())
-    parsed.refs = decode_refs(refs->second, strings);
+    parsed.refs = decode_refs(refs->second, strings, file_budget);
   if (const auto relations = chunks.find("rela"); relations != chunks.end())
-    parsed.relations = decode_relations(relations->second);
+    parsed.relations = decode_relations(relations->second, file_budget);
   return parsed;
 }
 
@@ -461,19 +628,32 @@ struct IndexFile {
 };
 
 std::vector<IndexFile>
-discover_index_files(const std::filesystem::path &directory) {
+discover_index_files(const std::filesystem::path &directory,
+                     const ClangdFactDecodeLimits &limits) {
   if (!std::filesystem::is_directory(directory))
     throw std::runtime_error("clangd index directory does not exist: " +
                              directory.string());
   std::vector<IndexFile> files;
+  std::uint64_t aggregate_bytes = 0;
   for (const auto &entry : std::filesystem::directory_iterator(directory)) {
     if (!entry.is_regular_file() || entry.path().extension() != ".idx")
       continue;
+    if (files.size() >= limits.max_index_files) {
+      throw std::runtime_error("clangd index file count exceeds safety limit " +
+                               std::to_string(limits.max_index_files));
+    }
     std::error_code size_error;
     const auto bytes = entry.file_size(size_error);
     if (size_error)
       throw std::runtime_error("cannot size clangd index: " +
                                entry.path().string());
+    if (bytes > limits.max_index_file_bytes) {
+      throw std::runtime_error("clangd index exceeds per-file safety limit " +
+                               std::to_string(limits.max_index_file_bytes) +
+                               ": " + entry.path().string());
+    }
+    consume_budget(static_cast<std::uint64_t>(bytes), aggregate_bytes,
+                   limits.max_aggregate_index_bytes, "aggregate index bytes");
     files.push_back(IndexFile{entry.path(),
                               entry.path().filename().generic_string(),
                               static_cast<std::uint64_t>(bytes)});
@@ -774,12 +954,14 @@ build_query_records(const CollectedRecords &collected,
 
 ClangdQueryRecords
 decode_clangd_query_records(const std::string &idx_directory,
-                            const std::string &project_root) {
+                            const std::string &project_root,
+                            const ClangdFactDecodeLimits &limits) {
   const auto total_started = Clock::now();
   ClangdFactDecodeProfile profile;
 
   const auto discover_started = Clock::now();
-  const auto files = discover_index_files(normalized_absolute(idx_directory));
+  const auto files =
+      discover_index_files(normalized_absolute(idx_directory), limits);
   const auto root = normalized_absolute(project_root);
   profile.file_count = files.size();
   for (const auto &file : files)
@@ -787,13 +969,25 @@ decode_clangd_query_records(const std::string &idx_directory,
   profile.discover_files_ns = elapsed_ns(discover_started, Clock::now());
 
   CollectedRecords collected;
+  DecodeBudget budget(limits);
+  std::uint64_t read_bytes = 0;
   for (const auto &file : files) {
     const auto read_started = Clock::now();
-    auto data = read_file(file.path);
+    auto data = read_file(file.path, limits);
+    consume_budget(static_cast<std::uint64_t>(data.size()), read_bytes,
+                   limits.max_aggregate_index_bytes, "aggregate index bytes");
     profile.read_files_ns += elapsed_ns(read_started, Clock::now());
 
     const auto parse_started = Clock::now();
-    auto parsed = parse_idx(data);
+    ParsedFile parsed;
+    try {
+      parsed = parse_idx(data, budget);
+    } catch (const std::bad_alloc &) {
+      throw;
+    } catch (const std::exception &error) {
+      throw std::runtime_error("cannot parse clangd index " +
+                               file.path.string() + ": " + error.what());
+    }
     profile.parse_files_ns += elapsed_ns(parse_started, Clock::now());
     profile.raw_symbol_count += parsed.symbols.size();
     for (const auto &group : parsed.refs)
@@ -816,6 +1010,10 @@ decode_clangd_query_records(const std::string &idx_directory,
     if (edge.type == EDGE_TYPE_REFERENCE)
       ++profile.reference_count;
   }
+  profile.index_bytes = read_bytes;
+  profile.decompressed_string_bytes = budget.string_table_bytes;
+  profile.materialized_string_bytes = budget.materialized_string_bytes;
+  profile.string_entry_count = budget.string_entries;
   profile.total_ns = elapsed_ns(total_started, Clock::now());
   return ClangdQueryRecords{std::move(records), profile};
 }

--- a/core/clangd_fact_query.h
+++ b/core/clangd_fact_query.h
@@ -8,6 +8,7 @@
 
 #include "decoded_records.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -17,6 +18,32 @@ namespace codenib::core {
 
 inline constexpr std::uint32_t CLANGD_FACT_QUERY_ABI_VERSION = 1;
 inline constexpr char CLANGD_FACT_QUERY_FORMAT[] = "clangd-riff-fact-query-v1";
+
+// clangd itself rejects non-current RIFF versions. CodeNib deliberately uses
+// an exact allowlist backed by checked fixtures and parity tests instead of
+// guessing that an unknown future layout remains compatible.
+inline constexpr std::array<std::uint32_t, 3> CLANGD_SUPPORTED_RIFF_VERSIONS{
+    {18, 19, 20}};
+
+// The native input is a local clangd artifact, but every attacker-controlled
+// size/count must remain finite before it can drive an allocation.
+struct ClangdFactDecodeLimits {
+  std::size_t max_index_files{200'000};
+  std::size_t max_chunks_per_file{128};
+  std::uint64_t max_index_file_bytes{512ULL * 1024ULL * 1024ULL};
+  std::uint64_t max_aggregate_index_bytes{8ULL * 1024ULL * 1024ULL * 1024ULL};
+  std::uint64_t max_string_table_bytes{256ULL * 1024ULL * 1024ULL};
+  std::uint64_t max_aggregate_string_table_bytes{2ULL * 1024ULL * 1024ULL *
+                                                 1024ULL};
+  std::size_t max_string_entries_per_file{1'000'000};
+  std::size_t max_aggregate_string_entries{20'000'000};
+  std::uint64_t max_materialized_string_bytes_per_file{512ULL * 1024ULL *
+                                                       1024ULL};
+  std::uint64_t max_aggregate_materialized_string_bytes{4ULL * 1024ULL *
+                                                        1024ULL * 1024ULL};
+  std::size_t max_records_per_file{2'000'000};
+  std::size_t max_aggregate_records{25'000'000};
+};
 
 // Timings cover the baseline query-ready path from an existing project-local
 // clangd index. External clangd generation is deliberately outside this
@@ -35,6 +62,9 @@ struct ClangdFactDecodeProfile {
   std::size_t reference_count{0};
   std::size_t decoded_record_count{0};
   std::uint64_t index_bytes{0};
+  std::uint64_t decompressed_string_bytes{0};
+  std::uint64_t materialized_string_bytes{0};
+  std::size_t string_entry_count{0};
 };
 
 struct ClangdQueryRecords {
@@ -45,7 +75,8 @@ struct ClangdQueryRecords {
 // Decode every direct *.idx child in stable filename order. Any read or parse
 // failure rejects the complete native candidate so Python auto mode can use
 // the established ClangdGraphDecoder without publishing partial rows.
-ClangdQueryRecords decode_clangd_query_records(const std::string &idx_directory,
-                                               const std::string &project_root);
+ClangdQueryRecords decode_clangd_query_records(
+    const std::string &idx_directory, const std::string &project_root,
+    const ClangdFactDecodeLimits &limits = ClangdFactDecodeLimits{});
 
 } // namespace codenib::core

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -180,8 +180,49 @@ make clangd-fact-query-profile \
 
 This result measures an already generated `.idx` directory through identical
 definition/reference work. It does not claim faster clangd generation. Native
-position/route lookup, serving integration, content receipts, and systematic
-format-version/resource hardening remain independent follow-up gates.
+position/route lookup, serving integration, and content receipts remain
+independent follow-up gates.
+
+### RIFF compatibility and resource safety
+
+Upstream clangd deliberately rejects every RIFF version except the one its
+binary currently writes and increments the version for breaking layouts.
+CodeNib therefore uses an exact allowlist, not a numeric range. Versions 18,
+19, and 20 are accepted because checked fixtures or real artifacts for all
+three preserve exact definition/reference parity. An unknown version fails
+native decoding until its layout passes the same gate. LLVM's
+[`Serialization.cpp`](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/index/Serialization.cpp)
+and [`RIFF.h`](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/index/RIFF.h)
+are the authoritative format sources.
+
+Every shard must contain exactly one 4-byte `meta` chunk and one `stri` chunk.
+The reader rejects duplicate known chunks, mismatched outer lengths, missing
+padding, truncated records, invalid string indexes/counts, overflowing
+varints, and zlib streams that do not consume exactly the declared input and
+output. No native index is returned until every shard has parsed, so a failure
+cannot publish partial records.
+
+`codenib_core.clangd_fact_query_contract()` exposes the compiled limits:
+
+| Dimension | Limit |
+| --- | ---: |
+| Direct `.idx` files | 200,000 |
+| RIFF chunks per file | 128 |
+| One `.idx` file | 512 MiB |
+| Aggregate `.idx` bytes | 8 GiB |
+| One decompressed string table | 256 MiB |
+| Aggregate decompressed string bytes | 2 GiB |
+| String entries per file / aggregate | 1,000,000 / 20,000,000 |
+| Copied string bytes per file / aggregate | 512 MiB / 4 GiB |
+| Decoded records per file / aggregate | 2,000,000 / 25,000,000 |
+
+File size/count declarations are checked during discovery and again before
+reading. Decompressed bytes are charged before the output buffer is allocated;
+string entries are charged before `std::string` construction; copied strings
+and decoded row counts are charged before assignment, `reserve()`, or row
+insertion. In `auto` mode a deterministic rejection is recorded in
+`query_fallback_error` and the established graph decoder is used. `required`
+fails closed, while `off` never invokes the native reader.
 
 ## Verify
 

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -752,10 +752,34 @@ stable shard-set SHA-256 values were
 Reproduce the report with `make clangd-fact-query-profile`.
 
 This promotion does not include or accelerate clangd index generation. RIFF
-version/resource hardening (#546), zlib CI enforcement (#547), content
-receipts (#548), serving integration (#549), mixed/RSS/concurrency matrices
-(#550), native position (#553), native route (#552), and durable FactBatch
-storage (#551) remain separate review and promotion gates.
+version/resource hardening (#546) and zlib CI enforcement (#547) are now
+implemented as independent production gates. Content receipts (#548), serving
+integration (#549), mixed/RSS/concurrency matrices (#550), native position
+(#553), native route (#552), and durable FactBatch storage (#551) remain
+separate review and promotion gates.
+
+Native clangd RIFF compatibility and resource-safety status
+([#546](https://github.com/sysevol-ai/CodeNib/issues/546)): the v1 reader now
+requires one 4-byte `meta` chunk, accepts only parity-tested versions 18, 19,
+and 20, and rejects duplicate known chunks before semantic decoding. Outer
+RIFF lengths/padding, record truncation, varint overflow, string indexes,
+header/reference counts, and exact zlib input/output completion are validated
+deterministically. Upstream clangd's current-version-only policy is documented
+from LLVM `Serialization.cpp` and `RIFF.h`; future versions remain fail-closed
+until their layout clears the same parity gate.
+
+The compiled contract publishes finite limits for direct file count, chunks,
+per-file and aggregate bytes, decompressed strings, string entries, copied
+string bytes, and decoded records. Discovery rejects impossible file sets
+before reading; decompression, object expansion, copies, `reserve()`, and row
+insertion consume their respective budgets before allocation. All parse
+failures include the shard filename and cannot return a partial native index.
+The deterministic matrix covers truncated headers/payloads, missing padding,
+duplicate chunks, unsupported versions, zlib mismatch/trailing input,
+oversized declarations, invalid counts, and sparse per-file/aggregate limits.
+`auto` falls back with the error recorded, `required` fails closed, and `off`
+preserves the established graph path. The same v18/v19/v20 fixture executes
+the exact public definition/reference parity assertions.
 
 Native core CI enforcement status
 ([#547](https://github.com/sysevol-ai/CodeNib/issues/547)): the trusted

--- a/test/ls_index/test_clangd_fact_query.py
+++ b/test/ls_index/test_clangd_fact_query.py
@@ -124,12 +124,23 @@ def _riff_bytes(chunks: list[tuple[bytes, bytes]]) -> bytes:
 
 
 def _empty_idx() -> bytes:
-    return _riff_bytes(
-        [
-            (b"meta", struct.pack("<I", 18)),
-            (b"stri", struct.pack("<I", 0) + b"\x00"),
-        ]
-    )
+    return _riff_bytes(_minimal_chunks())
+
+
+def _minimal_chunks(version: int = 18) -> list[tuple[bytes, bytes]]:
+    return [
+        (b"meta", struct.pack("<I", version)),
+        (b"stri", struct.pack("<I", 0) + b"\x00"),
+    ]
+
+
+def _set_meta_version(idx_directory: Path, before: int, after: int) -> None:
+    path = next(idx_directory.glob("*.idx"))
+    data = path.read_bytes()
+    old = b"meta" + struct.pack("<I", 4) + struct.pack("<I", before)
+    new = b"meta" + struct.pack("<I", 4) + struct.pack("<I", after)
+    assert data.count(old) == 1
+    path.write_bytes(data.replace(old, new, 1))
 
 
 @pytest.fixture()
@@ -318,6 +329,21 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
     assert contract == {
         "abi_version": 1,
         "format": "clangd-riff-fact-query-v1",
+        "supported_versions": [18, 19, 20],
+        "resource_limits": {
+            "max_index_files": 200_000,
+            "max_chunks_per_file": 128,
+            "max_index_file_bytes": 512 * 1024 * 1024,
+            "max_aggregate_index_bytes": 8 * 1024 * 1024 * 1024,
+            "max_string_table_bytes": 256 * 1024 * 1024,
+            "max_aggregate_string_table_bytes": 2 * 1024 * 1024 * 1024,
+            "max_string_entries_per_file": 1_000_000,
+            "max_aggregate_string_entries": 20_000_000,
+            "max_materialized_string_bytes_per_file": 512 * 1024 * 1024,
+            "max_aggregate_materialized_string_bytes": 4 * 1024 * 1024 * 1024,
+            "max_records_per_file": 2_000_000,
+            "max_aggregate_records": 25_000_000,
+        },
         "stable_filename_order": True,
         "preserves_unanchored_relations": True,
         "capabilities": {
@@ -335,10 +361,13 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
     assert not hasattr(index, "graph")
 
 
+@pytest.mark.parametrize("version", [18, 19, 20])
 def test_symbol_results_errors_counts_and_relations_match_graph(
-    clangd_fixture,
+    clangd_fixture, version: int
 ) -> None:
     root, idx_directory = clangd_fixture
+    if version != 18:
+        _set_meta_version(idx_directory, 18, version)
     graph = ClangdGraphDecoder(str(idx_directory), str(root)).materialize_code_graph()
     payload = codenib_core.decode_clangd_fact_query_index(
         idx_directory=str(idx_directory), project_root=str(root)
@@ -414,6 +443,242 @@ def test_native_file_discovery_is_stable_by_filename(
         assert _outcome(
             lambda seed=seed: lsp_references(left, symbol=seed, top_k=100)
         ) == _outcome(lambda seed=seed: lsp_references(right, symbol=seed, top_k=100))
+
+
+def test_native_reader_rejects_malformed_matrix(clangd_fixture) -> None:
+    root, idx_directory = clangd_fixture
+    path = next(idx_directory.glob("*.idx"))
+    limits = codenib_core.clangd_fact_query_contract()["resource_limits"]
+    minimal = _minimal_chunks()
+    valid = _riff_bytes(minimal)
+    symbol_id = bytes.fromhex("1112131415161718")
+    valid_symbol = _symbol(
+        symbol_id,
+        kind=12,
+        name_index=0,
+        scope_index=0,
+        file_index=0,
+        line=0,
+    )
+    oversized_strings = limits["max_string_table_bytes"] + 1
+    truncated_payload_body = b"CdIx" + b"meta" + struct.pack("<I", 4) + b"\x12\x00"
+    cases = [
+        ("short RIFF", b"RIFF", "not a RIFF file"),
+        (
+            "invalid outer length",
+            b"RIFF" + struct.pack("<I", 3) + b"CdIx",
+            "invalid RIFF length",
+        ),
+        ("trailing bytes", valid + b"x", "RIFF length does not match file size"),
+        (
+            "wrong form",
+            b"RIFF" + struct.pack("<I", 4) + b"NOPE",
+            "not a clangd CdIx index",
+        ),
+        (
+            "truncated chunk header",
+            b"RIFF" + struct.pack("<I", 8) + b"CdIxmeta",
+            "truncated RIFF chunk header",
+        ),
+        (
+            "truncated chunk payload",
+            b"RIFF"
+            + struct.pack("<I", len(truncated_payload_body))
+            + truncated_payload_body,
+            "truncated RIFF chunk payload",
+        ),
+        (
+            "missing padding",
+            b"RIFF" + struct.pack("<I", 13) + b"CdIxjunk" + struct.pack("<I", 1) + b"x",
+            "missing RIFF padding byte",
+        ),
+        (
+            "too many chunks",
+            _riff_bytes(
+                minimal + [(b"junk", b"")] * (limits["max_chunks_per_file"] - 1)
+            ),
+            "RIFF chunk count exceeds safety limit",
+        ),
+        ("missing meta", _riff_bytes([minimal[1]]), "missing required.*meta"),
+        (
+            "short meta",
+            _riff_bytes([(b"meta", b"\x12\x00\x00"), minimal[1]]),
+            "meta chunk length",
+        ),
+        (
+            "unsupported version",
+            _riff_bytes(_minimal_chunks(21)),
+            "unsupported clangd RIFF version 21",
+        ),
+        ("missing strings", _riff_bytes([minimal[0]]), "missing required.*stri"),
+        (
+            "bad zlib stream",
+            _riff_bytes([minimal[0], (b"stri", struct.pack("<I", 16) + b"bad")]),
+            "cannot decompress",
+        ),
+        (
+            "zlib trailing data",
+            _riff_bytes(
+                [
+                    minimal[0],
+                    (b"stri", struct.pack("<I", 1) + zlib.compress(b"\x00") + b"x"),
+                ]
+            ),
+            "cannot decompress",
+        ),
+        (
+            "oversized string declaration",
+            _riff_bytes([minimal[0], (b"stri", struct.pack("<I", oversized_strings))]),
+            "string table exceeds per-file safety limit",
+        ),
+        (
+            "varint overflow",
+            _riff_bytes(
+                minimal + [(b"symb", symbol_id + bytes((12, 2)) + (b"\x80" * 10))]
+            ),
+            "varint exceeds 10 bytes",
+        ),
+        (
+            "string index",
+            _riff_bytes(
+                minimal
+                + [
+                    (
+                        b"symb",
+                        _symbol(
+                            symbol_id,
+                            kind=12,
+                            name_index=9,
+                            scope_index=0,
+                            file_index=0,
+                            line=0,
+                        ),
+                    )
+                ]
+            ),
+            "string index is out of range",
+        ),
+        (
+            "include header count",
+            _riff_bytes(minimal + [(b"symb", valid_symbol[:-1] + _varint(100))]),
+            "invalid clangd include-header count",
+        ),
+        (
+            "reference count",
+            _riff_bytes(minimal + [(b"refs", symbol_id + _varint(2))]),
+            "invalid clangd reference count",
+        ),
+        (
+            "relation record",
+            _riff_bytes(minimal + [(b"rela", b"x" * 16)]),
+            "truncated clangd relation record",
+        ),
+    ]
+
+    for name, payload, message in cases:
+        path.write_bytes(payload)
+        errors = []
+        for _attempt in range(2):
+            with pytest.raises(RuntimeError, match=message) as raised:
+                codenib_core.decode_clangd_fact_query_index(
+                    idx_directory=str(idx_directory), project_root=str(root)
+                )
+            errors.append(str(raised.value))
+        assert errors[0] == errors[1], name
+        assert path.name in errors[0], name
+
+
+@pytest.mark.parametrize(
+    "chunk_id", [b"meta", b"srcs", b"stri", b"symb", b"refs", b"rela", b"cmdl"]
+)
+def test_native_reader_rejects_duplicate_known_chunks(
+    clangd_fixture, chunk_id: bytes
+) -> None:
+    root, idx_directory = clangd_fixture
+    path = next(idx_directory.glob("*.idx"))
+    payload = struct.pack("<I", 18) if chunk_id == b"meta" else b""
+    if chunk_id == b"stri":
+        payload = struct.pack("<I", 0) + b"\x00"
+    chunks = _minimal_chunks()
+    chunks.extend(((chunk_id, payload), (chunk_id, payload)))
+    path.write_bytes(_riff_bytes(chunks))
+
+    with pytest.raises(RuntimeError, match="duplicate clangd RIFF chunk"):
+        codenib_core.decode_clangd_fact_query_index(
+            idx_directory=str(idx_directory), project_root=str(root)
+        )
+
+
+def test_native_reader_rejects_resource_sizes_before_reading(
+    clangd_fixture, tmp_path: Path
+) -> None:
+    root, idx_directory = clangd_fixture
+    limits = codenib_core.clangd_fact_query_contract()["resource_limits"]
+    path = next(idx_directory.glob("*.idx"))
+    with path.open("wb") as stream:
+        stream.truncate(limits["max_index_file_bytes"] + 1)
+
+    with pytest.raises(RuntimeError, match="per-file safety limit"):
+        codenib_core.decode_clangd_fact_query_index(
+            idx_directory=str(idx_directory), project_root=str(root)
+        )
+
+    aggregate_directory = tmp_path / "aggregate-index"
+    aggregate_directory.mkdir()
+    file_size = limits["max_index_file_bytes"]
+    file_count = limits["max_aggregate_index_bytes"] // file_size + 1
+    for index in range(file_count):
+        with (aggregate_directory / f"{index}.idx").open("wb") as stream:
+            stream.truncate(file_size)
+
+    with pytest.raises(RuntimeError, match="aggregate index bytes"):
+        codenib_core.decode_clangd_fact_query_index(
+            idx_directory=str(aggregate_directory), project_root=str(root)
+        )
+
+
+def test_native_reader_caps_string_object_expansion(clangd_fixture) -> None:
+    root, idx_directory = clangd_fixture
+    limits = codenib_core.clangd_fact_query_contract()["resource_limits"]
+    path = next(idx_directory.glob("*.idx"))
+    too_many_strings = b"\x00" * (limits["max_string_entries_per_file"] + 1)
+    path.write_bytes(
+        _riff_bytes(
+            [
+                (b"meta", struct.pack("<I", 18)),
+                (b"stri", struct.pack("<I", 0) + too_many_strings),
+            ]
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="per-file entry limit"):
+        codenib_core.decode_clangd_fact_query_index(
+            idx_directory=str(idx_directory), project_root=str(root)
+        )
+
+
+def test_unsupported_version_auto_required_and_off_modes(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    _set_meta_version(idx_directory, 18, 21)
+    monkeypatch.setattr(clangd_decode, "_NATIVE_QUERY_PROMOTED", True)
+
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "auto")
+    fallback = ClangdGraphDecoder(str(idx_directory), str(root))
+    graph = fallback.decode_query_index()
+    assert isinstance(graph, CodeGraph)
+    assert fallback.query_backend == "legacy-query-fallback"
+    assert "unsupported clangd RIFF version 21" in fallback.query_fallback_error
+
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "required")
+    with pytest.raises(RuntimeError, match="unsupported clangd RIFF version 21"):
+        ClangdGraphDecoder(str(idx_directory), str(root)).decode_query_index()
+
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "off")
+    disabled = ClangdGraphDecoder(str(idx_directory), str(root))
+    assert isinstance(disabled.decode_query_index(), CodeGraph)
+    assert disabled.query_backend == "legacy-query-disabled"
 
 
 def test_selector_auto_off_required_and_failure_modes(


### PR DESCRIPTION
## Summary

Harden the native clangd RIFF reader so unsupported layouts and malformed or oversized shards fail deterministically before any partial FactQueryIndex can be published.

Closes #546

## Changes

- accept only parity-tested RIFF versions 18, 19, and 20 through an exact allowlist
- require valid unique critical chunks and reject malformed RIFF, zlib, varint, string-index, header-count, reference-count, and relation payloads
- enforce compiled file, byte, decompression, string-expansion, copy, and record budgets before allocation
- expose supported versions and resource limits through `clangd_fact_query_contract()`
- cover v18/v19/v20 parity, deterministic malformed fixtures, sparse resource failures, and `auto|required|off` behavior
- document the upstream LLVM version policy and update the durable C++ roadmap

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Tests

## Testing

- [x] Tests pass locally
- [x] Added new tests for the changes

- `make core-test` — four C++ executables passed; 101 Python tests passed, 4 expected fixture skips
- targeted native clangd suite — 22 passed
- unit tier with two previously audited environment-baseline deselections — 3872 passed, 13 skipped
- CI policy — 18 passed
- touched-file pre-commit — passed
- strict MkDocs build and public-doc boundary check — passed

## Checklist

- [x] My code follows the projects style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published