### PR TITLE
fix(cpp): bind clangd snapshots to index content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,8 +412,9 @@ core-test: core-build
 	./build/core/scip_decode_test
 	./build/core/graph_layers_test
 	./build/core/fact_batch_buffer_test
+	./build/core/content_digest_test
 	./build/core/fact_query_index_test
-	PYTHONPATH="build/core:$$PYTHONPATH" python -c 'import sys; import codenib_core as core; required = ("decode_clangd_fact_query_index", "clangd_fact_query_contract"); missing = [name for name in required if not hasattr(core, name)]; missing and sys.exit(f"codenib_core missing required bindings: {missing}")'
+	PYTHONPATH="build/core:$$PYTHONPATH" python -c 'import sys; import codenib_core as core; required = ("decode_clangd_fact_query_index", "clangd_fact_query_contract", "clangd_fact_query_snapshot"); missing = [name for name in required if not hasattr(core, name)]; missing and sys.exit(f"codenib_core missing required bindings: {missing}")'
 	PYTHONPATH="build/core:$$PYTHONPATH" python -m pytest -q \
 		test/scip/test_scip_core.py \
 		test/scip/test_scip_core_registry.py \

--- a/codenib/agent/lsp_provider.py
+++ b/codenib/agent/lsp_provider.py
@@ -413,6 +413,9 @@ def _normalize_capability(capability: str) -> str:
 def _graph_snapshot_id(graph: Any) -> Optional[str]:
     if graph is None:
         return None
+    content_snapshot = getattr(graph, "snapshot_id", None)
+    if content_snapshot:
+        return str(content_snapshot)
     igraph_obj = getattr(graph, "graph", None)
     node_count = _call_int(igraph_obj, "vcount")
     edge_count = _call_int(igraph_obj, "ecount")

--- a/codenib/ls_index/clangd_decode.py
+++ b/codenib/ls_index/clangd_decode.py
@@ -82,6 +82,8 @@ _NATIVE_QUERY_REQUIRED = frozenset({"required", "strict"})
 _NATIVE_QUERY_PROMOTED = True
 _NATIVE_QUERY_ABI_VERSION = 1
 _NATIVE_QUERY_FORMAT = "clangd-riff-fact-query-v1"
+_NATIVE_QUERY_NORMALIZATION_PROFILE = "clangd-native-normalization-v1"
+_NATIVE_QUERY_SNAPSHOT_SCHEMA = "clangd-fact-query-snapshot-v1"
 _NATIVE_QUERY_CAPABILITIES = {
     "definition_by_symbol": True,
     "references_by_symbol": True,
@@ -123,6 +125,12 @@ def _validate_native_query_contract(contract: Mapping[str, Any]) -> None:
             "compiled clangd FactQueryIndex contract mismatch: "
             f"expected format {_NATIVE_QUERY_FORMAT!r}"
         )
+    if contract.get("normalization_profile") != (_NATIVE_QUERY_NORMALIZATION_PROFILE):
+        raise RuntimeError("compiled clangd normalization profile mismatch")
+    if contract.get("snapshot_schema") != _NATIVE_QUERY_SNAPSHOT_SCHEMA:
+        raise RuntimeError("compiled clangd snapshot schema mismatch")
+    if contract.get("snapshot_digest") != "sha256":
+        raise RuntimeError("compiled clangd snapshot digest mismatch")
     if contract.get("stable_filename_order") is not True:
         raise RuntimeError("compiled clangd reader does not guarantee stable order")
     if contract.get("preserves_unanchored_relations") is not True:
@@ -420,7 +428,9 @@ class ClangdHybridQueryProvider:
         self.decoder = decoder
         self.graph = query_index
         self.provider_backend = decoder.query_backend
-        self._symbol_provider = StaticLSPProvider(query_index)
+        self._symbol_provider = StaticLSPProvider(
+            query_index, snapshot_id=decoder.query_snapshot_id
+        )
         self._graph_provider = None
         self.graph_materialization_count = 0
         self.last_fallback_reason = None
@@ -433,7 +443,9 @@ class ClangdHybridQueryProvider:
         self.last_fallback_reason = reason
         if self._graph_provider is None:
             graph = self.decoder.materialize_code_graph()
-            self._graph_provider = StaticLSPProvider(graph)
+            self._graph_provider = StaticLSPProvider(
+                graph, snapshot_id=self.snapshot_id
+            )
             self.graph_materialization_count += 1
         return self._graph_provider
 
@@ -506,10 +518,13 @@ class ClangdGraphDecoder:
         self._chunks_cache = {}
         self._graph_materialized = False
         self._range_indexes_built = False
+        self._records_collected = False
         self.query_index = None
         self.query_backend = "not-decoded"
         self.query_fallback_error = None
-        self.query_profile: dict[str, float | int] = {}
+        self.query_profile: dict[str, Any] = {}
+        self.query_snapshot_id: Optional[str] = None
+        self._native_snapshot_error: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -522,7 +537,12 @@ class ClangdGraphDecoder:
         logger.info(f"Starting clangd idx decode from {self.idx_directory}")
 
         # Pass 1: collect all data
+        if self.query_snapshot_id:
+            self._verify_native_snapshot("before legacy record collection")
         self._collect_all_idx()
+        if self.query_snapshot_id:
+            self._verify_native_snapshot("after legacy record collection")
+        self._records_collected = True
 
         # Build name mapping
         self._build_id_to_display()
@@ -530,6 +550,8 @@ class ClangdGraphDecoder:
         # Pass 2: build the graph
         self.code_graph.add_root_node(ROOT_NODE)
         self._build_graph()
+        if self.query_snapshot_id:
+            self.code_graph.snapshot_id = self.query_snapshot_id
         self._graph_materialized = True
 
         return self.code_graph
@@ -543,7 +565,65 @@ class ClangdGraphDecoder:
             self._range_indexes_built = True
         return graph
 
+    def _current_native_snapshot(self) -> Mapping[str, Any]:
+        try:
+            import codenib_core
+        except ImportError as exc:
+            raise RuntimeError(
+                "compiled codenib_core extension is unavailable"
+            ) from exc
+        snapshot = getattr(codenib_core, "clangd_fact_query_snapshot", None)
+        if not callable(snapshot):
+            raise RuntimeError(
+                "compiled core does not expose clangd snapshot verification"
+            )
+        receipt = snapshot(
+            idx_directory=str(self.idx_directory),
+            project_root=str(self.project_root),
+        )
+        if not isinstance(receipt, Mapping):
+            raise RuntimeError(
+                "compiled clangd snapshot verifier returned non-mapping data"
+            )
+        return receipt
+
+    def _verify_native_snapshot(self, stage: str) -> Mapping[str, Any] | None:
+        if self._native_snapshot_error is not None:
+            raise RuntimeError(self._native_snapshot_error)
+        if not self.query_snapshot_id:
+            return None
+        started = time.perf_counter()
+        try:
+            receipt = self._current_native_snapshot()
+        except MemoryError:
+            raise
+        except Exception as exc:
+            self._native_snapshot_error = (
+                f"clangd index snapshot verification failed {stage}: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            raise RuntimeError(self._native_snapshot_error) from exc
+        finally:
+            self.query_profile["lazy_snapshot_verify"] = (
+                float(self.query_profile.get("lazy_snapshot_verify", 0.0))
+                + time.perf_counter()
+                - started
+            )
+        observed = receipt.get("snapshot_id")
+        if observed != self.query_snapshot_id:
+            self._native_snapshot_error = (
+                f"clangd index snapshot changed {stage}: expected "
+                f"{self.query_snapshot_id}, observed {observed}"
+            )
+            raise RuntimeError(self._native_snapshot_error)
+        return receipt
+
     def _decode_native_query_index(self):
+        if self._records_collected or self._graph_materialized:
+            raise RuntimeError(
+                "native clangd snapshot cannot bind records collected before "
+                "the receipt"
+            )
         try:
             import codenib_core
         except ImportError as exc:
@@ -583,10 +663,17 @@ class ClangdGraphDecoder:
             raise RuntimeError(
                 "native clangd query index cannot preserve relation references"
             )
+        snapshot_id = payload.get("snapshot_id")
+        if not isinstance(snapshot_id, str) or not snapshot_id.startswith(
+            "clangd_fact_query:sha256:"
+        ):
+            raise RuntimeError("native clangd decoder returned an invalid snapshot")
+        if getattr(index, "snapshot_id", None) != snapshot_id:
+            raise RuntimeError("native clangd index and receipt snapshots disagree")
 
         native_decode = int(payload.get("native_decode_ns") or 0) / 1_000_000_000
         native_index = int(payload.get("native_index_ns") or 0) / 1_000_000_000
-        profile: dict[str, float | int] = {
+        profile: dict[str, Any] = {
             "binding": binding_seconds,
             "native_decode": native_decode,
             "native_index": native_index,
@@ -596,6 +683,9 @@ class ClangdGraphDecoder:
             "record_count": int(getattr(index, "record_count", 0)),
             "definition_count": int(getattr(index, "symbol_count", 0)),
             "reference_count": int(getattr(index, "reference_count", 0)),
+            "snapshot_id": snapshot_id,
+            "snapshot_file_count": int(payload.get("snapshot_file_count") or 0),
+            "snapshot_index_bytes": int(payload.get("snapshot_index_bytes") or 0),
         }
         count_fields = {
             "file_count",
@@ -610,6 +700,7 @@ class ClangdGraphDecoder:
             profile[f"native_{name}"] = (
                 int(value) if name in count_fields else int(value) / 1_000_000_000
             )
+        self.query_snapshot_id = snapshot_id
         return index, profile
 
     def decode_query_index(self):

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -50,6 +50,7 @@ find_package(ZLIB REQUIRED)
 add_library(codenib_core STATIC
     clangd_fact_query.cpp
     code_graph.cpp
+    content_digest.cpp
     fact_batch_buffer.cpp
     fact_query_index.cpp
     graph_layers.cpp
@@ -97,6 +98,12 @@ add_executable(fact_batch_buffer_test
 
 target_link_libraries(fact_batch_buffer_test PRIVATE codenib_core)
 
+add_executable(content_digest_test
+    tests/content_digest_test.cpp
+)
+
+target_link_libraries(content_digest_test PRIVATE codenib_core)
+
 add_executable(fact_query_index_test
     tests/fact_query_index_test.cpp
 )
@@ -122,6 +129,9 @@ if(CODENIB_ENABLE_O3)
     endif()
     if(TARGET fact_batch_buffer_test)
         target_compile_options(fact_batch_buffer_test PRIVATE -O3)
+    endif()
+    if(TARGET content_digest_test)
+        target_compile_options(content_digest_test PRIVATE -O3)
     endif()
     if(TARGET fact_query_index_test)
         target_compile_options(fact_query_index_test PRIVATE -O3)
@@ -201,6 +211,11 @@ if(CODENIB_ENABLE_DEBUG)
     if(TARGET fact_batch_buffer_test)
         target_compile_definitions(fact_batch_buffer_test PRIVATE CODENIB_DEBUG=1)
         target_compile_options(fact_batch_buffer_test PRIVATE ${_codenib_debug_flags})
+    endif()
+
+    if(TARGET content_digest_test)
+        target_compile_definitions(content_digest_test PRIVATE CODENIB_DEBUG=1)
+        target_compile_options(content_digest_test PRIVATE ${_codenib_debug_flags})
     endif()
 
     if(TARGET fact_query_index_test)

--- a/core/README.md
+++ b/core/README.md
@@ -19,6 +19,8 @@ core decoder continue to use the serial Python path.
   tables for the native/Python boundary.
 - `clangd_fact_query.{h,cpp}` — deterministic clangd RIFF shard decoding into
   provider-neutral records for graph-free symbol queries.
+- `content_digest.{h,cpp}` — dependency-free streaming SHA-256 for native
+  content receipts.
 - `graph_layers.{h,cpp}` — shared normalized edge-layer classification.
 - `scip_decode_base.{h,cpp}` — common loading, document scheduling, merge, and
   post-processing behavior.
@@ -27,7 +29,8 @@ core decoder continue to use the serial Python path.
 - `scip_decode_<language>.{h,cpp}` — language-specific decoder policy.
 - `scip_decoder_registry.{h,cpp}` — canonical decoder names and aliases.
 - `bindings/pybind_module.cpp` — Python bindings for `decode_scip(...)`,
-  `decode_scip_fact_buffer(...)`, `classify_edge_layers(...)`, and registry
+  `decode_scip_fact_buffer(...)`, clangd decode/receipt APIs,
+  `classify_edge_layers(...)`, and registry
   inspection.
 
 `codenib_core.decode_scip(...)` is a low-level flat transport API. It does not
@@ -128,8 +131,11 @@ For C and C++ projects with an existing project-local clangd index,
 stable filename order, decodes them into `DecodedRecords`, and builds the same
 `FactQueryIndex` without constructing `CodeGraph`, igraph, or Python record
 dictionaries. The v1 slice covers definition and reference lookup by symbol.
-clangd relation rows may be unanchored, so this provider explicitly opts into
-that record policy while still rejecting partial or invalid anchors.
+Each decode also exposes a content-bound snapshot over the query contract,
+normalized project root, exact supported RIFF versions, sorted shard names,
+and the exact bytes consumed by the decoder. clangd relation rows may be
+unanchored, so this provider explicitly opts into that record policy while
+still rejecting partial or invalid anchors.
 
 Use `LSIndexer.process_query_index()` for the capability-specific index or
 `process_query_provider()` for hybrid behavior. The provider keeps successful
@@ -150,10 +156,16 @@ make clangd-fact-query-profile \
   CLANGD_FACT_QUERY_PROFILE_EXTRA_ARGS='--iterations 15 --warmups 5'
 ```
 
+The first receipt hash shares the decoder's existing byte buffers. A second
+canonical read before publication detects mutation during decode, and the
+hybrid provider verifies the same receipt before and after lazy graph record
+collection. A mismatch fails the provider session rather than combining index
+generations; restart it to adopt new shards. Both receipt stages are included
+in the existing 20% profiling gate.
+
 This baseline makes no claim about clangd index generation time. Native
-position and route queries, serving integration, content receipts, and a
-hardened clangd artifact compatibility/resource contract remain separate
-promotion gates.
+position and route queries and serving integration remain separate promotion
+gates.
 
 ## Use Through Python
 

--- a/core/bindings/pybind_module.cpp
+++ b/core/bindings/pybind_module.cpp
@@ -241,6 +241,8 @@ py::dict clangd_decode_profile_to_dict(
   py::dict result;
   result["discover_files"] = profile.discover_files_ns;
   result["read_files"] = profile.read_files_ns;
+  result["hash_index"] = profile.hash_index_ns;
+  result["verify_snapshot"] = profile.verify_snapshot_ns;
   result["parse_files"] = profile.parse_files_ns;
   result["merge_records"] = profile.merge_records_ns;
   result["build_query_records"] = profile.build_query_records_ns;
@@ -391,8 +393,8 @@ py::dict decode_clangd_fact_query_index(const std::string &idx_directory,
     decoded =
         codenib::core::decode_clangd_query_records(idx_directory, project_root);
     decode_finished = clock::now();
-    index =
-        std::make_shared<codenib::core::FactQueryIndex>(decoded.records, false);
+    index = std::make_shared<codenib::core::FactQueryIndex>(
+        decoded.records, false, decoded.receipt.snapshot_id);
     index_finished = clock::now();
   }
 
@@ -407,6 +409,9 @@ py::dict decode_clangd_fact_query_index(const std::string &idx_directory,
   result["native_index_ns"] = elapsed_ns(decode_finished, index_finished);
   result["decode_profile_ns"] = clangd_decode_profile_to_dict(decoded.profile);
   result["graph_materialized"] = false;
+  result["snapshot_id"] = decoded.receipt.snapshot_id;
+  result["snapshot_file_count"] = decoded.receipt.file_count;
+  result["snapshot_index_bytes"] = decoded.receipt.index_bytes;
   return result;
 }
 
@@ -435,11 +440,30 @@ py::dict clangd_fact_query_contract() {
   py::dict result;
   result["abi_version"] = codenib::core::CLANGD_FACT_QUERY_ABI_VERSION;
   result["format"] = codenib::core::CLANGD_FACT_QUERY_FORMAT;
+  result["normalization_profile"] =
+      codenib::core::CLANGD_FACT_QUERY_NORMALIZATION_PROFILE;
+  result["snapshot_schema"] = codenib::core::CLANGD_FACT_QUERY_SNAPSHOT_SCHEMA;
+  result["snapshot_digest"] = "sha256";
   result["supported_versions"] = codenib::core::CLANGD_SUPPORTED_RIFF_VERSIONS;
   result["resource_limits"] = std::move(resource_limits);
   result["stable_filename_order"] = true;
   result["preserves_unanchored_relations"] = true;
   result["capabilities"] = fact_query_capabilities();
+  return result;
+}
+
+py::dict clangd_fact_query_snapshot(const std::string &idx_directory,
+                                    const std::string &project_root) {
+  codenib::core::ClangdIndexReceipt receipt;
+  {
+    py::gil_scoped_release release;
+    receipt = codenib::core::compute_clangd_index_receipt(
+        idx_directory, project_root, codenib::core::ClangdFactDecodeLimits{});
+  }
+  py::dict result;
+  result["snapshot_id"] = receipt.snapshot_id;
+  result["file_count"] = receipt.file_count;
+  result["index_bytes"] = receipt.index_bytes;
   return result;
 }
 
@@ -492,6 +516,8 @@ PYBIND11_MODULE(codenib_core, m) {
       .def_property_readonly(
           "requires_anchored_references",
           &codenib::core::FactQueryIndex::requires_anchored_references)
+      .def_property_readonly("snapshot_id",
+                             &codenib::core::FactQueryIndex::snapshot_id)
       .def("has_symbol", &codenib::core::FactQueryIndex::has_symbol)
       .def("get_node_info_by_name",
            [](const codenib::core::FactQueryIndex &index,
@@ -604,6 +630,10 @@ queries remain outside this baseline capability.
 
   m.def("clangd_fact_query_contract", &clangd_fact_query_contract,
         R"pbdoc(Return the baseline native clangd query ABI contract.)pbdoc");
+
+  m.def("clangd_fact_query_snapshot", &clangd_fact_query_snapshot,
+        py::arg("idx_directory"), py::arg("project_root"),
+        R"pbdoc(Return the current content-bound clangd index receipt.)pbdoc");
 
   m.def("canonical_scip_decoder_languages",
         &codenib::core::canonical_scip_decoder_languages,

--- a/core/clangd_fact_query.cpp
+++ b/core/clangd_fact_query.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "clangd_fact_query.h"
+#include "content_digest.h"
 
 #include <zlib.h>
 
@@ -668,6 +669,66 @@ discover_index_files(const std::filesystem::path &directory,
   return files;
 }
 
+void update_u64_le(Sha256 &digest, std::uint64_t value) {
+  std::array<std::uint8_t, 8> encoded{};
+  for (std::size_t index = 0; index < encoded.size(); ++index)
+    encoded[index] = static_cast<std::uint8_t>(value >> (index * 8U));
+  digest.update(encoded.data(), encoded.size());
+}
+
+void update_field(Sha256 &digest, std::string_view value) {
+  update_u64_le(digest, static_cast<std::uint64_t>(value.size()));
+  digest.update(value);
+}
+
+class IndexReceiptBuilder {
+public:
+  IndexReceiptBuilder(const std::filesystem::path &project_root,
+                      std::size_t file_count) {
+    update_field(digest_, "CodeNib clangd fact query snapshot");
+    update_field(digest_, CLANGD_FACT_QUERY_SNAPSHOT_SCHEMA);
+    update_field(digest_, CLANGD_FACT_QUERY_FORMAT);
+    update_u64_le(digest_, CLANGD_FACT_QUERY_ABI_VERSION);
+    update_field(digest_, CLANGD_FACT_QUERY_NORMALIZATION_PROFILE);
+    update_field(digest_, project_root.generic_string());
+    update_u64_le(digest_, CLANGD_SUPPORTED_RIFF_VERSIONS.size());
+    for (const auto version : CLANGD_SUPPORTED_RIFF_VERSIONS)
+      update_u64_le(digest_, version);
+    update_u64_le(digest_, file_count);
+  }
+
+  void add_file(const IndexFile &file, const std::vector<std::uint8_t> &data) {
+    update_field(digest_, file.name);
+    update_u64_le(digest_, static_cast<std::uint64_t>(data.size()));
+    digest_.update(data.data(), data.size());
+    index_bytes_ += static_cast<std::uint64_t>(data.size());
+  }
+
+  ClangdIndexReceipt finish(std::size_t file_count) const {
+    return ClangdIndexReceipt{"clangd_fact_query:sha256:" +
+                                  digest_.hex_digest(),
+                              file_count, index_bytes_};
+  }
+
+private:
+  Sha256 digest_;
+  std::uint64_t index_bytes_{0};
+};
+
+ClangdIndexReceipt receipt_from_files(const std::vector<IndexFile> &files,
+                                      const std::filesystem::path &project_root,
+                                      const ClangdFactDecodeLimits &limits) {
+  IndexReceiptBuilder builder(project_root, files.size());
+  std::uint64_t read_bytes = 0;
+  for (const auto &file : files) {
+    const auto data = read_file(file.path, limits);
+    consume_budget(static_cast<std::uint64_t>(data.size()), read_bytes,
+                   limits.max_aggregate_index_bytes, "aggregate index bytes");
+    builder.add_file(file, data);
+  }
+  return builder.finish(files.size());
+}
+
 bool path_has_prefix(const std::filesystem::path &path,
                      const std::filesystem::path &prefix) {
   auto path_part = path.begin();
@@ -970,6 +1031,7 @@ decode_clangd_query_records(const std::string &idx_directory,
 
   CollectedRecords collected;
   DecodeBudget budget(limits);
+  IndexReceiptBuilder receipt_builder(root, files.size());
   std::uint64_t read_bytes = 0;
   for (const auto &file : files) {
     const auto read_started = Clock::now();
@@ -977,6 +1039,10 @@ decode_clangd_query_records(const std::string &idx_directory,
     consume_budget(static_cast<std::uint64_t>(data.size()), read_bytes,
                    limits.max_aggregate_index_bytes, "aggregate index bytes");
     profile.read_files_ns += elapsed_ns(read_started, Clock::now());
+
+    const auto hash_started = Clock::now();
+    receipt_builder.add_file(file, data);
+    profile.hash_index_ns += elapsed_ns(hash_started, Clock::now());
 
     const auto parse_started = Clock::now();
     ParsedFile parsed;
@@ -1014,8 +1080,26 @@ decode_clangd_query_records(const std::string &idx_directory,
   profile.decompressed_string_bytes = budget.string_table_bytes;
   profile.materialized_string_bytes = budget.materialized_string_bytes;
   profile.string_entry_count = budget.string_entries;
+  auto receipt = receipt_builder.finish(files.size());
+  const auto verify_started = Clock::now();
+  const auto verified =
+      compute_clangd_index_receipt(idx_directory, project_root, limits);
+  profile.verify_snapshot_ns = elapsed_ns(verify_started, Clock::now());
+  if (verified.snapshot_id != receipt.snapshot_id) {
+    throw std::runtime_error(
+        "clangd index snapshot changed while native records were decoded");
+  }
   profile.total_ns = elapsed_ns(total_started, Clock::now());
-  return ClangdQueryRecords{std::move(records), profile};
+  return ClangdQueryRecords{std::move(records), profile, std::move(receipt)};
+}
+
+ClangdIndexReceipt
+compute_clangd_index_receipt(const std::string &idx_directory,
+                             const std::string &project_root,
+                             const ClangdFactDecodeLimits &limits) {
+  const auto files =
+      discover_index_files(normalized_absolute(idx_directory), limits);
+  return receipt_from_files(files, normalized_absolute(project_root), limits);
 }
 
 } // namespace codenib::core

--- a/core/clangd_fact_query.h
+++ b/core/clangd_fact_query.h
@@ -18,6 +18,10 @@ namespace codenib::core {
 
 inline constexpr std::uint32_t CLANGD_FACT_QUERY_ABI_VERSION = 1;
 inline constexpr char CLANGD_FACT_QUERY_FORMAT[] = "clangd-riff-fact-query-v1";
+inline constexpr char CLANGD_FACT_QUERY_NORMALIZATION_PROFILE[] =
+    "clangd-native-normalization-v1";
+inline constexpr char CLANGD_FACT_QUERY_SNAPSHOT_SCHEMA[] =
+    "clangd-fact-query-snapshot-v1";
 
 // clangd itself rejects non-current RIFF versions. CodeNib deliberately uses
 // an exact allowlist backed by checked fixtures and parity tests instead of
@@ -51,6 +55,8 @@ struct ClangdFactDecodeLimits {
 struct ClangdFactDecodeProfile {
   std::uint64_t discover_files_ns{0};
   std::uint64_t read_files_ns{0};
+  std::uint64_t hash_index_ns{0};
+  std::uint64_t verify_snapshot_ns{0};
   std::uint64_t parse_files_ns{0};
   std::uint64_t merge_records_ns{0};
   std::uint64_t build_query_records_ns{0};
@@ -67,15 +73,28 @@ struct ClangdFactDecodeProfile {
   std::size_t string_entry_count{0};
 };
 
+struct ClangdIndexReceipt {
+  std::string snapshot_id;
+  std::size_t file_count{0};
+  std::uint64_t index_bytes{0};
+};
+
 struct ClangdQueryRecords {
   std::shared_ptr<DecodedRecords> records;
   ClangdFactDecodeProfile profile;
+  ClangdIndexReceipt receipt;
 };
 
 // Decode every direct *.idx child in stable filename order. Any read or parse
 // failure rejects the complete native candidate so Python auto mode can use
 // the established ClangdGraphDecoder without publishing partial rows.
 ClangdQueryRecords decode_clangd_query_records(
+    const std::string &idx_directory, const std::string &project_root,
+    const ClangdFactDecodeLimits &limits = ClangdFactDecodeLimits{});
+
+// Re-read the canonical filename/byte stream and return its content identity.
+// Lazy graph consumers compare this receipt with the one published by decode.
+ClangdIndexReceipt compute_clangd_index_receipt(
     const std::string &idx_directory, const std::string &project_root,
     const ClangdFactDecodeLimits &limits = ClangdFactDecodeLimits{});
 

--- a/core/content_digest.cpp
+++ b/core/content_digest.cpp
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "content_digest.h"
+
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+
+namespace codenib::core {
+namespace {
+
+constexpr std::array<std::uint32_t, 64> ROUND_CONSTANTS{
+    0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U, 0x3956c25bU,
+    0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U, 0xd807aa98U, 0x12835b01U,
+    0x243185beU, 0x550c7dc3U, 0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U,
+    0xc19bf174U, 0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU,
+    0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU, 0x983e5152U,
+    0xa831c66dU, 0xb00327c8U, 0xbf597fc7U, 0xc6e00bf3U, 0xd5a79147U,
+    0x06ca6351U, 0x14292967U, 0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU,
+    0x53380d13U, 0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
+    0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U, 0xd192e819U,
+    0xd6990624U, 0xf40e3585U, 0x106aa070U, 0x19a4c116U, 0x1e376c08U,
+    0x2748774cU, 0x34b0bcb5U, 0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU,
+    0x682e6ff3U, 0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
+    0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U};
+
+std::uint32_t rotate_right(std::uint32_t value, unsigned int bits) {
+  return (value >> bits) | (value << (32U - bits));
+}
+
+} // namespace
+
+Sha256::Sha256()
+    : state_{{0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU, 0x510e527fU,
+              0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U}} {}
+
+void Sha256::update(const void *data, std::size_t size) {
+  if (size == 0)
+    return;
+  if (data == nullptr)
+    throw std::invalid_argument("SHA-256 update data must not be null");
+  if (size > std::numeric_limits<std::uint64_t>::max() - total_bytes_)
+    throw std::overflow_error("SHA-256 input length exceeds uint64");
+
+  const auto *bytes = static_cast<const std::uint8_t *>(data);
+  total_bytes_ += static_cast<std::uint64_t>(size);
+  if (buffer_size_ != 0) {
+    const auto count = std::min(size, buffer_.size() - buffer_size_);
+    std::copy_n(bytes, count, buffer_.begin() + buffer_size_);
+    buffer_size_ += count;
+    bytes += count;
+    size -= count;
+    if (buffer_size_ == buffer_.size()) {
+      transform(buffer_.data());
+      buffer_size_ = 0;
+    }
+  }
+  while (size >= buffer_.size()) {
+    transform(bytes);
+    bytes += buffer_.size();
+    size -= buffer_.size();
+  }
+  if (size != 0) {
+    std::copy_n(bytes, size, buffer_.begin());
+    buffer_size_ = size;
+  }
+}
+
+void Sha256::transform(const std::uint8_t *block) {
+  std::array<std::uint32_t, 64> words;
+  for (std::size_t index = 0; index < 16; ++index) {
+    const auto offset = index * 4;
+    words[index] = (static_cast<std::uint32_t>(block[offset]) << 24U) |
+                   (static_cast<std::uint32_t>(block[offset + 1]) << 16U) |
+                   (static_cast<std::uint32_t>(block[offset + 2]) << 8U) |
+                   static_cast<std::uint32_t>(block[offset + 3]);
+  }
+  for (std::size_t index = 16; index < words.size(); ++index) {
+    const auto value15 = words[index - 15];
+    const auto value2 = words[index - 2];
+    const auto sigma0 =
+        rotate_right(value15, 7) ^ rotate_right(value15, 18) ^ (value15 >> 3U);
+    const auto sigma1 =
+        rotate_right(value2, 17) ^ rotate_right(value2, 19) ^ (value2 >> 10U);
+    words[index] = words[index - 16] + sigma0 + words[index - 7] + sigma1;
+  }
+
+  auto a = state_[0];
+  auto b = state_[1];
+  auto c = state_[2];
+  auto d = state_[3];
+  auto e = state_[4];
+  auto f = state_[5];
+  auto g = state_[6];
+  auto h = state_[7];
+  for (std::size_t index = 0; index < words.size(); ++index) {
+    const auto sum1 =
+        rotate_right(e, 6) ^ rotate_right(e, 11) ^ rotate_right(e, 25);
+    const auto choose = (e & f) ^ ((~e) & g);
+    const auto temporary1 =
+        h + sum1 + choose + ROUND_CONSTANTS[index] + words[index];
+    const auto sum0 =
+        rotate_right(a, 2) ^ rotate_right(a, 13) ^ rotate_right(a, 22);
+    const auto majority = (a & b) ^ (a & c) ^ (b & c);
+    const auto temporary2 = sum0 + majority;
+    h = g;
+    g = f;
+    f = e;
+    e = d + temporary1;
+    d = c;
+    c = b;
+    b = a;
+    a = temporary1 + temporary2;
+  }
+  state_[0] += a;
+  state_[1] += b;
+  state_[2] += c;
+  state_[3] += d;
+  state_[4] += e;
+  state_[5] += f;
+  state_[6] += g;
+  state_[7] += h;
+}
+
+std::string Sha256::hex_digest() const {
+  Sha256 finalized = *this;
+  const auto bit_count = finalized.total_bytes_ * 8U;
+  std::array<std::uint8_t, 64> padding{};
+  padding[0] = 0x80U;
+  const auto padding_size = finalized.buffer_size_ < 56
+                                ? 56 - finalized.buffer_size_
+                                : 120 - finalized.buffer_size_;
+  finalized.update(padding.data(), padding_size);
+
+  std::array<std::uint8_t, 8> length{};
+  for (std::size_t index = 0; index < length.size(); ++index) {
+    length[length.size() - 1 - index] =
+        static_cast<std::uint8_t>(bit_count >> (index * 8U));
+  }
+  finalized.update(length.data(), length.size());
+
+  static constexpr std::array<char, 16> digits{{'0', '1', '2', '3', '4', '5',
+                                                '6', '7', '8', '9', 'a', 'b',
+                                                'c', 'd', 'e', 'f'}};
+  std::string result;
+  result.reserve(64);
+  for (const auto word : finalized.state_) {
+    for (int shift = 28; shift >= 0; shift -= 4)
+      result.push_back(digits[(word >> shift) & 0x0fU]);
+  }
+  return result;
+}
+
+std::string sha256_hex(std::string_view value) {
+  Sha256 digest;
+  digest.update(value);
+  return digest.hex_digest();
+}
+
+} // namespace codenib::core

--- a/core/content_digest.h
+++ b/core/content_digest.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace codenib::core {
+
+// Small dependency-free streaming SHA-256 implementation used for content
+// receipts. Only byte updates and hexadecimal output are public so receipt
+// callers cannot depend on digest internals.
+class Sha256 {
+public:
+  Sha256();
+
+  void update(const void *data, std::size_t size);
+  void update(std::string_view value) { update(value.data(), value.size()); }
+
+  std::string hex_digest() const;
+
+private:
+  void transform(const std::uint8_t *block);
+
+  std::array<std::uint32_t, 8> state_;
+  std::array<std::uint8_t, 64> buffer_{};
+  std::size_t buffer_size_{0};
+  std::uint64_t total_bytes_{0};
+};
+
+std::string sha256_hex(std::string_view value);
+
+} // namespace codenib::core

--- a/core/fact_query_index.cpp
+++ b/core/fact_query_index.cpp
@@ -37,8 +37,9 @@ bool has_suffix(const std::string &value, const std::string &suffix) {
 } // namespace
 
 FactQueryIndex::FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
-                               bool require_anchored_references)
-    : records_(std::move(records)),
+                               bool require_anchored_references,
+                               std::string snapshot_id)
+    : records_(std::move(records)), snapshot_id_(std::move(snapshot_id)),
       require_anchored_references_(require_anchored_references) {
   if (!records_)
     throw std::invalid_argument("FactQueryIndex records must not be null");

--- a/core/fact_query_index.h
+++ b/core/fact_query_index.h
@@ -34,7 +34,8 @@ public:
   };
 
   explicit FactQueryIndex(std::shared_ptr<const DecodedRecords> records,
-                          bool require_anchored_references = true);
+                          bool require_anchored_references = true,
+                          std::string snapshot_id = {});
 
   bool has_symbol(const std::string &name) const;
   std::optional<CodeGraph::VertexData>
@@ -55,6 +56,7 @@ public:
   bool requires_anchored_references() const {
     return require_anchored_references_;
   }
+  const std::string &snapshot_id() const { return snapshot_id_; }
 
 private:
   static std::string trim_symbol(std::string value);
@@ -65,6 +67,7 @@ private:
                         CodeGraph::VertexId id, std::size_t limit) const;
 
   std::shared_ptr<const DecodedRecords> records_;
+  std::string snapshot_id_;
   std::unordered_map<std::string, CodeGraph::VertexId> record_by_name_;
   std::unordered_map<std::string, CodeGraph::VertexId> definition_by_name_;
   std::unordered_map<std::string, std::vector<CodeGraph::VertexId>> aliases_;

--- a/core/tests/content_digest_test.cpp
+++ b/core/tests/content_digest_test.cpp
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2025-2026 CodeNib Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "content_digest.h"
+
+#include <cassert>
+#include <iostream>
+#include <string>
+
+int main() {
+  using codenib::core::Sha256;
+  using codenib::core::sha256_hex;
+
+  assert(sha256_hex("") == "e3b0c44298fc1c149afbf4c8996fb924"
+                           "27ae41e4649b934ca495991b7852b855");
+  assert(sha256_hex("abc") == "ba7816bf8f01cfea414140de5dae2223"
+                              "b00361a396177a9cb410ff61f20015ad");
+  assert(sha256_hex("abcdbcdecdefdefgefghfghighijhijk"
+                    "ijkljklmklmnlmnomnopnopq") ==
+         "248d6a61d20638b8e5c026930c3e6039"
+         "a33ce45964ff2167f6ecedd419db06c1");
+  assert(sha256_hex(std::string(1'000'000, 'a')) ==
+         "cdc76e5c9914fb9281a1c7e284d73e67"
+         "f1809a48a497200e046d39ccc7112cd0");
+
+  Sha256 incremental;
+  incremental.update("a");
+  incremental.update("b");
+  incremental.update("c");
+  assert(incremental.hex_digest() == sha256_hex("abc"));
+  assert(incremental.hex_digest() == sha256_hex("abc"));
+
+  const std::string block_boundary(65, 'x');
+  Sha256 split_boundary;
+  split_boundary.update(block_boundary.data(), 63);
+  split_boundary.update(block_boundary.data() + 63, 2);
+  assert(split_boundary.hex_digest() == sha256_hex(block_boundary));
+
+  std::cout << "content_digest_test: OK\n";
+  return 0;
+}

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -271,10 +271,12 @@ steps:
   make core-test
   ```
 
-  This incrementally reuses the configured build, runs all C++ executables,
-  verifies the required clangd bindings are present, and executes the SCIP,
-  Fact, clangd, and profiler-contract Python tests with `build/core` first on
-  `PYTHONPATH`. The same `make core-test` command is the local reproduction.
+  This incrementally reuses the configured build, runs all C++ executables
+  (including the content-digest vectors), verifies the required clangd decode,
+  contract, and snapshot bindings are present, and executes the SCIP, Fact,
+  clangd receipt/parity/fallback, and profiler-contract Python tests with
+  `build/core` first on `PYTHONPATH`. The same `make core-test` command is the
+  local reproduction.
 
 ### graph-consumer
 

--- a/docs/core_cpp.md
+++ b/docs/core_cpp.md
@@ -75,10 +75,11 @@ and returns no graph. Non-SCIP backends such as C/C++ ignore
 The pybind module also exposes lower-level `decode_scip(...)`,
 `decode_scip_fact_buffer(...)`, `fact_batch_buffer_contract(...)`,
 `decode_clangd_fact_query_index(...)`, `clangd_fact_query_contract()`,
-`classify_edge_layers(...)`, and decoder-registry inspection functions. These
-are primarily integration surfaces; application code should normally use
-`LSIndexer` so filtering, occurrence indexes, range indexes, and persistence
-remain consistent with the serial path.
+`clangd_fact_query_snapshot(...)`, `classify_edge_layers(...)`, and
+decoder-registry inspection functions. These are primarily integration
+surfaces; application code should normally use `LSIndexer` so filtering,
+occurrence indexes, range indexes, and persistence remain consistent with the
+serial path.
 
 ## Pre-Graph Decode Boundary
 
@@ -180,8 +181,30 @@ make clangd-fact-query-profile \
 
 This result measures an already generated `.idx` directory through identical
 definition/reference work. It does not claim faster clangd generation. Native
-position/route lookup, serving integration, and content receipts remain
-independent follow-up gates.
+position/route lookup and serving integration remain independent follow-up
+gates.
+
+### Content-bound snapshot receipt
+
+The native decoder hashes the exact shard bytes it already read, so the first
+receipt pass adds no second read. Its canonical length-delimited input binds the
+snapshot schema, query ABI and format, normalization profile, normalized
+project root, exact supported RIFF versions, sorted direct shard names, lengths,
+and bytes. The resulting
+`clangd_fact_query:sha256:<digest>` is exposed on `FactQueryIndex`, in the decode
+payload, through `clangd_fact_query_snapshot(...)`, and as `index_snapshot` in
+LSP provider metadata.
+
+After record construction, the decoder re-reads the current canonical stream
+before publishing. This second pass is required to detect file-list or byte
+mutation during decode; both `hash_index` and `verify_snapshot` are included in
+native startup timing and reported by `make clangd-fact-query-profile`. Before
+the hybrid provider lazily parses the complete graph, it verifies the same
+receipt before and after Python record collection. A mismatch fails that
+provider session permanently instead of mixing generations. Restart the
+provider to adopt a new index. If the native candidate fails before it is
+published, `auto` may fall back to one graph from the current generation while
+`required` propagates the failure.
 
 ### RIFF compatibility and resource safety
 
@@ -230,14 +253,15 @@ fails closed, while `off` never invokes the native reader.
 make core-test
 ```
 
-This runs the C++ smoke tests, graph-layer checks, registry consistency checks,
-Fact transport/query tests, native clangd result/error and fallback tests, and
-the serial/core parity fixtures available in the checkout. Before pytest it
-also requires the built extension to export the native clangd decode and
-contract bindings, so an absent or stale extension cannot turn that gate into
-a skip. Some integration-cache parity cases are skipped when their generated
-SCIP fixtures are not present, so a successful local run should be read
-together with its skip report.
+This runs the C++ smoke tests (including SHA-256 vectors), graph-layer checks,
+registry consistency checks, Fact transport/query tests, native clangd
+receipt/result/error/fallback tests, and the serial/core parity fixtures
+available in the checkout. Before pytest it also requires the built extension
+to export the native clangd decode, contract, and snapshot bindings, so an
+absent or stale extension cannot turn that gate into a skip. Some
+integration-cache parity cases are skipped when their generated SCIP fixtures
+are not present, so a successful local run should be read together with its
+skip report.
 
 ## Components
 
@@ -248,6 +272,8 @@ together with its skip report.
   postings.
 - `clangd_fact_query.{h,cpp}` decodes clangd RIFF shards into provider-neutral
   records for the query-specific path.
+- `content_digest.{h,cpp}` provides the dependency-free streaming SHA-256 used
+  by native content receipts.
 - `graph_layers.{h,cpp}` classifies normalized edge types into reusable graph
   layers.
 - `scip_decode_base.{h,cpp}` and `scip_decode_common.{h,cpp}` provide shared

--- a/docs/scip_multilanguage_roadmap.md
+++ b/docs/scip_multilanguage_roadmap.md
@@ -752,11 +752,11 @@ stable shard-set SHA-256 values were
 Reproduce the report with `make clangd-fact-query-profile`.
 
 This promotion does not include or accelerate clangd index generation. RIFF
-version/resource hardening (#546) and zlib CI enforcement (#547) are now
-implemented as independent production gates. Content receipts (#548), serving
-integration (#549), mixed/RSS/concurrency matrices (#550), native position
-(#553), native route (#552), and durable FactBatch storage (#551) remain
-separate review and promotion gates.
+version/resource hardening (#546), zlib CI enforcement (#547), and
+content-bound generation receipts (#548) are independent production gates.
+Serving integration (#549), mixed/RSS/concurrency matrices (#550), native
+position (#553), native route (#552), and durable FactBatch storage (#551)
+remain separate review and promotion gates.
 
 Native clangd RIFF compatibility and resource-safety status
 ([#546](https://github.com/sysevol-ai/CodeNib/issues/546)): the v1 reader now
@@ -781,16 +781,47 @@ oversized declarations, invalid counts, and sparse per-file/aggregate limits.
 preserves the established graph path. The same v18/v19/v20 fixture executes
 the exact public definition/reference parity assertions.
 
+Native clangd content-bound snapshot status
+([#548](https://github.com/sysevol-ai/CodeNib/issues/548)): every native decode
+now publishes a deterministic SHA-256 receipt over a length-delimited domain,
+snapshot schema, query ABI/format, normalization profile, normalized project
+root, exact RIFF allowlist, sorted direct shard names, shard lengths, and the
+exact bytes already read for decoding. Directory enumeration order therefore
+does not affect identity, while any filename, byte, supported-version set,
+query schema, normalization profile, or root identity does. The first hash is
+fused with the decoder's existing read buffers; a post-decode re-read proves
+the directory did not change before the native index is published.
+
+The receipt is exposed by the pybind index, decode payload, and
+`clangd_fact_query_snapshot(...)`. Provider metadata uses that identity instead
+of the old root/vertex/edge-count fallback. Before Python lazily collects the
+complete graph, it verifies the receipt both before and after collection. A
+changed file list or content permanently fails that provider session so symbol
+results from one generation cannot be combined with a graph from another.
+Native candidate failures before publication still follow the existing mode
+policy: `auto` may build one compatible graph from the then-current generation,
+while `required` fails closed. Callers restart the provider to adopt a later
+generation.
+
+The 2026-08-10 snapshot-enabled `cpp_simple` recheck used 223 shards and five
+alternating rounds with exact result parity. Median complete-graph startup was
+157.7 ms versus 23.9 ms for the native path, an 84.8% improvement after both
+receipt passes were included. The fused first-pass hash took 2.94 ms (12.6% of
+native startup); hashing plus publication verification took 7.09 ms. The
+maintained profiler now reports both stages and their fraction of startup, and
+the existing 20% acceleration decision includes their cost.
+
 Native core CI enforcement status
 ([#547](https://github.com/sysevol-ai/CodeNib/issues/547)): the trusted
 `scip-core` job now declares zlib development headers alongside RE2 and CMake,
 preserves the vendored-igraph and system-libstdc++ loader contracts, and calls
 the maintained `make core-test` gate instead of one SCIP-only pytest file. The
-gate runs all four C++ executables plus SCIP, Fact, native clangd, fallback, and
+gate runs all five C++ executables plus SCIP, Fact, native clangd, fallback, and
 profiler-contract Python tests. It first asserts that the built extension
-exports `decode_clangd_fact_query_index` and `clangd_fact_query_contract`, so a
-missing or stale extension cannot silently skip the clangd module. CI-policy
-tests pin the dependency probe, Make target, binding guard, and test inventory.
+exports `decode_clangd_fact_query_index`, `clangd_fact_query_contract`, and
+`clangd_fact_query_snapshot`, so a missing or stale extension cannot silently
+skip the clangd module. CI-policy tests pin the dependency probe, Make target,
+binding guard, and test inventory.
 The same `make core-test` command is the documented local reproduction; slow,
 billed, and external clangd-generation benchmarks remain outside this
 deterministic job.

--- a/scripts/profiling/profile_clangd_fact_query_index.py
+++ b/scripts/profiling/profile_clangd_fact_query_index.py
@@ -97,9 +97,16 @@ def profile_clangd_fact_query_index(
 
     from codenib.ls_index.clangd_decode import ClangdGraphDecoder
 
-    if not hasattr(codenib_core, "decode_clangd_fact_query_index"):
+    if not hasattr(codenib_core, "decode_clangd_fact_query_index") or not hasattr(
+        codenib_core, "clangd_fact_query_snapshot"
+    ):
         raise RuntimeError("compiled core does not expose clangd FactQueryIndex v1")
     contract = codenib_core.clangd_fact_query_contract()
+    initial_receipt = dict(
+        codenib_core.clangd_fact_query_snapshot(
+            idx_directory=str(idx_directory), project_root=str(project_root)
+        )
+    )
     initial_digest = _idx_digest(idx_directory)
 
     def legacy_arm() -> tuple[Any, dict[str, float]]:
@@ -133,6 +140,8 @@ def profile_clangd_fact_query_index(
         )
         if payload.get("graph_materialized") is not False:
             raise AssertionError("candidate payload reports graph materialization")
+        if payload.get("snapshot_id") != initial_receipt.get("snapshot_id"):
+            raise RuntimeError("clangd index changed during native startup")
         index = payload["index"]
         _, query = _timed(lambda: _query_workload(index, workload_symbols))
         native_decode = payload["native_decode_ns"] / 1_000_000_000
@@ -202,6 +211,13 @@ def profile_clangd_fact_query_index(
     final_digest = _idx_digest(idx_directory)
     if final_digest != initial_digest:
         raise RuntimeError("clangd index changed during benchmark")
+    final_receipt = dict(
+        codenib_core.clangd_fact_query_snapshot(
+            idx_directory=str(idx_directory), project_root=str(project_root)
+        )
+    )
+    if final_receipt != initial_receipt:
+        raise RuntimeError("clangd content receipt changed during benchmark")
     legacy_summary = {
         name: summarize_samples(values) for name, values in legacy_samples.items()
     }
@@ -216,6 +232,10 @@ def profile_clangd_fact_query_index(
         parity=parity,
         candidate_name="native-clangd-fact-query-index",
     )
+    hash_seconds = native_summary["native_stage_hash_index"]["median_seconds"]
+    verify_seconds = native_summary["native_stage_verify_snapshot"]["median_seconds"]
+    native_startup_seconds = native_summary["startup"]["median_seconds"]
+    receipt_seconds = hash_seconds + verify_seconds
     idx_sha256, idx_bytes, idx_files = initial_digest
     return {
         "schema_version": 1,
@@ -253,6 +273,17 @@ def profile_clangd_fact_query_index(
         },
         "legacy_clangd_graph": legacy_summary,
         "native_clangd_fact_query_index": native_summary,
+        "snapshot_receipt": {
+            **initial_receipt,
+            "hash_index_median_seconds": hash_seconds,
+            "verify_snapshot_median_seconds": verify_seconds,
+            "total_median_seconds": receipt_seconds,
+            "fraction_of_native_startup": (
+                receipt_seconds / native_startup_seconds
+                if native_startup_seconds > 0
+                else 0.0
+            ),
+        },
         "decision": decision,
     }
 

--- a/test/agent/test_lsp_provider.py
+++ b/test/agent/test_lsp_provider.py
@@ -96,6 +96,15 @@ def test_static_lsp_provider_returns_list_with_metadata():
     assert metadata["index_snapshot"] == "graph:demo"
 
 
+def test_static_lsp_provider_prefers_a_content_bound_graph_snapshot():
+    graph = _range_graph()
+    legacy_snapshot = StaticLSPProvider(graph).snapshot_id
+    graph.snapshot_id = "clangd_fact_query:sha256:content"
+
+    assert legacy_snapshot.startswith("symbol_graph:")
+    assert StaticLSPProvider(graph).snapshot_id == graph.snapshot_id
+
+
 def test_static_lsp_provider_uses_exact_scip_occurrences_for_native_positions():
     index = SCIPOccurrenceIndex(
         [

--- a/test/ls_index/test_clangd_fact_query.py
+++ b/test/ls_index/test_clangd_fact_query.py
@@ -6,8 +6,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
+import os
 import struct
 import zlib
 from pathlib import Path
@@ -135,12 +137,44 @@ def _minimal_chunks(version: int = 18) -> list[tuple[bytes, bytes]]:
 
 
 def _set_meta_version(idx_directory: Path, before: int, after: int) -> None:
-    path = next(idx_directory.glob("*.idx"))
+    path = (
+        idx_directory if idx_directory.is_file() else next(idx_directory.glob("*.idx"))
+    )
     data = path.read_bytes()
     old = b"meta" + struct.pack("<I", 4) + struct.pack("<I", before)
     new = b"meta" + struct.pack("<I", 4) + struct.pack("<I", after)
     assert data.count(old) == 1
     path.write_bytes(data.replace(old, new, 1))
+
+
+def _expected_snapshot_id(idx_directory: Path, project_root: Path) -> str:
+    digest = hashlib.sha256()
+
+    def field(value: str) -> None:
+        encoded = value.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "little"))
+        digest.update(encoded)
+
+    def uint64(value: int) -> None:
+        digest.update(value.to_bytes(8, "little"))
+
+    field("CodeNib clangd fact query snapshot")
+    field("clangd-fact-query-snapshot-v1")
+    field("clangd-riff-fact-query-v1")
+    uint64(1)
+    field("clangd-native-normalization-v1")
+    field(project_root.absolute().as_posix())
+    uint64(3)
+    for version in (18, 19, 20):
+        uint64(version)
+    files = sorted(idx_directory.glob("*.idx"), key=lambda path: path.name)
+    uint64(len(files))
+    for path in files:
+        data = path.read_bytes()
+        field(path.name)
+        uint64(len(data))
+        digest.update(data)
+    return f"clangd_fact_query:sha256:{digest.hexdigest()}"
 
 
 @pytest.fixture()
@@ -329,6 +363,9 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
     assert contract == {
         "abi_version": 1,
         "format": "clangd-riff-fact-query-v1",
+        "normalization_profile": "clangd-native-normalization-v1",
+        "snapshot_schema": "clangd-fact-query-snapshot-v1",
+        "snapshot_digest": "sha256",
         "supported_versions": [18, 19, 20],
         "resource_limits": {
             "max_index_files": 200_000,
@@ -359,6 +396,95 @@ def test_contract_and_graph_free_payload_are_explicit(clangd_fixture) -> None:
     assert index.materializes_graph is False
     assert index.requires_anchored_references is False
     assert not hasattr(index, "graph")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("normalization_profile", "changed", "normalization profile mismatch"),
+        ("snapshot_schema", "changed", "snapshot schema mismatch"),
+        ("snapshot_digest", "sha1", "snapshot digest mismatch"),
+    ],
+)
+def test_native_snapshot_contract_fails_closed(
+    field: str, value: str, message: str
+) -> None:
+    contract = dict(codenib_core.clangd_fact_query_contract())
+    contract[field] = value
+
+    with pytest.raises(RuntimeError, match=message):
+        _validate_native_query_contract(contract)
+
+
+def test_native_snapshot_receipt_matches_canonical_recipe(clangd_fixture) -> None:
+    root, idx_directory = clangd_fixture
+
+    payload = codenib_core.decode_clangd_fact_query_index(
+        idx_directory=str(idx_directory), project_root=str(root)
+    )
+    receipt = codenib_core.clangd_fact_query_snapshot(
+        idx_directory=str(idx_directory), project_root=str(root)
+    )
+    expected = _expected_snapshot_id(idx_directory, root)
+
+    assert payload["snapshot_id"] == expected
+    assert payload["index"].snapshot_id == expected
+    assert receipt == {
+        "snapshot_id": expected,
+        "file_count": 1,
+        "index_bytes": next(idx_directory.glob("*.idx")).stat().st_size,
+    }
+    assert payload["decode_profile_ns"]["hash_index"] > 0
+    assert payload["decode_profile_ns"]["verify_snapshot"] > 0
+
+
+def test_native_snapshot_is_order_independent_and_content_bound(
+    clangd_fixture, tmp_path: Path
+) -> None:
+    root, idx_directory = clangd_fixture
+    original = next(idx_directory.glob("*.idx")).read_bytes()
+    extra = _riff_bytes(_minimal_chunks(19))
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "a.idx").write_bytes(original)
+    (first / "b.idx").write_bytes(extra)
+    (second / "b.idx").write_bytes(extra)
+    (second / "a.idx").write_bytes(original)
+
+    def snapshot(directory: Path, project: Path = root) -> str:
+        return codenib_core.clangd_fact_query_snapshot(
+            idx_directory=str(directory), project_root=str(project)
+        )["snapshot_id"]
+
+    baseline = snapshot(first)
+    assert snapshot(second) == baseline
+
+    (second / "a.idx").rename(second / "renamed.idx")
+    assert snapshot(second) != baseline
+    (second / "renamed.idx").rename(second / "a.idx")
+    assert snapshot(second) == baseline
+
+    content_path = second / "a.idx"
+    content = bytearray(content_path.read_bytes())
+    timestamps = content_path.stat()
+    content[-1] ^= 1
+    content_path.write_bytes(content)
+    os.utime(
+        content_path,
+        ns=(timestamps.st_atime_ns, timestamps.st_mtime_ns),
+    )
+    assert snapshot(second) != baseline
+    content_path.write_bytes(original)
+    assert snapshot(second) == baseline
+
+    _set_meta_version(second / "a.idx", 18, 20)
+    assert snapshot(second) != baseline
+
+    other_root = tmp_path / "other-root"
+    other_root.mkdir()
+    assert snapshot(first, other_root) != baseline
 
 
 @pytest.mark.parametrize("version", [18, 19, 20])
@@ -749,9 +875,14 @@ def test_hybrid_uses_native_symbols_then_materializes_graph_once(
     target = bytes.fromhex("1112131415161718").hex()
 
     assert isinstance(provider, ClangdHybridQueryProvider)
-    assert [node.model_dump() for node in provider.definition(symbol=target)] == [
+    native_result = provider.definition(symbol=target)
+    assert [node.model_dump() for node in native_result] == [
         node.model_dump() for node in legacy.definition(symbol=target)
     ]
+    assert provider.snapshot_id.startswith("clangd_fact_query:sha256:")
+    assert native_result.provider_metadata_dict()["index_snapshot"] == (
+        provider.snapshot_id
+    )
     assert decoder._graph_materialized is False
 
     position_arguments = {
@@ -760,9 +891,13 @@ def test_hybrid_uses_native_symbols_then_materializes_graph_once(
         "character": 22,
         "top_k": 100,
     }
-    assert [
-        node.model_dump() for node in provider.definition(**position_arguments)
-    ] == [node.model_dump() for node in legacy.definition(**position_arguments)]
+    position_result = provider.definition(**position_arguments)
+    assert [node.model_dump() for node in position_result] == [
+        node.model_dump() for node in legacy.definition(**position_arguments)
+    ]
+    assert position_result.provider_metadata_dict()["index_snapshot"] == (
+        provider.snapshot_id
+    )
     assert decoder._graph_materialized is True
     assert provider.graph_materialization_count == 1
 
@@ -776,6 +911,74 @@ def test_hybrid_uses_native_symbols_then_materializes_graph_once(
         node.model_dump() for node in legacy.route(**route_arguments)
     ]
     assert provider.graph_materialization_count == 1
+
+
+def test_lazy_graph_fails_closed_when_snapshot_changes(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    monkeypatch.delenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", raising=False)
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    provider = decoder.decode_query_provider()
+    original_snapshot = provider.snapshot_id
+
+    _set_meta_version(idx_directory, 18, 19)
+
+    with pytest.raises(
+        RuntimeError, match="snapshot changed before legacy record collection"
+    ):
+        provider.route(symbols=["1112131415161718"], top_k=10)
+    assert decoder._graph_materialized is False
+    assert provider.snapshot_id == original_snapshot
+
+
+def test_lazy_graph_detects_mutation_during_record_collection(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    provider = decoder.decode_query_provider()
+    collect = decoder._collect_all_idx
+
+    def collect_then_mutate() -> None:
+        collect()
+        _set_meta_version(idx_directory, 18, 19)
+
+    monkeypatch.setattr(decoder, "_collect_all_idx", collect_then_mutate)
+
+    with pytest.raises(
+        RuntimeError, match="snapshot changed after legacy record collection"
+    ):
+        provider.route(symbols=["1112131415161718"], top_k=10)
+    assert decoder._graph_materialized is False
+
+
+def test_lazy_graph_detects_index_file_list_changes(clangd_fixture) -> None:
+    root, idx_directory = clangd_fixture
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    provider = decoder.decode_query_provider()
+    (idx_directory / "new.idx").write_bytes(_empty_idx())
+
+    with pytest.raises(RuntimeError, match="snapshot changed"):
+        provider.route(symbols=["1112131415161718"], top_k=10)
+    assert decoder._graph_materialized is False
+
+
+def test_native_snapshot_cannot_bind_a_preexisting_graph(
+    clangd_fixture, monkeypatch
+) -> None:
+    root, idx_directory = clangd_fixture
+    decoder = ClangdGraphDecoder(str(idx_directory), str(root))
+    graph = decoder.materialize_code_graph()
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "required")
+
+    with pytest.raises(RuntimeError, match="records collected before the receipt"):
+        decoder.decode_query_index()
+    assert decoder.query_snapshot_id is None
+
+    monkeypatch.setenv("CODENIB_NATIVE_CLANGD_FACT_QUERY_INDEX", "auto")
+    assert decoder.decode_query_index() is graph
+    assert decoder.query_backend == "legacy-query-fallback"
 
 
 def test_ls_indexer_exposes_query_index_and_provider(
@@ -819,6 +1022,10 @@ def test_profiler_records_parity_samples_order_and_contract(
     )
     assert len(report["raw_samples"]["legacy_clangd_graph"]["total"]) == 2
     assert len(report["raw_samples"]["native_clangd_fact_query_index"]["total"]) == 2
+    assert report["snapshot_receipt"]["snapshot_id"].startswith(
+        "clangd_fact_query:sha256:"
+    )
+    assert 0 <= report["snapshot_receipt"]["fraction_of_native_startup"] <= 1
     assert report["decision"]["parity"] is True
 
 

--- a/test/test_ci_policy.py
+++ b/test/test_ci_policy.py
@@ -309,10 +309,12 @@ def test_full_ci_enforces_the_maintained_native_core_gate() -> None:
     assert "pytest test/scip/test_scip_core.py" not in gate_run
     assert "LD_PRELOAD" in gate_run
     assert "decode_clangd_fact_query_index" in core_target
+    assert "clangd_fact_query_snapshot" in core_target
     for command in (
         "./build/core/scip_decode_test",
         "./build/core/graph_layers_test",
         "./build/core/fact_batch_buffer_test",
+        "./build/core/content_digest_test",
         "./build/core/fact_query_index_test",
         "test/ls_index/test_clangd_fact_query.py",
     ):


### PR DESCRIPTION
## Summary
Bind native clangd query sessions to a deterministic receipt over the exact index filenames and bytes consumed by the decoder. Fail closed before lazy graph materialization can mix index generations.

Closes #548

## Changes
- Add dependency-free streaming SHA-256 and a canonical receipt recipe bound to query ABI, normalization profile, RIFF allowlist, project root, sorted filenames, lengths, and bytes.
- Fuse the first hash with native reads, verify the shard stream again before publication, and expose snapshot identity through pybind, FactQueryIndex, provider metadata, and profiling output.
- Verify the receipt before and after lazy Python record collection; reject pre-collected graphs and changed file lists or content.
- Add deterministic receipt, mtime-independent mutation, lazy fail-closed, trace, performance-report, and CI-policy coverage.
- Update the durable C++ acceleration roadmap and core/CI documentation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [x] Tests

## Testing
- [x] Tests pass locally
- [x] Added new tests for the changes
- make core-test: five C++ executables; 110 Python tests passed, 4 expected cache-fixture skips.
- Targeted clangd/provider/CI-policy tests: 56 passed.
- Standard unit tier: 3873 passed, 13 skipped, with the two previously audited unrelated FAISS and cache-lock baseline tests explicitly deselected.
- pre-commit on every touched file: passed.
- python -m mkdocs build --strict: passed.
- python scripts/check_public_docs.py: passed.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published